### PR TITLE
Clean up some api tests

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -43,6 +43,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Maintain text color in hyperlinks card when hovered.
 * Prevent default behavior of copy button to avoid unintentional navigation when used in hyperlinks cards.
 * Prevent the submission of cycles for top-up review unless an amount has been entered first.
+* Fixed some tests that depended on execution order.
 
 #### Security
 

--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -155,7 +155,7 @@ describe("neurons api-service", () => {
   const neuronId = BigInt(12);
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
     resetNeuronsApiService();
   });
 

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -60,8 +60,6 @@ describe("canisters-api", () => {
   });
 
   describe("queryCanisters", () => {
-    afterEach(() => jest.clearAllMocks());
-
     it("should call the canister to list the canisters 🤪", async () => {
       await queryCanisters({ identity: mockIdentity, certified: true });
 
@@ -70,8 +68,6 @@ describe("canisters-api", () => {
   });
 
   describe("attachCanister", () => {
-    afterEach(() => jest.clearAllMocks());
-
     it("should call the nns dapp canister to attach the canister id", async () => {
       expect(mockNNSDappCanister.attachCanister).not.toBeCalled();
       await attachCanister({
@@ -117,8 +113,6 @@ describe("canisters-api", () => {
   });
 
   describe("renameCanister", () => {
-    beforeEach(() => jest.clearAllMocks());
-
     it("should call the nns dapp canister to rename the canister", async () => {
       await renameCanister({
         identity: mockIdentity,
@@ -148,8 +142,6 @@ describe("canisters-api", () => {
   });
 
   describe("updateSettings", () => {
-    afterEach(() => jest.clearAllMocks());
-
     it("should call the ic management canister to update settings", async () => {
       mockICManagementCanister.updateSettings.mockResolvedValue(undefined);
       await updateSettings({
@@ -179,8 +171,6 @@ describe("canisters-api", () => {
   });
 
   describe("detachCanister", () => {
-    afterEach(() => jest.clearAllMocks());
-
     it("should call the nns dapp canister to detach the canister id", async () => {
       await detachCanister({
         identity: mockIdentity,
@@ -222,7 +212,6 @@ describe("canisters-api", () => {
 
   describe("createCanister", () => {
     beforeEach(() => {
-      jest.clearAllMocks();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       jest.spyOn(global, "setTimeout").mockImplementation((cb: any) => cb());
       // Avoid to print errors during test
@@ -368,7 +357,6 @@ describe("canisters-api", () => {
 
   describe("topUpCanister", () => {
     beforeEach(() => {
-      jest.clearAllMocks();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       jest.spyOn(global, "setTimeout").mockImplementation((cb: any) => cb());
       // Avoid to print errors during test

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -36,12 +36,10 @@ describe("canisters-api", () => {
   const mockICManagementCanister = mock<ICManagementCanister>();
   const mockLedgerCanister = mock<LedgerCanister>();
 
-  afterAll(() => {
+  beforeEach(() => {
     jest.resetAllMocks();
     jest.clearAllTimers();
-  });
 
-  beforeEach(() => {
     jest.spyOn(console, "error").mockImplementation(() => undefined);
     const now = Date.now();
     jest.useFakeTimers().setSystemTime(now);
@@ -75,21 +73,24 @@ describe("canisters-api", () => {
     afterEach(() => jest.clearAllMocks());
 
     it("should call the nns dapp canister to attach the canister id", async () => {
+      expect(mockNNSDappCanister.attachCanister).not.toBeCalled();
       await attachCanister({
         identity: mockIdentity,
         canisterId: mockCanisterDetails.id,
         name: "test name",
       });
 
-      expect(mockNNSDappCanister.attachCanister).toBeCalled();
+      expect(mockNNSDappCanister.attachCanister).toBeCalledTimes(1);
     });
 
     it("should call the nns dapp canister to attach the canister id with empty string as name when not present", async () => {
+      expect(mockNNSDappCanister.attachCanister).not.toBeCalled();
       await attachCanister({
         identity: mockIdentity,
         canisterId: mockCanisterDetails.id,
       });
 
+      expect(mockNNSDappCanister.attachCanister).toBeCalledTimes(1);
       expect(mockNNSDappCanister.attachCanister).toBeCalledWith({
         canisterId: mockCanisterDetails.id,
         name: "",
@@ -98,6 +99,7 @@ describe("canisters-api", () => {
 
     it("should fail to attach if name is longer than max", async () => {
       const longName = "a".repeat(MAX_CANISTER_NAME_LENGTH + 1);
+      expect(mockNNSDappCanister.attachCanister).not.toBeCalled();
       const call = () =>
         attachCanister({
           identity: mockIdentity,


### PR DESCRIPTION
# Motivation

These tests fail if you change the order in which tests are run:

`frontend/src/tests/lib/api-services/governance.api-service.spec.ts` because some tests set mock behavior to make a mock fail while other tests don't set mock behavior and expect the mock calls not to fail.

`frontend/src/tests/lib/api/canisters.api.spec.ts` because one group of tests did its cleanup in `beforeEach` and the other in `afterEach`.

# Changes

1. `resetAllMocks` in beforeEach.
2. Remove `afterEach`.
3. Add some expectations about the state before the test

# Tests

Tests only

# Todos

- [ ] Add entry to changelog (if necessary).
Added an entry which should cover similar PRs as well.