### PR TITLE
Fix flaky proposals test

### DIFF
--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -77,6 +77,20 @@ test("Test neuron voting", async ({ page, context }) => {
   /*
    * Validate proposal details
    */
+  step("Filter Open Governance proposals");
+  // Filter by topic and status to get less proposals
+  // in case of a multiple dummy proposals created before calling this test
+  await appPo
+    .getProposalsPo()
+    .getNnsProposalFiltersPo()
+    .selectTopicFilter([Topic.Governance]);
+  await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
+  await appPo
+    .getProposalsPo()
+    .getNnsProposalFiltersPo()
+    .selectStatusFilter([ProposalStatus.Open]);
+  await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
+
   step("Open proposal details");
   const governanceProposalCard = await appPo
     .getProposalsPo()

--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -81,7 +81,7 @@ test("Test neuron voting", async ({ page, context }) => {
   const governanceProposalCard = await appPo
     .getProposalsPo()
     .getNnsProposalListPo()
-    .getFirstProposalCardPoForTopic("Governance");
+    .getFirstProposalCardPoForProposer(proposerNeuronId);
   expect(await governanceProposalCard.getProposalTopicText()).toBe(
     "Governance"
   );

--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -101,9 +101,9 @@ test("Test neuron voting", async ({ page, context }) => {
   );
 
   await governanceProposalCard.click();
+  await appPo.getProposalDetailPo().getNnsProposalPo().waitForContentLoaded();
 
   step("Check proposal details");
-  await appPo.getProposalDetailPo().getNnsProposalPo().waitForContentLoaded();
   const nnsProposalPo = appPo.getProposalDetailPo().getNnsProposalPo();
 
   // System info

--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -26,6 +26,55 @@ test("Test neuron voting", async ({ page, context }) => {
   await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
 
   /*
+   * Test proposal filters
+   */
+  step("Open proposals list");
+  await appPo.goToProposals();
+  await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
+
+  step(`Filter proposals by Topic`);
+  const getVisibleCardTopics = () =>
+    appPo.getProposalsPo().getNnsProposalListPo().getCardTopics();
+
+  await appPo
+    .getProposalsPo()
+    .getNnsProposalFiltersPo()
+    .selectTopicFilter([Topic.ExchangeRate]);
+  await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
+
+  expect(await getVisibleCardTopics()).toEqual(["Exchange Rate"]);
+
+  // Invert topic filter
+  await appPo
+    .getProposalsPo()
+    .getNnsProposalFiltersPo()
+    .selectAllTopicsExcept([Topic.ExchangeRate]);
+  await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
+
+  expect((await getVisibleCardTopics()).includes("Exchange Rate")).toBe(false);
+
+  step("Filter proposals by Status");
+  const getVisibleCardStatuses = () =>
+    appPo.getProposalsPo().getNnsProposalListPo().getCardStatuses();
+
+  await appPo
+    .getProposalsPo()
+    .getNnsProposalFiltersPo()
+    .selectStatusFilter([ProposalStatus.Open]);
+  await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
+
+  expect(await getVisibleCardStatuses()).toEqual(["Open"]);
+
+  // Invert status filter
+  await appPo
+    .getProposalsPo()
+    .getNnsProposalFiltersPo()
+    .selectAllStatusesExcept([ProposalStatus.Open]);
+  await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
+
+  expect(await getVisibleCardStatuses()).not.toContain("Open");
+
+  /*
    * Validate proposal details
    */
   step("Open proposal details");
@@ -80,53 +129,4 @@ test("Test neuron voting", async ({ page, context }) => {
   ).toHaveLength(1);
 
   await appPo.goBack();
-
-  /*
-   * Test proposal filters
-   */
-  step("Open proposals list");
-  await appPo.goToProposals();
-  await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
-
-  step(`Filter proposals by Topic`);
-  const getVisibleCardTopics = () =>
-    appPo.getProposalsPo().getNnsProposalListPo().getCardTopics();
-
-  await appPo
-    .getProposalsPo()
-    .getNnsProposalFiltersPo()
-    .selectTopicFilter([Topic.ExchangeRate]);
-  await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
-
-  expect(await getVisibleCardTopics()).toEqual(["Exchange Rate"]);
-
-  // Invert topic filter
-  await appPo
-    .getProposalsPo()
-    .getNnsProposalFiltersPo()
-    .selectAllTopicsExcept([Topic.ExchangeRate]);
-  await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
-
-  expect((await getVisibleCardTopics()).includes("Exchange Rate")).toBe(false);
-
-  step("Filter proposals by Status");
-  const getVisibleCardStatuses = () =>
-    appPo.getProposalsPo().getNnsProposalListPo().getCardStatuses();
-
-  await appPo
-    .getProposalsPo()
-    .getNnsProposalFiltersPo()
-    .selectStatusFilter([ProposalStatus.Open]);
-  await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
-
-  expect(await getVisibleCardStatuses()).toEqual(["Open"]);
-
-  // Invert status filter
-  await appPo
-    .getProposalsPo()
-    .getNnsProposalFiltersPo()
-    .selectAllStatusesExcept([ProposalStatus.Open]);
-  await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
-
-  expect(await getVisibleCardStatuses()).not.toContain("Open");
 });

--- a/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
@@ -60,20 +60,6 @@ export class NnsProposalListPo extends BasePageObject {
     throw new Error(`No proposal card found for proposer ${proposer}`);
   }
 
-  async getFirstProposalCardPoForTopic(
-    topicText: string
-  ): Promise<ProposalCardPo> {
-    const allCards = await this.getProposalCardPos();
-
-    for (const card of allCards) {
-      if ((await card.getProposalTopicText()) === topicText) {
-        return card;
-      }
-    }
-
-    throw new Error(`No proposal card found for topic "${topicText}"`);
-  }
-
   async getProposalIds(): Promise<string[]> {
     const cards = await this.getProposalCardPos();
     return Promise.all(cards.map((card) => card.getProposalId()));


### PR DESCRIPTION
# Motivation

Fix the flaky proposals test. The e2e test did assumption that the first Governance proposal it sees is one that was created. But e2e tests run in parallel and sometime this behaviour throws [an error](https://github.com/dfinity/nns-dapp/actions/runs/5833943590/job/15822555814).

# Changes

- replace `getFirstProposalCardPoForTopic` with `getFirstProposalCardPoForProposer`
- move filters test before proposal details (to be sure that filtering works as expected)
- apply filters before `getFirstProposalCardPoForProposer` to be sure that just created dummy proposals are on the first page.

# Tests

Yes

# Todos

- [ ] Add entry to changelog (if necessary).
