### PR TITLE
Reduce dependency on jest-spy.ts from service tests

### DIFF
--- a/frontend/jest-spy.ts
+++ b/frontend/jest-spy.ts
@@ -1,6 +1,12 @@
 import type { HttpAgent } from "@dfinity/agent";
 import { mock } from "jest-mock-extended";
 import * as agent from "./src/lib/api/agent.api";
+import * as authServices from "./src/lib/services/auth.services";
+import { mockGetIdentity } from "./src/tests/mocks/auth.store.mock";
 
 const mockCreateAgent = () => Promise.resolve(mock<HttpAgent>());
 jest.spyOn(agent, "createAgent").mockImplementation(mockCreateAgent);
+
+jest
+  .spyOn(authServices, "getAuthenticatedIdentity")
+  .mockImplementation(() => Promise.resolve(mockGetIdentity()));

--- a/frontend/jest-spy.ts
+++ b/frontend/jest-spy.ts
@@ -2,11 +2,12 @@ import type { HttpAgent } from "@dfinity/agent";
 import { mock } from "jest-mock-extended";
 import * as agent from "./src/lib/api/agent.api";
 import * as authServices from "./src/lib/services/auth.services";
-import { mockGetIdentity } from "./src/tests/mocks/auth.store.mock";
+import { resetIdentity, mockGetIdentity } from "./src/tests/mocks/auth.store.mock";
 
 const mockCreateAgent = () => Promise.resolve(mock<HttpAgent>());
 jest.spyOn(agent, "createAgent").mockImplementation(mockCreateAgent);
 
+resetIdentity();
 jest
   .spyOn(authServices, "getAuthenticatedIdentity")
   .mockImplementation(() => Promise.resolve(mockGetIdentity()));

--- a/frontend/jest-spy.ts
+++ b/frontend/jest-spy.ts
@@ -1,12 +1,6 @@
 import type { HttpAgent } from "@dfinity/agent";
 import { mock } from "jest-mock-extended";
 import * as agent from "./src/lib/api/agent.api";
-import * as authServices from "./src/lib/services/auth.services";
-import { mockGetIdentity } from "./src/tests/mocks/auth.store.mock";
 
 const mockCreateAgent = () => Promise.resolve(mock<HttpAgent>());
 jest.spyOn(agent, "createAgent").mockImplementation(mockCreateAgent);
-
-jest
-  .spyOn(authServices, "getAuthenticatedIdentity")
-  .mockImplementation(() => Promise.resolve(mockGetIdentity()));

--- a/frontend/jest-spy.ts
+++ b/frontend/jest-spy.ts
@@ -2,7 +2,10 @@ import type { HttpAgent } from "@dfinity/agent";
 import { mock } from "jest-mock-extended";
 import * as agent from "./src/lib/api/agent.api";
 import * as authServices from "./src/lib/services/auth.services";
-import { resetIdentity, mockGetIdentity } from "./src/tests/mocks/auth.store.mock";
+import {
+  mockGetIdentity,
+  resetIdentity,
+} from "./src/tests/mocks/auth.store.mock";
 
 const mockCreateAgent = () => Promise.resolve(mock<HttpAgent>());
 jest.spyOn(agent, "createAgent").mockImplementation(mockCreateAgent);

--- a/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
+++ b/frontend/src/tests/lib/components/header/AccountMenu.spec.ts
@@ -3,8 +3,7 @@
  */
 
 import AccountMenu from "$lib/components/header/AccountMenu.svelte";
-import { authStore } from "$lib/stores/auth.store";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 
 describe("AccountMenu", () => {
@@ -19,17 +18,16 @@ describe("AccountMenu", () => {
   });
 
   it("should display a sign-in button if not signed in", () => {
+    setNoIdentity();
     const { getByTestId } = render(AccountMenu);
 
     expect(getByTestId("toolbar-login")).not.toBeNull();
   });
 
   describe("signed in", () => {
-    beforeAll(() =>
-      jest
-        .spyOn(authStore, "subscribe")
-        .mockImplementation(mockAuthStoreSubscribe)
-    );
+    beforeEach(() => {
+      resetIdentity();
+    });
 
     it("should be open", async () => {
       const renderResult = render(AccountMenu);

--- a/frontend/src/tests/lib/components/warnings/Warnings.spec.ts
+++ b/frontend/src/tests/lib/components/warnings/Warnings.spec.ts
@@ -4,12 +4,11 @@
 
 import Warnings from "$lib/components/warnings/Warnings.svelte";
 import type { MetricsCallback } from "$lib/services/$public/worker-metrics.services";
-import { authStore } from "$lib/stores/auth.store";
 import { bitcoinConvertBlockIndexes } from "$lib/stores/bitcoin.store";
 import { layoutWarningToastId } from "$lib/stores/layout.store";
 import { metricsStore } from "$lib/stores/metrics.store";
 import type { DashboardMessageExecutionRateResponse } from "$lib/types/dashboard";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { toastsStore } from "@dfinity/gix-components";
 import { fireEvent } from "@testing-library/dom";
@@ -133,11 +132,9 @@ describe("Warnings", () => {
     });
 
     describe("signed in", () => {
-      beforeEach(() =>
-        jest
-          .spyOn(authStore, "subscribe")
-          .mockImplementation(mockAuthStoreSubscribe)
-      );
+      beforeEach(() => {
+        resetIdentity();
+      });
 
       it("should render ckBTC to BTC warning", async () => {
         bitcoinConvertBlockIndexes.addBlockIndex(1n);
@@ -184,6 +181,10 @@ describe("Warnings", () => {
     });
 
     describe("not signed in", () => {
+      beforeEach(() => {
+        setNoIdentity();
+      });
+
       it("should render no ckBTC warning", async () => {
         bitcoinConvertBlockIndexes.addBlockIndex(1n);
 
@@ -202,6 +203,10 @@ describe("Warnings", () => {
 
   describe("TestEnvironmentWarning", () => {
     describe("not signed in", () => {
+      beforeEach(() => {
+        setNoIdentity();
+      });
+
       it("should not render test environment warning", async () => {
         const { getByTestId } = render(Warnings, {
           props: {
@@ -214,11 +219,9 @@ describe("Warnings", () => {
     });
 
     describe("signed in", () => {
-      beforeAll(() =>
-        jest
-          .spyOn(authStore, "subscribe")
-          .mockImplementation(mockAuthStoreSubscribe)
-      );
+      beforeEach(() => {
+        resetIdentity();
+      });
 
       it("should render test environment warning", async () => {
         const { getByTestId } = render(Warnings, {

--- a/frontend/src/tests/lib/modals/sns/SnsIncreaseStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsIncreaseStakeNeuronModal.spec.ts
@@ -7,12 +7,12 @@ import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-tr
 import SnsIncreaseStakeNeuronModal from "$lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte";
 import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
 import { increaseStakeNeuron } from "$lib/services/sns-neurons.services";
-import { authStore } from "$lib/stores/auth.store";
 import { startBusy } from "$lib/stores/busy.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import {
-  mockAuthStoreSubscribe,
   mockPrincipal,
+  resetIdentity,
+  setNoIdentity,
 } from "$tests/mocks/auth.store.mock";
 import { mockStoreSubscribe } from "$tests/mocks/commont.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
@@ -119,6 +119,10 @@ describe("SnsIncreaseStakeNeuronModal", () => {
     });
 
     describe("user has not signed-in", () => {
+      beforeEach(() => {
+        setNoIdentity();
+      });
+
       it("should not be able to execute transaction", async () => {
         const renderResult: RenderResult<SvelteComponent> =
           await renderSnsIncreaseStakeNeuronModal();
@@ -133,10 +137,8 @@ describe("SnsIncreaseStakeNeuronModal", () => {
     });
 
     describe("user has signed-in", () => {
-      beforeAll(() => {
-        jest
-          .spyOn(authStore, "subscribe")
-          .mockImplementation(mockAuthStoreSubscribe);
+      beforeEach(() => {
+        resetIdentity();
       });
 
       it("should call increaseStakeNeuron service on confirm click", async () => {

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -4,6 +4,7 @@
 import * as aggregatorApi from "$lib/api/sns-aggregator.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import { initAppPrivateData } from "$lib/services/app.services";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockAccountDetails } from "$tests/mocks/icp-accounts.store.mock";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import { toastsStore } from "@dfinity/gix-components";
@@ -18,6 +19,7 @@ describe("app-services", () => {
   const mockNNSDappCanister = mock<NNSDappCanister>();
 
   beforeEach(() => {
+    resetIdentity();
     toastsStore.reset();
     jest.clearAllMocks();
     jest

--- a/frontend/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/canisters.services.spec.ts
@@ -1,6 +1,7 @@
 import * as api from "$lib/api/canisters.api";
 import * as ledgerApi from "$lib/api/icp-ledger.api";
 import { UserNotTheControllerError } from "$lib/canisters/ic-management/ic-management.errors";
+import * as authServices from "$lib/services/auth.services";
 import {
   addController,
   attachCanister,
@@ -17,6 +18,7 @@ import {
 import { canistersStore } from "$lib/stores/canisters.store";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import {
+  mockGetIdentity,
   mockIdentity,
   mockIdentityErrorMsg,
   resetIdentity,
@@ -97,6 +99,11 @@ describe("canisters-services", () => {
     spyGetExchangeRate = jest
       .spyOn(api, "getIcpToCyclesExchangeRate")
       .mockImplementation(() => Promise.resolve(exchangeRate));
+
+    resetIdentity();
+    jest
+      .spyOn(authServices, "getAuthenticatedIdentity")
+      .mockImplementation(mockGetIdentity);
   });
 
   describe("listCanisters", () => {

--- a/frontend/src/tests/lib/services/ckbtc-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts-balance.services.spec.ts
@@ -9,6 +9,7 @@ import * as services from "$lib/services/ckbtc-accounts-balance.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockCkBTCMainAccount,
   mockCkBTCToken,
@@ -23,6 +24,10 @@ jest.mock("$lib/stores/toasts.store", () => {
 });
 
 describe("ckbtc-accounts-balance.services", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
 

--- a/frontend/src/tests/lib/services/ckbtc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts.services.spec.ts
@@ -13,6 +13,7 @@ import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockCkBTCMainAccount,
   mockCkBTCToken,
@@ -29,6 +30,10 @@ jest.mock("$lib/services/ckbtc-transactions.services", () => {
 });
 
 describe("ckbtc-accounts-services", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
+
   describe("loadCkBTCAccounts", () => {
     beforeEach(() => {
       jest.clearAllMocks();

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -16,7 +16,7 @@ import * as toastsStore from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCkBTCAdditionalCanisters } from "$tests/mocks/canisters.mock";
 import {
   mockBTCAddressTestnet,
@@ -64,6 +64,7 @@ describe("ckbtc-convert-services", () => {
     });
 
   beforeEach(() => {
+    resetIdentity();
     jest.clearAllMocks();
     jest.clearAllTimers();
 

--- a/frontend/src/tests/lib/services/ckbtc-info.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-info.services.spec.ts
@@ -8,15 +8,24 @@ import {
   CKBTC_MINTER_CANISTER_ID,
   CKBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
+import * as authServices from "$lib/services/auth.services";
 import * as services from "$lib/services/ckbtc-info.services";
 import { ckBTCInfoStore } from "$lib/stores/ckbtc-info.store";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import {
+  mockGetIdentity,
+  mockIdentity,
+  resetIdentity,
+} from "$tests/mocks/auth.store.mock";
 import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("ckbtc-info-services", () => {
   beforeEach(() => {
+    resetIdentity();
+    jest
+      .spyOn(authServices, "getAuthenticatedIdentity")
+      .mockImplementation(mockGetIdentity);
     jest.clearAllMocks();
     ckBTCInfoStore.reset();
   });

--- a/frontend/src/tests/lib/services/ckbtc-info.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-info.services.spec.ts
@@ -22,12 +22,12 @@ import { get } from "svelte/store";
 
 describe("ckbtc-info-services", () => {
   beforeEach(() => {
+    jest.clearAllMocks();
+    ckBTCInfoStore.reset();
     resetIdentity();
     jest
       .spyOn(authServices, "getAuthenticatedIdentity")
       .mockImplementation(mockGetIdentity);
-    jest.clearAllMocks();
-    ckBTCInfoStore.reset();
   });
 
   describe("loadCkBTCInfo", () => {

--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -15,7 +15,7 @@ import * as busyStore from "$lib/stores/busy.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { ApiErrorKey } from "$lib/types/api.errors";
 import { page } from "$mocks/$app/stores";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockBTCAddressTestnet,
   mockCkBTCMainAccount,
@@ -33,6 +33,10 @@ import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("ckbtc-minter-services", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
+
   afterEach(() => jest.clearAllMocks());
 
   describe("loadBtcAddress", () => {

--- a/frontend/src/tests/lib/services/ckbtc-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-tokens.services.spec.ts
@@ -7,12 +7,16 @@ import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.co
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
 import * as services from "$lib/services/ckbtc-tokens.services";
 import { tokensStore } from "$lib/stores/tokens.store";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("ckbtc-tokens-services", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
+
   describe("loadCkBTCTokens", () => {
     beforeEach(() => {
       tokensStore.reset();

--- a/frontend/src/tests/lib/services/ckbtc-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-transactions.services.spec.ts
@@ -10,7 +10,7 @@ import {
 import { DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import * as services from "$lib/services/ckbtc-transactions.services";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
 import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import { waitFor } from "@testing-library/svelte";
@@ -18,6 +18,7 @@ import { get } from "svelte/store";
 
 describe("ckbtc-transactions-services", () => {
   beforeEach(() => {
+    resetIdentity();
     icrcTransactionsStore.reset();
   });
 

--- a/frontend/src/tests/lib/services/ckbtc-withdrawal-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-withdrawal-accounts.services.spec.ts
@@ -3,6 +3,7 @@ import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.co
 import * as minterServices from "$lib/services/ckbtc-minter.services";
 import { loadCkBTCWithdrawalAccount } from "$lib/services/ckbtc-withdrawal-accounts.services";
 import { ckBTCWithdrawalAccountsStore } from "$lib/stores/ckbtc-withdrawal-accounts.store";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockCkBTCWithdrawalAccount,
   mockCkBTCWithdrawalIcrcAccount,
@@ -15,6 +16,10 @@ import { tick } from "svelte";
 import { get } from "svelte/store";
 
 describe("ckbtc-withdrawal-accounts.services", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
+
   describe("loadCkBTCWithdrawalAccount", () => {
     beforeEach(() => {
       resetMockedConstants();

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -13,6 +13,7 @@ import { SYNC_ACCOUNTS_RETRY_SECONDS } from "$lib/constants/accounts.constants";
 import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { DEFAULT_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import { getLedgerIdentityProxy } from "$lib/proxy/icp-ledger.services.proxy";
+import * as authServices from "$lib/services/auth.services";
 import {
   addSubAccount,
   cancelPollAccounts,
@@ -35,6 +36,7 @@ import { mainTransactionFeeE8sStore } from "$lib/stores/transaction-fees.store";
 import type { NewTransaction } from "$lib/types/transaction";
 import { toIcpAccountIdentifier } from "$lib/utils/accounts.utils";
 import {
+  mockGetIdentity,
   mockIdentity,
   mockIdentityErrorMsg,
   resetIdentity,
@@ -91,6 +93,10 @@ describe("icp-accounts.services", () => {
     toastsStore.reset();
     icpAccountsStore.resetForTesting();
     overrideFeatureFlagsStore.reset();
+    resetIdentity();
+    jest
+      .spyOn(authServices, "getAuthenticatedIdentity")
+      .mockImplementation(mockGetIdentity);
   });
 
   const mockSnsAccountIcpAccountIdentifier = AccountIdentifier.fromPrincipal({

--- a/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
@@ -189,7 +189,6 @@ describe("icp-ledger.services", () => {
 
       it("should not register and sync accounts if no identity", async () => {
         setNoIdentity();
-        await new Promise((resolve) => setTimeout(resolve, 100));
 
         const call = async () =>
           await registerHardwareWallet({

--- a/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
@@ -17,12 +17,10 @@ import {
   resetIdentitiesCachedForTesting,
   showAddressAndPubKeyOnHardwareWallet,
 } from "$lib/services/icp-ledger.services";
-import { authStore } from "$lib/stores/auth.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { LedgerErrorKey, LedgerErrorMessage } from "$lib/types/ledger.errors";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import {
-  mockAuthStoreSubscribe,
   mockGetIdentity,
   mockIdentity,
   mockIdentityErrorMsg,
@@ -53,6 +51,10 @@ describe("icp-ledger.services", () => {
   beforeEach(() => {
     resetIdentitiesCachedForTesting();
     jest.clearAllMocks();
+    resetIdentity();
+    jest
+      .spyOn(authServices, "getAuthenticatedIdentity")
+      .mockImplementation(mockGetIdentity);
   });
 
   describe("connect hardware wallet", () => {
@@ -133,10 +135,6 @@ describe("icp-ledger.services", () => {
         .spyOn(accountsServices, "syncAccounts")
         .mockImplementation(jest.fn());
 
-      jest
-        .spyOn(authStore, "subscribe")
-        .mockImplementation(mockAuthStoreSubscribe);
-
       const mockCreateAgent = () => Promise.resolve(mock<Agent>());
       jest.spyOn(agent, "createAgent").mockImplementation(mockCreateAgent);
 
@@ -191,6 +189,7 @@ describe("icp-ledger.services", () => {
 
       it("should not register and sync accounts if no identity", async () => {
         setNoIdentity();
+        await new Promise((resolve) => setTimeout(resolve, 100));
 
         const call = async () =>
           await registerHardwareWallet({

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -1,8 +1,12 @@
 import { getIcrcAccountIdentity } from "$lib/services/icrc-accounts.services";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 
 describe("icrc-accounts-services", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
+
   describe("getIcrcAccountIdentity", () => {
     it("returns identity", async () => {
       const identity = await getIcrcAccountIdentity(mockSnsMainAccount);

--- a/frontend/src/tests/lib/services/known-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/known-neurons.services.spec.ts
@@ -1,7 +1,9 @@
 import * as api from "$lib/api/governance.api";
+import * as authServices from "$lib/services/auth.services";
 import { listKnownNeurons } from "$lib/services/known-neurons.services";
 import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
 import {
+  mockGetIdentity,
   mockIdentityErrorMsg,
   resetIdentity,
   setNoIdentity,
@@ -13,6 +15,13 @@ describe("knownNeurons-services", () => {
   const spyQueryKnownNeurons = jest
     .spyOn(api, "queryKnownNeurons")
     .mockResolvedValue([mockKnownNeuron]);
+
+  beforeEach(() => {
+    resetIdentity();
+    jest
+      .spyOn(authServices, "getAuthenticatedIdentity")
+      .mockImplementation(mockGetIdentity);
+  });
 
   it("should list known neurons", async () => {
     await listKnownNeurons();

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -5,6 +5,7 @@ import {
   E8S_PER_ICP,
 } from "$lib/constants/icp.constants";
 import { MIN_NEURON_STAKE } from "$lib/constants/neurons.constants";
+import * as authServices from "$lib/services/auth.services";
 import {
   getAccountIdentityByPrincipal,
   loadBalance,
@@ -19,6 +20,7 @@ import { NotAuthorizedNeuronError } from "$lib/types/neurons.errors";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
 import {
+  mockGetIdentity,
   mockIdentity,
   mockIdentityErrorMsg,
   resetIdentity,
@@ -160,7 +162,6 @@ describe("neurons-services", () => {
     jest.clearAllMocks();
     neuronsStore.reset();
     icpAccountsStore.resetForTesting();
-    resetIdentity();
     resetAccountIdentity();
     toastsStore.reset();
     resetNeuronsApiService();
@@ -190,6 +191,10 @@ describe("neurons-services", () => {
     spyStopDissolving.mockResolvedValue();
     spySetFollowees.mockResolvedValue();
     spyClaimOrRefresh.mockResolvedValue(undefined);
+    resetIdentity();
+    jest
+      .spyOn(authServices, "getAuthenticatedIdentity")
+      .mockImplementation(mockGetIdentity);
   });
 
   describe("stake new neuron", () => {

--- a/frontend/src/tests/lib/services/nns-reward-event.services.spec.ts
+++ b/frontend/src/tests/lib/services/nns-reward-event.services.spec.ts
@@ -15,15 +15,15 @@ describe("nns-reward-event-services", () => {
   let spyQueryLatestRewardEvent: jest.SpyInstance;
 
   beforeEach(() => {
-    resetIdentity();
-    jest
-      .spyOn(authServices, "getAuthenticatedIdentity")
-      .mockImplementation(mockGetIdentity);
     nnsLatestRewardEventStore.reset();
     jest.clearAllMocks();
     spyQueryLatestRewardEvent = jest
       .spyOn(api, "queryLastestRewardEvent")
       .mockResolvedValue(mockRewardEvent);
+    resetIdentity();
+    jest
+      .spyOn(authServices, "getAuthenticatedIdentity")
+      .mockImplementation(mockGetIdentity);
   });
 
   it("should load nns reward event store", async () => {

--- a/frontend/src/tests/lib/services/nns-reward-event.services.spec.ts
+++ b/frontend/src/tests/lib/services/nns-reward-event.services.spec.ts
@@ -1,7 +1,9 @@
 import * as api from "$lib/api/governance.api";
+import * as authServices from "$lib/services/auth.services";
 import { loadLatestRewardEvent } from "$lib/services/nns-reward-event.services";
 import { nnsLatestRewardEventStore } from "$lib/stores/nns-latest-reward-event.store";
 import {
+  mockGetIdentity,
   mockIdentityErrorMsg,
   resetIdentity,
   setNoIdentity,
@@ -13,6 +15,10 @@ describe("nns-reward-event-services", () => {
   let spyQueryLatestRewardEvent: jest.SpyInstance;
 
   beforeEach(() => {
+    resetIdentity();
+    jest
+      .spyOn(authServices, "getAuthenticatedIdentity")
+      .mockImplementation(mockGetIdentity);
     nnsLatestRewardEventStore.reset();
     jest.clearAllMocks();
     spyQueryLatestRewardEvent = jest

--- a/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
@@ -4,6 +4,7 @@ import * as services from "$lib/services/sns-accounts-balance.services";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import {
   mockSnsSummaryList,
@@ -19,6 +20,10 @@ jest.mock("$lib/stores/toasts.store", () => {
 });
 
 describe("sns-accounts-balance.services", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
 

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -9,7 +9,7 @@ import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { waitFor } from "@testing-library/svelte";
@@ -21,6 +21,10 @@ jest.mock("$lib/services/sns-transactions.services", () => ({
 }));
 
 describe("sns-accounts-services", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
+
   describe("loadSnsAccounts", () => {
     beforeEach(() => {
       jest.clearAllMocks();

--- a/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
@@ -8,7 +8,11 @@ import {
   neuronNeedsRefresh,
 } from "$lib/services/sns-neurons-check-balances.services";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
-import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
+import {
+  mockIdentity,
+  mockPrincipal,
+  resetIdentity,
+} from "$tests/mocks/auth.store.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { neuronSubaccount, type SnsNeuronId } from "@dfinity/sns";
 import { waitFor } from "@testing-library/svelte";
@@ -18,6 +22,7 @@ describe("sns-neurons-check-balances-services", () => {
   describe("checkSnsNeuronBalances", () => {
     beforeEach(() => {
       jest.clearAllMocks();
+      resetIdentity();
       snsNeuronsStore.reset();
       jest.spyOn(console, "error").mockImplementation(() => undefined);
     });

--- a/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
@@ -19,10 +19,12 @@ import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("sns-neurons-check-balances-services", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
   describe("checkSnsNeuronBalances", () => {
     beforeEach(() => {
       jest.clearAllMocks();
-      resetIdentity();
       snsNeuronsStore.reset();
       jest.spyOn(console, "error").mockImplementation(() => undefined);
     });

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -29,7 +29,11 @@ import {
 } from "$lib/utils/sns-neuron.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
 import { bytesToHexString } from "$lib/utils/utils";
-import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
+import {
+  mockIdentity,
+  mockPrincipal,
+  resetIdentity,
+} from "$tests/mocks/auth.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import {
   buildMockSnsNeuronsStoreSubscribe,
@@ -77,6 +81,10 @@ jest.mock("$lib/services/sns-accounts.services", () => {
 });
 
 describe("sns-neurons-services", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
+
   describe("syncSnsNeurons", () => {
     beforeEach(() => {
       jest.clearAllMocks();

--- a/frontend/src/tests/lib/services/sns-parameters.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-parameters.services.spec.ts
@@ -5,11 +5,15 @@
 import * as governanceApi from "$lib/api/sns-governance.api";
 import * as services from "$lib/services/sns-parameters.services";
 import { snsParametersStore } from "$lib/stores/sns-parameters.store";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { snsNervousSystemParametersMock } from "$tests/mocks/sns-neurons.mock";
 import { get } from "svelte/store";
 
 describe("sns-parameters-services", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
+
   describe("loadSnsParameters", () => {
     afterEach(() => {
       snsParametersStore.reset();

--- a/frontend/src/tests/lib/services/sns-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-tokens.services.spec.ts
@@ -5,13 +5,17 @@
 import * as ledgerApi from "$lib/api/sns-ledger.api";
 import * as services from "$lib/services/sns-tokens.services";
 import { tokensStore } from "$lib/stores/tokens.store";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import { Principal } from "@dfinity/principal";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("sns-tokens-services", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
+
   describe("loadSnsTokens", () => {
     beforeEach(() => {
       tokensStore.reset();

--- a/frontend/src/tests/lib/services/sns-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-transactions.services.spec.ts
@@ -14,9 +14,11 @@ import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("sns-transactions-services", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
   describe("loadSnsAccountTransactions", () => {
     beforeEach(() => {
-      resetIdentity();
       icrcTransactionsStore.reset();
     });
     afterEach(() => jest.clearAllMocks());

--- a/frontend/src/tests/lib/services/sns-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-transactions.services.spec.ts
@@ -6,7 +6,7 @@ import * as indexApi from "$lib/api/sns-index.api";
 import { DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import * as services from "$lib/services/sns-transactions.services";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { Principal } from "@dfinity/principal";
@@ -16,6 +16,7 @@ import { get } from "svelte/store";
 describe("sns-transactions-services", () => {
   describe("loadSnsAccountTransactions", () => {
     beforeEach(() => {
+      resetIdentity();
       icrcTransactionsStore.reset();
     });
     afterEach(() => jest.clearAllMocks());

--- a/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
@@ -8,7 +8,7 @@ import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
 import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
@@ -71,6 +71,7 @@ describe("sns-vote-registration-services", () => {
     });
 
   beforeEach(() => {
+    resetIdentity();
     jest.clearAllMocks();
 
     snsFunctionsStore.setProjectFunctions({

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -9,9 +9,9 @@ import * as services from "$lib/services/sns.services";
 import { authStore } from "$lib/stores/auth.store";
 import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import {
-  mockAuthStoreSubscribe,
   mockIdentity,
   mockPrincipal,
+  resetIdentity,
 } from "$tests/mocks/auth.store.mock";
 import {
   mockSnsSwapCommitment,
@@ -51,6 +51,7 @@ describe("sns-services", () => {
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   describe("getSwapAccount", () => {

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -6,7 +6,6 @@
 import * as api from "$lib/api/sns.api";
 import { WATCH_SALE_STATE_EVERY_MILLISECONDS } from "$lib/constants/sns.constants";
 import * as services from "$lib/services/sns.services";
-import { authStore } from "$lib/stores/auth.store";
 import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import {
   mockIdentity,
@@ -43,15 +42,12 @@ const {
 
 describe("sns-services", () => {
   beforeEach(() => {
+    resetIdentity();
     jest.useFakeTimers();
     jest.clearAllTimers();
     jest.clearAllMocks();
     snsSwapCommitmentsStore.reset();
     snsQueryStore.reset();
-    jest
-      .spyOn(authStore, "subscribe")
-      .mockImplementation(mockAuthStoreSubscribe);
-    resetIdentity();
   });
 
   describe("getSwapAccount", () => {
@@ -258,6 +254,7 @@ describe("sns-services", () => {
         rootCanisterId: commitment1.rootCanisterId.toText(),
         forceFetch: false,
       });
+      await runResolvedPromises();
       expect(queryCommitmentSpy).toBeCalledTimes(2);
 
       await waitFor(() =>
@@ -293,6 +290,7 @@ describe("sns-services", () => {
         rootCanisterId: commitment1.rootCanisterId.toText(),
         forceFetch: true,
       });
+      await runResolvedPromises();
 
       expect(queryCommitmentSpy).toBeCalledTimes(1);
     });
@@ -302,6 +300,7 @@ describe("sns-services", () => {
         rootCanisterId: commitment1.rootCanisterId.toText(),
         forceFetch: true,
       });
+      await runResolvedPromises();
       expect(queryCommitmentSpy).toBeCalledTimes(1);
       expect(queryCommitmentSpy).toBeCalledWith({
         rootCanisterId: commitment1.rootCanisterId.toText(),

--- a/frontend/src/tests/lib/services/transaction-fee.services.spec.ts
+++ b/frontend/src/tests/lib/services/transaction-fee.services.spec.ts
@@ -1,11 +1,15 @@
 import * as snsApi from "$lib/api/sns-ledger.api";
 import { loadSnsTransactionFee } from "$lib/services/transaction-fees.services";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { get } from "svelte/store";
 
 describe("transactionFee-services", () => {
   const fee = BigInt(30_000);
+
+  beforeEach(() => {
+    resetIdentity();
+  });
 
   describe("loadSnsTransactionFee", () => {
     describe("success", () => {

--- a/frontend/src/tests/lib/services/vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/vote-registration.services.spec.ts
@@ -5,6 +5,7 @@
 import * as governanceApi from "$lib/api/governance.api";
 import * as proposalsApi from "$lib/api/proposals.api";
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import * as authServices from "$lib/services/auth.services";
 import * as neuronsServices from "$lib/services/neurons.services";
 import { registerNnsVotes } from "$lib/services/nns-vote-registration.services";
 import { processRegisterVoteErrors } from "$lib/services/vote-registration.services";
@@ -14,7 +15,11 @@ import * as toastsStore from "$lib/stores/toasts.store";
 import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { waitForMilliseconds } from "$lib/utils/utils";
-import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
+import {
+  mockGetIdentity,
+  resetIdentity,
+  setNoIdentity,
+} from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
@@ -77,6 +82,10 @@ describe("vote-registration-services", () => {
       proposals: [proposal],
       certified: true,
     });
+    resetIdentity();
+    jest
+      .spyOn(authServices, "getAuthenticatedIdentity")
+      .mockImplementation(mockGetIdentity);
   });
 
   describe("success voting", () => {

--- a/frontend/src/tests/mocks/auth.store.mock.ts
+++ b/frontend/src/tests/mocks/auth.store.mock.ts
@@ -1,7 +1,8 @@
-import type { AuthStoreData } from "$lib/stores/auth.store";
+import { authStore, type AuthStoreData } from "$lib/stores/auth.store";
 import type { Identity } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import type { Subscriber } from "svelte/store";
+import { get } from "svelte/store";
 import en from "./i18n.mock";
 
 export const mockPrincipalText =
@@ -22,17 +23,16 @@ export const createMockIdentity = (p: number) => {
 
 export const mockIdentityErrorMsg = en.error.missing_identity;
 
-let testIdentity: Identity | null = mockIdentity;
+export const setNoIdentity = () => authStore.setForTesting(null);
+export const resetIdentity = () => authStore.setForTesting(mockIdentity);
 
-export const setNoIdentity = () => (testIdentity = null);
-export const resetIdentity = () => (testIdentity = mockIdentity);
-
-export const mockGetIdentity = () => {
-  if (!testIdentity) {
+export const mockGetIdentity = async () => {
+  const identity = get(authStore).identity;
+  if (!identity) {
     throw new Error(mockIdentityErrorMsg);
   }
 
-  return mockIdentity;
+  return identity;
 };
 
 /**


### PR DESCRIPTION
# Motivation

Modules that are imported before a test starts, can't be mocked from the test because the framework has to set up the mocking before the import happens.
This means anything imported from `jest-spy.ts` or `jest-setup.ts` can't be mocked.
I want to add tests for `frontend/src/lib/api/agent.api.ts` but I can't because `jest-spy` imports its dependencies.
My goal is to remove `jest-spy.ts` completely and make tests more explicit about what they mock.

In this PR I temporarily removed the mocking of `getAuthenticatedIdentity` from `jest-spy.ts` and made all tests under `frontend/src/tests/lib/services/app.services.spec.ts` pass.

The real `getAuthenticatedIdentity` uses more `awaits` than the mocked one so in some cases we need extra `awaits` in the test before making expectations.

Some tests use `setNoIdentity` which causes the mocked `getAuthenticatedIdentity` to throw an exception, which the real `getAuthenticatedIdentity` doesn't so to keep those tests working, `getAuthenticatedIdentity` must remain mocked.

# Changes

1. Change `frontend/src/tests/mocks/auth.store.mock.ts` to use `authStore` as its underlying data.
2. Call `resetIdentity` in tests that need the identity to make sure the `authStore` is populated and the real `getAuthenticatedIdentity` (or `mockGetIdentity`) can get the identity from it.
3. Call `resetIdentity()` in `jest-spy.ts` to make sure that the `authStore` is populated and the mocked `getAuthenticatedIdentity` still has the same behavior for tests that aren't fixed yet.
4. In tests that do `setNoIdentity()`, mock `getAuthenticatedIdentity` explicitly.
5. Remove an occasional interfering `mockAuthStoreSubscribe`.
6. Add `runResolvedPromises` where necessary to work with the real `getAuthenticatedIdentity`.
7. Fix a few non-service tests that used `authStore` (without `getAuthenticatedIdentity`) and relied on it starting out as empty without explicitly emptying it.

# Tests

Still pass. With and without mocking `getAuthenticatedIdentity` in `jest-spy.ts`.

# Todos

- [ ] Add entry to changelog (if necessary).
I will add an entry when `jest-spy.ts` is fully removed.
