### PR TITLE
Fix: Nns Followee component test

### DIFF
--- a/frontend/src/lib/stores/known-neurons.store.ts
+++ b/frontend/src/lib/stores/known-neurons.store.ts
@@ -18,7 +18,6 @@ const initKnownNeuronsStore = () => {
       set([...neurons]);
     },
 
-    // Used for testing
     reset() {
       set([]);
     },

--- a/frontend/src/lib/stores/known-neurons.store.ts
+++ b/frontend/src/lib/stores/known-neurons.store.ts
@@ -17,6 +17,11 @@ const initKnownNeuronsStore = () => {
     setNeurons(neurons: KnownNeuron[]) {
       set([...neurons]);
     },
+
+    // Used for testing
+    reset() {
+      set([]);
+    },
   };
 };
 

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
@@ -6,7 +6,7 @@ import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
 import en from "$tests/mocks/i18n.mock";
 import { Topic } from "@dfinity/nns";
 import { fireEvent } from "@testing-library/dom";
-import { render, waitFor } from "@testing-library/svelte";
+import { render } from "@testing-library/svelte";
 import FolloweeTest from "./FolloweeTest.svelte";
 
 describe("Followee", () => {
@@ -15,7 +15,10 @@ describe("Followee", () => {
     topics: [Topic.ExchangeRate, Topic.Governance, Topic.Kyc],
   };
 
-  beforeEach(() => jest.spyOn(console, "error").mockImplementation(jest.fn));
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(jest.fn);
+    knownNeuronsStore.reset();
+  });
 
   it("should render neuronId", () => {
     const { getByText } = render(FolloweeTest, {
@@ -64,12 +67,6 @@ describe("Followee", () => {
   });
 
   it("should render known neurons name", async () => {
-    const { getByText } = render(FolloweeTest, {
-      props: {
-        followee,
-      },
-    });
-
     knownNeuronsStore.setNeurons([
       {
         id: followee.neuronId,
@@ -77,6 +74,13 @@ describe("Followee", () => {
         description: "test-description",
       },
     ]);
-    await waitFor(() => expect(getByText("test-name")).toBeInTheDocument());
+
+    const { getByText } = render(FolloweeTest, {
+      props: {
+        followee,
+      },
+    });
+
+    expect(getByText("test-name")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Motivation

Fix src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts test.

The problem was that the knownNeuronsStore was filled in one test, but never reset. Yet, most of the tests relied on that neuron to NOT be a known neuron.

The solution is to reset the knownNeuronsStore before each test.

# Changes

* New method in knownsNeuronsStore "reset".
* Reset the knownNeuronsStore beforeEach for Followee.spec.
* Remove unnecessary `waitFor` in the last test case of Followee.spec.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Already covered by a changelog entry.