### PR TITLE
Fix: IncreaseNeuronStakeModal test

### DIFF
--- a/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
@@ -35,13 +35,17 @@ describe("IncreaseNeuronStakeModal", () => {
       },
     });
 
-  beforeAll(() =>
+  beforeEach(() =>
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe)
   );
 
   describe("when accounts store is empty", () => {
+    beforeEach(() => {
+      icpAccountsStore.resetForTesting();
+    });
+
     it("should fetch accounts and render account selector", async () => {
       const mainBalanceE8s = BigInt(10_000_000);
       jest


### PR DESCRIPTION
# Motivation

Fix src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts

The problem was that the test expected a store to be empty, but it didn't empty it before running it. When the order changed and the store was filled with data, the test failed.

# Changes

* Use beforeEach instead of beforeAll (not really needed, but we agreed this was the best practice).
* Reset icp accounts store before executing the test that expects the store to be empty.

# Tests

Only test changes

# Todos

- [ ] Add entry to changelog (if necessary).
Already covered by a changelog entry.