### PR TITLE
Security: Bump Rust version

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -49,6 +49,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Security
 
+* [CVE-2023-38497](https://blog.rust-lang.org/2023/08/03/cve-2023-38497.html): Update Rust from version `0.71.0` to `0.71.1`.
+
 ## Proposal 124014
 
 ### Application

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -49,7 +49,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Security
 
-* [CVE-2023-38497](https://blog.rust-lang.org/2023/08/03/cve-2023-38497.html): Update Rust from version `0.71.0` to `0.71.1`.
+* [CVE-2023-38497](https://blog.rust-lang.org/2023/08/03/cve-2023-38497.html): Update Rust from version `1.71.0` to `1.71.1`.
 
 ## Proposal 124014
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Please, from time to time, update this to the latest stable version on Rust Forge: https://forge.rust-lang.org/
-channel = "1.71.0"
+channel = "1.71.1"
 components = ["rustfmt", "clippy"]
 targets = [ "wasm32-unknown-unknown"]


### PR DESCRIPTION
# Motivation
There is a security advisory that recommends updating rust to 1.71.1.

Note: This is not super critical for us and we could just wait for the bot to make this PR but it's a line line change so why take the risk?

Note: The bot _may_ make a PR to downgrade to 0.71.0 but we can reject the PR.

# Changes
*  Update Rust from 1.71.0 to 1.71.1.

# Tests
CI should suffice.

# Todos

- [x] Add entry to changelog (if necessary).
