### PR TITLE
Stop publishing .wasm except with .gz

### DIFF
--- a/.github/actions/release_nns_dapp/action.yaml
+++ b/.github/actions/release_nns_dapp/action.yaml
@@ -21,14 +21,6 @@ runs:
         daily_build_name="nns-dapp-$(git rev-parse HEAD).wasm.gz"
         cp nns-dapp.wasm.gz "$daily_build_name"
         artefacts=(nns-dapp.wasm.gz nns-dapp_noassets.wasm.gz nns-dapp_production.wasm.gz nns-dapp_test.wasm.gz sns_aggregator.wasm.gz sns_aggregator_dev.wasm.gz assets.tar.xz "$daily_build_name" nns-dapp-arg-{mainnet,local}.{did,bin})
-        # For backwards compatibility we publish the wasms with a .wasm suffix as well:
-        for file in "${artefacts[@]}" ; do
-          [[ "${file}" == "${file%.wasm.gz}" ]]  || {
-            old_name="${file%.gz}"
-            cp "$file" "$old_name"
-            artefacts+=("$old_name")
-          }
-        done
         ls -l "${artefacts[@]}"
         for tag in $(git tag --points-at HEAD) ; do
           : Creates or updates a release for the tag

--- a/.github/actions/release_nns_dapp/template
+++ b/.github/actions/release_nns_dapp/template
@@ -22,7 +22,7 @@ GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-dfinity/nns-dapp}"
 GITHUB_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
 
 cat <<EOF
-This is a release of the $(nns-dapp) and $(sns_aggregator) canisters.
+This is a release of the \`nns-dapp\` and \`sns_aggregator\` canisters.
 
 Release: [$DFX_RELEASE_NAME](https://github.com/$GITHUB_REPOSITORY/releases/tag/$DFX_RELEASE_NAME)
 Commit: [$GITHUB_SHA](https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA)

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -43,6 +43,9 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Deprecated
 #### Removed
+
+* Remove compressed `.wasm` files from releases.  Please use `.wasm.gz` instead.
+
 #### Fixed
 
 * Avoid SIGPIPE in scripts/past-changelog-test which caused flakiness.

--- a/build.sh
+++ b/build.sh
@@ -53,6 +53,6 @@ set -x
 "$TOPLEVEL/build-frontend.sh"
 
 ###############
-# backend # (output: nns-dapp.wasm)
+# backend # (output: nns-dapp.wasm.gz)
 ###############
 "$TOPLEVEL/build-backend.sh"


### PR DESCRIPTION
# Motivation
Zipped `.wasm` extensions are now deprecated by `dfx`; such files must use the `.wasm.gz` suffix.  We switched to the `.wasm.gz` suffix in 394e50672ce8791934e85582b4cf07d7452474e9.  We continued supplying `.wasm` files alongside `.wasm.gz` files, to give projects that use our builds time to upgrade.  We would like to drop support for the deprecated extension now.

# Changes
* Drop `.wasm` files from releases; retain only `.wasm.gz`.
* Fix bug in the release text.
  * Note: In markdown, backticks are used to format code `like this.`  Backticks in markdown inside a shell script were not escaped, so treated as text to execute.  `shfmt` then joined into the action by changing the backticks to `$(the text to format)`.  This yielded an error message in the action:
    ```
    ./.github/actions/release_nns_dapp/template: line 24: nns-dapp: command not found
    ./.github/actions/release_nns_dapp/template: line 24: sns_aggregator: command not found
    ```
     and an incorrect release text: "This is a release of the  and  canisters."  This is now fixed.

# Tests
* See this release: https://github.com/dfinity/nns-dapp/releases/tag/untagged-56569216043fd00e1627
  - [x] Text is correct
  - [x] Wasms only as `.wasm.gz`
* We have probably found all projects that would be affected by this and notified them.  If we missed you, apologies.  Please get into contact and we will try to find a way of reaching you for future breaking changes.

# Todos

- [x] Add entry to changelog (if necessary).
