### PR TITLE
Refactor: Use new setSnsProjects

### DIFF
--- a/frontend/src/tests/lib/components/launchpad/Projects.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Projects.spec.ts
@@ -3,18 +3,18 @@
  */
 
 import Projects from "$lib/components/launchpad/Projects.svelte";
-import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
+import { snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import {
   mockSnsSummaryList,
   mockSnsSwapCommitment,
 } from "$tests/mocks/sns-projects.mock";
-import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
 
 describe("Projects", () => {
   beforeEach(() => {
-    snsQueryStore.reset();
+    resetSnsProjects();
     snsSwapCommitmentsStore.reset();
   });
 
@@ -30,11 +30,7 @@ describe("Projects", () => {
       SnsSwapLifecycle.Open,
     ];
 
-    snsQueryStore.setData(
-      snsResponsesForLifecycle({
-        lifecycles,
-      })
-    );
+    setSnsProjects(lifecycles.map((lifecycle) => ({ lifecycle })));
     snsSwapCommitmentsStore.setSwapCommitment({
       swapCommitment: mockSnsSwapCommitment(principal),
       certified: false,
@@ -62,11 +58,7 @@ describe("Projects", () => {
       SnsSwapLifecycle.Adopted,
     ];
 
-    snsQueryStore.setData(
-      snsResponsesForLifecycle({
-        lifecycles,
-      })
-    );
+    setSnsProjects(lifecycles.map((lifecycle) => ({ lifecycle })));
     snsSwapCommitmentsStore.setSwapCommitment({
       swapCommitment: mockSnsSwapCommitment(principal),
       certified: false,
@@ -94,11 +86,7 @@ describe("Projects", () => {
       SnsSwapLifecycle.Open,
     ];
 
-    snsQueryStore.setData(
-      snsResponsesForLifecycle({
-        lifecycles,
-      })
-    );
+    setSnsProjects(lifecycles.map((lifecycle) => ({ lifecycle })));
     snsSwapCommitmentsStore.setSwapCommitment({
       swapCommitment: mockSnsSwapCommitment(principal),
       certified: false,
@@ -119,7 +107,11 @@ describe("Projects", () => {
   it("should render a message when no open projects available", () => {
     const principal = mockSnsSummaryList[0].rootCanisterId;
 
-    snsQueryStore.setData([[], []]);
+    setSnsProjects([
+      {
+        lifecycle: SnsSwapLifecycle.Committed,
+      },
+    ]);
     snsSwapCommitmentsStore.setSwapCommitment({
       swapCommitment: mockSnsSwapCommitment(principal),
       certified: false,
@@ -138,7 +130,11 @@ describe("Projects", () => {
   it("should render a message when no adopted projects available", () => {
     const principal = mockSnsSummaryList[0].rootCanisterId;
 
-    snsQueryStore.setData([[], []]);
+    setSnsProjects([
+      {
+        lifecycle: SnsSwapLifecycle.Open,
+      },
+    ]);
     snsSwapCommitmentsStore.setSwapCommitment({
       swapCommitment: mockSnsSwapCommitment(principal),
       certified: false,
@@ -157,7 +153,11 @@ describe("Projects", () => {
   it("should render a message when no committed projects available", () => {
     const principal = mockSnsSummaryList[0].rootCanisterId;
 
-    snsQueryStore.setData([[], []]);
+    setSnsProjects([
+      {
+        lifecycle: SnsSwapLifecycle.Open,
+      },
+    ]);
     snsSwapCommitmentsStore.setSwapCommitment({
       swapCommitment: mockSnsSwapCommitment(principal),
       certified: false,

--- a/frontend/src/tests/lib/derived/sns/sns-projects.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-projects.derived.spec.ts
@@ -13,12 +13,11 @@ import { get } from "svelte/store";
 
 describe("projects.derived", () => {
   const principalRootCanisterId = rootCanisterIdMock;
+  beforeEach(() => {
+    resetSnsProjects();
+  });
 
   describe("projectsDerived", () => {
-    beforeAll(() => {
-      resetSnsProjects();
-    });
-
     snsSwapCommitmentsStore.setSwapCommitment({
       swapCommitment: mockSnsSwapCommitment(principalRootCanisterId),
       certified: true,
@@ -34,10 +33,6 @@ describe("projects.derived", () => {
     });
   });
   describe("filter projects derived", () => {
-    beforeEach(() => {
-      resetSnsProjects();
-    });
-
     snsSwapCommitmentsStore.setSwapCommitment({
       swapCommitment: mockSnsSwapCommitment(principalRootCanisterId),
       certified: true,

--- a/frontend/src/tests/lib/derived/sns/sns-projects.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-projects.derived.spec.ts
@@ -4,26 +4,20 @@ import {
   snsProjectsCommittedStore,
   snsProjectsStore,
 } from "$lib/derived/sns/sns-projects.derived";
-import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
-import {
-  mockSnsSummaryList,
-  mockSnsSwapCommitment,
-} from "$tests/mocks/sns-projects.mock";
-import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
+import { snsSwapCommitmentsStore } from "$lib/stores/sns.store";
+import { mockSnsSwapCommitment } from "$tests/mocks/sns-projects.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("projects.derived", () => {
+  const principalRootCanisterId = rootCanisterIdMock;
+
   describe("projectsDerived", () => {
     beforeAll(() => {
-      snsQueryStore.reset();
+      resetSnsProjects();
     });
-
-    afterAll(() => {
-      snsQueryStore.reset();
-    });
-
-    const principalRootCanisterId = mockSnsSummaryList[0].rootCanisterId;
 
     snsSwapCommitmentsStore.setSwapCommitment({
       swapCommitment: mockSnsSwapCommitment(principalRootCanisterId),
@@ -31,25 +25,18 @@ describe("projects.derived", () => {
     });
 
     it("should set projects of all statuses", () => {
-      snsQueryStore.setData(
-        snsResponsesForLifecycle({
-          lifecycles: [SnsSwapLifecycle.Open, SnsSwapLifecycle.Committed],
-        })
-      );
+      setSnsProjects([
+        { lifecycle: SnsSwapLifecycle.Open },
+        { lifecycle: SnsSwapLifecycle.Committed },
+      ]);
       const projects = get(snsProjectsStore);
       expect(projects).toHaveLength(2);
     });
   });
   describe("filter projects derived", () => {
-    beforeAll(() => {
-      snsQueryStore.reset();
+    beforeEach(() => {
+      resetSnsProjects();
     });
-
-    afterAll(() => {
-      snsQueryStore.reset();
-    });
-
-    const principalRootCanisterId = mockSnsSummaryList[0].rootCanisterId;
 
     snsSwapCommitmentsStore.setSwapCommitment({
       swapCommitment: mockSnsSwapCommitment(principalRootCanisterId),
@@ -57,53 +44,41 @@ describe("projects.derived", () => {
     });
 
     it("should filter projects that are active", () => {
-      snsQueryStore.setData(
-        snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Open] })
-      );
+      setSnsProjects([{ lifecycle: SnsSwapLifecycle.Open }]);
       const open = get(snsProjectsActivePadStore);
       expect(open.length).toEqual(1);
 
-      snsQueryStore.setData(
-        snsResponsesForLifecycle({
-          lifecycles: [SnsSwapLifecycle.Open, SnsSwapLifecycle.Committed],
-        })
-      );
+      setSnsProjects([
+        { lifecycle: SnsSwapLifecycle.Open },
+        { lifecycle: SnsSwapLifecycle.Committed },
+      ]);
       const open2 = get(snsProjectsActivePadStore);
       expect(open2.length).toEqual(2);
 
-      snsQueryStore.setData(
-        snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Unspecified] })
-      );
+      setSnsProjects([{ lifecycle: SnsSwapLifecycle.Unspecified }]);
       const noOpen = get(snsProjectsActivePadStore);
       expect(noOpen.length).toEqual(0);
     });
 
     it("should filter projects that are committed only", () => {
-      snsQueryStore.setData(
-        snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Committed] })
-      );
+      setSnsProjects([{ lifecycle: SnsSwapLifecycle.Committed }]);
 
       const committed = get(snsProjectsCommittedStore);
       expect(committed.length).toEqual(1);
 
-      snsQueryStore.setData(
-        snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Open] })
-      );
+      setSnsProjects([{ lifecycle: SnsSwapLifecycle.Open }]);
+
       const noCommitted = get(snsProjectsCommittedStore);
       expect(noCommitted.length).toEqual(0);
     });
 
     it("should filter projects that are adopted only", () => {
-      snsQueryStore.setData(
-        snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Adopted] })
-      );
+      setSnsProjects([{ lifecycle: SnsSwapLifecycle.Adopted }]);
 
       const adopted = get(snsProjectsAdoptedStore);
       expect(adopted.length).toEqual(1);
 
-      snsQueryStore.setData(
-        snsResponsesForLifecycle({ lifecycles: [SnsSwapLifecycle.Open] })
-      );
+      setSnsProjects([{ lifecycle: SnsSwapLifecycle.Open }]);
       const noAdopted = get(snsProjectsAdoptedStore);
       expect(noAdopted.length).toEqual(0);
     });


### PR DESCRIPTION
# Motivation

Final motivation: Stop using get_state. But on the way, clean the unnecessary complexity of snsQueryStore.

In this PR: Use the new test util setSnsProjects in more tests.

# Changes

* Move Projects.spec to use new test util.
* Move sns-projects.derived to use new test util.

# Tests

Only test changes

# Todos

- [ ] Add entry to changelog (if necessary).
Already covered by a changelog entry.
