### PR TITLE
Remove mocking getAuthenticatedIdentity from jest-spy.ts

### DIFF
--- a/frontend/jest-spy.ts
+++ b/frontend/jest-spy.ts
@@ -1,16 +1,6 @@
 import type { HttpAgent } from "@dfinity/agent";
 import { mock } from "jest-mock-extended";
 import * as agent from "./src/lib/api/agent.api";
-import * as authServices from "./src/lib/services/auth.services";
-import {
-  mockGetIdentity,
-  resetIdentity,
-} from "./src/tests/mocks/auth.store.mock";
 
 const mockCreateAgent = () => Promise.resolve(mock<HttpAgent>());
 jest.spyOn(agent, "createAgent").mockImplementation(mockCreateAgent);
-
-resetIdentity();
-jest
-  .spyOn(authServices, "getAuthenticatedIdentity")
-  .mockImplementation(() => Promise.resolve(mockGetIdentity()));

--- a/frontend/src/tests/lib/components/accounts/BitcoinAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BitcoinAddress.spec.ts
@@ -12,7 +12,7 @@ import {
 import { AppPath } from "$lib/constants/routes.constants";
 import { bitcoinAddressStore } from "$lib/stores/bitcoin.store";
 import { ckBTCInfoStore } from "$lib/stores/ckbtc-info.store";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockBTCAddressTestnet,
   mockCkBTCMainAccount,
@@ -38,6 +38,7 @@ describe("BitcoinAddress", () => {
   };
 
   beforeEach(() => {
+    resetIdentity();
     jest.clearAllMocks();
     bitcoinAddressStore.reset();
     ckBTCInfoStore.reset();

--- a/frontend/src/tests/lib/components/accounts/BitcoinEstimatedFee.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BitcoinEstimatedFee.spec.ts
@@ -8,7 +8,7 @@ import { CKBTC_MINTER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.cons
 import { TransactionNetwork } from "$lib/types/transaction";
 import { formatEstimatedFee } from "$lib/utils/bitcoin.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { render, waitFor } from "@testing-library/svelte";
 
@@ -18,6 +18,7 @@ describe("BitcoinEstimatedFee", () => {
   const result = { minter_fee: 123n, bitcoin_fee: 456n };
 
   beforeEach(() => {
+    resetIdentity();
     spyEstimateFee = jest
       .spyOn(minterApi, "estimateFee")
       .mockResolvedValue(result);

--- a/frontend/src/tests/lib/components/accounts/CkBTCWalletActions.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWalletActions.spec.ts
@@ -10,6 +10,7 @@ import {
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { CKBTC_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/ckbtc.constants";
 import { AppPath } from "$lib/constants/routes.constants";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { advanceTime } from "$tests/utils/timers.test-utils";
 import { waitFor } from "@testing-library/dom";
@@ -30,7 +31,10 @@ describe("CkBTCWalletActions", () => {
     });
   });
 
-  beforeEach(() => jest.useFakeTimers().setSystemTime(now));
+  beforeEach(() => {
+    resetIdentity();
+    jest.useFakeTimers().setSystemTime(now);
+  });
   afterEach(jest.clearAllTimers);
 
   const props = {

--- a/frontend/src/tests/lib/modals/accounts/CkBTCReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCReceiveModal.spec.ts
@@ -16,7 +16,7 @@ import { tokensStore } from "$lib/stores/tokens.store";
 import type { UniverseCanisterId } from "$lib/types/universe";
 import { formatEstimatedFee } from "$lib/utils/bitcoin.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCkBTCAdditionalCanisters } from "$tests/mocks/canisters.mock";
 import {
   mockBTCAddressTestnet,
@@ -41,6 +41,7 @@ describe("BtcCkBTCReceiveModal", () => {
   const reloadSpy = jest.fn();
 
   beforeEach(() => {
+    resetIdentity();
     jest.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
@@ -11,6 +11,7 @@ import DisburseNnsNeuronModal from "$lib/modals/neurons/DisburseNnsNeuronModal.s
 import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
 import { disburse } from "$lib/services/neurons.services";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountDetails,
   mockAccountsStoreData,
@@ -39,6 +40,7 @@ jest.mock("$lib/services/neurons.services", () => {
 
 describe("DisburseNnsNeuronModal", () => {
   beforeEach(() => {
+    resetIdentity();
     cancelPollAccounts();
   });
 

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -9,6 +9,7 @@ import NnsAccounts from "$lib/pages/NnsAccounts.svelte";
 import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { formatToken } from "$lib/utils/token.utils";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountDetails,
   mockHardwareWalletAccount,
@@ -25,6 +26,10 @@ jest.mock("$lib/api/nns-dapp.api");
 jest.mock("$lib/api/icp-ledger.api");
 
 describe("NnsAccounts", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
+
   afterEach(() => jest.clearAllMocks());
 
   describe("when there are accounts", () => {

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -11,6 +11,7 @@ import { neuronsStore } from "$lib/stores/neurons.store";
 import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
 import { dispatchIntersecting } from "$lib/utils/events.utils";
 import * as fakeGovernanceApi from "$tests/fakes/governance-api.fake";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockVoteRegistration } from "$tests/mocks/proposal.mock";
@@ -55,6 +56,7 @@ describe("NeuronDetail", () => {
     container.querySelector('[data-tid="skeleton-card"]');
 
   beforeEach(() => {
+    resetIdentity();
     neuronsStore.reset();
     voteRegistrationStore.reset();
     fakeGovernanceApi.addNeuronWith({ neuronId });

--- a/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
@@ -13,10 +13,10 @@ import * as fakeGovernanceApi from "$tests/fakes/governance-api.fake";
 import * as fakeSnsAggregatorApi from "$tests/fakes/sns-aggregator-api.fake";
 import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
 import * as fakeSnsLedgerApi from "$tests/fakes/sns-ledger-api.fake";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
-import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NeuronDetailPo } from "$tests/page-objects/NeuronDetail.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/dom";
@@ -42,6 +42,7 @@ describe("NeuronDetail", () => {
   fakeSnsAggregatorApi.install();
 
   beforeEach(() => {
+    resetIdentity();
     snsQueryStore.reset();
   });
 

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -13,8 +13,9 @@ import * as fakeGovernanceApi from "$tests/fakes/governance-api.fake";
 import * as fakeSnsAggregatorApi from "$tests/fakes/sns-aggregator-api.fake";
 import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
 import * as fakeSnsLedgerApi from "$tests/fakes/sns-ledger-api.fake";
-import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { NeuronsPo } from "$tests/page-objects/Neurons.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/dom";
@@ -39,6 +40,7 @@ describe("Neurons", () => {
   let testCommittedSnsNeuron;
 
   beforeEach(async () => {
+    resetIdentity();
     snsQueryStore.reset();
 
     fakeGovernanceApi.addNeuronWith({ neuronId: testNnsNeuronId });


### PR DESCRIPTION
# Motivation

Follow-up to https://github.com/dfinity/nns-dapp/pull/3092.
The goal is to remove `jest-spy.ts`.

# Changes

1. Stop mocking `getAuthenticatedIdentity` in `frontend/jest-spy.ts`.
2. Fix remaining tests that relied on `getAuthenticatedIdentity` being mocked by calling `resetIdentity()` in order to populate the real `authStore`.

# Tests

Only tests.

# Todos

- [ ] Add entry to changelog (if necessary).
I will add an entry when jest-spy.ts is fully removed.