### PR TITLE
Fix order dependency of auth.services.spec.ts

### DIFF
--- a/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -11,11 +11,7 @@ import {
 import { authStore } from "$lib/stores/auth.store";
 import * as busyStore from "$lib/stores/busy.store";
 import * as routeUtils from "$lib/utils/route.utils";
-import {
-  authStoreMock,
-  mockIdentity,
-  mutableMockAuthStoreSubscribe,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { AnonymousIdentity } from "@dfinity/agent";
 import { AuthClient, IdbStorage } from "@dfinity/auth-client";
 import { toastsStore } from "@dfinity/gix-components";
@@ -24,6 +20,11 @@ import { mock } from "jest-mock-extended";
 
 describe("auth-services", () => {
   const { reload, href, search } = window.location;
+
+  beforeEach(async () => {
+    jest.restoreAllMocks();
+    await authStore.signOut();
+  });
 
   beforeAll(() => {
     Object.defineProperty(window, "location", {
@@ -186,16 +187,8 @@ describe("auth-services", () => {
   });
 
   describe("getCurrentIdentity", () => {
-    jest
-      .spyOn(authStore, "subscribe")
-      .mockImplementation(mutableMockAuthStoreSubscribe);
-
-    afterAll(() => jest.clearAllMocks());
-
     it("should returns anonymous identity", () => {
-      authStoreMock.next({
-        identity: undefined,
-      });
+      authStore.setForTesting(undefined);
 
       expect(getCurrentIdentity().getPrincipal().toText()).toEqual(
         new AnonymousIdentity().getPrincipal().toText()
@@ -203,9 +196,7 @@ describe("auth-services", () => {
     });
 
     it("should returns signed-in identity", () => {
-      authStoreMock.next({
-        identity: mockIdentity,
-      });
+      authStore.setForTesting(mockIdentity);
 
       expect(getCurrentIdentity().getPrincipal().toText()).toEqual(
         mockIdentity.getPrincipal().toText()


### PR DESCRIPTION
# Motivation

Some tests in `frontend/src/tests/lib/services/auth.services.spec.ts` mock `AuthClient.create` but others rely on the real behavior of `AuthClient`.
The exists `jest.restoreAllMocks` which is even stronger than `jest.resetAllMocks` because in addition to resetting mock behavior, it also restores real behavior for mocks created with `jest.spyOn`.

# Changes

1. `jest.restoreAllMocks()` before each test to restore real behavior of `AuthClient`.
2. `authStore.signOut()` before each test to reset the `authStore`.
3. Use real `authStore` with `resetForTesting()` instead of `mutableMockAuthStoreSubscribe`.

# Tests

Ran with `--randomize` a number of times.

# Todos

- [ ] Add entry to changelog (if necessary).
covered
