### PR TITLE
fix: dissolvde typo

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -565,7 +565,7 @@
     "voting_power_zero_subtitle": "No Voting Power",
     "voting_power_zero": "None",
     "voting_power_tooltip_with_stake": "Calculated as: <br/>($token staked + maturity staked) x Dissolve Delay Bonus x Age Bonus<br/>($stake + $st4kedMaturity) x $delayMultiplier x $ageMultiplier",
-    "voting_power_section_description_expanded": "It is determined by the stake, state and dissolve delay. Calculated as: (neuron_stake + staked_maturity) × age_bonus × dissolvde_delay_bonus = ($stake + $maturityStaked) × $ageBonus × $dissolveBonus = $votingPower.",
+    "voting_power_section_description_expanded": "It is determined by the stake, state and dissolve delay. Calculated as: (neuron_stake + staked_maturity) × age_bonus × dissolved_delay_bonus = ($stake + $maturityStaked) × $ageBonus × $dissolveBonus = $votingPower.",
     "voting_power_section_description_expanded_zero": "The dissolve delay must be greater than $minDuration for the neuron to have voting power. Learn more about voting power on the <a href=\"$dashboardLink\" rel=\"noopener noreferrer\" aria-label=\"more info about voting power\" target=\"_blank\">dashboard</a>.",
     "voting_power_section_description_expanded_zero_nns": "The dissolve delay must be greater than 6 months for the neuron to have voting power. Learn more about voting power on the <a href=\"$dashboardLink\" rel=\"noopener noreferrer\" aria-label=\"more info about voting power\" target=\"_blank\">dashboard</a>.",
     "maturity_section_description": "Earn rewards by voting on proposals and/or following active neurons.",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -565,7 +565,7 @@
     "voting_power_zero_subtitle": "No Voting Power",
     "voting_power_zero": "None",
     "voting_power_tooltip_with_stake": "Calculated as: <br/>($token staked + maturity staked) x Dissolve Delay Bonus x Age Bonus<br/>($stake + $st4kedMaturity) x $delayMultiplier x $ageMultiplier",
-    "voting_power_section_description_expanded": "It is determined by the stake, state and dissolve delay. Calculated as: (neuron_stake + staked_maturity) × age_bonus × dissolved_delay_bonus = ($stake + $maturityStaked) × $ageBonus × $dissolveBonus = $votingPower.",
+    "voting_power_section_description_expanded": "It is determined by the stake, state and dissolve delay. Calculated as: (neuron_stake + staked_maturity) × age_bonus × dissolve_delay_bonus = ($stake + $maturityStaked) × $ageBonus × $dissolveBonus = $votingPower.",
     "voting_power_section_description_expanded_zero": "The dissolve delay must be greater than $minDuration for the neuron to have voting power. Learn more about voting power on the <a href=\"$dashboardLink\" rel=\"noopener noreferrer\" aria-label=\"more info about voting power\" target=\"_blank\">dashboard</a>.",
     "voting_power_section_description_expanded_zero_nns": "The dissolve delay must be greater than 6 months for the neuron to have voting power. Learn more about voting power on the <a href=\"$dashboardLink\" rel=\"noopener noreferrer\" aria-label=\"more info about voting power\" target=\"_blank\">dashboard</a>.",
     "maturity_section_description": "Earn rewards by voting on proposals and/or following active neurons.",

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronVotingPowerSection.spec.ts
@@ -69,7 +69,7 @@ describe("NnsStakeItemAction", () => {
     const po = renderComponent(neuron);
 
     expect(await po.getDescription()).toBe(
-      "It is determined by the stake, state and dissolve delay. Calculated as: (neuron_stake + staked_maturity) × age_bonus × dissolved_delay_bonus = (30.00 + 0) × 1.00 × 1.06 = 6.14."
+      "It is determined by the stake, state and dissolve delay. Calculated as: (neuron_stake + staked_maturity) × age_bonus × dissolve_delay_bonus = (30.00 + 0) × 1.00 × 1.06 = 6.14."
     );
   });
 

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronVotingPowerSection.spec.ts
@@ -69,7 +69,7 @@ describe("NnsStakeItemAction", () => {
     const po = renderComponent(neuron);
 
     expect(await po.getDescription()).toBe(
-      "It is determined by the stake, state and dissolve delay. Calculated as: (neuron_stake + staked_maturity) × age_bonus × dissolvde_delay_bonus = (30.00 + 0) × 1.00 × 1.06 = 6.14."
+      "It is determined by the stake, state and dissolve delay. Calculated as: (neuron_stake + staked_maturity) × age_bonus × dissolved_delay_bonus = (30.00 + 0) × 1.00 × 1.06 = 6.14."
     );
   });
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
@@ -75,7 +75,7 @@ describe("NnsStakeItemAction", () => {
     const po = renderComponent(neuronCanVote);
 
     expect(await po.getDescription()).toBe(
-      "It is determined by the stake, state and dissolve delay. Calculated as: (neuron_stake + staked_maturity) × age_bonus × dissolvde_delay_bonus = (3.14 + 1.00) × 1.25 × 1.01 = 5.23."
+      "It is determined by the stake, state and dissolve delay. Calculated as: (neuron_stake + staked_maturity) × age_bonus × dissolved_delay_bonus = (3.14 + 1.00) × 1.25 × 1.01 = 5.23."
     );
   });
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
@@ -75,7 +75,7 @@ describe("NnsStakeItemAction", () => {
     const po = renderComponent(neuronCanVote);
 
     expect(await po.getDescription()).toBe(
-      "It is determined by the stake, state and dissolve delay. Calculated as: (neuron_stake + staked_maturity) × age_bonus × dissolved_delay_bonus = (3.14 + 1.00) × 1.25 × 1.01 = 5.23."
+      "It is determined by the stake, state and dissolve delay. Calculated as: (neuron_stake + staked_maturity) × age_bonus × dissolve_delay_bonus = (3.14 + 1.00) × 1.25 × 1.01 = 5.23."
     );
   });
 


### PR DESCRIPTION
# Motivation

`dissolvde_...` => `dissolved_...`
