### PR TITLE
Fix: ICP Staked depends on token

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -26,6 +26,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Fixed
 
+* Fix wrong "ICP Staked" message in SNS neurons.
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/components/neuron-detail/StakeItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/StakeItemAction.svelte
@@ -6,6 +6,7 @@
   import { i18n } from "$lib/stores/i18n";
   import type { Universe } from "$lib/types/universe";
   import { formatToken } from "$lib/utils/token.utils";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
 
   export let universe: Universe;
   export let token: Token;
@@ -26,7 +27,9 @@
       <span data-tid="stake-value">{formatToken({ value: neuronStake })}</span
       ><span data-tid="token-symbol">{token.symbol}</span>
     </h4>
-    <p class="description">{$i18n.neurons.ic_stake}</p>
+    <p class="description" data-tid="staked-description">
+      {replacePlaceholders($i18n.neurons.ic_stake, { $token: token.symbol })}
+    </p>
   </div>
   <svelte:fragment slot="actions">
     {#if isIncreaseStakeAllowed}

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -283,7 +283,7 @@
     "hardware_wallet_control": "Hardware Wallet",
     "stake": "Stake",
     "amount_icp_stake": "$amount ICP Stake",
-    "ic_stake": "ICP Stake",
+    "ic_stake": "$token staked",
     "staked": "Of which staked",
     "inline_remaining": "$duration remaining",
     "remaining": "Remaining",

--- a/frontend/src/tests/lib/components/neuron-detail/NnsStakeItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsStakeItemAction.spec.ts
@@ -38,6 +38,12 @@ describe("NnsStakeItemAction", () => {
     expect(await po.getStake()).toBe("3.14");
   });
 
+  it("should render ICP in description", async () => {
+    const po = renderComponent(mockNeuron);
+
+    expect(await po.getDescription()).toBe("ICP staked");
+  });
+
   it("should render increase stake button", async () => {
     const po = renderComponent(mockNeuron);
 

--- a/frontend/src/tests/lib/components/neuron-detail/StakeItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/StakeItemAction.spec.ts
@@ -43,6 +43,17 @@ describe("StakeItemAction", () => {
     expect(await po.getTokenSymbol()).toBe("FLURB");
   });
 
+  it("should render token symbol in description", async () => {
+    const po = renderComponent({
+      token: {
+        ...mockToken,
+        symbol: "FLURB",
+      },
+    });
+
+    expect(await po.getDescription()).toBe("FLURB staked");
+  });
+
   it("should render increase stake button secondary variant", async () => {
     const po = renderComponent({});
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakeItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakeItemAction.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import SnsStakeItemAction from "$lib/components/sns-neuron-detail/SnsStakeItemAction.svelte";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import {
   createMockSnsNeuron,
   mockSnsNeuron,
@@ -14,12 +15,15 @@ import type { SnsNeuron } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
 describe("SnsStakeItemAction", () => {
-  const renderComponent = (neuron: SnsNeuron) => {
+  const renderComponent = (
+    neuron: SnsNeuron,
+    token: IcrcTokenMetadata = mockToken
+  ) => {
     const { container } = render(SnsStakeItemAction, {
       props: {
         neuron,
         universe: mockUniverse,
-        token: mockToken,
+        token,
       },
     });
 
@@ -35,6 +39,15 @@ describe("SnsStakeItemAction", () => {
     const po = renderComponent(neuron);
 
     expect(await po.getStake()).toBe("3.14");
+  });
+
+  it("should render token symbol in description", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+    });
+    const po = renderComponent(neuron, { ...mockToken, symbol: "TST" });
+
+    expect(await po.getDescription()).toBe("TST staked");
   });
 
   it("should render increase stake button", async () => {

--- a/frontend/src/tests/page-objects/StakeItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/StakeItemAction.page-object.ts
@@ -21,6 +21,10 @@ export class StakeItemActionPo extends BasePageObject {
     return this.getText("token-symbol");
   }
 
+  getDescription(): Promise<string> {
+    return this.getText("staked-description");
+  }
+
   hasIncreaseStakeButton(): Promise<boolean> {
     return this.getIncreaseStakeButtonPo().isPresent();
   }


### PR DESCRIPTION
# Motivation

There is a bug because the StakeItemAction always shows the description "ICP Stake".

Instead, it should show "ICP staked" or "CHAT staked" as in the Figma.

# Changes

* Change "ic_stake" message with a placeholder.
* Use the token for the message in StakeItemAction.svelte

# Tests

* Add test case in StakeItemAction.svelte
* Add test case in NnsStakeItemAction.svelte
* Add test case in SnsStakeItemAction.svelte
* Add method in StakeItemAction PO: getDescription.

# Todos

- [x] Add entry to changelog (if necessary).
