### PR TITLE
Move simplifyJson out of Json.spec

### DIFF
--- a/frontend/src/tests/lib/components/common/Json.spec.ts
+++ b/frontend/src/tests/lib/components/common/Json.spec.ts
@@ -6,12 +6,9 @@ import Json from "$lib/components/common/Json.svelte";
 import { bytesToHexString, stringifyJson } from "$lib/utils/utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { simplifyJson } from "$tests/utils/json.test-utils";
 import { fireEvent } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
-
-// remove (array-index:|spaces|")
-export const simplifyJson = (json: string | null) =>
-  json?.replace(/(\d+\s*:\s*)(\w+|"|{|}|\[|])/g, "$2").replace(/"| |,|\\/g, "");
 
 const testJsonRender = (json: unknown, result?: string) => {
   const { container } = render(Json, {

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.spec.ts
@@ -9,10 +9,10 @@ import {
   mockProposalInfo,
   proposalActionNnsFunction21,
 } from "$tests/mocks/proposal.mock";
+import { simplifyJson } from "$tests/utils/json.test-utils";
 import type { Proposal } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
 import { mock } from "jest-mock-extended";
-import { simplifyJson } from "../common/Json.spec";
 
 const proposalWithNnsFunctionAction = {
   ...mockProposalInfo.proposal,

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalProposerPayloadEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalProposerPayloadEntry.spec.ts
@@ -2,8 +2,8 @@
  * @jest-environment jsdom
  */
 import ProposalProposerPayloadEntry from "$lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte";
+import { simplifyJson } from "$tests/utils/json.test-utils";
 import { render, waitFor } from "@testing-library/svelte";
-import { simplifyJson } from "../common/Json.spec";
 
 describe("ProposalProposerPayloadEntry", () => {
   const nestedObj = { b: "c" };

--- a/frontend/src/tests/utils/json.test-utils.ts
+++ b/frontend/src/tests/utils/json.test-utils.ts
@@ -1,0 +1,3 @@
+// remove (array-index:|spaces|")
+export const simplifyJson = (json: string | null) =>
+  json?.replace(/(\d+\s*:\s*)(\w+|"|{|}|\[|])/g, "$2").replace(/"| |,|\\/g, "");


### PR DESCRIPTION
# Motivation

`NnsProposalProposerPayloadEntry.spec.ts` and `ProposalProposerPayloadEntry.spec.ts` were importing `Json.spec.ts` to get access to `simplifyJson` but this meant that when running any of these tests, it would run the tests from `Json.spec.ts` as well.
Tests shouldn't be importing other tests.

# Changes

1. Move `simplifyJson` into a separate file: `frontend/src/tests/utils/json.test-utils.ts`.
2. Import `frontend/src/tests/utils/json.test-utils.ts` instead of `Json.spec.ts`.

# Tests

only tests

# Todos

- [ ] Add entry to changelog (if necessary).
not worth it