### PR TITLE
GIX-1819: Identify Swap Participation Transaction

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -14,6 +14,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 * New tag for NNS neurons: "Hardware Wallet".
 * New derived state store for SNS projects.
+* Identify swap participation ICP transactions.
 
 #### Changed
 

--- a/frontend/src/lib/components/accounts/NnsTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/NnsTransactionCard.svelte
@@ -8,7 +8,6 @@
   import type { Transaction } from "$lib/types/transaction";
   import { createSwapCanisterAccountsStore } from "$lib/derived/sns-swap-canisters-accounts.derived";
   import type { Principal } from "@dfinity/principal";
-  import type { AccountIdentifier } from "@dfinity/nns";
   import type { Readable } from "svelte/store";
   import { authStore } from "$lib/stores/auth.store";
 
@@ -22,7 +21,7 @@
     account.principal ?? $authStore.identity?.getPrincipal();
 
   // Used to identify transactions related to a Swap.
-  let swapCanisterAccountsStore: Readable<AccountIdentifier[]>;
+  let swapCanisterAccountsStore: Readable<Set<string>>;
   $: swapCanisterAccountsStore =
     createSwapCanisterAccountsStore(accountPrincipal);
 

--- a/frontend/src/lib/components/accounts/NnsTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/NnsTransactionCard.svelte
@@ -6,10 +6,25 @@
   import TransactionCard from "./TransactionCard.svelte";
   import { ICPToken } from "@dfinity/utils";
   import type { Transaction } from "$lib/types/transaction";
+  import { createSwapCanisterAccountsStore } from "$lib/derived/sns-swap-canisters-accounts.derived";
+  import type { Principal } from "@dfinity/principal";
+  import type { AccountIdentifier } from "@dfinity/nns";
+  import type { Readable } from "svelte/store";
+  import { authStore } from "$lib/stores/auth.store";
 
   export let account: Account;
   export let transaction: NnsTransaction;
   export let toSelfTransaction = false;
+
+  // Subaccounts have no principal, but they belong to the II user.
+  let accountPrincipal: Principal | undefined;
+  $: accountPrincipal =
+    account.principal ?? $authStore.identity?.getPrincipal();
+
+  // Used to identify transactions related to a Swap.
+  let swapCanisterAccountsStore: Readable<AccountIdentifier[]>;
+  $: swapCanisterAccountsStore =
+    createSwapCanisterAccountsStore(accountPrincipal);
 
   let transactionData: Transaction | undefined;
 
@@ -21,6 +36,7 @@
           transaction,
           toSelfTransaction,
           account,
+          swapCanisterAccounts: $swapCanisterAccountsStore,
         });
       } catch (err: unknown) {
         transactionData = undefined;

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -62,7 +62,7 @@
 
   <div class="transaction">
     <KeyValuePair>
-      <h3 slot="key" class="value title">{headline}</h3>
+      <h3 slot="key" class="value title" data-tid="headline">{headline}</h3>
 
       <AmountDisplay
         slot="value"

--- a/frontend/src/lib/derived/sns-swap-canisters-accounts.derived.ts
+++ b/frontend/src/lib/derived/sns-swap-canisters-accounts.derived.ts
@@ -16,16 +16,18 @@ export const createSwapCanisterAccountsStore = (controller?: Principal) =>
   derived<SnsAggregatorStore, Set<string>>(
     snsAggregatorStore,
     ($snsAggregatorStore) =>
-      isNullish(controller) || isNullish($snsAggregatorStore.data)
-        ? (new Set() as Set<string>)
-        : new Set(
-            $snsAggregatorStore.data.map(({ canister_ids }) =>
-              getSwapCanisterAccount({
-                controller,
-                swapCanisterId: Principal.fromText(
-                  canister_ids.swap_canister_id
-                ),
-              }).toHex()
+      new Set(
+        isNullish(controller) || isNullish($snsAggregatorStore.data)
+          ? undefined
+          : new Set(
+              $snsAggregatorStore.data.map(({ canister_ids }) =>
+                getSwapCanisterAccount({
+                  controller,
+                  swapCanisterId: Principal.fromText(
+                    canister_ids.swap_canister_id
+                  ),
+                }).toHex()
+              )
             )
-          )
+      )
   );

--- a/frontend/src/lib/derived/sns-swap-canisters-accounts.derived.ts
+++ b/frontend/src/lib/derived/sns-swap-canisters-accounts.derived.ts
@@ -1,0 +1,23 @@
+import {
+  snsAggregatorStore,
+  type SnsAggregatorStore,
+} from "$lib/stores/sns-aggregator.store";
+import { getSwapCanisterAccount } from "$lib/utils/sns.utils";
+import type { AccountIdentifier } from "@dfinity/nns";
+import { Principal } from "@dfinity/principal";
+import { isNullish } from "@dfinity/utils";
+import { derived } from "svelte/store";
+
+export const createSwapCanisterAccountsStore = (controller?: Principal) =>
+  derived<SnsAggregatorStore, AccountIdentifier[]>(
+    snsAggregatorStore,
+    ($snsAggregatorStore) =>
+      isNullish(controller) || isNullish($snsAggregatorStore.data)
+        ? []
+        : $snsAggregatorStore.data.map(({ canister_ids }) =>
+            getSwapCanisterAccount({
+              controller,
+              swapCanisterId: Principal.fromText(canister_ids.swap_canister_id),
+            })
+          )
+  );

--- a/frontend/src/lib/derived/sns-swap-canisters-accounts.derived.ts
+++ b/frontend/src/lib/derived/sns-swap-canisters-accounts.derived.ts
@@ -3,21 +3,29 @@ import {
   type SnsAggregatorStore,
 } from "$lib/stores/sns-aggregator.store";
 import { getSwapCanisterAccount } from "$lib/utils/sns.utils";
-import type { AccountIdentifier } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { isNullish } from "@dfinity/utils";
 import { derived } from "svelte/store";
 
+/**
+ * Returns a derived store with a list of accounts based on the current swap canister ids.
+ *
+ * This accounts are used to participate in the swaps. We use this to identify swap participation transactions.
+ */
 export const createSwapCanisterAccountsStore = (controller?: Principal) =>
-  derived<SnsAggregatorStore, AccountIdentifier[]>(
+  derived<SnsAggregatorStore, Set<string>>(
     snsAggregatorStore,
     ($snsAggregatorStore) =>
       isNullish(controller) || isNullish($snsAggregatorStore.data)
-        ? []
-        : $snsAggregatorStore.data.map(({ canister_ids }) =>
-            getSwapCanisterAccount({
-              controller,
-              swapCanisterId: Principal.fromText(canister_ids.swap_canister_id),
-            })
+        ? (new Set() as Set<string>)
+        : new Set(
+            $snsAggregatorStore.data.map(({ canister_ids }) =>
+              getSwapCanisterAccount({
+                controller,
+                swapCanisterId: Principal.fromText(
+                  canister_ids.swap_canister_id
+                ),
+              }).toHex()
+            )
           )
   );

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -465,7 +465,7 @@
     "topUpNeuron": "Top-up Neuron",
     "createCanister": "Create Canister",
     "topUpCanister": "Top-up Canister",
-    "participateSwap": "Decentralized Swap"
+    "participateSwap": "Decentralization Swap"
   },
   "ckbtc_transaction_names": {
     "burn": "To: <span class=\"value\">BTC Network</span>",

--- a/frontend/src/lib/utils/transactions.utils.ts
+++ b/frontend/src/lib/utils/transactions.utils.ts
@@ -8,17 +8,16 @@ import {
   AccountTransactionType,
   TransactionNetwork,
 } from "$lib/types/transaction";
-import type { AccountIdentifier } from "@dfinity/nns";
 import { isNullish } from "@dfinity/utils";
 import { replacePlaceholders } from "./i18n.utils";
 import { stringifyJson } from "./utils";
 
 export const transactionType = ({
   transaction,
-  swapCanisterAccounts = [],
+  swapCanisterAccounts = new Set(),
 }: {
   transaction: NnsTransaction;
-  swapCanisterAccounts?: AccountIdentifier[];
+  swapCanisterAccounts?: Set<string>;
 }): AccountTransactionType => {
   const { transaction_type, transfer } = transaction;
   if (transaction_type.length === 0) {
@@ -33,11 +32,8 @@ export const transactionType = ({
   }
 
   if ("Send" in transfer) {
-    const swapCanisterAccountStrings = swapCanisterAccounts.map((account) =>
-      account.toHex()
-    );
     const { to } = transfer.Send;
-    if (swapCanisterAccountStrings.includes(to)) {
+    if (swapCanisterAccounts.has(to)) {
       return AccountTransactionType.ParticipateSwap;
     }
   }
@@ -113,7 +109,7 @@ export const mapNnsTransaction = ({
   transaction: NnsTransaction;
   account: Account;
   toSelfTransaction?: boolean;
-  swapCanisterAccounts?: AccountIdentifier[];
+  swapCanisterAccounts?: Set<string>;
 }): Transaction => {
   const { transfer, timestamp } = transaction;
   let from: AccountIdentifierString | undefined;

--- a/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
@@ -99,7 +99,6 @@ describe("NnsTransactionCard", () => {
     const { displayAmount } = mapNnsTransaction({
       account,
       transaction,
-      swapCanisterAccounts: [],
     });
 
     expect(getByTestId("token-value")?.textContent).toBe(
@@ -114,7 +113,6 @@ describe("NnsTransactionCard", () => {
     const { displayAmount } = mapNnsTransaction({
       account,
       transaction,
-      swapCanisterAccounts: [],
     });
 
     expect(getByTestId("token-value")?.textContent).toBe(

--- a/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
@@ -77,7 +77,7 @@ describe("NnsTransactionCard", () => {
       swapTransaction
     );
 
-    expect(queryByTestId("headline").textContent).toBe("Decentralized Swap");
+    expect(queryByTestId("headline").textContent).toBe("Decentralization Swap");
   });
 
   it("renders sent headline", () => {
@@ -96,10 +96,7 @@ describe("NnsTransactionCard", () => {
     const account = mockMainAccount;
     const transaction = mockSentToSubAccountTransaction;
     const { getByTestId } = renderTransactionCard(account, transaction);
-    const { displayAmount } = mapNnsTransaction({
-      account,
-      transaction,
-    });
+    const { displayAmount } = mapNnsTransaction({ account, transaction });
 
     expect(getByTestId("token-value")?.textContent).toBe(
       `-${formatToken({ value: displayAmount, detailed: true })}`
@@ -110,10 +107,7 @@ describe("NnsTransactionCard", () => {
     const account = mockSubAccount;
     const transaction = mockReceivedFromMainAccountTransaction;
     const { getByTestId } = renderTransactionCard(account, transaction);
-    const { displayAmount } = mapNnsTransaction({
-      account,
-      transaction,
-    });
+    const { displayAmount } = mapNnsTransaction({ account, transaction });
 
     expect(getByTestId("token-value")?.textContent).toBe(
       `+${formatToken({ value: displayAmount, detailed: true })}`

--- a/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
@@ -2,8 +2,11 @@
  * @jest-environment jsdom
  */
 
+import type { Transaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import NnsTransactionCard from "$lib/components/accounts/NnsTransactionCard.svelte";
+import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
+import { getSwapCanisterAccount } from "$lib/utils/sns.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import { mapNnsTransaction } from "$lib/utils/transactions.utils";
 import en from "$tests/mocks/i18n.mock";
@@ -11,6 +14,8 @@ import {
   mockMainAccount,
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
+import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
 import {
   mockReceivedFromMainAccountTransaction,
   mockSentToSubAccountTransaction,
@@ -43,6 +48,38 @@ describe("NnsTransactionCard", () => {
     expect(getByText(expectedText)).toBeInTheDocument();
   });
 
+  it("renders participate in swap transaction type", () => {
+    const swapCanisterId = principal(0);
+    const aggregatorData = {
+      ...aggregatorSnsMockDto,
+      canister_ids: {
+        ...aggregatorSnsMockDto.canister_ids,
+        swap_canister_id: swapCanisterId.toText(),
+      },
+    };
+    snsAggregatorStore.setData([aggregatorData]);
+    const swapCanisterAccount = getSwapCanisterAccount({
+      controller: mockMainAccount.principal,
+      swapCanisterId,
+    });
+    const swapTransaction: Transaction = {
+      ...mockReceivedFromMainAccountTransaction,
+      transfer: {
+        Send: {
+          fee: { e8s: BigInt(10000) },
+          amount: { e8s: BigInt(110000000) },
+          to: swapCanisterAccount.toHex(),
+        },
+      },
+    };
+    const { queryByTestId } = renderTransactionCard(
+      mockMainAccount,
+      swapTransaction
+    );
+
+    expect(queryByTestId("headline").textContent).toBe("Decentralized Swap");
+  });
+
   it("renders sent headline", () => {
     const { getByText } = renderTransactionCard(
       mockMainAccount,
@@ -59,7 +96,11 @@ describe("NnsTransactionCard", () => {
     const account = mockMainAccount;
     const transaction = mockSentToSubAccountTransaction;
     const { getByTestId } = renderTransactionCard(account, transaction);
-    const { displayAmount } = mapNnsTransaction({ account, transaction });
+    const { displayAmount } = mapNnsTransaction({
+      account,
+      transaction,
+      swapCanisterAccounts: [],
+    });
 
     expect(getByTestId("token-value")?.textContent).toBe(
       `-${formatToken({ value: displayAmount, detailed: true })}`
@@ -70,7 +111,11 @@ describe("NnsTransactionCard", () => {
     const account = mockSubAccount;
     const transaction = mockReceivedFromMainAccountTransaction;
     const { getByTestId } = renderTransactionCard(account, transaction);
-    const { displayAmount } = mapNnsTransaction({ account, transaction });
+    const { displayAmount } = mapNnsTransaction({
+      account,
+      transaction,
+      swapCanisterAccounts: [],
+    });
 
     expect(getByTestId("token-value")?.textContent).toBe(
       `+${formatToken({ value: displayAmount, detailed: true })}`

--- a/frontend/src/tests/lib/derived/sns-swap-canister-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-swap-canister-accounts.derived.spec.ts
@@ -26,16 +26,16 @@ describe("sns swap canisters accounts store", () => {
     const controller = mockPrincipal;
     const store = createSwapCanisterAccountsStore(controller);
 
-    expect(get(store)).toEqual([
-      getSwapCanisterAccount({ controller, swapCanisterId }),
-    ]);
+    expect(get(store)).toEqual(
+      new Set([getSwapCanisterAccount({ controller, swapCanisterId }).toHex()])
+    );
   });
 
   it("should return empty array if no aggregator data", () => {
     const controller = mockPrincipal;
     const store = createSwapCanisterAccountsStore(controller);
 
-    expect(get(store)).toHaveLength(0);
+    expect(get(store)).toEqual(new Set());
   });
 
   it("should empty array if no controller", () => {
@@ -43,7 +43,7 @@ describe("sns swap canisters accounts store", () => {
 
     const store = createSwapCanisterAccountsStore(undefined);
 
-    expect(get(store)).toHaveLength(0);
+    expect(get(store)).toEqual(new Set());
   });
 
   it("should convert multiple swap canister ids to accounts", () => {
@@ -60,9 +60,14 @@ describe("sns swap canisters accounts store", () => {
     const controller = mockPrincipal;
     const store = createSwapCanisterAccountsStore(controller);
 
-    expect(get(store)).toEqual([
-      getSwapCanisterAccount({ controller, swapCanisterId }),
-      getSwapCanisterAccount({ controller, swapCanisterId: swapCanisterId2 }),
-    ]);
+    expect(get(store)).toEqual(
+      new Set([
+        getSwapCanisterAccount({ controller, swapCanisterId }).toHex(),
+        getSwapCanisterAccount({
+          controller,
+          swapCanisterId: swapCanisterId2,
+        }).toHex(),
+      ])
+    );
   });
 });

--- a/frontend/src/tests/lib/derived/sns-swap-canister-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-swap-canister-accounts.derived.spec.ts
@@ -1,0 +1,68 @@
+import { createSwapCanisterAccountsStore } from "$lib/derived/sns-swap-canisters-accounts.derived";
+import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+import { getSwapCanisterAccount } from "$lib/utils/sns.utils";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { get } from "svelte/store";
+
+describe("sns swap canisters accounts store", () => {
+  const swapCanisterId = principal(0);
+  const aggregatorData = {
+    ...aggregatorSnsMockDto,
+    canister_ids: {
+      ...aggregatorSnsMockDto.canister_ids,
+      swap_canister_id: swapCanisterId.toText(),
+    },
+  };
+
+  beforeEach(() => {
+    snsAggregatorStore.reset();
+  });
+
+  it("should convert swap canisters to accounts for a given controller", () => {
+    snsAggregatorStore.setData([aggregatorData]);
+
+    const controller = mockPrincipal;
+    const store = createSwapCanisterAccountsStore(controller);
+
+    expect(get(store)).toEqual([
+      getSwapCanisterAccount({ controller, swapCanisterId }),
+    ]);
+  });
+
+  it("should return empty array if no aggregator data", () => {
+    const controller = mockPrincipal;
+    const store = createSwapCanisterAccountsStore(controller);
+
+    expect(get(store)).toHaveLength(0);
+  });
+
+  it("should empty array if no controller", () => {
+    snsAggregatorStore.setData([aggregatorData]);
+
+    const store = createSwapCanisterAccountsStore(undefined);
+
+    expect(get(store)).toHaveLength(0);
+  });
+
+  it("should convert multiple swap canister ids to accounts", () => {
+    const swapCanisterId2 = principal(1);
+    const aggregatorData2 = {
+      ...aggregatorSnsMockDto,
+      canister_ids: {
+        ...aggregatorSnsMockDto.canister_ids,
+        swap_canister_id: swapCanisterId2.toText(),
+      },
+    };
+    snsAggregatorStore.setData([aggregatorData, aggregatorData2]);
+
+    const controller = mockPrincipal;
+    const store = createSwapCanisterAccountsStore(controller);
+
+    expect(get(store)).toEqual([
+      getSwapCanisterAccount({ controller, swapCanisterId }),
+      getSwapCanisterAccount({ controller, swapCanisterId: swapCanisterId2 }),
+    ]);
+  });
+});

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -163,7 +163,7 @@ describe("transactions-utils", () => {
       expect(
         transactionType({
           transaction: swapTransaction,
-          swapCanisterAccounts: [swapCanisterAccount],
+          swapCanisterAccounts: new Set([swapCanisterAccount.toHex()]),
         })
       ).toBe(AccountTransactionType.ParticipateSwap);
     });
@@ -365,7 +365,7 @@ describe("transactions-utils", () => {
         transaction: swapTransaction,
         account: mockMainAccount,
         toSelfTransaction: false,
-        swapCanisterAccounts: [swapCanisterAccount],
+        swapCanisterAccounts: new Set([swapCanisterAccount.toHex()]),
       });
       expect(type).toBe(AccountTransactionType.ParticipateSwap);
     });


### PR DESCRIPTION
# Motivation

Users can identify transactions related to participating in a swap.

# Changes

* New derived store creator "createSwapCanisterAccountsStore". Returns a derived store of AccountIdentifiers based on the passed controller and the present swap canisters.
* New parameter "swapAccounts" in "mapNnsTransaction" util.
* New parameter "swapAccounts" in "transactionType" util. It uses this new parameter to identify swap participation transactions.
* NnsTransactionCard uses the new derived store and passes it to "mapNnsTransaction" so that the swap participation can be identified.

# Tests

* New test case in NnsTransactionCard spec file.
* Test new derived store.
* Fix tests with new signature.
* Add test case in "transactionType" to check it identifies swap participation transaction.
* Add test case in "mapNnsTransaction" to check it identifies swap participation transaction.

# Todos

- [ ] Add entry to changelog (if necessary).
