### PR TITLE
Set identity in CkBTCWalletFooter.spec.ts

### DIFF
--- a/frontend/src/tests/lib/components/accounts/CkBTCWalletFooter.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWalletFooter.spec.ts
@@ -7,6 +7,7 @@ import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-id
 import { AppPath } from "$lib/constants/routes.constants";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { Account } from "$lib/types/account";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockBTCAddressTestnet,
   mockCkBTCMainAccount,
@@ -27,7 +28,8 @@ jest.mock("$lib/api/ckbtc-minter.api", () => {
 });
 
 describe("CkBTCWalletFooter", () => {
-  beforeAll(() => {
+  beforeEach(() => {
+    resetIdentity();
     jest
       .spyOn(tokensStore, "subscribe")
       .mockImplementation(mockTokensSubscribe(mockUniversesTokens));


### PR DESCRIPTION
# Motivation

In `CkBTCWalletFooter.spec.ts` a test opens `CkBTCReceiveModal` which calls `loadBtcAddress`, which calls `getBTCAddress` which calls `getAuthenticatedIdentity()`. If no identity is set, `getAuthenticatedIdentity` tries to log the user out and reload the page, which is not possible during the test.
But the test manages to finish and pass before all of this happens. But then later this results in some confusing output such as:
```
PASS  src/tests/lib/components/accounts/CkBTCWalletFooter.spec.ts

  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "error while attempting to recover localstorage: TypeError: Cannot read properties of null (reading '_origin')".

      12 | function replaceRealLogger(logType: LogType) {
      13 |   const realLogger = console[logType];
    > 14 |   console[logType] = function (...args) {
         |         ^
      15 |     gotLogs = true;
      16 |     realLogger(...args);
      17 |   };

      at console.error (node_modules/@jest/console/build/BufferedConsole.js:127:10)
      at console.<computed> [as error] (src/tests/utils/console.test-utils.ts:14:9)
      at Function.create (node_modules/@dfinity/auth-client/src/index.ts:239:19)
      at Object.signOut (src/lib/stores/auth.store.ts:58:43)
      at logout (src/lib/services/auth.services.ts:29:5)
      at src/lib/services/auth.services.ts:60:13

 PASS  src/tests/lib/modals/canisters/RenameCanisterModal.spec.ts
 PASS  src/tests/lib/components/sns-neuron-detail/actions/DisburseSnsButton.spec.ts
.....
 PASS  src/tests/lib/stores/ckbtc-info.store.spec.ts
/Users/dskloet/dev/nns-dapp/tree6/frontend/node_modules/jsdom/lib/jsdom/browser/Window.js:376
      return idlUtils.wrapperForImpl(idlUtils.implForWrapper(window._document)._location);
                                                                              ^

TypeError: Cannot read properties of null (reading '_location')
    at Window.get location [as location] (/Users/dskloet/dev/nns-dapp/tree6/frontend/node_modules/jsdom/lib/jsdom/browser/Window.js:376:79)
    at appendMsgToUrl (/Users/dskloet/dev/nns-dapp/tree6/frontend/src/lib/services/auth.services.ts:75:32)
    at logout (/Users/dskloet/dev/nns-dapp/tree6/frontend/src/lib/services/auth.services.ts:31:9)
    at /Users/dskloet/dev/nns-dapp/tree6/frontend/src/lib/services/auth.services.ts:60:13

Node.js v18.14.0
 PASS  src/tests/lib/components/ic/AmountDisplay.spec.ts
```

This only seems to happen when running all the tests. Presumably because otherwise Jest is closed before the problems can be noticed.

# Changes

In `frontend/src/tests/lib/components/accounts/CkBTCWalletFooter.spec.ts`:
1. Set an identity so that `getAuthenticatedIdentity` doesn't try to log the user out.
2. Also change `beforeAll` to `beforeEach` because it's safer.

# Tests

Ran all the test twice and didn't get the confusing logs anymore.

# Todos

- [ ] Add entry to changelog (if necessary).
not worth it