### PR TITLE
Fix: HW cannot participate in swap

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -29,6 +29,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Fixed
 
 * Fix wrong "ICP Staked" message in SNS neurons.
+* Disable HW from participating in swaps.
 
 #### Security
 

--- a/frontend/src/lib/components/transaction/TransactionForm.svelte
+++ b/frontend/src/lib/components/transaction/TransactionForm.svelte
@@ -51,7 +51,10 @@
 
   let filterSourceAccounts: (account: Account) => boolean;
   $: filterSourceAccounts = (account: Account) => {
-    return !skipHardwareWallets || !isAccountHardwareWallet(account);
+    if (skipHardwareWallets) {
+      return !isAccountHardwareWallet(account);
+    }
+    return true;
   };
 
   let filterDestinationAccounts: (account: Account) => boolean;

--- a/frontend/src/lib/components/transaction/TransactionForm.svelte
+++ b/frontend/src/lib/components/transaction/TransactionForm.svelte
@@ -49,12 +49,14 @@
 
   export let validateAmount: ValidateAmountFn = () => undefined;
 
+  let filterSourceAccounts: (account: Account) => boolean;
+  $: filterSourceAccounts = (account: Account) => {
+    return !skipHardwareWallets || !isAccountHardwareWallet(account);
+  };
+
   let filterDestinationAccounts: (account: Account) => boolean;
   $: filterDestinationAccounts = (account: Account) => {
-    return (
-      account.identifier !== selectedAccount?.identifier ||
-      (skipHardwareWallets && isAccountHardwareWallet(account))
-    );
+    return account.identifier !== selectedAccount?.identifier;
   };
 
   let max = 0;
@@ -126,6 +128,7 @@
     {canSelectSource}
     {rootCanisterId}
     {token}
+    filterAccounts={filterSourceAccounts}
   />
 
   {#if canSelectDestination}

--- a/frontend/src/lib/components/transaction/TransactionForm.svelte
+++ b/frontend/src/lib/components/transaction/TransactionForm.svelte
@@ -51,10 +51,7 @@
 
   let filterSourceAccounts: (account: Account) => boolean;
   $: filterSourceAccounts = (account: Account) => {
-    if (skipHardwareWallets) {
-      return !isAccountHardwareWallet(account);
-    }
-    return true;
+    return !skipHardwareWallets || !isAccountHardwareWallet(account);
   };
 
   let filterDestinationAccounts: (account: Account) => boolean;

--- a/frontend/src/lib/modals/transaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/transaction/TransactionModal.svelte
@@ -18,7 +18,7 @@
   import { decodePayment } from "@dfinity/ledger";
   import { toastsError } from "$lib/stores/toasts.store";
 
-  export let testId: string | undefined = undefined;
+  export let testId = "transaction-modal-component";
   export let transactionInit: TransactionInit = {};
 
   // User inputs initialized with given initial parameters when component is mounted. If initial parameters vary, we do not want to overwrite what the user would have already entered.

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -24,6 +24,7 @@ import {
 import {
   mockAccountDetails,
   mockAccountsStoreData,
+  mockHardwareWalletAccount,
   mockMainAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
 import { renderModalContextWrapper } from "$tests/mocks/modal.mock";
@@ -131,6 +132,25 @@ describe("ParticipateSwapModal", () => {
     await reviewPo.clickSend();
     expect(initiateSnsSaleParticipation).toBeCalledTimes(1);
   };
+
+  describe("when hardware wallet account is available", () => {
+    beforeEach(() => {
+      icpAccountsStore.setForTesting({
+        main: mockMainAccount,
+        subAccounts: [],
+        hardwareWallets: [mockHardwareWalletAccount],
+        certified: true,
+      });
+    });
+
+    it("should not show hardware wallet account as selectable", async () => {
+      const po = await renderSwapModalPo();
+      const form = po.getTransactionFormPo();
+      expect(await form.getSourceAccounts()).toEqual([
+        mockMainAccount.identifier,
+      ]);
+    });
+  });
 
   describe("when accounts are available", () => {
     beforeEach(() => {

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -26,6 +26,7 @@ import {
   mockAccountsStoreData,
   mockHardwareWalletAccount,
   mockMainAccount,
+  mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
 import { renderModalContextWrapper } from "$tests/mocks/modal.mock";
 import {
@@ -137,7 +138,7 @@ describe("ParticipateSwapModal", () => {
     beforeEach(() => {
       icpAccountsStore.setForTesting({
         main: mockMainAccount,
-        subAccounts: [],
+        subAccounts: [mockSubAccount],
         hardwareWallets: [mockHardwareWalletAccount],
         certified: true,
       });
@@ -147,7 +148,8 @@ describe("ParticipateSwapModal", () => {
       const po = await renderSwapModalPo();
       const form = po.getTransactionFormPo();
       expect(await form.getSourceAccounts()).toEqual([
-        mockMainAccount.identifier,
+        "Main",
+        "test subaccount",
       ]);
     });
   });

--- a/frontend/src/tests/page-objects/Dropdown.page-object.ts
+++ b/frontend/src/tests/page-objects/Dropdown.page-object.ts
@@ -14,6 +14,8 @@ export class DropdownPo extends BasePageObject {
 
   async getOptions(): Promise<string[]> {
     const options = await this.root.querySelectorAll("option");
-    return Promise.all(options.map((option) => option.getValue()));
+    return Promise.all(
+      options.map(async (option) => (await option.getText()).trim())
+    );
   }
 }

--- a/frontend/src/tests/page-objects/Dropdown.page-object.ts
+++ b/frontend/src/tests/page-objects/Dropdown.page-object.ts
@@ -11,4 +11,9 @@ export class DropdownPo extends BasePageObject {
   select(option: string): Promise<void> {
     return this.root.querySelector("select").selectOption(option);
   }
+
+  async getOptions(): Promise<string[]> {
+    const options = await this.root.querySelectorAll("option");
+    return Promise.all(options.map((option) => option.getValue()));
+  }
 }

--- a/frontend/src/tests/page-objects/IcpTransactionModal.page-object.ts
+++ b/frontend/src/tests/page-objects/IcpTransactionModal.page-object.ts
@@ -1,7 +1,7 @@
-import { TransactionModalPo } from "$tests/page-objects/TransactionModal.page-object";
+import { TransactionModalBasePo } from "$tests/page-objects/TransactionModal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class IcpTransactionModalPo extends TransactionModalPo {
+export class IcpTransactionModalPo extends TransactionModalBasePo {
   private static readonly TID = "icp-transaction-modal-component";
 
   static under(element: PageObjectElement): IcpTransactionModalPo {

--- a/frontend/src/tests/page-objects/ParticipateSwapModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ParticipateSwapModal.page-object.ts
@@ -1,10 +1,10 @@
 import { AdditionalInfoFormPo } from "$tests/page-objects/AdditionalInfoForm.page-object";
 import { AdditionalInfoReviewPo } from "$tests/page-objects/AdditionalInfoReview.page-object";
 import { InProgressPo } from "$tests/page-objects/InProgress.page-object";
-import { TransactionModalPo } from "$tests/page-objects/TransactionModal.page-object";
+import { TransactionModalBasePo } from "$tests/page-objects/TransactionModal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class ParticipateSwapModalPo extends TransactionModalPo {
+export class ParticipateSwapModalPo extends TransactionModalBasePo {
   private static readonly TID = "participate-swap-modal-component";
 
   static under(element: PageObjectElement): ParticipateSwapModalPo | null {

--- a/frontend/src/tests/page-objects/SnsIncreaseStakeNeuronModal.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsIncreaseStakeNeuronModal.page-object.ts
@@ -1,7 +1,7 @@
-import { TransactionModalPo } from "$tests/page-objects/TransactionModal.page-object";
+import { TransactionModalBasePo } from "$tests/page-objects/TransactionModal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class SnsIncreaseStakeNeuronModalPo extends TransactionModalPo {
+export class SnsIncreaseStakeNeuronModalPo extends TransactionModalBasePo {
   private static readonly TID = "sns-increase-stake-neuron-modal-component";
 
   static under(

--- a/frontend/src/tests/page-objects/SnsStakeNeuronModal.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsStakeNeuronModal.page-object.ts
@@ -1,7 +1,7 @@
-import { TransactionModalPo } from "$tests/page-objects/TransactionModal.page-object";
+import { TransactionModalBasePo } from "$tests/page-objects/TransactionModal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class SnsStakeNeuronModalPo extends TransactionModalPo {
+export class SnsStakeNeuronModalPo extends TransactionModalBasePo {
   private static readonly TID = "sns-stake-neuron-modal-component";
 
   static under(element: PageObjectElement): SnsStakeNeuronModalPo | null {

--- a/frontend/src/tests/page-objects/TransactionForm.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionForm.page-object.ts
@@ -16,6 +16,10 @@ export class TransactionFormPo extends BasePageObject {
     return TransactionFromAccountPo.under(this.root);
   }
 
+  getSourceAccounts(): Promise<string[]> {
+    return this.getTransactionFromAccountPo().getAccounts();
+  }
+
   getSelectDestinationAddressPo(): SelectDestinationAddressPo {
     return SelectDestinationAddressPo.under(this.root);
   }

--- a/frontend/src/tests/page-objects/TransactionFromAccount.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionFromAccount.page-object.ts
@@ -18,4 +18,8 @@ export class TransactionFromAccountPo extends BasePageObject {
   async selectAccount(accountName: string): Promise<void> {
     await this.getDropdownPo().select(accountName);
   }
+
+  getAccounts(): Promise<string[]> {
+    return this.getDropdownPo().getOptions();
+  }
 }

--- a/frontend/src/tests/page-objects/TransactionModal.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionModal.page-object.ts
@@ -1,10 +1,11 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { TransactionFormPo } from "$tests/page-objects/TransactionForm.page-object";
 import { TransactionReviewPo } from "$tests/page-objects/TransactionReview.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
 
 // This should not be used directly but rather as a base class for specific
 // transaction modals.
-export class TransactionModalPo extends BasePageObject {
+export class TransactionModalBasePo extends BasePageObject {
   getTransactionFormPo(): TransactionFormPo {
     return TransactionFormPo.under(this.root);
   }
@@ -34,5 +35,13 @@ export class TransactionModalPo extends BasePageObject {
       );
     }
     await review.clickSend();
+  }
+}
+
+export class TransactionModalPo extends TransactionModalBasePo {
+  private static readonly TID = "transaction-modal-component";
+
+  static under(element: PageObjectElement): TransactionModalPo | null {
+    return new TransactionModalPo(element.byTestId(TransactionModalPo.TID));
   }
 }


### PR DESCRIPTION
# Motivation

We still don't allow HW to participate in the swap. Yet, there was a bug where the HW account was selectable in the modal to participate.

In case that the user selected the HW, they wouldn't participate with the HW. Instead, they would participate with the main account. Therefore, what the user selected, was ignored.

# Changes

* New variable "filterSourceAccounts" in TransactionForm using the prop "skipHardwareWallets".
* Pass the "filterSourceAccounts" to "TransactionFromAccount".
* Remove using the prop "skipHardwareWallets" when filtering the destination accounts. This was an error never seen because the TransactionForm had never "skipHardwareWallets" with selectable destination account.

# Tests

* Add methods to related POs to expose the available source accounts.
* Add a test case in ParticipateSwapModal to check that HW accounts are not available.

# Todos

- [x] Add entry to changelog (if necessary).
