### PR TITLE
Fix: Randomized test NnsStakeNeuronModal

### DIFF
--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -13,15 +13,10 @@ import {
   stakeNeuron,
   updateDelay,
 } from "$lib/services/neurons.services";
-import { authStore } from "$lib/stores/auth.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { formatVotingPower } from "$lib/utils/neuron.utils";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-  resetIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import {
   mockAccountDetails,
@@ -101,9 +96,6 @@ describe("NnsStakeNeuronModal", () => {
         ...mockAccountsStoreData,
         subAccounts: [mockSubAccount],
       });
-      jest
-        .spyOn(authStore, "subscribe")
-        .mockImplementation(mockAuthStoreSubscribe);
       jest
         .spyOn(LedgerCanister, "create")
         .mockImplementation(() => mock<LedgerCanister>());
@@ -415,9 +407,6 @@ describe("NnsStakeNeuronModal", () => {
         ...mockAccountsStoreData,
         hardwareWallets: [mockHardwareWalletAccount],
       });
-      jest
-        .spyOn(authStore, "subscribe")
-        .mockImplementation(mockAuthStoreSubscribe);
     });
 
     const createNeuron = async ({

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -20,6 +20,7 @@ import { formatVotingPower } from "$lib/utils/neuron.utils";
 import {
   mockAuthStoreSubscribe,
   mockIdentity,
+  resetIdentity,
 } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import {
@@ -86,6 +87,7 @@ jest.mock("$lib/stores/toasts.store", () => {
 
 describe("NnsStakeNeuronModal", () => {
   beforeEach(() => {
+    resetIdentity();
     cancelPollAccounts();
     jest.clearAllMocks();
   });
@@ -111,10 +113,6 @@ describe("NnsStakeNeuronModal", () => {
       queryBalanceSpy = jest
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockResolvedValue(newBalanceE8s);
-    });
-
-    afterEach(() => {
-      neuronsStore.setNeurons({ neurons: [], certified: true });
     });
 
     it("should display modal", async () => {
@@ -412,7 +410,6 @@ describe("NnsStakeNeuronModal", () => {
 
   describe("hardware wallet account selection", () => {
     beforeEach(() => {
-      jest.clearAllMocks();
       neuronsStore.setNeurons({ neurons: [], certified: true });
       icpAccountsStore.setForTesting({
         ...mockAccountsStoreData,
@@ -559,7 +556,6 @@ describe("NnsStakeNeuronModal", () => {
     beforeEach(() => {
       icpAccountsStore.resetForTesting();
       jest.clearAllTimers();
-      jest.clearAllMocks();
       const now = Date.now();
       jest.useFakeTimers().setSystemTime(now);
       const mainBalanceE8s = BigInt(10_000_000);


### PR DESCRIPTION
# Motivation

NnsStakeNeuronModal.spec file was failing when randomizing unit tests.

The problem: if the case "when accounts are not loaded" was run first, it was getting the authenticated identity and failing.

# Changes

* "resetIdentity" in the beforeEach of the test.
* Remove unnecessary clearing mocks and resetting store.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Already covered by a changelog entry.

