### PR TITLE
Fix: Remove unnecessary set

### DIFF
--- a/frontend/src/lib/derived/sns-swap-canisters-accounts.derived.ts
+++ b/frontend/src/lib/derived/sns-swap-canisters-accounts.derived.ts
@@ -18,16 +18,14 @@ export const createSwapCanisterAccountsStore = (controller?: Principal) =>
     ($snsAggregatorStore) =>
       new Set(
         isNullish(controller) || isNullish($snsAggregatorStore.data)
-          ? undefined
-          : new Set(
-              $snsAggregatorStore.data.map(({ canister_ids }) =>
-                getSwapCanisterAccount({
-                  controller,
-                  swapCanisterId: Principal.fromText(
-                    canister_ids.swap_canister_id
-                  ),
-                }).toHex()
-              )
+          ? []
+          : $snsAggregatorStore.data.map(({ canister_ids }) =>
+              getSwapCanisterAccount({
+                controller,
+                swapCanisterId: Principal.fromText(
+                  canister_ids.swap_canister_id
+                ),
+              }).toHex()
             )
       )
   );


### PR DESCRIPTION
# Motivation

Remove unnecessary code in sns swan canisters accounts store.

# Changes

Changes in sns-swap-canisters.accounts.derived.ts
* Remove extra `Set` around the array.
* Use `[]` instead of undefined when we want an empty set.

# Tests

Not necessary.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
