### PR TITLE
Remove update-chromedriver job from nightly.yaml

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -65,29 +65,8 @@ jobs:
           # do not pull: if this branch is behind, then we might as well let
           # the pushing fail
           pull_strategy: "NO-PULL"
-  update-chromedriver:
-    needs: update-ii # Forces git updates to run sequentially so that they don't conflict.
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Get node version
-        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - name: Commit updated chromedriver
-        uses: EndBug/add-and-commit@v9.1.1
-        with:
-          add: .
-          author_name: Nightly GitHub Action
-          author_email: "<nobody@dfinity.org>"
-          message: "Update chromedriver"
-          # do not pull: if this branch is behind, then we might as well let
-          # the pushing fail
-          pull_strategy: "NO-PULL"
   nightly-passes:
-    needs: ["tag-main", "update-ii", "update-chromedriver"]
+    needs: ["tag-main", "update-ii"]
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
# Motivation

The essential step in the `update-chromedriver` job was already removed in https://github.com/dfinity/nns-dapp/pull/3084 so the job doesn't really do anything now.

# Changes

Remove the `update-chromedriver` job entirely from `.github/workflows/nightly.yaml`.

# Tests

no

# Todos

- [ ] Add entry to changelog (if necessary).
Will add when everything related to wdio e2e tests has been removed.