### PR TITLE
Fix: Randomized test SnsIncreaseStakeNeuronModal

### DIFF
--- a/frontend/src/tests/lib/modals/sns/SnsIncreaseStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsIncreaseStakeNeuronModal.spec.ts
@@ -77,12 +77,12 @@ describe("SnsIncreaseStakeNeuronModal", () => {
   };
 
   beforeEach(() => {
+    jest.clearAllMocks();
     page.mock({
       routeId: AppPath.Neuron,
       data: { universe: rootCanisterId.toText() },
     });
     setSnsProjects([snsProjectParams]);
-    jest.clearAllMocks();
   });
 
   describe("accounts and params are not loaded", () => {


### PR DESCRIPTION
# Motivation

Test SnsIncreaseStakeNeuronModal.spec fails when randomizing unit tests order.

The problem was that the tests in "accounts and params are not loaded" relied in the stores to be empty. Yet, when the order changed and the ones below were executed, the store mocks returns data.

I could have fixed it by adding a "resetAllMocks". But instead, I decided to remove the store mocks because it's not our current pattern to do so.

# Changes

In SnsIncreaseStakeNeuronModal.spec
* Remove the jest.spyOn mocks.
* Instead, prepare the stores to be as expected.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not worth a changelog entry.
