### PR TITLE
Fix: Randomized test sns neuron services

### DIFF
--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -1133,9 +1133,10 @@ describe("sns-neurons-services", () => {
       const spySplitNeuron = jest
         .spyOn(governanceApi, "splitNeuron")
         .mockImplementation(() => Promise.resolve());
-      const spyLoadNeurons = jest
-        .spyOn(services, "loadNeurons")
-        .mockResolvedValue(undefined);
+      const spyQuery = jest
+        .spyOn(governanceApi, "querySnsNeurons")
+        .mockImplementation(() => Promise.resolve([mockSnsNeuron]));
+
       const amount = 10;
 
       const neuronMinimumStake = 1000n;
@@ -1146,7 +1147,7 @@ describe("sns-neurons-services", () => {
         neuronMinimumStake,
       });
       expect(success).toBeTruthy();
-      expect(spyLoadNeurons).toBeCalled();
+      expect(spyQuery).toBeCalled();
       expect(spySplitNeuron).toBeCalledWith({
         neuronId: mockSnsNeuron.id[0] as SnsNeuronId,
         identity: mockIdentity,


### PR DESCRIPTION
# Motivation

Test sns-neuron-services.spec fails when randomizing unit tests order.

The problem was that one test was mocking a service used in another test. Preventing from reaching the call to the api.

Solution: remove the mock and test that api is called instead.

# Changes

* In sns-neuron services remove mock to "loadNeurons". Instead, check that "querySnsNeurons" is called.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not worth an entry in the changelog.