### PR TITLE
Fix: Remove done TODO comment

### DIFF
--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -30,7 +30,6 @@ export const loadSnsProjects = async (): Promise<void> => {
   try {
     const aggregatorData = await querySnsProjects();
     snsAggregatorStore.setData(aggregatorData);
-    // TODO: Store this in a svelte store.
     const cachedSnses = convertDtoData(aggregatorData);
     const identity = getCurrentIdentity();
     // We load the wrappers to avoid making calls to SNS-W and Root canister for each project.


### PR DESCRIPTION
# Motivation

Remove a TODO comment because it's already done.

# Changes

* In the "loadSnsProjects" there was a todo to add the aggregator data to a store. This is already done.

# Tests

Only comment changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not worth an entry.