### PR TITLE
Fix 'should retrieve btc' in ckbtc-convert.services.spec.ts

### DIFF
--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -14,6 +14,7 @@ import { bitcoinConvertBlockIndexes } from "$lib/stores/bitcoin.store";
 import { ckBTCWithdrawalAccountsStore } from "$lib/stores/ckbtc-withdrawal-accounts.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
+import { ConvertBtcStep } from "$lib/types/ckbtc-convert";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
 import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
@@ -339,7 +340,11 @@ describe("ckbtc-convert-services", () => {
       block_index: 1n,
     };
 
-    const retrieveBtcSpy = minterCanisterMock.retrieveBtc.mockResolvedValue(ok);
+    const retrieveBtcSpy = minterCanisterMock.retrieveBtc;
+
+    beforeEach(() => {
+      retrieveBtcSpy.mockResolvedValue(ok);
+    });
 
     it("should retrieve btc", async () => {
       const updateProgressSpy = jest.fn();
@@ -358,8 +363,12 @@ describe("ckbtc-convert-services", () => {
       expect(loadCkBTCAccountTransactions).not.toBeCalled();
       expect(loadCkBTCWithdrawalAccount).toBeCalled();
 
-      // SEND_BTC + RELOAD + DONE
-      expect(updateProgressSpy).toBeCalledTimes(3);
+      // INITIALIZATION + SEND_BTC + RELOAD + DONE
+      expect(updateProgressSpy).toBeCalledTimes(4);
+      expect(updateProgressSpy).nthCalledWith(1, ConvertBtcStep.INITIALIZATION);
+      expect(updateProgressSpy).nthCalledWith(2, ConvertBtcStep.SEND_BTC);
+      expect(updateProgressSpy).nthCalledWith(3, ConvertBtcStep.RELOAD);
+      expect(updateProgressSpy).nthCalledWith(4, ConvertBtcStep.DONE);
     });
 
     it("should display an error if retrieve btc fails", async () => {


### PR DESCRIPTION
# Motivation

The test sets mock behavior in a `describe` block, outside `beforeEach` or `it`.
This gets executed in a surprising order, because first the framework collects all the tests that should be executed by running the describe blocks, and then it runs all the tests.
So the behavior set by
```
const retrieveBtcSpy = minterCanisterMock.retrieveBtc.mockResolvedValue(ok);
```
was replaced by
```
minterCanisterMock.retrieveBtc.mockImplementation(async () => {
  throw new Error();
});
```
inside another test which ran after the `describe` block ran but before the `"should retrieve btc"` test ran.
This meant that in the `"should retrieve btc"`, btc were not actually retrieved.

The test checked that `updateProgressSpy` was called 3 times, and assumed (with comment) this was for `SEND_BTC + RELOAD + DONE`, but actually it was for `INITIALIZATION + SEND + RELOAD`.

When the mock setup is fixed, `updateProgressSpy` is actually called 4 times, with `INITIALIZATION + SEND_BTC + RELOAD + DONE`.

There are more broken tests in this file but it's tricky so I'm doing one step at a time.

# Changes

1. Define mock behavior inside `beforeEach`.

# Tests

Previously the test would fail when run in isolation but now it passes in isolation.

# Todos

- [ ] Add entry to changelog (if necessary).
covered by an existing entry
