### PR TITLE
Remove jest-spy.ts

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -51,6 +51,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Removed
 
 * Remove compressed `.wasm` files from releases.  Please use `.wasm.gz` instead.
+* Remove `frontend/jest-spy.ts`.
 
 #### Fixed
 

--- a/frontend/jest-spy.ts
+++ b/frontend/jest-spy.ts
@@ -1,6 +1,0 @@
-import type { HttpAgent } from "@dfinity/agent";
-import { mock } from "jest-mock-extended";
-import * as agent from "./src/lib/api/agent.api";
-
-const mockCreateAgent = () => Promise.resolve(mock<HttpAgent>());
-jest.spyOn(agent, "createAgent").mockImplementation(mockCreateAgent);

--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -13,7 +13,7 @@ module.exports = {
     "\\.(svg|png)$": "<rootDir>/jest-transform.cjs",
   },
   moduleFileExtensions: ["js", "ts", "svelte"],
-  setupFilesAfterEnv: ["<rootDir>/jest-setup.ts", "<rootDir>/jest-spy.ts"],
+  setupFilesAfterEnv: ["<rootDir>/jest-setup.ts"],
   collectCoverageFrom: ["src/**/*.{ts,tsx,svelte,js,jsx}"],
   testEnvironmentOptions: {
     url: "https://nns.internetcomputer.org/",

--- a/frontend/src/tests/lib/api/accounts.api.spec.ts
+++ b/frontend/src/tests/lib/api/accounts.api.spec.ts
@@ -3,15 +3,21 @@ import {
   getTransactions,
   renameSubAccount,
 } from "$lib/api/accounts.api";
+import * as agent from "$lib/api/agent.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import type { GetTransactionsResponse } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockSubAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockSentToSubAccountTransaction } from "$tests/mocks/transaction.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import { mock } from "jest-mock-extended";
 
 describe("accounts-api", () => {
   afterAll(() => jest.clearAllMocks());
+
+  beforeEach(() => {
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
+  });
 
   it("should call nnsDappCanister to create subaccount", async () => {
     const nnsDappMock = mock<NNSDappCanister>();

--- a/frontend/src/tests/lib/api/ckbtc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/ckbtc-index.api.spec.ts
@@ -1,8 +1,10 @@
+import * as agent from "$lib/api/agent.api";
 import { getCkBTCTransactions } from "$lib/api/ckbtc-index.api";
 import { CKBTC_INDEX_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import { IcrcIndexCanister, type IcrcTransaction } from "@dfinity/ledger";
-import mock from "jest-mock-extended/lib/Mock";
+import { mock } from "jest-mock-extended";
 
 describe("ckbtc-index api", () => {
   const indexCanisterMock = mock<IcrcIndexCanister>();
@@ -14,6 +16,10 @@ describe("ckbtc-index api", () => {
   });
 
   afterAll(() => jest.clearAllMocks());
+
+  beforeEach(() => {
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
+  });
 
   const params = {
     identity: mockIdentity,

--- a/frontend/src/tests/lib/api/ckbtc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/ckbtc-ledger.api.spec.ts
@@ -1,3 +1,4 @@
+import * as agent from "$lib/api/agent.api";
 import { getCkBTCAccount, getCkBTCToken } from "$lib/api/ckbtc-ledger.api";
 import { CKBTC_LEDGER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
@@ -5,8 +6,9 @@ import {
   mockQueryTokenResponse,
   mockSnsToken,
 } from "$tests/mocks/sns-projects.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import { IcrcLedgerCanister } from "@dfinity/ledger";
-import mock from "jest-mock-extended/lib/Mock";
+import { mock } from "jest-mock-extended";
 
 describe("ckbtc-ledger api", () => {
   const ledgerCanisterMock = mock<IcrcLedgerCanister>();
@@ -18,6 +20,10 @@ describe("ckbtc-ledger api", () => {
   });
 
   afterAll(() => jest.clearAllMocks());
+
+  beforeEach(() => {
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
+  });
 
   describe("getCkBTCAccount", () => {
     it("returns main account with balance", async () => {

--- a/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
+++ b/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
@@ -16,7 +16,7 @@ import {
 } from "$tests/mocks/ckbtc-minter.mock";
 import type { HttpAgent } from "@dfinity/agent";
 import { CkBTCMinterCanister, type RetrieveBtcOk } from "@dfinity/ckbtc";
-import mock from "jest-mock-extended/lib/Mock";
+import { mock } from "jest-mock-extended";
 
 describe("ckbtc-minter api", () => {
   const minterCanisterMock = mock<CkBTCMinterCanister>();

--- a/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
+++ b/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
@@ -1,3 +1,4 @@
+import * as agent from "$lib/api/agent.api";
 import {
   estimateFee,
   getBTCAddress,
@@ -13,6 +14,7 @@ import {
   mockCkBTCMinterInfo,
   mockUpdateBalanceOk,
 } from "$tests/mocks/ckbtc-minter.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import { CkBTCMinterCanister, type RetrieveBtcOk } from "@dfinity/ckbtc";
 import mock from "jest-mock-extended/lib/Mock";
 
@@ -26,6 +28,10 @@ describe("ckbtc-minter api", () => {
   });
 
   afterAll(() => jest.clearAllMocks());
+
+  beforeEach(() => {
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
+  });
 
   const params = {
     identity: mockIdentity,

--- a/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
@@ -1,3 +1,4 @@
+import * as agent from "$lib/api/agent.api";
 import {
   queryAccountBalance,
   sendICP,
@@ -5,11 +6,16 @@ import {
 } from "$lib/api/icp-ledger.api";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import { AccountIdentifier, LedgerCanister } from "@dfinity/nns";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
 
 describe("icp-ledger.api", () => {
+  beforeEach(() => {
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
+  });
+
   describe("sendICP", () => {
     let spyTransfer;
 

--- a/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
@@ -1,3 +1,4 @@
+import * as agent from "$lib/api/agent.api";
 import {
   executeIcrcTransfer,
   getIcrcAccount,
@@ -10,8 +11,9 @@ import {
   mockQueryTokenResponse,
   mockSnsToken,
 } from "$tests/mocks/sns-projects.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import { IcrcLedgerCanister } from "@dfinity/ledger";
-import mock from "jest-mock-extended/lib/Mock";
+import { mock } from "jest-mock-extended";
 
 describe("icrc-ledger api", () => {
   const ledgerCanisterMock = mock<IcrcLedgerCanister>();
@@ -20,6 +22,7 @@ describe("icrc-ledger api", () => {
     jest
       .spyOn(IcrcLedgerCanister, "create")
       .mockImplementation(() => ledgerCanisterMock);
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/frontend/src/tests/lib/api/nns-dapp.api.spec.ts
+++ b/frontend/src/tests/lib/api/nns-dapp.api.spec.ts
@@ -1,10 +1,16 @@
+import * as agent from "$lib/api/agent.api";
 import { addAccount, queryAccount } from "$lib/api/nns-dapp.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockAccountDetails } from "$tests/mocks/icp-accounts.store.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import { mock } from "jest-mock-extended";
 
 describe("nns-dapp api", () => {
+  beforeEach(() => {
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
+  });
+
   describe("addAccount", () => {
     const nnsDappCanister = mock<NNSDappCanister>();
     nnsDappCanister.getAccount.mockResolvedValue(mockAccountDetails);

--- a/frontend/src/tests/lib/api/proposals.api.spec.ts
+++ b/frontend/src/tests/lib/api/proposals.api.spec.ts
@@ -1,3 +1,4 @@
+import * as agent from "$lib/api/agent.api";
 import {
   queryProposal,
   queryProposalPayload,
@@ -8,6 +9,7 @@ import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { MockGovernanceCanister } from "$tests/mocks/governance.canister.mock";
 import { mockProposals } from "$tests/mocks/proposals.store.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import { GovernanceCanister } from "@dfinity/nns";
 import { mock } from "jest-mock-extended";
 
@@ -23,6 +25,7 @@ describe("proposals-api", () => {
       .mockImplementation((): GovernanceCanister => mockGovernanceCanister);
 
     spyListProposals = jest.spyOn(mockGovernanceCanister, "listProposals");
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   afterEach(() => spyListProposals.mockClear());

--- a/frontend/src/tests/lib/api/sns-sale.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-sale.api.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as agent from "$lib/api/agent.api";
 import {
   getOpenTicket,
   newSaleTicket,
@@ -22,6 +23,7 @@ import {
   swapCanisterIdMock,
 } from "$tests/mocks/sns.api.mock";
 import { snsTicketMock } from "$tests/mocks/sns.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import type { SnsWasmCanisterOptions } from "@dfinity/nns";
 import { SnsSwapCanister } from "@dfinity/sns";
 import { mock } from "jest-mock-extended";
@@ -67,6 +69,7 @@ describe("sns-sale.api", () => {
         notifyParticipation: notifyParticipationSpy,
       })
     );
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   it("should query open ticket", async () => {

--- a/frontend/src/tests/lib/api/sns-wrapper.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-wrapper.api.spec.ts
@@ -1,3 +1,4 @@
+import * as agent from "$lib/api/agent.api";
 import {
   buildAndStoreWrapper,
   clearWrapperCache,
@@ -13,8 +14,8 @@ import {
   rootCanisterIdMock,
   swapCanisterIdMock,
 } from "$tests/mocks/sns.api.mock";
-import type { Agent } from "@dfinity/agent";
-import mock from "jest-mock-extended/lib/Mock";
+import type { Agent, HttpAgent } from "@dfinity/agent";
+import { mock } from "jest-mock-extended";
 
 const listSnsesSpy = jest.fn().mockResolvedValue(deployedSnsMock);
 const initSnsWrapperSpy = jest.fn().mockResolvedValue(
@@ -43,6 +44,7 @@ describe("sns-wrapper api", () => {
   beforeEach(() => {
     clearWrapperCache();
     jest.clearAllMocks();
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   describe("wrappers", () => {

--- a/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
@@ -1,14 +1,12 @@
-import { createAgent } from "$lib/api/agent.api";
 import { toCanisterDetails } from "$lib/canisters/ic-management/converters";
 import { ICManagementCanister } from "$lib/canisters/ic-management/ic-management.canister";
 import { UserNotTheControllerError } from "$lib/canisters/ic-management/ic-management.errors";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockCanisterDetails,
   mockCanisterId,
   mockCanisterSettings,
 } from "$tests/mocks/canisters.mock";
-import type { ActorSubclass } from "@dfinity/agent";
+import type { ActorSubclass, HttpAgent } from "@dfinity/agent";
 import type { CanisterStatusResponse } from "@dfinity/ic-management";
 import type { _SERVICE as IcManagementService } from "@dfinity/ic-management/dist/candid/ic-management";
 import { Principal } from "@dfinity/principal";
@@ -16,10 +14,8 @@ import { mock } from "jest-mock-extended";
 
 describe("ICManagementCanister", () => {
   const createICManagement = async (service: IcManagementService) => {
-    const defaultAgent = await createAgent({ identity: mockIdentity });
-
     return ICManagementCanister.create({
-      agent: defaultAgent,
+      agent: mock<HttpAgent>(),
       serviceOverride: service as ActorSubclass<IcManagementService>,
     });
   };

--- a/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
@@ -1,4 +1,3 @@
-import { createAgent } from "$lib/api/agent.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import {
   AccountNotFoundError,
@@ -20,23 +19,23 @@ import type {
   CreateSubAccountResponse,
   GetAccountResponse,
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
-import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockCanister, mockCanisters } from "$tests/mocks/canisters.mock";
 import {
   mockAccountDetails,
   mockSubAccountDetails,
 } from "$tests/mocks/icp-accounts.store.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import { AccountIdentifier } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { mock } from "jest-mock-extended";
 
 describe("NNSDapp", () => {
   const createNnsDapp = async (service: NNSDappService) => {
-    const defaultAgent = await createAgent({ identity: mockIdentity });
     const canisterId = Principal.fromText("aaaaa-aa");
 
     return NNSDappCanister.create({
-      agent: defaultAgent,
+      agent: mock<HttpAgent>(),
       certifiedServiceOverride: service,
       canisterId,
     });

--- a/frontend/src/tests/lib/canisters/tvl.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/tvl.canister.spec.ts
@@ -1,17 +1,15 @@
-import { createAgent } from "$lib/api/agent.api";
 import { TVLCanister } from "$lib/canisters/tvl/tvl.canister";
 import type { _SERVICE as TVLService } from "$lib/canisters/tvl/tvl.types";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { mock } from "jest-mock-extended";
 
 describe("TVL canister", () => {
   const createTVLCanister = async (service: TVLService) => {
-    const defaultAgent = await createAgent({ identity: mockIdentity });
     const canisterId = Principal.fromText("aaaaa-aa");
 
     return TVLCanister.create({
-      agent: defaultAgent,
+      agent: mock<HttpAgent>(),
       certifiedServiceOverride: service,
       canisterId,
     });

--- a/frontend/src/tests/lib/components/neurons/BallotSummary.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/BallotSummary.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as agent from "$lib/api/agent.api";
 import BallotSummary from "$lib/components/neuron-detail/Ballots/BallotSummary.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
@@ -12,9 +13,11 @@ import { BallotSummaryPo } from "$tests/page-objects/BallotSummary.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { silentConsoleErrors } from "$tests/utils/utils.test-utils";
+import type { HttpAgent } from "@dfinity/agent";
 import type { BallotInfo, Proposal } from "@dfinity/nns";
 import { GovernanceCanister, Vote } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
 
 describe("BallotSummary", () => {
   const mockBallot: BallotInfo = {
@@ -39,6 +42,7 @@ describe("BallotSummary", () => {
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   it("should render proposal id", async () => {

--- a/frontend/src/tests/lib/components/neurons/Ballots.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/Ballots.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as agent from "$lib/api/agent.api";
 import Ballots from "$lib/components/neuron-detail/Ballots/Ballots.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
@@ -10,9 +11,11 @@ import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockProposals } from "$tests/mocks/proposals.store.mock";
 import { silentConsoleErrors } from "$tests/utils/utils.test-utils";
+import type { HttpAgent } from "@dfinity/agent";
 import type { BallotInfo } from "@dfinity/nns";
 import { GovernanceCanister, Vote } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
 
 describe("Ballots", () => {
   const mockBallot: BallotInfo = {
@@ -32,6 +35,7 @@ describe("Ballots", () => {
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   it("should render multiple ballots", async () => {

--- a/frontend/src/tests/lib/components/neurons/VoteHistoryCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/VoteHistoryCard.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as agent from "$lib/api/agent.api";
 import VotingHistoryCard from "$lib/components/neurons/VotingHistoryCard.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
@@ -10,9 +11,11 @@ import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockProposals } from "$tests/mocks/proposals.store.mock";
 import { silentConsoleErrors } from "$tests/utils/utils.test-utils";
+import type { HttpAgent } from "@dfinity/agent";
 import type { Proposal } from "@dfinity/nns";
 import { GovernanceCanister, Vote } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
 
 describe("VoteHistoryCard", () => {
   const props = {
@@ -44,6 +47,7 @@ describe("VoteHistoryCard", () => {
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   it("should render title", async () => {

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as agent from "$lib/api/agent.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import NnsProposalProposerPayloadEntry from "$lib/components/proposal-detail/NnsProposalProposerPayloadEntry.svelte";
 import { proposalPayloadsStore } from "$lib/stores/proposals.store";
@@ -11,6 +12,7 @@ import {
 } from "$tests/mocks/proposal.mock";
 import { simplifyJson } from "$tests/utils/json.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import type { HttpAgent } from "@dfinity/agent";
 import type { Proposal } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 import { mock } from "jest-mock-extended";
@@ -32,6 +34,7 @@ describe("NnsProposalProposerPayloadEntry", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     proposalPayloadsStore.reset();
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   it("should trigger getProposalPayload", async () => {

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalSystemInfoProposerEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalSystemInfoProposerEntry.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as agent from "$lib/api/agent.api";
 import ProposalSystemInfoProposerEntry from "$lib/components/proposal-detail/ProposalSystemInfoProposerEntry.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import {
@@ -10,11 +11,14 @@ import {
   mutableMockAuthStoreSubscribe,
 } from "$tests/mocks/auth.store.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
 
 describe("ProposalMeta", () => {
   beforeEach(() => {
     jest.spyOn(console, "error").mockImplementation(jest.fn);
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   jest

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/NnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/NnsVotingCard.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as agent from "$lib/api/agent.api";
 import VotingCard from "$lib/components/proposal-detail/VotingCard/VotingCard.svelte";
 import { SECONDS_IN_YEAR } from "$lib/constants/constants";
 import { authStore } from "$lib/stores/auth.store";
@@ -16,11 +17,13 @@ import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import { MockGovernanceCanister } from "$tests/mocks/governance.canister.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import type { Ballot, NeuronInfo, ProposalInfo } from "@dfinity/nns";
 import { GovernanceCanister, ProposalStatus, Vote } from "@dfinity/nns";
 import { SnsNeuronPermissionType } from "@dfinity/sns";
 import { fireEvent, screen } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
 import { tick } from "svelte";
 import { writable } from "svelte/store";
 import ContextWrapperTest from "../../ContextWrapperTest.svelte";
@@ -70,6 +73,7 @@ describe("VotingCard", () => {
       .mockImplementation(mockAuthStoreSubscribe);
 
     neuronsStore.setNeurons({ neurons: [], certified: true });
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   afterAll(() => {

--- a/frontend/src/tests/lib/components/proposals/Proposer.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/Proposer.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as agent from "$lib/api/agent.api";
 import Proposer from "$lib/components/proposals/Proposer.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
@@ -9,8 +10,10 @@ import { MockGovernanceCanister } from "$tests/mocks/governance.canister.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import { mockProposals } from "$tests/mocks/proposals.store.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import { GovernanceCanister } from "@dfinity/nns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
 
 describe("Proposer", () => {
   const props = {
@@ -28,6 +31,7 @@ describe("Proposer", () => {
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   it("should render proposer", () => {

--- a/frontend/src/tests/lib/modals/neurons/VotingHistoryModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/VotingHistoryModal.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as agent from "$lib/api/agent.api";
 import VotingHistoryModal from "$lib/modals/neurons/VotingHistoryModal.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
@@ -9,8 +10,10 @@ import { MockGovernanceCanister } from "$tests/mocks/governance.canister.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import { mockProposals } from "$tests/mocks/proposals.store.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import { GovernanceCanister } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
 
 describe("VotingHistoryModal", () => {
   const props = {
@@ -28,6 +31,7 @@ describe("VotingHistoryModal", () => {
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   it("should display modal", () => {

--- a/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
+import * as agent from "$lib/api/agent.api";
 import * as governanceApi from "$lib/api/governance.api";
 import ProposalDetail from "$lib/pages/NnsProposalDetail.svelte";
 import { authStore } from "$lib/stores/auth.store";
@@ -22,8 +23,10 @@ import {
   mockProposals,
 } from "$tests/mocks/proposals.store.mock";
 import { silentConsoleErrors } from "$tests/utils/utils.test-utils";
+import type { HttpAgent } from "@dfinity/agent";
 import { GovernanceCanister, LedgerCanister } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
 
 jest.mock("$lib/api/governance.api");
 
@@ -60,6 +63,7 @@ describe("ProposalDetail", () => {
     jest
       .spyOn(neuronsStore, "subscribe")
       .mockImplementation(buildMockNeuronsStoreSubscribe([], false));
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   const props = {

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
+import * as agent from "$lib/api/agent.api";
 import * as governanceApi from "$lib/api/governance.api";
 import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
 import NnsProposals from "$lib/pages/NnsProposals.svelte";
@@ -29,12 +30,14 @@ import {
   mockProposals,
   mockProposalsStoreSubscribe,
 } from "$tests/mocks/proposals.store.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import {
   GovernanceCanister,
   type Proposal,
   type ProposalInfo,
 } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
 import type { Subscriber } from "svelte/store";
 
 jest.mock("$lib/api/governance.api");
@@ -51,6 +54,7 @@ describe("NnsProposals", () => {
     jest.clearAllMocks();
     resetNeuronsApiService();
     neuronsStore.reset();
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   describe("logged in user", () => {

--- a/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as agent from "$lib/api/agent.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import NeuronDetail from "$lib/routes/NeuronDetail.svelte";
@@ -17,10 +18,12 @@ import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NeuronDetailPo } from "$tests/page-objects/NeuronDetail.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { HttpAgent } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
 
 jest.mock("$lib/api/sns-aggregator.api");
 jest.mock("$lib/api/governance.api");
@@ -44,6 +47,7 @@ describe("NeuronDetail", () => {
   beforeEach(() => {
     resetIdentity();
     snsQueryStore.reset();
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   describe("nns neuron", () => {

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as agent from "$lib/api/agent.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import Neurons from "$lib/routes/Neurons.svelte";
@@ -16,10 +17,12 @@ import * as fakeSnsLedgerApi from "$tests/fakes/sns-ledger-api.fake";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { NeuronsPo } from "$tests/page-objects/Neurons.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { HttpAgent } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
 
 jest.mock("$lib/api/governance.api");
 jest.mock("$lib/api/sns-aggregator.api");
@@ -62,6 +65,7 @@ describe("Neurons", () => {
       rootCanisterId: testOpenSnsCanisterId.toText(),
       lifecycle: SnsSwapLifecycle.Open,
     });
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
 
     await loadSnsProjects();
   });

--- a/frontend/src/tests/lib/services/_public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns.services.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as agent from "$lib/api/agent.api";
 import * as aggregatorApi from "$lib/api/sns-aggregator.api";
 import * as governanceApi from "$lib/api/sns-governance.api";
 import {
@@ -30,7 +31,9 @@ import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
+import type { HttpAgent } from "@dfinity/agent";
 import { waitFor } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
 import { get } from "svelte/store";
 
 jest.mock("$lib/api/sns.api");
@@ -50,6 +53,10 @@ const blockedPaths = [
 
 describe("SNS public services", () => {
   blockAllCallsTo(blockedPaths);
+
+  beforeEach(() => {
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
+  });
 
   describe("loadSnsNervousSystemFunctions", () => {
     beforeEach(() => {

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -1,12 +1,14 @@
 /**
  * @jest-environment jsdom
  */
+import * as agent from "$lib/api/agent.api";
 import * as aggregatorApi from "$lib/api/sns-aggregator.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
 import { initAppPrivateData } from "$lib/services/app.services";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockAccountDetails } from "$tests/mocks/icp-accounts.store.mock";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import { toastsStore } from "@dfinity/gix-components";
 import { LedgerCanister } from "@dfinity/nns";
 import { mock } from "jest-mock-extended";
@@ -38,6 +40,7 @@ describe("app-services", () => {
 
     mockNNSDappCanister.getAccount.mockResolvedValue(mockAccountDetails);
     mockLedgerCanister.accountBalance.mockResolvedValue(BigInt(100_000_000));
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   it("should init Nns", async () => {

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as agent from "$lib/api/agent.api";
 import * as ledgerApi from "$lib/api/ckbtc-ledger.api";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import {
@@ -26,13 +27,14 @@ import {
 } from "$tests/mocks/ckbtc-accounts.mock";
 import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
 import { mockTokens } from "$tests/mocks/tokens.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import { CkBTCMinterCanister, type RetrieveBtcOk } from "@dfinity/ckbtc";
 import {
   IcrcLedgerCanister,
   decodeIcrcAccount,
   encodeIcrcAccount,
 } from "@dfinity/ledger";
-import mock from "jest-mock-extended/lib/Mock";
+import { mock } from "jest-mock-extended";
 
 jest.mock("$lib/services/ckbtc-transactions.services", () => {
   return {
@@ -71,6 +73,7 @@ describe("ckbtc-convert-services", () => {
     jest
       .spyOn(CkBTCMinterCanister, "create")
       .mockImplementation(() => minterCanisterMock);
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
 
     jest.spyOn(console, "error").mockImplementation(() => undefined);
 

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as agent from "$lib/api/agent.api";
 import * as ledgerApi from "$lib/api/sns-ledger.api";
 import * as services from "$lib/services/sns-accounts.services";
 import { loadSnsAccountTransactions } from "$lib/services/sns-transactions.services";
@@ -12,7 +13,9 @@ import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
+import type { HttpAgent } from "@dfinity/agent";
 import { waitFor } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
 import { tick } from "svelte";
 import { get } from "svelte/store";
 
@@ -23,6 +26,7 @@ jest.mock("$lib/services/sns-transactions.services", () => ({
 describe("sns-accounts-services", () => {
   beforeEach(() => {
     resetIdentity();
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   describe("loadSnsAccounts", () => {

--- a/frontend/src/tests/workflows/CreateSubaccount.spec.ts
+++ b/frontend/src/tests/workflows/CreateSubaccount.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { createSubAccount } from "$lib/api/accounts.api";
+import * as agent from "$lib/api/agent.api";
 import * as ledgerApi from "$lib/api/icp-ledger.api";
 import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
@@ -16,8 +17,10 @@ import {
   mockMainAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
+import type { HttpAgent } from "@dfinity/agent";
 import { fireEvent, waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
+import { mock } from "jest-mock-extended";
 
 jest.mock("$lib/api/accounts.api", () => {
   return {
@@ -43,6 +46,7 @@ describe("Accounts", () => {
     queryAccountSpy = jest
       .spyOn(nnsDappApi, "queryAccount")
       .mockResolvedValue(mockAccountDetails);
+    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
   it("should create a subaccount in NNS", async () => {


### PR DESCRIPTION
# Motivation

Modules imported before a test is loaded can't be mocked.
This means that `jest-spy.ts`, which is loaded before a test file is loaded, prevent us from testing certain things.
`jest-spy.ts` currently only mocks `createAgent` from `$lib/api/agent.api`, which can just be done explicitly in tests which need it.

# Changes

1. Remove `frontend/jest-spy.ts`.
2. Don't reference `frontend/jest-spy.ts` from `frontend/jest.config.cjs`.
3. In tests that need `createAgent` mocked, mock it explicitly.
4. In tests that call `createAgent` to get a mock agent, just create a mock agent directly.
5. Consistently use `import { mock } from "jest-mock-extended";` instead of sometimes `import mock from "jest-mock-extended/lib/Mock";`

# Tests

All tests still pass.

# Todos

- [x] Add entry to changelog (if necessary).
