### PR TITLE
Clean up ckbtc-convert.services.spec.ts

### DIFF
--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -85,7 +85,7 @@ describe("ckbtc-convert-services", () => {
 
   beforeEach(() => {
     resetIdentity();
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
     jest.clearAllTimers();
 
     ckBTCWithdrawalAccountsStore.reset();


### PR DESCRIPTION
# Motivation

The test sets mock behavior in a describe block, outside beforeEach or it.
This gets executed in a surprising order, because first the framework collects all the tests that should be executed by running the describe blocks, and then it runs all the tests.

This means that the structure of the code may suggest a certain test runs with a certain mock behavior, while it actually runs with the mock behavior define in another test or `describe` block.

Additionally, `beforeEach(() => ckBTCWithdrawalAccountsStore.reset);` has no effect because `() => ckBTCWithdrawalAccountsStore.reset` returns the `reset` function but doesn't call it.


# Changes

1. Make sure all mock behavior is defined in either `beforeEach` or inside a test.
2. Be explicit about which steps we expect to be performed.
3. Reset `ckBTCWithdrawalAccountsStore` in the top-level `beforeEach`.
3. Call `jest.restoreAllMock()` in the top-level `beforeEach` to make sure every test has a clean slate of mocks.
5. Change `beforeAll` to `beforeEach`.
6. Move declarations in `describe` blocks to the top of the block for consistency.
7. Remove redundant mock behavior to return `undefined` as it has no effect on test success.

# Tests

Previously the test would fail when run in a different order, but now it passes:
```
npm run test -- src/tests/lib/services/ckbtc-convert.services.spec.ts &&  for x in 1 2 3 4 5; do npm run test -- src/tests/lib/services/ckbtc-convert.services.spec.ts --randomize --seed $x; done
```

# Todos

- [ ] Add entry to changelog (if necessary).
Covered by an existing entry

