### PR TITLE
GIX-1821: Use "Open" filter for lauchpad proposals

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -21,6 +21,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Update SNS Swap types to match the latest canister interface. 
 * Hide by default the proposal summary in ballots.
 * Review checkboxes vertical alignment, border contrast on dark mode and remove hover background colors
+* Launchpad proposal requests only Open proposals of the SNS topic.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/services/$public/proposals.services.ts
+++ b/frontend/src/lib/services/$public/proposals.services.ts
@@ -24,7 +24,7 @@ import {
   proposalsHaveSameIds,
 } from "$lib/utils/proposals.utils";
 import type { Identity } from "@dfinity/agent";
-import type { ProposalId, ProposalInfo, Topic } from "@dfinity/nns";
+import type { ProposalId, ProposalInfo } from "@dfinity/nns";
 import { get } from "svelte/store";
 import { getCurrentIdentity } from "../auth.services";
 import {
@@ -174,30 +174,6 @@ const findProposals = async ({
     logMessage: `Syncing proposals ${
       beforeProposal === undefined ? "" : `from: ${hashCode(beforeProposal)}`
     }`,
-  });
-};
-
-export const loadProposalsByTopic = async ({
-  topic,
-  certified,
-}: {
-  topic: Topic;
-  certified: boolean;
-}): Promise<ProposalInfo[]> => {
-  const filters: ProposalsFiltersStore = {
-    ...get(proposalsFiltersStore),
-    topics: [topic],
-    rewards: [],
-    status: [],
-    excludeVotedProposals: false,
-    lastAppliedFilter: undefined,
-  };
-
-  return queryProposals({
-    beforeProposal: undefined,
-    identity: getCurrentIdentity(),
-    filters,
-    certified,
   });
 };
 

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -1,9 +1,9 @@
+import { queryProposals } from "$lib/api/proposals.api";
 import { querySnsProjects } from "$lib/api/sns-aggregator.api";
 import { getNervousSystemFunctions } from "$lib/api/sns-governance.api";
 import { buildAndStoreWrapper } from "$lib/api/sns-wrapper.api";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
-import { loadProposalsByTopic } from "$lib/services/$public/proposals.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import { i18n } from "$lib/stores/i18n";
 import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
@@ -19,7 +19,7 @@ import { isForceCallStrategy } from "$lib/utils/env.utils";
 import { toToastError } from "$lib/utils/error.utils";
 import { mapOptionalToken } from "$lib/utils/icrc-tokens.utils";
 import { convertDtoData } from "$lib/utils/sns-aggregator-converters.utils";
-import { Topic, type ProposalInfo } from "@dfinity/nns";
+import { ProposalStatus, Topic, type ProposalInfo } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import type { SnsNervousSystemFunction } from "@dfinity/sns";
 import { nonNullish, toNullable } from "@dfinity/utils";
@@ -149,10 +149,18 @@ export const loadProposalsSnsCF = async (): Promise<void> => {
   return queryAndUpdate<ProposalInfo[], unknown>({
     identityType: "anonymous",
     strategy: FORCE_CALL_STRATEGY,
-    request: ({ certified }) =>
-      loadProposalsByTopic({
+    request: ({ certified, identity }) =>
+      queryProposals({
+        beforeProposal: undefined,
+        identity,
+        filters: {
+          topics: [Topic.SnsAndCommunityFund],
+          rewards: [],
+          status: [ProposalStatus.Open],
+          excludeVotedProposals: false,
+          lastAppliedFilter: undefined,
+        },
         certified,
-        topic: Topic.SnsAndCommunityFund,
       }),
     onLoad: ({ response: proposals, certified }) =>
       snsProposalsStore.setProposals({


### PR DESCRIPTION
# Motivation

The launchpad renders the open proposals related to SNSes. We were fetching all the proposals of the topic and then filtering only the Open ones. We had a problem because there were big SNS proposals and the message limit was reached.

The way to solve it for the launchpad is to request only the OPEN and SNS topic.

# Changes

* Remove service "loadProposalsByTopic".
* Use queryProposals api in "loadProposalsSnsCF" with the topic and status filter.

# Tests

* Change the test of the Proposals.spec to spy on the api function and test that it's called with the proper values.

# Todos

- [x] Add entry to changelog (if necessary).
