### PR TITLE
GIX-1822: Fail gracefully on list proposal payload size error

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -15,6 +15,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * New tag for NNS neurons: "Hardware Wallet".
 * New derived state store for SNS projects.
 * Identify swap participation ICP transactions.
+* Improve error messaging on payload size limit in proposals list page.
 
 #### Changed
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -45,6 +45,7 @@
     "sns_accounts_balance_load": "An error occurred while loading the balance of the accounts.",
     "icrc_token_load": "An error occurred while loading the token balance or metadata.",
     "list_proposals": "There was an unexpected issue while searching for the proposals.",
+    "list_proposals_payload_too_large": "The current results are too large. Please try another filter with less results.",
     "get_proposal": "There was an unexpected issue while fetching proposal $proposalId.",
     "wrong_proposal_id": "The id \"$proposalId\" is not a valid proposal id.",
     "list_canisters": "There was an unexpected issue while searching for the canisters.",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -45,7 +45,7 @@
     "sns_accounts_balance_load": "An error occurred while loading the balance of the accounts.",
     "icrc_token_load": "An error occurred while loading the token balance or metadata.",
     "list_proposals": "There was an unexpected issue while searching for the proposals.",
-    "list_proposals_payload_too_large": "The current results are too large. Please try another filter with less results.",
+    "list_proposals_payload_too_large": "The current proposals response is too large. Please adjust proposal filters to get less results.",
     "get_proposal": "There was an unexpected issue while fetching proposal $proposalId.",
     "wrong_proposal_id": "The id \"$proposalId\" is not a valid proposal id.",
     "list_canisters": "There was an unexpected issue while searching for the canisters.",

--- a/frontend/src/lib/services/$public/proposals.services.ts
+++ b/frontend/src/lib/services/$public/proposals.services.ts
@@ -18,7 +18,7 @@ import {
 import { toastsError, toastsShow } from "$lib/stores/toasts.store";
 import { hashCode } from "$lib/utils/dev.utils";
 import { isForceCallStrategy } from "$lib/utils/env.utils";
-import { errorToString } from "$lib/utils/error.utils";
+import { errorToString, isPayloadSizeError } from "$lib/utils/error.utils";
 import {
   excludeProposals,
   proposalsHaveSameIds,
@@ -51,9 +51,13 @@ const handleFindProposalsError = ({
   ) {
     proposalsStore.setProposals({ proposals: [], certified });
 
+    const resultsTooLarge = isPayloadSizeError(err);
+
     toastsError({
-      labelKey: "error.list_proposals",
-      err,
+      labelKey: resultsTooLarge
+        ? "error.list_proposals_payload_too_large"
+        : "error.list_proposals",
+      err: resultsTooLarge ? undefined : err,
     });
   }
 };

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -49,6 +49,7 @@ interface I18nError {
   sns_accounts_balance_load: string;
   icrc_token_load: string;
   list_proposals: string;
+  list_proposals_payload_too_large: string;
   get_proposal: string;
   wrong_proposal_id: string;
   list_canisters: string;

--- a/frontend/src/lib/utils/error.utils.ts
+++ b/frontend/src/lib/utils/error.utils.ts
@@ -20,7 +20,7 @@ import {
   TransferError,
 } from "@dfinity/nns";
 import { SnsGovernanceError } from "@dfinity/sns";
-import { InvalidPercentageError } from "@dfinity/utils";
+import { InvalidPercentageError, nonNullish } from "@dfinity/utils";
 import { translate, type I18nSubstitutions } from "./i18n.utils";
 
 export const errorToString = (err?: unknown): string | undefined => {
@@ -142,4 +142,25 @@ export const toToastError = ({
       substitutions: (err as ErrorSubstitutions).substitutions,
     }),
   };
+};
+
+/**
+ * Identifies errors of payload size at the Replica level.
+ *
+ * Error message example: "Call failed:
+ * Canister: rrkah-fqaaa-aaaaa-aaaaq-cai
+ * Method: list_proposals (query)
+ * "Status": "rejected"
+ * "Code": "CanisterError"
+ * "Message": "IC0504: Canister rrkah-fqaaa-aaaaa-aaaaq-cai violated contract: ic0.msg_reply_data_append: application payload size (3824349) cannot be larger than 3145728""
+ */
+export const isPayloadSizeError = (err: unknown): boolean => {
+  if (typeof err === "object" && nonNullish(err) && "message" in err) {
+    const message = err.message as string;
+    return (
+      message.includes("payload size") &&
+      message.includes("cannot be larger than")
+    );
+  }
+  return false;
 };

--- a/frontend/src/tests/lib/services/_public/proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/proposals.services.spec.ts
@@ -136,7 +136,7 @@ describe("proposals-services", () => {
 
         expect(get(toastsStore)[0]).toMatchObject({
           level: "error",
-          text: "The current results are too large. Please try another filter with less results.",
+          text: "The current proposals response is too large. Please adjust proposal filters to get less results.",
         });
       });
 

--- a/frontend/src/tests/lib/services/_public/proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/proposals.services.spec.ts
@@ -27,6 +27,7 @@ import {
   resetIdentity,
 } from "$tests/mocks/auth.store.mock";
 import { mockProposals } from "$tests/mocks/proposals.store.mock";
+import { toastsStore } from "@dfinity/gix-components";
 import type { ProposalInfo } from "@dfinity/nns";
 import { get } from "svelte/store";
 
@@ -109,6 +110,52 @@ describe("proposals-services", () => {
           loadFinished: spy,
         });
         expect(spy).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe("list proposal fails", () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+        toastsStore.reset();
+        jest.spyOn(console, "error").mockImplementation(() => undefined);
+      });
+
+      it("show add toast error size too large", async () => {
+        const message = `Call failed:
+        Canister: rrkah-fqaaa-aaaaa-aaaaq-cai
+        Method: list_proposals (query)
+        "Status": "rejected"
+        "Code": "CanisterError"
+        "Message": "IC0504: Canister rrkah-fqaaa-aaaaa-aaaaq-cai violated contract: ic0.msg_reply_data_append: application payload size (3824349) cannot be larger than 3145728"`;
+        jest.spyOn(api, "queryProposals").mockRejectedValue(new Error(message));
+        await listProposals({
+          loadFinished: () => {
+            // do nothing here
+          },
+        });
+
+        expect(get(toastsStore)[0]).toMatchObject({
+          level: "error",
+          text: "The current results are too large. Please try another filter with less results.",
+        });
+      });
+
+      it("show error message from api", async () => {
+        const errorMessage = "Error message from api.";
+        jest
+          .spyOn(api, "queryProposals")
+          .mockRejectedValue(new Error(errorMessage));
+        await listProposals({
+          loadFinished: () => {
+            // do nothing here
+          },
+        });
+
+        expect(get(toastsStore)[0].text).toMatch(errorMessage);
+        expect(get(toastsStore)[0]).toMatchObject({
+          level: "error",
+          text: "There was an unexpected issue while searching for the proposals. Error message from api.",
+        });
       });
     });
 

--- a/frontend/src/tests/lib/utils/error.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/error.utils.spec.ts
@@ -1,5 +1,9 @@
 import { HardwareWalletAttachError } from "$lib/canisters/nns-dapp/nns-dapp.errors";
-import { errorToString, toToastError } from "$lib/utils/error.utils";
+import {
+  errorToString,
+  isPayloadSizeError,
+  toToastError,
+} from "$lib/utils/error.utils";
 import en from "$tests/mocks/i18n.mock";
 
 class TestError extends Error {
@@ -66,6 +70,25 @@ describe("error-utils", () => {
           err,
         })
       ).toEqual({ labelKey: "error.rename_subaccount" });
+    });
+  });
+
+  describe("isPayloadSizeError", () => {
+    it("returns true for payload size error", () => {
+      const message = `Call failed:
+       Canister: rrkah-fqaaa-aaaaa-aaaaq-cai
+       Method: list_proposals (query)
+       "Status": "rejected"
+       "Code": "CanisterError"
+       "Message": "IC0504: Canister rrkah-fqaaa-aaaaa-aaaaq-cai violated contract: ic0.msg_reply_data_append: application payload size (3824349) cannot be larger than 3145728"`;
+      const err = new Error(message);
+      expect(isPayloadSizeError(err)).toBe(true);
+    });
+
+    it("returns false for other errors and non errors", () => {
+      expect(isPayloadSizeError(new Error("test"))).toBe(false);
+      expect(isPayloadSizeError(undefined)).toBe(false);
+      expect(isPayloadSizeError({})).toBe(false);
     });
   });
 });


### PR DESCRIPTION
# Motivation

We had a problem because there were big SNS proposals and the message limit was reached. The current UX was not the best and didn't explain what the user could do.

In this PR: We catch that specific message and change it for a message that the user can understand and act upon.

# Changes

* New error util "isPayloadSizeError".
* Use new util in "handleFindProposalsError" which is used in "listProposals" service.

# Tests

* Test new error util.
* Add test cases in "listProposals" service for when api fails.

# Todos

- [ ] Add entry to changelog (if necessary).
