### PR TITLE
GIX-1820: Identify Swap Refund Transaction

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -465,6 +465,7 @@
     "topUpNeuron": "Top-up Neuron",
     "createCanister": "Create Canister",
     "topUpCanister": "Top-up Canister",
+    "refundSwap": "Swap Refund",
     "participateSwap": "Decentralization Swap"
   },
   "ckbtc_transaction_names": {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -481,6 +481,7 @@ interface I18nTransaction_names {
   topUpNeuron: string;
   createCanister: string;
   topUpCanister: string;
+  refundSwap: string;
   participateSwap: string;
 }
 

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -63,6 +63,7 @@ export enum AccountTransactionType {
   CreateCanister = "createCanister",
   TopUpCanister = "topUpCanister",
   ParticipateSwap = "participateSwap",
+  RefundSwap = "refundSwap",
 }
 
 export interface Transaction {

--- a/frontend/src/lib/utils/transactions.utils.ts
+++ b/frontend/src/lib/utils/transactions.utils.ts
@@ -38,6 +38,13 @@ export const transactionType = ({
     }
   }
 
+  if ("Receive" in transfer) {
+    const { from } = transfer.Receive;
+    if (swapCanisterAccounts.has(from)) {
+      return AccountTransactionType.RefundSwap;
+    }
+  }
+
   if ("Transfer" in transaction_type[0]) {
     return AccountTransactionType.Send;
   } else if ("StakeNeuron" in transaction_type[0]) {

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -168,6 +168,30 @@ describe("transactions-utils", () => {
       ).toBe(AccountTransactionType.ParticipateSwap);
     });
 
+    it("determines type by swapCanisterAccounts and Receive transaction", () => {
+      const swapCanisterId = principal(0);
+      const swapCanisterAccount = getSwapCanisterAccount({
+        controller: mockMainAccount.principal,
+        swapCanisterId,
+      });
+      const swapTransaction: Transaction = {
+        ...mockReceivedFromMainAccountTransaction,
+        transfer: {
+          Receive: {
+            fee: { e8s: BigInt(10000) },
+            amount: { e8s: BigInt(110000000) },
+            from: swapCanisterAccount.toHex(),
+          },
+        },
+      };
+      expect(
+        transactionType({
+          transaction: swapTransaction,
+          swapCanisterAccounts: new Set([swapCanisterAccount.toHex()]),
+        })
+      ).toBe(AccountTransactionType.RefundSwap);
+    });
+
     it("determines type withoug transaction_type value", () => {
       expect(
         transactionType({
@@ -368,6 +392,31 @@ describe("transactions-utils", () => {
         swapCanisterAccounts: new Set([swapCanisterAccount.toHex()]),
       });
       expect(type).toBe(AccountTransactionType.ParticipateSwap);
+    });
+
+    it("supports swap refund transaction type", () => {
+      const swapCanisterId = principal(0);
+      const swapCanisterAccount = getSwapCanisterAccount({
+        controller: mockMainAccount.principal,
+        swapCanisterId,
+      });
+      const swapTransaction: Transaction = {
+        ...mockReceivedFromMainAccountTransaction,
+        transfer: {
+          Receive: {
+            fee: { e8s: BigInt(10000) },
+            amount: { e8s: BigInt(110000000) },
+            from: swapCanisterAccount.toHex(),
+          },
+        },
+      };
+      const { type } = mapNnsTransaction({
+        transaction: swapTransaction,
+        account: mockMainAccount,
+        toSelfTransaction: false,
+        swapCanisterAccounts: new Set([swapCanisterAccount.toHex()]),
+      });
+      expect(type).toBe(AccountTransactionType.RefundSwap);
     });
   });
 


### PR DESCRIPTION
# Motivation

The transactions list in the ICP wallet identifies the swap participation transaction. Therefore, we should also identify the refunds.

# Changes

* Add a transaction type in `AccountTransactionType`.
* Add a check in `transactionType` util to identify swap refunds.

# Tests

* Test new case in `transactionType`.
* Test new case in `mapNnsTransaction`.

# Todos

- [ ] Add entry to changelog (if necessary).
