### PR TITLE
Test pagination

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -337,28 +337,8 @@ jobs:
             echo ERROR: Expected to have $expect SNS in the aggregator but found $actual.
             scripts/sns/aggregator/get_log
           }
-      - name: Get the first page of data from the sns aggregator
-        run: |
-          AGGREGATOR_CANISTER_ID="$(dfx canister id sns_aggregator)"
-          curl --retry 5 -Lf "http://${AGGREGATOR_CANISTER_ID}.localhost:8080/v1/sns/list/page/0/slow.json" | tee aggregate-1.json || {
-            echo "ERROR: Failed to get data."
-            scripts/sns/aggregator/get_log
-          }
-          expect=10
-          actual="$(jq length aggregate-1.json)"
-          (( expect == actual ))  || {
-            echo ERROR: Expected to have $expect SNS in the aggregator but found $actual.
-            scripts/sns/aggregator/get_log
-          }
-      - name: Get the second page of data from the sns aggregator
-        run: |
-          AGGREGATOR_CANISTER_ID="$(dfx canister id sns_aggregator)"
-          curl -Lf "http://${AGGREGATOR_CANISTER_ID}.localhost:8080/v1/sns/list/page/1/slow.json" | tee aggregate-1.json
-          expect=2
-          actual="$(jq length aggregate-1.json)"
-          (( expect == actual ))  || {
-            echo ERROR: Expected to have $expect SNS in the aggregator but found $actual.
-          }
+      - name: Test the paginated endpoint
+        run: scripts/sns/aggregator/test-pagination --num 12
       - name: Get logs
         run: |
           scripts/sns/aggregator/get_log > ,logs
@@ -370,15 +350,8 @@ jobs:
           }
       - name: Upgrade the aggregator to self with a slow refresh rate
         run: dfx canister install --mode upgrade --wasm sns_aggregator_dev.wasm.gz --upgrade-unchanged sns_aggregator '(opt record { update_interval_ms = 1_000_000_000; fast_interval_ms = 1_000_000_000; })'
-      - name: Expect the first page of data to be retained over the upgrade
-        run: |
-          AGGREGATOR_CANISTER_ID="$(dfx canister id sns_aggregator)"
-          curl -Lf "http://${AGGREGATOR_CANISTER_ID}.localhost:8080/v1/sns/list/page/0/slow.json" | tee aggregate-1.json
-          expect=10
-          actual="$(jq length aggregate-1.json)"
-          (( expect == actual ))  || {
-            echo ERROR: Expected to have $expect SNS in the aggregator but found $actual.
-          }
+      - name: Expect the paginated data to be retained over the upgrade
+        run: scripts/sns/aggregator/test-pagination --num 12
       - name: Expect the latest data to be retained over the upgrade
         run: |
           AGGREGATOR_CANISTER_ID="$(dfx canister id sns_aggregator)"

--- a/CHANGELOG-Sns_Aggregator.md
+++ b/CHANGELOG-Sns_Aggregator.md
@@ -9,9 +9,11 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 ## Unreleased
 
 ### Added
-- Display commit, branch name and similar data when deploying to a test canister.
+* More tests that the SNS aggregator contains the expected number of SNSs.
+* Display commit, branch name and similar data when deploying to a test canister.
 ### Changed
 ### Fixed
+* Update the path to the `nns-sns-wasm` .did file.
 * Update the index.html when it has changed.
 ### Security
 ### Not Published

--- a/dfx.json
+++ b/dfx.json
@@ -72,7 +72,7 @@
       "build": [
         "true"
       ],
-      "candid": "target/ic/sns_wasm.did",
+      "candid": "declarations/sns_wasm/sns_wasm.did",
       "wasm": "target/ic/sns-wasm-canister.wasm",
       "type": "custom",
       "remote": {

--- a/scripts/sns/aggregator/test-pagination
+++ b/scripts/sns/aggregator/test-pagination
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+# shellcheck disable=SC2317
+print_help() {
+  cat <<-EOF
+
+	Tests that SNSs can be obtained without error from the aggregator.
+
+	Prerequisites:
+	 * The aggregator has been installed.
+	 * The aggregator has had time to populate its cache, so all data should be present and correct.
+	 * No new SNSs are being added, as this could cause a race condition when checking
+	  the number of SNSs against the "latest" endpoint.
+	EOF
+}
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/../../clap.bash"
+# Define options
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+clap.define short=s long=num desc="The number of SNSs" variable=NUM_SNS default=""
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+EXIT=0
+
+AGGREGATOR_CANISTER_URL="$(dfx-canister-url --network "$DFX_NETWORK" sns_aggregator)"
+curl --fail -sSL "$AGGREGATOR_CANISTER_URL" >/dev/null || {
+  echo "ERROR: SNS aggregator not found at $AGGREGATOR_CANISTER_URL"
+  exit 1
+} >&2
+[[ "" != "${NUM_SNS:-}" ]] || NUM_SNS="$(curl --fail -sSL "${AGGREGATOR_CANISTER_URL}/v1/sns/list/latest/slow.json" | jq '.[0].index +1' 2>/dev/null || echo 0)"
+
+(
+  printf "\n\n\n=========================================\n"
+  printf "%s\n" "Test that:" \
+    " * Successive pages can be downloaded until we get a page that is not full." \
+    " * These pages provide the same number of SNS suggested by the 'latest' API."
+  PAGE_SIZE=10
+  PAGE_FILE="$(mktemp aggregator-last-page-XXXXX.json)"
+  for ((page = 0, sns_count = 0; ; page++)); do
+    # Get the page
+    curl -Lf "${AGGREGATOR_CANISTER_URL}/v1/sns/list/page/${page}/slow.json" -o "$PAGE_FILE"
+    # Verify that the expected number of SNSs is prseent.
+    expect=$((sns_count + PAGE_SIZE > NUM_SNS ? NUM_SNS - sns_count : PAGE_SIZE))
+    actual="$(jq length "$PAGE_FILE")"
+    sns_count=$((sns_count + actual))
+    ((expect == actual)) || {
+      echo ERROR: Expected to have $expect SNS in the aggregator page $page but found $actual.
+      echo Data is in: $PAGE_FILE
+      exit 1
+    } >&2
+    # Verify that the SNS indices in each page are as expected
+    expect="$(seq "$((PAGE_SIZE * page))" "$((sns_count - 1))")"
+    actual="$(jq '.[]|.index' "$PAGE_FILE")"
+    [[ "$expect" == "$actual" ]] || {
+      echo ERROR: Expected to have $expect SNS in the aggregator page $page but found $actual.
+      echo Data is in: $PAGE_FILE
+      exit 1
+    } >&2
+    # A caller should be able to get pages until we have all SNSs
+    # Note: This will change, so that we can get pages until we geta non-empty page.
+    ((sns_count < NUM_SNS)) || break
+  done
+)

--- a/scripts/sns/aggregator/test-pagination
+++ b/scripts/sns/aggregator/test-pagination
@@ -19,17 +19,25 @@ print_help() {
 source "$SOURCE_DIR/../../clap.bash"
 # Define options
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
-clap.define short=s long=num desc="The number of SNSs" variable=NUM_SNS default=""
+clap.define short=s long=num desc="The number of SNSs; should match dfx canister call nns-sns-wasm list_deployed_snses --network XXX '(record {})' | idl2json | jq '.instances | length'" variable=NUM_SNS default=""
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-EXIT=0
 
+# Get and check the canister URL.
 AGGREGATOR_CANISTER_URL="$(dfx-canister-url --network "$DFX_NETWORK" sns_aggregator)"
 curl --fail -sSL "$AGGREGATOR_CANISTER_URL" >/dev/null || {
   echo "ERROR: SNS aggregator not found at $AGGREGATOR_CANISTER_URL"
   exit 1
 } >&2
-[[ "" != "${NUM_SNS:-}" ]] || NUM_SNS="$(curl --fail -sSL "${AGGREGATOR_CANISTER_URL}/v1/sns/list/latest/slow.json" | jq '.[0].index +1' 2>/dev/null || echo 0)"
+
+# Get the number of SNSs
+sns_from_latest() {
+  curl --fail -sSL "${AGGREGATOR_CANISTER_URL}/v1/sns/list/latest/slow.json" | jq '.[0].index +1' 2>/dev/null || echo 0
+}
+sns_from_wasm_canister() {
+  dfx canister call nns-sns-wasm list_deployed_snses --network "$DFX_NETWORK" '(record {})' | idl2json | jq '.instances | length'
+}
+[[ "" != "${NUM_SNS:-}" ]] || NUM_SNS="$(sns_from_wasm_canister || sns_from_latest)"
 
 (
   printf "\n\n\n=========================================\n"
@@ -37,27 +45,29 @@ curl --fail -sSL "$AGGREGATOR_CANISTER_URL" >/dev/null || {
     " * Successive pages can be downloaded until we get a page that is not full." \
     " * These pages provide the same number of SNS suggested by the 'latest' API."
   PAGE_SIZE=10
-  PAGE_FILE="$(mktemp aggregator-last-page-XXXXX.json)"
   for ((page = 0, sns_count = 0; ; page++)); do
     # Get the page
+    PAGE_FILE="$(mktemp aggregator-last-page-XXXXX.json)"
     curl -Lf "${AGGREGATOR_CANISTER_URL}/v1/sns/list/page/${page}/slow.json" -o "$PAGE_FILE"
     # Verify that the expected number of SNSs is prseent.
     expect=$((sns_count + PAGE_SIZE > NUM_SNS ? NUM_SNS - sns_count : PAGE_SIZE))
     actual="$(jq length "$PAGE_FILE")"
     sns_count=$((sns_count + actual))
     ((expect == actual)) || {
-      echo ERROR: Expected to have $expect SNS in the aggregator page $page but found $actual.
-      echo Data is in: $PAGE_FILE
+      echo "ERROR: Expected to have $expect SNS in the aggregator page $page but found $actual."
+      echo "Data is in: $PAGE_FILE"
       exit 1
     } >&2
     # Verify that the SNS indices in each page are as expected
     expect="$(seq "$((PAGE_SIZE * page))" "$((sns_count - 1))")"
     actual="$(jq '.[]|.index' "$PAGE_FILE")"
     [[ "$expect" == "$actual" ]] || {
-      echo ERROR: Expected to have $expect SNS in the aggregator page $page but found $actual.
-      echo Data is in: $PAGE_FILE
+      echo "ERROR: Expected to have $expect SNS in the aggregator page $page but found $actual."
+      echo "Data is in: $PAGE_FILE"
       exit 1
     } >&2
+    # Clean up
+    rm "$PAGE_FILE"
     # A caller should be able to get pages until we have all SNSs
     # Note: This will change, so that we can get pages until we geta non-empty page.
     ((sns_count < NUM_SNS)) || break

--- a/scripts/sns/aggregator/test-pagination
+++ b/scripts/sns/aggregator/test-pagination
@@ -49,7 +49,7 @@ sns_from_wasm_canister() {
     # Get the page
     PAGE_FILE="$(mktemp aggregator-last-page-XXXXX.json)"
     curl -Lf "${AGGREGATOR_CANISTER_URL}/v1/sns/list/page/${page}/slow.json" -o "$PAGE_FILE"
-    # Verify that the expected number of SNSs is prseent.
+    # Verify that the expected number of SNSs is present.
     expect=$((sns_count + PAGE_SIZE > NUM_SNS ? NUM_SNS - sns_count : PAGE_SIZE))
     actual="$(jq length "$PAGE_FILE")"
     sns_count=$((sns_count + actual))

--- a/scripts/sns/aggregator/test-pagination
+++ b/scripts/sns/aggregator/test-pagination
@@ -12,7 +12,7 @@ print_help() {
 	 * The aggregator has been installed.
 	 * The aggregator has had time to populate its cache, so all data should be present and correct.
 	 * No new SNSs are being added, as this could cause a race condition when checking
-	  the number of SNSs against the "latest" endpoint.
+	   the number of SNSs against the "latest" endpoint.
 	EOF
 }
 # Source the clap.bash file ---------------------------------------------------
@@ -42,8 +42,8 @@ sns_from_wasm_canister() {
 (
   printf "\n\n\n=========================================\n"
   printf "%s\n" "Test that:" \
-    " * Successive pages can be downloaded until we get a page that is not full." \
-    " * These pages provide the same number of SNS suggested by the 'latest' API."
+    " * These pages provide the expected number of SNSs" \
+    " * The SNS indices on each page are as expected."
   PAGE_SIZE=10
   for ((page = 0, sns_count = 0; ; page++)); do
     # Get the page
@@ -69,7 +69,7 @@ sns_from_wasm_canister() {
     # Clean up
     rm "$PAGE_FILE"
     # A caller should be able to get pages until we have all SNSs
-    # Note: This will change, so that we can get pages until we geta non-empty page.
+    # Note: This will change, so that we can get pages until we get a non-empty page.
     ((sns_count < NUM_SNS)) || break
   done
 )


### PR DESCRIPTION
# Motivation
We are about to change the pagination; it would be good to be sure that the pagination is as expected.

# Changes
* Add a test that the pages are present and contain the expected SNS indices.
* Update the `nns-sns-wasm` .did file path to use the file we have committed in the repo.
  * Note: This means that the .did file is available and can be used without building, unlike the previous code.
  * Note: The existing path was built when building custom sns canisters for e2e tests, however the old e2e tests with the custom builds may be deleted soon.
  * Note: There are probbaly other .did paths that should be updated, but only this update is needed for the API call made in the test.

# Tests
* This PR contains a test and the test is exercised in CI.
* I have run this test against mainnet and the app subnet aggregator:
  ```
   max@sinkpad:~/dfn/nns-dapp/branches/test-pagination (2:03:06)$ dfx-canister-set-id --canister_name sns_aggregator --canister_id otgyv-wyaaa-aaaak-qcgba-cai --network ic
   max@sinkpad:~/dfn/nns-dapp/branches/test-pagination (2:03:18)$ scripts/sns/aggregator/test-pagination --network ic
   max@sinkpad:~/dfn/nns-dapp/branches/test-pagination (2:03:22)$ scripts/sns/aggregator/test-pagination --network mainnet
   max@sinkpad:~/dfn/nns-dapp/branches/test-pagination (2:03:26)$ 
  ```
  (I have deleted stdout to keep the text short)

# Todos

- [x] Add entry to changelog (if necessary).
