### PR TITLE
GIX-1823: New sns lifecycle store

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -16,6 +16,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * New derived state store for SNS projects.
 * Identify swap participation ICP transactions.
 * Improve error messaging on payload size limit in proposals list page.
+* New lifecycle store for SNS projects.
 
 #### Changed
 

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -7,6 +7,7 @@ import {
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { WATCH_SALE_STATE_EVERY_MILLISECONDS } from "$lib/constants/sns.constants";
 import { getOrCreateDerivedStateStore } from "$lib/stores/sns-derived-state.store";
+import { getOrCreateLifecycleStore } from "$lib/stores/sns-lifecycle.store";
 import {
   snsQueryStore,
   snsSummariesStore,
@@ -214,10 +215,19 @@ export const loadSnsLifecycle = async ({
         identity,
         certified,
       }),
-    onLoad: ({ response: lifecycleResponse }) => {
+    onLoad: ({ response: lifecycleResponse, certified }) => {
       const lifecycle = fromNullable(lifecycleResponse?.lifecycle ?? []);
       if (nonNullish(lifecycle)) {
         snsQueryStore.updateLifecycle({ lifecycle, rootCanisterId });
+      }
+      if (nonNullish(lifecycleResponse)) {
+        const lifecycleStore = getOrCreateLifecycleStore(
+          Principal.from(rootCanisterId)
+        );
+        lifecycleStore.setData({
+          data: lifecycleResponse,
+          certified,
+        });
       }
     },
     onError: ({ error: err, certified }) => {

--- a/frontend/src/lib/stores/sns-lifecycle.store.ts
+++ b/frontend/src/lib/stores/sns-lifecycle.store.ts
@@ -1,0 +1,56 @@
+import type { Principal } from "@dfinity/principal";
+import type { SnsGetLifecycleResponse } from "@dfinity/sns";
+import { nonNullish } from "@dfinity/utils";
+import { writable, type Readable } from "svelte/store";
+
+interface SnsLifecycleData {
+  data: SnsGetLifecycleResponse;
+  certified: boolean;
+}
+
+export interface SnsLifecycleStore
+  extends Readable<SnsLifecycleData | undefined> {
+  setData: (data: SnsLifecycleData) => void;
+  reset: () => void;
+}
+
+let stores: Map<string, SnsLifecycleStore> = new Map();
+
+export const resetLiefcycleStoresForTesting = () => {
+  stores = new Map();
+};
+
+/**
+ * A store that contains the lifecycle of a specific sns project.
+ *
+ * - setData: replace the current lifecycle with a new one.
+ */
+const createSnsLifecycleStore = (): SnsLifecycleStore => {
+  const { subscribe, set } = writable<SnsLifecycleData | undefined>(undefined);
+
+  return {
+    subscribe,
+
+    setData(data: SnsLifecycleData) {
+      set(data);
+    },
+
+    reset() {
+      set(undefined);
+    },
+  };
+};
+
+export const getOrCreateLifecycleStore = (
+  rootCanisterId: Principal
+): SnsLifecycleStore => {
+  const key = rootCanisterId.toText();
+  const existingStore = stores.get(key);
+  if (nonNullish(existingStore)) {
+    return existingStore;
+  }
+
+  const newStore = createSnsLifecycleStore();
+  stores.set(key, newStore);
+  return newStore;
+};

--- a/frontend/src/lib/stores/sns-lifecycle.store.ts
+++ b/frontend/src/lib/stores/sns-lifecycle.store.ts
@@ -14,10 +14,10 @@ export interface SnsLifecycleStore
   reset: () => void;
 }
 
-let stores: Map<string, SnsLifecycleStore> = new Map();
+const stores: Map<string, SnsLifecycleStore> = new Map();
 
 export const resetLiefcycleStoresForTesting = () => {
-  stores = new Map();
+  stores.clear();
 };
 
 /**

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -10,6 +10,7 @@ import {
   getOrCreateDerivedStateStore,
   resetDerivedStateStoresForTesting,
 } from "$lib/stores/sns-derived-state.store";
+import { getOrCreateLifecycleStore } from "$lib/stores/sns-lifecycle.store";
 import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import {
   mockIdentity,
@@ -369,6 +370,9 @@ describe("sns-services", () => {
         (swap) => swap.rootCanisterId === rootCanisterId1.toText()
       )?.swap[0].lifecycle;
       expect(updatedLifecycle).toEqual(newLifeCycle);
+
+      const lifecycleStore = getOrCreateLifecycleStore(rootCanisterId1);
+      expect(get(lifecycleStore).data).toEqual(lifeCycleResponse);
     });
   });
 });

--- a/frontend/src/tests/lib/stores/sns-lifecycle.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-lifecycle.store.spec.ts
@@ -1,0 +1,42 @@
+import {
+  getOrCreateLifecycleStore,
+  resetLiefcycleStoresForTesting,
+} from "$lib/stores/sns-lifecycle.store";
+import {
+  mockLifecycleResponse,
+  principal,
+} from "$tests/mocks/sns-projects.mock";
+import { get } from "svelte/store";
+
+describe("sns lifecycle store", () => {
+  beforeEach(() => {
+    resetLiefcycleStoresForTesting();
+  });
+
+  it("should create a store for a given root canister id and store lifecycle", () => {
+    const rootCanisterId = principal(0);
+    const store = getOrCreateLifecycleStore(rootCanisterId);
+
+    store.setData({
+      certified: true,
+      data: mockLifecycleResponse,
+    });
+
+    expect(get(store).data).toEqual(mockLifecycleResponse);
+  });
+
+  it("should cache stores per root canister id", () => {
+    const rootCanisterId = principal(0);
+    const store = getOrCreateLifecycleStore(rootCanisterId);
+
+    const store2 = getOrCreateLifecycleStore(rootCanisterId);
+    expect(store).toBe(store2);
+  });
+
+  it("should not cache stores for different root canister id", () => {
+    const store = getOrCreateLifecycleStore(principal(0));
+
+    const store2 = getOrCreateLifecycleStore(principal(1));
+    expect(store).not.toBe(store2);
+  });
+});

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -16,6 +16,7 @@ import { Principal } from "@dfinity/principal";
 import {
   SnsSwapLifecycle,
   type SnsGetDerivedStateResponse,
+  type SnsGetLifecycleResponse,
   type SnsGetMetadataResponse,
   type SnsParams,
   type SnsSwap,
@@ -389,4 +390,9 @@ export const mockTokenStore = (run: Subscriber<Token>) => {
 export const mockUniverse: Universe = {
   canisterId: principal(0).toText(),
   summary: mockSnsFullProject.summary,
+};
+
+export const mockLifecycleResponse: SnsGetLifecycleResponse = {
+  lifecycle: [SnsSwapLifecycle.Open],
+  decentralization_sale_open_timestamp_seconds: [],
 };


### PR DESCRIPTION
# Motivation

Final motivation: Stop using get_state. But on the way, clean the unnecessary complexity of snsQueryStore.

In this PR: Introduce a new Svelte store that will store the data from the get_lifecycle call.

This store is needed to store the latest lifecycle after the user's participation.

# Changes

* New sns lifecycle store creator with caching.
* Load the store when the derived state is fetched directly in "loadSnsLifecycle".

# Tests

* Test the new store
* Test that "loadSnsTotalCommitment" also loads the new store.

# Todos

- [x] Add entry to changelog (if necessary).
