### PR TITLE
Add tests for createAgent

### DIFF
--- a/frontend/src/tests/lib/api/agent.api.spec.ts
+++ b/frontend/src/tests/lib/api/agent.api.spec.ts
@@ -1,0 +1,62 @@
+import * as agentApi from "$lib/api/agent.api";
+import type { HttpAgent, Identity } from "@dfinity/agent";
+import { Principal } from "@dfinity/principal";
+import * as utils from "@dfinity/utils";
+import { mock } from "jest-mock-extended";
+
+jest.mock("@dfinity/utils");
+
+const host = "http://localhost:8000";
+const testPrincipal1 = Principal.fromHex("123123123");
+const testPrincipal2 = Principal.fromHex("456456456");
+
+const createIdentity = (principal: Principal) =>
+  ({
+    getPrincipal: () => principal,
+  } as Identity);
+
+const createAgent = (identity: Identity) =>
+  agentApi.createAgent({
+    identity,
+    host,
+  });
+
+describe("agent-api", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    agentApi.resetAgents();
+
+    jest
+      .spyOn(utils, "createAgent")
+      .mockImplementation(async ({ identity }) => {
+        const mockAgent = mock<HttpAgent>();
+        mockAgent.getPrincipal.mockResolvedValue(identity.getPrincipal());
+        return mockAgent;
+      });
+  });
+
+  it("createAgent should create an agent", async () => {
+    const testIdentity = createIdentity(testPrincipal1);
+    const agent = await createAgent(testIdentity);
+
+    expect(await agent.getPrincipal()).toEqual(testPrincipal1);
+  });
+
+  it("createAgent should cache the agent for the same identity", async () => {
+    const testIdentity = createIdentity(testPrincipal1);
+    const agent1 = await createAgent(testIdentity);
+    const agent2 = await createAgent(testIdentity);
+
+    expect(agent1).toBe(agent2);
+  });
+
+  it("createAgent returns a different agent for a different identity", async () => {
+    const testIdentity1 = createIdentity(testPrincipal1);
+    const testIdentity2 = createIdentity(testPrincipal2);
+    const agent1 = await createAgent(testIdentity1);
+    const agent2 = await createAgent(testIdentity2);
+
+    expect(await agent1.getPrincipal()).toEqual(testPrincipal1);
+    expect(await agent2.getPrincipal()).toEqual(testPrincipal2);
+  });
+});


### PR DESCRIPTION
# Motivation

I want add a wrapper for `Agent` which provides a different `Identity` instance and use that to wrap agents cached in the agent API.
But before I do, I'm adding some test coverage to the agent API because currently there is none.

# Changes

Add tests for `createAgent` from `agent.api.ts`.

# Tests

yes

# Todos

- [ ] Add entry to changelog (if necessary).
will add when I add the agent wrapper