### PR TITLE
GIX-1824: Fix Canisters.spec

### DIFF
--- a/frontend/src/tests/lib/pages/Canisters.spec.ts
+++ b/frontend/src/tests/lib/pages/Canisters.spec.ts
@@ -56,11 +56,13 @@ describe("Canisters", () => {
   });
 
   it("should subscribe to store", () => {
+    expect(authStoreMock).not.toHaveBeenCalled();
     render(Canisters);
     expect(authStoreMock).toHaveBeenCalled();
   });
 
   it("should load canisters", () => {
+    expect(listCanisters).not.toHaveBeenCalled();
     render(Canisters);
     expect(listCanisters).toHaveBeenCalled();
   });

--- a/frontend/src/tests/lib/pages/Canisters.spec.ts
+++ b/frontend/src/tests/lib/pages/Canisters.spec.ts
@@ -54,10 +54,15 @@ describe("Canisters", () => {
     expect(getByText(en.core.ic)).toBeInTheDocument();
   });
 
-  it("should subscribe to store", () =>
-    expect(authStoreMock).toHaveBeenCalled());
+  it("should subscribe to store", () => {
+    render(Canisters);
+    expect(authStoreMock).toHaveBeenCalled();
+  });
 
-  it("should load canisters", () => expect(listCanisters).toHaveBeenCalled());
+  it("should load canisters", () => {
+    render(Canisters);
+    expect(listCanisters).toHaveBeenCalled();
+  });
 
   it("should render a principal as text", () => {
     const { getByText } = render(Canisters);

--- a/frontend/src/tests/lib/pages/Canisters.spec.ts
+++ b/frontend/src/tests/lib/pages/Canisters.spec.ts
@@ -39,6 +39,7 @@ describe("Canisters", () => {
   let authStoreMock: jest.SpyInstance;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     authStoreMock = jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);


### PR DESCRIPTION
# Motivation

Some test cases in Canisters.spec relied on the page to be rendered in previous unit tests to pass.

# Changes

* Render the page in the specific test cases instead or relying in the previous renders.
* Clear all mocks to make sure the call belong to the test.

# Tests

Only test changes

# Todos

- [ ] Add entry to changelog (if necessary).
Already covered by a changelog entry.
