### PR TITLE
GIX-1824: Fix SnsAccounts.spec

### DIFF
--- a/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
@@ -142,7 +142,7 @@ describe("SnsAccounts", () => {
 
   describe("when no accounts", () => {
     it("should not render a token amount component nor zero", async () => {
-      const { container } = await render(SnsAccounts);
+      const { container } = await renderAndFinishLoading({});
       expect(hasAmountRendered(container)).toBe(false);
     });
   });


### PR DESCRIPTION
# Motivation

Fix SnsAccounts.spec.

The problem was that two mocks were messing up with the test cases if set in a different order. Some test cases relied on the mocks, others not. Clearing mocks was not enough, we had to resetAllMocks. Yet, instead of resetting the mocks, I removed the mocks and relied on filling the stores properly.

# Changes

In SnsAccounts.spec
* Remove mock on "snsProjectSelectedStore".
* Move page.mock to the main beforeEach.
* Remove mock on "snsProjectAccountsStore".

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Already covered by a changelog entry.
