### PR TITLE
GIX-1824: Fix LinkCanisterModal.spec

### DIFF
--- a/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
@@ -25,6 +25,10 @@ jest.mock("$lib/stores/toasts.store", () => {
 });
 
 describe("LinkCanisterModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("should display modal", () => {
     const { container } = render(LinkCanisterModal);
 
@@ -65,6 +69,7 @@ describe("LinkCanisterModal", () => {
     const onClose = jest.fn();
     component.$on("nnsClose", onClose);
 
+    expect(attachCanister).not.toBeCalled();
     await clickByTestId(queryByTestId, "link-canister-button");
     expect(attachCanister).toBeCalled();
 
@@ -78,10 +83,11 @@ describe("LinkCanisterModal", () => {
 
     await fillForm({
       container,
-      name: "test",
-      principalText: "z".repeat(MAX_CANISTER_NAME_LENGTH),
+      name: "z".repeat(MAX_CANISTER_NAME_LENGTH),
+      principalText: "aaaaa-aa",
     });
 
+    expect(attachCanister).not.toBeCalled();
     await clickByTestId(queryByTestId, "link-canister-button");
     expect(attachCanister).toBeCalled();
   });


### PR DESCRIPTION
# Motivation

Fix LinkCanisterModal.spec

The problem was that `"should attach a canister by id if name is maximum length"` test should be failing, but it was passing because the mock was not being cleared and the api was called in a previous test. If I cleared to mocks in the beforeEach, the test was failing with the normal order.

The problem with the test was that the principal was not a valid principal. It was mixing up principalText and name. I changed so that the name had the max length, and set a valid principalText. That fixed the test.

I also added an expect before clicking the button that the api was not called.

# Changes

In LinkCanisterModal.spec
* Add jest.clearAllMocks in beforeEach.
* Add a valid principal in "principalText" for `"should attach a canister by id if name is maximum length"` and the max length name in the `name` field.
* Add expectations of api not being called.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Already covered by a changelog entry.
