### PR TITLE
GIX-1823: Converter agg data to SnsSummary

### DIFF
--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -372,7 +372,7 @@ const convertDtoToTokenMetadata = (
 
 const convertDtoToSnsSummarySwap = (
   swap: CachedSnsSwapDto
-): SnsSummarySwap | undefined => ({
+): SnsSummarySwap => ({
   ...convertSwap(swap),
   decentralization_sale_open_timestamp_seconds: convertOptionalNumToBigInt(
     swap.decentralization_sale_open_timestamp_seconds
@@ -384,16 +384,13 @@ const convertDtoToSnsSwapDerivedState = (
   data: CachedSnsSwapDerivedDto
 ): SnsSwapDerivedState => convertDerived(data);
 
-const isValidSummary = (entry: Partial<SnsSummary>): entry is SnsSummary =>
-  entry.swap !== undefined &&
-  entry.swap.params !== undefined &&
-  entry.swapCanisterId !== undefined &&
-  entry.governanceCanisterId !== undefined &&
-  entry.ledgerCanisterId !== undefined &&
-  entry.indexCanisterId !== undefined &&
-  entry.derived !== undefined &&
-  entry.metadata !== undefined &&
-  entry.token !== undefined;
+type PartialSummary = Omit<SnsSummary, "metadata" | "token"> & {
+  metadata?: SnsSummaryMetadata;
+  token?: IcrcTokenMetadata;
+};
+
+const isValidSummary = (entry: PartialSummary): entry is SnsSummary =>
+  entry.metadata !== undefined && entry.token !== undefined;
 
 export const convertDtoToSnsSummary = ({
   canister_ids: {
@@ -408,7 +405,7 @@ export const convertDtoToSnsSummary = ({
   swap_state,
   derived_state,
 }: CachedSnsDto): SnsSummary | undefined => {
-  const partialSummary: Partial<SnsSummary> = {
+  const partialSummary: PartialSummary = {
     rootCanisterId: Principal.from(root_canister_id),
     swapCanisterId: Principal.from(swap_canister_id),
     governanceCanisterId: Principal.from(governance_canister_id),

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -1,5 +1,12 @@
+import DEFAULT_SNS_LOGO from "$lib/assets/sns-logo-default.svg";
 import { SNS_AGGREGATOR_CANISTER_URL } from "$lib/constants/environment.constants";
 import { AGGREGATOR_CANISTER_VERSION } from "$lib/constants/sns.constants";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
+import type {
+  SnsSummary,
+  SnsSummaryMetadata,
+  SnsSummarySwap,
+} from "$lib/types/sns";
 import type {
   CachedFunctionTypeDto,
   CachedLifecycleResponseDto,
@@ -27,6 +34,8 @@ import type {
   SnsSwapInit,
 } from "@dfinity/sns";
 import { isNullish, nonNullish, toNullable } from "@dfinity/utils";
+import { mapOptionalToken } from "./icrc-tokens.utils";
+import { isPngAsset } from "./utils";
 
 const aggregatorCanisterLogoPath = (rootCanisterId: string) =>
   `${SNS_AGGREGATOR_CANISTER_URL}/${AGGREGATOR_CANISTER_VERSION}/sns/root/${rootCanisterId}/logo.png`;
@@ -166,30 +175,25 @@ const convertSwapInitParams = (
       })
     : [];
 
-const convertSwapParams = (
-  params: CachedSwapParamsDto | null | undefined
-): [SnsParams] | [] =>
-  nonNullish(params)
-    ? toNullable({
-        min_participant_icp_e8s: BigInt(params.min_participant_icp_e8s),
-        max_icp_e8s: BigInt(params.max_icp_e8s),
-        min_icp_e8s: BigInt(params.min_icp_e8s),
-        sns_token_e8s: BigInt(params.sns_token_e8s),
-        min_participants: params.min_participants,
-        max_participant_icp_e8s: BigInt(params.max_participant_icp_e8s),
-        swap_due_timestamp_seconds: BigInt(params.swap_due_timestamp_seconds),
-        neuron_basket_construction_parameters: toNullable({
-          dissolve_delay_interval_seconds: BigInt(
-            params.neuron_basket_construction_parameters
-              .dissolve_delay_interval_seconds
-          ),
-          count: BigInt(params.neuron_basket_construction_parameters.count),
-        }),
-        sale_delay_seconds: toNullable(
-          convertOptionalNumToBigInt(params.sale_delay_seconds)
-        ),
-      })
-    : [];
+const convertSwapParams = (params: CachedSwapParamsDto): SnsParams => ({
+  min_participant_icp_e8s: BigInt(params.min_participant_icp_e8s),
+  max_icp_e8s: BigInt(params.max_icp_e8s),
+  min_icp_e8s: BigInt(params.min_icp_e8s),
+  sns_token_e8s: BigInt(params.sns_token_e8s),
+  min_participants: params.min_participants,
+  max_participant_icp_e8s: BigInt(params.max_participant_icp_e8s),
+  swap_due_timestamp_seconds: BigInt(params.swap_due_timestamp_seconds),
+  neuron_basket_construction_parameters: toNullable({
+    dissolve_delay_interval_seconds: BigInt(
+      params.neuron_basket_construction_parameters
+        .dissolve_delay_interval_seconds
+    ),
+    count: BigInt(params.neuron_basket_construction_parameters.count),
+  }),
+  sale_delay_seconds: toNullable(
+    convertOptionalNumToBigInt(params.sale_delay_seconds)
+  ),
+});
 
 const convertLifecycleResponse = (
   response: CachedLifecycleResponseDto
@@ -233,7 +237,7 @@ const convertSwap = ({
       ? toNullable(convertOptionalNumToBigInt(open_sns_token_swap_proposal_id))
       : [],
   init: convertSwapInitParams(init),
-  params: convertSwapParams(params),
+  params: isNullish(params) ? [] : [convertSwapParams(params)],
 });
 
 const convertDerived = ({
@@ -324,7 +328,7 @@ const convertSnsData = ({
   icrc1_total_supply: BigInt(icrc1_total_supply),
   derived_state: convertDerivedToResponse(derived_state),
   swap_params: {
-    params: convertSwapParams(swap_params.params),
+    params: [convertSwapParams(swap_params.params)],
   },
   init: {
     init: convertSwapInitParams(init.init),
@@ -334,3 +338,87 @@ const convertSnsData = ({
 
 export const convertDtoData = (data: CachedSnsDto[]): CachedSns[] =>
   data.map(convertSnsData);
+
+/**
+ * Metadata is given only if all its properties are defined.
+ */
+const convertDtoToSnsSummaryMetadata = (
+  { url, name, description }: CachedSnsMetadataDto,
+  rootCanisterId: string
+): SnsSummaryMetadata | undefined => {
+  const nullishLogo = aggregatorCanisterLogoPath(rootCanisterId);
+
+  if (isNullish(url) || isNullish(name) || isNullish(description)) {
+    return undefined;
+  }
+
+  // We have to check if the logo is a png asset for security reasons.
+  // Default logo can be svg.
+  return {
+    logo: isPngAsset(nullishLogo) ? nullishLogo : DEFAULT_SNS_LOGO,
+    url,
+    name,
+    description,
+  };
+};
+
+/**
+ * Token metadata is given only if all IcrcTokenMetadata properties are defined.
+ */
+const convertDtoToTokenMetadata = (
+  data: CachedSnsTokenMetadataDto
+): IcrcTokenMetadata | undefined =>
+  mapOptionalToken(convertIcrc1Metadata(data));
+
+const convertDtoToSnsSummarySwap = (
+  swap: CachedSnsSwapDto
+): SnsSummarySwap | undefined => ({
+  ...convertSwap(swap),
+  decentralization_sale_open_timestamp_seconds: convertOptionalNumToBigInt(
+    swap.decentralization_sale_open_timestamp_seconds
+  ),
+  params: convertSwapParams(swap.params),
+});
+
+const convertDtoToSnsSwapDerivedState = (
+  data: CachedSnsSwapDerivedDto
+): SnsSwapDerivedState => convertDerived(data);
+
+const isValidSummary = (entry: Partial<SnsSummary>): entry is SnsSummary =>
+  entry.swap !== undefined &&
+  entry.swap.params !== undefined &&
+  entry.swapCanisterId !== undefined &&
+  entry.governanceCanisterId !== undefined &&
+  entry.ledgerCanisterId !== undefined &&
+  entry.indexCanisterId !== undefined &&
+  entry.derived !== undefined &&
+  entry.metadata !== undefined &&
+  entry.token !== undefined;
+
+export const convertDtoToSnsSummary = ({
+  canister_ids: {
+    root_canister_id,
+    swap_canister_id,
+    governance_canister_id,
+    ledger_canister_id,
+    index_canister_id,
+  },
+  meta,
+  icrc1_metadata,
+  swap_state,
+  derived_state,
+}: CachedSnsDto): SnsSummary | undefined => {
+  const partialSummary: Partial<SnsSummary> = {
+    rootCanisterId: Principal.from(root_canister_id),
+    swapCanisterId: Principal.from(swap_canister_id),
+    governanceCanisterId: Principal.from(governance_canister_id),
+    ledgerCanisterId: Principal.from(ledger_canister_id),
+    indexCanisterId: Principal.from(index_canister_id),
+    metadata: convertDtoToSnsSummaryMetadata(meta, root_canister_id),
+    token: convertDtoToTokenMetadata(icrc1_metadata),
+    swap: convertDtoToSnsSummarySwap(swap_state.swap),
+    derived: convertDtoToSnsSwapDerivedState(derived_state),
+  };
+
+  return isValidSummary(partialSummary) ? partialSummary : undefined;
+};

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -380,10 +380,6 @@ const convertDtoToSnsSummarySwap = (
   params: convertSwapParams(swap.params),
 });
 
-const convertDtoToSnsSwapDerivedState = (
-  data: CachedSnsSwapDerivedDto
-): SnsSwapDerivedState => convertDerived(data);
-
 type PartialSummary = Omit<SnsSummary, "metadata" | "token"> & {
   metadata?: SnsSummaryMetadata;
   token?: IcrcTokenMetadata;
@@ -414,7 +410,7 @@ export const convertDtoToSnsSummary = ({
     metadata: convertDtoToSnsSummaryMetadata(meta, root_canister_id),
     token: convertDtoToTokenMetadata(icrc1_metadata),
     swap: convertDtoToSnsSummarySwap(swap_state.swap),
-    derived: convertDtoToSnsSwapDerivedState(derived_state),
+    derived: convertDerived(derived_state),
   };
 
   return isValidSummary(partialSummary) ? partialSummary : undefined;

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -1,3 +1,4 @@
+import type { CachedSnsDto } from "$lib/types/sns-aggregator";
 import {
   convertDtoData,
   convertDtoToSnsSummary,
@@ -18,6 +19,242 @@ describe("sns aggregator converters utils", () => {
   });
 
   describe("convertDtoToSnsSummary", () => {
+    const mockData: CachedSnsDto = {
+      index: 7,
+      canister_ids: {
+        root_canister_id: "5psbn-niaaa-aaaaq-aaa4q-cai",
+        governance_canister_id: "5grkr-3aaaa-aaaaq-aaa5a-cai",
+        index_canister_id: "5tw34-2iaaa-aaaaq-aaa6q-cai",
+        swap_canister_id: "5ux5i-xqaaa-aaaaq-aaa6a-cai",
+        ledger_canister_id: "5bqmf-wyaaa-aaaaq-aaa5q-cai",
+      },
+      list_sns_canisters: {
+        root: "5psbn-niaaa-aaaaq-aaa4q-cai",
+        swap: "5ux5i-xqaaa-aaaaq-aaa6a-cai",
+        ledger: "5bqmf-wyaaa-aaaaq-aaa5q-cai",
+        index: "5tw34-2iaaa-aaaaq-aaa6q-cai",
+        governance: "5grkr-3aaaa-aaaaq-aaa5a-cai",
+        dapps: [
+          "7xnbj-wqaaa-aaaap-aa4ea-cai",
+          "5escj-6iaaa-aaaap-aa4kq-cai",
+          "443xk-qiaaa-aaaap-aa4oq-cai",
+          "4sz2c-lyaaa-aaaap-aa4pq-cai",
+          "zjdgt-niaaa-aaaap-aa4qq-cai",
+          "zhbl3-wyaaa-aaaap-aa4rq-cai",
+        ],
+        archives: [],
+      },
+      meta: {
+        url: "https://catalyze.one",
+        name: "Catalyze",
+        description:
+          "Catalyze is a one-stop social-fi application for organising your Web3 experience",
+      },
+      parameters: {
+        reserved_ids: [],
+        functions: [
+          {
+            id: 0,
+            name: "All Topics",
+            description:
+              "Catch-all w.r.t to following for all types of proposals.",
+            function_type: { NativeNervousSystemFunction: {} },
+          },
+          {
+            id: 1,
+            name: "Motion",
+            description:
+              "Side-effect-less proposals to set general governance direction.",
+            function_type: { NativeNervousSystemFunction: {} },
+          },
+          {
+            id: 2,
+            name: "Manage nervous system parameters",
+            description:
+              "Proposal to change the core parameters of SNS governance.",
+            function_type: { NativeNervousSystemFunction: {} },
+          },
+          {
+            id: 3,
+            name: "Upgrade SNS controlled canister",
+            description:
+              "Proposal to upgrade the wasm of an SNS controlled canister.",
+            function_type: { NativeNervousSystemFunction: {} },
+          },
+          {
+            id: 4,
+            name: "Add nervous system function",
+            description:
+              "Proposal to add a new, user-defined, nervous system function:a canister call which can then be executed by proposal.",
+            function_type: { NativeNervousSystemFunction: {} },
+          },
+          {
+            id: 5,
+            name: "Remove nervous system function",
+            description:
+              "Proposal to remove a user-defined nervous system function,which will be no longer executable by proposal.",
+            function_type: { NativeNervousSystemFunction: {} },
+          },
+          {
+            id: 6,
+            name: "Execute nervous system function",
+            description:
+              "Proposal to execute a user-defined nervous system function,previously added by an AddNervousSystemFunction proposal. A canister call will be made when executed.",
+            function_type: { NativeNervousSystemFunction: {} },
+          },
+          {
+            id: 7,
+            name: "Upgrade SNS to next version",
+            description: "Proposal to upgrade the WASM of a core SNS canister.",
+            function_type: { NativeNervousSystemFunction: {} },
+          },
+          {
+            id: 8,
+            name: "Manage SNS metadata",
+            description:
+              "Proposal to change the metadata associated with an SNS.",
+            function_type: { NativeNervousSystemFunction: {} },
+          },
+          {
+            id: 9,
+            name: "Transfer SNS treasury funds",
+            description:
+              "Proposal to transfer funds from an SNS Governance controlled treasury account",
+            function_type: { NativeNervousSystemFunction: {} },
+          },
+          {
+            id: 10,
+            name: "Register dapp canisters",
+            description: "Proposal to register a dapp canister with the SNS.",
+            function_type: { NativeNervousSystemFunction: {} },
+          },
+          {
+            id: 11,
+            name: "Deregister Dapp Canisters",
+            description:
+              "Proposal to deregister a previously-registered dapp canister from the SNS.",
+            function_type: { NativeNervousSystemFunction: {} },
+          },
+        ],
+      },
+      swap_state: {
+        swap: {
+          lifecycle: 2,
+          init: {
+            nns_proposal_id: null,
+            sns_root_canister_id: "5psbn-niaaa-aaaaq-aaa4q-cai",
+            min_participant_icp_e8s: null,
+            neuron_basket_construction_parameters: null,
+            fallback_controller_principal_ids: [
+              "ledm3-52ncq-rffuv-6ed44-hg5uo-iicyu-pwkzj-syfva-heo4k-p7itq-aqe",
+              "efaeg-aiaaa-aaaap-aan6a-cai",
+            ],
+            max_icp_e8s: null,
+            neuron_minimum_stake_e8s: 400000000,
+            confirmation_text: null,
+            swap_start_timestamp_seconds: null,
+            swap_due_timestamp_seconds: null,
+            min_participants: null,
+            sns_token_e8s: null,
+            nns_governance_canister_id: "rrkah-fqaaa-aaaaa-aaaaq-cai",
+            transaction_fee_e8s: 100000,
+            icp_ledger_canister_id: "ryjl3-tyaaa-aaaaa-aaaba-cai",
+            sns_ledger_canister_id: "5bqmf-wyaaa-aaaaq-aaa5q-cai",
+            neurons_fund_participants: null,
+            should_auto_finalize: null,
+            max_participant_icp_e8s: null,
+            sns_governance_canister_id: "5grkr-3aaaa-aaaaq-aaa5a-cai",
+            restricted_countries: { iso_codes: ["US"] },
+            min_icp_e8s: null,
+          },
+          params: {
+            min_participant_icp_e8s: 100000000,
+            neuron_basket_construction_parameters: {
+              dissolve_delay_interval_seconds: 5259486,
+              count: 7,
+            },
+            max_icp_e8s: 130000000000000,
+            swap_due_timestamp_seconds: 1691785258,
+            min_participants: 125,
+            sns_token_e8s: 11250000000000000,
+            sale_delay_seconds: null,
+            max_participant_icp_e8s: 15000000000000,
+            min_icp_e8s: 65000000000000,
+          },
+          open_sns_token_swap_proposal_id: 123772,
+          decentralization_sale_open_timestamp_seconds: 1690786778,
+        },
+        derived: {
+          buyer_total_icp_e8s: 50669291278205,
+          sns_tokens_per_icp: 222.02797,
+        },
+      },
+      icrc1_metadata: [
+        ["icrc1:decimals", { Nat: [8] }],
+        ["icrc1:name", { Text: "CatalyzeDAO" }],
+        ["icrc1:symbol", { Text: "CAT" }],
+        ["icrc1:fee", { Nat: [100000] }],
+      ],
+      icrc1_fee: [100000],
+      icrc1_total_supply: 50000000000000000,
+      swap_params: {
+        params: {
+          min_participant_icp_e8s: 100000000,
+          neuron_basket_construction_parameters: {
+            dissolve_delay_interval_seconds: 5259486,
+            count: 7,
+          },
+          max_icp_e8s: 130000000000000,
+          swap_due_timestamp_seconds: 1691785258,
+          min_participants: 125,
+          sns_token_e8s: 11250000000000000,
+          sale_delay_seconds: null,
+          max_participant_icp_e8s: 15000000000000,
+          min_icp_e8s: 65000000000000,
+        },
+      },
+      init: {
+        init: {
+          nns_proposal_id: null,
+          sns_root_canister_id: "5psbn-niaaa-aaaaq-aaa4q-cai",
+          min_participant_icp_e8s: null,
+          neuron_basket_construction_parameters: null,
+          fallback_controller_principal_ids: [
+            "ledm3-52ncq-rffuv-6ed44-hg5uo-iicyu-pwkzj-syfva-heo4k-p7itq-aqe",
+            "efaeg-aiaaa-aaaap-aan6a-cai",
+          ],
+          max_icp_e8s: null,
+          neuron_minimum_stake_e8s: 400000000,
+          confirmation_text: null,
+          swap_start_timestamp_seconds: null,
+          swap_due_timestamp_seconds: null,
+          min_participants: null,
+          sns_token_e8s: null,
+          nns_governance_canister_id: "rrkah-fqaaa-aaaaa-aaaaq-cai",
+          transaction_fee_e8s: 100000,
+          icp_ledger_canister_id: "ryjl3-tyaaa-aaaaa-aaaba-cai",
+          sns_ledger_canister_id: "5bqmf-wyaaa-aaaaq-aaa5q-cai",
+          neurons_fund_participants: null,
+          should_auto_finalize: null,
+          max_participant_icp_e8s: null,
+          sns_governance_canister_id: "5grkr-3aaaa-aaaaq-aaa5a-cai",
+          restricted_countries: { iso_codes: ["US"] },
+          min_icp_e8s: null,
+        },
+      },
+      derived_state: {
+        sns_tokens_per_icp: 222.02796936035156,
+        buyer_total_icp_e8s: 50669291278205,
+        cf_participant_count: 145,
+        direct_participant_count: 224,
+        cf_neuron_count: 178,
+      },
+      lifecycle: {
+        decentralization_sale_open_timestamp_seconds: 1690786778,
+        lifecycle: 2,
+      },
+    };
+
     it("returns sns summary from aggregator data", () => {
       const {
         canister_ids: {
@@ -27,9 +264,9 @@ describe("sns aggregator converters utils", () => {
           ledger_canister_id,
           index_canister_id,
         },
-      } = aggregatorSnsMockDto;
+      } = mockData;
 
-      expect(convertDtoToSnsSummary(aggregatorSnsMockDto)).toEqual({
+      expect(convertDtoToSnsSummary(mockData)).toEqual({
         rootCanisterId: Principal.from(root_canister_id),
         swapCanisterId: Principal.from(swap_canister_id),
         governanceCanisterId: Principal.from(governance_canister_id),
@@ -122,9 +359,9 @@ describe("sns aggregator converters utils", () => {
 
     it("returns undefined if a metadata required field is missing", () => {
       const aggregatorMissingMetadata = {
-        ...aggregatorSnsMockDto,
+        ...mockData,
         meta: {
-          ...aggregatorSnsMockDto.meta,
+          ...mockData.meta,
           name: null,
         },
       };
@@ -133,8 +370,8 @@ describe("sns aggregator converters utils", () => {
 
     it("returns undefined if a token metadata required field is missing", () => {
       const aggregatorMissingMetadata = {
-        ...aggregatorSnsMockDto,
-        icrc1_metadata: aggregatorSnsMockDto.icrc1_metadata.filter(
+        ...mockData,
+        icrc1_metadata: mockData.icrc1_metadata.filter(
           ([key]) => key !== "icrc1:symbol"
         ),
       };

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -119,5 +119,26 @@ describe("sns aggregator converters utils", () => {
         },
       });
     });
+
+    it("returns undefined if a metadata required field is missing", () => {
+      const aggregatorMissingMetadata = {
+        ...aggregatorSnsMockDto,
+        meta: {
+          ...aggregatorSnsMockDto.meta,
+          name: null,
+        },
+      };
+      expect(convertDtoToSnsSummary(aggregatorMissingMetadata)).toBeUndefined();
+    });
+
+    it("returns undefined if a token metadata required field is missing", () => {
+      const aggregatorMissingMetadata = {
+        ...aggregatorSnsMockDto,
+        icrc1_metadata: aggregatorSnsMockDto.icrc1_metadata.filter(
+          ([key]) => key !== "icrc1:symbol"
+        ),
+      };
+      expect(convertDtoToSnsSummary(aggregatorMissingMetadata)).toBeUndefined();
+    });
   });
 });

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -1,11 +1,123 @@
-import { convertDtoData } from "$lib/utils/sns-aggregator-converters.utils";
+import {
+  convertDtoData,
+  convertDtoToSnsSummary,
+} from "$lib/utils/sns-aggregator-converters.utils";
 import {
   aggregatorSnsMock,
   aggregatorSnsMockDto,
 } from "$tests/mocks/sns-aggregator.mock";
+import { Principal } from "@dfinity/principal";
 
 describe("sns aggregator converters utils", () => {
-  it("converts aggregator types to ic-js types", () => {
-    expect(convertDtoData([aggregatorSnsMockDto])).toEqual([aggregatorSnsMock]);
+  describe("convertDtoData", () => {
+    it("converts aggregator types to ic-js types", () => {
+      expect(convertDtoData([aggregatorSnsMockDto])).toEqual([
+        aggregatorSnsMock,
+      ]);
+    });
+  });
+
+  describe("convertDtoToSnsSummary", () => {
+    it("returns sns summary from aggregator data", () => {
+      const {
+        canister_ids: {
+          root_canister_id,
+          swap_canister_id,
+          governance_canister_id,
+          ledger_canister_id,
+          index_canister_id,
+        },
+      } = aggregatorSnsMockDto;
+
+      expect(convertDtoToSnsSummary(aggregatorSnsMockDto)).toEqual({
+        rootCanisterId: Principal.from(root_canister_id),
+        swapCanisterId: Principal.from(swap_canister_id),
+        governanceCanisterId: Principal.from(governance_canister_id),
+        ledgerCanisterId: Principal.from(ledger_canister_id),
+        indexCanisterId: Principal.from(index_canister_id),
+        metadata: {
+          description:
+            "Catalyze is a one-stop social-fi application for organising your Web3 experience",
+          logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/5psbn-niaaa-aaaaq-aaa4q-cai/logo.png",
+          name: "Catalyze",
+          url: "https://catalyze.one",
+        },
+        token: {
+          fee: 100000n,
+          name: "CatalyzeDAO",
+          symbol: "CAT",
+        },
+        swap: {
+          already_tried_to_auto_finalize: [],
+          auto_finalize_swap_response: [],
+          buyers: [],
+          cf_participants: [],
+          decentralization_sale_open_timestamp_seconds: 1690786778n,
+          finalize_swap_in_progress: [],
+          init: [
+            {
+              confirmation_text: [],
+              fallback_controller_principal_ids: [
+                "ledm3-52ncq-rffuv-6ed44-hg5uo-iicyu-pwkzj-syfva-heo4k-p7itq-aqe",
+                "efaeg-aiaaa-aaaap-aan6a-cai",
+              ],
+              icp_ledger_canister_id: "ryjl3-tyaaa-aaaaa-aaaba-cai",
+              max_icp_e8s: [],
+              max_participant_icp_e8s: [],
+              min_icp_e8s: [],
+              min_participant_icp_e8s: [],
+              min_participants: [],
+              neuron_basket_construction_parameters: [],
+              neuron_minimum_stake_e8s: [400000000n],
+              neurons_fund_participants: [],
+              nns_governance_canister_id: "rrkah-fqaaa-aaaaa-aaaaq-cai",
+              nns_proposal_id: [],
+              restricted_countries: [
+                {
+                  iso_codes: ["US"],
+                },
+              ],
+              should_auto_finalize: [],
+              sns_governance_canister_id: "5grkr-3aaaa-aaaaq-aaa5a-cai",
+              sns_ledger_canister_id: "5bqmf-wyaaa-aaaaq-aaa5q-cai",
+              sns_root_canister_id: "5psbn-niaaa-aaaaq-aaa4q-cai",
+              sns_token_e8s: [],
+              swap_due_timestamp_seconds: [],
+              swap_start_timestamp_seconds: [],
+              transaction_fee_e8s: [100000n],
+            },
+          ],
+          lifecycle: 2,
+          neuron_recipes: [],
+          next_ticket_id: [],
+          open_sns_token_swap_proposal_id: [123772n],
+          params: {
+            max_icp_e8s: 130000000000000n,
+            max_participant_icp_e8s: 15000000000000n,
+            min_icp_e8s: 65000000000000n,
+            min_participant_icp_e8s: 100000000n,
+            min_participants: 125,
+            neuron_basket_construction_parameters: [
+              {
+                count: 7n,
+                dissolve_delay_interval_seconds: 5259486n,
+              },
+            ],
+            sale_delay_seconds: [],
+            sns_token_e8s: 11250000000000000n,
+            swap_due_timestamp_seconds: 1691785258n,
+          },
+          purge_old_tickets_last_completion_timestamp_nanoseconds: [],
+          purge_old_tickets_next_principal: [],
+        },
+        derived: {
+          buyer_total_icp_e8s: 50669291278205n,
+          cf_neuron_count: [178n],
+          cf_participant_count: [145n],
+          direct_participant_count: [224n],
+          sns_tokens_per_icp: 222.02796936035156,
+        },
+      });
+    });
   });
 });


### PR DESCRIPTION
# Motivation

Final motivation: Stop using get_state. But on the way, clean the unnecessary complexity of snsQueryStore.

In this PR: Introduce the converter from sns aggreagator data to SnsSummary.

The SnsSummary type is used in the `snsSummariesStore` to return a list of SnsSummary.

After this PR, we can enable using the aggregator data instead of snsQueryStore.

Then, we can remove snsQueryStore.

# Changes

* New sns aggregator converter `convertDtoToSnsSummary`. Some of the utils are similar to utils in sns.utils.ts. I didn't use those on purpose because I want to remove them along the snsQueryStore.

# Tests

* Add a test for the new converter `convertDtoToSnsSummary`.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet worth an entry.