### PR TITLE
GIX-1823: Use one store for sns derived state

### DIFF
--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -6,7 +6,7 @@ import {
 } from "$lib/api/sns.api";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { WATCH_SALE_STATE_EVERY_MILLISECONDS } from "$lib/constants/sns.constants";
-import { getOrCreateDerivedStateStore } from "$lib/stores/sns-derived-state.store";
+import { snsDerivedStateStore } from "$lib/stores/sns-derived-state.store";
 import { getOrCreateLifecycleStore } from "$lib/stores/sns-lifecycle.store";
 import {
   snsQueryStore,
@@ -165,12 +165,10 @@ export const loadSnsTotalCommitment = async ({
     onLoad: ({ response: derivedState, certified }) => {
       if (derivedState !== undefined) {
         snsQueryStore.updateDerivedState({ derivedState, rootCanisterId });
-        const store = getOrCreateDerivedStateStore(
-          Principal.fromText(rootCanisterId)
-        );
-        store.setDerivedState({
+        snsDerivedStateStore.setDerivedState({
+          rootCanisterId: Principal.fromText(rootCanisterId),
           certified,
-          derivedState,
+          data: derivedState,
         });
       }
     },

--- a/frontend/src/lib/stores/sns-derived-state.store.ts
+++ b/frontend/src/lib/stores/sns-derived-state.store.ts
@@ -1,6 +1,5 @@
 import type { Principal } from "@dfinity/principal";
 import type { SnsGetDerivedStateResponse } from "@dfinity/sns";
-import { nonNullish } from "@dfinity/utils";
 import { writable, type Readable } from "svelte/store";
 
 interface SnsDerivedStateProjectData {
@@ -15,18 +14,12 @@ interface SnsDerivedStateData {
 export interface SnsDerivedStateStore
   extends Readable<SnsDerivedStateData | undefined> {
   setDerivedState: (params: {
+    rootCanisterId: Principal;
     data: SnsGetDerivedStateResponse;
     certified: boolean;
-    rootCanisterId: Principal;
   }) => void;
   reset: () => void;
 }
-
-let stores: Map<string, SnsDerivedStateStore> = new Map();
-
-export const resetDerivedStateStoresForTesting = () => {
-  stores = new Map();
-};
 
 /**
  * A store that contains the derived state of all sns projects.
@@ -64,17 +57,3 @@ const initSnsDerivedStateStore = (): SnsDerivedStateStore => {
 };
 
 export const snsDerivedStateStore = initSnsDerivedStateStore();
-
-export const getOrCreateDerivedStateStore = (
-  rootCanisterId: Principal
-): SnsDerivedStateStore => {
-  const key = rootCanisterId.toText();
-  const existingStore = stores.get(key);
-  if (nonNullish(existingStore)) {
-    return existingStore;
-  }
-
-  const newStore = initSnsDerivedStateStore();
-  stores.set(key, newStore);
-  return newStore;
-};

--- a/frontend/src/lib/stores/sns-derived-state.store.ts
+++ b/frontend/src/lib/stores/sns-derived-state.store.ts
@@ -29,9 +29,9 @@ export const resetDerivedStateStoresForTesting = () => {
 };
 
 /**
- * A store that contains the derived state of a specific sns project.
+ * A store that contains the derived state of all sns projects.
  *
- * - setDerivedState: replace the current derived state with a new one.
+ * - setDerivedState: replace the derived state of an sns project with a new one.
  */
 const initSnsDerivedStateStore = (): SnsDerivedStateStore => {
   const { subscribe, set, update } = writable<SnsDerivedStateData>({});

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -6,10 +6,7 @@
 import * as api from "$lib/api/sns.api";
 import { WATCH_SALE_STATE_EVERY_MILLISECONDS } from "$lib/constants/sns.constants";
 import * as services from "$lib/services/sns.services";
-import {
-  resetDerivedStateStoresForTesting,
-  snsDerivedStateStore,
-} from "$lib/stores/sns-derived-state.store";
+import { snsDerivedStateStore } from "$lib/stores/sns-derived-state.store";
 import { getOrCreateLifecycleStore } from "$lib/stores/sns-lifecycle.store";
 import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import {
@@ -53,7 +50,6 @@ describe("sns-services", () => {
     jest.useFakeTimers();
     jest.clearAllTimers();
     jest.clearAllMocks();
-    resetDerivedStateStoresForTesting();
     snsSwapCommitmentsStore.reset();
     snsQueryStore.reset();
     snsDerivedStateStore.reset();

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -163,7 +163,9 @@ describe("sns-services", () => {
         fromNullable(derivedState.sns_tokens_per_icp)
       );
 
-      expect(get(snsDerivedStateStore)?.derivedState).toEqual(derivedState);
+      expect(
+        get(snsDerivedStateStore)[rootCanisterId1.toText()]?.derivedState
+      ).toEqual(derivedState);
     });
 
     it("should call api with the strategy passed", async () => {

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -7,8 +7,8 @@ import * as api from "$lib/api/sns.api";
 import { WATCH_SALE_STATE_EVERY_MILLISECONDS } from "$lib/constants/sns.constants";
 import * as services from "$lib/services/sns.services";
 import {
-  getOrCreateDerivedStateStore,
   resetDerivedStateStoresForTesting,
+  snsDerivedStateStore,
 } from "$lib/stores/sns-derived-state.store";
 import { getOrCreateLifecycleStore } from "$lib/stores/sns-lifecycle.store";
 import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
@@ -56,6 +56,7 @@ describe("sns-services", () => {
     resetDerivedStateStoresForTesting();
     snsSwapCommitmentsStore.reset();
     snsQueryStore.reset();
+    snsDerivedStateStore.reset();
   });
 
   describe("getSwapAccount", () => {
@@ -162,8 +163,7 @@ describe("sns-services", () => {
         fromNullable(derivedState.sns_tokens_per_icp)
       );
 
-      const derivedStateStore = getOrCreateDerivedStateStore(rootCanisterId1);
-      expect(get(derivedStateStore)?.derivedState).toEqual(derivedState);
+      expect(get(snsDerivedStateStore)?.derivedState).toEqual(derivedState);
     });
 
     it("should call api with the strategy passed", async () => {


### PR DESCRIPTION
# Motivation

We want to use the snsDerivedStateStore in the derived store `snsSummariesStore`. To do that, we can't use dynamic creationg of the store. To allow dynamic creation of the store, we would need to also create dynamically `snsSummariesStore`. This is a bigger refactor than expected and not sure it's worth the effort now.

Therfore, I implemented the same pattern of storing all project data in one single store using the root canister id as key in the snsDerivedStateStore.

# Changes

* `snsDerivedStateStore` doesn't create store dynamically. It's one store to rule them all.
* Refactor where this store was created.

# Tests

* Test new capabilities and remove old ones.
* Change test after refactor.

# Todos

- [ ] Add entry to changelog (if necessary).
Not worth a changelog entry.