### PR TITLE
GIX-1823: Use one snsLifecycleStore

### DIFF
--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -7,7 +7,7 @@ import {
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { WATCH_SALE_STATE_EVERY_MILLISECONDS } from "$lib/constants/sns.constants";
 import { snsDerivedStateStore } from "$lib/stores/sns-derived-state.store";
-import { getOrCreateLifecycleStore } from "$lib/stores/sns-lifecycle.store";
+import { snsLifecycleStore } from "$lib/stores/sns-lifecycle.store";
 import {
   snsQueryStore,
   snsSummariesStore,
@@ -219,10 +219,8 @@ export const loadSnsLifecycle = async ({
         snsQueryStore.updateLifecycle({ lifecycle, rootCanisterId });
       }
       if (nonNullish(lifecycleResponse)) {
-        const lifecycleStore = getOrCreateLifecycleStore(
-          Principal.from(rootCanisterId)
-        );
-        lifecycleStore.setData({
+        snsLifecycleStore.setData({
+          rootCanisterId: Principal.from(rootCanisterId),
           data: lifecycleResponse,
           certified,
         });

--- a/frontend/src/lib/stores/sns-lifecycle.store.ts
+++ b/frontend/src/lib/stores/sns-lifecycle.store.ts
@@ -1,56 +1,58 @@
 import type { Principal } from "@dfinity/principal";
 import type { SnsGetLifecycleResponse } from "@dfinity/sns";
-import { nonNullish } from "@dfinity/utils";
 import { writable, type Readable } from "svelte/store";
 
-interface SnsLifecycleData {
+interface SnsLifecycleProjectData {
   data: SnsGetLifecycleResponse;
   certified: boolean;
 }
 
-export interface SnsLifecycleStore
-  extends Readable<SnsLifecycleData | undefined> {
-  setData: (data: SnsLifecycleData) => void;
+interface SnsLifecycleData {
+  [rootCanisterId: string]: SnsLifecycleProjectData;
+}
+
+export interface SnsLifecycleStore extends Readable<SnsLifecycleData> {
+  setData: (data: {
+    rootCanisterId: Principal;
+    data: SnsGetLifecycleResponse;
+    certified: boolean;
+  }) => void;
   reset: () => void;
 }
 
-const stores: Map<string, SnsLifecycleStore> = new Map();
-
-export const resetLiefcycleStoresForTesting = () => {
-  stores.clear();
-};
-
 /**
- * A store that contains the lifecycle of a specific sns project.
+ * A store that contains the lifecycle all sns projects.
  *
- * - setData: replace the current lifecycle with a new one.
+ * - setData: replace the project lifecycle with a new one.
  */
-const createSnsLifecycleStore = (): SnsLifecycleStore => {
-  const { subscribe, set } = writable<SnsLifecycleData | undefined>(undefined);
+const initSnsLifecycleStore = (): SnsLifecycleStore => {
+  const { subscribe, set, update } = writable<SnsLifecycleData>({});
 
   return {
     subscribe,
 
-    setData(data: SnsLifecycleData) {
-      set(data);
+    setData({
+      rootCanisterId,
+      data,
+      certified,
+    }: {
+      rootCanisterId: Principal;
+      data: SnsGetLifecycleResponse;
+      certified: boolean;
+    }) {
+      update((currentState) => ({
+        ...currentState,
+        [rootCanisterId.toText()]: {
+          data,
+          certified,
+        },
+      }));
     },
 
     reset() {
-      set(undefined);
+      set({});
     },
   };
 };
 
-export const getOrCreateLifecycleStore = (
-  rootCanisterId: Principal
-): SnsLifecycleStore => {
-  const key = rootCanisterId.toText();
-  const existingStore = stores.get(key);
-  if (nonNullish(existingStore)) {
-    return existingStore;
-  }
-
-  const newStore = createSnsLifecycleStore();
-  stores.set(key, newStore);
-  return newStore;
-};
+export const snsLifecycleStore = initSnsLifecycleStore();

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -7,7 +7,7 @@ import * as api from "$lib/api/sns.api";
 import { WATCH_SALE_STATE_EVERY_MILLISECONDS } from "$lib/constants/sns.constants";
 import * as services from "$lib/services/sns.services";
 import { snsDerivedStateStore } from "$lib/stores/sns-derived-state.store";
-import { getOrCreateLifecycleStore } from "$lib/stores/sns-lifecycle.store";
+import { snsLifecycleStore } from "$lib/stores/sns-lifecycle.store";
 import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import {
   mockIdentity,
@@ -369,8 +369,9 @@ describe("sns-services", () => {
       )?.swap[0].lifecycle;
       expect(updatedLifecycle).toEqual(newLifeCycle);
 
-      const lifecycleStore = getOrCreateLifecycleStore(rootCanisterId1);
-      expect(get(lifecycleStore).data).toEqual(lifeCycleResponse);
+      expect(get(snsLifecycleStore)[rootCanisterId1.toText()].data).toEqual(
+        lifeCycleResponse
+      );
     });
   });
 });

--- a/frontend/src/tests/lib/stores/sns-lifecycle.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-lifecycle.store.spec.ts
@@ -1,42 +1,80 @@
-import {
-  getOrCreateLifecycleStore,
-  resetLiefcycleStoresForTesting,
-} from "$lib/stores/sns-lifecycle.store";
+import { snsLifecycleStore } from "$lib/stores/sns-lifecycle.store";
 import {
   mockLifecycleResponse,
   principal,
 } from "$tests/mocks/sns-projects.mock";
+import { SnsSwapLifecycle, type SnsGetLifecycleResponse } from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("sns lifecycle store", () => {
+  const anotherLifecycleResponse: SnsGetLifecycleResponse = {
+    ...mockLifecycleResponse,
+    lifecycle: [SnsSwapLifecycle.Committed],
+  };
+
   beforeEach(() => {
-    resetLiefcycleStoresForTesting();
+    snsLifecycleStore.reset();
   });
 
   it("should create a store for a given root canister id and store lifecycle", () => {
     const rootCanisterId = principal(0);
-    const store = getOrCreateLifecycleStore(rootCanisterId);
 
-    store.setData({
+    snsLifecycleStore.setData({
       certified: true,
+      rootCanisterId,
       data: mockLifecycleResponse,
     });
 
-    expect(get(store).data).toEqual(mockLifecycleResponse);
+    expect(get(snsLifecycleStore)[rootCanisterId.toText()].data).toEqual(
+      mockLifecycleResponse
+    );
   });
 
-  it("should cache stores per root canister id", () => {
+  it("should store multiple derived states", () => {
     const rootCanisterId = principal(0);
-    const store = getOrCreateLifecycleStore(rootCanisterId);
+    const rootCanisterId2 = principal(1);
 
-    const store2 = getOrCreateLifecycleStore(rootCanisterId);
-    expect(store).toBe(store2);
+    snsLifecycleStore.setData({
+      certified: true,
+      rootCanisterId,
+      data: mockLifecycleResponse,
+    });
+
+    snsLifecycleStore.setData({
+      certified: true,
+      rootCanisterId: rootCanisterId2,
+      data: anotherLifecycleResponse,
+    });
+
+    expect(get(snsLifecycleStore)[rootCanisterId.toText()].data).toEqual(
+      mockLifecycleResponse
+    );
+    expect(get(snsLifecycleStore)[rootCanisterId2.toText()].data).toEqual(
+      anotherLifecycleResponse
+    );
   });
 
-  it("should not cache stores for different root canister id", () => {
-    const store = getOrCreateLifecycleStore(principal(0));
+  it("should override derived states", () => {
+    const rootCanisterId = principal(0);
 
-    const store2 = getOrCreateLifecycleStore(principal(1));
-    expect(store).not.toBe(store2);
+    snsLifecycleStore.setData({
+      certified: true,
+      rootCanisterId,
+      data: mockLifecycleResponse,
+    });
+
+    expect(get(snsLifecycleStore)[rootCanisterId.toText()].data).toEqual(
+      mockLifecycleResponse
+    );
+
+    snsLifecycleStore.setData({
+      certified: true,
+      rootCanisterId,
+      data: anotherLifecycleResponse,
+    });
+
+    expect(get(snsLifecycleStore)[rootCanisterId.toText()].data).toEqual(
+      anotherLifecycleResponse
+    );
   });
 });


### PR DESCRIPTION
# Motivation

Similar to #3144 

We want to use the snsLifecycleStore in the derived store snsSummariesStore. To do that, we can't use dynamic creation of the store. To allow dynamic creation of the store, we would need to also create dynamically snsSummariesStore. This is a bigger refactor than expected and not sure it's worth the effort now.

Therefore, I implemented the same pattern of storing all project data in one single store using the root canister id as key in the snsLifecycleStore.

# Changes

* Change snsLifecycleStore to use only one store to rule them all.
* Change usage of the store.

# Tests

* Change test cases for snsLifecycleStore.
* Change related tests after refactor.

# Todos

- [ ] Add entry to changelog (if necessary).
Not worth a changelog entry
