### PR TITLE
Remove references to old e2e-tests/

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -9,8 +9,6 @@ This document list a couple of useful information to develop the NNS-dapp fronte
 - [Testnet](#testnet)
 - [Preview](#preview)
   - [Configure](#configure)
-- [e2e](#e2e)
-  - [Running against local server](#running-against-local-server)
 - [Requirements](#requirements)
 - [Dependencies](#dependencies)
 - [ckBTC deployment](#ckbtc-deployment)
@@ -77,18 +75,6 @@ To develop and run locally the dapp against a testnet, proceed as following:
 - Start `npm run dev` in the `./frontend/` folder to serve the application
 
 e.g. replace `<testnet_name>` with `small11`
-
-## e2e
-
-e2e tests also need a `.env` configuration. Such file can also be generated with the help of the `./config.sh` script by providing a specific output parameter.
-
-e.g. `DFX_NETWORK=<testnet_name> ENV_OUTPUT_FILE=./e2e-tests/.env ./config.sh`
-
-### Running against local server
-
-If you wish to run the e2e tests against your local server, please note:
-
-* The II version deployed locally might be different than the version pinned to run the test. Therefore you might need to adapt the selectors in [./e2e-tests/components/ii-congratulations-page.ts](./e2e-tests/components/ii-congratulations-page.ts).
 
 ## Requirements
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -28,7 +28,7 @@ After installing the project, you can run the test suite:
 npm run test
 ```
 
-There is also a project to run e2e tests [here](../e2e-tests/README.md).
+There is also a project to run e2e tests [here](src/tests/e2e/README.md).
 
 ## Style
 

--- a/scripts/fmt
+++ b/scripts/fmt
@@ -5,7 +5,6 @@ cd "$(dirname "$(realpath "$0")")/.."
 set -x
 time xargs -P8 -I{} bash -c "{}" <<EOF
 ./scripts/fmt-frontend
-./scripts/fmt-e2e
 ./scripts/fmt-json
 ./scripts/fmt-rs
 ./scripts/fmt-sh

--- a/scripts/fmt-e2e
+++ b/scripts/fmt-e2e
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -euxo pipefail
-cd "$(dirname "$(realpath "$0")")/.."
-
-cd e2e-tests
-test -x node_modules/.bin/prettier || npm ci
-npm run format


### PR DESCRIPTION
# Motivation

Wdio e2e tests have been replaced with Playwright e2e tests.

# Changes

1. Removing section about e2e config from `HACKING.md`. The new e2e tests have their own documentation in `frontend/src/tests/e2e/README.md`.
2. Link to the new e2e tests instead of the old ones from `frontend/README.md`.
3. Remove scripts to format `e2e-tests/`.

# Tests

no

# Todos

- [ ] Add entry to changelog (if necessary).
Will add an entry once `e2e-tests/` is removed entrirely.
