### PR TITLE
Fix: Do not use real time in tests

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -53,6 +53,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Changed
 
 * Moved e2e-tests/scripts/ to scripts/e2e-tests/.
+* Change some unit tests to set a system time and not rely on actual time.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -24,7 +24,9 @@ import { NeuronState } from "@dfinity/nns";
 import { fireEvent, render } from "@testing-library/svelte";
 
 describe("NnsNeuronCard", () => {
+  const nowInSeconds = 1689843195;
   beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(nowInSeconds * 1000);
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
@@ -211,7 +213,7 @@ describe("NnsNeuronCard", () => {
   });
 
   it("renders proper text when status is DISSOLVING", async () => {
-    const ONE_YEAR_FROM_NOW = SECONDS_IN_YEAR + Math.round(Date.now() / 1000);
+    const ONE_YEAR_FROM_NOW = nowInSeconds + SECONDS_IN_YEAR;
     const { getByText } = render(NnsNeuronCard, {
       props: {
         neuron: {

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
@@ -4,6 +4,7 @@
 
 import * as snsGovernanceApi from "$lib/api/sns-governance.api";
 import SnsVotingCard from "$lib/components/sns-proposals/SnsVotingCard.svelte";
+import { SECONDS_IN_DAY } from "$lib/constants/constants";
 import { authStore } from "$lib/stores/auth.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { snsParametersStore } from "$lib/stores/sns-parameters.store";
@@ -37,6 +38,7 @@ import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 
 describe("SnsVotingCard", () => {
+  const nowInSeconds = 1689843195;
   const testBallots: [string, SnsBallot][] = [
     [
       "01",
@@ -63,13 +65,15 @@ describe("SnsVotingCard", () => {
       },
     ],
   ];
+  const neuronCreatedAt = BigInt(nowInSeconds - SECONDS_IN_DAY * 2);
+  const proposalCreatedAt = BigInt(nowInSeconds - SECONDS_IN_DAY);
   const testProposal: SnsProposalData = {
     ...createSnsProposal({
       proposalId: 123n,
       status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
       rewardStatus: SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
       ballots: testBallots,
-      createdAt: BigInt(Math.round(Date.now() / 1000)),
+      createdAt: proposalCreatedAt,
     }),
   };
   const permissionsWithTypeVote = [
@@ -86,6 +90,7 @@ describe("SnsVotingCard", () => {
       ...createMockSnsNeuron({
         id: [1],
         state: NeuronState.Locked,
+        createdTimestampSeconds: neuronCreatedAt,
       }),
       permissions: permissionsWithTypeVote,
     },
@@ -93,6 +98,7 @@ describe("SnsVotingCard", () => {
       ...createMockSnsNeuron({
         id: [2],
         state: NeuronState.Locked,
+        createdTimestampSeconds: neuronCreatedAt,
       }),
       permissions: permissionsWithTypeVote,
     },
@@ -110,6 +116,7 @@ describe("SnsVotingCard", () => {
     });
 
   beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(nowInSeconds * 1000);
     snsNeuronsStore.reset();
     jest
       .spyOn(authStore, "subscribe")
@@ -223,7 +230,7 @@ describe("SnsVotingCard", () => {
       status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_EXECUTED,
       rewardStatus: SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
       ballots: testBallots,
-      createdAt: BigInt(Math.round(Date.now() / 1000)),
+      createdAt: proposalCreatedAt,
     });
     snsNeuronsStore.setNeurons({
       rootCanisterId: mockSnsCanisterId,

--- a/frontend/src/tests/lib/components/proposals/NnsProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/NnsProposalCard.spec.ts
@@ -13,6 +13,12 @@ import { ProposalStatus, Topic } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 
 describe("NnsProposalCard", () => {
+  const nowInSeconds = 1689843195;
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(nowInSeconds * 1000);
+  });
+
   it("should render a proposal title", () => {
     const { getByText } = render(NnsProposalCard, {
       props: {
@@ -91,7 +97,7 @@ describe("NnsProposalCard", () => {
 
     const durationTillDeadline =
       (mockProposals[0].deadlineTimestampSeconds as bigint) -
-      BigInt(Math.round(Date.now() / 1000));
+      BigInt(nowInSeconds);
 
     const text = `${secondsToDuration(durationTillDeadline)} ${
       en.proposal_detail.remaining

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -168,6 +168,10 @@ describe("sns-neuron utils", () => {
   const monthAgo = BigInt(nowSeconds - SECONDS_IN_MONTH);
   const oneWeek = BigInt(SECONDS_IN_DAY * 7);
 
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(nowSeconds * 1000);
+  });
+
   describe("sortNeuronsByCreatedTimestamp", () => {
     it("should sort neurons by created_timestamp_seconds", () => {
       const neuron1 = {
@@ -226,7 +230,7 @@ describe("sns-neuron utils", () => {
       const dissolveState = neuron.dissolve_state[0];
       if ("WhenDissolvedTimestampSeconds" in dissolveState) {
         dissolveState.WhenDissolvedTimestampSeconds = BigInt(
-          Math.floor(Date.now() / 1000 - 3600)
+          Math.floor(nowSeconds - 3600)
         );
       }
       expect(getSnsNeuronState(neuron)).toEqual(NeuronState.Dissolved);
@@ -261,7 +265,7 @@ describe("sns-neuron utils", () => {
     });
 
     it("returns dissolve date", () => {
-      const todayInSeconds = BigInt(Math.round(Date.now() / 1000));
+      const todayInSeconds = BigInt(nowSeconds);
       const dissolveDate = todayInSeconds + BigInt(SECONDS_IN_YEAR);
       const neuron: SnsNeuron = {
         ...mockSnsNeuron,
@@ -281,7 +285,7 @@ describe("sns-neuron utils", () => {
     });
 
     it("returns time in seconds until dissolve", () => {
-      const todayInSeconds = BigInt(Math.round(Date.now() / 1000));
+      const todayInSeconds = BigInt(nowSeconds);
       const delayInSeconds = todayInSeconds + BigInt(SECONDS_IN_YEAR);
       const neuron: SnsNeuron = {
         ...mockSnsNeuron,


### PR DESCRIPTION
# Motivation

Two days ago, I had a unit test failure because a test was relying on real time instead of setting the system time.

In this PR: I looked at all the tests that were using real time and changed it.

# Changes

* Set time for NnsNeuronCard.spec.
* Set time and clarify dependencies of creation times with a variable in SnsVotingCard.spec.
* Set time in NnsProposalCard.spec
* Set time in sns-neuron.utils.spec

# Tests

Only test changes.

# Todos

- [x] Add entry to changelog (if necessary).
