### PR TITLE
Rename: loadSnsTotalCommitment

### DIFF
--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -9,7 +9,7 @@
   import {
     loadSnsLifecycle,
     loadSnsSwapCommitment,
-    loadSnsTotalCommitment,
+    loadSnsDerivedState,
     watchSnsTotalCommitment,
   } from "$lib/services/sns.services";
   import { snsSwapCommitmentsStore } from "$lib/stores/sns.store";
@@ -66,7 +66,7 @@
     }
 
     await Promise.all([
-      loadSnsTotalCommitment({ rootCanisterId, strategy: "update" }),
+      loadSnsDerivedState({ rootCanisterId, strategy: "update" }),
       loadSnsLifecycle({ rootCanisterId }),
       loadSnsSwapCommitment({
         rootCanisterId,

--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -146,7 +146,7 @@ export const loadSnsSwapCommitment = async ({
   });
 };
 
-export const loadSnsTotalCommitment = async ({
+export const loadSnsDerivedState = async ({
   rootCanisterId,
   strategy,
 }: {
@@ -193,7 +193,7 @@ export const watchSnsTotalCommitment = ({
   rootCanisterId: string;
 }) => {
   const id = setInterval(() => {
-    loadSnsTotalCommitment({ rootCanisterId, strategy: "query" });
+    loadSnsDerivedState({ rootCanisterId, strategy: "query" });
   }, WATCH_SALE_STATE_EVERY_MILLISECONDS);
 
   return () => {

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -37,7 +37,7 @@ const {
   getSwapAccount,
   loadSnsSwapCommitments,
   loadSnsSwapCommitment,
-  loadSnsTotalCommitment,
+  loadSnsDerivedState,
   watchSnsTotalCommitment,
 } = services;
 
@@ -108,7 +108,7 @@ describe("sns-services", () => {
     });
   });
 
-  describe("loadSnsTotalCommitment", () => {
+  describe("loadSnsDerivedState", () => {
     it("should call api to get total commitments and load them in stores", async () => {
       const derivedState: SnsGetDerivedStateResponse = {
         sns_tokens_per_icp: [2],
@@ -143,7 +143,7 @@ describe("sns-services", () => {
         fromNullable(derivedState.sns_tokens_per_icp)
       );
 
-      await loadSnsTotalCommitment({
+      await loadSnsDerivedState({
         rootCanisterId: rootCanisterId1.toText(),
       });
       expect(spy).toBeCalled();
@@ -176,7 +176,7 @@ describe("sns-services", () => {
         .spyOn(api, "querySnsDerivedState")
         .mockImplementation(() => Promise.resolve(derivedState));
 
-      await loadSnsTotalCommitment({
+      await loadSnsDerivedState({
         rootCanisterId: mockPrincipal.toText(),
         strategy: "update",
       });


### PR DESCRIPTION
# Motivation

Rename the service loadSnsTotalCommitment to loadSnsDerivedState to make it clearer what it does.

# Changes

* Rename `loadSnsTotalCommitment` to `loadSnsDerivedState` and where is imported and used.

# Tests

* Add the rename in the test file where it's used.

# Todos

- [ ] Add entry to changelog (if necessary).
Not worth a changelog entry.
