### PR TITLE
Refactor: Create principal id from index

### DIFF
--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -26,7 +26,7 @@ import {
   type SnsTransferableAmount,
 } from "@dfinity/sns";
 import type { Token } from "@dfinity/utils";
-import { nonNullish, toNullable } from "@dfinity/utils";
+import { hexStringToUint8Array, nonNullish, toNullable } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
 
 export const mockProjectSubscribe =
@@ -38,23 +38,7 @@ export const mockProjectSubscribe =
   };
 
 export const principal = (index: number): Principal =>
-  [
-    Principal.fromText(
-      "2vtpp-r6lcd-cbfas-qbabv-wxrv5-lsrkj-c4dtb-6ets3-srlqe-xpuzf-vqe"
-    ),
-    Principal.fromText(
-      "nv24n-kslcc-636yn-hazy3-t2zgj-fsrkg-2uhfm-vumlm-vqolw-6ciai-tae"
-    ),
-    Principal.fromText(
-      "2lwez-knpss-xe26y-sqpx3-7m5ev-gbqwb-ogdk4-af53j-r7fed-k5df4-uqe"
-    ),
-    Principal.fromText(
-      "vxi5c-ydsws-tmett-fndw6-7qwga-thtxc-epwtj-st3wy-jc464-muowb-eqe"
-    ),
-    Principal.fromText(
-      "4etav-nasrq-uvswa-iqsll-6spts-ryhsl-e4yf6-xtycj-4sxvp-ciay5-yae"
-    ),
-  ][index];
+  Principal.fromUint8Array(hexStringToUint8Array(index.toString(16) + "0x01"));
 
 export const createTransferableAmount = (
   amount: bigint

--- a/frontend/src/tests/utils/sns.test-utils.ts
+++ b/frontend/src/tests/utils/sns.test-utils.ts
@@ -10,7 +10,6 @@ import {
 } from "$tests/mocks/sns-response.mock";
 import type { Principal } from "@dfinity/principal";
 import type { SnsSwapLifecycle } from "@dfinity/sns";
-import { isNullish } from "@dfinity/utils";
 
 export const setSnsProjects = (
   params: {
@@ -23,11 +22,6 @@ export const setSnsProjects = (
     tokenMetadata?: Partial<IcrcTokenMetadata>;
   }[]
 ) => {
-  if (
-    params.filter(({ rootCanisterId }) => isNullish(rootCanisterId)).length > 5
-  ) {
-    throw new Error("Too many projects without canister id.");
-  }
   const responses = params.map(
     (
       {


### PR DESCRIPTION
# Motivation

Have an easier way to create multiple principals.

# Changes

* Reimplement the function `principal` from `sns-projects.mock` to create a principal based on a number.
* Remove check in `setSnsProjects` for number of projects to set based on the previous limitation of `principal`.

# Tests

* Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
