### PR TITLE
detailed min participation

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -18,6 +18,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Improve error messaging on payload size limit in proposals list page.
 * New lifecycle store for SNS projects.
 * New feature flag ENABLE_SNS_AGGREGATOR_STORE.
+* Detailed `min_participant_icp_e8s` rendering hack for Modclub SNS.
 
 #### Changed
 

--- a/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
@@ -85,7 +85,7 @@
   </KeyValuePair>
   <KeyValuePair>
     <span slot="key">{$i18n.sns_project_detail.min_commitment} </span>
-    <AmountDisplay slot="value" amount={minCommitmentIcp} singleLine />
+    <AmountDisplay slot="value" amount={minCommitmentIcp} detailed singleLine />
   </KeyValuePair>
   <KeyValuePair>
     <span slot="key">{$i18n.sns_project_detail.max_commitment} </span>

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -221,6 +221,7 @@ export const validParticipation = ({
       substitutions: {
         $amount: formatToken({
           value: project.summary.swap.params.min_participant_icp_e8s,
+          detailed: true,
         }),
       },
     };


### PR DESCRIPTION
# Motivation

Modclub set `"min_participant_icp_e8s":100000278` which we round in the UI to 1.00 ICP.
Then when you try to participate with 1 ICP you get an error saying
"Sorry, the amount is too small. You need a minimum of 1.00 ICP to participate in this swap."

# Changes

Call `formatToken` with `detailed: true`. This renders all significant digits if amount >= 0.01 (if I understand the code correctly).

# Tests

no

# Todos

- [x] Add entry to changelog (if necessary).
