### PR TITLE
Fix: Aggregator type and subsequent converter

### DIFF
--- a/frontend/src/lib/types/sns-aggregator.ts
+++ b/frontend/src/lib/types/sns-aggregator.ts
@@ -161,7 +161,7 @@ export type CachedSnsSwapDerivedDto = {
 };
 
 type CachedSwapParamsResponseDto = {
-  params: CachedSwapParamsDto;
+  params: CachedSwapParamsDto | null;
 };
 
 type CachedInitResponseDto = {

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -328,7 +328,9 @@ const convertSnsData = ({
   icrc1_total_supply: BigInt(icrc1_total_supply),
   derived_state: convertDerivedToResponse(derived_state),
   swap_params: {
-    params: [convertSwapParams(swap_params.params)],
+    params: isNullish(swap_params.params)
+      ? []
+      : [convertSwapParams(swap_params.params)],
   },
   init: {
     init: convertSwapInitParams(init.init),

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -1,4 +1,4 @@
-import type { CachedSnsDto } from "$lib/types/sns-aggregator";
+import type { CachedSns, CachedSnsDto } from "$lib/types/sns-aggregator";
 import {
   convertDtoData,
   convertDtoToSnsSummary,
@@ -15,6 +15,22 @@ describe("sns aggregator converters utils", () => {
       expect(convertDtoData([aggregatorSnsMockDto])).toEqual([
         aggregatorSnsMock,
       ]);
+    });
+
+    it("converts aggregator types to ic-js types if no swap params", () => {
+      const aggregatorDto: CachedSnsDto = {
+        ...aggregatorSnsMockDto,
+        swap_params: {
+          params: null,
+        },
+      };
+      const expected: CachedSns = {
+        ...aggregatorSnsMock,
+        swap_params: {
+          params: [],
+        },
+      };
+      expect(convertDtoData([aggregatorDto])).toEqual([expected]);
     });
   });
 


### PR DESCRIPTION
# Motivation

Type of the SNS aggregator for `swap_params` was wrong. It was "CachedSwapParamsDto | null", not just "CachedSwapParamsDto".

# Changes

* Change the type of `CachedSnsDto`.
* Change converter accordingly.

# Tests

* Add a test with the specific field.

# Todos

- [ ] Add entry to changelog (if necessary).
Not worth a new entry yet.
