### PR TITLE
Chore: Add Launchpad test with prod data

### DIFF
--- a/frontend/src/tests/workflows/Launchpad/LaunchpadWithLayout.svelte
+++ b/frontend/src/tests/workflows/Launchpad/LaunchpadWithLayout.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import Launchpad from "../../../routes/(app)/(nns)/launchpad/+page.svelte";
+  import LaunchpadLayout from "../../../routes/(app)/(nns)/launchpad/+layout.svelte";
+  import MainLayout from "../../../routes/(app)/+layout.svelte";
+</script>
+
+<MainLayout>
+  <LaunchpadLayout>
+    <Launchpad />
+  </LaunchpadLayout>
+</MainLayout>
+```

--- a/frontend/src/tests/workflows/Launchpad/ProdLaunchpad.spec.ts
+++ b/frontend/src/tests/workflows/Launchpad/ProdLaunchpad.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as proposalsApi from "$lib/api/proposals.api";
+import { authStore } from "$lib/stores/auth.store";
+import tenAggregatedSnses from "$tests/mocks/sns-aggregator.mock.json";
+import { LaunchpadPo } from "$tests/page-objects/Launchpad.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { toastsStore } from "@dfinity/gix-components";
+import { render, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import Launchpad from "./LaunchpadWithLayout.svelte";
+
+jest.mock("$lib/api/proposals.api");
+
+describe("Launchpad", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authStore.setForTesting(undefined);
+
+    jest
+      .spyOn(proposalsApi, "queryProposals")
+      .mockImplementation(() => Promise.resolve([]));
+
+    const mockFetch = jest.fn();
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(tenAggregatedSnses),
+      })
+      .mockReturnValueOnce({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+    global.fetch = mockFetch;
+  });
+
+  it("loads with prod data", async () => {
+    const { container } = render(Launchpad);
+
+    const po = LaunchpadPo.under(new JestPageObjectElement(container));
+
+    await po.getCommittedProjectsPo().waitForContentLoaded();
+
+    await waitFor(async () =>
+      expect(
+        (
+          await po.getCommittedProjectsPo().getProjectCardPos()
+        ).length
+      ).toBeGreaterThan(0)
+    );
+
+    expect(get(toastsStore).length).toBe(0);
+  });
+});


### PR DESCRIPTION
# Motivation

We had a bug because the type of the aggregator in ths NNS Dapp was not correct and when it tried to convert a certain field it failed.

In this PR, I try to add a test that renders the Launchpad with prod data from the aggregator. I then check that there are committed projects and no errors.

# Changes

* New test  in workflows/Launchpad/ProdLaunchpad.spec.ts.
* New test component in workflows/Launchpad/LaunchpadWithLayout.svelte. This is used to trigger the same flows as the svelte app. In this scenario, the call to the SNS aggregator.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
