### PR TITLE
Fix: SnsProposals.spec

### DIFF
--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -4,6 +4,7 @@
 
 import SnsProposals from "$lib/pages/SnsProposals.svelte";
 import { authStore } from "$lib/stores/auth.store";
+import { snsFiltersStore } from "$lib/stores/sns-filters.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
 import { page } from "$mocks/$app/stores";
@@ -43,6 +44,7 @@ describe("SnsProposals", () => {
     jest.clearAllMocks();
     snsProposalsStore.reset();
     snsFunctionsStore.reset();
+    snsFiltersStore.reset();
     setSnsProjects([
       {
         rootCanisterId,


### PR DESCRIPTION
# Motivation

The SnsProposals.spec was failing when being randomized.

The problem was that filters set in one tests were interfering with other tests. The solution is to reset the snsFiltersStore in the beforeEach.

# Changes

* Add a `snsFiltersStore.reset();` in the beforeEach of SnsProposals.spec.

# Tests

Only test changes

# Todos

- [ ] Add entry to changelog (if necessary).
Already covered by a changelog entry.
