### PR TITLE
E2E: Wait for content to load after going to the neurons tab

### DIFF
--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -111,6 +111,7 @@ export class AppPo extends BasePageObject {
     await this.getMenuItemsPo().clickNeuronStaking();
     // Menu closes automatically.
     await this.getBackdropPo().waitForAbsent();
+    await this.getNeuronsPo().waitForContentLoaded();
   }
 
   async goToNeuronDetails(neuronId: string): Promise<void> {

--- a/frontend/src/tests/page-objects/Neurons.page-object.ts
+++ b/frontend/src/tests/page-objects/Neurons.page-object.ts
@@ -43,4 +43,11 @@ export class NeuronsPo extends BasePageObject {
     ]);
     return nnsLoaded || snsLoaded;
   }
+
+  async waitForContentLoaded(): Promise<void> {
+    await Promise.race([
+      this.getNnsNeuronsPo().waitForContentLoaded(),
+      this.getSnsNeuronsPo().waitForContentLoaded(),
+    ]);
+  }
 }


### PR DESCRIPTION
# Motivation

Some [flakiness was observed](https://github.com/dfinity/nns-dapp/actions/runs/5925864493/job/16066262925?pr=3155) in the e2e test that disburses a neuron.
What happened is that after going to the neurons tab, no neuron cards were visible.
When I tried manually going from the accounts tab to the neurons tab, I noticed that the accounts tab was still there for a short time before the neurons tab renders.

# Changes

In `AppPo.goToNeurons()` wait for the neurons tab to be loaded before continuing.

# Tests

I wasn't able to reproduce the flakiness but the tests still pass with this change as well and it seems like it should help.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary