### PR TITLE
Improve ProjectSwapDetails.spec.ts

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
@@ -70,7 +70,7 @@
       <AmountDisplay slot="value" amount={snsTotalTokenSupply} singleLine />
     </KeyValuePair>
   {/if}
-  <KeyValuePair>
+  <KeyValuePair testId="sns-tokens-distributed">
     <span slot="key">{$i18n.sns_project_detail.total_tokens} </span>
     <AmountDisplay slot="value" amount={snsTokens} singleLine />
   </KeyValuePair>
@@ -83,15 +83,15 @@
       })}</span
     >
   </KeyValuePair>
-  <KeyValuePair>
+  <KeyValuePair testId="sns-min-participant-commitment">
     <span slot="key">{$i18n.sns_project_detail.min_commitment} </span>
     <AmountDisplay slot="value" amount={minCommitmentIcp} detailed singleLine />
   </KeyValuePair>
-  <KeyValuePair>
+  <KeyValuePair testId="sns-max-participant-commitment">
     <span slot="key">{$i18n.sns_project_detail.max_commitment} </span>
     <AmountDisplay slot="value" amount={maxCommitmentIcp} singleLine />
   </KeyValuePair>
-  <KeyValuePair>
+  <KeyValuePair testId="sns-sale-end">
     <span slot="key">{$i18n.sns_project_detail.sale_end} </span>
     <DateSeconds
       slot="value"

--- a/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
@@ -3,14 +3,13 @@
  */
 
 import ProjectSwapDetails from "$lib/components/project-detail/ProjectSwapDetails.svelte";
+import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { snsTotalTokenSupplyStore } from "$lib/stores/sns-total-token-supply.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
-import { secondsToDate, secondsToTime } from "$lib/utils/date.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import {
   createSummary,
   mockSnsFullProject,
-  mockSnsParams,
   mockSummary,
 } from "$tests/mocks/sns-projects.mock";
 import { renderContextCmp } from "$tests/mocks/sns.mock";
@@ -19,89 +18,69 @@ import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { TokenAmount } from "@dfinity/utils";
 
 describe("ProjectSwapDetails", () => {
+  const renderComponent = (props): ProjectSwapDetailsPo => {
+    const { container } = renderContextCmp({
+      ...props,
+      Component: ProjectSwapDetails,
+    });
+
+    return ProjectSwapDetailsPo.under(new JestPageObjectElement(container));
+  };
+
   beforeEach(() => {
     snsTotalTokenSupplyStore.reset();
   });
 
-  it("should render total tokens", () => {
-    const { container } = renderContextCmp({
-      summary: mockSummary,
+  it("should render total distributed tokens", async () => {
+    const po = await renderComponent({
+      summary: createSummary({
+        tokensDistributed: 7125n * BigInt(E8S_PER_ICP),
+      }),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-      Component: ProjectSwapDetails,
     });
 
-    const element = Array.from(
-      container.querySelectorAll('[data-tid="token-value"]')
-    )[0];
-
-    expect(element?.innerHTML).toEqual(
-      `${(Number(mockSnsParams.sns_token_e8s) / 100000000).toFixed(2)}`
-    );
+    expect(await po.getTokensDistributed()).toEqual("7'125.00");
   });
 
   it("should render min participants", async () => {
-    const { container } = renderContextCmp({
+    const po = renderComponent({
       summary: createSummary({ minParticipants: 1430 }),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-      Component: ProjectSwapDetails,
     });
-
-    const po = ProjectSwapDetailsPo.under(new JestPageObjectElement(container));
 
     expect(await po.getMinParticipants()).toEqual("1’430");
   });
 
-  it("should render min commitment", () => {
-    const { container } = renderContextCmp({
-      summary: mockSummary,
+  it("should render min commitment", async () => {
+    const po = renderComponent({
+      summary: createSummary({
+        minParticipantCommitment: BigInt(2.5 * E8S_PER_ICP),
+      }),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-      Component: ProjectSwapDetails,
     });
 
-    const element = Array.from(
-      container.querySelectorAll('[data-tid="token-value"]')
-    )[1];
-
-    expect(element?.innerHTML).toEqual(
-      `${(Number(mockSnsParams.min_participant_icp_e8s) / 100000000).toFixed(
-        2
-      )}`
-    );
+    expect(await po.getMinParticipantCommitment()).toEqual("2.50 ICP");
   });
 
-  it("should render max commitment", () => {
-    const { container } = renderContextCmp({
-      summary: mockSummary,
+  it("should render max commitment", async () => {
+    const po = renderComponent({
+      summary: createSummary({
+        maxParticipantCommitment: BigInt(345 * E8S_PER_ICP),
+      }),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-      Component: ProjectSwapDetails,
     });
 
-    const element = Array.from(
-      container.querySelectorAll('[data-tid="token-value"]')
-    )[2];
-
-    expect(element?.innerHTML).toEqual(
-      `${(Number(mockSnsParams.max_participant_icp_e8s) / 100000000).toFixed(
-        2
-      )}`
-    );
+    expect(await po.getMaxParticipantCommitment()).toEqual("345.00 ICP");
   });
 
-  it("should render sale end", () => {
-    const { queryByTestId } = renderContextCmp({
-      summary: mockSummary,
+  it("should render sale end", async () => {
+    const swapDeadline = new Date("2023-10-04T15:00:00.000Z").getTime() / 1000;
+    const po = renderComponent({
+      summary: createSummary({ swapDueTimestampSeconds: BigInt(swapDeadline) }),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-      Component: ProjectSwapDetails,
     });
 
-    const element = queryByTestId("date-seconds");
-
-    const seconds = Number(
-      mockSnsFullProject.summary.swap.params.swap_due_timestamp_seconds
-    );
-    expect(element?.innerHTML).toEqual(
-      `${secondsToDate(seconds)} ${secondsToTime(seconds)}`
-    );
+    expect(await po.getSaleEnd()).toEqual("Oct 4, 2023 3:00 PM");
   });
 
   it("should render total token supply if present", async () => {
@@ -110,14 +89,11 @@ describe("ProjectSwapDetails", () => {
       amount: totalSupply,
       token: mockSummary.token,
     });
-    const { container } = renderContextCmp({
+    const po = renderComponent({
       summary: mockSummary,
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
       totalTokensSupply,
-      Component: ProjectSwapDetails,
     });
-
-    const po = ProjectSwapDetailsPo.under(new JestPageObjectElement(container));
 
     expect(await po.getTotalSupply()).toMatch(
       formatToken({ value: totalSupply })
@@ -125,25 +101,19 @@ describe("ProjectSwapDetails", () => {
   });
 
   it("should not render restricted countries if absent", async () => {
-    const { container } = renderContextCmp({
+    const po = renderComponent({
       summary: createSummary({ restrictedCountries: [] }),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-      Component: ProjectSwapDetails,
     });
-
-    const po = ProjectSwapDetailsPo.under(new JestPageObjectElement(container));
 
     expect(await po.getExcludedCountriesPo().isPresent()).toBe(false);
   });
 
   it("should render restricted countries", async () => {
-    const { container } = renderContextCmp({
+    const po = renderComponent({
       summary: createSummary({ restrictedCountries: ["CH", "US"] }),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-      Component: ProjectSwapDetails,
     });
-
-    const po = ProjectSwapDetailsPo.under(new JestPageObjectElement(container));
 
     expect(await po.getExcludedCountriesPo().getValueText()).toBe("CH, US");
   });

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -305,15 +305,24 @@ export const createSummary = ({
   restrictedCountries = undefined,
   minParticipants = 20,
   buyersCount = 300n,
+  tokensDistributed = 2_000_000_000_000n,
+  minParticipantCommitment = 100_000_000n,
+  maxParticipantCommitment = 100_000_000n,
+  swapDueTimestampSeconds = 1630444800n,
 }: {
   lifecycle?: SnsSwapLifecycle;
   confirmationText?: string | undefined;
   restrictedCountries?: string[] | undefined;
   minParticipants?: number;
   buyersCount?: bigint | null;
+  tokensDistributed?: bigint;
+  minParticipantCommitment?: bigint;
+  maxParticipantCommitment?: bigint;
+  swapDueTimestampSeconds?: bigint;
 }): SnsSummary => {
   const init: SnsSwapInit = {
     ...mockInit,
+    swap_due_timestamp_seconds: [swapDueTimestampSeconds],
     confirmation_text: toNullable(confirmationText),
     restricted_countries: nonNullish(restrictedCountries)
       ? [{ iso_codes: restrictedCountries }]
@@ -322,6 +331,10 @@ export const createSummary = ({
   const params: SnsParams = {
     ...mockSnsParams,
     min_participants: minParticipants,
+    sns_token_e8s: tokensDistributed,
+    min_participant_icp_e8s: minParticipantCommitment,
+    max_participant_icp_e8s: maxParticipantCommitment,
+    swap_due_timestamp_seconds: swapDueTimestampSeconds,
   };
   const derived: SnsSwapDerivedState = {
     ...mockDerived,

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -297,7 +297,7 @@ export const createSummary = ({
   buyersCount = 300n,
   tokensDistributed = 2_000_000_000_000n,
   minParticipantCommitment = 100_000_000n,
-  maxParticipantCommitment = 100_000_000n,
+  maxParticipantCommitment = 5_000_000_000n,
   swapDueTimestampSeconds = 1630444800n,
 }: {
   lifecycle?: SnsSwapLifecycle;

--- a/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectSwapDetails.page-object.ts
@@ -16,6 +16,12 @@ export class ProjectSwapDetailsPo extends BasePageObject {
     ).getAmount();
   }
 
+  getTokensDistributed(): Promise<string> {
+    return AmountDisplayPo.under(
+      this.root.querySelector("[data-tid=sns-tokens-distributed]")
+    ).getAmount();
+  }
+
   getExcludedCountriesPo(): KeyValuePairPo {
     return KeyValuePairPo.under({
       element: this.root,
@@ -27,6 +33,31 @@ export class ProjectSwapDetailsPo extends BasePageObject {
     return KeyValuePairPo.under({
       element: this.root,
       testId: "project-swap-min-participants",
+    }).getValueText();
+  }
+
+  async getMinParticipantCommitment(): Promise<string> {
+    return (
+      await KeyValuePairPo.under({
+        element: this.root,
+        testId: "sns-min-participant-commitment",
+      }).getValueText()
+    ).trim();
+  }
+
+  async getMaxParticipantCommitment(): Promise<string> {
+    return (
+      await KeyValuePairPo.under({
+        element: this.root,
+        testId: "sns-max-participant-commitment",
+      }).getValueText()
+    ).trim();
+  }
+
+  getSaleEnd(): Promise<string> {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "sns-sale-end",
     }).getValueText();
   }
 }


### PR DESCRIPTION
# Motivation

I wanted to add unit tests for https://github.com/dfinity/nns-dapp/pull/3150 but I noticed some issues in `ProjectSwapDetails.spec.ts` so I wanted to fix those first.

`ProjectSwapDetails.spec.ts` expects token values to appear in a certain order in the UI and it queries all of them with the same query and then uses a magic index into that list.
Because of this it also relies on different values being different otherwise we wouldn't notice of some swapped places in the order.

# Changes

1. Use page objects in all the tests in `ProjectSwapDetails.spec.ts`.
2. Set specific values on the input and expect those specific values to be rendered instead of depending on what happens to be in the mock data.
3. Add necessary test IDs.
4. Add getters on `ProjectSwapDetails.page-object.ts`.
5. Allow more customization in `createSummary`.

# Tests

Apart from added test ID in component, the changes are test only.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary