### PR TITLE
Fix: ProjectDetail.spec randomization

### DIFF
--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -538,6 +538,12 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
         };
         jest
           .spyOn(snsApi, "querySnsSwapCommitment")
+          // Query call
+          .mockResolvedValueOnce({
+            rootCanisterId,
+            myCommitment: initialCommitment,
+          } as SnsSwapCommitment)
+          // Update call
           .mockResolvedValueOnce({
             rootCanisterId,
             myCommitment: initialCommitment,


### PR DESCRIPTION
# Motivation

ProjectDetail.spec failed when tests were randomized.

The problem is hard to explain. When `"should participate without user interaction if there is an open ticket."` was called first, then `"successful participation"` failed.

They failed because the swap participation on reload return no participation. As if no participation went through and it didn't show in the UI.

This participation seemed to come from the mock set in `"should participate without user interaction if there is an open ticket."`. Because when I commented it, the test `"successful participation"` passed successfully.

Why that was, I don't know.

In this PR, I discovered a problem in the test `"should participate without user interaction if there is an open ticket."`. The problem doesn't seem to have relation with the problem, but it seems to fix it 🤷 .

The problem is that it was mocking only one call for no swap commitment. Instead of the two calls (query + update) that the code does.

Why this fixes it, it's a mystery to me. But I believe that the change was still worth it.

# Changes

* Add a mock once for `querySnsSwapCommitment` in `"should participate without user interaction if there is an open ticket."`.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Already covered by a changelog entry.
