### PR TITLE
Unit tests for detailed min participation

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -48,6 +48,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Allow specifying a test_filter to the e2e CI action.
 * New test util to set SNS projects for testing.
 * Make scripts/past-changelog-test check again the previous commit when run on main.
+* Unit tests for the detailed `min_participant_icp_e8s` rendering.
 
 #### Changed
 

--- a/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
@@ -62,6 +62,17 @@ describe("ProjectSwapDetails", () => {
     expect(await po.getMinParticipantCommitment()).toEqual("2.50 ICP");
   });
 
+  it("should render min commitment with many significant decimals", async () => {
+    const po = renderComponent({
+      summary: createSummary({
+        minParticipantCommitment: 100000278n,
+      }),
+      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
+    });
+
+    expect(await po.getMinParticipantCommitment()).toEqual("1.00000278 ICP");
+  });
+
   it("should render max commitment", async () => {
     const po = renderComponent({
       summary: createSummary({

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -222,7 +222,7 @@ describe("ParticipateSwapModal", () => {
       expect(await form.isContinueButtonEnabled()).toBe(true);
     });
 
-    it("should not show an error when amount is no too small", async () => {
+    it("should not show an error when amount is not too small", async () => {
       const po = await renderSwapModalPo({
         swapCommitment: {
           ...mockSwapCommitment,

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -67,6 +67,7 @@ jest.mock("$lib/services/sns-sale.services", () => ({
 type SwapModalParams = {
   swapCommitment?: SnsSwapCommitment | undefined;
   confirmationText?: string | undefined;
+  minParticipantCommitment?: bigint | undefined;
 };
 
 describe("ParticipateSwapModal", () => {
@@ -85,13 +86,17 @@ describe("ParticipateSwapModal", () => {
   const renderSwapModal = ({
     swapCommitment,
     confirmationText,
+    minParticipantCommitment,
   }: SwapModalParams = {}) =>
     renderModalContextWrapper({
       Component: ParticipateSwapModal,
       contextKey: PROJECT_DETAIL_CONTEXT_KEY,
       contextValue: {
         store: writable<ProjectDetailStore>({
-          summary: createSummary({ confirmationText }),
+          summary: createSummary({
+            confirmationText,
+            minParticipantCommitment,
+          }),
           swapCommitment,
         }),
         reload,
@@ -215,6 +220,51 @@ describe("ParticipateSwapModal", () => {
       const form = po.getTransactionFormPo();
       await form.enterAmount(10);
       expect(await form.isContinueButtonEnabled()).toBe(true);
+    });
+
+    it("should not show an error when amount is no too small", async () => {
+      const po = await renderSwapModalPo({
+        swapCommitment: {
+          ...mockSwapCommitment,
+          myCommitment: createBuyersState(BigInt(0)),
+        },
+        minParticipantCommitment: BigInt(100000000),
+      });
+      const form = po.getTransactionFormPo();
+      await form.enterAmount(1);
+      expect(await form.getAmountInputPo().hasError()).toBe(false);
+    });
+
+    it("should show an error when amount is too small", async () => {
+      const po = await renderSwapModalPo({
+        swapCommitment: {
+          ...mockSwapCommitment,
+          myCommitment: createBuyersState(BigInt(0)),
+        },
+        minParticipantCommitment: BigInt(100000000),
+      });
+      const form = po.getTransactionFormPo();
+      await form.enterAmount(0.01);
+      expect(await form.getAmountInputPo().hasError()).toBe(true);
+      expect(await form.getAmountInputPo().getErrorMessage()).toBe(
+        "Sorry, the amount is too small. You need a minimum of 1.00 ICP to participate in this swap."
+      );
+    });
+
+    it("should show an error with enough significant digits", async () => {
+      const po = await renderSwapModalPo({
+        swapCommitment: {
+          ...mockSwapCommitment,
+          myCommitment: createBuyersState(BigInt(0)),
+        },
+        minParticipantCommitment: BigInt(100000278),
+      });
+      const form = po.getTransactionFormPo();
+      await form.enterAmount(0.01);
+      expect(await form.getAmountInputPo().hasError()).toBe(true);
+      expect(await form.getAmountInputPo().getErrorMessage()).toBe(
+        "Sorry, the amount is too small. You need a minimum of 1.00000278 ICP to participate in this swap."
+      );
     });
 
     describe("when user has non-zero swap commitment", () => {

--- a/frontend/src/tests/page-objects/AmountInput.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountInput.page-object.ts
@@ -11,4 +11,12 @@ export class AmountInputPo extends BasePageObject {
   enterAmount(amount: number): Promise<void> {
     return this.getTextInput().typeText(amount.toString());
   }
+
+  hasError(): Promise<boolean> {
+    return this.root.byTestId("input-error-message").isPresent();
+  }
+
+  async getErrorMessage(): Promise<string> {
+    return (await this.getText("input-error-message")).trim();
+  }
 }


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/3150 was merged in a hurry without unit tests.

# Changes

1. Unit test in `ProjectSwapDetails.spec.ts` for detailed min participation rendering.
2. Unit test in `ParticipateSwapModal.spec.ts` for "not enough commitment" error message with detailed min participation.

# Tests

only

# Todos

- [x] Add entry to changelog (if necessary).
