### PR TITLE
Fix: More SNS aggregator optional types

### DIFF
--- a/frontend/src/lib/types/sns-aggregator.ts
+++ b/frontend/src/lib/types/sns-aggregator.ts
@@ -53,9 +53,9 @@ export type CachedSns = {
 };
 
 export type CachedSnsMetadataDto = {
-  url: string;
-  name: string;
-  description: string;
+  url: string | null;
+  name: string | null;
+  description: string | null;
 };
 
 interface GenericNervousSystemFunctionDto {
@@ -72,8 +72,8 @@ export type CachedFunctionTypeDto =
 export type CachedNervousFunctionDto = {
   id: number;
   name: string;
-  description: string;
-  function_type: CachedFunctionTypeDto;
+  description: string | null;
+  function_type: CachedFunctionTypeDto | null;
 };
 
 type CachedCountriesDto = {
@@ -141,9 +141,9 @@ export type CachedSnsSwapDto = {
   lifecycle: number;
   decentralization_sale_open_timestamp_seconds?: number;
   finalize_swap_in_progress?: boolean;
-  init: CachedSwapInitParamsDto;
-  params: CachedSwapParamsDto;
-  open_sns_token_swap_proposal_id: number;
+  init: CachedSwapInitParamsDto | null;
+  params: CachedSwapParamsDto | null;
+  open_sns_token_swap_proposal_id: number | null;
 };
 
 export type CachedSnsSwapDerivedDto = {
@@ -159,7 +159,7 @@ type CachedSwapParamsResponseDto = {
 };
 
 type CachedInitResponseDto = {
-  init: CachedSwapInitParamsDto;
+  init: CachedSwapInitParamsDto | null;
 };
 
 export type CachedLifecycleResponseDto = {

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -100,7 +100,7 @@ export const convertNervousFuncttion = ({
 });
 
 const convertSwapInitParams = (
-  init: CachedSwapInitParamsDto
+  init: CachedSwapInitParamsDto | null
 ): [SnsSwapInit] | [] =>
   nonNullish(init)
     ? toNullable({
@@ -225,7 +225,7 @@ const convertSwap = ({
     open_sns_token_swap_proposal_id !== undefined
       ? toNullable(convertOptionalNumToBigInt(open_sns_token_swap_proposal_id))
       : [],
-  init: nonNullish(init) ? convertSwapInitParams(init) : [],
+  init: convertSwapInitParams(init),
   params: isNullish(params) ? [] : [convertSwapParams(params)],
 });
 

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -394,7 +394,7 @@ describe("sns aggregator converters utils", () => {
     });
   });
 
-  describe("convertNervousFuncttion", () => {
+  describe("convertNervousFunction", () => {
     it("converts nervous function to ic-js type", () => {
       const nsFunction = {
         id: 0,

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -377,5 +377,19 @@ describe("sns aggregator converters utils", () => {
       };
       expect(convertDtoToSnsSummary(aggregatorMissingMetadata)).toBeUndefined();
     });
+
+    it("returns undefined if a swap params required field is missing", () => {
+      const aggregatorMissingMetadata: CachedSnsDto = {
+        ...mockData,
+        swap_state: {
+          ...mockData.swap_state,
+          swap: {
+            ...mockData.swap_state.swap,
+            params: null,
+          },
+        },
+      };
+      expect(convertDtoToSnsSummary(aggregatorMissingMetadata)).toBeUndefined();
+    });
   });
 });

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -2,6 +2,7 @@ import type { CachedSnsDto } from "$lib/types/sns-aggregator";
 import {
   convertDtoData,
   convertDtoToSnsSummary,
+  convertNervousFuncttion,
 } from "$lib/utils/sns-aggregator-converters.utils";
 import {
   aggregatorSnsMock,
@@ -390,6 +391,44 @@ describe("sns aggregator converters utils", () => {
         },
       };
       expect(convertDtoToSnsSummary(aggregatorMissingMetadata)).toBeUndefined();
+    });
+  });
+
+  describe("convertNervousFuncttion", () => {
+    it("converts nervous function to ic-js type", () => {
+      const nsFunction = {
+        id: 0,
+        name: "All Topics",
+        description: "Catch-all w.r.t to following for all types of proposals.",
+        function_type: { NativeNervousSystemFunction: {} },
+      };
+
+      expect(convertNervousFuncttion(nsFunction)).toEqual({
+        id: 0n,
+        name: "All Topics",
+        description: [
+          "Catch-all w.r.t to following for all types of proposals.",
+        ],
+        function_type: [{ NativeNervousSystemFunction: {} }],
+      });
+    });
+
+    it("returns function_type as empty array when null", () => {
+      const nsFunction = {
+        id: 0,
+        name: "All Topics",
+        description: "Catch-all w.r.t to following for all types of proposals.",
+        function_type: null,
+      };
+
+      expect(convertNervousFuncttion(nsFunction)).toEqual({
+        id: 0n,
+        name: "All Topics",
+        description: [
+          "Catch-all w.r.t to following for all types of proposals.",
+        ],
+        function_type: [],
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -380,7 +380,7 @@ describe("sns aggregator converters utils", () => {
     });
 
     it("returns undefined if a swap params required field is missing", () => {
-      const aggregatorMissingMetadata: CachedSnsDto = {
+      const aggregatorMissingSwapParams: CachedSnsDto = {
         ...mockData,
         swap_state: {
           ...mockData.swap_state,
@@ -390,7 +390,9 @@ describe("sns aggregator converters utils", () => {
           },
         },
       };
-      expect(convertDtoToSnsSummary(aggregatorMissingMetadata)).toBeUndefined();
+      expect(
+        convertDtoToSnsSummary(aggregatorMissingSwapParams)
+      ).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
# Motivation

We realized that some of our SNS aggregator types were not correct. It seems that the changes were not exhaustive and there are more fields that can still be optional.

I based my findings on the actual types of the canisters. Where the response said `[] | [T]`, I changed it to `null | T`.

# Changes

* Change value of some fields in SNS aggregator to make them optional.
* Fix converters after change.

# Tests

* Test the new functionality when converting the summary that might return undefined if swap params are not defined.
* Add a test for `convertNervousFuncttion` (typo will be addressed in another PR)

# Todos

- [ ] Add entry to changelog (if necessary).
Already covered by a changelog entry.
