### PR TITLE
Rustdoc - fix

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,6 +55,8 @@ jobs:
           cargo test --all-targets --all-features
         env:
           RUST_BACKTRACE: 1
+      - name: Lint rustdoc
+        run: ./scripts/lint-rustdoc
   svelte-tests:
     runs-on: ubuntu-latest-m
     defaults:

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -41,6 +41,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Not Published
 
 ### Operations
+* Improve the rust document generation.
 
 #### Added
 

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -87,7 +87,7 @@ impl NamedCanister {
     /// Note: This allocates a string, so for sorting long lists this will be slow.
     /// - Consider using `sort_by_cached_key(|x| x.sorting_key())`, if allowed in canisters.
     /// - Determine whether the native ordering of principals is acceptable.  If so, the key can
-    ///   be of type (bool, &str, &Principal) where the string is the name.
+    ///   be of type `(bool, &str, &Principal)` where the string is the name.
     fn sorting_key(&self) -> (bool, String) {
         if self.name.is_empty() {
             (true, self.canister_id.to_string())

--- a/rs/backend/src/arguments.rs
+++ b/rs/backend/src/arguments.rs
@@ -102,7 +102,7 @@ pub fn configname2attributename(name: &str) -> String {
     "data-".to_owned() + &name.replace('_', "-").to_lowercase()
 }
 
-/// Escapes a configuration value per the OWASP recommendation: https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#output-encoding-for-html-contexts
+/// Escapes a configuration value per the OWASP recommendation: <https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#output-encoding-for-html-contexts>
 pub fn configvalue2attributevalue(value: &str) -> String {
     value
         .replace('&', "&amp;")

--- a/rs/backend/src/arguments.rs
+++ b/rs/backend/src/arguments.rs
@@ -12,10 +12,10 @@ use regex::{Captures, Regex};
 use serde::Serialize;
 use std::collections::HashMap;
 
-/// Init and post_upgrade arguments
+/// `init` and `post_upgrade` arguments
 #[derive(Debug, Default, Eq, PartialEq, CandidType, Serialize, Deserialize)]
 pub struct CanisterArguments {
-    /// Values that are to be set in the web front end, by injecting them into Javascript.
+    /// Values that are to be set in the web front end, by injecting them into JavaScript.
     pub args: Vec<(String, String)>,
 }
 
@@ -25,12 +25,12 @@ thread_local! {
 }
 
 impl CanisterArguments {
-    /// HTML meta tag to be included in every index.html
+    /// HTML meta tag to be included in every `index.html`.
     ///
     /// Canister arguments are included in the meta tag as data attributes.  Thus:
     /// - Arguments are upper snake case with digits: `SAMPLE_ARG2`
     /// - In the tag, arguments are lower kebab case data attributes: `data-sample-arg2`
-    /// - In Javascript the tag can be read as camel case with:
+    /// - In JavaScript the tag can be read as camel case with:
     ///   `document.querySelector('meta[name="nns-dapp-vars"]').dataset.sampleArg2`
     ///
     /// In Rust, the substitution is as follows:

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -118,24 +118,24 @@ impl Assets {
     ///   directory may be returned, e.g. `/launchpad/index.html`
     /// - "" -> "/index.html" A directory does not need a trailing slash.  E.g. `/launchpad` may
     ///   serve `/launchpad/index.html`.  Please note that if this is done, relative URLs in
-    ///   index.html will break so be careful if using this much requested but error-prone option.
+    ///   `index.html` will break so be careful if using this much requested but error-prone option.
     const SUFFIX_REWRITES: [(&str, &str); 3] = [("", ""), ("/", "/index.html"), ("", "/index.html")];
     /// Inserts an asset into the database.
     ///
     /// - The asset encoding is deduced from the asset path suffix.  Thus
-    ///   e.g. foo.js.gz should be entered with the .gz suffix.
+    ///   e.g. `foo.js.gz` should be entered with the `.gz` suffix.
     pub fn insert<S: Into<String>>(&mut self, path: S, asset: Asset) {
         self.0.insert(path.into(), asset);
     }
     /// Gets a given URL path from the assets, if available.
     ///
-    /// - If the path looks like an index, the canonical suffix "/index.html" will be used.
+    /// - If the path looks like an index, the canonical suffix `/index.html` will be used.
     /// - The retrieval search will look for compressed versions of the data.  E.g. if
-    ///   foo.json is requested and foo.json.gz is available, that will be returned along with
-    ///   "gzip" as the encoding.  The encoding can be set in the browser response HTTP header
-    ///   so that the browser will decompress the data before giving it to the requestor.  If
-    ///   the requestor wishes to receive the compressed data, without transparent decoding,
-    ///   the requestor should ask for "foo.json.gz" instead of "foo.json".
+    ///   `foo.json` is requested and foo.json.gz is available, that will be returned along with
+    ///   `gzip` as the encoding.  The encoding can be set in the browser response HTTP header
+    ///   so that the browser will decompress the data before giving it to the requester.  If
+    ///   the requester wishes to receive the compressed data, without transparent decoding,
+    ///   the requester should ask for `foo.json.gz` instead of `foo.json`.
     /// - The current asset signature scheme supports only one signature per path, so we cannot
     ///   take browser capabilities into account.
     pub fn get(&self, path: &str) -> Option<(ContentEncoding, &Asset)> {
@@ -292,7 +292,7 @@ fn content_type_of(request_path: &str) -> Option<&'static str> {
 }
 
 /// List of recommended security headers as per <https://owasp.org/www-project-secure-headers/>
-/// These headers enable browser security features (like limit access to platform apis and set
+/// These headers enable browser security features (like limit access to platform APIs and set
 /// iFrame policies, etc.).
 /// TODO <https://dfinity.atlassian.net/browse/L2-185>: Add CSP and Permissions-Policy
 fn security_headers() -> Vec<HeaderField> {
@@ -358,9 +358,9 @@ pub fn insert_asset_into_state<S: Into<String> + Clone>(state: &State, path: S, 
     assets.insert(path, asset);
 }
 
-/// Adds the files bundled in the wasm to the state.
+/// Adds the files bundled in the WASM to the state.
 ///
-/// Note: Used both in init and post_upgrade
+/// Note: Used both in `init` and `post_upgrade`
 pub fn init_assets() {
     #[cfg(feature = "assets")]
     {

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -291,10 +291,10 @@ fn content_type_of(request_path: &str) -> Option<&'static str> {
     })
 }
 
-/// List of recommended security headers as per https://owasp.org/www-project-secure-headers/
+/// List of recommended security headers as per <https://owasp.org/www-project-secure-headers/>
 /// These headers enable browser security features (like limit access to platform apis and set
 /// iFrame policies, etc.).
-/// TODO https://dfinity.atlassian.net/browse/L2-185: Add CSP and Permissions-Policy
+/// TODO <https://dfinity.atlassian.net/browse/L2-185>: Add CSP and Permissions-Policy
 fn security_headers() -> Vec<HeaderField> {
     vec![
         ("X-Frame-Options".to_string(), "DENY".to_string()),

--- a/rs/backend/src/lib.rs
+++ b/rs/backend/src/lib.rs
@@ -1,4 +1,8 @@
 //! Library for <https://nns.ic0.app>
+//!
+//! Note: The types are accessed by the nns-dapp directly from main.rs, not via this library.
+//!
+//! Note: This library is for utilities and tools that need access to the types.
 pub mod accounts_store;
 pub mod arguments;
 pub mod assets;

--- a/rs/backend/src/lib.rs
+++ b/rs/backend/src/lib.rs
@@ -1,1 +1,13 @@
+//! Library for <https://nns.ic0.app>
+pub mod accounts_store;
 pub mod arguments;
+pub mod assets;
+pub mod constants;
+pub mod metrics_encoder;
+pub mod multi_part_transactions_processor;
+pub mod perf;
+pub mod state;
+pub mod stats;
+pub mod time;
+
+use crate::state::{StableState, STATE};

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -43,7 +43,7 @@ fn init(args: Option<CanisterArguments>) {
     perf::record_instruction_count("init stop");
 }
 
-/// Redundant function, never called but reqired as this is main.rs.
+/// Redundant function, never called but required as this is main.rs.
 fn main() {}
 
 #[pre_upgrade]
@@ -122,7 +122,7 @@ fn add_account_impl() -> AccountIdentifier {
 
 /// Returns a page of transactions for a given `AccountIdentifier`.
 ///
-/// The `AccountIdentifier` must be linked to the caller's account, else an empty Vec will be
+/// The `AccountIdentifier` must be linked to the caller's account, else an empty `Vec` will be
 /// returned.
 #[export_name = "canister_query get_transactions"]
 pub fn get_transactions() {
@@ -170,7 +170,7 @@ fn rename_sub_account_impl(request: RenameSubAccountRequest) -> RenameSubAccount
 ///
 /// A single hardware wallet can be linked to multiple user accounts, but in order to make calls to
 /// the IC from the account, the user must use the hardware wallet to sign each request.
-/// Some readonly calls do not require signing, eg. viewing the account's ICP balance.
+/// Some read-only calls do not require signing, e.g. viewing the account's ICP balance.
 #[export_name = "canister_update register_hardware_wallet"]
 pub fn register_hardware_wallet() {
     over(candid_one, register_hardware_wallet_impl);
@@ -274,7 +274,7 @@ fn get_stats_impl() -> stats::Stats {
 ///
 /// These background processes include:
 /// - Sync transactions from the ledger
-/// - Process any queued 'multi-part' actions (eg. staking a neuron or topping up a canister)
+/// - Process any queued 'multi-part' actions (e.g. staking a neuron or topping up a canister)
 /// - Prune old transactions if memory usage is too high
 #[export_name = "canister_heartbeat"]
 pub fn canister_heartbeat() {

--- a/rs/backend/src/perf.rs
+++ b/rs/backend/src/perf.rs
@@ -1,4 +1,4 @@
-//! Capture snd store performance counters.
+//! Capture and store performance counters.
 use crate::stats::Stats;
 use crate::{StableState, STATE};
 use candid::CandidType;

--- a/rs/backend/src/proposals.rs
+++ b/rs/backend/src/proposals.rs
@@ -94,7 +94,7 @@ pub enum ArchiveIntegration {
     Pull,
 }
 
-/// Best effort to determine the types of a cansiter args.
+/// Best effort to determine the types of a canister args.
 fn canister_arg_types(canister_id: Option<CanisterId>) -> IDLTypes {
     // If canister id is II
     // use InternetIdentityInit type

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -66,15 +66,15 @@ impl State {
     fn schema_version_from_stable_memory() -> Option<u32> {
         None // The schema is currently unversioned.
     }
-    /// Create the state from stable memory in the post_upgrade() hook.
+    /// Create the state from stable memory in the `post_upgrade()` hook.
     ///
     /// Note: The stable memory may have been created by any of these schemas:
     /// - The previous schema, when first migrating from the previous schema to the current schema.
-    /// - The curent schema, if upgrading without changing the schema.
+    /// - The current schema, if upgrading without changing the schema.
     /// - The next schema, if a new schema was deployed and we need to roll back.
     ///
     /// Note: Changing the schema requires at least two deployments:
-    /// - Deploy a relase with a parser for the new schema.
+    /// - Deploy a release with a parser for the new schema.
     /// - Then, deploy a release that writes the new schema.
     /// This way it is possible to roll back after deploying the new schema.
     pub fn post_upgrade() -> Self {
@@ -99,7 +99,7 @@ impl State {
         let bytes = self.encode();
         stable::set(&bytes);
     }
-    /// Create the state from stable memory in the post_upgrade() hook.
+    /// Create the state from stable memory in the `post_upgrade()` hook.
     fn post_upgrade_unversioned() -> Self {
         let bytes = stable::get();
         State::decode(bytes).unwrap_or_else(|e| {

--- a/rs/backend/src/stats.rs
+++ b/rs/backend/src/stats.rs
@@ -111,7 +111,7 @@ pub fn stable_memory_size_bytes() -> u64 {
     }
 }
 
-/// The wasm memory size in bytes
+/// The WASM memory size in bytes
 pub fn wasm_memory_size_bytes() -> u64 {
     #[cfg(target_arch = "wasm32")]
     {

--- a/rs/sns_aggregator/src/assets.rs
+++ b/rs/sns_aggregator/src/assets.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 /// A standard HTTP header
 type HeaderField = (String, String);
 
-/// The standardised data structure for HTTP responses as supported natively by the replica.
+/// The standardized data structure for HTTP responses as supported natively by the replica.
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct HttpRequest {
     /// The HTTP method of the request, such as "GET" or "POST".
@@ -25,10 +25,10 @@ pub struct HttpRequest {
     pub body: ByteBuf,
 }
 
-/// The standardised data structure for HTTP responses as supported natively by the replica.
+/// The standardized data structure for HTTP responses as supported natively by the replica.
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct HttpResponse {
-    /// The HTTP status code.  E.g. 200 for succcess, 4xx for "you did something wrong", 5xx for "we broke".
+    /// The HTTP status code.  E.g. 200 for success, 4xx for "you did something wrong", 5xx for "we broke".
     pub status_code: u16,
     /// The headers of the HTTP response
     pub headers: Vec<HeaderField>,
@@ -142,7 +142,7 @@ fn content_type_of(request_path: &str) -> Option<&'static str> {
 }
 
 /// List of recommended security headers as per <https://owasp.org/www-project-secure-headers/>
-/// These headers enable browser security features (like limit access to platform apis and set
+/// These headers enable browser security features (like limit access to platform APIs and set
 /// iFrame policies, etc.).
 /// TODO <https://dfinity.atlassian.net/browse/L2-185>: Add CSP and Permissions-Policy
 fn security_headers() -> Vec<HeaderField> {
@@ -260,7 +260,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
 
 /// Inserts a favicon into the certified assets, if there is not one already.
 ///
-/// Note: If a browser visits the aggregation canister directy, it will request
+/// Note: If a browser visits the aggregation canister directly, it will request
 ///       a favicon.  As there is none, the asset canister will return an error
 ///       and the error also has no certification header, so for two reasons the
 ///       users will see errors in their console.  While these errors are not an

--- a/rs/sns_aggregator/src/assets.rs
+++ b/rs/sns_aggregator/src/assets.rs
@@ -141,10 +141,10 @@ fn content_type_of(request_path: &str) -> Option<&'static str> {
     })
 }
 
-/// List of recommended security headers as per https://owasp.org/www-project-secure-headers/
+/// List of recommended security headers as per <https://owasp.org/www-project-secure-headers/>
 /// These headers enable browser security features (like limit access to platform apis and set
 /// iFrame policies, etc.).
-/// TODO https://dfinity.atlassian.net/browse/L2-185: Add CSP and Permissions-Policy
+/// TODO <https://dfinity.atlassian.net/browse/L2-185>: Add CSP and Permissions-Policy
 fn security_headers() -> Vec<HeaderField> {
     vec![
         ("Access-Control-Allow-Origin".to_string(), "*".to_string()),

--- a/rs/sns_aggregator/src/conversion.rs
+++ b/rs/sns_aggregator/src/conversion.rs
@@ -1,8 +1,8 @@
 //! Methods for converting between types
 
-/// `ic_cdk` and `dfinity core` have different CanisterId types so we need to convert.  Genius.
+/// `ic_cdk` and `dfinity core` have different `CanisterId` types so we need to convert.  Genius.
 ///
-/// We use a macro rather than importing PrincipalId from the core types as the core types may differ between SNS canisters.
+/// We use a macro rather than importing `PrincipalId` from the core types as the core types may differ between SNS canisters.
 #[macro_export]
 macro_rules! convert_canister_id {
     ($x:expr) => {{

--- a/rs/sns_aggregator/src/fast_scheduler.rs
+++ b/rs/sns_aggregator/src/fast_scheduler.rs
@@ -20,11 +20,11 @@ pub struct FastScheduler {
     /// The time of the next sale start, with a trigger to start collecting data then.
     ///
     /// The time is in seconds since the UNIX epoch, as provided by ic0::time() / 1_000_000_000.
-    /// See: https://internetcomputer.org/docs/current/references/ic-interface-spec#system-api-time
+    /// See: <https://internetcomputer.org/docs/current/references/ic-interface-spec#system-api-time>
     next_start_seconds: Option<(u64, TimerId)>,
 }
 impl FastScheduler {
-    /// Lifecycle of an open swap with an active sale.  See https://github.com/dfinity/ic/blob/master/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
+    /// Lifecycle of an open swap with an active sale.  See <https://github.com/dfinity/ic/blob/master/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto>
     const LIFECYCLE_OPEN: i32 = 2;
     /// A lifecycle state that can lead to open.
     const LIFECYCLE_PENDING: i32 = 1;

--- a/rs/sns_aggregator/src/fast_scheduler.rs
+++ b/rs/sns_aggregator/src/fast_scheduler.rs
@@ -19,7 +19,7 @@ pub struct FastScheduler {
     update_timer: Option<TimerId>,
     /// The time of the next sale start, with a trigger to start collecting data then.
     ///
-    /// The time is in seconds since the UNIX epoch, as provided by ic0::time() / 1_000_000_000.
+    /// The time is in seconds since the UNIX epoch, as provided by `ic0::time() / 1_000_000_000`.
     /// See: <https://internetcomputer.org/docs/current/references/ic-interface-spec#system-api-time>
     next_start_seconds: Option<(u64, TimerId)>,
 }

--- a/rs/sns_aggregator/src/lib.rs
+++ b/rs/sns_aggregator/src/lib.rs
@@ -25,7 +25,7 @@ use types::Icrc1Value;
 
 /// API method for basic health checks.
 ///
-/// TODO: Provide useful metrics at http://${canister_domain}/metrics
+/// TODO: Provide useful metrics at `http://${canister_domain}/metrics`
 #[candid_method(query)]
 #[ic_cdk_macros::query]
 fn health_check() -> String {
@@ -52,7 +52,7 @@ async fn get_canister_status() -> ic_ic00_types::CanisterStatusResultV2 {
     result.unwrap_or_else(|err| panic!("Couldn't get canister_status of {}. Err: {:#?}", own_canister_id, err))
 }
 
-/// API method to get the current config
+/// API method to get the current configuration.
 #[candid_method(query)]
 #[ic_cdk_macros::query]
 #[allow(clippy::expect_used)] // This is a query call, no real damage can ensue to this canister.
@@ -106,7 +106,7 @@ fn http_request(/* req: HttpRequest */) /* -> HttpResponse */
 /// Function called when a canister is first created IF it is created
 /// with this code.
 ///
-/// Note: If the canister os created with e.g. `dfx canister create`
+/// Note: If the canister is created with e.g. `dfx canister create`
 ///       and then `dfx deploy`, `init(..)` is never called.
 #[ic_cdk_macros::init]
 #[candid_method(init)]
@@ -115,7 +115,7 @@ fn init(config: Option<Config>) {
     setup(config);
 }
 
-/// Function called before upgrade to a new wasm.
+/// Function called before upgrade to a new WASM.
 #[ic_cdk_macros::pre_upgrade]
 fn pre_upgrade() {
     // Make an effort to save state.  If it doesn't work, it doesn't matter much
@@ -138,7 +138,7 @@ fn pre_upgrade() {
     });
 }
 
-/// Function called after a canister has been upgraded to a new wasm.
+/// Function called after a canister has been upgraded to a new WASM.
 #[ic_cdk_macros::post_upgrade]
 fn post_upgrade(config: Option<Config>) {
     crate::state::log("Calling post_upgrade...".to_string());
@@ -161,10 +161,10 @@ fn post_upgrade(config: Option<Config>) {
     setup(config);
 }
 
-/// Method to allow reconfiguration without a wasm change.
+/// Method to allow reconfiguration without a WASM change.
 ///
 /// Note: This _could_ be exposed in production if limited to the controllers
-///  - Controllers can be obtained by the async call: agent.read_state_canister_info(canister_id, "controllers")
+///  - Controllers can be obtained by the async call: `agent.read_state_canister_info(canister_id, "controllers")`
 #[cfg(feature = "reconfigurable")]
 #[ic_cdk_macros::update]
 #[candid_method(update)]
@@ -172,7 +172,7 @@ fn reconfigure(config: Option<Config>) {
     setup(config);
 }
 
-/// Code that needs to be run on init and after every upgrade.
+/// Code that needs to be run on `init` and after every upgrade.
 fn setup(config: Option<Config>) {
     // Note: This is intentionally highly visible in logs.
     crate::state::log(format!(

--- a/rs/sns_aggregator/src/state.rs
+++ b/rs/sns_aggregator/src/state.rs
@@ -29,19 +29,19 @@ pub struct State {
     pub timer_id: RefCell<Option<TimerId>>,
     /// Scheduler for updating data on SNSs with active swaps
     pub fast_scheduler: RefCell<FastScheduler>,
-    /// State perserved across upgrades, as long as the new data structures
+    /// State preserved across upgrades, as long as the new data structures
     /// are compatible.
     pub stable: RefCell<StableState>,
     /// Hashes for the assets, needed for signing.
     ///
-    /// Note: It would be nice to store the asset hashes in stable memory, however RBTree does not support
+    /// Note: It would be nice to store the asset hashes in stable memory, however `RBTree` does not support
     /// the required macros for serialization and deserialization.  Instead, we recompute this after upgrade.
     pub asset_hashes: RefCell<AssetHashes>,
     /// Log errors when getting data from upstream
     pub log: RefCell<VecDeque<String>>,
 }
 impl State {
-    /// Util to get a swap canister ID
+    /// Utility to get a swap canister ID
     pub fn swap_canister_from_index(&self, index: SnsIndex) -> Result<CanisterId, String> {
         self.stable
             .borrow()
@@ -54,7 +54,7 @@ impl State {
             .swap_canister_id
             .ok_or_else(|| format!("SNS {index} has no known swap canister"))
     }
-    /// Util to get a root canister ID
+    /// Utility to get a root canister ID
     pub fn root_canister_from_index(&self, index: SnsIndex) -> Result<CanisterId, String> {
         self.stable
             .borrow()
@@ -81,10 +81,10 @@ pub struct StableState {
     pub sns_cache: RefCell<SnsCache>,
     /// Pre-signed data that can be served as high performance certified query calls.
     ///
-    /// - /sns/list/latest/slow.json
-    /// - /sns/list/0-9/slow.json ... <- Index is used for pagination.  SNSs are arranged in decades.
-    /// - /sns/root/${sns_root}/logo.{jpg/png/...}
-    /// - /sns/root/${sns_root}/slow.json
+    /// - `/sns/list/latest/slow.json`
+    /// - `/sns/list/0-9/slow.json` <- Index is used for pagination.  SNSs are arranged in decades.
+    /// - `/sns/root/${sns_root}/logo.{jpg/png/...}`
+    /// - `/sns/root/${sns_root}/slow.json`
     pub assets: RefCell<Assets>,
 }
 
@@ -134,7 +134,7 @@ pub fn log(message: String) {
 impl State {
     /// The maximum number of SNS included in a response.
     ///
-    /// Pages are pre-computed to contain indices [0..PAGE_SIZE-1], [PAGE_SIZE..2*PAGE_SIZE-1] and so on.
+    /// Pages are pre-computed to contain indices `[0..PAGE_SIZE-1], [PAGE_SIZE..2*PAGE_SIZE-1]` and so on.
     ///
     /// Also, the list of most recent SNSs is limited to the page size.
     pub const PAGE_SIZE: u64 = 10;
@@ -147,7 +147,7 @@ impl State {
     }
     /// Adds pre-signed responses for the API version 1.
     ///
-    /// - /sns/index/{index}.json <- All aggregate data about the SNS, in JSON format.
+    /// - `/sns/index/{index}.json` <- All aggregate data about the SNS, in JSON format.
     pub fn insert_sns_v1(index: u64, upstream_data: UpstreamData) -> Result<(), anyhow::Error> {
         let prefix = Self::PREFIX_V1;
         let root_canister_id = convert_canister_id!(upstream_data.canister_ids.root_canister_id);
@@ -265,7 +265,7 @@ impl State {
         }
     }
 
-    /// Commands to call on init or post_upgrade.
+    /// Commands to call on `init` or `post_upgrade`.
     pub fn setup() {
         // Establish the invariant that the last page is not full.
         STATE.with(Self::ensure_last_page_is_not_full_v1);

--- a/rs/sns_aggregator/src/types.rs
+++ b/rs/sns_aggregator/src/types.rs
@@ -23,6 +23,6 @@ pub use serde::Serialize;
 /// A named empty record.
 ///
 /// Many candid interfaces take an empty record as their argument.
-/// Anonymous empty records are not handled correctly by didc, so we name them 'EmptyRecord'.
+/// Anonymous empty records are not handled correctly by `didc`, so we name them '`EmptyRecord'.`
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]
 pub struct EmptyRecord {}

--- a/scripts/lint-rustdoc
+++ b/scripts/lint-rustdoc
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+RUSTDOCFLAGS="-D warnings"
+export RUSTDOCFLAGS
+./scripts/nns-dapp/doc
+./scripts/sns/aggregator/doc

--- a/scripts/nns-dapp/doc
+++ b/scripts/nns-dapp/doc
@@ -1,0 +1,1 @@
+cargo doc --document-private-items --package nns-dapp "${@}"

--- a/scripts/sns/aggregator/doc
+++ b/scripts/sns/aggregator/doc
@@ -1,0 +1,1 @@
+cargo doc --document-private-items --package sns_aggregator "${@}"


### PR DESCRIPTION
# Motivation
Rust code documentation can be parsed and displayed in a nice, readable way by rustdoc.

The sns aggregator documentation is available in this way, but unfortunately most of the nns-dapp code is inaccessible, making it unnecessarily to read.

# Changes
* Make the nns-dapp code accessible to the nns-dapp lib, which is the entry point for rustdoc.
  * Note: `rustdoc` _does_ have limited support for documentation of binaries, however it is not good.
* Fix rustdoc links
* Test the rustdoc in CI.
* Add two utility scripts to make it easy to generate documentation without retyping a bunch of flags.
  * Note: `rustdoc` flags such as `--open` are passed through the script.
* Performed a quick pass checking spelling and formatting.  E.g. code `should be in backticks`.

# Tests
*  `cargo doc` is now tested in CI.

# Todos

- [x] Add entry to changelog (if necessary).
