### PR TITLE
IdentityAgentWrapper to use cached agent with specified identity

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -25,6 +25,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Hide by default the proposal summary in ballots.
 * Review checkboxes vertical alignment, border contrast on dark mode and remove hover background colors
 * Launchpad proposal requests only Open proposals of the SNS topic.
+* When reusing cached agents, use the current identity instead of the one in the cached agent.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/api/agent.api.ts
+++ b/frontend/src/lib/api/agent.api.ts
@@ -1,9 +1,131 @@
 import { FETCH_ROOT_KEY } from "$lib/constants/environment.constants";
-import type { Agent, Identity } from "@dfinity/agent";
-import { createAgent as createAgentUtil, nonNullish } from "@dfinity/utils";
+import type {
+  Agent,
+  ApiQueryResponse,
+  CallOptions,
+  HttpAgent,
+  Identity,
+  QueryFields,
+  ReadStateOptions,
+  ReadStateResponse,
+  SubmitResponse,
+} from "@dfinity/agent";
+import { IdentityInvalidError } from "@dfinity/agent";
+import type { JsonObject } from "@dfinity/candid";
+import type { Principal } from "@dfinity/principal";
+import {
+  createAgent as createAgentUtil,
+  isNullish,
+  nonNullish,
+} from "@dfinity/utils";
 
 type PrincipalAsText = string;
-let agents: Record<PrincipalAsText, Agent> | undefined | null = undefined;
+let agents: Record<PrincipalAsText, HttpAgent> | undefined | null = undefined;
+
+/**
+ * Allows using an existing agent with a different identity, by calling every
+ * method on the wrapped agent, but passing in the new identity.
+ */
+class IdentityAgentWrapper implements Agent {
+  private identity: Identity | null;
+  private readonly wrappedAgent: HttpAgent;
+
+  constructor({
+    identity,
+    wrappedAgent,
+  }: {
+    identity: Identity;
+    wrappedAgent: HttpAgent;
+  }) {
+    this.identity = identity;
+    this.wrappedAgent = wrappedAgent;
+  }
+
+  getValidIdentity(overrideIdentity?: Identity | undefined | null): Identity {
+    const usedIdentity =
+      overrideIdentity !== undefined ? overrideIdentity : this.identity;
+    if (isNullish(usedIdentity)) {
+      throw new IdentityInvalidError(
+        "This identity has expired due this application's security policy. Please refresh your authentication."
+      );
+    }
+    return usedIdentity;
+  }
+
+  get rootKey(): ArrayBuffer | null {
+    return this.wrappedAgent.rootKey;
+  }
+
+  async getPrincipal(): Promise<Principal> {
+    return this.getValidIdentity().getPrincipal();
+  }
+
+  createReadStateRequest?(
+    options: ReadStateOptions,
+    identity?: Identity
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  ): Promise<any> {
+    return this.wrappedAgent.createReadStateRequest(
+      options,
+      this.getValidIdentity(identity)
+    );
+  }
+
+  readState(
+    effectiveCanisterId: Principal | string,
+    options: ReadStateOptions,
+    identity?: Identity,
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+    request?: any
+  ): Promise<ReadStateResponse> {
+    return this.wrappedAgent.readState(
+      effectiveCanisterId,
+      options,
+      this.getValidIdentity(identity),
+      request
+    );
+  }
+
+  call(
+    canisterId: Principal | string,
+    fields: CallOptions,
+    identity?: Identity
+  ): Promise<SubmitResponse> {
+    return this.wrappedAgent.call(
+      canisterId,
+      fields,
+      this.getValidIdentity(identity)
+    );
+  }
+
+  async status(): Promise<JsonObject> {
+    return this.wrappedAgent.status();
+  }
+
+  async query(
+    canisterId: Principal | string,
+    options: QueryFields,
+    identity?: Identity | Promise<Identity>
+  ): Promise<ApiQueryResponse> {
+    return this.wrappedAgent.query(
+      canisterId,
+      options,
+      this.getValidIdentity(await identity)
+    );
+  }
+
+  fetchRootKey(): Promise<ArrayBuffer> {
+    return this.wrappedAgent.fetchRootKey();
+  }
+
+  invalidateIdentity?(): void {
+    this.identity = null;
+  }
+
+  replaceIdentity?(identity: Identity): void {
+    this.identity = identity;
+  }
+}
 
 export const createAgent = async ({
   identity,
@@ -28,7 +150,10 @@ export const createAgent = async ({
     };
   }
 
-  return agents[principalAsText];
+  return new IdentityAgentWrapper({
+    identity,
+    wrappedAgent: agents[principalAsText],
+  });
 };
 
 export const resetAgents = () => (agents = null);

--- a/frontend/src/tests/lib/api/agent.api.spec.ts
+++ b/frontend/src/tests/lib/api/agent.api.spec.ts
@@ -324,21 +324,15 @@ describe("agent-api", () => {
     const testIdentity2 = createIdentity(testPrincipal1);
 
     const mockAgent = mock<HttpAgent>();
-    let agent1: Agent;
-    let agent2: Agent;
 
     beforeEach(async () => {
       utilsCreateAgentSpy.mockResolvedValue(mockAgent);
-
-      expect(utilsCreateAgentSpy).not.toBeCalled();
-
-      agent1 = await createAgent(testIdentity1);
-      agent2 = await createAgent(testIdentity2);
-
-      expect(utilsCreateAgentSpy).toBeCalledTimes(1);
     });
 
     it("for method createReadStateRequest()", async () => {
+      const agent1 = await createAgent(testIdentity1);
+      const agent2 = await createAgent(testIdentity2);
+
       const param = {
         path: [[Int8Array.from([3, 4, 5])]],
       } as unknown as ReadStateOptions;
@@ -367,6 +361,9 @@ describe("agent-api", () => {
     });
 
     it("for method readState()", async () => {
+      const agent1 = await createAgent(testIdentity1);
+      const agent2 = await createAgent(testIdentity2);
+
       const effectiveCanisterId = "effectiveCanisterId";
       const options = {
         path: [[Int8Array.from([7, 1, 2])]],
@@ -403,6 +400,9 @@ describe("agent-api", () => {
     });
 
     it("for method call()", async () => {
+      const agent1 = await createAgent(testIdentity1);
+      const agent2 = await createAgent(testIdentity2);
+
       expect(mockAgent.call).not.toBeCalled();
       await agent1.call("canisterId", {} as CallOptions);
 
@@ -421,6 +421,9 @@ describe("agent-api", () => {
     });
 
     it("for method query()", async () => {
+      const agent1 = await createAgent(testIdentity1);
+      const agent2 = await createAgent(testIdentity2);
+
       const params = [
         "canisterId",
         { methodName: "bar" } as QueryFields,

--- a/frontend/src/tests/lib/api/agent.api.spec.ts
+++ b/frontend/src/tests/lib/api/agent.api.spec.ts
@@ -1,5 +1,4 @@
 import * as agentApi from "$lib/api/agent.api";
-import { allowLoggingInOneTestForDebugging } from "$tests/utils/console.test-utils";
 import type {
   Agent,
   ApiQueryResponse,
@@ -43,7 +42,6 @@ describe("agent-api", () => {
   const utilsCreateAgentSpy = jest.spyOn(utils, "createAgent");
 
   beforeEach(() => {
-    allowLoggingInOneTestForDebugging();
     jest.resetAllMocks();
     agentApi.resetAgents();
 

--- a/frontend/src/tests/lib/api/agent.api.spec.ts
+++ b/frontend/src/tests/lib/api/agent.api.spec.ts
@@ -58,9 +58,9 @@ describe("agent-api", () => {
   it("createAgent should cache the underlying agent for the same identity", async () => {
     const testIdentity = createIdentity(testPrincipal1);
     expect(utilsCreateAgentSpy).not.toBeCalled();
-    const agent1 = await createAgent(testIdentity);
+    await createAgent(testIdentity);
     expect(utilsCreateAgentSpy).toBeCalledTimes(1);
-    const agent2 = await createAgent(testIdentity);
+    await createAgent(testIdentity);
     expect(utilsCreateAgentSpy).toBeCalledTimes(1);
   });
 

--- a/frontend/src/tests/lib/api/agent.api.spec.ts
+++ b/frontend/src/tests/lib/api/agent.api.spec.ts
@@ -1,10 +1,28 @@
 import * as agentApi from "$lib/api/agent.api";
-import type { HttpAgent, Identity } from "@dfinity/agent";
+import { allowLoggingInOneTestForDebugging } from "$tests/utils/console.test-utils";
+import type {
+  Agent,
+  ApiQueryResponse,
+  CallOptions,
+  HttpAgent,
+  Identity,
+  QueryFields,
+  ReadStateOptions,
+  SubmitResponse,
+} from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import * as utils from "@dfinity/utils";
 import { mock } from "jest-mock-extended";
 
-jest.mock("@dfinity/utils");
+jest.mock("@dfinity/utils", () => {
+  const originalModule = jest.requireActual("@dfinity/utils");
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    createAgent: jest.fn(),
+  };
+});
 
 const host = "http://localhost:8000";
 const testPrincipal1 = Principal.fromHex("123123123");
@@ -22,17 +40,14 @@ const createAgent = (identity: Identity) =>
   });
 
 describe("agent-api", () => {
+  const utilsCreateAgentSpy = jest.spyOn(utils, "createAgent");
+
   beforeEach(() => {
+    allowLoggingInOneTestForDebugging();
     jest.resetAllMocks();
     agentApi.resetAgents();
 
-    jest
-      .spyOn(utils, "createAgent")
-      .mockImplementation(async ({ identity }) => {
-        const mockAgent = mock<HttpAgent>();
-        mockAgent.getPrincipal.mockResolvedValue(identity.getPrincipal());
-        return mockAgent;
-      });
+    utilsCreateAgentSpy.mockResolvedValue(mock<HttpAgent>());
   });
 
   it("createAgent should create an agent", async () => {
@@ -42,21 +57,388 @@ describe("agent-api", () => {
     expect(await agent.getPrincipal()).toEqual(testPrincipal1);
   });
 
-  it("createAgent should cache the agent for the same identity", async () => {
+  it("createAgent should cache the underlying agent for the same identity", async () => {
     const testIdentity = createIdentity(testPrincipal1);
+    expect(utilsCreateAgentSpy).not.toBeCalled();
     const agent1 = await createAgent(testIdentity);
+    expect(utilsCreateAgentSpy).toBeCalledTimes(1);
     const agent2 = await createAgent(testIdentity);
-
-    expect(agent1).toBe(agent2);
+    expect(utilsCreateAgentSpy).toBeCalledTimes(1);
   });
 
   it("createAgent returns a different agent for a different identity", async () => {
     const testIdentity1 = createIdentity(testPrincipal1);
     const testIdentity2 = createIdentity(testPrincipal2);
+
+    expect(utilsCreateAgentSpy).not.toBeCalled();
+
+    const mockAgent1 = mock<HttpAgent>();
+    utilsCreateAgentSpy.mockResolvedValue(mockAgent1);
     const agent1 = await createAgent(testIdentity1);
+    expect(utilsCreateAgentSpy).toBeCalledTimes(1);
+
+    const mockAgent2 = mock<HttpAgent>();
+    utilsCreateAgentSpy.mockResolvedValue(mockAgent2);
     const agent2 = await createAgent(testIdentity2);
+    expect(utilsCreateAgentSpy).toBeCalledTimes(2);
 
     expect(await agent1.getPrincipal()).toEqual(testPrincipal1);
     expect(await agent2.getPrincipal()).toEqual(testPrincipal2);
+
+    // The underlying agents are also different.
+    expect(mockAgent1.call).not.toBeCalled();
+    expect(mockAgent2.call).not.toBeCalled();
+    agent1.call("canisterId", {} as CallOptions);
+    expect(mockAgent1.call).toBeCalledTimes(1);
+    expect(mockAgent2.call).not.toBeCalled();
+    agent2.call("canisterId", {} as CallOptions);
+    expect(mockAgent1.call).toBeCalledTimes(1);
+    expect(mockAgent2.call).toBeCalledTimes(1);
+  });
+
+  describe("agent forwards method calls to the underlying agent", () => {
+    const testIdentity = createIdentity(testPrincipal1);
+
+    let mockAgent: jest.Mocked<HttpAgent>;
+    let agent: Agent;
+
+    beforeEach(async () => {
+      mockAgent = mock<HttpAgent>();
+      utilsCreateAgentSpy.mockResolvedValue(mockAgent);
+
+      agent = await createAgent(testIdentity);
+    });
+
+    it("for rootKey getter", async () => {
+      const rootKey = new Int8Array([1, 2, 3]);
+
+      mockAgent.rootKey = rootKey;
+
+      expect(agent.rootKey).toEqual(rootKey);
+    });
+
+    it("for method createReadStateRequest", async () => {
+      const returnValue = "returnValue";
+      mockAgent.createReadStateRequest.mockResolvedValue(returnValue);
+
+      const param = {
+        path: [[Int8Array.from([3, 4, 5])]],
+      } as unknown as ReadStateOptions;
+
+      expect(mockAgent.createReadStateRequest).not.toBeCalled();
+
+      expect(await agent.createReadStateRequest(param)).toEqual(returnValue);
+
+      expect(mockAgent.createReadStateRequest).toBeCalledTimes(1);
+      expect(mockAgent.createReadStateRequest).toBeCalledWith(
+        param,
+        testIdentity
+      );
+    });
+
+    it("for method readState", async () => {
+      const readStateResponse = { certificate: Int8Array.from([1, 9, 3]) };
+
+      mockAgent.readState.mockResolvedValue(readStateResponse);
+
+      const effectiveCanisterId = "effectiveCanisterId";
+      const options = {
+        path: [[Int8Array.from([7, 1, 2])]],
+      } as unknown as ReadStateOptions;
+      const request = "request";
+
+      expect(mockAgent.readState).not.toBeCalled();
+
+      expect(
+        await agent.readState(
+          effectiveCanisterId,
+          options,
+          undefined, // identity
+          request
+        )
+      ).toEqual(readStateResponse);
+
+      expect(mockAgent.readState).toBeCalledTimes(1);
+      expect(mockAgent.readState).toBeCalledWith(
+        effectiveCanisterId,
+        options,
+        testIdentity,
+        request
+      );
+    });
+
+    it("for method call", async () => {
+      const submitResponse = Int8Array.from([
+        5, 2, 3,
+      ]) as unknown as SubmitResponse;
+
+      mockAgent.call.mockResolvedValue(submitResponse);
+
+      const params = [
+        "canisterId",
+        { methodName: "foo" } as CallOptions,
+      ] as const;
+
+      expect(mockAgent.call).not.toBeCalled();
+
+      expect(await agent.call(...params)).toEqual(submitResponse);
+
+      expect(mockAgent.call).toBeCalledTimes(1);
+      expect(mockAgent.call).toBeCalledWith(...params, testIdentity);
+    });
+
+    it("for method status", async () => {
+      expect(mockAgent.status).not.toBeCalled();
+
+      const status = { status: "ok" };
+      mockAgent.status.mockResolvedValue(status);
+
+      expect(await agent.status()).toEqual(status);
+
+      expect(mockAgent.status).toBeCalledTimes(1);
+    });
+
+    it("for method query", async () => {
+      const apiQueryResponse = "queryResponse" as unknown as ApiQueryResponse;
+
+      mockAgent.query.mockResolvedValue(apiQueryResponse);
+
+      const params = [
+        "canisterId",
+        { methodName: "bar" } as QueryFields,
+      ] as const;
+
+      expect(mockAgent.query).not.toBeCalled();
+
+      expect(await agent.query(...params)).toEqual(apiQueryResponse);
+
+      expect(mockAgent.query).toBeCalledTimes(1);
+      expect(mockAgent.query).toBeCalledWith(...params, testIdentity);
+    });
+
+    it("for method fetchRootKey", async () => {
+      const rootKey = new Int8Array([3, 2, 3]);
+
+      mockAgent.fetchRootKey.mockResolvedValue(rootKey);
+
+      expect(mockAgent.fetchRootKey).not.toBeCalled();
+
+      expect(await agent.fetchRootKey()).toEqual(rootKey);
+
+      expect(mockAgent.fetchRootKey).toBeCalledTimes(1);
+    });
+  });
+
+  describe("invalidateIdentity", () => {
+    const testIdentity = createIdentity(testPrincipal1);
+
+    let mockAgent: jest.Mocked<HttpAgent>;
+    let agent: Agent;
+
+    beforeEach(async () => {
+      mockAgent = mock<HttpAgent>();
+      utilsCreateAgentSpy.mockResolvedValue(mockAgent);
+
+      agent = await createAgent(testIdentity);
+    });
+
+    it("makes getPrincipal throw", async () => {
+      const call = async () => agent.getPrincipal();
+
+      // Does not throw at first:
+      await call();
+
+      agent.invalidateIdentity();
+
+      await expect(call).rejects.toThrow();
+    });
+
+    it("makes createReadStateRequest throw", async () => {
+      const param = {
+        path: [[Int8Array.from([3, 4, 5])]],
+      } as unknown as ReadStateOptions;
+
+      const call = async () => agent.createReadStateRequest(param);
+
+      // Does not throw at first:
+      await call();
+
+      agent.invalidateIdentity();
+
+      await expect(call).rejects.toThrow();
+    });
+
+    it("makes readState throw", async () => {
+      const effectiveCanisterId = "effectiveCanisterId";
+      const options = {
+        path: [[Int8Array.from([7, 1, 2])]],
+      } as unknown as ReadStateOptions;
+      const request = "request";
+
+      const call = async () =>
+        agent.readState(effectiveCanisterId, options, undefined, request);
+
+      // Does not throw at first:
+      await call();
+
+      agent.invalidateIdentity();
+
+      await expect(call).rejects.toThrow();
+    });
+
+    it("makes query throw", async () => {
+      const params = [
+        "canisterId",
+        { methodName: "bar" } as QueryFields,
+      ] as const;
+
+      const call = async () => agent.query(...params);
+
+      // Does not throw at first:
+      await call();
+
+      agent.invalidateIdentity();
+
+      await expect(call).rejects.toThrow();
+    });
+
+    it("makes call throw", async () => {
+      const params = [
+        "canisterId",
+        { methodName: "foo" } as CallOptions,
+      ] as const;
+
+      const call = async () => agent.call(...params);
+
+      // Does not throw at first:
+      await call();
+
+      agent.invalidateIdentity();
+
+      await expect(call).rejects.toThrow();
+    });
+  });
+
+  describe("createAgent uses a cached underlying agent with the specified identity", () => {
+    const testIdentity1 = createIdentity(testPrincipal1);
+    // Note: testIdentity2 has the same principal as testIdentity1, but they are
+    // different objects.
+    const testIdentity2 = createIdentity(testPrincipal1);
+
+    const mockAgent = mock<HttpAgent>();
+    let agent1: Agent;
+    let agent2: Agent;
+
+    beforeEach(async () => {
+      utilsCreateAgentSpy.mockResolvedValue(mockAgent);
+
+      expect(utilsCreateAgentSpy).not.toBeCalled();
+
+      agent1 = await createAgent(testIdentity1);
+      agent2 = await createAgent(testIdentity2);
+
+      expect(utilsCreateAgentSpy).toBeCalledTimes(1);
+    });
+
+    it("for method createReadStateRequest()", async () => {
+      const param = {
+        path: [[Int8Array.from([3, 4, 5])]],
+      } as unknown as ReadStateOptions;
+
+      expect(mockAgent.createReadStateRequest).not.toBeCalled();
+
+      await agent1.createReadStateRequest(param);
+
+      expect(mockAgent.createReadStateRequest).toBeCalledTimes(1);
+      expect(mockAgent.createReadStateRequest).toBeCalledWith(
+        param,
+        testIdentity1
+      );
+      expect(mockAgent.createReadStateRequest).not.toBeCalledWith(
+        param,
+        testIdentity2
+      );
+
+      await agent2.createReadStateRequest(param);
+
+      expect(mockAgent.createReadStateRequest).toBeCalledTimes(2);
+      expect(mockAgent.createReadStateRequest).toBeCalledWith(
+        param,
+        testIdentity2
+      );
+    });
+
+    it("for method readState()", async () => {
+      const effectiveCanisterId = "effectiveCanisterId";
+      const options = {
+        path: [[Int8Array.from([7, 1, 2])]],
+      } as unknown as ReadStateOptions;
+      const request = "request";
+
+      expect(mockAgent.readState).not.toBeCalled();
+
+      await agent1.readState(effectiveCanisterId, options, undefined, request);
+
+      expect(mockAgent.readState).toBeCalledTimes(1);
+      expect(mockAgent.readState).toBeCalledWith(
+        effectiveCanisterId,
+        options,
+        testIdentity1,
+        request
+      );
+      expect(mockAgent.readState).not.toBeCalledWith(
+        effectiveCanisterId,
+        options,
+        testIdentity2,
+        request
+      );
+
+      await agent2.readState(effectiveCanisterId, options, undefined, request);
+
+      expect(mockAgent.readState).toBeCalledTimes(2);
+      expect(mockAgent.readState).toBeCalledWith(
+        effectiveCanisterId,
+        options,
+        testIdentity2,
+        request
+      );
+    });
+
+    it("for method call()", async () => {
+      expect(mockAgent.call).not.toBeCalled();
+      await agent1.call("canisterId", {} as CallOptions);
+
+      expect(mockAgent.call).toBeCalledTimes(1);
+      expect(mockAgent.call).toBeCalledWith("canisterId", {}, testIdentity1);
+      expect(mockAgent.call).not.toBeCalledWith(
+        "canisterId",
+        {},
+        testIdentity2
+      );
+
+      await agent2.call("canisterId", {} as CallOptions);
+
+      expect(mockAgent.call).toBeCalledTimes(2);
+      expect(mockAgent.call).toBeCalledWith("canisterId", {}, testIdentity2);
+    });
+
+    it("for method query()", async () => {
+      const params = [
+        "canisterId",
+        { methodName: "bar" } as QueryFields,
+      ] as const;
+
+      expect(mockAgent.query).not.toBeCalled();
+      await agent1.query(...params);
+
+      expect(mockAgent.query).toBeCalledTimes(1);
+      expect(mockAgent.query).toBeCalledWith(...params, testIdentity1);
+      expect(mockAgent.query).not.toBeCalledWith(...params, testIdentity2);
+
+      await agent2.query(...params);
+
+      expect(mockAgent.query).toBeCalledTimes(2);
+      expect(mockAgent.query).toBeCalledWith(...params, testIdentity2);
+    });
   });
 });


### PR DESCRIPTION
# Motivation

We cache created agents for performance (according to https://github.com/dfinity/nns-dapp/pull/1600).
But the agent keeps a reference to the identity used to create the agent which means the identity is implicitly cached as well.
This has been causing problems with hardware wallet interactions where we need to keep state on the identity to indicate that a ledger transfer is for the purpose of staking a neuron.

# Changes

1. Add a wrapper agent which uses a newly specified identity instead of the identity used to create the agent originally.
2. When returning an agent from the cache, wrap it in the wrapper such that the current identity is used instead of the previously cached one.

# Tests

1. Method calls are forwarded to the underlying agent.
2. The identity can be invalidated.
3. Method calls on different wrappers result in calls on the same underlying agent with different identities.

# Todos

- [x] Add entry to changelog (if necessary).
