### PR TITLE
GIX-1823: Use sns aggregator store in snsSummariesStore

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -42,6 +42,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Not Published
 
+* Use new stores as source of data instead of snsQueryStore.
+
 ### Operations
 * Improve the rust document generation.
 

--- a/frontend/src/lib/stores/sns-derived-state.store.ts
+++ b/frontend/src/lib/stores/sns-derived-state.store.ts
@@ -7,12 +7,11 @@ interface SnsDerivedStateProjectData {
   certified: boolean;
 }
 
-interface SnsDerivedStateData {
+export interface SnsDerivedStateData {
   [rootCanisterId: string]: SnsDerivedStateProjectData;
 }
 
-export interface SnsDerivedStateStore
-  extends Readable<SnsDerivedStateData | undefined> {
+export interface SnsDerivedStateStore extends Readable<SnsDerivedStateData> {
   setDerivedState: (params: {
     rootCanisterId: Principal;
     data: SnsGetDerivedStateResponse;

--- a/frontend/src/lib/stores/sns-lifecycle.store.ts
+++ b/frontend/src/lib/stores/sns-lifecycle.store.ts
@@ -7,7 +7,7 @@ interface SnsLifecycleProjectData {
   certified: boolean;
 }
 
-interface SnsLifecycleData {
+export interface SnsLifecycleData {
   [rootCanisterId: string]: SnsLifecycleProjectData;
 }
 

--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -344,12 +344,12 @@ const overrideLifecycle =
     }
     const projectData = lifecycleStore[summary.rootCanisterId.toText()];
     const lifecycle = fromNullable(projectData?.data.lifecycle ?? []);
-    const saleOpenTimestamp = fromNullable(
-      projectData?.data.decentralization_sale_open_timestamp_seconds
-    );
     if (isNullish(lifecycle)) {
       return summary;
     }
+    const saleOpenTimestamp = fromNullable(
+      projectData?.data.decentralization_sale_open_timestamp_seconds ?? []
+    );
     return {
       ...summary,
       swap: {

--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -8,13 +8,28 @@ import type {
   SnsSwapDerivedState,
   SnsSwapLifecycle,
 } from "@dfinity/sns";
-import { fromNullable, isNullish, nonNullish } from "@dfinity/utils";
+import {
+  fromDefinedNullable,
+  fromNullable,
+  isNullish,
+  nonNullish,
+} from "@dfinity/utils";
 import { derived, writable, type Readable } from "svelte/store";
 import { ENABLE_SNS_AGGREGATOR_STORE } from "./feature-flags.store";
 import {
   snsAggregatorStore,
   type SnsAggregatorStore,
 } from "./sns-aggregator.store";
+import {
+  snsDerivedStateStore,
+  type SnsDerivedStateData,
+  type SnsDerivedStateStore,
+} from "./sns-derived-state.store";
+import {
+  snsLifecycleStore,
+  type SnsLifecycleData,
+  type SnsLifecycleStore,
+} from "./sns-lifecycle.store";
 
 // ************** Proposals for Launchpad **************
 
@@ -273,23 +288,116 @@ export const snsQueryStoreIsLoading = derived<SnsQueryStore, boolean>(
 );
 
 /**
+ * Two similar endpoints return different types of data:
+ * - get_derived_state returns SnsGetDerivedStateResponse
+ * - the "derived" inside get_state returns SnsSwapDerivedState
+ *
+ * The SnsSummary was initially done from get_state.
+ *
+ * The difference is in two fields that are optional in the get_derived_state response.
+ */
+const convertToDerivedState = (
+  data: SnsGetDerivedStateResponse
+): SnsSwapDerivedState | undefined =>
+  isNullish(fromNullable(data.sns_tokens_per_icp)) ||
+  isNullish(data.buyer_total_icp_e8s)
+    ? undefined
+    : {
+        ...data,
+        sns_tokens_per_icp: fromDefinedNullable(data.sns_tokens_per_icp),
+        buyer_total_icp_e8s: fromDefinedNullable(data.buyer_total_icp_e8s),
+      };
+
+/**
+ * Override the derived state in the SnsSummary with the one from the store.
+ */
+const overrideDerivedState =
+  (derivedStore: SnsDerivedStateData) =>
+  (summary: SnsSummary | undefined): SnsSummary | undefined => {
+    if (isNullish(summary)) {
+      return undefined;
+    }
+    const projectDerivedState = derivedStore[summary.rootCanisterId.toText()];
+    const derivedState = nonNullish(projectDerivedState)
+      ? convertToDerivedState(projectDerivedState.derivedState)
+      : undefined;
+    if (nonNullish(derivedState)) {
+      return {
+        ...summary,
+        derived: derivedState,
+      };
+    }
+    return summary;
+  };
+
+/**
+ * Override the lifecycle in the SnsSummary with the one from the store.
+ */
+const overrieLifecycle =
+  (lifecycleStore: SnsLifecycleData) =>
+  (summary: SnsSummary | undefined): SnsSummary | undefined => {
+    if (isNullish(summary)) {
+      return undefined;
+    }
+    const projectData = lifecycleStore[summary.rootCanisterId.toText()];
+    const lifecycle = fromNullable(projectData?.data.lifecycle ?? []);
+    const saleOpenTimestamp = fromNullable(
+      projectData?.data.decentralization_sale_open_timestamp_seconds
+    );
+    if (nonNullish(lifecycle)) {
+      return {
+        ...summary,
+        swap: {
+          ...summary.swap,
+          lifecycle,
+          decentralization_sale_open_timestamp_seconds: saleOpenTimestamp,
+        },
+      };
+    }
+    return summary;
+  };
+
+/**
  * The response of the Snses about metadata and swap derived to data that can be used by NNS-dapp - i.e. it filters undefined and optional swap data, sort data for consistency
  */
 export const snsSummariesStore = derived<
-  [SnsQueryStore, SnsAggregatorStore, Readable<boolean>],
+  [
+    SnsQueryStore,
+    SnsAggregatorStore,
+    SnsDerivedStateStore,
+    SnsLifecycleStore,
+    Readable<boolean>
+  ],
   SnsSummary[]
 >(
-  [snsQueryStore, snsAggregatorStore, ENABLE_SNS_AGGREGATOR_STORE],
-  ([data, aggregatorData, enableSnsAggregatorStore]) => {
+  [
+    snsQueryStore,
+    snsAggregatorStore,
+    snsDerivedStateStore,
+    snsLifecycleStore,
+    ENABLE_SNS_AGGREGATOR_STORE,
+  ],
+  ([
+    data,
+    aggregatorData,
+    derivedStates,
+    lifecycles,
+    enableSnsAggregatorStore,
+  ]) => {
     if (!enableSnsAggregatorStore) {
       return mapAndSortSnsQueryToSummaries({
         metadata: data?.metadata ?? [],
         swaps: data?.swaps ?? [],
       });
     }
+    // The aggregator data is fetched on init.
+    // Derived state is fetched regularly in the background or after a participation. Therefore, we consider it as the latest data.
+    // Lifecycle data is fetched after a participation. Therefore, we consider it as the latest data.
     return (
       aggregatorData.data
-        ?.map((data) => convertDtoToSnsSummary(data))
+        ?.map(convertDtoToSnsSummary)
+        .map(overrideDerivedState(derivedStates))
+        .map(overrieLifecycle(lifecycles))
         .filter((optionalSummary): optionalSummary is SnsSummary =>
           nonNullish(optionalSummary)
         ) ?? []

--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -318,22 +318,25 @@ const overrideDerivedState =
       return undefined;
     }
     const projectDerivedState = derivedStore[summary.rootCanisterId.toText()];
-    const derivedState = nonNullish(projectDerivedState)
-      ? convertToDerivedState(projectDerivedState.derivedState)
-      : undefined;
-    if (nonNullish(derivedState)) {
-      return {
-        ...summary,
-        derived: derivedState,
-      };
+    if (isNullish(projectDerivedState?.derivedState)) {
+      return summary;
     }
-    return summary;
+    const convertedData = convertToDerivedState(
+      projectDerivedState.derivedState
+    );
+    if (isNullish(convertedData)) {
+      return summary;
+    }
+    return {
+      ...summary,
+      derived: convertedData,
+    };
   };
 
 /**
  * Override the lifecycle in the SnsSummary with the one from the store.
  */
-const overrieLifecycle =
+const overrideLifecycle =
   (lifecycleStore: SnsLifecycleData) =>
   (summary: SnsSummary | undefined): SnsSummary | undefined => {
     if (isNullish(summary)) {
@@ -344,17 +347,17 @@ const overrieLifecycle =
     const saleOpenTimestamp = fromNullable(
       projectData?.data.decentralization_sale_open_timestamp_seconds
     );
-    if (nonNullish(lifecycle)) {
-      return {
-        ...summary,
-        swap: {
-          ...summary.swap,
-          lifecycle,
-          decentralization_sale_open_timestamp_seconds: saleOpenTimestamp,
-        },
-      };
+    if (isNullish(lifecycle)) {
+      return summary;
     }
-    return summary;
+    return {
+      ...summary,
+      swap: {
+        ...summary.swap,
+        lifecycle,
+        decentralization_sale_open_timestamp_seconds: saleOpenTimestamp,
+      },
+    };
   };
 
 /**
@@ -397,7 +400,7 @@ export const snsSummariesStore = derived<
       aggregatorData.data
         ?.map(convertDtoToSnsSummary)
         .map(overrideDerivedState(derivedStates))
-        .map(overrieLifecycle(lifecycles))
+        .map(overrideLifecycle(lifecycles))
         .filter((optionalSummary): optionalSummary is SnsSummary =>
           nonNullish(optionalSummary)
         ) ?? []

--- a/frontend/src/tests/e2e/sns-participation.spec.ts
+++ b/frontend/src/tests/e2e/sns-participation.spec.ts
@@ -5,7 +5,7 @@ import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test SNS participation", async ({ page, context }) => {
-  await page.goto("/");
+  await page.goto("/accounts");
   await expect(page).toHaveTitle("NNS Dapp");
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/sns-participation.spec.ts
+++ b/frontend/src/tests/e2e/sns-participation.spec.ts
@@ -5,7 +5,7 @@ import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test SNS participation", async ({ page, context }) => {
-  await page.goto("/accounts");
+  await page.goto("/");
   await expect(page).toHaveTitle("NNS Dapp");
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/lib/stores/sns.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns.store.spec.ts
@@ -38,6 +38,13 @@ import {
 import { get } from "svelte/store";
 
 describe("sns.store", () => {
+  beforeEach(() => {
+    snsQueryStore.reset();
+    snsAggregatorStore.reset();
+    snsDerivedStateStore.reset();
+    snsLifecycleStore.reset();
+  });
+
   describe("snsSwapStatesStore", () => {
     it("should store swap states", () => {
       const swapCommitment = mockSnsSwapCommitment(
@@ -118,10 +125,6 @@ describe("sns.store", () => {
   });
 
   describe("query store", () => {
-    beforeAll(() => snsQueryStore.reset());
-
-    afterEach(() => snsQueryStore.reset());
-
     it("should set the data", () => {
       const data = snsResponsesForLifecycle({
         lifecycles: [SnsSwapLifecycle.Open],
@@ -480,13 +483,6 @@ describe("sns.store", () => {
   });
 
   describe("snsSummariesStore", () => {
-    beforeEach(() => {
-      snsQueryStore.reset();
-      snsAggregatorStore.reset();
-      snsDerivedStateStore.reset();
-      snsLifecycleStore.reset();
-    });
-
     describe("flag ENABLE_SNS_AGGREGATOR_STORE not enabled", () => {
       beforeEach(() => {
         overrideFeatureFlagsStore.setFlag("ENABLE_SNS_AGGREGATOR_STORE", false);

--- a/frontend/src/tests/lib/stores/sns.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns.store.spec.ts
@@ -1,9 +1,14 @@
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+import { snsDerivedStateStore } from "$lib/stores/sns-derived-state.store";
+import { snsLifecycleStore } from "$lib/stores/sns-lifecycle.store";
 import {
   openSnsProposalsStore,
   snsProposalsStore,
   snsProposalsStoreIsLoading,
   snsQueryStore,
   snsQueryStoreIsLoading,
+  snsSummariesStore,
   snsSwapCommitmentsStore,
   type SnsQueryStoreData,
 } from "$lib/stores/sns.store";
@@ -11,14 +16,22 @@ import type { SnsSwapCommitment } from "$lib/types/sns";
 import type { QuerySnsSwapState } from "$lib/types/sns.query";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import {
+  aggregatorSnsMockDto,
+  aggregatorSnsMockWith,
+} from "$tests/mocks/sns-aggregator.mock";
+import {
+  mockDerivedResponse,
+  mockLifecycleResponse,
   mockSnsSummaryList,
   mockSnsSwapCommitment,
 } from "$tests/mocks/sns-projects.mock";
 import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { ProposalStatus } from "@dfinity/nns";
 import {
   SnsSwapLifecycle,
   type SnsGetDerivedStateResponse,
+  type SnsGetLifecycleResponse,
   type SnsSwap,
   type SnsSwapDerivedState,
 } from "@dfinity/sns";
@@ -463,6 +476,115 @@ describe("sns.store", () => {
       const updatedStore = get(snsQueryStore);
       const stateInStore = swapState({ rootCanisterId, store: updatedStore });
       expect(stateInStore).toEqual(expectedState);
+    });
+  });
+
+  describe("snsSummariesStore", () => {
+    beforeEach(() => {
+      snsQueryStore.reset();
+      snsAggregatorStore.reset();
+      snsDerivedStateStore.reset();
+      snsLifecycleStore.reset();
+    });
+
+    describe("flag ENABLE_SNS_AGGREGATOR_STORE not enabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_SNS_AGGREGATOR_STORE", false);
+      });
+
+      it("uses snsQueryStore as source of data", () => {
+        snsAggregatorStore.reset();
+        const data = snsResponsesForLifecycle({
+          lifecycles: [SnsSwapLifecycle.Open],
+          certified: true,
+        });
+        snsQueryStore.setData(data);
+
+        expect(get(snsSummariesStore)).toHaveLength(1);
+      });
+
+      it("does NOT use snsAggregator as source of data", () => {
+        snsAggregatorStore.setData([aggregatorSnsMockDto]);
+        snsQueryStore.reset();
+
+        expect(get(snsSummariesStore)).toHaveLength(0);
+      });
+    });
+
+    describe("flag ENABLE_SNS_AGGREGATOR_STORE is enabled", () => {
+      const rootCanisterId = rootCanisterIdMock;
+
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_SNS_AGGREGATOR_STORE", true);
+      });
+
+      it("does not snsQueryStore as source of data", () => {
+        snsAggregatorStore.reset();
+        const data = snsResponsesForLifecycle({
+          lifecycles: [SnsSwapLifecycle.Open],
+          certified: true,
+        });
+        snsQueryStore.setData(data);
+
+        expect(get(snsSummariesStore)).toHaveLength(0);
+      });
+
+      it("uses snsAggregator as source of data", () => {
+        snsAggregatorStore.setData([aggregatorSnsMockDto]);
+        snsQueryStore.reset();
+
+        expect(get(snsSummariesStore)).toHaveLength(1);
+      });
+
+      it("derived state is overriden with data in snsDerivedStateStore", () => {
+        const newSnsTokensPerIcp = 4;
+        const aggregatorData = aggregatorSnsMockWith({
+          rootCanisterId: rootCanisterId.toText(),
+        });
+        snsAggregatorStore.setData([aggregatorData]);
+        snsQueryStore.reset();
+
+        expect(get(snsSummariesStore)[0].derived.sns_tokens_per_icp).not.toBe(
+          newSnsTokensPerIcp
+        );
+
+        const newDerivedState: SnsGetDerivedStateResponse = {
+          ...mockDerivedResponse,
+          sns_tokens_per_icp: [newSnsTokensPerIcp],
+        };
+        snsDerivedStateStore.setDerivedState({
+          certified: true,
+          rootCanisterId,
+          data: newDerivedState,
+        });
+
+        expect(get(snsSummariesStore)[0].derived.sns_tokens_per_icp).toBe(
+          newSnsTokensPerIcp
+        );
+      });
+
+      it("lifestate is overriden with data in snsDerivedStateStore", () => {
+        const newLifecycle = SnsSwapLifecycle.Open;
+        const aggregatorData = aggregatorSnsMockWith({
+          rootCanisterId: rootCanisterId.toText(),
+        });
+        snsAggregatorStore.setData([aggregatorData]);
+        snsQueryStore.reset();
+
+        expect(get(snsSummariesStore)[0].swap.lifecycle).not.toBe(newLifecycle);
+
+        const newLifecycleResponse: SnsGetLifecycleResponse = {
+          ...mockLifecycleResponse,
+          lifecycle: [newLifecycle],
+        };
+        snsLifecycleStore.setData({
+          certified: true,
+          rootCanisterId,
+          data: newLifecycleResponse,
+        });
+
+        expect(get(snsSummariesStore)[0].swap.lifecycle).toBe(newLifecycle);
+      });
     });
   });
 });


### PR DESCRIPTION
# Motivation

We want to move away from get_state deprecated endpoint. Before doing that, we need to move away from snsQueryStore.

In this PR, the snsAggregatorStore and other stores are used in the snsSummariesStore instead of the snsQueryStore.

# Changes

* Use new stores in snsSummariesStore.

# Tests

* Test store in different cases.

# Todos

- [x] Add entry to changelog (if necessary).
