### PR TITLE
Fix ordered dependence in html.utils.spec.ts

### DIFF
--- a/frontend/src/tests/lib/utils/html.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/html.utils.spec.ts
@@ -94,7 +94,10 @@ describe("markdown.utils", () => {
 
   describe("markdown", () => {
     let renderer: unknown;
-    beforeAll(() => {
+
+    beforeEach(() => {
+      renderer = undefined;
+
       function marked(...args) {
         renderer = args[1];
         return args[0] + "-markdown";
@@ -116,6 +119,8 @@ describe("markdown.utils", () => {
     });
 
     it("should call markedjs/marked with custom renderers", async () => {
+      await markdownToHTML("test");
+
       expect(renderer).toEqual({
         renderer: {
           link: targetBlankLinkRenderer,


### PR DESCRIPTION
# Motivation

Test `"should call markedjs/marked with custom renderers"` literally depended on the test before it calling `markdownToHTML()`.

# Changes

1. Change `beforeAll` to `beforeEach` to give each test a clean slate.
2. Reset `renderer` in `beforeEach`.
3. Call `markdownToHTML()` in both tests rather than one test relying on the other.

# Tests

Passed with 5 different randomize seeds.

# Todos

- [ ] Add entry to changelog (if necessary).
Already covered