### PR TITLE
Rm unused var

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -105,9 +105,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
-        env:
-          SHELLCHECK_OPTS: -e SC1090 -e SC2119 -e SC1091
+        run: |
+          sudo apt-get update
+          sudo apt-get install -yy shellcheck
+          ./scripts/lint-sh
   ic-commit-consistency:
     name: IC Commit
     runs-on: ubuntu-20.04

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -44,6 +44,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 ### Operations
 * Improve the rust document generation.
+* Fix shellcheck issues.
 
 #### Added
 

--- a/scripts/nns-dapp/release-sop.test
+++ b/scripts/nns-dapp/release-sop.test
@@ -30,7 +30,7 @@ test_with_data() {
     else
       (
         echo "ERROR: actual output differs from expected output. See diff above."
-        echo "Run '"$0" --update' to update the tests."
+        echo "Run '\"$0\" --update' to update the tests."
         echo "FAILED: $1"
       ) >&2
       exit 1

--- a/scripts/past-changelog-test.test
+++ b/scripts/past-changelog-test.test
@@ -47,9 +47,7 @@ if ! "$SCRIPT"; then
 fi
 git checkout CHANGELOG-Nns-Dapp.md
 
-sed '199i\
-* changed on line 199
-' CHANGELOG-Nns-Dapp.md | sponge CHANGELOG-Nns-Dapp.md
+sed '199i* changed on line 199\n' CHANGELOG-Nns-Dapp.md | sponge CHANGELOG-Nns-Dapp.md
 if "$SCRIPT"; then
   echo "Should have failed with change on line 199." >&2
   exit 1

--- a/scripts/past-changelog-test.test
+++ b/scripts/past-changelog-test.test
@@ -3,7 +3,6 @@ set -xeuo pipefail
 
 SOURCE_DIR="$(dirname "${BASH_SOURCE[0]}")"
 SCRIPT="$SOURCE_DIR/past-changelog-test"
-CHANGELOG="CHANGELOG-Nns-Dapp.md"
 
 if ! "$SCRIPT"; then
   echo "Should have passed without additional changes." >&2


### PR DESCRIPTION
# Motivation
CI uses a third party action to run shellcheck, rather than `./scripts/lint-sh`.  Unsurprisingly the two have got out of sync, resulting in warnings whenever shellcheck is run locally.

# Changes
* Use `./scripts/lint-sh` in CI, instead of the third party action.
* Fix shellcheck issues.

# Tests
* See CI.

# Todos

- [x] Add entry to changelog (if necessary).
