### PR TITLE
Fix orderer dependency in ckbtc.utils.spec.ts

### DIFF
--- a/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
@@ -7,7 +7,10 @@ import { formatToken } from "$lib/utils/token.utils";
 import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
-import { mockedConstants } from "$tests/utils/mockable-constants.test-utils";
+import {
+  mockedConstants,
+  resetMockedConstants,
+} from "$tests/utils/mockable-constants.test-utils";
 
 describe("ckbtc.utils", () => {
   const RETRIEVE_BTC_MIN_AMOUNT = 100_000n;
@@ -25,6 +28,10 @@ describe("ckbtc.utils", () => {
       certified: true,
     },
   };
+
+  beforeEach(() => {
+    resetMockedConstants();
+  });
 
   it("should not throw error", () => {
     expect(() =>


### PR DESCRIPTION
# Motivation

One of the tests sets `mockedConstants.FORCE_CALL_STRATEGY = "query"` but doesn't reset it.

# Changes

Call `resetMockedConstants()` in `beforeEach`.

# Tests

passed

# Todos

- [ ] Add entry to changelog (if necessary).
covered