### PR TITLE
Fix order dependence in sns-proposals.services.spec.ts

### DIFF
--- a/frontend/src/tests/lib/services/_public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns-proposals.services.spec.ts
@@ -39,6 +39,7 @@ describe("sns-proposals services", () => {
     snsProposalsStore.reset();
     toastsStore.reset();
     jest.clearAllMocks();
+    jest.spyOn(console, "error").mockRestore();
   });
   const proposal1: SnsProposalData = {
     ...mockSnsProposal,
@@ -475,6 +476,7 @@ describe("sns-proposals services", () => {
       });
 
       it("should call handle error if api call fails", async () => {
+        jest.spyOn(console, "error").mockImplementation(() => undefined);
         jest.spyOn(api, "queryProposal").mockRejectedValue(new Error("error"));
         const handleErrorSpy = jest.fn();
         const setProposalSpy = jest.fn();
@@ -490,6 +492,7 @@ describe("sns-proposals services", () => {
       });
 
       it("should show error if api call fails", async () => {
+        jest.spyOn(console, "error").mockImplementation(() => undefined);
         jest.spyOn(api, "queryProposal").mockRejectedValue(new Error("error"));
         const handleErrorSpy = jest.fn();
         const setProposalSpy = jest.fn();


### PR DESCRIPTION
# Motivation

Some tests were generating errors on the console but only one of the tests mocked the console.
So if another test logged to the console, it would fail.

# Changes

Explicitly mock `console.error` in the tests that require it and restore the mock before every test.

# Tests

Pass with random seeds 1 - 20.

# Todos

- [ ] Add entry to changelog (if necessary).
covered