### PR TITLE
Fix: Enable images e2e test

### DIFF
--- a/frontend/src/tests/e2e/images.spec.ts
+++ b/frontend/src/tests/e2e/images.spec.ts
@@ -5,7 +5,6 @@ import { expect, test } from "@playwright/test";
 
 const expectImagesLoaded = async ({ page, sources }) => {
   const images = page.locator("img");
-  console.log("images", images);
   await expect(images).toHaveCount(sources.length);
   const imageSources = await Promise.all(
     (await images.all()).map((img) => img.getAttribute("src"))
@@ -30,7 +29,7 @@ const expectImagesLoaded = async ({ page, sources }) => {
   }, sources.length);
 };
 
-test("Test images load on home page", async ({ page, context }) => {
+test("Test images load on accounts page", async ({ page, context }) => {
   await page.goto("/accounts");
   await expect(page).toHaveTitle("Account / NNS Dapp");
 

--- a/frontend/src/tests/e2e/images.spec.ts
+++ b/frontend/src/tests/e2e/images.spec.ts
@@ -5,6 +5,7 @@ import { expect, test } from "@playwright/test";
 
 const expectImagesLoaded = async ({ page, sources }) => {
   const images = page.locator("img");
+  console.log("images", images);
   await expect(images).toHaveCount(sources.length);
   const imageSources = await Promise.all(
     (await images.all()).map((img) => img.getAttribute("src"))
@@ -29,20 +30,14 @@ const expectImagesLoaded = async ({ page, sources }) => {
   }, sources.length);
 };
 
-test.skip("Test images load on home page", async ({ page, context }) => {
+test("Test images load on home page", async ({ page, context }) => {
   await page.goto("/accounts");
   await expect(page).toHaveTitle("Account / NNS Dapp");
 
   await step("Check images before signing");
   await expectImagesLoaded({
     page,
-    sources: [
-      "576.png",
-      "logo-nns.svg",
-      "logo-onchain-light.svg",
-      "menu-bg-light.png",
-      "nns-logo.svg",
-    ],
+    sources: ["logo-nns.svg", "logo-onchain-light.svg", "menu-bg-light.png"],
   });
 
   await signInWithNewUser({ page, context });


### PR DESCRIPTION
# Motivation

An e2e was skipped in #3179 

In this PR, I enable it and fix it.

# Changes

* Enable the images e2e test.
* Change the expected images.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessayr.