### PR TITLE
Initialize NnsProposals as loading

### DIFF
--- a/frontend/src/lib/pages/NnsProposals.svelte
+++ b/frontend/src/lib/pages/NnsProposals.svelte
@@ -36,7 +36,7 @@
     listNeurons();
   }
 
-  let loading = false;
+  let loading = true;
   let hidden = false;
   let initialized = false;
 


### PR DESCRIPTION
# Motivation

I've seen a few failures like this:
https://github.com/dfinity/nns-dapp/actions/runs/5949476993/job/16135403216
In the `neurons.spec.ts` e2e test, after navigating to the proposals tab, it waits for content to be loaded but then see 0 proposal cards.

I was able to reproduce this locally after adding some logging, but unfortunately only once.
But my guess is that the component renders in non-loading state (without skeletons) before the skeletons are rendered.
At this point the test assumes loading is finished and expects the proposals to be already there.

# Changes

Initialize `frontend/src/lib/pages/NnsProposals.svelte` in loading state.

# Tests

I'm not sure how to test this given that `loading` is anyway immediately set to true in `onMount`.
But when I logged the value of `loadingAnimation`, it did log as `undefined` before it logged as `"skeleton"` so I think it's worth a try anyway.

# Todos

- [ ] Add entry to changelog (if necessary).
not sure what to put, probably not worth it