### PR TITLE
Fix: Render accoungs landing page in login

### DIFF
--- a/frontend/src/lib/pages/SignInAccounts.svelte
+++ b/frontend/src/lib/pages/SignInAccounts.svelte
@@ -11,7 +11,7 @@
   // TODO(GIX-1071): this static pre-rendering component should be improved with some more information and shiny design
 </script>
 
-<main class="sign-in">
+<main class="sign-in" data-tid="accounts-landing-page">
   <h1>{$i18n.auth_accounts.title}</h1>
 
   <p>

--- a/frontend/src/routes/(login)/+page.svelte
+++ b/frontend/src/routes/(login)/+page.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
-  import { AppPath } from "$lib/constants/routes.constants";
-  import { onMount } from "svelte";
-
-  onMount(() => {
-    goto(AppPath.Accounts, { replaceState: true });
-  });
+  import Content from "$lib/components/layout/Content.svelte";
+  import Layout from "$lib/components/layout/Layout.svelte";
+  import LayoutList from "$lib/components/layout/LayoutList.svelte";
+  import Warnings from "$lib/components/warnings/Warnings.svelte";
+  import SignInAccounts from "$lib/pages/SignInAccounts.svelte";
+  import { i18n } from "$lib/stores/i18n";
 </script>
+
+<Warnings ckBTCWarnings testEnvironmentWarning />
+
+<LayoutList title={$i18n.navigation.tokens}>
+  <Layout>
+    <Content>
+      <SignInAccounts />
+    </Content>
+  </Layout>
+</LayoutList>

--- a/frontend/src/tests/routes/login/page.spec.ts
+++ b/frontend/src/tests/routes/login/page.spec.ts
@@ -2,24 +2,13 @@
  * @jest-environment jsdom
  */
 
-import { AppPath } from "$lib/constants/routes.constants";
-import { pageStore } from "$lib/derived/page.derived";
 import App from "$routes/(login)/+page.svelte";
-import { render, waitFor } from "@testing-library/svelte";
-import { get } from "svelte/store";
+import { render } from "@testing-library/svelte";
 
 describe("Layout", () => {
-  afterAll(() => {
-    jest.clearAllMocks();
-    jest.restoreAllMocks();
-  });
+  it("should render accounts landing page", async () => {
+    const { queryByTestId } = render(App);
 
-  it("should redirect to accounts", async () => {
-    render(App);
-
-    await waitFor(() => {
-      const { path } = get(pageStore);
-      expect(path).toEqual(AppPath.Accounts);
-    });
+    expect(queryByTestId("accounts-landing-page")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Motivation

Render the accounts landing page in `/`.

# Changes

* Render the same components as in `/accounts` when user is not logged in in `(login)/+page.svelte`.

# Tests

* Test that it renders the proper UI.

# Todos

- [ ] Add entry to changelog (if necessary).
