### PR TITLE
Fix order dependence in proposals.services.spec.ts

### DIFF
--- a/frontend/src/tests/lib/services/_public/proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/proposals.services.spec.ts
@@ -303,8 +303,6 @@ describe("proposals-services", () => {
   });
 
   describe("filter", () => {
-    const spySetProposals = jest.spyOn(proposalsStore, "setProposals");
-    const spyPushProposals = jest.spyOn(proposalsStore, "pushProposals");
     let spyQueryProposals;
 
     beforeEach(() => {


### PR DESCRIPTION
# Motivation

The test would fail when run in randomized order.

The test sets mock behavior in a `describe` block, outside `beforeEach` or `it`.
This gets executed in a surprising order, because first the framework collects all the tests that should be executed by running the `describe` blocks, and then it runs all the tests.

This means that the structure of the code may suggest a certain test runs with a certain mock behavior, while it actually runs with the mock behavior defined in another test or `describe` block.

# Changes

1. Move mock behavior defined in `describe` blocks, inside `beforeEach` in that block.
2. Move all cleanup to top-level `beforeEach`.
3. Remove all `beforeAll`, `afterEach` and `afterAll`.
4. Explicitly mock `authStore.subscribe` with either `mockAuthStoreSubscribe` or `mockAuthStoreNoIdentitySubscribe`.
5. Add expectations that spies aren't called before they are expected to be called.


# Tests

Ran with 20 different randomizations.

# Todos

- [ ] Add entry to changelog (if necessary).
already covered