### PR TITLE
Static loading spinner

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -128,8 +128,140 @@
     <!-- LINKS_PRELOADER -->
 
     %sveltekit.head%
+
+    <style>
+      .spinner {
+        --spinner-size: 30px;
+
+        width: var(--spinner-size);
+        height: var(--spinner-size);
+
+        animation: spinner-linear-rotate 2000ms linear infinite;
+
+        position: absolute;
+        top: calc(50% - (var(--spinner-size) / 2));
+        left: calc(50% - (var(--spinner-size) / 2));
+
+        --radius: 45px;
+        --circumference: calc(3.14159265359 * var(--radius) * 2);
+
+        --start: calc((1 - 0.05) * var(--circumference));
+        --end: calc((1 - 0.8) * var(--circumference));
+      }
+
+      .spinner circle {
+        stroke-dasharray: var(--circumference);
+        stroke-width: 10%;
+        transform-origin: 50% 50% 0;
+
+        transition-property: stroke;
+
+        animation-name: spinner-stroke-rotate-100;
+        animation-duration: 4000ms;
+        animation-timing-function: cubic-bezier(0.35, 0, 0.25, 1);
+        animation-iteration-count: infinite;
+
+        fill: transparent;
+        stroke: currentColor;
+
+        transition: stroke-dashoffset 225ms linear;
+      }
+
+      @keyframes spinner-linear-rotate {
+        0% {
+          transform: rotate(0deg);
+        }
+        100% {
+          transform: rotate(360deg);
+        }
+      }
+
+      @keyframes spinner-stroke-rotate-100 {
+        0% {
+          stroke-dashoffset: var(--start);
+          transform: rotate(0);
+        }
+        12.5% {
+          stroke-dashoffset: var(--end);
+          transform: rotate(0);
+        }
+        12.5001% {
+          stroke-dashoffset: var(--end);
+          transform: rotateX(180deg) rotate(72.5deg);
+        }
+        25% {
+          stroke-dashoffset: var(--start);
+          transform: rotateX(180deg) rotate(72.5deg);
+        }
+
+        25.0001% {
+          stroke-dashoffset: var(--start);
+          transform: rotate(270deg);
+        }
+        37.5% {
+          stroke-dashoffset: var(--end);
+          transform: rotate(270deg);
+        }
+        37.5001% {
+          stroke-dashoffset: var(--end);
+          transform: rotateX(180deg) rotate(161.5deg);
+        }
+        50% {
+          stroke-dashoffset: var(--start);
+          transform: rotateX(180deg) rotate(161.5deg);
+        }
+
+        50.0001% {
+          stroke-dashoffset: var(--start);
+          transform: rotate(180deg);
+        }
+        62.5% {
+          stroke-dashoffset: var(--end);
+          transform: rotate(180deg);
+        }
+        62.5001% {
+          stroke-dashoffset: var(--end);
+          transform: rotateX(180deg) rotate(251.5deg);
+        }
+        75% {
+          stroke-dashoffset: var(--start);
+          transform: rotateX(180deg) rotate(251.5deg);
+        }
+
+        75.0001% {
+          stroke-dashoffset: var(--start);
+          transform: rotate(90deg);
+        }
+        87.5% {
+          stroke-dashoffset: var(--end);
+          transform: rotate(90deg);
+        }
+        87.5001% {
+          stroke-dashoffset: var(--end);
+          transform: rotateX(180deg) rotate(341.5deg);
+        }
+        100% {
+          stroke-dashoffset: var(--start);
+          transform: rotateX(180deg) rotate(341.5deg);
+        }
+      }
+    </style>
   </head>
   <body>
     <div>%sveltekit.body%</div>
+
+    <!-- All resources required to boot the dapp can take some times to be downloaded on the IC. -->
+    <!-- That's why we are displaying a spinner while the dapp is starting. -->
+    <!-- Spinner which is then removed as soon as the authentication is initialized (regardless if sign-in or sign-out) -->
+    <svg
+      class="spinner"
+      preserveAspectRatio="xMidYMid meet"
+      focusable="false"
+      aria-hidden="true"
+      data-tid="spinner"
+      viewBox="0 0 100 100"
+    >
+      <circle cx="50%" cy="50%" r="45" />
+    </svg>
   </body>
 </html>

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -130,13 +130,13 @@
     %sveltekit.head%
 
     <style>
-      .spinner {
+      #app-spinner {
         --spinner-size: 30px;
 
         width: var(--spinner-size);
         height: var(--spinner-size);
 
-        animation: spinner-linear-rotate 2000ms linear infinite;
+        animation: app-spinner-linear-rotate 2000ms linear infinite;
 
         position: absolute;
         top: calc(50% - (var(--spinner-size) / 2));
@@ -149,14 +149,14 @@
         --end: calc((1 - 0.8) * var(--circumference));
       }
 
-      .spinner circle {
+      #app-spinner circle {
         stroke-dasharray: var(--circumference);
         stroke-width: 10%;
         transform-origin: 50% 50% 0;
 
         transition-property: stroke;
 
-        animation-name: spinner-stroke-rotate-100;
+        animation-name: app-spinner-stroke-rotate-100;
         animation-duration: 4000ms;
         animation-timing-function: cubic-bezier(0.35, 0, 0.25, 1);
         animation-iteration-count: infinite;
@@ -167,7 +167,7 @@
         transition: stroke-dashoffset 225ms linear;
       }
 
-      @keyframes spinner-linear-rotate {
+      @keyframes app-spinner-linear-rotate {
         0% {
           transform: rotate(0deg);
         }
@@ -176,7 +176,7 @@
         }
       }
 
-      @keyframes spinner-stroke-rotate-100 {
+      @keyframes app-spinner-stroke-rotate-100 {
         0% {
           stroke-dashoffset: var(--start);
           transform: rotate(0);
@@ -254,7 +254,7 @@
     <!-- That's why we are displaying a spinner while the dapp is starting. -->
     <!-- Spinner which is then removed as soon as the authentication is initialized (regardless if sign-in or sign-out) -->
     <svg
-      class="spinner"
+      id="app-spinner"
       preserveAspectRatio="xMidYMid meet"
       focusable="false"
       aria-hidden="true"

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -15,6 +15,8 @@
   import { referrerPathStore } from "$lib/stores/routes.store";
   import { referrerPathForNav } from "$lib/utils/page.utils";
   import { authStore } from "$lib/stores/auth.store";
+  import { isNullish } from "@dfinity/utils";
+  import {browser} from "$app/environment";
 
   onMount(async () => await Promise.all([initAppAuth(), initAppPublicData()]));
 
@@ -29,12 +31,30 @@
     // TODO: e2e to test this
     referrerPathStore.set(referrerPathForNav(nav))
   );
+
+  // To improve the UX while the app is loading on mainnet we display a spinner which is attached statically in the index.html files.
+  // Once the authentication has been initialized we know most JavaScript resources has been loaded and therefore we can hide the spinner, the loading information.
+  $: (() => {
+    if (!browser) {
+      return;
+    }
+
+    if ($authStore === undefined) {
+      return;
+    }
+
+    const spinner = document.querySelector("body > svg.spinner");
+
+    if (isNullish(spinner)) {
+      return;
+    }
+
+    document.body.removeChild(spinner);
+  })();
 </script>
 
 <!-- We are waiting agent-js / the auth store to be loaded before rendering the pages to avoid visual glitch -->
-{#if $authStore.identity === undefined}
-  <Spinner />
-{:else}
+{#if $authStore.identity !== undefined}
   <slot />
 {/if}
 

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -3,7 +3,7 @@
   import { confirmCloseApp } from "$lib/utils/before-unload.utils";
   import { voteRegistrationActive } from "$lib/utils/proposals.utils";
   import { onMount } from "svelte";
-  import { Toasts, BusyScreen, Spinner } from "@dfinity/gix-components";
+  import { Toasts, BusyScreen } from "@dfinity/gix-components";
   import {
     initAppAuth,
     initAppPublicData,
@@ -15,8 +15,7 @@
   import { referrerPathStore } from "$lib/stores/routes.store";
   import { referrerPathForNav } from "$lib/utils/page.utils";
   import { authStore } from "$lib/stores/auth.store";
-  import { isNullish } from "@dfinity/utils";
-  import {browser} from "$app/environment";
+  import { browser } from "$app/environment";
 
   onMount(async () => await Promise.all([initAppAuth(), initAppPublicData()]));
 
@@ -43,13 +42,8 @@
       return;
     }
 
-    const spinner = document.querySelector("body > svg.spinner");
-
-    if (isNullish(spinner)) {
-      return;
-    }
-
-    document.body.removeChild(spinner);
+    const spinner = document.querySelector("body > #app-spinner");
+    spinner?.remove();
   })();
 </script>
 

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -38,6 +38,7 @@
       return;
     }
 
+    // We want to display a spinner until the authentication is loaded. This to avoid a glitch when either the landing page or effective content (sign-in / sign-out) is presented.
     if ($authStore === undefined) {
       return;
     }

--- a/frontend/src/tests/e2e/design.spec.ts
+++ b/frontend/src/tests/e2e/design.spec.ts
@@ -13,6 +13,15 @@ test.describe("Design", () => {
     await expect(page).toHaveScreenshot();
   });
 
+  test("App loading spinner is removed", async ({ page }) => {
+    await page.goto("/");
+
+    // Wait for the button to make sure the app is loaded
+    await page.locator("[data-tid=login-button]").waitFor();
+
+    expect(await page.locator("#app-spinner").count()).toEqual(0);
+  });
+
   test.describe("Signed-in", () => {
     // Reuse single page between tests
     // Source: https://playwright.dev/docs/test-retries#reuse-single-page-between-tests

--- a/frontend/src/tests/routes/app/layout.spec.ts
+++ b/frontend/src/tests/routes/app/layout.spec.ts
@@ -6,9 +6,7 @@ import {
   initAppAuth,
   initAppPublicData,
 } from "$lib/services/$public/app.services";
-import { authStore } from "$lib/stores/auth.store";
 import App from "$routes/(app)/+layout.svelte";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { render, waitFor } from "@testing-library/svelte";
 
 jest.mock("$lib/services/$public/app.services", () => ({
@@ -32,27 +30,5 @@ describe("Layout", () => {
     render(App);
 
     await waitFor(() => expect(initAppPublicData).toHaveBeenCalled());
-  });
-
-  it("should render a spinner while loading the auth", async () => {
-    authStore.setForTesting(undefined);
-
-    const { getByTestId } = render(App);
-
-    expect(getByTestId("spinner")).toBeInTheDocument();
-  });
-
-  it("should hide the spinner when auth loaded", async () => {
-    authStore.setForTesting(undefined);
-
-    const { getByTestId, container } = render(App);
-
-    expect(getByTestId("spinner")).toBeInTheDocument();
-
-    authStore.setForTesting(mockIdentity);
-
-    await waitFor(() =>
-      expect(container.querySelector('[data-tid="spinner"]')).toBeNull()
-    );
   });
 });


### PR DESCRIPTION
# Motivation

We have no control on the way the chunks are loaded. As a result, it's possible that it waits until most chunks are loaded before displaying the hints - the spinner - that the dapp is booting which is leading to an unfriendly UX as a blank screen might be displaying for a while.

By rendering a spinner within the static html page and removing it once most of the JS files are loaded, we can overcome this "race condition".

# Changes

- add (copy) spinner in `app.html`
- when the auth is ready, which indicates most JS resources are loaded, remove the spinner

# Tests

https://kgqse-raaaa-aaaaa-aactq-cai.nnsdapp.dfinity.network/
https://kgqse-raaaa-aaaaa-aactq-cai.nnsdapp.dfinity.network/accounts

https://xnjld-hqaaa-aaaal-qb56q-cai.icp0.io/

# Screenshots

Mainnet - current main - Fast 3g network => spinner appears for a milli second when all js is loaded

![mainnet-no-spinner](https://github.com/dfinity/nns-dapp/assets/16886711/6a740ee4-0b83-4b1c-b3b4-137c78df2657)

Mainnet - this PR - Fast 3g network

![mainnet-spinner](https://github.com/dfinity/nns-dapp/assets/16886711/5dd86910-d627-4e3e-b4ab-52e27f3a58dd)

Mainnet this PR - full speed network

![full-speed](https://github.com/dfinity/nns-dapp/assets/16886711/d3efe0de-02f3-442b-89dd-c6364a997949)
