### PR TITLE
Fix: Safari page banner

### DIFF
--- a/frontend/src/lib/pages/SignInAccounts.svelte
+++ b/frontend/src/lib/pages/SignInAccounts.svelte
@@ -9,27 +9,14 @@
     title: $i18n.wallet.title,
     header: "",
   });
-
-  let innerWidth = 0;
-
-  let size = 86;
-
-  const onWindowSizeChange = (innerWidth: number) => {
-    // Change size of the icon
-    size = innerWidth > 768 ? 144 : 86;
-  };
-
-  $: onWindowSizeChange(innerWidth);
 </script>
-
-<svelte:window bind:innerWidth />
 
 <main class="sign-in" data-tid="accounts-landing-page">
   <!-- Safari doesn't handle well grid inside flexbox -->
   <!-- https://stackoverflow.com/questions/62075401/safari-grid-in-flexbox-produces-height-overflow -->
   <div>
     <PageBanner>
-      <IconAccountsPage slot="image" {size} />
+      <IconAccountsPage slot="image" />
       <svelte:fragment slot="title">{$i18n.auth_accounts.title}</svelte:fragment
       >
       <p class="description" slot="description">{$i18n.auth_accounts.text}</p>

--- a/frontend/src/lib/pages/SignInAccounts.svelte
+++ b/frontend/src/lib/pages/SignInAccounts.svelte
@@ -9,15 +9,33 @@
     title: $i18n.wallet.title,
     header: "",
   });
+
+  let innerWidth = 0;
+
+  let size = 86;
+
+  const onWindowSizeChange = (innerWidth: number) => {
+    // Change size of the icon
+    size = innerWidth > 768 ? 144 : 86;
+  };
+
+  $: onWindowSizeChange(innerWidth);
 </script>
 
+<svelte:window bind:innerWidth />
+
 <main class="sign-in" data-tid="accounts-landing-page">
-  <PageBanner>
-    <IconAccountsPage slot="image" />
-    <svelte:fragment slot="title">{$i18n.auth_accounts.title}</svelte:fragment>
-    <p class="description" slot="description">{$i18n.auth_accounts.text}</p>
-    <SignIn slot="actions" />
-  </PageBanner>
+  <!-- Safari doesn't handle well grid inside flexbox -->
+  <!-- https://stackoverflow.com/questions/62075401/safari-grid-in-flexbox-produces-height-overflow -->
+  <div>
+    <PageBanner>
+      <IconAccountsPage slot="image" {size} />
+      <svelte:fragment slot="title">{$i18n.auth_accounts.title}</svelte:fragment
+      >
+      <p class="description" slot="description">{$i18n.auth_accounts.text}</p>
+      <SignIn slot="actions" />
+    </PageBanner>
+  </div>
 
   <EmptyCards />
 </main>

--- a/frontend/src/lib/pages/SignInCanisters.svelte
+++ b/frontend/src/lib/pages/SignInCanisters.svelte
@@ -6,12 +6,18 @@
 </script>
 
 <main class="sign-in">
-  <PageBanner>
-    <IconCanistersPage slot="image" />
-    <svelte:fragment slot="title">{$i18n.auth_canisters.title}</svelte:fragment>
-    <p class="description" slot="description">{$i18n.auth_canisters.text}</p>
-    <SignIn slot="actions" />
-  </PageBanner>
+  <!-- Safari doesn't handle well grid inside flexbox -->
+  <!-- https://stackoverflow.com/questions/62075401/safari-grid-in-flexbox-produces-height-overflow -->
+  <div>
+    <PageBanner>
+      <IconCanistersPage slot="image" />
+      <svelte:fragment slot="title"
+        >{$i18n.auth_canisters.title}</svelte:fragment
+      >
+      <p class="description" slot="description">{$i18n.auth_canisters.text}</p>
+      <SignIn slot="actions" />
+    </PageBanner>
+  </div>
 
   <EmptyCards />
 </main>

--- a/frontend/src/lib/pages/SignInNeurons.svelte
+++ b/frontend/src/lib/pages/SignInNeurons.svelte
@@ -12,12 +12,16 @@
 </script>
 
 <main class="sign-in">
-  <PageBanner>
-    <IconNeuronsPage slot="image" />
-    <svelte:fragment slot="title">{$i18n.auth_neurons.title}</svelte:fragment>
-    <p class="description" slot="description">{$i18n.auth_neurons.text}</p>
-    <SignIn slot="actions" />
-  </PageBanner>
+  <!-- Safari doesn't handle well grid inside flexbox -->
+  <!-- https://stackoverflow.com/questions/62075401/safari-grid-in-flexbox-produces-height-overflow -->
+  <div>
+    <PageBanner>
+      <IconNeuronsPage slot="image" />
+      <svelte:fragment slot="title">{$i18n.auth_neurons.title}</svelte:fragment>
+      <p class="description" slot="description">{$i18n.auth_neurons.text}</p>
+      <SignIn slot="actions" />
+    </PageBanner>
+  </div>
 
   <EmptyCards />
 </main>

--- a/frontend/src/lib/pages/SignInSettings.svelte
+++ b/frontend/src/lib/pages/SignInSettings.svelte
@@ -6,12 +6,17 @@
 </script>
 
 <main class="sign-in">
-  <PageBanner>
-    <IconSettingsPage slot="image" />
-    <svelte:fragment slot="title">{$i18n.navigation.settings}</svelte:fragment>
-    <p class="description" slot="description">{$i18n.auth_accounts.text}</p>
-    <SignIn slot="actions" />
-  </PageBanner>
+  <!-- Safari doesn't handle well grid inside flexbox -->
+  <!-- https://stackoverflow.com/questions/62075401/safari-grid-in-flexbox-produces-height-overflow -->
+  <div>
+    <PageBanner>
+      <IconSettingsPage slot="image" />
+      <svelte:fragment slot="title">{$i18n.navigation.settings}</svelte:fragment
+      >
+      <p class="description" slot="description">{$i18n.auth_accounts.text}</p>
+      <SignIn slot="actions" />
+    </PageBanner>
+  </div>
 
   <EmptyCards />
 </main>


### PR DESCRIPTION
# Motivation

PageBanner in Safari doesn't render properly.

In this PR, it fixes the overflow.

In another PR: upgrade gix-components and svg should be visible.

# Changes

* Wrap the PageBanner within a div. Having a grid inside a flexbox doesn't work well for Safari.

# Tests

Only UI changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Already covered by the changelog entry of the new landing pages. They have not yet been released.
