### PR TITLE
Fix order dependence in HardwareWalletName.spec.ts

### DIFF
--- a/frontend/src/tests/lib/components/accounts/HardwareWalletName.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletName.spec.ts
@@ -13,16 +13,9 @@ import AddAccountTest from "./AddAccountTest.svelte";
 describe("HardwareWalletName", () => {
   const props = { testComponent: HardwareWalletName };
 
-  beforeAll(() =>
+  beforeEach(() =>
     addAccountStoreMock.set({
       type: "hardwareWallet",
-      hardwareWalletName: undefined,
-    })
-  );
-
-  afterAll(() =>
-    addAccountStoreMock.set({
-      type: undefined,
       hardwareWalletName: undefined,
     })
   );


### PR DESCRIPTION
# Motivation

One of the tests updates global state in `addAccountStoreMock` and a test (that normally runs before it) expects the global state to be empty.
The global state was only set in `beforeAll`.

# Changes

1. Change `beforeAll` to `beforeEach`.
2. Remove `afterAll`.

# Tests

pass

# Todos

- [ ] Add entry to changelog (if necessary).
covered