### PR TITLE
Fix order dependence in NnsProposal.spec.ts

### DIFF
--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
@@ -27,6 +27,10 @@ jest.mock("$lib/api/nns-dapp.api");
 describe("Proposal", () => {
   blockAllCallsTo(["$lib/api/nns-dapp.api"]);
 
+  beforeEach(() => {
+    referrerPathStore.set(undefined);
+  });
+
   const renderProposalModern = (id = 1000n) =>
     render(NnsProposalTest, {
       props: {


### PR DESCRIPTION
# Motivation

One test sets `referrerPathStore` but it's never reset, which can affect other tests depending on the order.

# Changes

Reset `referrerPathStore` in `beforeEach`.

# Tests

Pass with 20 different random seeds.

# Todos

- [ ] Add entry to changelog (if necessary).
covered