### PR TITLE
Fix order dependence in NnsVotingCard.spec.ts

### DIFF
--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/NnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/NnsVotingCard.spec.ts
@@ -68,6 +68,7 @@ describe("VotingCard", () => {
   );
 
   beforeEach(() => {
+    jest.clearAllMocks();
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
@@ -139,6 +140,7 @@ describe("VotingCard", () => {
     });
 
     it("should trigger register-vote and neuron-list updates", async () => {
+      expect(spyRegisterVote).not.toBeCalled();
       await fireEvent.click(screen.queryByTestId("vote-yes") as Element);
       await fireEvent.click(screen.queryByTestId("confirm-yes") as Element);
       await waitFor(() =>
@@ -148,6 +150,7 @@ describe("VotingCard", () => {
     });
 
     it("should trigger register-vote YES", async () => {
+      expect(spyRegisterVote).not.toBeCalled();
       await fireEvent.click(screen.queryByTestId("vote-yes") as Element);
       await fireEvent.click(screen.queryByTestId("confirm-yes") as Element);
       await waitFor(() =>
@@ -157,10 +160,12 @@ describe("VotingCard", () => {
           proposalId: proposalInfo.id,
         })
       );
+      expect(spyRegisterVote).toBeCalledTimes(neurons.length);
     });
 
     // it's on to show "console.error('vote:..." in the output (because of NO mock in canister)
     it("should trigger register-vote NO", async () => {
+      expect(spyRegisterVote).not.toBeCalled();
       await fireEvent.click(screen.queryByTestId("vote-no") as Element);
       await fireEvent.click(screen.queryByTestId("confirm-yes") as Element);
 
@@ -179,6 +184,7 @@ describe("VotingCard", () => {
           proposalId: proposalInfo.id,
         })
       );
+      expect(spyRegisterVote).toBeCalledTimes(neurons.length);
     });
   });
 });


### PR DESCRIPTION
# Motivation

One test was expecting a specific number of calls to `spyRegisterVote` but the mock wasn't cleared between tests.

# Changes

1. `jest.clearAllMocks()` in `beforeEach`.
2. Expect no calls before each test and a specific number of calls after each test.

# Tests

Passes with random seed 1-20.

# Todos

- [ ] Add entry to changelog (if necessary).
covered