### PR TITLE
Fix order dependence in Summary.spec.ts

### DIFF
--- a/frontend/__mocks__/$app/stores.ts
+++ b/frontend/__mocks__/$app/stores.ts
@@ -3,16 +3,18 @@ import { ROUTE_ID_GROUP_APP } from "$lib/constants/routes.constants";
 import type { Page } from "@sveltejs/kit";
 import { writable } from "svelte/store";
 
+const initialStoreValue = {
+  data: {
+    universe: OWN_CANISTER_ID_TEXT,
+    path: undefined,
+  },
+  route: {
+    id: undefined,
+  },
+};
+
 const initPageStoreMock = () => {
-  const { subscribe, set } = writable<Partial<Page>>({
-    data: {
-      universe: OWN_CANISTER_ID_TEXT,
-      path: undefined,
-    },
-    route: {
-      id: undefined,
-    },
-  });
+  const { subscribe, set } = writable<Partial<Page>>(initialStoreValue);
 
   return {
     subscribe,
@@ -30,6 +32,8 @@ const initPageStoreMock = () => {
         // We mock only ROUTE_ID_GROUP_APP and no other sub-group-ids because we do not need these for our test suite and it simplifies the usage of the mock calls
         route: { id: `${ROUTE_ID_GROUP_APP}${routeId}` },
       }),
+
+    reset: () => set(initialStoreValue),
   };
 };
 

--- a/frontend/src/tests/lib/components/summary/Summary.spec.ts
+++ b/frontend/src/tests/lib/components/summary/Summary.spec.ts
@@ -17,13 +17,18 @@ import {
 import { render } from "@testing-library/svelte";
 
 describe("Summary", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    page.reset();
+  });
+
   it("should render a logo", () => {
     const { getByTestId } = render(Summary);
     expect(getByTestId("project-logo")).not.toBeNull();
   });
 
   describe("no universe", () => {
-    beforeAll(() => {
+    beforeEach(() => {
       jest
         .spyOn(snsProjectSelectedStore, "subscribe")
         .mockImplementation(mockStoreSubscribe(mockSnsFullProject));
@@ -53,15 +58,17 @@ describe("Summary", () => {
       jest.resetAllMocks();
     });
 
-    beforeAll(() =>
+    beforeEach(() =>
       jest
         .spyOn(snsProjectSelectedStore, "subscribe")
         .mockImplementation(mockStoreSubscribe(undefined))
     );
 
-    afterAll(() => jest.clearAllMocks());
-
     it("should render internet computer", () => {
+      page.mock({
+        data: { universe: mockSnsFullProject.rootCanisterId.toText() },
+      });
+
       const { container } = render(Summary);
 
       expect(
@@ -71,7 +78,7 @@ describe("Summary", () => {
   });
 
   describe("sns", () => {
-    beforeAll(() => {
+    beforeEach(() => {
       jest
         .spyOn(snsProjectsCommittedStore, "subscribe")
         .mockImplementation(mockProjectSubscribe([mockSnsFullProject]));
@@ -81,8 +88,6 @@ describe("Summary", () => {
         routeId: AppPath.Accounts,
       });
     });
-
-    afterAll(() => jest.clearAllMocks());
 
     it("should render project", () => {
       const { container } = render(Summary);
@@ -95,14 +100,12 @@ describe("Summary", () => {
   });
 
   describe("ckBTC", () => {
-    beforeAll(() => {
+    beforeEach(() => {
       page.mock({
         data: { universe: CKBTC_UNIVERSE_CANISTER_ID.toText() },
         routeId: AppPath.Accounts,
       });
     });
-
-    afterAll(() => jest.clearAllMocks());
 
     it("should render ckBTC", () => {
       const { container } = render(Summary);


### PR DESCRIPTION
# Motivation

Some tests used `page.mock` and some tests relied on the initial value of the `page` store without resetting it.
In fact, there was no way provided to reset it.

# Changes

1. Add `reset` method to mock `page` store.
2. In `frontend/src/tests/lib/components/summary/Summary.spec.ts`, call `page.reset()` in `beforeEach`.
3. In individual tests, change `beforeAll` to `beforeEach` because the top-level `beforeEach` is called after the sub-level `beforeAll`.
4. Remove `afterAll`s and instead fo `jest.clearAllMocks` in top-level `beforeEach`. (drive-by)

# Tests

Pass with random seed 1-20.

# Todos

- [ ] Add entry to changelog (if necessary).
covered?