### PR TITLE
Fix order dependence in Warnings.spec.ts

### DIFF
--- a/frontend/src/tests/lib/components/warnings/Warnings.spec.ts
+++ b/frontend/src/tests/lib/components/warnings/Warnings.spec.ts
@@ -37,6 +37,10 @@ jest.mock("$lib/constants/environment.constants.ts", () => ({
 }));
 
 describe("Warnings", () => {
+  beforeEach(() => {
+    metricsCallback = undefined;
+  });
+
   describe("TransactionRateWarning", () => {
     beforeEach(() => metricsStore.set(undefined));
 
@@ -80,6 +84,9 @@ describe("Warnings", () => {
       const tmp = container.querySelector(".toast .close");
       tmp && fireEvent.click(tmp);
 
+      // Wait for initialization of the callback
+      await waitFor(() => expect(metricsCallback).not.toBeUndefined());
+
       metricsCallback?.({
         metrics: {
           transactionRate: transactionRateNormalLoad,
@@ -93,6 +100,9 @@ describe("Warnings", () => {
 
     it("should render transaction warning once", async () => {
       const { container } = render(WarningsTest);
+
+      // Wait for initialization of the callback
+      await waitFor(() => expect(metricsCallback).not.toBeUndefined());
 
       metricsCallback?.({
         metrics: {


### PR DESCRIPTION
# Motivation

`metricsCallback` is initialized while rendering the component.
One of the tests explicitly waited for this but the others didn't and may have reused the value from the other test.

# Changes

1. Reset `metricsCallback` before each test.
2. Wait for `metricsCallback` to be initialized in each test.

# Tests

Pass with random seed 1 - 20.

# Todos

- [ ] Add entry to changelog (if necessary).
covered