### PR TITLE
Fix order dependence in intersection.directives.spec.ts

### DIFF
--- a/frontend/src/tests/lib/directives/intersection.directives.spec.ts
+++ b/frontend/src/tests/lib/directives/intersection.directives.spec.ts
@@ -34,6 +34,8 @@ describe("IntersectionDirectives", () => {
   afterEach(() => jest.clearAllMocks());
 
   it("should trigger an intersect event", () => {
+    mockIntersectionObserverIsIntersecting(true);
+
     render(IntersectionTest);
 
     expect(spy).toHaveBeenCalled();


### PR DESCRIPTION
# Motivation

There are 2 tests: one tests with `IsIntersecting = true` and the other with `IsIntersecting = false`.
But `IsIntersecting = true` is assumed implicitly as default value.

# Changes

Set `IsIntersecting` explicitly in both tests.

# Tests

Tests now pass in both orders.

# Todos

- [ ] Add entry to changelog (if necessary).
covered