### PR TITLE
Fix: CkBTCAcconts.spec

### DIFF
--- a/frontend/src/tests/lib/pages/CkBTCAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCAccounts.spec.ts
@@ -59,7 +59,8 @@ jest.mock("$lib/services/worker-balances.services", () => ({
 }));
 
 describe("CkBTCAccounts", () => {
-  beforeAll(() => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     jest
       .spyOn(tokensStore, "subscribe")
       .mockImplementation(mockTokensSubscribe(mockUniversesTokens));
@@ -71,7 +72,7 @@ describe("CkBTCAccounts", () => {
   });
 
   describe("when there are accounts in the store", () => {
-    beforeAll(() => {
+    beforeEach(() => {
       icrcAccountsStore.set({
         accounts: {
           accounts: [mockCkBTCMainAccount],
@@ -119,7 +120,7 @@ describe("CkBTCAccounts", () => {
   });
 
   describe("when no accounts", () => {
-    beforeAll(() => {
+    beforeEach(() => {
       icrcAccountsStore.reset();
     });
 


### PR DESCRIPTION
# Motivation

One of the tests required to go first because the mocks were not cleared and it checked that a function was not called.

I also changed all the beforeAll to beforeEach.

# Changes

In ckBTCAccounts.spec
* Add clear mocks in main beforeEach
* Change beforeAll for beforeEach

# Tests

Only test changes

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary
