### PR TITLE
Fix order dependency in CkBTCReceiveModal.spec.ts

### DIFF
--- a/frontend/src/tests/lib/modals/accounts/CkBTCReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCReceiveModal.spec.ts
@@ -41,8 +41,11 @@ describe("BtcCkBTCReceiveModal", () => {
   const reloadSpy = jest.fn();
 
   beforeEach(() => {
+    jest.restoreAllMocks();
     resetIdentity();
-    jest.clearAllMocks();
+    bitcoinAddressStore.reset();
+    ckBTCInfoStore.reset();
+    page.reset();
   });
 
   const renderReceiveModal = ({
@@ -255,7 +258,7 @@ describe("BtcCkBTCReceiveModal", () => {
   });
 
   describe("without btc", () => {
-    beforeAll(() => {
+    beforeEach(() => {
       jest
         .spyOn(tokensStore, "subscribe")
         .mockImplementation(mockTokensSubscribe(mockUniversesTokens));


### PR DESCRIPTION
# Motivation

One test expected `bitcoinAddressStore` to start out empty but another test filled it and didn't reset it.

# Changes

1. Reset `bitcoinAddressStore` in `beforeEach` to fix the test.
2. Reset some other state to provide a more consistent environment for the tests.
3. Change `beforeEach` to `beforeAll`.

# Tests

Passes with random seed 1 - 20.

# Todos

- [ ] Add entry to changelog (if necessary).
covered