### PR TITLE
Fix: Typo in convertNervousFuncttion

### DIFF
--- a/frontend/src/lib/derived/sns-ns-functions-project.derived.ts
+++ b/frontend/src/lib/derived/sns-ns-functions-project.derived.ts
@@ -7,7 +7,7 @@ import {
   type SnsNervousSystemFunctionsStore,
 } from "$lib/stores/sns-functions.store";
 import type { CachedSnsDto } from "$lib/types/sns-aggregator";
-import { convertNervousFuncttion } from "$lib/utils/sns-aggregator-converters.utils";
+import { convertNervousFunction } from "$lib/utils/sns-aggregator-converters.utils";
 import type { Principal } from "@dfinity/principal";
 import type { SnsNervousSystemFunction } from "@dfinity/sns";
 import { nonNullish } from "@dfinity/utils";
@@ -37,7 +37,7 @@ export const createSnsNsFunctionsProjectStore = (
         );
       if (nonNullish(aggregatorProject)) {
         return aggregatorProject.parameters.functions.map(
-          convertNervousFuncttion
+          convertNervousFunction
         );
       }
       return undefined;

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -85,7 +85,7 @@ const convertFunctionType = (
   };
 };
 
-export const convertNervousFuncttion = ({
+export const convertNervousFunction = ({
   id,
   name,
   description,
@@ -302,7 +302,7 @@ const convertSnsData = ({
   list_sns_canisters,
   meta: convertMeta(meta, canister_ids.root_canister_id),
   parameters: {
-    functions: parameters.functions.map(convertNervousFuncttion),
+    functions: parameters.functions.map(convertNervousFunction),
     reserved_ids: parameters.reserved_ids.map(BigInt),
   },
   swap_state: {

--- a/frontend/src/tests/lib/derived/sns-ns-functions-project.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-ns-functions-project.derived.spec.ts
@@ -1,7 +1,7 @@
 import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
 import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
-import { convertNervousFuncttion } from "$lib/utils/sns-aggregator-converters.utils";
+import { convertNervousFunction } from "$lib/utils/sns-aggregator-converters.utils";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import {
   aggregatorSnsMockDto,
@@ -45,7 +45,7 @@ describe("nsFunctionsProjectStore", () => {
 
     const store = createSnsNsFunctionsProjectStore(rootCanisterId);
     expect(get(store)).toEqual([nervousSystemFunctionMock]);
-    expect(get(store)).not.toEqual(functions.map(convertNervousFuncttion));
+    expect(get(store)).not.toEqual(functions.map(convertNervousFunction));
   });
 
   it("returns the functions from snsAggregator if no functions in snsFunctionsStore", () => {
@@ -53,7 +53,7 @@ describe("nsFunctionsProjectStore", () => {
     const functions = aggregatorSnsMockDto.parameters.functions;
 
     const store = createSnsNsFunctionsProjectStore(rootCanisterId);
-    expect(get(store)).toEqual(functions.map(convertNervousFuncttion));
+    expect(get(store)).toEqual(functions.map(convertNervousFunction));
   });
 
   it("returns undefined if project is not set in no store", () => {

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -2,7 +2,7 @@ import type { CachedSnsDto } from "$lib/types/sns-aggregator";
 import {
   convertDtoData,
   convertDtoToSnsSummary,
-  convertNervousFuncttion,
+  convertNervousFunction,
 } from "$lib/utils/sns-aggregator-converters.utils";
 import {
   aggregatorSnsMock,
@@ -405,7 +405,7 @@ describe("sns aggregator converters utils", () => {
         function_type: { NativeNervousSystemFunction: {} },
       };
 
-      expect(convertNervousFuncttion(nsFunction)).toEqual({
+      expect(convertNervousFunction(nsFunction)).toEqual({
         id: 0n,
         name: "All Topics",
         description: [
@@ -423,7 +423,7 @@ describe("sns aggregator converters utils", () => {
         function_type: null,
       };
 
-      expect(convertNervousFuncttion(nsFunction)).toEqual({
+      expect(convertNervousFunction(nsFunction)).toEqual({
         id: 0n,
         name: "All Topics",
         description: [


### PR DESCRIPTION
# Motivation

There was a typo in the function `convertNervousFuncttion` with two `t`.

# Changes

* Rename from `convertNervousFuncttion` to `convertNervousFunction`.

# Tests

* Rename also in tests.
* 
# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
