### PR TITLE
Fix order dependence in CkBTCTransactionModal.spec.ts

### DIFF
--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -39,12 +39,7 @@ import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import { SvelteComponent, tick } from "svelte";
 import { get } from "svelte/store";
 
-jest.mock("$lib/services/ckbtc-accounts.services", () => {
-  return {
-    ckBTCTransferTokens: jest.fn().mockResolvedValue({ success: true }),
-  };
-});
-
+jest.mock("$lib/services/ckbtc-accounts.services");
 jest.mock("$lib/services/ckbtc-convert.services");
 
 describe("CkBTCTransactionModal", () => {
@@ -63,7 +58,12 @@ describe("CkBTCTransactionModal", () => {
       },
     });
 
-  beforeAll(() => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+
+    jest
+      .mocked(ckBTCTransferTokens)
+      .mockResolvedValue({ blockIndex: undefined });
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
@@ -492,6 +492,7 @@ describe("CkBTCTransactionModal", () => {
       jest
         .spyOn(services, "convertCkBTCToBtc")
         .mockResolvedValue({ success: true });
+      jest.spyOn(services, "retrieveBtc").mockResolvedValue({ success: true });
 
       const result = await renderTransactionModal(mockCkBTCWithdrawalAccount);
 


### PR DESCRIPTION
# Motivation

`"should render progress without step transfer"` relied on (one of) the previous 2 tests mocking `services.retrieveBtc` (by calling `testRetrieveBTC`) so it failed when run individually.

# Changes

1. Explicitly mock `services.retrieveBtc` in `"should render progress without step transfer"`
2. Restore all mocks in top-level `beforeEach` to make sure no tests depend on mocks defined in other tests.
3. Defined mock behavior of `ckBTCTransferTokens` instead of in the global scope, otherwise it will now be restored in `beforeEach`.

# Tests

Passes with random seed 1 - 20.

# Todos

- [ ] Add entry to changelog (if necessary).
covered