### PR TITLE
Fix order dependence in Settings.spec.ts

### DIFF
--- a/frontend/src/tests/lib/routes/Settings.spec.ts
+++ b/frontend/src/tests/lib/routes/Settings.spec.ts
@@ -14,7 +14,8 @@ import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Settings", () => {
-  beforeAll(() => {
+  beforeEach(() => {
+    authRemainingTimeStore.set(undefined);
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);


### PR DESCRIPTION
# Motivation

`"should render a skeleton while loading expired session time"` expects `authRemainingTimeStore` to start out empty but it's never reset when other tests fill it.

# Changes

Reset `authRemainingTimeStore` in top-level `beforeEach`.

# Tests

Pass with random seeds 1 - 20.

# Todos

- [ ] Add entry to changelog (if necessary).
covered