### PR TITLE
Fix order dependence in NnsWallet.spec.ts

### DIFF
--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -55,6 +55,10 @@ describe("NnsWallet", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.clearAllTimers();
+    cancelPollAccounts();
+    icpAccountsStore.resetForTesting();
+
     jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
@@ -81,8 +85,6 @@ describe("NnsWallet", () => {
 
   describe("no accounts", () => {
     beforeEach(() => {
-      cancelPollAccounts();
-      icpAccountsStore.resetForTesting();
       jest
         .spyOn(nnsDappApi, "queryAccount")
         .mockResolvedValue(mockAccountDetails);
@@ -124,8 +126,7 @@ describe("NnsWallet", () => {
   });
 
   describe("accounts loaded", () => {
-    beforeAll(() => {
-      jest.clearAllMocks();
+    beforeEach(() => {
       icpAccountsStore.setForTesting(mockAccountsStoreData);
     });
 
@@ -269,10 +270,6 @@ describe("NnsWallet", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: jest.SpyInstance;
     beforeEach(() => {
-      icpAccountsStore.resetForTesting();
-      jest.clearAllTimers();
-      jest.clearAllMocks();
-      cancelPollAccounts();
       const now = Date.now();
       jest.useFakeTimers().setSystemTime(now);
       const mainBalanceE8s = BigInt(10_000_000);


### PR DESCRIPTION
# Motivation

`"should display receive modal information"` expects `icpAccountsStore` to be filled with certified data to avoid calling `queryAccount` via `pollAccounts`.
The certified test data was put in `icpAccountsStore` in `beforeAll` rather than `beforeEach`.
If `"should reload account after finish receiving tokens"` was run first, it would end up with non-certified data in `icpAccountsStore` and so `"should display receive modal information"` would fail when doing `queryAccount` which wasn't mocked.

The solution is to put the certified data in `icpAccountsStore` in `beforeEach` so that each test gets a fresh store.


# Changes

1. Change `beforeAll` to `beforeEach`.
2. Move all cleanup to top-level `beforeEach` (drive-by)

# Tests

Passes with random seeds 1 - 20

# Todos

- [ ] Add entry to changelog (if necessary).
covered