### PR TITLE
GIX-1841: Upgrade ic-js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -748,9 +748,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "0.0.10-next-2023-08-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.10-next-2023-08-24.tgz",
-      "integrity": "sha512-0gfroev0e6Ih+Q9aRjj1h/9AunKERb9ulSFgQxxsb+/rrd7c6odx//vOjkqmqZmIzm/ccK95JjzYYSchG0yoPg==",
+      "version": "0.0.10-next-2023-08-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.10-next-2023-08-28.1.tgz",
+      "integrity": "sha512-hPpSTEO1nu4H/iqbaGPoUEdePEKAaXO4kz8JyqTDN8XyGO0mSrePGxb89D2BenzM72O6scP45l0ZnsOjBFXYkw==",
       "dependencies": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -764,9 +764,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.17-next-2023-08-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.17-next-2023-08-24.tgz",
-      "integrity": "sha512-dzmwAdAoznumE2SZ5BMs24P/EcpU3CI/04TDzn8hPWsLJDeIzfVljinzOh3586UiE0pwApR9p7GJKtisxlMfZg==",
+      "version": "0.0.17-next-2023-08-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.17-next-2023-08-28.1.tgz",
+      "integrity": "sha512-zkzsZ8a1rt/utKu4G6trbHiKNv/Qc+Y9CZ+FqyLxOdZ364al6DmhtXTrv+Ck9JtVCKshfToQovP9K4egTiS3ew==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -789,9 +789,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "0.0.7-next-2023-08-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.7-next-2023-08-24.tgz",
-      "integrity": "sha512-xrYTw4TZao1x6ws0qgrKYpN38jeK9WzoS4HCsET8/jhtnCRkH6eNsPphJp+BZqcS7l5TQ3QuiQveQtoLsQUjXg==",
+      "version": "0.0.7-next-2023-08-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.7-next-2023-08-28.1.tgz",
+      "integrity": "sha512-MHGKzjYqL0Oopk9km9AzfmKEBn/IubSTtslG/wrFqTvHzymi9s8XYcRuJNL4iZHmRXGt4lDEJhaIWHngWMptLw==",
       "dependencies": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -820,9 +820,9 @@
       }
     },
     "node_modules/@dfinity/ledger": {
-      "version": "0.0.14-next-2023-08-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.14-next-2023-08-24.tgz",
-      "integrity": "sha512-0njERxjApLgzcFTLYi+fP8vwmCbVrTvXWeSM95ZnHJpNS8Y3gSUVXWoWYBVPAAhUyscWbC/O4rXVVzFcP/LDzQ==",
+      "version": "0.0.14-next-2023-08-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.14-next-2023-08-28.1.tgz",
+      "integrity": "sha512-djfhCc5ou1ZTjzLtG9unVQZFt92i6z0Re8TgOAf1jpRPyWemWmvE39rYtXYujfP9grgKruYM9tR4s1TCAkmpAQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.16.6-next-2023-08-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.6-next-2023-08-24.tgz",
-      "integrity": "sha512-GW7PokqUUSqO+hGj/i3e/1cQIuaFWyNoVjoJLIfzbp8CsyzHyuwisXNSc0FHJ2LynRiGJ0svc1sKO4aJ7VJGCg==",
+      "version": "0.16.6-next-2023-08-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.6-next-2023-08-28.1.tgz",
+      "integrity": "sha512-WwEQkuVMZk0B8yK5aY2lFqGPCgE0lW6RdcdQALCGx4TFvEEydrGjfvrpbIkrb3uB35ABMPve4x8cIZwsXEHYSA==",
       "dependencies": {
         "js-sha256": "^0.9.0",
         "randombytes": "^2.1.0"
@@ -847,9 +847,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "0.0.7-next-2023-08-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.7-next-2023-08-24.tgz",
-      "integrity": "sha512-b2/blR540uvdI6Iv0YoIJx8nhSLByt5vPAk+eVMuMYUj2hYyAm4BaVvawAP95FwfkVocoxGDDE+Uc2f3bh8aUg==",
+      "version": "0.0.7-next-2023-08-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.7-next-2023-08-28.1.tgz",
+      "integrity": "sha512-IOCGY8vb9kOD5SUbuNmj/wdDpz9ogY1kVoUz3oE1qXoSkipDEr+ELNa4/Ytb4/no32H9bUwRCNQ2Doy2JanKvg==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -863,9 +863,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.21-next-2023-08-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.21-next-2023-08-24.tgz",
-      "integrity": "sha512-j885Jba6dncrhFrg05hlw/SQTTINCo4UgJsZdQ5vgSg0Xrnmx7UpDMg5f8koHVWmxaEjHCZHc7RSCHEFUGfDfQ==",
+      "version": "0.0.21-next-2023-08-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.21-next-2023-08-28.1.tgz",
+      "integrity": "sha512-P76TIQomeuwvSFr9lBSQ4vg/wPKPQivSYhAdWBksTco4LS/IRz1fAVfUbTcqV7oJtLqxEKyYV8wJ1+iPpYAHwg==",
       "dependencies": {
         "js-sha256": "^0.9.0"
       },
@@ -878,9 +878,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.21-next-2023-08-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.21-next-2023-08-24.tgz",
-      "integrity": "sha512-4+6lFXS8db+0qr2Hf0tGJqJ0lp1l3/CYqRZhIUT4KZ9PlI3AraG52rSyESDVXKRQRLWoxCqKjV6+eOyRy/WKrg==",
+      "version": "0.0.21-next-2023-08-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.21-next-2023-08-28.1.tgz",
+      "integrity": "sha512-X5vSIKcblje1TVX9SOriKhVAGZBtwlUJSTovu8s5wfWU59pvR6TTa1aAJkwGm1WHU/G0zYpOcpPG8EVEAqJmDw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -10048,9 +10048,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "0.0.10-next-2023-08-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.10-next-2023-08-24.tgz",
-      "integrity": "sha512-0gfroev0e6Ih+Q9aRjj1h/9AunKERb9ulSFgQxxsb+/rrd7c6odx//vOjkqmqZmIzm/ccK95JjzYYSchG0yoPg==",
+      "version": "0.0.10-next-2023-08-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.10-next-2023-08-28.1.tgz",
+      "integrity": "sha512-hPpSTEO1nu4H/iqbaGPoUEdePEKAaXO4kz8JyqTDN8XyGO0mSrePGxb89D2BenzM72O6scP45l0ZnsOjBFXYkw==",
       "requires": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -10058,9 +10058,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.17-next-2023-08-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.17-next-2023-08-24.tgz",
-      "integrity": "sha512-dzmwAdAoznumE2SZ5BMs24P/EcpU3CI/04TDzn8hPWsLJDeIzfVljinzOh3586UiE0pwApR9p7GJKtisxlMfZg==",
+      "version": "0.0.17-next-2023-08-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.17-next-2023-08-28.1.tgz",
+      "integrity": "sha512-zkzsZ8a1rt/utKu4G6trbHiKNv/Qc+Y9CZ+FqyLxOdZ364al6DmhtXTrv+Ck9JtVCKshfToQovP9K4egTiS3ew==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -10074,9 +10074,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "0.0.7-next-2023-08-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.7-next-2023-08-24.tgz",
-      "integrity": "sha512-xrYTw4TZao1x6ws0qgrKYpN38jeK9WzoS4HCsET8/jhtnCRkH6eNsPphJp+BZqcS7l5TQ3QuiQveQtoLsQUjXg==",
+      "version": "0.0.7-next-2023-08-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.7-next-2023-08-28.1.tgz",
+      "integrity": "sha512-MHGKzjYqL0Oopk9km9AzfmKEBn/IubSTtslG/wrFqTvHzymi9s8XYcRuJNL4iZHmRXGt4lDEJhaIWHngWMptLw==",
       "requires": {
         "base58-js": "^1.0.5",
         "bech32": "^2.0.0",
@@ -10094,24 +10094,24 @@
       }
     },
     "@dfinity/ledger": {
-      "version": "0.0.14-next-2023-08-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.14-next-2023-08-24.tgz",
-      "integrity": "sha512-0njERxjApLgzcFTLYi+fP8vwmCbVrTvXWeSM95ZnHJpNS8Y3gSUVXWoWYBVPAAhUyscWbC/O4rXVVzFcP/LDzQ==",
+      "version": "0.0.14-next-2023-08-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.14-next-2023-08-28.1.tgz",
+      "integrity": "sha512-djfhCc5ou1ZTjzLtG9unVQZFt92i6z0Re8TgOAf1jpRPyWemWmvE39rYtXYujfP9grgKruYM9tR4s1TCAkmpAQ==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "0.16.6-next-2023-08-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.6-next-2023-08-24.tgz",
-      "integrity": "sha512-GW7PokqUUSqO+hGj/i3e/1cQIuaFWyNoVjoJLIfzbp8CsyzHyuwisXNSc0FHJ2LynRiGJ0svc1sKO4aJ7VJGCg==",
+      "version": "0.16.6-next-2023-08-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.6-next-2023-08-28.1.tgz",
+      "integrity": "sha512-WwEQkuVMZk0B8yK5aY2lFqGPCgE0lW6RdcdQALCGx4TFvEEydrGjfvrpbIkrb3uB35ABMPve4x8cIZwsXEHYSA==",
       "requires": {
         "js-sha256": "^0.9.0",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "0.0.7-next-2023-08-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.7-next-2023-08-24.tgz",
-      "integrity": "sha512-b2/blR540uvdI6Iv0YoIJx8nhSLByt5vPAk+eVMuMYUj2hYyAm4BaVvawAP95FwfkVocoxGDDE+Uc2f3bh8aUg==",
+      "version": "0.0.7-next-2023-08-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.7-next-2023-08-28.1.tgz",
+      "integrity": "sha512-IOCGY8vb9kOD5SUbuNmj/wdDpz9ogY1kVoUz3oE1qXoSkipDEr+ELNa4/Ytb4/no32H9bUwRCNQ2Doy2JanKvg==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -10125,17 +10125,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.21-next-2023-08-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.21-next-2023-08-24.tgz",
-      "integrity": "sha512-j885Jba6dncrhFrg05hlw/SQTTINCo4UgJsZdQ5vgSg0Xrnmx7UpDMg5f8koHVWmxaEjHCZHc7RSCHEFUGfDfQ==",
+      "version": "0.0.21-next-2023-08-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.21-next-2023-08-28.1.tgz",
+      "integrity": "sha512-P76TIQomeuwvSFr9lBSQ4vg/wPKPQivSYhAdWBksTco4LS/IRz1fAVfUbTcqV7oJtLqxEKyYV8wJ1+iPpYAHwg==",
       "requires": {
         "js-sha256": "^0.9.0"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.21-next-2023-08-24",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.21-next-2023-08-24.tgz",
-      "integrity": "sha512-4+6lFXS8db+0qr2Hf0tGJqJ0lp1l3/CYqRZhIUT4KZ9PlI3AraG52rSyESDVXKRQRLWoxCqKjV6+eOyRy/WKrg==",
+      "version": "0.0.21-next-2023-08-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.21-next-2023-08-28.1.tgz",
+      "integrity": "sha512-X5vSIKcblje1TVX9SOriKhVAGZBtwlUJSTovu8s5wfWU59pvR6TTa1aAJkwGm1WHU/G0zYpOcpPG8EVEAqJmDw==",
       "requires": {}
     },
     "@esbuild/android-arm": {


### PR DESCRIPTION
# Motivation

We want to show in the project status whether the swap is finalizing.

In this PR, upgrade the next dependencies to be able to use a new method added in sns-js: [getFinalizationStatus](https://github.com/dfinity/ic-js/pull/400)

# Changes

* Upgrade next dependencies.

# Tests

Not necessary

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
