### PR TITLE
Revert "Cut release"

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -12,44 +12,6 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Added
 
-#### Changed
-
-#### Deprecated
-#### Removed
-
-#### Fixed
-
-* Header in accounts, canisters and neurons was not visible after user came back from logging in.
-
-#### Security
-
-#### Not Published
-
-### Operations
-
-#### Added
-
-#### Changed
-
-#### Deprecated
-#### Removed
-
-#### Fixed
-
-#### Security
-
-## Proposal 124252 (cherry-pick)
-
-### Application
-
-#### Fixed
-
-## Proposal 124280
-
-### Application
-
-#### Added
-
 * New tag for NNS neurons: "Hardware Wallet".
 * New derived state store for SNS projects.
 * Identify swap participation ICP transactions.
@@ -70,6 +32,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * New landing pages for Accounts, Neurons, Canister and Settings when not logged in.
 * Remove login page and redirect to accounts instead.
 
+#### Deprecated
 #### Removed
 
 * Remove ENABLE_SIMULATE_MERGE_NEURONS flag.
@@ -77,13 +40,15 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Fixed
 
 * Fix wrong "ICP Staked" message in SNS neurons.
+* Header in accounts, canisters and neurons was not visible after user came back from logging in.
+
+#### Security
 
 #### Not Published
 
 * Use new stores as source of data instead of snsQueryStore.
 
 ### Operations
-
 * Format markdown files, such as `README.md`, except changelogs and frontend markdown files.
 * Improve the rust document generation.
 * Fix shellcheck issues.
@@ -103,6 +68,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Moved e2e-tests/scripts/ to scripts/e2e-tests/.
 * Change some unit tests to set a system time and not rely on actual time.
 
+#### Deprecated
 #### Removed
 
 * Remove compressed `.wasm` files from releases.  Please use `.wasm.gz` instead.
@@ -117,6 +83,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 * Fixed some tests that depended on execution order.
 * [CVE-2023-38497](https://blog.rust-lang.org/2023/08/03/cve-2023-38497.html): Update Rust from version `1.71.0` to `1.71.1`.
+
 ## Proposal 124252 (cherry-pick)
 
 ### Application


### PR DESCRIPTION
This reverts commit 042437bf53097518bd23f1cad35cbea72abbdbff.

# Motivation
The above commit was accidentally pushed to main.

- Following the NNS dapp SOP, the Release branch upstream ended up  having main as the upstream.  Not sure how.
- The github repository settings required branch protections to be enabled explicitly. (They have been enabled now)

# Changes
- Revert the unintended commit.

# Tests
None

# Todos

- [ ] Add entry to changelog (if necessary).  Not applicable; this is a revert.
