### PR TITLE
Remove unused filter from NnsDestinationAddress

### DIFF
--- a/frontend/src/lib/components/accounts/NnsDestinationAddress.svelte
+++ b/frontend/src/lib/components/accounts/NnsDestinationAddress.svelte
@@ -6,8 +6,6 @@
   import NnsSelectAccount from "./NnsSelectAccount.svelte";
   import { createEventDispatcher, onMount } from "svelte";
 
-  export let filterIdentifier: string | undefined = undefined;
-
   let address: string;
   let mounted = false;
 
@@ -35,7 +33,6 @@
       on:nnsSelectAccount={onSelectAccount}
       disableSelection={!emptyAddress(address)}
       displayTitle={true}
-      {filterIdentifier}
     />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
@@ -6,7 +6,6 @@ import NnsDestinationAddress from "$lib/components/accounts/NnsDestinationAddres
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
   mockAccountsStoreSubscribe,
-  mockMainAccount,
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
 import { render } from "@testing-library/svelte";
@@ -40,17 +39,5 @@ describe("NnsDestinationAddress", () => {
     expect(
       getByText(mockSubAccount2.identifier, { exact: false })
     ).toBeInTheDocument();
-  });
-
-  it("should filter selected account", () => {
-    const { getByText } = render(NnsDestinationAddress, {
-      props: {
-        filterIdentifier: mockMainAccount.identifier,
-      },
-    });
-
-    expect(() =>
-      getByText(mockMainAccount.identifier, { exact: false })
-    ).toThrow();
   });
 });


### PR DESCRIPTION
# Motivation

`NnsDestinationAddress` has a prop `filterIdentifier` which is not passed in from anywhere so it's always `undefined`.

# Changes

1. Remove `filterIdentifier` from `NnsDestinationAddress`.
2. Remove the test that tests the filter.

# Tests

Remaining tests still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not worth it