### PR TITLE
Improve NnsDestinationAddress.spec.ts

### DIFF
--- a/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
@@ -5,7 +5,7 @@
 import NnsDestinationAddress from "$lib/components/accounts/NnsDestinationAddress.svelte";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
-  mockAccountsStoreSubscribe,
+  mockMainAccount,
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
 import { NnsDestinationAddressPo } from "$tests/page-objects/NnsDestinationAddress.page-object";
@@ -21,11 +21,13 @@ describe("NnsDestinationAddress", () => {
   let onAccountSelectedSpy: jest.Mock;
 
   beforeEach(() => {
-    jest
-      .spyOn(icpAccountsStore, "subscribe")
-      .mockImplementation(
-        mockAccountsStoreSubscribe([mockSubAccount, mockSubAccount2])
-      );
+    jest.restoreAllMocks();
+
+    icpAccountsStore.setForTesting({
+      main: mockMainAccount,
+      subAccounts: [mockSubAccount, mockSubAccount2],
+      hardwareWallets: [],
+    });
     onAccountSelectedSpy = jest.fn();
   });
 

--- a/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
@@ -72,4 +72,18 @@ describe("NnsDestinationAddress", () => {
     });
     expect(onAccountSelectedSpy).toBeCalledTimes(1);
   });
+
+  it("should dispatch event with entered account identifier", async () => {
+    const po = renderComponent();
+    await po.enterAddress(mockSubAccount.identifier);
+
+    expect(onAccountSelectedSpy).not.toBeCalled();
+
+    await po.clickContinue();
+
+    expect(onAccountSelectedSpy).toBeCalledWith({
+      address: mockSubAccount.identifier,
+    });
+    expect(onAccountSelectedSpy).toBeCalledTimes(1);
+  });
 });

--- a/frontend/src/tests/page-objects/AccountCard.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountCard.page-object.ts
@@ -35,4 +35,8 @@ export class AccountCardPo extends BasePageObject {
   getAccountAddress(): Promise<string> {
     return this.getHashPo().getText();
   }
+
+  getIdentifier(): Promise<string> {
+    return this.getText("identifier");
+  }
 }

--- a/frontend/src/tests/page-objects/NnsDestinationAddress.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsDestinationAddress.page-object.ts
@@ -18,4 +18,12 @@ export class NnsDestinationAddressPo extends BasePageObject {
   selectMainAccount(): Promise<void> {
     return this.getNnsSelectAccountPo().selectMainAccount();
   }
+
+  enterAddress(address: string): Promise<void> {
+    return this.getTextInput().typeText(address);
+  }
+
+  clickContinue(): Promise<void> {
+    return this.click("address-submit-button");
+  }
 }

--- a/frontend/src/tests/page-objects/NnsSelectAccount.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsSelectAccount.page-object.ts
@@ -9,6 +9,18 @@ export class NnsSelectAccountPo extends BasePageObject {
     return new NnsSelectAccountPo(element.byTestId(NnsSelectAccountPo.TID));
   }
 
+  async getAccountCardPoForIdentifier(
+    identifier: string
+  ): Promise<AccountCardPo> {
+    const accountCards = await AccountCardPo.allUnder(this.root);
+    for (const accountCard of accountCards) {
+      if ((await accountCard.getIdentifier()) === identifier) {
+        return accountCard;
+      }
+    }
+    throw new Error(`Account card with identifier ${identifier} not found`);
+  }
+
   getMainAccountCardPo(): AccountCardPo {
     // There might be multiple cards but the first one should be the main account.
     return AccountCardPo.under(this.root);


### PR DESCRIPTION
# Motivation

I want to bring `NnsDestinationAddress`, which is only used in `DisburseNnsNeuronModal`, more in line with the account picker in the transaction modal.
But before I do, I want to make sure there is proper test coverage so I don't break anything.

# Changes

1. Use page objects in `frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts`.
2. Create spies in `beforeEach` instead of directly in the `describe` block.
3. Add a test where it selects an account from the list.
4. Add a test where it enters an identifier in the input field.
5. Add required functionality to page objects.

# Tests

Only tests

# Todos

- [ ] Add entry to changelog (if necessary).
not worth it