### PR TITLE
Scipt to increment the patch version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -237,6 +237,10 @@ jobs:
         run: sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
       - name: Bumping the package versions works
         run: ./scripts/nns-dapp/bump-patch
+      - name: Set git user
+        run: |
+                  git config --global user.email "gix-bot@dfinity.org"
+                  git config --global user.name "GIX bot"
       - name: Command creates commits
         run: |
           original_commit="$(git rev-parse HEAD)"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -227,6 +227,25 @@ jobs:
       - uses: actions/checkout@v3
       - name: docker-build prints help
         run: ./scripts/docker-build --help | grep -i usage
+  minor-version-bump-works:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install yq
+        run: sudo snap install yq
+      - name: Bumping the package versions works
+        run: ./scripts/nns-dapp/bump-patch
+      - name: Command creates commits
+        run: |
+          original_commit="$(git rev-parse HEAD)"
+          ./scripts/nns-dapp/bump-patch --commit
+          num_commits="$(git log --oneline "$original_commit..HEAD" | wc -l)"
+          (( num_commits == 2 )) || {
+                  echo "Expected two commits.  Got:"
+                  git log --oneline "$original_commit..HEAD"
+                  exit 1
+          } >&2
+          # TODO: Verify that the commits contain the expected changes.
   download-nns-dapp-ci-wasm:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -239,8 +239,8 @@ jobs:
         run: ./scripts/nns-dapp/bump-patch
       - name: Set git user
         run: |
-                  git config --global user.email "gix-bot@dfinity.org"
-                  git config --global user.name "GIX bot"
+          git config --global user.email "gix-bot@dfinity.org"
+          git config --global user.name "GIX bot"
       - name: Command creates commits
         run: |
           original_commit="$(git rev-parse HEAD)"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -233,6 +233,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install yq
         run: sudo snap install yq
+      - name: Install sponge
+        run: sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
       - name: Bumping the package versions works
         run: ./scripts/nns-dapp/bump-patch
       - name: Command creates commits

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Install sponge
         run: sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
       - name: Bumping the package versions works
-        run: ./scripts/nns-dapp/bump-patch
+        run: ./scripts/nns-dapp/bump-patch.test
       - name: Set git user
         run: |
           git config --global user.email "gix-bot@dfinity.org"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -240,6 +240,7 @@ jobs:
       - name: Command creates commits
         run: |
           original_commit="$(git rev-parse HEAD)"
+          git checkout .
           ./scripts/nns-dapp/bump-patch --commit
           num_commits="$(git log --oneline "$original_commit..HEAD" | wc -l)"
           (( num_commits == 2 )) || {
@@ -286,7 +287,7 @@ jobs:
       - run: scripts/past-changelog-test
       - run: scripts/past-changelog-test.test
   checks-pass:
-    needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "split-changelog", "past-changelog"]
+    needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "split-changelog", "past-changelog", "minor-version-bump-works"]
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -28,6 +28,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Not Published
 
 ### Operations
+- Add a command to increment the package versions.
 
 #### Added
 

--- a/scripts/nns-dapp/bump-patch
+++ b/scripts/nns-dapp/bump-patch
@@ -37,5 +37,5 @@ npm install
 test -z "${COMMIT_CHANGES:-}" || git commit -a -m "Increment nns-dapp frontend patch version"
 popd
 awk -F'"' '/^version *= *"[0-9.]+"/{split($2,v,".");v[3]++;printf "version = \"%s.%s.%s\"\n", v[1], v[2], v[3];next}{print}' Cargo.toml | sponge Cargo.toml
-cargo check # Updates cargo lock but saves time by not creating binaries.
+cargo fetch # Updates cargo lock but saves time by not creating binaries.
 test -z "${COMMIT_CHANGES:-}" || git commit -a -m "Increment nns-dapp backend and sns aggregator patch version"

--- a/scripts/nns-dapp/bump-patch
+++ b/scripts/nns-dapp/bump-patch
@@ -49,7 +49,9 @@ popd
 #  - yq currently parses TOML but does not emit TOML, so we cannot currently use that to edit Cargo.toml.
 #    Again, if that changes we can use that.
 #
-# ... Increment the minor version in Cargo.toml
+# ... Increment the patch version in Cargo.toml
+#     - On the version line, gets the version number, splits by ".", increments the third field and prints a new version line.
+#     - Other lines are passed through unmodified.
 awk -F'"' '/^version *= *"[0-9.]+"/{split($2,v,".");v[3]++;printf "version = \"%s.%s.%s\"\n", v[1], v[2], v[3];next}{print}' Cargo.toml | sponge Cargo.toml
 # ... Update Cargo.lock
 cargo fetch # Updates cargo lock but saves time by not creating binaries.

--- a/scripts/nns-dapp/bump-patch
+++ b/scripts/nns-dapp/bump-patch
@@ -26,6 +26,9 @@ test -z "${COMMIT_CHANGES:-}" || [[ "$(git status --untracked-files=no --porcela
   echo "       Untracked files will be ignored, but changes to tracked files"
   echo "       should be removed or committed."
   echo "       Please do so before re-running this command."
+  echo
+  echo "Changes:"
+  git status --untracked-files=no --porcelain | head
   exit 1
 } >&2
 pushd frontend

--- a/scripts/nns-dapp/bump-patch
+++ b/scripts/nns-dapp/bump-patch
@@ -33,5 +33,5 @@ npm install
 git commit -a -m "Increment nns-dapp frontend patch version"
 popd
 awk -F'"' '/^version *= *"[0-9.]+"/{split($2,v,".");v[3]++;printf "version = \"%s.%s.%s\"\n", v[1], v[2], v[3];next}{print}' Cargo.toml | sponge Cargo.toml
-cargo build
+cargo check # Updates cargo lock but saves time by not creating binaries.
 git commit -a -m "Increment nns-dapp backend and sns aggregator patch version"

--- a/scripts/nns-dapp/bump-patch
+++ b/scripts/nns-dapp/bump-patch
@@ -36,6 +36,22 @@ npm version patch
 npm install
 test -z "${COMMIT_CHANGES:-}" || git commit -a -m "Increment nns-dapp frontend patch version"
 popd
+
+# Update the nns-dapp Rust package version:
+#
+# Note: The code uses awk to edit the Cargo.toml.  Alternatives considered:
+#  - I looked for a cargo extension similar to `npm version`.  I found this:
+#      https://github.com/filipstefansson/cargo-semver
+#    It works, but has not released version 1.0.0 yet, is not used much, the install instructions
+#    on crates.io are out of date and the author has not responded to recent issues.  If that
+#    changes, we could use `cargo semver bump patch`.  This also updates the Cargo.lock.
+#  - I checked `cargo metadata` but taht does not seem to have an option for editing the metadata.
+#  - yq currently parses TOML but does not emit TOML, so we cannot currently use that to edit Cargo.toml.
+#    Again, if that changes we can use that.
+#
+# ... Increment the minor version in Cargo.toml
 awk -F'"' '/^version *= *"[0-9.]+"/{split($2,v,".");v[3]++;printf "version = \"%s.%s.%s\"\n", v[1], v[2], v[3];next}{print}' Cargo.toml | sponge Cargo.toml
+# ... Update Cargo.lock
 cargo fetch # Updates cargo lock but saves time by not creating binaries.
+
 test -z "${COMMIT_CHANGES:-}" || git commit -a -m "Increment nns-dapp backend and sns aggregator patch version"

--- a/scripts/nns-dapp/bump-patch
+++ b/scripts/nns-dapp/bump-patch
@@ -45,7 +45,7 @@ popd
 #    It works, but has not released version 1.0.0 yet, is not used much, the install instructions
 #    on crates.io are out of date and the author has not responded to recent issues.  If that
 #    changes, we could use `cargo semver bump patch`.  This also updates the Cargo.lock.
-#  - I checked `cargo metadata` but taht does not seem to have an option for editing the metadata.
+#  - I checked `cargo metadata` but that does not seem to have an option for editing the metadata.
 #  - yq currently parses TOML but does not emit TOML, so we cannot currently use that to edit Cargo.toml.
 #    Again, if that changes we can use that.
 #

--- a/scripts/nns-dapp/bump-patch
+++ b/scripts/nns-dapp/bump-patch
@@ -2,7 +2,6 @@
 set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
-. "$SOURCE_DIR/versions.bash"
 
 print_help() {
   cat <<-EOF
@@ -16,7 +15,7 @@ print_help() {
 }
 
 # Source the clap.bash file ---------------------------------------------------
-source "$SOURCE_DIR/clap.bash"
+source "$SOURCE_DIR/../clap.bash"
 # Define options
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"

--- a/scripts/nns-dapp/bump-patch
+++ b/scripts/nns-dapp/bump-patch
@@ -17,10 +17,11 @@ print_help() {
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/../clap.bash"
 # Define options
+clap.define short=c long=commit desc="Commit changes" variable=COMMIT_CHANGES nargs=0
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-[[ "$(git status --untracked-files=no --porcelain)" == "" ]] || {
+test -z "${COMMIT_CHANGES:-}" || [[ "$(git status --untracked-files=no --porcelain)" == "" ]] || {
   echo "ERROR: Git should be clean before running this command."
   echo "       Untracked files will be ignored, but changes to tracked files"
   echo "       should be removed or committed."
@@ -30,8 +31,8 @@ source "$(clap.build)"
 pushd frontend
 npm version patch
 npm install
-git commit -a -m "Increment nns-dapp frontend patch version"
+test -z "${COMMIT_CHANGES:-}" || git commit -a -m "Increment nns-dapp frontend patch version"
 popd
 awk -F'"' '/^version *= *"[0-9.]+"/{split($2,v,".");v[3]++;printf "version = \"%s.%s.%s\"\n", v[1], v[2], v[3];next}{print}' Cargo.toml | sponge Cargo.toml
 cargo check # Updates cargo lock but saves time by not creating binaries.
-git commit -a -m "Increment nns-dapp backend and sns aggregator patch version"
+test -z "${COMMIT_CHANGES:-}" || git commit -a -m "Increment nns-dapp backend and sns aggregator patch version"

--- a/scripts/nns-dapp/bump-patch
+++ b/scripts/nns-dapp/bump-patch
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+. "$SOURCE_DIR/versions.bash"
+
+print_help() {
+  cat <<-EOF
+
+	Increment the patch version of the nns-dapp frontend and backend.
+
+	Note: As the SNS aggregator shares the NNS dapp backend version number,
+	this will also increase the aggregator version number.  The two projects
+	should probably have independent version numbers.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+[[ "$(git status --untracked-files=no --porcelain)" == "" ]] || {
+  echo "ERROR: Git should be clean before running this command."
+  echo "       Untracked files will be ignored, but changes to tracked files"
+  echo "       should be removed or committed."
+  echo "       Please do so before re-running this command."
+  exit 1
+} >&2
+pushd frontend
+npm version patch
+npm install
+git commit -a -m "Increment nns-dapp frontend patch version"
+popd
+awk -F'"' '/^version *= *"[0-9.]+"/{split($2,v,".");v[3]++;printf "version = \"%s.%s.%s\"\n", v[1], v[2], v[3];next}{print}' Cargo.toml | sponge Cargo.toml
+cargo build
+git commit -a -m "Increment nns-dapp backend and sns aggregator patch version"

--- a/scripts/nns-dapp/bump-patch.test
+++ b/scripts/nns-dapp/bump-patch.test
@@ -31,7 +31,6 @@ test -z "${COMMIT_CHANGES:-}" || [[ "$(git status --untracked-files=no --porcela
 
 (
   printf "########\n## %s\n" "Verifies that the expected files are changed"
-  git stash # Make sure that git is clean.
   "${SOURCE_DIR}/bump-patch"
   actual_changes="$(git diff --numstat)"
   [[ "$expected_file_changes" == "$actual_changes" ]] || {

--- a/scripts/nns-dapp/bump-patch.test
+++ b/scripts/nns-dapp/bump-patch.test
@@ -3,12 +3,12 @@ set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 expected_file_changes() {
-	# Expect these changes:
-	# Cargo.lock: 2 changes: the nns-dapp and sns_aggregator package versions.
-	# Cargo.toml: 1 change: The workspace version.
-	# frontend/package.json: 1 change: The package version.
-	# frontend/package-lock.json: The number of changes seems to be unbounded in principle but 2 in practice.
-	cat <<-EOF
+  # Expect these changes:
+  # Cargo.lock: 2 changes: the nns-dapp and sns_aggregator package versions.
+  # Cargo.toml: 1 change: The workspace version.
+  # frontend/package.json: 1 change: The package version.
+  # frontend/package-lock.json: The number of changes seems to be unbounded in principle but 2 in practice.
+  cat <<-EOF
 	2	2	Cargo.lock
 	1	1	Cargo.toml
 	2	2	frontend/package-lock.json
@@ -18,25 +18,25 @@ expected_file_changes() {
 expected_file_changes="$(expected_file_changes)"
 
 (
-    printf "########\n## %s\n" "Verifies that the expected files are changed"
-    git stash # Make sure that git is clean.
-    "${SOURCE_DIR}/bump-patch"
-    actual_changes="$(git diff --numstat)"
-    [[ "$expected_file_changes" == "$actual_changes" ]] || {
-    	echo "ERROR: Unexpected file changes."
-        echo
-        echo "Expected:"
-	echo "$expected_file_changes"
-        echo
-        echo "Actual:"
-	echo "$actual_changes"
-	echo
-	echo "Diff:"
-	diff <(echo "$expected_file_changes") <(echo "$actual_changes")
-	echo "Changes checked with: git diff --numstat"
-	    exit 1
-    } >&2
-    git checkout .
+  printf "########\n## %s\n" "Verifies that the expected files are changed"
+  git stash # Make sure that git is clean.
+  "${SOURCE_DIR}/bump-patch"
+  actual_changes="$(git diff --numstat)"
+  [[ "$expected_file_changes" == "$actual_changes" ]] || {
+    echo "ERROR: Unexpected file changes."
+    echo
+    echo "Expected:"
+    echo "$expected_file_changes"
+    echo
+    echo "Actual:"
+    echo "$actual_changes"
+    echo
+    echo "Diff:"
+    diff <(echo "$expected_file_changes") <(echo "$actual_changes")
+    echo "Changes checked with: git diff --numstat"
+    exit 1
+  } >&2
+  git checkout .
 )
 
 # TODO:  Verify that the version number has bumped in:

--- a/scripts/nns-dapp/bump-patch.test
+++ b/scripts/nns-dapp/bump-patch.test
@@ -17,6 +17,18 @@ expected_file_changes() {
 }
 expected_file_changes="$(expected_file_changes)"
 
+# Check that git is clean before running this test.
+test -z "${COMMIT_CHANGES:-}" || [[ "$(git status --untracked-files=no --porcelain)" == "" ]] || {
+  echo "ERROR: Git should be clean before running this command."
+  echo "       Untracked files will be ignored, but changes to tracked files"
+  echo "       should be removed or committed."
+  echo "       Please do so before re-running this command."
+  echo
+  echo "Changes:"
+  git status --untracked-files=no --porcelain | head
+  exit 1
+} >&2
+
 (
   printf "########\n## %s\n" "Verifies that the expected files are changed"
   git stash # Make sure that git is clean.

--- a/scripts/nns-dapp/bump-patch.test
+++ b/scripts/nns-dapp/bump-patch.test
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+expected_file_changes() {
+	# Expect these changes:
+	# Cargo.lock: 2 changes: the nns-dapp and sns_aggregator package versions.
+	# Cargo.toml: 1 change: The workspace version.
+	# frontend/package.json: 1 change: The package version.
+	# frontend/package-lock.json: The number of changes seems to be unbounded in principle but 2 in practice.
+	cat <<-EOF
+	2	2	Cargo.lock
+	1	1	Cargo.toml
+	2	2	frontend/package-lock.json
+	1	1	frontend/package.json
+	EOF
+}
+expected_file_changes="$(expected_file_changes)"
+
+(
+    printf "########\n## %s\n" "Verifies that the expected files are changed"
+    git stash # Make sure that git is clean.
+    "${SOURCE_DIR}/bump-patch"
+    actual_changes="$(git diff --numstat)"
+    [[ "$expected_file_changes" == "$actual_changes" ]] || {
+    	echo "ERROR: Unexpected file changes."
+        echo
+        echo "Expected:"
+	echo "$expected_file_changes"
+        echo
+        echo "Actual:"
+	echo "$actual_changes"
+	echo
+	echo "Diff:"
+	diff <(echo "$expected_file_changes") <(echo "$actual_changes")
+	echo "Changes checked with: git diff --numstat"
+	    exit 1
+    } >&2
+    git checkout .
+)
+
+# TODO:  Verify that the version number has bumped in:
+# - Cargo.toml (version can be obtained with: yq -r '.workspace.package.version' -o json Cargo.toml
+# - Cargo.lock (seems to be too hard for yq?)
+# - package.json
+# - package-lock.json
+
+# TODO:
+# - Verify that the changes are as expected when committing.


### PR DESCRIPTION
# Motivation
The nns dapp release process includes incrementing the patch version of the frontend and cargo versions.  Let's automate that.

# Changes
- Add a script that increments the patch versions.

# Tests
- The effect of running this command can be seen here: https://github.com/dfinity/nns-dapp/compare/bump-patch...test-patch
- A minimal test is included and exercised in CI.

# Todos

- [x] Add entry to changelog (if necessary).
- [ ] Create full tests.  I don't want to spend the time now.
- [ ] Use this in the release procedure.  https://www.notion.so/dfinityorg/Checklist-YYYY-MM-DD-0e1db3aadfc140ab9bd9c2f3957ba25d