### PR TITLE
Don't call callback after balance worker is stopped

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -22,6 +22,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Fixed
 
 * Header in accounts, canisters and neurons was not visible after user came back from logging in.
+* Address issue with displayed SNS balances on quickly switching between SNSes.
 
 #### Security
 

--- a/frontend/src/lib/services/worker-balances.services.ts
+++ b/frontend/src/lib/services/worker-balances.services.ts
@@ -65,6 +65,7 @@ export const initBalancesWorker = async (): Promise<BalancesWorker> => {
       });
     },
     stopBalancesTimer: () => {
+      balancesCallback = undefined;
       balancesWorker.postMessage({
         msg: "nnsStopBalancesTimer",
       });


### PR DESCRIPTION
# Motivation

There is a bug where if you quickly switch between SNS universes multiple times, we show the balance of one token for a different token.
There are several issues that might contribute to this:
1. `rootCanisterId` and `ledgerCanisterId` are passed independently from `SnsAccountsBalancesObserver` to `SnsBalancesObserver` and are acquired from different stores which are not guaranteed to be in sync at the time these values are passed.
2. When the callback in `SnsBalancesObserver` is called from the `BalancesWorker`, it uses the value of `rootCanisterId` at the time the callback is called, rather than the value it had at the time the worker was initialized with the corresponding `ledgerCanisterId`.
3. If the `BalancesWorker` receives a response, it will still call the callback on `SnsBalancesObserver` even if the worker was already stopped.

This PR addresses the 3rd issue, which seems to prevent the bug from happening, at least most of the time.

# Changes

1. Reset the callback in `stopBalancesTimer` in `frontend/src/lib/services/worker-balances.services.ts` so that it will never be called after the worker is stopped.
2. Add missing tests that the callback is called when the worker sends a response message.
3. Add test that the callback is not called when the worker sends a response message after the worker is stopped.

# Tests

Before:

https://github.com/dfinity/nns-dapp/assets/122978264/4fa64102-c483-487d-bd86-d73f5d7f83b4

After:

https://github.com/dfinity/nns-dapp/assets/122978264/49194ebf-087a-4aa6-a1bf-1553fb57be19

# Todos

- [x] Add entry to changelog (if necessary).
