### PR TITLE
Bigger icon and description first on Sns project page

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -16,6 +16,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Changed
 
+* Bigger icon and description first on Sns project page.
+
 #### Deprecated
 #### Removed
 

--- a/frontend/src/lib/components/project-detail/ProjectMetadataSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectMetadataSection.svelte
@@ -30,19 +30,23 @@
   {#if isNullish(metadata) || isNullish(token)}
     <SkeletonDetails />
   {:else}
-    <div data-tid="sns-project-detail-metadata">
+    <div data-tid="sns-project-detail-metadata" class="container">
       <div class="title">
-        <Logo src={metadata.logo} alt={$i18n.sns_launchpad.project_logo} />
+        <Logo
+          src={metadata.logo}
+          alt={$i18n.sns_launchpad.project_logo}
+          size="big"
+        />
         <h1 class="content-cell-title" data-tid="project-name">
           {metadata.name}
         </h1>
       </div>
-      <a href={metadata.url} target="_blank" rel="noopener noreferrer"
-        >{metadata.url}</a
-      >
       <p class="description content-cell-details">
         {metadata.description}
       </p>
+      <a href={metadata.url} target="_blank" rel="noopener noreferrer"
+        >{metadata.url}</a
+      >
     </div>
   {/if}
 </TestIdWrapper>
@@ -57,5 +61,9 @@
 
   p {
     margin-top: var(--padding);
+  }
+
+  .container {
+    padding: 0 0 var(--padding);
   }
 </style>


### PR DESCRIPTION
# Motivation

It looks better. It's easier to read.

# Changes

- bigger icon on Sns project page
- description before url

# Screenshot

Currently:

<img width="1536" alt="Capture d’écran 2023-08-29 à 18 39 38" src="https://github.com/dfinity/nns-dapp/assets/16886711/d8494331-b6aa-48a4-b131-93e2c97c1a55">

Afterwards:

<img width="1536" alt="Capture d’écran 2023-08-29 à 18 39 32" src="https://github.com/dfinity/nns-dapp/assets/16886711/71cf5312-5c45-4438-a2cf-dca7b5f204f3">

Mockup on mainnet:

![image](https://github.com/dfinity/nns-dapp/assets/16886711/32ac8cae-8734-4788-96eb-8a18d19eb0db)

