### PR TITLE
Format dropdown options without whitespace

### DIFF
--- a/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -61,9 +61,9 @@
     testId="select-account-dropdown"
   >
     {#each selectableAccounts as { identifier, name } (identifier)}
-      <DropdownItem value={identifier}>
-        {name ?? $i18n.accounts.main}
-      </DropdownItem>
+      <DropdownItem value={identifier}
+        >{name ?? $i18n.accounts.main}</DropdownItem
+      >
     {/each}
   </Dropdown>
 {/if}

--- a/frontend/src/tests/page-objects/Dropdown.page-object.ts
+++ b/frontend/src/tests/page-objects/Dropdown.page-object.ts
@@ -14,8 +14,6 @@ export class DropdownPo extends BasePageObject {
 
   async getOptions(): Promise<string[]> {
     const options = await this.root.querySelectorAll("option");
-    return Promise.all(
-      options.map(async (option) => (await option.getText()).trim())
-    );
+    return Promise.all(options.map((option) => option.getText()));
   }
 }


### PR DESCRIPTION
# Motivation

In `frontend/src/lib/components/accounts/SelectAccountDropdown.svelte` dropdown options were formatted such that extra whitespace appears in the option text. This makes it harder to find the right option in tests and is simply unnecessary.

# Changes

1. Format the options such that no additional whitespace appears in the options.
2. Remove a `trim()` which is now unnecessary.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary