### PR TITLE
Use page objects in DisburseNnsNeuronModal.spec.ts

### DIFF
--- a/frontend/src/tests/page-objects/NnsSelectAccount.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsSelectAccount.page-object.ts
@@ -9,10 +9,14 @@ export class NnsSelectAccountPo extends BasePageObject {
     return new NnsSelectAccountPo(element.byTestId(NnsSelectAccountPo.TID));
   }
 
+  getAccountCardPos(): Promise<AccountCardPo[]> {
+    return AccountCardPo.allUnder(this.root);
+  }
+
   async getAccountCardPoForIdentifier(
     identifier: string
   ): Promise<AccountCardPo> {
-    const accountCards = await AccountCardPo.allUnder(this.root);
+    const accountCards = await this.getAccountCardPos();
     for (const accountCard of accountCards) {
       if ((await accountCard.getIdentifier()) === identifier) {
         return accountCard;


### PR DESCRIPTION
# Motivation

I plan to change `DisburseNnsNeuronModal` to use `SelectDestinationAddress` to bring it more in line with `TransactionModal`.
The test will be easier to adapt when it uses page objects already.

# Changes

1. Use page objects in `DisburseNnsNeuronModal.spec.ts`.
2. When the test expects a promise to have not yet resolved (when loading accounts) use an explicitly not-yet-resolved promise.

# Tests

only tests

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary