### PR TITLE
E2E: Only toggle the address select if necessary

### DIFF
--- a/frontend/src/tests/page-objects/SelectDestinationAddress.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectDestinationAddress.page-object.ts
@@ -24,9 +24,16 @@ export class SelectDestinationAddressPo extends BasePageObject {
     return this.getTogglePo().toggle();
   }
 
+  async enableSelect(): Promise<void> {
+    return this.getTogglePo().setDisabled();
+  }
+
+  async enableTextInput(): Promise<void> {
+    return this.getTogglePo().setEnabled();
+  }
+
   async selectAccount(accountName: string): Promise<void> {
-    // TODO: Only toggle if necessary.
-    await this.toggleSelect();
+    await this.enableSelect();
     await this.getDropdownPo().select(accountName);
   }
 }

--- a/frontend/src/tests/page-objects/Toggle.page-object.ts
+++ b/frontend/src/tests/page-objects/Toggle.page-object.ts
@@ -14,7 +14,7 @@ export class TogglePo extends BasePageObject {
     return this.root.querySelector("input[type=checkbox]").isChecked();
   }
 
-  async setEnabled(enabled: boolean = true): Promise<void> {
+  async setEnabled(enabled = true): Promise<void> {
     if ((await this.isEnabled()) !== enabled) {
       await this.toggle();
     }

--- a/frontend/src/tests/page-objects/Toggle.page-object.ts
+++ b/frontend/src/tests/page-objects/Toggle.page-object.ts
@@ -9,4 +9,18 @@ export class TogglePo extends BasePageObject {
   toggle(): Promise<void> {
     return this.root.querySelector("label").click();
   }
+
+  async isEnabled(): Promise<boolean> {
+    return this.root.querySelector("input[type=checkbox]").isChecked();
+  }
+
+  async setEnabled(enabled: boolean = true): Promise<void> {
+    if ((await this.isEnabled()) !== enabled) {
+      await this.toggle();
+    }
+  }
+
+  setDisabled(): Promise<void> {
+    return this.setEnabled(false);
+  }
 }

--- a/frontend/src/tests/page-objects/jest.page-object.ts
+++ b/frontend/src/tests/page-objects/jest.page-object.ts
@@ -130,7 +130,7 @@ export class JestPageObjectElement implements PageObjectElement {
     return this.element && Array.from(this.element.classList);
   }
 
-  async isChecked(): Promise<boolean | null> {
+  async isChecked(): Promise<boolean> {
     throw new Error("Not implemented");
   }
 

--- a/frontend/src/tests/page-objects/playwright.page-object.ts
+++ b/frontend/src/tests/page-objects/playwright.page-object.ts
@@ -80,7 +80,7 @@ export class PlaywrightPageObjectElement implements PageObjectElement {
     return classNames?.split(" ");
   }
 
-  isChecked(): Promise<boolean | null> {
+  isChecked(): Promise<boolean> {
     return this.locator.isChecked();
   }
 

--- a/frontend/src/tests/types/page-object.types.ts
+++ b/frontend/src/tests/types/page-object.types.ts
@@ -29,7 +29,7 @@ export interface PageObjectElement {
   getClasses(): Promise<string[] | null>;
   click(): Promise<void>;
   input(value: string): Promise<void>;
-  isChecked(): Promise<boolean | null>;
+  isChecked(): Promise<boolean>;
   typeText(text: string): Promise<void>;
   selectOption(option: string): Promise<void>;
   getValue(): Promise<string>;


### PR DESCRIPTION
# Motivation

There is a TODO in `frontend/src/tests/page-objects/SelectDestinationAddress.page-object.ts` to only toggle the input method if necessary.
I'm working on a PR to reuse the `SelectDestinationAddress` component in the `DisburseNnsNeuronModal` component and for that's it's useful to finally do this TODO.

# Changes

1. Fix the type of `isChecked`. There is no reason for it to return `null`.
2. Add functionality to `frontend/src/tests/page-objects/Toggle.page-object.ts` to check the value and set a specific value.
3. Add functions to `frontend/src/tests/page-objects/SelectDestinationAddress.page-object.ts` to specifically enable select input or text input.
4. Specifically choose select input before selecting an account.

# Tests

test changes only

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary