### PR TITLE
GIX-1823: Use ENABLE_SNS_AGGREGATOR_STORE in sns.services

### DIFF
--- a/frontend/src/lib/services/sns.services.ts
+++ b/frontend/src/lib/services/sns.services.ts
@@ -6,6 +6,7 @@ import {
 } from "$lib/api/sns.api";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { WATCH_SALE_STATE_EVERY_MILLISECONDS } from "$lib/constants/sns.constants";
+import { ENABLE_SNS_AGGREGATOR_STORE } from "$lib/stores/feature-flags.store";
 import { snsDerivedStateStore } from "$lib/stores/sns-derived-state.store";
 import { snsLifecycleStore } from "$lib/stores/sns-lifecycle.store";
 import {
@@ -164,7 +165,10 @@ export const loadSnsDerivedState = async ({
       }),
     onLoad: ({ response: derivedState, certified }) => {
       if (derivedState !== undefined) {
-        snsQueryStore.updateDerivedState({ derivedState, rootCanisterId });
+        const useAggregatorStore = get(ENABLE_SNS_AGGREGATOR_STORE);
+        if (!useAggregatorStore) {
+          snsQueryStore.updateDerivedState({ derivedState, rootCanisterId });
+        }
         snsDerivedStateStore.setDerivedState({
           rootCanisterId: Principal.fromText(rootCanisterId),
           certified,
@@ -215,7 +219,8 @@ export const loadSnsLifecycle = async ({
       }),
     onLoad: ({ response: lifecycleResponse, certified }) => {
       const lifecycle = fromNullable(lifecycleResponse?.lifecycle ?? []);
-      if (nonNullish(lifecycle)) {
+      const useAggregatorStore = get(ENABLE_SNS_AGGREGATOR_STORE);
+      if (nonNullish(lifecycle) && !useAggregatorStore) {
         snsQueryStore.updateLifecycle({ lifecycle, rootCanisterId });
       }
       if (nonNullish(lifecycleResponse)) {


### PR DESCRIPTION
# Motivation

Final motivation: set ENABLE_SNS_AGGREGATOR_STORE to `true`.

Do not set the snsQueryStore in the services unless `ENABLE_SNS_AGGREGATOR_STORE` is false.

Otherwise, the tests need to also fill the `snsQueryStore` and we want to remove it.

# Changes

* Use ENABLE_SNS_AGGREGATOR_STORE in `loadSnsDerivedState` and `loadSnsLifecycle`.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
