### PR TITLE
GIX-1823: Use aggregator ns functions

### DIFF
--- a/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
   import { i18n } from "$lib/stores/i18n";
-  import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
   import { secondsToDateTime } from "$lib/utils/date.utils";
   import { mapProposalInfo } from "$lib/utils/sns-proposals.utils";
   import type { Principal } from "@dfinity/principal";
@@ -13,6 +12,8 @@
   import { nonNullish } from "@dfinity/utils";
   import ProposalSystemInfoEntry from "../proposal-detail/ProposalSystemInfoEntry.svelte";
   import SnsProposerEntry from "./SnsProposerEntry.svelte";
+  import type { Readable } from "svelte/store";
+  import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
 
   export let proposal: SnsProposalData;
   export let rootCanisterId: Principal;
@@ -31,9 +32,8 @@
   let failed_timestamp_seconds: bigint;
   let proposer: SnsNeuronId | undefined;
 
-  let nsFunctions: SnsNervousSystemFunction[];
-  $: nsFunctions =
-    $snsFunctionsStore[rootCanisterId.toText()]?.nsFunctions || [];
+  let functionsStore: Readable<SnsNervousSystemFunction[] | undefined>;
+  $: functionsStore = createSnsNsFunctionsProjectStore(rootCanisterId);
 
   $: ({
     type,
@@ -47,7 +47,10 @@
     executed_timestamp_seconds,
     failed_timestamp_seconds,
     proposer,
-  } = mapProposalInfo({ proposalData: proposal, nsFunctions }));
+  } = mapProposalInfo({
+    proposalData: proposal,
+    nsFunctions: $functionsStore,
+  }));
 </script>
 
 <div

--- a/frontend/src/lib/derived/sns-ns-functions-project.derived.ts
+++ b/frontend/src/lib/derived/sns-ns-functions-project.derived.ts
@@ -10,7 +10,7 @@ import type { CachedSnsDto } from "$lib/types/sns-aggregator";
 import { convertNervousFunction } from "$lib/utils/sns-aggregator-converters.utils";
 import type { Principal } from "@dfinity/principal";
 import type { SnsNervousSystemFunction } from "@dfinity/sns";
-import { nonNullish } from "@dfinity/utils";
+import { isNullish, nonNullish } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 
 export type SnsNervousSystemFunctionsProjectStore = Readable<
@@ -18,7 +18,7 @@ export type SnsNervousSystemFunctionsProjectStore = Readable<
 >;
 
 export const createSnsNsFunctionsProjectStore = (
-  rootCanisterId: Principal
+  rootCanisterId: Principal | null | undefined
 ): SnsNervousSystemFunctionsProjectStore =>
   derived<
     [SnsNervousSystemFunctionsStore, SnsAggregatorStore],
@@ -26,6 +26,9 @@ export const createSnsNsFunctionsProjectStore = (
   >(
     [snsFunctionsStore, snsAggregatorStore],
     ([snsFunctions, aggregatorData]) => {
+      if (isNullish(rootCanisterId)) {
+        return undefined;
+      }
       const rootCanisterIdText = rootCanisterId.toText();
       if (nonNullish(snsFunctions[rootCanisterIdText])) {
         return snsFunctions[rootCanisterIdText].nsFunctions;

--- a/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/FollowSnsNeuronsModal.svelte
@@ -1,18 +1,19 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
   import FollowSnsTopicSection from "$lib/components/sns-neuron-detail/FollowSnsTopicSection.svelte";
   import { Modal, Spinner } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import type { SnsNeuron } from "@dfinity/sns";
   import type { SnsNervousSystemFunction } from "@dfinity/sns";
   import Separator from "$lib/components/ui/Separator.svelte";
+  import type { Readable } from "svelte/store";
+  import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
 
   export let neuron: SnsNeuron;
   export let rootCanisterId: Principal;
 
-  let functions: SnsNervousSystemFunction[] | undefined;
-  $: functions = $snsFunctionsStore[rootCanisterId.toString()]?.nsFunctions;
+  let functionsStore: Readable<SnsNervousSystemFunction[] | undefined>;
+  $: functionsStore = createSnsNsFunctionsProjectStore(rootCanisterId);
 </script>
 
 <Modal
@@ -27,10 +28,10 @@
 
   <Separator spacing="medium" />
 
-  {#if functions === undefined}
+  {#if $functionsStore === undefined}
     <Spinner />
   {:else}
-    {#each functions as nsFunction (nsFunction.id.toString())}
+    {#each $functionsStore as nsFunction (nsFunction.id.toString())}
       <FollowSnsTopicSection {nsFunction} {rootCanisterId} {neuron} />
     {/each}
   {/if}

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -3,7 +3,6 @@
   import type { SnsProposalData } from "@dfinity/sns";
   import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
   import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
-  import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
   import type { SnsNervousSystemFunction } from "@dfinity/sns";
   import SnsProposalsList from "$lib/components/sns-proposals/SnsProposalsList.svelte";
   import {
@@ -19,6 +18,8 @@
   import { nonNullish } from "@dfinity/utils";
   import { snsFilteredProposalsStore } from "$lib/derived/sns/sns-filtered-proposals.derived";
   import type { Principal } from "@dfinity/principal";
+  import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
+  import type { Readable } from "svelte/store";
 
   let currentProjectCanisterId: Principal | undefined = undefined;
   const onSnsProjectChanged = async (
@@ -81,10 +82,10 @@
       )
     : undefined;
 
-  let nsFunctions: SnsNervousSystemFunction[] | undefined;
-  $: nsFunctions = nonNullish(currentProjectCanisterId)
-    ? $snsFunctionsStore[currentProjectCanisterId.toText()]?.nsFunctions
-    : undefined;
+  let nsFunctionsStore: Readable<SnsNervousSystemFunction[] | undefined>;
+  $: nsFunctionsStore = createSnsNsFunctionsProjectStore(
+    currentProjectCanisterId
+  );
 
   let disableInfiniteScroll: boolean;
   $: disableInfiniteScroll = nonNullish(currentProjectCanisterId)
@@ -94,7 +95,7 @@
 
 <SnsProposalsList
   {proposals}
-  {nsFunctions}
+  nsFunctions={$nsFunctionsStore}
   on:nnsIntersect={loadNextPage}
   {disableInfiniteScroll}
   {loadingNextPage}

--- a/frontend/src/lib/services/sns-vote-registration.services.ts
+++ b/frontend/src/lib/services/sns-vote-registration.services.ts
@@ -1,5 +1,6 @@
 import { registerVote as registerSnsVoteApi } from "$lib/api/sns-governance.api";
 import { SNS_NEURON_ID_DISPLAY_LENGTH } from "$lib/constants/sns-neurons.constants";
+import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
 import { getSnsNeuronIdentity } from "$lib/services/sns-neurons.services";
 import {
   manageVotesRegistration,
@@ -7,7 +8,6 @@ import {
   updateVoteRegistrationToastMessage,
   voteRegistrationByProposal,
 } from "$lib/services/vote-registration.services";
-import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
@@ -49,8 +49,8 @@ export const registerSnsVotes = async ({
   vote: SnsVote;
   updateProposalCallback: (proposal: SnsProposalData) => void;
 }): Promise<void> => {
-  const nsFunctions: SnsNervousSystemFunction[] =
-    get(snsFunctionsStore)[universeCanisterId.toText()]?.nsFunctions;
+  const nsFunctionsStore = createSnsNsFunctionsProjectStore(universeCanisterId);
+  const nsFunctions: SnsNervousSystemFunction[] = get(nsFunctionsStore) ?? [];
   const proposalType =
     mapSnsProposal({ proposalData: proposal, nsFunctions }).type ?? "";
 
@@ -106,8 +106,8 @@ const snsNeuronRegistrationComplete = async ({
     proposalIdString,
     universeCanisterId,
   });
-  const nsFunctions: SnsNervousSystemFunction[] =
-    get(snsFunctionsStore)[universeCanisterId.toText()]?.nsFunctions;
+  const nsFunctionsStore = createSnsNsFunctionsProjectStore(universeCanisterId);
+  const nsFunctions: SnsNervousSystemFunction[] = get(nsFunctionsStore) ?? [];
   const proposalType =
     mapSnsProposal({ proposalData: proposal, nsFunctions }).type ?? "";
 
@@ -186,8 +186,8 @@ const registerSnsNeuronsVote = async ({
 }) => {
   const identity = await getSnsNeuronIdentity();
   const proposalId = fromDefinedNullable(proposal.id);
-  const nsFunctions: SnsNervousSystemFunction[] =
-    get(snsFunctionsStore)[universeCanisterId.toText()]?.nsFunctions;
+  const nsFunctionsStore = createSnsNsFunctionsProjectStore(universeCanisterId);
+  const nsFunctions: SnsNervousSystemFunction[] = get(nsFunctionsStore) ?? [];
   const proposalType =
     mapSnsProposal({ proposalData: proposal, nsFunctions }).type ?? "";
   const successfulVotedNeurons: SnsNeuron[] = [];

--- a/frontend/src/lib/stores/sns-functions.store.ts
+++ b/frontend/src/lib/stores/sns-functions.store.ts
@@ -73,4 +73,5 @@ const initSnsFunctionsStore = (): SnsNervousSystemFunctionsStore => {
   };
 };
 
+// TODO: expose update only functions instead of a readable store
 export const snsFunctionsStore = initSnsFunctionsStore();


### PR DESCRIPTION
# Motivation

The service `loadSnsNervousSystemFunctions` checked the dynamic derived store `createSnsNsFunctionsProjectStore` to check whether it should load more nervous functions or not.

If that store has data, then call to get the functions and load then in snsFunctionsStore is skipped.

That means, that we can't rely on the data in snsFunctionsStore, because it might not be populated.

At the moment, this is working because after getting the aggregator data, we also load the data in snsFunctionsStore. But, just like we stop loading snsQueryStore, we will also stop loading snsFunctionsStore.

In this PR, I changed the usage of snsFunctionsStore for the dynamic derived store `createSnsNsFunctionsProjectStore`.

# Changes

* `` accepts rootCanisterId undefined or null. This make it easy to be used in components.
* Use `createSnsNsFunctionsProjectStore` in SnsProposalSystemInfoSection.
* Use `createSnsNsFunctionsProjectStore` in FollowSnsNeuronModal.
* Use `createSnsNsFunctionsProjectStore` in SnsProposals.
* Use `createSnsNsFunctionsProjectStore` in sns vote registration services.

# Tests

* Tests don't need to change `createSnsNsFunctionsProjectStore` uses also snsFunctionsStore and tests already populated that store.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.