### PR TITLE
GIX-1823: Refactor snsQueryStoreIsLoading

### DIFF
--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -282,9 +282,13 @@ const initSnsQueryStore = (): SnsQueryStore => {
  */
 export const snsQueryStore = initSnsQueryStore();
 
-export const snsQueryStoreIsLoading = derived<SnsQueryStore, boolean>(
-  snsQueryStore,
-  (data: SnsQueryStoreData) => isNullish(data)
+export const snsQueryStoreIsLoading = derived<
+  [SnsQueryStore, SnsAggregatorStore],
+  boolean
+>(
+  [snsQueryStore, snsAggregatorStore],
+  ([snsQueryStoreData, aggregatorData]) =>
+    isNullish(snsQueryStoreData) && isNullish(aggregatorData.data)
 );
 
 /**

--- a/frontend/src/tests/lib/stores/sns.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns.store.spec.ts
@@ -151,19 +151,6 @@ describe("sns.store", () => {
       expect(store).toBeUndefined();
     });
 
-    it("should set the store as loading state", () => {
-      const data = snsResponsesForLifecycle({
-        lifecycles: [SnsSwapLifecycle.Open],
-        certified: true,
-      });
-
-      snsQueryStore.setData(data);
-      expect(get(snsQueryStoreIsLoading)).toBe(false);
-
-      snsQueryStore.reset();
-      expect(get(snsQueryStoreIsLoading)).toBe(true);
-    });
-
     it("should update the data", () => {
       const data = snsResponsesForLifecycle({
         lifecycles: [SnsSwapLifecycle.Open, SnsSwapLifecycle.Pending],
@@ -225,6 +212,31 @@ describe("sns.store", () => {
           (swap) => swap.rootCanisterId === rootCanisterId
         )
       ).toBeUndefined();
+    });
+  });
+
+  describe("snsQueryStoreIsLoading", () => {
+    it("should not be loading if snsQueryStore is set", () => {
+      snsQueryStore.reset();
+      snsAggregatorStore.reset();
+      expect(get(snsQueryStoreIsLoading)).toBe(true);
+
+      const data = snsResponsesForLifecycle({
+        lifecycles: [SnsSwapLifecycle.Open],
+        certified: true,
+      });
+
+      snsQueryStore.setData(data);
+      expect(get(snsQueryStoreIsLoading)).toBe(false);
+    });
+
+    it("should not be loading if sns aggregator store is set", () => {
+      snsQueryStore.reset();
+      snsAggregatorStore.reset();
+      expect(get(snsQueryStoreIsLoading)).toBe(true);
+
+      snsAggregatorStore.setData([aggregatorSnsMockDto]);
+      expect(get(snsQueryStoreIsLoading)).toBe(false);
     });
   });
 


### PR DESCRIPTION
# Motivation

Stop using snsQueryStore. `snsQueryStoreIsLoading` has snsQueryStore as its only dependency.

In this PR, use also the snsAggregatorStore inside `snsQueryStoreIsLoading` to return whether data is loading or not.

# Changes

* Add dependency of snsAggregator store in snsQueryStoreIsLoading.

# Tests

* Add a describe for only `snsQueryStoreIsLoading` with two test cases. Instead of having one test case for it.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary
