### PR TITLE
Add an iterator over values

### DIFF
--- a/rs/backend/src/accounts_store/schema.rs
+++ b/rs/backend/src/accounts_store/schema.rs
@@ -77,4 +77,7 @@ pub trait AccountsDbTrait {
             None
         }
     }
+
+    /// Iterates over accounts in the data store.
+    fn values(&self) -> Box<dyn Iterator<Item = Account> + '_>;
 }

--- a/rs/backend/src/accounts_store/schema/map.rs
+++ b/rs/backend/src/accounts_store/schema/map.rs
@@ -24,6 +24,10 @@ impl AccountsDbTrait for AccountsDbAsMap {
     fn db_accounts_len(&self) -> u64 {
         self.accounts.len() as u64
     }
+    fn values(&self) -> Box<dyn Iterator<Item = Account> + '_> {
+        let iterator = self.accounts.values().cloned();
+        Box::new(iterator)
+    }
 }
 
 #[cfg(test)]

--- a/rs/backend/src/accounts_store/schema/map.rs
+++ b/rs/backend/src/accounts_store/schema/map.rs
@@ -59,4 +59,9 @@ mod tests {
     fn map_account_counts_should_be_correct() {
         generic_tests::assert_account_count_is_correct(AccountsDbAsMap::default());
     }
+
+    #[test]
+    fn map_accounts_db_should_iterate_over_values() {
+        generic_tests::assert_iterates_over_values(AccountsDbAsMap::default());
+    }
 }


### PR DESCRIPTION
# Motivation
The accounts store tests include an iterator over values.  We will need that in account databases, if we are to keep that test in the current form.  There seems no harm in having such an iterator so just add it.

# Changes
* Add an iterator over accounts.

# Tests
- This PR includes a simple test that inserts a few values and verifies that the account IDs from the iterator are as expected.
- The iterator will be used in this test: https://github.com/dfinity/nns-dapp/blob/main/rs/backend/src/accounts_store/tests.rs#L1378

# Todos

- [ ] Add entry to changelog (if necessary).
   I think this is not necessary; this is a small PR currently affecting tests only and has no user-facing changes.