### PR TITLE
Change account storage from HashMap to BTreeMap

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -17,6 +17,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Changed
 
 * Bigger icon and description first on Sns project page.
+* Change accounts storage heap structure from `HashMap` to `BTreeMap`.
 
 #### Deprecated
 #### Removed

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -17,7 +17,7 @@ use itertools::Itertools;
 use on_wire::{FromWire, IntoWire};
 use serde::Deserialize;
 use std::cmp::{min, Ordering};
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::ops::RangeTo;
 use std::time::{Duration, SystemTime};
 
@@ -29,7 +29,7 @@ type TransactionIndex = u64;
 #[derive(Default, Debug, Eq, PartialEq)]
 pub struct AccountsStore {
     // TODO(NNS1-720): Use AccountIdentifier directly as the key for this HashMap
-    accounts: HashMap<Vec<u8>, Account>,
+    accounts: BTreeMap<Vec<u8>, Account>,
     hardware_wallets_and_sub_accounts: HashMap<AccountIdentifier, AccountWrapper>,
     // pending_transactions: HashMap<(from, to), (TransactionType, timestamp_ms_since_epoch)>
     pending_transactions: HashMap<(AccountIdentifier, AccountIdentifier), (TransactionType, u64)>,
@@ -1501,7 +1501,7 @@ impl StableState for AccountsStore {
             last_ledger_sync_timestamp_nanos,
             neurons_topped_up_count,
         ): (
-            HashMap<Vec<u8>, Account>,
+            BTreeMap<Vec<u8>, Account>,
             HashMap<AccountIdentifier, AccountWrapper>,
             HashMap<(AccountIdentifier, AccountIdentifier), (TransactionType, u64)>,
             VecDeque<Transaction>,


### PR DESCRIPTION
# Motivation
We wish to be able to iterate over accounts in a consistent way so that we can migrate accounts from one schema to another in chunks.  `HashMap` does not guarantee a stable order for iterating whereas BTree does.  Let us convert, but be cautious of any change in cycle consumption.

Notes:

- The Candid serialization of `HashMap` and `BTreeMap` is the same: As a vector of `(key, value)` tuples.
- The pre-upgrade cycle count was last measured as 5% of the limit, so it is almost certainly not a concern.  It would be nice to have this available as a statistic in PRs though.
- `BTreeMap` does support [`Cursor`](https://doc.rust-lang.org/std/collections/btree_map/struct.Cursor.html) but unfortunately all the useful cursor API methods are still labelled experimental.  Why is this relevant?  Suppose that accounts up to key `x` have been migrated.  One could then look up the [entry](https://doc.rust-lang.org/std/collections/btree_map/enum.Entry.html) for `x` and use the cursor to get the next 100 accounts for migration.  This would be a lot more efficient than iterating over all keys until `x` is found.  Going forward, it would also be useful to have cursors on `StableBTreeMap`s.

# Changes
- Change the account storage type from `HashMap` to `BTreeMap`.

# Tests
Here are the cycle counts from two CI runs, one with BTreeMap and one with HashMap.

### HashMap
![Screenshot from 2023-08-31 02-15-11](https://github.com/dfinity/nns-dapp/assets/5982633/1d8a1fc2-7c70-458a-bc56-1555f374756f)
[The CI run.](https://github.com/dfinity/nns-dapp/actions/runs/6025533342)

### BTreeMap
![Screenshot from 2023-08-31 02-14-53](https://github.com/dfinity/nns-dapp/assets/5982633/e2072cf1-9d1c-4511-80eb-c7bf4c063754)
[The CI run](https://github.com/dfinity/nns-dapp/actions/runs/6026859114)

# Todos

- [ ] Add entry to changelog (if necessary).
