### PR TITLE
GIX-1841: Add sns finalization status stores

### DIFF
--- a/frontend/src/lib/stores/sns-finalization-status.store.ts
+++ b/frontend/src/lib/stores/sns-finalization-status.store.ts
@@ -1,3 +1,4 @@
+import { isSnsFinalizing } from "$lib/utils/sns.utils";
 import type { Principal } from "@dfinity/principal";
 import type { SnsGetAutoFinalizationStatusResponse } from "@dfinity/sns";
 import { isNullish, nonNullish } from "@dfinity/utils";
@@ -56,6 +57,6 @@ export const createIsSnsFinalizingStore = (rootCanisterId: Principal) => {
       return false;
     }
 
-    return finalizationData.data;
+    return isSnsFinalizing(finalizationData.data);
   });
 };

--- a/frontend/src/lib/stores/sns-finalization-status.store.ts
+++ b/frontend/src/lib/stores/sns-finalization-status.store.ts
@@ -1,6 +1,6 @@
 import type { Principal } from "@dfinity/principal";
 import type { SnsGetAutoFinalizationStatusResponse } from "@dfinity/sns";
-import { fromNullable, isNullish, nonNullish } from "@dfinity/utils";
+import { isNullish, nonNullish } from "@dfinity/utils";
 import { derived, writable, type Readable } from "svelte/store";
 
 interface SnsFinalizationStatusData {
@@ -56,13 +56,6 @@ export const createIsSnsFinalizingStore = (rootCanisterId: Principal) => {
       return false;
     }
 
-    const {
-      data: { has_auto_finalize_been_attempted, auto_finalize_swap_response },
-    } = finalizationData;
-
-    return (
-      fromNullable(has_auto_finalize_been_attempted) &&
-      isNullish(fromNullable(auto_finalize_swap_response))
-    );
+    return finalizationData.data;
   });
 };

--- a/frontend/src/lib/stores/sns-finalization-status.store.ts
+++ b/frontend/src/lib/stores/sns-finalization-status.store.ts
@@ -1,0 +1,68 @@
+import type { Principal } from "@dfinity/principal";
+import type { SnsGetAutoFinalizationStatusResponse } from "@dfinity/sns";
+import { fromNullable, isNullish, nonNullish } from "@dfinity/utils";
+import { derived, writable, type Readable } from "svelte/store";
+
+interface SnsFinalizationStatusData {
+  data: SnsGetAutoFinalizationStatusResponse;
+  certified: boolean;
+}
+
+export interface SnsFinalizationStatusStore
+  extends Readable<SnsFinalizationStatusData> {
+  setData: (data: SnsFinalizationStatusData) => void;
+}
+
+// Cache stores by root canister id.
+const stores: Map<string, SnsFinalizationStatusStore> = new Map();
+
+export const resetSnsFinalizationStatusStore = () => {
+  stores.clear();
+};
+
+const initStore = (): SnsFinalizationStatusStore => {
+  const { subscribe, set } = writable<SnsFinalizationStatusData>(undefined);
+
+  const store = {
+    subscribe,
+    setData(params: SnsFinalizationStatusData) {
+      set(params);
+    },
+  };
+
+  return store;
+};
+
+export const getOrCreateSnsFinalizationStatusStore = (
+  rootCanisterId: Principal
+): SnsFinalizationStatusStore => {
+  const store = stores.get(rootCanisterId.toText());
+
+  if (nonNullish(store)) {
+    return store;
+  }
+
+  const newStore = initStore();
+  stores.set(rootCanisterId.toText(), newStore);
+
+  return newStore;
+};
+
+export const createIsSnsFinalizingStore = (rootCanisterId: Principal) => {
+  const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+
+  return derived(store, (finalizationData) => {
+    if (isNullish(finalizationData)) {
+      return false;
+    }
+
+    const {
+      data: { has_auto_finalize_been_attempted, auto_finalize_swap_response },
+    } = finalizationData;
+
+    return (
+      fromNullable(has_auto_finalize_been_attempted) &&
+      isNullish(fromNullable(auto_finalize_swap_response))
+    );
+  });
+};

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -17,6 +17,7 @@ import { mapOptionalToken } from "$lib/utils/icrc-tokens.utils";
 import { AccountIdentifier, SubAccount } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import type {
+  SnsGetAutoFinalizationStatusResponse,
   SnsGetMetadataResponse,
   SnsParams,
   SnsSwap,
@@ -293,4 +294,22 @@ export const parseSnsSwapSaleBuyerCount = (
       ?.split(/\s/)?.[1]
   );
   return isNaN(value) ? undefined : value;
+};
+
+/**
+ * An SNS is in finalization state if:
+ *
+ * 1. `has_auto_finalize_been_attempted` is true
+ * 2. `auto_finalize_swap_response` is empty
+ */
+export const isSnsFinalizing = (
+  finalizationStatus: SnsGetAutoFinalizationStatusResponse
+): boolean => {
+  const { has_auto_finalize_been_attempted, auto_finalize_swap_response } =
+    finalizationStatus;
+
+  return (
+    Boolean(fromNullable(has_auto_finalize_been_attempted)) &&
+    isNullish(fromNullable(auto_finalize_swap_response))
+  );
 };

--- a/frontend/src/tests/lib/stores/sns-finalization-status.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-finalization-status.store.spec.ts
@@ -1,0 +1,142 @@
+import {
+  createIsSnsFinalizingStore,
+  getOrCreateSnsFinalizationStatusStore,
+  resetSnsFinalizationStatusStore,
+} from "$lib/stores/sns-finalization-status.store";
+import {
+  createFinalizationStatusMock,
+  snsFinalizationStatusResponseMock,
+} from "$tests/mocks/sns-finalization-status.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import type { SnsGetAutoFinalizationStatusResponse } from "@dfinity/sns";
+import { get } from "svelte/store";
+
+describe("sns finalization status stores", () => {
+  const rootCanisterId = principal(0);
+  const rootCanisterId2 = principal(1);
+  beforeEach(() => {
+    resetSnsFinalizationStatusStore();
+  });
+
+  describe("getOrCreateSnsFinalizationStatusStore", () => {
+    it("set finalization data", () => {
+      const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+
+      store.setData({
+        data: snsFinalizationStatusResponseMock,
+        certified: true,
+      });
+
+      expect(get(store).data).toEqual(snsFinalizationStatusResponseMock);
+
+      const anotherResponse = {
+        ...snsFinalizationStatusResponseMock,
+        has_auto_finalize_been_attempted: [true] as [boolean],
+      };
+
+      store.setData({
+        data: anotherResponse,
+        certified: true,
+      });
+
+      expect(get(store).data).toEqual(anotherResponse);
+    });
+
+    it("caches stores", () => {
+      const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+
+      const store2 = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+
+      expect(store).toBe(store2);
+    });
+
+    it("creates stores per rootCansiterId", () => {
+      const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+
+      const store2 = getOrCreateSnsFinalizationStatusStore(rootCanisterId2);
+
+      expect(store).not.toBe(store2);
+
+      store.setData({
+        data: snsFinalizationStatusResponseMock,
+        certified: true,
+      });
+
+      expect(get(store).data).toEqual(snsFinalizationStatusResponseMock);
+
+      const anotherResponse = {
+        ...snsFinalizationStatusResponseMock,
+        has_auto_finalize_been_attempted: [true] as [boolean],
+      };
+
+      store2.setData({
+        data: anotherResponse,
+        certified: true,
+      });
+
+      expect(get(store2).data).toEqual(anotherResponse);
+    });
+  });
+
+  describe("createIsSnsFinalizingStore", () => {
+    it("returns true if finalizing", () => {
+      const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+      const finalizingResponse = createFinalizationStatusMock(true);
+
+      store.setData({
+        data: finalizingResponse,
+        certified: true,
+      });
+
+      const isFinalizingStore = createIsSnsFinalizingStore(rootCanisterId);
+
+      expect(get(isFinalizingStore)).toBe(true);
+    });
+
+    it("returns false if not finalizing because not attempted", () => {
+      const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+      const finalizingResponse: SnsGetAutoFinalizationStatusResponse = {
+        is_auto_finalize_enabled: [true],
+        auto_finalize_swap_response: [],
+        has_auto_finalize_been_attempted: [false],
+      };
+
+      store.setData({
+        data: finalizingResponse,
+        certified: true,
+      });
+
+      const isFinalizingStore = createIsSnsFinalizingStore(rootCanisterId);
+
+      expect(get(isFinalizingStore)).toBe(false);
+    });
+
+    it("returns false if not finalizing because it finished", () => {
+      const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+      const finalizingResponse: SnsGetAutoFinalizationStatusResponse = {
+        is_auto_finalize_enabled: [true],
+        auto_finalize_swap_response: [
+          {
+            set_dapp_controllers_call_result: [],
+            settle_community_fund_participation_result: [],
+            error_message: [],
+            set_mode_call_result: [],
+            sweep_icp_result: [],
+            claim_neuron_result: [],
+            sweep_sns_result: [],
+          },
+        ],
+        has_auto_finalize_been_attempted: [true],
+      };
+
+      store.setData({
+        data: finalizingResponse,
+        certified: true,
+      });
+
+      const isFinalizingStore = createIsSnsFinalizingStore(rootCanisterId);
+
+      expect(get(isFinalizingStore)).toBe(false);
+    });
+  });
+});

--- a/frontend/src/tests/lib/stores/sns-finalization-status.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-finalization-status.store.spec.ts
@@ -93,6 +93,12 @@ describe("sns finalization status stores", () => {
       expect(get(isFinalizingStore)).toBe(true);
     });
 
+    it("returns false if the store not set", () => {
+      const isFinalizingStore = createIsSnsFinalizingStore(rootCanisterId);
+
+      expect(get(isFinalizingStore)).toBe(false);
+    });
+
     it("returns false if not finalizing because not attempted", () => {
       const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
       const finalizingResponse: SnsGetAutoFinalizationStatusResponse = {

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -5,10 +5,12 @@ import {
   getSwapCanisterAccount,
   hasOpenTicketInProcess,
   isInternalRefreshBuyerTokensError,
+  isSnsFinalizing,
   mapAndSortSnsQueryToSummaries,
   parseSnsSwapSaleBuyerCount,
 } from "$lib/utils/sns.utils";
 import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { createFinalizationStatusMock } from "$tests/mocks/sns-finalization-status.mock";
 import {
   createBuyersState,
   mockDerived,
@@ -25,6 +27,7 @@ import { snsTicketMock } from "$tests/mocks/sns.mock";
 import { IcrcMetadataResponseEntries } from "@dfinity/ledger";
 import { AccountIdentifier } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
+import type { SnsGetAutoFinalizationStatusResponse } from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("sns-utils", () => {
@@ -418,6 +421,44 @@ sale_participants_count ${saleBuyerCount} 1677707139456
           "The swap has already reached its target"
         )
       ).toBe(false);
+    });
+  });
+
+  describe("isSnsFinalizing", () => {
+    it("returns true if finalizing", () => {
+      const finalizingResponse = createFinalizationStatusMock(true);
+
+      expect(isSnsFinalizing(finalizingResponse)).toBe(true);
+    });
+
+    it("returns false if not finalizing because not attempted", () => {
+      const finalizingResponse: SnsGetAutoFinalizationStatusResponse = {
+        is_auto_finalize_enabled: [true],
+        auto_finalize_swap_response: [],
+        has_auto_finalize_been_attempted: [false],
+      };
+
+      expect(isSnsFinalizing(finalizingResponse)).toBe(false);
+    });
+
+    it("returns false if not finalizing because it finished", () => {
+      const finalizingResponse: SnsGetAutoFinalizationStatusResponse = {
+        is_auto_finalize_enabled: [true],
+        auto_finalize_swap_response: [
+          {
+            set_dapp_controllers_call_result: [],
+            settle_community_fund_participation_result: [],
+            error_message: [],
+            set_mode_call_result: [],
+            sweep_icp_result: [],
+            claim_neuron_result: [],
+            sweep_sns_result: [],
+          },
+        ],
+        has_auto_finalize_been_attempted: [true],
+      };
+
+      expect(isSnsFinalizing(finalizingResponse)).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/mocks/sns-finalization-status.mock.ts
+++ b/frontend/src/tests/mocks/sns-finalization-status.mock.ts
@@ -1,0 +1,28 @@
+import type { SnsGetAutoFinalizationStatusResponse } from "@dfinity/sns";
+
+export const snsFinalizationStatusResponseMock: SnsGetAutoFinalizationStatusResponse =
+  {
+    auto_finalize_swap_response: [],
+    has_auto_finalize_been_attempted: [false],
+    is_auto_finalize_enabled: [true],
+  };
+
+export const createFinalizationStatusMock = (
+  isFinalizing: boolean
+): SnsGetAutoFinalizationStatusResponse => ({
+  is_auto_finalize_enabled: [true],
+  auto_finalize_swap_response: isFinalizing
+    ? []
+    : [
+        {
+          set_dapp_controllers_call_result: [],
+          settle_community_fund_participation_result: [],
+          error_message: [],
+          set_mode_call_result: [],
+          sweep_icp_result: [],
+          claim_neuron_result: [],
+          sweep_sns_result: [],
+        },
+      ],
+  has_auto_finalize_been_attempted: isFinalizing ? [true] : [false],
+});

--- a/frontend/src/tests/mocks/sns-finalization-status.mock.ts
+++ b/frontend/src/tests/mocks/sns-finalization-status.mock.ts
@@ -11,18 +11,8 @@ export const createFinalizationStatusMock = (
   isFinalizing: boolean
 ): SnsGetAutoFinalizationStatusResponse => ({
   is_auto_finalize_enabled: [true],
-  auto_finalize_swap_response: isFinalizing
-    ? []
-    : [
-        {
-          set_dapp_controllers_call_result: [],
-          settle_community_fund_participation_result: [],
-          error_message: [],
-          set_mode_call_result: [],
-          sweep_icp_result: [],
-          claim_neuron_result: [],
-          sweep_sns_result: [],
-        },
-      ],
-  has_auto_finalize_been_attempted: isFinalizing ? [true] : [false],
+  // This needs to be empty.
+  // Check `isSnsFinalizing` sns util for more details
+  auto_finalize_swap_response: [],
+  has_auto_finalize_been_attempted: [isFinalizing],
 });


### PR DESCRIPTION
# Motivation

We want to add a new sns project status: Finalizing.

In this PR, I introduce the store where the data from the endpoint will be saved and a derived store with the logic to return whether the project is finalizing or not.

# Changes

* New dynamic store creator: `getOrCreateSnsFinalizationStatusStore`.
* New dynamic derived store: `createIsSnsFinalizingStore`.

# Tests

* Test new stores.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet necessary.
