### PR TITLE
Chore: Clean newUI methods of neuron detail PO

### DIFF
--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -65,7 +65,7 @@ test("Test SNS governance", async ({ page, context }) => {
   await neuronCard.click();
   const neuronDetail = appPo.getNeuronDetailPo().getSnsNeuronDetailPo();
   expect(await neuronDetail.getUniverse()).toBe(snsProjectName);
-  expect(await neuronDetail.getStakeNewUI()).toBe(formattedStake);
+  expect(await neuronDetail.getStake()).toBe(formattedStake);
   expect(await neuronDetail.getHotkeyPrincipals()).toEqual([]);
 
   step("SN003: User can add a hotkey");

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -156,7 +156,7 @@ describe("SnsNeuronDetail", () => {
       const po = await renderComponent(props);
 
       // `neuronStake` to string formatted as expected
-      expect(await po.getStakeNewUI()).toBe("1.00");
+      expect(await po.getStake()).toBe("1.00");
       const amountToStake = 20;
       fakeSnsGovernanceApi.setNeuronWith({
         rootCanisterId,
@@ -164,11 +164,11 @@ describe("SnsNeuronDetail", () => {
         cached_neuron_stake_e8s: numberToE8s(neuronStake + amountToStake),
       });
 
-      await po.increaseStakeNewUI(amountToStake);
+      await po.increaseStake(amountToStake);
       await runResolvedPromises();
 
       // `neuronStake` + 10 to string and formatted as expected
-      expect(await po.getStakeNewUI()).toBe("21.00");
+      expect(await po.getStake()).toBe("21.00");
       expect(increaseStakeNeuron).toHaveBeenCalledTimes(1);
       expect(increaseStakeNeuron).toHaveBeenCalledWith({
         neuronId: validNeuronId,

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -40,11 +40,6 @@ export class NnsNeuronDetailPo extends BasePageObject {
     );
   }
 
-  // TODO: To be removed https://dfinity.atlassian.net/browse/GIX-1688
-  hasJoinFundCard(): Promise<boolean> {
-    return this.root.byTestId("neuron-join-fund-card-component").isPresent();
-  }
-
   async disburseNeuron(): Promise<void> {
     await this.getVotingPowerSectionPo().clickDisburse();
     await this.getNnsNeuronModalsPo()
@@ -56,12 +51,8 @@ export class NnsNeuronDetailPo extends BasePageObject {
     return NnsNeuronPageHeaderPo.under(this.root);
   }
 
-  getNeuronIdNewUi(): Promise<string | null> {
+  getNeuronId(): Promise<string> {
     return this.getPageHeaderPo().getNeuronId();
-  }
-
-  async getNeuronId(): Promise<string> {
-    return this.getNeuronIdNewUi();
   }
 
   getUniverse(): Promise<string> {

--- a/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDetail.page-object.ts
@@ -32,8 +32,7 @@ export class SnsNeuronDetailPo extends BasePageObject {
     return SnsNeuronHotkeysCardPo.under(this.root);
   }
 
-  // TODO: Rename GIX-1688
-  getStakeNewUI(): Promise<string> {
+  getStake(): Promise<string> {
     return this.getVotingPowerSectionPo().getStakeAmount();
   }
 
@@ -61,8 +60,7 @@ export class SnsNeuronDetailPo extends BasePageObject {
     return SnsIncreaseStakeNeuronModalPo.under(this.root);
   }
 
-  // TODO: Rename GIX-1688
-  async increaseStakeNewUI(amount: number): Promise<void> {
+  async increaseStake(amount: number): Promise<void> {
     await this.getVotingPowerSectionPo().clickIncrease();
     await this.getIncreaseStakeModalPo().increase(amount);
   }


### PR DESCRIPTION
# Motivation

Rename some methods that were specific to a feature flag in Neuron Details POs.

# Changes

* Rename some methods to not reference "newUI" or similar.
* Remove unused method `hasJoinFundCard`

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Already covered by a changelog entry.
