### PR TITLE
Support wallet.~ domains

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -13,6 +13,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Added
 
 * Disburse maturity of sns neurons.
+* Make NNS Dapp accessible via wallet.ic0.app and wallet.internetcomputer.org.
 
 #### Changed
 

--- a/frontend/src/lib/constants/origin.constants.ts
+++ b/frontend/src/lib/constants/origin.constants.ts
@@ -1,2 +1,6 @@
 export const NNS_IC_APP_DERIVATION_ORIGIN = "https://nns.ic0.app";
-export const NNS_IC_ORG_ALTERNATIVE_ORIGIN = "https://nns.internetcomputer.org";
+export const NNS_IC_ORG_ALTERNATIVE_ORIGINS = [
+  "https://nns.internetcomputer.org",
+  "https://wallet.internetcomputer.org",
+  "https://wallet.ic0.app",
+];

--- a/frontend/src/lib/stores/auth.store.ts
+++ b/frontend/src/lib/stores/auth.store.ts
@@ -23,7 +23,7 @@ let authClient: AuthClient | undefined | null;
 
 const getIdentityProvider = () => {
   // If we are in mainnet in the old domain, we use the old identity provider.
-  if (location.host === "nns.ic0.app") {
+  if (location.host.endsWith(".ic0.app")) {
     return OLD_MAINNET_IDENTITY_SERVICE_URL;
   }
 

--- a/frontend/src/lib/utils/env.utils.ts
+++ b/frontend/src/lib/utils/env.utils.ts
@@ -1,5 +1,5 @@
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
-import { NNS_IC_ORG_ALTERNATIVE_ORIGIN } from "$lib/constants/origin.constants";
+import { NNS_IC_ORG_ALTERNATIVE_ORIGINS } from "$lib/constants/origin.constants";
 
 /**
  * To be use when Rollup fails to resolve import "$app/environment". This can happen because we manually define chunks and SvelteKit is not entirely resilient to bundler reordering.
@@ -18,7 +18,7 @@ export const isNnsAlternativeOrigin = (): boolean => {
     location: { origin },
   } = window;
 
-  return origin === NNS_IC_ORG_ALTERNATIVE_ORIGIN;
+  return NNS_IC_ORG_ALTERNATIVE_ORIGINS.includes(origin);
 };
 
 /**

--- a/frontend/src/tests/lib/stores/auth.store.spec.ts
+++ b/frontend/src/tests/lib/stores/auth.store.spec.ts
@@ -3,7 +3,10 @@
  */
 
 import * as utils from "$lib/api/agent.api";
-import { OLD_MAINNET_IDENTITY_SERVICE_URL } from "$lib/constants/identity.constants";
+import {
+  IDENTITY_SERVICE_URL,
+  OLD_MAINNET_IDENTITY_SERVICE_URL,
+} from "$lib/constants/identity.constants";
 import { authStore } from "$lib/stores/auth.store";
 import { AuthClient } from "@dfinity/auth-client";
 import { mock } from "jest-mock-extended";
@@ -38,11 +41,63 @@ describe("auth-store", () => {
     });
   });
 
-  it("should call auth-client with old identity provider if currently in the old", async () => {
+  it("should call auth-client with identity provider", async () => {
+    const { host } = window.location;
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { host: "nns.internetcomputer.org" },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore: test file
+    mockAuthClient.login = async ({
+      onSuccess,
+      identityProvider,
+    }: {
+      onSuccess: () => void;
+      identityProvider: string;
+    }) => {
+      expect(identityProvider).toBe(IDENTITY_SERVICE_URL);
+      onSuccess();
+    };
+
+    await authStore.signIn(() => {
+      // do nothing on error here
+    });
+    window.location.host = host;
+  });
+
+  it("should call auth-client with old identity provider for nns.ic0.app", async () => {
     const { host } = window.location;
     Object.defineProperty(window, "location", {
       writable: true,
       value: { host: "nns.ic0.app" },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore: test file
+    mockAuthClient.login = async ({
+      onSuccess,
+      identityProvider,
+    }: {
+      onSuccess: () => void;
+      identityProvider: string;
+    }) => {
+      expect(identityProvider).toBe(OLD_MAINNET_IDENTITY_SERVICE_URL);
+      onSuccess();
+    };
+
+    await authStore.signIn(() => {
+      // do nothing on error here
+    });
+    window.location.host = host;
+  });
+
+  it("should call auth-client with old identity provider for wallet.ic0.app", async () => {
+    const { host } = window.location;
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { host: "wallet.ic0.app" },
     });
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/frontend/src/tests/lib/utils/env.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/env.utils.spec.ts
@@ -23,67 +23,41 @@ describe("env-utils", () => {
       });
     });
 
-    it("should be an alternative origin", () => {
+    const setOrigin = (origin: string) => {
       Object.defineProperty(window, "location", {
         writable: true,
         value: {
           ...location,
-          origin: `https://nns.internetcomputer.org`,
+          origin,
         },
       });
+    };
 
+    it("should be an alternative origin", () => {
+      setOrigin("https://nns.internetcomputer.org");
+      expect(isNnsAlternativeOrigin()).toBeTruthy();
+
+      setOrigin("https://wallet.internetcomputer.org");
+      expect(isNnsAlternativeOrigin()).toBeTruthy();
+
+      setOrigin("https://wallet.ic0.app");
       expect(isNnsAlternativeOrigin()).toBeTruthy();
     });
 
     it("should not be an alternative origin", () => {
-      Object.defineProperty(window, "location", {
-        writable: true,
-        value: {
-          ...location,
-          origin: `https://nns.ic0.app`,
-        },
-      });
-
+      setOrigin("https://nns.ic0.app");
       expect(isNnsAlternativeOrigin()).toBe(false);
 
-      Object.defineProperty(window, "location", {
-        writable: true,
-        value: {
-          ...location,
-          origin: `https://ic0.app`,
-        },
-      });
-
+      setOrigin("https://ic0.app");
       expect(isNnsAlternativeOrigin()).toBe(false);
 
-      Object.defineProperty(window, "location", {
-        writable: true,
-        value: {
-          ...location,
-          origin: `https://test.com`,
-        },
-      });
-
+      setOrigin("https://test.com");
       expect(isNnsAlternativeOrigin()).toBe(false);
 
-      Object.defineProperty(window, "location", {
-        writable: true,
-        value: {
-          ...location,
-          origin: `https://internetcomputer.org`,
-        },
-      });
-
+      setOrigin("https://internetcomputer.org");
       expect(isNnsAlternativeOrigin()).toBe(false);
 
-      Object.defineProperty(window, "location", {
-        writable: true,
-        value: {
-          ...location,
-          origin: `https://ii.internetcomputer.org`,
-        },
-      });
-
+      setOrigin("https://ii.internetcomputer.org");
       expect(isNnsAlternativeOrigin()).toBe(false);
     });
   });

--- a/frontend/static/.well-known/ic-domains
+++ b/frontend/static/.well-known/ic-domains
@@ -1,1 +1,3 @@
 nns.internetcomputer.org
+wallet.internetcomputer.org
+wallet.ic0.app

--- a/frontend/static/.well-known/ii-alternative-origins
+++ b/frontend/static/.well-known/ii-alternative-origins
@@ -1,1 +1,1 @@
-{"alternativeOrigins": ["https://nns.internetcomputer.org"]}
+{"alternativeOrigins": ["https://nns.internetcomputer.org", "https://wallet.internetcomputer.org", "https://wallet.ic0.app"]}


### PR DESCRIPTION
# Motivation

We want to make NNS Dapp accessible on `wallet.ic0.app` and `wallet.internetcomputer.org`.

# Changes

1. Add both domains to `frontend/static/.well-known/ic-domains`. This allows the canister to be accessible on those domain.
2. Add both origins to `frontend/static/.well-known/ii-alternative-origins`. This allows people to get the same principal from Internet Identity on those domains as they get on `nns.ic0.app`.
3. Make `isNnsAlternativeOrigin` return `true` for the new origins. This causes the app to pass a `derivationOrigin` of `"https://nns.ic0.app"` to Internet Identity on line 90 of `frontend/src/lib/stores/auth.store.ts`.
4. Use `identity.ic0.app` (instead of `identity.internetcomputer.org`) for any domain ending in `.ic0.app`, not just `nns.ic0.app`.
5. Add missing test that we use `identity.internetcomputer.org` by default.
6. Add tests for the other changes.

# Tests

Unit tests pass.
Not sure how to test if it actually works, short of releasing.

# Todos

- [x] Add entry to changelog (if necessary).
