### PR TITLE
GIX-1759: Remove unnecessary variant prop

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte
@@ -31,7 +31,7 @@
     >{$i18n.neuron_detail.available_description}</svelte:fragment
   >
   {#if isControllable}
-    <NnsStakeMaturityButton {neuron} variant="secondary" />
+    <NnsStakeMaturityButton {neuron} />
     <SpawnNeuronButton {neuron} />
   {/if}
 </CommonItemAction>

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte
@@ -113,7 +113,7 @@
       <JoinCommunityFundCheckbox {neuron} />
     {/if}
     {#if isControllable}
-      <SplitNnsNeuronButton {neuron} variant="secondary" />
+      <SplitNnsNeuronButton {neuron} />
     {/if}
   </div>
 </Section>

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte
@@ -68,6 +68,6 @@
     {/if}</svelte:fragment
   >
   {#if isControllable}
-    <IncreaseDissolveDelayButton variant="secondary" />
+    <IncreaseDissolveDelayButton />
   {/if}
 </CommonItemAction>

--- a/frontend/src/lib/components/neuron-detail/StakeItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/StakeItemAction.svelte
@@ -33,7 +33,7 @@
   </div>
   <svelte:fragment slot="actions">
     {#if isIncreaseStakeAllowed}
-      <IncreaseStakeButton variant="secondary" on:increaseStake />
+      <IncreaseStakeButton on:increaseStake />
     {/if}
   </svelte:fragment>
 </ItemAction>

--- a/frontend/src/lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/IncreaseDissolveDelayButton.svelte
@@ -8,8 +8,6 @@
   import { openNnsNeuronModal } from "$lib/utils/modals.utils";
   import { NeuronState } from "@dfinity/nns";
 
-  export let variant: "primary" | "secondary" = "primary";
-
   const { store }: NnsNeuronContext = getContext<NnsNeuronContext>(
     NNS_NEURON_CONTEXT_KEY
   );
@@ -19,7 +17,7 @@
 </script>
 
 <button
-  class={variant}
+  class="secondary"
   data-tid="increase-dissolve-delay-button-component"
   on:click={() =>
     openNnsNeuronModal({

--- a/frontend/src/lib/components/neuron-detail/actions/IncreaseStakeButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/IncreaseStakeButton.svelte
@@ -2,13 +2,11 @@
   import { i18n } from "$lib/stores/i18n";
   import { createEventDispatcher } from "svelte";
 
-  export let variant: "primary" | "secondary" = "primary";
-
   const dispatch = createEventDispatcher();
 </script>
 
 <button
-  class={variant}
+  class="secondary"
   data-tid="increase-stake-button-component"
   on:click={() => dispatch("increaseStake")}
   >{$i18n.neuron_detail.increase_stake}</button

--- a/frontend/src/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.svelte
@@ -7,15 +7,12 @@
   import { openNnsNeuronModal } from "$lib/utils/modals.utils";
   import IncreaseStakeButton from "./IncreaseStakeButton.svelte";
 
-  export let variant: "primary" | "secondary" = "primary";
-
   const { store }: NnsNeuronContext = getContext<NnsNeuronContext>(
     NNS_NEURON_CONTEXT_KEY
   );
 </script>
 
 <IncreaseStakeButton
-  {variant}
   on:increaseStake={() =>
     openNnsNeuronModal({
       type: "increase-stake",

--- a/frontend/src/lib/components/neuron-detail/actions/NnsStakeMaturityButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/NnsStakeMaturityButton.svelte
@@ -10,7 +10,6 @@
   import StakeMaturityButton from "$lib/components/neuron-detail/actions/StakeMaturityButton.svelte";
 
   export let neuron: NeuronInfo;
-  export let variant: "primary" | "secondary" = "primary";
 
   let enoughMaturity: boolean;
   $: enoughMaturity = hasEnoughMaturityToStake(neuron);
@@ -26,4 +25,4 @@
     });
 </script>
 
-<StakeMaturityButton {enoughMaturity} {variant} on:click={showModal} />
+<StakeMaturityButton {enoughMaturity} on:click={showModal} />

--- a/frontend/src/lib/components/neuron-detail/actions/SplitNnsNeuronButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/SplitNnsNeuronButton.svelte
@@ -13,7 +13,6 @@
   import { ICPToken } from "@dfinity/utils";
 
   export let neuron: NeuronInfo;
-  export let variant: "primary" | "secondary" = "primary";
 
   let splittable: boolean;
   $: splittable = neuronCanBeSplit({
@@ -28,7 +27,7 @@
 </script>
 
 {#if splittable}
-  <button on:click={openModal} class={variant} data-tid={testId}
+  <button on:click={openModal} class="secondary" data-tid={testId}
     >{$i18n.neuron_detail.split_neuron}</button
   >
 {:else}
@@ -45,7 +44,7 @@
       }
     )}
   >
-    <button on:click={openModal} class={variant} disabled data-tid={testId}
+    <button on:click={openModal} class="secondary" disabled data-tid={testId}
       >{$i18n.neuron_detail.split_neuron}</button
     >
   </Tooltip>

--- a/frontend/src/lib/components/neuron-detail/actions/StakeMaturityButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/StakeMaturityButton.svelte
@@ -3,11 +3,10 @@
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
 
   export let enoughMaturity: boolean;
-  export let variant: "primary" | "secondary" = "primary";
 </script>
 
 {#if enoughMaturity}
-  <button class={variant} on:click data-tid="stake-maturity-button"
+  <button class="secondary" on:click data-tid="stake-maturity-button"
     >{$i18n.neuron_detail.stake_maturity}</button
   >
 {:else}
@@ -15,7 +14,7 @@
     id="stake-maturity-tooltip"
     text={$i18n.neuron_detail.stake_maturity_disabled_tooltip}
   >
-    <button disabled class={variant} data-tid="stake-maturity-button"
+    <button disabled class="secondary" data-tid="stake-maturity-button"
       >{$i18n.neuron_detail.stake_maturity}</button
     >
   </Tooltip>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.svelte
@@ -36,7 +36,7 @@
     >{$i18n.neuron_detail.available_description}</svelte:fragment
   >
   {#if allowedToStakeMaturity}
-    <SnsStakeMaturityButton variant="secondary" />
+    <SnsStakeMaturityButton />
   {/if}
 
   {#if allowedToDisburseMaturity && $ENABLE_DISBURSE_MATURITY}

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.svelte
@@ -70,6 +70,6 @@
     {/if}</svelte:fragment
   >
   {#if allowedToDissolve}
-    <IncreaseSnsDissolveDelayButton {neuron} variant="secondary" />
+    <IncreaseSnsDissolveDelayButton {neuron} />
   {/if}
 </CommonItemAction>

--- a/frontend/src/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.svelte
@@ -7,7 +7,6 @@
   import { NeuronState } from "@dfinity/nns";
 
   export let neuron: SnsNeuron;
-  export let variant: "primary" | "secondary" = "primary";
 
   let isUnlocked: boolean;
   $: isUnlocked = getSnsNeuronState(neuron) === NeuronState.Dissolved;
@@ -15,7 +14,7 @@
 
 <VestingTooltipWrapper {neuron}>
   <button
-    class={variant}
+    class="secondary"
     disabled={isVesting(neuron)}
     data-tid="sns-increase-dissolve-delay"
     on:click={() => openSnsNeuronModal({ type: "increase-dissolve-delay" })}

--- a/frontend/src/lib/components/sns-neuron-detail/actions/SnsIncreaseStakeButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/SnsIncreaseStakeButton.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
   import { openSnsNeuronModal } from "$lib/utils/modals.utils";
   import IncreaseStakeButton from "$lib/components/neuron-detail/actions/IncreaseStakeButton.svelte";
-
-  export let variant: "primary" | "secondary" = "primary";
 </script>
 
 <IncreaseStakeButton
-  {variant}
   on:increaseStake={() =>
     openSnsNeuronModal({
       type: "increase-stake",

--- a/frontend/src/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.svelte
@@ -9,8 +9,6 @@
   import { getContext } from "svelte";
   import StakeMaturityButton from "$lib/components/neuron-detail/actions/StakeMaturityButton.svelte";
 
-  export let variant: "primary" | "secondary" = "primary";
-
   const context: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
   const { store }: SelectedSnsNeuronContext = context;
@@ -24,4 +22,4 @@
   const showModal = () => openSnsNeuronModal({ type: "stake-maturity" });
 </script>
 
-<StakeMaturityButton {enoughMaturity} {variant} on:click={showModal} />
+<StakeMaturityButton {enoughMaturity} on:click={showModal} />

--- a/frontend/src/tests/lib/components/neuron-detail/StakeItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/StakeItemAction.spec.ts
@@ -54,11 +54,10 @@ describe("StakeItemAction", () => {
     expect(await po.getDescription()).toBe("FLURB staked");
   });
 
-  it("should render increase stake button secondary variant", async () => {
+  it("should render increase stake button", async () => {
     const po = renderComponent({});
 
     expect(await po.hasIncreaseStakeButton()).toBe(true);
-    expect(await po.getIncreaseStakeButtonPo().getVariant()).toBe("secondary");
   });
 
   it("should not render increase stake button", async () => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/IncreaseStakeButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/IncreaseStakeButton.spec.ts
@@ -32,16 +32,4 @@ describe("IncreaseStakeButton", () => {
 
     expect(increaseStake).toBeCalledTimes(1);
   });
-
-  it("renders variant primary by default", async () => {
-    const po = await renderComponent({});
-    expect(await po.getVariant()).toBe("primary");
-  });
-
-  it("renders variant secondary if set", async () => {
-    const po = await renderComponent({
-      variant: "secondary",
-    });
-    expect(await po.getVariant()).toBe("secondary");
-  });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsIncreaseStakeButton.spec.ts
@@ -27,25 +27,6 @@ describe("NnsIncreaseStakeButton", () => {
     expect(getByText(en.neuron_detail.increase_stake)).toBeInTheDocument();
   });
 
-  it("uses variant", () => {
-    const variant = "secondary";
-    const { queryByTestId } = render(NeuronContextTest, {
-      props: {
-        neuron: mockNeuron,
-        testComponent: NnsIncreaseStakeButton,
-        componentProps: {
-          variant,
-        },
-      },
-    });
-
-    expect(
-      queryByTestId("increase-stake-button-component").classList.contains(
-        variant
-      )
-    ).toBe(true);
-  });
-
   it("opens Increase Neuron Stake Modal", async () => {
     // To avoid that the modal requests the accounts
     icpAccountsStore.setForTesting(mockAccountsStoreData);

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/IncreaseSnsDissolveDelayButton.spec.ts
@@ -42,14 +42,10 @@ describe("IncreaseSnsDissolveDelayButton", () => {
     page.mock({ data: { universe: rootCanisterId.toText() } });
   });
 
-  const renderComponent = (
-    neuron: SnsNeuron,
-    variant: "primary" | "secondary" = "primary"
-  ) => {
+  const renderComponent = (neuron: SnsNeuron) => {
     const { container } = render(IncreaseSnsDissolveDelayButton, {
       props: {
         neuron,
-        variant,
       },
     });
 
@@ -74,16 +70,6 @@ describe("IncreaseSnsDissolveDelayButton", () => {
     });
     const po = renderComponent(unlockedNeuron);
     expect(await po.getText()).toEqual("Set Dissolve Delay");
-  });
-
-  it("should set variant", async () => {
-    const unlockedNeuron = createMockSnsNeuron({
-      id: [1],
-      state: NeuronState.Dissolved,
-    });
-    const variant = "secondary";
-    const po = renderComponent(unlockedNeuron, variant);
-    expect(await po.getClasses()).toContain(variant);
   });
 
   it("should open increase increase dissolve delay modal", async () => {

--- a/frontend/src/tests/page-objects/IncreaseStakeButton.page-object.ts
+++ b/frontend/src/tests/page-objects/IncreaseStakeButton.page-object.ts
@@ -9,19 +9,4 @@ export class IncreaseStakeButtonPo extends BasePageObject {
       element.byTestId(IncreaseStakeButtonPo.TID)
     );
   }
-
-  async getVariant(): Promise<string> {
-    const allowedVariants = ["primary", "secondary"];
-    const classes = (await this.root.getClasses()).filter((c) =>
-      allowedVariants.includes(c)
-    );
-    if (classes.length !== 1) {
-      throw new Error(
-        `Expected one of ${allowedVariants.join(", ")} but got ${classes.join(
-          ", "
-        )}`
-      );
-    }
-    return classes[0];
-  }
 }


### PR DESCRIPTION
# Motivation

A "variant" prop was introduced to reused the same buttons when implementing a new UI for neuron details.

The old UI has already been removed.

In this PR, I remove the "variant" prop which is not needed anymore and set the buttons to "secondary".

# Changes

* Remove "variant" prop in neuron related buttons.

# Tests

* Remove tests regarding the variant prop.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary. Already covered by the changelog entry specifying cleaning components.