### PR TITLE
GIX-1823: Set sns aggregator store flag true for tests

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -50,6 +50,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Changed
 - Use the upstream notification action directly, rather than using a local copy.
 - Support comments in proposal titles.  Example: `Proposal 1111 (cherry-pick)`
+* Set `ENABLE_SNS_AGGREGATOR_STORE` true in unit tests.
 
 #### Deprecated
 #### Removed

--- a/frontend/jest-setup.ts
+++ b/frontend/jest-setup.ts
@@ -36,7 +36,7 @@ jest.mock("./src/lib/utils/env-vars.utils.ts", () => ({
       ENABLE_CKTESTBTC: true,
       ENABLE_ICP_ICRC: false,
       ENABLE_INSTANT_UNLOCK: true,
-      ENABLE_SNS_AGGREGATOR_STORE: false,
+      ENABLE_SNS_AGGREGATOR_STORE: true,
       ENABLE_DISBURSE_MATURITY: true,
       TEST_FLAG_EDITABLE: true,
       TEST_FLAG_NOT_EDITABLE: true,

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -37,8 +37,6 @@ describe("SnsProposals", () => {
     )[0];
 
   const rootCanisterId = mockPrincipal;
-  const functionName = "test_function";
-  const functionId = BigInt(3);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -50,7 +48,14 @@ describe("SnsProposals", () => {
   });
 
   describe("logged in user", () => {
+    const functionName = "test_function";
+    const functionId = BigInt(3);
     beforeEach(() => {
+      fakeSnsGovernanceApi.addNervousSystemFunctionWith({
+        rootCanisterId,
+        name: functionName,
+        id: functionId,
+      });
       jest
         .spyOn(authStore, "subscribe")
         .mockImplementation(mockAuthStoreSubscribe);
@@ -138,6 +143,9 @@ describe("SnsProposals", () => {
         identity: new AnonymousIdentity(),
         rootCanisterId,
       });
+      fakeSnsGovernanceApi.addNervousSystemFunctionWith({
+        rootCanisterId,
+      });
     });
 
     describe("Matching results", () => {
@@ -183,6 +191,10 @@ describe("SnsProposals", () => {
         rootCanisterId,
         ...proposals[1],
         action: functionId,
+      });
+      fakeSnsGovernanceApi.addNervousSystemFunctionWith({
+        rootCanisterId,
+        id: functionId,
       });
     });
 

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -37,6 +37,8 @@ describe("SnsProposals", () => {
     )[0];
 
   const rootCanisterId = mockPrincipal;
+  const functionName = "test_function";
+  const functionId = BigInt(3);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -48,14 +50,7 @@ describe("SnsProposals", () => {
   });
 
   describe("logged in user", () => {
-    const functionName = "test_function";
-    const functionId = BigInt(3);
     beforeEach(() => {
-      fakeSnsGovernanceApi.addNervousSystemFunctionWith({
-        rootCanisterId,
-        name: functionName,
-        id: functionId,
-      });
       jest
         .spyOn(authStore, "subscribe")
         .mockImplementation(mockAuthStoreSubscribe);
@@ -143,9 +138,6 @@ describe("SnsProposals", () => {
         identity: new AnonymousIdentity(),
         rootCanisterId,
       });
-      fakeSnsGovernanceApi.addNervousSystemFunctionWith({
-        rootCanisterId,
-      });
     });
 
     describe("Matching results", () => {
@@ -191,10 +183,6 @@ describe("SnsProposals", () => {
         rootCanisterId,
         ...proposals[1],
         action: functionId,
-      });
-      fakeSnsGovernanceApi.addNervousSystemFunctionWith({
-        rootCanisterId,
-        id: functionId,
       });
     });
 

--- a/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
@@ -7,7 +7,6 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import NeuronDetail from "$lib/routes/NeuronDetail.svelte";
 import { loadSnsProjects } from "$lib/services/$public/sns.services";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { page } from "$mocks/$app/stores";
 import * as fakeGovernanceApi from "$tests/fakes/governance-api.fake";
@@ -18,6 +17,7 @@ import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NeuronDetailPo } from "$tests/page-objects/NeuronDetail.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { resetSnsProjects } from "$tests/utils/sns.test-utils";
 import type { HttpAgent } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
@@ -46,7 +46,7 @@ describe("NeuronDetail", () => {
 
   beforeEach(() => {
     resetIdentity();
-    snsQueryStore.reset();
+    resetSnsProjects();
     jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
@@ -123,10 +123,8 @@ describe("NeuronDetail", () => {
       // Load SNS projects after rendering to make sure we don't load
       // NnsNeuronDetail instead, which was a bug we had.
       await loadSnsProjects();
-      expect(await po.isContentLoaded()).toBe(false);
-      await waitFor(async () => {
-        expect(await po.isContentLoaded()).toBe(true);
-      });
+      expect(await po.isContentLoaded()).toBe(true);
+
       expect(await po.hasNnsNeuronDetailPo()).toBe(false);
       expect(await po.hasSnsNeuronDetailPo()).toBe(true);
       expect(await po.getSnsNeuronDetailPo().isContentLoaded()).toBe(true);

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -19,6 +19,7 @@ import {
   mockSnsSwapCommitment,
   principal,
 } from "$tests/mocks/sns-projects.mock";
+import { snsResponsesFor } from "$tests/mocks/sns-response.mock";
 import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import {
   advanceTime,
@@ -52,6 +53,7 @@ describe("sns-services", () => {
     jest.clearAllTimers();
     jest.clearAllMocks();
     snsSwapCommitmentsStore.reset();
+    snsQueryStore.reset();
     resetSnsProjects();
     snsDerivedStateStore.reset();
     overrideFeatureFlagsStore.setFlag("ENABLE_SNS_AGGREGATOR_STORE", false);
@@ -124,16 +126,17 @@ describe("sns-services", () => {
           direct_participant_count: [],
           cf_neuron_count: [],
         };
-        setSnsProjects([
+        const responses = snsResponsesFor([
           {
-            rootCanisterId: rootCanisterId1,
+            principal: rootCanisterId1,
             lifecycle: SnsSwapLifecycle.Open,
           },
           {
-            rootCanisterId: rootCanisterId2,
+            principal: rootCanisterId2,
             lifecycle: SnsSwapLifecycle.Open,
           },
         ]);
+        snsQueryStore.setData(responses);
 
         const spy = jest
           .spyOn(api, "querySnsDerivedState")
@@ -198,16 +201,17 @@ describe("sns-services", () => {
           direct_participant_count: [],
           cf_neuron_count: [],
         };
-        setSnsProjects([
+        const responses = snsResponsesFor([
           {
-            rootCanisterId: rootCanisterId1,
+            principal: rootCanisterId1,
             lifecycle: SnsSwapLifecycle.Open,
           },
           {
-            rootCanisterId: rootCanisterId2,
+            principal: rootCanisterId2,
             lifecycle: SnsSwapLifecycle.Open,
           },
         ]);
+        snsQueryStore.setData(responses);
 
         const spy = jest
           .spyOn(api, "querySnsDerivedState")
@@ -261,16 +265,17 @@ describe("sns-services", () => {
           direct_participant_count: [],
           cf_neuron_count: [],
         };
-        setSnsProjects([
+        const responses = snsResponsesFor([
           {
-            rootCanisterId: rootCanisterId1,
+            principal: rootCanisterId1,
             lifecycle: SnsSwapLifecycle.Open,
           },
           {
-            rootCanisterId: rootCanisterId2,
+            principal: rootCanisterId2,
             lifecycle: SnsSwapLifecycle.Open,
           },
         ]);
+        snsQueryStore.setData(responses);
 
         const initStore = get(snsQueryStore);
         const initState = initStore.swaps.find(
@@ -336,16 +341,17 @@ describe("sns-services", () => {
           direct_participant_count: [],
           cf_neuron_count: [],
         };
-        setSnsProjects([
+        const responses = snsResponsesFor([
           {
-            rootCanisterId: rootCanisterId1,
+            principal: rootCanisterId1,
             lifecycle: SnsSwapLifecycle.Open,
           },
           {
-            rootCanisterId: rootCanisterId2,
+            principal: rootCanisterId2,
             lifecycle: SnsSwapLifecycle.Open,
           },
         ]);
+        snsQueryStore.setData(responses);
 
         const spy = jest
           .spyOn(api, "querySnsDerivedState")
@@ -473,16 +479,17 @@ describe("sns-services", () => {
           decentralization_sale_open_timestamp_seconds: [BigInt(1)],
         };
         const dataLifecycle = SnsSwapLifecycle.Open;
-        setSnsProjects([
+        const responses = snsResponsesFor([
           {
-            rootCanisterId: rootCanisterId1,
+            principal: rootCanisterId1,
             lifecycle: dataLifecycle,
           },
           {
-            rootCanisterId: rootCanisterId2,
+            principal: rootCanisterId2,
             lifecycle: SnsSwapLifecycle.Open,
           },
         ]);
+        snsQueryStore.setData(responses);
 
         const spy = jest
           .spyOn(api, "querySnsLifecycle")
@@ -516,16 +523,17 @@ describe("sns-services", () => {
           decentralization_sale_open_timestamp_seconds: [BigInt(1)],
         };
         const dataLifecycle = SnsSwapLifecycle.Open;
-        setSnsProjects([
+        const responses = snsResponsesFor([
           {
-            rootCanisterId: rootCanisterId1,
+            principal: rootCanisterId1,
             lifecycle: dataLifecycle,
           },
           {
-            rootCanisterId: rootCanisterId2,
+            principal: rootCanisterId2,
             lifecycle: SnsSwapLifecycle.Open,
           },
         ]);
+        snsQueryStore.setData(responses);
 
         const spy = jest
           .spyOn(api, "querySnsLifecycle")

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -1,7 +1,15 @@
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
-import type { CachedSns, CachedSnsDto } from "$lib/types/sns-aggregator";
+import type {
+  CachedNervousFunctionDto,
+  CachedSns,
+  CachedSnsDto,
+  CachedSnsTokenMetadataDto,
+} from "$lib/types/sns-aggregator";
 import tenAggregatedSnses from "$tests/mocks/sns-aggregator.mock.json";
-import { SnsSwapLifecycle } from "@dfinity/sns";
+import { IcrcMetadataResponseEntries } from "@dfinity/ledger";
+import { SnsSwapLifecycle, type SnsNervousSystemFunction } from "@dfinity/sns";
+import { fromNullable, nonNullish } from "@dfinity/utils";
+import { mockQueryTokenResponse } from "./sns-projects.mock";
 
 // TS is not smart enough to infer the type from the JSON file.
 export const aggregatorMockSnsesDataDto: CachedSnsDto[] =
@@ -238,23 +246,118 @@ export const aggregatorSnsMock: CachedSns = {
   },
 };
 
+const convertToNervousFunctionDto = ({
+  id,
+  name,
+  description,
+}: SnsNervousSystemFunction): CachedNervousFunctionDto => ({
+  id: Number(id),
+  name,
+  description: fromNullable(description),
+  // Not necessary to convert this, it's not used
+  function_type: { NativeNervousSystemFunction: {} },
+});
+
+const createQueryMetadataResponse = ({
+  name,
+  symbol,
+}: Partial<
+  Pick<IcrcTokenMetadata, "name" | "symbol">
+>): CachedSnsTokenMetadataDto =>
+  mockQueryTokenResponse.map(([key, value]) => {
+    if (key === IcrcMetadataResponseEntries.NAME) {
+      return [key, { Text: name }];
+    }
+    if (key === IcrcMetadataResponseEntries.SYMBOL) {
+      return [key, { Text: symbol }];
+    }
+    if (key === IcrcMetadataResponseEntries.DECIMALS && "Nat" in value) {
+      return [key, { Nat: [Number(value.Nat)] }];
+    }
+    if (key === IcrcMetadataResponseEntries.FEE && "Nat" in value) {
+      return [key, { Nat: [Number(value.Nat)] }];
+    }
+    throw new Error(`The key ${key} is not supported yet.`);
+  });
+
 export const aggregatorSnsMockWith = ({
   rootCanisterId = "4nwps-saaaa-aaaaa-aabjq-cai",
   lifecycle = SnsSwapLifecycle.Committed,
+  restrictedCountries,
+  directParticipantCount,
+  projectName,
+  tokenMetadata,
+  index,
+  nervousFunctions,
 }: {
   rootCanisterId?: string;
   lifecycle?: SnsSwapLifecycle;
+  restrictedCountries?: string[];
+  // TODO: Change to `undefined` or `number`.
+  directParticipantCount?: [] | [bigint];
+  projectName?: string;
+  tokenMetadata?: Partial<IcrcTokenMetadata>;
+  index?: number;
+  nervousFunctions?: SnsNervousSystemFunction[];
 }): CachedSnsDto => ({
+  index: index ?? aggregatorSnsMockDto.index,
   ...aggregatorSnsMockDto,
   canister_ids: {
     ...aggregatorSnsMockDto.canister_ids,
     root_canister_id: rootCanisterId,
+  },
+  list_sns_canisters: {
+    ...aggregatorSnsMockDto.list_sns_canisters,
+    root: rootCanisterId,
   },
   swap_state: {
     ...aggregatorSnsMockDto.swap_state,
     swap: {
       ...aggregatorSnsMockDto.swap_state.swap,
       lifecycle,
+      init: {
+        ...aggregatorSnsMockDto.swap_state.swap.init,
+        restricted_countries: nonNullish(restrictedCountries)
+          ? { iso_codes: restrictedCountries }
+          : aggregatorSnsMockDto.swap_state.swap.init.restricted_countries,
+      },
     },
+    derived: {
+      ...aggregatorSnsMockDto.swap_state.derived,
+      direct_participant_count: nonNullish(directParticipantCount?.[0])
+        ? Number(directParticipantCount[0]) ?? null
+        : aggregatorSnsMockDto.swap_state.derived.direct_participant_count,
+    },
+  },
+  parameters: {
+    ...aggregatorSnsMockDto.parameters,
+    functions:
+      nervousFunctions?.map(convertToNervousFunctionDto) ??
+      aggregatorSnsMockDto.parameters.functions,
+  },
+  meta: {
+    ...aggregatorSnsMockDto.meta,
+    name: projectName ?? aggregatorSnsMockDto.meta.name,
+  },
+  init: {
+    init: {
+      ...aggregatorSnsMockDto.init.init,
+      restricted_countries: nonNullish(restrictedCountries)
+        ? { iso_codes: restrictedCountries }
+        : aggregatorSnsMockDto.swap_state.swap.init.restricted_countries,
+    },
+  },
+  derived_state: {
+    ...aggregatorSnsMockDto.derived_state,
+    direct_participant_count: nonNullish(directParticipantCount?.[0])
+      ? Number(directParticipantCount[0]) ?? null
+      : aggregatorSnsMockDto.swap_state.derived.direct_participant_count,
+  },
+  icrc1_metadata: nonNullish(tokenMetadata)
+    ? createQueryMetadataResponse(tokenMetadata)
+    : aggregatorSnsMockDto.icrc1_metadata,
+  lifecycle: {
+    ...aggregatorSnsMockDto.lifecycle,
+    lifecycle: lifecycle ?? aggregatorSnsMockDto.lifecycle.lifecycle,
   },
 });

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -362,22 +362,6 @@ export const mockQueryTokenResponse: IcrcTokenMetadataResponse = [
   [IcrcMetadataResponseEntries.FEE, { Nat: mockSnsToken.fee }],
 ];
 
-export const createQueryMetadataResponse = ({
-  name,
-  symbol,
-}: Partial<
-  Pick<IcrcTokenMetadata, "name" | "symbol">
->): IcrcTokenMetadataResponse =>
-  mockQueryTokenResponse.map(([key, value]) => {
-    if (key === IcrcMetadataResponseEntries.NAME) {
-      return [key, { Text: name }];
-    }
-    if (key === IcrcMetadataResponseEntries.SYMBOL) {
-      return [key, { Text: symbol }];
-    }
-    return [key, value];
-  });
-
 export const mockQueryMetadata: QuerySnsMetadata = {
   rootCanisterId: principal(0).toText(),
   certified: true,


### PR DESCRIPTION
# Motivation

Set ENABLE_SNS_AGGREGATOR_STORE `true` for tests.

# Changes

* Set ENABLE_SNS_AGGREGATOR_STORE to `true` in jest.setup.ts
* Use snsQueryStore in sns services spec file. This should have never been setSnsProjects.
* Add more parameters to `aggregatorSnsMockWith`.
* Use aggregatorStore in setSnsProjects test util.

# Tests

Only test changes.

# Todos

- [x] Add entry to changelog (if necessary).
