### PR TITLE
Add QrWizardModal component

### DIFF
--- a/frontend/src/lib/modals/transaction/QrWizardModal.svelte
+++ b/frontend/src/lib/modals/transaction/QrWizardModal.svelte
@@ -19,15 +19,7 @@
     },
   ];
 
-  let modal: WizardModal;
-
-  export const next = () => {
-    modal.next();
-  };
-
-  export const back = () => {
-    modal.back();
-  };
+  export let modal: WizardModal;
 
   export const set = (step: number) => {
     modal.set(step);

--- a/frontend/src/lib/modals/transaction/QrWizardModal.svelte
+++ b/frontend/src/lib/modals/transaction/QrWizardModal.svelte
@@ -25,7 +25,7 @@
     modal.set(step);
   };
 
-  const setStepName = (stepName: string) => {
+  const goStep = (stepName: string) => {
     const stepNumber = stepsPlusQr.findIndex(({ name }) => name === stepName);
     set(stepNumber);
   };
@@ -36,14 +36,14 @@
   export const scanQrCode = async () => {
     const prevStep = currentStep;
 
-    setStepName(STEP_QRCODE);
+    goStep(STEP_QRCODE);
 
     return new Promise<string | undefined>((resolve) => {
       resolveQrCodePromise = resolve;
     }).finally(() => {
       // TypeScript can't know that currentStep is defined before scanQrCode
       // will be called.
-      setStepName(prevStep?.name || steps[0].name);
+      goStep(prevStep?.name || steps[0].name);
     });
   };
 

--- a/frontend/src/lib/modals/transaction/QrWizardModal.svelte
+++ b/frontend/src/lib/modals/transaction/QrWizardModal.svelte
@@ -49,10 +49,12 @@
 
   const onQRCode = ({ detail: value }: CustomEvent<string>) => {
     resolveQrCodePromise?.(value);
+    resolveQrCodePromise = undefined;
   };
 
   const onCancel = () => {
     resolveQrCodePromise?.(undefined);
+    resolveQrCodePromise = undefined;
   };
 </script>
 

--- a/frontend/src/lib/modals/transaction/QrWizardModal.svelte
+++ b/frontend/src/lib/modals/transaction/QrWizardModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { QrResponse, QrResult } from "$lib/types/qr-wizard-modal";
   import TransactionQRCode from "$lib/components/transaction/TransactionQRCode.svelte";
   import { toastsError } from "$lib/stores/toasts.store";
   import {
@@ -37,15 +38,6 @@
     set(stepNumber);
   };
 
-  type QrResult = "success" | "canceled" | "token_incompatible";
-
-  type QrResponse = {
-    result: QrResult;
-    identifier?: string;
-    token?: string;
-    amount?: number;
-  };
-
   let resolveQrCodePromise:
     | (({ result, value }: { result: QrResult; value?: string }) => void)
     | undefined = undefined;
@@ -62,6 +54,8 @@
     if (result !== "success") {
       return { result };
     }
+    // Because `result === "success"`, value is defined.
+    // This is just here to convince TypeScript.
     assertNonNullish(value);
 
     const payment = decodePayment(value);

--- a/frontend/src/lib/modals/transaction/QrWizardModal.svelte
+++ b/frontend/src/lib/modals/transaction/QrWizardModal.svelte
@@ -65,19 +65,17 @@
   };
 </script>
 
-{#if nonNullish(stepsPlusQr)}
-  <WizardModal
-    {testId}
-    steps={stepsPlusQr}
-    bind:currentStep
-    bind:this={modal}
-    on:nnsClose
-    {disablePointerEvents}
-  >
-    <slot name="title" slot="title" />
-    <slot />
-    {#if currentStep?.name === STEP_QRCODE}
-      <TransactionQRCode on:nnsCancel={onCancel} on:nnsQRCode={onQRCode} />
-    {/if}
-  </WizardModal>
-{/if}
+<WizardModal
+  {testId}
+  steps={stepsPlusQr}
+  bind:currentStep
+  bind:this={modal}
+  on:nnsClose
+  {disablePointerEvents}
+>
+  <slot name="title" slot="title" />
+  <slot />
+  {#if currentStep?.name === STEP_QRCODE}
+    <TransactionQRCode on:nnsCancel={onCancel} on:nnsQRCode={onQRCode} />
+  {/if}
+</WizardModal>

--- a/frontend/src/lib/modals/transaction/QrWizardModal.svelte
+++ b/frontend/src/lib/modals/transaction/QrWizardModal.svelte
@@ -2,7 +2,6 @@
   import { WizardModal } from "@dfinity/gix-components";
   import type { WizardStep, WizardSteps } from "@dfinity/gix-components";
   import TransactionQRCode from "$lib/components/transaction/TransactionQRCode.svelte";
-  import { nonNullish } from "@dfinity/utils";
 
   export let testId: string | undefined = undefined;
   export let steps: WizardSteps;

--- a/frontend/src/lib/modals/transaction/QrWizardModal.svelte
+++ b/frontend/src/lib/modals/transaction/QrWizardModal.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
-  import { WizardModal } from "@dfinity/gix-components";
-  import type { WizardStep, WizardSteps } from "@dfinity/gix-components";
   import TransactionQRCode from "$lib/components/transaction/TransactionQRCode.svelte";
+  import { toastsError } from "$lib/stores/toasts.store";
+  import {
+    WizardModal,
+    type WizardStep,
+    type WizardSteps,
+  } from "@dfinity/gix-components";
+  import { decodePayment } from "@dfinity/ledger";
+  import type { Token } from "@dfinity/utils";
+  import { isNullish, nonNullish, assertNonNullish } from "@dfinity/utils";
 
   export let testId: string | undefined = undefined;
   export let steps: WizardSteps;
@@ -30,30 +37,92 @@
     set(stepNumber);
   };
 
-  let resolveQrCodePromise: ((value: string | undefined) => void) | undefined =
-    undefined;
+  type QrResult = "success" | "canceled" | "token_incompatible";
 
-  export const scanQrCode = async () => {
+  type QrResponse = {
+    result: QrResult;
+    identifier?: string;
+    token?: string;
+    amount?: number;
+  };
+
+  let resolveQrCodePromise:
+    | (({ result, value }: { result: QrResult; value?: string }) => void)
+    | undefined = undefined;
+
+  const decodeQrCode = ({
+    result,
+    value,
+    requiredToken,
+  }: {
+    result: QrResult;
+    value?: string | undefined;
+    requiredToken?: Token | undefined;
+  }): QrResponse => {
+    if (result !== "success") {
+      return { result };
+    }
+    assertNonNullish(value);
+
+    const payment = decodePayment(value);
+
+    if (isNullish(payment)) {
+      return { result, identifier: value };
+    }
+
+    const { token, identifier, amount } = payment;
+
+    if (
+      nonNullish(requiredToken) &&
+      token.toLowerCase() !== requiredToken.symbol.toLowerCase()
+    ) {
+      toastsError({
+        labelKey: "error.qrcode_token_incompatible",
+      });
+      return { result: "token_incompatible" };
+    }
+
+    return { result, identifier, token, amount };
+  };
+
+  export const scanQrCode = async ({
+    requiredToken,
+  }: {
+    requiredToken: Token;
+  }): Promise<QrResponse> => {
     const prevStep = currentStep;
 
     goStep(STEP_QRCODE);
 
-    return new Promise<string | undefined>((resolve) => {
+    return new Promise<{ result: QrResult; value?: string }>((resolve) => {
       resolveQrCodePromise = resolve;
-    }).finally(() => {
-      // TypeScript can't know that currentStep is defined before scanQrCode
-      // will be called.
-      goStep(prevStep?.name || steps[0].name);
-    });
+    })
+      .then(({ result, value }) => {
+        return decodeQrCode({
+          result,
+          value,
+          requiredToken,
+        });
+      })
+      .finally(() => {
+        // TypeScript can't know that currentStep is defined before scanQrCode
+        // will be called.
+        goStep(prevStep?.name || steps[0].name);
+      });
   };
 
   const onQRCode = ({ detail: value }: CustomEvent<string>) => {
-    resolveQrCodePromise?.(value);
+    resolveQrCodePromise?.({
+      result: "success",
+      value,
+    });
     resolveQrCodePromise = undefined;
   };
 
   const onCancel = () => {
-    resolveQrCodePromise?.(undefined);
+    resolveQrCodePromise?.({
+      result: "canceled",
+    });
     resolveQrCodePromise = undefined;
   };
 </script>

--- a/frontend/src/lib/modals/transaction/QrWizardModal.svelte
+++ b/frontend/src/lib/modals/transaction/QrWizardModal.svelte
@@ -2,16 +2,16 @@
   import { WizardModal } from "@dfinity/gix-components";
   import type { WizardStep, WizardSteps } from "@dfinity/gix-components";
   import TransactionQRCode from "$lib/components/transaction/TransactionQRCode.svelte";
-  import { isNullish, nonNullish } from "@dfinity/utils";
+  import { nonNullish } from "@dfinity/utils";
 
   export let testId: string | undefined = undefined;
-  export let steps: WizardStep[];
+  export let steps: WizardSteps;
   export let currentStep: WizardStep | undefined = undefined;
   export let disablePointerEvents = false;
 
   const STEP_QRCODE = "QRCode";
 
-  let stepsPlusQr: WizardStep;
+  let stepsPlusQr: WizardSteps;
   $: stepsPlusQr = [
     ...steps,
     {
@@ -39,7 +39,7 @@
     set(stepNumber);
   };
 
-  let resolveQrCodePromise: (value: string | undefined) => void | undefined =
+  let resolveQrCodePromise: ((value: string | undefined) => void) | undefined =
     undefined;
 
   export const scanQrCode = async () => {
@@ -50,7 +50,9 @@
     return new Promise<string | undefined>((resolve) => {
       resolveQrCodePromise = resolve;
     }).finally(() => {
-      setStepName(prevStep.name);
+      // TypeScript can't know that currentStep is defined before scanQrCode
+      // will be called.
+      setStepName(prevStep?.name || steps[0].name);
     });
   };
 

--- a/frontend/src/lib/modals/transaction/QrWizardModal.svelte
+++ b/frontend/src/lib/modals/transaction/QrWizardModal.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import { WizardModal } from "@dfinity/gix-components";
+  import type { WizardStep, WizardSteps } from "@dfinity/gix-components";
+  import TransactionQRCode from "$lib/components/transaction/TransactionQRCode.svelte";
+  import { isNullish, nonNullish } from "@dfinity/utils";
+
+  export let testId: string | undefined = undefined;
+  export let steps: WizardStep[];
+  export let currentStep: WizardStep | undefined = undefined;
+  export let disablePointerEvents = false;
+
+  const STEP_QRCODE = "QRCode";
+
+  let stepsPlusQr: WizardStep;
+  $: stepsPlusQr = [
+    ...steps,
+    {
+      name: STEP_QRCODE,
+      title: "",
+    },
+  ];
+
+  let modal: WizardModal;
+
+  export const next = () => {
+    modal.next();
+  };
+
+  export const back = () => {
+    modal.back();
+  };
+
+  export const set = (step: number) => {
+    modal.set(step);
+  };
+
+  const setStepName = (stepName: string) => {
+    const stepNumber = stepsPlusQr.findIndex(({ name }) => name === stepName);
+    set(stepNumber);
+  };
+
+  let resolveQrCodePromise: (value: string | undefined) => void | undefined =
+    undefined;
+
+  export const scanQrCode = async () => {
+    const prevStep = currentStep;
+
+    setStepName(STEP_QRCODE);
+
+    return new Promise<string | undefined>((resolve) => {
+      resolveQrCodePromise = resolve;
+    }).finally(() => {
+      setStepName(prevStep.name);
+    });
+  };
+
+  const onQRCode = ({ detail: value }: CustomEvent<string>) => {
+    resolveQrCodePromise?.(value);
+  };
+
+  const onCancel = () => {
+    resolveQrCodePromise?.(undefined);
+  };
+</script>
+
+{#if nonNullish(stepsPlusQr)}
+  <WizardModal
+    {testId}
+    steps={stepsPlusQr}
+    bind:currentStep
+    bind:this={modal}
+    on:nnsClose
+    {disablePointerEvents}
+  >
+    <slot name="title" slot="title" />
+    <slot />
+    {#if currentStep?.name === STEP_QRCODE}
+      <TransactionQRCode on:nnsCancel={onCancel} on:nnsQRCode={onQRCode} />
+    {/if}
+  </WizardModal>
+{/if}

--- a/frontend/src/lib/modals/transaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/transaction/TransactionModal.svelte
@@ -75,7 +75,8 @@
     },
   ];
 
-  let modal: QrWizardModal;
+  let modal: WizardModal;
+  let scanQrCode: () => Promise<string>;
 
   const goNext = () => {
     modal.next();
@@ -89,7 +90,7 @@
 
   export const goProgress = () => goStep(STEP_PROGRESS);
   const goQRCode = async () => {
-    const value = await modal.scanQrCode();
+    const value = await scanQrCode();
     if (nonNullish(value)) {
       onQRCode(value);
     }
@@ -129,7 +130,8 @@
   {testId}
   {steps}
   bind:currentStep
-  bind:this={modal}
+  bind:modal
+  bind:scanQrCode
   on:nnsClose
   disablePointerEvents={currentStep?.name === STEP_PROGRESS}
 >

--- a/frontend/src/lib/modals/transaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/transaction/TransactionModal.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import QrWizardModal from "./QrWizardModal.svelte";
-  import { WizardModal } from "@dfinity/gix-components";
   import type { WizardStep, WizardSteps } from "@dfinity/gix-components";
   import type { Account } from "$lib/types/account";
   import TransactionForm from "$lib/components/transaction/TransactionForm.svelte";
@@ -12,7 +11,6 @@
     TransactionNetwork,
     ValidateAmountFn,
   } from "$lib/types/transaction";
-  import TransactionQRCode from "$lib/components/transaction/TransactionQRCode.svelte";
   import { isNullish, nonNullish } from "@dfinity/utils";
   import TransactionReceivedAmount from "$lib/components/transaction/TransactionReceivedAmount.svelte";
   import type { TransactionSelectDestinationMethods } from "$lib/types/transaction";
@@ -61,7 +59,6 @@
   // Wizard modal steps and navigation
   const STEP_FORM = "Form";
   const STEP_PROGRESS = "Progress";
-  const STEP_QRCODE = "QRCode";
 
   const steps: WizardSteps = [
     {

--- a/frontend/src/lib/modals/transaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/transaction/TransactionModal.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import QrWizardModal from "./QrWizardModal.svelte";
-  import type { WizardStep, WizardSteps } from "@dfinity/gix-components";
+  import type {
+    WizardModal,
+    WizardStep,
+    WizardSteps,
+  } from "@dfinity/gix-components";
   import type { Account } from "$lib/types/account";
   import TransactionForm from "$lib/components/transaction/TransactionForm.svelte";
   import TransactionReview from "$lib/components/transaction/TransactionReview.svelte";

--- a/frontend/src/lib/modals/transaction/TransactionModal.svelte
+++ b/frontend/src/lib/modals/transaction/TransactionModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import QrWizardModal from "./QrWizardModal.svelte";
+  import type { QrResponse } from "$lib/types/qr-wizard-modal";
   import type {
     WizardModal,
     WizardStep,
@@ -78,12 +79,11 @@
   ];
 
   let modal: WizardModal;
-  let scanQrCode: ({ requiredToken }: { requiredToken: Token }) => Promise<{
-    result: "success" | "canceled" | "token_incompatible";
-    identifier?: string;
-    token?: string;
-    amount?: number;
-  }>;
+  let scanQrCode: ({
+    requiredToken,
+  }: {
+    requiredToken: Token;
+  }) => Promise<QrResponse>;
 
   const goNext = () => {
     modal.next();
@@ -110,11 +110,11 @@
       return;
     }
 
+    selectedDestinationAddress = identifier;
+
     if (nonNullish(paymentAmount)) {
       amount = paymentAmount;
     }
-
-    selectedDestinationAddress = identifier;
   };
 </script>
 

--- a/frontend/src/lib/types/qr-wizard-modal.ts
+++ b/frontend/src/lib/types/qr-wizard-modal.ts
@@ -1,0 +1,8 @@
+export type QrResult = "success" | "canceled" | "token_incompatible";
+
+export type QrResponse = {
+  result: QrResult;
+  identifier?: string;
+  token?: string;
+  amount?: number;
+};

--- a/frontend/src/tests/lib/modals/transaction/QrWizardModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/QrWizardModal.spec.ts
@@ -16,11 +16,11 @@ describe("QrWizardModal", () => {
   };
 
   const goToNextStep = (component) => {
-    return component.$$.ctx[component.$$.props["next"]]();
+    return component.$$.ctx[component.$$.props["modal"]].next();
   };
 
   const goToPreviousStep = (component) => {
-    return component.$$.ctx[component.$$.props["back"]]();
+    return component.$$.ctx[component.$$.props["modal"]].back();
   };
 
   it("moves to QRCode step when scanQrCode is called", async () => {

--- a/frontend/src/tests/lib/modals/transaction/QrWizardModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/QrWizardModal.spec.ts
@@ -4,6 +4,7 @@
 
 import QrWizardModal from "$lib/modals/transaction/QrWizardModal.svelte";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { ICPToken } from "@dfinity/utils";
 import { fireEvent, render } from "@testing-library/svelte";
 
 describe("QrWizardModal", () => {
@@ -12,7 +13,9 @@ describe("QrWizardModal", () => {
   };
 
   const scanQrCode = (component) => {
-    return component.$$.ctx[component.$$.props["scanQrCode"]]();
+    return component.$$.ctx[component.$$.props["scanQrCode"]]({
+      requiredToken: ICPToken,
+    });
   };
 
   const goToNextStep = (component) => {
@@ -41,7 +44,7 @@ describe("QrWizardModal", () => {
     expect(getCurrentStep(component).name).toEqual("QRCode");
   });
 
-  it("resolves scanQrCode() to undefined when canceled", async () => {
+  it("resolves scanQrCode() to 'canceled' when canceled", async () => {
     const steps = [
       {
         title: "Step 1",
@@ -67,7 +70,7 @@ describe("QrWizardModal", () => {
     await runResolvedPromises();
 
     expect(qrPromiseResolved).toBeCalled();
-    expect(await qrPromise).toBeUndefined();
+    expect(await qrPromise).toEqual({ result: "canceled" });
   });
 
   it("can go to next step and back", async () => {

--- a/frontend/src/tests/lib/modals/transaction/QrWizardModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/QrWizardModal.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import QrWizardModal from "$lib/modals/transaction/QrWizardModal.svelte";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { fireEvent, render } from "@testing-library/svelte";
+
+describe("QrWizardModal", () => {
+  const getCurrentStep = (component) => {
+    return component.$$.ctx[component.$$.props["currentStep"]];
+  };
+
+  const scanQrCode = (component) => {
+    return component.$$.ctx[component.$$.props["scanQrCode"]]();
+  };
+
+  const goToNextStep = (component) => {
+    return component.$$.ctx[component.$$.props["next"]]();
+  };
+
+  const goToPreviousStep = (component) => {
+    return component.$$.ctx[component.$$.props["back"]]();
+  };
+
+  it("moves to QRCode step when scanQrCode is called", async () => {
+    const steps = [
+      {
+        title: "Step 1",
+        name: "step1",
+      },
+    ];
+
+    const { component } = render(QrWizardModal, { steps });
+
+    expect(getCurrentStep(component).name).toEqual("step1");
+
+    scanQrCode(component);
+    await runResolvedPromises();
+
+    expect(getCurrentStep(component).name).toEqual("QRCode");
+  });
+
+  it("resolves scanQrCode() to undefined when canceled", async () => {
+    const steps = [
+      {
+        title: "Step 1",
+        name: "step1",
+      },
+    ];
+
+    const { getByTestId, component } = render(QrWizardModal, { steps });
+
+    const qrPromise = scanQrCode(component);
+    const qrPromiseResolved = jest.fn();
+    qrPromise.then(qrPromiseResolved);
+
+    await runResolvedPromises();
+
+    expect(getCurrentStep(component).name).toEqual("QRCode");
+
+    const cancelButton = getByTestId("transaction-qrcode-button-cancel");
+    expect(cancelButton).toBeInTheDocument();
+
+    expect(qrPromiseResolved).not.toBeCalled();
+    fireEvent.click(cancelButton);
+    await runResolvedPromises();
+
+    expect(qrPromiseResolved).toBeCalled();
+    expect(await qrPromise).toBeUndefined();
+  });
+
+  it("can go to next step and back", async () => {
+    const steps = [
+      {
+        title: "Step 1",
+        name: "step1",
+      },
+      {
+        title: "Step 2",
+        name: "step2",
+      },
+    ];
+
+    const { component } = render(QrWizardModal, { steps });
+
+    expect(getCurrentStep(component).name).toEqual("step1");
+
+    goToNextStep(component);
+    await runResolvedPromises();
+    expect(getCurrentStep(component).name).toEqual("step2");
+
+    goToPreviousStep(component);
+    await runResolvedPromises();
+    expect(getCurrentStep(component).name).toEqual("step1");
+  });
+
+  it("scanQrCode returns to original step when canceled", async () => {
+    const steps = [
+      {
+        title: "Step 1",
+        name: "step1",
+      },
+      {
+        title: "Step 2",
+        name: "step2",
+      },
+      {
+        title: "Step 3",
+        name: "step3",
+      },
+    ];
+
+    const { getByTestId, component } = render(QrWizardModal, { steps });
+
+    expect(getCurrentStep(component).name).toEqual("step1");
+
+    goToNextStep(component);
+    await runResolvedPromises();
+    expect(getCurrentStep(component).name).toEqual("step2");
+
+    scanQrCode(component);
+    await runResolvedPromises();
+
+    expect(getCurrentStep(component).name).toEqual("QRCode");
+
+    const cancelButton = getByTestId("transaction-qrcode-button-cancel");
+    fireEvent.click(cancelButton);
+    await runResolvedPromises();
+
+    expect(getCurrentStep(component).name).toEqual("step2");
+  });
+});


### PR DESCRIPTION
# Motivation

Using the QR code scanner requires adding an extra step to a `WizardModal` and switching back and forth between them.
This is currently done in `TransactionModal`.
I want to reuse the QR code scanner in the `DisburseNnsNeuronModal` so I want to streamline its usage.

# Changes

1. Add `QrWizardModal` which manages going to and from the QR Code step.
2. Use `QrWizardModal` in `TransactionModal`.
3. Tests for `QrWizardModal`.

# Tests

Tested manually on local that scanning a QR code when making a transaction still works.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary for a small refactoring