### PR TITLE
GIX-1823: Remove setSnsProjects from SnsProposals.spec

### DIFF
--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -16,12 +16,10 @@ import {
 } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
-import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { AnonymousIdentity } from "@dfinity/agent";
 import {
   SnsProposalDecisionStatus,
   SnsProposalRewardStatus,
-  SnsSwapLifecycle,
   type SnsProposalData,
 } from "@dfinity/sns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
@@ -45,12 +43,6 @@ describe("SnsProposals", () => {
     snsProposalsStore.reset();
     snsFunctionsStore.reset();
     snsFiltersStore.reset();
-    setSnsProjects([
-      {
-        rootCanisterId,
-        lifecycle: SnsSwapLifecycle.Committed,
-      },
-    ]);
     // Reset to default value
     page.mock({ data: { universe: rootCanisterId.toText() } });
   });


### PR DESCRIPTION
# Motivation

SnsProposals.spec doesn't depend on setting SNS projects. Therefore, setting it was unnecessary.

# Changes

* Remove `setSnsProjects` call from `SnsProposals.spec`

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary
