### PR TITLE
GIX-1841: SNS Project "finalizing" status

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -46,6 +46,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 * `--import-from-index-html` flag on `scripts/canister_ids` to get canister IDs from an existing (testnet) release.
 * A dictionary for spell-checking.
+* New "finalizing" status in SNS project detail page.
 
 #### Changed
 - Use the upstream notification action directly, rather than using a local copy.

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -704,6 +704,7 @@
     "status_aborted": "Aborted",
     "status_pending": "Upcoming swap",
     "status_unspecified": "Unspecified",
+    "status_finalizing": "Finalizing",
     "participate_swap_description": "Participate in decentralization swap",
     "understand_agree": "I understand that I cannot withdraw or edit my commitment after I select \"Send Now,\" and that my commitment may be returned to my main ICP account if the swap is unsuccessful for any reason.",
     "participate_success": "Your participation has been successfully committed.",

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -42,6 +42,7 @@
   import { userCountryIsNeeded } from "$lib/utils/projects.utils";
   import { loadUserCountry } from "$lib/services/user-country.services";
   import { hasBuyersCount } from "$lib/utils/sns-swap.utils";
+  import { loadSnsFinalizationStatus } from "$lib/services/sns-finalization.services";
 
   export let rootCanisterId: string | undefined | null;
 
@@ -76,6 +77,7 @@
         },
         forceFetch: true,
       }),
+      loadSnsFinalizationStatus(Principal.fromText(rootCanisterId)),
     ]);
   };
 
@@ -165,6 +167,13 @@
   });
   $: if (shouldLoadUserCountry) {
     loadUserCountry();
+  }
+
+  $: if (
+    nonNullish(rootCanisterId) &&
+    $projectDetailStore.summary?.swap.lifecycle === SnsSwapLifecycle.Committed
+  ) {
+    loadSnsFinalizationStatus(Principal.fromText(rootCanisterId));
   }
 
   let derivedStateHasBuyersCount: boolean | undefined;

--- a/frontend/src/lib/services/sns-finalization.services.ts
+++ b/frontend/src/lib/services/sns-finalization.services.ts
@@ -1,0 +1,39 @@
+import { queryFinalizationStatus } from "$lib/api/sns-sale.api";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
+import { getOrCreateSnsFinalizationStatusStore } from "$lib/stores/sns-finalization-status.store";
+import type { Principal } from "@dfinity/principal";
+import type { SnsGetAutoFinalizationStatusResponse } from "@dfinity/sns";
+import { nonNullish } from "@dfinity/utils";
+import { queryAndUpdate } from "./utils.services";
+
+export const loadSnsFinalizationStatus = async (rootCanisterId: Principal) => {
+  await queryAndUpdate<
+    SnsGetAutoFinalizationStatusResponse | undefined,
+    unknown
+  >({
+    strategy: FORCE_CALL_STRATEGY,
+    identityType: "anonymous",
+    request: ({ certified, identity }) =>
+      queryFinalizationStatus({
+        rootCanisterId,
+        identity,
+        certified,
+      }),
+    onLoad: ({ response, certified }) => {
+      // If the response is `undefined`, it means the method is not supported.
+      // In that case, there is no need to update the store.
+      if (nonNullish(response)) {
+        const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+        store.setData({
+          data: response,
+          certified,
+        });
+      }
+    },
+    onError: ({ error: err }) => {
+      // Ignore the error. This is a bonus feature. If it fails, the UX isn't affected.
+      console.error(err);
+    },
+    logMessage: "Querying SNS finalization status",
+  });
+};

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -729,6 +729,7 @@ interface I18nSns_project_detail {
   status_aborted: string;
   status_pending: string;
   status_unspecified: string;
+  status_finalizing: string;
   participate_swap_description: string;
   understand_agree: string;
   participate_success: string;

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -300,10 +300,9 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
       it("should query finalization status and load it in store", async () => {
         render(ProjectDetail, props);
 
-        await waitFor(() => {
-          const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
-          expect(get(store).data).toEqual(snsFinalizationStatusResponseMock);
-        });
+        await runResolvedPromises();
+        const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+        expect(get(store)?.data).toEqual(snsFinalizationStatusResponseMock);
       });
     });
   });

--- a/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as saleApi from "$lib/api/sns-sale.api";
+import { loadSnsFinalizationStatus } from "$lib/services/sns-finalization.services";
+import {
+  getOrCreateSnsFinalizationStatusStore,
+  resetSnsFinalizationStatusStore,
+} from "$lib/stores/sns-finalization-status.store";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { snsFinalizationStatusResponseMock } from "$tests/mocks/sns-finalization-status.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { get } from "svelte/store";
+
+describe("sns-finalization-services", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
+
+  describe("loadSnsFinalizationStatus", () => {
+    const rootCanisterId = principal(0);
+    afterEach(() => {
+      jest.clearAllMocks();
+      resetSnsFinalizationStatusStore();
+    });
+
+    it("should call api.queryFinalizationStatus and load finalization status in store", async () => {
+      const spyQuery = jest
+        .spyOn(saleApi, "queryFinalizationStatus")
+        .mockResolvedValue(snsFinalizationStatusResponseMock);
+
+      await loadSnsFinalizationStatus(rootCanisterId);
+
+      const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+      expect(get(store).data).toEqual(snsFinalizationStatusResponseMock);
+      expect(spyQuery).toBeCalled();
+    });
+
+    it("should call api.queryFinalizationStatus but not load finalization status in store if response is `undefined`", async () => {
+      const spyQuery = jest
+        .spyOn(saleApi, "queryFinalizationStatus")
+        .mockResolvedValue(undefined);
+
+      await loadSnsFinalizationStatus(rootCanisterId);
+
+      const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+      expect(get(store)).toBeUndefined();
+      expect(spyQuery).toBeCalled();
+    });
+  });
+});

--- a/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
@@ -33,7 +33,10 @@ describe("sns-finalization-services", () => {
       await loadSnsFinalizationStatus(rootCanisterId);
 
       const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
-      expect(get(store).data).toEqual(snsFinalizationStatusResponseMock);
+      expect(get(store)).toEqual({
+        data: snsFinalizationStatusResponseMock,
+        certified: false,
+      });
       expect(spyQuery).toBeCalled();
     });
 


### PR DESCRIPTION
# Motivation

Sns projects perform a finalization process after the swap finishes. This process might take a few hours. During this time, the users don't get the neurons yet, even though the project has finished.

To improve the UX, we want to show a different status in the project detail page during this process takes place.

In this PR, the finalization information is loaded when a user visits the project detail page and also after participation.

# Changes

* Use new store `isFinalizingStore` in ProjectStatus.svelte to show the new status or the lifecycle status.
* New service `loadSnsFinalizationStatus` to fetch and load the finalization in a store.
* Use the new service `loadSnsFinalizationStatus` in ProjectDetai page when the project is committed.

# Tests

* Test new functionality in ProjectStatus
* Test that finalization status is shown after participation in ProjectDetail.spec
* Test new service `loadSnsFinalizationStatus`.

# Todos

- [x] Add entry to changelog (if necessary).
