### PR TITLE
GIX-1760: Fix spacings nns neuron detail

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.svelte
@@ -15,7 +15,6 @@
   import FollowNeuronsButton from "../actions/FollowNeuronsButton.svelte";
   import Followee from "./Followee.svelte";
   import { KeyValuePairInfo } from "@dfinity/gix-components";
-  import Separator from "$lib/components/ui/Separator.svelte";
 
   export let neuron: NeuronInfo;
   let isControllable: boolean;
@@ -35,7 +34,7 @@
   onMount(listKnownNeurons);
 </script>
 
-<CardInfo>
+<CardInfo noMargin>
   <KeyValuePairInfo testId="neuron-following">
     <h3 slot="key">{$i18n.neuron_detail.following_title}</h3>
     <svelte:fragment slot="info"
@@ -57,8 +56,6 @@
     {/if}
   </div>
 </CardInfo>
-
-<Separator />
 
 <style lang="scss">
   h3 {

--- a/frontend/src/lib/components/neuron-detail/NeuronProposalsCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronProposalsCard.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import CardInfo from "$lib/components/ui/CardInfo.svelte";
   import { Spinner } from "@dfinity/gix-components";
-  import Separator from "$lib/components/ui/Separator.svelte";
 
   export let loading = false;
 </script>
 
 <!-- ONLY FOR TESTNET. NO UNIT TESTS -->
-<CardInfo>
+<CardInfo noMargin>
   <h3 slot="start">Proposals TESTNET ONLY</h3>
 
   <div>
@@ -25,8 +24,6 @@
     </button>
   </div>
 </CardInfo>
-
-<Separator />
 
 <style lang="scss">
   h3 {

--- a/frontend/src/lib/components/neuron-detail/NeuronVotingHistoryCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronVotingHistoryCard.svelte
@@ -7,7 +7,7 @@
   export let neuron: NeuronInfo;
 </script>
 
-<CardInfo>
+<CardInfo noMargin>
   <h3>{$i18n.neuron_detail.voting_history}</h3>
   <Ballots {neuron} />
 </CardInfo>

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronHotkeysCard.svelte
@@ -13,7 +13,6 @@
   import CardInfo from "$lib/components/ui/CardInfo.svelte";
   import AddHotkeyButton from "./actions/AddHotkeyButton.svelte";
   import { goto } from "$app/navigation";
-  import Separator from "$lib/components/ui/Separator.svelte";
   import ConfirmRemoveCurrentUserHotkey from "$lib/modals/neurons/ConfirmRemoveCurrentUserHotkey.svelte";
 
   export let neuron: NeuronInfo;
@@ -65,7 +64,7 @@
   };
 </script>
 
-<CardInfo>
+<CardInfo noMargin>
   <h3 slot="start">{$i18n.neuron_detail.hotkeys_title}</h3>
   {#if hotkeys.length === 0}
     <p>{$i18n.neuron_detail.no_notkeys}</p>
@@ -92,8 +91,6 @@
     </div>
   {/if}
 </CardInfo>
-
-<Separator />
 
 {#if showConfirmationHotkey !== undefined}
   <!-- The extra const is required for TS to understand that showConfirmationHotkey is a string, not undefined -->

--- a/frontend/src/lib/components/ui/CardInfo.svelte
+++ b/frontend/src/lib/components/ui/CardInfo.svelte
@@ -3,12 +3,13 @@
 
   // Same data-tid as <Card /> for backwards compatibility with existing jest test
   export let testId = "card";
+  export let noMargin = false;
 
   let showHeadline: boolean;
   $: showHeadline = $$slots.start !== undefined || $$slots.end !== undefined;
 </script>
 
-<article data-tid={testId}>
+<article data-tid={testId} class:noMargin>
   {#if showHeadline}
     <ColumnRow>
       <slot name="start" slot="start" />
@@ -29,5 +30,10 @@
     outline: 2px solid transparent;
 
     box-shadow: none;
+
+    &.noMargin {
+      margin: 0;
+      padding: 0;
+    }
   }
 </style>

--- a/frontend/src/lib/components/ui/SkeletonCard.svelte
+++ b/frontend/src/lib/components/ui/SkeletonCard.svelte
@@ -2,43 +2,38 @@
   import { Card } from "@dfinity/gix-components";
   import CardInfo from "./CardInfo.svelte";
   import { SkeletonText } from "@dfinity/gix-components";
-  import type { SvelteComponent } from "svelte";
   import type { CardType } from "$lib/types/card";
   import Separator from "$lib/components/ui/Separator.svelte";
+  import SkeletonCardContent from "./SkeletonCardContent.svelte";
 
   export let size: "small" | "medium" | "large" = "small";
   export let cardType: CardType = "card";
   export let separator = false;
   export let noMargin = false;
-
-  const cards: Record<CardType, typeof SvelteComponent> = {
-    card: Card,
-    info: CardInfo,
-  };
 </script>
 
-<svelte:component this={cards[cardType]} testId="skeleton-card" {noMargin}>
-  <div class="small" slot="start">
-    <SkeletonText />
-  </div>
-  <div class="small" slot="end">
-    <SkeletonText />
-  </div>
-  <div class="content">
-    <SkeletonText />
-    <SkeletonText />
-
-    {#if ["large", "medium"].includes(size)}
+<!-- We need to explictly use the `Card` or `CardInfo` because props are different -->
+{#if cardType === "info"}
+  <CardInfo {noMargin} testId="skeleton-card">
+    <div class="small" slot="start">
       <SkeletonText />
+    </div>
+    <div class="small" slot="end">
       <SkeletonText />
-    {/if}
-
-    {#if size === "large"}
+    </div>
+    <SkeletonCardContent {size} />
+  </CardInfo>
+{:else}
+  <Card testId="skeleton-card">
+    <div class="small" slot="start">
       <SkeletonText />
+    </div>
+    <div class="small" slot="end">
       <SkeletonText />
-    {/if}
-  </div>
-</svelte:component>
+    </div>
+    <SkeletonCardContent {size} />
+  </Card>
+{/if}
 
 {#if separator}
   <Separator />
@@ -47,11 +42,5 @@
 <style lang="scss">
   .small {
     width: 20%;
-  }
-
-  .content {
-    display: flex;
-    flex-direction: column;
-    gap: var(--padding_2x);
   }
 </style>

--- a/frontend/src/lib/components/ui/SkeletonCard.svelte
+++ b/frontend/src/lib/components/ui/SkeletonCard.svelte
@@ -9,6 +9,7 @@
   export let size: "small" | "medium" | "large" = "small";
   export let cardType: CardType = "card";
   export let separator = false;
+  export let noMargin = false;
 
   const cards: Record<CardType, typeof SvelteComponent> = {
     card: Card,
@@ -16,7 +17,7 @@
   };
 </script>
 
-<svelte:component this={cards[cardType]} testId="skeleton-card">
+<svelte:component this={cards[cardType]} testId="skeleton-card" {noMargin}>
   <div class="small" slot="start">
     <SkeletonText />
   </div>

--- a/frontend/src/lib/components/ui/SkeletonCardContent.svelte
+++ b/frontend/src/lib/components/ui/SkeletonCardContent.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { SkeletonText } from "@dfinity/gix-components";
+
+  export let size: "small" | "medium" | "large" = "small";
+</script>
+
+<div class="content">
+  <SkeletonText />
+  <SkeletonText />
+
+  {#if ["large", "medium"].includes(size)}
+    <SkeletonText />
+    <SkeletonText />
+  {/if}
+
+  {#if size === "large"}
+    <SkeletonText />
+    <SkeletonText />
+  {/if}
+</div>
+
+<style lang="scss">
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding_2x);
+  }
+</style>

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -153,15 +153,16 @@
             <Separator spacing="none" />
             <NnsNeuronAdvancedSection {neuron} />
             <Separator spacing="none" />
+            <NeuronFollowingCard {neuron} />
+            <Separator spacing="none" />
+            <NnsNeuronHotkeysCard {neuron} />
+            <Separator spacing="none" />
+            {#if IS_TESTNET}
+              <NnsNeuronProposalsCard {neuron} />
+              <Separator spacing="none" />
+            {/if}
+            <NeuronVotingHistoryCard {neuron} />
           </div>
-          <NeuronFollowingCard {neuron} />
-
-          {#if IS_TESTNET}
-            <NnsNeuronProposalsCard {neuron} />
-          {/if}
-
-          <NnsNeuronHotkeysCard {neuron} />
-          <NeuronVotingHistoryCard {neuron} />
         {:else}
           <SkeletonCard size="large" cardType="info" separator />
           <SkeletonCard cardType="info" separator />

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -143,31 +143,32 @@
     <main class="legacy">
       <section data-tid="neuron-detail">
         {#if neuron && !inVotingProcess}
-          <div class="section-wrapper">
-            <NnsNeuronPageHeader {neuron} />
-            <NnsNeuronPageHeading {neuron} />
+          <NnsNeuronPageHeader {neuron} />
+          <NnsNeuronPageHeading {neuron} />
+          <Separator spacing="none" />
+          <NnsNeuronVotingPowerSection {neuron} />
+          <Separator spacing="none" />
+          <NnsNeuronMaturitySection {neuron} />
+          <Separator spacing="none" />
+          <NnsNeuronAdvancedSection {neuron} />
+          <Separator spacing="none" />
+          <NeuronFollowingCard {neuron} />
+          <Separator spacing="none" />
+          <NnsNeuronHotkeysCard {neuron} />
+          <Separator spacing="none" />
+          {#if IS_TESTNET}
+            <NnsNeuronProposalsCard {neuron} />
             <Separator spacing="none" />
-            <NnsNeuronVotingPowerSection {neuron} />
-            <Separator spacing="none" />
-            <NnsNeuronMaturitySection {neuron} />
-            <Separator spacing="none" />
-            <NnsNeuronAdvancedSection {neuron} />
-            <Separator spacing="none" />
-            <NeuronFollowingCard {neuron} />
-            <Separator spacing="none" />
-            <NnsNeuronHotkeysCard {neuron} />
-            <Separator spacing="none" />
-            {#if IS_TESTNET}
-              <NnsNeuronProposalsCard {neuron} />
-              <Separator spacing="none" />
-            {/if}
-            <NeuronVotingHistoryCard {neuron} />
-          </div>
+          {/if}
+          <NeuronVotingHistoryCard {neuron} />
         {:else}
-          <SkeletonCard size="large" cardType="info" separator />
-          <SkeletonCard cardType="info" separator />
-          <SkeletonCard cardType="info" separator />
-          <SkeletonCard cardType="info" separator />
+          <SkeletonCard noMargin size="large" cardType="info" />
+          <Separator spacing="none" />
+          <SkeletonCard noMargin cardType="info" />
+          <Separator spacing="none" />
+          <SkeletonCard noMargin cardType="info" />
+          <Separator spacing="none" />
+          <SkeletonCard noMargin cardType="info" />
         {/if}
       </section>
     </main>
@@ -177,7 +178,7 @@
 </TestIdWrapper>
 
 <style lang="scss">
-  .section-wrapper {
+  section {
     display: flex;
     flex-direction: column;
     gap: var(--padding-4x);


### PR DESCRIPTION
# Motivation

The different sections of NnsNeuronDetails page had the vertical spacing set in different places. This made it easy to have a different spacing between them.

In this PR, all the spacing is set in the parent and the children have no vertical spacing.

# Changes

* Add `noMargin` prop to CardInfo.
* Add `noMargin` prop to SkeletonCard.
* All sections and separators in NnsNeuronDetails are siblings in the html. Just like it looks like in the UI.
* Use the `noMargin` prop and remove the separator in NeuronFollowingCard, NeuronProposalsCard, NeuronVotingHistoryCard and NnsNeuronHotkeysCard.
* Moved the testnet only MakeProposalsCard above the NeuronVotingHistoryCard to have the beginning like the mainnet. I didn't move it below NeuronVotingHistoryCard because this one has an infinite scroll.

# Tests

Only CSS changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary. No UI nor UX change.