### PR TITLE
GIX-1761: Align spacings sns neuron detail

### DIFF
--- a/frontend/src/lib/components/neuron-detail/SnsPermissionsCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/SnsPermissionsCard.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import CardInfo from "../ui/CardInfo.svelte";
-  import Separator from "../ui/Separator.svelte";
   import { openSnsNeuronModal } from "$lib/utils/modals.utils";
   import { SnsNeuronPermissionType, type SnsNeuron } from "@dfinity/sns";
   import TagsList from "../ui/TagsList.svelte";

--- a/frontend/src/lib/components/neuron-detail/SnsPermissionsCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/SnsPermissionsCard.svelte
@@ -26,7 +26,7 @@
 </script>
 
 <!-- ONLY FOR TESTNET. NO UNIT TESTS -->
-<CardInfo>
+<CardInfo noMargin>
   <h3 slot="start">Permissions TESTNET ONLY</h3>
 
   {#each neuron?.permissions || [] as permission}
@@ -53,8 +53,6 @@
     >
   </div>
 </CardInfo>
-
-<Separator />
 
 <style lang="scss">
   h3 {

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
@@ -18,7 +18,6 @@
   import { getContext } from "svelte";
   import CardInfo from "$lib/components/ui/CardInfo.svelte";
   import FollowSnsNeuronsButton from "./actions/FollowSnsNeuronsButton.svelte";
-  import Separator from "$lib/components/ui/Separator.svelte";
   import SnsFollowee from "./SnsFollowee.svelte";
   import SkeletonFollowees from "../ui/SkeletonFollowees.svelte";
   import {

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
@@ -71,7 +71,7 @@
     isNullish($nsFunctions);
 </script>
 
-<CardInfo testId="sns-neuron-following-card-component">
+<CardInfo noMargin testId="sns-neuron-following-card-component">
   <KeyValuePairInfo testId="sns-neuron-following">
     <h3 slot="key">{$i18n.neuron_detail.following_title}</h3>
     <svelte:fragment slot="info"
@@ -100,8 +100,6 @@
     </div>
   {/if}
 </CardInfo>
-
-<Separator />
 
 <style lang="scss">
   h3 {

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -107,7 +107,7 @@
 
 <TestIdWrapper testId="sns-neuron-hotkeys-card-component">
   {#if neuron !== undefined && neuron !== null}
-    <CardInfo testId="sns-hotkeys-card">
+    <CardInfo noMargin testId="sns-hotkeys-card">
       <div class="title" slot="start">
         <h3>{$i18n.neuron_detail.hotkeys_title}</h3>
         {#if showTooltip}

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -28,7 +28,7 @@
   import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
   import type { Token } from "@dfinity/utils";
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
-  import { nonNullish } from "@dfinity/utils";
+  import { nonNullish, isNullish } from "@dfinity/utils";
   import { IS_TESTNET } from "$lib/constants/environment.constants";
   import SnsNeuronProposalsCard from "$lib/components/neuron-detail/SnsNeuronProposalsCard.svelte";
   import SnsPermissionsCard from "$lib/components/neuron-detail/SnsPermissionsCard.svelte";
@@ -150,9 +150,9 @@
 
   let loading: boolean;
   $: loading =
-    $selectedSnsNeuronStore.neuron === null ||
-    parameters === undefined ||
-    transactionFee === undefined;
+    isNullish($selectedSnsNeuronStore.neuron) ||
+    isNullish(parameters) ||
+    isNullish(transactionFee);
 </script>
 
 <TestIdWrapper testId="sns-neuron-detail-component">

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -160,45 +160,41 @@
     <main class="legacy">
       <section data-tid="sns-neuron-detail-page">
         {#if loading}
-          <SkeletonCard size="large" cardType="info" separator />
-          <SkeletonCard cardType="info" separator />
-          <SkeletonCard cardType="info" separator />
-          <SkeletonCard cardType="info" separator />
-        {:else}
-          {#if nonNullish(parameters) && nonNullish(token) && nonNullish($selectedSnsNeuronStore.neuron) && nonNullish(transactionFee)}
-            <div class="section-wrapper">
-              <SnsNeuronPageHeader {token} />
-              <SnsNeuronPageHeading
-                {parameters}
-                neuron={$selectedSnsNeuronStore.neuron}
-              />
-              <Separator spacing="none" />
-              <SnsNeuronVotingPowerSection
-                neuron={$selectedSnsNeuronStore.neuron}
-                {parameters}
-                {token}
-              />
-              <Separator spacing="none" />
-              <SnsNeuronMaturitySection
-                neuron={$selectedSnsNeuronStore.neuron}
-              />
-              <Separator spacing="none" />
-              <SnsNeuronAdvancedSection
-                neuron={$selectedSnsNeuronStore.neuron}
-                {governanceCanisterId}
-                {parameters}
-                {token}
-                {transactionFee}
-              />
-              <Separator spacing="none" />
-            </div>
-          {/if}
+          <SkeletonCard noMargin size="large" cardType="info" />
+          <SkeletonCard noMargin cardType="info" separator />
+          <SkeletonCard noMargin cardType="info" separator />
+          <SkeletonCard noMargin cardType="info" separator />
+          <!-- `loading` already checks for all that but TS is not smart enough to understand it -->
+        {:else if nonNullish(parameters) && nonNullish(token) && nonNullish($selectedSnsNeuronStore.neuron) && nonNullish(transactionFee)}
+          <SnsNeuronPageHeader {token} />
+          <SnsNeuronPageHeading
+            {parameters}
+            neuron={$selectedSnsNeuronStore.neuron}
+          />
+          <Separator spacing="none" />
+          <SnsNeuronVotingPowerSection
+            neuron={$selectedSnsNeuronStore.neuron}
+            {parameters}
+            {token}
+          />
+          <Separator spacing="none" />
+          <SnsNeuronMaturitySection neuron={$selectedSnsNeuronStore.neuron} />
+          <Separator spacing="none" />
+          <SnsNeuronAdvancedSection
+            neuron={$selectedSnsNeuronStore.neuron}
+            {governanceCanisterId}
+            {parameters}
+            {token}
+            {transactionFee}
+          />
+          <Separator spacing="none" />
           <SnsNeuronFollowingCard />
-          {#if nonNullish(parameters)}
-            <SnsNeuronHotkeysCard {parameters} />
-          {/if}
+          <Separator spacing="none" />
+          <SnsNeuronHotkeysCard {parameters} />
           {#if IS_TESTNET}
+            <Separator spacing="none" />
             <SnsNeuronProposalsCard />
+            <Separator spacing="none" />
             <SnsPermissionsCard />
           {/if}
         {/if}
@@ -210,7 +206,7 @@
 </TestIdWrapper>
 
 <style lang="scss">
-  .section-wrapper {
+  section {
     display: flex;
     flex-direction: column;
     gap: var(--padding-4x);


### PR DESCRIPTION
# Motivation

The different sections of SnsNeuronDetails page had the vertical spacing set in different places. This made it easy to have a different spacing between them.

In this PR, all the spacing is set in the parent and the children have no vertical spacing.

# Changes

* All sections and separators in SnsNeuronDetails are siblings in the html. Just like it looks like in the UI.
* Use the noMargin prop and remove the separator in SnsNeuronPermissionsCard, SnsNeuronFollowingCard, SnsNeuronHotkeysCard.

# Tests

Only CSS changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
