### PR TITLE
Use page objects in SelectUniverseCard.spec.ts

### DIFF
--- a/frontend/src/lib/components/universe/UniverseAccountsBalance.svelte
+++ b/frontend/src/lib/components/universe/UniverseAccountsBalance.svelte
@@ -22,7 +22,7 @@
       : undefined;
 </script>
 
-<div class="amount">
+<div class="amount" data-tid="universe-accounts-balance-component">
   {#if nonNullish(balance)}
     <AmountDisplay text amount={balance} />
   {:else}

--- a/frontend/src/tests/page-objects/Card.page-object.ts
+++ b/frontend/src/tests/page-objects/Card.page-object.ts
@@ -19,4 +19,16 @@ export class CardPo extends BasePageObject {
   async isDisabled(): Promise<boolean> {
     return this.hasClass("disabled");
   }
+
+  async isFramed(): Promise<boolean> {
+    return this.hasClass("framed");
+  }
+
+  async isTransparent(): Promise<boolean> {
+    return this.hasClass("transparent");
+  }
+
+  async hasIcon(): Promise<boolean> {
+    return this.root.querySelector("svg").isPresent();
+  }
 }

--- a/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
@@ -1,8 +1,14 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { CardPo } from "$tests/page-objects/Card.page-object";
+import { UniverseAccountsBalancePo } from "$tests/page-objects/UniverseAccountsBalance.page-object";
+import { UniverseLogoPo } from "$tests/page-objects/UniverseLogo.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class SelectUniverseCardPo extends BasePageObject {
+export class SelectUniverseCardPo extends CardPo {
   private static readonly TID = "select-universe-card";
+
+  static under(element: PageObjectElement): SelectUniverseCardPo {
+    return new SelectUniverseCardPo(element.byTestId(SelectUniverseCardPo.TID));
+  }
 
   static async allUnder(
     element: PageObjectElement
@@ -27,7 +33,31 @@ export class SelectUniverseCardPo extends BasePageObject {
       .map((el) => new SelectUniverseCardPo(el));
   }
 
+  getUniverseAccountsBalancePo(): UniverseAccountsBalancePo {
+    return UniverseAccountsBalancePo.under(this.root);
+  }
+
+  getUniverseLogoPo(): UniverseLogoPo {
+    return UniverseLogoPo.under(this.root);
+  }
+
   getName(): Promise<string> {
     return this.root.querySelector("span.name").getText();
+  }
+
+  getLogoAltText(): Promise<string> {
+    return this.getUniverseLogoPo().getLogoAltText();
+  }
+
+  getLogoSource(): Promise<string> {
+    return this.getUniverseLogoPo().getLogoSource();
+  }
+
+  getBalance(): Promise<string> {
+    return this.getUniverseAccountsBalancePo().getBalance();
+  }
+
+  hasBalance(): Promise<boolean> {
+    return this.getUniverseAccountsBalancePo().isPresent();
   }
 }

--- a/frontend/src/tests/page-objects/UniverseAccountsBalance.page-object.ts
+++ b/frontend/src/tests/page-objects/UniverseAccountsBalance.page-object.ts
@@ -1,0 +1,25 @@
+import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class UniverseAccountsBalancePo extends BasePageObject {
+  private static readonly TID = "universe-accounts-balance-component";
+
+  static under(element: PageObjectElement): UniverseAccountsBalancePo {
+    return new UniverseAccountsBalancePo(
+      element.byTestId(UniverseAccountsBalancePo.TID)
+    );
+  }
+
+  getAmountDisplayPo(): AmountDisplayPo {
+    return AmountDisplayPo.under(this.root);
+  }
+
+  isLoaded(): Promise<boolean> {
+    return this.getAmountDisplayPo().isPresent();
+  }
+
+  getBalance(): Promise<string> {
+    return this.getAmountDisplayPo().getAmount();
+  }
+}

--- a/frontend/src/tests/page-objects/UniverseLogo.page-object.ts
+++ b/frontend/src/tests/page-objects/UniverseLogo.page-object.ts
@@ -1,0 +1,18 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class UniverseLogoPo extends BasePageObject {
+  private static readonly TID = "project-logo";
+
+  static under(element: PageObjectElement): UniverseLogoPo {
+    return new UniverseLogoPo(element.byTestId(UniverseLogoPo.TID));
+  }
+
+  getLogoAltText(): Promise<string> {
+    return this.root.byTestId("logo").getAttribute("alt");
+  }
+
+  getLogoSource(): Promise<string> {
+    return this.root.byTestId("logo").getAttribute("src");
+  }
+}


### PR DESCRIPTION
# Motivation

It's easier to modify the test when it uses page objects.
I want to modify the test in another PR in order to show the universe selector, but without balances, even when the user is not logged in.

# Changes

1. Add required functionality to page objects.
2. Add required `data-tid` to `frontend/src/lib/components/universe/UniverseAccountsBalance.svelte`.
3. Use page objects in `frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts`
4. Use real `icpAccountsStore` instead of mocking it.
5. Set and expect explicit values for the balances.

# Tests

yes

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary