### PR TITLE
Use page objects in SelectUniverseDropdown.spec.ts

### DIFF
--- a/frontend/src/lib/components/universe/SelectUniverseDropdown.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseDropdown.svelte
@@ -2,6 +2,7 @@
   import { BREAKPOINT_LARGE } from "@dfinity/gix-components";
   import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
   import SelectUniverseCard from "$lib/components/universe/SelectUniverseCard.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import SelectUniverseModal from "$lib/modals/universe/SelectUniverseModal.svelte";
 
   let showProjectPicker = false;
@@ -20,13 +21,15 @@
 
 <svelte:window bind:innerWidth />
 
-<SelectUniverseCard
-  universe={$selectedUniverseStore}
-  selected={true}
-  role="dropdown"
-  on:click={() => (showProjectPicker = true)}
-/>
+<TestIdWrapper testId="select-universe-dropdown-component">
+  <SelectUniverseCard
+    universe={$selectedUniverseStore}
+    selected={true}
+    role="dropdown"
+    on:click={() => (showProjectPicker = true)}
+  />
 
-{#if showProjectPicker}
-  <SelectUniverseModal on:nnsClose={() => (showProjectPicker = false)} />
-{/if}
+  {#if showProjectPicker}
+    <SelectUniverseModal on:nnsClose={() => (showProjectPicker = false)} />
+  {/if}
+</TestIdWrapper>

--- a/frontend/src/tests/lib/components/universe/SelectUniverseDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseDropdown.spec.ts
@@ -8,7 +8,6 @@ import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.d
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
-import { formatToken } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
 import { mockStoreSubscribe } from "$tests/mocks/commont.mock";
 import {
@@ -18,15 +17,15 @@ import {
 import {
   mockProjectSubscribe,
   mockSnsFullProject,
-  mockSnsToken,
   mockTokenStore,
 } from "$tests/mocks/sns-projects.mock";
 import {
   mockTokensSubscribe,
   mockUniversesTokens,
 } from "$tests/mocks/tokens.mock";
-import { fireEvent } from "@testing-library/dom";
-import { render, waitFor } from "@testing-library/svelte";
+import { SelectUniverseDropdownPo } from "$tests/page-objects/SelectUniverseDropdown.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
 
 describe("SelectUniverseDropdown", () => {
   jest
@@ -54,20 +53,22 @@ describe("SelectUniverseDropdown", () => {
     });
   });
 
-  it("should render a universe card with a role button", () => {
-    const { getByTestId } = render(SelectUniverseDropdown);
+  const renderComponent = () => {
+    const { container } = render(SelectUniverseDropdown);
+    return SelectUniverseDropdownPo.under(new JestPageObjectElement(container));
+  };
 
-    const card = getByTestId("select-universe-card");
-    expect(card).not.toBeNull();
-    expect(card.getAttribute("role")).toEqual("button");
+  it("should render a universe card with a role button", async () => {
+    const po = renderComponent();
+
+    expect(await po.getSelectUniverseCardPo().isPresent()).toBe(true);
+    expect(await po.getSelectUniverseCardPo().isButton()).toBe(true);
   });
 
   it("should render logo of universe", async () => {
-    const { getByTestId } = render(SelectUniverseDropdown);
-    await waitFor(() =>
-      expect(getByTestId("logo")?.getAttribute("src")).toEqual(
-        mockSnsFullProject.summary.metadata.logo
-      )
+    const po = renderComponent();
+    expect(await po.getSelectUniverseCardPo().getLogoSource()).toBe(
+      mockSnsFullProject.summary.metadata.logo
     );
   });
 
@@ -79,15 +80,29 @@ describe("SelectUniverseDropdown", () => {
       });
     });
 
-    it("should render a skeleton on load balance", () => {
-      const { container } = render(SelectUniverseDropdown);
-      expect(container.querySelector(".skeleton")).not.toBeNull();
+    it("should render a skeleton on load balance", async () => {
+      const po = renderComponent();
+      expect(
+        await po
+          .getSelectUniverseCardPo()
+          .getUniverseAccountsBalancePo()
+          .isLoading()
+      ).toBe(true);
     });
   });
 
   describe("balance", () => {
     beforeEach(() => {
-      const accounts = [mockSnsMainAccount, mockSnsSubAccount];
+      const accounts = [
+        {
+          ...mockSnsMainAccount,
+          balanceE8s: 100_000_000n,
+        },
+        {
+          ...mockSnsSubAccount,
+          balanceE8s: 23_000_000n,
+        },
+      ];
       const rootCanisterId = mockSnsFullProject.rootCanisterId;
 
       snsAccountsStore.setAccounts({
@@ -103,21 +118,24 @@ describe("SelectUniverseDropdown", () => {
     });
 
     it("should render total balance of the project", async () => {
-      const { getByTestId } = render(SelectUniverseDropdown);
+      const po = renderComponent();
+      // Expect 1.00 + 0.23
       expect(
-        getByTestId("token-value-label")?.textContent.trim() ?? ""
-      ).toEqual(
-        `${formatToken({
-          value: mockSnsMainAccount.balanceE8s + mockSnsSubAccount.balanceE8s,
-        })} ${mockSnsToken.symbol}`
-      );
+        (
+          await po
+            .getSelectUniverseCardPo()
+            .getUniverseAccountsBalancePo()
+            .getText()
+        ).trim()
+      ).toBe("1.23 TST");
     });
   });
 
   it("should open modal", async () => {
-    const { getByTestId } = render(SelectUniverseDropdown);
+    const po = renderComponent();
 
-    await fireEvent.click(getByTestId("select-universe-card") as HTMLElement);
-    expect(getByTestId("select-universe-modal")).toBeInTheDocument();
+    expect(await po.getSelectUniverseListPo().isPresent()).toBe(false);
+    await po.getSelectUniverseCardPo().click();
+    expect(await po.getSelectUniverseListPo().isPresent()).toBe(true);
   });
 });

--- a/frontend/src/tests/page-objects/Card.page-object.ts
+++ b/frontend/src/tests/page-objects/Card.page-object.ts
@@ -31,4 +31,8 @@ export class CardPo extends BasePageObject {
   async hasIcon(): Promise<boolean> {
     return this.root.querySelector("svg").isPresent();
   }
+
+  async isButton(): Promise<boolean> {
+    return (await this.root.getAttribute("role")) === "button";
+  }
 }

--- a/frontend/src/tests/page-objects/SelectUniverseDropdown.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectUniverseDropdown.page-object.ts
@@ -1,0 +1,24 @@
+import { SelectUniverseCardPo } from "$tests/page-objects/SelectUniverseCard.page-object";
+import { SelectUniverseListPo } from "$tests/page-objects/SelectUniverseList.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SelectUniverseDropdownPo extends BasePageObject {
+  private static readonly TID = "select-universe-dropdown-component";
+
+  static under(element: PageObjectElement): SelectUniverseDropdownPo {
+    return new SelectUniverseDropdownPo(
+      element.byTestId(SelectUniverseDropdownPo.TID)
+    );
+  }
+
+  // There are multiple SelectUniverseCard components in the dropdown, but the
+  // first one should always be the button to open the dropdown.
+  getSelectUniverseCardPo(): SelectUniverseCardPo {
+    return SelectUniverseCardPo.under(this.root);
+  }
+
+  getSelectUniverseListPo(): SelectUniverseListPo {
+    return SelectUniverseListPo.under(this.root);
+  }
+}

--- a/frontend/src/tests/page-objects/UniverseAccountsBalance.page-object.ts
+++ b/frontend/src/tests/page-objects/UniverseAccountsBalance.page-object.ts
@@ -19,6 +19,10 @@ export class UniverseAccountsBalancePo extends BasePageObject {
     return this.getAmountDisplayPo().isPresent();
   }
 
+  isLoading(): Promise<boolean> {
+    return this.isPresent("skeleton-text");
+  }
+
   getBalance(): Promise<string> {
     return this.getAmountDisplayPo().getAmount();
   }

--- a/frontend/src/tests/page-objects/simple-base.page-object.ts
+++ b/frontend/src/tests/page-objects/simple-base.page-object.ts
@@ -9,8 +9,15 @@ export class SimpleBasePageObject {
     this.root = root;
   }
 
-  isPresent(): Promise<boolean> {
-    return this.root.isPresent();
+  getElement(tid: string | undefined = undefined): PageObjectElement {
+    if (isNullish(tid)) {
+      return this.root;
+    }
+    return this.root.byTestId(tid);
+  }
+
+  isPresent(tid: string | undefined = undefined): Promise<boolean> {
+    return this.getElement(tid).isPresent();
   }
 
   waitFor(): Promise<void> {
@@ -22,16 +29,10 @@ export class SimpleBasePageObject {
   }
 
   click(tid: string | undefined = undefined): Promise<void> {
-    if (isNullish(tid)) {
-      return this.root.click();
-    }
-    return this.root.byTestId(tid).click();
+    return this.getElement(tid).click();
   }
 
   getText(tid: string | undefined = undefined): Promise<string> {
-    if (isNullish(tid)) {
-      return this.root.getText();
-    }
-    return this.root.byTestId(tid).getText();
+    return this.getElement(tid).getText();
   }
 }


### PR DESCRIPTION
# Motivation

It's easier to modify the test when it uses page objects.
I want to modify the test in another PR in order to show the universe selector, but without balances, even when the user is not logged in.

# Changes

1. Add test ID to `frontend/src/lib/components/universe/SelectUniverseDropdown.svelte`
2. Add `SelectUniverseDropdownPo`.
3. Add `isButton` to `CardPo`.
4. Allow passing a test ID to `.isPresent()` to check presence of a child with a specific ID.
5. Change `SelectUniverseDropdown.spec.ts` to use page object and specify and expect explicit values.

# Tests

Manually checked that the dropdown still looks the same.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary