### PR TITLE
Removed unused prop hash from AccountCard

### DIFF
--- a/frontend/src/lib/components/accounts/AccountCard.svelte
+++ b/frontend/src/lib/components/accounts/AccountCard.svelte
@@ -2,7 +2,6 @@
   import type { Account } from "$lib/types/account";
   import { Card } from "@dfinity/gix-components";
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
-  import Identifier from "$lib/components/ui/Identifier.svelte";
   import IdentifierHash from "$lib/components/ui/IdentifierHash.svelte";
   import AccountBadge from "./AccountBadge.svelte";
   import { nonNullish } from "@dfinity/utils";
@@ -11,7 +10,6 @@
   import { pageStore } from "$lib/derived/page.derived";
 
   export let account: Account;
-  export let hash = false;
   export let token: Token | undefined;
   export let role: "button" | "link" = "link";
 
@@ -49,11 +47,7 @@
     />
   {/if}
 
-  {#if hash}
-    <IdentifierHash {identifier} />
-  {:else}
-    <Identifier {identifier} />
-  {/if}
+  <IdentifierHash {identifier} />
 </Card>
 
 <style lang="scss">

--- a/frontend/src/lib/pages/CkBTCAccounts.svelte
+++ b/frontend/src/lib/pages/CkBTCAccounts.svelte
@@ -74,7 +74,7 @@
       universeId={$selectedCkBTCUniverseIdStore}
     >
       {#each accounts as account}
-        <AccountCard hash {account} token={token?.token}
+        <AccountCard {account} token={token?.token}
           >{account.name ?? $i18n.accounts.main}</AccountCard
         >
       {/each}

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -26,16 +26,16 @@
     <!-- Workaround: Type checker does not get $accountsStore.main is defined here -->
     {@const mainAccount = $icpAccountsStore.main}
 
-    <AccountCard hash account={mainAccount} token={ICPToken}
+    <AccountCard account={mainAccount} token={ICPToken}
       >{$i18n.accounts.main}</AccountCard
     >
     {#each $icpAccountsStore.subAccounts ?? [] as subAccount}
-      <AccountCard hash account={subAccount} token={ICPToken}
+      <AccountCard account={subAccount} token={ICPToken}
         >{subAccount.name}</AccountCard
       >
     {/each}
     {#each $icpAccountsStore.hardwareWallets ?? [] as walletAccount}
-      <AccountCard hash account={walletAccount} token={ICPToken}
+      <AccountCard account={walletAccount} token={ICPToken}
         >{walletAccount.name}</AccountCard
       >
     {/each}

--- a/frontend/src/lib/pages/SnsAccounts.svelte
+++ b/frontend/src/lib/pages/SnsAccounts.svelte
@@ -37,7 +37,7 @@
   {:else}
     <SnsAccountsBalancesObserver>
       {#each $snsProjectAccountsStore ?? [] as account}
-        <AccountCard hash {account} {token}
+        <AccountCard {account} {token}
           >{account.name ?? $i18n.accounts.main}</AccountCard
         >
       {/each}

--- a/frontend/src/tests/lib/components/accounts/AccountCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/AccountCard.spec.ts
@@ -31,10 +31,7 @@ describe("AccountCard", () => {
 
   it("should render a hashed account identifier", () => {
     const { getByText } = render(AccountCard, {
-      props: {
-        ...props,
-        hash: true,
-      },
+      props,
     });
 
     expect(

--- a/frontend/src/tests/page-objects/AccountCard.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountCard.page-object.ts
@@ -35,8 +35,4 @@ export class AccountCardPo extends BasePageObject {
   getAccountAddress(): Promise<string> {
     return this.getHashPo().getText();
   }
-
-  getIdentifier(): Promise<string> {
-    return this.getText("identifier");
-  }
 }


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/3268, every component that uses `AccountCard`, sets the `hash` prop.
So there is no reason to have it.

# Changes

Remove the `hash` prop from `AccountCard` and assume it's always true.

# Tests

pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary