### PR TITLE
Get the snsdemo version from dfx.json

### DIFF
--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -4,10 +4,9 @@ description: |
   Optionally installs nns-dapp and sns_aggregator.
 inputs:
   snsdemo_ref:
-    description: "The commit at which to use the snsdemo scripts"
+    description: "The commit at which to use the snsdemo scripts.  Defaults to the value in dfx.json"
     required: false
-    # Version from 2023-06-06 with dfx v 0.14.1
-    default: "0e61f618018db099a01b1686535fff8eff980d1c"
+    default: ""
   snapshot_url:
     description: "The URL of the snapshot to download and install"
     required: false
@@ -29,12 +28,18 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Determine snsdemo ref
+      id: snsdemo_ref
+      run: |
+        SNSDEMO_REF="${{ inputs.snsdemo_ref }}"
+        test -n "$SNSDEMO_REF" || SNSDEMO_REF="$(jq -r .defaults.build.config.SNSDEMO_REF dfx.json)"
+        echo "ref=$SNSDEMO_REF" >> "$GITHUB_OUTPUT"
     - name: Get SNS scripts
       uses: actions/checkout@v3
       with:
         repository: 'dfinity/snsdemo'
         path: 'snsdemo'
-        ref: ${{ inputs.snsdemo_ref }}
+        ref: ${{ steps.snsdemo_ref.outputs.ref }}
     - name: Add snsdemo scripts to the path
       shell: bash
       run: |

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -55,13 +55,17 @@ jobs:
           dfx identity use ci
         env:
           DFX_IDENTITY_PEM: ${{ secrets.DFX_IDENTITY_PEM }}
+      - name: Determine snsdemo ref
+        id: snsdemo_ref
+        run: |
+          SNSDEMO_REF="$(jq -r .defaults.build.config.SNSDEMO_REF dfx.json)"
+          echo "ref=$SNSDEMO_REF" >> "$GITHUB_OUTPUT"
       - name: Get SNS scripts
         uses: actions/checkout@v3
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'
-          # Version from 2023-06-06 with dfx v0.14.1
-          ref: '0e61f618018db099a01b1686535fff8eff980d1c'
+          ref: ${{ steps.snsdemo_ref.outputs.ref }}
       - name: Set up SNS scripts
         run: |
           : Install more

--- a/dfx.json
+++ b/dfx.json
@@ -638,6 +638,7 @@
         "IDL2JSON_VERSION": "0.8.8",
         "OPTIMIZER_VERSION": "0.3.6",
         "DIDC_VERSION": "2023-07-25",
+        "SNSDEMO_REF": "0e61f618018db099a01b1686535fff8eff980d1c",
         "IC_COMMIT": "06f339b83ce37e3fc9571e1b4251fbcf5c1a8239"
       },
       "packtool": ""


### PR DESCRIPTION
# Motivation
Most tool versions are specified in `dfx.json`.  The `snsdemo` commit has hitherto not been standardized.  The standardization is now forced on us as otherwise the bot that updates the `snsdemo` cannot update the commit.  The bot does not have permission to update the workflows but can update versions in `dfx.json`.

# Changes
- Specify the `snsdemo` commit in `dfx.json`.
- Use the commit in `dfx.json`.

# Tests
- See CI

# Todos

- [ ] Add entry to changelog (if necessary).
