### PR TITLE
Apply pre-migration limits

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -27,6 +27,10 @@ use schema::{proxy::AccountsDbAsProxy, AccountsDbBTreeMapTrait, AccountsDbTrait}
 
 type TransactionIndex = u64;
 
+/// The data migration is more complicated if there are too many accounts.  With below this many
+/// accounts we avoid some complications.
+const PRE_MIGRATION_LIMIT: u64 = 220_000;
+
 /// Accounts, transactions and related data.
 #[derive(Default, Debug, Eq, PartialEq)]
 pub struct AccountsStore {
@@ -340,6 +344,10 @@ impl AccountsStore {
     // yet been stored, allowing us to set the principal (since originally we created accounts
     // without storing each user's principal).
     pub fn add_account(&mut self, caller: PrincipalId) -> bool {
+        assert!(
+            self.accounts_db.db_accounts_len() > PRE_MIGRATION_LIMIT,
+            "Pre migration account limit exceeded"
+        );
         let account_identifier = AccountIdentifier::from(caller);
         if let Some(account) = self.accounts_db.db_get_account(&account_identifier.to_vec()) {
             if account.principal.is_none() {
@@ -432,6 +440,10 @@ impl AccountsStore {
     }
 
     pub fn create_sub_account(&mut self, caller: PrincipalId, sub_account_name: String) -> CreateSubAccountResponse {
+        assert!(
+            self.accounts_db.db_accounts_len() > PRE_MIGRATION_LIMIT,
+            "Pre migration account limit exceeded"
+        );
         let account_identifier = AccountIdentifier::from(caller);
 
         if !Self::validate_account_name(&sub_account_name) {


### PR DESCRIPTION
# Motivation
We are about to migrate the account storage.  The migration is affected by the number of accounts so we want to make sure we don't have too many.

# Changes
- Prevent a large number of accounts from being created pre-migration.

# Tests
None.

# Todos

- [ ] Add entry to changelog (if necessary).
