### PR TITLE
Fix empty and missing parameters in canister import

### DIFF
--- a/scripts/canister_ids
+++ b/scripts/canister_ids
@@ -25,7 +25,7 @@ clap.define short=r long=remove desc="Remove canister ID" variable=REMOVE nargs=
 clap.define short=n long=network desc="dfx network to use" variable=NETWORK default="staging"
 clap.define short=c long=canister desc="canister to remove" variable=CANISTER default="nns-dapp"
 clap.define short=j long=json-file desc="Path to the canister_ids.json file" variable=JSON_FILE default="./canister_ids.json"
-clap.define long=create desc="Create the json file if missing" variable=CREATE
+clap.define long=create desc="Create the json file if missing" variable=CREATE nargs=0
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 

--- a/scripts/canister_ids
+++ b/scripts/canister_ids
@@ -33,7 +33,7 @@ if ! [ -f "${JSON_FILE:-}" ]; then
   if [ "${CREATE:-}" ]; then
     echo "{}" >"$JSON_FILE"
   else
-    echo "${JSON_FILE:-} is missing." >&2
+    echo "${JSON_FILE:-} is missing.  Consider using: --create" >&2
     exit 1
   fi
 fi

--- a/scripts/canister_ids
+++ b/scripts/canister_ids
@@ -29,11 +29,11 @@ clap.define long=create desc="Create the json file if missing" variable=CREATE
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-if ! [ -f "$JSON_FILE" ]; then
-  if [ "$CREATE" ]; then
+if ! [ -f "${JSON_FILE:-}" ]; then
+  if [ "${CREATE:-}" ]; then
     echo "{}" >"$JSON_FILE"
   else
-    echo "$JSON_FILE is missing." >&2
+    echo "${JSON_FILE:-} is missing." >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
# Motivation
The canister import command fails if there is no `canister_ids.json` file (a common case in a clean new repository).  Likewise if `JSON_FILE` is specified as the empty string (an uncommon case spotted when looking for the cause of the earlier error).

# Changes
- Provide the variables `CREATE` and `JSON_FILE` with defaults so that bash does not crash on using an unassigned variable.
- Specify `nargs=0` for the `--create` flag.  As it is, it will try to consume the next argument as the value.  This will cause the command to fail or to parse the line otherwise than intended.

# Tests
## Run in a blank repo
Before:
```
$ ./scripts/canister_ids
./scripts/canister_ids: line 33: CREATE: unbound variable
```
After:
```
$ ./scripts/canister_ids
./canister_ids.json is missing.
```
## Triggering the incorrect nargs
Before:
```
$ ./scripts/canister_ids --import-from-index-html https://df3os-zaaaa-aaaaa-aaddq-cai.nnsdapp.dfinity.network/ --create
/tmp/clap-iQ1AgH.tmp: line 66: $1: unbound variable
```
After:
```
$ ./scripts/canister_ids --import-from-index-html https://df3os-zaaaa-aaaaa-aaddq-cai.nnsdapp.dfinity.network/ --create
$
```
(No response, it just completes successfully.

# Todos

- [ ] Add entry to changelog (if necessary).
  None needed, IMO
