### PR TITLE
Add tests for SetDissolveDelay component

### DIFF
--- a/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
@@ -3,40 +3,276 @@
  */
 import SetDissolveDelay from "$lib/components/neurons/SetDissolveDelay.svelte";
 import {
+  SECONDS_IN_DAY,
   SECONDS_IN_EIGHT_YEARS,
   SECONDS_IN_HALF_YEAR,
 } from "$lib/constants/constants";
+import en from "$tests/mocks/i18n.mock";
 import { SetDissolveDelayPo } from "$tests/page-objects/SetDissolveDelay.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NeuronState } from "@dfinity/nns";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
+const defaultComponentProps = {
+  neuronState: NeuronState.Locked,
+  neuronDissolveDelaySeconds: 0,
+  neuronStake: TokenAmount.fromE8s({
+    amount: BigInt(200_000_000),
+    token: ICPToken,
+  }),
+  delayInSeconds: 0,
+  minDelayInSeconds: 0,
+  minProjectDelayInSeconds: SECONDS_IN_HALF_YEAR,
+  maxDelayInSeconds: SECONDS_IN_EIGHT_YEARS,
+  calculateVotingPower: () => 0,
+  minDissolveDelayDescription: "",
+};
+
 describe("SetDissolveDelay", () => {
+  const renderComponent = (props = {}) => {
+    const { container } = render(SetDissolveDelay, {
+      props: {
+        ...defaultComponentProps,
+        ...props,
+      },
+    });
+    return SetDissolveDelayPo.under(new JestPageObjectElement(container));
+  };
+
   describe("current dissolve delay is Max - (less than a day in seconds)", () => {
     it("should enable button if user clicks Max button", async () => {
       const neuronDissolveDelaySeconds = SECONDS_IN_EIGHT_YEARS - 10;
-      const { container } = render(SetDissolveDelay, {
-        props: {
-          neuronState: NeuronState.Locked,
-          neuronDissolveDelaySeconds: BigInt(neuronDissolveDelaySeconds),
-          neuronStake: TokenAmount.fromE8s({
-            amount: BigInt(200_000_000),
-            token: ICPToken,
-          }),
-          delayInSeconds: neuronDissolveDelaySeconds,
-          minDelayInSeconds: neuronDissolveDelaySeconds,
-          minProjectDelayInSeconds: SECONDS_IN_HALF_YEAR,
-          maxDelayInSeconds: SECONDS_IN_EIGHT_YEARS,
-          calculateVotingPower: () => 0,
-          minDissolveDelayDescription: "",
-        },
+      const po = renderComponent({
+        neuronDissolveDelaySeconds: BigInt(neuronDissolveDelaySeconds),
+        delayInSeconds: neuronDissolveDelaySeconds,
+        minDelayInSeconds: neuronDissolveDelaySeconds,
+        maxDelayInSeconds: SECONDS_IN_EIGHT_YEARS,
       });
-      const po = SetDissolveDelayPo.under(new JestPageObjectElement(container));
       expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
 
       await po.clickMax();
       expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
     });
+  });
+
+  it("should initialize text and slider correctly", async () => {
+    const neuronDissolveDelaySeconds = 90 * SECONDS_IN_DAY;
+    const po = renderComponent({
+      neuronDissolveDelaySeconds: BigInt(neuronDissolveDelaySeconds),
+      delayInSeconds: neuronDissolveDelaySeconds,
+      minDelayInSeconds: neuronDissolveDelaySeconds,
+    });
+
+    expect(await po.getDays()).toBe(90);
+    expect(await po.getSliderDays()).toBe(90);
+  });
+
+  it("fractional days get rounded up", async () => {
+    // 1 extra second turns into 1 extra day.
+    const neuronDissolveDelaySeconds = 90 * SECONDS_IN_DAY + 1;
+    const po = renderComponent({
+      neuronDissolveDelaySeconds: BigInt(neuronDissolveDelaySeconds),
+      delayInSeconds: neuronDissolveDelaySeconds,
+      minDelayInSeconds: neuronDissolveDelaySeconds,
+    });
+
+    expect(await po.getDays()).toBe(91);
+    expect(await po.getSliderDays()).toBe(91);
+  });
+
+  it("should update slider on text input", async () => {
+    const po = renderComponent();
+    await po.enterDays(1);
+    expect(await po.getSliderDays()).toBe(1);
+
+    await po.enterDays(1000);
+    expect(await po.getSliderDays()).toBe(1000);
+
+    await po.enterDays(0);
+    expect(await po.getSliderDays()).toBe(0);
+  });
+
+  it("should update text on slider input", async () => {
+    const po = renderComponent();
+    await po.setSliderDays(1);
+    expect(await po.getDays()).toBe(1);
+
+    await po.setSliderDays(1000);
+    expect(await po.getDays()).toBe(1000);
+
+    await po.setSliderDays(0);
+    expect(await po.getDays()).toBe(0);
+  });
+
+  describe("should update error message and button state", () => {
+    it("when text input below or equal to current delay", async () => {
+      const neuronDays = 365;
+      const neuronDissolveDelaySeconds = neuronDays * SECONDS_IN_DAY;
+      const projectMinDays = 183;
+
+      const po = renderComponent({
+        neuronDissolveDelaySeconds: BigInt(neuronDissolveDelaySeconds),
+        minProjectDelayInSeconds: projectMinDays * SECONDS_IN_DAY,
+        delayInSeconds: neuronDissolveDelaySeconds,
+        minDelayInSeconds: neuronDissolveDelaySeconds,
+        maxDelayInSeconds: SECONDS_IN_EIGHT_YEARS,
+      });
+
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
+      expect(await po.getErrorMessage()).toBe(null);
+
+      await po.enterDays(neuronDays);
+      expect(await po.getErrorMessage()).toBe(
+        en.neurons.dissolve_delay_below_current
+      );
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
+
+      await po.enterDays(neuronDays + 1);
+      expect(await po.getErrorMessage()).toBe(null);
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
+    });
+
+    it("when text input below min project delay", async () => {
+      const neuronDays = 0;
+      const neuronDissolveDelaySeconds = neuronDays * SECONDS_IN_DAY;
+      const projectMinDays = 183;
+
+      const po = renderComponent({
+        neuronDissolveDelaySeconds: BigInt(neuronDissolveDelaySeconds),
+        minProjectDelayInSeconds: projectMinDays * SECONDS_IN_DAY,
+        delayInSeconds: neuronDissolveDelaySeconds,
+        minDelayInSeconds: neuronDissolveDelaySeconds,
+        maxDelayInSeconds: SECONDS_IN_EIGHT_YEARS,
+      });
+
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
+      expect(await po.getErrorMessage()).toBe(null);
+
+      await po.enterDays(projectMinDays - 1);
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
+      expect(await po.getErrorMessage()).toBe(
+        en.neurons.dissolve_delay_below_minimum
+      );
+
+      await po.enterDays(projectMinDays);
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
+      expect(await po.getErrorMessage()).toBe(null);
+    });
+
+    it("when text input above max project delay", async () => {
+      const projectMaxDays = 3000;
+
+      const po = renderComponent({
+        maxDelayInSeconds: SECONDS_IN_DAY * projectMaxDays,
+      });
+
+      await po.enterDays(projectMaxDays);
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
+      expect(await po.getErrorMessage()).toBe(null);
+      await po.enterDays(projectMaxDays + 1);
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
+      expect(await po.getErrorMessage()).toBe(
+        en.neurons.dissolve_delay_above_maximum
+      );
+    });
+
+    it("when slider input below or equal to current delay", async () => {
+      const neuronDays = 365;
+      const neuronDissolveDelaySeconds = neuronDays * SECONDS_IN_DAY;
+      const projectMinDays = 183;
+
+      const po = renderComponent({
+        neuronDissolveDelaySeconds: BigInt(neuronDissolveDelaySeconds),
+        minProjectDelayInSeconds: projectMinDays * SECONDS_IN_DAY,
+        delayInSeconds: neuronDissolveDelaySeconds,
+        minDelayInSeconds: neuronDissolveDelaySeconds,
+        maxDelayInSeconds: SECONDS_IN_EIGHT_YEARS,
+      });
+
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
+      expect(await po.getErrorMessage()).toBe(null);
+
+      await po.setSliderDays(neuronDays);
+      // Moving the slider doesn't update the error message.
+      // TODO: Fix this.
+      //expect(await po.getErrorMessage()).toBe(en.neurons.dissolve_delay_below_current);
+      expect(await po.getErrorMessage()).toBe(null);
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
+
+      await po.setSliderDays(neuronDays + 1);
+      expect(await po.getErrorMessage()).toBe(null);
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
+    });
+
+    it("when slider input below min project delay", async () => {
+      const neuronDays = 0;
+      const neuronDissolveDelaySeconds = neuronDays * SECONDS_IN_DAY;
+      const projectMinDays = 183;
+
+      const po = renderComponent({
+        neuronDissolveDelaySeconds: BigInt(neuronDissolveDelaySeconds),
+        minProjectDelayInSeconds: projectMinDays * SECONDS_IN_DAY,
+        delayInSeconds: neuronDissolveDelaySeconds,
+        minDelayInSeconds: neuronDissolveDelaySeconds,
+        maxDelayInSeconds: SECONDS_IN_EIGHT_YEARS,
+      });
+
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
+      expect(await po.getErrorMessage()).toBe(null);
+
+      await po.setSliderDays(projectMinDays - 1);
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
+      // Moving the slider doesn't update the error message.
+      // TODO: Fix this.
+      //expect(await po.getErrorMessage()).toBe(en.neurons.dissolve_delay_below_minimum);
+      expect(await po.getErrorMessage()).toBe(null);
+
+      await po.setSliderDays(projectMinDays);
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
+      expect(await po.getErrorMessage()).toBe(null);
+    });
+  });
+
+  it("can set same number of days when current number of days is fractional", async () => {
+    // 1 extra second turns into 1 extra day.
+    const neuronDissolveDelaySeconds = 1000 * SECONDS_IN_DAY + 1;
+    const po = renderComponent({
+      neuronDissolveDelaySeconds: BigInt(neuronDissolveDelaySeconds),
+      delayInSeconds: neuronDissolveDelaySeconds,
+      minDelayInSeconds: neuronDissolveDelaySeconds,
+    });
+
+    expect(await po.getDays()).toBe(1001);
+    expect(await po.getSliderDays()).toBe(1001);
+
+    expect(await po.getErrorMessage()).toBe(null);
+    // 1001 days in seconds is greater than the current dissolve delay of 1000
+    // days plus 1 second, so setting 1001 days is allowed and the button should
+    // start out as enabled. But currently it doesn't.
+    // TODO: Fix this.
+    //expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
+    expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
+
+    await po.enterDays(1002);
+    expect(await po.getErrorMessage()).toBe(null);
+    expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
+
+    await po.enterDays(1000);
+    expect(await po.getErrorMessage()).toBe(
+      en.neurons.dissolve_delay_below_current
+    );
+    expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
+
+    await po.enterDays(1001);
+    // 1001 days is greater than 1000 days plus 1 second so setting 1001 days is
+    // allowed and the button is correctly enabled. But we incorrectly also show
+    // an error message.
+    // TODO: Fix this.
+    //expect(await po.getErrorMessage()).toBe(null);
+    expect(await po.getErrorMessage()).toBe(
+      en.neurons.dissolve_delay_below_current
+    );
+    expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
   });
 });

--- a/frontend/src/tests/page-objects/InputRange.page-object.ts
+++ b/frontend/src/tests/page-objects/InputRange.page-object.ts
@@ -1,0 +1,18 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class InputRangePo extends BasePageObject {
+  private static readonly TID = "input-range";
+
+  static under(element: PageObjectElement): InputRangePo {
+    return new InputRangePo(element.byTestId(InputRangePo.TID));
+  }
+
+  setValue(value: number): Promise<void> {
+    return this.root.input(`${value}`);
+  }
+
+  async getValue(): Promise<number> {
+    return Number(await this.root.getValue());
+  }
+}

--- a/frontend/src/tests/page-objects/InputWithError.page-object.ts
+++ b/frontend/src/tests/page-objects/InputWithError.page-object.ts
@@ -40,7 +40,7 @@ export class InputWithErrorPo extends SimpleBasePageObject {
   }
 
   async getErrorMessage(): Promise<string | null> {
-    return this.root.byTestId("input-error-message").isPresent()
+    return (await this.root.byTestId("input-error-message").isPresent())
       ? (await this.getText("input-error-message")).trim()
       : null;
   }

--- a/frontend/src/tests/page-objects/NeuronSelectPercentage.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronSelectPercentage.page-object.ts
@@ -1,4 +1,5 @@
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { InputRangePo } from "$tests/page-objects/InputRange.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -18,8 +19,8 @@ export class NeuronSelectPercentagePo extends BasePageObject {
     });
   }
 
-  getInputRange(): PageObjectElement {
-    return this.root.byTestId("input-range");
+  getInputRangePo(): InputRangePo {
+    return InputRangePo.under(this.root);
   }
 
   clickNextButton(): Promise<void> {
@@ -31,6 +32,6 @@ export class NeuronSelectPercentagePo extends BasePageObject {
   }
 
   setPercentage(percentage: number): Promise<void> {
-    return this.getInputRange().input(`${percentage}`);
+    return this.getInputRangePo().setValue(percentage);
   }
 }

--- a/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
@@ -1,5 +1,7 @@
+import { SECONDS_IN_DAY } from "$lib/constants/constants";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
-import { TextInputPo } from "$tests/page-objects/TextInput.page-object";
+import { InputRangePo } from "$tests/page-objects/InputRange.page-object";
+import { InputWithErrorPo } from "$tests/page-objects/InputWithError.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -10,8 +12,8 @@ export class SetDissolveDelayPo extends BasePageObject {
     return new SetDissolveDelayPo(element.byTestId(SetDissolveDelayPo.TID));
   }
 
-  getTextInputPo(): TextInputPo {
-    return TextInputPo.under({ element: this.root });
+  getInputWithErrorPo(): InputWithErrorPo {
+    return InputWithErrorPo.under({ element: this.root });
   }
 
   getUpdateButtonPo(): ButtonPo {
@@ -23,6 +25,10 @@ export class SetDissolveDelayPo extends BasePageObject {
       element: this.root,
       testId: "max-button",
     });
+  }
+
+  getInputRangePo(): InputRangePo {
+    return InputRangePo.under(this.root);
   }
 
   clickUpdate(): Promise<void> {
@@ -45,8 +51,31 @@ export class SetDissolveDelayPo extends BasePageObject {
     if (days === "max") {
       await this.clickMax();
     } else {
-      await this.getTextInputPo().typeText(days.toString());
+      await this.enterDays(days);
     }
     await this.clickUpdate();
+  }
+
+  async enterDays(days: number): Promise<void> {
+    await this.getInputWithErrorPo().typeText(days.toString());
+  }
+
+  async getDays(): Promise<number> {
+    return Number(await this.getInputWithErrorPo().getValue());
+  }
+
+  getErrorMessage(): Promise<string> {
+    return this.getInputWithErrorPo().getErrorMessage();
+  }
+
+  async getSliderDays(): Promise<number> {
+    // We round up to be consistent with `secondsToDays` in `date.utils.ts`.
+    return Math.ceil(
+      (await this.getInputRangePo().getValue()) / SECONDS_IN_DAY
+    );
+  }
+
+  setSliderDays(days: number): Promise<void> {
+    return this.getInputRangePo().setValue(days * SECONDS_IN_DAY);
   }
 }


### PR DESCRIPTION
# Motivation

Currently we don't allow setting a dissolve delay on a neuron that would not result in voting power because the delay is too short.
We want to start allowing this.

But currently `SetDissolveDelay` is very complicated and also has several bugs:

1. Error messages are only updated on text input and not on slider input.
2. When the current dissolve delay is not a whole number of days, increasing it by less than a day to a whole number of days is allowed. But we still show an error message that it's not allowed even though the button is enabled.
3. The slider has second granularity but we only display days so we might display X days but that will not actually be the dissolve delay you get.

I want to simplify the code and fix the bugs but I want to make sure I don't break the component.

But currently the component has very limited test coverage.

So this PR increases the test coverage and adds comments about tests that had to be changed because the bugs need to be fixed first.

# Changes

1. Add and use page object for `InputRange`.
2. Fix a bug in `frontend/src/tests/page-objects/InputWithError.page-object.ts` where it treated a `Promise<boolean>` as a `boolean` which was always truthy, even if the promise would resolve to `false`.
3. Add more functionality to `SetDissolveDelayPo` page object.
4. Add tests to `frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts`

# Tests

test only

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary