### PR TITLE
E2E: Wait for proposal card instead of skeleton card

### DIFF
--- a/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
@@ -16,6 +16,10 @@ export class NnsProposalListPo extends BasePageObject {
     return SkeletonCardPo.under(this.root);
   }
 
+  getProposalCardPo(): ProposalCardPo {
+    return ProposalCardPo.under(this.root);
+  }
+
   getProposalCardPos(): Promise<ProposalCardPo[]> {
     return ProposalCardPo.allUnder(this.root);
   }
@@ -84,8 +88,10 @@ export class NnsProposalListPo extends BasePageObject {
   }
 
   async waitForContentLoaded(): Promise<void> {
-    await this.waitFor();
-    await this.getSkeletonCardPo().waitForAbsent();
+    await Promise.race([
+      this.getProposalCardPo().waitFor(),
+      this.waitFor("no-proposals-msg"),
+    ]);
   }
 
   async getVisibleProposalIds(proposerNeuronId: string): Promise<string[]> {

--- a/frontend/src/tests/page-objects/simple-base.page-object.ts
+++ b/frontend/src/tests/page-objects/simple-base.page-object.ts
@@ -20,8 +20,8 @@ export class SimpleBasePageObject {
     return this.getElement(tid).isPresent();
   }
 
-  waitFor(): Promise<void> {
-    return this.root.waitFor();
+  waitFor(tid: string | undefined = undefined): Promise<void> {
+    return this.getElement(tid).waitFor();
   }
 
   waitForAbsent(timeout?: number): Promise<void> {


### PR DESCRIPTION
# Motivation

Once again we had an [e2e flake](https://github.com/dfinity/nns-dapp/actions/runs/6110153913/job/16582777946?pr=3280) because no proposal cards were present even though the skeleton cards had disappeared.
So I want to try a different approach for `waitForContentLoaded`.

# Changes

1. Instead of waiting for the skeleton card to go away, wait for either at least one proposal card or the "no proposals" message to be present.
2. Support passing a `tid` parameter to `waitFor` to specify a specific child element, same as with `isPresent`, `click`, etc.

# Tests

test only

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary