### PR TITLE
Snsdemo release

### DIFF
--- a/.github/actions/build_nns_dapp/action.yaml
+++ b/.github/actions/build_nns_dapp/action.yaml
@@ -51,8 +51,8 @@ runs:
       id: snsdemo_ref
       shell: bash
       run: |
-        SNSDEMO_COMMIT="$(jq -r .defaults.build.config.SNSDEMO_COMMIT dfx.json)"
-        echo "ref=$SNSDEMO_COMMIT" >> "$GITHUB_OUTPUT"
+        SNSDEMO_RELEASE="$(jq -r .defaults.build.config.SNSDEMO_RELEASE dfx.json)"
+        echo "ref=$SNSDEMO_RELEASE" >> "$GITHUB_OUTPUT"
     - name: Get SNS scripts
       if: ${{ steps.have_snsdemo.outputs.have_snsdemo }} == 'false'
       uses: actions/checkout@v3

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -4,13 +4,13 @@ description: |
   Optionally installs nns-dapp and sns_aggregator.
 inputs:
   snsdemo_ref:
-    description: "The commit at which to use the snsdemo scripts.  Defaults to the value in dfx.json"
+    description: "The git ref at which to use the snsdemo scripts.  Defaults to the release tag in dfx.json"
     required: false
     default: ""
   snapshot_url:
-    description: "The URL of the snapshot to download and install"
+    description: "The URL of the snapshot to download and install.  Defaults to the URL of the release tag in dfx.json."
     required: false
-    default: "https://github.com/dfinity/snsdemo/releases/download/release-2023-07-07/snsdemo_snapshot_ubuntu-22.04.tar.xz"
+    default: ""
   nns_dapp_wasm:
     description: "The name of the nns-dapp wasm to install"
     required: false
@@ -33,8 +33,15 @@ runs:
       shell: bash
       run: |
         SNSDEMO_REF="${{ inputs.snsdemo_ref }}"
-        test -n "$SNSDEMO_REF" || SNSDEMO_REF="$(jq -r .defaults.build.config.SNSDEMO_COMMIT dfx.json)"
+        test -n "$SNSDEMO_REF" || SNSDEMO_REF="$(jq -r .defaults.build.config.SNSDEMO_RELEASE dfx.json)"
         echo "ref=$SNSDEMO_REF" >> "$GITHUB_OUTPUT"
+    - name: Determine snsdemo snapshot URL
+      id: snsdemo_snapshot
+      shell: bash
+      run: |
+        URL="${{ inputs.snapshot_url }}"
+        test -n "$URL" || URL="https://github.com/dfinity/snsdemo/releases/download/${{ steps.snsdemo_ref.outputs.ref }}/snsdemo_snapshot_ubuntu-22.04.tar.xz"
+        echo "url=$URL" >> "$GITHUB_OUTPUT"
     - name: Get SNS scripts
       uses: actions/checkout@v3
       with:
@@ -54,7 +61,7 @@ runs:
     - name: Get test environment
       shell: bash
       run: |
-        curl -fL --retry 5 ${{ inputs.snapshot_url }} > state.tar.xz
+        curl -fL --retry 5 ${{ steps.snsdemo_snapshot.outputs.url }} > state.tar.xz
         dfx-snapshot-restore --snapshot state.tar.xz --verbose
         dfx identity use snsdemo8
         dfx-sns-demo-healthcheck

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Determine snsdemo ref
         id: snsdemo_ref
         run: |
-          SNSDEMO_REF="$(jq -r .defaults.build.config.SNSDEMO_COMMIT dfx.json)"
+          SNSDEMO_REF="$(jq -r .defaults.build.config.SNSDEMO_RELEASE dfx.json)"
           echo "ref=$SNSDEMO_REF" >> "$GITHUB_OUTPUT"
       - name: Get SNS scripts
         uses: actions/checkout@v3

--- a/dfx.json
+++ b/dfx.json
@@ -638,7 +638,7 @@
         "IDL2JSON_VERSION": "0.8.8",
         "OPTIMIZER_VERSION": "0.3.6",
         "DIDC_VERSION": "2023-07-25",
-        "SNSDEMO_COMMIT": "0e61f618018db099a01b1686535fff8eff980d1c",
+        "SNSDEMO_RELEASE": "release-2023-07-07",
         "IC_COMMIT": "06f339b83ce37e3fc9571e1b4251fbcf5c1a8239"
       },
       "packtool": ""


### PR DESCRIPTION
# Motivation
The snsdemo version is currently specified as a commit in `dfx.json`.  Unfortunately this version is not applied to the snsdemo snapshot.

# Changes
- Use a release tag to specify which version the nns-dapp should use, instead of a commit.
- Use the release tag to get the sns snapshot.

# Tests
See CI.

# Todos

- [ ] Add entry to changelog (if necessary).
  I think this is too minor a tweak to warrant a chnagelog entry.  No frontend or canister changes and only a minor operations tweak.
