### PR TITLE
Fix and simplify SetDissolveDelay.svelte

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -32,6 +32,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Fixed
 
+* Fixed issues with SetDissolveDelay component.
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/components/neurons/SetNnsDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/SetNnsDissolveDelay.svelte
@@ -39,7 +39,6 @@
   {neuronStake}
   minProjectDelayInSeconds={SECONDS_IN_HALF_YEAR}
   maxDelayInSeconds={SECONDS_IN_EIGHT_YEARS}
-  minDelayInSeconds={Number(neuron.dissolveDelaySeconds)}
   {calculateVotingPower}
   minDissolveDelayDescription={$i18n.neurons.dissolve_delay_description}
 >

--- a/frontend/src/lib/components/sns-neurons/SetSnsDissolveDelay.svelte
+++ b/frontend/src/lib/components/sns-neurons/SetSnsDissolveDelay.svelte
@@ -82,7 +82,6 @@
   {neuronDissolveDelaySeconds}
   {neuronStake}
   minProjectDelayInSeconds={minSnsDissolveDelaySeconds}
-  minDelayInSeconds={Number(neuronDissolveDelaySeconds)}
   maxDelayInSeconds={maxSnsDelayInSeconds}
   {calculateVotingPower}
   {minDissolveDelayDescription}

--- a/frontend/src/lib/utils/date.utils.ts
+++ b/frontend/src/lib/utils/date.utils.ts
@@ -157,6 +157,8 @@ export const secondsToTime = (seconds: number): string => {
 
 export const secondsToDays = (seconds: number): number =>
   Math.ceil(seconds / SECONDS_IN_DAY);
+export const secondsToDaysRoundedDown = (seconds: number): number =>
+  Math.floor(seconds / SECONDS_IN_DAY);
 export const daysToSeconds = (days: number): number => days * SECONDS_IN_DAY;
 
 export const nowInSeconds = (): number => Math.round(Date.now() / 1000);

--- a/frontend/src/tests/lib/modals/neurons/IncreaseDissolveDelayModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/IncreaseDissolveDelayModal.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { SECONDS_IN_YEAR } from "$lib/constants/constants";
+import { SECONDS_IN_DAY, SECONDS_IN_YEAR } from "$lib/constants/constants";
 import IncreaseDissolveDelayModal from "$lib/modals/neurons/IncreaseDissolveDelayModal.svelte";
 import { updateDelay } from "$lib/services/neurons.services";
 import { renderModal } from "$tests/mocks/modal.mock";
@@ -59,7 +59,7 @@ describe("IncreaseDissolveDelayModal", () => {
 
     inputRange &&
       (await fireEvent.input(inputRange, {
-        target: { value: SECONDS_IN_YEAR * 2 },
+        target: { value: 365 * 2 },
       }));
 
     const goToConfirmDelayButton = container.querySelector(
@@ -86,10 +86,12 @@ describe("IncreaseDissolveDelayModal", () => {
   });
 
   it("should not be able to change dissolve delay below current value", async () => {
-    const currentNeuronDissoveDelay = SECONDS_IN_YEAR;
+    const currentNeuronDissoveDelayDays = 366;
     const editableNeuron = {
       ...mockNeuron,
-      dissolveDelaySeconds: BigInt(currentNeuronDissoveDelay),
+      dissolveDelaySeconds: BigInt(
+        currentNeuronDissoveDelayDays * SECONDS_IN_DAY
+      ),
     };
     const { container } = await renderIncreaseDelayModal(editableNeuron);
 
@@ -103,7 +105,7 @@ describe("IncreaseDissolveDelayModal", () => {
 
     inputRange &&
       (await fireEvent.input(inputRange, {
-        target: { value: currentNeuronDissoveDelay / 2 },
+        target: { value: currentNeuronDissoveDelayDays / 2 },
       }));
 
     const goToConfirmDelayButton = container.querySelector(
@@ -115,7 +117,7 @@ describe("IncreaseDissolveDelayModal", () => {
     );
     inputRange &&
       (await waitFor(() =>
-        expect(inputRange.value).toBe(String(currentNeuronDissoveDelay))
+        expect(inputRange.value).toBe(String(currentNeuronDissoveDelayDays))
       ));
   });
 });

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -234,7 +234,7 @@ describe("NnsStakeNeuronModal", () => {
       );
       const inputRange = container.querySelector('input[type="range"]');
 
-      const FIVE_MONTHS = 60 * 60 * 24 * 30 * 5;
+      const FIVE_MONTHS = 30 * 5;
       inputRange &&
         (await fireEvent.input(inputRange, {
           target: { value: FIVE_MONTHS },
@@ -325,7 +325,7 @@ describe("NnsStakeNeuronModal", () => {
       );
       const inputRange = container.querySelector('input[type="range"]');
 
-      const ONE_YEAR = 60 * 60 * 24 * 365;
+      const ONE_YEAR = 365;
       inputRange &&
         (await fireEvent.input(inputRange, {
           target: { value: ONE_YEAR },
@@ -483,7 +483,7 @@ describe("NnsStakeNeuronModal", () => {
       );
       const inputRange = container.querySelector('input[type="range"]');
 
-      const ONE_YEAR = 60 * 60 * 24 * 365;
+      const ONE_YEAR = 365;
       inputRange &&
         (await fireEvent.input(inputRange, {
           target: { value: ONE_YEAR },

--- a/frontend/src/tests/lib/modals/sns/IncreaseSnsDissolveDelayModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/IncreaseSnsDissolveDelayModal.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import * as snsGovernanceApi from "$lib/api/sns-governance.api";
-import { SECONDS_IN_YEAR } from "$lib/constants/constants";
+import { SECONDS_IN_DAY, SECONDS_IN_YEAR } from "$lib/constants/constants";
 import IncreaseSnsDissolveDelayModal from "$lib/modals/sns/neurons/IncreaseSnsDissolveDelayModal.svelte";
 import * as authServices from "$lib/services/auth.services";
 import { loadSnsParameters } from "$lib/services/sns-parameters.services";
@@ -96,16 +96,16 @@ describe("IncreaseSnsDissolveDelayModal", () => {
   });
 
   it("should use current dissolve delay value when locked", async () => {
-    const dissolveDelaySeconds = 12345555n;
+    const dissolveDelayDays = 12345;
     const neuron = createMockSnsNeuron({
       id: [1],
       state: NeuronState.Locked,
-      dissolveDelaySeconds,
+      dissolveDelaySeconds: BigInt(dissolveDelayDays * SECONDS_IN_DAY),
     });
     const { queryByTestId } = await renderIncreaseDelayModal(neuron);
 
     expect((queryByTestId("input-range") as HTMLInputElement).value).toBe(
-      dissolveDelaySeconds.toString()
+      dissolveDelayDays.toString()
     );
   });
 
@@ -121,7 +121,7 @@ describe("IncreaseSnsDissolveDelayModal", () => {
     const { queryByTestId } = await renderIncreaseDelayModal(neuron);
 
     expect((queryByTestId("input-range") as HTMLInputElement).value).toBe(
-      SECONDS_IN_YEAR.toString()
+      "366"
     );
   });
 
@@ -145,7 +145,7 @@ describe("IncreaseSnsDissolveDelayModal", () => {
 
     inputRange &&
       (await fireEvent.input(inputRange, {
-        target: { value: SECONDS_IN_YEAR * 2 },
+        target: { value: 365 * 2 },
       }));
 
     const goToConfirmDelayButton = container.querySelector(

--- a/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
@@ -1,4 +1,3 @@
-import { SECONDS_IN_DAY } from "$lib/constants/constants";
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { InputRangePo } from "$tests/page-objects/InputRange.page-object";
 import { InputWithErrorPo } from "$tests/page-objects/InputWithError.page-object";
@@ -20,6 +19,13 @@ export class SetDissolveDelayPo extends BasePageObject {
     return this.getButton("go-confirm-delay-button");
   }
 
+  getMinButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "min-button",
+    });
+  }
+
   getMaxButtonPo(): ButtonPo {
     return ButtonPo.under({
       element: this.root,
@@ -37,6 +43,10 @@ export class SetDissolveDelayPo extends BasePageObject {
 
   clickMax(): Promise<void> {
     return this.getMaxButtonPo().click();
+  }
+
+  clickMin(): Promise<void> {
+    return this.getMinButtonPo().click();
   }
 
   clickSkip() {
@@ -69,13 +79,10 @@ export class SetDissolveDelayPo extends BasePageObject {
   }
 
   async getSliderDays(): Promise<number> {
-    // We round up to be consistent with `secondsToDays` in `date.utils.ts`.
-    return Math.ceil(
-      (await this.getInputRangePo().getValue()) / SECONDS_IN_DAY
-    );
+    return this.getInputRangePo().getValue();
   }
 
   setSliderDays(days: number): Promise<void> {
-    return this.getInputRangePo().setValue(days * SECONDS_IN_DAY);
+    return this.getInputRangePo().setValue(days);
   }
 }


### PR DESCRIPTION
# Motivation

`SetDissolveDelay.svelte` has several bugs:
1. Error messages are only updated on text input and not on slider input.
2. When the current dissolve delay is not a whole number of days, increasing it by less than a day to a whole number of days is allowed. But we still show an error message that it's not allowed even though the button is enabled.
3. The slider has second granularity but we only display days so we might display X days but that will not actually be the dissolve delay you get.

It is also overly complicated because:
1. The slider has granularity in seconds while the text input has granularity in days and both numbers need to be kept in sync.
2. Disabling the button has logic based on seconds while the error message has separate logic based on days.
3. There is a `minDelayInSeconds` prop which is not actually the minimum allowed value but rather all allowed values are strictly greater than this value.


# Changes

1. Use days for all logic. And only convert back to seconds (as a whole multiple of the number of seconds in a day) to export the output prop.
2. Determine whether the button is disable based on the error message rather than separate logic.
3. Use the `neuronDissolveDelaySeconds` for the lower bound and remove the redundant `minDelayInSeconds` prop.
4. Update the error message also on slider input.
5. Update the tests to use days for the range input instead of seconds.
6. Fix the tests that were forced to have wrong expectations because of the existing bugs.
7. Add missing test coverage for min/max buttons and prop syncing.

# Tests

Unit tests added and updated.
Also tested manually.

# Todos

- [x] Add entry to changelog (if necessary).
