### PR TITLE
GIX-1874: Dev example SNS Aggregator landing page

### DIFF
--- a/rs/sns_aggregator/src/index.html
+++ b/rs/sns_aggregator/src/index.html
@@ -22,6 +22,9 @@
         --blue-bolt: #00bbf9;
         --verdigris: #56a3a6;
         --sea-green: #00f5d4;
+        --grey: #ccc;
+        --dark-grey: #333;
+        --light-grey: #f5f5f5;
 
         --padding-3x: calc(var(--padding) * 3);
         --padding-2x: calc(var(--padding) * 2);
@@ -32,6 +35,7 @@
         --border-size: calc(var(--padding) / 6);
         --border-radius: var(--padding);
         --border-radius-0_5x: calc(var(--padding) / 2);
+        --border-radius-0_25x: calc(var(--padding) / 4);
       }
 
       body {
@@ -308,6 +312,26 @@
       mark.open {
         background: var(--verdigris);
       }
+
+      pre {
+        display: block;
+        padding: var(--padding-0_5x);
+        margin: 0 0 var(--padding-0_5x);
+        line-height: 1.4em;
+  
+        color: var(--dark-grey);
+        background-color: var(--light-grey);
+        border: 1px solid var(--grey);
+        border-radius: var(--border-radius-0_25x);
+
+        word-break: break-all;
+        /* Reference: https://css-tricks.com/snippets/css/make-pre-text-wrap/ */
+        white-space: pre-wrap;       /* css-3 */
+        white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+        white-space: -pre-wrap;      /* Opera 4-6 */
+        white-space: -o-pre-wrap;    /* Opera 7 */
+        word-wrap: break-word;       /* Internet Explorer 5.5+ */
+      }
     </style>
   </head>
   <body>
@@ -332,6 +356,16 @@
           </li>
           <li>The SNS logo is at: /v1/sns/root/$CANISTER_ID/logo.png</li>
         </ul>
+
+        <h3>Integration example from the browser:</h3>
+
+        <p>
+          The aggregator offers multiple endpoints to collect the paginated list of launched SNSes or an endpoint for the latest SNSes.
+        </p>
+        <pre>
+// Use `fetch` to get the response from the aggregator
+const response = await fetch("https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io/v1/sns/list/page/0/slow.json");
+const snses = await response.json();</pre>
       </section>
 
       <h2>


### PR DESCRIPTION
# Motivation

Make it more obvious how developers can integrate with SNS Aggregator.

# Changes

* Add an example of how to fetch the SNS Aggregator data in the landing page.

# Tests

Not necessary.

# Todos

- [ ] Add entry to changelog (if necessary).
