### PR TITLE
GIX-1848: Fix Sent transaction icon background color dark

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -34,6 +34,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Fixed
 
 * Fixed issues with SetDissolveDelay component.
+* Fix sent transaction icon background color dark theme.
 
 #### Security
 

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -163,7 +163,7 @@
       color: var(--positive-emphasis);
 
       &.send {
-        background: var(--card-background);
+        background: var(--background);
         color: var(--disable-contrast);
       }
     }


### PR DESCRIPTION
# Motivation

The background of the Sent transaction icon is not visible. See screenshot.

# Changes

* Change the background on dark theme of the send icon for transactions.

# Tests

* Only UI changes.

# Todos

- [x] Add entry to changelog (if necessary).
