### PR TITLE
Feat: Add metadata logo path to SNS aggregator data

### DIFF
--- a/CHANGELOG-Sns_Aggregator.md
+++ b/CHANGELOG-Sns_Aggregator.md
@@ -16,6 +16,7 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 ### Added
 ### Changed
 * Various minor style improvements: favicon, spacing, status "open" color and text clamp
+* New field `logo` in the `meta` data with the relative path to the logo asset.
 ### Fixed
 ### Security
 ### Not Published

--- a/CHANGELOG-Sns_Aggregator.md
+++ b/CHANGELOG-Sns_Aggregator.md
@@ -9,6 +9,9 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 ## Unreleased
 
 ### Wasm changes
+
+* New field `logo` in the `meta` data with the relative path to the logo asset.
+
 ### Operations
 
 ## [Proposal 124250](https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=124250)
@@ -16,7 +19,6 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 ### Added
 ### Changed
 * Various minor style improvements: favicon, spacing, status "open" color and text clamp
-* New field `logo` in the `meta` data with the relative path to the logo asset.
 ### Fixed
 ### Security
 ### Not Published

--- a/rs/sns_aggregator/src/types/slow.rs
+++ b/rs/sns_aggregator/src/types/slow.rs
@@ -44,13 +44,15 @@ pub struct SlowSnsData {
     pub lifecycle: Option<GetLifecycleResponse>,
 }
 
+/// Transforms the canister response GetMetadataResponse into the Aggregator data SlowMetadata.
+/// It substitutes the logo in base 64 by the path to the logo asset if present.
 pub fn from_get_metadata_response(upstream: &GetMetadataResponse, root_canister_id: Option<Principal>) -> SlowMetadata {
     SlowMetadata {
         url: upstream.url.clone(),
         name: upstream.name.clone(),
         description: upstream.description.clone(),
         logo: match (upstream.logo.clone(), root_canister_id) {
-            (Some(_), Some(canister_id)) => Some(format!("/sns/root/{}/logo.png", canister_id.to_string())),
+            (Some(_), Some(canister_id)) => Some(format!("/sns/root/{}/logo.png", canister_id.to_text())),
             _ => None,
         },
     }

--- a/rs/sns_aggregator/src/types/slow.rs
+++ b/rs/sns_aggregator/src/types/slow.rs
@@ -87,8 +87,9 @@ impl From<&UpstreamData> for SlowMetadata {
             url: upstream.meta.url.clone(),
             name: upstream.meta.name.clone(),
             description: upstream.meta.description.clone(),
+            // Logo URL example: https://3r4gx-wqaaa-aaaaq-aaaia-cai.ic0.app/v1/sns/root/u67kc-jyaaa-aaaaq-aabpq-cai/logo.png
             logo: match (upstream.meta.logo.clone(), upstream.list_sns_canisters.root) {
-                (Some(_), Some(canister_id)) => Some(format!("/sns/root/{}/logo.png", canister_id.to_text())),
+                (Some(_), Some(canister_id)) => Some(format!("/v1/sns/root/{}/logo.png", canister_id.to_text())),
                 _ => None,
             },
         }

--- a/rs/sns_aggregator/src/types/slow.rs
+++ b/rs/sns_aggregator/src/types/slow.rs
@@ -50,9 +50,9 @@ pub fn from_get_metadata_response(upstream: &GetMetadataResponse, root_canister_
         name: upstream.name.clone(),
         description: upstream.description.clone(),
         logo: match (upstream.logo.clone(), root_canister_id) {
-            (Some(_), Some(canister_id))  => Some(format!("/sns/root/{}/logo.png", canister_id.to_string())),
+            (Some(_), Some(canister_id)) => Some(format!("/sns/root/{}/logo.png", canister_id.to_string())),
             _ => None,
-        }
+        },
     }
 }
 


### PR DESCRIPTION
# Motivation

The logo to the SNS Metadata needs to be hardcoded by the frontend following a specific pattern.

In this PR, I add the relative path of the logo so that the logic of where the logo lives lies only in the SNS aggregator canister.

Another reason is because the logo is optional. Therefore, this way it's easier to know whether the logo is present or not. Otherwise, we would need to try to fetch the asset and check it.

# Changes

* New field `logo` in `SlowMetadata`.
* Change `SlowMetadata::from` to use `UpstreamData` to access the root canister id.

# Tests

Tests are skipped.

# Todos

- [x] Add entry to changelog (if necessary).
