### PR TITLE
GIX-1864: Improve ICP logo token selector

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -17,6 +17,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Show the token selector also when not signed in.
 * Use consistent positioning for the copy icon in the Hash component.
 * Allow setting a dissolve delay that's shorter than what's required for voting power.
+* Improve contrast of token selector's logo in light theme.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -42,6 +42,7 @@
   on:click
   {icon}
   testId="select-universe-card"
+  noPadding
 >
   <div class="container" class:selected>
     <UniverseLogo size="big" {universe} framed={true} />
@@ -67,11 +68,20 @@
     display: flex;
     align-items: center;
     gap: var(--padding-2x);
+    // Same as Card padding
+    // We want to padding in the container to use the hover effect on ALL the card surface.
+    padding: calc(var(--padding-2x) - var(--card-border-size));
 
     --value-color: var(--text-color);
 
     &:not(.selected) {
       --logo-framed-background: transparent;
+    }
+
+    &:hover,
+    &:focus,
+    &.selected {
+      --logo-framed-background: var(--input-border-color);
     }
   }
 


### PR DESCRIPTION
# Motivation

The logo of ICP in the token selector doesn't have enough contrast when user hovers or when it's the selected one.

In this PR, I add an outline to the logo to help with the contrast. See screencast.

# Changes

* Use `noPadding` prop in Card for `SelectUniverseCard` and change the variable that sets the logo frame color on hover, focus and selected.

# Tests

* Only CSS changes.

# Todos

- [ ] Add entry to changelog (if necessary).
