### PR TITLE
GIX-1878: Fix TVL text color

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -25,6 +25,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 * Fixed issues with SetDissolveDelay component.
 * Fix sent transaction icon background color dark theme.
+* Improve text color of total value locked's label.
 
 #### Security
 

--- a/frontend/src/lib/components/metrics/TotalValueLocked.svelte
+++ b/frontend/src/lib/components/metrics/TotalValueLocked.svelte
@@ -74,7 +74,7 @@
       gap: var(--padding-0_5x);
 
       background: rgba(var(--focus-background-rgb), 0.8);
-      color: var(--text2-color);
+      color: var(--description-color);
 
       .total {
         color: var(--text-color);


### PR DESCRIPTION
# Motivation

TVL title text is not clearly visible in light theme. See screenshot of "Before".

The reason is that `--text2-color` was not present in the light theme.

The solution is to use `--description-color`. `--text2-color` will be removed because it's not used anywhere else.

# Changes

* Change the color of TotalValueLocked to `--description-color`.

# Tests

* Only CSS changes

# Todos

- [x] Add entry to changelog (if necessary).
