### PR TITLE
Chore: Add sns agg to debug store

### DIFF
--- a/frontend/src/lib/derived/debug.derived.ts
+++ b/frontend/src/lib/derived/debug.derived.ts
@@ -14,6 +14,7 @@ import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
+import { snsQueryStore } from "$lib/stores/sns.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import {
   voteRegistrationStore,
@@ -119,6 +120,7 @@ export const initDebugStore = () =>
       transactionsFeesStore,
       snsProposalStore,
       snsAggregatorStore,
+      snsQueryStore,
     ],
     ([
       $busyStore,
@@ -147,6 +149,7 @@ export const initDebugStore = () =>
       $transactionsFeesStore,
       $snsProposalStore,
       $aggregatorStore,
+      $snsQueryStore,
     ]) => ({
       busy: $busyStore,
       accounts: $accountsStore,
@@ -174,5 +177,6 @@ export const initDebugStore = () =>
       snsFunctions: $snsFunctionsStore,
       transactionsFees: $transactionsFeesStore,
       aggregatorStore: $aggregatorStore,
+      snsQueryStore: $snsQueryStore,
     })
   );

--- a/frontend/src/lib/derived/debug.derived.ts
+++ b/frontend/src/lib/derived/debug.derived.ts
@@ -11,6 +11,7 @@ import {
   proposalsStore,
 } from "$lib/stores/proposals.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
+import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
@@ -117,6 +118,7 @@ export const initDebugStore = () =>
       snsFunctionsStore,
       transactionsFeesStore,
       snsProposalStore,
+      snsAggregatorStore,
     ],
     ([
       $busyStore,
@@ -144,6 +146,7 @@ export const initDebugStore = () =>
       $snsFunctionsStore,
       $transactionsFeesStore,
       $snsProposalStore,
+      $aggregatorStore,
     ]) => ({
       busy: $busyStore,
       accounts: $accountsStore,
@@ -170,5 +173,6 @@ export const initDebugStore = () =>
       projects: $projectsStore,
       snsFunctions: $snsFunctionsStore,
       transactionsFees: $transactionsFeesStore,
+      aggregatorStore: $aggregatorStore,
     })
   );

--- a/frontend/src/lib/directives/debug.directives.ts
+++ b/frontend/src/lib/directives/debug.directives.ts
@@ -224,6 +224,8 @@ const anonymiseStoreState = async () => {
     snsTransactions,
     transactionsFees,
     transactions,
+    snsQueryStore,
+    aggregatorStore,
   } = get(debugStore);
 
   return {
@@ -300,6 +302,8 @@ const anonymiseStoreState = async () => {
       anonymizeTransactionStore
     ),
     transactionsFees,
+    snsQueryStore,
+    aggregatorStore,
   };
 };
 


### PR DESCRIPTION
# Motivation

To help debug possible problems in mainnet, we should add the snsAggregatorStore and snsQueryStore to the debug store to access the values stored there.

# Changes

* Add `snsAggregatorStore` and `snsQueryStore` to `initDebugStore`.

# Tests

I downloaded the JSON from localhost and the data was there.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
