### PR TITLE
Fix: Partial different derived state in snsQueryStore

### DIFF
--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -19,10 +19,11 @@ import { isForceCallStrategy } from "$lib/utils/env.utils";
 import { toToastError } from "$lib/utils/error.utils";
 import { mapOptionalToken } from "$lib/utils/icrc-tokens.utils";
 import { convertDtoData } from "$lib/utils/sns-aggregator-converters.utils";
+import { convertDerivedStateResponseToDerivedState } from "$lib/utils/sns.utils";
 import { ProposalStatus, Topic, type ProposalInfo } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import type { SnsNervousSystemFunction } from "@dfinity/sns";
-import { fromNullable, nonNullish, toNullable } from "@dfinity/utils";
+import { nonNullish, toNullable } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { getCurrentIdentity } from "../auth.services";
 
@@ -78,17 +79,12 @@ export const loadSnsProjects = async (): Promise<void> => {
         indexCanisterId: Principal.fromText(sns.canister_ids.index_canister_id),
         swap: toNullable(sns.swap_state.swap),
         // The endpoint `get_state` and `get_derived_state` return different fields and decimal precision.
-        // We want to use the info in `derived_state` immediately
-        // instead of changing it afterwards to avoid having a partial different data in the snsQueryStore.
-        derived: toNullable({
-          sns_tokens_per_icp:
-            fromNullable(sns.derived_state.sns_tokens_per_icp) ?? 0,
-          buyer_total_icp_e8s:
-            fromNullable(sns.derived_state.buyer_total_icp_e8s) ?? 0n,
-          cf_participant_count: sns.derived_state.cf_participant_count,
-          direct_participant_count: sns.derived_state.direct_participant_count,
-          cf_neuron_count: sns.derived_state.cf_neuron_count,
-        }),
+        // * `sns.swap_state` is the response from `get_state`
+        // * `sns.derived_state` is the response from `get_derived_state`
+        // We want to use the info in `derived_state` immediately instead of changing it afterwards to avoid having a partial different data in the snsQueryStore.
+        derived: toNullable(
+          convertDerivedStateResponseToDerivedState(sns.derived_state)
+        ),
       })),
     ];
     snsQueryStore.setData(snsQueryStoreData);

--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -218,7 +218,7 @@ const initSnsQueryStore = (): SnsQueryStore => {
     }) {
       const newDerivedState =
         convertDerivedStateResponseToDerivedState(derivedState);
-      // Ignore updating ths store if the mandatory fields are not present.
+      // Ignore updating the store if the mandatory fields are not present.
       if (isNullish(newDerivedState)) {
         return;
       }

--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -1,7 +1,10 @@
 import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
 import type { QuerySnsMetadata, QuerySnsSwapState } from "$lib/types/sns.query";
 import { convertDtoToSnsSummary } from "$lib/utils/sns-aggregator-converters.utils";
-import { mapAndSortSnsQueryToSummaries } from "$lib/utils/sns.utils";
+import {
+  convertDerivedStateResponseToDerivedState,
+  mapAndSortSnsQueryToSummaries,
+} from "$lib/utils/sns.utils";
 import { ProposalStatus, type ProposalInfo } from "@dfinity/nns";
 import type {
   SnsGetDerivedStateResponse,
@@ -213,22 +216,13 @@ const initSnsQueryStore = (): SnsQueryStore => {
       derivedState: SnsGetDerivedStateResponse;
       rootCanisterId: string;
     }) {
-      const sns_tokens_per_icp = fromNullable(derivedState.sns_tokens_per_icp);
-      const buyer_total_icp_e8s = fromNullable(
-        derivedState.buyer_total_icp_e8s
-      );
-      // We don't update the store if any of the derived state mandatory fields is undefined.
-      if (
-        sns_tokens_per_icp === undefined ||
-        buyer_total_icp_e8s === undefined
-      ) {
+      const newDerivedState =
+        convertDerivedStateResponseToDerivedState(derivedState);
+      // Ignore updating ths store if the mandatory fields are not present.
+      if (isNullish(newDerivedState)) {
         return;
       }
-      const newDerivedState: SnsSwapDerivedState = {
-        ...derivedState,
-        sns_tokens_per_icp,
-        buyer_total_icp_e8s,
-      };
+
       update((data: SnsQueryStoreData) => ({
         metadata: data?.metadata ?? [],
         swaps: (data?.swaps ?? []).map((swap) =>

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -18,11 +18,13 @@ import { AccountIdentifier, SubAccount } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import type {
   SnsGetAutoFinalizationStatusResponse,
+  SnsGetDerivedStateResponse,
   SnsGetMetadataResponse,
   SnsParams,
   SnsSwap,
   SnsSwapDerivedState,
 } from "@dfinity/sns";
+import type { DerivedState } from "@dfinity/sns/dist/candid/sns_swap";
 import { fromNullable, isNullish, nonNullish } from "@dfinity/utils";
 import { isPngAsset } from "./utils";
 
@@ -312,4 +314,20 @@ export const isSnsFinalizing = (
     Boolean(fromNullable(has_auto_finalize_been_attempted)) &&
     isNullish(fromNullable(auto_finalize_swap_response))
   );
+};
+
+export const convertDerivedStateResponseToDerivedState = (
+  derivedState: SnsGetDerivedStateResponse
+): DerivedState | undefined => {
+  const sns_tokens_per_icp = fromNullable(derivedState.sns_tokens_per_icp);
+  const buyer_total_icp_e8s = fromNullable(derivedState.buyer_total_icp_e8s);
+  // This is not expected, but in case it happens, we want to fail fast.
+  if (sns_tokens_per_icp === undefined || buyer_total_icp_e8s === undefined) {
+    return;
+  }
+  return {
+    ...derivedState,
+    sns_tokens_per_icp,
+    buyer_total_icp_e8s,
+  };
 };


### PR DESCRIPTION
# Motivation

Part of the response of `get_state` is the derived state, which we can also get from `get_derived_state`. Yet, the endpoint returns different fields and different precision for one of the fields (`sns_tokens_per_icp`).

When we were populating the snsQueryStore in the service `loadSnsProjects`, we were using first the data from the `get_state`, and right after we were updating it with the data from `get_derived_state`.

This caused that the sns summary from snsQueryStore and from snsAggregatorStore didn't match for some time.

# Changes

* Use the data from `get_derived_state` in the first place instead of updating it afterward.

# Tests

* The tests didn't cover the moment when the stores were different because it happens in the middle of the function. Yet, when I removed the call to `updateDerivedState`, the test failed. Therefore, it was checking that both derived states from snsAggregator and snsQueryStore where the same. Then, I fixed the test by changing the value in the field `derived` for the snsQueryStore. 

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
