### PR TITLE
Chore: Add warn log if summaries are different

### DIFF
--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -393,6 +393,10 @@ export const snsSummariesStore = derived<
       swaps: data?.swaps ?? [],
     });
 
+    if (!enableSnsAggregatorStore) {
+      return snsQuerySummaries;
+    }
+
     const aggregatorSummaries =
       aggregatorData.data
         ?.map(convertDtoToSnsSummary)
@@ -425,9 +429,6 @@ export const snsSummariesStore = derived<
       console.warn(differentSummaries(aggregatorSummaries, snsQuerySummaries));
     }
 
-    if (!enableSnsAggregatorStore) {
-      return snsQuerySummaries;
-    }
     // The aggregator data is fetched on init.
     // Derived state is fetched regularly in the background or after a participation. Therefore, we consider it as the latest data.
     // Lifecycle data is fetched after a participation. Therefore, we consider it as the latest data.

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -389,6 +389,13 @@ export const differentSummaries = (
       stringifyJson(summary1.swap) !== stringifyJson(summary2?.swap) ||
       stringifyJson(summary1.derived) !== stringifyJson(summary2?.derived) ||
       stringifyJson(summary1.token) !== stringifyJson(summary2?.token) ||
-      stringifyJson(summary1.metadata) !== stringifyJson(summary2?.metadata)
+      stringifyJson(summary1.metadata) !== stringifyJson(summary2?.metadata) ||
+      summary1.governanceCanisterId.toText() !==
+        summary2?.governanceCanisterId.toText() ||
+      summary1.swapCanisterId.toText() !== summary2?.swapCanisterId.toText() ||
+      summary1.rootCanisterId.toText() !== summary2?.rootCanisterId.toText() ||
+      summary1.ledgerCanisterId.toText() !==
+        summary2?.ledgerCanisterId.toText() ||
+      summary1.indexCanisterId.toText() !== summary2?.indexCanisterId.toText()
     );
   });

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -15,6 +15,7 @@ import { nowInSeconds } from "./date.utils";
 import type { I18nSubstitutions } from "./i18n.utils";
 import { getCommitmentE8s } from "./sns.utils";
 import { formatToken } from "./token.utils";
+import { stringifyJson } from "./utils";
 
 export const filterProjectsStatus = ({
   swapLifecycle,
@@ -373,3 +374,21 @@ export const participateButtonStatus = ({
 
   return "enabled";
 };
+
+export const differentSummaries = (
+  summaries1: SnsSummary[],
+  summaries2: SnsSummary[]
+): SnsSummary[] =>
+  summaries1.filter((summary1) => {
+    const summary2 = summaries2.find(
+      ({ rootCanisterId }) =>
+        rootCanisterId.toText() === summary1.rootCanisterId.toText()
+    );
+    // We compare the inner fields because the order when stringifying it might be different
+    return (
+      stringifyJson(summary1.swap) !== stringifyJson(summary2?.swap) ||
+      stringifyJson(summary1.derived) !== stringifyJson(summary2?.derived) ||
+      stringifyJson(summary1.token) !== stringifyJson(summary2?.token) ||
+      stringifyJson(summary1.metadata) !== stringifyJson(summary2?.metadata)
+    );
+  });

--- a/frontend/src/tests/lib/stores/sns.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns.store.spec.ts
@@ -13,7 +13,11 @@ import {
   type SnsQueryStoreData,
 } from "$lib/stores/sns.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
-import type { QuerySnsSwapState } from "$lib/types/sns.query";
+import type { QuerySnsMetadata, QuerySnsSwapState } from "$lib/types/sns.query";
+import {
+  convertDtoData,
+  convertDtoToSnsSummary,
+} from "$lib/utils/sns-aggregator-converters.utils";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import {
   aggregatorSnsMockDto,
@@ -28,6 +32,7 @@ import {
 import { snsResponsesForLifecycle } from "$tests/mocks/sns-response.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { ProposalStatus } from "@dfinity/nns";
+import { Principal } from "@dfinity/principal";
 import {
   SnsSwapLifecycle,
   type SnsGetDerivedStateResponse,
@@ -35,10 +40,12 @@ import {
   type SnsSwap,
   type SnsSwapDerivedState,
 } from "@dfinity/sns";
+import { fromNullable, toNullable } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("sns.store", () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     snsQueryStore.reset();
     snsAggregatorStore.reset();
     snsDerivedStateStore.reset();
@@ -514,7 +521,119 @@ describe("sns.store", () => {
   describe("snsSummariesStore", () => {
     describe("flag ENABLE_SNS_AGGREGATOR_STORE not enabled", () => {
       beforeEach(() => {
+        jest.spyOn(console, "warn").mockImplementation(() => undefined);
         overrideFeatureFlagsStore.setFlag("ENABLE_SNS_AGGREGATOR_STORE", false);
+      });
+
+      it("warns when snsAggregatorStore and snsQueryStore have different number of summaries", () => {
+        expect(console.warn).not.toHaveBeenCalled();
+        snsAggregatorStore.setData([aggregatorSnsMockDto]);
+        const data = snsResponsesForLifecycle({
+          lifecycles: [SnsSwapLifecycle.Open, SnsSwapLifecycle.Open],
+          certified: true,
+        });
+        snsQueryStore.setData(data);
+
+        get(snsSummariesStore);
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalledWith(
+          "The aggregator and query data do not match. Aggregator data: 1, query data: 2."
+        );
+      });
+
+      it("warns when snsAggregatorStore and snsQueryStore return different summary data for the same SNS project", () => {
+        expect(console.warn).not.toHaveBeenCalled();
+        snsAggregatorStore.setData([aggregatorSnsMockDto]);
+        const cachedSnses = convertDtoData([aggregatorSnsMockDto]);
+        const snsQueryStoreData: [QuerySnsMetadata[], QuerySnsSwapState[]] = [
+          cachedSnses.map((sns) => ({
+            rootCanisterId: sns.canister_ids.root_canister_id,
+            certified: true,
+            metadata: sns.meta,
+            token: sns.icrc1_metadata,
+          })),
+          cachedSnses.map((sns) => ({
+            rootCanisterId: sns.canister_ids.root_canister_id,
+            certified: true,
+            swapCanisterId: Principal.fromText(
+              sns.canister_ids.swap_canister_id
+            ),
+            governanceCanisterId: Principal.fromText(
+              sns.canister_ids.governance_canister_id
+            ),
+            ledgerCanisterId: Principal.fromText(
+              sns.canister_ids.ledger_canister_id
+            ),
+            indexCanisterId: Principal.fromText(
+              sns.canister_ids.index_canister_id
+            ),
+            swap: toNullable(sns.swap_state.swap),
+            derived: toNullable({
+              // THIS IS DIFFERENT
+              sns_tokens_per_icp: 0,
+              buyer_total_icp_e8s:
+                fromNullable(sns.derived_state.buyer_total_icp_e8s) ?? 0n,
+              cf_participant_count: sns.derived_state.cf_participant_count,
+              direct_participant_count:
+                sns.derived_state.direct_participant_count,
+              cf_neuron_count: sns.derived_state.cf_neuron_count,
+            }),
+          })),
+        ];
+        snsQueryStore.setData(snsQueryStoreData);
+
+        const expectedSummary = convertDtoToSnsSummary(aggregatorSnsMockDto);
+
+        get(snsSummariesStore);
+        expect(console.warn).toHaveBeenCalledTimes(2);
+        expect(console.warn).toHaveBeenCalledWith(
+          "The aggregator and query data do not match. Check below and the debug store for more information."
+        );
+        expect(console.warn).toHaveBeenCalledWith([expectedSummary]);
+      });
+
+      it("doesn't warn anything if snsQueryStore and snsAggregator return the same summary", () => {
+        snsAggregatorStore.setData([aggregatorSnsMockDto]);
+        const cachedSnses = convertDtoData([aggregatorSnsMockDto]);
+        const snsQueryStoreData: [QuerySnsMetadata[], QuerySnsSwapState[]] = [
+          cachedSnses.map((sns) => ({
+            rootCanisterId: sns.canister_ids.root_canister_id,
+            certified: true,
+            metadata: sns.meta,
+            token: sns.icrc1_metadata,
+          })),
+          cachedSnses.map((sns) => ({
+            rootCanisterId: sns.canister_ids.root_canister_id,
+            certified: true,
+            swapCanisterId: Principal.fromText(
+              sns.canister_ids.swap_canister_id
+            ),
+            governanceCanisterId: Principal.fromText(
+              sns.canister_ids.governance_canister_id
+            ),
+            ledgerCanisterId: Principal.fromText(
+              sns.canister_ids.ledger_canister_id
+            ),
+            indexCanisterId: Principal.fromText(
+              sns.canister_ids.index_canister_id
+            ),
+            swap: toNullable(sns.swap_state.swap),
+            derived: toNullable({
+              sns_tokens_per_icp:
+                fromNullable(sns.derived_state.sns_tokens_per_icp) ?? 0,
+              buyer_total_icp_e8s:
+                fromNullable(sns.derived_state.buyer_total_icp_e8s) ?? 0n,
+              cf_participant_count: sns.derived_state.cf_participant_count,
+              direct_participant_count:
+                sns.derived_state.direct_participant_count,
+              cf_neuron_count: sns.derived_state.cf_neuron_count,
+            }),
+          })),
+        ];
+        snsQueryStore.setData(snsQueryStoreData);
+
+        get(snsSummariesStore);
+        expect(console.warn).not.toHaveBeenCalled();
       });
 
       it("uses snsQueryStore as source of data", () => {

--- a/frontend/src/tests/lib/stores/sns.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns.store.spec.ts
@@ -525,6 +525,32 @@ describe("sns.store", () => {
         overrideFeatureFlagsStore.setFlag("ENABLE_SNS_AGGREGATOR_STORE", false);
       });
 
+      it("uses snsQueryStore as source of data", () => {
+        snsAggregatorStore.reset();
+        const data = snsResponsesForLifecycle({
+          lifecycles: [SnsSwapLifecycle.Open],
+          certified: true,
+        });
+        snsQueryStore.setData(data);
+
+        expect(get(snsSummariesStore)).toHaveLength(1);
+      });
+
+      it("does NOT use snsAggregator as source of data", () => {
+        snsAggregatorStore.setData([aggregatorSnsMockDto]);
+        snsQueryStore.reset();
+
+        expect(get(snsSummariesStore)).toHaveLength(0);
+      });
+    });
+
+    describe("flag ENABLE_SNS_AGGREGATOR_STORE is enabled", () => {
+      const rootCanisterId = rootCanisterIdMock;
+
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_SNS_AGGREGATOR_STORE", true);
+      });
+
       it("warns when snsAggregatorStore and snsQueryStore have different number of summaries", () => {
         expect(console.warn).not.toHaveBeenCalled();
         snsAggregatorStore.setData([aggregatorSnsMockDto]);
@@ -634,32 +660,6 @@ describe("sns.store", () => {
 
         get(snsSummariesStore);
         expect(console.warn).not.toHaveBeenCalled();
-      });
-
-      it("uses snsQueryStore as source of data", () => {
-        snsAggregatorStore.reset();
-        const data = snsResponsesForLifecycle({
-          lifecycles: [SnsSwapLifecycle.Open],
-          certified: true,
-        });
-        snsQueryStore.setData(data);
-
-        expect(get(snsSummariesStore)).toHaveLength(1);
-      });
-
-      it("does NOT use snsAggregator as source of data", () => {
-        snsAggregatorStore.setData([aggregatorSnsMockDto]);
-        snsQueryStore.reset();
-
-        expect(get(snsSummariesStore)).toHaveLength(0);
-      });
-    });
-
-    describe("flag ENABLE_SNS_AGGREGATOR_STORE is enabled", () => {
-      const rootCanisterId = rootCanisterIdMock;
-
-      beforeEach(() => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_SNS_AGGREGATOR_STORE", true);
       });
 
       it("does not snsQueryStore as source of data", () => {

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -6,6 +6,7 @@ import {
   canUserParticipateToSwap,
   commitmentExceedsAmountLeft,
   currentUserMaxCommitment,
+  differentSummaries,
   durationTillSwapDeadline,
   durationTillSwapStart,
   filterActiveProjects,
@@ -1217,6 +1218,30 @@ describe("project-utils", () => {
           })
         ).toBe("enabled");
       });
+    });
+  });
+
+  describe("differentSummaries", () => {
+    it("should return empty array for the same summaries", () => {
+      expect(
+        differentSummaries([summaryUsRestricted], [summaryUsRestricted])
+      ).toHaveLength(0);
+    });
+
+    it("should return the different summaries", () => {
+      const sameButDifferent: SnsSummary = {
+        ...summaryNoRestricted,
+        token: {
+          ...summaryNoRestricted.token,
+          name: "not the same",
+        },
+      };
+      expect(
+        differentSummaries(
+          [summaryUsRestricted, sameButDifferent],
+          [summaryUsRestricted, summaryNoRestricted]
+        )
+      ).toEqual([sameButDifferent]);
     });
   });
 });


### PR DESCRIPTION
# Motivation

We want to stop using snsQueryStore and use snsAggregatorStore instead.

To be sure this is safe, we will log a warning if they create different summaries.

PENDING: Merge #3312 

# Changes

* Compare summaries from snsQueryStore and snsAggregatorStore in snsSummariesStore.
* New project util `differentSummaries`.

# Tests

* Test new project util `differentSummaries`.
* Test that `snsSummariesStore` logs warning if summaires don't match.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
