### PR TITLE
Update downgrade-upgrade test

### DIFF
--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -5,6 +5,7 @@ ICP
 schemas
 WASM
 Wasm
+Wasms
 OWASP
 <
 >

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -39,6 +39,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Changed
 * Specify the `snsdemo` version in `dfx.json`.
+* Support using the nns-dapp downgrade-upgrade test with Wasms other than prod.
 
 #### Deprecated
 #### Removed

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -3,8 +3,6 @@ set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
-PROD_WASM="nns-dapp-prod.wasm.gz" # TODO: Switch to a test build, when available for the prod tag.
-
 help_text() {
   cat <<-EOF
 	Tests:
@@ -17,6 +15,7 @@ help_text() {
 source "$SOURCE_DIR/../clap.bash"
 # Define options
 clap.define short=w long=wasm desc="The wasm built from the local code." variable=CURRENT_WASM default=""
+clap.define short=p long=wasm desc="A test build of the production wasm" variable=PROD_WASM default=""
 clap.define short=a long=accounts desc="Accounts will be created until there are at least this many." variable=NUM_TOY_ACCOUNTS default="200000"
 clap.define short=c long=chunk desc="The accounts are created in chunks of this size." variable=TOY_ACCOUNT_CHUNK_SIZE default="10000"
 # Source the output file ----------------------------------------------------------
@@ -32,9 +31,16 @@ get_current_wasm() {
 }
 
 get_prod_wasm() {
-  # TODO: Use the test build once available for the prod release.
   # Note: Using the test build allows us to get arbitrary test accounts from the canister.
-  curl -sL https://github.com/dfinity/nns-dapp/releases/download/prod/nns-dapp.wasm.gz >"$PROD_WASM"
+  if test -n "${PROD_WASM:-}"; then
+    test -f "${PROD_WASM}" || {
+      echo "ERROR: The specified production wasm file does not exist at: '$PROD_WASM'"
+      exit 1
+    } >&2
+  else
+    PROD_WASM="$(mktemp nns-dapp-prod-XXXXXX --suffix .wasm.gz)"
+    curl -sL https://github.com/dfinity/nns-dapp/releases/download/prod/nns-dapp_test.wasm.gz >"$PROD_WASM"
+  fi
 }
 
 # Gets the number of transactions; this list may be pruned so is not invariant.
@@ -47,13 +53,16 @@ get_upgrade_invariant_stats() {
 }
 # Gets some sample accounts
 sample_toy_accounts() {
-  echo "Sample accounts will be available once the production commit has a test wasm with get_toy_account()."
-  # seq 0 "$TOY_ACCOUNT_CHUNK_SIZE" "$((NUM_TOY_ACCOUNTS - 1))" | xargs -I{} dfx canister call nns-dapp get_toy_account "({})" --query
+  seq 0 "$TOY_ACCOUNT_CHUNK_SIZE" "$((NUM_TOY_ACCOUNTS - 1))" | xargs -I{} dfx canister call nns-dapp get_toy_account "({})" --query
 }
 # Gets data that should be invariant across upgrades
 get_upgrade_invariants() {
+  echo "==== UPGRADE INVARIANT STATS ===="
   get_upgrade_invariant_stats
+  echo "==== END ===="
+  echo "==== SAMPLE INVARIANT STATS ===="
   sample_toy_accounts
+  echo "==== END ===="
 }
 
 # Verifies that the state is at least as large as expected.

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -15,7 +15,7 @@ help_text() {
 source "$SOURCE_DIR/../clap.bash"
 # Define options
 clap.define short=w long=wasm desc="The wasm built from the local code." variable=CURRENT_WASM default=""
-clap.define short=p long=wasm desc="A test build of the production wasm" variable=PROD_WASM default=""
+clap.define short=p long=prod desc="A test build of the production wasm" variable=PROD_WASM default=""
 clap.define short=a long=accounts desc="Accounts will be created until there are at least this many." variable=NUM_TOY_ACCOUNTS default="200000"
 clap.define short=c long=chunk desc="The accounts are created in chunks of this size." variable=TOY_ACCOUNT_CHUNK_SIZE default="10000"
 # Source the output file ----------------------------------------------------------


### PR DESCRIPTION
# Motivation
The downgrade-upgrade test needs to be able to verify that accounts are preserved across schema updates.

# Changes
- Make it possible to specify a wasm to downgrade to.  This way the test can be run with a wasm that implements the future schema `S0.early` and another, `undefined.late` that is not yet in production.
- Get account data; this was already present but commented out as prod did not have account data in a stable, usable form.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [x] Add entry to changelog (if necessary).
