### PR TITLE
GIX-1891: Include active disbursements in maturity section count

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsViewActiveDisbursementsItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsViewActiveDisbursementsItemAction.svelte
@@ -18,7 +18,7 @@
     testId="sns-view-active-disbursements-item-action-component"
   >
     <IconPace slot="icon" />
-    <span slot="title" data-tid="disbursement-count"
+    <span slot="title" data-tid="disbursement-total"
       >{formatMaturity(disbursingMaturity)}</span
     >
     <svelte:fragment slot="subtitle"

--- a/frontend/src/lib/components/sns-neuron-detail/SnsViewActiveDisbursementsItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsViewActiveDisbursementsItemAction.svelte
@@ -4,21 +4,22 @@
   import CommonItemAction from "$lib/components/ui/CommonItemAction.svelte";
   import type { SnsNeuron } from "@dfinity/sns";
   import SnsViewActiveDisbursementsButton from "$lib/components/sns-neuron-detail/actions/SnsViewActiveDisbursementsButton.svelte";
+  import { totalDisbursingMaturity } from "$lib/utils/sns-neuron.utils";
+  import { formatMaturity } from "$lib/utils/neuron.utils";
 
   export let neuron: SnsNeuron;
 
-  let disbursementsInProgress: number;
-  $: disbursementsInProgress =
-    neuron?.disburse_maturity_in_progress.length ?? 0;
+  let disbursingMaturity: bigint;
+  $: disbursingMaturity = totalDisbursingMaturity(neuron);
 </script>
 
-{#if disbursementsInProgress > 0}
+{#if disbursingMaturity > 0n}
   <CommonItemAction
     testId="sns-view-active-disbursements-item-action-component"
   >
     <IconPace slot="icon" />
     <span slot="title" data-tid="disbursement-count"
-      >{disbursementsInProgress}</span
+      >{formatMaturity(disbursingMaturity)}</span
     >
     <svelte:fragment slot="subtitle"
       >{$i18n.neuron_detail.view_active_disbursements_status}</svelte:fragment

--- a/frontend/src/lib/modals/sns/neurons/SnsActiveDisbursementsModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsActiveDisbursementsModal.svelte
@@ -9,6 +9,7 @@
   import { tokensStore } from "$lib/stores/tokens.store";
   import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
   import { formatMaturity } from "$lib/utils/neuron.utils";
+  import { totalDisbursingMaturity } from "$lib/utils/sns-neuron.utils";
 
   export let neuron: SnsNeuron;
 
@@ -23,10 +24,7 @@
 
   // calculate the total maturity
   let totalMaturity: bigint;
-  $: totalMaturity = neuron.disburse_maturity_in_progress.reduce(
-    (acc, disbursement) => acc + disbursement.amount_e8s,
-    BigInt(0)
-  );
+  $: totalMaturity = totalDisbursingMaturity(neuron);
 
   const dispatch = createEventDispatcher();
   const close = () => dispatch("nnsClose");

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -488,12 +488,11 @@ export const formattedMaturity = (
  * Format the sum of the maturity in a value (token "currency") way.
  * @param {SnsNeuron} neuron The neuron that contains the `maturity_e8s_equivalent` and `staked_maturity_e8s_equivalent` which will be summed and formatted
  */
-export const formattedTotalMaturity = (
-  neuron: SnsNeuron | null | undefined
-): string =>
+export const formattedTotalMaturity = (neuron: SnsNeuron): string =>
   formatToken({
     value:
-      (neuron?.maturity_e8s_equivalent ?? BigInt(0)) +
+      neuron.maturity_e8s_equivalent +
+      totalDisbursingMaturity(neuron) +
       (fromNullable(neuron?.staked_maturity_e8s_equivalent ?? []) ?? BigInt(0)),
   });
 
@@ -961,3 +960,11 @@ export const neuronDashboardUrl = ({
   `https://dashboard.internetcomputer.org/sns/${rootCanisterId.toText()}/neuron/${getSnsNeuronIdAsHexString(
     neuron
   )}`;
+
+export const totalDisbursingMaturity = ({
+  disburse_maturity_in_progress,
+}: SnsNeuron): bigint =>
+  disburse_maturity_in_progress.reduce(
+    (acc, disbursement) => acc + disbursement.amount_e8s,
+    BigInt(0)
+  );

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.spec.ts
@@ -16,6 +16,7 @@ describe("SnsNeuronMaturitySection", () => {
     id: [1],
     stakedMaturity: 100_000_000n,
     maturity: 214_000_000n,
+    activeDisbursementsE8s: [200_000_000n],
   });
   const renderComponent = (neuron: SnsNeuron) => {
     const { container } = render(NeuronContextActionsTest, {
@@ -35,7 +36,7 @@ describe("SnsNeuronMaturitySection", () => {
   it("should render total maturity", async () => {
     const po = renderComponent(mockNeuron);
 
-    expect(await po.getTotalMaturity()).toBe("3.14");
+    expect(await po.getTotalMaturity()).toBe("5.14");
   });
 
   it("should render item actions", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsViewActiveDisbursementsItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsViewActiveDisbursementsItemAction.spec.ts
@@ -57,6 +57,6 @@ describe("SnsViewActiveDisbursementsItemAction", () => {
       disburse_maturity_in_progress: [disbursement1, disbursement2],
     });
 
-    expect(await po.getDisbursementCount()).toBe("3.00");
+    expect(await po.getDisbursementTotal()).toBe("3.00");
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsViewActiveDisbursementsItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsViewActiveDisbursementsItemAction.spec.ts
@@ -3,24 +3,14 @@
  */
 
 import SnsViewActiveDisbursementsItemAction from "$lib/components/sns-neuron-detail/SnsViewActiveDisbursementsItemAction.svelte";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
-import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
+import {
+  mockActiveDisbursement,
+  mockSnsNeuron,
+} from "$tests/mocks/sns-neurons.mock";
 import { SnsViewActiveDisbursementsItemActionPo } from "$tests/page-objects/SnsViewActiveDisbursementsItemAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import type { SnsNeuron } from "@dfinity/sns";
-import type { DisburseMaturityInProgress } from "@dfinity/sns/dist/candid/sns_governance";
 import { render } from "@testing-library/svelte";
-
-const testActiveDisbursement: DisburseMaturityInProgress = {
-  timestamp_of_disbursement_seconds: 10000n,
-  amount_e8s: 1000000n,
-  account_to_disburse_to: [
-    {
-      owner: [mockPrincipal],
-      subaccount: [],
-    },
-  ],
-};
 
 describe("SnsViewActiveDisbursementsItemAction", () => {
   const renderComponent = (neuron: SnsNeuron) => {
@@ -47,21 +37,26 @@ describe("SnsViewActiveDisbursementsItemAction", () => {
   it("should render components when disbursements available", async () => {
     const po = renderComponent({
       ...mockSnsNeuron,
-      disburse_maturity_in_progress: [testActiveDisbursement],
+      disburse_maturity_in_progress: [mockActiveDisbursement],
     });
 
     expect(await po.isPresent()).toBe(true);
   });
 
-  it("should render disbursement count", async () => {
+  it("should render disbursement amount", async () => {
+    const disbursement1 = {
+      ...mockActiveDisbursement,
+      amount_e8s: 100_000_000n,
+    };
+    const disbursement2 = {
+      ...mockActiveDisbursement,
+      amount_e8s: 200_000_000n,
+    };
     const po = renderComponent({
       ...mockSnsNeuron,
-      disburse_maturity_in_progress: [
-        testActiveDisbursement,
-        testActiveDisbursement,
-      ],
+      disburse_maturity_in_progress: [disbursement1, disbursement2],
     });
 
-    expect(await po.getDisbursementCount()).toBe(2);
+    expect(await po.getDisbursementCount()).toBe("3.00");
   });
 });

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -14,13 +14,27 @@ import {
   type SnsNervousSystemParameters,
   type SnsNeuron,
 } from "@dfinity/sns";
-import type { NeuronPermission } from "@dfinity/sns/dist/candid/sns_governance";
+import type {
+  DisburseMaturityInProgress,
+  NeuronPermission,
+} from "@dfinity/sns/dist/candid/sns_governance";
 import { arrayOfNumberToUint8Array, isNullish } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
-import { mockIdentity } from "./auth.store.mock";
+import { mockIdentity, mockPrincipal } from "./auth.store.mock";
 import { rootCanisterIdMock } from "./sns.api.mock";
 
 export const mockSnsNeuronTimestampSeconds = 3600 * 24 * 6;
+
+export const mockActiveDisbursement: DisburseMaturityInProgress = {
+  timestamp_of_disbursement_seconds: 10000n,
+  amount_e8s: 1000000n,
+  account_to_disburse_to: [
+    {
+      owner: [mockPrincipal],
+      subaccount: [],
+    },
+  ],
+};
 
 export const createMockSnsNeuron = ({
   stake = BigInt(1_000_000_000),
@@ -38,6 +52,7 @@ export const createMockSnsNeuron = ({
   maturity = BigInt(100_000_000),
   createdTimestampSeconds = BigInt(nowInSeconds() - SECONDS_IN_DAY),
   sourceNnsNeuronId,
+  activeDisbursementsE8s = [],
 }: {
   stake?: bigint;
   id: number[];
@@ -56,6 +71,7 @@ export const createMockSnsNeuron = ({
   createdTimestampSeconds?: bigint;
   // Having a sourceNnsNeuronId makes the neuron a CF neuron.
   sourceNnsNeuronId?: NeuronId;
+  activeDisbursementsE8s?: bigint[];
 }): SnsNeuron => {
   return {
     id: [{ id: arrayOfNumberToUint8Array(id) }],
@@ -90,7 +106,10 @@ export const createMockSnsNeuron = ({
         : vesting
         ? [BigInt(SECONDS_IN_MONTH)]
         : [BigInt(SECONDS_IN_HOUR)],
-    disburse_maturity_in_progress: [],
+    disburse_maturity_in_progress: activeDisbursementsE8s.map((amountE8s) => ({
+      ...mockActiveDisbursement,
+      amount_e8s: amountE8s,
+    })),
   };
 };
 

--- a/frontend/src/tests/page-objects/SnsViewActiveDisbursementsItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsViewActiveDisbursementsItemAction.page-object.ts
@@ -14,6 +14,6 @@ export class SnsViewActiveDisbursementsItemActionPo extends BasePageObject {
   }
 
   async getDisbursementTotal(): Promise<string> {
-    return (await this.root.byTestId("disbursement-count").getText()).trim();
+    return (await this.root.byTestId("disbursement-total").getText()).trim();
   }
 }

--- a/frontend/src/tests/page-objects/SnsViewActiveDisbursementsItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsViewActiveDisbursementsItemAction.page-object.ts
@@ -13,7 +13,7 @@ export class SnsViewActiveDisbursementsItemActionPo extends BasePageObject {
     );
   }
 
-  async getDisbursementCount(): Promise<string> {
+  async getDisbursementTotal(): Promise<string> {
     return (await this.root.byTestId("disbursement-count").getText()).trim();
   }
 }

--- a/frontend/src/tests/page-objects/SnsViewActiveDisbursementsItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsViewActiveDisbursementsItemAction.page-object.ts
@@ -13,10 +13,7 @@ export class SnsViewActiveDisbursementsItemActionPo extends BasePageObject {
     );
   }
 
-  async getDisbursementCount(): Promise<number> {
-    return Number.parseInt(
-      (await this.root.byTestId("disbursement-count").getText()).trim(),
-      10
-    );
+  async getDisbursementCount(): Promise<string> {
+    return (await this.root.byTestId("disbursement-count").getText()).trim();
   }
 }


### PR DESCRIPTION
# Motivation

Disbursing maturity should count for the total maturity. Therefore, we also want to include the total maturity being disburse, instead of the count of disbursements.

# Changes

* `formattedTotalMaturity` for sns neurons includes the disbursing maturity.
* New neuron util `totalDisbursingMaturity`.
* Use `totalDisbursingMaturity` in SnsViewActiveDisbursementsItemAction instead of the count.
* Use `totalDisbursingMaturity` in SnsActiveDisbursementsModal

# Tests

* Add active disbursements in the test for SnsNeuronMaturitySection.
* Add field `activeDisbursementsE8s` to `createMockSnsNeuron`.
* Move a mock of active disbursements to sns-neurons.mock.
* Change tests accordingly in SnsViewActiveDisbursementsItemAction
* Add a test case for `formattedTotalMaturity`.

# Todos

- [ ] Add entry to changelog (if necessary).
Covered already by the entry of disbursing maturity.
