### PR TITLE
Add sendIcpIcrc1 to ledger API

### DIFF
--- a/frontend/src/lib/api/icp-ledger.api.ts
+++ b/frontend/src/lib/api/icp-ledger.api.ts
@@ -62,8 +62,8 @@ export const sendICP = async ({
  *
  * @param {Object} params
  * @param {Identity} params.identity user identity
- * @param {string} params.to send ICP to destination address - an account identifier
- * @param {ICP} params.amount the amount to be transferred in ICP
+ * @param {IcrcAccount} params.to destination account
+ * @param {TokenAmount} params.amount the amount to be transferred in ICP
  * @param {number[] | undefined} params.fromSubAccount the optional subaccount that would be the source of the transaction
  * @param {bigint | undefined} params.createdAt the optional timestamp of the transaction. Used to avoid deduplication.
  */

--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -92,7 +92,7 @@ export const icrcTransfer = async ({
   identity: Identity;
   canisterId: Principal;
 } & Omit<IcrcTransferParams, "transfer">): Promise<IcrcBlockIndex> => {
-  logWithTimestamp("Getting ckBTC transfer: call...");
+  logWithTimestamp("Making ICRC-1 transfer: call...");
 
   const {
     canister: { transfer: transferApi },
@@ -103,7 +103,7 @@ export const icrcTransfer = async ({
     transfer: transferApi,
   });
 
-  logWithTimestamp("Getting ckBTC transfer: done");
+  logWithTimestamp("Making ICRC-1 transfer: done");
 
   return blockIndex;
 };

--- a/frontend/src/lib/services/icp-accounts.services.ts
+++ b/frontend/src/lib/services/icp-accounts.services.ts
@@ -3,8 +3,11 @@ import {
   getTransactions,
   renameSubAccount as renameSubAccountApi,
 } from "$lib/api/accounts.api";
-import { queryAccountBalance, sendICP } from "$lib/api/icp-ledger.api";
-import { icrcTransfer } from "$lib/api/icrc-ledger.api";
+import {
+  queryAccountBalance,
+  sendICP,
+  sendIcpIcrc1,
+} from "$lib/api/icp-ledger.api";
 import { addAccount, queryAccount } from "$lib/api/nns-dapp.api";
 import { AccountNotFoundError } from "$lib/canisters/nns-dapp/nns-dapp.errors";
 import type {
@@ -17,7 +20,6 @@ import {
   SYNC_ACCOUNTS_RETRY_MAX_ATTEMPTS,
   SYNC_ACCOUNTS_RETRY_SECONDS,
 } from "$lib/constants/accounts.constants";
-import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { DEFAULT_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
@@ -30,7 +32,6 @@ import {
   type SingleMutationIcpAccountsStore,
 } from "$lib/stores/icp-accounts.store";
 import { toastsError } from "$lib/stores/toasts.store";
-import { mainTransactionFeeE8sStore } from "$lib/stores/transaction-fees.store";
 import type {
   Account,
   AccountIdentifierText,
@@ -45,7 +46,6 @@ import {
   invalidIcrcAddress,
   toIcpAccountIdentifier,
 } from "$lib/utils/accounts.utils";
-import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import {
   isForceCallStrategy,
   notForceCallStrategy,
@@ -313,17 +313,12 @@ export const transferICP = async ({
       return { success: false };
     }
 
-    const feeE8s = get(mainTransactionFeeE8sStore);
-
     await (validIcrcAddress
-      ? icrcTransfer({
+      ? sendIcpIcrc1({
           identity,
           to: decodeIcrcAccount(to),
           fromSubAccount: subAccount,
-          amount: tokenAmount.toE8s(),
-          canisterId: LEDGER_CANISTER_ID,
-          createdAt: nowInBigIntNanoSeconds(),
-          fee: feeE8s,
+          amount: tokenAmount,
         })
       : sendICP({
           identity,

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -10,7 +10,6 @@ import * as nnsdappApi from "$lib/api/nns-dapp.api";
 import { AccountNotFoundError } from "$lib/canisters/nns-dapp/nns-dapp.errors";
 import type { AccountDetails } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { SYNC_ACCOUNTS_RETRY_SECONDS } from "$lib/constants/accounts.constants";
-import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { DEFAULT_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import { getLedgerIdentityProxy } from "$lib/proxy/icp-ledger.services.proxy";
 import * as authServices from "$lib/services/auth.services";
@@ -32,7 +31,6 @@ import {
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import * as toastsFunctions from "$lib/stores/toasts.store";
-import { mainTransactionFeeE8sStore } from "$lib/stores/transaction-fees.store";
 import type { NewTransaction } from "$lib/types/transaction";
 import { toIcpAccountIdentifier } from "$lib/utils/accounts.utils";
 import {
@@ -823,9 +821,9 @@ describe("icp-accounts.services", () => {
     });
 
     it("should transfer ICP using an Icrc destination address", async () => {
-      const spy = jest
-        .spyOn(icrcLedgerApi, "icrcTransfer")
-        .mockResolvedValue(BigInt(1));
+      const spySendIcpIcrc1 = jest
+        .spyOn(ledgerApi, "sendIcpIcrc1")
+        .mockResolvedValue(BigInt(20));
 
       await transferICP({
         ...transferICPParams,
@@ -834,16 +832,11 @@ describe("icp-accounts.services", () => {
 
       expect(spySendICP).not.toHaveBeenCalled();
 
-      const feeE8s = get(mainTransactionFeeE8sStore);
-
-      expect(spy).toHaveBeenCalledWith({
+      expect(spySendIcpIcrc1).toHaveBeenCalledWith({
         amount: TokenAmount.fromNumber({
           amount: transferICPParams.amount,
           token: ICPToken,
-        }).toE8s(),
-        canisterId: LEDGER_CANISTER_ID,
-        createdAt: expect.any(BigInt),
-        fee: feeE8s,
+        }),
         fromSubAccount: undefined,
         identity: mockIdentity,
         to: decodeIcrcAccount(mockSnsMainAccount.identifier),


### PR DESCRIPTION
# Motivation

We want to stop generating account identifiers in the client and use ICRC-1 instead.
We have a generic `icrcTransfer` API method but for cases where we want to send ICP it's convenient to have a method similar to `sendICP` that does an ICRC-1 transfer without having to specify the canister ID and the fee.

This will be used in future PRs for swap participation and canister top-ups.

# Changes

1. Add `sendIcpIcrc1` to `frontend/src/lib/api/icp-ledger.api.ts`.
2. Call `sendIcpIcrc1` from `frontend/src/lib/services/icp-accounts.services.ts` instead of calling `icrcTransfer` directly.
3. Use `DEFAULT_TRANSACTION_FEE_E8S` directly in the API, instead of using `mainTransactionFeeE8sStore` in the service. `mainTransactionFeeE8sStore` is anyway just populated with `DEFAULT_TRANSACTION_FEE_E8S`, [here](https://github.com/dfinity/nns-dapp/blob/fe5a7e8f67e780cfa696f658fe81f2e4293b0b84/frontend/src/lib/stores/transaction-fees.store.ts#L33).

Drive by: Fix confusing `logWithTimestamp` message.

# Tests

1. Update `frontend/src/tests/lib/services/icp-accounts.services.spec.ts` to expect a call to `sendIcpIcrc1` instead of `icrcTransfer`.
2. Add tests for `sendIcpIcrc1` to `frontend/src/tests/lib/api/icp-ledger.api.spec.ts`.
3. Tested manually on local with ICRC-1 addresses and legacy account identifiers.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary yet, still just refactoring