### PR TITLE
Remove transfer from IcrcTransferParams

### DIFF
--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -81,7 +81,6 @@ export interface IcrcTransferParams {
   fromSubAccount?: SubAccountArray;
   createdAt?: bigint;
   fee: bigint;
-  transfer: (params: TransferParams) => Promise<IcrcBlockIndex>;
 }
 
 export const icrcTransfer = async ({
@@ -91,7 +90,7 @@ export const icrcTransfer = async ({
 }: {
   identity: Identity;
   canisterId: Principal;
-} & Omit<IcrcTransferParams, "transfer">): Promise<IcrcBlockIndex> => {
+} & IcrcTransferParams): Promise<IcrcBlockIndex> => {
   logWithTimestamp("Getting ckBTC transfer: call...");
 
   const {
@@ -122,7 +121,9 @@ export const executeIcrcTransfer = async ({
   createdAt,
   transfer: transferApi,
   ...rest
-}: IcrcTransferParams): Promise<IcrcBlockIndex> =>
+}: IcrcTransferParams & {
+  transfer: (params: TransferParams) => Promise<IcrcBlockIndex>;
+}): Promise<IcrcBlockIndex> =>
   transferApi({
     to: {
       owner,

--- a/frontend/src/lib/api/sns-ledger.api.ts
+++ b/frontend/src/lib/api/sns-ledger.api.ts
@@ -98,7 +98,7 @@ export const snsTransfer = async ({
 }: {
   identity: Identity;
   rootCanisterId: Principal;
-} & Omit<IcrcTransferParams, "transfer">): Promise<IcrcBlockIndex> => {
+} & IcrcTransferParams): Promise<IcrcBlockIndex> => {
   logWithTimestamp("Getting Sns transfer: call...");
 
   const { transfer: transferApi } = await wrapper({

--- a/frontend/src/lib/services/ckbtc-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts.services.ts
@@ -90,7 +90,7 @@ export const ckBTCTransferTokens = async ({
     transfer: async (
       params: {
         identity: Identity;
-      } & Omit<IcrcTransferParams, "transfer">
+      } & IcrcTransferParams
     ) =>
       await icrcTransfer({
         ...params,

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -37,7 +37,7 @@ export const transferTokens = async ({
   transfer: (
     params: {
       identity: Identity;
-    } & Omit<IcrcTransferParams, "transfer">
+    } & IcrcTransferParams
   ) => Promise<IcrcBlockIndex>;
   reloadAccounts: () => Promise<void>;
   reloadTransactions: () => Promise<void>;

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -88,7 +88,7 @@ export const snsTransferTokens = async ({
     transfer: async (
       params: {
         identity: Identity;
-      } & Omit<IcrcTransferParams, "transfer">
+      } & IcrcTransferParams
     ) =>
       await snsTransfer({
         ...params,


### PR DESCRIPTION
# Motivation

The type `IcrcTransferParams` is defined as
```
export interface IcrcTransferParams {
  to: IcrcAccount;
  amount: bigint;
  memo?: Uint8Array;
  fromSubAccount?: SubAccountArray;
  createdAt?: bigint;
  fee: bigint;
  transfer: (params: TransferParams) => Promise<IcrcBlockIndex>;
}
```

The field `transfer` is only used by `executeIcrcTransfer` and every other place where `IcrcTransferParams` is used, it's used as `Omit<IcrcTransferParams, "transfer">`.

# Changes

Remove `transfer` from `IcrcTransferParams` and at it back only to the params of `executeIcrcTransfer`.

# Tests

`npm run build`
`npm run check`
`npm run test`

All still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary