### PR TITLE
Bump ic-js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -749,9 +749,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "0.0.12-next-2023-09-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.12-next-2023-09-12.1.tgz",
-      "integrity": "sha512-FT9BfI6h0Q8Ju6HrtHPxiv4bkP63DblNf8hJo/o5LC1q3H3o0CeJy31cRWMFFJaEtjfzRCh7EZ/Vs4KHSd5Ffw==",
+      "version": "0.0.12-next-2023-09-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.12-next-2023-09-18.1.tgz",
+      "integrity": "sha512-cLIyJjdI6xAVu68zd87waOXQGZsCeEHb68Au+0QHYi5B0z4hiufJDOFg3ODTujGbKPUF+44wLcSQDbtkPKgN5g==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -765,9 +765,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.19-next-2023-09-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.19-next-2023-09-12.1.tgz",
-      "integrity": "sha512-/S8RvE89uyT0uwuGyJOOgutuNo7i2h0DA1bKqzL9bayJiMY8KTcQO/Saq8sDpcXk/Xda11swk1VW0azXAXDs2w==",
+      "version": "0.0.19-next-2023-09-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.19-next-2023-09-18.1.tgz",
+      "integrity": "sha512-1tJbDRUdpSIowA3TwmDDmngXOutczsKU2CcLPyx6FiBEyf7U00f/wntSOGDQGvqEsou+ETh/khX+7BbablqPhg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -790,9 +790,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "0.0.9-next-2023-09-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.9-next-2023-09-12.1.tgz",
-      "integrity": "sha512-hSvlEKk89JitjA/qbDdeiJKcW006/4GMy4J4dj1BzEPKzsA8dexCtthbKCWQgaBeGbSH2WJaPxUKk9WVvTuWLA==",
+      "version": "0.0.9-next-2023-09-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.9-next-2023-09-18.1.tgz",
+      "integrity": "sha512-0vwkjm3oz/YpgLSMgzWybV99OldPfD7VTIJcuwmmr6Fkw8fVO8uxN/aDWbAZOye0/bEUgmlYHTRZqCAU7x//0w==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/@dfinity/ledger": {
-      "version": "0.0.16-next-2023-09-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.16-next-2023-09-12.1.tgz",
-      "integrity": "sha512-ehgnuaAGI18l243JutBxJ1mnUsKpoa2pAXot0gsjt0GFK4UbvHBQr4ZMlae0nwlYeZuuHBMnwqeM4orirwmIpg==",
+      "version": "0.0.16-next-2023-09-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.16-next-2023-09-18.1.tgz",
+      "integrity": "sha512-rOqxa3HdwLTY+X27xsoHHe8M+hhHVsHe6RdylaZ10chKHWD1a7u2TXunyMZvyGEuYiKw/kr/S4Yh789EL5Y+Kw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -827,9 +827,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.16.8-next-2023-09-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.8-next-2023-09-12.1.tgz",
-      "integrity": "sha512-p/Zb9zK++rVuAGTK8pUdiOVK+vadelkbm7O6fnBDc4ZudAJyHLR+CuRtWjCqjR34r3Lv39a2dQoTg4kxQnvgFQ==",
+      "version": "0.16.8-next-2023-09-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.8-next-2023-09-18.1.tgz",
+      "integrity": "sha512-2rmXgQ8Hb/pvP99gN3zzrgRg5VuKIxzXEVPdcgT15BMdYdXic4pUqcxO0Fe0OZmX4L3kaSg6SYv5gD5v2+xnsQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -843,9 +843,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "0.0.9-next-2023-09-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.9-next-2023-09-12.1.tgz",
-      "integrity": "sha512-pI2TPRzAj0nClMx3aRl6XSA09z9S2R/N+rA39zOMlXckqyhscMNfGlc3OFI1oSHuqYadXpZBWfaonDoutr8j6w==",
+      "version": "0.0.9-next-2023-09-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.9-next-2023-09-18.1.tgz",
+      "integrity": "sha512-kmmP5u4WSQUczFOpBbPYgvvIO4A40worGPw/Yrf2EGCtT/TMmAC23Wqsp3azhE2t7dQ1jTtE50P5bURR8iGmsA==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -859,9 +859,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.23-next-2023-09-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.23-next-2023-09-12.1.tgz",
-      "integrity": "sha512-I83OiuKzJiCrJmojelJZn7HeCki1wnrUENPt+sEtNy3vhLvW1yh91nw2GjvdMFfSj2xoGSLmJYjJyi4xOssbVQ==",
+      "version": "0.0.23-next-2023-09-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.23-next-2023-09-18.1.tgz",
+      "integrity": "sha512-1wtTVmSWBFtem9YtXHt59XOug3cYSHPV2hpUBP5z6B0fkHxpjvaeJZAWxqXZFqj8nfX8WUdIhPzhSVPVCoMZ/w==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -874,9 +874,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.23-next-2023-09-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.23-next-2023-09-12.1.tgz",
-      "integrity": "sha512-18e/XdV/5M934GAt7vjaeWhDMvSRk4P1SnvFzIc9Et1VQAObJt9vpKOpfemsdaZz9V2EHoaJXZJTMrNyDHZ85Q==",
+      "version": "0.0.23-next-2023-09-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.23-next-2023-09-18.1.tgz",
+      "integrity": "sha512-ASQEj4LvV96+9znKgxgpkraLLfRpoGIIDFoajqBpMn1CI7Plij1zQq5snsi2O1mBXgK70pLUoHAYwWPBrk4lzA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -10052,9 +10052,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "0.0.12-next-2023-09-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.12-next-2023-09-12.1.tgz",
-      "integrity": "sha512-FT9BfI6h0Q8Ju6HrtHPxiv4bkP63DblNf8hJo/o5LC1q3H3o0CeJy31cRWMFFJaEtjfzRCh7EZ/Vs4KHSd5Ffw==",
+      "version": "0.0.12-next-2023-09-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.12-next-2023-09-18.1.tgz",
+      "integrity": "sha512-cLIyJjdI6xAVu68zd87waOXQGZsCeEHb68Au+0QHYi5B0z4hiufJDOFg3ODTujGbKPUF+44wLcSQDbtkPKgN5g==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -10062,9 +10062,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.19-next-2023-09-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.19-next-2023-09-12.1.tgz",
-      "integrity": "sha512-/S8RvE89uyT0uwuGyJOOgutuNo7i2h0DA1bKqzL9bayJiMY8KTcQO/Saq8sDpcXk/Xda11swk1VW0azXAXDs2w==",
+      "version": "0.0.19-next-2023-09-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.19-next-2023-09-18.1.tgz",
+      "integrity": "sha512-1tJbDRUdpSIowA3TwmDDmngXOutczsKU2CcLPyx6FiBEyf7U00f/wntSOGDQGvqEsou+ETh/khX+7BbablqPhg==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -10078,9 +10078,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "0.0.9-next-2023-09-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.9-next-2023-09-12.1.tgz",
-      "integrity": "sha512-hSvlEKk89JitjA/qbDdeiJKcW006/4GMy4J4dj1BzEPKzsA8dexCtthbKCWQgaBeGbSH2WJaPxUKk9WVvTuWLA==",
+      "version": "0.0.9-next-2023-09-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.9-next-2023-09-18.1.tgz",
+      "integrity": "sha512-0vwkjm3oz/YpgLSMgzWybV99OldPfD7VTIJcuwmmr6Fkw8fVO8uxN/aDWbAZOye0/bEUgmlYHTRZqCAU7x//0w==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -10094,24 +10094,24 @@
       }
     },
     "@dfinity/ledger": {
-      "version": "0.0.16-next-2023-09-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.16-next-2023-09-12.1.tgz",
-      "integrity": "sha512-ehgnuaAGI18l243JutBxJ1mnUsKpoa2pAXot0gsjt0GFK4UbvHBQr4ZMlae0nwlYeZuuHBMnwqeM4orirwmIpg==",
+      "version": "0.0.16-next-2023-09-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.16-next-2023-09-18.1.tgz",
+      "integrity": "sha512-rOqxa3HdwLTY+X27xsoHHe8M+hhHVsHe6RdylaZ10chKHWD1a7u2TXunyMZvyGEuYiKw/kr/S4Yh789EL5Y+Kw==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "0.16.8-next-2023-09-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.8-next-2023-09-12.1.tgz",
-      "integrity": "sha512-p/Zb9zK++rVuAGTK8pUdiOVK+vadelkbm7O6fnBDc4ZudAJyHLR+CuRtWjCqjR34r3Lv39a2dQoTg4kxQnvgFQ==",
+      "version": "0.16.8-next-2023-09-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.8-next-2023-09-18.1.tgz",
+      "integrity": "sha512-2rmXgQ8Hb/pvP99gN3zzrgRg5VuKIxzXEVPdcgT15BMdYdXic4pUqcxO0Fe0OZmX4L3kaSg6SYv5gD5v2+xnsQ==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "0.0.9-next-2023-09-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.9-next-2023-09-12.1.tgz",
-      "integrity": "sha512-pI2TPRzAj0nClMx3aRl6XSA09z9S2R/N+rA39zOMlXckqyhscMNfGlc3OFI1oSHuqYadXpZBWfaonDoutr8j6w==",
+      "version": "0.0.9-next-2023-09-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.9-next-2023-09-18.1.tgz",
+      "integrity": "sha512-kmmP5u4WSQUczFOpBbPYgvvIO4A40worGPw/Yrf2EGCtT/TMmAC23Wqsp3azhE2t7dQ1jTtE50P5bURR8iGmsA==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -10125,17 +10125,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.23-next-2023-09-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.23-next-2023-09-12.1.tgz",
-      "integrity": "sha512-I83OiuKzJiCrJmojelJZn7HeCki1wnrUENPt+sEtNy3vhLvW1yh91nw2GjvdMFfSj2xoGSLmJYjJyi4xOssbVQ==",
+      "version": "0.0.23-next-2023-09-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.23-next-2023-09-18.1.tgz",
+      "integrity": "sha512-1wtTVmSWBFtem9YtXHt59XOug3cYSHPV2hpUBP5z6B0fkHxpjvaeJZAWxqXZFqj8nfX8WUdIhPzhSVPVCoMZ/w==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.23-next-2023-09-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.23-next-2023-09-12.1.tgz",
-      "integrity": "sha512-18e/XdV/5M934GAt7vjaeWhDMvSRk4P1SnvFzIc9Et1VQAObJt9vpKOpfemsdaZz9V2EHoaJXZJTMrNyDHZ85Q==",
+      "version": "0.0.23-next-2023-09-18.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.23-next-2023-09-18.1.tgz",
+      "integrity": "sha512-ASQEj4LvV96+9znKgxgpkraLLfRpoGIIDFoajqBpMn1CI7Plij1zQq5snsi2O1mBXgK70pLUoHAYwWPBrk4lzA==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/lib/utils/anonymize.utils.ts
+++ b/frontend/src/lib/utils/anonymize.utils.ts
@@ -321,6 +321,7 @@ const anonymizeSnsTransaction = async (
     burn: await anonymizeTransfer(tx.burn as TransferOpt),
     mint: await anonymizeTransfer(tx.mint as TransferOpt),
     transfer: await anonymizeTransfer(tx.transfer as TransferOpt),
+    approve: await anonymizeTransfer(tx.approve as TransferOpt),
   };
 };
 

--- a/frontend/src/lib/utils/sns-ledger.utils.ts
+++ b/frontend/src/lib/utils/sns-ledger.utils.ts
@@ -1,4 +1,7 @@
-import { IcrcTransferError } from "@dfinity/ledger";
+import {
+  IcrcTransferError,
+  type IcrcTransferVariatError,
+} from "@dfinity/ledger";
 import { toToastError } from "./error.utils";
 import type { I18nSubstitutions } from "./i18n.utils";
 
@@ -14,7 +17,7 @@ export const ledgerErrorToToastError = ({
   substitutions?: I18nSubstitutions;
 } => {
   if (err instanceof IcrcTransferError) {
-    const error: IcrcTransferError = err;
+    const error: IcrcTransferError<IcrcTransferVariatError> = err;
     if ("GenericError" in error.errorType) {
       return {
         labelKey: "error.transaction_error",


### PR DESCRIPTION
# Motivation

We want to use `stakeNeuronIcrc1` added in https://github.com/dfinity/ic-js/pull/418.

*Note*: Manual changes were required to make nns-dapp build again.

# Changes

1. `npm run update:next`
2. Anonimize the `approve` field of a transaction in `anonymizeSnsTransaction`.
3. Provide a type parameter to `IcrcTransferError`. I used `IcrcTransferVariatError` because https://github.com/dfinity/ic-js/pull/416, `IcrcTransferError.errorType` was of type `TransferError` and `TransferError` is exported as `IcrcTransferVariatError` [here](https://github.com/dfinity/ic-js/blob/4c8dd0b22416f86f75b5a957fa6a210b44fd5156/packages/ledger/src/index.ts#L12). But I have no idea if this makes sense or what `IcrcTransferVariatError` is. I guess it's a typo?

# Tests

Existing tests pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary