### PR TITLE
Chore: Remove dependency on neuron context

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.svelte
@@ -36,10 +36,10 @@
     >{$i18n.neuron_detail.available_description}</svelte:fragment
   >
   {#if allowedToStakeMaturity}
-    <SnsStakeMaturityButton />
+    <SnsStakeMaturityButton {neuron} />
   {/if}
 
   {#if allowedToDisburseMaturity && $ENABLE_DISBURSE_MATURITY}
-    <SnsDisburseMaturityButton />
+    <SnsDisburseMaturityButton {neuron} />
   {/if}
 </CommonItemAction>

--- a/frontend/src/lib/components/sns-neuron-detail/actions/SnsDisburseMaturityButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/SnsDisburseMaturityButton.svelte
@@ -2,19 +2,9 @@
   import { hasEnoughMaturityToStakeOrDisburse } from "$lib/utils/sns-neuron.utils";
   import { openSnsNeuronModal } from "$lib/utils/modals.utils";
   import type { SnsNeuron } from "@dfinity/sns";
-  import {
-    SELECTED_SNS_NEURON_CONTEXT_KEY,
-    type SelectedSnsNeuronContext,
-  } from "$lib/types/sns-neuron-detail.context";
-  import { getContext } from "svelte";
   import DisburseMaturityButton from "$lib/components/neuron-detail/actions/DisburseMaturityButton.svelte";
 
-  const context: SelectedSnsNeuronContext =
-    getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
-  const { store }: SelectedSnsNeuronContext = context;
-
-  let neuron: SnsNeuron | undefined | null;
-  $: ({ neuron } = $store);
+  export let neuron: SnsNeuron;
 
   let enoughMaturity: boolean;
   $: enoughMaturity = hasEnoughMaturityToStakeOrDisburse(neuron);

--- a/frontend/src/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.svelte
@@ -2,19 +2,9 @@
   import { hasEnoughMaturityToStakeOrDisburse } from "$lib/utils/sns-neuron.utils";
   import { openSnsNeuronModal } from "$lib/utils/modals.utils";
   import type { SnsNeuron } from "@dfinity/sns";
-  import {
-    SELECTED_SNS_NEURON_CONTEXT_KEY,
-    type SelectedSnsNeuronContext,
-  } from "$lib/types/sns-neuron-detail.context";
-  import { getContext } from "svelte";
   import StakeMaturityButton from "$lib/components/neuron-detail/actions/StakeMaturityButton.svelte";
 
-  const context: SelectedSnsNeuronContext =
-    getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);
-  const { store }: SelectedSnsNeuronContext = context;
-
-  let neuron: SnsNeuron | undefined | null;
-  $: ({ neuron } = $store);
+  export let neuron: SnsNeuron;
 
   let enoughMaturity: boolean;
   $: enoughMaturity = hasEnoughMaturityToStakeOrDisburse(neuron);

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.spec.ts
@@ -9,7 +9,6 @@ import {
   mockAuthStoreSubscribe,
   mockIdentity,
 } from "$tests/mocks/auth.store.mock";
-import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import {
   allSnsNeuronPermissions,
   createMockSnsNeuron,
@@ -19,7 +18,6 @@ import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import type { Principal } from "@dfinity/principal";
 import { SnsNeuronPermissionType, type SnsNeuron } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
-import NeuronContextActionsTest from "./SnsNeuronContextTest.svelte";
 
 describe("SnsAvailableMaturityItemAction", () => {
   const controllerPermissions = {
@@ -32,12 +30,9 @@ describe("SnsAvailableMaturityItemAction", () => {
     permissions: [controllerPermissions],
   });
   const renderComponent = (neuron: SnsNeuron) => {
-    const { container } = render(NeuronContextActionsTest, {
+    const { container } = render(SnsAvailableMaturityItemAction, {
       props: {
         neuron,
-        passPropNeuron: true,
-        rootCanisterId: mockCanisterId,
-        testComponent: SnsAvailableMaturityItemAction,
       },
     });
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsDisburseMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsDisburseMaturityButton.spec.ts
@@ -3,20 +3,16 @@
  */
 
 import SnsDisburseMaturityButton from "$lib/components/sns-neuron-detail/actions/SnsDisburseMaturityButton.svelte";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { DisburseMaturityButtonPo } from "$tests/page-objects/DisburseMaturityButton.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
-import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
 describe("SnsDisburseMaturityButton", () => {
   const renderComponent = (neuron) => {
-    const { container } = render(SnsNeuronContextTest, {
+    const { container } = render(SnsDisburseMaturityButton, {
       props: {
         neuron,
-        rootCanisterId: mockPrincipal,
-        testComponent: SnsDisburseMaturityButton,
       },
     });
     return DisburseMaturityButtonPo.under(new JestPageObjectElement(container));

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.spec.ts
@@ -3,11 +3,9 @@
  */
 
 import SnsStakeMaturityButton from "$lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.svelte";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
-import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
 describe("SnsStakeMaturityButton", () => {
   afterEach(() => {
@@ -15,13 +13,11 @@ describe("SnsStakeMaturityButton", () => {
   });
 
   it("should open stake maturity modal", async () => {
-    const { getByText, getByTestId } = render(SnsNeuronContextTest, {
+    const { getByText, getByTestId } = render(SnsStakeMaturityButton, {
       props: {
         neuron: {
           ...mockSnsNeuron,
         },
-        rootCanisterId: mockPrincipal,
-        testComponent: SnsStakeMaturityButton,
       },
     });
 
@@ -35,15 +31,13 @@ describe("SnsStakeMaturityButton", () => {
   });
 
   it("should be disabled if no maturity to stake", async () => {
-    const { getByTestId } = render(SnsNeuronContextTest, {
+    const { getByTestId } = render(SnsStakeMaturityButton, {
       props: {
         neuron: {
           ...mockSnsNeuron,
           maturity_e8s_equivalent: BigInt(0),
           staked_maturity_e8s_equivalent: [],
         },
-        rootCanisterId: mockPrincipal,
-        testComponent: SnsStakeMaturityButton,
       },
     });
 


### PR DESCRIPTION
# Motivation

Simplify testing and components.

Remove the usage of the neuron context in SnsAvailableMaturityItemAction.svelte.

# Changes

* Expect the neuron as a prop.

# Tests

* Adapt tests.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
