### PR TITLE
Fix: Setup SnsDisburseMaturityModal.spec

### DIFF
--- a/frontend/src/lib/modals/sns/neurons/SnsDisburseMaturityModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsDisburseMaturityModal.svelte
@@ -11,7 +11,6 @@
   import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
   import { tokensStore } from "$lib/stores/tokens.store";
   import type { Token } from "@dfinity/utils";
-  import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
 
   export let neuron: SnsNeuron;
   export let neuronId: SnsNeuronId;
@@ -27,7 +26,7 @@
   );
 
   let token: Token | undefined;
-  $: token = $tokensStore[$selectedUniverseIdStore.toText()]?.token;
+  $: token = $tokensStore[rootCanisterId.toText()]?.token;
 
   const dispatcher = createEventDispatcher();
   const close = () => dispatcher("nnsClose");

--- a/frontend/src/tests/lib/modals/sns/SnsDisburseMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsDisburseMaturityModal.spec.ts
@@ -5,12 +5,14 @@
 import { disburseMaturity } from "$lib/api/sns-governance.api";
 import SnsDisburseMaturityModal from "$lib/modals/sns/neurons/SnsDisburseMaturityModal.svelte";
 import { authStore } from "$lib/stores/auth.store";
+import { tokensStore } from "$lib/stores/tokens.store";
 import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import {
   createMockSnsNeuron,
   mockSnsNeuron,
 } from "$tests/mocks/sns-neurons.mock";
+import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import { DisburseMaturityModalPo } from "$tests/page-objects/DisburseMaturityModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import type { SnsNeuron } from "@dfinity/sns";
@@ -20,6 +22,7 @@ jest.mock("$lib/api/sns-governance.api");
 
 describe("SnsDisburseMaturityModal", () => {
   const reloadNeuron = jest.fn();
+  const rootCanisterId = mockPrincipal;
 
   const renderSnsDisburseMaturityModal = async (
     neuron: SnsNeuron = mockSnsNeuron
@@ -29,7 +32,7 @@ describe("SnsDisburseMaturityModal", () => {
       props: {
         neuronId: neuron.id,
         neuron,
-        rootCanisterId: mockPrincipal,
+        rootCanisterId,
         reloadNeuron,
       },
     });
@@ -39,6 +42,10 @@ describe("SnsDisburseMaturityModal", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     authStore.setForTesting(mockIdentity);
+    tokensStore.setToken({
+      canisterId: rootCanisterId,
+      token: mockSnsToken,
+    });
   });
 
   it("should display total maturity", async () => {
@@ -77,7 +84,7 @@ describe("SnsDisburseMaturityModal", () => {
     await po.clickNextButton();
 
     expect(await po.getConfirmPercentage()).toBe("50%");
-    expect(await po.getConfirmTokens()).toBe("0.48-0.53 ICP");
+    expect(await po.getConfirmTokens()).toBe("0.48-0.53 TST");
     expect(await po.getConfirmDestination()).toBe("Main");
   });
 


### PR DESCRIPTION
# Motivation

Fix broken setup in SnsDisburseMaturityModal test.

# Changes

* SnsDisburseMaturityModal: Use the rootCanisterId passed instead of accessing the derived store of the page store.

# Tests

* Set the tokenStore with a mock token. Fix the expected value.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.