### PR TITLE
Fix: Docker build

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -49,6 +49,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Fixed
 
+* Fix build script by pinning cargo-binstall version.
+
 #### Security
 
 ## Proposal 124486

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,9 @@ WORKDIR /
 RUN DFX_VERSION="$(cat config/dfx_version)" sh -c "$(curl -fsSL https://sdk.dfinity.org/install.sh)" && dfx --version
 # TODO: Make didc support binstall, then use cargo binstall --no-confirm didc here.
 RUN set +x && curl -Lf --retry 5 "https://github.com/dfinity/candid/releases/download/$(cat config/didc_version)/didc-linux64" | install -m 755 /dev/stdin "/usr/local/bin/didc" && didc --version
-RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/181b5293e73cfe16f7a79c5b3a4339bd522d31f3/install-from-binstall-release.sh | bash && cargo binstall -V
+RUN curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.3.0/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar -xvzf -
+# Force install of cargo-binstall 1.3.0, latest version 1.3.1 breaks.
+RUN ./cargo-binstall -y --force cargo-binstall@1.3.0
 RUN cargo binstall --no-confirm "ic-wasm@$(cat config/ic_wasm_version)" && command -v ic-wasm
 
 # Title: Gets the deployment configuration


### PR DESCRIPTION
# Motivation

docker-build script isn't working.

The problem seems to be when installing ic-wasm with cargo-binstall.

There was a new release of cargo-binstall and this one started breaking the build script.

In this PR, I install the previous version of cargo-binstall manually instead of relying in the installer script.

# Changes

* In Dockerfile, install a specific version of cargo-binstall manually.

# Tests

Tested in the gix machine.

# Todos

- [x] Add entry to changelog (if necessary).
