### PR TITLE
Fix: SnsStakeMaturityButton spec file

### DIFF
--- a/frontend/src/lib/modals/neurons/StakeMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/StakeMaturityModal.svelte
@@ -38,7 +38,13 @@
   const goToConfirm = () => modal.next();
 </script>
 
-<WizardModal {steps} bind:currentStep on:nnsClose bind:this={modal}>
+<WizardModal
+  {steps}
+  bind:currentStep
+  on:nnsClose
+  bind:this={modal}
+  testId="stake-maturity-modal-component"
+>
   <svelte:fragment slot="title"
     >{currentStep?.title ?? steps[0].title}</svelte:fragment
   >

--- a/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte
@@ -90,117 +90,111 @@
     <AddSnsHotkeyModal on:nnsClose={close} />
   {/if}
 
-  {#if nonNullish(rootCanisterId) && nonNullish(token)}
-    {#if type === "increase-dissolve-delay"}
-      <IncreaseSnsDissolveDelayModal
-        {rootCanisterId}
-        {neuron}
-        {token}
-        {reloadNeuron}
-        on:nnsClose={close}
-      />
-    {/if}
+  {#if type === "increase-dissolve-delay" && nonNullish(rootCanisterId) && nonNullish(token)}
+    <IncreaseSnsDissolveDelayModal
+      {rootCanisterId}
+      {neuron}
+      {token}
+      {reloadNeuron}
+      on:nnsClose={close}
+    />
+  {/if}
 
-    {#if type === "disburse"}
-      <DisburseSnsNeuronModal
-        {rootCanisterId}
-        {neuron}
-        {reloadNeuron}
-        on:nnsClose={close}
-      />
-    {/if}
+  {#if type === "disburse" && nonNullish(rootCanisterId)}
+    <DisburseSnsNeuronModal
+      {rootCanisterId}
+      {neuron}
+      {reloadNeuron}
+      on:nnsClose={close}
+    />
+  {/if}
 
-    {#if type === "follow"}
-      <FollowSnsNeuronsModal {neuron} on:nnsClose={close} {rootCanisterId} />
-    {/if}
+  {#if type === "follow" && nonNullish(rootCanisterId)}
+    <FollowSnsNeuronsModal {neuron} on:nnsClose={close} {rootCanisterId} />
+  {/if}
 
-    {#if nonNullish(neuronId)}
-      {#if type === "stake-maturity"}
-        <SnsStakeMaturityModal
-          {reloadNeuron}
-          on:nnsClose={close}
-          {neuronId}
-          {neuron}
-          {rootCanisterId}
-        />
-      {/if}
+  {#if type === "stake-maturity" && nonNullish(rootCanisterId) && nonNullish(neuronId)}
+    <SnsStakeMaturityModal
+      {reloadNeuron}
+      on:nnsClose={close}
+      {neuronId}
+      {neuron}
+      {rootCanisterId}
+    />
+  {/if}
 
-      {#if type === "disburse-maturity"}
-        <SnsDisburseMaturityModal
-          {reloadNeuron}
-          on:nnsClose={close}
-          {neuronId}
-          {neuron}
-          {rootCanisterId}
-        />
-      {/if}
+  {#if type === "disburse-maturity" && nonNullish(rootCanisterId) && nonNullish(neuronId)}
+    <SnsDisburseMaturityModal
+      {reloadNeuron}
+      on:nnsClose={close}
+      {neuronId}
+      {neuron}
+      {rootCanisterId}
+    />
+  {/if}
 
-      {#if type === "view-active-disbursements"}
-        <SnsActiveDisbursementsModal on:nnsClose={close} {neuron} />
-      {/if}
+  {#if type === "view-active-disbursements"}
+    <SnsActiveDisbursementsModal on:nnsClose={close} {neuron} />
+  {/if}
 
-      {#if type === "auto-stake-maturity"}
-        <SnsAutoStakeMaturityModal
-          {reloadNeuron}
-          on:nnsClose={close}
-          {neuronId}
-          {neuron}
-          {rootCanisterId}
-        />
-      {/if}
+  {#if type === "auto-stake-maturity" && nonNullish(rootCanisterId) && nonNullish(neuronId)}
+    <SnsAutoStakeMaturityModal
+      {reloadNeuron}
+      on:nnsClose={close}
+      {neuronId}
+      {neuron}
+      {rootCanisterId}
+    />
+  {/if}
 
-      {#if nonNullish(parameters) && nonNullish(transactionFee)}
-        {#if type === "split-neuron"}
-          <SplitSnsNeuronModal
-            {rootCanisterId}
-            {neuron}
-            {token}
-            {parameters}
-            {transactionFee}
-            {reloadNeuron}
-            on:nnsClose={close}
-          />
-        {/if}
-      {/if}
+  {#if type === "split-neuron" && nonNullish(rootCanisterId) && nonNullish(neuronId) && nonNullish(token) && nonNullish(parameters) && nonNullish(transactionFee)}
+    <SplitSnsNeuronModal
+      {rootCanisterId}
+      {neuron}
+      {token}
+      {parameters}
+      {transactionFee}
+      {reloadNeuron}
+      on:nnsClose={close}
+    />
+  {/if}
 
-      {#if type === "increase-stake"}
-        <SnsIncreaseStakeNeuronModal
-          {rootCanisterId}
-          {token}
-          {neuronId}
-          {reloadNeuron}
-          on:nnsClose={close}
-        />
-      {/if}
+  {#if type === "increase-stake" && nonNullish(rootCanisterId) && nonNullish(token) && nonNullish(neuronId)}
+    <SnsIncreaseStakeNeuronModal
+      {rootCanisterId}
+      {token}
+      {neuronId}
+      {reloadNeuron}
+      on:nnsClose={close}
+    />
+  {/if}
 
-      {#if type === "dev-add-permissions" && IS_TESTNET}
-        <AddPermissionsModal
-          {rootCanisterId}
-          {neuronId}
-          {reloadNeuron}
-          on:nnsClose={close}
-          mode="add"
-        />
-      {/if}
+  {#if type === "dev-add-permissions" && IS_TESTNET && nonNullish(rootCanisterId) && nonNullish(neuronId)}
+    <AddPermissionsModal
+      {rootCanisterId}
+      {neuronId}
+      {reloadNeuron}
+      on:nnsClose={close}
+      mode="add"
+    />
+  {/if}
 
-      {#if type === "dev-remove-permissions" && IS_TESTNET}
-        <AddPermissionsModal
-          {rootCanisterId}
-          {neuronId}
-          {reloadNeuron}
-          on:nnsClose={close}
-          mode="remove"
-        />
-      {/if}
+  {#if type === "dev-remove-permissions" && IS_TESTNET && nonNullish(rootCanisterId) && nonNullish(neuronId)}
+    <AddPermissionsModal
+      {rootCanisterId}
+      {neuronId}
+      {reloadNeuron}
+      on:nnsClose={close}
+      mode="remove"
+    />
+  {/if}
 
-      {#if type === "dev-add-maturity" && IS_TESTNET}
-        <AddMaturityModal
-          {rootCanisterId}
-          {neuronId}
-          {reloadNeuron}
-          on:nnsClose={close}
-        />
-      {/if}
-    {/if}
+  {#if type === "dev-add-maturity" && IS_TESTNET && nonNullish(rootCanisterId) && nonNullish(neuronId)}
+    <AddMaturityModal
+      {rootCanisterId}
+      {neuronId}
+      {reloadNeuron}
+      on:nnsClose={close}
+    />
   {/if}
 {/if}

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.spec.ts
@@ -3,9 +3,10 @@
  */
 
 import SnsStakeMaturityButton from "$lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.svelte";
-import en from "$tests/mocks/i18n.mock";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
 describe("SnsStakeMaturityButton", () => {
   afterEach(() => {
@@ -13,20 +14,22 @@ describe("SnsStakeMaturityButton", () => {
   });
 
   it("should open stake maturity modal", async () => {
-    const { getByText, getByTestId } = render(SnsStakeMaturityButton, {
+    const { getByTestId } = render(SnsNeuronContextTest, {
       props: {
         neuron: {
           ...mockSnsNeuron,
+          maturity_e8s_equivalent: 100_000_000n,
         },
+        testComponent: SnsStakeMaturityButton,
+        passPropNeuron: true,
+        rootCanisterId: mockPrincipal,
       },
     });
 
     fireEvent.click(getByTestId("stake-maturity-button") as HTMLButtonElement);
 
     await waitFor(() =>
-      expect(
-        getByText(en.neuron_detail.stake_maturity_modal_title)
-      ).toBeInTheDocument()
+      expect(getByTestId("stake-maturity-modal-component")).toBeInTheDocument()
     );
   });
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.spec.ts
@@ -5,7 +5,7 @@
 import SnsStakeMaturityButton from "$lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.svelte";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { fireEvent, render } from "@testing-library/svelte";
 import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
 describe("SnsStakeMaturityButton", () => {
@@ -14,7 +14,7 @@ describe("SnsStakeMaturityButton", () => {
   });
 
   it("should open stake maturity modal", async () => {
-    const { getByTestId } = render(SnsNeuronContextTest, {
+    const { queryByTestId, getByTestId } = render(SnsNeuronContextTest, {
       props: {
         neuron: {
           ...mockSnsNeuron,
@@ -26,11 +26,15 @@ describe("SnsStakeMaturityButton", () => {
       },
     });
 
-    fireEvent.click(getByTestId("stake-maturity-button") as HTMLButtonElement);
+    expect(
+      queryByTestId("stake-maturity-modal-component")
+    ).not.toBeInTheDocument();
 
-    await waitFor(() =>
-      expect(getByTestId("stake-maturity-modal-component")).toBeInTheDocument()
+    await fireEvent.click(
+      getByTestId("stake-maturity-button") as HTMLButtonElement
     );
+
+    expect(queryByTestId("stake-maturity-modal-component")).toBeInTheDocument();
   });
 
   it("should be disabled if no maturity to stake", async () => {


### PR DESCRIPTION
# Motivation

One test for SnsStakeMaturityButton was not correct. The test passed because the expected text (title of the modal) was the same text as the button.

In this PR, I added a testId to the modal and checked the presence of the modal with test id. The test failed.

The test also failed because it required a token in the store to be present. That is not necessary for the modal, but it was inside an `if` checking the presence of the token.

Therefore, in this PR, I also refactored the SnsNeuronModals to check for presence next to the type of the modal. This way it's easier to understand what is strictly necessary in each modal.

# Changes

* Add testId to StakeMaturityModal.
* Move modals and conditions in SnsNeuronModals.

# Tests

* Use `SnsNeuronContextTest` in `SnsStakeMaturityButton.spec` to check that modal is opened.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
