### PR TITLE
Fix: Better min and max range in disburse maturity

### DIFF
--- a/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
@@ -14,7 +14,6 @@
   } from "@dfinity/gix-components";
   import { formatToken } from "$lib/utils/token.utils";
   import { formatMaturity } from "$lib/utils/neuron.utils";
-  import Tooltip from "$lib/components/ui/Tooltip.svelte";
 
   export let availableMaturityE8s: bigint;
   export let tokenSymbol: string;
@@ -158,22 +157,9 @@
               { $symbol: tokenSymbol }
             )}</span
           >
-          <span class="value" slot="value"
-            ><Tooltip
-              id="disburse-range"
-              text={`${formatToken({
-                value: predictedMinE8s,
-                detailed: true,
-              })}-${formatToken({
-                value: predictedMaxE8s,
-                detailed: true,
-              })} ${tokenSymbol}`}
-            >
-              <span data-tid="confirm-tokens">
-                {predictedMinimumTokens}-{predictedMaximumTokens}
-                {tokenSymbol}
-              </span>
-            </Tooltip>
+          <span data-tid="confirm-tokens" class="value" slot="value"
+            >{predictedMinimumTokens}-{predictedMaximumTokens}
+            {tokenSymbol}
           </span>
         </KeyValuePair>
         <KeyValuePair>

--- a/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
@@ -70,12 +70,14 @@
   let predictedMinimumTokens: string;
   $: predictedMinimumTokens = formatToken({
     value: predictedMinE8s,
+    roundingMode: "floor",
   });
   let predictedMaxE8s: bigint;
   $: predictedMaxE8s = BigInt(Math.ceil(Number(maturityToDisburseE8s) * 1.05));
   let predictedMaximumTokens: string;
   $: predictedMaximumTokens = formatToken({
     value: predictedMaxE8s,
+    roundingMode: "ceil",
   });
 </script>
 

--- a/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
@@ -14,6 +14,7 @@
   } from "@dfinity/gix-components";
   import { formatToken } from "$lib/utils/token.utils";
   import { formatMaturity } from "$lib/utils/neuron.utils";
+  import Tooltip from "$lib/components/ui/Tooltip.svelte";
 
   export let availableMaturityE8s: bigint;
   export let tokenSymbol: string;
@@ -64,13 +65,17 @@
     (availableMaturityE8s * BigInt(percentageToDisburse)) / 100n;
 
   // +/- 5%
+  let predictedMinE8s: bigint;
+  $: predictedMinE8s = BigInt(Math.floor(Number(maturityToDisburseE8s) * 0.95));
   let predictedMinimumTokens: string;
   $: predictedMinimumTokens = formatToken({
-    value: BigInt(Math.round(Number(maturityToDisburseE8s) * 0.95)),
+    value: predictedMinE8s,
   });
+  let predictedMaxE8s: bigint;
+  $: predictedMaxE8s = BigInt(Math.ceil(Number(maturityToDisburseE8s) * 1.05));
   let predictedMaximumTokens: string;
   $: predictedMaximumTokens = formatToken({
-    value: BigInt(Math.round(Number(maturityToDisburseE8s) * 1.05)),
+    value: predictedMaxE8s,
   });
 </script>
 
@@ -151,9 +156,22 @@
               { $symbol: tokenSymbol }
             )}</span
           >
-          <span data-tid="confirm-tokens" class="value" slot="value"
-            >{predictedMinimumTokens}-{predictedMaximumTokens}
-            {tokenSymbol}
+          <span class="value" slot="value"
+            ><Tooltip
+              id="disburse-range"
+              text={`${formatToken({
+                value: predictedMinE8s,
+                detailed: true,
+              })}-${formatToken({
+                value: predictedMaxE8s,
+                detailed: true,
+              })} ${tokenSymbol}`}
+            >
+              <span data-tid="confirm-tokens">
+                {predictedMinimumTokens}-{predictedMaximumTokens}
+                {tokenSymbol}
+              </span>
+            </Tooltip>
           </span>
         </KeyValuePair>
         <KeyValuePair>

--- a/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
@@ -64,18 +64,14 @@
     (availableMaturityE8s * BigInt(percentageToDisburse)) / 100n;
 
   // +/- 5%
-  let predictedMinE8s: bigint;
-  $: predictedMinE8s = BigInt(Math.floor(Number(maturityToDisburseE8s) * 0.95));
   let predictedMinimumTokens: string;
   $: predictedMinimumTokens = formatToken({
-    value: predictedMinE8s,
+    value: BigInt(Math.floor(Number(maturityToDisburseE8s) * 0.95)),
     roundingMode: "floor",
   });
-  let predictedMaxE8s: bigint;
-  $: predictedMaxE8s = BigInt(Math.ceil(Number(maturityToDisburseE8s) * 1.05));
   let predictedMaximumTokens: string;
   $: predictedMaximumTokens = formatToken({
-    value: predictedMaxE8s,
+    value: BigInt(Math.ceil(Number(maturityToDisburseE8s) * 1.05)),
     roundingMode: "ceil",
   });
 </script>

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -14,6 +14,18 @@ const countDecimals = (value: number): number => {
   return Math.max(split[1]?.length ?? 0, ICP_DISPLAYED_DECIMALS);
 };
 
+// Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat
+type RoundMode =
+  | "ceil"
+  | "floor"
+  | "expand"
+  | "trunc"
+  | "halfCeil"
+  | "halfFloor"
+  | "halfExpand"
+  | "halfTrunc"
+  | "halfEven";
+
 /**
  * Jira L2-666:
  * - If ICP is zero then 0 should be displayed - i.e. without decimals
@@ -27,9 +39,11 @@ const countDecimals = (value: number): number => {
 export const formatToken = ({
   value,
   detailed = false,
+  roundingMode,
 }: {
   value: bigint;
   detailed?: boolean | "height_decimals";
+  roundingMode?: RoundMode;
 }): string => {
   if (value === BigInt(0)) {
     return "0";
@@ -52,6 +66,11 @@ export const formatToken = ({
   return new Intl.NumberFormat("en-US", {
     minimumFractionDigits: decimals,
     maximumFractionDigits: decimals,
+    // "roundingMode" not present in `NumberFormatOptions`.
+    // But it's supported by most modern browsers: https://caniuse.com/mdn-javascript_builtins_intl_numberformat_numberformat_options_roundingmode_parameter
+    // eslint-disable-next-line
+    // @ts-ignore
+    roundingMode,
   })
     .format(converted)
     .replace(/,/g, "'");

--- a/frontend/src/tests/lib/modals/sns/SnsDisburseMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsDisburseMaturityModal.spec.ts
@@ -99,12 +99,19 @@ describe("SnsDisburseMaturityModal", () => {
   });
 
   it("should display summary information in the last step", async () => {
-    const po = await renderSnsDisburseMaturityModal();
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      maturity: 1_233_123_112n,
+    });
+    const po = await renderSnsDisburseMaturityModal(neuron);
     await po.setPercentage(50);
     await po.clickNextButton();
 
     expect(await po.getConfirmPercentage()).toBe("50%");
-    expect(await po.getConfirmTokens()).toBe("0.48-0.53 TST");
+    expect(await po.getConfirmTokens()).toBe("5.86-6.47 TST");
+    expect(await po.getConfirmTokensDetailed()).toBe(
+      "5.85733478-6.47389634 TST"
+    );
     expect(await po.getConfirmDestination()).toBe("Main");
   });
 

--- a/frontend/src/tests/lib/modals/sns/SnsDisburseMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsDisburseMaturityModal.spec.ts
@@ -101,14 +101,14 @@ describe("SnsDisburseMaturityModal", () => {
   it("should display summary information in the last step", async () => {
     const neuron = createMockSnsNeuron({
       id: [1],
-      maturity: 1_233_123_112n,
+      maturity: 1_000_000_000n,
     });
     const po = await renderSnsDisburseMaturityModal(neuron);
     await po.setPercentage(50);
     await po.clickNextButton();
 
     expect(await po.getConfirmPercentage()).toBe("50%");
-    expect(await po.getConfirmTokens()).toBe("5.86-6.47 TST");
+    expect(await po.getConfirmTokens()).toBe("4.75-5.25 TST");
     expect(await po.getConfirmDestination()).toBe("Main");
   });
 
@@ -123,6 +123,9 @@ describe("SnsDisburseMaturityModal", () => {
     await po.setPercentage(100);
     await po.clickNextButton();
 
+    // with 123123213n maturity
+    // -5% is 1,169670524, which should show as 1.16 with the rounding mode "floor"
+    // +5% is 1,292793737, which should show as 1.30 with the rounding mode "ceil"
     expect(await po.getConfirmTokens()).toBe("1.16-1.30 TST");
   });
 

--- a/frontend/src/tests/lib/modals/sns/SnsDisburseMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsDisburseMaturityModal.spec.ts
@@ -112,9 +112,7 @@ describe("SnsDisburseMaturityModal", () => {
     expect(await po.getConfirmDestination()).toBe("Main");
   });
 
-  // NodeJS supports roundingMode since v19
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#browser_compatibility
-  it.skip("should display range with floor and ceil rounding", async () => {
+  it("should display range with floor and ceil rounding", async () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       maturity: 123123213n,
@@ -123,10 +121,13 @@ describe("SnsDisburseMaturityModal", () => {
     await po.setPercentage(100);
     await po.clickNextButton();
 
+    // NodeJS supports roundingMode since v19
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#browser_compatibility
     // with 123123213n maturity
     // -5% is 1,169670524, which should show as 1.16 with the rounding mode "floor"
     // +5% is 1,292793737, which should show as 1.30 with the rounding mode "ceil"
-    expect(await po.getConfirmTokens()).toBe("1.16-1.30 TST");
+    // expect(await po.getConfirmTokens()).toBe("1.16-1.30 TST");
+    expect(await po.getConfirmTokens()).toBe("1.17-1.29 TST");
   });
 
   const disburse = async (neuron: SnsNeuron) => {

--- a/frontend/src/tests/lib/modals/sns/SnsDisburseMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsDisburseMaturityModal.spec.ts
@@ -109,9 +109,6 @@ describe("SnsDisburseMaturityModal", () => {
 
     expect(await po.getConfirmPercentage()).toBe("50%");
     expect(await po.getConfirmTokens()).toBe("5.86-6.47 TST");
-    expect(await po.getConfirmTokensDetailed()).toBe(
-      "5.85733478-6.47389634 TST"
-    );
     expect(await po.getConfirmDestination()).toBe("Main");
   });
 
@@ -126,10 +123,7 @@ describe("SnsDisburseMaturityModal", () => {
     await po.setPercentage(100);
     await po.clickNextButton();
 
-    expect(await po.getConfirmTokens()).toBe("1.17-1.29 TST");
-    expect(await po.getConfirmTokensDetailed()).toBe(
-      "5.85733478-6.47389634 TST"
-    );
+    expect(await po.getConfirmTokens()).toBe("1.16-1.30 TST");
   });
 
   const disburse = async (neuron: SnsNeuron) => {

--- a/frontend/src/tests/lib/modals/sns/SnsDisburseMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsDisburseMaturityModal.spec.ts
@@ -115,6 +115,23 @@ describe("SnsDisburseMaturityModal", () => {
     expect(await po.getConfirmDestination()).toBe("Main");
   });
 
+  // NodeJS supports roundingMode since v19
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#browser_compatibility
+  it.skip("should display range with floor and ceil rounding", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      maturity: 123123213n,
+    });
+    const po = await renderSnsDisburseMaturityModal(neuron);
+    await po.setPercentage(100);
+    await po.clickNextButton();
+
+    expect(await po.getConfirmTokens()).toBe("1.17-1.29 TST");
+    expect(await po.getConfirmTokensDetailed()).toBe(
+      "5.85733478-6.47389634 TST"
+    );
+  });
+
   const disburse = async (neuron: SnsNeuron) => {
     const po = await renderSnsDisburseMaturityModal(neuron);
     await po.setPercentage(50);

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -102,11 +102,14 @@ describe("token-utils", () => {
     ).toEqual(`2'000'000.00000000`);
   });
 
-  // NodeJS supports roundingMode since v19
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#browser_compatibility
-  it.skip("should use roundingMode", () => {
+  it("should use roundingMode", () => {
+    // NodeJS supports roundingMode since v19
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#browser_compatibility
+    // expect(formatToken({ value: 111_100_000n, roundingMode: "ceil" })).toEqual(
+    //   "1.12"
+    // );
     expect(formatToken({ value: 111_100_000n, roundingMode: "ceil" })).toEqual(
-      "1.12"
+      "1.11"
     );
   });
 

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -102,6 +102,14 @@ describe("token-utils", () => {
     ).toEqual(`2'000'000.00000000`);
   });
 
+  // NodeJS supports roundingMode since v19
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#browser_compatibility
+  it.skip("should use roundingMode", () => {
+    expect(formatToken({ value: 111_100_000n, roundingMode: "ceil" })).toEqual(
+      "1.12"
+    );
+  });
+
   describe("sumAmountE8s", () => {
     it("should sum amounts of E8s values", () => {
       const icp0 = 0n;

--- a/frontend/src/tests/page-objects/DisburseMaturityModal.page-object.ts
+++ b/frontend/src/tests/page-objects/DisburseMaturityModal.page-object.ts
@@ -2,7 +2,6 @@ import { NeuronConfirmActionScreenPo } from "$tests/page-objects/NeuronConfirmAc
 import { NeuronSelectPercentagePo } from "$tests/page-objects/NeuronSelectPercentage.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { TooltipPo } from "./Tooltip.page-object";
 
 export class DisburseMaturityModalPo extends BasePageObject {
   private static readonly TID = "disburse-maturity-modal-component";
@@ -59,9 +58,5 @@ export class DisburseMaturityModalPo extends BasePageObject {
 
   getConfirmDestination(): Promise<string> {
     return this.getNeuronConfirmActionScreenPo().getText("confirm-destination");
-  }
-
-  getTooltipPo(): TooltipPo {
-    return TooltipPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/DisburseMaturityModal.page-object.ts
+++ b/frontend/src/tests/page-objects/DisburseMaturityModal.page-object.ts
@@ -64,8 +64,4 @@ export class DisburseMaturityModalPo extends BasePageObject {
   getTooltipPo(): TooltipPo {
     return TooltipPo.under(this.root);
   }
-
-  getConfirmTokensDetailed(): Promise<string> {
-    return this.getTooltipPo().getText();
-  }
 }

--- a/frontend/src/tests/page-objects/DisburseMaturityModal.page-object.ts
+++ b/frontend/src/tests/page-objects/DisburseMaturityModal.page-object.ts
@@ -2,6 +2,7 @@ import { NeuronConfirmActionScreenPo } from "$tests/page-objects/NeuronConfirmAc
 import { NeuronSelectPercentagePo } from "$tests/page-objects/NeuronSelectPercentage.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { TooltipPo } from "./Tooltip.page-object";
 
 export class DisburseMaturityModalPo extends BasePageObject {
   private static readonly TID = "disburse-maturity-modal-component";
@@ -58,5 +59,13 @@ export class DisburseMaturityModalPo extends BasePageObject {
 
   getConfirmDestination(): Promise<string> {
     return this.getNeuronConfirmActionScreenPo().getText("confirm-destination");
+  }
+
+  getTooltipPo(): TooltipPo {
+    return TooltipPo.under(this.root);
+  }
+
+  getConfirmTokensDetailed(): Promise<string> {
+    return this.getTooltipPo().getText();
   }
 }


### PR DESCRIPTION
# Motivation

The range of the predicted tokens in the disbursing flow is an approximation of two decimals. By default, the decimals were rounded the standard way. That meant that the min range could be rounded up and give a wrong min, or the max range rounded down and give a wrong max.

In this PR, we add the `roundingMode` parameter to `formatToken` and use it for the range.

# Changes

* Add `roundingMode` param to `formatToken`.
* Use param `roundingMode` for the range in DisburseMaturityModal confirmation screen.

# Tests

* Add skipped tests because the new parameter is only supported in node 19 and we are in node 18.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary. Covered by an entry.
