### PR TITLE
E2E: Work around flakiness loading proposals

### DIFF
--- a/frontend/src/lib/pages/NnsProposals.svelte
+++ b/frontend/src/lib/pages/NnsProposals.svelte
@@ -128,6 +128,11 @@
     debounceFindProposals?.();
   };
 
+  // Neurons and proposals are loaded at the same time. But once neurons are
+  // loaded, proposals are loaded again. So it's possible that the component
+  // goes back into loading state immediately after proposals are loaded.
+  // TODO: Fix NnsProposals to load proposals only once and remove the
+  // work-around from NnsProposalList.page-object.ts
   $: $definedNeuronsStore, applyFilter($proposalsFiltersStore);
 
   $: $authStore.identity, (() => proposalsFiltersStore.reload())();

--- a/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
@@ -88,10 +88,15 @@ export class NnsProposalListPo extends BasePageObject {
   }
 
   async waitForContentLoaded(): Promise<void> {
-    await Promise.race([
-      this.getProposalCardPo().waitFor(),
-      this.waitFor("no-proposals-msg"),
-    ]);
+    this.getSkeletonCardPo().waitForAbsent();
+    // The NnsProposals component loads neurons and proposals at the same time.
+    // But once neurons are loaded, it loads proposals again. So it's possible
+    // that the component goes back into loading state immediately after
+    // proposals are loaded.
+    // TODO: Fix NnsProposals to load proposals only once and remove the 2 lines
+    // below.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    this.getSkeletonCardPo().waitForAbsent();
   }
 
   async getVisibleProposalIds(proposerNeuronId: string): Promise<string[]> {


### PR DESCRIPTION
# Motivation

We've seen flakiness with `e2e/neurons.spec.ts` for a while. I think I finally figured out what happens.

The `NnsProposals` component loads neurons and proposals at the same time.
But once neurons are loaded, it loads proposals again. So it's possible
that the component goes back into loading state immediately after
proposals are loaded.

I was able to reproduce this by adding an artificial delay in `listNeurons`. Then you consistently see the skeletons reappear after the disappear.

Unfortunately the component is very complicated so it's not easy to fix without a major cleanup.
So until we have time to clean this up, we should work around the issue to avoid flakiness with the test.

# Changes

Once proposals are loaded, wait 1 second and wait again for proposals to be loaded if necessary.

# Tests

Still pass. Hopefully less flaky in the future.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary