### PR TITLE
Feat: Remove "Project" from ProjectCard

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -21,6 +21,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Use consistent positioning for the copy icon in the Hash component.
 * Allow setting a dissolve delay that's shorter than what's required for voting power.
 * Improve contrast of token selector's logo in light theme.
+* Remove the "Project" leading word in the SNS Project card.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -24,9 +24,6 @@
     metadata: { logo, name, description },
   } = summary);
 
-  let title: string;
-  $: title = `${$i18n.sns_project.project} ${name}`;
-
   let commitmentE8s: bigint | undefined;
   $: commitmentE8s = getCommitmentE8s(swapCommitment);
 
@@ -45,7 +42,7 @@
 >
   <div class="title" slot="start">
     <Logo src={logo} alt={$i18n.sns_launchpad.project_logo} size="big" />
-    <h3 data-tid="project-name">{title}</h3>
+    <h3 data-tid="project-name">{name}</h3>
   </div>
 
   <p class="value description">{description}</p>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -691,9 +691,6 @@
     "project_logo": "project logo",
     "no_proposals": "There are no decentralisation swap proposals open at the moment."
   },
-  "sns_project": {
-    "project": "Project"
-  },
   "sns_project_detail": {
     "token_name": "Token Name",
     "token_symbol": "Token Symbol",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -716,10 +716,6 @@ interface I18nSns_launchpad {
   no_proposals: string;
 }
 
-interface I18nSns_project {
-  project: string;
-}
-
 interface I18nSns_project_detail {
   token_name: string;
   token_symbol: string;
@@ -1279,7 +1275,6 @@ interface I18n {
   proposal_detail__ineligible: I18nProposal_detail__ineligible;
   neuron_detail: I18nNeuron_detail;
   sns_launchpad: I18nSns_launchpad;
-  sns_project: I18nSns_project;
   sns_project_detail: I18nSns_project_detail;
   sns_sale: I18nSns_sale;
   sns_neuron_detail: I18nSns_neuron_detail;

--- a/frontend/src/tests/e2e/sns-participation.spec.ts
+++ b/frontend/src/tests/e2e/sns-participation.spec.ts
@@ -35,7 +35,7 @@ test("Test SNS participation", async ({ page, context }) => {
   const projectDetail = appPo.getProjectDetailPo();
   await projectDetail.waitForContentLoaded();
   const projectName = await projectDetail.getProjectName();
-  expect(`Project ${projectName}`).toBe(snsProjectName);
+  expect(projectName).toBe(snsProjectName);
   expect(await projectDetail.getTokenSymbol()).not.toBe("");
   expect(await projectDetail.getStatus()).toBe("Accepting Participation");
 

--- a/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
@@ -44,18 +44,18 @@ describe("ProjectCard", () => {
       );
     });
 
-    it("should render a title", () => {
-      const { getByText } = render(ProjectCard, {
+    it("should render a title", async () => {
+      const { container } = render(ProjectCard, {
         props: {
           project: mockSnsFullProject,
         },
       });
 
-      expect(
-        getByText(
-          `${en.sns_project.project} ${mockSnsFullProject.summary.metadata.name}`
-        )
-      ).toBeInTheDocument();
+      const po = ProjectCardPo.under(new JestPageObjectElement(container));
+
+      expect(await po.getProjectName()).toBe(
+        mockSnsFullProject.summary.metadata.name
+      );
     });
 
     it("should render a description", () => {


### PR DESCRIPTION
# Motivation

Remove the word "Project" from the ProjectCard. Leave instead only the SNS name.

# Changes

* Remove the "Project" word from ProjectCard.svelte.
* Remove i18n keys.

# Tests

* Adapt test.

# Todos

- [x] Add entry to changelog (if necessary).
