### PR TITLE
E2E: Work around images not loading

### DIFF
--- a/frontend/src/tests/e2e/images.spec.ts
+++ b/frontend/src/tests/e2e/images.spec.ts
@@ -25,8 +25,10 @@ const expectImagesLoaded = async ({ page, sources }) => {
     // viewport.
     images.forEach((img) => img.scrollIntoView());
     return images.every((img) => img.complete);
-  }, sources.length);
+  }, sources.length, {timeout: 10000});
 };
+
+test.describe.configure({ retries: 2 });
 
 test("Test images load on accounts page", async ({ page, context }) => {
   await page.goto("/accounts");

--- a/frontend/src/tests/e2e/images.spec.ts
+++ b/frontend/src/tests/e2e/images.spec.ts
@@ -16,16 +16,20 @@ const expectImagesLoaded = async ({ page, sources }) => {
   baseImageSources.sort();
   expect(baseImageSources).toEqual(sources);
 
-  await page.waitForFunction((expectedImageCount) => {
-    const images = Array.from(document.querySelectorAll("img"));
-    if (images.length !== expectedImageCount) {
-      return false;
-    }
-    // The browser might decide not to load images that are outside the
-    // viewport.
-    images.forEach((img) => img.scrollIntoView());
-    return images.every((img) => img.complete);
-  }, sources.length, {timeout: 10000});
+  await page.waitForFunction(
+    (expectedImageCount) => {
+      const images = Array.from(document.querySelectorAll("img"));
+      if (images.length !== expectedImageCount) {
+        return false;
+      }
+      // The browser might decide not to load images that are outside the
+      // viewport.
+      images.forEach((img) => img.scrollIntoView());
+      return images.every((img) => img.complete);
+    },
+    sources.length,
+    { timeout: 10000 }
+  );
 };
 
 test.describe.configure({ retries: 2 });


### PR DESCRIPTION
# Motivation

We have an e2e test that tests that images load.
Sometimes images don't load and the test times out:
https://github.com/dfinity/nns-dapp/actions/runs/6245207559?pr=3337

I'm not sure why they don't always load on CI but let's retry the test when they don't.

# Changes

1. Set a timeout on waiting for images to be loaded.
2. Retry the test up to 2 times when it fails.

# Tests

Still pass, hopefully less flaky.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary