### PR TITLE
Add governance API function stakeNeuronIcrc1

### DIFF
--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -411,13 +411,53 @@ export const stakeNeuron = async ({
 
   const createdAt = nowInBigIntNanoSeconds();
   const response = await canister.stakeNeuron({
-    stake: stake,
+    stake,
     principal: controller,
     fromSubAccount,
     ledgerCanister,
     createdAt,
   });
   logWithTimestamp(`Staking Neuron complete.`);
+  return response;
+};
+
+export type ApiStakeNeuronIcrc1Params = ApiCallParams & {
+  stake: bigint;
+  controller: Principal;
+  ledgerCanisterIdentity: Identity;
+  fromSubAccount?: Uint8Array;
+};
+
+/**
+ * Uses governance and ledger canisters to create a neuron
+ */
+export const stakeNeuronIcrc1 = async ({
+  stake,
+  controller,
+  ledgerCanisterIdentity,
+  identity,
+  fromSubAccount,
+}: ApiStakeNeuronIcrc1Params): Promise<NeuronId> => {
+  // Ledger HW app currently (2023-09-21) doesn't support staking with ICRC-1
+  // but it should be supported in the future so we keep the code similar to the
+  // non-ICRC-1 flow above.
+  logWithTimestamp(`Staking Neuron ICRC-1 call...`);
+  const { canister } = await governanceCanister({ identity });
+
+  // The use case of staking from Hardware wallet uses a different agent for governance and ledger canister.
+  const { canister: ledgerCanister } = await getLedgerCanister({
+    identity: ledgerCanisterIdentity,
+  });
+
+  const createdAt = nowInBigIntNanoSeconds();
+  const response = await canister.stakeNeuronIcrc1({
+    stake,
+    principal: controller,
+    fromSubAccount,
+    ledgerCanister,
+    createdAt,
+  });
+  logWithTimestamp(`Staking Neuron ICRC-1 complete.`);
   return response;
 };
 

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -19,6 +19,7 @@ import {
   splitNeuron,
   stakeMaturity,
   stakeNeuron,
+  stakeNeuronIcrc1,
   startDissolving,
   stopDissolving,
 } from "$lib/api/governance.api";
@@ -62,14 +63,59 @@ describe("neurons-api", () => {
       .spyOn(LedgerCanister, "create")
       .mockImplementation(() => mock<LedgerCanister>());
 
+    expect(mockGovernanceCanister.stakeNeuron).not.toBeCalled();
+
+    const stake = BigInt(20_000_000);
+    const controller = mockIdentity.getPrincipal();
+    const fromSubAccount = [2, 3, 4];
+
     await stakeNeuron({
-      stake: BigInt(20_000_000),
-      controller: mockIdentity.getPrincipal(),
+      stake,
+      controller,
       ledgerCanisterIdentity: mockIdentity,
       identity: mockIdentity,
+      fromSubAccount,
     });
 
-    expect(mockGovernanceCanister.stakeNeuron).toBeCalled();
+    expect(mockGovernanceCanister.stakeNeuron).toBeCalledTimes(1);
+    expect(mockGovernanceCanister.stakeNeuron).toBeCalledWith(
+      expect.objectContaining({
+        stake,
+        principal: controller,
+        fromSubAccount,
+      })
+    );
+  });
+
+  it("stakeNeuronIcrc1 creates a new neuron", async () => {
+    jest
+      .spyOn(LedgerCanister, "create")
+      .mockImplementation(() => mock<LedgerCanister>());
+
+    expect(mockGovernanceCanister.stakeNeuronIcrc1).not.toBeCalled();
+
+    const stake = BigInt(20_000_000);
+    const controller = mockIdentity.getPrincipal();
+    const fromSubAccount = new Uint8Array([5, 6, 7]);
+
+    await stakeNeuronIcrc1({
+      stake,
+      controller,
+      ledgerCanisterIdentity: mockIdentity,
+      identity: mockIdentity,
+      fromSubAccount,
+    });
+
+    expect(mockGovernanceCanister.stakeNeuronIcrc1).toBeCalledTimes(1);
+    expect(mockGovernanceCanister.stakeNeuronIcrc1).toBeCalledWith(
+      expect.objectContaining({
+        stake,
+        principal: controller,
+        fromSubAccount,
+      })
+    );
+
+    expect(mockGovernanceCanister.stakeNeuron).not.toBeCalled();
   });
 
   it("queryNeurons fetches neurons", async () => {


### PR DESCRIPTION
# Motivation

We want to stake neurons using an ICRC-1 transfer when possible.

# Changes

Support the new `stakeNeuronIcrc1` function in the governance API.

# Tests

Improved existing test for `stakeNeuron` and added an analogous test for `stakeNeuronIcrc1`.

# Todos

- [ ] Add entry to changelog (if necessary).
Will add when it's all hooked up.