### PR TITLE
Add stakeNeuronIcrc1 to governance API service

### DIFF
--- a/frontend/src/lib/api-services/governance.api-service.ts
+++ b/frontend/src/lib/api-services/governance.api-service.ts
@@ -20,6 +20,7 @@ import {
   splitNeuron,
   stakeMaturity,
   stakeNeuron,
+  stakeNeuronIcrc1,
   startDissolving,
   stopDissolving,
   type ApiAutoStakeMaturityParams,
@@ -35,6 +36,7 @@ import {
   type ApiSpawnNeuronParams,
   type ApiSplitNeuronParams,
   type ApiStakeMaturityParams,
+  type ApiStakeNeuronIcrc1Params,
   type ApiStakeNeuronParams,
   type RegisterVoteParams,
 } from "$lib/api/governance.api";
@@ -197,6 +199,9 @@ export const governanceApiService = {
   },
   stakeNeuron(params: ApiStakeNeuronParams) {
     return clearCacheAfter(stakeNeuron(params));
+  },
+  stakeNeuronIcrc1(params: ApiStakeNeuronIcrc1Params) {
+    return clearCacheAfter(stakeNeuronIcrc1(params));
   },
   startDissolving(params: ApiManageNeuronParams) {
     return clearCacheAfter(startDissolving(params));

--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -988,6 +988,41 @@ describe("neurons api-service", () => {
     });
   });
 
+  describe("stakeNeuronIcrc1", () => {
+    const params = {
+      identity: mockIdentity,
+      stake: BigInt(10_000_000),
+      controller: mockPrincipal,
+      ledgerCanisterIdentity: mockIdentity,
+      fromSubaccount: new Uint8Array(),
+    };
+
+    it("should call stakeNeuronIcrc1 api", async () => {
+      jest.spyOn(api, "stakeNeuronIcrc1").mockResolvedValueOnce(neuronId);
+      expect(await governanceApiService.stakeNeuronIcrc1(params)).toEqual(
+        neuronId
+      );
+      expect(api.stakeNeuronIcrc1).toHaveBeenCalledWith(params);
+      expect(api.stakeNeuronIcrc1).toHaveBeenCalledTimes(1);
+    });
+
+    it("should invalidate the cache", async () => {
+      await shouldInvalidateCache({
+        apiFunc: api.stakeNeuronIcrc1,
+        apiServiceFunc: governanceApiService.stakeNeuronIcrc1,
+        params,
+      });
+    });
+
+    it("should invalidate the cache on failure", async () => {
+      await shouldInvalidateCacheOnFailure({
+        apiFunc: api.stakeNeuronIcrc1,
+        apiServiceFunc: governanceApiService.stakeNeuronIcrc1,
+        params,
+      });
+    });
+  });
+
   describe("startDissolving", () => {
     const params = {
       neuronId,


### PR DESCRIPTION
# Motivation

We want to stake neurons using an ICRC-1 transfer when possible.
We access the governance API through the governance API service, which caches certified responses.

# Changes

Add stakeNeuronIcrc1 to governance API service, which calls the governance API.

# Tests

Unit tests added

# Todos

- [ ] Add entry to changelog (if necessary).
Will add when it's all hooked up