### PR TITLE
Add sendIcpIcrc1 to ICP ledger API

### DIFF
--- a/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
@@ -2,6 +2,7 @@ import * as agent from "$lib/api/agent.api";
 import {
   queryAccountBalance,
   sendICP,
+  sendIcpIcrc1,
   transactionFee,
 } from "$lib/api/icp-ledger.api";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
@@ -27,7 +28,11 @@ describe("icp-ledger.api", () => {
 
     const now = Date.now();
     const nowInBigIntNanoSeconds = BigInt(now) * BigInt(1_000_000);
-    beforeAll(() => {
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.clearAllTimers();
+
       const ledgerMock = mock<LedgerCanister>();
       ledgerMock.transfer.mockResolvedValue(BigInt(0));
       jest.useFakeTimers().setSystemTime(now);
@@ -37,11 +42,6 @@ describe("icp-ledger.api", () => {
         .mockImplementation((): LedgerCanister => ledgerMock);
 
       spyTransfer = jest.spyOn(ledgerMock, "transfer");
-    });
-
-    afterAll(() => {
-      jest.clearAllMocks();
-      jest.clearAllTimers();
     });
 
     it("should call ledger to send ICP", async () => {
@@ -111,6 +111,145 @@ describe("icp-ledger.api", () => {
         amount: amount.toE8s(),
         memo,
         createdAt,
+      });
+    });
+  });
+
+  describe("sendIcpIcrc1", () => {
+    let spyTransfer;
+
+    const owner = mockIdentity.getPrincipal();
+    const amount = TokenAmount.fromE8s({
+      amount: BigInt(11_000),
+      token: ICPToken,
+    });
+
+    const now = Date.now();
+    const nowInBigIntNanoSeconds = BigInt(now) * BigInt(1_000_000);
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.clearAllTimers();
+
+      const ledgerMock = mock<LedgerCanister>();
+      ledgerMock.icrc1Transfer.mockResolvedValue(BigInt(0));
+      jest.useFakeTimers().setSystemTime(now);
+
+      jest
+        .spyOn(LedgerCanister, "create")
+        .mockImplementation((): LedgerCanister => ledgerMock);
+
+      spyTransfer = jest.spyOn(ledgerMock, "icrc1Transfer");
+    });
+
+    it("should call ledger to send ICP", async () => {
+      await sendIcpIcrc1({
+        identity: mockIdentity,
+        to: { owner },
+        amount,
+      });
+
+      expect(spyTransfer).toHaveBeenCalledWith({
+        to: { owner, subaccount: [] },
+        amount: amount.toE8s(),
+        createdAt: nowInBigIntNanoSeconds,
+        fromSubAccount: undefined,
+        memo: undefined,
+      });
+    });
+
+    it("should call ledger to send ICP with fee", async () => {
+      const fee = 15000n;
+      await sendIcpIcrc1({
+        identity: mockIdentity,
+        to: { owner },
+        amount,
+        fee,
+      });
+
+      expect(spyTransfer).toHaveBeenCalledWith({
+        to: { owner, subaccount: [] },
+        amount: amount.toE8s(),
+        fee,
+        fromSubAccount: undefined,
+        createdAt: nowInBigIntNanoSeconds,
+        memo: undefined,
+      });
+    });
+
+    it("should call ledger to send ICP with subaccount Id", async () => {
+      const fromSubAccount = new Uint8Array([
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 1,
+      ]);
+      await sendIcpIcrc1({
+        identity: mockIdentity,
+        to: { owner },
+        amount,
+        fromSubAccount,
+      });
+
+      expect(spyTransfer).toHaveBeenCalledWith({
+        to: { owner, subaccount: [] },
+        amount: amount.toE8s(),
+        fromSubAccount,
+        createdAt: nowInBigIntNanoSeconds,
+        memo: undefined,
+      });
+    });
+
+    it("should call ledger to send ICP with memo", async () => {
+      const memo = Uint8Array.from([4, 4, 5, 5]);
+      await sendIcpIcrc1({
+        identity: mockIdentity,
+        to: { owner },
+        amount,
+        memo,
+      });
+
+      expect(spyTransfer).toHaveBeenCalledWith({
+        to: { owner, subaccount: [] },
+        amount: amount.toE8s(),
+        memo,
+        createdAt: nowInBigIntNanoSeconds,
+        fromSubAccount: undefined,
+      });
+    });
+
+    it("should call ledger to send ICP with createdAt", async () => {
+      const memo = Uint8Array.from([4, 4, 5, 5]);
+      const createdAt = BigInt(123456);
+      await sendIcpIcrc1({
+        identity: mockIdentity,
+        to: { owner },
+        amount,
+        memo,
+        createdAt,
+      });
+
+      expect(spyTransfer).toHaveBeenCalledWith({
+        to: { owner, subaccount: [] },
+        amount: amount.toE8s(),
+        memo,
+        createdAt,
+        fromSubAccount: undefined,
+      });
+    });
+
+    it("should call ledger to send ICP with subaccount", async () => {
+      const subaccount = Uint8Array.from([9, 9, 3, 3]);
+      await sendIcpIcrc1({
+        identity: mockIdentity,
+        to: { owner, subaccount },
+        amount,
+      });
+
+      expect(spyTransfer).toHaveBeenCalledWith({
+        to: { owner, subaccount: [subaccount] },
+        amount: amount.toE8s(),
+        memo: undefined,
+        createdAt: nowInBigIntNanoSeconds,
+        fromSubAccount: undefined,
       });
     });
   });

--- a/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
@@ -14,6 +14,9 @@ import { mock } from "jest-mock-extended";
 
 describe("icp-ledger.api", () => {
   beforeEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+
     jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
@@ -30,9 +33,6 @@ describe("icp-ledger.api", () => {
     const nowInBigIntNanoSeconds = BigInt(now) * BigInt(1_000_000);
 
     beforeEach(() => {
-      jest.clearAllMocks();
-      jest.clearAllTimers();
-
       const ledgerMock = mock<LedgerCanister>();
       ledgerMock.transfer.mockResolvedValue(BigInt(0));
       jest.useFakeTimers().setSystemTime(now);
@@ -128,9 +128,6 @@ describe("icp-ledger.api", () => {
     const nowInBigIntNanoSeconds = BigInt(now) * BigInt(1_000_000);
 
     beforeEach(() => {
-      jest.clearAllMocks();
-      jest.clearAllTimers();
-
       const ledgerMock = mock<LedgerCanister>();
       ledgerMock.icrc1Transfer.mockResolvedValue(BigInt(0));
       jest.useFakeTimers().setSystemTime(now);


### PR DESCRIPTION
# Motivation

We want to use the ICRC-1 interface of the ICP ledger canister when participating in a swap or topping up a canister etc.

# Changes

Add `sendIcpIcrc1` function to `icp-ledger.api` similar to the existing `sendICP` function on the same API.

# Tests

Duplicated the existing tests for `sendICP` and added a test for the fee that can be passed in.

# Todos

- [ ] Add entry to changelog (if necessary).
Will add when it's used.