### PR TITLE
Call stakeNeuronIcrc1 behind a feature flag

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -38,6 +38,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Not Published
 
+* Use ICRC-1 transfer when staking a neuron, behind a feature flag.
+
 ### Operations
 
 #### Added

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -198,129 +198,258 @@ describe("neurons-services", () => {
   });
 
   describe("stake new neuron", () => {
-    it("should stake a neuron from main account", async () => {
-      expect(spyStakeNeuron).not.toBeCalled();
-      const newNeuronId = await stakeNeuron({
-        amount: 10,
-        account: mockMainAccount,
+    describe("with ENABLE_STAKE_NEURON_ICRC1 disabled", () => {
+      it("should stake a neuron from main account", async () => {
+        expect(spyStakeNeuron).not.toBeCalled();
+        const newNeuronId = await stakeNeuron({
+          amount: 10,
+          account: mockMainAccount,
+        });
+
+        expect(spyStakeNeuron).toBeCalledWith({
+          controller: mockIdentity.getPrincipal(),
+          fromSubAccount: undefined,
+          identity: mockIdentity,
+          ledgerCanisterIdentity: mockIdentity,
+          stake: BigInt(10 * E8S_PER_ICP),
+        });
+        expect(spyStakeNeuron).toBeCalledTimes(1);
+        expect(newNeuronId).toEqual(mockNeuron.neuronId);
       });
 
-      expect(spyStakeNeuron).toBeCalledWith({
-        controller: mockIdentity.getPrincipal(),
-        fromSubAccount: undefined,
-        identity: mockIdentity,
-        ledgerCanisterIdentity: mockIdentity,
-        stake: BigInt(10 * E8S_PER_ICP),
+      it("should stake and load a neuron from subaccount", async () => {
+        expect(spyStakeNeuron).not.toBeCalled();
+        const newNeuronId = await stakeNeuron({
+          amount: 10,
+          account: mockSubAccount,
+        });
+
+        expect(spyStakeNeuron).toBeCalledWith({
+          controller: mockIdentity.getPrincipal(),
+          fromSubAccount: mockSubAccount.subAccount,
+          identity: mockIdentity,
+          ledgerCanisterIdentity: mockIdentity,
+          stake: BigInt(10 * E8S_PER_ICP),
+        });
+        expect(spyStakeNeuron).toBeCalledTimes(1);
+        expect(newNeuronId).toEqual(mockNeuron.neuronId);
       });
-      expect(spyStakeNeuron).toBeCalledTimes(1);
-      expect(newNeuronId).toEqual(mockNeuron.neuronId);
+
+      it("should stake neuron from hardware wallet", async () => {
+        const mockHardkwareWalletIdentity = {
+          getPrincipal: () => mockHardwareWalletAccount.principal,
+        } as unknown as Identity;
+        setAccountIdentity(mockHardkwareWalletIdentity);
+
+        expect(spyStakeNeuron).not.toBeCalled();
+
+        const newNeuronId = await stakeNeuron({
+          amount: 10,
+          account: mockHardwareWalletAccount,
+        });
+
+        expect(spyStakeNeuron).toBeCalledWith({
+          controller: mockHardwareWalletAccount.principal,
+          identity: new AnonymousIdentity(),
+          fromSubAccount: undefined,
+          ledgerCanisterIdentity: mockHardkwareWalletIdentity,
+          stake: BigInt(10 * E8S_PER_ICP),
+        });
+        expect(spyStakeNeuron).toBeCalledTimes(1);
+        expect(newNeuronId).toEqual(mockNeuron.neuronId);
+      });
+
+      it(`stakeNeuron return undefined if amount less than ${
+        E8S_PER_ICP / E8S_PER_ICP
+      } ICP`, async () => {
+        jest
+          .spyOn(LedgerCanister, "create")
+          .mockImplementation(() => mock<LedgerCanister>());
+
+        const response = await stakeNeuron({
+          amount: 0.1,
+          account: mockMainAccount,
+        });
+
+        expect(response).toBeUndefined();
+        expectToastError(en.error.amount_not_enough_stake_neuron);
+        expect(spyStakeNeuron).not.toBeCalled();
+      });
+
+      it("stake neuron should return undefined if amount not valid", async () => {
+        jest
+          .spyOn(LedgerCanister, "create")
+          .mockImplementation(() => mock<LedgerCanister>());
+
+        const response = await stakeNeuron({
+          amount: NaN,
+          account: mockMainAccount,
+        });
+
+        expect(response).toBeUndefined();
+        expectToastError("Invalid number NaN");
+        expect(spyStakeNeuron).not.toBeCalled();
+      });
+
+      it("stake neuron should return undefined if not enough funds in account", async () => {
+        jest
+          .spyOn(LedgerCanister, "create")
+          .mockImplementation(() => mock<LedgerCanister>());
+
+        // 10 ICPs
+        const amount = 10;
+        const response = await stakeNeuron({
+          amount,
+          account: {
+            ...mockMainAccount,
+            balanceE8s: BigInt(amount - 1),
+          },
+        });
+
+        expect(response).toBeUndefined();
+        expectToastError(en.error.insufficient_funds);
+        expect(spyStakeNeuron).not.toBeCalled();
+      });
+
+      it("should not stake neuron if no identity", async () => {
+        setNoAccountIdentity();
+
+        const response = await stakeNeuron({
+          amount: 10,
+          account: mockMainAccount,
+        });
+
+        expect(response).toBeUndefined();
+        expectToastError("Cannot read properties of null");
+        expect(spyStakeNeuron).not.toBeCalled();
+      });
     });
+      
+    describe("with ENABLE_STAKE_NEURON_ICRC1 enabled", () => {
+      it("should stake a neuron from main account", async () => {
+        expect(spyStakeNeuron).not.toBeCalled();
+        const newNeuronId = await stakeNeuron({
+          amount: 10,
+          account: mockMainAccount,
+        });
 
-    it("should stake and load a neuron from subaccount", async () => {
-      expect(spyStakeNeuron).not.toBeCalled();
-      const newNeuronId = await stakeNeuron({
-        amount: 10,
-        account: mockSubAccount,
+        expect(spyStakeNeuron).toBeCalledWith({
+          controller: mockIdentity.getPrincipal(),
+          fromSubAccount: undefined,
+          identity: mockIdentity,
+          ledgerCanisterIdentity: mockIdentity,
+          stake: BigInt(10 * E8S_PER_ICP),
+        });
+        expect(spyStakeNeuron).toBeCalledTimes(1);
+        expect(newNeuronId).toEqual(mockNeuron.neuronId);
       });
 
-      expect(spyStakeNeuron).toBeCalledWith({
-        controller: mockIdentity.getPrincipal(),
-        fromSubAccount: mockSubAccount.subAccount,
-        identity: mockIdentity,
-        ledgerCanisterIdentity: mockIdentity,
-        stake: BigInt(10 * E8S_PER_ICP),
-      });
-      expect(spyStakeNeuron).toBeCalledTimes(1);
-      expect(newNeuronId).toEqual(mockNeuron.neuronId);
-    });
+      it("should stake and load a neuron from subaccount", async () => {
+        expect(spyStakeNeuron).not.toBeCalled();
+        const newNeuronId = await stakeNeuron({
+          amount: 10,
+          account: mockSubAccount,
+        });
 
-    it("should stake neuron from hardware wallet", async () => {
-      const mockHardkwareWalletIdentity = {
-        getPrincipal: () => mockHardwareWalletAccount.principal,
-      } as unknown as Identity;
-      setAccountIdentity(mockHardkwareWalletIdentity);
-
-      expect(spyStakeNeuron).not.toBeCalled();
-
-      const newNeuronId = await stakeNeuron({
-        amount: 10,
-        account: mockHardwareWalletAccount,
+        expect(spyStakeNeuron).toBeCalledWith({
+          controller: mockIdentity.getPrincipal(),
+          fromSubAccount: mockSubAccount.subAccount,
+          identity: mockIdentity,
+          ledgerCanisterIdentity: mockIdentity,
+          stake: BigInt(10 * E8S_PER_ICP),
+        });
+        expect(spyStakeNeuron).toBeCalledTimes(1);
+        expect(newNeuronId).toEqual(mockNeuron.neuronId);
       });
 
-      expect(spyStakeNeuron).toBeCalledWith({
-        controller: mockHardwareWalletAccount.principal,
-        identity: new AnonymousIdentity(),
-        fromSubAccount: undefined,
-        ledgerCanisterIdentity: mockHardkwareWalletIdentity,
-        stake: BigInt(10 * E8S_PER_ICP),
-      });
-      expect(spyStakeNeuron).toBeCalledTimes(1);
-      expect(newNeuronId).toEqual(mockNeuron.neuronId);
-    });
+      it("should stake neuron from hardware wallet", async () => {
+        const mockHardkwareWalletIdentity = {
+          getPrincipal: () => mockHardwareWalletAccount.principal,
+        } as unknown as Identity;
+        setAccountIdentity(mockHardkwareWalletIdentity);
 
-    it(`stakeNeuron return undefined if amount less than ${
-      E8S_PER_ICP / E8S_PER_ICP
-    } ICP`, async () => {
-      jest
-        .spyOn(LedgerCanister, "create")
-        .mockImplementation(() => mock<LedgerCanister>());
+        expect(spyStakeNeuron).not.toBeCalled();
 
-      const response = await stakeNeuron({
-        amount: 0.1,
-        account: mockMainAccount,
-      });
+        const newNeuronId = await stakeNeuron({
+          amount: 10,
+          account: mockHardwareWalletAccount,
+        });
 
-      expect(response).toBeUndefined();
-      expectToastError(en.error.amount_not_enough_stake_neuron);
-      expect(spyStakeNeuron).not.toBeCalled();
-    });
-
-    it("stake neuron should return undefined if amount not valid", async () => {
-      jest
-        .spyOn(LedgerCanister, "create")
-        .mockImplementation(() => mock<LedgerCanister>());
-
-      const response = await stakeNeuron({
-        amount: NaN,
-        account: mockMainAccount,
+        expect(spyStakeNeuron).toBeCalledWith({
+          controller: mockHardwareWalletAccount.principal,
+          identity: new AnonymousIdentity(),
+          fromSubAccount: undefined,
+          ledgerCanisterIdentity: mockHardkwareWalletIdentity,
+          stake: BigInt(10 * E8S_PER_ICP),
+        });
+        expect(spyStakeNeuron).toBeCalledTimes(1);
+        expect(newNeuronId).toEqual(mockNeuron.neuronId);
       });
 
-      expect(response).toBeUndefined();
-      expectToastError("Invalid number NaN");
-      expect(spyStakeNeuron).not.toBeCalled();
-    });
+      it(`stakeNeuron return undefined if amount less than ${
+        E8S_PER_ICP / E8S_PER_ICP
+      } ICP`, async () => {
+        jest
+          .spyOn(LedgerCanister, "create")
+          .mockImplementation(() => mock<LedgerCanister>());
 
-    it("stake neuron should return undefined if not enough funds in account", async () => {
-      jest
-        .spyOn(LedgerCanister, "create")
-        .mockImplementation(() => mock<LedgerCanister>());
+        const response = await stakeNeuron({
+          amount: 0.1,
+          account: mockMainAccount,
+        });
 
-      // 10 ICPs
-      const amount = 10;
-      const response = await stakeNeuron({
-        amount,
-        account: {
-          ...mockMainAccount,
-          balanceE8s: BigInt(amount - 1),
-        },
+        expect(response).toBeUndefined();
+        expectToastError(en.error.amount_not_enough_stake_neuron);
+        expect(spyStakeNeuron).not.toBeCalled();
       });
 
-      expect(response).toBeUndefined();
-      expectToastError(en.error.insufficient_funds);
-      expect(spyStakeNeuron).not.toBeCalled();
-    });
+      it("stake neuron should return undefined if amount not valid", async () => {
+        jest
+          .spyOn(LedgerCanister, "create")
+          .mockImplementation(() => mock<LedgerCanister>());
 
-    it("should not stake neuron if no identity", async () => {
-      setNoAccountIdentity();
+        const response = await stakeNeuron({
+          amount: NaN,
+          account: mockMainAccount,
+        });
 
-      const response = await stakeNeuron({
-        amount: 10,
-        account: mockMainAccount,
+        expect(response).toBeUndefined();
+        expectToastError("Invalid number NaN");
+        expect(spyStakeNeuron).not.toBeCalled();
       });
 
-      expect(response).toBeUndefined();
-      expectToastError("Cannot read properties of null");
-      expect(spyStakeNeuron).not.toBeCalled();
+      it("stake neuron should return undefined if not enough funds in account", async () => {
+        jest
+          .spyOn(LedgerCanister, "create")
+          .mockImplementation(() => mock<LedgerCanister>());
+
+        // 10 ICPs
+        const amount = 10;
+        const response = await stakeNeuron({
+          amount,
+          account: {
+            ...mockMainAccount,
+            balanceE8s: BigInt(amount - 1),
+          },
+        });
+
+        expect(response).toBeUndefined();
+        expectToastError(en.error.insufficient_funds);
+        expect(spyStakeNeuron).not.toBeCalled();
+      });
+
+      it("should not stake neuron if no identity", async () => {
+        setNoAccountIdentity();
+
+        const response = await stakeNeuron({
+          amount: 10,
+          account: mockMainAccount,
+        });
+
+        expect(response).toBeUndefined();
+        expectToastError("Cannot read properties of null");
+        expect(spyStakeNeuron).not.toBeCalled();
+      });
     });
   });
 


### PR DESCRIPTION
# Motivation

We want to use ICRC-1 transfers when possible.

Note: I made a separate commit to duplicate the tests to make reviewing easier.

# Changes

Use `stakeNeuronIcrc1` when `ENABLE_STAKE_NEURON_ICRC1` is enabled, except for when a hardware wallet is used.

# Tests

Duplicated the existing tests. One group with ENABLE_STAKE_NEURON_ICRC1 disabled and one enabled.

# Todos

- [x] Add entry to changelog (if necessary).
