### PR TITLE
GIX-1911: Split participation in progress bar

### DIFF
--- a/frontend/src/lib/components/project-detail/CommitmentProgressBar.svelte
+++ b/frontend/src/lib/components/project-detail/CommitmentProgressBar.svelte
@@ -2,10 +2,14 @@
   import { TokenAmount, ICPToken } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
-  import { ProgressBar } from "@dfinity/gix-components";
+  import {
+    ProgressBar,
+    type ProgressBarSegment,
+  } from "@dfinity/gix-components";
 
   export let max: bigint;
-  export let value: bigint;
+  export let directParticipation: bigint;
+  export let nfParticipation: bigint;
   export let minimumIndicator: bigint | undefined = undefined;
 
   let width: number | undefined;
@@ -14,9 +18,19 @@
     minimumIndicator !== undefined && width !== undefined
       ? (Number(minimumIndicator) / Number(max)) * width
       : undefined;
+
+  let segments: ProgressBarSegment[] = [];
+  $: segments = [
+    { value: Number(nfParticipation), color: "var(--positive-emphasis)" },
+    {
+      value: Number(directParticipation),
+      color: "var(--warning-emphasis)",
+    },
+  ];
 </script>
 
-<ProgressBar max={Number(max)} value={Number(value)} color="warning">
+<!-- TODO: Remove value={0} after https://github.com/dfinity/gix-components/pull/298 is merged -->
+<ProgressBar max={Number(max)} value={0} {segments}>
   <div class="info" slot="top">
     <p class="right">
       <span>

--- a/frontend/src/lib/getters/sns-summary.ts
+++ b/frontend/src/lib/getters/sns-summary.ts
@@ -10,3 +10,8 @@ export const getConditionsToAccept = (
   summary: SnsSummary
 ): string | undefined =>
   fromNullable(fromNullable(summary.swap.init)?.confirmation_text || []);
+
+// TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
+export const getNeuronsFundParticipation = (
+  _summary: SnsSummary
+): bigint | undefined => undefined;

--- a/frontend/src/tests/lib/components/project-detail/CommitmentProgressBar.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/CommitmentProgressBar.spec.ts
@@ -7,7 +7,7 @@ import { render } from "@testing-library/svelte";
 
 describe("CommitmentProgressBar", () => {
   const props = {
-    directParticipation: 1327n,
+    directParticipation: 1500n,
     nfParticipation: 0n,
     max: BigInt(3000),
     minimumIndicator: BigInt(1500),
@@ -44,8 +44,8 @@ describe("CommitmentProgressBar", () => {
     ).toEqual(`${Number(props.minimumIndicator) / 100000000} ICP`);
   });
 
-  it("should display the value adding NF and direct commitments", async () => {
-    const nfParticipation = 1000n;
+  it("should display NF and direct commitments", async () => {
+    const nfParticipation = 500n;
     const { container } = render(CommitmentProgressBar, {
       props: {
         ...props,
@@ -54,6 +54,9 @@ describe("CommitmentProgressBar", () => {
     });
     expect(container.querySelector("progress").value).toBe(
       Number(props.directParticipation + nfParticipation)
+    );
+    expect(container.querySelector("progress").style.cssText).toBe(
+      "--progress-bar-background: linear-gradient(to right, var(--positive-emphasis) 0% 25%, var(--warning-emphasis) 25% 100%);"
     );
   });
 });

--- a/frontend/src/tests/lib/components/project-detail/CommitmentProgressBar.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/CommitmentProgressBar.spec.ts
@@ -7,7 +7,8 @@ import { render } from "@testing-library/svelte";
 
 describe("CommitmentProgressBar", () => {
   const props = {
-    value: BigInt(1327),
+    directParticipation: 1327n,
+    nfParticipation: 0n,
     max: BigInt(3000),
     minimumIndicator: BigInt(1500),
   };
@@ -25,7 +26,8 @@ describe("CommitmentProgressBar", () => {
   it("should not display minimum indicators if not provided", async () => {
     const { queryByTestId } = render(CommitmentProgressBar, {
       props: {
-        value: props.value,
+        directParticipation: props.directParticipation,
+        nfParticipation: props.nfParticipation,
         max: props.max,
       },
     });
@@ -40,5 +42,18 @@ describe("CommitmentProgressBar", () => {
     expect(
       queryByTestId("commitment-min-indicator-value")?.textContent.trim()
     ).toEqual(`${Number(props.minimumIndicator) / 100000000} ICP`);
+  });
+
+  it("should display the value adding NF and direct commitments", async () => {
+    const nfParticipation = 1000n;
+    const { container } = render(CommitmentProgressBar, {
+      props: {
+        ...props,
+        nfParticipation,
+      },
+    });
+    expect(container.querySelector("progress").value).toBe(
+      Number(props.directParticipation + nfParticipation)
+    );
   });
 });


### PR DESCRIPTION
# Motivation

We want to differentiate between direct and Neurons' Fund participation.

In this PR, the differentiation is done only in the progress bar.

This is not yet supported because it's missing the field in the API response. Therefore, I used a getter that returns undefined.

I don't think there is any need for a feature flag. As soon as the field is available, we should support it.

# Changes

* Add a new sns summary getter `getNeuronsFundParticipation` that returns `undefined`.
* Change prop `value` in CommitmentProgressBar to two props `directParticipation` and `nfParticipation`.
* Use the new `segments` prop of the ProgressBar instead of the `value`.
* Use the new getter `getNeuronsFundParticipation` in ProjectCommitment to use new props in CommitmentProgressBar.

# Tests

* Adapt tests of CommitmentProgressBar to new props and add a test case.
* Add a test case in ProjectCommitment.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary yet because there is no change for the user until the field is supported by the API.
