### PR TITLE
Update rust

### DIFF
--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -6,6 +6,10 @@ on:
     # check for new rust versions weekly
     - cron: '30 3 * * FRI'
   workflow_dispatch:
+  push:
+    branches:
+      # The development branch for this workflow:
+      - "update-rust"
 jobs:
   rust-update:
     runs-on: ubuntu-latest
@@ -13,13 +17,14 @@ jobs:
       - uses: actions/checkout@v3
         # First, check rust GitHub releases for a new version. We assume that the
         # latest version's tag name is the version.
+      - name: Install yq
+        run: sudo snap install yq
       - name: Check new rust version
         id: update
         run: |
           current_rust_version=$(cat ./rust-toolchain.toml | sed -n 's/^channel[[:space:]]*=[[:space:]]"\(.*\)"/\1/p')
           echo "current rust version '$current_rust_version'"
-          release_data=$(curl --silent -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/rust-lang/rust/releases/latest)
-          latest_rust_version=$(echo -n "$release_data" | jq -cMr .tag_name)
+          latest_rust_version=$(curl -sSL https://static.rust-lang.org/dist/channel-rust-stable.toml | yq -oy -p toml '.pkg.rust.target.x86_64-unknown-linux-gnu.url' | sed -E 's!https://.*rust-([0-9]+[.][0-9]+[.][0-9]+).*!\1!g')
 
           # The GitHub API has some hiccups, so we check the value before going further
           if [ -z "$latest_rust_version" ] || [ "$latest_rust_version" = "null" ]

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           current_rust_version=$(cat ./rust-toolchain.toml | sed -n 's/^channel[[:space:]]*=[[:space:]]"\(.*\)"/\1/p')
           echo "current rust version '$current_rust_version'"
-          latest_rust_version=$(curl -sSL https://static.rust-lang.org/dist/channel-rust-stable.toml | yq -oy -p toml '.pkg.rust.target.x86_64-unknown-linux-gnu.url' | sed -E 's!https://.*rust-([0-9]+[.][0-9]+[.][0-9]+).*!\1!g')
+          latest_rust_version=$(curl -sSL https://static.rust-lang.org/dist/channel-rust-stable.toml | yq -p toml -oy .pkg.rust.version | awk '{print $1}')
 
           # The GitHub API has some hiccups, so we check the value before going further
           if [ -z "$latest_rust_version" ] || [ "$latest_rust_version" = "null" ]


### PR DESCRIPTION
# Motivation
The rust updater tries to update to the wrong version.  It gets the latest release from GitHub, however that does not correspond to the latest stable version.  In fact, it currently matches an older release that presumably had a patch release.

# Changes
- Determine the latest stable version directly from the channel toml.
  - Note: This is the authoritative file used by [`rustup`](https://rustup.rs/) (see [the code](https://github.com/rust-lang/rustup/blob/d4c684485cb5c817d00aa6c6c0aee44da80450c7/src/test/mock/clitools.rs#L989)), [rust-forge](https://forge.rust-lang.org/) (see [the code](https://github.com/rust-lang/rust-forge/blob/533d65ea37246388d914c1fcff2fb79e2556d23f/blacksmith/src/lib.rs#L17)).

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
