### PR TITLE
GIX-1911: Split total commitment

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -14,10 +14,7 @@
   import { snsSwapMetricsStore } from "$lib/stores/sns-swap-metrics.store";
   import { nonNullish } from "@dfinity/utils";
   import { swapSaleBuyerCount } from "$lib/utils/sns-swap.utils";
-  import {
-    getNeuronsFundParticipation,
-    isNeuronsFundParticipationPresent,
-  } from "$lib/getters/sns-summary";
+  import { getNeuronsFundParticipation } from "$lib/getters/sns-summary";
 
   const { store: projectDetailStore } = getContext<ProjectDetailContext>(
     PROJECT_DETAIL_CONTEXT_KEY

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -43,15 +43,6 @@
     token: ICPToken,
   });
 
-  let directCommitmentE8s: bigint;
-  $: directCommitmentE8s = buyersTotalCommitment - neuronsFundCommitmentE8s;
-
-  let directCommitmentIcp: TokenAmount;
-  $: directCommitmentIcp = TokenAmount.fromE8s({
-    amount: directCommitmentE8s,
-    token: ICPToken,
-  });
-
   let saleBuyerCount: number | undefined;
   $: saleBuyerCount = swapSaleBuyerCount({
     rootCanisterId: $projectDetailStore?.summary?.rootCanisterId,
@@ -59,18 +50,27 @@
     derivedState: summary.derived,
   });
 
-  let neuronsFundCommitmentE8s: bigint;
-  $: neuronsFundCommitmentE8s = getNeuronsFundParticipation(summary) ?? 0n;
+  let neuronsFundCommitmentE8s: bigint | undefined;
+  $: neuronsFundCommitmentE8s = getNeuronsFundParticipation(summary);
 
   let neuronsFundCommitmentIcp: TokenAmount;
   $: neuronsFundCommitmentIcp = TokenAmount.fromE8s({
-    amount: neuronsFundCommitmentE8s,
+    amount: neuronsFundCommitmentE8s ?? 0n,
     token: ICPToken,
   });
 
   let isNeuronsFundCommitmentAvailable: boolean;
-  $: isNeuronsFundCommitmentAvailable =
-    isNeuronsFundParticipationPresent(summary);
+  $: isNeuronsFundCommitmentAvailable = nonNullish(neuronsFundCommitmentE8s);
+
+  let directCommitmentE8s: bigint;
+  $: directCommitmentE8s =
+    buyersTotalCommitment - (neuronsFundCommitmentE8s ?? 0n);
+
+  let directCommitmentIcp: TokenAmount;
+  $: directCommitmentIcp = TokenAmount.fromE8s({
+    amount: directCommitmentE8s,
+    token: ICPToken,
+  });
 </script>
 
 {#if nonNullish(saleBuyerCount)}
@@ -109,7 +109,7 @@
 <div data-tid="sns-project-commitment-progress">
   <CommitmentProgressBar
     directParticipation={directCommitmentE8s}
-    nfParticipation={neuronsFundCommitmentE8s}
+    nfParticipation={neuronsFundCommitmentE8s ?? 0n}
     max={max_icp_e8s}
     minimumIndicator={min_icp_e8s}
   />

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -70,8 +70,6 @@
 
   <AmountDisplay slot="value" amount={buyersTotalCommitmentIcp} singleLine />
 </KeyValuePair>
-<!-- Even if the Neurons' Fund participation is 0, we want to show it. -->
-<!-- Yet, we only want to show it in those swaps that the field is available. -->
 {#if isFullProjectCommitmentSplit(projectCommitments)}
   <KeyValuePair testId="sns-project-current-nf-commitment">
     <span slot="key" class="detail-data">

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -14,7 +14,11 @@
   import { snsSwapMetricsStore } from "$lib/stores/sns-swap-metrics.store";
   import { nonNullish } from "@dfinity/utils";
   import { swapSaleBuyerCount } from "$lib/utils/sns-swap.utils";
-  import { getNeuronsFundParticipation } from "$lib/getters/sns-summary";
+  import {
+    getProjectCommitmentSplit,
+    isFullProjectCommitmentSplit,
+    type ProjectCommitmentSplit,
+  } from "$lib/utils/projects.utils";
 
   const { store: projectDetailStore } = getContext<ProjectDetailContext>(
     PROJECT_DETAIL_CONTEXT_KEY
@@ -31,8 +35,11 @@
   let max_icp_e8s: bigint;
   $: ({ min_icp_e8s, max_icp_e8s } = params);
 
+  let projectCommitments: ProjectCommitmentSplit;
+  $: projectCommitments = getProjectCommitmentSplit(summary);
+
   let buyersTotalCommitment: bigint;
-  $: ({ buyer_total_icp_e8s: buyersTotalCommitment } = summary.derived);
+  $: buyersTotalCommitment = projectCommitments.totalCommitmentE8s;
 
   let buyersTotalCommitmentIcp: TokenAmount;
   $: buyersTotalCommitmentIcp = TokenAmount.fromE8s({
@@ -45,28 +52,6 @@
     rootCanisterId: $projectDetailStore?.summary?.rootCanisterId,
     swapMetrics: $snsSwapMetricsStore,
     derivedState: summary.derived,
-  });
-
-  let neuronsFundCommitmentE8s: bigint | undefined;
-  $: neuronsFundCommitmentE8s = getNeuronsFundParticipation(summary);
-
-  let neuronsFundCommitmentIcp: TokenAmount;
-  $: neuronsFundCommitmentIcp = TokenAmount.fromE8s({
-    amount: neuronsFundCommitmentE8s ?? 0n,
-    token: ICPToken,
-  });
-
-  let isNeuronsFundCommitmentAvailable: boolean;
-  $: isNeuronsFundCommitmentAvailable = nonNullish(neuronsFundCommitmentE8s);
-
-  let directCommitmentE8s: bigint;
-  $: directCommitmentE8s =
-    buyersTotalCommitment - (neuronsFundCommitmentE8s ?? 0n);
-
-  let directCommitmentIcp: TokenAmount;
-  $: directCommitmentIcp = TokenAmount.fromE8s({
-    amount: directCommitmentE8s,
-    token: ICPToken,
   });
 </script>
 
@@ -87,30 +72,54 @@
 </KeyValuePair>
 <!-- Even if the Neurons' Fund participation is 0, we want to show it. -->
 <!-- Yet, we only want to show it in those swaps that the field is available. -->
-{#if isNeuronsFundCommitmentAvailable}
+{#if isFullProjectCommitmentSplit(projectCommitments)}
   <KeyValuePair testId="sns-project-current-nf-commitment">
     <span slot="key" class="detail-data">
       {$i18n.sns_project_detail.current_nf_commitment}
     </span>
 
-    <AmountDisplay slot="value" amount={neuronsFundCommitmentIcp} singleLine />
+    <AmountDisplay
+      slot="value"
+      amount={TokenAmount.fromE8s({
+        amount: projectCommitments.nfCommitmentE8s,
+        token: ICPToken,
+      })}
+      singleLine
+    />
   </KeyValuePair>
   <KeyValuePair testId="sns-project-current-direct-commitment">
     <span slot="key" class="detail-data">
       {$i18n.sns_project_detail.current_direct_commitment}
     </span>
 
-    <AmountDisplay slot="value" amount={directCommitmentIcp} singleLine />
+    <AmountDisplay
+      slot="value"
+      amount={TokenAmount.fromE8s({
+        amount: projectCommitments.directCommitmentE8s,
+        token: ICPToken,
+      })}
+      singleLine
+    />
   </KeyValuePair>
+  <div data-tid="sns-project-commitment-progress">
+    <CommitmentProgressBar
+      directParticipation={projectCommitments.directCommitmentE8s}
+      nfParticipation={projectCommitments.nfCommitmentE8s}
+      max={max_icp_e8s}
+      minimumIndicator={min_icp_e8s}
+    />
+  </div>
+{:else}
+  <!-- We show the progress bar with only directParticipation if NF participation is not present -->
+  <div data-tid="sns-project-commitment-progress">
+    <CommitmentProgressBar
+      directParticipation={projectCommitments.totalCommitmentE8s}
+      nfParticipation={0n}
+      max={max_icp_e8s}
+      minimumIndicator={min_icp_e8s}
+    />
+  </div>
 {/if}
-<div data-tid="sns-project-commitment-progress">
-  <CommitmentProgressBar
-    directParticipation={directCommitmentE8s}
-    nfParticipation={neuronsFundCommitmentE8s ?? 0n}
-    max={max_icp_e8s}
-    minimumIndicator={min_icp_e8s}
-  />
-</div>
 
 <style lang="scss">
   .detail-data {

--- a/frontend/src/lib/getters/sns-summary.ts
+++ b/frontend/src/lib/getters/sns-summary.ts
@@ -15,3 +15,8 @@ export const getConditionsToAccept = (
 export const getNeuronsFundParticipation = (
   _summary: SnsSummary
 ): bigint | undefined => undefined;
+
+// TODO: https://dfinity.atlassian.net/browse/GIX-1909 check if nf participation field is present
+export const isNeuronsFundParticipationPresent = (
+  _summary: SnsSummary
+): boolean => false;

--- a/frontend/src/lib/getters/sns-summary.ts
+++ b/frontend/src/lib/getters/sns-summary.ts
@@ -15,8 +15,3 @@ export const getConditionsToAccept = (
 export const getNeuronsFundParticipation = (
   _summary: SnsSummary
 ): bigint | undefined => undefined;
-
-// TODO: https://dfinity.atlassian.net/browse/GIX-1909 check if nf participation field is present
-export const isNeuronsFundParticipationPresent = (
-  _summary: SnsSummary
-): boolean => false;

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -700,6 +700,8 @@
     "max_commitment": "Maximum Commitment",
     "min_participants": "Minimum Participants",
     "current_overall_commitment": "Current Overall Commitment",
+    "current_nf_commitment": "Neurons' Fund Commitment",
+    "current_direct_commitment": "Direct Commitment",
     "current_sale_buyer_count": "Current Total Participants",
     "min_commitment_goal": "Minimum Commitment Goal",
     "max_commitment_goal": "Maximum Commitment Goal",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -725,6 +725,8 @@ interface I18nSns_project_detail {
   max_commitment: string;
   min_participants: string;
   current_overall_commitment: string;
+  current_nf_commitment: string;
+  current_direct_commitment: string;
   current_sale_buyer_count: string;
   min_commitment_goal: string;
   max_commitment_goal: string;

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -415,8 +415,7 @@ export type ProjectCommitmentSplit =
 export const isFullProjectCommitmentSplit = (
   commitment: ProjectCommitmentSplit
 ): commitment is FullProjectCommitmentSplit =>
-  nonNullish((commitment as FullProjectCommitmentSplit).directCommitmentE8s) &&
-  nonNullish((commitment as FullProjectCommitmentSplit).nfCommitmentE8s);
+  "directCommitmentE8s" in commitment && "nfCommitmentE8s" in commitment;
 
 export const getProjectCommitmentSplit = (
   summary: SnsSummary

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -1,6 +1,9 @@
 import { NOT_LOADED } from "$lib/constants/stores.constants";
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
-import { getDeniedCountries } from "$lib/getters/sns-summary";
+import {
+  getDeniedCountries,
+  getNeuronsFundParticipation,
+} from "$lib/getters/sns-summary";
 import type { Country } from "$lib/types/location";
 import type {
   SnsSummary,
@@ -399,3 +402,35 @@ export const differentSummaries = (
       summary1.indexCanisterId.toText() !== summary2?.indexCanisterId.toText()
     );
   });
+
+export type FullProjectCommitmentSplit = {
+  totalCommitmentE8s: bigint;
+  directCommitmentE8s: bigint;
+  nfCommitmentE8s: bigint;
+};
+export type ProjectCommitmentSplit =
+  | { totalCommitmentE8s: bigint }
+  | FullProjectCommitmentSplit;
+
+export const isFullProjectCommitmentSplit = (
+  commitment: ProjectCommitmentSplit
+): commitment is FullProjectCommitmentSplit =>
+  nonNullish((commitment as FullProjectCommitmentSplit).directCommitmentE8s) &&
+  nonNullish((commitment as FullProjectCommitmentSplit).nfCommitmentE8s);
+
+export const getProjectCommitmentSplit = (
+  summary: SnsSummary
+): ProjectCommitmentSplit => {
+  const nfCommitmentE8s = getNeuronsFundParticipation(summary);
+  if (nonNullish(nfCommitmentE8s)) {
+    return {
+      totalCommitmentE8s: summary.derived.buyer_total_icp_e8s,
+      directCommitmentE8s:
+        summary.derived.buyer_total_icp_e8s - nfCommitmentE8s,
+      nfCommitmentE8s,
+    };
+  }
+  return {
+    totalCommitmentE8s: summary.derived.buyer_total_icp_e8s,
+  };
+};

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -143,95 +143,78 @@ describe("ProjectCommitment", () => {
     );
   });
 
-  describe("when neurons fund participation is not available", () => {
-    beforeEach(() => {
-      // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
-      jest
-        .spyOn(summaryGetters, "isNeuronsFundParticipationPresent")
-        .mockImplementation(() => false);
+  it("should not render detailed participation if neurons fund participation is not available", () => {
+    // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
+    jest
+      .spyOn(summaryGetters, "getNeuronsFundParticipation")
+      .mockImplementation(() => undefined);
+    const { queryByTestId } = renderContextCmp({
+      summary,
+      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
+      Component: ProjectCommitment,
     });
 
-    it("should not render detailed participation if neurons fund participation is available", () => {
-      const { queryByTestId } = renderContextCmp({
-        summary,
-        swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-        Component: ProjectCommitment,
-      });
-
-      expect(
-        queryByTestId("sns-project-current-nf-commitment")
-      ).not.toBeInTheDocument();
-      expect(
-        queryByTestId("sns-project-current-direct-commitment")
-      ).not.toBeInTheDocument();
-    });
+    expect(
+      queryByTestId("sns-project-current-nf-commitment")
+    ).not.toBeInTheDocument();
+    expect(
+      queryByTestId("sns-project-current-direct-commitment")
+    ).not.toBeInTheDocument();
   });
 
-  describe("when neurons fund participation is available", () => {
+  it("should render detailed participation if neurons fund participation is available", () => {
     const directCommitment = 20000000000n;
-    beforeEach(() => {
-      // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
-      jest
-        .spyOn(summaryGetters, "isNeuronsFundParticipationPresent")
-        .mockImplementation(() => true);
-    });
+    const nfCommitment = 10000000000n;
+    // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
+    jest
+      .spyOn(summaryGetters, "getNeuronsFundParticipation")
+      .mockImplementation(() => nfCommitment);
 
-    it("should render detailed participation if neurons fund participation is available", () => {
-      const nfCommitment = 10000000000n;
-      // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
-      jest
-        .spyOn(summaryGetters, "getNeuronsFundParticipation")
-        .mockImplementation(() => nfCommitment);
-
-      const { queryByTestId } = renderContextCmp({
-        summary: {
-          ...summary,
-          derived: {
-            ...summary.derived,
-            buyer_total_icp_e8s: directCommitment + nfCommitment,
-          },
+    const { queryByTestId } = renderContextCmp({
+      summary: {
+        ...summary,
+        derived: {
+          ...summary.derived,
+          buyer_total_icp_e8s: directCommitment + nfCommitment,
         },
-        swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-        Component: ProjectCommitment,
-      });
-
-      expect(
-        queryByTestId("sns-project-current-nf-commitment").textContent.trim()
-      ).toBe("Neurons' Fund Commitment 100.00 ICP");
-      expect(
-        queryByTestId(
-          "sns-project-current-direct-commitment"
-        ).textContent.trim()
-      ).toBe("Direct Commitment 200.00 ICP");
+      },
+      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
+      Component: ProjectCommitment,
     });
 
-    it("should render detailed participation if neurons fund participation is available even with NF participation as 0", () => {
-      const nfCommitment = 0n;
-      // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
-      jest
-        .spyOn(summaryGetters, "getNeuronsFundParticipation")
-        .mockImplementation(() => nfCommitment);
+    expect(
+      queryByTestId("sns-project-current-nf-commitment").textContent.trim()
+    ).toBe("Neurons' Fund Commitment 100.00 ICP");
+    expect(
+      queryByTestId("sns-project-current-direct-commitment").textContent.trim()
+    ).toBe("Direct Commitment 200.00 ICP");
+  });
 
-      const { queryByTestId } = renderContextCmp({
-        summary: {
-          ...summary,
-          derived: {
-            ...summary.derived,
-            buyer_total_icp_e8s: directCommitment + nfCommitment,
-          },
+  it("should render detailed participation if neurons fund participation is available even with NF participation as 0", () => {
+    const directCommitment = 20000000000n;
+    const nfCommitment = 0n;
+    // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
+    jest
+      .spyOn(summaryGetters, "getNeuronsFundParticipation")
+      .mockImplementation(() => nfCommitment);
+
+    const { queryByTestId } = renderContextCmp({
+      summary: {
+        ...summary,
+        derived: {
+          ...summary.derived,
+          buyer_total_icp_e8s: directCommitment + nfCommitment,
         },
-        swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-        Component: ProjectCommitment,
-      });
-
-      expect(
-        queryByTestId("sns-project-current-nf-commitment").textContent.trim()
-      ).toBe("Neurons' Fund Commitment 0 ICP");
-      expect(
-        queryByTestId(
-          "sns-project-current-direct-commitment"
-        ).textContent.trim()
-      ).toBe("Direct Commitment 200.00 ICP");
+      },
+      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
+      Component: ProjectCommitment,
     });
+
+    expect(
+      queryByTestId("sns-project-current-nf-commitment").textContent.trim()
+    ).toBe("Neurons' Fund Commitment 0 ICP");
+    expect(
+      queryByTestId("sns-project-current-direct-commitment").textContent.trim()
+    ).toBe("Direct Commitment 200.00 ICP");
   });
 });

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -143,6 +143,30 @@ describe("ProjectCommitment", () => {
     );
   });
 
+  describe("when neurons fund participation is not available", () => {
+    beforeEach(() => {
+      // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
+      jest
+        .spyOn(summaryGetters, "isNeuronsFundParticipationPresent")
+        .mockImplementation(() => false);
+    });
+
+    it("should not render detailed participation if neurons fund participation is available", () => {
+      const { queryByTestId } = renderContextCmp({
+        summary,
+        swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
+        Component: ProjectCommitment,
+      });
+
+      expect(
+        queryByTestId("sns-project-current-nf-commitment")
+      ).not.toBeInTheDocument();
+      expect(
+        queryByTestId("sns-project-current-direct-commitment")
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe("when neurons fund participation is available", () => {
     const directCommitment = 20000000000n;
     beforeEach(() => {

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -142,4 +142,72 @@ describe("ProjectCommitment", () => {
       Number(directCommitment + nfCommitment)
     );
   });
+
+  describe("when neurons fund participation is available", () => {
+    const directCommitment = 20000000000n;
+    beforeEach(() => {
+      // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
+      jest
+        .spyOn(summaryGetters, "isNeuronsFundParticipationPresent")
+        .mockImplementation(() => true);
+    });
+
+    it("should render detailed participation if neurons fund participation is available", () => {
+      const nfCommitment = 10000000000n;
+      // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
+      jest
+        .spyOn(summaryGetters, "getNeuronsFundParticipation")
+        .mockImplementation(() => nfCommitment);
+
+      const { queryByTestId } = renderContextCmp({
+        summary: {
+          ...summary,
+          derived: {
+            ...summary.derived,
+            buyer_total_icp_e8s: directCommitment + nfCommitment,
+          },
+        },
+        swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
+        Component: ProjectCommitment,
+      });
+
+      expect(
+        queryByTestId("sns-project-current-nf-commitment").textContent.trim()
+      ).toBe("Neurons' Fund Commitment 100.00 ICP");
+      expect(
+        queryByTestId(
+          "sns-project-current-direct-commitment"
+        ).textContent.trim()
+      ).toBe("Direct Commitment 200.00 ICP");
+    });
+
+    it("should render detailed participation if neurons fund participation is available even with NF participation as 0", () => {
+      const nfCommitment = 0n;
+      // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
+      jest
+        .spyOn(summaryGetters, "getNeuronsFundParticipation")
+        .mockImplementation(() => nfCommitment);
+
+      const { queryByTestId } = renderContextCmp({
+        summary: {
+          ...summary,
+          derived: {
+            ...summary.derived,
+            buyer_total_icp_e8s: directCommitment + nfCommitment,
+          },
+        },
+        swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
+        Component: ProjectCommitment,
+      });
+
+      expect(
+        queryByTestId("sns-project-current-nf-commitment").textContent.trim()
+      ).toBe("Neurons' Fund Commitment 0 ICP");
+      expect(
+        queryByTestId(
+          "sns-project-current-direct-commitment"
+        ).textContent.trim()
+      ).toBe("Direct Commitment 200.00 ICP");
+    });
+  });
 });


### PR DESCRIPTION
# Motivation

We want to add the deails of how much the NF is participating in a swap.

# Changes

* New project util `getProjectCommitmentSplit` that returns a variant with the commitments split or only the total commitment.
* Add the details of NF and direct commitments below the current overall commitment in ProjectCommitment if NF commitment is present.

# Tests

* Test new project util.
* Add test cases for new functionality.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet worth an entry because the functionality is not available.
