### PR TITLE
E2E: Don't expect < 20 votes on proposal

### DIFF
--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -186,7 +186,7 @@ test("Test neuron voting", async ({ page, context }) => {
   // Votes result
   expect(
     await nnsProposalPo.getVotesResultPo().getAdoptVotingPower()
-  ).toBeLessThanOrEqual(20);
+  ).toBeGreaterThanOrEqual(0);
   expect(await nnsProposalPo.getVotesResultPo().getRejectVotingPower()).toBe(0);
 
   // Summary

--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -186,7 +186,7 @@ test("Test neuron voting", async ({ page, context }) => {
   // Votes result
   expect(
     await nnsProposalPo.getVotesResultPo().getAdoptVotingPower()
-  ).toBeGreaterThanOrEqual(0);
+  ).toBeGreaterThan(0);
   expect(await nnsProposalPo.getVotesResultPo().getRejectVotingPower()).toBe(0);
 
   // Summary


### PR DESCRIPTION
# Motivation

E2e test `propopsals.spec.ts` [flaked](https://github.com/dfinity/nns-dapp/actions/runs/6275972422/attempts/1) because it expects < 20 votes on a proposal on line 189.
But on line 67 it casts 20 votes on some proposal. So the expectation only passes if those 2 proposals are different and the test doesn't do anything to make sure they are different.
The expectation was added in https://github.com/dfinity/nns-dapp/pull/3033 and the voting was added in https://github.com/dfinity/nns-dapp/pull/3224.

# Changes

Make the expectation less specific by expecting any > 0 number of votes. If should have some votes because the proposer vote "yes" by default.

# Tests

Pass. Hopefully less flaky.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary