### PR TITLE
GIX-1881: toAccount disburse maturity service & api

### DIFF
--- a/frontend/src/lib/api/sns-governance.api.ts
+++ b/frontend/src/lib/api/sns-governance.api.ts
@@ -1,6 +1,7 @@
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
 import type { Identity } from "@dfinity/agent";
+import type { IcrcAccount } from "@dfinity/ledger";
 import type { Principal } from "@dfinity/principal";
 import type {
   SnsListProposalsParams,
@@ -471,11 +472,13 @@ export const disburseMaturity = async ({
   rootCanisterId,
   identity,
   percentageToDisburse,
+  toAccount,
 }: {
   neuronId: SnsNeuronId;
   rootCanisterId: Principal;
   identity: Identity;
   percentageToDisburse: number;
+  toAccount?: IcrcAccount;
 }): Promise<void> => {
   logWithTimestamp(`Disburse maturity: call...`);
 
@@ -488,6 +491,7 @@ export const disburseMaturity = async ({
   await percentageToDisburseApi({
     neuronId,
     percentageToDisburse,
+    toAccount,
   });
 
   logWithTimestamp(`Disburse maturity: complete`);

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -61,6 +61,7 @@ import {
   fromDefinedNullable,
   fromNullable,
   isNullish,
+  nonNullish,
 } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { getAuthenticatedIdentity } from "./auth.services";
@@ -776,19 +777,26 @@ export const disburseMaturity = async ({
   neuronId,
   rootCanisterId,
   percentageToDisburse,
+  toAccountAddress,
 }: {
   neuronId: SnsNeuronId;
   rootCanisterId: Principal;
   percentageToDisburse: number;
+  toAccountAddress?: string;
 }): Promise<{ success: boolean }> => {
   try {
     const identity = await getSnsNeuronIdentity();
+
+    const toAccount = nonNullish(toAccountAddress)
+      ? decodeIcrcAccount(toAccountAddress)
+      : undefined;
 
     await disburseMaturityApi({
       neuronId,
       rootCanisterId,
       percentageToDisburse,
       identity,
+      toAccount,
     });
 
     return { success: true };

--- a/frontend/src/tests/lib/api/sns-governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-governance.api.spec.ts
@@ -7,6 +7,7 @@ import {
   autoStakeMaturity,
   claimNeuron,
   disburse,
+  disburseMaturity,
   getNervousSystemFunctions,
   getNeuronBalance,
   getSnsNeuron,
@@ -89,6 +90,7 @@ describe("sns-api", () => {
   const autoStakeMaturitySpy = jest.fn().mockResolvedValue(undefined);
   const listProposalsSpy = jest.fn().mockResolvedValue(proposals);
   const getProposalSpy = jest.fn().mockResolvedValue(mockSnsProposal);
+  const disburseMaturitySpy = jest.fn().mockResolvedValue(undefined);
   const nervousSystemFunctionsMock: SnsListNervousSystemFunctionsResponse = {
     reserved_ids: new BigUint64Array(),
     functions: [nervousSystemFunctionMock],
@@ -99,6 +101,10 @@ describe("sns-api", () => {
   const nervousSystemParametersSpy = jest
     .fn()
     .mockResolvedValue(snsNervousSystemParametersMock);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   beforeAll(() => {
     jest
@@ -143,13 +149,9 @@ describe("sns-api", () => {
         autoStakeMaturity: autoStakeMaturitySpy,
         listProposals: listProposalsSpy,
         getProposal: getProposalSpy,
+        disburseMaturity: disburseMaturitySpy,
       })
     );
-  });
-
-  afterAll(() => {
-    jest.clearAllMocks();
-    jest.restoreAllMocks();
   });
 
   it("should query sns neurons", async () => {
@@ -399,5 +401,47 @@ describe("sns-api", () => {
     expect(getProposalSpy).toBeCalledWith({ proposalId });
     expect(getProposalSpy).toBeCalledTimes(1);
     expect(res).toEqual(mockSnsProposal);
+  });
+
+  describe("disburseMaturity", () => {
+    it("should disburse maturity", async () => {
+      const res = await disburseMaturity({
+        identity: mockIdentity,
+        rootCanisterId: rootCanisterIdMock,
+        neuronId: mockSnsNeuron.id[0],
+        percentageToDisburse: 33,
+      });
+
+      expect(res).toBeUndefined();
+      expect(disburseMaturitySpy).toBeCalledTimes(1);
+      expect(disburseMaturitySpy).toBeCalledWith({
+        neuronId: mockSnsNeuron.id[0],
+        percentageToDisburse: 33,
+      });
+    });
+
+    it("should disburse maturity with account", async () => {
+      const ownerText =
+        "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae";
+      const owner = Principal.fromText(ownerText);
+      const toAccount = {
+        owner,
+        subaccount: undefined,
+      };
+      await disburseMaturity({
+        identity: mockIdentity,
+        rootCanisterId: rootCanisterIdMock,
+        neuronId: mockSnsNeuron.id[0],
+        percentageToDisburse: 33,
+        toAccount,
+      });
+
+      expect(disburseMaturitySpy).toBeCalledTimes(1);
+      expect(disburseMaturitySpy).toBeCalledWith({
+        neuronId: mockSnsNeuron.id[0],
+        percentageToDisburse: 33,
+        toAccount,
+      });
+    });
   });
 });

--- a/frontend/src/tests/lib/api/sns-governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-governance.api.spec.ts
@@ -405,6 +405,7 @@ describe("sns-api", () => {
 
   describe("disburseMaturity", () => {
     it("should disburse maturity", async () => {
+      expect(disburseMaturitySpy).not.toBeCalled();
       const res = await disburseMaturity({
         identity: mockIdentity,
         rootCanisterId: rootCanisterIdMock,
@@ -428,6 +429,8 @@ describe("sns-api", () => {
         owner,
         subaccount: undefined,
       };
+
+      expect(disburseMaturitySpy).not.toBeCalled();
       await disburseMaturity({
         identity: mockIdentity,
         rootCanisterId: rootCanisterIdMock,

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -82,12 +82,12 @@ jest.mock("$lib/services/sns-accounts.services", () => {
 
 describe("sns-neurons-services", () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     resetIdentity();
   });
 
   describe("syncSnsNeurons", () => {
     beforeEach(() => {
-      jest.clearAllMocks();
       snsNeuronsStore.reset();
 
       snsParametersStore.reset();
@@ -286,7 +286,6 @@ describe("sns-neurons-services", () => {
 
   describe("loadNeurons", () => {
     beforeEach(() => {
-      jest.clearAllMocks();
       snsNeuronsStore.reset();
       jest.spyOn(console, "error").mockImplementation(() => undefined);
     });
@@ -315,7 +314,6 @@ describe("sns-neurons-services", () => {
 
   describe("getSnsNeuron", () => {
     beforeEach(() => {
-      jest.clearAllMocks();
       snsNeuronsStore.reset();
       jest.spyOn(console, "error").mockImplementation(() => undefined);
     });
@@ -628,7 +626,6 @@ describe("sns-neurons-services", () => {
     const now = nowInSeconds * 1000;
 
     beforeEach(() => {
-      jest.clearAllTimers();
       jest.useFakeTimers().setSystemTime(now);
       spyOnSetDissolveDelay.mockClear();
     });
@@ -658,7 +655,6 @@ describe("sns-neurons-services", () => {
   describe("stakeNeuron", () => {
     afterEach(() => {
       transactionsFeesStore.reset();
-      jest.clearAllMocks();
     });
 
     it("should call sns api stakeNeuron, query neurons again and load sns accounts", async () => {
@@ -765,16 +761,19 @@ describe("sns-neurons-services", () => {
   });
 
   describe("disburseMaturity", () => {
-    it("should call api.disburseMaturity", async () => {
-      const neuronId = mockSnsNeuron.id[0] as SnsNeuronId;
-      const identity = mockIdentity;
-      const rootCanisterId = mockPrincipal;
-      const percentageToDisburse = 75;
+    const rootCanisterId = mockPrincipal;
+    const neuronId = mockSnsNeuron.id[0] as SnsNeuronId;
+    const identity = mockIdentity;
+    const percentageToDisburse = 75;
+    let spyOnDisburseMaturity: jest.SpyInstance;
 
-      const spyOnDisburseMaturity = jest
+    beforeEach(() => {
+      spyOnDisburseMaturity = jest
         .spyOn(governanceApi, "disburseMaturity")
         .mockImplementation(() => Promise.resolve());
+    });
 
+    it("should call api.disburseMaturity with account destinatoin", async () => {
       const { success } = await disburseMaturity({
         neuronId,
         rootCanisterId,
@@ -788,6 +787,35 @@ describe("sns-neurons-services", () => {
         rootCanisterId,
         percentageToDisburse,
         identity,
+      });
+    });
+
+    it("should decode the destination address to an ICRC account", async () => {
+      const ownerText =
+        "k2t6j-2nvnp-4zjm3-25dtz-6xhaa-c7boj-5gayf-oj3xs-i43lp-teztq-6ae";
+      const owner = Principal.fromText(ownerText);
+      const subaccount = Uint8Array.from([...Array(32)].map((_, i) => i + 1));
+      const subaccountHex =
+        "102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+      const checksum = "dfxgiyy";
+      const destinationAddress = `${ownerText}-${checksum}.${subaccountHex}`;
+      await disburseMaturity({
+        rootCanisterId,
+        neuronId: mockSnsNeuron.id[0],
+        percentageToDisburse: 33,
+        toAccountAddress: destinationAddress,
+      });
+
+      expect(spyOnDisburseMaturity).toBeCalledTimes(1);
+      expect(spyOnDisburseMaturity).toBeCalledWith({
+        identity,
+        rootCanisterId,
+        neuronId: mockSnsNeuron.id[0],
+        percentageToDisburse: 33,
+        toAccount: {
+          owner,
+          subaccount,
+        },
       });
     });
   });
@@ -806,8 +834,6 @@ describe("sns-neurons-services", () => {
     const followeeHex2 = subaccountToHexString(followee2.id);
     const rootCanisterId = mockPrincipal;
     const functionId = BigInt(3);
-
-    afterEach(() => jest.clearAllMocks());
 
     it("should call sns api setFollowees with new followee when topic already has followees", async () => {
       const queryNeuronSpy = jest
@@ -927,8 +953,6 @@ describe("sns-neurons-services", () => {
     };
     const rootCanisterId = mockPrincipal;
     const functionId = BigInt(3);
-
-    afterEach(() => jest.clearAllMocks());
 
     it("should call sns api setFollowees with followee removed from list", async () => {
       const neuron: SnsNeuron = {


### PR DESCRIPTION
# Motivation

Add `toAccount` to disburse maturity service and api.

# Changes

* Add parameter `toAccount` to disbrse maturity sns governance api.
* Add `toAccountAddress` to disburseMaturity sns service. Convert string to ICRC account to send it to api.

# Tests

* Add tests for disburseMaturity sns governance api (it was missing).
* Add test case for disburseMaturity sns service.
* I moved the `jest.clearMocks` to a main `beforeEach` in both files.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet necessary. I'll add an entry when the new parameter is used from the UI.