### PR TITLE
GIX-1881: Add destination disburse maturity

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -14,6 +14,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 * Add the amount of maturity related to a selected percentage.
 * Disburse maturity of sns neurons.
+* Select destination when disbursing maturity.
 
 #### Changed
 

--- a/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
@@ -14,7 +14,7 @@
   } from "@dfinity/gix-components";
   import { formatToken } from "$lib/utils/token.utils";
   import { formatMaturity } from "$lib/utils/neuron.utils";
-  import QrWizardModal from "../transaction/QrWizardModal.svelte";
+  import QrWizardModal from "$lib/modals/transaction/QrWizardModal.svelte";
   import SelectDestinationAddress from "$lib/components/accounts/SelectDestinationAddress.svelte";
   import type { Principal } from "@dfinity/principal";
   import { assertNonNullish, type Token } from "@dfinity/utils";
@@ -28,7 +28,7 @@
   export let rootCanisterId: Principal;
   export let token: Token;
   export let minimumAmountE8s: bigint;
-  // Using `undefined` allows only ICRC accounts.
+  // Using `undefined` allows only ICRC
   export let selectedNetwork: TransactionNetwork | undefined = undefined;
 
   const steps: WizardSteps = [

--- a/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
@@ -19,7 +19,7 @@
   import type { Principal } from "@dfinity/principal";
   import { assertNonNullish, type Token } from "@dfinity/utils";
   import type { QrResponse } from "$lib/types/qr-wizard-modal";
-  import { TransactionNetwork } from "$lib/types/transaction";
+  import type { TransactionNetwork } from "$lib/types/transaction";
   import { getAccountByRootCanister } from "$lib/utils/accounts.utils";
   import { universesAccountsStore } from "$lib/derived/universes-accounts.derived";
 
@@ -28,6 +28,8 @@
   export let rootCanisterId: Principal;
   export let token: Token;
   export let minimumAmountE8s: bigint;
+  // Using `undefined` allows only ICRC accounts.
+  export let selectedNetwork: TransactionNetwork | undefined = undefined;
 
   const steps: WizardSteps = [
     {
@@ -167,7 +169,7 @@
           {rootCanisterId}
           bind:selectedDestinationAddress
           bind:showManualAddress
-          selectedNetwork={TransactionNetwork.ICP}
+          {selectedNetwork}
           on:nnsOpenQRCodeReader={goQRCode}
         />
       </div>

--- a/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
@@ -20,6 +20,8 @@
   import { assertNonNullish, type Token } from "@dfinity/utils";
   import type { QrResponse } from "$lib/types/qr-wizard-modal";
   import { TransactionNetwork } from "$lib/types/transaction";
+  import { getAccountByRootCanister } from "$lib/utils/accounts.utils";
+  import { universesAccountsStore } from "$lib/derived/universes-accounts.derived";
 
   export let availableMaturityE8s: bigint;
   export let tokenSymbol: string;
@@ -109,6 +111,17 @@
 
     selectedDestinationAddress = identifier;
   };
+
+  // Note: This doesn't support subaccount names. Yet, we don't have subaccounts for SNS, nor are we planning to add in the near future.
+  let destinationAddressName: string | undefined = undefined;
+  $: destinationAddressName =
+    getAccountByRootCanister({
+      identifier: selectedDestinationAddress,
+      rootCanisterId,
+      universesAccounts: $universesAccountsStore,
+    })?.type === "main"
+      ? $i18n.accounts.main
+      : selectedDestinationAddress;
 </script>
 
 <QrWizardModal
@@ -211,7 +224,7 @@
             data-tid="confirm-destination"
             class="value destination-value"
             slot="value"
-            >{$i18n.accounts.main}
+            >{destinationAddressName}
           </span>
         </KeyValuePair>
       </div>

--- a/frontend/src/lib/modals/sns/neurons/SnsDisburseMaturityModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsDisburseMaturityModal.svelte
@@ -15,8 +15,9 @@
   export let rootCanisterId: Principal;
   export let reloadNeuron: () => Promise<void>;
 
-  let token: IcrcTokenMetadata | undefined;
-  $: token = $tokensStore[rootCanisterId.toText()]?.token;
+  let token: IcrcTokenMetadata;
+  // Modal can't appear without the token being loaded.
+  $: token = $tokensStore[rootCanisterId.toText()]?.token as IcrcTokenMetadata;
 
   let minimumAmountE8s: bigint;
   // Token is loaded with all the projects from the aggregator.
@@ -27,14 +28,18 @@
   const close = () => dispatcher("nnsClose");
 
   const disburseMaturity = async ({
-    detail: { percentageToDisburse },
-  }: CustomEvent<{ percentageToDisburse: number }>) => {
+    detail: { percentageToDisburse, destinationAddress },
+  }: CustomEvent<{
+    percentageToDisburse: number;
+    destinationAddress: string;
+  }>) => {
     startBusy({ initiator: "disburse-maturity" });
 
     const { success } = await disburseMaturityService({
       neuronId,
       percentageToDisburse,
       rootCanisterId,
+      toAccountAddress: destinationAddress,
     });
 
     await reloadNeuron();
@@ -55,5 +60,7 @@
   {minimumAmountE8s}
   tokenSymbol={token?.symbol ?? ""}
   on:nnsDisburseMaturity={disburseMaturity}
+  {rootCanisterId}
+  {token}
   on:nnsClose
 />

--- a/frontend/src/tests/lib/modals/sns/SnsDisburseMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsDisburseMaturityModal.spec.ts
@@ -107,6 +107,19 @@ describe("SnsDisburseMaturityModal", () => {
     expect(await po.getText()).toContain(`13%`);
   });
 
+  it("should show error if account is not ICRC", async () => {
+    const po = await renderSnsDisburseMaturityModal(mockSnsNeuron);
+    const destinationPo = po.getSelectDestinationAddressPo();
+    // This is a valid ICP address, but not valid ICRC address.
+    await destinationPo.enterAddress(
+      "d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f"
+    );
+    await destinationPo.blurInput();
+    expect(await destinationPo.getErrorMessage()).toBe(
+      "Please enter a valid address."
+    );
+  });
+
   it("should display summary information in the last step", async () => {
     const neuron = createMockSnsNeuron({
       id: [1],

--- a/frontend/src/tests/page-objects/AddressInput.page-object.ts
+++ b/frontend/src/tests/page-objects/AddressInput.page-object.ts
@@ -1,6 +1,8 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
+// NOTE: This element is an InputWithError itself.
+// DO NOT TRY TO SELECT THE INPUT WITHIN IT.
 export class AddressInputPo extends BasePageObject {
   private static readonly TID = "address-input-component";
 
@@ -10,5 +12,13 @@ export class AddressInputPo extends BasePageObject {
 
   enterAddress(address: string): Promise<void> {
     return this.getTextInput().typeText(address);
+  }
+
+  async getErrorMessage(): Promise<string> {
+    return (await this.getText("input-error-message")).trim();
+  }
+
+  blur(): Promise<void> {
+    return this.getTextInput().blur();
   }
 }

--- a/frontend/src/tests/page-objects/DisburseMaturityModal.page-object.ts
+++ b/frontend/src/tests/page-objects/DisburseMaturityModal.page-object.ts
@@ -2,6 +2,7 @@ import { NeuronConfirmActionScreenPo } from "$tests/page-objects/NeuronConfirmAc
 import { NeuronSelectPercentagePo } from "$tests/page-objects/NeuronSelectPercentage.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { SelectDestinationAddressPo } from "./SelectDestinationAddress.page-object";
 
 export class DisburseMaturityModalPo extends BasePageObject {
   private static readonly TID = "disburse-maturity-modal-component";
@@ -58,5 +59,9 @@ export class DisburseMaturityModalPo extends BasePageObject {
 
   getConfirmDestination(): Promise<string> {
     return this.getNeuronConfirmActionScreenPo().getText("confirm-destination");
+  }
+
+  getSelectDestinationAddressPo(): SelectDestinationAddressPo {
+    return SelectDestinationAddressPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/SelectDestinationAddress.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectDestinationAddress.page-object.ts
@@ -50,4 +50,12 @@ export class SelectDestinationAddressPo extends BasePageObject {
     await this.enableTextInput();
     await this.getAddressInputPo().enterAddress(address);
   }
+
+  async getErrorMessage(): Promise<string> {
+    return this.getAddressInputPo().getErrorMessage();
+  }
+
+  blurInput(): Promise<void> {
+    return this.getAddressInputPo().blur();
+  }
 }

--- a/frontend/src/tests/page-objects/jest.page-object.ts
+++ b/frontend/src/tests/page-objects/jest.page-object.ts
@@ -170,4 +170,9 @@ export class JestPageObjectElement implements PageObjectElement {
       return false;
     }
   }
+
+  async blur(): Promise<void> {
+    await this.waitFor();
+    await fireEvent.blur(this.element);
+  }
 }

--- a/frontend/src/tests/page-objects/playwright.page-object.ts
+++ b/frontend/src/tests/page-objects/playwright.page-object.ts
@@ -115,4 +115,8 @@ export class PlaywrightPageObjectElement implements PageObjectElement {
   async isVisible(): Promise<boolean> {
     throw new Error("Not implement");
   }
+
+  async blur(): Promise<void> {
+    throw new Error("Not implement");
+  }
 }

--- a/frontend/src/tests/page-objects/simple-base.page-object.ts
+++ b/frontend/src/tests/page-objects/simple-base.page-object.ts
@@ -35,4 +35,8 @@ export class SimpleBasePageObject {
   getText(tid: string | undefined = undefined): Promise<string> {
     return this.getElement(tid).getText();
   }
+
+  async blur(): Promise<void> {
+    return this.root.blur();
+  }
 }

--- a/frontend/src/tests/types/page-object.types.ts
+++ b/frontend/src/tests/types/page-object.types.ts
@@ -34,4 +34,5 @@ export interface PageObjectElement {
   selectOption(option: string): Promise<void>;
   getValue(): Promise<string>;
   isVisible(): Promise<boolean>;
+  blur(): Promise<void>;
 }


### PR DESCRIPTION
# Motivation

Users can select a destination when disbursing maturity.

# Changes

* Use `QrWizardModal` and `SelectDestinationAddress` in DisburseMaturityModal.
* Add props `rootCanisterId`, `token` and `selectedNetwork` to DisburrseMaturityModal.
* SnsDisburseMaturityModal passes new props to DisburseMaturityModal. `selectedNetwork` is left `undefined` on purpose because it means using ICRC accounts.
* Add `destinationAddress` to the `nnsDisburseMaturity` event caught by SnsDisburseMaturityModal.
* Use the new parameter `toAccount` of the disburse maturity service.

# Tests

* Add a test case that user can disburse maturity to another account and that it gets an error if a non-ICRC account is used.
* Add `blur` method to jest-page-object.
* Add a few methods to the related POs.

# Todos

- [x] Add entry to changelog (if necessary).
