### PR TITLE
Chore: Rename CommitmentProgressBarPo method

### DIFF
--- a/frontend/src/tests/lib/components/project-detail/CommitmentProgressBar.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/CommitmentProgressBar.spec.ts
@@ -31,7 +31,7 @@ describe("CommitmentProgressBar", () => {
       directParticipation: 150_000_000n,
       nfParticipation: 0n,
     });
-    expect(await po.getProgressBarTotalCommitmentE8s()).toBe(150000000n);
+    expect(await po.getTotalCommitmentE8s()).toBe(150000000n);
   });
 
   it("should render sume of direct and NF participation value in progress bar", async () => {
@@ -40,7 +40,7 @@ describe("CommitmentProgressBar", () => {
       directParticipation: 300_000_000n,
       nfParticipation: 150_000_000n,
     });
-    expect(await po.getProgressBarTotalCommitmentE8s()).toBe(450000000n);
+    expect(await po.getTotalCommitmentE8s()).toBe(450000000n);
   });
 
   it("should display maximum and minimum indicators", async () => {
@@ -92,7 +92,7 @@ describe("CommitmentProgressBar", () => {
     });
     expect(await po.getNFCommitmentE8s()).toEqual(0n);
     expect(await po.getDirectCommitmentE8s()).toEqual(300_000_000n);
-    expect(await po.getProgressBarTotalCommitmentE8s()).toEqual(300_000_000n);
+    expect(await po.getTotalCommitmentE8s()).toEqual(300_000_000n);
   });
 
   it("should display NF and direct commitments", async () => {

--- a/frontend/src/tests/page-objects/CommitmentProgressBarPo.page-object.ts
+++ b/frontend/src/tests/page-objects/CommitmentProgressBarPo.page-object.ts
@@ -26,7 +26,7 @@ export class CommitmentProgressBarPo extends BasePageObject {
     return (await this.getText("commitment-max-indicator-value")).trim();
   }
 
-  async getProgressBarTotalCommitmentE8s(): Promise<bigint> {
+  async getTotalCommitmentE8s(): Promise<bigint> {
     // The `value` property has the value of the max value but the `value` attribute has the value of the progress.
     const valueString = await this.root
       .querySelector("progress")
@@ -61,16 +61,14 @@ export class CommitmentProgressBarPo extends BasePageObject {
       );
     }
 
-    const totalCommitment = Number(
-      await this.getProgressBarTotalCommitmentE8s()
-    );
+    const totalCommitment = Number(await this.getTotalCommitmentE8s());
     const nfPercentage = Number(firstPercentage);
 
     return BigInt(Math.round((totalCommitment * nfPercentage) / 100));
   }
 
   async getDirectCommitmentE8s(): Promise<bigint> {
-    const totalCommitment = await this.getProgressBarTotalCommitmentE8s();
+    const totalCommitment = await this.getTotalCommitmentE8s();
     return BigInt(totalCommitment - (await this.getNFCommitmentE8s()));
   }
 }


### PR DESCRIPTION
# Motivation

I merged the PR before making a requested change in a comment.

https://github.com/dfinity/nns-dapp/pull/3365#discussion_r1336020288

# Changes

* Rename method in CommitmentProgressBarPo

# Tests

* Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
