### PR TITLE
Chore: Move blur from SimpleBaseObject to TextInputPo

### DIFF
--- a/frontend/src/tests/page-objects/TextInput.page-object.ts
+++ b/frontend/src/tests/page-objects/TextInput.page-object.ts
@@ -39,4 +39,8 @@ export class TextInputPo extends SimpleBasePageObject {
   async isRequired(): Promise<boolean> {
     return (await this.root.getAttribute("required")) !== null;
   }
+
+  async blur(): Promise<void> {
+    return this.root.blur();
+  }
 }

--- a/frontend/src/tests/page-objects/simple-base.page-object.ts
+++ b/frontend/src/tests/page-objects/simple-base.page-object.ts
@@ -35,8 +35,4 @@ export class SimpleBasePageObject {
   getText(tid: string | undefined = undefined): Promise<string> {
     return this.getElement(tid).getText();
   }
-
-  async blur(): Promise<void> {
-    return this.root.blur();
-  }
 }


### PR DESCRIPTION
# Motivation

Keep SimpleBasePageObject interface small.

# Changes

* Move `blur` method to `TextInputPo`.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
