### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -42,7 +42,6 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Security
 
 ## Proposal 124787
-124788
 
 ### Application
 

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -12,6 +12,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Added
 
+* Select destination when disbursing maturity.
+
 #### Changed
 
 * Use ICRC-1 transfer on ICP ledger canister instead of generic ICRC-1 ledger canister.
@@ -49,7 +51,6 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 * Add the amount of maturity related to a selected percentage.
 * Disburse maturity of sns neurons.
-* Select destination when disbursing maturity.
 
 #### Changed
 


### PR DESCRIPTION
# Motivation
The command that splits the changelog after a release added both proposals at that commit, not just the `nns-dapp` proposal.

# Changes
- Delete the aggregator proposal number from the `nns-dapp` changelog.

# Tests
Note: There is a CI check that ensures that the changelog is not modified.  That will have to be overridden.

# Todos

- [ ] Add entry to changelog (if necessary).
  - Not applicable
