### PR TITLE
Fix pattern for nns-dapp proposals

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -32,6 +32,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Added
 
 #### Changed
+* Fix the proposal matching pattern in `nns-dapp/split-changelog` that used to match aggregator proposals as well.
 * Fix the rust-update action.
 
 #### Deprecated

--- a/scripts/nns-dapp/split-changelog
+++ b/scripts/nns-dapp/split-changelog
@@ -78,7 +78,7 @@ sed -e 's@^+[-*]@+&@' <"$PATCH" | patch "$CHANGELOG"
   grep -v '^[-* ] ' "$CHANGELOG" | sed -E 's@^\+([-* ] )@* @'
 
   # Get proposal number from tags applied to same commit as prod tag
-  PROPOSAL_NUMBER="${PROPOSAL_NUMBER:-"$(git tag --contains "$COMMIT" | grep 'proposal-[0-9]\+' | cut -d- -f2)"}"
+  PROPOSAL_NUMBER="${PROPOSAL_NUMBER:-"$(git tag --contains "$COMMIT" | grep -E '^proposal-[0-9]+$' | cut -d- -f2)"}"
   PROPOSAL_NUMBER="${PROPOSAL_NUMBER:-XXXXXX}"
 
   # Append the tail of the old changelog with entries before the release was cut.


### PR DESCRIPTION
# Motivation
The `nns-dapp/split-changelog` command erroneously matches aggregator proposal tags.

- `nns-dapp` proposals are tagged `proposal-$PROPOSAL_NUMBER` e.g. `proposal-1234`.
- `sns_aggregator` proposals are tagged `proposal-$PROPOSAL_NUMBER-agg` e.g. `proposal-1234-agg`.

The pattern in `nns-dapp/split-changelog` matches both.

# Changes
- Match only nns-dapp proposal tags.

# Tests
The last release commit has the following tags:
```
max@sinkpad:~/dfn/nns-dapp/branches/fix-changelog (7)$ git tag --contains 05982aef608988cd2f88855723560203d288cc38
aggregator-prod
aggregator-release-candidate
nightly-2023-09-22
nightly-2023-09-23
nightly-2023-09-24
nightly-2023-09-25
nightly-2023-09-26
prod
proposal-124787
proposal-124788-agg
release-candidate
tip
```
The old pattern matched these tags:
```
max@sinkpad:~/dfn/nns-dapp/branches/fix-changelog (2:27)$ git tag --contains 05982aef608988cd2f88855723560203d288cc38 | grep 'proposal-[0-9]\+'
proposal-124787
proposal-124788-agg
```
The new pattern matches these tags:
```
max@sinkpad:~/dfn/nns-dapp/branches/fix-changelog (2:33)$ git tag --contains 05982aef608988cd2f88855723560203d288cc38 | grep -E '^proposal-[0-9]+$'
proposal-124787
```

# Todos

- [ ] Add entry to changelog (if necessary).
