### PR TITLE
Chore: ProjectCommitmentPO

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -19,6 +19,7 @@
     isFullProjectCommitmentSplit,
     type ProjectCommitmentSplit,
   } from "$lib/utils/projects.utils";
+  import TestIdWrapper from "../common/TestIdWrapper.svelte";
 
   const { store: projectDetailStore } = getContext<ProjectDetailContext>(
     PROJECT_DETAIL_CONTEXT_KEY
@@ -55,69 +56,73 @@
   });
 </script>
 
-{#if nonNullish(saleBuyerCount)}
-  <KeyValuePair testId="sns-project-current-sale-buyer-count">
+<TestIdWrapper testId="project-commitment-component">
+  {#if nonNullish(saleBuyerCount)}
+    <KeyValuePair>
+      <span slot="key">
+        {$i18n.sns_project_detail.current_sale_buyer_count}
+      </span>
+      <span slot="value" data-tid="sns-project-current-sale-buyer-count"
+        >{saleBuyerCount}</span
+      >
+    </KeyValuePair>
+  {/if}
+  <KeyValuePair testId="sns-project-current-commitment">
     <span slot="key">
-      {$i18n.sns_project_detail.current_sale_buyer_count}
-    </span>
-    <span slot="value">{saleBuyerCount}</span>
-  </KeyValuePair>
-{/if}
-<KeyValuePair testId="sns-project-current-commitment">
-  <span slot="key">
-    {$i18n.sns_project_detail.current_overall_commitment}
-  </span>
-
-  <AmountDisplay slot="value" amount={buyersTotalCommitmentIcp} singleLine />
-</KeyValuePair>
-{#if isFullProjectCommitmentSplit(projectCommitments)}
-  <KeyValuePair testId="sns-project-current-nf-commitment">
-    <span slot="key" class="detail-data">
-      {$i18n.sns_project_detail.current_nf_commitment}
+      {$i18n.sns_project_detail.current_overall_commitment}
     </span>
 
-    <AmountDisplay
-      slot="value"
-      amount={TokenAmount.fromE8s({
-        amount: projectCommitments.nfCommitmentE8s,
-        token: ICPToken,
-      })}
-      singleLine
-    />
+    <AmountDisplay slot="value" amount={buyersTotalCommitmentIcp} singleLine />
   </KeyValuePair>
-  <KeyValuePair testId="sns-project-current-direct-commitment">
-    <span slot="key" class="detail-data">
-      {$i18n.sns_project_detail.current_direct_commitment}
-    </span>
+  {#if isFullProjectCommitmentSplit(projectCommitments)}
+    <KeyValuePair testId="sns-project-current-nf-commitment">
+      <span slot="key" class="detail-data">
+        {$i18n.sns_project_detail.current_nf_commitment}
+      </span>
 
-    <AmountDisplay
-      slot="value"
-      amount={TokenAmount.fromE8s({
-        amount: projectCommitments.directCommitmentE8s,
-        token: ICPToken,
-      })}
-      singleLine
-    />
-  </KeyValuePair>
-  <div data-tid="sns-project-commitment-progress">
-    <CommitmentProgressBar
-      directParticipation={projectCommitments.directCommitmentE8s}
-      nfParticipation={projectCommitments.nfCommitmentE8s}
-      max={max_icp_e8s}
-      minimumIndicator={min_icp_e8s}
-    />
-  </div>
-{:else}
-  <!-- We show the progress bar with only directParticipation if NF participation is not present -->
-  <div data-tid="sns-project-commitment-progress">
-    <CommitmentProgressBar
-      directParticipation={projectCommitments.totalCommitmentE8s}
-      nfParticipation={0n}
-      max={max_icp_e8s}
-      minimumIndicator={min_icp_e8s}
-    />
-  </div>
-{/if}
+      <AmountDisplay
+        slot="value"
+        amount={TokenAmount.fromE8s({
+          amount: projectCommitments.nfCommitmentE8s,
+          token: ICPToken,
+        })}
+        singleLine
+      />
+    </KeyValuePair>
+    <KeyValuePair testId="sns-project-current-direct-commitment">
+      <span slot="key" class="detail-data">
+        {$i18n.sns_project_detail.current_direct_commitment}
+      </span>
+
+      <AmountDisplay
+        slot="value"
+        amount={TokenAmount.fromE8s({
+          amount: projectCommitments.directCommitmentE8s,
+          token: ICPToken,
+        })}
+        singleLine
+      />
+    </KeyValuePair>
+    <div data-tid="sns-project-commitment-progress">
+      <CommitmentProgressBar
+        directParticipation={projectCommitments.directCommitmentE8s}
+        nfParticipation={projectCommitments.nfCommitmentE8s}
+        max={max_icp_e8s}
+        minimumIndicator={min_icp_e8s}
+      />
+    </div>
+  {:else}
+    <!-- We show the progress bar with only directParticipation if NF participation is not present -->
+    <div data-tid="sns-project-commitment-progress">
+      <CommitmentProgressBar
+        directParticipation={projectCommitments.totalCommitmentE8s}
+        nfParticipation={0n}
+        max={max_icp_e8s}
+        minimumIndicator={min_icp_e8s}
+      />
+    </div>
+  {/if}
+</TestIdWrapper>
 
 <style lang="scss">
   .detail-data {

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -104,7 +104,7 @@ describe("ProjectCommitment", () => {
     });
     const po = renderComponent(summary);
     const progressBarPo = po.getCommitmentProgressBarPo();
-    expect(await progressBarPo.getProgressBarTotalCommitmentE8s()).toBe(
+    expect(await progressBarPo.getTotalCommitmentE8s()).toBe(
       directCommitment + nfCommitment
     );
   });

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -5,15 +5,15 @@
 import ProjectCommitment from "$lib/components/project-detail/ProjectCommitment.svelte";
 import * as summaryGetters from "$lib/getters/sns-summary";
 import { snsSwapMetricsStore } from "$lib/stores/sns-swap-metrics.store";
-import type { SnsSwapCommitment } from "$lib/types/sns";
-import { formatToken } from "$lib/utils/token.utils";
-import en from "$tests/mocks/i18n.mock";
+import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
 import {
   createSummary,
   mockSnsFullProject,
   summaryForLifecycle,
 } from "$tests/mocks/sns-projects.mock";
 import { renderContextCmp } from "$tests/mocks/sns.mock";
+import { ProjectCommitmentPo } from "$tests/page-objects/ProjectCommitment.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 
 // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
@@ -23,25 +23,34 @@ describe("ProjectCommitment", () => {
   const summary = summaryForLifecycle(SnsSwapLifecycle.Open);
   const saleBuyerCount = 1_000_000;
 
+  const renderComponent = (
+    summary: SnsSummary,
+    swapCommitment: SnsSwapCommitment = mockSnsFullProject.swapCommitment
+  ) => {
+    const { container } = renderContextCmp({
+      summary,
+      swapCommitment,
+      Component: ProjectCommitment,
+    });
+
+    return ProjectCommitmentPo.under(new JestPageObjectElement(container));
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("should render min and max commitment", () => {
-    const { queryByTestId } = renderContextCmp({
-      summary,
-      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-      Component: ProjectCommitment,
+  it("should render min and max commitment", async () => {
+    const summary = createSummary({
+      maxTotalCommitment: 50000000000n,
+      minTotalCommitment: 20000000000n,
     });
-    expect(
-      queryByTestId("commitment-max-indicator-value")?.textContent.trim()
-    ).toEqual(`${formatToken({ value: summary.swap.params.max_icp_e8s })} ICP`);
-    expect(
-      queryByTestId("commitment-min-indicator-value")?.textContent.trim()
-    ).toEqual(`${formatToken({ value: summary.swap.params.min_icp_e8s })} ICP`);
+    const po = renderComponent(summary);
+    expect(await po.getMaxCommitment()).toEqual("500.00 ICP");
+    expect(await po.getMinCommitment()).toEqual("200.00 ICP");
   });
 
-  it("should render total participants from swap metrics", () => {
+  it("should render total participants from swap metrics", async () => {
     snsSwapMetricsStore.setMetrics({
       rootCanisterId: mockSnsFullProject.swapCommitment.rootCanisterId,
       metrics: {
@@ -53,23 +62,11 @@ describe("ProjectCommitment", () => {
       buyersCount: null,
     });
 
-    const { queryByTestId } = renderContextCmp({
-      summary: summaryWithoutBuyers,
-      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-      Component: ProjectCommitment,
-    });
-
-    const textContent: string =
-      queryByTestId("sns-project-current-sale-buyer-count")?.textContent ?? "";
-
-    expect(
-      textContent.includes(en.sns_project_detail.current_sale_buyer_count)
-    ).toBeTruthy();
-
-    expect(textContent.includes(`${saleBuyerCount}`)).toBeTruthy();
+    const po = renderComponent(summaryWithoutBuyers);
+    expect(await po.getParticipantsCount()).toEqual(saleBuyerCount);
   });
 
-  it("should render total participants from derived state", () => {
+  it("should render total participants from derived state", async () => {
     snsSwapMetricsStore.setMetrics({
       rootCanisterId: mockSnsFullProject.swapCommitment.rootCanisterId,
       metrics: {
@@ -81,44 +78,20 @@ describe("ProjectCommitment", () => {
       buyersCount: BigInt(saleBuyerCount),
     });
 
-    const { queryByTestId } = renderContextCmp({
-      summary: summaryWithBuyersCount,
-      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-      Component: ProjectCommitment,
-    });
-
-    const textContent: string =
-      queryByTestId("sns-project-current-sale-buyer-count")?.textContent ?? "";
-
-    expect(
-      textContent.includes(en.sns_project_detail.current_sale_buyer_count)
-    ).toBeTruthy();
-
-    expect(textContent.includes(`${saleBuyerCount}`)).toBeTruthy();
+    const po = renderComponent(summaryWithBuyersCount);
+    expect(await po.getParticipantsCount()).toEqual(saleBuyerCount);
   });
 
-  it("should render overall current commitment", () => {
-    const { queryByTestId } = renderContextCmp({
-      summary,
-      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-      Component: ProjectCommitment,
+  it("should render overall current commitment", async () => {
+    const summary = createSummary({
+      currentTotalCommitment: 50000000000n,
     });
+    const po = renderComponent(summary);
 
-    const textContent: string =
-      queryByTestId("sns-project-current-commitment")?.textContent ?? "";
-
-    expect(
-      textContent.includes(en.sns_project_detail.current_overall_commitment)
-    ).toBeTruthy();
-
-    expect(
-      textContent.includes(
-        `${formatToken({ value: summary.derived.buyer_total_icp_e8s })} ICP`
-      )
-    ).toBeTruthy();
+    expect(po.getCurrentTotalCommitment()).resolves.toEqual("500.00 ICP");
   });
 
-  it("should render a progress bar with total participation adding NF and direct commitments", () => {
+  it("should render a progress bar with total participation adding NF and direct commitments", async () => {
     const directCommitment = 20000000000n;
     const nfCommitment = 10000000000n;
     // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
@@ -126,43 +99,45 @@ describe("ProjectCommitment", () => {
       .spyOn(summaryGetters, "getNeuronsFundParticipation")
       .mockImplementation(() => nfCommitment);
 
-    const { container } = renderContextCmp({
-      summary: {
-        ...summary,
-        derived: {
-          ...summary.derived,
-          buyer_total_icp_e8s: directCommitment + nfCommitment,
-        },
-      },
-      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-      Component: ProjectCommitment,
+    const summary = createSummary({
+      currentTotalCommitment: directCommitment + nfCommitment,
     });
-
-    expect(container.querySelector("progress").value).toBe(
-      Number(directCommitment + nfCommitment)
+    const po = renderComponent(summary);
+    const progressBarPo = po.getCommitmentProgressBarPo();
+    expect(await progressBarPo.getProgressBarTotalCommitmentE8s()).toBe(
+      directCommitment + nfCommitment
     );
   });
 
-  it("should not render detailed participation if neurons fund participation is not available", () => {
+  it("should render a progress bar with different participations", async () => {
+    const directCommitment = 30000000000n;
+    const nfCommitment = 10000000000n;
+    // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
+    jest
+      .spyOn(summaryGetters, "getNeuronsFundParticipation")
+      .mockImplementation(() => nfCommitment);
+
+    const summary = createSummary({
+      currentTotalCommitment: directCommitment + nfCommitment,
+    });
+    const po = renderComponent(summary);
+    const progressBarPo = po.getCommitmentProgressBarPo();
+    expect(await progressBarPo.getNFCommitmentE8s()).toBe(nfCommitment);
+    expect(await progressBarPo.getDirectCommitmentE8s()).toBe(directCommitment);
+  });
+
+  it("should not render detailed participation if neurons fund participation is not available", async () => {
     // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
     jest
       .spyOn(summaryGetters, "getNeuronsFundParticipation")
       .mockImplementation(() => undefined);
-    const { queryByTestId } = renderContextCmp({
-      summary,
-      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-      Component: ProjectCommitment,
-    });
 
-    expect(
-      queryByTestId("sns-project-current-nf-commitment")
-    ).not.toBeInTheDocument();
-    expect(
-      queryByTestId("sns-project-current-direct-commitment")
-    ).not.toBeInTheDocument();
+    const po = renderComponent(summary);
+    expect(await po.hasNeuronsFundParticipation()).toBe(false);
+    expect(await po.hasDirectParticipation()).toBe(false);
   });
 
-  it("should render detailed participation if neurons fund participation is available", () => {
+  it("should render detailed participation if neurons fund participation is available", async () => {
     const directCommitment = 20000000000n;
     const nfCommitment = 10000000000n;
     // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
@@ -170,27 +145,15 @@ describe("ProjectCommitment", () => {
       .spyOn(summaryGetters, "getNeuronsFundParticipation")
       .mockImplementation(() => nfCommitment);
 
-    const { queryByTestId } = renderContextCmp({
-      summary: {
-        ...summary,
-        derived: {
-          ...summary.derived,
-          buyer_total_icp_e8s: directCommitment + nfCommitment,
-        },
-      },
-      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-      Component: ProjectCommitment,
+    const summary = createSummary({
+      currentTotalCommitment: directCommitment + nfCommitment,
     });
-
-    expect(
-      queryByTestId("sns-project-current-nf-commitment").textContent.trim()
-    ).toBe("Neurons' Fund Commitment 100.00 ICP");
-    expect(
-      queryByTestId("sns-project-current-direct-commitment").textContent.trim()
-    ).toBe("Direct Commitment 200.00 ICP");
+    const po = renderComponent(summary);
+    expect(await po.getNeuronsFundParticipation()).toEqual("100.00 ICP");
+    expect(await po.getDirectParticipation()).toEqual("200.00 ICP");
   });
 
-  it("should render detailed participation if neurons fund participation is available even with NF participation as 0", () => {
+  it("should render detailed participation if neurons fund participation is available even with NF participation as 0", async () => {
     const directCommitment = 20000000000n;
     const nfCommitment = 0n;
     // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
@@ -198,23 +161,11 @@ describe("ProjectCommitment", () => {
       .spyOn(summaryGetters, "getNeuronsFundParticipation")
       .mockImplementation(() => nfCommitment);
 
-    const { queryByTestId } = renderContextCmp({
-      summary: {
-        ...summary,
-        derived: {
-          ...summary.derived,
-          buyer_total_icp_e8s: directCommitment + nfCommitment,
-        },
-      },
-      swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
-      Component: ProjectCommitment,
+    const summary = createSummary({
+      currentTotalCommitment: directCommitment + nfCommitment,
     });
-
-    expect(
-      queryByTestId("sns-project-current-nf-commitment").textContent.trim()
-    ).toBe("Neurons' Fund Commitment 0 ICP");
-    expect(
-      queryByTestId("sns-project-current-direct-commitment").textContent.trim()
-    ).toBe("Direct Commitment 200.00 ICP");
+    const po = renderComponent(summary);
+    expect(await po.getNeuronsFundParticipation()).toEqual("0 ICP");
+    expect(await po.getDirectParticipation()).toEqual("200.00 ICP");
   });
 });

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -299,6 +299,9 @@ export const createSummary = ({
   minParticipantCommitment = 100_000_000n,
   maxParticipantCommitment = 5_000_000_000n,
   swapDueTimestampSeconds = 1630444800n,
+  minTotalCommitment,
+  maxTotalCommitment,
+  currentTotalCommitment,
 }: {
   lifecycle?: SnsSwapLifecycle;
   confirmationText?: string | undefined;
@@ -309,6 +312,9 @@ export const createSummary = ({
   minParticipantCommitment?: bigint;
   maxParticipantCommitment?: bigint;
   swapDueTimestampSeconds?: bigint;
+  minTotalCommitment?: bigint;
+  maxTotalCommitment?: bigint;
+  currentTotalCommitment?: bigint;
 }): SnsSummary => {
   const init: SnsSwapInit = {
     ...mockInit,
@@ -325,10 +331,14 @@ export const createSummary = ({
     min_participant_icp_e8s: minParticipantCommitment,
     max_participant_icp_e8s: maxParticipantCommitment,
     swap_due_timestamp_seconds: swapDueTimestampSeconds,
+    min_icp_e8s: minTotalCommitment ?? mockSnsParams.min_icp_e8s,
+    max_icp_e8s: maxTotalCommitment ?? mockSnsParams.max_icp_e8s,
   };
   const derived: SnsSwapDerivedState = {
     ...mockDerived,
     direct_participant_count: buyersCount === null ? [] : [buyersCount],
+    buyer_total_icp_e8s:
+      currentTotalCommitment ?? mockDerived.buyer_total_icp_e8s,
   };
   const summary = summaryForLifecycle(lifecycle);
   return {

--- a/frontend/src/tests/page-objects/KeyValuePair.page-object.ts
+++ b/frontend/src/tests/page-objects/KeyValuePair.page-object.ts
@@ -1,5 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { nonNullish } from "@dfinity/utils";
 
 export class KeyValuePairPo extends BasePageObject {
   static under({
@@ -16,7 +17,8 @@ export class KeyValuePairPo extends BasePageObject {
     return this.root.querySelector("dt").getText();
   }
 
-  async getValueText(): Promise<string> {
-    return this.root.querySelector("dd").getText();
+  async getValueText(): Promise<string | null> {
+    const text = await this.root.querySelector("dd").getText();
+    return nonNullish(text) ? text.trim() : null;
   }
 }

--- a/frontend/src/tests/page-objects/ProjectCommitment.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectCommitment.page-object.ts
@@ -1,0 +1,65 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { CommitmentProgressBarPo } from "./CommitmentProgressBarPo.page-object";
+import { KeyValuePairPo } from "./KeyValuePair.page-object";
+
+export class ProjectCommitmentPo extends BasePageObject {
+  private static readonly TID = "project-commitment-component";
+
+  static under(element: PageObjectElement): ProjectCommitmentPo {
+    return new ProjectCommitmentPo(element.byTestId(ProjectCommitmentPo.TID));
+  }
+
+  getCommitmentProgressBarPo(): CommitmentProgressBarPo {
+    return CommitmentProgressBarPo.under(this.root);
+  }
+
+  getMaxCommitment(): Promise<string> {
+    return this.getCommitmentProgressBarPo().getMaxCommitment();
+  }
+
+  getMinCommitment(): Promise<string> {
+    return this.getCommitmentProgressBarPo().getMinCommitment();
+  }
+
+  async getParticipantsCount(): Promise<number> {
+    return Number(await this.getText("sns-project-current-sale-buyer-count"));
+  }
+
+  async getCurrentTotalCommitment(): Promise<string> {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "sns-project-current-commitment",
+    }).getValueText();
+  }
+
+  getNeuronsFundParticipationElement(): KeyValuePairPo {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "sns-project-current-nf-commitment",
+    });
+  }
+
+  hasNeuronsFundParticipation(): Promise<boolean> {
+    return this.getNeuronsFundParticipationElement().isPresent();
+  }
+
+  getNeuronsFundParticipation(): Promise<string> {
+    return this.getNeuronsFundParticipationElement().getValueText();
+  }
+
+  getDirectParticipationElement(): KeyValuePairPo {
+    return KeyValuePairPo.under({
+      element: this.root,
+      testId: "sns-project-current-direct-commitment",
+    });
+  }
+
+  hasDirectParticipation(): Promise<boolean> {
+    return this.getDirectParticipationElement().isPresent();
+  }
+
+  getDirectParticipation(): Promise<string> {
+    return this.getDirectParticipationElement().getValueText();
+  }
+}


### PR DESCRIPTION
# Motivation

Improve testing with a new PO for ProjectCommitment component.

# Changes

* Wrap ProjectCommitment with TestIdWrapper.
* New PO: ProjectCommitmentPo.
* Trim the value in getValueText of KeyValuePairPo and change the return value. It was wrong always saying `null`. I don't know why TS didn't catch it.
* Add new params to `createSummary` helper.
* Use new PO and `createSummary` helper in ProjectCommitment.spec file.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
