### PR TITLE
Toy accounts for unit tests

### DIFF
--- a/rs/backend/src/accounts_store/toy_data.rs
+++ b/rs/backend/src/accounts_store/toy_data.rs
@@ -110,7 +110,13 @@ pub fn toy_account(account_index: u64, size: ToyAccountSize) -> Account {
         account.default_account_transactions.push(transaction_index);
     }
     for hardware_wallet_index in 0..size.hardware_wallets as u64 {
-        let principal = PrincipalId::new_user_test_id(account_index + hardware_wallet_index + 999); // Toy hardware wallet principal.
+        // Note: The principal is currently unused but in case it is used in future tests we make a
+        // modest attempt to avoid collisions by:
+        //
+        // * Avoiding small numbers, as they may appear in other tests.
+        // * Avoiding collisions between principals generated in this way; a user will need a
+        //   million hardware wallets before we can have a collision.
+        let principal = PrincipalId::new_user_test_id(account_index * 1_000_000 + hardware_wallet_index + 100_000); // Toy hardware wallet principal.
         let hardware_wallet = NamedHardwareWalletAccount {
             name: format!("hw_wallet_{account_index}_{hardware_wallet_index}"),
             principal,

--- a/rs/backend/src/accounts_store/toy_data.rs
+++ b/rs/backend/src/accounts_store/toy_data.rs
@@ -1,11 +1,16 @@
 //! Test data for unit tests and test networks.
 
 use crate::accounts_store::{
-    convert_byte_to_sub_account, schema::AccountsDbTrait, Account, AccountIdentifier, AccountsStore,
-    AttachCanisterRequest, CanisterId, Memo, NamedCanister, NamedHardwareWalletAccount, NamedSubAccount, NeuronDetails,
-    NeuronId, Operation, PrincipalId, RegisterHardwareWalletRequest, TimeStamp, Tokens, Transaction, TransactionType,
+    schema::AccountsDbTrait, Account, AccountIdentifier, AccountsStore, AttachCanisterRequest, CanisterId, Memo,
+    NeuronDetails, NeuronId, Operation, PrincipalId, RegisterHardwareWalletRequest, TimeStamp, Tokens, Transaction,
+    TransactionType,
 };
+
+#[cfg(test)]
 use std::collections::HashMap;
+
+#[cfg(test)]
+use crate::accounts_store::{convert_byte_to_sub_account, NamedCanister, NamedHardwareWalletAccount, NamedSubAccount};
 
 const MAX_SUB_ACCOUNTS_PER_ACCOUNT: u64 = 3; // Toy accounts have between 0 and this many subaccounts.
 const MAX_HARDWARE_WALLETS_PER_ACCOUNT: u64 = 1; // Toy accounts have between 0 and this many hardware wallets.
@@ -66,7 +71,7 @@ impl From<&Account> for ToyAccountSize {
 //
 // TODO: Delete the `toy_account()` function in rs/backend/src/accounts_store/schema/tests.rs and
 // use this instead.
-#[allow(dead_code)]
+#[cfg(test)]
 pub fn toy_account(account_index: u64, size: ToyAccountSize) -> Account {
     let principal = PrincipalId::new_user_test_id(account_index);
     let account_identifier = AccountIdentifier::from(principal);

--- a/rs/backend/src/accounts_store/toy_data.rs
+++ b/rs/backend/src/accounts_store/toy_data.rs
@@ -1,9 +1,11 @@
 //! Test data for unit tests and test networks.
 
 use crate::accounts_store::{
-    schema::AccountsDbTrait, AccountIdentifier, AccountsStore, AttachCanisterRequest, CanisterId, Memo, NeuronDetails,
+    convert_byte_to_sub_account, schema::AccountsDbTrait, Account, AccountIdentifier, AccountsStore,
+    AttachCanisterRequest, CanisterId, Memo, NamedCanister, NamedHardwareWalletAccount, NamedSubAccount, NeuronDetails,
     NeuronId, Operation, PrincipalId, RegisterHardwareWalletRequest, TimeStamp, Tokens, Transaction, TransactionType,
 };
+use std::collections::HashMap;
 
 const MAX_SUB_ACCOUNTS_PER_ACCOUNT: u64 = 3; // Toy accounts have between 0 and this many subaccounts.
 const MAX_HARDWARE_WALLETS_PER_ACCOUNT: u64 = 1; // Toy accounts have between 0 and this many hardware wallets.
@@ -11,8 +13,131 @@ const MAX_CANISTERS_PER_ACCOUNT: u64 = 2; // Toy accounts have between 0 and thi
 const NEURONS_PER_ACCOUNT: f32 = 0.3;
 const TRANSACTIONS_PER_ACCOUNT: f32 = 3.0;
 
+/// A specification for how large a toy account should be.
+///
+/// Note: The keys correspond to those in the `AccountsStoreHistogram`.
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+pub struct ToyAccountSize {
+    /// The number of sub-accounts
+    pub sub_accounts: usize,
+    /// The number of canisters
+    pub canisters: usize,
+    /// The number of transaction indices for the main account; transactions are stored outside the
+    /// account.
+    pub default_account_transactions: usize,
+    /// The number of transactions per sub-account.
+    pub sub_account_transactions: usize,
+    /// The number of hardware wallets.
+    pub hardware_wallets: usize,
+}
+
+impl From<&Account> for ToyAccountSize {
+    fn from(account: &Account) -> Self {
+        let sub_accounts = account.sub_accounts.len();
+        let canisters = account.canisters.len();
+        let default_account_transactions = account.default_account_transactions.len();
+        // Average number of transactions per sub-account, rounded down.  When creating a toy
+        // account, all sub-accounts have the same number of transactions however that can change.
+        let total_sub_account_transactions: usize = account
+            .sub_accounts
+            .values()
+            .map(|sub_account| sub_account.transactions.len())
+            .sum();
+        let sub_account_transactions: usize = if sub_accounts == 0 {
+            0
+        } else {
+            total_sub_account_transactions / sub_accounts
+        };
+        let hardware_wallets = account.hardware_wallet_accounts.len();
+        ToyAccountSize {
+            sub_accounts,
+            canisters,
+            default_account_transactions,
+            sub_account_transactions,
+            hardware_wallets,
+        }
+    }
+}
+
+/// Creates a toy account data structure.
+///
+/// Warning: The meaning of the data in the account is in no way coherent or semantically
+/// correct.
+//
+// TODO: Delete the `toy_account()` function in rs/backend/src/accounts_store/schema/tests.rs and
+// use this instead.
+#[allow(dead_code)]
+pub fn toy_account(account_index: u64, size: ToyAccountSize) -> Account {
+    let principal = PrincipalId::new_user_test_id(account_index);
+    let account_identifier = AccountIdentifier::from(principal);
+    let mut account = Account {
+        principal: Some(principal),
+        account_identifier,
+        default_account_transactions: Vec::new(),
+        sub_accounts: HashMap::new(),
+        hardware_wallet_accounts: Vec::new(),
+        canisters: Vec::new(),
+    };
+    // Creates linked sub-accounts:
+    // Note: Successive accounts have 0, 1, 2 ... MAX_SUB_ACCOUNTS_PER_ACCOUNT-1 sub accounts, restarting at 0.
+    for sub_account_index in 0..size.sub_accounts as u8 {
+        let sub_account_name = format!("sub_account_{account_index}_{sub_account_index}");
+        let sub_account = convert_byte_to_sub_account(sub_account_index);
+        let sub_account_identifier = AccountIdentifier::new(principal, Some(sub_account));
+        let mut named_sub_account = NamedSubAccount::new(sub_account_name.clone(), sub_account_identifier);
+        named_sub_account.transactions = (0..size.sub_account_transactions as u64).collect();
+        account.sub_accounts.insert(sub_account_index, named_sub_account);
+    }
+    // Attaches canisters to the account.
+    for canister_index in 0..size.canisters {
+        let canister_id = CanisterId::from(canister_index as u64);
+        let canister = NamedCanister {
+            name: format!("canister_{account_index}_{canister_index}"),
+            canister_id,
+        };
+        account.canisters.push(canister);
+    }
+    for transaction_index in 0..size.default_account_transactions as u64 {
+        // Note: Normally a transaction would be added to the list of transactions in the accounts
+        // store and the index of that transaction would be stored in the account itself.  Given
+        // that we are creating a standalong account, without an account store, the index is
+        // meaningless.
+        account.default_account_transactions.push(transaction_index);
+    }
+    for hardware_wallet_index in 0..size.hardware_wallets as u64 {
+        let principal = PrincipalId::new_user_test_id(account_index + hardware_wallet_index + 999); // Toy hardware wallet principal.
+        let hardware_wallet = NamedHardwareWalletAccount {
+            name: format!("hw_wallet_{account_index}_{hardware_wallet_index}"),
+            principal,
+            transactions: Vec::new(),
+        };
+        account.hardware_wallet_accounts.push(hardware_wallet);
+    }
+
+    // FIN
+    account
+}
+
+#[test]
+fn toy_account_should_have_the_requested_size() {
+    let requested_size = ToyAccountSize {
+        sub_accounts: 1,
+        canisters: 2,
+        default_account_transactions: 3,
+        sub_account_transactions: 4,
+        hardware_wallets: 5,
+    };
+    let account = toy_account(9, requested_size);
+    let actual_size = ToyAccountSize::from(&account);
+    assert_eq!(requested_size, actual_size);
+}
+
 impl AccountsStore {
     /// Creates the given number of toy accounts, with linked sub-accounts, hardware wallets, pending transactions, and canisters.
+    ///
+    /// Note: The acccount is created with `AccountsStore` API calls, so the `AccountsStore` should
+    /// be internally consistent, however the data is not expected to be consistent with other
+    /// canisters.  For example, account IDs can be complete nonsense compared with ledger data.
     ///
     /// # Returns
     /// - The index of the first account created by this call.  The account indices are `first...first+num_accounts-1`.


### PR DESCRIPTION
# Motivation
We need sample accounts of various sizes for use in low level unit tests.

There is already code for creating toy accounts as part of an `AccountStore`, but this is unsuitable when we don't need the `AccountStore` or its execution environment.  We need just the banana, not the gorilla holding it or the jungle around the gorilla.

# Changes
- Add test code for creating toy accounts.

# Tests
- A test is included that checks that the toy account has the specified size.

# Todos

- [ ] Add entry to changelog (if necessary).
