### PR TITLE
Get binstall version from dfx.json

### DIFF
--- a/.github/actions/install_binstall/action.yaml
+++ b/.github/actions/install_binstall/action.yaml
@@ -1,0 +1,13 @@
+name: 'Installs binstall'
+description: |
+  Installs `cargo binstall` at the version specified in dfx.json
+inputs:
+runs:
+  using: "composite"
+  steps:
+    - name: Install binstall
+      shell: bash
+      run: |
+        BINSTALL_VERSION="$(jq -r .defaults.build.config.BINSTALL_VERSION dfx.json)"
+        curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/cargo-bins/cargo-binstall/releases/download/v${BINSTALL_VERSION}/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar -xvzf -
+        ./cargo-binstall -y --force "cargo-binstall@$BINSTALL_VERSION"

--- a/.github/actions/install_binstall/action.yaml
+++ b/.github/actions/install_binstall/action.yaml
@@ -1,7 +1,6 @@
 name: 'Installs binstall'
 description: |
   Installs `cargo binstall` at the version specified in dfx.json
-inputs:
 runs:
   using: "composite"
   steps:

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -52,11 +52,12 @@ runs:
       shell: bash
       run: |
         echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
+    - name: Install cargo binstall
+      uses: ./.github/actions/install_binstall
     - name: Install SNS script dependencies
       shell: bash
       run: |
         dfx-software-dfx-install --version "$(jq -r .dfx dfx.json)"
-        curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/181b5293e73cfe16f7a79c5b3a4339bd522d31f3/install-from-binstall-release.sh | bash
         cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)"
     - name: Get test environment
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,10 +196,11 @@ jobs:
         with:
           path: ${{ steps.ic-wasm-version.outputs.IC_WASM_PATH }}
           key: ${{ runner.os }}-${{ steps.ic-wasm-version.outputs.IC_WASM_VERSION }}-ic-wasm
+      - name: Install cargo binstall
+        uses: ./.github/actions/install_binstall
       - name: Install ic-wasm
         if: steps.cache-ic-wasm.outputs.cache-hit != 'true'
         run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/181b5293e73cfe16f7a79c5b3a4339bd522d31f3/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm "ic-wasm@${{ steps.ic-wasm-version.outputs.IC_WASM_VERSION }}"
           command -v ic-wasm || {
             echo "ERROR: Failed to install ic-wasm"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -185,9 +185,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dfx
         run: DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+      - name: Install cargo binstall
+        uses: ./.github/actions/install_binstall
       - name: Install tools
         run: |
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/181b5293e73cfe16f7a79c5b3a4339bd522d31f3/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)"
       - name: Check mainnet config
         run: bash -x config.test
@@ -211,8 +212,8 @@ jobs:
           version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
           # TODO: Make `didc` support `binstall`, then use `binstall` here.
           curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
-      - name: Install binstall
-        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/181b5293e73cfe16f7a79c5b3a4339bd522d31f3/install-from-binstall-release.sh | bash && cargo binstall -V
+      - name: Install cargo binstall
+        uses: ./.github/actions/install_binstall
       - name: Install idl2json
         run: cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)" && idl2json --version
       - name: Install sponge

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -34,6 +34,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Added
 
 #### Changed
+
+* Specify the version of `binstall` in `dfx.json`.
 * Fix the proposal matching pattern in `nns-dapp/split-changelog` that used to match aggregator proposals as well.
 * Fix the rust-update action.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN jq -r '.defaults.build.config.NODE_VERSION' dfx.json > config/node_version
 RUN jq -r '.defaults.build.config.DIDC_VERSION' dfx.json > config/didc_version
 RUN jq -r '.defaults.build.config.OPTIMIZER_VERSION' dfx.json > config/optimizer_version
 RUN jq -r '.defaults.build.config.IC_WASM_VERSION' dfx.json > config/ic_wasm_version
+RUN jq -r '.defaults.build.config.BINSTALL_VERSION' dfx.json > config/binstall_version
 
 # This is the "builder", i.e. the base image used later to build the final code.
 FROM base as builder
@@ -75,9 +76,8 @@ WORKDIR /
 RUN DFX_VERSION="$(cat config/dfx_version)" sh -c "$(curl -fsSL https://sdk.dfinity.org/install.sh)" && dfx --version
 # TODO: Make didc support binstall, then use cargo binstall --no-confirm didc here.
 RUN set +x && curl -Lf --retry 5 "https://github.com/dfinity/candid/releases/download/$(cat config/didc_version)/didc-linux64" | install -m 755 /dev/stdin "/usr/local/bin/didc" && didc --version
-RUN curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.3.0/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar -xvzf -
-# Force install of cargo-binstall 1.3.0, latest version 1.3.1 breaks.
-RUN ./cargo-binstall -y --force cargo-binstall@1.3.0
+RUN curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/cargo-bins/cargo-binstall/releases/download/v$(cat config/binstall_version)/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar -xvzf -
+RUN ./cargo-binstall -y --force "cargo-binstall@$(cat config/binstall_version)"
 RUN cargo binstall --no-confirm "ic-wasm@$(cat config/ic_wasm_version)" && command -v ic-wasm
 
 # Title: Gets the deployment configuration

--- a/dfx.json
+++ b/dfx.json
@@ -639,7 +639,7 @@
         "IC_WASM_VERSION": "0.3.6",
         "IDL2JSON_VERSION": "0.8.8",
         "OPTIMIZER_VERSION": "0.3.6",
-	"BINSTALL_VERSION": "1.3.0",
+        "BINSTALL_VERSION": "1.3.0",
         "DIDC_VERSION": "2023-09-05",
         "SNSDEMO_RELEASE": "release-2023-07-07",
         "IC_COMMIT": "06f339b83ce37e3fc9571e1b4251fbcf5c1a8239"

--- a/dfx.json
+++ b/dfx.json
@@ -639,6 +639,7 @@
         "IC_WASM_VERSION": "0.3.6",
         "IDL2JSON_VERSION": "0.8.8",
         "OPTIMIZER_VERSION": "0.3.6",
+	"BINSTALL_VERSION": "1.3.0",
         "DIDC_VERSION": "2023-09-05",
         "SNSDEMO_RELEASE": "release-2023-07-07",
         "IC_COMMIT": "06f339b83ce37e3fc9571e1b4251fbcf5c1a8239"

--- a/scripts/setup
+++ b/scripts/setup
@@ -168,7 +168,10 @@ install_rust() {
 }
 
 install_binstall() {
-  curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/181b5293e73cfe16f7a79c5b3a4339bd522d31f3/install-from-binstall-release.sh | bash && cargo binstall -V
+  local BINSTALL_VERSION
+  BINSTALL_VERSION="$(jq -r .defaults.build.config.BINSTALL_VERSION dfx.json)"
+  curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/cargo-bins/cargo-binstall/releases/download/v${BINSTALL_VERSION}/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar -xvzf -
+  ./cargo-binstall -y --force "cargo-binstall@$BINSTALL_VERSION"
 }
 
 install_xz_darwin() {


### PR DESCRIPTION
# Motivation
There have been several breakages in the last few hours caused by the latest `binstall` being unavailable.

# Changes
* Specify the version of `binstall` in `dfx.json`, with the other tool versions.
* Create an action to install `binstall` with the specified version and use it, rather than other methods, wherever `binstall` is installed in GitHub workflows.
* Elsewhere, use the version from `dfx.json` directly.

# Tests
- See CI

# Todos

- [x] Add entry to changelog (if necessary).
