### PR TITLE
Disburse maturity validation update

### DIFF
--- a/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
@@ -20,7 +20,10 @@
   import { assertNonNullish, type Token } from "@dfinity/utils";
   import type { QrResponse } from "$lib/types/qr-wizard-modal";
   import type { TransactionNetwork } from "$lib/types/transaction";
-  import { getAccountByRootCanister } from "$lib/utils/accounts.utils";
+  import {
+    getAccountByRootCanister,
+    invalidAddress,
+  } from "$lib/utils/accounts.utils";
   import { universesAccountsStore } from "$lib/derived/universes-accounts.derived";
 
   export let availableMaturityE8s: bigint;
@@ -49,13 +52,21 @@
   $: selectedMaturityE8s =
     (availableMaturityE8s * BigInt(percentageToDisburse)) / 100n;
 
-  let disableDisburse = false;
-  $: disableDisburse = selectedMaturityE8s < minimumAmountE8s;
+  let notEnoughMaturitySelected = false;
+  $: notEnoughMaturitySelected = selectedMaturityE8s < minimumAmountE8s;
+
+  let disabled = false;
+  $: disabled =
+    invalidAddress({
+      address: selectedDestinationAddress,
+      network: undefined,
+      rootCanisterId,
+    }) || notEnoughMaturitySelected;
 
   // Show the text only if the selected percentage is greater than 0.
   let disabledText: string | undefined = undefined;
   $: disabledText =
-    disableDisburse && percentageToDisburse > 0
+    notEnoughMaturitySelected && percentageToDisburse > 0
       ? replacePlaceholders(
           $i18n.neuron_detail.disburse_maturity_disabled_tooltip_non_zero,
           { $amount: formatToken({ value: minimumAmountE8s }) }
@@ -144,7 +155,7 @@
       on:nnsSelectPercentage={goToConfirm}
       on:nnsCancel={close}
       bind:percentage={percentageToDisburse}
-      disabled={disableDisburse}
+      {disabled}
       {disabledText}
     >
       <div class="percentage-container" slot="description">

--- a/frontend/src/tests/lib/modals/sns/SnsDisburseMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsDisburseMaturityModal.spec.ts
@@ -68,6 +68,24 @@ describe("SnsDisburseMaturityModal", () => {
     expect(await po.isNextButtonDisabled()).toBe(true);
   });
 
+  it("should disable next button when destination address is not selected", async () => {
+    const po = await renderSnsDisburseMaturityModal();
+    await po.setPercentage(10);
+    const destinationPo = po.getSelectDestinationAddressPo();
+    await destinationPo.enterAddress("");
+    await destinationPo.blurInput();
+    expect(await po.isNextButtonDisabled()).toBe(true);
+  });
+
+  it("should disable next button when destination address is valid", async () => {
+    const po = await renderSnsDisburseMaturityModal();
+    await po.setPercentage(10);
+    const destinationPo = po.getSelectDestinationAddressPo();
+    await destinationPo.enterAddress("INVALID_ADDRESS");
+    await destinationPo.blurInput();
+    expect(await po.isNextButtonDisabled()).toBe(true);
+  });
+
   it("should enable next button when not 0 selected", async () => {
     const po = await renderSnsDisburseMaturityModal();
     await po.setPercentage(1);


### PR DESCRIPTION
# Motivation

Disable the disburse maturity next step when no/wrong destination address.

# Changes

- update disabled logic

# Tests

- add address selection tests

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary

# Screenshots

## Before

https://github.com/dfinity/nns-dapp/assets/98811342/d41b1ae0-c24c-4a0d-a891-169fe9055bca



## After

https://github.com/dfinity/nns-dapp/assets/98811342/ac0aa937-5cef-4342-b2a5-0a73de1e246e



