### PR TITLE
Remove unsed TransactionToBeProcessed

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -134,12 +134,6 @@ struct Transaction {
 }
 
 #[derive(Copy, Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
-pub enum TransactionToBeProcessed {
-    StakeNeuron(PrincipalId, Memo),
-    TopUpNeuron(PrincipalId, Memo),
-}
-
-#[derive(Copy, Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
 pub struct CreateCanisterArgs {
     pub controller: PrincipalId,
     pub amount: Tokens,


### PR DESCRIPTION
# Motivation

The `pub enum TransactionToBeProcessed` was replaced by `MultiPartTransactionToBeProcessed` in https://github.com/dfinity/nns-dapp/pull/83 and has been unused for over 2 years.
Keeping it around is confused.

# Changes

Remove `TransactionToBeProcessed`.

# Tests

The canister still builds.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary