### PR TITLE
GIX-1859: New components for the new Canister Details page header

### DIFF
--- a/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
@@ -4,31 +4,33 @@
   import type { CanisterDetails } from "$lib/canisters/ic-management/ic-management.canister.types";
   import { i18n } from "$lib/stores/i18n";
   import { SkeletonText } from "@dfinity/gix-components";
+  import TestIdWrapper from "../common/TestIdWrapper.svelte";
 
   export let canisterDetails: CanisterDetails | undefined;
-  export let controller: boolean | undefined;
+  export let isController: boolean | undefined;
 </script>
 
-{#if controller === undefined}
-  <div class="skeleton">
-    <SkeletonText tagName="h1" />
-  </div>
-{:else if !controller}
-  <h1>Balance unavailable</h1>
-{:else if nonNullish(canisterDetails)}
-  <AmountDisplay
-    amount={TokenAmount.fromE8s({
-      amount: canisterDetails.cycles,
-      token: { name: "cycles", symbol: $i18n.canisters.t_cycles },
-    })}
-    size="huge"
-    singleLine
-  />
-{:else}
-  <div class="skeleton">
-    <SkeletonText tagName="h1" />
-  </div>
-{/if}
+<TestIdWrapper testId="canister-heading-title-component">
+  {#if nonNullish(canisterDetails)}
+    <AmountDisplay
+      amount={TokenAmount.fromE8s({
+        amount: canisterDetails.cycles,
+        token: { name: "cycles", symbol: $i18n.canisters.t_cycles },
+      })}
+      size="huge"
+      singleLine
+    />
+    <!-- Only when we have loaded the data and we know whether the user is the controller -->
+  {:else if isController === false}
+    <h1 data-tid="caniter-title-balance-unavailable">
+      {$i18n.canister_detail.balance_unavailable}
+    </h1>
+  {:else}
+    <div data-tid="skeleton" class="skeleton">
+      <SkeletonText tagName="h1" />
+    </div>
+  {/if}
+</TestIdWrapper>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";

--- a/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
   import { TokenAmount, nonNullish } from "@dfinity/utils";
-  import AmountDisplay from "../ic/AmountDisplay.svelte";
+  import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import type { CanisterDetails } from "$lib/canisters/ic-management/ic-management.canister.types";
   import { i18n } from "$lib/stores/i18n";
   import { SkeletonText } from "@dfinity/gix-components";
   import TestIdWrapper from "../common/TestIdWrapper.svelte";
 
-  export let canisterDetails: CanisterDetails | undefined;
+  export let details: CanisterDetails | undefined;
   export let isController: boolean | undefined;
 </script>
 
 <TestIdWrapper testId="canister-heading-title-component">
-  {#if nonNullish(canisterDetails)}
+  {#if nonNullish(details)}
     <AmountDisplay
       amount={TokenAmount.fromE8s({
-        amount: canisterDetails.cycles,
+        amount: details.cycles,
         token: { name: "cycles", symbol: $i18n.canisters.t_cycles },
       })}
       size="huge"
@@ -40,6 +40,7 @@
   }
 
   .skeleton {
+    // This is a width for the skeleton that looks good on desktop and mobile.
     width: 300px;
     max-width: 90%;
   }

--- a/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { TokenAmount, nonNullish } from "@dfinity/utils";
+  import AmountDisplay from "../ic/AmountDisplay.svelte";
+  import type { CanisterDetails } from "$lib/canisters/ic-management/ic-management.canister.types";
+  import { i18n } from "$lib/stores/i18n";
+  import { SkeletonText } from "@dfinity/gix-components";
+
+  export let canisterDetails: CanisterDetails | undefined;
+  export let controller: boolean | undefined;
+</script>
+
+{#if controller === undefined}
+  <div class="skeleton">
+    <SkeletonText tagName="h1" />
+  </div>
+{:else if !controller}
+  <h1>Balance unavailable</h1>
+{:else if nonNullish(canisterDetails)}
+  <AmountDisplay
+    amount={TokenAmount.fromE8s({
+      amount: canisterDetails.cycles,
+      token: { name: "cycles", symbol: $i18n.canisters.t_cycles },
+    })}
+    size="huge"
+    singleLine
+  />
+{:else}
+  <div class="skeleton">
+    <SkeletonText tagName="h1" />
+  </div>
+{/if}
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+
+  .skeleton {
+    width: 90%;
+
+    @include media.min-width(small) {
+      width: 40%;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
@@ -35,11 +35,12 @@
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";
 
-  .skeleton {
-    width: 90%;
+  h1 {
+    margin: 0;
+  }
 
-    @include media.min-width(small) {
-      width: 40%;
-    }
+  .skeleton {
+    width: 300px;
+    max-width: 90%;
   }
 </style>

--- a/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
@@ -41,7 +41,8 @@
 
   .skeleton {
     // This is a width for the skeleton that looks good on desktop and mobile.
-    width: 300px;
-    max-width: 90%;
+    // Based on $breakpoint-xsmall: 320px;
+    width: 320px;
+    max-width: calc(100% - var(--padding-2x));
   }
 </style>

--- a/frontend/src/lib/components/canister-detail/CanisterPageHeader.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterPageHeader.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import type { CanisterDetails } from "$lib/canisters/nns-dapp/nns-dapp.types";
+  import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
   import { NNS_UNIVERSE } from "$lib/derived/selectable-universes.derived";
   import PageHeader from "../common/PageHeader.svelte";
   import IdentifierHash from "../ui/IdentifierHash.svelte";
   import UniversePageSummary from "../universe/UniversePageSummary.svelte";
 
-  export let canister: CanisterDetails;
+  export let canister: CanisterInfo;
 </script>
 
 <PageHeader testId="canister-page-header-component">

--- a/frontend/src/lib/components/canister-detail/CanisterPageHeader.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterPageHeader.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import type { CanisterDetails } from "$lib/canisters/nns-dapp/nns-dapp.types";
+  import { NNS_UNIVERSE } from "$lib/derived/selectable-universes.derived";
+  import PageHeader from "../common/PageHeader.svelte";
+  import IdentifierHash from "../ui/IdentifierHash.svelte";
+  import UniversePageSummary from "../universe/UniversePageSummary.svelte";
+
+  export let canister: CanisterDetails;
+</script>
+
+<PageHeader testId="canister-page-header-component">
+  <UniversePageSummary slot="start" universe={NNS_UNIVERSE} />
+  <span
+    slot="end"
+    class="description header-end"
+    data-tid="canister-id-element"
+  >
+    <IdentifierHash identifier={canister.canister_id.toText()} />
+  </span>
+</PageHeader>
+
+<style lang="scss">
+  .header-end {
+    // The IdentifierHash has the copy button at the end which has some extra padding.
+    // This is needed to align in the center the UniversePageSummary and the IdentifierHash in mobile view.
+    padding-left: var(--padding-1_5x);
+  }
+</style>

--- a/frontend/src/lib/components/canister-detail/CanisterPageHeader.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterPageHeader.svelte
@@ -10,13 +10,9 @@
 
 <PageHeader testId="canister-page-header-component">
   <UniversePageSummary slot="start" universe={NNS_UNIVERSE} />
-  <span
-    slot="end"
-    class="description header-end"
-    data-tid="canister-id-element"
-  >
+  <div slot="end" class="description header-end" data-tid="canister-id-element">
     <IdentifierHash identifier={canister.canister_id.toText()} />
-  </span>
+  </div>
 </PageHeader>
 
 <style lang="scss">

--- a/frontend/src/lib/components/canister-detail/CanisterPageHeading.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterPageHeading.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import type { CanisterDetails } from "$lib/canisters/ic-management/ic-management.canister.types";
+  import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
+  import PageHeading from "../common/PageHeading.svelte";
+  import UnlinkCanisterButton from "./UnlinkCanisterButton.svelte";
+  import RenameCanisterButton from "./RenameCanisterButton.svelte";
+  import CanisterHeadingTitle from "./CanisterHeadingTitle.svelte";
+
+  export let canisterDetails: CanisterDetails | undefined;
+  export let canister: CanisterInfo;
+  export let controller: boolean | undefined;
+</script>
+
+<!-- We can't set conditional slots. -->
+{#if canister.name.length === 0}
+  <PageHeading testId="canister-page-heading-component">
+    <CanisterHeadingTitle slot="title" {canisterDetails} {controller} />
+    <svelte:fragment slot="tags">
+      <UnlinkCanisterButton canisterId={canister.canister_id} />
+      <RenameCanisterButton />
+    </svelte:fragment>
+  </PageHeading>
+{:else}
+  <PageHeading testId="canister-page-heading-component">
+    <CanisterHeadingTitle slot="title" {canisterDetails} {controller} />
+    <span slot="subtitle" data-tid="canister-name">
+      {canister.name}
+    </span>
+    <svelte:fragment slot="tags">
+      <UnlinkCanisterButton canisterId={canister.canister_id} />
+      <RenameCanisterButton />
+    </svelte:fragment>
+  </PageHeading>
+{/if}

--- a/frontend/src/lib/components/canister-detail/CanisterPageHeading.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterPageHeading.svelte
@@ -14,7 +14,11 @@
 <!-- We can't set conditional slots. -->
 {#if canister.name.length === 0}
   <PageHeading testId="canister-page-heading-component">
-    <CanisterHeadingTitle slot="title" {canisterDetails} {isController} />
+    <CanisterHeadingTitle
+      slot="title"
+      details={canisterDetails}
+      {isController}
+    />
     <svelte:fragment slot="tags">
       <UnlinkCanisterButton canisterId={canister.canister_id} />
       <RenameCanisterButton />
@@ -22,7 +26,11 @@
   </PageHeading>
 {:else}
   <PageHeading testId="canister-page-heading-component">
-    <CanisterHeadingTitle slot="title" {canisterDetails} {isController} />
+    <CanisterHeadingTitle
+      slot="title"
+      details={canisterDetails}
+      {isController}
+    />
     <span slot="subtitle" data-tid="subtitle">
       {canister.name}
     </span>

--- a/frontend/src/lib/components/canister-detail/CanisterPageHeading.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterPageHeading.svelte
@@ -8,13 +8,13 @@
 
   export let canisterDetails: CanisterDetails | undefined;
   export let canister: CanisterInfo;
-  export let controller: boolean | undefined;
+  export let isController: boolean | undefined;
 </script>
 
 <!-- We can't set conditional slots. -->
 {#if canister.name.length === 0}
   <PageHeading testId="canister-page-heading-component">
-    <CanisterHeadingTitle slot="title" {canisterDetails} {controller} />
+    <CanisterHeadingTitle slot="title" {canisterDetails} {isController} />
     <svelte:fragment slot="tags">
       <UnlinkCanisterButton canisterId={canister.canister_id} />
       <RenameCanisterButton />
@@ -22,8 +22,8 @@
   </PageHeading>
 {:else}
   <PageHeading testId="canister-page-heading-component">
-    <CanisterHeadingTitle slot="title" {canisterDetails} {controller} />
-    <span slot="subtitle" data-tid="canister-name">
+    <CanisterHeadingTitle slot="title" {canisterDetails} {isController} />
+    <span slot="subtitle" data-tid="subtitle">
       {canister.name}
     </span>
     <svelte:fragment slot="tags">

--- a/frontend/src/lib/components/common/PageHeading.svelte
+++ b/frontend/src/lib/components/common/PageHeading.svelte
@@ -11,9 +11,11 @@
 <div class="container" data-tid={testId}>
   <div class="title-wrapper">
     <slot name="title" />
-    <h4 class="description">
-      <slot name="subtitle" />
-    </h4>
+    {#if hasSubtitle}
+      <h4 class="description">
+        <slot name="subtitle" />
+      </h4>
+    {/if}
   </div>
   {#if hasTags}
     <div class="tags">

--- a/frontend/src/lib/components/common/PageHeading.svelte
+++ b/frontend/src/lib/components/common/PageHeading.svelte
@@ -3,6 +3,9 @@
 
   let hasTags: boolean;
   $: hasTags = $$slots.tags !== undefined;
+
+  let hasSubtitle: boolean;
+  $: hasSubtitle = $$slots.subtitle !== undefined;
 </script>
 
 <div class="container" data-tid={testId}>

--- a/frontend/src/lib/components/common/PageHeading.svelte
+++ b/frontend/src/lib/components/common/PageHeading.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
+  import { nonNullish } from "@dfinity/utils";
+
   export let testId: string | undefined = undefined;
 
   let hasTags: boolean;
   $: hasTags = $$slots.tags !== undefined;
 
   let hasSubtitle: boolean;
-  $: hasSubtitle = $$slots.subtitle !== undefined;
+  $: hasSubtitle = nonNullish($$slots.subtitle);
 </script>
 
 <div class="container" data-tid={testId}>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -454,6 +454,7 @@
     "rename_canister": "Rename Canister",
     "rename_canister_title": "Enter New Canister Name",
     "rename_canister_placeholder": "Canister Name",
+    "balance_unavailable": "Balance unavailable",
     "status_stopped": "Stopped",
     "status_stopping": "Stopping",
     "status_running": "Running"

--- a/frontend/src/lib/pages/CanisterDetail.svelte
+++ b/frontend/src/lib/pages/CanisterDetail.svelte
@@ -37,7 +37,6 @@
   import type { CanisterDetailModal } from "$lib/types/canister-detail.modal";
   import RenameCanisterButton from "$lib/components/canister-detail/RenameCanisterButton.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
-  import CanisterPageHeader from "$lib/components/canister-detail/CanisterPageHeader.svelte";
 
   // BEGIN: loading and navigation
 
@@ -191,7 +190,6 @@
     <main class="legacy">
       <section>
         {#if canisterInfo !== undefined}
-          <CanisterPageHeader canister={canisterInfo} />
           <CanisterCardTitle canister={canisterInfo} titleTag="h1" />
           <CanisterCardSubTitle canister={canisterInfo} />
           <div class="actions">

--- a/frontend/src/lib/pages/CanisterDetail.svelte
+++ b/frontend/src/lib/pages/CanisterDetail.svelte
@@ -37,6 +37,7 @@
   import type { CanisterDetailModal } from "$lib/types/canister-detail.modal";
   import RenameCanisterButton from "$lib/components/canister-detail/RenameCanisterButton.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import CanisterPageHeader from "$lib/components/canister-detail/CanisterPageHeader.svelte";
 
   // BEGIN: loading and navigation
 
@@ -190,6 +191,7 @@
     <main class="legacy">
       <section>
         {#if canisterInfo !== undefined}
+          <CanisterPageHeader canister={canisterInfo} />
           <CanisterCardTitle canister={canisterInfo} titleTag="h1" />
           <CanisterCardSubTitle canister={canisterInfo} />
           <div class="actions">

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -469,6 +469,7 @@ interface I18nCanister_detail {
   rename_canister: string;
   rename_canister_title: string;
   rename_canister_placeholder: string;
+  balance_unavailable: string;
   status_stopped: string;
   status_stopping: string;
   status_running: string;

--- a/frontend/src/tests/lib/components/canister-detail/CanisterHeadingTitle.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/CanisterHeadingTitle.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { CanisterDetails } from "$lib/canisters/ic-management/ic-management.canister.types";
+import CanisterHeadingTitle from "$lib/components/canister-detail/CanisterHeadingTitle.svelte";
+import { mockCanisterDetails } from "$tests/mocks/canisters.mock";
+import { CanisterHeadingTitlePo } from "$tests/page-objects/CanisterHeadingTitle.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("CanisterHeadingTitle", () => {
+  const renderComponent = (
+    canisterDetails: CanisterDetails | undefined,
+    isController: boolean | undefined
+  ) => {
+    const { container } = render(CanisterHeadingTitle, {
+      props: { canisterDetails, isController },
+    });
+
+    return CanisterHeadingTitlePo.under(new JestPageObjectElement(container));
+  };
+
+  it("renders skeleton if controller is undefined", async () => {
+    const po = renderComponent(undefined, undefined);
+    expect(await po.hasSkeleton()).toBe(true);
+  });
+
+  // This is an edge case because the we know whether the user is the controller when we load the canister details.
+  it("renders skeleton if controller is true but canister details are not yet loaded", async () => {
+    const po = renderComponent(undefined, true);
+    expect(await po.hasSkeleton()).toBe(true);
+  });
+
+  it("renders unavailable balance if user is not the controller", async () => {
+    const po = renderComponent(undefined, false);
+    expect(await po.getTitle()).toBe("Balance unavailable");
+  });
+
+  it("renders cycles balance if defined", async () => {
+    const canisterDetails = {
+      ...mockCanisterDetails,
+      cycles: 314000000n,
+    };
+    const po1 = renderComponent(canisterDetails, true);
+    expect(await po1.getTitle()).toBe("3.14 T Cycles");
+
+    const po2 = renderComponent(canisterDetails, false);
+    expect(await po2.getTitle()).toBe("3.14 T Cycles");
+
+    const po3 = renderComponent(canisterDetails, undefined);
+    expect(await po3.getTitle()).toBe("3.14 T Cycles");
+  });
+});

--- a/frontend/src/tests/lib/components/canister-detail/CanisterHeadingTitle.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/CanisterHeadingTitle.spec.ts
@@ -11,11 +11,11 @@ import { render } from "@testing-library/svelte";
 
 describe("CanisterHeadingTitle", () => {
   const renderComponent = (
-    canisterDetails: CanisterDetails | undefined,
+    details: CanisterDetails | undefined,
     isController: boolean | undefined
   ) => {
     const { container } = render(CanisterHeadingTitle, {
-      props: { canisterDetails, isController },
+      props: { details, isController },
     });
 
     return CanisterHeadingTitlePo.under(new JestPageObjectElement(container));

--- a/frontend/src/tests/lib/components/canister-detail/CanisterPageHeader.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/CanisterPageHeader.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import CanisterPageHeader from "$lib/components/canister-detail/CanisterPageHeader.svelte";
+import { mockCanister } from "$tests/mocks/canisters.mock";
+import { CanisterHeaderPo } from "$tests/page-objects/CanisterHeader.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { Principal } from "@dfinity/principal";
+import { render } from "@testing-library/svelte";
+
+describe("CanisterHeadingTitle", () => {
+  const renderComponent = (canister: CanisterInfo) => {
+    const { container } = render(CanisterPageHeader, {
+      props: { canister },
+    });
+
+    return CanisterHeaderPo.under(new JestPageObjectElement(container));
+  };
+
+  it("renders Internet Computer universe", async () => {
+    const po = renderComponent(mockCanister);
+    expect(await po.getUniverseText()).toBe("Internet Computer");
+  });
+
+  it("renders canister id", async () => {
+    const canister = {
+      ...mockCanister,
+      canister_id: Principal.fromText("ryjl3-tyaaa-aaaaa-aaaba-cai"),
+    };
+    const po = renderComponent(canister);
+    expect(await po.getCanisterIdText()).toBe("ryjl3-t...aba-cai");
+  });
+});

--- a/frontend/src/tests/lib/components/canister-detail/CanisterPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/CanisterPageHeading.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { CanisterDetails } from "$lib/canisters/ic-management/ic-management.canister.types";
+import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import CanisterPageHeading from "$lib/components/canister-detail/CanisterPageHeading.svelte";
+import { mockCanister, mockCanisterDetails } from "$tests/mocks/canisters.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { CanisterPageHeadingPo } from "$tests/page-objects/CanisterPageHeading.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("CanisterHeadingTitle", () => {
+  const canisterId = principal(0);
+  const eventListener = jest.fn();
+
+  const renderComponent = (
+    canister: CanisterInfo,
+    canisterDetails: CanisterDetails | undefined,
+    isController: boolean | undefined
+  ) => {
+    const { container } = render(CanisterPageHeading, {
+      props: { canisterDetails, isController, canister },
+    });
+
+    return CanisterPageHeadingPo.under(new JestPageObjectElement(container));
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.removeEventListener("nnsCanisterDetailModal", eventListener);
+  });
+
+  it("renders the canister page title", async () => {
+    const po = renderComponent(mockCanister, undefined, undefined);
+    expect(await po.hasTitle()).toBe(true);
+  });
+
+  it("renders the cycles as title when present", async () => {
+    const canisterDetails = {
+      ...mockCanisterDetails,
+      cycles: 314000000n,
+    };
+    const po = renderComponent(mockCanister, canisterDetails, undefined);
+    expect(await po.getTitle()).toBe("3.14 T Cycles");
+  });
+
+  it("renders the canister name as subtitle if present", async () => {
+    const name = "My Canister";
+    const canisterInfo = {
+      ...mockCanister,
+      name,
+    };
+    const po = renderComponent(canisterInfo, undefined, undefined);
+    expect(await po.getSubtitle()).toBe(name);
+  });
+
+  it("dispatches unlink canister modal event when unlink button is clicked", async () => {
+    const canisterInfo = {
+      ...mockCanister,
+      canister_id: canisterId,
+    };
+    window.addEventListener("nnsCanisterDetailModal", eventListener);
+    expect(eventListener).not.toHaveBeenCalled();
+
+    const po = renderComponent(canisterInfo, undefined, undefined);
+    await po.clickUnlink();
+    expect(eventListener).toHaveBeenCalledTimes(1);
+    const $event = new CustomEvent("nnsCanisterDetailModal", {
+      detail: { type: "unlink", canisterId },
+      bubbles: true,
+    });
+    expect(eventListener).toHaveBeenCalledWith($event);
+  });
+
+  it("dispatches rename canister modal event when rename button is clicked", async () => {
+    const canisterInfo = {
+      ...mockCanister,
+      canister_id: canisterId,
+    };
+    window.addEventListener("nnsCanisterDetailModal", eventListener);
+    expect(eventListener).not.toHaveBeenCalled();
+
+    const po = renderComponent(canisterInfo, undefined, undefined);
+    await po.clickRename();
+    expect(eventListener).toHaveBeenCalledTimes(1);
+    const $event = new CustomEvent("nnsCanisterDetailModal", {
+      detail: { type: "rename" },
+      bubbles: true,
+    });
+    expect(eventListener).toHaveBeenCalledWith($event);
+  });
+});

--- a/frontend/src/tests/page-objects/CanisterHeader.page-object.ts
+++ b/frontend/src/tests/page-objects/CanisterHeader.page-object.ts
@@ -1,0 +1,23 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { UniversePageSummaryPo } from "./UniversePageSummary.page-object";
+
+export class CanisterHeaderPo extends BasePageObject {
+  private static readonly TID = "canister-page-header-component";
+
+  static under(element: PageObjectElement): CanisterHeaderPo {
+    return new CanisterHeaderPo(element.byTestId(CanisterHeaderPo.TID));
+  }
+
+  getUniversePageSummaryPo(): UniversePageSummaryPo {
+    return UniversePageSummaryPo.under(this.root);
+  }
+
+  getUniverseText(): Promise<string> {
+    return this.getUniversePageSummaryPo().getTitle();
+  }
+
+  getCanisterIdText(): Promise<string> {
+    return this.getText("identifier");
+  }
+}

--- a/frontend/src/tests/page-objects/CanisterHeadingTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/CanisterHeadingTitle.page-object.ts
@@ -1,0 +1,24 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class CanisterHeadingTitlePo extends BasePageObject {
+  private static readonly TID = "canister-heading-title-component";
+
+  static under(element: PageObjectElement): CanisterHeadingTitlePo {
+    return new CanisterHeadingTitlePo(
+      element.byTestId(CanisterHeadingTitlePo.TID)
+    );
+  }
+
+  hasSkeleton(): Promise<boolean> {
+    return this.root.byTestId("skeleton").isPresent();
+  }
+
+  async getTitle(): Promise<string | null> {
+    if (await this.hasSkeleton()) {
+      return null;
+    } else {
+      return (await this.root.getText()).trim();
+    }
+  }
+}

--- a/frontend/src/tests/page-objects/CanisterPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/CanisterPageHeading.page-object.ts
@@ -1,0 +1,37 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { CanisterHeadingTitlePo } from "./CanisterHeadingTitle.page-object";
+
+export class CanisterPageHeadingPo extends BasePageObject {
+  private static readonly TID = "canister-page-heading-component";
+
+  static under(element: PageObjectElement): CanisterPageHeadingPo {
+    return new CanisterPageHeadingPo(
+      element.byTestId(CanisterPageHeadingPo.TID)
+    );
+  }
+
+  getCanisterHeadingTitlePo(): CanisterHeadingTitlePo {
+    return CanisterHeadingTitlePo.under(this.root);
+  }
+
+  hasTitle(): Promise<boolean> {
+    return this.getCanisterHeadingTitlePo().isPresent();
+  }
+
+  getTitle(): Promise<string | null> {
+    return this.getCanisterHeadingTitlePo().getTitle();
+  }
+
+  getSubtitle(): Promise<string | null> {
+    return this.root.byTestId("subtitle").getText();
+  }
+
+  clickUnlink(): Promise<void> {
+    return this.getButton("unlink-canister-button").click();
+  }
+
+  clickRename(): Promise<void> {
+    return this.getButton("rename-canister-button-component").click();
+  }
+}


### PR DESCRIPTION
# Motivation

Change the canister details header to be more consistent with the new header in neuron details.

In this PR, I introduce, but not use the components needed to render it.

In another PR, I'll use them in the CanisterDetails and I'll change the tests in there as well.

# Changes

* New component CanisterHeadingTitle.
* New component CanisterPageHeader.
* New component CanisterPageHeading that uses new component CanisterHeadingTitle.
* Check whether the "subtitle" slot is present in the PageHeading. Otherwise, there is an empty space because it uses flex and gap with an empty element.

# Tests

* Test files and POs for CanisterHeadingTitle, CanisterPageHeader, CanisterPageHeading

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet. I'll add it with the PR that uses the components.
