### PR TITLE
Replace "Edit percentage" with custom label

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -19,6 +19,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Use ICRC-1 transfer on ICP ledger canister instead of generic ICRC-1 ledger canister.
 * Allow `get_histogram` (an unstable API) only as a query call.
 * Set `ENABLE_SNS_AGGREGATOR_STORE` true for production.
+* Use custom button label for disburse maturity flow.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/components/neuron-detail/NeuronConfirmActionScreen.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronConfirmActionScreen.svelte
@@ -4,6 +4,8 @@
   import { i18n } from "$lib/stores/i18n";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
+  export let editLabel = $i18n.neuron_detail.edit_percentage;
+
   const dispatcher = createEventDispatcher();
   const confirm = () => dispatcher("nnsConfirm");
   const cancel = () => dispatcher("nnsCancel");
@@ -14,7 +16,7 @@
 
   <div class="toolbar">
     <button class="secondary" on:click={cancel} data-tid="cancel-action-button">
-      {$i18n.neuron_detail.edit_percentage}
+      {editLabel}
     </button>
     <button
       class="primary"

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -607,6 +607,7 @@
     "disburse_maturity_confirmation_amount": "Maturity Disbursed (Number)",
     "disburse_maturity_confirmation_tokens": "Estimated newly minted $symbol",
     "disburse_maturity_confirmation_destination": "To Account:",
+    "disburse_maturity_edit": "Edit Disbursement",
     "stake": "Stake",
     "spawn_neuron": "Spawn Neuron",
     "spawn": "Spawn",

--- a/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
@@ -192,6 +192,7 @@
     <NeuronConfirmActionScreen
       on:nnsConfirm={disburseNeuronMaturity}
       on:nnsCancel={modal.back}
+      editLabel={$i18n.neuron_detail.disburse_maturity_edit}
     >
       {$i18n.neuron_detail.disburse_maturity_confirmation_description}
       <div class="confirm-container">

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -630,6 +630,7 @@ interface I18nNeuron_detail {
   disburse_maturity_confirmation_amount: string;
   disburse_maturity_confirmation_tokens: string;
   disburse_maturity_confirmation_destination: string;
+  disburse_maturity_edit: string;
   stake: string;
   spawn_neuron: string;
   spawn: string;

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronConfirmActionScreen.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronConfirmActionScreen.spec.ts
@@ -20,6 +20,21 @@ describe("NeuronConfirmActionScreen", () => {
     expect(element).toBeInTheDocument();
   });
 
+  it("should render custom edit button", () => {
+    const editLabel = "CUSTOM-EDIT-BUTTON";
+    const { getByText } = render(NeuronConfirmActionScreenTest, {
+      props: { editLabel },
+    });
+
+    expect(getByText(editLabel)).toBeInTheDocument();
+  });
+
+  it("should render default edit button label when not provided", () => {
+    const { getByText } = render(NeuronConfirmActionScreenTest);
+
+    expect(getByText("Edit percentage")).toBeInTheDocument();
+  });
+
   it("should trigger nnsConfirm event on click button", async () => {
     const spy = jest.fn();
     const { queryByTestId } = render(NeuronConfirmActionScreenTest, {

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronConfirmActionScreenTest.svelte
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronConfirmActionScreenTest.svelte
@@ -2,8 +2,9 @@
   import NeuronConfirmActionScreen from "$lib/components/neuron-detail/NeuronConfirmActionScreen.svelte";
 
   export let spy: () => void = () => undefined;
+  export let editLabel: string | undefined = undefined;
 </script>
 
-<NeuronConfirmActionScreen on:nnsConfirm={spy}>
+<NeuronConfirmActionScreen on:nnsConfirm={spy} {editLabel}>
   <h3 data-tid="test-main-info">Main information</h3>
 </NeuronConfirmActionScreen>


### PR DESCRIPTION
# Motivation

Make the edit button label dynamic for `ConfirmActionScreen`.

# Changes

- new prop `editLabel`
- set custom value for disburse maturity

# Tests

Manually

![image](https://github.com/dfinity/nns-dapp/assets/98811342/f1f1a775-d17d-4826-a55d-b84d62c56474)


<img width="632" alt="Screenshot 2023-09-27 at 10 00 00" src="https://github.com/dfinity/nns-dapp/assets/98811342/1f096206-4215-48a6-b1df-8d560ad7e3ea">


# Todos

- [ ] Add entry to changelog (if necessary).
not needed