### PR TITLE
Bump ic-js; rename icrc1Memo

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -25,6 +25,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Security
 
+* Rename `memo` on the ICRC-1 interface of the ICP ledger API to `icrc1Memo` and add a warning about the `memo` and `icrc1Memo` being unrelated.
+
 #### Not Published
 
 * Use ICRC-1 transfer when staking a neuron, behind a feature flag.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -749,9 +749,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "0.0.12-next-2023-09-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.12-next-2023-09-22.1.tgz",
-      "integrity": "sha512-rvhgtUba2o0Bdn+VFml9y9ZtkBdxagZXHobzW/gqzeIDZ/hjB8tMdOkEydRNV+hGbHQ2vsB2oOdd2GpKNrQBzg==",
+      "version": "0.0.12-next-2023-09-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.12-next-2023-09-27.tgz",
+      "integrity": "sha512-JPUbnxPJM/zJfF1cKPaoSKNj5W1IVvTEZgcQBkfx8m/0LjkrqGFrhzkDu/dF0aweq6TsYWsGFukbtOP/mYBkGQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -765,9 +765,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.19-next-2023-09-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.19-next-2023-09-22.1.tgz",
-      "integrity": "sha512-1KsWV/Cwf4Qby8iAPNYiznau/YqpfPxGOiiJFvb8vJP3DDxTZiQO7MKJ59PQWzGQaDKxF3/PksIId9xrkElo0Q==",
+      "version": "0.0.19-next-2023-09-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.19-next-2023-09-27.tgz",
+      "integrity": "sha512-Esv2PgtxX3JudCVCBiRzU2Q3WsxfL6LFo74oaOYpY1qVAqcJztCCwJAPl++RgGVg1bdJsRbbrcGzDsrbq2XF8A==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -790,9 +790,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "0.0.9-next-2023-09-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.9-next-2023-09-22.1.tgz",
-      "integrity": "sha512-40BeNY8emuTwrFC4tDA5Xl30cTcr/PgcWxzfXc0fCmk7IptQMTgoMgKnvauWTN+VZi0QVajOzghkyWDM5khjGg==",
+      "version": "0.0.9-next-2023-09-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.9-next-2023-09-27.tgz",
+      "integrity": "sha512-V+dI8RU7XACnedmFikuLkFJgWx8DslCPRsItRo02D5F+8GhREoZPfiJYT0/i7STrnvJlhVMqkf33Z7KIkxNerA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/@dfinity/ledger": {
-      "version": "0.0.16-next-2023-09-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.16-next-2023-09-22.1.tgz",
-      "integrity": "sha512-RhrdX86RQuZsDNTZwWY8pp1vQHw/MT8f5AbPW0vUaB/AIygyjbXcbaHBXT3gAfuAoGg3CQHVAY3EwDQRqjgUXQ==",
+      "version": "0.0.16-next-2023-09-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.16-next-2023-09-27.tgz",
+      "integrity": "sha512-7trsnsgJD8Ybnlll4WS9kBE9XTdxnRj1GAC/PPVlL5PS9SIBh0SwkM/C6Plo28m7dWkp6EBjxRHdhw8alkZX/w==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -827,9 +827,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.16.8-next-2023-09-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.8-next-2023-09-22.1.tgz",
-      "integrity": "sha512-SSRb5K71psWnkh+nmGwmUi/UbhvRO+ZQsiw10wbNz2PCBHNifRYC5778p6BcCldJVfy8yED4gYvOdosYlxq/vQ==",
+      "version": "0.16.8-next-2023-09-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.8-next-2023-09-27.tgz",
+      "integrity": "sha512-MIfy5y0FhyHjgclIfpy1XchfOy2vDJre1niInQ2XIVDIgGXMhgQ030IvMH8f4mLJA/IDz1XRHYeAt5ZUnfP44Q==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -843,9 +843,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "0.0.9-next-2023-09-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.9-next-2023-09-22.1.tgz",
-      "integrity": "sha512-isfGt2okYfu/DNebMQHN9KsTzRnnIXD0NwFblt+hNWwPBQ1ZN5BbQsd8q3zL66yt5LcboAkzMcT9p/GvJ/S4Lw==",
+      "version": "0.0.9-next-2023-09-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.9-next-2023-09-27.tgz",
+      "integrity": "sha512-4e/KpwKVharhuqyAaNK/AKEpsMEFWuj6ob5ikl0LtY3+psqMcWw7gjM9p11wXWHV6F0z8ZAZy4+aCigJkjxTrA==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -859,9 +859,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.23-next-2023-09-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.23-next-2023-09-22.1.tgz",
-      "integrity": "sha512-t2gp3KBBYZdDxg28DRHOFIPRSmrJlEkjqhjrOcupzdAycsAQXAlAWFiiSM90x7IQj9YmfUbJUsNVVTiBPULhDg==",
+      "version": "0.0.23-next-2023-09-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.23-next-2023-09-27.tgz",
+      "integrity": "sha512-q9ku6BFn+bQjNratvpY5Cck9ajKpl4Ui17aXOwheWOJUnYoFyeLQXkrRntw6lr7KuZMe0c7hpOC+zpDSNtTTPA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -874,9 +874,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.23-next-2023-09-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.23-next-2023-09-22.1.tgz",
-      "integrity": "sha512-4xb12XGboR5fJcfXN3OLCYhxJ3zxcXrxcJt1juO4zxV5iiIk48VuKoga6Lp3fVRrM+dHaBx+1nPiJVx1ZOi8yQ==",
+      "version": "0.0.23-next-2023-09-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.23-next-2023-09-27.tgz",
+      "integrity": "sha512-z2dQCJFzvbSUjLmiTPYSLD6vmkvRhFsEwnQEXRJOePf499SrudZwFYji8ti2XhVJ4mO+g/1S9Eyzfm25CPhfDQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -10052,9 +10052,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "0.0.12-next-2023-09-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.12-next-2023-09-22.1.tgz",
-      "integrity": "sha512-rvhgtUba2o0Bdn+VFml9y9ZtkBdxagZXHobzW/gqzeIDZ/hjB8tMdOkEydRNV+hGbHQ2vsB2oOdd2GpKNrQBzg==",
+      "version": "0.0.12-next-2023-09-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.12-next-2023-09-27.tgz",
+      "integrity": "sha512-JPUbnxPJM/zJfF1cKPaoSKNj5W1IVvTEZgcQBkfx8m/0LjkrqGFrhzkDu/dF0aweq6TsYWsGFukbtOP/mYBkGQ==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -10062,9 +10062,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.19-next-2023-09-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.19-next-2023-09-22.1.tgz",
-      "integrity": "sha512-1KsWV/Cwf4Qby8iAPNYiznau/YqpfPxGOiiJFvb8vJP3DDxTZiQO7MKJ59PQWzGQaDKxF3/PksIId9xrkElo0Q==",
+      "version": "0.0.19-next-2023-09-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.19-next-2023-09-27.tgz",
+      "integrity": "sha512-Esv2PgtxX3JudCVCBiRzU2Q3WsxfL6LFo74oaOYpY1qVAqcJztCCwJAPl++RgGVg1bdJsRbbrcGzDsrbq2XF8A==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -10078,9 +10078,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "0.0.9-next-2023-09-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.9-next-2023-09-22.1.tgz",
-      "integrity": "sha512-40BeNY8emuTwrFC4tDA5Xl30cTcr/PgcWxzfXc0fCmk7IptQMTgoMgKnvauWTN+VZi0QVajOzghkyWDM5khjGg==",
+      "version": "0.0.9-next-2023-09-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.9-next-2023-09-27.tgz",
+      "integrity": "sha512-V+dI8RU7XACnedmFikuLkFJgWx8DslCPRsItRo02D5F+8GhREoZPfiJYT0/i7STrnvJlhVMqkf33Z7KIkxNerA==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -10094,24 +10094,24 @@
       }
     },
     "@dfinity/ledger": {
-      "version": "0.0.16-next-2023-09-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.16-next-2023-09-22.1.tgz",
-      "integrity": "sha512-RhrdX86RQuZsDNTZwWY8pp1vQHw/MT8f5AbPW0vUaB/AIygyjbXcbaHBXT3gAfuAoGg3CQHVAY3EwDQRqjgUXQ==",
+      "version": "0.0.16-next-2023-09-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.16-next-2023-09-27.tgz",
+      "integrity": "sha512-7trsnsgJD8Ybnlll4WS9kBE9XTdxnRj1GAC/PPVlL5PS9SIBh0SwkM/C6Plo28m7dWkp6EBjxRHdhw8alkZX/w==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "0.16.8-next-2023-09-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.8-next-2023-09-22.1.tgz",
-      "integrity": "sha512-SSRb5K71psWnkh+nmGwmUi/UbhvRO+ZQsiw10wbNz2PCBHNifRYC5778p6BcCldJVfy8yED4gYvOdosYlxq/vQ==",
+      "version": "0.16.8-next-2023-09-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.8-next-2023-09-27.tgz",
+      "integrity": "sha512-MIfy5y0FhyHjgclIfpy1XchfOy2vDJre1niInQ2XIVDIgGXMhgQ030IvMH8f4mLJA/IDz1XRHYeAt5ZUnfP44Q==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "0.0.9-next-2023-09-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.9-next-2023-09-22.1.tgz",
-      "integrity": "sha512-isfGt2okYfu/DNebMQHN9KsTzRnnIXD0NwFblt+hNWwPBQ1ZN5BbQsd8q3zL66yt5LcboAkzMcT9p/GvJ/S4Lw==",
+      "version": "0.0.9-next-2023-09-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.9-next-2023-09-27.tgz",
+      "integrity": "sha512-4e/KpwKVharhuqyAaNK/AKEpsMEFWuj6ob5ikl0LtY3+psqMcWw7gjM9p11wXWHV6F0z8ZAZy4+aCigJkjxTrA==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -10125,17 +10125,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.23-next-2023-09-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.23-next-2023-09-22.1.tgz",
-      "integrity": "sha512-t2gp3KBBYZdDxg28DRHOFIPRSmrJlEkjqhjrOcupzdAycsAQXAlAWFiiSM90x7IQj9YmfUbJUsNVVTiBPULhDg==",
+      "version": "0.0.23-next-2023-09-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.23-next-2023-09-27.tgz",
+      "integrity": "sha512-q9ku6BFn+bQjNratvpY5Cck9ajKpl4Ui17aXOwheWOJUnYoFyeLQXkrRntw6lr7KuZMe0c7hpOC+zpDSNtTTPA==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.23-next-2023-09-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.23-next-2023-09-22.1.tgz",
-      "integrity": "sha512-4xb12XGboR5fJcfXN3OLCYhxJ3zxcXrxcJt1juO4zxV5iiIk48VuKoga6Lp3fVRrM+dHaBx+1nPiJVx1ZOi8yQ==",
+      "version": "0.0.23-next-2023-09-27",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.23-next-2023-09-27.tgz",
+      "integrity": "sha512-z2dQCJFzvbSUjLmiTPYSLD6vmkvRhFsEwnQEXRJOePf499SrudZwFYji8ti2XhVJ4mO+g/1S9Eyzfm25CPhfDQ==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/lib/api/icp-ledger.api.ts
+++ b/frontend/src/lib/api/icp-ledger.api.ts
@@ -52,6 +52,11 @@ export const sendICP = async ({
   return response;
 };
 
+// WARNING: When using the ICRC-1 interface of the ICP ledger canister, there is
+// no relationship between the memo and the icrc1Memo of a transaction. The
+// ICRC-1 interface simply cannot set the memo field and the non-ICRC-1
+// interface cannot set the icrc1Memo field, even though the icrc1Memo field is
+// called just "memo" in canister method params.
 /**
  * Transfer ICP between accounts.
  *
@@ -68,7 +73,7 @@ export const sendIcpIcrc1 = async ({
   to,
   amount,
   fee,
-  memo,
+  icrc1Memo,
   fromSubAccount,
   createdAt,
 }: {
@@ -76,7 +81,7 @@ export const sendIcpIcrc1 = async ({
   to: IcrcAccount;
   amount: TokenAmount;
   fee?: bigint;
-  memo?: Uint8Array;
+  icrc1Memo?: Uint8Array;
   fromSubAccount?: Uint8Array;
   createdAt?: bigint;
 }): Promise<BlockHeight> => {
@@ -91,7 +96,7 @@ export const sendIcpIcrc1 = async ({
     amount: amount.toE8s(),
     fee,
     fromSubAccount,
-    memo,
+    icrc1Memo,
     createdAt: createdAt ?? nowInBigIntNanoSeconds(),
   });
   logWithTimestamp(`Sending ICRC-1 icp complete.`);

--- a/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
@@ -195,39 +195,39 @@ describe("icp-ledger.api", () => {
       });
     });
 
-    it("should call ledger to send ICP with memo", async () => {
-      const memo = Uint8Array.from([4, 4, 5, 5]);
+    it("should call ledger to send ICP with icrc1Memo", async () => {
+      const icrc1Memo = Uint8Array.from([4, 4, 5, 5]);
       await sendIcpIcrc1({
         identity: mockIdentity,
         to: { owner },
         amount,
-        memo,
+        icrc1Memo,
       });
 
       expect(spyTransfer).toHaveBeenCalledWith({
         to: { owner, subaccount: [] },
         amount: amount.toE8s(),
-        memo,
+        icrc1Memo,
         createdAt: nowInBigIntNanoSeconds,
         fromSubAccount: undefined,
       });
     });
 
     it("should call ledger to send ICP with createdAt", async () => {
-      const memo = Uint8Array.from([4, 4, 5, 5]);
+      const icrc1Memo = Uint8Array.from([4, 4, 5, 5]);
       const createdAt = BigInt(123456);
       await sendIcpIcrc1({
         identity: mockIdentity,
         to: { owner },
         amount,
-        memo,
+        icrc1Memo,
         createdAt,
       });
 
       expect(spyTransfer).toHaveBeenCalledWith({
         to: { owner, subaccount: [] },
         amount: amount.toE8s(),
-        memo,
+        icrc1Memo,
         createdAt,
         fromSubAccount: undefined,
       });
@@ -244,7 +244,7 @@ describe("icp-ledger.api", () => {
       expect(spyTransfer).toHaveBeenCalledWith({
         to: { owner, subaccount: [subaccount] },
         amount: amount.toE8s(),
-        memo: undefined,
+        icrc1Memo: undefined,
         createdAt: nowInBigIntNanoSeconds,
         fromSubAccount: undefined,
       });


### PR DESCRIPTION
# Motivation

ic-js was changed to rename the `memo` parameter on the ICRC-1 interface of the ICP ledger canister.

# Changes

1. `npm run update:next`
2. Use the new parameter name.
3. Add a warning about the memos being different.

# Tests

Updated

# Todos

- [x] Add entry to changelog (if necessary).
