### PR TITLE
Remove extra space from AmountDisplay

### DIFF
--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -33,9 +33,9 @@
     class:tabular-num={detailed === "height_decimals"}
     >{`${sign}${formatToken({ value: amount.toE8s(), detailed })}`}</span
   >
-  <span class="label">{label !== undefined ? label : amount.token.symbol}</span>
-
-  {#if copy}
+  <span class="label">{label !== undefined ? label : amount.token.symbol}</span
+  >{#if copy}
+    {" "}
     <Copy value={formatToken({ value: amount.toE8s(), detailed: true })} />
   {/if}
 </div>

--- a/frontend/src/tests/page-objects/KeyValuePair.page-object.ts
+++ b/frontend/src/tests/page-objects/KeyValuePair.page-object.ts
@@ -1,6 +1,5 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { nonNullish } from "@dfinity/utils";
 
 export class KeyValuePairPo extends BasePageObject {
   static under({
@@ -17,8 +16,7 @@ export class KeyValuePairPo extends BasePageObject {
     return this.root.querySelector("dt").getText();
   }
 
-  async getValueText(): Promise<string | null> {
-    const text = await this.root.querySelector("dd").getText();
-    return nonNullish(text) ? text.trim() : null;
+  getValueText(): Promise<string | null> {
+    return this.root.querySelector("dd").getText();
   }
 }


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/3379 had to add a `trim()` which shouldn't be necessary.
It was necessary because `AmountDisplay` renders an unnecessary space.
`AmountDisplay` has an optional copy icon. If the copy icon is rendered, we want there to be a space between the amount and the copy icon. But if there is no copy icon, there also shouldn't be a space.
I think this might be a bug in Svelte template parsing but we can work around it.

# Changes

1. Render the space separating the amount and the copy icon inside the `{#if copy}` block.
2. Remove the `trim()` from `frontend/src/tests/page-objects/KeyValuePair.page-object.ts`

# Tests

Pass
Also manually checked that it renders correctly with copy icon (in the wallet summary) and without (in the transaction history).
Try it here: https://fswcu-uqaaa-aaaaa-aadwq-cai.nnsdapp.dfinity.network/

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary