### PR TITLE
Feat: Improve spacing in PageHeading

### DIFF
--- a/frontend/src/lib/components/common/PageHeading.svelte
+++ b/frontend/src/lib/components/common/PageHeading.svelte
@@ -6,10 +6,12 @@
 </script>
 
 <div class="container" data-tid={testId}>
-  <slot name="title" />
-  <h4 class="description">
-    <slot name="subtitle" />
-  </h4>
+  <div class="title-wrapper">
+    <slot name="title" />
+    <h4 class="description">
+      <slot name="subtitle" />
+    </h4>
+  </div>
   {#if hasTags}
     <div class="tags">
       <slot name="tags" />
@@ -21,11 +23,19 @@
   .container {
     display: flex;
     flex-direction: column;
-    gap: var(--padding-1_5x);
+    gap: var(--padding-2x);
     justify-content: center;
     align-items: center;
 
     width: 100%;
+
+    .title-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: var(--padding-1_5x);
+      justify-content: center;
+      align-items: center;
+    }
 
     h4 {
       margin: 0;


### PR DESCRIPTION
# Motivation

Current PageHeading has the same distance between subtitle and tags slot. Yet, the subtitle belongs more to the title than to the tags slot.

In this PR, improve the spacing to give more room between the box of title + subtitle and the tags slot.

# Changes

* In PageHeading, wrap title and subtitle in an element to give them extra space.

# Tests

Only UI changes.

# Todos

- [ ] Add entry to changelog (if necessary).
