### PR TITLE
build: increase JavaScript heap memory for CI build

### DIFF
--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -12,7 +12,7 @@ test -e frontend/.env || {
 ###################
 # frontend # (output: frontend/public/)
 ###################
-(cd "$TOPLEVEL/frontend" && npm ci && npm run build)
+(cd "$TOPLEVEL/frontend" && npm ci && npm run build --node-options="--max-old-space-size=4096")
 
 #################
 # assets.tar.xz #


### PR DESCRIPTION
# Motivation

In PR #3392 we aim to review the chunking strategy of the frontend dapp which results in an higher consumption of memory when the dapp is build. As a result, the CI is unable to run few jobs because not enough memory is allocated within the CI. For example see the result of this job: https://github.com/dfinity/nns-dapp/actions/runs/6325689226/job/17177726097?pr=3392

To overcome the issue, this PR set a larger memory using the option [--max-old-space-size](https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes) provided by NodeJS.

This job for example confirms the solution: https://github.com/dfinity/nns-dapp/actions/runs/6326554570/job/17180366956?pr=3392

# Notes

The high usage of memory is confirmed by the team of Rollup for example in this [comment](https://github.com/rollup/rollup/issues/4243#issuecomment-942953302).