### PR TITLE
Update SNS aggregator changelog

### DIFF
--- a/CHANGELOG-Sns_Aggregator.md
+++ b/CHANGELOG-Sns_Aggregator.md
@@ -10,6 +10,12 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 
 ### Wasm changes
 
+### Operations
+
+## [Proposal 124788](https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=124788)
+
+### Wasm changes
+
 * In fast updates, update `derived_state` and `lifecycle` as well as the now deprecated `swap_state`.
 * New field `logo` in the `meta` data with the relative path to the logo asset.
 * Add a getting started section in landing page.


### PR DESCRIPTION
# Motivation
A release was made of the SNS aggregator; the unreleased changelog entries have now been released.

I note that the earlier changelog entries are somewhat broken; a proposal is listed twice.  However I propose to make the release cut and then fix the earlier proposal entry in a separate PR.

# Changes
- Cut the changelog for the last SNS aggregator release.

# Tests
The proposal in the section title is correct and the link is the right one.

# Todos

- [ ] Add entry to changelog (if necessary).
  - Not applicable
