### PR TITLE
Escape raw html tag in markdown by default

### DIFF
--- a/frontend/src/lib/components/ui/Markdown.svelte
+++ b/frontend/src/lib/components/ui/Markdown.svelte
@@ -8,7 +8,7 @@
   let error = false;
   const transform = async (text: string) => {
     try {
-      html = await markdownToHTML(text);
+      html = await markdownToHTML({ text });
     } catch (err) {
       console.error(err);
       error = true;

--- a/frontend/src/lib/utils/html.utils.ts
+++ b/frontend/src/lib/utils/html.utils.ts
@@ -51,15 +51,28 @@ export const renderer = (marked: Marked): Renderer => {
   return renderer;
 };
 
+export const escapeHtml = (html: string): string =>
+  html.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
 /**
- * Uses markedjs
+ * Uses markedjs.
+ * Escape raw HTML tags by default (<script> -> &lt;script&gt;)
  * @see {@link https://github.com/markedjs/marked}
  */
-export const markdownToHTML = async (text: string): Promise<string> => {
+export const markdownToHTML = async ({
+  text,
+  escapeRawHtmlTags = true,
+}: {
+  text: string;
+  escapeRawHtmlTags?: boolean;
+}): Promise<string> => {
+  if (escapeRawHtmlTags)
+    text = text.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+
   const url = "/assets/libs/marked.min.js";
   // The dynamic import cannot be analyzed by Vite. As it is intended, we use the /* @vite-ignore */ comment inside the import() call to suppress this warning.
   const { marked }: { marked: Marked } = await import(/* @vite-ignore */ url);
-  return marked(text, {
+  return marked(escapeRawHtmlTags ? escapeHtml(text) : text, {
     renderer: renderer(marked),
   });
 };


### PR DESCRIPTION
# Motivation

Escape raw html tags in markdown content to increase the security.

# Changes

- add optional `escapeRawHtmlTags` to `markdownToHTML` function

# Tests

TBD

# Todos

- [ ] Add entry to changelog (if necessary).

# Screenshots

There is a raw html in the [provided sample](https://dashboard.internetcomputer.org/proposal/104084):

## before
<img width="825" alt="Screenshot 2023-09-27 at 15 20 21" src="https://github.com/dfinity/nns-dapp/assets/98811342/6e925de2-904a-42ca-a8ba-105a181dae9a">

## after

| NNS-DAPP | Dashboard |
|--------|--------|
| <img width="544" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/3a92ef4d-ff71-4c69-8be9-e689bb8853bf"> | <img width="694" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/fd02cd9b-ebe2-4d43-b420-c8344814e5b8"> | 



