### PR TITLE
Fix aggregator changelog

### DIFF
--- a/CHANGELOG-Sns_Aggregator.md
+++ b/CHANGELOG-Sns_Aggregator.md
@@ -20,12 +20,6 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 
 ### Wasm changes
 
-### Operations
-
-## [Proposal 124788](https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=124788)
-
-### Wasm changes
-
 * In fast updates, update `derived_state` and `lifecycle` as well as the now deprecated `swap_state`.
 * New field `logo` in the `meta` data with the relative path to the logo asset.
 * Add a getting started section in landing page.

--- a/CHANGELOG-Sns_Aggregator.md
+++ b/CHANGELOG-Sns_Aggregator.md
@@ -8,9 +8,13 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 
 ## Unreleased
 
-### Wasm changes
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
 
-### Operations
 
 ## [Proposal 124788](https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=124788)
 
@@ -19,19 +23,7 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 * In fast updates, update `derived_state` and `lifecycle` as well as the now deprecated `swap_state`.
 * New field `logo` in the `meta` data with the relative path to the logo asset.
 * Add a getting started section in landing page.
-
-### Operations
-
-## [Proposal 124250](https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=124250)
-
-### Added
-### Changed
 * Various minor style improvements: favicon, spacing, status "open" color and text clamp
-### Fixed
-### Security
-### Not Published
-### Removed
-### Deprecated
 
 ## [Proposal 124250](https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=124250)
 
@@ -43,10 +35,6 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 ### Fixed
 * Update the path to the `nns-sns-wasm` .did file.
 * Update the index.html when it has changed.
-### Security
-### Not Published
-### Removed
-### Deprecated
 
 ## [Proposal 123719](https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=123719)
 

--- a/CHANGELOG-Sns_Aggregator.md
+++ b/CHANGELOG-Sns_Aggregator.md
@@ -10,6 +10,12 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 
 ### Wasm changes
 
+### Operations
+
+## [Proposal 124788](https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=124788)
+
+### Wasm changes
+
 * In fast updates, update `derived_state` and `lifecycle` as well as the now deprecated `swap_state`.
 * New field `logo` in the `meta` data with the relative path to the logo asset.
 * Add a getting started section in landing page.


### PR DESCRIPTION
# Motivation
The aggregator changelog was invalid with "Proposal 124250" repeated and multiple empty sections.

It appears that the earlier entry corresponded to the actual [proposal 124250](https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=124250); that contains some empty sections that should have been purged but otherwise that section is correct.

The duplicate section is:

> Various minor style improvements: favicon, spacing, status "open" color and text clamp

This appears to match the rejected [proposal 124535](https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=124535) although that proposal has a different summary.

The proposal was rejected due to reproducibility issues, not due to any fundamental rejection by the community of the changes, so the changes from 124535 were included in the next proposal ([124788](https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=124788)).

# Conclusion
* It looks as if the proposal rejection might have thrown the normal release procedure out of whack.  We probably need to document the rejection path more thoroughly and provide better tooling.
* Minimal changes should be made to the changelog to make it an accurate, well formed history.

# Changes
- Remove the empty sections.
- Remove the duplicate proposal header and add the line under that section to the release that actually included that change.
- Reinstate the section headers that were lost.

# Tests
- See feedback by humans.

# Todos

- [ ] Add entry to changelog (if necessary).
 - Not applicable
