### PR TITLE
Chore lm update next deps

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -749,9 +749,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "0.0.12-next-2023-09-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.12-next-2023-09-27.tgz",
-      "integrity": "sha512-JPUbnxPJM/zJfF1cKPaoSKNj5W1IVvTEZgcQBkfx8m/0LjkrqGFrhzkDu/dF0aweq6TsYWsGFukbtOP/mYBkGQ==",
+      "version": "0.0.12-next-2023-09-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.12-next-2023-09-28.tgz",
+      "integrity": "sha512-jaJuu5qHy2Ca0g6tQHey2D2LqhMlUnkvi7Pzqd77vxLldrHeJMGgQYhhEbnPYgNkB5dGSM9qB8BiwZ3htQYfcQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -765,9 +765,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.19-next-2023-09-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.19-next-2023-09-27.tgz",
-      "integrity": "sha512-Esv2PgtxX3JudCVCBiRzU2Q3WsxfL6LFo74oaOYpY1qVAqcJztCCwJAPl++RgGVg1bdJsRbbrcGzDsrbq2XF8A==",
+      "version": "0.0.19-next-2023-09-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.19-next-2023-09-28.tgz",
+      "integrity": "sha512-A7cFQI8DHZzOzSja1eeBs7LQknI67KNztk3D+wBsV2grTWh4xd9Inn8gb6zkpOWBfb5lOU03fbqwczdEcMRdaA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -790,9 +790,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "0.0.9-next-2023-09-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.9-next-2023-09-27.tgz",
-      "integrity": "sha512-V+dI8RU7XACnedmFikuLkFJgWx8DslCPRsItRo02D5F+8GhREoZPfiJYT0/i7STrnvJlhVMqkf33Z7KIkxNerA==",
+      "version": "0.0.9-next-2023-09-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.9-next-2023-09-28.tgz",
+      "integrity": "sha512-G+n/Lwlc9e6wLDtmfMT1nnhGeB1jAELFKBTLmxQZUSY++F9p14KuSXWv0/QttpkWNH11JdFbKjtnAQTQI0OdEw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/@dfinity/ledger": {
-      "version": "0.0.16-next-2023-09-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.16-next-2023-09-27.tgz",
-      "integrity": "sha512-7trsnsgJD8Ybnlll4WS9kBE9XTdxnRj1GAC/PPVlL5PS9SIBh0SwkM/C6Plo28m7dWkp6EBjxRHdhw8alkZX/w==",
+      "version": "0.0.16-next-2023-09-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.16-next-2023-09-28.tgz",
+      "integrity": "sha512-UjzxamoUo1UBe/0/PPyIe29pjpd2KRRuCHWPrTkyTqMeN3huaPbSM4WYfWnVIT5FXvRrmR9zjB5EbUJv0sH4Iw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -827,9 +827,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.16.8-next-2023-09-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.8-next-2023-09-27.tgz",
-      "integrity": "sha512-MIfy5y0FhyHjgclIfpy1XchfOy2vDJre1niInQ2XIVDIgGXMhgQ030IvMH8f4mLJA/IDz1XRHYeAt5ZUnfP44Q==",
+      "version": "0.16.8-next-2023-09-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.8-next-2023-09-28.tgz",
+      "integrity": "sha512-SivRlq8/zxN5nU+xdnI+j2+nzs/tQXbfWsdEbwmwwbcu7nERU2FMWPE6ee1ie05aSLqFuGE2sZK2RiGuR6mJDA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -843,9 +843,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "0.0.9-next-2023-09-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.9-next-2023-09-27.tgz",
-      "integrity": "sha512-4e/KpwKVharhuqyAaNK/AKEpsMEFWuj6ob5ikl0LtY3+psqMcWw7gjM9p11wXWHV6F0z8ZAZy4+aCigJkjxTrA==",
+      "version": "0.0.9-next-2023-09-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.9-next-2023-09-28.tgz",
+      "integrity": "sha512-4F59pMIL8zPrHLBwf+TDiFgWBgVehxHffo1xpXR6prDRlhvFCpjZbjSgUtPqlXvK6PItRJtNXakbdz7x0SJtWQ==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -859,9 +859,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.23-next-2023-09-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.23-next-2023-09-27.tgz",
-      "integrity": "sha512-q9ku6BFn+bQjNratvpY5Cck9ajKpl4Ui17aXOwheWOJUnYoFyeLQXkrRntw6lr7KuZMe0c7hpOC+zpDSNtTTPA==",
+      "version": "0.0.23-next-2023-09-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.23-next-2023-09-28.tgz",
+      "integrity": "sha512-3FdhXY/Vsc6zHrzaE+DJp2cFq3czmJwqwv5+C+q6GFbzebxvCb6YykuTE24z+mvBjRL6Rot0qs5rmtKj4n9OKA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -874,9 +874,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.23-next-2023-09-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.23-next-2023-09-27.tgz",
-      "integrity": "sha512-z2dQCJFzvbSUjLmiTPYSLD6vmkvRhFsEwnQEXRJOePf499SrudZwFYji8ti2XhVJ4mO+g/1S9Eyzfm25CPhfDQ==",
+      "version": "0.0.23-next-2023-09-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.23-next-2023-09-28.tgz",
+      "integrity": "sha512-k443ORC/Equy9dXCJGmDD+JO3hb92XWGSG6l1LIhqEF1TUr+NVRG9ed9dtxJeNK0GJ1twzv0WnszjIqPv8xr4A==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -10052,9 +10052,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "0.0.12-next-2023-09-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.12-next-2023-09-27.tgz",
-      "integrity": "sha512-JPUbnxPJM/zJfF1cKPaoSKNj5W1IVvTEZgcQBkfx8m/0LjkrqGFrhzkDu/dF0aweq6TsYWsGFukbtOP/mYBkGQ==",
+      "version": "0.0.12-next-2023-09-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.12-next-2023-09-28.tgz",
+      "integrity": "sha512-jaJuu5qHy2Ca0g6tQHey2D2LqhMlUnkvi7Pzqd77vxLldrHeJMGgQYhhEbnPYgNkB5dGSM9qB8BiwZ3htQYfcQ==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -10062,9 +10062,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.19-next-2023-09-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.19-next-2023-09-27.tgz",
-      "integrity": "sha512-Esv2PgtxX3JudCVCBiRzU2Q3WsxfL6LFo74oaOYpY1qVAqcJztCCwJAPl++RgGVg1bdJsRbbrcGzDsrbq2XF8A==",
+      "version": "0.0.19-next-2023-09-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.19-next-2023-09-28.tgz",
+      "integrity": "sha512-A7cFQI8DHZzOzSja1eeBs7LQknI67KNztk3D+wBsV2grTWh4xd9Inn8gb6zkpOWBfb5lOU03fbqwczdEcMRdaA==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -10078,9 +10078,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "0.0.9-next-2023-09-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.9-next-2023-09-27.tgz",
-      "integrity": "sha512-V+dI8RU7XACnedmFikuLkFJgWx8DslCPRsItRo02D5F+8GhREoZPfiJYT0/i7STrnvJlhVMqkf33Z7KIkxNerA==",
+      "version": "0.0.9-next-2023-09-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.9-next-2023-09-28.tgz",
+      "integrity": "sha512-G+n/Lwlc9e6wLDtmfMT1nnhGeB1jAELFKBTLmxQZUSY++F9p14KuSXWv0/QttpkWNH11JdFbKjtnAQTQI0OdEw==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -10094,24 +10094,24 @@
       }
     },
     "@dfinity/ledger": {
-      "version": "0.0.16-next-2023-09-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.16-next-2023-09-27.tgz",
-      "integrity": "sha512-7trsnsgJD8Ybnlll4WS9kBE9XTdxnRj1GAC/PPVlL5PS9SIBh0SwkM/C6Plo28m7dWkp6EBjxRHdhw8alkZX/w==",
+      "version": "0.0.16-next-2023-09-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.16-next-2023-09-28.tgz",
+      "integrity": "sha512-UjzxamoUo1UBe/0/PPyIe29pjpd2KRRuCHWPrTkyTqMeN3huaPbSM4WYfWnVIT5FXvRrmR9zjB5EbUJv0sH4Iw==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "0.16.8-next-2023-09-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.8-next-2023-09-27.tgz",
-      "integrity": "sha512-MIfy5y0FhyHjgclIfpy1XchfOy2vDJre1niInQ2XIVDIgGXMhgQ030IvMH8f4mLJA/IDz1XRHYeAt5ZUnfP44Q==",
+      "version": "0.16.8-next-2023-09-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.8-next-2023-09-28.tgz",
+      "integrity": "sha512-SivRlq8/zxN5nU+xdnI+j2+nzs/tQXbfWsdEbwmwwbcu7nERU2FMWPE6ee1ie05aSLqFuGE2sZK2RiGuR6mJDA==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "0.0.9-next-2023-09-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.9-next-2023-09-27.tgz",
-      "integrity": "sha512-4e/KpwKVharhuqyAaNK/AKEpsMEFWuj6ob5ikl0LtY3+psqMcWw7gjM9p11wXWHV6F0z8ZAZy4+aCigJkjxTrA==",
+      "version": "0.0.9-next-2023-09-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.9-next-2023-09-28.tgz",
+      "integrity": "sha512-4F59pMIL8zPrHLBwf+TDiFgWBgVehxHffo1xpXR6prDRlhvFCpjZbjSgUtPqlXvK6PItRJtNXakbdz7x0SJtWQ==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -10125,17 +10125,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.23-next-2023-09-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.23-next-2023-09-27.tgz",
-      "integrity": "sha512-q9ku6BFn+bQjNratvpY5Cck9ajKpl4Ui17aXOwheWOJUnYoFyeLQXkrRntw6lr7KuZMe0c7hpOC+zpDSNtTTPA==",
+      "version": "0.0.23-next-2023-09-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.23-next-2023-09-28.tgz",
+      "integrity": "sha512-3FdhXY/Vsc6zHrzaE+DJp2cFq3czmJwqwv5+C+q6GFbzebxvCb6YykuTE24z+mvBjRL6Rot0qs5rmtKj4n9OKA==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.23-next-2023-09-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.23-next-2023-09-27.tgz",
-      "integrity": "sha512-z2dQCJFzvbSUjLmiTPYSLD6vmkvRhFsEwnQEXRJOePf499SrudZwFYji8ti2XhVJ4mO+g/1S9Eyzfm25CPhfDQ==",
+      "version": "0.0.23-next-2023-09-28",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.23-next-2023-09-28.tgz",
+      "integrity": "sha512-k443ORC/Equy9dXCJGmDD+JO3hb92XWGSG6l1LIhqEF1TUr+NVRG9ed9dtxJeNK0GJ1twzv0WnszjIqPv8xr4A==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -172,6 +172,7 @@ const convertSwapInitParams = (
           init.fallback_controller_principal_ids,
         nns_governance_canister_id: init.nns_governance_canister_id,
         icp_ledger_canister_id: init.icp_ledger_canister_id,
+        neurons_fund_participation_constraints: [],
       })
     : [];
 
@@ -227,6 +228,8 @@ const convertSwap = ({
       : [],
   init: convertSwapInitParams(init),
   params: isNullish(params) ? [] : [convertSwapParams(params)],
+  neurons_fund_participation_icp_e8s: [],
+  direct_participation_icp_e8s: [],
 });
 
 const convertDerived = ({
@@ -247,6 +250,8 @@ const convertDerived = ({
   cf_neuron_count: nonNullish(cf_neuron_count)
     ? toNullable(BigInt(cf_neuron_count))
     : [],
+  neurons_fund_participation_icp_e8s: [],
+  direct_participation_icp_e8s: [],
 });
 
 const convertDerivedToResponse = ({
@@ -269,6 +274,8 @@ const convertDerivedToResponse = ({
   cf_neuron_count: nonNullish(cf_neuron_count)
     ? toNullable(BigInt(cf_neuron_count))
     : [],
+  direct_participation_icp_e8s: [],
+  neurons_fund_participation_icp_e8s: [],
 });
 
 const convertIcrc1Metadata = (


### PR DESCRIPTION
# Motivation

We want to use the new fields related to the NF enhancements for swaps.

In this PR, I updated the next dependencies and fixed some incompatibilities.

# Changes

## Automatic changes

Running `npm run update:next`.
* Changes in package-lock.json.

## Manual

* Changes in `frontend/src/lib/utils/sns-aggregator-converters.utils.ts`.
The support for this fields in the SNS aggretor is in `main`. But I will add the integration with those fields in another PR.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
