### PR TITLE
Better PR body

### DIFF
--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -5,9 +5,6 @@ on:
   schedule:
     # check for new `didc` releases daily at 7:30
     - cron: '30 7 * * *'
-  push:
-    branches:
-      - doc-didc-update
   workflow_dispatch:
 jobs:
   didc-update:
@@ -23,8 +20,7 @@ jobs:
           current_didc_release=$(jq -r '.defaults.build.config.DIDC_VERSION' dfx.json)
           echo "current didc release '$current_didc_release'"
 
-          #latest_didc_release=$(curl -sSL https://api.github.com/repos/dfinity/candid/releases/latest | jq .tag_name -r)
-          latest_didc_release="DO.NOT.MERGE"
+          latest_didc_release=$(curl -sSL https://api.github.com/repos/dfinity/candid/releases/latest | jq .tag_name -r)
           echo "latest didc release '$latest_didc_release'"
 
           if [ "$current_didc_release" != "$latest_didc_release" ]

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -53,7 +53,7 @@ jobs:
             A newer version of `didc` is available.
 
             # Changes
-            ## Changes made by a bot
+            ## Changes made by a bot triggered by ${{ github.actor }}
             - Update the version of `didc` specified in `dfx.json`.
 
             ## Changes made by a human (delete if inapplicable)

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     # check for new `didc` releases daily at 7:30
     - cron: '30 7 * * *'
+  push:
+    branches:
+      - doc-didc-update
   workflow_dispatch:
 jobs:
   didc-update:
@@ -20,7 +23,8 @@ jobs:
           current_didc_release=$(jq -r '.defaults.build.config.DIDC_VERSION' dfx.json)
           echo "current didc release '$current_didc_release'"
 
-          latest_didc_release=$(curl -sSL https://api.github.com/repos/dfinity/candid/releases/latest | jq .tag_name -r)
+          #latest_didc_release=$(curl -sSL https://api.github.com/repos/dfinity/candid/releases/latest | jq .tag_name -r)
+          latest_didc_release="DO.NOT.MERGE"
           echo "latest didc release '$latest_didc_release'"
 
           if [ "$current_didc_release" != "$latest_didc_release" ]

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -48,6 +48,20 @@ jobs:
           branch: bot-didc-update
           delete-branch: true
           title: 'Update didc release'
+          body: |
+            # Motivation
+            A newer version of `didc` is available.
+
+            # Changes
+            ## Changes made by a bot
+            - Update the version of `didc` specified in `dfx.json`.
+
+            ## Changes made by a human (delete if inapplicable)
+
+            # Tests
+            - CI contains tests that detect most breaking changes in `didc`.
+            - [ ] Please check [the didc release notes](https://github.com/dfinity/candid/releases) (if any).
+            - [ ] Please check [the didc git history](https://github.com/dfinity/candid/commits/master/tools/didc) (if reasonably short and understandable).
           # Since this is a scheduled job, a failure won't be shown on any
           # PR status. To notify the team, we send a message to our Slack channel on failure.
       - name: Notify Slack on failure

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -46,6 +46,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Changed
 
+* Populate the PR description of the `didc` updater.
 * Update the `snsdemo` test environment, `dfx` and the IC commit of the NNS canisters.
 * Fix the `release-sop` command that set `origin/main` as the upstream.
 * Specify the version of `binstall` in `dfx.json`.


### PR DESCRIPTION
# Motivation
The bot that updates `didc` to the latest release makes PRs without a meaningful description.  See [an example](https://github.com/dfinity/nns-dapp/pull/3403).

The PR description:
- Should broadly follow our usual template
- Should have separate sections for changes made by the bot and changes made by a human.

# Changes
- Update the proposal text.

# Tests
- The body is well formed:
```
max@sinkpad:~/dfn/nns-dapp/branches/doc-didc-update (18:56)$ yq -r '.jobs["didc-update"].steps[2].with.body' .github/workflows/update-didc.yml
# Motivation
A newer version of `didc` is available.

# Changes
## Changes made by a bot triggered by ${{ github.actor }}
- Update the version of `didc` specified in `dfx.json`.

## Changes made by a human (delete if inapplicable)

# Tests
- CI contains tests that detect most breaking changes in `didc`.
- [ ] Please check [the didc release notes](https://github.com/dfinity/candid/releases) (if any).
- [ ] Please check [the didc git history](https://github.com/dfinity/candid/commits/master/tools/didc) (if reasonably short and understandable).

max@sinkpad:~/dfn/nns-dapp/branches/doc-didc-update (24:39)$ 
```
- Here is an example, showing the actor being filled in: https://github.com/dfinity/nns-dapp/pull/3406

# Todos

- [x] Add entry to changelog (if necessary).
