### PR TITLE
GIX-1931: Hide commitment split if NF participation is 0

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -16,7 +16,6 @@
   import { swapSaleBuyerCount } from "$lib/utils/sns-swap.utils";
   import {
     getProjectCommitmentSplit,
-    isFullProjectCommitmentSplit,
     type ProjectCommitmentSplit,
   } from "$lib/utils/projects.utils";
   import TestIdWrapper from "../common/TestIdWrapper.svelte";
@@ -74,7 +73,7 @@
 
     <AmountDisplay slot="value" amount={buyersTotalCommitmentIcp} singleLine />
   </KeyValuePair>
-  {#if isFullProjectCommitmentSplit(projectCommitments)}
+  {#if "nfCommitmentE8s" in projectCommitments && projectCommitments.nfCommitmentE8s > 0n}
     <KeyValuePair testId="sns-project-current-nf-commitment">
       <span slot="key" class="detail-data">
         {$i18n.sns_project_detail.current_nf_commitment}

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -412,11 +412,6 @@ export type ProjectCommitmentSplit =
   | { totalCommitmentE8s: bigint }
   | FullProjectCommitmentSplit;
 
-export const isFullProjectCommitmentSplit = (
-  commitment: ProjectCommitmentSplit
-): commitment is FullProjectCommitmentSplit =>
-  "directCommitmentE8s" in commitment && "nfCommitmentE8s" in commitment;
-
 export const getProjectCommitmentSplit = (
   summary: SnsSummary
 ): ProjectCommitmentSplit => {

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -153,7 +153,7 @@ describe("ProjectCommitment", () => {
     expect(await po.getDirectParticipation()).toEqual("200.00 ICP");
   });
 
-  it("should render detailed participation if neurons fund participation is available even with NF participation as 0", async () => {
+  it("should not render detailed participation if neurons fund participation is zero", async () => {
     const directCommitment = 20000000000n;
     const nfCommitment = 0n;
     // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
@@ -165,7 +165,7 @@ describe("ProjectCommitment", () => {
       currentTotalCommitment: directCommitment + nfCommitment,
     });
     const po = renderComponent(summary);
-    expect(await po.getNeuronsFundParticipation()).toEqual("0 ICP");
-    expect(await po.getDirectParticipation()).toEqual("200.00 ICP");
+    expect(await po.hasNeuronsFundParticipation()).toBe(false);
+    expect(await po.hasDirectParticipation()).toBe(false);
   });
 });


### PR DESCRIPTION
# Motivation

We agreed with design and product to hide the split of direct and NF commitment until the NF commitment is more than 0.

# Changes

* Change the condition to show the split to the NF commitment greater than 0.
* Remove unused helper `isFullProjectCommitmentSplit`.

# Tests

I even did TDD in for this task. First I changed the test. It failed. Then I changed the code and see it pass 🚀 
* Change the description and expectation of the test case when NF is zero.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary yet.
