### PR TITLE
Fix: SkeletonHeading width

### DIFF
--- a/frontend/src/lib/components/ui/SkeletonHeading.svelte
+++ b/frontend/src/lib/components/ui/SkeletonHeading.svelte
@@ -13,10 +13,9 @@
   @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   div {
-    width: 90%;
-
-    @include media.min-width(small) {
-      width: 40%;
-    }
+    // This is a width for the skeleton that looks good on desktop and mobile.
+    // Based on $breakpoint-xsmall: 320px;
+    width: 320px;
+    max-width: calc(100% - var(--padding-2x));
   }
 </style>


### PR DESCRIPTION
# Motivation

The width of the SkeletonHeading was almost zero.

Problem: the width was set as %. But the parent's width is determined by the content.

# Changes

* Set a width in pixels for title text in `SkeletonHeading`.

# Tests

Not necessary.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary. New skeletons were recently introduced and this fix is covered by the entry of those.
