### PR TITLE
Move script loader to body

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -124,7 +124,6 @@
       }
     </script>
 
-    <!-- SCRIPT_LOADER -->
     <!-- LINKS_PRELOADER -->
 
     %sveltekit.head%
@@ -263,5 +262,7 @@
     >
       <circle cx="50%" cy="50%" r="45" />
     </svg>
+
+    <!-- SCRIPT_LOADER -->
   </body>
 </html>


### PR DESCRIPTION
# Motivation

In Juno, I encountered a runtime issue in SvelteKit: "Cannot read properties of undefined (reading '$$')" along with a white screen of death in the production build. After reviewing my chunking strategy, I eventually identified the problem as a loading race condition within Svelte. This issue can be resolved by injecting the loader script tag within the body instead of the head, which is a common strategy for executing a script tag.

While we currently do not encounter this issue in the NNS dapp, I believe it's worth preparing for it in advance.

# Changes

- move `SCRIPT_LOADER` in HTML page from `head` to `body`
