### PR TITLE
Don't trim newlines on mock outputs for release-sop

### DIFF
--- a/scripts/nns-dapp/release-sop
+++ b/scripts/nns-dapp/release-sop
@@ -56,8 +56,8 @@ execute() {
     echo "No mock behavior for: $cmd" >&2
     exit 1
   fi
-  stdout="$(echo "$entry" | jq -r .stdout | tr -d '\n')"
-  stderr="$(echo "$entry" | jq -r .stderr | tr -d '\n')"
+  stdout="$(echo "$entry" | jq -r .stdout)"
+  stderr="$(echo "$entry" | jq -r .stderr)"
   echo -n "$stdout"
   echo -n "$stderr" >&2
   exitCode="$(echo "$entry" | jq -r .exitCode)"


### PR DESCRIPTION
# Motivation

When `release-sop` is tested, we provide mock behavior for the commands it executes.
Newlines are removed from the output provided in the mock behavior, using `| tr -d '\n'`.
But this is not necessary because we also pass `-n` to `echo` when outputting the output.
And it turns out that `| tr -d '\n'` actually removes inner newlines as well which is interfering with other improvements I want to make to the script.

# Changes

Remove `| tr -d '\n'` applied to the mock output.

# Tests

Still pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary