### PR TITLE
Feat: Change canister detail page title

### DIFF
--- a/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
@@ -2,11 +2,14 @@
   import { TokenAmount, nonNullish } from "@dfinity/utils";
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import type { CanisterDetails } from "$lib/canisters/ic-management/ic-management.canister.types";
+  import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
   import { i18n } from "$lib/stores/i18n";
   import { SkeletonText } from "@dfinity/gix-components";
   import TestIdWrapper from "../common/TestIdWrapper.svelte";
+  import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 
   export let details: CanisterDetails | undefined;
+  export let canister: CanisterInfo;
   export let isController: boolean | undefined;
 </script>
 
@@ -23,7 +26,11 @@
     <!-- Only when we have loaded the data and we know whether the user is the controller -->
   {:else if isController === false}
     <h1 data-tid="caniter-title-balance-unavailable">
-      {$i18n.canister_detail.balance_unavailable}
+      {#if canister.name.length === 0}
+        {shortenWithMiddleEllipsis(canister.canister_id.toText())}
+      {:else}
+        {canister.name}
+      {/if}
     </h1>
   {:else}
     <div data-tid="skeleton" class="skeleton">

--- a/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
@@ -6,7 +6,6 @@
   import { i18n } from "$lib/stores/i18n";
   import { SkeletonText } from "@dfinity/gix-components";
   import TestIdWrapper from "../common/TestIdWrapper.svelte";
-  import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 
   export let details: CanisterDetails | undefined;
   export let canister: CanisterInfo;
@@ -27,7 +26,7 @@
   {:else if isController === false}
     <h1 data-tid="caniter-title-balance-unavailable">
       {#if canister.name.length === 0}
-        {shortenWithMiddleEllipsis(canister.canister_id.toText())}
+        {canister.canister_id.toText()}
       {:else}
         {canister.name}
       {/if}
@@ -44,6 +43,8 @@
 
   h1 {
     margin: 0;
+    // Needed if the canister id is very long for mobile and uses multiple lines.
+    text-align: center;
   }
 
   .skeleton {

--- a/frontend/src/lib/components/canister-detail/CanisterPageHeading.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterPageHeading.svelte
@@ -12,11 +12,12 @@
 </script>
 
 <!-- We can't set conditional slots. -->
-{#if canister.name.length === 0}
+{#if canister.name.length === 0 || !isController}
   <PageHeading testId="canister-page-heading-component">
     <CanisterHeadingTitle
       slot="title"
       details={canisterDetails}
+      {canister}
       {isController}
     />
     <svelte:fragment slot="tags">
@@ -29,6 +30,7 @@
     <CanisterHeadingTitle
       slot="title"
       details={canisterDetails}
+      {canister}
       {isController}
     />
     <span slot="subtitle" data-tid="subtitle">

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -454,7 +454,6 @@
     "rename_canister": "Rename Canister",
     "rename_canister_title": "Enter New Canister Name",
     "rename_canister_placeholder": "Canister Name",
-    "balance_unavailable": "Balance unavailable",
     "status_stopped": "Stopped",
     "status_stopping": "Stopping",
     "status_running": "Running"

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -469,7 +469,6 @@ interface I18nCanister_detail {
   rename_canister: string;
   rename_canister_title: string;
   rename_canister_placeholder: string;
-  balance_unavailable: string;
   status_stopped: string;
   status_stopping: string;
   status_running: string;

--- a/frontend/src/tests/lib/components/canister-detail/CanisterHeadingTitle.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/CanisterHeadingTitle.spec.ts
@@ -3,19 +3,22 @@
  */
 
 import type { CanisterDetails } from "$lib/canisters/ic-management/ic-management.canister.types";
+import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import CanisterHeadingTitle from "$lib/components/canister-detail/CanisterHeadingTitle.svelte";
-import { mockCanisterDetails } from "$tests/mocks/canisters.mock";
+import { mockCanister, mockCanisterDetails } from "$tests/mocks/canisters.mock";
 import { CanisterHeadingTitlePo } from "$tests/page-objects/CanisterHeadingTitle.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { Principal } from "@dfinity/principal";
 import { render } from "@testing-library/svelte";
 
 describe("CanisterHeadingTitle", () => {
   const renderComponent = (
     details: CanisterDetails | undefined,
-    isController: boolean | undefined
+    isController: boolean | undefined,
+    canister: CanisterInfo = mockCanister
   ) => {
     const { container } = render(CanisterHeadingTitle, {
-      props: { details, isController },
+      props: { details, isController, canister },
     });
 
     return CanisterHeadingTitlePo.under(new JestPageObjectElement(container));
@@ -32,9 +35,24 @@ describe("CanisterHeadingTitle", () => {
     expect(await po.hasSkeleton()).toBe(true);
   });
 
-  it("renders unavailable balance if user is not the controller", async () => {
-    const po = renderComponent(undefined, false);
-    expect(await po.getTitle()).toBe("Balance unavailable");
+  it("renders canister name if user is not the controller and name is present", async () => {
+    const canisterName = "My Canister";
+    const canister = {
+      ...mockCanister,
+      name: canisterName,
+    };
+    const po = renderComponent(undefined, false, canister);
+    expect(await po.getTitle()).toBe(canisterName);
+  });
+
+  it("renders canister id if user is not the controller and name is not present", async () => {
+    const canister = {
+      ...mockCanister,
+      name: "",
+      canister_id: Principal.fromText("ryjl3-tyaaa-aaaaa-aaaba-cai"),
+    };
+    const po = renderComponent(undefined, false, canister);
+    expect(await po.getTitle()).toBe("ryjl3-t...aba-cai");
   });
 
   it("renders cycles balance if defined", async () => {

--- a/frontend/src/tests/lib/components/canister-detail/CanisterHeadingTitle.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/CanisterHeadingTitle.spec.ts
@@ -46,13 +46,14 @@ describe("CanisterHeadingTitle", () => {
   });
 
   it("renders canister id if user is not the controller and name is not present", async () => {
+    const canisterIdText = "ryjl3-tyaaa-aaaaa-aaaba-cai";
     const canister = {
       ...mockCanister,
       name: "",
-      canister_id: Principal.fromText("ryjl3-tyaaa-aaaaa-aaaba-cai"),
+      canister_id: Principal.fromText(canisterIdText),
     };
     const po = renderComponent(undefined, false, canister);
-    expect(await po.getTitle()).toBe("ryjl3-t...aba-cai");
+    expect(await po.getTitle()).toBe(canisterIdText);
   });
 
   it("renders cycles balance if defined", async () => {

--- a/frontend/src/tests/lib/components/canister-detail/CanisterPageHeader.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/CanisterPageHeader.spec.ts
@@ -10,7 +10,7 @@ import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { Principal } from "@dfinity/principal";
 import { render } from "@testing-library/svelte";
 
-describe("CanisterHeadingTitle", () => {
+describe("CanisterPageHeader", () => {
   const renderComponent = (canister: CanisterInfo) => {
     const { container } = render(CanisterPageHeader, {
       props: { canister },

--- a/frontend/src/tests/lib/components/canister-detail/CanisterPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/CanisterPageHeading.spec.ts
@@ -46,14 +46,25 @@ describe("CanisterHeadingTitle", () => {
     expect(await po.getTitle()).toBe("3.14 T Cycles");
   });
 
-  it("renders the canister name as subtitle if present", async () => {
+  it("renders the canister name as subtitle if present and user is the controller", async () => {
     const name = "My Canister";
     const canisterInfo = {
       ...mockCanister,
       name,
     };
-    const po = renderComponent(canisterInfo, undefined, undefined);
+    const po = renderComponent(canisterInfo, undefined, true);
     expect(await po.getSubtitle()).toBe(name);
+  });
+
+  it("renders the canister name in title and no subtitle if user is not the controller", async () => {
+    const name = "My Canister";
+    const canisterInfo = {
+      ...mockCanister,
+      name,
+    };
+    const po = renderComponent(canisterInfo, undefined, false);
+    expect(await po.getTitle()).toBe(name);
+    expect(await po.hasSubtitle()).toBe(false);
   });
 
   it("dispatches unlink canister modal event when unlink button is clicked", async () => {

--- a/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
@@ -143,15 +143,15 @@ describe("CanisterDetail", () => {
       jest
         .spyOn(canisterApi, "queryCanisterDetails")
         .mockRejectedValue(new UserNotTheControllerError());
+    });
+
+    it("should not render controllers card if user is not the controller", async () => {
       jest.spyOn(canisterApi, "queryCanisters").mockResolvedValue([
         {
           canister_id: canisterId,
           name: "",
         },
       ]);
-    });
-
-    it("should not render controllers card if user is not the controller", async () => {
       const { queryByTestId } = render(CanisterDetail, props);
 
       await runResolvedPromises();
@@ -161,9 +161,27 @@ describe("CanisterDetail", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("should render 'Balance unavailable' as title", async () => {
+    it("should render canister id as title if canister has no name", async () => {
+      jest.spyOn(canisterApi, "queryCanisters").mockResolvedValue([
+        {
+          canister_id: canisterId,
+          name: "",
+        },
+      ]);
       const po = await renderComponent();
-      expect(await po.getTitle()).toBe("Balance unavailable");
+      expect(await po.getTitle()).toBe("ryjl3-t...aba-cai");
+    });
+
+    it("should render canister id as title", async () => {
+      const canisterName = "canister name";
+      jest.spyOn(canisterApi, "queryCanisters").mockResolvedValue([
+        {
+          canister_id: canisterId,
+          name: canisterName,
+        },
+      ]);
+      const po = await renderComponent();
+      expect(await po.getTitle()).toBe(canisterName);
     });
   });
 

--- a/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/CanisterDetail.spec.ts
@@ -17,6 +17,7 @@ import { CanisterDetailPo } from "$tests/page-objects/CanisterDetail.page-object
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { Principal } from "@dfinity/principal";
 import { render } from "@testing-library/svelte";
 
 jest.mock("$lib/api/canisters.api");
@@ -162,14 +163,15 @@ describe("CanisterDetail", () => {
     });
 
     it("should render canister id as title if canister has no name", async () => {
+      const canisterIdText = "ryjl3-tyaaa-aaaaa-aaaba-cai";
       jest.spyOn(canisterApi, "queryCanisters").mockResolvedValue([
         {
-          canister_id: canisterId,
+          canister_id: Principal.fromText(canisterIdText),
           name: "",
         },
       ]);
       const po = await renderComponent();
-      expect(await po.getTitle()).toBe("ryjl3-t...aba-cai");
+      expect(await po.getTitle()).toBe(canisterIdText);
     });
 
     it("should render canister id as title", async () => {


### PR DESCRIPTION
# Motivation

The title "Balance unavailable" was not very user friendly when the user was not the controller.

Instead, the title will be now the canister name or the id when the user is not the controller. In that case, there is no need for the subtitle.

# Changes

* Change the title in CanisterHeadingTitle when the user is not the controller. To access the name, I added the prop `canister`.
* Pass the `canister` prop to CanisterHeadingTitle in CanisterPageHeading.
* Add the logic of not the controller to render the PageHeading without title in CanisterPageHeading.
* Remove the `balance_unavailable` i18n key.

# Tests

* Change and add test cases for new functionality in CanisterHeadingTItle.spec
* Change and add test cases for new functionality in CanisterPageHeading.spec
* Change and add test cases for new functionality in CanisterDetail.spec

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary. Covered by the entry that there is a new canister header.
