### PR TITLE
Chore: Disable NNS proposal args

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -220,9 +220,9 @@ jobs:
         run: sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
       - name: Install dfx
         run: DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
-      # TODO: Fix so that it doesn't rely on mainnet?
-      # - name: Test getting proposal args
-      #   run: scripts/dfx-nns-proposal-args.test
+        # TODO: Fix so that it doesn't rely on mainnet?
+        # - name: Test getting proposal args
+        #   run: scripts/dfx-nns-proposal-args.test
   docker-build-cli-flags:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Test chunking
         run: scripts/nns-dapp/split-assets.test
   dfx-nns-proposal-args-works:
-    # TODO: Reenable once fixed
+    # TODO: Reenable (add it in line 338) once fixed, should it depend on mainnet?
     if: false
     name: Can get NNS proposal args
     runs-on: ubuntu-20.04
@@ -335,7 +335,7 @@ jobs:
       - run: scripts/past-changelog-test
       - run: scripts/past-changelog-test.test
   checks-pass:
-    needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "dfx-nns-proposal-args-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "split-changelog", "past-changelog", "minor-version-bump-works"]
+    needs: ["formatting", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "split-changelog", "past-changelog", "minor-version-bump-works"]
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -200,6 +200,8 @@ jobs:
       - name: Test chunking
         run: scripts/nns-dapp/split-assets.test
   dfx-nns-proposal-args-works:
+    # TODO: Reenable once fixed
+    if: false
     name: Can get NNS proposal args
     runs-on: ubuntu-20.04
     steps:
@@ -220,9 +222,8 @@ jobs:
         run: sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
       - name: Install dfx
         run: DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
-        # TODO: Fix so that it doesn't rely on mainnet?
-        # - name: Test getting proposal args
-        #   run: scripts/dfx-nns-proposal-args.test
+      - name: Test getting proposal args
+        run: scripts/dfx-nns-proposal-args.test
   docker-build-cli-flags:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -220,8 +220,9 @@ jobs:
         run: sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
       - name: Install dfx
         run: DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
-      - name: Test getting proposal args
-        run: scripts/dfx-nns-proposal-args.test
+      # TODO: Fix so that it doesn't rely on mainnet?
+      # - name: Test getting proposal args
+      #   run: scripts/dfx-nns-proposal-args.test
   docker-build-cli-flags:
     runs-on: ubuntu-20.04
     steps:

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -62,6 +62,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Deprecated
 #### Removed
 
+* Comment and skip dfx-nns-proposal-args.test.
+
 #### Fixed
 
 #### Security


### PR DESCRIPTION
# Motivation

`scripts/dfx-nns-proposal-args.test` is failing.

Disable until we fix it.

# Changes

* Comment the lines in the workflow that run the script.

# Tests

Tests should be now green.

# Todos

- [x] Add entry to changelog (if necessary).
