### PR TITLE
Bump ic-js v1.0.0-next

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -749,9 +749,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "0.0.12-next-2023-09-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.12-next-2023-09-28.tgz",
-      "integrity": "sha512-jaJuu5qHy2Ca0g6tQHey2D2LqhMlUnkvi7Pzqd77vxLldrHeJMGgQYhhEbnPYgNkB5dGSM9qB8BiwZ3htQYfcQ==",
+      "version": "1.0.0-next-2023-10-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.0-next-2023-10-02.1.tgz",
+      "integrity": "sha512-+KUkxRfhgei9whqG7whs98k/KTqn22XwowW8YryiO7uaA13/iDHOm+dF4U3DXhN5ehr2GQUw/ufNWqwut6E9OA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -765,9 +765,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "0.0.19-next-2023-09-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.19-next-2023-09-28.tgz",
-      "integrity": "sha512-A7cFQI8DHZzOzSja1eeBs7LQknI67KNztk3D+wBsV2grTWh4xd9Inn8gb6zkpOWBfb5lOU03fbqwczdEcMRdaA==",
+      "version": "1.0.0-next-2023-10-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-02.1.tgz",
+      "integrity": "sha512-nPsqrzdpnw/GU5bZUs/louGZlV2gcS1HsNQTepJtzxc9XRNJZFIhrw8AnA8azN/s5V4Q25SsurH9PvYbhYljJw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -790,9 +790,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "0.0.9-next-2023-09-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.9-next-2023-09-28.tgz",
-      "integrity": "sha512-G+n/Lwlc9e6wLDtmfMT1nnhGeB1jAELFKBTLmxQZUSY++F9p14KuSXWv0/QttpkWNH11JdFbKjtnAQTQI0OdEw==",
+      "version": "1.0.0-next-2023-10-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-02.1.tgz",
+      "integrity": "sha512-7UvkxAtroXV86JJO7LxV1uSpYd6BShq/h14EFVD4mQd5ymIFoajzF8wXs4hFnOqHCQm64r4HB0hXjrDcwDp6kQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/@dfinity/ledger": {
-      "version": "0.0.16-next-2023-09-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.16-next-2023-09-28.tgz",
-      "integrity": "sha512-UjzxamoUo1UBe/0/PPyIe29pjpd2KRRuCHWPrTkyTqMeN3huaPbSM4WYfWnVIT5FXvRrmR9zjB5EbUJv0sH4Iw==",
+      "version": "1.0.0-next-2023-10-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-1.0.0-next-2023-10-02.1.tgz",
+      "integrity": "sha512-L+YouK2HH1lT0eMmqCM6DS8zEhg3U8oOsIWewnRg2n2c16JjkydMRWZJb+iB7dFL4aqeB90T5nvzpZqgNtNUdQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -827,9 +827,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "0.16.8-next-2023-09-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.8-next-2023-09-28.tgz",
-      "integrity": "sha512-SivRlq8/zxN5nU+xdnI+j2+nzs/tQXbfWsdEbwmwwbcu7nERU2FMWPE6ee1ie05aSLqFuGE2sZK2RiGuR6mJDA==",
+      "version": "1.0.0-next-2023-10-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-1.0.0-next-2023-10-02.1.tgz",
+      "integrity": "sha512-9CHSQRsPA96X3rSsOObJfkmmsc0UHaqeOqN3ULAtBvy2GuPMLGn1lWxhaO9PxsYpry2we6U1/szcrevhxbVztw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -843,9 +843,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "0.0.9-next-2023-09-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.9-next-2023-09-28.tgz",
-      "integrity": "sha512-4F59pMIL8zPrHLBwf+TDiFgWBgVehxHffo1xpXR6prDRlhvFCpjZbjSgUtPqlXvK6PItRJtNXakbdz7x0SJtWQ==",
+      "version": "1.0.0-next-2023-10-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-02.1.tgz",
+      "integrity": "sha512-QaSlHHPlzaflN8zwfjeVIbR+wjV8FdIKgdBdU+x7EFMjNilveAdd3tS8zOJjGy/eCUROMBNTV26Aa04a5mY9Xg==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -859,9 +859,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "0.0.23-next-2023-09-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.23-next-2023-09-28.tgz",
-      "integrity": "sha512-3FdhXY/Vsc6zHrzaE+DJp2cFq3czmJwqwv5+C+q6GFbzebxvCb6YykuTE24z+mvBjRL6Rot0qs5rmtKj4n9OKA==",
+      "version": "1.0.0-next-2023-10-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.0-next-2023-10-02.1.tgz",
+      "integrity": "sha512-idCIIQlhvrGvVTUpEZymdqErkfvkLvHxo1Wu3jZ5TnyiuK0BFwtmxJOJx2y1pOdCnBkMGxnZiCVPBlxpqV2knQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -874,9 +874,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.23-next-2023-09-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.23-next-2023-09-28.tgz",
-      "integrity": "sha512-k443ORC/Equy9dXCJGmDD+JO3hb92XWGSG6l1LIhqEF1TUr+NVRG9ed9dtxJeNK0GJ1twzv0WnszjIqPv8xr4A==",
+      "version": "1.0.0-next-2023-10-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-02.1.tgz",
+      "integrity": "sha512-pcsZKDz1ZChXUk60yr5U6yF5FU6KgXdzja99hy/pM/7eVtp8YArXkwWMe5CJEXG0zC855d6mL3teKy5xPwfJ5Q==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -10052,9 +10052,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "0.0.12-next-2023-09-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-0.0.12-next-2023-09-28.tgz",
-      "integrity": "sha512-jaJuu5qHy2Ca0g6tQHey2D2LqhMlUnkvi7Pzqd77vxLldrHeJMGgQYhhEbnPYgNkB5dGSM9qB8BiwZ3htQYfcQ==",
+      "version": "1.0.0-next-2023-10-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.0-next-2023-10-02.1.tgz",
+      "integrity": "sha512-+KUkxRfhgei9whqG7whs98k/KTqn22XwowW8YryiO7uaA13/iDHOm+dF4U3DXhN5ehr2GQUw/ufNWqwut6E9OA==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -10062,9 +10062,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "0.0.19-next-2023-09-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-0.0.19-next-2023-09-28.tgz",
-      "integrity": "sha512-A7cFQI8DHZzOzSja1eeBs7LQknI67KNztk3D+wBsV2grTWh4xd9Inn8gb6zkpOWBfb5lOU03fbqwczdEcMRdaA==",
+      "version": "1.0.0-next-2023-10-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-02.1.tgz",
+      "integrity": "sha512-nPsqrzdpnw/GU5bZUs/louGZlV2gcS1HsNQTepJtzxc9XRNJZFIhrw8AnA8azN/s5V4Q25SsurH9PvYbhYljJw==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -10078,9 +10078,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "0.0.9-next-2023-09-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-0.0.9-next-2023-09-28.tgz",
-      "integrity": "sha512-G+n/Lwlc9e6wLDtmfMT1nnhGeB1jAELFKBTLmxQZUSY++F9p14KuSXWv0/QttpkWNH11JdFbKjtnAQTQI0OdEw==",
+      "version": "1.0.0-next-2023-10-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-02.1.tgz",
+      "integrity": "sha512-7UvkxAtroXV86JJO7LxV1uSpYd6BShq/h14EFVD4mQd5ymIFoajzF8wXs4hFnOqHCQm64r4HB0hXjrDcwDp6kQ==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -10094,24 +10094,24 @@
       }
     },
     "@dfinity/ledger": {
-      "version": "0.0.16-next-2023-09-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-0.0.16-next-2023-09-28.tgz",
-      "integrity": "sha512-UjzxamoUo1UBe/0/PPyIe29pjpd2KRRuCHWPrTkyTqMeN3huaPbSM4WYfWnVIT5FXvRrmR9zjB5EbUJv0sH4Iw==",
+      "version": "1.0.0-next-2023-10-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger/-/ledger-1.0.0-next-2023-10-02.1.tgz",
+      "integrity": "sha512-L+YouK2HH1lT0eMmqCM6DS8zEhg3U8oOsIWewnRg2n2c16JjkydMRWZJb+iB7dFL4aqeB90T5nvzpZqgNtNUdQ==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "0.16.8-next-2023-09-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-0.16.8-next-2023-09-28.tgz",
-      "integrity": "sha512-SivRlq8/zxN5nU+xdnI+j2+nzs/tQXbfWsdEbwmwwbcu7nERU2FMWPE6ee1ie05aSLqFuGE2sZK2RiGuR6mJDA==",
+      "version": "1.0.0-next-2023-10-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-1.0.0-next-2023-10-02.1.tgz",
+      "integrity": "sha512-9CHSQRsPA96X3rSsOObJfkmmsc0UHaqeOqN3ULAtBvy2GuPMLGn1lWxhaO9PxsYpry2we6U1/szcrevhxbVztw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "0.0.9-next-2023-09-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-0.0.9-next-2023-09-28.tgz",
-      "integrity": "sha512-4F59pMIL8zPrHLBwf+TDiFgWBgVehxHffo1xpXR6prDRlhvFCpjZbjSgUtPqlXvK6PItRJtNXakbdz7x0SJtWQ==",
+      "version": "1.0.0-next-2023-10-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-02.1.tgz",
+      "integrity": "sha512-QaSlHHPlzaflN8zwfjeVIbR+wjV8FdIKgdBdU+x7EFMjNilveAdd3tS8zOJjGy/eCUROMBNTV26Aa04a5mY9Xg==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -10125,17 +10125,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "0.0.23-next-2023-09-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-0.0.23-next-2023-09-28.tgz",
-      "integrity": "sha512-3FdhXY/Vsc6zHrzaE+DJp2cFq3czmJwqwv5+C+q6GFbzebxvCb6YykuTE24z+mvBjRL6Rot0qs5rmtKj4n9OKA==",
+      "version": "1.0.0-next-2023-10-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.0-next-2023-10-02.1.tgz",
+      "integrity": "sha512-idCIIQlhvrGvVTUpEZymdqErkfvkLvHxo1Wu3jZ5TnyiuK0BFwtmxJOJx2y1pOdCnBkMGxnZiCVPBlxpqV2knQ==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.23-next-2023-09-28",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.23-next-2023-09-28.tgz",
-      "integrity": "sha512-k443ORC/Equy9dXCJGmDD+JO3hb92XWGSG6l1LIhqEF1TUr+NVRG9ed9dtxJeNK0GJ1twzv0WnszjIqPv8xr4A==",
+      "version": "1.0.0-next-2023-10-02.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-02.1.tgz",
+      "integrity": "sha512-pcsZKDz1ZChXUk60yr5U6yF5FU6KgXdzja99hy/pM/7eVtp8YArXkwWMe5CJEXG0zC855d6mL3teKy5xPwfJ5Q==",
       "requires": {}
     },
     "@esbuild/android-arm": {


### PR DESCRIPTION
# Motivation

We have release v1.0.0 of all ic-js libs (see [release notes](https://github.com/dfinity/ic-js/releases/tag/v1.0.0)). This PR bump the next versions accordingly.
