### PR TITLE
Use clap in did2rs

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -40,6 +40,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Changed
 
+* Use `clap` argument parsing in `did2rs`.
 * Populate the PR description of the `didc` updater.
 * Update the `snsdemo` test environment, `dfx` and the IC commit of the NNS canisters.
 * Update the snsdemo commit & automate further updates.

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -32,18 +32,21 @@ print_help() {
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/clap.bash"
 # Define options
+clap.define short=c long=canister desc="The canister name" variable=CANISTER_NAME
+clap.define short=d long=did desc="The did path.  Default: {GIT_ROOT}/declarations/{CANISTER_NAME}/{CANISTER_NAME}.did" variable=DID_PATH
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
 ##########################
 # Get working dir and args
 ##########################
-CANISTER_NAME="$(basename "${1%.did}")"
+CANISTER_NAME="${CANISTER_NAME:-${1:-${DID_PATH:-}}}"
+CANISTER_NAME="$(basename "${CANISTER_NAME%.did}")"
 GIT_ROOT="$(git rev-parse --show-toplevel)"
 
 RUST_PATH="${GIT_ROOT}/rs/sns_aggregator/src/types/ic_${CANISTER_NAME}.rs"
 PATCH_PATH="${GIT_ROOT}/rs/sns_aggregator/src/types/ic_${CANISTER_NAME}.patch"
-DID_PATH="${GIT_ROOT}/declarations/${CANISTER_NAME}/${CANISTER_NAME}.did"
+DID_PATH="${DID_PATH:-${GIT_ROOT}/declarations/${CANISTER_NAME}/${CANISTER_NAME}.did}"
 
 cd "$GIT_ROOT"
 

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
 
 ##########################
 # Hjelpe meg!
@@ -26,10 +28,12 @@ print_help() {
 
 	EOF
 }
-[[ "${1:-}" != "--help" ]] || {
-  print_help
-  exit 0
-}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
 
 ##########################
 # Get working dir and args


### PR DESCRIPTION
# Motivation
`did2rs` currently hand-parses command line arguments.  With `clap` this parsing can be standardized.

# Changes
- Add the `clap` CLI parser to `did2rs`
- Add a flag to specify the canister name, but support the former positional argument as well.
- Add a flag to override the default location of the `.did` file.

# Tests
See CI - usage should work exactly as before.

# Todos

- [x] Add entry to changelog (if necessary).
