### PR TITLE
GIX-1922: Undo CommitmentProgressBar split commitments

### DIFF
--- a/frontend/src/lib/components/project-detail/CommitmentProgressBar.svelte
+++ b/frontend/src/lib/components/project-detail/CommitmentProgressBar.svelte
@@ -2,14 +2,10 @@
   import { TokenAmount, ICPToken } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
-  import {
-    ProgressBar,
-    type ProgressBarSegment,
-  } from "@dfinity/gix-components";
+  import { ProgressBar } from "@dfinity/gix-components";
 
   export let max: bigint;
-  export let directParticipation: bigint;
-  export let nfParticipation: bigint;
+  export let participationE8s: bigint;
   export let minimumIndicator: bigint | undefined = undefined;
 
   let width: number | undefined;
@@ -18,20 +14,12 @@
     minimumIndicator !== undefined && width !== undefined
       ? (Number(minimumIndicator) / Number(max)) * width
       : undefined;
-
-  let segments: ProgressBarSegment[] = [];
-  $: segments = [
-    { value: Number(nfParticipation), color: "var(--positive-emphasis)" },
-    {
-      value: Number(directParticipation),
-      color: "var(--warning-emphasis)",
-    },
-  ];
 </script>
 
 <ProgressBar
   max={Number(max)}
-  {segments}
+  value={Number(participationE8s)}
+  color="warning"
   testId="commitment-progress-bar-component"
 >
   <div class="info" slot="top">

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -74,22 +74,8 @@
     <AmountDisplay slot="value" amount={buyersTotalCommitmentIcp} singleLine />
   </KeyValuePair>
   {#if "nfCommitmentE8s" in projectCommitments && projectCommitments.nfCommitmentE8s > 0n}
-    <KeyValuePair testId="sns-project-current-nf-commitment">
-      <span slot="key" class="detail-data">
-        {$i18n.sns_project_detail.current_nf_commitment}
-      </span>
-
-      <AmountDisplay
-        slot="value"
-        amount={TokenAmount.fromE8s({
-          amount: projectCommitments.nfCommitmentE8s,
-          token: ICPToken,
-        })}
-        singleLine
-      />
-    </KeyValuePair>
     <KeyValuePair testId="sns-project-current-direct-commitment">
-      <span slot="key" class="detail-data">
+      <span slot="key">
         {$i18n.sns_project_detail.current_direct_commitment}
       </span>
 
@@ -104,27 +90,32 @@
     </KeyValuePair>
     <div data-tid="sns-project-commitment-progress">
       <CommitmentProgressBar
-        directParticipation={projectCommitments.directCommitmentE8s}
-        nfParticipation={projectCommitments.nfCommitmentE8s}
+        participationE8s={projectCommitments.directCommitmentE8s}
         max={max_icp_e8s}
         minimumIndicator={min_icp_e8s}
       />
     </div>
+    <KeyValuePair testId="sns-project-current-nf-commitment">
+      <span slot="key">
+        {$i18n.sns_project_detail.current_nf_commitment}
+      </span>
+
+      <AmountDisplay
+        slot="value"
+        amount={TokenAmount.fromE8s({
+          amount: projectCommitments.nfCommitmentE8s,
+          token: ICPToken,
+        })}
+        singleLine
+      />
+    </KeyValuePair>
   {:else}
-    <!-- We show the progress bar with only directParticipation if NF participation is not present -->
     <div data-tid="sns-project-commitment-progress">
       <CommitmentProgressBar
-        directParticipation={projectCommitments.totalCommitmentE8s}
-        nfParticipation={0n}
+        participationE8s={projectCommitments.totalCommitmentE8s}
         max={max_icp_e8s}
         minimumIndicator={min_icp_e8s}
       />
     </div>
   {/if}
 </TestIdWrapper>
-
-<style lang="scss">
-  .detail-data {
-    padding-left: var(--padding-2x);
-  }
-</style>

--- a/frontend/src/tests/lib/components/project-detail/CommitmentProgressBar.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/CommitmentProgressBar.spec.ts
@@ -9,15 +9,13 @@ import { render } from "@testing-library/svelte";
 
 describe("CommitmentProgressBar", () => {
   const props = {
-    directParticipation: 1500n,
-    nfParticipation: 0n,
+    participationE8s: 1500n,
     max: BigInt(3000),
     minimumIndicator: BigInt(1500),
   };
 
   const renderComponent = (props: {
-    directParticipation: bigint;
-    nfParticipation: bigint;
+    participationE8s: bigint;
     max: bigint;
     minimumIndicator?: bigint;
   }) => {
@@ -28,19 +26,9 @@ describe("CommitmentProgressBar", () => {
   it("should render direct participation value in progress bar if no NF participation", async () => {
     const po = renderComponent({
       ...props,
-      directParticipation: 150_000_000n,
-      nfParticipation: 0n,
+      participationE8s: 150_000_000n,
     });
-    expect(await po.getTotalCommitmentE8s()).toBe(150000000n);
-  });
-
-  it("should render sume of direct and NF participation value in progress bar", async () => {
-    const po = renderComponent({
-      ...props,
-      directParticipation: 300_000_000n,
-      nfParticipation: 150_000_000n,
-    });
-    expect(await po.getTotalCommitmentE8s()).toBe(450000000n);
+    expect(await po.getCommitmentE8s()).toBe(150000000n);
   });
 
   it("should display maximum and minimum indicators", async () => {
@@ -51,8 +39,7 @@ describe("CommitmentProgressBar", () => {
 
   it("should not display minimum indicators if not provided", async () => {
     const po = renderComponent({
-      directParticipation: props.directParticipation,
-      nfParticipation: props.nfParticipation,
+      participationE8s: props.participationE8s,
       max: props.max,
     });
     expect(await po.hasMinCommitmentIndicator()).toBe(false);
@@ -66,42 +53,5 @@ describe("CommitmentProgressBar", () => {
     });
     expect(await po.getMinCommitment()).toBe("1.50 ICP");
     expect(await po.getMaxCommitment()).toBe("30.00 ICP");
-  });
-
-  it("should display NF and direct commitments", async () => {
-    const nfParticipation = 500n;
-    const { container } = render(CommitmentProgressBar, {
-      props: {
-        ...props,
-        nfParticipation,
-      },
-    });
-    expect(container.querySelector("progress").value).toBe(
-      Number(props.directParticipation + nfParticipation)
-    );
-    expect(container.querySelector("progress").style.cssText).toBe(
-      "--progress-bar-background: linear-gradient(to right, var(--positive-emphasis) 0% 25%, var(--warning-emphasis) 25% 100%);"
-    );
-  });
-
-  it("should display only direct commitment if no NF commitment", async () => {
-    const po = renderComponent({
-      ...props,
-      directParticipation: 300_000_000n,
-      nfParticipation: 0n,
-    });
-    expect(await po.getNFCommitmentE8s()).toEqual(0n);
-    expect(await po.getDirectCommitmentE8s()).toEqual(300_000_000n);
-    expect(await po.getTotalCommitmentE8s()).toEqual(300_000_000n);
-  });
-
-  it("should display NF and direct commitments", async () => {
-    const po = renderComponent({
-      ...props,
-      directParticipation: 300_000_000n,
-      nfParticipation: 100_000_000n,
-    });
-    expect(await po.getNFCommitmentE8s()).toEqual(100_000_000n);
-    expect(await po.getDirectCommitmentE8s()).toEqual(300_000_000n);
   });
 });

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -91,25 +91,22 @@ describe("ProjectCommitment", () => {
     expect(po.getCurrentTotalCommitment()).resolves.toEqual("500.00 ICP");
   });
 
-  it("should render a progress bar with total participation adding NF and direct commitments", async () => {
-    const directCommitment = 20000000000n;
-    const nfCommitment = 10000000000n;
+  it("should render a progress bar with overall participation if NF is not available", async () => {
+    const overallCommitment = 30000000000n;
     // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
     jest
       .spyOn(summaryGetters, "getNeuronsFundParticipation")
-      .mockImplementation(() => nfCommitment);
+      .mockImplementation(() => undefined);
 
     const summary = createSummary({
-      currentTotalCommitment: directCommitment + nfCommitment,
+      currentTotalCommitment: overallCommitment,
     });
     const po = renderComponent(summary);
     const progressBarPo = po.getCommitmentProgressBarPo();
-    expect(await progressBarPo.getTotalCommitmentE8s()).toBe(
-      directCommitment + nfCommitment
-    );
+    expect(await progressBarPo.getCommitmentE8s()).toBe(overallCommitment);
   });
 
-  it("should render a progress bar with different participations", async () => {
+  it("should render a progress bar with direct participation if NF is available", async () => {
     const directCommitment = 30000000000n;
     const nfCommitment = 10000000000n;
     // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
@@ -122,8 +119,7 @@ describe("ProjectCommitment", () => {
     });
     const po = renderComponent(summary);
     const progressBarPo = po.getCommitmentProgressBarPo();
-    expect(await progressBarPo.getNFCommitmentE8s()).toBe(nfCommitment);
-    expect(await progressBarPo.getDirectCommitmentE8s()).toBe(directCommitment);
+    expect(await progressBarPo.getCommitmentE8s()).toBe(directCommitment);
   });
 
   it("should not render detailed participation if neurons fund participation is not available", async () => {

--- a/frontend/src/tests/page-objects/CommitmentProgressBarPo.page-object.ts
+++ b/frontend/src/tests/page-objects/CommitmentProgressBarPo.page-object.ts
@@ -26,49 +26,11 @@ export class CommitmentProgressBarPo extends BasePageObject {
     return (await this.getText("commitment-max-indicator-value")).trim();
   }
 
-  async getTotalCommitmentE8s(): Promise<bigint> {
+  async getCommitmentE8s(): Promise<bigint> {
     // The `value` property has the value of the max value but the `value` attribute has the value of the progress.
     const valueString = await this.root
       .querySelector("progress")
       .getAttribute("value");
     return BigInt(valueString);
-  }
-
-  /**
-   * Uses the slices of the linear gradient to determine the segments of the progress bar.
-   *
-   * Example of inline-style: "--progress-bar-background: linear-gradient(to right, var(--positive-emphasis) 0% 25%, var(--warning-emphasis) 25% 100%);"
-   */
-  async getNFCommitmentE8s(): Promise<bigint> {
-    const inlineStyleRegex =
-      /--progress-bar-background: linear-gradient\(to right, var\(.*\) 0% (\d+(?:\.\d+)?)%, var\(.*\) (\d+(?:\.\d+)?)% 100%\);/g;
-
-    const inlineStyle = await this.root
-      .querySelector("progress")
-      .getAttribute("style");
-
-    const matches = inlineStyleRegex.exec(inlineStyle);
-
-    if (matches === null) {
-      throw new Error(`Invalid inline style: ${inlineStyle}`);
-    }
-
-    const [_inlineStyle, firstPercentage, secondPercentage] = matches;
-
-    if (firstPercentage !== secondPercentage) {
-      throw new Error(
-        `The first and second percentage should be the same: ${firstPercentage} !== ${secondPercentage}`
-      );
-    }
-
-    const totalCommitment = Number(await this.getTotalCommitmentE8s());
-    const nfPercentage = Number(firstPercentage);
-
-    return BigInt(Math.round((totalCommitment * nfPercentage) / 100));
-  }
-
-  async getDirectCommitmentE8s(): Promise<bigint> {
-    const totalCommitment = await this.getTotalCommitmentE8s();
-    return BigInt(totalCommitment - (await this.getNFCommitmentE8s()));
   }
 }


### PR DESCRIPTION
# Motivation

The new participation UI doesn't show a progress bar with commitments of NF and direct as different colors. Instead, if shows only the direct participation only.

In this PR, I remove the props, logic and tests that allow the CommitmentProgressBar to show multiple commitments.

I have also adapted the commitment when NF is present, to show only the direct participation. Yet, the UI still needs some changes that will be done in another PR.

# Changes

* Change props `directParticipation` and `nfParticipation` for `participationE8s` in CommitmentProgressBar. Adapt logic inside.
* In ProjectCommitment, use the overall commitment or the direct commitment for the CommitmentProgressBar. I also moved the label and value of the NF commitment after the progress bar. Even though this UI is not available, I didn't want it to be in a confusing state. I also removed the left spacing of the labels for direct and NF commitments.

# Tests

* Fix, change and remove tests in ProjectCommitment.
* Fix, change and remove tests in CommitmentProgressBar.
* Rename and remove unncessary methods from CommitmentProgressBarPo.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet necessary.