### PR TITLE
Chore: Add test when second page of agg is empty

### DIFF
--- a/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
@@ -51,6 +51,33 @@ describe("sns-aggregator api", () => {
       expect(projects).toHaveLength(11);
     });
 
+    it("should work even when second page is empty", async () => {
+      const mockFetch = jest.fn();
+      mockFetch
+        .mockReturnValueOnce(
+          Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(tenAggregatedSnses),
+          })
+        )
+        .mockReturnValueOnce(
+          Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve([]),
+          })
+        );
+      global.fetch = mockFetch;
+      const projects = await querySnsProjects();
+      expect(mockFetch).toHaveBeenCalledWith(
+        `https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/list/page/0/slow.json`
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        `https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/list/page/1/slow.json`
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(projects).toHaveLength(10);
+    });
+
     it("should not fail if second page response is not ok", async () => {
       jest.spyOn(console, "error").mockImplementation(() => undefined);
       const mockFetch = jest.fn();


### PR DESCRIPTION
# Motivation

Increase test coverage of SNS aggregator api.

In this PR, check that when a page returns empty, the api function still works as expected.

# Changes

* Add one test case to sns-aggregator.api.spec.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary