### PR TITLE
GIX-1922: New UI for participation

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -41,6 +41,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Not Published
 
+* New UI to better explain the commitment of Neurons' Fund and direct participation.
+
 ### Operations
 
 #### Added

--- a/frontend/src/lib/components/project-detail/CommitmentProgressBar.svelte
+++ b/frontend/src/lib/components/project-detail/CommitmentProgressBar.svelte
@@ -7,6 +7,7 @@
   export let max: bigint;
   export let participationE8s: bigint;
   export let minimumIndicator: bigint | undefined = undefined;
+  export let color: "warning" | "primary";
 
   let width: number | undefined;
   let minIndicatorPosition: number | undefined;
@@ -19,7 +20,7 @@
 <ProgressBar
   max={Number(max)}
   value={Number(participationE8s)}
-  color="warning"
+  {color}
   testId="commitment-progress-bar-component"
 >
   <div class="info" bind:clientWidth={width} slot="bottom">

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -89,8 +89,8 @@
     <div data-tid="sns-project-commitment-progress">
       <CommitmentProgressBar
         participationE8s={projectCommitments.directCommitmentE8s}
-        max={projectCommitments.maximumDirectCommitmentE8s}
-        minimumIndicator={projectCommitments.minimumDirectCommitmentE8s}
+        max={projectCommitments.maxDirectCommitmentE8s}
+        minimumIndicator={projectCommitments.minDirectCommitmentE8s}
         color="primary"
       />
     </div>
@@ -98,9 +98,9 @@
     <!-- The spacing between component is set using flex in the parent. -->
     <div>
       <KeyValuePairInfo testId="sns-project-current-nf-commitment">
-        <span slot="key">
+        <svelte:fragment slot="key">
           {$i18n.sns_project_detail.current_nf_commitment}
-        </span>
+        </svelte:fragment>
 
         <div slot="info" class="description">
           <Html
@@ -143,11 +143,11 @@
     display: flex;
     align-items: center;
     gap: var(--padding-0_5x);
+
     // This is the dot with the participation color next to the label
     &::before {
       content: "";
       display: block;
-      width: var(--padding);
       height: var(--padding);
       background: var(--primary);
       border-radius: var(--padding);

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -148,8 +148,10 @@
     &::before {
       content: "";
       display: block;
+
       height: var(--padding);
-      background: var(--primary);
+      width: var(--padding);
+
       border-radius: var(--padding);
       background: var(--primary);
     }

--- a/frontend/src/lib/getters/sns-summary.ts
+++ b/frontend/src/lib/getters/sns-summary.ts
@@ -15,3 +15,13 @@ export const getConditionsToAccept = (
 export const getNeuronsFundParticipation = (
   _summary: SnsSummary
 ): bigint | undefined => undefined;
+
+// TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+export const getMiniumDirectParticipation = (
+  _summary: SnsSummary
+): bigint | undefined => undefined;
+
+// TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+export const getMaximunDirectParticipation = (
+  _summary: SnsSummary
+): bigint | undefined => undefined;

--- a/frontend/src/lib/getters/sns-summary.ts
+++ b/frontend/src/lib/getters/sns-summary.ts
@@ -17,11 +17,11 @@ export const getNeuronsFundParticipation = (
 ): bigint | undefined => undefined;
 
 // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-export const getMiniumDirectParticipation = (
+export const getMinDirectParticipation = (
   _summary: SnsSummary
 ): bigint | undefined => undefined;
 
 // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-export const getMaximunDirectParticipation = (
+export const getMaxDirectParticipation = (
   _summary: SnsSummary
 ): bigint | undefined => undefined;

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -731,6 +731,7 @@
     "max_user_commitment_reached": "Maximum commitment reached",
     "not_eligible_to_participate": "You are not eligible to participate in this swap.",
     "getting_sns_open_ticket": "We're connecting with the SNS swap. This might take more than a minute.",
+    "current_nf_commitment_description": "The NF commitment increases based on direct participation. <a href=\"https://internetcomputer.org/docs/current/tokenomics/nns/neurons-fund\" rel=\"noopener noreferrer\" aria-label=\"more info about neurons' fund\" target=\"_blank\">Learn more</a>.",
     "sign_in": "Sign in to participate"
   },
   "sns_sale": {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -756,6 +756,7 @@ interface I18nSns_project_detail {
   max_user_commitment_reached: string;
   not_eligible_to_participate: string;
   getting_sns_open_ticket: string;
+  current_nf_commitment_description: string;
   sign_in: string;
 }
 

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -2,8 +2,8 @@ import { NOT_LOADED } from "$lib/constants/stores.constants";
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
 import {
   getDeniedCountries,
-  getMaximunDirectParticipation,
-  getMiniumDirectParticipation,
+  getMaxDirectParticipation,
+  getMinDirectParticipation,
   getNeuronsFundParticipation,
 } from "$lib/getters/sns-summary";
 import type { Country } from "$lib/types/location";
@@ -409,8 +409,8 @@ export type FullProjectCommitmentSplit = {
   totalCommitmentE8s: bigint;
   directCommitmentE8s: bigint;
   nfCommitmentE8s: bigint;
-  minimumDirectCommitmentE8s: bigint;
-  maximumDirectCommitmentE8s: bigint;
+  minDirectCommitmentE8s: bigint;
+  maxDirectCommitmentE8s: bigint;
 };
 export type ProjectCommitmentSplit =
   | { totalCommitmentE8s: bigint }
@@ -420,20 +420,20 @@ export const getProjectCommitmentSplit = (
   summary: SnsSummary
 ): ProjectCommitmentSplit => {
   const nfCommitmentE8s = getNeuronsFundParticipation(summary);
-  const minimumDirectCommitmentE8s = getMiniumDirectParticipation(summary);
-  const maximumDirectCommitmentE8s = getMaximunDirectParticipation(summary);
+  const minDirectCommitmentE8s = getMinDirectParticipation(summary);
+  const maxDirectCommitmentE8s = getMaxDirectParticipation(summary);
   if (
     nonNullish(nfCommitmentE8s) &&
-    nonNullish(minimumDirectCommitmentE8s) &&
-    nonNullish(maximumDirectCommitmentE8s)
+    nonNullish(minDirectCommitmentE8s) &&
+    nonNullish(maxDirectCommitmentE8s)
   ) {
     return {
       totalCommitmentE8s: summary.derived.buyer_total_icp_e8s,
       directCommitmentE8s:
         summary.derived.buyer_total_icp_e8s - nfCommitmentE8s,
       nfCommitmentE8s,
-      minimumDirectCommitmentE8s,
-      maximumDirectCommitmentE8s,
+      minDirectCommitmentE8s,
+      maxDirectCommitmentE8s,
     };
   }
   return {

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -2,6 +2,8 @@ import { NOT_LOADED } from "$lib/constants/stores.constants";
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
 import {
   getDeniedCountries,
+  getMaximunDirectParticipation,
+  getMiniumDirectParticipation,
   getNeuronsFundParticipation,
 } from "$lib/getters/sns-summary";
 import type { Country } from "$lib/types/location";
@@ -407,6 +409,8 @@ export type FullProjectCommitmentSplit = {
   totalCommitmentE8s: bigint;
   directCommitmentE8s: bigint;
   nfCommitmentE8s: bigint;
+  minimumDirectCommitmentE8s: bigint;
+  maximumDirectCommitmentE8s: bigint;
 };
 export type ProjectCommitmentSplit =
   | { totalCommitmentE8s: bigint }
@@ -416,15 +420,28 @@ export const getProjectCommitmentSplit = (
   summary: SnsSummary
 ): ProjectCommitmentSplit => {
   const nfCommitmentE8s = getNeuronsFundParticipation(summary);
-  if (nonNullish(nfCommitmentE8s)) {
+  const minimumDirectCommitmentE8s = getMiniumDirectParticipation(summary);
+  const maximumDirectCommitmentE8s = getMaximunDirectParticipation(summary);
+  if (
+    nonNullish(nfCommitmentE8s) &&
+    nonNullish(minimumDirectCommitmentE8s) &&
+    nonNullish(maximumDirectCommitmentE8s)
+  ) {
     return {
       totalCommitmentE8s: summary.derived.buyer_total_icp_e8s,
       directCommitmentE8s:
         summary.derived.buyer_total_icp_e8s - nfCommitmentE8s,
       nfCommitmentE8s,
+      minimumDirectCommitmentE8s,
+      maximumDirectCommitmentE8s,
     };
   }
   return {
     totalCommitmentE8s: summary.derived.buyer_total_icp_e8s,
   };
 };
+
+export const isCommitmentSplitWithNeuronsFund = (
+  commitmentSplit: ProjectCommitmentSplit
+): commitmentSplit is FullProjectCommitmentSplit =>
+  "nfCommitmentE8s" in commitmentSplit;

--- a/frontend/src/tests/lib/components/project-detail/CommitmentProgressBar.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/CommitmentProgressBar.spec.ts
@@ -8,16 +8,19 @@ import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 
 describe("CommitmentProgressBar", () => {
+  const color: "primary" | "warning" = "primary";
   const props = {
     participationE8s: 1500n,
     max: BigInt(3000),
     minimumIndicator: BigInt(1500),
+    color,
   };
 
   const renderComponent = (props: {
     participationE8s: bigint;
     max: bigint;
     minimumIndicator?: bigint;
+    color: "primary" | "warning";
   }) => {
     const { container } = render(CommitmentProgressBar, { props });
     return CommitmentProgressBarPo.under(new JestPageObjectElement(container));
@@ -36,10 +39,20 @@ describe("CommitmentProgressBar", () => {
     expect(await po.hasMinCommitmentIndicator()).toBe(true);
   });
 
+  it("should use the color prop", async () => {
+    const color1 = "warning";
+    const po = renderComponent({
+      ...props,
+      color: color1,
+    });
+    expect(await po.getColor()).toBe(color1);
+  });
+
   it("should not display minimum indicators if not provided", async () => {
     const po = renderComponent({
       participationE8s: props.participationE8s,
       max: props.max,
+      color,
     });
     expect(await po.hasMinCommitmentIndicator()).toBe(false);
   });

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -102,11 +102,11 @@ describe("ProjectCommitment", () => {
         .mockImplementation(() => nfCommitment);
       // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
       jest
-        .spyOn(summaryGetters, "getMiniumDirectParticipation")
+        .spyOn(summaryGetters, "getMinDirectParticipation")
         .mockImplementation(() => 10000000000n);
       // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
       jest
-        .spyOn(summaryGetters, "getMaximunDirectParticipation")
+        .spyOn(summaryGetters, "getMaxDirectParticipation")
         .mockImplementation(() => 100000000000n);
     });
 
@@ -136,11 +136,11 @@ describe("ProjectCommitment", () => {
         .mockImplementation(() => 0n);
       // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
       jest
-        .spyOn(summaryGetters, "getMiniumDirectParticipation")
+        .spyOn(summaryGetters, "getMinDirectParticipation")
         .mockImplementation(() => 10000000000n);
       // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
       jest
-        .spyOn(summaryGetters, "getMaximunDirectParticipation")
+        .spyOn(summaryGetters, "getMaxDirectParticipation")
         .mockImplementation(() => 100000000000n);
     });
 
@@ -167,11 +167,11 @@ describe("ProjectCommitment", () => {
         .mockImplementation(() => undefined);
       // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
       jest
-        .spyOn(summaryGetters, "getMiniumDirectParticipation")
+        .spyOn(summaryGetters, "getMinDirectParticipation")
         .mockImplementation(() => undefined);
       // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
       jest
-        .spyOn(summaryGetters, "getMaximunDirectParticipation")
+        .spyOn(summaryGetters, "getMaxDirectParticipation")
         .mockImplementation(() => undefined);
     });
 

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -9,7 +9,6 @@ import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
 import {
   createSummary,
   mockSnsFullProject,
-  summaryForLifecycle,
 } from "$tests/mocks/sns-projects.mock";
 import { renderContextCmp } from "$tests/mocks/sns.mock";
 import { ProjectCommitmentPo } from "$tests/page-objects/ProjectCommitment.page-object";
@@ -20,7 +19,6 @@ import { SnsSwapLifecycle } from "@dfinity/sns";
 jest.mock("$lib/getters/sns-summary.ts");
 
 describe("ProjectCommitment", () => {
-  const summary = summaryForLifecycle(SnsSwapLifecycle.Open);
   const saleBuyerCount = 1_000_000;
 
   const renderComponent = (
@@ -91,77 +89,108 @@ describe("ProjectCommitment", () => {
     expect(po.getCurrentTotalCommitment()).resolves.toEqual("500.00 ICP");
   });
 
-  it("should render a progress bar with overall participation if NF is not available", async () => {
-    const overallCommitment = 30000000000n;
-    // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
-    jest
-      .spyOn(summaryGetters, "getNeuronsFundParticipation")
-      .mockImplementation(() => undefined);
+  describe("when Neurons' Fund enhancements fields are available", () => {
+    const nfCommitment = 10000000000n;
+    const directCommitment = 30000000000n;
+    const summary = createSummary({
+      currentTotalCommitment: directCommitment + nfCommitment,
+    });
 
+    beforeEach(() => {
+      jest
+        .spyOn(summaryGetters, "getNeuronsFundParticipation")
+        .mockImplementation(() => nfCommitment);
+      // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+      jest
+        .spyOn(summaryGetters, "getMiniumDirectParticipation")
+        .mockImplementation(() => 10000000000n);
+      // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+      jest
+        .spyOn(summaryGetters, "getMaximunDirectParticipation")
+        .mockImplementation(() => 100000000000n);
+    });
+
+    it("should render a progress bar with direct participation", async () => {
+      const po = renderComponent(summary);
+      const progressBarPo = po.getCommitmentProgressBarPo();
+      expect(await progressBarPo.getCommitmentE8s()).toBe(directCommitment);
+    });
+
+    it("should render detailed participation if neurons fund participation is available", async () => {
+      const po = renderComponent(summary);
+      expect(await po.getNeuronsFundParticipation()).toEqual("100.00 ICP");
+      expect(await po.getDirectParticipation()).toEqual("300.00 ICP");
+    });
+
+    it("should render progress bar with primary color", async () => {
+      const po = renderComponent(summary);
+      const progressBarPo = po.getCommitmentProgressBarPo();
+      expect(await progressBarPo.getColor()).toEqual("primary");
+    });
+  });
+
+  describe("when Neurons' Fund enhancements fields are available and NF commitment is 0", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(summaryGetters, "getNeuronsFundParticipation")
+        .mockImplementation(() => 0n);
+      // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+      jest
+        .spyOn(summaryGetters, "getMiniumDirectParticipation")
+        .mockImplementation(() => 10000000000n);
+      // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+      jest
+        .spyOn(summaryGetters, "getMaximunDirectParticipation")
+        .mockImplementation(() => 100000000000n);
+    });
+
+    it("should render detailed participation if neurons fund participation is zero", async () => {
+      const directCommitment = 20000000000n;
+      const summary = createSummary({
+        currentTotalCommitment: directCommitment,
+      });
+      const po = renderComponent(summary);
+      expect(await po.getNeuronsFundParticipation()).toEqual("0 ICP");
+      expect(await po.getDirectParticipation()).toEqual("200.00 ICP");
+    });
+  });
+
+  describe("when Neurons' Fund enhancements fields are not available", () => {
+    const overallCommitment = 30000000000n;
     const summary = createSummary({
       currentTotalCommitment: overallCommitment,
     });
-    const po = renderComponent(summary);
-    const progressBarPo = po.getCommitmentProgressBarPo();
-    expect(await progressBarPo.getCommitmentE8s()).toBe(overallCommitment);
-  });
 
-  it("should render a progress bar with direct participation if NF is available", async () => {
-    const directCommitment = 30000000000n;
-    const nfCommitment = 10000000000n;
-    // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
-    jest
-      .spyOn(summaryGetters, "getNeuronsFundParticipation")
-      .mockImplementation(() => nfCommitment);
-
-    const summary = createSummary({
-      currentTotalCommitment: directCommitment + nfCommitment,
+    beforeEach(() => {
+      jest
+        .spyOn(summaryGetters, "getNeuronsFundParticipation")
+        .mockImplementation(() => undefined);
+      // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+      jest
+        .spyOn(summaryGetters, "getMiniumDirectParticipation")
+        .mockImplementation(() => undefined);
+      // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+      jest
+        .spyOn(summaryGetters, "getMaximunDirectParticipation")
+        .mockImplementation(() => undefined);
     });
-    const po = renderComponent(summary);
-    const progressBarPo = po.getCommitmentProgressBarPo();
-    expect(await progressBarPo.getCommitmentE8s()).toBe(directCommitment);
-  });
 
-  it("should not render detailed participation if neurons fund participation is not available", async () => {
-    // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
-    jest
-      .spyOn(summaryGetters, "getNeuronsFundParticipation")
-      .mockImplementation(() => undefined);
-
-    const po = renderComponent(summary);
-    expect(await po.hasNeuronsFundParticipation()).toBe(false);
-    expect(await po.hasDirectParticipation()).toBe(false);
-  });
-
-  it("should render detailed participation if neurons fund participation is available", async () => {
-    const directCommitment = 20000000000n;
-    const nfCommitment = 10000000000n;
-    // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
-    jest
-      .spyOn(summaryGetters, "getNeuronsFundParticipation")
-      .mockImplementation(() => nfCommitment);
-
-    const summary = createSummary({
-      currentTotalCommitment: directCommitment + nfCommitment,
+    it("should render a progress bar with overall participation", async () => {
+      const po = renderComponent(summary);
+      const progressBarPo = po.getCommitmentProgressBarPo();
+      expect(await progressBarPo.getCommitmentE8s()).toBe(overallCommitment);
     });
-    const po = renderComponent(summary);
-    expect(await po.getNeuronsFundParticipation()).toEqual("100.00 ICP");
-    expect(await po.getDirectParticipation()).toEqual("200.00 ICP");
-  });
 
-  it("should not render detailed participation if neurons fund participation is zero", async () => {
-    const directCommitment = 20000000000n;
-    const nfCommitment = 0n;
-    // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
-    jest
-      .spyOn(summaryGetters, "getNeuronsFundParticipation")
-      .mockImplementation(() => nfCommitment);
-
-    const summary = createSummary({
-      currentTotalCommitment: directCommitment + nfCommitment,
+    it("should not render detailed participation", async () => {
+      const po = renderComponent(summary);
+      expect(await po.hasNeuronsFundParticipation()).toBe(false);
+      expect(await po.hasDirectParticipation()).toBe(false);
     });
-    const po = renderComponent(summary);
-    expect(await po.hasNeuronsFundParticipation()).toBe(false);
-    expect(await po.hasDirectParticipation()).toBe(false);
+
+    it("should render progress bar with warning color", async () => {
+      const po = renderComponent(summary);
+      const progressBarPo = po.getCommitmentProgressBarPo();
+      expect(await progressBarPo.getColor()).toEqual("warning");
+    });
   });
 });

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1275,63 +1275,126 @@ describe("project-utils", () => {
 
   describe("getProjectCommitmentSplit", () => {
     const defaultSummary = summaryForLifecycle(SnsSwapLifecycle.Open);
+    const nfCommitment = 10000000000n;
+    const directCommitment = 20000000000n;
+    const summary = {
+      ...defaultSummary,
+      derived: {
+        ...defaultSummary.derived,
+        buyer_total_icp_e8s: directCommitment + nfCommitment,
+      },
+    };
 
-    it("returns the commitments split if NF participation is present", () => {
-      const directCommitment = 20000000000n;
-      const nfCommitment = 10000000000n;
-      // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
-      jest
-        .spyOn(summaryGetters, "getNeuronsFundParticipation")
-        .mockImplementation(() => nfCommitment);
-      const summary = {
-        ...defaultSummary,
-        derived: {
-          ...defaultSummary.derived,
-          buyer_total_icp_e8s: directCommitment + nfCommitment,
-        },
-      };
-      expect(getProjectCommitmentSplit(summary)).toEqual({
-        totalCommitmentE8s: 30000000000n,
-        directCommitmentE8s: 20000000000n,
-        nfCommitmentE8s: 10000000000n,
+    describe("when NF participation is present", () => {
+      beforeEach(() => {
+        // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
+        jest
+          .spyOn(summaryGetters, "getNeuronsFundParticipation")
+          .mockImplementation(() => nfCommitment);
+      });
+
+      it("returns the commitments split if min-max direct participations are present", () => {
+        const minDirectParticipation = 10000000000n;
+        const maxDirectParticipation = 100000000000n;
+        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+        jest
+          .spyOn(summaryGetters, "getMiniumDirectParticipation")
+          .mockImplementation(() => minDirectParticipation);
+        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+        jest
+          .spyOn(summaryGetters, "getMaximunDirectParticipation")
+          .mockImplementation(() => maxDirectParticipation);
+
+        expect(getProjectCommitmentSplit(summary)).toEqual({
+          totalCommitmentE8s: 30000000000n,
+          directCommitmentE8s: 20000000000n,
+          nfCommitmentE8s: 10000000000n,
+          minimumDirectCommitmentE8s: minDirectParticipation,
+          maximumDirectCommitmentE8s: maxDirectParticipation,
+        });
+      });
+
+      it("returns the full commitment if min direct participation is not present", () => {
+        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+        jest
+          .spyOn(summaryGetters, "getMiniumDirectParticipation")
+          .mockImplementation(() => undefined);
+        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+        jest
+          .spyOn(summaryGetters, "getMaximunDirectParticipation")
+          .mockImplementation(() => 100000000000n);
+        expect(getProjectCommitmentSplit(summary)).toEqual({
+          totalCommitmentE8s: 30000000000n,
+        });
+      });
+
+      it("returns the full commitment if max direct participation is not present", () => {
+        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+        jest
+          .spyOn(summaryGetters, "getMiniumDirectParticipation")
+          .mockImplementation(() => 100000000000n);
+        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+        jest
+          .spyOn(summaryGetters, "getMaximunDirectParticipation")
+          .mockImplementation(() => undefined);
+        expect(getProjectCommitmentSplit(summary)).toEqual({
+          totalCommitmentE8s: 30000000000n,
+        });
       });
     });
 
-    it("returns the commitments split if NF participation is present even when 0", () => {
-      const directCommitment = 20000000000n;
-      const nfCommitment = 0n;
-      // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
-      jest
-        .spyOn(summaryGetters, "getNeuronsFundParticipation")
-        .mockImplementation(() => nfCommitment);
-      const summary = {
-        ...defaultSummary,
-        derived: {
-          ...defaultSummary.derived,
-          buyer_total_icp_e8s: directCommitment + nfCommitment,
-        },
-      };
-      expect(getProjectCommitmentSplit(summary)).toEqual({
-        totalCommitmentE8s: 20000000000n,
-        directCommitmentE8s: 20000000000n,
-        nfCommitmentE8s: 0n,
+    describe("when NF participation is 0", () => {
+      it("returns the commitments split if NF participation is present even when 0", () => {
+        const directCommitment = 20000000000n;
+        const nfCommitment = 0n;
+        const minDirectParticipation = 10000000000n;
+        const maxDirectParticipation = 100000000000n;
+        // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
+        jest
+          .spyOn(summaryGetters, "getNeuronsFundParticipation")
+          .mockImplementation(() => nfCommitment);
+        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+        jest
+          .spyOn(summaryGetters, "getMiniumDirectParticipation")
+          .mockImplementation(() => minDirectParticipation);
+        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+        jest
+          .spyOn(summaryGetters, "getMaximunDirectParticipation")
+          .mockImplementation(() => maxDirectParticipation);
+        const summary = {
+          ...defaultSummary,
+          derived: {
+            ...defaultSummary.derived,
+            buyer_total_icp_e8s: directCommitment + nfCommitment,
+          },
+        };
+        expect(getProjectCommitmentSplit(summary)).toEqual({
+          totalCommitmentE8s: 20000000000n,
+          directCommitmentE8s: 20000000000n,
+          nfCommitmentE8s: 0n,
+          minimumDirectCommitmentE8s: minDirectParticipation,
+          maximumDirectCommitmentE8s: maxDirectParticipation,
+        });
       });
     });
 
-    it("returns only the full commitmentif NF participation is not present", () => {
-      // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
-      jest
-        .spyOn(summaryGetters, "getNeuronsFundParticipation")
-        .mockImplementation(() => undefined);
-      const summary = {
-        ...defaultSummary,
-        derived: {
-          ...defaultSummary.derived,
-          buyer_total_icp_e8s: 20000000000n,
-        },
-      };
-      expect(getProjectCommitmentSplit(summary)).toEqual({
-        totalCommitmentE8s: 20000000000n,
+    describe("when NF participation is not present", () => {
+      it("returns the full commitment even if min-max direct participation are present", () => {
+        // TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
+        jest
+          .spyOn(summaryGetters, "getNeuronsFundParticipation")
+          .mockImplementation(() => undefined);
+        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+        jest
+          .spyOn(summaryGetters, "getMiniumDirectParticipation")
+          .mockImplementation(() => 100000000000n);
+        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
+        jest
+          .spyOn(summaryGetters, "getMaximunDirectParticipation")
+          .mockImplementation(() => 1000000000000n);
+        expect(getProjectCommitmentSplit(summary)).toEqual({
+          totalCommitmentE8s: 30000000000n,
+        });
       });
     });
   });

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1298,30 +1298,30 @@ describe("project-utils", () => {
         const maxDirectParticipation = 100000000000n;
         // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
         jest
-          .spyOn(summaryGetters, "getMiniumDirectParticipation")
+          .spyOn(summaryGetters, "getMinDirectParticipation")
           .mockImplementation(() => minDirectParticipation);
         // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
         jest
-          .spyOn(summaryGetters, "getMaximunDirectParticipation")
+          .spyOn(summaryGetters, "getMaxDirectParticipation")
           .mockImplementation(() => maxDirectParticipation);
 
         expect(getProjectCommitmentSplit(summary)).toEqual({
           totalCommitmentE8s: 30000000000n,
           directCommitmentE8s: 20000000000n,
           nfCommitmentE8s: 10000000000n,
-          minimumDirectCommitmentE8s: minDirectParticipation,
-          maximumDirectCommitmentE8s: maxDirectParticipation,
+          minDirectCommitmentE8s: minDirectParticipation,
+          maxDirectCommitmentE8s: maxDirectParticipation,
         });
       });
 
       it("returns the full commitment if min direct participation is not present", () => {
         // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
         jest
-          .spyOn(summaryGetters, "getMiniumDirectParticipation")
+          .spyOn(summaryGetters, "getMinDirectParticipation")
           .mockImplementation(() => undefined);
         // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
         jest
-          .spyOn(summaryGetters, "getMaximunDirectParticipation")
+          .spyOn(summaryGetters, "getMaxDirectParticipation")
           .mockImplementation(() => 100000000000n);
         expect(getProjectCommitmentSplit(summary)).toEqual({
           totalCommitmentE8s: 30000000000n,
@@ -1331,11 +1331,11 @@ describe("project-utils", () => {
       it("returns the full commitment if max direct participation is not present", () => {
         // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
         jest
-          .spyOn(summaryGetters, "getMiniumDirectParticipation")
+          .spyOn(summaryGetters, "getMinDirectParticipation")
           .mockImplementation(() => 100000000000n);
         // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
         jest
-          .spyOn(summaryGetters, "getMaximunDirectParticipation")
+          .spyOn(summaryGetters, "getMaxDirectParticipation")
           .mockImplementation(() => undefined);
         expect(getProjectCommitmentSplit(summary)).toEqual({
           totalCommitmentE8s: 30000000000n,
@@ -1355,11 +1355,11 @@ describe("project-utils", () => {
           .mockImplementation(() => nfCommitment);
         // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
         jest
-          .spyOn(summaryGetters, "getMiniumDirectParticipation")
+          .spyOn(summaryGetters, "getMinDirectParticipation")
           .mockImplementation(() => minDirectParticipation);
         // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
         jest
-          .spyOn(summaryGetters, "getMaximunDirectParticipation")
+          .spyOn(summaryGetters, "getMaxDirectParticipation")
           .mockImplementation(() => maxDirectParticipation);
         const summary = {
           ...defaultSummary,
@@ -1372,8 +1372,8 @@ describe("project-utils", () => {
           totalCommitmentE8s: 20000000000n,
           directCommitmentE8s: 20000000000n,
           nfCommitmentE8s: 0n,
-          minimumDirectCommitmentE8s: minDirectParticipation,
-          maximumDirectCommitmentE8s: maxDirectParticipation,
+          minDirectCommitmentE8s: minDirectParticipation,
+          maxDirectCommitmentE8s: maxDirectParticipation,
         });
       });
     });
@@ -1386,11 +1386,11 @@ describe("project-utils", () => {
           .mockImplementation(() => undefined);
         // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
         jest
-          .spyOn(summaryGetters, "getMiniumDirectParticipation")
+          .spyOn(summaryGetters, "getMinDirectParticipation")
           .mockImplementation(() => 100000000000n);
         // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
         jest
-          .spyOn(summaryGetters, "getMaximunDirectParticipation")
+          .spyOn(summaryGetters, "getMaxDirectParticipation")
           .mockImplementation(() => 1000000000000n);
         expect(getProjectCommitmentSplit(summary)).toEqual({
           totalCommitmentE8s: 30000000000n,

--- a/frontend/src/tests/page-objects/CommitmentProgressBarPo.page-object.ts
+++ b/frontend/src/tests/page-objects/CommitmentProgressBarPo.page-object.ts
@@ -29,4 +29,10 @@ export class CommitmentProgressBarPo extends BasePageObject {
       .getAttribute("value");
     return BigInt(valueString);
   }
+
+  // The color prop is added as a class to the progress element.
+  async getColor(): Promise<string> {
+    const progressElement = this.root.querySelector("progress");
+    return (await progressElement.getClasses())[0];
+  }
 }


### PR DESCRIPTION
# Motivation

Rearrange the UI and use the new fields for min and max direct participation.

# Changes

* New prop to CommitmentProgress bar "color".
* New summary getters `getMiniumDirectParticipation` and `getMaximumDirectParticipation`.
* In the ProjectCommitment, move the section with direct participation progress bar above the overall commitment.
* In the ProjectCommitment, use a `KeyValuePairInfo` for the NF Commitment.
* Add two fields in `FullProjectCommitmentSplit` for max and minimum direct commitment.
* New project util `isCommitmentSplitWithNeuronsFund`.
* Check whether the commitment is `FullProjectCommitmentSplit` to show the direct commitment and NF values.

# Tests

* Test that CommitmentProgress uses prop "color".
* Divide test cases in describes and change cases accordingly in ProjectCommitment.spec
* Add test cases for `getProjectCommitmentSplit`.
* Add method to CommitmentProgressPo.

# Todos

- [x] Add entry to changelog (if necessary).
