### PR TITLE
Chore: Remove unnecessary snsQueryStore reset

### DIFF
--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -9,7 +9,6 @@ import * as services from "$lib/services/sns-transactions.services";
 import * as workerBalances from "$lib/services/worker-balances.services";
 import * as workerTransactions from "$lib/services/worker-transactions.services";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -77,7 +76,6 @@ describe("SnsWallet", () => {
   const rootCanisterIdText = rootCanisterId.toText();
 
   beforeEach(() => {
-    snsQueryStore.reset();
     snsAccountsStore.reset();
     transactionsFeesStore.reset();
     setSnsProjects([

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -7,7 +7,6 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import Neurons from "$lib/routes/Neurons.svelte";
 import { loadSnsProjects } from "$lib/services/$public/sns.services";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { page } from "$mocks/$app/stores";
 import * as fakeGovernanceApi from "$tests/fakes/governance-api.fake";
@@ -44,7 +43,6 @@ describe("Neurons", () => {
 
   beforeEach(async () => {
     resetIdentity();
-    snsQueryStore.reset();
 
     fakeGovernanceApi.addNeuronWith({ neuronId: testNnsNeuronId });
     testCommittedSnsNeuron = fakeSnsGovernanceApi.addNeuronWith({

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -21,7 +21,6 @@ import { authStore } from "$lib/stores/auth.store";
 import * as busyStore from "$lib/stores/busy.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { nanoSecondsToDateTime } from "$lib/utils/date.utils";
@@ -171,7 +170,6 @@ describe("sns-api", () => {
     spyOnNewSaleTicketApi.mockResolvedValue(testSnsTicket.ticket);
     spyOnNotifyPaymentFailureApi.mockResolvedValue(undefined);
     jest.spyOn(console, "error").mockReturnValue();
-    snsQueryStore.reset();
     spyOnQueryBalance.mockResolvedValue(newBalanceE8s);
 
     setUpMockSnsProjectStore({ rootCanisterId: testSnsTicket.rootCanisterId });


### PR DESCRIPTION
# Motivation

Final motivation is to remove snsQueryStore.

In this PR, remove unnecessary references to snsQueryStore in some tests.

# Changes

* Remove resetting snsQueryStore in three tests.
Tests still pass

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
