### PR TITLE
Fix: Do not hard-wire traits

### DIFF
--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -46,9 +46,6 @@ GIT_ROOT="$(git rev-parse --show-toplevel)"
 PATCH_PATH="${PATCH_PATH:-${RUST_PATH%.rs}.patch}"
 DID_PATH="${DID_PATH:-${GIT_ROOT}/declarations/${CANISTER_NAME}/${CANISTER_NAME}.did}"
 
-# TODO: Provide this as an argument.
-TRAITS="Serialize, Clone, Debug"
-
 cd "$GIT_ROOT"
 
 : "Ensure that tools are installed and working.  Rustfmt in particular can self-upgrade when called and the self-upgrade can fail."


### PR DESCRIPTION
# Motivation
Traits are now provided to `did2rs` using a command line flag.  Unfortunately the traits are still hard wired.

Annoying, as I removed the hard-wired code but probably in the wrong branch or failed to commit the change. :-(

# Changes
No longer hard-wire the traits.

# Tests
The traits passed in by `./scripts/sns/aggregator/did2rs` are the same as the formerly hard-wired ones.  This should mean that there are no changes to the aggregator source code and patch files.  Furthermore consistency of this is checked in CI.

Locally, I am able to generate Rust code with different traits.

# Todos

- [ ] Add entry to changelog (if necessary).
  - Not needed, I think.