### PR TITLE
Use Principal instead of candid::Principal

### DIFF
--- a/rs/sns_aggregator/src/types/ic_sns_governance.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_governance.rs a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-index 5138a0301..4b35107c4 100644
+index 699d84ad7..af9969652 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_governance.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_governance.rs
 @@ -518,7 +518,7 @@ pub struct GetMaturityModulationResponse {

--- a/rs/sns_aggregator/src/types/ic_sns_governance.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_governance.rs a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-index 7edf9991d..d779ceeaa 100644
+index 5138a0301..4b35107c4 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_governance.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_governance.rs
-@@ -517,7 +517,7 @@ pub struct GetMaturityModulationResponse {
+@@ -518,7 +518,7 @@ pub struct GetMaturityModulationResponse {
  #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
  pub struct GetMetadataArg {}
  
@@ -11,7 +11,7 @@ index 7edf9991d..d779ceeaa 100644
  pub struct GetMetadataResponse {
      pub url: Option<String>,
      pub logo: Option<String>,
-@@ -610,7 +610,7 @@ pub struct GetSnsInitializationParametersResponse {
+@@ -611,7 +611,7 @@ pub struct GetSnsInitializationParametersResponse {
      pub sns_initialization_parameters: String,
  }
  

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -5,8 +5,8 @@
 #![allow(dead_code)]
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
-use ic_cdk::api::call::CallResult;
 use candid::Principal;
+use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -6,16 +6,17 @@
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use ic_cdk::api::call::CallResult;
+use candid::Principal;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
-// use candid::{self, CandidType, Decode, Deserialize, Encode, candid::Principal};
+// use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
 // use ic_cdk::api::call::CallResult as Result;
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GenericNervousSystemFunction {
-    pub validator_canister_id: Option<candid::Principal>,
-    pub target_canister_id: Option<candid::Principal>,
+    pub validator_canister_id: Option<Principal>,
+    pub target_canister_id: Option<Principal>,
     pub validator_method_name: Option<String>,
     pub target_method_name: Option<String>,
 }
@@ -167,7 +168,7 @@ pub struct Tally {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RegisterDappCanisters {
-    pub canister_ids: Vec<candid::Principal>,
+    pub canister_ids: Vec<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -178,7 +179,7 @@ pub struct Subaccount {
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct TransferSnsTreasuryFunds {
     pub from_treasury: i32,
-    pub to_principal: Option<candid::Principal>,
+    pub to_principal: Option<Principal>,
     pub to_subaccount: Option<Subaccount>,
     pub memo: Option<u64>,
     pub amount_e8s: u64,
@@ -188,14 +189,14 @@ pub struct TransferSnsTreasuryFunds {
 pub struct UpgradeSnsControlledCanister {
     pub new_canister_wasm: serde_bytes::ByteBuf,
     pub mode: Option<i32>,
-    pub canister_id: Option<candid::Principal>,
+    pub canister_id: Option<Principal>,
     pub canister_upgrade_arg: Option<serde_bytes::ByteBuf>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DeregisterDappCanisters {
-    pub canister_ids: Vec<candid::Principal>,
-    pub new_controllers: Vec<candid::Principal>,
+    pub canister_ids: Vec<Principal>,
+    pub new_controllers: Vec<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -283,7 +284,7 @@ pub struct Follow {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Account {
-    pub owner: Option<candid::Principal>,
+    pub owner: Option<Principal>,
     pub subaccount: Option<Subaccount>,
 }
 
@@ -336,7 +337,7 @@ pub struct FinalizeDisburseMaturity {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct MemoAndController {
-    pub controller: Option<candid::Principal>,
+    pub controller: Option<Principal>,
     pub memo: u64,
 }
 
@@ -354,13 +355,13 @@ pub struct ClaimOrRefresh {
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RemoveNeuronPermissions {
     pub permissions_to_remove: Option<NeuronPermissionList>,
-    pub principal_id: Option<candid::Principal>,
+    pub principal_id: Option<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct AddNeuronPermissions {
     pub permissions_to_add: Option<NeuronPermissionList>,
-    pub principal_id: Option<candid::Principal>,
+    pub principal_id: Option<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -404,7 +405,7 @@ pub struct NeuronInFlightCommand {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronPermission {
-    pub principal: Option<candid::Principal>,
+    pub principal: Option<Principal>,
     pub permission_type: Vec<i32>,
 }
 
@@ -442,7 +443,7 @@ pub struct Neuron {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Governance {
-    pub root_canister_id: Option<candid::Principal>,
+    pub root_canister_id: Option<Principal>,
     pub id_to_nervous_system_functions: Vec<(u64, NervousSystemFunction)>,
     pub metrics: Option<GovernanceCachedMetrics>,
     pub maturity_modulation: Option<MaturityModulation>,
@@ -453,8 +454,8 @@ pub struct Governance {
     pub sns_initialization_parameters: String,
     pub latest_reward_event: Option<RewardEvent>,
     pub pending_version: Option<UpgradeInProgress>,
-    pub swap_canister_id: Option<candid::Principal>,
-    pub ledger_canister_id: Option<candid::Principal>,
+    pub swap_canister_id: Option<Principal>,
+    pub ledger_canister_id: Option<Principal>,
     pub proposals: Vec<(u64, ProposalData)>,
     pub in_flight_commands: Vec<(String, NeuronInFlightCommand)>,
     pub sns_metadata: Option<ManageSnsMetadata>,
@@ -464,12 +465,12 @@ pub struct Governance {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronParameters {
-    pub controller: Option<candid::Principal>,
+    pub controller: Option<Principal>,
     pub dissolve_delay_seconds: Option<u64>,
     pub source_nns_neuron_id: Option<u64>,
     pub stake_e8s: Option<u64>,
     pub followees: Vec<NeuronId>,
-    pub hotkey: Option<candid::Principal>,
+    pub hotkey: Option<Principal>,
     pub neuron_id: Option<NeuronId>,
 }
 
@@ -578,7 +579,7 @@ pub enum CanisterStatusType {
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DefiniteCanisterSettingsArgs {
     pub freezing_threshold: candid::Nat,
-    pub controllers: Vec<candid::Principal>,
+    pub controllers: Vec<Principal>,
     pub memory_allocation: candid::Nat,
     pub compute_allocation: candid::Nat,
 }
@@ -618,7 +619,7 @@ pub struct ListNervousSystemFunctionsResponse {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListNeurons {
-    pub of_principal: Option<candid::Principal>,
+    pub of_principal: Option<Principal>,
     pub limit: u32,
     pub start_page_at: Option<NeuronId>,
 }
@@ -732,7 +733,7 @@ pub struct SetMode {
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SetModeRet {}
 
-pub struct Service(pub candid::Principal);
+pub struct Service(pub Principal);
 impl Service {
     pub async fn claim_swap_neurons(&self, arg0: ClaimSwapNeuronsRequest) -> CallResult<(ClaimSwapNeuronsResponse,)> {
         ic_cdk::call(self.0, "claim_swap_neurons", (arg0,)).await

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index f62428fc2..43cfb3e71 100644
+index 95c04d544..789073e75 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-@@ -110,17 +110,15 @@ pub struct BlockRange {
+@@ -111,17 +111,15 @@ pub struct BlockRange {
      pub blocks: Vec<Block>,
  }
  
@@ -23,7 +23,7 @@ index f62428fc2..43cfb3e71 100644
  pub struct GetBlocksResponse {
      pub certificate: Option<serde_bytes::ByteBuf>,
      pub first_index: BlockIndex,
-@@ -198,17 +196,15 @@ pub struct TransactionRange {
+@@ -199,17 +197,15 @@ pub struct TransactionRange {
      pub transactions: Vec<Transaction>,
  }
  

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index 95c04d544..789073e75 100644
+index f46d01978..a407881a7 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 @@ -111,17 +111,15 @@ pub struct BlockRange {

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -5,8 +5,8 @@
 #![allow(dead_code)]
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
-use ic_cdk::api::call::CallResult;
 use candid::Principal;
+use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -6,10 +6,11 @@
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use ic_cdk::api::call::CallResult;
+use candid::Principal;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
-// use candid::{self, CandidType, Decode, Deserialize, Encode, candid::Principal};
+// use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
 // use ic_cdk::api::call::CallResult as Result;
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -23,7 +24,7 @@ pub enum MetadataValue {
 pub type Subaccount = serde_bytes::ByteBuf;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Account {
-    pub owner: candid::Principal,
+    pub owner: Principal,
     pub subaccount: Option<Subaccount>,
 }
 
@@ -59,7 +60,7 @@ pub struct InitArgsArchiveOptions {
     pub max_message_size_bytes: Option<u64>,
     pub cycles_for_archive_creation: Option<u64>,
     pub node_max_memory_size_bytes: Option<u64>,
-    pub controller_id: candid::Principal,
+    pub controller_id: Principal,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -320,7 +321,7 @@ pub enum TransferFromResult {
     Err(TransferFromError),
 }
 
-pub struct Service(pub candid::Principal);
+pub struct Service(pub Principal);
 impl Service {
     pub async fn get_blocks(&self, arg0: GetBlocksArgs) -> CallResult<(GetBlocksResponse,)> {
         ic_cdk::call(self.0, "get_blocks", (arg0,)).await

--- a/rs/sns_aggregator/src/types/ic_sns_root.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_root.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_root.rs a/rs/sns_aggregator/src/types/ic_sns_root.rs
-index 8a74499ac..42c22d575 100644
+index 91b761207..740fd15dd 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_root.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_root.rs
 @@ -134,7 +134,7 @@ pub struct GetSnsCanistersSummaryResponse {

--- a/rs/sns_aggregator/src/types/ic_sns_root.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_root.patch
@@ -1,13 +1,13 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_root.rs a/rs/sns_aggregator/src/types/ic_sns_root.rs
-index fe1e3ee0a..f65c1f3ca 100644
+index 8a74499ac..42c22d575 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_root.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_root.rs
-@@ -133,7 +133,7 @@ pub struct GetSnsCanistersSummaryResponse {
+@@ -134,7 +134,7 @@ pub struct GetSnsCanistersSummaryResponse {
  #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
  pub struct ListSnsCanistersArg {}
  
 -#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 +#[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]
  pub struct ListSnsCanistersResponse {
-     pub root: Option<candid::Principal>,
-     pub swap: Option<candid::Principal>,
+     pub root: Option<Principal>,
+     pub swap: Option<Principal>,

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -5,8 +5,8 @@
 #![allow(dead_code)]
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
-use ic_cdk::api::call::CallResult;
 use candid::Principal;
+use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -6,27 +6,28 @@
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use ic_cdk::api::call::CallResult;
+use candid::Principal;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
-// use candid::{self, CandidType, Decode, Deserialize, Encode, candid::Principal};
+// use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
 // use ic_cdk::api::call::CallResult as Result;
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SnsRootCanister {
-    pub dapp_canister_ids: Vec<candid::Principal>,
+    pub dapp_canister_ids: Vec<Principal>,
     pub testflight: bool,
     pub latest_ledger_archive_poll_timestamp_seconds: Option<u64>,
-    pub archive_canister_ids: Vec<candid::Principal>,
-    pub governance_canister_id: Option<candid::Principal>,
-    pub index_canister_id: Option<candid::Principal>,
-    pub swap_canister_id: Option<candid::Principal>,
-    pub ledger_canister_id: Option<candid::Principal>,
+    pub archive_canister_ids: Vec<Principal>,
+    pub governance_canister_id: Option<Principal>,
+    pub index_canister_id: Option<Principal>,
+    pub swap_canister_id: Option<Principal>,
+    pub ledger_canister_id: Option<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CanisterIdRecord {
-    pub canister_id: candid::Principal,
+    pub canister_id: Principal,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -41,7 +42,7 @@ pub enum CanisterStatusType {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DefiniteCanisterSettings {
-    pub controllers: Vec<candid::Principal>,
+    pub controllers: Vec<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -71,9 +72,9 @@ pub enum AuthzChangeOp {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct MethodAuthzChange {
-    pub principal: Option<candid::Principal>,
+    pub principal: Option<Principal>,
     pub method_name: String,
-    pub canister: candid::Principal,
+    pub canister: Principal,
     pub operation: AuthzChangeOp,
 }
 
@@ -83,7 +84,7 @@ pub struct ChangeCanisterProposal {
     pub wasm_module: serde_bytes::ByteBuf,
     pub stop_before_installing: bool,
     pub mode: CanisterInstallMode,
-    pub canister_id: candid::Principal,
+    pub canister_id: Principal,
     pub query_allocation: Option<candid::Nat>,
     pub authz_changes: Vec<MethodAuthzChange>,
     pub memory_allocation: Option<candid::Nat>,
@@ -98,7 +99,7 @@ pub struct GetSnsCanistersSummaryRequest {
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DefiniteCanisterSettingsArgs {
     pub freezing_threshold: candid::Nat,
-    pub controllers: Vec<candid::Principal>,
+    pub controllers: Vec<Principal>,
     pub memory_allocation: candid::Nat,
     pub compute_allocation: candid::Nat,
 }
@@ -116,7 +117,7 @@ pub struct CanisterStatusResultV2 {
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CanisterSummary {
     pub status: Option<CanisterStatusResultV2>,
-    pub canister_id: Option<candid::Principal>,
+    pub canister_id: Option<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -135,18 +136,18 @@ pub struct ListSnsCanistersArg {}
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]
 pub struct ListSnsCanistersResponse {
-    pub root: Option<candid::Principal>,
-    pub swap: Option<candid::Principal>,
-    pub ledger: Option<candid::Principal>,
-    pub index: Option<candid::Principal>,
-    pub governance: Option<candid::Principal>,
-    pub dapps: Vec<candid::Principal>,
-    pub archives: Vec<candid::Principal>,
+    pub root: Option<Principal>,
+    pub swap: Option<Principal>,
+    pub ledger: Option<Principal>,
+    pub index: Option<Principal>,
+    pub governance: Option<Principal>,
+    pub dapps: Vec<Principal>,
+    pub archives: Vec<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RegisterDappCanisterRequest {
-    pub canister_id: Option<candid::Principal>,
+    pub canister_id: Option<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -154,7 +155,7 @@ pub struct RegisterDappCanisterRet {}
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RegisterDappCanistersRequest {
-    pub canister_ids: Vec<candid::Principal>,
+    pub canister_ids: Vec<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -163,7 +164,7 @@ pub struct RegisterDappCanistersRet {}
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SetDappControllersRequest {
     pub canister_ids: Option<RegisterDappCanistersRequest>,
-    pub controller_principal_ids: Vec<candid::Principal>,
+    pub controller_principal_ids: Vec<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -175,7 +176,7 @@ pub struct CanisterCallError {
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct FailedUpdate {
     pub err: Option<CanisterCallError>,
-    pub dapp_canister_id: Option<candid::Principal>,
+    pub dapp_canister_id: Option<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -183,7 +184,7 @@ pub struct SetDappControllersResponse {
     pub failed_updates: Vec<FailedUpdate>,
 }
 
-pub struct Service(pub candid::Principal);
+pub struct Service(pub Principal);
 impl Service {
     pub async fn canister_status(&self, arg0: CanisterIdRecord) -> CallResult<(CanisterStatusResult,)> {
         ic_cdk::call(self.0, "canister_status", (arg0,)).await

--- a/rs/sns_aggregator/src/types/ic_sns_swap.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_swap.rs a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-index 5e6caeb2e..a55187e93 100644
+index 12352a3f5..d6a852cc2 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_swap.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-@@ -13,13 +13,13 @@ use candid::Principal;
+@@ -13,13 +13,13 @@ use ic_cdk::api::call::CallResult;
  // use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
  // use ic_cdk::api::call::CallResult as Result;
  

--- a/rs/sns_aggregator/src/types/ic_sns_swap.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.patch
@@ -1,9 +1,9 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_swap.rs a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-index ce89bff03..00f3788c4 100644
+index 5e6caeb2e..a55187e93 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_swap.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-@@ -12,13 +12,13 @@ use ic_cdk::api::call::CallResult;
- // use candid::{self, CandidType, Decode, Deserialize, Encode, candid::Principal};
+@@ -13,13 +13,13 @@ use candid::Principal;
+ // use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
  // use ic_cdk::api::call::CallResult as Result;
  
 -#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -18,7 +18,7 @@ index ce89bff03..00f3788c4 100644
  pub struct LinearScalingCoefficient {
      pub slope_numerator: Option<u64>,
      pub intercept_icp_e8s: Option<u64>,
-@@ -27,36 +27,36 @@ pub struct LinearScalingCoefficient {
+@@ -28,36 +28,36 @@ pub struct LinearScalingCoefficient {
      pub to_direct_participation_icp_e8s: Option<u64>,
  }
  
@@ -61,7 +61,7 @@ index ce89bff03..00f3788c4 100644
  pub struct Init {
      pub nns_proposal_id: Option<u64>,
      pub sns_root_canister_id: String,
-@@ -165,7 +165,7 @@ pub struct SettleCommunityFundParticipationResult {
+@@ -166,7 +166,7 @@ pub struct SettleCommunityFundParticipationResult {
  
  #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
  pub enum Possibility2 {
@@ -70,7 +70,7 @@ index ce89bff03..00f3788c4 100644
      Err(CanisterCallError),
  }
  
-@@ -339,7 +339,7 @@ pub struct GetOpenTicketResponse {
+@@ -340,7 +340,7 @@ pub struct GetOpenTicketResponse {
  #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
  pub struct GetSaleParametersArg {}
  
@@ -79,7 +79,7 @@ index ce89bff03..00f3788c4 100644
  pub struct Params {
      pub min_participant_icp_e8s: u64,
      pub neuron_basket_construction_parameters: Option<NeuronBasketConstructionParameters>,
-@@ -428,7 +428,7 @@ pub struct DerivedState {
+@@ -429,7 +429,7 @@ pub struct DerivedState {
      pub cf_neuron_count: Option<u64>,
  }
  

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -6,10 +6,11 @@
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use ic_cdk::api::call::CallResult;
+use candid::Principal;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
-// use candid::{self, CandidType, Decode, Deserialize, Encode, candid::Principal};
+// use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
 // use ic_cdk::api::call::CallResult as Result;
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
@@ -85,7 +86,7 @@ pub struct Init {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ErrorRefundIcpRequest {
-    pub source_principal_id: Option<candid::Principal>,
+    pub source_principal_id: Option<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -122,7 +123,7 @@ pub struct CanisterCallError {
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct FailedUpdate {
     pub err: Option<CanisterCallError>,
-    pub dapp_canister_id: Option<candid::Principal>,
+    pub dapp_canister_id: Option<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -206,7 +207,7 @@ pub struct GetAutoFinalizationStatusResponse {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetBuyerStateRequest {
-    pub principal_id: Option<candid::Principal>,
+    pub principal_id: Option<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -252,7 +253,7 @@ pub enum CanisterStatusType {
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DefiniteCanisterSettingsArgs {
     pub freezing_threshold: candid::Nat,
-    pub controllers: Vec<candid::Principal>,
+    pub controllers: Vec<Principal>,
     pub memory_allocation: candid::Nat,
     pub compute_allocation: candid::Nat,
 }
@@ -303,7 +304,7 @@ pub struct GetOpenTicketArg {}
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Icrc1Account {
-    pub owner: Option<candid::Principal>,
+    pub owner: Option<Principal>,
     pub subaccount: Option<serde_bytes::ByteBuf>,
 }
 
@@ -449,7 +450,7 @@ pub struct ListDirectParticipantsRequest {
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Participant {
     pub participation: Option<BuyerState>,
-    pub participant_id: Option<candid::Principal>,
+    pub participant_id: Option<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -526,7 +527,7 @@ pub struct RefreshBuyerTokensResponse {
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RestoreDappControllersArg {}
 
-pub struct Service(pub candid::Principal);
+pub struct Service(pub Principal);
 impl Service {
     pub async fn error_refund_icp(&self, arg0: ErrorRefundIcpRequest) -> CallResult<(ErrorRefundIcpResponse,)> {
         ic_cdk::call(self.0, "error_refund_icp", (arg0,)).await

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -5,8 +5,8 @@
 #![allow(dead_code)]
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
-use ic_cdk::api::call::CallResult;
 use candid::Principal;
+use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_wasm.rs a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-index 071de200f..2ed0f25a6 100644
+index 448637889..b27865401 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 @@ -281,7 +281,7 @@ pub struct InsertUpgradePathEntriesResponse {

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.patch
@@ -1,13 +1,13 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_wasm.rs a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-index 69b5618ea..8d35b62e5 100644
+index 071de200f..2ed0f25a6 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-@@ -280,7 +280,7 @@ pub struct InsertUpgradePathEntriesResponse {
+@@ -281,7 +281,7 @@ pub struct InsertUpgradePathEntriesResponse {
  #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
  pub struct ListDeployedSnsesArg {}
  
 -#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 +#[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]
  pub struct DeployedSns {
-     pub root_canister_id: Option<candid::Principal>,
-     pub governance_canister_id: Option<candid::Principal>,
+     pub root_canister_id: Option<Principal>,
+     pub governance_canister_id: Option<Principal>,

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -5,8 +5,8 @@
 #![allow(dead_code)]
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
-use ic_cdk::api::call::CallResult;
 use candid::Principal;
+use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -6,17 +6,18 @@
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use ic_cdk::api::call::CallResult;
+use candid::Principal;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
-// use candid::{self, CandidType, Decode, Deserialize, Encode, candid::Principal};
+// use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
 // use ic_cdk::api::call::CallResult as Result;
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SnsWasmCanisterInitPayload {
-    pub allowed_principals: Vec<candid::Principal>,
+    pub allowed_principals: Vec<Principal>,
     pub access_controls_enabled: bool,
-    pub sns_subnet_ids: Vec<candid::Principal>,
+    pub sns_subnet_ids: Vec<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -55,7 +56,7 @@ pub struct NeuronBasketConstructionParameters {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Canister {
-    pub id: Option<candid::Principal>,
+    pub id: Option<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -103,7 +104,7 @@ pub struct TreasuryDistribution {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronDistribution {
-    pub controller: Option<candid::Principal>,
+    pub controller: Option<Principal>,
     pub dissolve_delay_seconds: u64,
     pub memo: u64,
     pub stake_e8s: u64,
@@ -198,17 +199,17 @@ pub struct DappCanistersTransferResult {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SnsCanisterIds {
-    pub root: Option<candid::Principal>,
-    pub swap: Option<candid::Principal>,
-    pub ledger: Option<candid::Principal>,
-    pub index: Option<candid::Principal>,
-    pub governance: Option<candid::Principal>,
+    pub root: Option<Principal>,
+    pub swap: Option<Principal>,
+    pub ledger: Option<Principal>,
+    pub index: Option<Principal>,
+    pub governance: Option<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DeployNewSnsResponse {
     pub dapp_canisters_transfer_result: Option<DappCanistersTransferResult>,
-    pub subnet_id: Option<candid::Principal>,
+    pub subnet_id: Option<Principal>,
     pub error: Option<SnsWasmError>,
     pub canisters: Option<SnsCanisterIds>,
 }
@@ -218,7 +219,7 @@ pub struct GetAllowedPrincipalsArg {}
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetAllowedPrincipalsResponse {
-    pub allowed_principals: Vec<candid::Principal>,
+    pub allowed_principals: Vec<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -233,7 +234,7 @@ pub struct SnsVersion {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetNextSnsVersionRequest {
-    pub governance_canister_id: Option<candid::Principal>,
+    pub governance_canister_id: Option<Principal>,
     pub current_version: Option<SnsVersion>,
 }
 
@@ -247,7 +248,7 @@ pub struct GetSnsSubnetIdsArg {}
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetSnsSubnetIdsResponse {
-    pub sns_subnet_ids: Vec<candid::Principal>,
+    pub sns_subnet_ids: Vec<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -269,7 +270,7 @@ pub struct SnsUpgrade {
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct InsertUpgradePathEntriesRequest {
     pub upgrade_path: Vec<SnsUpgrade>,
-    pub sns_governance_canister_id: Option<candid::Principal>,
+    pub sns_governance_canister_id: Option<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -282,11 +283,11 @@ pub struct ListDeployedSnsesArg {}
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]
 pub struct DeployedSns {
-    pub root_canister_id: Option<candid::Principal>,
-    pub governance_canister_id: Option<candid::Principal>,
-    pub index_canister_id: Option<candid::Principal>,
-    pub swap_canister_id: Option<candid::Principal>,
-    pub ledger_canister_id: Option<candid::Principal>,
+    pub root_canister_id: Option<Principal>,
+    pub governance_canister_id: Option<Principal>,
+    pub index_canister_id: Option<Principal>,
+    pub swap_canister_id: Option<Principal>,
+    pub ledger_canister_id: Option<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -298,7 +299,7 @@ pub struct ListDeployedSnsesResponse {
 pub struct ListUpgradeStepsRequest {
     pub limit: u32,
     pub starting_at: Option<SnsVersion>,
-    pub sns_governance_canister_id: Option<candid::Principal>,
+    pub sns_governance_canister_id: Option<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -324,8 +325,8 @@ pub struct ListUpgradeStepsResponse {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct UpdateAllowedPrincipalsRequest {
-    pub added_principals: Vec<candid::Principal>,
-    pub removed_principals: Vec<candid::Principal>,
+    pub added_principals: Vec<Principal>,
+    pub removed_principals: Vec<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -341,8 +342,8 @@ pub struct UpdateAllowedPrincipalsResponse {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct UpdateSnsSubnetListRequest {
-    pub sns_subnet_ids_to_add: Vec<candid::Principal>,
-    pub sns_subnet_ids_to_remove: Vec<candid::Principal>,
+    pub sns_subnet_ids_to_add: Vec<Principal>,
+    pub sns_subnet_ids_to_remove: Vec<Principal>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -350,7 +351,7 @@ pub struct UpdateSnsSubnetListResponse {
     pub error: Option<SnsWasmError>,
 }
 
-pub struct Service(pub candid::Principal);
+pub struct Service(pub Principal);
 impl Service {
     pub async fn add_wasm(&self, arg0: AddWasmRequest) -> CallResult<(AddWasmResponse,)> {
         ic_cdk::call(self.0, "add_wasm", (arg0,)).await

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -121,9 +121,6 @@ cd "$GIT_ROOT"
 
 	    # Replace invalid "{}" in generated Rust code with "EmptyRecord":
 	    /^pub (struct|enum) /,/^}/{s/ *\{\},$/(EmptyRecord),/g};
-
-	    # Use candid::Principal instead of raw Principal
-	    s/\<Principal\>/candid::&/g;
 	    ' |
     rustfmt --edition 2021
 } >"${RUST_PATH}"

--- a/scripts/sns/aggregator/did2rs.header
+++ b/scripts/sns/aggregator/did2rs.header
@@ -5,5 +5,5 @@
 #![allow(dead_code)]
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
-use ic_cdk::api::call::CallResult;
 use candid::Principal;
+use ic_cdk::api::call::CallResult;

--- a/scripts/sns/aggregator/did2rs.header
+++ b/scripts/sns/aggregator/did2rs.header
@@ -6,3 +6,4 @@
 
 use crate::types::{CandidType, Deserialize, EmptyRecord, Serialize};
 use ic_cdk::api::call::CallResult;
+use candid::Principal;


### PR DESCRIPTION
# Motivation
`didc2rs` changes every principal to `candid::Principal`.  This is unnecessary.

# Changes
- Import `candid::Principal` in the the header.
- Remove the code that changes `Principal`.

# Tests
See CI.

# Todos

- [ ] Add entry to changelog (if necessary).
  - Too minor, IMO, and covered by existing changelog entries about simplifying `did2rs`.
