### PR TITLE
Chore: Clean up sns services spec from snsQueryStore

### DIFF
--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -8,7 +8,7 @@ import { WATCH_SALE_STATE_EVERY_MILLISECONDS } from "$lib/constants/sns.constant
 import * as services from "$lib/services/sns.services";
 import { snsDerivedStateStore } from "$lib/stores/sns-derived-state.store";
 import { snsLifecycleStore } from "$lib/stores/sns-lifecycle.store";
-import { snsQueryStore, snsSwapCommitmentsStore } from "$lib/stores/sns.store";
+import { snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import {
   mockIdentity,
   mockPrincipal,
@@ -18,7 +18,6 @@ import {
   mockSnsSwapCommitment,
   principal,
 } from "$tests/mocks/sns-projects.mock";
-import { snsResponsesFor } from "$tests/mocks/sns-response.mock";
 import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import {
   advanceTime,
@@ -30,7 +29,6 @@ import type {
   SnsGetLifecycleResponse,
 } from "@dfinity/sns";
 import { SnsSwapLifecycle } from "@dfinity/sns";
-import { fromNullable } from "@dfinity/utils";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
@@ -52,7 +50,6 @@ describe("sns-services", () => {
     jest.clearAllTimers();
     jest.clearAllMocks();
     snsSwapCommitmentsStore.reset();
-    snsQueryStore.reset();
     resetSnsProjects();
     snsDerivedStateStore.reset();
   });
@@ -121,17 +118,6 @@ describe("sns-services", () => {
         direct_participation_icp_e8s: [],
         neurons_fund_participation_icp_e8s: [],
       };
-      const responses = snsResponsesFor([
-        {
-          principal: rootCanisterId1,
-          lifecycle: SnsSwapLifecycle.Open,
-        },
-        {
-          principal: rootCanisterId2,
-          lifecycle: SnsSwapLifecycle.Open,
-        },
-      ]);
-      snsQueryStore.setData(responses);
 
       const spy = jest
         .spyOn(api, "querySnsDerivedState")
@@ -145,17 +131,6 @@ describe("sns-services", () => {
       expect(
         get(snsDerivedStateStore)[rootCanisterId1.toText()]?.derivedState
       ).toEqual(derivedState);
-
-      const store = get(snsQueryStore);
-      const states = store.swaps.find(
-        (swap) => swap.rootCanisterId === rootCanisterId1.toText()
-      )?.derived[0];
-      expect(states?.buyer_total_icp_e8s).not.toEqual(
-        fromNullable(derivedState.buyer_total_icp_e8s)
-      );
-      expect(states?.sns_tokens_per_icp).not.toEqual(
-        fromNullable(derivedState.sns_tokens_per_icp)
-      );
     });
 
     it("should call api with the strategy passed", async () => {
@@ -197,17 +172,6 @@ describe("sns-services", () => {
         direct_participation_icp_e8s: [],
         neurons_fund_participation_icp_e8s: [],
       };
-      const responses = snsResponsesFor([
-        {
-          principal: rootCanisterId1,
-          lifecycle: SnsSwapLifecycle.Open,
-        },
-        {
-          principal: rootCanisterId2,
-          lifecycle: SnsSwapLifecycle.Open,
-        },
-      ]);
-      snsQueryStore.setData(responses);
 
       const spy = jest
         .spyOn(api, "querySnsDerivedState")
@@ -231,17 +195,6 @@ describe("sns-services", () => {
 
       // Even after waiting a long time there shouldn't be more calls.
       expect(spy).toBeCalledTimes(expectedCalls);
-
-      const updatedStore = get(snsQueryStore);
-      const updatedState = updatedStore.swaps.find(
-        (swap) => swap.rootCanisterId === rootCanisterId1.toText()
-      )?.derived[0];
-      expect(updatedState?.buyer_total_icp_e8s).not.toEqual(
-        fromNullable(derivedState.buyer_total_icp_e8s)
-      );
-      expect(updatedState?.sns_tokens_per_icp).not.toEqual(
-        fromNullable(derivedState.sns_tokens_per_icp)
-      );
 
       expect(
         get(snsDerivedStateStore)[rootCanisterId1.toText()]?.derivedState
@@ -328,18 +281,6 @@ describe("sns-services", () => {
         lifecycle: [newLifeCycle],
         decentralization_sale_open_timestamp_seconds: [BigInt(1)],
       };
-      const dataLifecycle = SnsSwapLifecycle.Open;
-      const responses = snsResponsesFor([
-        {
-          principal: rootCanisterId1,
-          lifecycle: dataLifecycle,
-        },
-        {
-          principal: rootCanisterId2,
-          lifecycle: SnsSwapLifecycle.Open,
-        },
-      ]);
-      snsQueryStore.setData(responses);
 
       const spy = jest
         .spyOn(api, "querySnsLifecycle")
@@ -353,11 +294,6 @@ describe("sns-services", () => {
       expect(get(snsLifecycleStore)[rootCanisterId1.toText()].data).toEqual(
         lifeCycleResponse
       );
-      const updatedStore = get(snsQueryStore);
-      const updatedLifecycle = updatedStore?.swaps.find(
-        (swap) => swap.rootCanisterId === rootCanisterId1.toText()
-      )?.swap[0].lifecycle;
-      expect(updatedLifecycle).not.toEqual(newLifeCycle);
     });
   });
 });


### PR DESCRIPTION
# Motivation

Final motivation: remove snsQueryStore.

In this PR, sns services spec file was filling up the snsQueryStore and then checking the values. The services being tested do not use the snsQueryStore. Therefore, it was a mistake to add those checks and those filling stores.

# Changes

* Remove filling up and checking the snsQueryStore in sns.services.spec

# Tests

Only changes in test files.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
