### PR TITLE
Chore: Remove writing to snsQueryStore in sns public services

### DIFF
--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -9,21 +9,19 @@ import { i18n } from "$lib/stores/i18n";
 import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { snsTotalTokenSupplyStore } from "$lib/stores/sns-total-token-supply.store";
-import { snsProposalsStore, snsQueryStore } from "$lib/stores/sns.store";
+import { snsProposalsStore } from "$lib/stores/sns.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { tokensStore, type TokensStoreData } from "$lib/stores/tokens.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
-import type { QuerySnsMetadata, QuerySnsSwapState } from "$lib/types/sns.query";
 import { isForceCallStrategy } from "$lib/utils/env.utils";
 import { toToastError } from "$lib/utils/error.utils";
 import { mapOptionalToken } from "$lib/utils/icrc-tokens.utils";
 import { convertDtoData } from "$lib/utils/sns-aggregator-converters.utils";
-import { convertDerivedStateResponseToDerivedState } from "$lib/utils/sns.utils";
 import { ProposalStatus, Topic, type ProposalInfo } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import type { SnsNervousSystemFunction } from "@dfinity/sns";
-import { nonNullish, toNullable } from "@dfinity/utils";
+import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { getCurrentIdentity } from "../auth.services";
 
@@ -59,35 +57,6 @@ export const loadSnsProjects = async (): Promise<void> => {
         });
       })
     );
-    const snsQueryStoreData: [QuerySnsMetadata[], QuerySnsSwapState[]] = [
-      cachedSnses.map((sns) => ({
-        rootCanisterId: sns.canister_ids.root_canister_id,
-        certified: true,
-        metadata: sns.meta,
-        token: sns.icrc1_metadata,
-      })),
-      cachedSnses.map((sns) => ({
-        rootCanisterId: sns.canister_ids.root_canister_id,
-        certified: true,
-        swapCanisterId: Principal.fromText(sns.canister_ids.swap_canister_id),
-        governanceCanisterId: Principal.fromText(
-          sns.canister_ids.governance_canister_id
-        ),
-        ledgerCanisterId: Principal.fromText(
-          sns.canister_ids.ledger_canister_id
-        ),
-        indexCanisterId: Principal.fromText(sns.canister_ids.index_canister_id),
-        swap: toNullable(sns.swap_state.swap),
-        // The endpoint `get_state` and `get_derived_state` return different fields and decimal precision.
-        // * `sns.swap_state` is the response from `get_state`
-        // * `sns.derived_state` is the response from `get_derived_state`
-        // We want to use the info in `derived_state` immediately instead of changing it afterwards to avoid having a partial different data in the snsQueryStore.
-        derived: toNullable(
-          convertDerivedStateResponseToDerivedState(sns.derived_state)
-        ),
-      })),
-    ];
-    snsQueryStore.setData(snsQueryStoreData);
     snsTotalTokenSupplyStore.setTotalTokenSupplies(
       cachedSnses.map(({ icrc1_total_supply, canister_ids }) => ({
         rootCanisterId: Principal.fromText(canister_ids.root_canister_id),

--- a/frontend/src/tests/lib/services/_public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns.services.spec.ts
@@ -13,7 +13,6 @@ import { authStore } from "$lib/stores/auth.store";
 import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { snsTotalTokenSupplyStore } from "$lib/stores/sns-total-token-supply.store";
-import { snsQueryStore } from "$lib/stores/sns.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
@@ -126,7 +125,6 @@ describe("SNS public services", () => {
 
   describe("loadSnsProjects", () => {
     beforeEach(() => {
-      snsQueryStore.reset();
       snsFunctionsStore.reset();
       transactionsFeesStore.reset();
       snsAggregatorStore.reset();
@@ -148,9 +146,6 @@ describe("SNS public services", () => {
       const rootCanisterId = aggregatorSnsMockDto.canister_ids.root_canister_id;
       expect(spyQuerySnsProjects).toBeCalled();
 
-      const queryStore = get(snsQueryStore);
-      expect(queryStore.metadata.length).toBeGreaterThan(0);
-      expect(queryStore.swaps.length).toBeGreaterThan(0);
       const functionsStore = get(snsFunctionsStore);
       expect(functionsStore[rootCanisterId]).not.toBeUndefined();
       const feesStore = get(transactionsFeesStore);
@@ -211,33 +206,6 @@ describe("SNS public services", () => {
       expect(data).not.toBeUndefined();
       expect(data?.certified).toBeTruthy();
       expect(data?.totalSupply).toEqual(BigInt(totalSupply));
-    });
-
-    it("loads derived state from property derived state", async () => {
-      jest
-        .spyOn(aggregatorApi, "querySnsProjects")
-        .mockImplementation(() => Promise.resolve([aggregatorSnsMockDto]));
-
-      await loadSnsProjects();
-
-      const queryStore = get(snsQueryStore);
-      const derivedState = queryStore.swaps[0]?.derived[0];
-      const expectedDerivedState = aggregatorSnsMockDto.derived_state;
-      expect(derivedState.buyer_total_icp_e8s).toBe(
-        BigInt(expectedDerivedState.buyer_total_icp_e8s)
-      );
-      expect(derivedState.sns_tokens_per_icp).toBe(
-        expectedDerivedState.sns_tokens_per_icp
-      );
-      expect(derivedState.cf_neuron_count[0]).toBe(
-        BigInt(expectedDerivedState.cf_neuron_count)
-      );
-      expect(derivedState.cf_participant_count[0]).toBe(
-        BigInt(expectedDerivedState.cf_participant_count)
-      );
-      expect(derivedState.direct_participant_count[0]).toBe(
-        BigInt(expectedDerivedState.direct_participant_count)
-      );
     });
   });
 });


### PR DESCRIPTION
# Motivation

The snsQueryStore is not read anymore. Therefore, writing to it is fruitless.

# Changes

* Remove the code that fills the snsQueryStore in the `loadSnsProjects` sns service.

# Tests

* Remove the checks and test cases of the snsQueryStore in the related test file.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
