### PR TITLE
GIX-1930: Use NF and direct commitment fields

### DIFF
--- a/frontend/src/lib/getters/sns-summary.ts
+++ b/frontend/src/lib/getters/sns-summary.ts
@@ -14,7 +14,7 @@ export const getConditionsToAccept = (
 export const getNeuronsFundParticipation = ({
   derived,
 }: SnsSummary): bigint | undefined =>
-  derived.neurons_fund_participation_icp_e8s[0];
+  fromNullable(derived.neurons_fund_participation_icp_e8s);
 
 // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
 export const getMinDirectParticipation = (

--- a/frontend/src/lib/getters/sns-summary.ts
+++ b/frontend/src/lib/getters/sns-summary.ts
@@ -11,10 +11,10 @@ export const getConditionsToAccept = (
 ): string | undefined =>
   fromNullable(fromNullable(summary.swap.init)?.confirmation_text || []);
 
-// TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
-export const getNeuronsFundParticipation = (
-  _summary: SnsSummary
-): bigint | undefined => undefined;
+export const getNeuronsFundParticipation = ({
+  derived,
+}: SnsSummary): bigint | undefined =>
+  derived.neurons_fund_participation_icp_e8s[0];
 
 // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
 export const getMinDirectParticipation = (

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -420,17 +420,18 @@ export const getProjectCommitmentSplit = (
   summary: SnsSummary
 ): ProjectCommitmentSplit => {
   const nfCommitmentE8s = getNeuronsFundParticipation(summary);
+  const directCommitmentE8s = summary.derived.direct_participation_icp_e8s[0];
   const minDirectCommitmentE8s = getMinDirectParticipation(summary);
   const maxDirectCommitmentE8s = getMaxDirectParticipation(summary);
   if (
     nonNullish(nfCommitmentE8s) &&
+    nonNullish(directCommitmentE8s) &&
     nonNullish(minDirectCommitmentE8s) &&
     nonNullish(maxDirectCommitmentE8s)
   ) {
     return {
       totalCommitmentE8s: summary.derived.buyer_total_icp_e8s,
-      directCommitmentE8s:
-        summary.derived.buyer_total_icp_e8s - nfCommitmentE8s,
+      directCommitmentE8s,
       nfCommitmentE8s,
       minDirectCommitmentE8s,
       maxDirectCommitmentE8s,

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -14,8 +14,12 @@ import type {
 } from "$lib/types/sns";
 import type { StoreData } from "$lib/types/store";
 import { SnsSwapLifecycle, type SnsSwapTicket } from "@dfinity/sns";
-import type { TokenAmount } from "@dfinity/utils";
-import { isNullish, nonNullish } from "@dfinity/utils";
+import {
+  fromNullable,
+  isNullish,
+  nonNullish,
+  type TokenAmount,
+} from "@dfinity/utils";
 import { nowInSeconds } from "./date.utils";
 import type { I18nSubstitutions } from "./i18n.utils";
 import { getCommitmentE8s } from "./sns.utils";
@@ -420,7 +424,9 @@ export const getProjectCommitmentSplit = (
   summary: SnsSummary
 ): ProjectCommitmentSplit => {
   const nfCommitmentE8s = getNeuronsFundParticipation(summary);
-  const directCommitmentE8s = summary.derived.direct_participation_icp_e8s[0];
+  const directCommitmentE8s = fromNullable(
+    summary.derived.direct_participation_icp_e8s
+  );
   const minDirectCommitmentE8s = getMinDirectParticipation(summary);
   const maxDirectCommitmentE8s = getMaxDirectParticipation(summary);
   if (

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -15,9 +15,6 @@ import { ProjectCommitmentPo } from "$tests/page-objects/ProjectCommitment.page-
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 
-// TODO: https://dfinity.atlassian.net/browse/GIX-1909 use nf participation field when present
-jest.mock("$lib/getters/sns-summary.ts");
-
 describe("ProjectCommitment", () => {
   const saleBuyerCount = 1_000_000;
 
@@ -94,12 +91,11 @@ describe("ProjectCommitment", () => {
     const directCommitment = 30000000000n;
     const summary = createSummary({
       currentTotalCommitment: directCommitment + nfCommitment,
+      directCommitment,
+      neuronsFundCommitment: nfCommitment,
     });
 
     beforeEach(() => {
-      jest
-        .spyOn(summaryGetters, "getNeuronsFundParticipation")
-        .mockImplementation(() => nfCommitment);
       // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
       jest
         .spyOn(summaryGetters, "getMinDirectParticipation")
@@ -131,9 +127,6 @@ describe("ProjectCommitment", () => {
 
   describe("when Neurons' Fund enhancements fields are available and NF commitment is 0", () => {
     beforeEach(() => {
-      jest
-        .spyOn(summaryGetters, "getNeuronsFundParticipation")
-        .mockImplementation(() => 0n);
       // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
       jest
         .spyOn(summaryGetters, "getMinDirectParticipation")
@@ -148,6 +141,8 @@ describe("ProjectCommitment", () => {
       const directCommitment = 20000000000n;
       const summary = createSummary({
         currentTotalCommitment: directCommitment,
+        neuronsFundCommitment: 0n,
+        directCommitment,
       });
       const po = renderComponent(summary);
       expect(await po.getNeuronsFundParticipation()).toEqual("0 ICP");
@@ -159,12 +154,11 @@ describe("ProjectCommitment", () => {
     const overallCommitment = 30000000000n;
     const summary = createSummary({
       currentTotalCommitment: overallCommitment,
+      neuronsFundCommitment: undefined,
+      directCommitment: undefined,
     });
 
     beforeEach(() => {
-      jest
-        .spyOn(summaryGetters, "getNeuronsFundParticipation")
-        .mockImplementation(() => undefined);
       // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
       jest
         .spyOn(summaryGetters, "getMinDirectParticipation")

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -350,12 +350,8 @@ export const createSummary = ({
     direct_participant_count: buyersCount === null ? [] : [buyersCount],
     buyer_total_icp_e8s:
       currentTotalCommitment ?? mockDerived.buyer_total_icp_e8s,
-    neurons_fund_participation_icp_e8s: nonNullish(neuronsFundCommitment)
-      ? [neuronsFundCommitment]
-      : [],
-    direct_participation_icp_e8s: nonNullish(directCommitment)
-      ? [directCommitment]
-      : [],
+    neurons_fund_participation_icp_e8s: toNullable(neuronsFundCommitment),
+    direct_participation_icp_e8s: toNullable(directCommitment),
   };
   const summary = summaryForLifecycle(lifecycle);
   return {

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -309,6 +309,8 @@ export const createSummary = ({
   minTotalCommitment,
   maxTotalCommitment,
   currentTotalCommitment,
+  neuronsFundCommitment,
+  directCommitment,
 }: {
   lifecycle?: SnsSwapLifecycle;
   confirmationText?: string | undefined;
@@ -322,6 +324,8 @@ export const createSummary = ({
   minTotalCommitment?: bigint;
   maxTotalCommitment?: bigint;
   currentTotalCommitment?: bigint;
+  neuronsFundCommitment?: bigint;
+  directCommitment?: bigint;
 }): SnsSummary => {
   const init: SnsSwapInit = {
     ...mockInit,
@@ -346,6 +350,12 @@ export const createSummary = ({
     direct_participant_count: buyersCount === null ? [] : [buyersCount],
     buyer_total_icp_e8s:
       currentTotalCommitment ?? mockDerived.buyer_total_icp_e8s,
+    neurons_fund_participation_icp_e8s: nonNullish(neuronsFundCommitment)
+      ? [neuronsFundCommitment]
+      : [],
+    direct_participation_icp_e8s: nonNullish(directCommitment)
+      ? [directCommitment]
+      : [],
   };
   const summary = summaryForLifecycle(lifecycle);
   return {


### PR DESCRIPTION
# Motivation

Use the summary fields for Neurons' Fund and direct commitments.

That doesn't mean that the functionality is available in mainnet. The functionality depends yet on two more fields that are not yet supported. The fields to give the min and max direct commitment.

# Changes

* Use the summary field for NF commitment in `getNeuronsFundParticipation`.
* Use the summary field for direct commitment in `getProjectCommitmentSplit`. We didn't expect it to have a field, that's why we didn't use a getter initially. But better use it than rely on the calculation.

# Tests

* Add new fields to test util `createSummary`.
* Tests don't rely on mocking the `getNeuronsFundParticipation` and instead build the desired summary.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.