### PR TITLE
Fix vitest timezone

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "test": "npm run vitest && npm run deprecated-jest-test",
     "test-e2e": "tsc --noEmit -p src/tests/e2e/tsconfig.json && playwright test",
     "deprecated-jest-test": "TZ=UTC jest",
-    "vitest": "vitest --config ./vitest.config.ts",
+    "vitest": "TZ=UTC vitest --config ./vitest.config.ts",
     "update:next": "npm update @dfinity/utils @dfinity/nns-proto @dfinity/ledger-icrc @dfinity/ledger-icp @dfinity/nns @dfinity/sns @dfinity/cmc @dfinity/ckbtc @dfinity/ic-management",
     "update:agent": "npm rm @dfinity/agent @dfinity/auth-client @dfinity/candid @dfinity/identity @dfinity/principal @dfinity/nns @dfinity/nns-proto @dfinity/cmc @dfinity/sns @dfinity/utils @dfinity/ledger-icrc @dfinity/ledger-icp @dfinity/ckbtc @dfinity/ic-management && npm i @dfinity/agent @dfinity/auth-client @dfinity/candid @dfinity/identity @dfinity/principal @dfinity/utils@next @dfinity/ledger-icrc@next @dfinity/ledger-icp@next @dfinity/nns@next @dfinity/nns-proto@next @dfinity/cmc@next @dfinity/sns@next @dfinity/ckbtc@next @dfinity/ic-management@next && ../scripts/revert-next.sh",
     "update:gix": "npm update @dfinity/gix-components",


### PR DESCRIPTION
# Motivation

Fix timezone for running vitest locally.

```
FAIL  src/vitests/lib/components/accounts/IcrcTransactionCard.spec.ts > IcrcTransactionCard > displays transaction date and time
AssertionError: expected 'Jan 1, 1970 1:00 AM' to include '12:00 AM'
 ❯ src/vitests/lib/components/accounts/IcrcTransactionCard.spec.ts:163:51
    161|
    162|     expect(div?.textContent).toContain("Jan 1, 1970");
    163|     expect(normalizeWhitespace(div?.textContent)).toContain("12:00 AM");
       |                                                   ^
    164|   });
    165|
```
