### PR TITLE
Migrare routes tests to vitest

### DIFF
--- a/frontend/__mocks__/$app/stores.ts
+++ b/frontend/__mocks__/$app/stores.ts
@@ -38,3 +38,5 @@ const initPageStoreMock = () => {
 };
 
 export const page = initPageStoreMock();
+
+export const navigating = writable(null);

--- a/frontend/src/vitests/routes/app/accounts/layout.spec.ts
+++ b/frontend/src/vitests/routes/app/accounts/layout.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import AccountsLayout from "$routes/(app)/(u)/(accounts)/+layout.svelte";
 import { render } from "@testing-library/svelte";

--- a/frontend/src/vitests/routes/app/accounts/page.spec.ts
+++ b/frontend/src/vitests/routes/app/accounts/page.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { authStore } from "$lib/stores/auth.store";
 import AccountsPage from "$routes/(app)/(u)/(accounts)/accounts/+page.svelte";
 import {
@@ -11,9 +7,9 @@ import {
 import { render } from "@testing-library/svelte";
 
 describe("Accounts page", () => {
-  jest
-    .spyOn(authStore, "subscribe")
-    .mockImplementation(mutableMockAuthStoreSubscribe);
+  vi.spyOn(authStore, "subscribe").mockImplementation(
+    mutableMockAuthStoreSubscribe
+  );
 
   beforeAll(() => {
     authStoreMock.next({
@@ -21,7 +17,7 @@ describe("Accounts page", () => {
     });
   });
 
-  afterAll(() => jest.clearAllMocks());
+  afterAll(() => vi.clearAllMocks());
 
   it("should render sign-in if not logged in", () => {
     const { getByTestId } = render(AccountsPage);

--- a/frontend/src/vitests/routes/app/canister/page.spec.ts
+++ b/frontend/src/vitests/routes/app/canister/page.spec.ts
@@ -1,19 +1,15 @@
-/**
- * @jest-environment jsdom
- */
-
 import { authStore } from "$lib/stores/auth.store";
-import WalletPage from "$routes/(app)/(u)/(detail)/wallet/+page.svelte";
+import CanisterPage from "$routes/(app)/(nns)/canister/+page.svelte";
 import {
   authStoreMock,
   mutableMockAuthStoreSubscribe,
 } from "$tests/mocks/auth.store.mock";
 import { render } from "@testing-library/svelte";
 
-describe("Wallet page", () => {
-  jest
-    .spyOn(authStore, "subscribe")
-    .mockImplementation(mutableMockAuthStoreSubscribe);
+describe("Canister page", () => {
+  vi.spyOn(authStore, "subscribe").mockImplementation(
+    mutableMockAuthStoreSubscribe
+  );
 
   beforeAll(() => {
     authStoreMock.next({
@@ -21,13 +17,13 @@ describe("Wallet page", () => {
     });
   });
 
-  afterAll(() => jest.clearAllMocks());
+  afterAll(() => vi.clearAllMocks());
 
   it("should render sign-in if not logged in", () => {
-    const { getByTestId } = render(WalletPage, {
+    const { getByTestId } = render(CanisterPage, {
       props: {
         data: {
-          account: "test",
+          canister: "test",
         },
       },
     });

--- a/frontend/src/vitests/routes/app/canisters/layout.spec.ts
+++ b/frontend/src/vitests/routes/app/canisters/layout.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import CanistersLayout from "$routes/(app)/(nns)/canisters/+layout.svelte";
 import { render } from "@testing-library/svelte";

--- a/frontend/src/vitests/routes/app/canisters/page.spec.ts
+++ b/frontend/src/vitests/routes/app/canisters/page.spec.ts
@@ -1,19 +1,15 @@
-/**
- * @jest-environment jsdom
- */
-
 import { authStore } from "$lib/stores/auth.store";
-import NeuronsPage from "$routes/(app)/(u)/(list)/neurons/+page.svelte";
+import CanistersPage from "$routes/(app)/(nns)/canisters/+page.svelte";
 import {
   authStoreMock,
   mutableMockAuthStoreSubscribe,
 } from "$tests/mocks/auth.store.mock";
 import { render } from "@testing-library/svelte";
 
-describe("Neurons page", () => {
-  jest
-    .spyOn(authStore, "subscribe")
-    .mockImplementation(mutableMockAuthStoreSubscribe);
+describe("Canisters page", () => {
+  vi.spyOn(authStore, "subscribe").mockImplementation(
+    mutableMockAuthStoreSubscribe
+  );
 
   beforeAll(() => {
     authStoreMock.next({
@@ -21,10 +17,10 @@ describe("Neurons page", () => {
     });
   });
 
-  afterAll(() => jest.clearAllMocks());
+  afterAll(() => vi.clearAllMocks());
 
   it("should render sign-in if not logged in", () => {
-    const { getByTestId } = render(NeuronsPage);
+    const { getByTestId } = render(CanistersPage);
 
     expect(getByTestId("login-button")).not.toBeNull();
   });

--- a/frontend/src/vitests/routes/app/layout.spec.ts
+++ b/frontend/src/vitests/routes/app/layout.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import {
   initAppAuth,
   initAppPublicData,
@@ -9,15 +5,15 @@ import {
 import App from "$routes/(app)/+layout.svelte";
 import { render, waitFor } from "@testing-library/svelte";
 
-jest.mock("$lib/services/$public/app.services", () => ({
-  initAppAuth: jest.fn(() => Promise.resolve()),
-  initAppPublicData: jest.fn(() => Promise.resolve()),
+vi.mock("$lib/services/$public/app.services", () => ({
+  initAppAuth: vi.fn(() => Promise.resolve()),
+  initAppPublicData: vi.fn(() => Promise.resolve()),
 }));
 
 describe("Layout", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
-    jest.restoreAllMocks();
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it("should init the auth on mount", async () => {

--- a/frontend/src/vitests/routes/app/neuron/page.spec.ts
+++ b/frontend/src/vitests/routes/app/neuron/page.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { authStore } from "$lib/stores/auth.store";
 import NeuronPage from "$routes/(app)/(u)/(detail)/neuron/+page.svelte";
 import {
@@ -11,9 +7,9 @@ import {
 import { render } from "@testing-library/svelte";
 
 describe("Neuron page", () => {
-  jest
-    .spyOn(authStore, "subscribe")
-    .mockImplementation(mutableMockAuthStoreSubscribe);
+  vi.spyOn(authStore, "subscribe").mockImplementation(
+    mutableMockAuthStoreSubscribe
+  );
 
   beforeAll(() => {
     authStoreMock.next({
@@ -21,7 +17,7 @@ describe("Neuron page", () => {
     });
   });
 
-  afterAll(() => jest.clearAllMocks());
+  afterAll(() => vi.clearAllMocks());
 
   it("should render sign-in if not logged in", () => {
     const { getByTestId } = render(NeuronPage, {

--- a/frontend/src/vitests/routes/app/neurons/layout.spec.ts
+++ b/frontend/src/vitests/routes/app/neurons/layout.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import NeuronsLayout from "$routes/(app)/(u)/(list)/neurons/+layout.svelte";
 import { render } from "@testing-library/svelte";

--- a/frontend/src/vitests/routes/app/neurons/page.spec.ts
+++ b/frontend/src/vitests/routes/app/neurons/page.spec.ts
@@ -1,19 +1,15 @@
-/**
- * @jest-environment jsdom
- */
-
 import { authStore } from "$lib/stores/auth.store";
-import CanistersPage from "$routes/(app)/(nns)/canisters/+page.svelte";
+import NeuronsPage from "$routes/(app)/(u)/(list)/neurons/+page.svelte";
 import {
   authStoreMock,
   mutableMockAuthStoreSubscribe,
 } from "$tests/mocks/auth.store.mock";
 import { render } from "@testing-library/svelte";
 
-describe("Canisters page", () => {
-  jest
-    .spyOn(authStore, "subscribe")
-    .mockImplementation(mutableMockAuthStoreSubscribe);
+describe("Neurons page", () => {
+  vi.spyOn(authStore, "subscribe").mockImplementation(
+    mutableMockAuthStoreSubscribe
+  );
 
   beforeAll(() => {
     authStoreMock.next({
@@ -21,10 +17,10 @@ describe("Canisters page", () => {
     });
   });
 
-  afterAll(() => jest.clearAllMocks());
+  afterAll(() => vi.clearAllMocks());
 
   it("should render sign-in if not logged in", () => {
-    const { getByTestId } = render(CanistersPage);
+    const { getByTestId } = render(NeuronsPage);
 
     expect(getByTestId("login-button")).not.toBeNull();
   });

--- a/frontend/src/vitests/routes/app/proposals/layout.spec.ts
+++ b/frontend/src/vitests/routes/app/proposals/layout.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
@@ -13,7 +9,7 @@ import { get } from "svelte/store";
 
 describe("Layout", () => {
   afterAll(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it("should go back to the proposal page", async () => {

--- a/frontend/src/vitests/routes/app/root/page.spec.ts
+++ b/frontend/src/vitests/routes/app/root/page.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import App from "$routes/(app)/(u)/(accounts)/+page.svelte";
 import { render } from "@testing-library/svelte";
 

--- a/frontend/src/vitests/routes/app/settings/layout.spec.ts
+++ b/frontend/src/vitests/routes/app/settings/layout.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
@@ -13,7 +9,7 @@ import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Layout", () => {
-  beforeAll(() => jest.resetAllMocks());
+  beforeAll(() => vi.resetAllMocks());
 
   const renderSettingsAndBack = () => {
     page.mock({
@@ -47,7 +43,7 @@ describe("Layout", () => {
   it("should go back to referrer", async () => {
     referrerPathStore.set(AppPath.Wallet);
 
-    const spy = jest.spyOn(history, "back");
+    const spy = vi.spyOn(history, "back");
 
     renderSettingsAndBack();
 

--- a/frontend/src/vitests/routes/app/settings/page.spec.ts
+++ b/frontend/src/vitests/routes/app/settings/page.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { authStore } from "$lib/stores/auth.store";
 import SettingsPage from "$routes/(app)/(nns)/settings/+page.svelte";
 import {
@@ -12,9 +8,9 @@ import {
 import { render } from "@testing-library/svelte";
 
 describe("Settings page", () => {
-  jest
-    .spyOn(authStore, "subscribe")
-    .mockImplementation(mutableMockAuthStoreSubscribe);
+  vi.spyOn(authStore, "subscribe").mockImplementation(
+    mutableMockAuthStoreSubscribe
+  );
 
   describe("not signed in", () => {
     beforeAll(() => {

--- a/frontend/src/vitests/routes/app/wallet/page.spec.ts
+++ b/frontend/src/vitests/routes/app/wallet/page.spec.ts
@@ -1,19 +1,15 @@
-/**
- * @jest-environment jsdom
- */
-
 import { authStore } from "$lib/stores/auth.store";
-import CanisterPage from "$routes/(app)/(nns)/canister/+page.svelte";
+import WalletPage from "$routes/(app)/(u)/(detail)/wallet/+page.svelte";
 import {
   authStoreMock,
   mutableMockAuthStoreSubscribe,
 } from "$tests/mocks/auth.store.mock";
 import { render } from "@testing-library/svelte";
 
-describe("Canister page", () => {
-  jest
-    .spyOn(authStore, "subscribe")
-    .mockImplementation(mutableMockAuthStoreSubscribe);
+describe("Wallet page", () => {
+  vi.spyOn(authStore, "subscribe").mockImplementation(
+    mutableMockAuthStoreSubscribe
+  );
 
   beforeAll(() => {
     authStoreMock.next({
@@ -21,13 +17,13 @@ describe("Canister page", () => {
     });
   });
 
-  afterAll(() => jest.clearAllMocks());
+  afterAll(() => vi.clearAllMocks());
 
   it("should render sign-in if not logged in", () => {
-    const { getByTestId } = render(CanisterPage, {
+    const { getByTestId } = render(WalletPage, {
       props: {
         data: {
-          canister: "test",
+          account: "test",
         },
       },
     });

--- a/frontend/src/vitests/routes/layout.spec.ts
+++ b/frontend/src/vitests/routes/layout.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { initAppPrivateDataProxy } from "$lib/proxy/app.services.proxy";
 import { initAuthWorker } from "$lib/services/worker-auth.services";
 import { authStore } from "$lib/stores/auth.store";
@@ -15,8 +11,8 @@ import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { render } from "@testing-library/svelte";
 
-jest.mock("$lib/services/worker-auth.services", () => ({
-  initAuthWorker: jest.fn(() =>
+vi.mock("$lib/services/worker-auth.services", () => ({
+  initAuthWorker: vi.fn(() =>
     Promise.resolve({
       syncAuthIdle: () => {
         // Do nothing
@@ -25,21 +21,21 @@ jest.mock("$lib/services/worker-auth.services", () => ({
   ),
 }));
 
-jest.mock("$lib/services/app.services", () => ({
-  initApp: jest.fn(() => Promise.resolve()),
+vi.mock("$lib/services/app.services", () => ({
+  initApp: vi.fn(() => Promise.resolve()),
 }));
 
-jest.mock("$lib/proxy/app.services.proxy");
+vi.mock("$lib/proxy/app.services.proxy");
 
 describe("Layout", () => {
   beforeEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
 
-    jest
-      .spyOn(authStore, "subscribe")
-      .mockImplementation(mutableMockAuthStoreSubscribe);
+    vi.spyOn(authStore, "subscribe").mockImplementation(
+      mutableMockAuthStoreSubscribe
+    );
 
-    jest.spyOn(authStore, "sync").mockImplementation(() => Promise.resolve());
+    vi.spyOn(authStore, "sync").mockImplementation(() => Promise.resolve());
   });
 
   it("should init the app after sign in", async () => {
@@ -69,7 +65,7 @@ describe("Layout", () => {
   });
 
   it("should reset toasts on sign in", async () => {
-    const spy = jest.spyOn(toastsStore, "reset");
+    const spy = vi.spyOn(toastsStore, "reset");
     expect(spy).not.toBeCalled();
 
     render(App);

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -8,7 +8,7 @@ import { TextDecoder, TextEncoder } from "util";
 import { vi } from "vitest";
 import { browser, building } from "./__mocks__/$app/environment";
 import { afterNavigate, goto } from "./__mocks__/$app/navigation";
-import { page } from "./__mocks__/$app/stores";
+import { navigating, page } from "./__mocks__/$app/stores";
 import { IntersectionObserverPassive } from "./src/tests/mocks/infinitescroll.mock";
 import localStorageMock from "./src/tests/mocks/local-storage.mock";
 import { failTestsThatLogToConsole } from "./src/tests/utils/console.test-utils";
@@ -93,4 +93,5 @@ vi.mock("$app/navigation", () => ({
 
 vi.mock("$app/stores", () => ({
   page,
+  navigating,
 }));


### PR DESCRIPTION
# Changes

- migrate routes related tests to vitest.
- mock `navigating` object of svelte (otherwise it throws an undefined issue)
