### PR TITLE
Chore: Remove update:next script

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -68,6 +68,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Removed
 
 * Comment and skip dfx-nns-proposal-args.test.
+* Remove npm script `update:next`.
 
 #### Fixed
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,6 @@
     "test-e2e": "tsc --noEmit -p src/tests/e2e/tsconfig.json && playwright test",
     "deprecated-jest-test": "TZ=UTC jest",
     "vitest": "TZ=UTC vitest --config ./vitest.config.ts",
-    "update:next": "npm update @dfinity/utils @dfinity/nns-proto @dfinity/ledger-icrc @dfinity/ledger-icp @dfinity/nns @dfinity/sns @dfinity/cmc @dfinity/ckbtc @dfinity/ic-management",
     "update:agent": "npm rm @dfinity/agent @dfinity/auth-client @dfinity/candid @dfinity/identity @dfinity/principal @dfinity/nns @dfinity/nns-proto @dfinity/cmc @dfinity/sns @dfinity/utils @dfinity/ledger-icrc @dfinity/ledger-icp @dfinity/ckbtc @dfinity/ic-management && npm i @dfinity/agent @dfinity/auth-client @dfinity/candid @dfinity/identity @dfinity/principal @dfinity/utils@next @dfinity/ledger-icrc@next @dfinity/ledger-icp@next @dfinity/nns@next @dfinity/nns-proto@next @dfinity/cmc@next @dfinity/sns@next @dfinity/ckbtc@next @dfinity/ic-management@next && ../scripts/revert-next.sh",
     "update:gix": "npm update @dfinity/gix-components",
     "upgrade:next": "npm rm @dfinity/nns @dfinity/nns-proto @dfinity/cmc @dfinity/sns @dfinity/utils @dfinity/ledger-icrc @dfinity/ledger-icp @dfinity/ckbtc @dfinity/ic-management && npm i @dfinity/nns@next @dfinity/nns-proto@next @dfinity/cmc@next @dfinity/sns@next @dfinity/utils@next @dfinity/ledger-icrc@next @dfinity/ledger-icp@next @dfinity/ckbtc@next @dfinity/ic-management@next && ../scripts/revert-next.sh"


### PR DESCRIPTION
# Motivation

`npm run update:next` doesn't install the next dependencies for ledger-icp and ledger-icrc.

Instead, we can upgrade using `npm run upgrade:next`. There is no reason to have two scripts that do the same thing anyway, so I'm removing one.

# Changes

* Remove update:next from packgage.json scripts

# Tests

Not necessary.

# Todos

- [x] Add entry to changelog (if necessary).
