### PR TITLE
GIX-1928: Add maturity in NNS neurons

### DIFF
--- a/frontend/src/lib/api/governace-test.api.ts
+++ b/frontend/src/lib/api/governace-test.api.ts
@@ -1,0 +1,31 @@
+import { GOVERNANCE_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { HOST } from "$lib/constants/environment.constants";
+import type { Identity } from "@dfinity/agent";
+import { GovernanceTestCanister, type Neuron } from "@dfinity/nns";
+import { createAgent } from "./agent.api";
+
+const governanceTestCanister = async (identity: Identity) => {
+  const agent = await createAgent({
+    identity,
+    host: HOST,
+  });
+
+  return GovernanceTestCanister.create({
+    agent,
+    canisterId: GOVERNANCE_CANISTER_ID,
+  });
+};
+
+export const updateNeuron = async ({
+  neuron,
+  identity,
+}: {
+  neuron: Neuron;
+  identity: Identity;
+}): Promise<undefined> => {
+  const canister = await governanceTestCanister(identity);
+
+  await canister.updateNeuron(neuron);
+
+  return;
+};

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronTestnetFunctionsCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronTestnetFunctionsCard.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import CardInfo from "../ui/CardInfo.svelte";
+  import { openNnsNeuronModal } from "$lib/utils/modals.utils";
+  import type { NeuronInfo } from "@dfinity/nns";
+
+  export let neuron: NeuronInfo;
+
+  const openAddMaturityModal = async () => {
+    openNnsNeuronModal({ type: "dev-add-maturity", data: { neuron } });
+  };
+</script>
+
+<!-- ONLY FOR TESTNET. NO UNIT TESTS -->
+<CardInfo>
+  <h3 slot="start">Neuron TESTNET ONLY</h3>
+
+  <div>
+    <button on:click={openAddMaturityModal} class="primary">Add Maturity</button
+    >
+  </div>
+</CardInfo>
+
+<style lang="scss">
+  h3 {
+    line-height: var(--line-height-standard);
+  }
+
+  div {
+    display: flex;
+    justify-content: flex-start;
+  }
+</style>

--- a/frontend/src/lib/modals/neurons/NnsNeuronModals.svelte
+++ b/frontend/src/lib/modals/neurons/NnsNeuronModals.svelte
@@ -21,6 +21,8 @@
     NnsNeuronModalVotingHistory,
   } from "$lib/types/nns-neuron-detail.modal";
   import { nonNullish } from "@dfinity/utils";
+  import { IS_TESTNET } from "$lib/constants/environment.constants";
+  import NnsAddMaturityModal from "../sns/neurons/NnsAddMaturityModal.svelte";
 
   let modal: NnsNeuronModal<NnsNeuronModalData> | undefined;
   const close = () => (modal = undefined);
@@ -82,6 +84,10 @@
 
     {#if type === "add-hotkey"}
       <AddHotkeyModal on:nnsClose={close} {neuron} />
+    {/if}
+
+    {#if type === "dev-add-maturity" && IS_TESTNET}
+      <NnsAddMaturityModal {neuron} on:nnsClose={close} />
     {/if}
   {/if}
 

--- a/frontend/src/lib/modals/sns/neurons/AddMaturityModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/AddMaturityModal.svelte
@@ -29,6 +29,7 @@
       return;
     }
 
+    transferring = true;
     startBusy({ initiator: "dev-add-sns-neuron-maturity" });
 
     await addMaturity({
@@ -38,6 +39,7 @@
     });
     await reloadNeuron();
 
+    transferring = false;
     dispatcher("nnsClose");
     stopBusy("dev-add-sns-neuron-maturity");
   };

--- a/frontend/src/lib/modals/sns/neurons/NnsAddMaturityModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/NnsAddMaturityModal.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { Modal, Spinner } from "@dfinity/gix-components";
+  import { createEventDispatcher } from "svelte";
+  import { startBusy, stopBusy } from "$lib/stores/busy.store";
+  import { toastsError } from "$lib/stores/toasts.store";
+  import Input from "$lib/components/ui/Input.svelte";
+  import { numberToE8s } from "$lib/utils/token.utils";
+  import { addMaturity } from "$lib/services/nns-neurons-dev.services";
+  import type { NeuronInfo } from "@dfinity/nns";
+
+  export let neuron: NeuronInfo;
+
+  const dispatcher = createEventDispatcher();
+
+  let inputValue: number | undefined = undefined;
+  let transferring = false;
+
+  let invalidForm: boolean;
+  $: invalidForm = inputValue === undefined || inputValue <= 0;
+
+  const onSubmit = async () => {
+    if (invalidForm || inputValue === undefined) {
+      toastsError({
+        labelKey: "Invalid maturity input.",
+      });
+      return;
+    }
+
+    startBusy({ initiator: "dev-add-nns-neuron-maturity" });
+
+    await addMaturity({
+      neuron,
+      amountE8s: numberToE8s(inputValue),
+    });
+
+    dispatcher("nnsClose");
+    stopBusy("dev-add-nns-neuron-maturity");
+  };
+</script>
+
+<!-- ONLY FOR TESTNET. NO UNIT TESTS -->
+<Modal role="alert" on:nnsClose>
+  <span slot="title">{`Add Nns Neuron Maturity`}</span>
+
+  <form id="get-maturity-form" on:submit|preventDefault={onSubmit}>
+    <span class="label">How much?</span>
+
+    <Input
+      placeholderLabelKey="core.amount"
+      name="tokens"
+      inputType="icp"
+      bind:value={inputValue}
+      disabled={transferring}
+    />
+  </form>
+
+  <button
+    form="get-maturity-form"
+    type="submit"
+    class="primary"
+    slot="footer"
+    disabled={invalidForm || transferring}
+  >
+    {#if transferring}
+      <Spinner />
+    {:else}
+      Add Maturity
+    {/if}
+  </button>
+</Modal>

--- a/frontend/src/lib/modals/sns/neurons/NnsAddMaturityModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/NnsAddMaturityModal.svelte
@@ -40,7 +40,7 @@
 
 <!-- ONLY FOR TESTNET. NO UNIT TESTS -->
 <Modal role="alert" on:nnsClose>
-  <span slot="title">{`Add Nns Neuron Maturity`}</span>
+  <span slot="title">Add Nns Neuron Maturity</span>
 
   <form id="get-maturity-form" on:submit|preventDefault={onSubmit}>
     <span class="label">How much?</span>

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -39,6 +39,7 @@
   import NnsNeuronPageHeading from "$lib/components/neuron-detail/NnsNeuronPageHeading.svelte";
   import SkeletonHeader from "$lib/components/ui/SkeletonHeader.svelte";
   import SkeletonHeading from "$lib/components/ui/SkeletonHeading.svelte";
+  import NnsNeuronTestnetFunctionsCard from "$lib/components/neuron-detail/NnsNeuronTestnetFunctionsCard.svelte";
 
   export let neuronIdText: string | undefined | null;
 
@@ -160,6 +161,8 @@
           <Separator spacing="none" />
           {#if IS_TESTNET}
             <NnsNeuronProposalsCard {neuron} />
+            <Separator spacing="none" />
+            <NnsNeuronTestnetFunctionsCard {neuron} />
             <Separator spacing="none" />
           {/if}
           <NeuronVotingHistoryCard {neuron} />

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -289,7 +289,7 @@ export const listNeurons = async ({
 };
 
 // We always want to call this with the user identity
-const getAndLoadNeuron = async (neuronId: NeuronId) => {
+export const getAndLoadNeuron = async (neuronId: NeuronId) => {
   const identity = await getAuthenticatedIdentity();
   const neuron: NeuronInfo | undefined = await getNeuron({
     neuronId,

--- a/frontend/src/lib/services/nns-neurons-dev.services.ts
+++ b/frontend/src/lib/services/nns-neurons-dev.services.ts
@@ -1,6 +1,7 @@
 import { updateNeuron } from "$lib/api/governace-test.api";
 import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
 import type { E8s, Neuron, NeuronInfo } from "@dfinity/nns";
+import { isNullish } from "@dfinity/utils";
 import { getAuthenticatedIdentity } from "./auth.services";
 import { getAndLoadNeuron } from "./neurons.services";
 
@@ -13,6 +14,12 @@ export const addMaturity = async ({
 }): Promise<void> => {
   try {
     const identity = await getAuthenticatedIdentity();
+
+    if (isNullish(neuron.fullNeuron)) {
+      throw new Error(
+        `Full neuron is not defined for neuron ${neuron.neuronId}`
+      );
+    }
 
     const newNeuron: Neuron = {
       ...neuron.fullNeuron,

--- a/frontend/src/lib/services/nns-neurons-dev.services.ts
+++ b/frontend/src/lib/services/nns-neurons-dev.services.ts
@@ -1,0 +1,39 @@
+import { updateNeuron } from "$lib/api/governace-test.api";
+import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
+import type { E8s, Neuron, NeuronInfo } from "@dfinity/nns";
+import { getAuthenticatedIdentity } from "./auth.services";
+import { getAndLoadNeuron } from "./neurons.services";
+
+export const addMaturity = async ({
+  neuron,
+  amountE8s,
+}: {
+  neuron: NeuronInfo;
+  amountE8s: E8s;
+}): Promise<void> => {
+  try {
+    const identity = await getAuthenticatedIdentity();
+
+    const newNeuron: Neuron = {
+      ...neuron.fullNeuron,
+      maturityE8sEquivalent:
+        neuron.fullNeuron.maturityE8sEquivalent + amountE8s,
+    };
+
+    await updateNeuron({
+      neuron: newNeuron,
+      identity,
+    });
+
+    await getAndLoadNeuron(neuron.neuronId);
+
+    toastsSuccess({
+      labelKey: "neuron_detail.add_maturity_success",
+    });
+  } catch (err) {
+    toastsError({
+      labelKey: "error.add_maturity",
+      err,
+    });
+  }
+};

--- a/frontend/src/lib/stores/busy.store.ts
+++ b/frontend/src/lib/stores/busy.store.ts
@@ -44,6 +44,7 @@ export type BusyStateInitiatorType =
   | "load-sns-filters"
   | "dev-add-sns-neuron-permissions"
   | "dev-add-sns-neuron-maturity"
+  | "dev-add-nns-neuron-maturity"
   | "load-sns-accounts"
   | "update-ckbtc-balance"
   | "reload-receive-account";

--- a/frontend/src/lib/types/nns-neuron-detail.modal.ts
+++ b/frontend/src/lib/types/nns-neuron-detail.modal.ts
@@ -14,6 +14,7 @@ export type NnsNeuronModalType =
   | "merge-maturity"
   | "spawn"
   | "join-community-fund"
+  | "dev-add-maturity"
   | "voting-history";
 
 export interface NnsNeuronModalData {


### PR DESCRIPTION
# Motivation

Test maturity related functionality easily with NNS neurons.

In this PR, add a card with a modal to add maturity to NNS neurons with the `update_neuron` endpoint in the governance test canister.

# Changes

* New governance test api: `updateNeuron`.
* New card in nns neuron detail page: NnsNeuronTestnetFunctionsCard.
* New modal `NnsAddMaturityModal`.
* Add new modal in NnsNeuronModals only for Testnet.
* New dev service for nns neurons `addMaturity`.

# Tests

Only dev environment feature.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.