### PR TITLE
Increase local Playwright timeout

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   testDir: "./src/tests/e2e",
   snapshotPathTemplate: './src/tests/e2e/screenshots/{testFilePath}-{arg}-{projectName}-{platform}{ext}',
   /* Maximum time one test can run for. */
-  timeout: (process.env.CI ? 300 : 90) * 1000,
+  timeout: 300 * 1000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.


### PR DESCRIPTION
# Motivation

Some tests have become quite long.
We also have a faster machine on CI then we used to have in the beginning.
So having a different timeout on CI vs. locally isn't really warranted anymore.

# Changes

Set the Playwright timeout to 5 minutes regardless of whether the test runs locally or on CI.

# Tests

CI passes

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary