### PR TITLE
feat (proposal rendering): Get sns_wasm types from .did file

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -16,8 +16,8 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 
 #### Changed
 
-* Update the governance canister schema used for proposal rendering to the schema from `2023-09-27`.
-* Get the governance canister schema direcly from the `.did` file rather than importing the whole governance canister crate to get the types.
+* Update the governance canister and SNS Wasm schema used for proposal rendering to the schema from `2023-09-27`.
+* Get the governance canister and SNS Wasm schemas direcly from the `.did` file rather than importing the whole canisters to get the types.
 * Make a histogram of transactions per account, used to optimize the new account storage.
 * Include a copy of the `nns-governance` candid file in the `nns-dapp` repository.
 * Update the IC commit in the `proposals` crate to `release-2023-08-01_23-01`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,15 +1895,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-canister-profiler"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "ic-metrics-encoder",
- "ic0",
-]
-
-[[package]]
 name = "ic-canisters-http-types"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0#89129b8212791d7e05cab62ff08eece2888a86e0"
@@ -2802,21 +2793,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-icrc1-client"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "async-trait",
- "candid",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "ic-icrc1-index"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0#89129b8212791d7e05cab62ff08eece2888a86e0"
@@ -2825,40 +2801,15 @@ dependencies = [
  "candid",
  "ciborium",
  "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-canister-profiler 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
+ "ic-canister-profiler",
  "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-cdk 0.6.10",
  "ic-cdk-macros",
  "ic-cdk-timers 0.1.2",
  "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-icrc1-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
+ "ic-icrc1-ledger",
  "ic-metrics-encoder",
  "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "num-traits",
- "scopeguard",
- "serde",
-]
-
-[[package]]
-name = "ic-icrc1-index"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "async-trait",
- "candid",
- "ciborium",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-canister-profiler 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-cdk 0.7.4",
- "ic-cdk-macros",
- "ic-cdk-timers 0.1.2",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-icrc1-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-icrc1-tokens-u64",
- "ic-ledger-hash-of",
- "ic-metrics-encoder",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
  "num-traits",
  "scopeguard",
  "serde",
@@ -2880,7 +2831,7 @@ dependencies = [
  "ic-cdk-macros",
  "ic-crypto-tree-hash 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-icrc1-client 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
+ "ic-icrc1-client",
  "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-metrics-encoder",
@@ -2888,46 +2839,6 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_bytes",
-]
-
-[[package]]
-name = "ic-icrc1-ledger"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "async-trait",
- "candid",
- "ciborium",
- "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-canister-log 0.2.0",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-cdk 0.7.4",
- "ic-cdk-macros",
- "ic-crypto-tree-hash 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-icrc1-client 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-icrc1-tokens-u64",
- "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-hash-of",
- "ic-metrics-encoder",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "num-traits",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "ic-icrc1-tokens-u64"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "candid",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-stable-structures",
- "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -3213,18 +3124,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-nervous-system-proto"
-version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "candid",
- "comparable",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "prost",
- "serde",
-]
-
-[[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.0.1"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
@@ -3383,14 +3282,14 @@ dependencies = [
  "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-nervous-system-common-build-metadata 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-nervous-system-common-test-keys",
- "ic-nervous-system-proto 0.0.1 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
+ "ic-nervous-system-proto",
  "ic-nns-common 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-sns-init 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-sns-root 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-sns-swap 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-sns-wasm 1.0.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
+ "ic-sns-init",
+ "ic-sns-root",
+ "ic-sns-swap",
+ "ic-sns-wasm",
  "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "itertools",
  "lazy_static",
@@ -3402,21 +3301,6 @@ dependencies = [
  "serde",
  "strum 0.23.0",
  "strum_macros 0.23.1",
-]
-
-[[package]]
-name = "ic-nns-handler-root-interface"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "async-trait",
- "candid",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nervous-system-clients",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "serde",
 ]
 
 [[package]]
@@ -3603,12 +3487,12 @@ dependencies = [
  "hex",
  "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-canister-log 0.8.0",
- "ic-canister-profiler 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
+ "ic-canister-profiler",
  "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-crypto-sha 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-icrc1-client 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
+ "ic-icrc1-client",
  "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-metrics-encoder",
  "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
@@ -3634,59 +3518,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-sns-governance"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "async-trait",
- "base64 0.13.1",
- "build-info",
- "build-info-build",
- "bytes",
- "candid",
- "clap",
- "comparable",
- "csv",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-canister-log 0.2.0",
- "ic-canister-profiler 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-icrc1-client 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-metrics-encoder",
- "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nervous-system-common-build-metadata 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nervous-system-root 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nervous-system-runtime",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "lazy_static",
- "maplit",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "prost",
- "prost-build",
- "rand",
- "rand_chacha",
- "registry-canister 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "rust_decimal",
- "rust_decimal_macros",
- "serde",
- "strum 0.18.0",
- "strum_macros 0.18.0",
-]
-
-[[package]]
 name = "ic-sns-init"
 version = "0.1.0"
 source = "git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0#89129b8212791d7e05cab62ff08eece2888a86e0"
@@ -3699,50 +3530,16 @@ dependencies = [
  "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-crypto-sha 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-icrc1-index 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-icrc1-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
+ "ic-icrc1-index",
+ "ic-icrc1-ledger",
  "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-sns-governance 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-sns-root 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-sns-swap 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
+ "ic-sns-governance",
+ "ic-sns-root",
+ "ic-sns-swap",
  "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "lazy_static",
- "maplit",
- "num",
- "prost",
- "regex",
- "serde",
- "serde_json",
- "serde_yaml",
-]
-
-[[package]]
-name = "ic-sns-init"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "base64 0.13.1",
- "candid",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-crypto-sha2",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-icrc1-index 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-icrc1-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nervous-system-proto 0.0.1 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-sns-governance 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-sns-root 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-sns-swap 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "isocountry",
  "lazy_static",
  "maplit",
  "num",
@@ -3775,40 +3572,8 @@ dependencies = [
  "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-nervous-system-common-build-metadata 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-nervous-system-root 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-sns-swap 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
+ "ic-sns-swap",
  "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "num-traits",
- "prost",
- "serde",
-]
-
-[[package]]
-name = "ic-sns-root"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "async-trait",
- "build-info",
- "build-info-build",
- "candid",
- "comparable",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "futures",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-canister-log 0.2.0",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-cdk 0.7.4",
- "ic-cdk-macros",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-metrics-encoder",
- "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nervous-system-common-build-metadata 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nervous-system-root 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nervous-system-runtime",
- "ic-sns-swap 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
  "num-traits",
  "prost",
  "serde",
@@ -3841,7 +3606,7 @@ dependencies = [
  "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-nervous-system-root 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-sns-governance 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
+ "ic-sns-governance",
  "ic-stable-structures",
  "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
@@ -3852,51 +3617,6 @@ dependencies = [
  "prost",
  "prost-build",
  "registry-canister 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "rust_decimal",
- "serde",
- "strum 0.18.0",
- "strum_macros 0.18.0",
-]
-
-[[package]]
-name = "ic-sns-swap"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "async-trait",
- "build-info",
- "build-info-build",
- "bytes",
- "candid",
- "comparable",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-canister-log 0.2.0",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-crypto-sha2",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-metrics-encoder",
- "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nervous-system-proto 0.0.1 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nervous-system-runtime",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-sns-governance 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-stable-structures",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "itertools",
- "lazy_static",
- "maplit",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "prost",
- "prost-build",
- "registry-canister 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
  "rust_decimal",
  "serde",
  "strum 0.18.0",
@@ -3923,46 +3643,11 @@ dependencies = [
  "ic-metrics-encoder",
  "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-sns-governance 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-sns-init 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-sns-root 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
+ "ic-sns-governance",
+ "ic-sns-init",
+ "ic-sns-root",
  "ic-types 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "maplit",
- "prost",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "ic-sns-wasm"
-version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "async-trait",
- "build-info",
- "candid",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "futures",
- "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-cdk 0.7.4",
- "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-metrics-encoder",
- "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nervous-system-proto 0.0.1 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nervous-system-runtime",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nns-handler-root-interface",
- "ic-sns-governance 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-sns-init 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-sns-root 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
  "maplit",
  "prost",
  "serde",
@@ -4426,16 +4111,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "isocountry"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea1dc4bf0fb4904ba83ffdb98af3d9c325274e92e6e295e4151e86c96363e04"
-dependencies = [
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4715,7 +4390,7 @@ dependencies = [
  "ic-nns-common 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-nns-governance",
- "ic-sns-swap 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
+ "ic-sns-swap",
  "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "itertools",
  "lazy_static",
@@ -5332,7 +5007,6 @@ dependencies = [
  "ic-nervous-system-root 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
  "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
  "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-sns-wasm 1.0.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
  "idl2json",
  "registry-canister 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
  "serde",

--- a/rs/proposals/Cargo.toml
+++ b/rs/proposals/Cargo.toml
@@ -23,7 +23,6 @@ ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "relea
 ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
 ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
 ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-ic-sns-wasm = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
 registry-canister = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
 
 ic-cdk = { workspace = true }

--- a/rs/proposals/src/canisters/mod.rs
+++ b/rs/proposals/src/canisters/mod.rs
@@ -1,1 +1,2 @@
 pub mod nns_governance;
+pub mod sns_wasm;

--- a/rs/proposals/src/canisters/sns_wasm.rs
+++ b/rs/proposals/src/canisters/sns_wasm.rs
@@ -1,0 +1,3 @@
+//! Code for interacting with the NNS SNS Wasm canister.
+
+pub mod api;

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,0 +1,408 @@
+#![allow(clippy::all)]
+#![allow(clippy::missing_docs_in_private_items)]
+#![allow(non_camel_case_types)]
+#![allow(dead_code, unused_imports)]
+use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
+use ic_cdk::api::call::CallResult;
+use serde::Serialize;
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct EmptyRecord {}
+// This is an experimental feature to generate Rust binding from Candid.
+// You may want to manually adjust some of the types.
+// #![allow(dead_code, unused_imports)]
+// use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
+// use ic_cdk::api::call::CallResult as Result;
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct SnsWasmCanisterInitPayload {
+    pub allowed_principals: Vec<Principal>,
+    pub access_controls_enabled: bool,
+    pub sns_subnet_ids: Vec<Principal>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct SnsWasm {
+    pub wasm: serde_bytes::ByteBuf,
+    pub canister_type: i32,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct AddWasmRequest {
+    pub hash: serde_bytes::ByteBuf,
+    pub wasm: Option<SnsWasm>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct SnsWasmError {
+    pub message: String,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub enum Result_ {
+    Error(SnsWasmError),
+    Hash(serde_bytes::ByteBuf),
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct AddWasmResponse {
+    pub result: Option<Result_>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct NeuronBasketConstructionParameters {
+    pub dissolve_delay_interval_seconds: u64,
+    pub count: u64,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct Canister {
+    pub id: Option<Principal>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct DappCanisters {
+    pub canisters: Vec<Canister>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct LinearScalingCoefficient {
+    pub slope_numerator: Option<u64>,
+    pub intercept_icp_e8s: Option<u64>,
+    pub from_direct_participation_icp_e8s: Option<u64>,
+    pub slope_denominator: Option<u64>,
+    pub to_direct_participation_icp_e8s: Option<u64>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct NeuronsFundParticipationConstraints {
+    pub coefficient_intervals: Vec<LinearScalingCoefficient>,
+    pub max_neurons_fund_participation_icp_e8s: Option<u64>,
+    pub min_direct_participation_threshold_icp_e8s: Option<u64>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct CfNeuron {
+    pub nns_neuron_id: u64,
+    pub amount_icp_e8s: u64,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct CfParticipant {
+    pub hotkey_principal: String,
+    pub cf_neurons: Vec<CfNeuron>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct NeuronsFundParticipants {
+    pub participants: Vec<CfParticipant>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct TreasuryDistribution {
+    pub total_e8s: u64,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct NeuronDistribution {
+    pub controller: Option<Principal>,
+    pub dissolve_delay_seconds: u64,
+    pub memo: u64,
+    pub stake_e8s: u64,
+    pub vesting_period_seconds: Option<u64>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct DeveloperDistribution {
+    pub developer_neurons: Vec<NeuronDistribution>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct AirdropDistribution {
+    pub airdrop_neurons: Vec<NeuronDistribution>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct SwapDistribution {
+    pub total_e8s: u64,
+    pub initial_swap_amount_e8s: u64,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct FractionalDeveloperVotingPower {
+    pub treasury_distribution: Option<TreasuryDistribution>,
+    pub developer_distribution: Option<DeveloperDistribution>,
+    pub airdrop_distribution: Option<AirdropDistribution>,
+    pub swap_distribution: Option<SwapDistribution>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub enum InitialTokenDistribution {
+    FractionalDeveloperVotingPower(FractionalDeveloperVotingPower),
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct Countries {
+    pub iso_codes: Vec<String>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct SnsInitPayload {
+    pub url: Option<String>,
+    pub max_dissolve_delay_seconds: Option<u64>,
+    pub max_dissolve_delay_bonus_percentage: Option<u64>,
+    pub nns_proposal_id: Option<u64>,
+    pub min_participant_icp_e8s: Option<u64>,
+    pub neuron_basket_construction_parameters: Option<NeuronBasketConstructionParameters>,
+    pub fallback_controller_principal_ids: Vec<String>,
+    pub token_symbol: Option<String>,
+    pub final_reward_rate_basis_points: Option<u64>,
+    pub max_icp_e8s: Option<u64>,
+    pub neuron_minimum_stake_e8s: Option<u64>,
+    pub confirmation_text: Option<String>,
+    pub logo: Option<String>,
+    pub name: Option<String>,
+    pub swap_start_timestamp_seconds: Option<u64>,
+    pub swap_due_timestamp_seconds: Option<u64>,
+    pub initial_voting_period_seconds: Option<u64>,
+    pub neuron_minimum_dissolve_delay_to_vote_seconds: Option<u64>,
+    pub description: Option<String>,
+    pub max_neuron_age_seconds_for_age_bonus: Option<u64>,
+    pub min_participants: Option<u64>,
+    pub initial_reward_rate_basis_points: Option<u64>,
+    pub wait_for_quiet_deadline_increase_seconds: Option<u64>,
+    pub transaction_fee_e8s: Option<u64>,
+    pub dapp_canisters: Option<DappCanisters>,
+    pub neurons_fund_participation_constraints: Option<NeuronsFundParticipationConstraints>,
+    pub neurons_fund_participants: Option<NeuronsFundParticipants>,
+    pub max_age_bonus_percentage: Option<u64>,
+    pub initial_token_distribution: Option<InitialTokenDistribution>,
+    pub reward_rate_transition_duration_seconds: Option<u64>,
+    pub token_logo: Option<String>,
+    pub token_name: Option<String>,
+    pub max_participant_icp_e8s: Option<u64>,
+    pub proposal_reject_cost_e8s: Option<u64>,
+    pub restricted_countries: Option<Countries>,
+    pub min_icp_e8s: Option<u64>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct DeployNewSnsRequest {
+    pub sns_init_payload: Option<SnsInitPayload>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct DappCanistersTransferResult {
+    pub restored_dapp_canisters: Vec<Canister>,
+    pub nns_controlled_dapp_canisters: Vec<Canister>,
+    pub sns_controlled_dapp_canisters: Vec<Canister>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct SnsCanisterIds {
+    pub root: Option<Principal>,
+    pub swap: Option<Principal>,
+    pub ledger: Option<Principal>,
+    pub index: Option<Principal>,
+    pub governance: Option<Principal>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct DeployNewSnsResponse {
+    pub dapp_canisters_transfer_result: Option<DappCanistersTransferResult>,
+    pub subnet_id: Option<Principal>,
+    pub error: Option<SnsWasmError>,
+    pub canisters: Option<SnsCanisterIds>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct GetAllowedPrincipalsArg {}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct GetAllowedPrincipalsResponse {
+    pub allowed_principals: Vec<Principal>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct SnsVersion {
+    pub archive_wasm_hash: serde_bytes::ByteBuf,
+    pub root_wasm_hash: serde_bytes::ByteBuf,
+    pub swap_wasm_hash: serde_bytes::ByteBuf,
+    pub ledger_wasm_hash: serde_bytes::ByteBuf,
+    pub governance_wasm_hash: serde_bytes::ByteBuf,
+    pub index_wasm_hash: serde_bytes::ByteBuf,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct GetNextSnsVersionRequest {
+    pub governance_canister_id: Option<Principal>,
+    pub current_version: Option<SnsVersion>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct GetNextSnsVersionResponse {
+    pub next_version: Option<SnsVersion>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct GetSnsSubnetIdsArg {}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct GetSnsSubnetIdsResponse {
+    pub sns_subnet_ids: Vec<Principal>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct GetWasmRequest {
+    pub hash: serde_bytes::ByteBuf,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct GetWasmResponse {
+    pub wasm: Option<SnsWasm>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct SnsUpgrade {
+    pub next_version: Option<SnsVersion>,
+    pub current_version: Option<SnsVersion>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct InsertUpgradePathEntriesRequest {
+    pub upgrade_path: Vec<SnsUpgrade>,
+    pub sns_governance_canister_id: Option<Principal>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct InsertUpgradePathEntriesResponse {
+    pub error: Option<SnsWasmError>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct ListDeployedSnsesArg {}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct DeployedSns {
+    pub root_canister_id: Option<Principal>,
+    pub governance_canister_id: Option<Principal>,
+    pub index_canister_id: Option<Principal>,
+    pub swap_canister_id: Option<Principal>,
+    pub ledger_canister_id: Option<Principal>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct ListDeployedSnsesResponse {
+    pub instances: Vec<DeployedSns>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct ListUpgradeStepsRequest {
+    pub limit: u32,
+    pub starting_at: Option<SnsVersion>,
+    pub sns_governance_canister_id: Option<Principal>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct PrettySnsVersion {
+    pub archive_wasm_hash: String,
+    pub root_wasm_hash: String,
+    pub swap_wasm_hash: String,
+    pub ledger_wasm_hash: String,
+    pub governance_wasm_hash: String,
+    pub index_wasm_hash: String,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct ListUpgradeStep {
+    pub pretty_version: Option<PrettySnsVersion>,
+    pub version: Option<SnsVersion>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct ListUpgradeStepsResponse {
+    pub steps: Vec<ListUpgradeStep>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct UpdateAllowedPrincipalsRequest {
+    pub added_principals: Vec<Principal>,
+    pub removed_principals: Vec<Principal>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub enum UpdateAllowedPrincipalsResult {
+    Error(SnsWasmError),
+    AllowedPrincipals(GetAllowedPrincipalsResponse),
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct UpdateAllowedPrincipalsResponse {
+    pub update_allowed_principals_result: Option<UpdateAllowedPrincipalsResult>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct UpdateSnsSubnetListRequest {
+    pub sns_subnet_ids_to_add: Vec<Principal>,
+    pub sns_subnet_ids_to_remove: Vec<Principal>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct UpdateSnsSubnetListResponse {
+    pub error: Option<SnsWasmError>,
+}
+
+pub struct Service(pub Principal);
+impl Service {
+    pub async fn add_wasm(&self, arg0: AddWasmRequest) -> CallResult<(AddWasmResponse,)> {
+        ic_cdk::call(self.0, "add_wasm", (arg0,)).await
+    }
+    pub async fn deploy_new_sns(&self, arg0: DeployNewSnsRequest) -> CallResult<(DeployNewSnsResponse,)> {
+        ic_cdk::call(self.0, "deploy_new_sns", (arg0,)).await
+    }
+    pub async fn get_allowed_principals(
+        &self,
+        arg0: GetAllowedPrincipalsArg,
+    ) -> CallResult<(GetAllowedPrincipalsResponse,)> {
+        ic_cdk::call(self.0, "get_allowed_principals", (arg0,)).await
+    }
+    pub async fn get_latest_sns_version_pretty(&self, arg0: ()) -> CallResult<(Vec<(String, String)>,)> {
+        ic_cdk::call(self.0, "get_latest_sns_version_pretty", (arg0,)).await
+    }
+    pub async fn get_next_sns_version(
+        &self,
+        arg0: GetNextSnsVersionRequest,
+    ) -> CallResult<(GetNextSnsVersionResponse,)> {
+        ic_cdk::call(self.0, "get_next_sns_version", (arg0,)).await
+    }
+    pub async fn get_sns_subnet_ids(&self, arg0: GetSnsSubnetIdsArg) -> CallResult<(GetSnsSubnetIdsResponse,)> {
+        ic_cdk::call(self.0, "get_sns_subnet_ids", (arg0,)).await
+    }
+    pub async fn get_wasm(&self, arg0: GetWasmRequest) -> CallResult<(GetWasmResponse,)> {
+        ic_cdk::call(self.0, "get_wasm", (arg0,)).await
+    }
+    pub async fn insert_upgrade_path_entries(
+        &self,
+        arg0: InsertUpgradePathEntriesRequest,
+    ) -> CallResult<(InsertUpgradePathEntriesResponse,)> {
+        ic_cdk::call(self.0, "insert_upgrade_path_entries", (arg0,)).await
+    }
+    pub async fn list_deployed_snses(&self, arg0: ListDeployedSnsesArg) -> CallResult<(ListDeployedSnsesResponse,)> {
+        ic_cdk::call(self.0, "list_deployed_snses", (arg0,)).await
+    }
+    pub async fn list_upgrade_steps(&self, arg0: ListUpgradeStepsRequest) -> CallResult<(ListUpgradeStepsResponse,)> {
+        ic_cdk::call(self.0, "list_upgrade_steps", (arg0,)).await
+    }
+    pub async fn update_allowed_principals(
+        &self,
+        arg0: UpdateAllowedPrincipalsRequest,
+    ) -> CallResult<(UpdateAllowedPrincipalsResponse,)> {
+        ic_cdk::call(self.0, "update_allowed_principals", (arg0,)).await
+    }
+    pub async fn update_sns_subnet_list(
+        &self,
+        arg0: UpdateSnsSubnetListRequest,
+    ) -> CallResult<(UpdateSnsSubnetListResponse,)> {
+        ic_cdk::call(self.0, "update_sns_subnet_list", (arg0,)).await
+    }
+}

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -215,13 +215,13 @@ fn debug<T: Debug>(value: T) -> String {
 
 mod def {
     use crate::canister_arg_types;
+    use crate::canisters::sns_wasm::api::{SnsUpgrade, SnsVersion};
     use crate::{decode_arg, Json};
-    use candid::CandidType;
+    use candid::{CandidType, Principal};
     use ic_base_types::{CanisterId, PrincipalId};
     use ic_crypto_sha2::Sha256;
     use ic_ic00_types::CanisterInstallMode;
     use ic_nervous_system_common::MethodAuthzChange;
-    use ic_sns_wasm::pb::v1::{SnsUpgrade, SnsVersion};
     use serde::{Deserialize, Serialize};
     use std::convert::TryFrom;
     use std::fmt::Write;
@@ -468,7 +468,7 @@ mod def {
 
     // NNS function 30 - AddSnsWasm
     // https://github.com/dfinity/ic/blob/187e933e73867efc3993572abc6344b8cedfafe5/rs/nns/sns-wasm/gen/ic_sns_wasm.pb.v1.rs#L62
-    pub type AddWasmRequest = ic_sns_wasm::pb::v1::AddWasmRequest;
+    pub type AddWasmRequest = crate::canisters::sns_wasm::api::AddWasmRequest;
 
     #[derive(CandidType, Serialize, Deserialize, Clone)]
     pub struct SnsWasmTrimmed {
@@ -546,11 +546,11 @@ mod def {
 
     // NNS function 34 - UpdateSnsSubnetListRequest
     // https://gitlab.com/dfinity-lab/public/ic/-/blob/e5dfd171dc6f2180c1112569766e14dd2c10a090/rs/nns/sns-wasm/canister/sns-wasm.did#L77
-    pub type UpdateSnsSubnetListRequest = ic_sns_wasm::pb::v1::UpdateSnsSubnetListRequest;
+    pub type UpdateSnsSubnetListRequest = crate::canisters::sns_wasm::api::UpdateSnsSubnetListRequest;
 
     // NNS function 35 - UpdateAllowedPrincipals
     // https://github.com/dfinity/ic/blob/8d135c4eec4645837962797b7bdac930085c0dbb/rs/nns/sns-wasm/gen/ic_sns_wasm.pb.v1.rs#L255
-    pub type UpdateAllowedPrincipalsRequest = ic_sns_wasm::pb::v1::UpdateAllowedPrincipalsRequest;
+    pub type UpdateAllowedPrincipalsRequest = crate::canisters::sns_wasm::api::UpdateAllowedPrincipalsRequest;
 
     // NNS function 36 - RetireReplicaVersion
     // https://github.com/dfinity/ic/blob/c2ad499466967a9a5557d737c2b9c0b9fa8ad53f/rs/registry/canister/src/mutations/do_retire_replica_version.rs#L143
@@ -559,7 +559,7 @@ mod def {
 
     // NNS function 37 - InsertUpgradePathEntriesRequest
     // https://github.com/dfinity/ic/blob/8b674edbb228acfc19923d5c914807166edcd909/rs/nns/sns-wasm/gen/ic_sns_wasm.pb.v1.rs#L128
-    pub type InsertUpgradePathEntriesRequest = ic_sns_wasm::pb::v1::InsertUpgradePathEntriesRequest;
+    pub type InsertUpgradePathEntriesRequest = crate::canisters::sns_wasm::api::InsertUpgradePathEntriesRequest;
 
     #[derive(CandidType, Serialize, Deserialize, Clone)]
     pub struct SnsVersionHumanReadable {
@@ -580,7 +580,7 @@ mod def {
     #[derive(CandidType, Serialize, Deserialize, Clone)]
     pub struct InsertUpgradePathEntriesRequestHumanReadable {
         pub upgrade_path: Vec<SnsUpgradeHumanReadable>,
-        pub sns_governance_canister_id: Option<PrincipalId>,
+        pub sns_governance_canister_id: Option<Principal>,
     }
 
     impl From<SnsVersion> for SnsVersionHumanReadable {


### PR DESCRIPTION
# Motivation
We would like to free the nns-dapp from the code and libraries pulled in by the nns-sns-wasm canister.

# Changes
* Remove the dependency on the `sns_wasm` canister from the proposals rendering crate.
* Derive the `nns-sns-wasm` canister types from `.did`.

Note: The `.didc` is from 2023-09-27 whereas the removed library is from `2023-08-01`.

# Tests
## Does proposal rendering still work?
There are existing Rust tests for proposal rendering; these should suffice.
## Is this actually reducing dependencies?
We can get a rough measure of the number of dependencies in the proposal rendering crate with:
```
cargo tree -p proposals | wc -l
```
For the current release candidate, i.e. a recent commit on main, this yields 1555 entries.  In this branch this has dropped to 1172 and, critically, no longer contains the timer crate.

# Todos

- [x] Add entry to changelog (if necessary).
