### PR TITLE
GIX-1860: Refactor PageHeading subtitle slot

### DIFF
--- a/frontend/src/lib/components/canister-detail/CanisterPageHeading.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterPageHeading.svelte
@@ -5,40 +5,27 @@
   import UnlinkCanisterButton from "./UnlinkCanisterButton.svelte";
   import RenameCanisterButton from "./RenameCanisterButton.svelte";
   import CanisterHeadingTitle from "./CanisterHeadingTitle.svelte";
+  import HeadingSubtitle from "../common/HeadingSubtitle.svelte";
 
   export let canisterDetails: CanisterDetails | undefined;
   export let canister: CanisterInfo;
   export let isController: boolean | undefined;
 </script>
 
-<!-- We can't set conditional slots. -->
-{#if canister.name.length === 0 || !isController}
-  <PageHeading testId="canister-page-heading-component">
-    <CanisterHeadingTitle
-      slot="title"
-      details={canisterDetails}
-      {canister}
-      {isController}
-    />
-    <svelte:fragment slot="tags">
-      <UnlinkCanisterButton canisterId={canister.canister_id} />
-      <RenameCanisterButton />
-    </svelte:fragment>
-  </PageHeading>
-{:else}
-  <PageHeading testId="canister-page-heading-component">
-    <CanisterHeadingTitle
-      slot="title"
-      details={canisterDetails}
-      {canister}
-      {isController}
-    />
-    <span slot="subtitle" data-tid="subtitle">
-      {canister.name}
-    </span>
-    <svelte:fragment slot="tags">
-      <UnlinkCanisterButton canisterId={canister.canister_id} />
-      <RenameCanisterButton />
-    </svelte:fragment>
-  </PageHeading>
-{/if}
+<PageHeading testId="canister-page-heading-component">
+  <CanisterHeadingTitle
+    slot="title"
+    details={canisterDetails}
+    {canister}
+    {isController}
+  />
+  <svelte:fragment slot="subtitle">
+    {#if canister.name.length > 0 && isController}
+      <HeadingSubtitle testId="subtitle">{canister.name}</HeadingSubtitle>
+    {/if}
+  </svelte:fragment>
+  <svelte:fragment slot="tags">
+    <UnlinkCanisterButton canisterId={canister.canister_id} />
+    <RenameCanisterButton />
+  </svelte:fragment>
+</PageHeading>

--- a/frontend/src/lib/components/common/HeadingSubtitle.svelte
+++ b/frontend/src/lib/components/common/HeadingSubtitle.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  export let testId: string | undefined = undefined;
+</script>
+
+<h4 data-tid={testId} class="description"><slot /></h4>
+
+<style lang="scss">
+  h4 {
+    margin: 0;
+    font-weight: normal;
+  }
+</style>

--- a/frontend/src/lib/components/common/PageHeading.svelte
+++ b/frontend/src/lib/components/common/PageHeading.svelte
@@ -1,23 +1,14 @@
 <script lang="ts">
-  import { nonNullish } from "@dfinity/utils";
-
   export let testId: string | undefined = undefined;
 
   let hasTags: boolean;
   $: hasTags = $$slots.tags !== undefined;
-
-  let hasSubtitle: boolean;
-  $: hasSubtitle = nonNullish($$slots.subtitle);
 </script>
 
 <div class="container" data-tid={testId}>
   <div class="title-wrapper">
     <slot name="title" />
-    {#if hasSubtitle}
-      <h4 class="description">
-        <slot name="subtitle" />
-      </h4>
-    {/if}
+    <slot name="subtitle" />
   </div>
   {#if hasTags}
     <div class="tags">
@@ -42,11 +33,6 @@
       gap: var(--padding-1_5x);
       justify-content: center;
       align-items: center;
-    }
-
-    h4 {
-      margin: 0;
-      font-weight: normal;
     }
 
     .tags {

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -15,6 +15,7 @@
   import { authStore } from "$lib/stores/auth.store";
   import HeadingTag from "../common/HeadingTag.svelte";
   import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import HeadingSubtitle from "../common/HeadingSubtitle.svelte";
 
   export let neuron: NeuronInfo;
 
@@ -40,7 +41,7 @@
 
 <PageHeading testId="nns-neuron-page-heading-component">
   <AmountDisplay slot="title" {amount} size="huge" singleLine />
-  <span slot="subtitle" data-tid="voting-power">
+  <HeadingSubtitle slot="subtitle" testId="voting-power">
     {#if canVote}
       {replacePlaceholders($i18n.neuron_detail.voting_power_subtitle, {
         $votingPower: formatVotingPower(neuron.votingPower),
@@ -48,7 +49,7 @@
     {:else}
       {$i18n.neuron_detail.voting_power_zero_subtitle}
     {/if}
-  </span>
+  </HeadingSubtitle>
   <svelte:fragment slot="tags">
     {#each neuronTags as tag}
       <HeadingTag testId="neuron-tag">{tag.text}</HeadingTag>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
@@ -15,6 +15,7 @@
   import { formatVotingPower } from "$lib/utils/neuron.utils";
   import { authStore } from "$lib/stores/auth.store";
   import HeadingTag from "../common/HeadingTag.svelte";
+  import HeadingSubtitle from "../common/HeadingSubtitle.svelte";
 
   export let neuron: SnsNeuron;
   export let parameters: SnsNervousSystemParameters;
@@ -47,7 +48,7 @@
       <AmountDisplay {amount} size="huge" singleLine />
     {/if}
   </svelte:fragment>
-  <span slot="subtitle" data-tid="voting-power">
+  <HeadingSubtitle slot="subtitle" testId="voting-power">
     {#if votingPower > 0}
       {replacePlaceholders($i18n.neuron_detail.voting_power_subtitle, {
         $votingPower: formatVotingPower(votingPower),
@@ -55,7 +56,7 @@
     {:else}
       {$i18n.neuron_detail.voting_power_zero_subtitle}
     {/if}
-  </span>
+  </HeadingSubtitle>
   <svelte:fragment slot="tags">
     {#if isHotkey}
       <HeadingTag testId="hotkey-tag">{$i18n.neurons.hotkey_control}</HeadingTag


### PR DESCRIPTION
# Motivation

Avoid the problem with the PageHeading spacing when the subtitle was not defined.

At the same time, we learned that the PageHeading might get two subtitles; therefore, a slot without being wrapped makes it more flexible.

# Changes

* Remove the `h4` wrapping the "subtitle" slot in PageHeading.
* New component "HeadingSubtitle" which has the style of the `h4` inside the PageHeading.
* Use the new component as subtitle slot for PageHeading in NnsNeuronPageHeading, SnsNeuronPageHeading and CanisterPageHeading.

# Tests

Only refactor of purely UI components. Functionality didn't change which is confirmed by tests passing without extra changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.