### PR TITLE
GIX-1860: Change Wallet Header

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -20,6 +20,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Get the governance, registry and SNS Wasm schemas direcly from `.did` files rather than importing the canisters.
 * Improve security by escaping additional images in the proposal summary markdown.
 * Internal change: remove unused snsQueryStore.
+* New header UI in the wallet pages.
 
 #### Deprecated
 #### Removed
@@ -66,8 +67,6 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * New labels for min and max participation.
 * Improve security by escaping additional images in the proposal summary markdown.
 * Internal change: remove unused snsQueryStore.
-* New Tag style. Used in followees topic and project status.
-* New header UI in the wallet pages.
 
 #### Removed
 

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -20,6 +20,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Get the governance, registry and SNS Wasm schemas direcly from `.did` files rather than importing the canisters.
 * Improve security by escaping additional images in the proposal summary markdown.
 * Internal change: remove unused snsQueryStore.
+* New Tag style. Used in followees topic and project status.
 * New header UI in the wallet pages.
 
 #### Deprecated

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -67,6 +67,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Improve security by escaping additional images in the proposal summary markdown.
 * Internal change: remove unused snsQueryStore.
 * New Tag style. Used in followees topic and project status.
+* New header UI in the wallet pages.
 
 #### Removed
 

--- a/frontend/src/lib/components/accounts/CkBTCWalletActions.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWalletActions.svelte
@@ -16,32 +16,16 @@
     });
 </script>
 
-<div
-  role={!inline ? "menubar" : undefined}
-  class:inline
-  data-tid="manual-refresh-balance-container"
+<button
+  class={inline ? "text" : "secondary"}
+  type="button"
+  on:click={updateBalance}
+  data-tid="manual-refresh-balance"
 >
-  <button
-    class={inline ? "text" : "secondary"}
-    type="button"
-    on:click={updateBalance}
-    data-tid="manual-refresh-balance"
-  >
-    {$i18n.ckbtc.refresh_balance}
-  </button>
-</div>
+  {$i18n.ckbtc.refresh_balance}
+</button>
 
 <style lang="scss">
-  @use "../../themes/mixins/section";
-
-  [role="menubar"] {
-    @include section.actions;
-  }
-
-  .inline {
-    display: inline-block;
-  }
-
   .text {
     text-decoration: underline;
     padding: 0;

--- a/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
@@ -44,9 +44,3 @@
     {/if}
   {/if}
 </div>
-
-<style lang="scss">
-  .container {
-    padding-top: var(--padding);
-  }
-</style>

--- a/frontend/src/lib/components/accounts/TransactionList.svelte
+++ b/frontend/src/lib/components/accounts/TransactionList.svelte
@@ -2,7 +2,6 @@
   import type { Transaction as NnsTransaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
   import type { Account } from "$lib/types/account";
   import { i18n } from "$lib/stores/i18n";
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
   import NnsTransactionCard from "./NnsTransactionCard.svelte";
   import { getContext } from "svelte";
@@ -27,7 +26,8 @@
   $: extendedTransactions = mapToSelfTransaction(transactions ?? []);
 </script>
 
-<TestIdWrapper testId="transaction-list-component">
+<!-- We want this `div` as wrapper so that the parent doesn't apply spacing between the elements. -->
+<div data-tid="transaction-list-component">
   {#if account === undefined || transactions === undefined}
     <SkeletonCard cardType="info" />
   {:else if transactions.length === 0}
@@ -39,7 +39,7 @@
       </div>
     {/each}
   {/if}
-</TestIdWrapper>
+</div>
 
 <style lang="scss">
   .flip:first-of-type {

--- a/frontend/src/lib/components/accounts/WalletPageHeading.svelte
+++ b/frontend/src/lib/components/accounts/WalletPageHeading.svelte
@@ -11,7 +11,6 @@
   import { i18n } from "$lib/stores/i18n";
   import { formatToken } from "$lib/utils/token.utils";
   import IdentifierHash from "../ui/IdentifierHash.svelte";
-  import TestIdWrapper from "../common/TestIdWrapper.svelte";
   import Tooltip from "../ui/Tooltip.svelte";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
 

--- a/frontend/src/lib/components/accounts/WalletPageHeading.svelte
+++ b/frontend/src/lib/components/accounts/WalletPageHeading.svelte
@@ -12,10 +12,20 @@
   import { formatToken } from "$lib/utils/token.utils";
   import IdentifierHash from "../ui/IdentifierHash.svelte";
   import TestIdWrapper from "../common/TestIdWrapper.svelte";
+  import Tooltip from "../ui/Tooltip.svelte";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
 
   export let balance: TokenAmount | undefined = undefined;
   export let accountName: string;
   export let principal: Principal | undefined = undefined;
+
+  let detailedAccountBalance: string | undefined;
+  $: detailedAccountBalance = nonNullish(balance)
+    ? formatToken({
+        value: balance.toE8s(),
+        detailed: true,
+      })
+    : undefined;
 
   const updateLayoutTitle = ($event: Event) => {
     const {
@@ -35,15 +45,24 @@
 </script>
 
 <PageHeading testId="wallet-page-heading-component">
-  <TestIdWrapper slot="title" testId="wallet-page-heading-title">
-    {#if nonNullish(balance)}
-      <AmountDisplay amount={balance} size="huge" singleLine />
+  <svelte:fragment slot="title">
+    <!-- TS is not smart enough to understand that if `balance` is defined, then `detailedAccountBalance` is also defined -->
+    {#if nonNullish(balance) && nonNullish(detailedAccountBalance)}
+      <Tooltip
+        id="wallet-detailed-icp"
+        text={replacePlaceholders($i18n.accounts.current_balance_detail, {
+          $amount: detailedAccountBalance,
+          $token: balance.token.symbol,
+        })}
+      >
+        <AmountDisplay amount={balance} size="huge" singleLine />
+      </Tooltip>
     {:else}
       <div data-tid="skeleton" class="skeleton">
         <SkeletonText tagName="h1" />
       </div>
     {/if}
-  </TestIdWrapper>
+  </svelte:fragment>
   <div
     slot="subtitle"
     class="subtitles"

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import { Island, Spinner } from "@dfinity/gix-components";
-  import Summary from "$lib/components/summary/Summary.svelte";
-  import WalletSummary from "$lib/components/accounts/WalletSummary.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
   import { writable } from "svelte/store";
   import {
@@ -13,7 +11,7 @@
   import { setContext } from "svelte";
   import { findAccount, hasAccounts } from "$lib/utils/accounts.utils";
   import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
-  import { isNullish, nonNullish } from "@dfinity/utils";
+  import { TokenAmount, isNullish, nonNullish } from "@dfinity/utils";
   import {
     loadCkBTCAccounts,
     syncCkBTCAccounts,
@@ -38,6 +36,9 @@
   import type { TokensStoreUniverseData } from "$lib/stores/tokens.store";
   import { loadCkBTCInfo } from "$lib/services/ckbtc-info.services";
   import CkBTCBalancesObserver from "$lib/components/accounts/CkBTCBalancesObserver.svelte";
+  import WalletPageHeader from "$lib/components/accounts/WalletPageHeader.svelte";
+  import { CKBTC_UNIVERSE } from "$lib/derived/ckbtc-universes.derived";
+  import WalletPageHeading from "$lib/components/accounts/WalletPageHeading.svelte";
 
   export let accountIdentifier: string | undefined | null = undefined;
 
@@ -184,24 +185,33 @@
 <Island>
   <main class="legacy" data-tid="ckbtc-wallet">
     <section>
-      {#if loaded}
-        <Summary />
-
-        <WalletSummary detailedBalance token={token?.token} />
-
-        {#if nonNullish(canisters) && nonNullish($selectedAccountStore.account) && nonNullish($selectedCkBTCUniverseIdStore)}
-          <CkBTCBalancesObserver
-            universeId={$selectedCkBTCUniverseIdStore}
-            accounts={[$selectedAccountStore.account]}
-            reload={reloadOnlyAccountFromStore}
+      {#if loaded && nonNullish(canisters) && nonNullish($selectedAccountStore.account) && nonNullish($selectedCkBTCUniverseIdStore) && nonNullish(token)}
+        <CkBTCBalancesObserver
+          universeId={$selectedCkBTCUniverseIdStore}
+          accounts={[$selectedAccountStore.account]}
+          reload={reloadOnlyAccountFromStore}
+        >
+          <WalletPageHeader
+            universe={CKBTC_UNIVERSE}
+            walletAddress={$selectedAccountStore.account.identifier}
+          />
+          <WalletPageHeading
+            accountName={$selectedAccountStore.account.name ?? ""}
+            balance={TokenAmount.fromE8s({
+              amount: $selectedAccountStore.account.balanceE8s,
+              token: token?.token,
+            })}
           >
             <CkBTCWalletActions
               reload={reloadAccount}
               minterCanisterId={canisters.minterCanisterId}
             />
+          </WalletPageHeading>
 
-            <Separator />
+          <Separator spacing="none" />
 
+          <!-- Transactions and the explanation go together. -->
+          <div>
             <BitcoinAddress
               account={$selectedAccountStore.account}
               universeId={$selectedCkBTCUniverseIdStore}
@@ -216,8 +226,8 @@
               indexCanisterId={canisters.indexCanisterId}
               token={token?.token}
             />
-          </CkBTCBalancesObserver>
-        {/if}
+          </div>
+        </CkBTCBalancesObserver>
       {:else}
         <Spinner />
       {/if}
@@ -228,3 +238,11 @@
     <CkBTCWalletFooter />
   {/if}
 </Island>
+
+<style lang="scss">
+  section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-4x);
+  }
+</style>

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -28,7 +28,10 @@
   } from "$lib/derived/universes-tokens.derived";
   import CkBTCWalletFooter from "$lib/components/accounts/CkBTCWalletFooter.svelte";
   import type { UniverseCanisterId } from "$lib/types/universe";
-  import { selectedCkBTCUniverseIdStore } from "$lib/derived/selected-universe.derived";
+  import {
+    selectedCkBTCUniverseIdStore,
+    selectedUniverseStore,
+  } from "$lib/derived/selected-universe.derived";
   import type { CkBTCAdditionalCanisters } from "$lib/types/ckbtc-canisters";
   import { CKBTC_ADDITIONAL_CANISTERS } from "$lib/constants/ckbtc-additional-canister-ids.constants";
   import BitcoinAddress from "$lib/components/accounts/BitcoinAddress.svelte";
@@ -37,7 +40,6 @@
   import { loadCkBTCInfo } from "$lib/services/ckbtc-info.services";
   import CkBTCBalancesObserver from "$lib/components/accounts/CkBTCBalancesObserver.svelte";
   import WalletPageHeader from "$lib/components/accounts/WalletPageHeader.svelte";
-  import { CKBTC_UNIVERSE } from "$lib/derived/ckbtc-universes.derived";
   import WalletPageHeading from "$lib/components/accounts/WalletPageHeading.svelte";
 
   export let accountIdentifier: string | undefined | null = undefined;
@@ -192,11 +194,12 @@
           reload={reloadOnlyAccountFromStore}
         >
           <WalletPageHeader
-            universe={CKBTC_UNIVERSE}
+            universe={$selectedUniverseStore}
             walletAddress={$selectedAccountStore.account.identifier}
           />
           <WalletPageHeading
-            accountName={$selectedAccountStore.account.name ?? ""}
+            accountName={$selectedAccountStore.account.name ??
+              $i18n.accounts.main}
             balance={TokenAmount.fromE8s({
               amount: $selectedAccountStore.account.balanceE8s,
               token: token?.token,

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -3,7 +3,6 @@
   import { Spinner, busy } from "@dfinity/gix-components";
   import { setContext } from "svelte";
   import { writable } from "svelte/store";
-  import WalletSummary from "$lib/components/accounts/WalletSummary.svelte";
   import { snsProjectAccountsStore } from "$lib/derived/sns/sns-project-accounts.derived";
   import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
   import { debugSelectedAccountStore } from "$lib/derived/debug.derived";
@@ -18,12 +17,11 @@
   import SnsTransactionsList from "$lib/components/accounts/SnsTransactionsList.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
   import { Island } from "@dfinity/gix-components";
-  import Summary from "$lib/components/summary/Summary.svelte";
   import {
     snsOnlyProjectStore,
     snsProjectSelectedStore,
   } from "$lib/derived/sns/sns-selected-project.derived";
-  import { isNullish, nonNullish } from "@dfinity/utils";
+  import { TokenAmount, isNullish, nonNullish } from "@dfinity/utils";
   import IC_LOGO from "$lib/assets/icp.svg";
   import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
   import { loadSnsAccountTransactions } from "$lib/services/sns-transactions.services";
@@ -33,6 +31,8 @@
   import { tokensStore } from "$lib/stores/tokens.store";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import SnsBalancesObserver from "$lib/components/accounts/SnsBalancesObserver.svelte";
+  import WalletPageHeader from "$lib/components/accounts/WalletPageHeader.svelte";
+  import WalletPageHeading from "$lib/components/accounts/WalletPageHeading.svelte";
 
   let showModal: "send" | undefined = undefined;
 
@@ -129,17 +129,25 @@
 <Island>
   <main class="legacy" data-tid="sns-wallet">
     <section>
-      {#if nonNullish($selectedAccountStore.account) && nonNullish($snsOnlyProjectStore) && nonNullish($snsProjectSelectedStore)}
+      {#if nonNullish($selectedAccountStore.account) && nonNullish($snsOnlyProjectStore) && nonNullish($snsProjectSelectedStore) && nonNullish(token)}
         <SnsBalancesObserver
           rootCanisterId={$snsOnlyProjectStore}
           accounts={[$selectedAccountStore.account]}
           ledgerCanisterId={$snsProjectSelectedStore.summary.ledgerCanisterId}
         >
-          <Summary />
+          <WalletPageHeader
+            universe={$selectedUniverseStore}
+            walletAddress={$selectedAccountStore.account.identifier}
+          />
+          <WalletPageHeading
+            balance={TokenAmount.fromE8s({
+              amount: $selectedAccountStore.account.balanceE8s,
+              token,
+            })}
+            accountName={$selectedAccountStore.account.name ?? ""}
+          />
 
-          <WalletSummary {token} />
-
-          <Separator />
+          <Separator spacing="none" />
 
           <SnsTransactionsList
             rootCanisterId={$snsOnlyProjectStore}
@@ -177,3 +185,11 @@
     loadTransactions
   />
 {/if}
+
+<style lang="scss">
+  section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-4x);
+  }
+</style>

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -144,7 +144,8 @@
               amount: $selectedAccountStore.account.balanceE8s,
               token,
             })}
-            accountName={$selectedAccountStore.account.name ?? ""}
+            accountName={$selectedAccountStore.account.name ??
+              $i18n.accounts.main}
           />
 
           <Separator spacing="none" />

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -22,7 +22,6 @@ import {
   mockCkBTCMainAccount,
   mockCkBTCToken,
 } from "$tests/mocks/ckbtc-accounts.mock";
-import en from "$tests/mocks/i18n.mock";
 import { mockUniversesTokens } from "$tests/mocks/tokens.mock";
 import { selectSegmentBTC } from "$tests/utils/accounts.test-utils";
 import { advanceTime } from "$tests/utils/timers.test-utils";
@@ -168,13 +167,11 @@ describe("CkBTCWallet", () => {
     it("should render ckTESTBTC name", async () => {
       const { getByTestId } = render(CkBTCWallet, props);
 
-      await waitFor(() => {
-        const titleRow = getByTestId("projects-summary");
-        expect(titleRow).not.toBeNull();
+      await waitFor(() =>
         expect(
-          titleRow?.textContent?.includes(en.ckbtc.test_title)
-        ).toBeTruthy();
-      });
+          getByTestId("universe-page-summary-component").textContent.trim()
+        ).toBe("ckTESTBTC")
+      );
     });
 
     it("should hide spinner when selected account is loaded", async () => {
@@ -183,32 +180,17 @@ describe("CkBTCWallet", () => {
       await waitFor(() => expect(queryByTestId("spinner")).toBeNull());
     });
 
-    it("should render wallet summary", async () => {
+    it("should render `Main` as subtitle", async () => {
       const { queryByTestId } = render(CkBTCWallet, props);
 
       await waitFor(() =>
-        expect(queryByTestId("wallet-summary")).toBeInTheDocument()
+        expect(queryByTestId("wallet-page-heading-subtitle").textContent).toBe(
+          "Main"
+        )
       );
     });
 
-    it("should render a detailed balance in summary", async () => {
-      const { queryByTestId } = render(CkBTCWallet, props);
-
-      await waitFor(() =>
-        expect(queryByTestId("wallet-summary")).toBeInTheDocument()
-      );
-
-      const icp: HTMLSpanElement | null = queryByTestId("token-value");
-
-      expect(icp?.innerHTML).toEqual(
-        `${formatToken({
-          value: mockCkBTCMainAccount.balanceE8s,
-          detailed: true,
-        })}`
-      );
-    });
-
-    it("should render a balance with token in summary", async () => {
+    it("should render a balance with token", async () => {
       const { getByTestId } = render(CkBTCWallet, props);
 
       await waitFor(() =>
@@ -218,7 +200,6 @@ describe("CkBTCWallet", () => {
       expect(getByTestId("token-value-label")?.textContent.trim()).toEqual(
         `${formatToken({
           value: mockCkBTCMainAccount.balanceE8s,
-          detailed: true,
         })} ${mockCkBTCToken.symbol}`
       );
     });
@@ -248,18 +229,15 @@ describe("CkBTCWallet", () => {
     it("should update account after transfer tokens", async () => {
       const result = render(CkBTCAccountsTest, { props: modalProps });
 
-      const { queryByTestId, getByTestId, container } = result;
+      const { queryByTestId, getByTestId } = result;
 
       // Check original sum
       await waitFor(() =>
         expect(
-          container.querySelector("#wallet-detailed-icp")?.textContent ?? ""
-        ).toContain(
-          `${formatToken({
-            value: mockCkBTCMainAccount.balanceE8s,
-            detailed: true,
-          })}`
-        )
+          queryByTestId("wallet-page-heading-component").querySelector(
+            "[data-tid='token-value-label']"
+          )?.textContent
+        ).toBe("4'445'566.99 ckBTC")
       );
 
       // Make transfer
@@ -280,8 +258,10 @@ describe("CkBTCWallet", () => {
       // Account should have been updated and sum should be reflected
       await waitFor(() =>
         expect(
-          container.querySelector("#wallet-detailed-icp")?.textContent ?? ""
-        ).toContain(`${formatToken({ value: expectedBalanceAfterTransfer })}`)
+          queryByTestId("wallet-page-heading-component").querySelector(
+            "[data-tid='token-value-label']"
+          )?.textContent
+        ).toContain(formatToken({ value: expectedBalanceAfterTransfer }))
       );
     });
 
@@ -302,7 +282,6 @@ describe("CkBTCWallet", () => {
         expect(getByTestId("token-value")?.textContent ?? "").toEqual(
           `${formatToken({
             value: mockCkBTCMainAccount.balanceE8s,
-            detailed: true,
           })}`
         )
       );

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -117,10 +117,12 @@ describe("NnsWallet", () => {
     it("should show new accounts after being loaded", async () => {
       const { queryByTestId } = render(NnsWallet, props);
 
-      expect(queryByTestId("projects-summary")).toBeNull();
+      expect(queryByTestId("wallet-page-heading-component")).toBeNull();
 
       await waitFor(() =>
-        expect(queryByTestId("projects-summary")).toBeInTheDocument()
+        expect(
+          queryByTestId("wallet-page-heading-component")
+        ).toBeInTheDocument()
       );
     });
   });
@@ -133,9 +135,9 @@ describe("NnsWallet", () => {
     it("should render nns project name", async () => {
       const { getByTestId } = render(NnsWallet, props);
 
-      const titleRow = getByTestId("projects-summary");
+      const titleRow = getByTestId("universe-page-summary-component");
 
-      expect(titleRow).not.toBeNull();
+      expect(titleRow.textContent.trim()).toBe("Internet Computer");
     });
 
     it("should render a balance with token in summary", async () => {

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -265,6 +265,12 @@ describe("NnsWallet", () => {
         })
       ).toBeInTheDocument();
     });
+
+    it("should display hardware wallet buttons", async () => {
+      const { queryByTestId } = render(NnsWallet, props);
+      expect(queryByTestId("ledger-list-button")).toBeInTheDocument();
+      expect(queryByTestId("ledger-show-button")).toBeInTheDocument();
+    });
   });
 
   describe("when no accounts and user navigates away", () => {

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -142,9 +142,9 @@ describe("SnsWallet", () => {
     it("should render sns project name", async () => {
       const { getByTestId } = render(SnsWallet, props);
 
-      const titleRow = getByTestId("projects-summary");
+      const titleRow = getByTestId("universe-page-summary-component");
 
-      expect(titleRow).not.toBeNull();
+      expect(titleRow.textContent.trim()).toBe("Catalyze");
     });
 
     it("should hide spinner when selected account is loaded", async () => {
@@ -153,14 +153,21 @@ describe("SnsWallet", () => {
       await waitFor(() => expect(queryByTestId("spinner")).toBeNull());
     });
 
-    it("should render wallet summary and transactions", async () => {
+    it("should render transactions", async () => {
       const { queryByTestId } = render(SnsWallet, props);
 
       await waitFor(() =>
-        expect(queryByTestId("wallet-summary")).toBeInTheDocument()
-      );
-      await waitFor(() =>
         expect(queryByTestId("transactions-list")).toBeInTheDocument()
+      );
+    });
+
+    it("should render 'Main' as subtitle", async () => {
+      const { queryByTestId } = render(SnsWallet, props);
+
+      await waitFor(() =>
+        expect(queryByTestId("wallet-page-heading-subtitle").textContent).toBe(
+          "Main"
+        )
       );
     });
 

--- a/frontend/src/tests/page-objects/WalletPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/WalletPageHeading.page-object.ts
@@ -1,6 +1,8 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { AmountDisplayPo } from "./AmountDisplay.page-object";
 import { HashPo } from "./Hash.page-object";
+import { TooltipPo } from "./Tooltip.page-object";
 
 export class WalletPageHeadingPo extends BasePageObject {
   private static readonly TID = "wallet-page-heading-component";
@@ -9,8 +11,15 @@ export class WalletPageHeadingPo extends BasePageObject {
     return new WalletPageHeadingPo(element.byTestId(WalletPageHeadingPo.TID));
   }
 
-  getTitle(): Promise<string> {
-    return this.getText("wallet-page-heading-title");
+  async getTitle(): Promise<string | null> {
+    if (await this.hasSkeleton()) {
+      return null;
+    }
+    return AmountDisplayPo.under(this.root).getText();
+  }
+
+  getTooltipText(): Promise<string> {
+    return TooltipPo.under(this.root).getText();
   }
 
   hasSkeleton(): Promise<boolean> {

--- a/frontend/src/vitests/lib/components/accounts/CkBTCWalletActions.spec.ts
+++ b/frontend/src/vitests/lib/components/accounts/CkBTCWalletActions.spec.ts
@@ -47,25 +47,6 @@ describe("CkBTCWalletActions", () => {
     expect(button?.textContent).toEqual(en.ckbtc.refresh_balance);
   });
 
-  it("should render a menubar", () => {
-    const { getByTestId } = render(CkBTCWalletActions, { props });
-    expect(
-      getByTestId("manual-refresh-balance-container")?.getAttribute("role")
-    ).toEqual("menubar");
-  });
-
-  it("should not render a menubar", () => {
-    const { getByTestId } = render(CkBTCWalletActions, {
-      props: {
-        ...props,
-        inline: true,
-      },
-    });
-    expect(
-      getByTestId("manual-refresh-balance-container")?.hasAttribute("role")
-    ).toEqual(false);
-  });
-
   it("should call update balance", async () => {
     const spyUpdateBalance = vi.spyOn(api, "updateBalance");
 

--- a/frontend/src/vitests/lib/components/accounts/WalletPageHeading.spec.ts
+++ b/frontend/src/vitests/lib/components/accounts/WalletPageHeading.spec.ts
@@ -36,12 +36,23 @@ describe("WalletPageHeading", () => {
 
   it("should render balance as title and no skeleton", async () => {
     const balance = TokenAmount.fromString({
-      amount: "3.14",
+      amount: "3.14159265",
       token: ICPToken,
     }) as TokenAmount;
     const po = renderComponent({ balance, accountName });
 
     expect(await po.getTitle()).toBe("3.14 ICP");
+    expect(await po.hasSkeleton()).toBe(false);
+  });
+
+  it("should render tooltip with detailed balance", async () => {
+    const balance = TokenAmount.fromString({
+      amount: "3.14159265",
+      token: ICPToken,
+    }) as TokenAmount;
+    const po = renderComponent({ balance, accountName });
+
+    expect(await po.getTooltipText()).toBe("Current balance: 3.14159265 ICP");
     expect(await po.hasSkeleton()).toBe(false);
   });
 


### PR DESCRIPTION
# Motivation

Adapt the wallet pages to the new header UI.

# Changes

* Use the new WalletPageHeader and WalletPageHeading in NnsWallet.
* Use the new WalletPageHeader and WalletPageHeading in SnsWallet.
* Use the new WalletPageHeader and WalletPageHeading in CkBTCWallet.
* Add Tooltip with detailed balance to WalletPageHeading.
* Remove the menu bar from CkBTCWalletActions. Not needed anymore.
* Remove padding top in IcrcTransactionsList. Not needed anymore.
* Wrap TransactionsList with an element to prevent the parent from setting the spacing of the elements.

# Tests

* Add a test in NnsWallet page to check that HW buttons are displayed.
* Remove tests regarding menu bar in CkBTCWalletActions.
* Fix NnsWallet.spec, SnsWallet.spec and CkBTCWallet.spec

# Todos

- [x] Add entry to changelog (if necessary).
