### PR TITLE
GetTokens: Don't check SNS balance for ckBTC

### DIFF
--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -13,8 +13,9 @@
   import { Spinner, IconAccountBalance } from "@dfinity/gix-components";
   import { toastsError } from "$lib/stores/toasts.store";
   import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
+  import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-  import { ICPToken, type Token } from "@dfinity/utils";
+  import { ICPToken, type Token, nonNullish } from "@dfinity/utils";
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { browser } from "$app/environment";
@@ -25,10 +26,13 @@
   let inputValue: number | undefined = undefined;
 
   let selectedProjectId = OWN_CANISTER_ID;
-  $: selectedProjectId = $selectedUniverseIdStore;
+  $: selectedProjectId = $snsOnlyProjectStore;
 
   let isNns: boolean;
-  $: isNns = selectedProjectId.toText() === OWN_CANISTER_ID.toText();
+  $: isNns = $selectedUniverseIdStore.toText() === OWN_CANISTER_ID.toText();
+
+  let isSns: boolean;
+  $: isSns = nonNullish($snsOnlyProjectStore);
 
   const onSubmit = async () => {
     if (invalidForm || inputValue === undefined) {
@@ -42,7 +46,7 @@
 
     try {
       // Default to transfer ICPs if the test account's balance of the selected universe is 0.
-      if (isNns || tokenBalanceE8s === 0n) {
+      if (!isSns || tokenBalanceE8s === 0n) {
         await getICPs(inputValue);
       } else {
         await getTokens({
@@ -77,7 +81,7 @@
   $: selectedProjectId,
     (async () => {
       // This was executed at build time and it depends on `window` in `base64ToUInt8Array` helper inside dev.api.ts
-      if (browser) {
+      if (browser && isSns) {
         tokenBalanceE8s = await getTestBalance(selectedProjectId);
       }
     })();

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -15,6 +15,7 @@
   import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
   import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+  import type { Principal } from "@dfinity/principal";
   import { ICPToken, type Token, nonNullish } from "@dfinity/utils";
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
   import { authSignedInStore } from "$lib/derived/auth.derived";
@@ -25,14 +26,11 @@
 
   let inputValue: number | undefined = undefined;
 
-  let selectedProjectId = OWN_CANISTER_ID;
+  let selectedProjectId: Principal | undefined;
   $: selectedProjectId = $snsOnlyProjectStore;
 
   let isNns: boolean;
   $: isNns = $selectedUniverseIdStore.toText() === OWN_CANISTER_ID.toText();
-
-  let isSns: boolean;
-  $: isSns = nonNullish($snsOnlyProjectStore);
 
   const onSubmit = async () => {
     if (invalidForm || inputValue === undefined) {
@@ -46,7 +44,7 @@
 
     try {
       // Default to transfer ICPs if the test account's balance of the selected universe is 0.
-      if (isSns && tokenBalanceE8s > 0n) {
+      if (nonNullish(selectedProjectId) && tokenBalanceE8s > 0n) {
         await getTokens({
           tokens: inputValue,
           rootCanisterId: selectedProjectId,
@@ -81,7 +79,7 @@
   $: selectedProjectId,
     (async () => {
       // This was executed at build time and it depends on `window` in `base64ToUInt8Array` helper inside dev.api.ts
-      if (browser && isSns) {
+      if (browser && nonNullish(selectedProjectId)) {
         tokenBalanceE8s = await getTestBalance(selectedProjectId);
       }
     })();

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -46,13 +46,13 @@
 
     try {
       // Default to transfer ICPs if the test account's balance of the selected universe is 0.
-      if (!isSns || tokenBalanceE8s === 0n) {
-        await getICPs(inputValue);
-      } else {
+      if (isSns && tokenBalanceE8s > 0n) {
         await getTokens({
           tokens: inputValue,
           rootCanisterId: selectedProjectId,
         });
+      } else {
+        await getICPs(inputValue);
       }
 
       reset();


### PR DESCRIPTION
# Motivation

We have a Get Tokens button which gives either ICP or SNS tokens.
It only gives SNS tokens if an SNS universe is selected and the faucet address has positive balance for that SNS.
Currently we also try to fetch the SNS faucet balance if the universe is not an SNS universe, for example with ckBTC.
This results in an error on the console.

# Changes

Only try to fetch SNS faucet balance if the selected universe is an SNS.

# Tests

Manually tried getting ICP while ckBTC or ICP or SNS without faucet balance universe is select.
And getting SNS tokens while an SNS with balance is selected.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary