### PR TITLE
Get BTC button

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -13,6 +13,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 #### Added
 
 * New feature flag `ENABLE_FULL_WIDTH_PROPOSAL`.
+* Get BTC button to use the mock bitcoin canister to test ckBTC.
 
 #### Changed
 

--- a/frontend/src/lib/api/dev.api.ts
+++ b/frontend/src/lib/api/dev.api.ts
@@ -5,7 +5,7 @@ import { invalidIcrcAddress } from "$lib/utils/accounts.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import { isUniverseNns } from "$lib/utils/universe.utils";
 import type { Identity } from "@dfinity/agent";
-import { HttpAgent, type Agent } from "@dfinity/agent";
+import { Actor, HttpAgent, type Agent } from "@dfinity/agent";
 import { Ed25519KeyIdentity } from "@dfinity/identity";
 import type { BlockHeight } from "@dfinity/ledger-icp";
 import { AccountIdentifier, LedgerCanister } from "@dfinity/ledger-icp";
@@ -276,4 +276,64 @@ export const addMaturity = async ({
   });
 
   logWithTimestamp("Adding neuron maturity: done");
+};
+
+// Generated with `didc bind -t js bitcoin_mock.did`, and then everything but
+// push_utxo_to_address manually removed.
+const mockBitcoinIdlFactory = ({ IDL }) => {
+  const OutPoint = IDL.Record({
+    txid: IDL.Vec(IDL.Nat8),
+    vout: IDL.Nat32,
+  });
+  const Utxo = IDL.Record({
+    height: IDL.Nat32,
+    value: IDL.Nat64,
+    outpoint: OutPoint,
+  });
+  const PushUtxoToAddress = IDL.Record({ utxo: Utxo, address: IDL.Text });
+  return IDL.Service({
+    push_utxo_to_address: IDL.Func([PushUtxoToAddress], [], []),
+  });
+};
+
+// The Bitcoin canister is accessed through the virtual management canister
+// and its ID is hard-coded in the execution environment, here:
+// https://github.com/dfinity/ic/blob/bb093eeca3d25b10f5eaa4e5843811c3201c941c/rs/config/src/execution_environment.rs#L100
+const HARD_CODED_BITCOIN_CANISTER_ID = "ghsi2-tqaaa-aaaan-aaaca-cai";
+
+export const receiveMockBtc = async ({
+  btcAddress,
+  amountE8s,
+}: {
+  btcAddress: string;
+  amountE8s: bigint;
+}) => {
+  const agent = new HttpAgent({
+    host: HOST,
+  });
+  await agent.fetchRootKey();
+  const actor = Actor.createActor(mockBitcoinIdlFactory, {
+    agent,
+    canisterId: HARD_CODED_BITCOIN_CANISTER_ID,
+  });
+  const txid = new Uint8Array(32);
+  // The txid just needs to be different each time so it does not get
+  // deduplicated by the ckbtc minter.
+  for (let i = 0; i < txid.length; i++) {
+    txid[i] = Math.floor(Math.random() * 256);
+  }
+  await actor.push_utxo_to_address({
+    utxo: {
+      // The height defines the number of confirmations. > 12 should mean the
+      // amount can be credited although the current mock bitcoin canister does
+      // not even seem to check this.
+      height: 15,
+      value: amountE8s,
+      outpoint: {
+        txid,
+        vout: 0,
+      },
+    },
+    address: btcAddress,
+  });
 };

--- a/frontend/src/lib/api/dev.api.ts
+++ b/frontend/src/lib/api/dev.api.ts
@@ -6,6 +6,7 @@ import { logWithTimestamp } from "$lib/utils/dev.utils";
 import { isUniverseNns } from "$lib/utils/universe.utils";
 import type { Identity } from "@dfinity/agent";
 import { Actor, HttpAgent, type Agent } from "@dfinity/agent";
+import type { IDL } from "@dfinity/candid";
 import { Ed25519KeyIdentity } from "@dfinity/identity";
 import type { BlockHeight } from "@dfinity/ledger-icp";
 import { AccountIdentifier, LedgerCanister } from "@dfinity/ledger-icp";
@@ -280,7 +281,7 @@ export const addMaturity = async ({
 
 // Generated with `didc bind -t js bitcoin_mock.did`, and then everything but
 // push_utxo_to_address manually removed.
-const mockBitcoinIdlFactory = ({ IDL }) => {
+const mockBitcoinIdlFactory: IDL.InterfaceFactory = ({ IDL }) => {
   const OutPoint = IDL.Record({
     txid: IDL.Vec(IDL.Nat8),
     vout: IDL.Nat32,

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -93,14 +93,14 @@
       }
     })();
 
-  // If the test account balance is 0, don't show a button that won't work. Show the ICP token instead.
+  // If the SNS test account balance is 0, don't show a button that won't work. Show the ICP token instead.
   let tokenSymbol: string;
   $: tokenSymbol =
-    ($isCkBTCUniverseStore
+    nonNullish(selectedProjectId) && tokenBalanceE8s > 0n
+      ? $snsTokenSymbolSelectedStore?.symbol ?? ICPToken.symbol
+      : $isCkBTCUniverseStore
       ? $i18n.ckbtc.btc
-      : tokenBalanceE8s === 0n
-      ? ICPToken.symbol
-      : $snsTokenSymbolSelectedStore?.symbol) ?? ICPToken.symbol;
+      : ICPToken.symbol;
 </script>
 
 <TestIdWrapper testId="get-tokens-component">

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -13,8 +13,9 @@
   import { Spinner, IconAccountBalance } from "@dfinity/gix-components";
   import { toastsError } from "$lib/stores/toasts.store";
   import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
+  import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-  import { ICPToken, type Token } from "@dfinity/utils";
+  import { ICPToken, type Token, nonNullish } from "@dfinity/utils";
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { browser } from "$app/environment";
@@ -25,10 +26,13 @@
   let inputValue: number | undefined = undefined;
 
   let selectedProjectId = OWN_CANISTER_ID;
-  $: selectedProjectId = $selectedUniverseIdStore;
+  $: selectedProjectId = $snsOnlyProjectStore;
 
   let isNns: boolean;
-  $: isNns = selectedProjectId.toText() === OWN_CANISTER_ID.toText();
+  $: isNns = $selectedUniverseIdStore.toText() === OWN_CANISTER_ID.toText();
+
+  let isSns: boolean;
+  $: isSns = nonNullish($snsOnlyProjectStore);
 
   const onSubmit = async () => {
     if (invalidForm || inputValue === undefined) {
@@ -42,7 +46,7 @@
 
     try {
       // Default to transfer ICPs if the test account's balance of the selected universe is 0.
-      if (isNns || tokenBalanceE8s === 0n) {
+      if (!isSns || tokenBalanceE8s === 0n) {
         await getICPs(inputValue);
       } else {
         await getTokens({
@@ -77,7 +81,7 @@
   $: selectedProjectId,
     (async () => {
       // This was executed at build time and it depends on `window` in `base64ToUInt8Array` helper inside dev.api.ts
-      if (browser) {
+      if (browser && isSns) {
         tokenBalanceE8s = await getTestBalance(selectedProjectId);
       }
     })();

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -9,10 +9,15 @@
     getICPs,
     getTestBalance,
     getTokens,
+    getBTC,
   } from "$lib/services/dev.services";
   import { Spinner, IconAccountBalance } from "@dfinity/gix-components";
+  import { i18n } from "$lib/stores/i18n";
   import { toastsError } from "$lib/stores/toasts.store";
-  import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
+  import {
+    isCkBTCUniverseStore,
+    selectedUniverseIdStore,
+  } from "$lib/derived/selected-universe.derived";
   import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import type { Principal } from "@dfinity/principal";
@@ -48,6 +53,10 @@
         await getTokens({
           tokens: inputValue,
           rootCanisterId: selectedProjectId,
+        });
+      } else if ($isCkBTCUniverseStore) {
+        await getBTC({
+          amount: inputValue,
         });
       } else {
         await getICPs(inputValue);
@@ -85,10 +94,13 @@
     })();
 
   // If the test account balance is 0, don't show a button that won't work. Show the ICP token instead.
-  let token: Token;
-  $: token =
-    (tokenBalanceE8s === 0n ? ICPToken : $snsTokenSymbolSelectedStore) ??
-    ICPToken;
+  let tokenSymbol: string;
+  $: tokenSymbol =
+    ($isCkBTCUniverseStore
+      ? "BTC" /*$i18n.ckbtc.btc*/
+      : tokenBalanceE8s === 0n
+      ? ICPToken.symbol
+      : $snsTokenSymbolSelectedStore?.symbol) ?? ICPToken.symbol;
 </script>
 
 <TestIdWrapper testId="get-tokens-component">
@@ -98,15 +110,15 @@
       data-tid={`get-${isNns || tokenBalanceE8s === 0n ? "icp" : "sns"}-button`}
       on:click|preventDefault|stopPropagation={() => (visible = true)}
       class="open"
-      title={`Get ${token.symbol}`}
+      title={`Get ${tokenSymbol}`}
     >
       <IconAccountBalance />
-      <span>{`Get ${token.symbol}`}</span>
+      <span>{`Get ${tokenSymbol}`}</span>
     </button>
   {/if}
 
   <Modal {visible} role="alert" on:nnsClose={onClose}>
-    <span slot="title">{`Get ${token.symbol}`}</span>
+    <span slot="title">{`Get ${tokenSymbol}`}</span>
 
     <form
       id="get-icp-form"

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -15,6 +15,7 @@
   import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
   import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+  import type { Principal } from "@dfinity/principal";
   import { ICPToken, type Token, nonNullish } from "@dfinity/utils";
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
   import { authSignedInStore } from "$lib/derived/auth.derived";
@@ -25,14 +26,11 @@
 
   let inputValue: number | undefined = undefined;
 
-  let selectedProjectId = OWN_CANISTER_ID;
+  let selectedProjectId: Principal | undefined;
   $: selectedProjectId = $snsOnlyProjectStore;
 
   let isNns: boolean;
   $: isNns = $selectedUniverseIdStore.toText() === OWN_CANISTER_ID.toText();
-
-  let isSns: boolean;
-  $: isSns = nonNullish($snsOnlyProjectStore);
 
   const onSubmit = async () => {
     if (invalidForm || inputValue === undefined) {
@@ -46,7 +44,7 @@
 
     try {
       // Default to transfer ICPs if the test account's balance of the selected universe is 0.
-      if (isSns && tokenBalanceE8s > 0n) {
+      if (nonNullish(selectedProjectId) && tokenBalanceE8s > 0n) {
         await getTokens({
           tokens: inputValue,
           rootCanisterId: selectedProjectId,
@@ -81,7 +79,7 @@
   $: selectedProjectId,
     (async () => {
       // This was executed at build time and it depends on `window` in `base64ToUInt8Array` helper inside dev.api.ts
-      if (browser && isSns) {
+      if (browser && nonNullish(selectedProjectId)) {
         tokenBalanceE8s = await getTestBalance(selectedProjectId);
       }
     })();

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -21,7 +21,7 @@
   import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import type { Principal } from "@dfinity/principal";
-  import { ICPToken, type Token, nonNullish } from "@dfinity/utils";
+  import { ICPToken, nonNullish } from "@dfinity/utils";
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { browser } from "$app/environment";
@@ -97,7 +97,7 @@
   let tokenSymbol: string;
   $: tokenSymbol =
     ($isCkBTCUniverseStore
-      ? "BTC" /*$i18n.ckbtc.btc*/
+      ? $i18n.ckbtc.btc
       : tokenBalanceE8s === 0n
       ? ICPToken.symbol
       : $snsTokenSymbolSelectedStore?.symbol) ?? ICPToken.symbol;

--- a/frontend/src/lib/components/ic/GetTokens.svelte
+++ b/frontend/src/lib/components/ic/GetTokens.svelte
@@ -46,13 +46,13 @@
 
     try {
       // Default to transfer ICPs if the test account's balance of the selected universe is 0.
-      if (!isSns || tokenBalanceE8s === 0n) {
-        await getICPs(inputValue);
-      } else {
+      if (isSns && tokenBalanceE8s > 0n) {
         await getTokens({
           tokens: inputValue,
           rootCanisterId: selectedProjectId,
         });
+      } else {
+        await getICPs(inputValue);
       }
 
       reset();

--- a/frontend/src/lib/services/dev.services.ts
+++ b/frontend/src/lib/services/dev.services.ts
@@ -1,9 +1,13 @@
+import { getBTCAddress } from "$lib/api/ckbtc-minter.api";
 import {
   acquireICPTs,
   acquireSnsTokens,
   getTestAccountBalance,
+  receiveMockBtc,
 } from "$lib/api/dev.api";
+import { CKBTC_MINTER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { E8S_PER_ICP } from "$lib/constants/icp.constants";
+import { getAuthenticatedIdentity } from "$lib/services/auth.services";
 import type { IcpAccountsStoreData } from "$lib/stores/icp-accounts.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
@@ -76,4 +80,16 @@ export const getTokens = async ({
 
   // Reload accounts to sync tokens that have been transferred
   await loadSnsAccounts({ rootCanisterId });
+};
+
+export const getBTC = async ({ amount }: { amount: number }) => {
+  const identity = await getAuthenticatedIdentity();
+  const btcAddress = await getBTCAddress({
+    canisterId: CKBTC_MINTER_CANISTER_ID,
+    identity,
+  });
+  await receiveMockBtc({
+    btcAddress,
+    amountE8s: BigInt(amount * E8S_PER_ICP),
+  });
 };


### PR DESCRIPTION
# Motivation

We want to be able to test ckBTC locally and on CI.
We can get ckBTC by requesting a BTC deposit address from the minter and sending BTC to it.
Using the mock bitcoin canister we can fake send BTC to the deposit address.

# Changes

1. When the ckBTC universe is selected show a "Get BTC" button instead of the "Get ICP" button.
2. When the button is clicked, we request a BTC address and tell the mock bitcoin canister to fake a transation to that address.

After this the use can click "Refresh Balance" in the ckBTC wallet to mint ckBTC into their account.

It's not much code so I didn't make it a dynamic import, but let me know if I should make it a dynamic import instead.

# Tests

Tested manually with a new snsdemo snapshot.

# Todos

- [x] Add entry to changelog (if necessary).
