### PR TITLE
test: revert migrated tests

### DIFF
--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import * as minterApi from "$lib/api/ckbtc-minter.api";
 import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { E8S_PER_ICP } from "$lib/constants/icp.constants";
@@ -35,8 +39,8 @@ import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import { SvelteComponent, tick } from "svelte";
 import { get } from "svelte/store";
 
-vi.mock("$lib/services/ckbtc-accounts.services");
-vi.mock("$lib/services/ckbtc-convert.services");
+jest.mock("$lib/services/ckbtc-accounts.services");
+jest.mock("$lib/services/ckbtc-convert.services");
 
 describe("CkBTCTransactionModal", () => {
   const renderTransactionModal = (selectedAccount?: Account) =>
@@ -55,10 +59,14 @@ describe("CkBTCTransactionModal", () => {
     });
 
   beforeEach(() => {
-    vi.restoreAllMocks();
+    jest.restoreAllMocks();
 
-    vi.mocked(ckBTCTransferTokens).mockResolvedValue({ blockIndex: undefined });
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    jest
+      .mocked(ckBTCTransferTokens)
+      .mockResolvedValue({ blockIndex: undefined });
+    jest
+      .spyOn(authStore, "subscribe")
+      .mockImplementation(mockAuthStoreSubscribe);
 
     icrcAccountsStore.set({
       accounts: {
@@ -83,10 +91,9 @@ describe("CkBTCTransactionModal", () => {
       routeId: AppPath.Accounts,
     });
 
-    vi.spyOn(minterApi, "estimateFee").mockResolvedValue({
-      minter_fee: 123n,
-      bitcoin_fee: 456n,
-    });
+    jest
+      .spyOn(minterApi, "estimateFee")
+      .mockResolvedValue({ minter_fee: 123n, bitcoin_fee: 456n });
   });
 
   it("should transfer tokens", async () => {
@@ -107,7 +114,7 @@ describe("CkBTCTransactionModal", () => {
     success: boolean;
     eventName: "nnsClose" | "nnsTransfer";
   }) => {
-    const spy = vi
+    const spy = jest
       .spyOn(services, "convertCkBTCToBtc")
       .mockResolvedValue({ success });
 
@@ -126,7 +133,7 @@ describe("CkBTCTransactionModal", () => {
     success: boolean;
     eventName: "nnsClose" | "nnsTransfer";
   }) => {
-    const spy = vi
+    const spy = jest
       .spyOn(services, "retrieveBtc")
       .mockResolvedValue({ success });
 
@@ -149,7 +156,7 @@ describe("CkBTCTransactionModal", () => {
   }) => {
     const result = await renderTransactionModal(selectedAccount);
 
-    const onEnd = vi.fn();
+    const onEnd = jest.fn();
     result.component.$on(eventName, onEnd);
 
     await testTransferTokens({
@@ -170,9 +177,9 @@ describe("CkBTCTransactionModal", () => {
   });
 
   it("should render progress when converting ckBTC to Bitcoin", async () => {
-    vi.spyOn(services, "convertCkBTCToBtc").mockResolvedValue({
-      success: true,
-    });
+    jest
+      .spyOn(services, "convertCkBTCToBtc")
+      .mockResolvedValue({ success: true });
 
     const result = await renderTransactionModal();
 
@@ -182,8 +189,8 @@ describe("CkBTCTransactionModal", () => {
       destinationAddress: mockBTCAddressTestnet,
     });
 
-    await waitFor(() =>
-      expect(result.getByTestId("in-progress-warning")).not.toBeNull()
+    await waitFor(
+      expect(result.getByTestId("in-progress-warning")).not.toBeNull
     );
 
     // In progress + transfer to ledger + sending BTC + reload
@@ -198,8 +205,8 @@ describe("CkBTCTransactionModal", () => {
       selectedNetwork: TransactionNetwork.ICP,
     });
 
-    await waitFor(() =>
-      expect(() => result.getByTestId("in-progress-warning")).toThrow()
+    await waitFor(
+      expect(() => result.getByTestId("in-progress-warning")).toThrow
     );
   });
 
@@ -481,10 +488,10 @@ describe("CkBTCTransactionModal", () => {
     });
 
     it("should render progress without step transfer", async () => {
-      vi.spyOn(services, "convertCkBTCToBtc").mockResolvedValue({
-        success: true,
-      });
-      vi.spyOn(services, "retrieveBtc").mockResolvedValue({ success: true });
+      jest
+        .spyOn(services, "convertCkBTCToBtc")
+        .mockResolvedValue({ success: true });
+      jest.spyOn(services, "retrieveBtc").mockResolvedValue({ success: true });
 
       const result = await renderTransactionModal(mockCkBTCWithdrawalAccount);
 
@@ -493,8 +500,8 @@ describe("CkBTCTransactionModal", () => {
         destinationAddress: mockBTCAddressTestnet,
       });
 
-      await waitFor(() =>
-        expect(result.getByTestId("in-progress-warning")).not.toBeNull()
+      await waitFor(
+        expect(result.getByTestId("in-progress-warning")).not.toBeNull
       );
 
       // In progress + sending BTC + reload

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
 import * as api from "$lib/api/governance.api";
 import NnsNeurons from "$lib/pages/NnsNeurons.svelte";
@@ -10,11 +14,11 @@ import { NeuronState } from "@dfinity/nns";
 import { render, waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
 
-vi.mock("$lib/api/governance.api");
+jest.mock("$lib/api/governance.api");
 
 describe("NnsNeurons", () => {
   beforeEach(() => {
-    vi.resetAllMocks();
+    jest.resetAllMocks();
     resetNeuronsApiService();
     neuronsStore.reset();
   });
@@ -36,10 +40,10 @@ describe("NnsNeurons", () => {
     const neurons = [mockNeuron, spawningNeuron, mockNeuron2];
 
     beforeEach(() => {
-      vi.spyOn(authServices, "getAuthenticatedIdentity").mockResolvedValue(
-        mockIdentity
-      );
-      vi.spyOn(api, "queryNeurons").mockResolvedValue(neurons);
+      jest
+        .spyOn(authServices, "getAuthenticatedIdentity")
+        .mockResolvedValue(mockIdentity);
+      jest.spyOn(api, "queryNeurons").mockResolvedValue(neurons);
     });
 
     it("should render spawning neurons as disabled", async () => {
@@ -68,10 +72,10 @@ describe("NnsNeurons", () => {
 
   describe("no neurons", () => {
     beforeEach(() => {
-      vi.spyOn(authServices, "getAuthenticatedIdentity").mockResolvedValue(
-        mockIdentity
-      );
-      vi.spyOn(api, "queryNeurons").mockResolvedValue([]);
+      jest
+        .spyOn(authServices, "getAuthenticatedIdentity")
+        .mockResolvedValue(mockIdentity);
+      jest.spyOn(api, "queryNeurons").mockResolvedValue([]);
     });
 
     it("should render an empty message", async () => {
@@ -85,10 +89,10 @@ describe("NnsNeurons", () => {
 
   describe("navigating", () => {
     beforeEach(() => {
-      vi.spyOn(authServices, "getAuthenticatedIdentity").mockResolvedValue(
-        mockIdentity
-      );
-      vi.spyOn(api, "queryNeurons").mockResolvedValue([]);
+      jest
+        .spyOn(authServices, "getAuthenticatedIdentity")
+        .mockResolvedValue(mockIdentity);
+      jest.spyOn(api, "queryNeurons").mockResolvedValue([]);
     });
 
     it("should call query neurons twice when rendered", async () => {

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
 import {
   sortedSnsCFNeuronsStore,
@@ -24,32 +28,32 @@ import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import type { SnsNeuron } from "@dfinity/sns";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
-import type { SpyInstance } from "vitest";
 
-vi.mock("$lib/services/sns-neurons.services", () => {
+jest.mock("$lib/services/sns-neurons.services", () => {
   return {
-    syncSnsNeurons: vi.fn().mockReturnValue(undefined),
+    syncSnsNeurons: jest.fn().mockReturnValue(undefined),
   };
 });
 
-vi.mock("$lib/services/sns-accounts.services", () => {
+jest.mock("$lib/services/sns-accounts.services", () => {
   return {
-    syncSnsAccounts: vi.fn().mockReturnValue(undefined),
+    syncSnsAccounts: jest.fn().mockReturnValue(undefined),
   };
 });
 
-vi.mock("$lib/services/sns-parameters.services", () => {
+jest.mock("$lib/services/sns-parameters.services", () => {
   return {
-    loadSnsParameters: vi.fn().mockResolvedValue(undefined),
+    loadSnsParameters: jest.fn().mockResolvedValue(undefined),
   };
 });
 
 describe("SnsNeurons", () => {
-  let authStoreMock: SpyInstance;
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  let authStoreMock: jest.MockedFunction<any>;
 
   beforeEach(() => {
     page.mock({ data: { universe: rootCanisterIdMock.toText() } });
-    authStoreMock = vi
+    authStoreMock = jest
       .spyOn(authStore, "subscribe")
       .mockImplementation(mockAuthStoreSubscribe);
 
@@ -61,7 +65,7 @@ describe("SnsNeurons", () => {
     ]);
   });
 
-  afterEach(() => vi.clearAllMocks());
+  afterEach(() => jest.clearAllMocks());
 
   describe("without neurons from CF", () => {
     beforeEach(() => {
@@ -71,18 +75,20 @@ describe("SnsNeurons", () => {
       const neuron2 = createMockSnsNeuron({
         id: [1, 2, 4],
       });
-      vi.spyOn(sortedSnsUserNeuronsStore, "subscribe").mockImplementation(
-        buildMockSortedSnsNeuronsStoreSubscribe([neuron1, neuron2])
-      );
-      vi.spyOn(sortedSnsCFNeuronsStore, "subscribe").mockImplementation(
-        buildMockSortedSnsNeuronsStoreSubscribe([])
-      );
-      vi.spyOn(snsParametersStore, "subscribe").mockImplementation(
-        buildMockSnsParametersStore()
-      );
+      jest
+        .spyOn(sortedSnsUserNeuronsStore, "subscribe")
+        .mockImplementation(
+          buildMockSortedSnsNeuronsStoreSubscribe([neuron1, neuron2])
+        );
+      jest
+        .spyOn(sortedSnsCFNeuronsStore, "subscribe")
+        .mockImplementation(buildMockSortedSnsNeuronsStoreSubscribe([]));
+      jest
+        .spyOn(snsParametersStore, "subscribe")
+        .mockImplementation(buildMockSnsParametersStore());
     });
 
-    afterEach(() => vi.clearAllMocks());
+    afterEach(() => jest.clearAllMocks());
 
     it("should subscribe to store and call services to set up data", async () => {
       render(SnsNeurons);
@@ -119,15 +125,15 @@ describe("SnsNeurons", () => {
         }),
         source_nns_neuron_id: [BigInt(123)],
       };
-      vi.spyOn(sortedSnsUserNeuronsStore, "subscribe").mockImplementation(
-        buildMockSortedSnsNeuronsStoreSubscribe([neuron1])
-      );
-      vi.spyOn(sortedSnsCFNeuronsStore, "subscribe").mockImplementation(
-        buildMockSortedSnsNeuronsStoreSubscribe([neuron2])
-      );
+      jest
+        .spyOn(sortedSnsUserNeuronsStore, "subscribe")
+        .mockImplementation(buildMockSortedSnsNeuronsStoreSubscribe([neuron1]));
+      jest
+        .spyOn(sortedSnsCFNeuronsStore, "subscribe")
+        .mockImplementation(buildMockSortedSnsNeuronsStoreSubscribe([neuron2]));
     });
 
-    afterEach(() => vi.clearAllMocks());
+    afterEach(() => jest.clearAllMocks());
 
     it("should render SnsNeuronCards for each neuron", async () => {
       const { queryAllByTestId } = render(SnsNeurons);
@@ -175,15 +181,15 @@ describe("SnsNeurons", () => {
         }),
         source_nns_neuron_id: [BigInt(123)],
       };
-      vi.spyOn(sortedSnsUserNeuronsStore, "subscribe").mockImplementation(
-        buildMockSortedSnsNeuronsStoreSubscribe([])
-      );
-      vi.spyOn(sortedSnsCFNeuronsStore, "subscribe").mockImplementation(
-        buildMockSortedSnsNeuronsStoreSubscribe([neuron2])
-      );
+      jest
+        .spyOn(sortedSnsUserNeuronsStore, "subscribe")
+        .mockImplementation(buildMockSortedSnsNeuronsStoreSubscribe([]));
+      jest
+        .spyOn(sortedSnsCFNeuronsStore, "subscribe")
+        .mockImplementation(buildMockSortedSnsNeuronsStoreSubscribe([neuron2]));
     });
 
-    afterEach(() => vi.clearAllMocks());
+    afterEach(() => jest.clearAllMocks());
 
     it("should render Community Fund title", async () => {
       const { queryByTestId } = render(SnsNeurons);
@@ -203,20 +209,20 @@ describe("SnsNeurons", () => {
   });
 
   describe("no neurons", () => {
-    vi.spyOn(snsProjectSelectedStore, "subscribe").mockImplementation(
-      mockStoreSubscribe(mockSnsFullProject)
-    );
+    jest
+      .spyOn(snsProjectSelectedStore, "subscribe")
+      .mockImplementation(mockStoreSubscribe(mockSnsFullProject));
 
     beforeAll(() => {
-      vi.spyOn(sortedSnsUserNeuronsStore, "subscribe").mockImplementation(
-        buildMockSortedSnsNeuronsStoreSubscribe([])
-      );
-      vi.spyOn(sortedSnsCFNeuronsStore, "subscribe").mockImplementation(
-        buildMockSortedSnsNeuronsStoreSubscribe([])
-      );
+      jest
+        .spyOn(sortedSnsUserNeuronsStore, "subscribe")
+        .mockImplementation(buildMockSortedSnsNeuronsStoreSubscribe([]));
+      jest
+        .spyOn(sortedSnsCFNeuronsStore, "subscribe")
+        .mockImplementation(buildMockSortedSnsNeuronsStoreSubscribe([]));
     });
 
-    afterAll(() => vi.clearAllMocks());
+    afterAll(() => jest.clearAllMocks());
 
     it("should render empty text if no neurons", async () => {
       const { getByText } = render(SnsNeurons);


### PR DESCRIPTION
# Motivation

Our CI has issue with last few tests that were migrated to vitest. As a results, lots of build never ends - hangs forever.

Of those problematic tests we identitied two in https://github.com/dfinity/nns-dapp/actions/runs/6460468191/job/17538215849.

That's why this revert those two PRs for now.

- SnsNeurons.spec.ts

Failed to terminate worker while running /home/runner/work/nns-dapp/nns-dapp/frontend/src/vitests/lib/pages/SnsNeurons.spec.ts.

- CkBTCTransactionModal.spec.ts

Error: Global crypto was not available and none was provided. Please inlcude a SubtleCrypto implementation. See https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto

ReferenceError: localStorage is not defined
 ❯ _openDbStore node_modules/@dfinity/auth-client/src/db.ts:17:29
 ❯ Function.create node_modules/@dfinity/auth-client/src/db.ts:76:4

# Notes

From the two, the first with the "failed to terminate" seems the be the reason of the ci hanging