### PR TITLE
GIX-1948: Use success intent for accepting participation tag

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -22,6 +22,7 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 * Internal change: remove unused snsQueryStore.
 * New Tag style. Used in followees topic and project status.
 * New header UI in the wallet pages.
+* New Tag style when swap is open.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/components/project-detail/ProjectStatus.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatus.svelte
@@ -49,7 +49,9 @@
 
 <div data-tid="project-status-component">
   <h2 class="content-cell-title">{$i18n.sns_project_detail.status}</h2>
-  <Tag>{statusText}</Tag>
+  <Tag intent={lifecycle === SnsSwapLifecycle.Open ? "success" : "info"}
+    >{statusText}</Tag
+  >
 </div>
 
 <style lang="scss">

--- a/frontend/src/vitests/lib/components/project-detail/ProjectStatus.spec.ts
+++ b/frontend/src/vitests/lib/components/project-detail/ProjectStatus.spec.ts
@@ -18,17 +18,18 @@ describe("ProjectStatus", () => {
     resetSnsFinalizationStatusStore();
   });
 
-  it("should render accepting participation text when open", () => {
-    const { queryByText } = renderContextCmp({
+  it("should render accepting participation text when open with success intent", () => {
+    const { queryByText, queryByTestId } = renderContextCmp({
       summary: summaryForLifecycle(SnsSwapLifecycle.Open),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
       Component: ProjectStatus,
     });
     expect(queryByText(en.sns_project_detail.status_open)).toBeInTheDocument();
+    expect(queryByTestId("tag").classList.contains("success")).toBe(true);
   });
 
   it("should render pending text when not yet open", () => {
-    const { queryByText } = renderContextCmp({
+    const { queryByText, queryByTestId } = renderContextCmp({
       summary: summaryForLifecycle(SnsSwapLifecycle.Pending),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
       Component: ProjectStatus,
@@ -37,10 +38,11 @@ describe("ProjectStatus", () => {
     expect(
       queryByText(en.sns_project_detail.status_pending)
     ).toBeInTheDocument();
+    expect(queryByTestId("tag").classList.contains("info")).toBe(true);
   });
 
   it("should render unspecified text if not defined", () => {
-    const { queryByText } = renderContextCmp({
+    const { queryByText, queryByTestId } = renderContextCmp({
       summary: summaryForLifecycle(SnsSwapLifecycle.Unspecified),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
       Component: ProjectStatus,
@@ -49,10 +51,11 @@ describe("ProjectStatus", () => {
     expect(
       queryByText(en.sns_project_detail.status_unspecified)
     ).toBeInTheDocument();
+    expect(queryByTestId("tag").classList.contains("info")).toBe(true);
   });
 
   it("should render committed text", () => {
-    const { queryByText } = renderContextCmp({
+    const { queryByText, queryByTestId } = renderContextCmp({
       summary: summaryForLifecycle(SnsSwapLifecycle.Committed),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
       Component: ProjectStatus,
@@ -61,10 +64,11 @@ describe("ProjectStatus", () => {
     expect(
       queryByText(en.sns_project_detail.status_committed)
     ).toBeInTheDocument();
+    expect(queryByTestId("tag").classList.contains("info")).toBe(true);
   });
 
   it("should render starting soon text", () => {
-    const { queryByText } = renderContextCmp({
+    const { queryByText, queryByTestId } = renderContextCmp({
       summary: summaryForLifecycle(SnsSwapLifecycle.Adopted),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
       Component: ProjectStatus,
@@ -73,10 +77,11 @@ describe("ProjectStatus", () => {
     expect(
       queryByText(en.sns_project_detail.status_adopted)
     ).toBeInTheDocument();
+    expect(queryByTestId("tag").classList.contains("info")).toBe(true);
   });
 
   it("should render aborted text when cancelled", () => {
-    const { queryByText } = renderContextCmp({
+    const { queryByText, queryByTestId } = renderContextCmp({
       summary: summaryForLifecycle(SnsSwapLifecycle.Aborted),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
       Component: ProjectStatus,
@@ -85,6 +90,7 @@ describe("ProjectStatus", () => {
     expect(
       queryByText(en.sns_project_detail.status_aborted)
     ).toBeInTheDocument();
+    expect(queryByTestId("tag").classList.contains("info")).toBe(true);
   });
 
   it("should render finalizing text when swap is finalizing", () => {
@@ -94,7 +100,7 @@ describe("ProjectStatus", () => {
       data: createFinalizationStatusMock(true),
       certified: true,
     });
-    const { queryByText } = renderContextCmp({
+    const { queryByText, queryByTestId } = renderContextCmp({
       summary,
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
       Component: ProjectStatus,
@@ -103,6 +109,7 @@ describe("ProjectStatus", () => {
     expect(
       queryByText(en.sns_project_detail.status_finalizing)
     ).toBeInTheDocument();
+    expect(queryByTestId("tag").classList.contains("info")).toBe(true);
   });
 
   it("should render committed text if finalizing data is not finalizing", () => {

--- a/frontend/src/vitests/lib/components/project-detail/ProjectStatus.spec.ts
+++ b/frontend/src/vitests/lib/components/project-detail/ProjectStatus.spec.ts
@@ -26,6 +26,7 @@ describe("ProjectStatus", () => {
     });
     expect(queryByText(en.sns_project_detail.status_open)).toBeInTheDocument();
     expect(queryByTestId("tag").classList.contains("success")).toBe(true);
+    expect(queryByTestId("tag").classList.contains("info")).toBe(false);
   });
 
   it("should render pending text when not yet open", () => {
@@ -39,6 +40,7 @@ describe("ProjectStatus", () => {
       queryByText(en.sns_project_detail.status_pending)
     ).toBeInTheDocument();
     expect(queryByTestId("tag").classList.contains("info")).toBe(true);
+    expect(queryByTestId("tag").classList.contains("success")).toBe(false);
   });
 
   it("should render unspecified text if not defined", () => {
@@ -52,6 +54,7 @@ describe("ProjectStatus", () => {
       queryByText(en.sns_project_detail.status_unspecified)
     ).toBeInTheDocument();
     expect(queryByTestId("tag").classList.contains("info")).toBe(true);
+    expect(queryByTestId("tag").classList.contains("success")).toBe(false);
   });
 
   it("should render committed text", () => {
@@ -78,6 +81,7 @@ describe("ProjectStatus", () => {
       queryByText(en.sns_project_detail.status_adopted)
     ).toBeInTheDocument();
     expect(queryByTestId("tag").classList.contains("info")).toBe(true);
+    expect(queryByTestId("tag").classList.contains("success")).toBe(false);
   });
 
   it("should render aborted text when cancelled", () => {
@@ -91,6 +95,7 @@ describe("ProjectStatus", () => {
       queryByText(en.sns_project_detail.status_aborted)
     ).toBeInTheDocument();
     expect(queryByTestId("tag").classList.contains("info")).toBe(true);
+    expect(queryByTestId("tag").classList.contains("success")).toBe(false);
   });
 
   it("should render finalizing text when swap is finalizing", () => {
@@ -110,6 +115,7 @@ describe("ProjectStatus", () => {
       queryByText(en.sns_project_detail.status_finalizing)
     ).toBeInTheDocument();
     expect(queryByTestId("tag").classList.contains("info")).toBe(true);
+    expect(queryByTestId("tag").classList.contains("success")).toBe(false);
   });
 
   it("should render committed text if finalizing data is not finalizing", () => {


### PR DESCRIPTION
# Motivation

Improve the information on the status of a swap by changing the Tag style when the swap is open.

# Changes

* Set the "intent" of the Tag to "success" when the swap is open.

# Tests

* Test that the Tag has "success" when open and "info" when not.

# Todos

- [x] Add entry to changelog (if necessary).
