### PR TITLE
Use child_process strategy to spread tests

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -67,6 +67,7 @@ export default defineConfig(
       },
       // Vitest issue: https://github.com/vitest-dev/vitest/issues/2834#issuecomment-1439576110
       alias: [{ find: /^svelte$/, replacement: "svelte/internal" }],
+      poolMatchGlobs: [["**/vitests/**", "child_process"]],
     },
   })
 );


### PR DESCRIPTION
# Motivation

Locally I can reproduce the issue with open handles running `ProjectCommitment.spec.ts`.

When I switch the threading strategy to a file system based with `child_process` the issue is solved. Therefore this PR provide such configuration.

# Documentation

I don't know if vitest documentation is up-to-date regarding pool and threads. Either it is newer or older than the vitest version we are using, which is the last one. child_process is defined there https://vitest.dev/config/#forks