### PR TITLE
Fix hanging process after test

### DIFF
--- a/frontend/src/vitests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/vitests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -9,6 +9,7 @@ import {
 import { renderContextCmp } from "$tests/mocks/sns.mock";
 import { ProjectCommitmentPo } from "$tests/page-objects/ProjectCommitment.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { advanceTime } from "$vitests/utils/timers.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 
 describe("ProjectCommitment", () => {
@@ -29,7 +30,14 @@ describe("ProjectCommitment", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+
+    vi.clearAllTimers();
+    vi.useFakeTimers().setSystemTime(new Date());
   });
+
+  // Fix "Failed to terminate worker while running. Tests closed successfully but something prevents Vite server from exiting"
+  // Related issue: https://github.com/vitest-dev/vitest/issues/2008#issuecomment-1434789112
+  afterEach(async () => await advanceTime(5000));
 
   it("should render min and max commitment", async () => {
     const summary = createSummary({


### PR DESCRIPTION
# Motivation

`ProjectCommitment.spec.ts`  leads to an hanging process when tested with vitest:

> # FILEHANDLE
> node:internal/async_hooks:202
> 
> # FILEHANDLE
> node:internal/async_hooks:202
> close timed out after 30000ms
> Failed to terminate worker while running /Users/daviddalbusco/projects/dfinity/nns-dapp/frontend/src/vitests/lib/components/project-detail/ProjectCommitment.spec.ts.
> Tests closed successfully but something prevents Vite server from exiting
> You can try to identify the cause by enabling "hanging-process" reporter. See https://vitest.dev/config/#reporters

If found a related issue in vitests with many comments: https://github.com/vitest-dev/vitest/issues/2008
One of [those](https://github.com/vitest-dev/vitest/issues/2008#issuecomment-1434789112) mention that the issue was related to a debounce. So I thought we might face similar situation and advanced the time on after each which resolved the issue.
