### PR TITLE
T Cycles display on canister page

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -31,6 +31,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Separators in project page appearing without data inside.
+* Cycles displayed as T Cycles on canister detail page.
 
 #### Security
 

--- a/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import { TokenAmount, nonNullish } from "@dfinity/utils";
-  import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
+  import { nonNullish } from "@dfinity/utils";
   import type { CanisterDetails } from "$lib/canisters/ic-management/ic-management.canister.types";
   import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
   import { i18n } from "$lib/stores/i18n";

--- a/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
@@ -6,7 +6,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { SkeletonText } from "@dfinity/gix-components";
   import TestIdWrapper from "../common/TestIdWrapper.svelte";
-  import {formatCyclesToTCycles} from "$lib/utils/canisters.utils";
+  import { formatCyclesToTCycles } from "$lib/utils/canisters.utils";
 
   export let details: CanisterDetails | undefined;
   export let canister: CanisterInfo;
@@ -16,9 +16,7 @@
 <TestIdWrapper testId="canister-heading-title-component">
   {#if nonNullish(details)}
     <p class="cycles">
-      <span class="value"
-      >{formatCyclesToTCycles(details.cycles)}</span
-      >
+      <span class="value">{formatCyclesToTCycles(details.cycles)}</span>
       <span class="label">{$i18n.canister_detail.t_cycles}</span>
     </p>
     <!-- Only when we have loaded the data and we know whether the user is the controller -->

--- a/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
+++ b/frontend/src/lib/components/canister-detail/CanisterHeadingTitle.svelte
@@ -6,6 +6,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { SkeletonText } from "@dfinity/gix-components";
   import TestIdWrapper from "../common/TestIdWrapper.svelte";
+  import {formatCyclesToTCycles} from "$lib/utils/canisters.utils";
 
   export let details: CanisterDetails | undefined;
   export let canister: CanisterInfo;
@@ -14,14 +15,12 @@
 
 <TestIdWrapper testId="canister-heading-title-component">
   {#if nonNullish(details)}
-    <AmountDisplay
-      amount={TokenAmount.fromE8s({
-        amount: details.cycles,
-        token: { name: "cycles", symbol: $i18n.canisters.t_cycles },
-      })}
-      size="huge"
-      singleLine
-    />
+    <p class="cycles">
+      <span class="value"
+      >{formatCyclesToTCycles(details.cycles)}</span
+      >
+      <span class="label">{$i18n.canister_detail.t_cycles}</span>
+    </p>
     <!-- Only when we have loaded the data and we know whether the user is the controller -->
   {:else if isController === false}
     <h1 data-tid="caniter-title-balance-unavailable">
@@ -40,6 +39,7 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
 
   h1 {
     margin: 0;
@@ -52,5 +52,10 @@
     // Based on $breakpoint-xsmall: 320px;
     width: 320px;
     max-width: calc(100% - var(--padding-2x));
+  }
+
+  .cycles {
+    font-size: var(--font-size-huge);
+    text-align: center;
   }
 </style>

--- a/frontend/src/vitests/lib/components/canister-detail/CanisterHeadingTitle.spec.ts
+++ b/frontend/src/vitests/lib/components/canister-detail/CanisterHeadingTitle.spec.ts
@@ -55,15 +55,15 @@ describe("CanisterHeadingTitle", () => {
   it("renders cycles balance if defined", async () => {
     const canisterDetails = {
       ...mockCanisterDetails,
-      cycles: 314000000n,
+      cycles: 246913400000000n,
     };
     const po1 = renderComponent(canisterDetails, true);
-    expect(await po1.getTitle()).toBe("3.14 T Cycles");
+    expect(await po1.getTitle()).toBe("246.913 T Cycles");
 
     const po2 = renderComponent(canisterDetails, false);
-    expect(await po2.getTitle()).toBe("3.14 T Cycles");
+    expect(await po2.getTitle()).toBe("246.913 T Cycles");
 
     const po3 = renderComponent(canisterDetails, undefined);
-    expect(await po3.getTitle()).toBe("3.14 T Cycles");
+    expect(await po3.getTitle()).toBe("246.913 T Cycles");
   });
 });

--- a/frontend/src/vitests/lib/components/canister-detail/CanisterPageHeading.spec.ts
+++ b/frontend/src/vitests/lib/components/canister-detail/CanisterPageHeading.spec.ts
@@ -36,10 +36,10 @@ describe("CanisterHeadingTitle", () => {
   it("renders the cycles as title when present", async () => {
     const canisterDetails = {
       ...mockCanisterDetails,
-      cycles: 314000000n,
+      cycles: 3_140_000_000_000n,
     };
     const po = renderComponent(mockCanister, canisterDetails, undefined);
-    expect(await po.getTitle()).toBe("3.14 T Cycles");
+    expect(await po.getTitle()).toBe("3.140 T Cycles");
   });
 
   it("renders the canister name as subtitle if present and user is the controller", async () => {

--- a/frontend/src/vitests/lib/pages/CanisterDetail.spec.ts
+++ b/frontend/src/vitests/lib/pages/CanisterDetail.spec.ts
@@ -128,10 +128,10 @@ describe("CanisterDetail", () => {
     it("shuold render cycles balance as title", async () => {
       vi.spyOn(canisterApi, "queryCanisterDetails").mockResolvedValue({
         ...mockCanisterDetails,
-        cycles: 100_000_000n,
+        cycles: 1_000_000_000_000n,
       });
       const po = await renderComponent();
-      expect(await po.getTitle()).toBe("1.00 T Cycles");
+      expect(await po.getTitle()).toBe("1.000 T Cycles");
     });
   });
 


### PR DESCRIPTION
# Motivation

Cycles are not displayed as T Cycles on canister detail page - i.e. value is 10000 too high.

# Changes

- use cycles utils to format value

# Screenshots

Is:

<img width="1536" alt="Capture d’écran 2023-10-11 à 07 43 55" src="https://github.com/dfinity/nns-dapp/assets/16886711/f796cc38-1fdc-4895-870c-b4dd5c67c76c">

Fix:

<img width="1536" alt="Capture d’écran 2023-10-11 à 07 44 07" src="https://github.com/dfinity/nns-dapp/assets/16886711/66844872-1464-4d0e-ab04-fd7bd0c2f0c2">
