### PR TITLE
GIX-1935: Add fields SNS aggregator

### DIFF
--- a/declarations/nns_governance/nns_governance.did
+++ b/declarations/nns_governance/nns_governance.did
@@ -100,6 +100,11 @@ type Committed = record {
   total_neurons_fund_contribution_icp_e8s : opt nat64;
   sns_governance_canister_id : opt principal;
 };
+type Committed_1 = record {
+  total_direct_participation_icp_e8s : opt nat64;
+  total_neurons_fund_participation_icp_e8s : opt nat64;
+  sns_governance_canister_id : opt principal;
+};
 type Configure = record { operation : opt Operation };
 type Countries = record { iso_codes : vec text };
 type CreateServiceNervousSystem = record {
@@ -207,6 +212,9 @@ type GovernanceParameters = record {
   proposal_initial_voting_period : opt Duration;
   proposal_rejection_fee : opt Tokens;
   voting_reward_parameters : opt VotingRewardParameters;
+};
+type IdealMatchedParticipationFunction = record {
+  serialized_representation : opt text;
 };
 type Image = record { base64_encoding : opt text };
 type IncreaseDissolveDelay = record {
@@ -363,10 +371,30 @@ type NeuronStakeTransfer = record {
   transfer_timestamp : nat64;
   block_height : nat64;
 };
+type NeuronsFundNeuron = record {
+  hotkey_principal : opt text;
+  is_capped : opt bool;
+  nns_neuron_id : opt nat64;
+  amount_icp_e8s : opt nat64;
+};
+type NeuronsFundNeuron_1 = record {
+  hotkey_principal : opt principal;
+  is_capped : opt bool;
+  nns_neuron_id : opt nat64;
+  amount_icp_e8s : opt nat64;
+};
+type NeuronsFundParticipation = record {
+  neurons_fund_snapshot : opt NeuronsFundSnapshot;
+  ideal_matched_participation_function : opt IdealMatchedParticipationFunction;
+};
+type NeuronsFundSnapshot = record {
+  neurons_fund_neurons : vec NeuronsFundNeuron_1;
+};
 type NodeProvider = record {
   id : opt principal;
   reward_account : opt AccountIdentifier;
 };
+type Ok = record { neurons_fund_neurons : vec NeuronsFundNeuron };
 type OpenSnsTokenSwap = record {
   community_fund_investment_e8s : opt nat64;
   target_swap_canister_id : opt principal;
@@ -392,7 +420,9 @@ type Params = record {
   sns_token_e8s : nat64;
   sale_delay_seconds : opt nat64;
   max_participant_icp_e8s : nat64;
+  min_direct_participation_icp_e8s : opt nat64;
   min_icp_e8s : nat64;
+  max_direct_participation_icp_e8s : opt nat64;
 };
 type Percentage = record { basis_points : opt nat64 };
 type Progress = variant { LastNeuronId : NeuronId };
@@ -404,6 +434,7 @@ type Proposal = record {
 };
 type ProposalData = record {
   id : opt NeuronId;
+  neurons_fund_participation : opt NeuronsFundParticipation;
   failure_reason : opt GovernanceError;
   cf_participants : vec CfParticipant;
   ballots : vec record { nat64; Ballot };
@@ -450,6 +481,8 @@ type Result_4 = variant { Ok : RewardNodeProviders; Err : GovernanceError };
 type Result_5 = variant { Ok : NeuronInfo; Err : GovernanceError };
 type Result_6 = variant { Ok : NodeProvider; Err : GovernanceError };
 type Result_7 = variant { Committed : Committed; Aborted : record {} };
+type Result_8 = variant { Committed : Committed_1; Aborted : record {} };
+type Result_9 = variant { Ok : Ok; Err : GovernanceError };
 type RewardEvent = record {
   rounds_since_last_distribution : opt nat64;
   day_after_genesis : nat64;
@@ -487,6 +520,11 @@ type SettleCommunityFundParticipation = record {
   result : opt Result_7;
   open_sns_token_swap_proposal_id : opt nat64;
 };
+type SettleNeuronsFundParticipationRequest = record {
+  result : opt Result_8;
+  nns_proposal_id : opt nat64;
+};
+type SettleNeuronsFundParticipationResponse = record { result : opt Result_9 };
 type Spawn = record {
   percentage_to_spawn : opt nat32;
   new_controller : opt principal;
@@ -517,8 +555,10 @@ type SwapParameters = record {
   confirmation_text : opt text;
   maximum_participant_icp : opt Tokens;
   minimum_icp : opt Tokens;
+  minimum_direct_participation_icp : opt Tokens;
   minimum_participant_icp : opt Tokens;
   start_time : opt GlobalTimeOfDay;
+  maximum_direct_participation_icp : opt Tokens;
   maximum_icp : opt Tokens;
   neurons_fund_investment_icp : opt Tokens;
   restricted_countries : opt Countries;
@@ -574,6 +614,9 @@ service : (Governance) -> {
   settle_community_fund_participation : (SettleCommunityFundParticipation) -> (
       Result,
     );
+  settle_neurons_fund_participation : (
+      SettleNeuronsFundParticipationRequest,
+    ) -> (SettleNeuronsFundParticipationResponse);
   simulate_manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
   transfer_gtc_neuron : (NeuronId, NeuronId) -> (Result);
   update_node_provider : (UpdateNodeProvider) -> (Result);

--- a/declarations/nns_registry/nns_registry.did
+++ b/declarations/nns_registry/nns_registry.did
@@ -1,3 +1,8 @@
+type AddApiBoundaryNodePayload = record {
+  node_id : principal;
+  domain : text;
+  version : text;
+};
 type AddFirewallRulesPayload = record {
   expected_hash : text;
   scope : FirewallRulesScope;
@@ -159,6 +164,7 @@ type RecoverSubnetPayload = record {
   state_hash : vec nat8;
   time_ns : nat64;
 };
+type RemoveApiBoundaryNodesPayload = record { node_ids : vec principal };
 type RemoveFirewallRulesPayload = record {
   expected_hash : text;
   scope : FirewallRulesScope;
@@ -201,6 +207,14 @@ type SubnetFeatures = record {
   http_requests : bool;
 };
 type SubnetType = variant { application; verified_application; system };
+type UpdateApiBoundaryNodeDomainPayload = record {
+  node_id : principal;
+  domain : text;
+};
+type UpdateApiBoundaryNodesVersionPayload = record {
+  version : text;
+  node_ids : vec principal;
+};
 type UpdateElectedHostosVersionsPayload = record {
   release_package_urls : vec text;
   hostos_version_to_elect : opt text;
@@ -279,6 +293,7 @@ type UpdateUnassignedNodesConfigPayload = record {
   ssh_readonly_access : opt vec text;
 };
 service : {
+  add_api_boundary_node : (AddApiBoundaryNodePayload) -> ();
   add_firewall_rules : (AddFirewallRulesPayload) -> ();
   add_node : (AddNodePayload) -> (Result);
   add_node_operator : (AddNodeOperatorPayload) -> ();
@@ -298,6 +313,7 @@ service : {
   get_subnet_for_canister : (GetSubnetForCanisterRequest) -> (Result_4) query;
   prepare_canister_migration : (PrepareCanisterMigrationPayload) -> (Result_1);
   recover_subnet : (RecoverSubnetPayload) -> ();
+  remove_api_boundary_nodes : (RemoveApiBoundaryNodesPayload) -> ();
   remove_firewall_rules : (RemoveFirewallRulesPayload) -> ();
   remove_node_directly : (RemoveNodeDirectlyPayload) -> ();
   remove_node_operators : (RemoveNodeOperatorsPayload) -> ();
@@ -306,6 +322,10 @@ service : {
   reroute_canister_ranges : (RerouteCanisterRangesPayload) -> (Result_1);
   retire_replica_version : (RetireReplicaVersionPayload) -> ();
   set_firewall_config : (SetFirewallConfigPayload) -> ();
+  update_api_boundary_node_domain : (UpdateApiBoundaryNodeDomainPayload) -> ();
+  update_api_boundary_nodes_version : (
+      UpdateApiBoundaryNodesVersionPayload,
+    ) -> ();
   update_elected_hostos_versions : (UpdateElectedHostosVersionsPayload) -> ();
   update_elected_replica_versions : (UpdateElectedReplicaVersionsPayload) -> ();
   update_firewall_rules : (AddFirewallRulesPayload) -> ();

--- a/declarations/sns_swap/sns_swap.did
+++ b/declarations/sns_swap/sns_swap.did
@@ -103,8 +103,10 @@ type Init = record {
   should_auto_finalize : opt bool;
   max_participant_icp_e8s : opt nat64;
   sns_governance_canister_id : text;
+  min_direct_participation_icp_e8s : opt nat64;
   restricted_countries : opt Countries;
   min_icp_e8s : opt nat64;
+  max_direct_participation_icp_e8s : opt nat64;
 };
 type InvalidUserAmount = record {
   min_amount_icp_e8s_included : nat64;
@@ -174,7 +176,9 @@ type Params = record {
   sns_token_e8s : nat64;
   sale_delay_seconds : opt nat64;
   max_participant_icp_e8s : nat64;
+  min_direct_participation_icp_e8s : opt nat64;
   min_icp_e8s : nat64;
+  max_direct_participation_icp_e8s : opt nat64;
 };
 type Participant = record {
   participation : opt BuyerState;

--- a/declarations/sns_wasm/sns_wasm.did
+++ b/declarations/sns_wasm/sns_wasm.did
@@ -141,9 +141,11 @@ type SnsInitPayload = record {
   token_logo : opt text;
   token_name : opt text;
   max_participant_icp_e8s : opt nat64;
+  min_direct_participation_icp_e8s : opt nat64;
   proposal_reject_cost_e8s : opt nat64;
   restricted_countries : opt Countries;
   min_icp_e8s : opt nat64;
+  max_direct_participation_icp_e8s : opt nat64;
 };
 type SnsUpgrade = record {
   next_version : opt SnsVersion;

--- a/dfx.json
+++ b/dfx.json
@@ -640,8 +640,8 @@
         "OPTIMIZER_VERSION": "0.3.6",
         "BINSTALL_VERSION": "1.3.0",
         "DIDC_VERSION": "2023-09-27",
-        "SNSDEMO_RELEASE": "release-2023-09-27",
-        "IC_COMMIT": "96184d42331028a46fe3265583792f8c5f807cf8"
+        "SNSDEMO_RELEASE": "release-2023-10-11",
+        "IC_COMMIT": "15e69667ae983fa92c33794a3954d9ca87518af6"
       },
       "packtool": ""
     }

--- a/rs/sns_aggregator/src/types/ic_sns_swap.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.patch
@@ -1,5 +1,5 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_swap.rs a/rs/sns_aggregator/src/types/ic_sns_swap.rs
-index 12352a3f5..d6a852cc2 100644
+index 9e782c650..5cebd0ad6 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_swap.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_swap.rs
 @@ -13,13 +13,13 @@ use ic_cdk::api::call::CallResult;
@@ -61,7 +61,7 @@ index 12352a3f5..d6a852cc2 100644
  pub struct Init {
      pub nns_proposal_id: Option<u64>,
      pub sns_root_canister_id: String,
-@@ -166,7 +166,7 @@ pub struct SettleCommunityFundParticipationResult {
+@@ -168,7 +168,7 @@ pub struct SettleCommunityFundParticipationResult {
  
  #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
  pub enum Possibility2 {
@@ -70,7 +70,7 @@ index 12352a3f5..d6a852cc2 100644
      Err(CanisterCallError),
  }
  
-@@ -340,7 +340,7 @@ pub struct GetOpenTicketResponse {
+@@ -342,7 +342,7 @@ pub struct GetOpenTicketResponse {
  #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
  pub struct GetSaleParametersArg {}
  
@@ -79,7 +79,7 @@ index 12352a3f5..d6a852cc2 100644
  pub struct Params {
      pub min_participant_icp_e8s: u64,
      pub neuron_basket_construction_parameters: Option<NeuronBasketConstructionParameters>,
-@@ -429,7 +429,7 @@ pub struct DerivedState {
+@@ -433,7 +433,7 @@ pub struct DerivedState {
      pub cf_neuron_count: Option<u64>,
  }
  

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -80,8 +80,10 @@ pub struct Init {
     pub should_auto_finalize: Option<bool>,
     pub max_participant_icp_e8s: Option<u64>,
     pub sns_governance_canister_id: String,
+    pub min_direct_participation_icp_e8s: Option<u64>,
     pub restricted_countries: Option<Countries>,
     pub min_icp_e8s: Option<u64>,
+    pub max_direct_participation_icp_e8s: Option<u64>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -350,7 +352,9 @@ pub struct Params {
     pub sns_token_e8s: u64,
     pub sale_delay_seconds: Option<u64>,
     pub max_participant_icp_e8s: u64,
+    pub min_direct_participation_icp_e8s: Option<u64>,
     pub min_icp_e8s: u64,
+    pub max_direct_participation_icp_e8s: Option<u64>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_wasm.rs a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-index 448637889..b27865401 100644
+index fa3ab977f..6c61e246b 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
-@@ -281,7 +281,7 @@ pub struct InsertUpgradePathEntriesResponse {
+@@ -283,7 +283,7 @@ pub struct InsertUpgradePathEntriesResponse {
  #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
  pub struct ListDeployedSnsesArg {}
  

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -180,9 +180,11 @@ pub struct SnsInitPayload {
     pub token_logo: Option<String>,
     pub token_name: Option<String>,
     pub max_participant_icp_e8s: Option<u64>,
+    pub min_direct_participation_icp_e8s: Option<u64>,
     pub proposal_reject_cost_e8s: Option<u64>,
     pub restricted_countries: Option<Countries>,
     pub min_icp_e8s: Option<u64>,
+    pub max_direct_participation_icp_e8s: Option<u64>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]


### PR DESCRIPTION
# Motivation
We would like to keep the testing environment, provided by snsdemo, up to date.

# Changes

## Automatic changes

* Updated `snsdemo` version in `dfx.json`.
* Ensured that the `dfx` version and IC commit in `dfx.json` match `snsdemo`.
* Updated the NNS canister `.did` file imports and derived rust code.
* Changes in the Rust types.

## Manual changes

* `.patch` files. I got the changes from the failing [test of the automatic changes](https://github.com/dfinity/nns-dapp/actions/runs/6480889411/job/17597322117?pr=3526#step:5:43).

# Tests
  - [x] Please check the API updates for any breaking changes that affect our code.
  - [x] Please check for new proposal types.