### PR TITLE
GIX-1823: Add swap params and lifecycle to SnsSummary

### DIFF
--- a/frontend/src/lib/types/sns.ts
+++ b/frontend/src/lib/types/sns.ts
@@ -2,6 +2,7 @@ import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import type { Principal } from "@dfinity/principal";
 import type {
   CfParticipant,
+  SnsGetLifecycleResponse,
   SnsNeuronRecipe,
   SnsParams,
   SnsSwapBuyerState,
@@ -79,6 +80,16 @@ export interface SnsSummary {
    * Data from `get_init` call.
    */
   init?: SnsSwapInit;
+
+  /**
+   * Data from `get_sale_parameters` call.
+   */
+  swapParams?: SnsParams;
+
+  /**
+   * Data from `get_lifecycle` call.
+   */
+  lifecycle?: SnsGetLifecycleResponse;
 }
 
 export interface SnsSwapCommitment {

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -9,6 +9,7 @@ import type {
 } from "$lib/types/sns";
 import type {
   CachedFunctionTypeDto,
+  CachedLifecycleResponseDto,
   CachedNervousFunctionDto,
   CachedNeuronsFundParticipationConstraints,
   CachedSnsDto,
@@ -23,6 +24,7 @@ import type { IcrcTokenMetadataResponse } from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
 import type {
   SnsFunctionType,
+  SnsGetLifecycleResponse,
   SnsNervousSystemFunction,
   SnsNeuronsFundParticipationConstraints,
   SnsParams,
@@ -361,6 +363,17 @@ const convertDtoToSnsSummarySwap = (
   };
 };
 
+const convertDtoToLifecycle = (
+  data: CachedLifecycleResponseDto
+): SnsGetLifecycleResponse => ({
+  decentralization_sale_open_timestamp_seconds: toNullable(
+    convertOptionalNumToBigInt(
+      data.decentralization_sale_open_timestamp_seconds
+    )
+  ),
+  lifecycle: toNullable(data.lifecycle),
+});
+
 type PartialSummary = Omit<SnsSummary, "metadata" | "token" | "swap"> & {
   metadata?: SnsSummaryMetadata;
   token?: IcrcTokenMetadata;
@@ -385,6 +398,8 @@ export const convertDtoToSnsSummary = ({
   swap_state,
   derived_state,
   init,
+  swap_params,
+  lifecycle,
 }: CachedSnsDto): SnsSummary | undefined => {
   const partialSummary: PartialSummary = {
     rootCanisterId: Principal.from(root_canister_id),
@@ -397,6 +412,10 @@ export const convertDtoToSnsSummary = ({
     swap: convertDtoToSnsSummarySwap(swap_state.swap),
     derived: convertDerived(derived_state),
     init: convertSwapInitParams(init.init),
+    swapParams: nonNullish(swap_params.params)
+      ? convertSwapParams(swap_params.params)
+      : undefined,
+    lifecycle: convertDtoToLifecycle(lifecycle),
   };
 
   return isValidSummary(partialSummary) ? partialSummary : undefined;

--- a/frontend/src/vitests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/vitests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -407,6 +407,26 @@ describe("sns aggregator converters utils", () => {
           min_icp_e8s: [],
           neurons_fund_participation_constraints: [],
         },
+        swapParams: {
+          min_participant_icp_e8s: 100000000n,
+          neuron_basket_construction_parameters: [
+            {
+              dissolve_delay_interval_seconds: 5259486n,
+              count: 7n,
+            },
+          ],
+          max_icp_e8s: 130000000000000n,
+          swap_due_timestamp_seconds: 1691785258n,
+          min_participants: 125,
+          sns_token_e8s: 11250000000000000n,
+          sale_delay_seconds: [],
+          max_participant_icp_e8s: 15000000000000n,
+          min_icp_e8s: 65000000000000n,
+        },
+        lifecycle: {
+          decentralization_sale_open_timestamp_seconds: [1690786778n],
+          lifecycle: [2],
+        },
       });
     });
 


### PR DESCRIPTION
# Motivation

Stop using deprecated endpoint `get_state`.

In this PR, add the data from `get_sale_parameters` and `get_lifecycle` to SnsSummary.

# Changes

* Add optional new fields `lifecycle` and `swapParams` to SnsSummary.
* Populate new fields in `convertDtoToSnsSummary`.

# Tests

* Fix tests with new expectations.

# Todos

- [ ] Add entry to changelog (if necessary).
 Not necessary.
