### PR TITLE
GIX-1936: Upgrade next dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -751,9 +751,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "1.0.1-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-10-05.1.tgz",
-      "integrity": "sha512-XyVtibXznkM39SsG9yD93XQfRYCHOF7tI3Azhi8vZyqcuVu/4nv1IwDokWD20Nld1yZnUDKY1U+KvEsesrT0dw==",
+      "version": "1.0.1-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-10-11.2.tgz",
+      "integrity": "sha512-Piv09LKmJbn2AJSpTOtReObcQPFGXWQ10fte8LjY3kCMm++uie8CeJmnQ87wVzDHbsOGDZYfSsl6LB70CMVKZw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -767,9 +767,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "1.0.0-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-05.1.tgz",
-      "integrity": "sha512-I0R/rHsraE78XFRFfC45XiEozHNPezL5nwg4Pb+K1khaJ8LSNvHsUZUK/5e0HMzAnQGlhsjyEHq7OImS9oA/AQ==",
+      "version": "1.0.0-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-11.2.tgz",
+      "integrity": "sha512-4jNCpYpdUEn5+OZueoPeAb9uraXaqW88qNsPHqUHWoNOVdT7/n+s8D3Hi4pOnxgzRn9CzQ+v+ZoRuRlKLSoPnw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -792,9 +792,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "1.0.0-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-05.1.tgz",
-      "integrity": "sha512-2ffzcSAxB/maZyBWlNARvjz1mTKrviTcqMl3cCmuBsgzFQGOx++X8wN44CFNtkRs4hikHQfGBrv2oDydVWgldw==",
+      "version": "1.0.0-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-11.2.tgz",
+      "integrity": "sha512-ewr6Q0r06MmTVhvF+s4OiNCDjHJ+T3FBpKtwWn+Og96zud7naBXwMHPbNciTjUHQO5GoZ2kHg5CcoEPQ/8CEfA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -818,9 +818,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "1.0.0-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-10-05.1.tgz",
-      "integrity": "sha512-D2Ed8ARaRL/oy0fnQyoulgckPJAZWyhQnxYBGymZqr2u7OKv3XvwwLjrmOhA3Zilo/aYaVpHSva5cqevmM6AIA==",
+      "version": "1.0.0-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-10-11.2.tgz",
+      "integrity": "sha512-wF1jaM3Ykmeh+R6X5znkc4Zo1ofqV+Ates9oJHqQAZszs600w/PpYinOROrDV2xL2LV6ROPhSECjkHYVYago1Q==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -830,9 +830,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "1.0.0-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-10-05.1.tgz",
-      "integrity": "sha512-oBjLlhi8LzgiJt8+/b3dUdftPfe1PdVLCdQ4AejQjN9QZMu8UI7Qoo0xxj0h0sQBe/RVMtGRPOC6g+7jOc1O+A==",
+      "version": "1.0.0-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-10-11.2.tgz",
+      "integrity": "sha512-bATHdRW47FKBm34SjibIehrOpoddsaZCalBqmSHU50mt3SzGFac/fQkK0WTNyvlqvB3hYYdcqN5c+E0AOC1Olg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -841,9 +841,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "2.0.0-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-10-05.1.tgz",
-      "integrity": "sha512-cFBawidkH64QFK5UzfJBbw5pEiTcGYDMdunyvaXQzXo6XhtKPO2MkGE7RCPxaZ97D193fOM3Qwnv9A4dnAYBJQ==",
+      "version": "2.0.0-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-10-11.2.tgz",
+      "integrity": "sha512-AGwRTAXLFXDj86/+qfr7ZsPVENb1h+5BAoQ5tHDdRcHtH6ZojGM8VAOtmd1yuySlsgC9WTElWPOpVinTjy3Qpw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -858,9 +858,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.0-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-05.1.tgz",
-      "integrity": "sha512-/QUUI5h+ZMUB+1AF06/1zPJfELzEz7EBdym58l5cQSe8jOKat1kEtuWzP2rorhGSHa8id8NE3ebW/VG9FbUEWg==",
+      "version": "1.0.0-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-11.2.tgz",
+      "integrity": "sha512-sCARWq+ZVF0ezThw4a2UnRH9C+v/RQ11B3owc0yrI1cMgUIHwnpqWTTzlMXljupSlkvTC4fmwjhRGNYh2Div4Q==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -874,9 +874,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "1.0.1-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-10-05.1.tgz",
-      "integrity": "sha512-VqUUKJ4+G5iTqTOMtwM0hkQGlNRHKR1oyuIGjHx6lR+BkJ6lw5Qyi0zP9ypqrgmeQ6/V0ajb4mWcGFkdDtznoA==",
+      "version": "1.0.1-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-10-11.2.tgz",
+      "integrity": "sha512-QjVy36o4KAcmEif0pY801S9puHvOD/FWxdz7Jmi0gbBQnFe/wdnDpNO/FvsIkZHbsc0LSWvK95RpgIX9Z4I6Mg==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -889,9 +889,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "1.0.0-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-05.1.tgz",
-      "integrity": "sha512-4SfOcRcub16h3n1t1LIRMMM0nscbboS0ALnmRLfIeYbe04wjKKqFqj4NJSEeL7/3km/sBWQ2ujyqJxRKQj2IqQ==",
+      "version": "1.0.0-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-11.2.tgz",
+      "integrity": "sha512-HhzC4x4F8r06WDZLy99/A1p+GKuQSpNGvZMf6V8Q2WpDAs8t5Mit5mn/eFmCQoSazOcW/ifAM64lWaAW3C5e2A==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -10179,9 +10179,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "1.0.1-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-10-05.1.tgz",
-      "integrity": "sha512-XyVtibXznkM39SsG9yD93XQfRYCHOF7tI3Azhi8vZyqcuVu/4nv1IwDokWD20Nld1yZnUDKY1U+KvEsesrT0dw==",
+      "version": "1.0.1-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-10-11.2.tgz",
+      "integrity": "sha512-Piv09LKmJbn2AJSpTOtReObcQPFGXWQ10fte8LjY3kCMm++uie8CeJmnQ87wVzDHbsOGDZYfSsl6LB70CMVKZw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -10189,9 +10189,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "1.0.0-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-05.1.tgz",
-      "integrity": "sha512-I0R/rHsraE78XFRFfC45XiEozHNPezL5nwg4Pb+K1khaJ8LSNvHsUZUK/5e0HMzAnQGlhsjyEHq7OImS9oA/AQ==",
+      "version": "1.0.0-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-11.2.tgz",
+      "integrity": "sha512-4jNCpYpdUEn5+OZueoPeAb9uraXaqW88qNsPHqUHWoNOVdT7/n+s8D3Hi4pOnxgzRn9CzQ+v+ZoRuRlKLSoPnw==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -10205,9 +10205,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "1.0.0-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-05.1.tgz",
-      "integrity": "sha512-2ffzcSAxB/maZyBWlNARvjz1mTKrviTcqMl3cCmuBsgzFQGOx++X8wN44CFNtkRs4hikHQfGBrv2oDydVWgldw==",
+      "version": "1.0.0-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-11.2.tgz",
+      "integrity": "sha512-ewr6Q0r06MmTVhvF+s4OiNCDjHJ+T3FBpKtwWn+Og96zud7naBXwMHPbNciTjUHQO5GoZ2kHg5CcoEPQ/8CEfA==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -10221,30 +10221,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "1.0.0-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-10-05.1.tgz",
-      "integrity": "sha512-D2Ed8ARaRL/oy0fnQyoulgckPJAZWyhQnxYBGymZqr2u7OKv3XvwwLjrmOhA3Zilo/aYaVpHSva5cqevmM6AIA==",
+      "version": "1.0.0-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-10-11.2.tgz",
+      "integrity": "sha512-wF1jaM3Ykmeh+R6X5znkc4Zo1ofqV+Ates9oJHqQAZszs600w/PpYinOROrDV2xL2LV6ROPhSECjkHYVYago1Q==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "1.0.0-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-10-05.1.tgz",
-      "integrity": "sha512-oBjLlhi8LzgiJt8+/b3dUdftPfe1PdVLCdQ4AejQjN9QZMu8UI7Qoo0xxj0h0sQBe/RVMtGRPOC6g+7jOc1O+A==",
+      "version": "1.0.0-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-10-11.2.tgz",
+      "integrity": "sha512-bATHdRW47FKBm34SjibIehrOpoddsaZCalBqmSHU50mt3SzGFac/fQkK0WTNyvlqvB3hYYdcqN5c+E0AOC1Olg==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "2.0.0-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-10-05.1.tgz",
-      "integrity": "sha512-cFBawidkH64QFK5UzfJBbw5pEiTcGYDMdunyvaXQzXo6XhtKPO2MkGE7RCPxaZ97D193fOM3Qwnv9A4dnAYBJQ==",
+      "version": "2.0.0-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-10-11.2.tgz",
+      "integrity": "sha512-AGwRTAXLFXDj86/+qfr7ZsPVENb1h+5BAoQ5tHDdRcHtH6ZojGM8VAOtmd1yuySlsgC9WTElWPOpVinTjy3Qpw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.0-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-05.1.tgz",
-      "integrity": "sha512-/QUUI5h+ZMUB+1AF06/1zPJfELzEz7EBdym58l5cQSe8jOKat1kEtuWzP2rorhGSHa8id8NE3ebW/VG9FbUEWg==",
+      "version": "1.0.0-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-11.2.tgz",
+      "integrity": "sha512-sCARWq+ZVF0ezThw4a2UnRH9C+v/RQ11B3owc0yrI1cMgUIHwnpqWTTzlMXljupSlkvTC4fmwjhRGNYh2Div4Q==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -10258,17 +10258,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "1.0.1-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-10-05.1.tgz",
-      "integrity": "sha512-VqUUKJ4+G5iTqTOMtwM0hkQGlNRHKR1oyuIGjHx6lR+BkJ6lw5Qyi0zP9ypqrgmeQ6/V0ajb4mWcGFkdDtznoA==",
+      "version": "1.0.1-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-10-11.2.tgz",
+      "integrity": "sha512-QjVy36o4KAcmEif0pY801S9puHvOD/FWxdz7Jmi0gbBQnFe/wdnDpNO/FvsIkZHbsc0LSWvK95RpgIX9Z4I6Mg==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "1.0.0-next-2023-10-05.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-05.1.tgz",
-      "integrity": "sha512-4SfOcRcub16h3n1t1LIRMMM0nscbboS0ALnmRLfIeYbe04wjKKqFqj4NJSEeL7/3km/sBWQ2ujyqJxRKQj2IqQ==",
+      "version": "1.0.0-next-2023-10-11.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-11.2.tgz",
+      "integrity": "sha512-HhzC4x4F8r06WDZLy99/A1p+GKuQSpNGvZMf6V8Q2WpDAs8t5Mit5mn/eFmCQoSazOcW/ifAM64lWaAW3C5e2A==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -210,6 +210,8 @@ const convertSwapInitParams = (
               )
             )
           : [],
+        min_direct_participation_icp_e8s: [],
+        max_direct_participation_icp_e8s: [],
       }
     : undefined;
 
@@ -231,6 +233,8 @@ const convertSwapParams = (params: CachedSwapParamsDto): SnsParams => ({
   sale_delay_seconds: toNullable(
     convertOptionalNumToBigInt(params.sale_delay_seconds)
   ),
+  min_direct_participation_icp_e8s: [],
+  max_direct_participation_icp_e8s: [],
 });
 
 const convertSwap = ({

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -94,6 +94,8 @@ export const mockSnsParams: SnsParams = {
   max_participant_icp_e8s: BigInt(5000000000),
   min_icp_e8s: BigInt(1500 * 100000000),
   sale_delay_seconds: [],
+  min_direct_participation_icp_e8s: [],
+  max_direct_participation_icp_e8s: [],
 };
 
 export const mockInit: SnsSwapInit = {
@@ -125,6 +127,8 @@ export const mockInit: SnsSwapInit = {
   restricted_countries: [],
   min_icp_e8s: [1_500_000_000n],
   neurons_fund_participation_constraints: [],
+  min_direct_participation_icp_e8s: [],
+  max_direct_participation_icp_e8s: [],
 };
 
 export const mockSwap: SnsSummarySwap = {

--- a/frontend/src/vitests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/vitests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -275,7 +275,7 @@ describe("sns aggregator converters utils", () => {
       },
     };
 
-    it.only("returns sns summary from aggregator data", () => {
+    it("returns sns summary from aggregator data", () => {
       const {
         canister_ids: {
           root_canister_id,

--- a/frontend/src/vitests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/vitests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -275,7 +275,7 @@ describe("sns aggregator converters utils", () => {
       },
     };
 
-    it("returns sns summary from aggregator data", () => {
+    it.only("returns sns summary from aggregator data", () => {
       const {
         canister_ids: {
           root_canister_id,
@@ -343,6 +343,8 @@ describe("sns aggregator converters utils", () => {
               swap_start_timestamp_seconds: [],
               transaction_fee_e8s: [100000n],
               neurons_fund_participation_constraints: [],
+              max_direct_participation_icp_e8s: [],
+              min_direct_participation_icp_e8s: [],
             },
           ],
           lifecycle: 2,
@@ -364,6 +366,8 @@ describe("sns aggregator converters utils", () => {
             sale_delay_seconds: [],
             sns_token_e8s: 11250000000000000n,
             swap_due_timestamp_seconds: 1691785258n,
+            max_direct_participation_icp_e8s: [],
+            min_direct_participation_icp_e8s: [],
           },
           purge_old_tickets_last_completion_timestamp_nanoseconds: [],
           purge_old_tickets_next_principal: [],
@@ -406,6 +410,8 @@ describe("sns aggregator converters utils", () => {
           restricted_countries: [{ iso_codes: ["US"] }],
           min_icp_e8s: [],
           neurons_fund_participation_constraints: [],
+          max_direct_participation_icp_e8s: [],
+          min_direct_participation_icp_e8s: [],
         },
         swapParams: {
           min_participant_icp_e8s: 100000000n,

--- a/frontend/src/vitests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/vitests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -428,6 +428,8 @@ describe("sns aggregator converters utils", () => {
           sale_delay_seconds: [],
           max_participant_icp_e8s: 15000000000000n,
           min_icp_e8s: 65000000000000n,
+          max_direct_participation_icp_e8s: [],
+          min_direct_participation_icp_e8s: [],
         },
         lifecycle: {
           decentralization_sale_open_timestamp_seconds: [1690786778n],


### PR DESCRIPTION
# Motivation

Support new fields for the Neurons' Fund enhancements.

In this PR, upgrade "next" dependencies and fix types.

Not in this PR, use the aggregator fields to populate the fields for SnsSummary. Here I'm only fixing the type inconsistencies by adding the fields empty.

# Changes

## Automatic changes

* `package.lock.json` by `npm run upgrade:next`.

## Manual changes

* Add new fields in the SNS Aggregator converters.

# Tests

* Add new fields in the mocks.
* Fix tests for sns-aggregator.converters

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet necessary.
