### PR TITLE
Update changelog link in Slack message

### DIFF
--- a/scripts/nns-dapp/release-sop
+++ b/scripts/nns-dapp/release-sop
@@ -364,7 +364,7 @@ post_rc_on_slack() {
     echo ":rocket: *New RC ${BRANCH_NAME}* : $STAGING_URL"
     echo "Commit: $COMMIT"
     echo "WASM hash: $WASM_HASH"
-    echo "Change log: https://github.com/dfinity/nns-dapp/blob/release-candidate/CHANGELOG-Nns-Dapp.md"
+    echo "Change log: https://github.com/dfinity/nns-dapp/blob/release-candidate/CHANGELOG-Nns-Dapp-unreleased.md"
     echo "[QR Code](https://api.qrserver.com/v1/create-qr-code/?size=500x500&data=$STAGING_URL)"
     echo "Please try it out."
     echo


### PR DESCRIPTION
# Motivation

We moved unreleased changes in the changelog to a different file.
The Slack message in the `release-sop` script links to the changelog.

# Changes

Update the Slack message in the `release-sop` script to point to the unreleased changelog.

# Tests

no

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary