### PR TITLE
Migrate remaining route test to vitest

### DIFF
--- a/frontend/src/vitests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/vitests/lib/routes/Neurons.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import * as agent from "$lib/api/agent.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
@@ -21,13 +17,13 @@ import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
-import { mock } from "jest-mock-extended";
+import { mock } from "vitest-mock-extended";
 
-jest.mock("$lib/api/governance.api");
-jest.mock("$lib/api/sns-aggregator.api");
-jest.mock("$lib/api/sns-governance.api");
-jest.mock("$lib/api/sns-ledger.api");
-jest.mock("$lib/api/sns.api");
+vi.mock("$lib/api/governance.api");
+vi.mock("$lib/api/sns-aggregator.api");
+vi.mock("$lib/api/sns-governance.api");
+vi.mock("$lib/api/sns-ledger.api");
+vi.mock("$lib/api/sns.api");
 
 const testCommittedSnsCanisterId = Principal.fromHex("897654");
 const testOpenSnsCanisterId = Principal.fromHex("567812");
@@ -63,7 +59,7 @@ describe("Neurons", () => {
       rootCanisterId: testOpenSnsCanisterId.toText(),
       lifecycle: SnsSwapLifecycle.Open,
     });
-    jest.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
+    vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
 
     await loadSnsProjects();
   });


### PR DESCRIPTION
# Motivation

Migrate `Neurons.spec` route test to vitest.

# Notes

It does not seem to need particular changes and our improvement of the configuration seems to handle hanging process, so let's see in the CI.
