### PR TITLE
Chore: Migrate sns-sale services

### DIFF
--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -14,7 +14,12 @@ import {
 import { getConditionsToAccept } from "$lib/getters/sns-summary";
 import { getCurrentIdentity } from "$lib/services/auth.services";
 import { loadBalance } from "$lib/services/icp-accounts.services";
-import { toastsError, toastsHide, toastsShow } from "$lib/stores/toasts.store";
+import {
+  toastsError,
+  toastsHide,
+  toastsShow,
+  toastsSuccess,
+} from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import type { Account } from "$lib/types/account";
 import { ApiErrorKey } from "$lib/types/api.errors";
@@ -68,7 +73,6 @@ import { get } from "svelte/store";
 import { DEFAULT_TOAST_DURATION_MILLIS } from "../constants/constants";
 import { SALE_PARTICIPATION_RETRY_SECONDS } from "../constants/sns.constants";
 import { snsTicketsStore } from "../stores/sns-tickets.store";
-import { toastsSuccess } from "../stores/toasts.store";
 import { nanoSecondsToDateTime } from "../utils/date.utils";
 import { logWithTimestamp } from "../utils/dev.utils";
 import { formatToken } from "../utils/token.utils";

--- a/frontend/src/vitests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/vitests/lib/services/sns-sale.services.spec.ts
@@ -152,6 +152,9 @@ describe("sns-api", () => {
     spyOnSendICP.mockReset();
     spyOnNotifyParticipation.mockReset();
     spyOnToastsShow.mockReset();
+    // `mockReset` seems to add a mock not calling the actual function and not only reset the spy.
+    // And because the service relies on the return value of the spy, we need to mock the return value.
+    // Jest was calling the original function instead.
     spyOnToastsShow.mockReturnValue(Symbol("toast-id"));
     spyOnToastsSuccess.mockReset();
     spyOnToastsError.mockReset();
@@ -507,7 +510,7 @@ describe("sns-api", () => {
         expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(expectedCalls);
       });
 
-      it.only("should hide toast when stop retrying", async () => {
+      it("should hide toast when stop retrying", async () => {
         snsSwapCanister.getOpenTicket.mockRejectedValue(
           new Error("network error")
         );

--- a/frontend/src/vitests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/vitests/lib/services/sns-sale.services.spec.ts
@@ -184,7 +184,7 @@ describe("sns-api", () => {
       certified: true,
     });
 
-    (importSnsWasmCanister as vi.Mock).mockResolvedValue({
+    (importSnsWasmCanister as Mock).mockResolvedValue({
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       create: (options: SnsWasmCanisterOptions) => ({
         listSnses: () => Promise.resolve(deployedSnsMock),

--- a/frontend/src/vitests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/vitests/lib/services/sns-sale.services.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import * as ledgerApi from "$lib/api/icp-ledger.api";
 import { SALE_PARTICIPATION_RETRY_SECONDS } from "$lib/constants/sns.constants";
 import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
@@ -53,7 +49,7 @@ import { snsTicketMock } from "$tests/mocks/sns.mock";
 import {
   advanceTime,
   runResolvedPromises,
-} from "$tests/utils/timers.test-utils";
+} from "$vitests/utils/timers.test-utils";
 import type { Agent, Identity } from "@dfinity/agent";
 import {
   InsufficientFundsError,
@@ -77,21 +73,22 @@ import {
   arrayOfNumberToUint8Array,
   toNullable,
 } from "@dfinity/utils";
-import mock from "jest-mock-extended/lib/Mock";
 import { get } from "svelte/store";
+import type { Mock } from "vitest";
+import { mock } from "vitest-mock-extended";
 
-jest.mock("$lib/proxy/api.import.proxy");
-jest.mock("$lib/api/agent.api", () => {
+vi.mock("$lib/proxy/api.import.proxy");
+vi.mock("$lib/api/agent.api", () => {
   return {
     createAgent: () => Promise.resolve(mock<Agent>()),
   };
 });
 
-jest.mock("$lib/constants/sns.constants", () => ({
+vi.mock("$lib/constants/sns.constants", () => ({
   SALE_PARTICIPATION_RETRY_SECONDS: 1,
 }));
 
-jest.mock("$lib/api/icp-ledger.api");
+vi.mock("$lib/api/icp-ledger.api");
 
 const identity: Identity | undefined = mockIdentity;
 const rootCanisterIdMock = identity.getPrincipal();
@@ -103,7 +100,7 @@ const setUpMockSnsProjectStore = ({
   rootCanisterId: Principal;
   confirmationText?: string | undefined;
 }) => {
-  jest.spyOn(snsProjectsStore, "subscribe").mockImplementation(
+  vi.spyOn(snsProjectsStore, "subscribe").mockImplementation(
     mockProjectSubscribe([
       {
         ...mockSnsFullProject,
@@ -127,14 +124,14 @@ describe("sns-api", () => {
     ],
   };
 
-  const spyOnSendICP = jest.spyOn(ledgerApi, "sendICP");
+  const spyOnSendICP = vi.spyOn(ledgerApi, "sendICP");
   const newBalanceE8s = 100_000_000n;
-  const spyOnQueryBalance = jest.spyOn(ledgerApi, "queryAccountBalance");
-  const spyOnNotifyParticipation = jest.fn();
-  const spyOnToastsShow = jest.spyOn(toastsStore, "toastsShow");
-  const spyOnToastsSuccess = jest.spyOn(toastsStore, "toastsSuccess");
-  const spyOnToastsError = jest.spyOn(toastsStore, "toastsError");
-  const spyOnToastsHide = jest.spyOn(toastsStore, "toastsHide");
+  const spyOnQueryBalance = vi.spyOn(ledgerApi, "queryAccountBalance");
+  const spyOnNotifyParticipation = vi.fn();
+  const spyOnToastsShow = vi.spyOn(toastsStore, "toastsShow");
+  const spyOnToastsSuccess = vi.spyOn(toastsStore, "toastsSuccess");
+  const spyOnToastsError = vi.spyOn(toastsStore, "toastsError");
+  const spyOnToastsHide = vi.spyOn(toastsStore, "toastsHide");
   const testRootCanisterId = rootCanisterIdMock;
   const swapCanisterId = swapCanisterIdMock;
   const testSnsTicket = snsTicketMock({
@@ -143,8 +140,8 @@ describe("sns-api", () => {
   });
   const testTicket = testSnsTicket.ticket;
   const snsSwapCanister = mock<SnsSwapCanister>();
-  const spyOnNewSaleTicketApi = jest.fn();
-  const spyOnNotifyPaymentFailureApi = jest.fn();
+  const spyOnNewSaleTicketApi = vi.fn();
+  const spyOnNotifyPaymentFailureApi = vi.fn();
   const ticketFromStore = (rootCanisterId = testRootCanisterId) =>
     get(snsTicketsStore)[rootCanisterId.toText()];
 
@@ -155,21 +152,22 @@ describe("sns-api", () => {
     spyOnSendICP.mockReset();
     spyOnNotifyParticipation.mockReset();
     spyOnToastsShow.mockReset();
+    spyOnToastsShow.mockReturnValue(Symbol("toast-id"));
     spyOnToastsSuccess.mockReset();
     spyOnToastsError.mockReset();
     snsSwapCanister.getOpenTicket.mockReset();
     spyOnNewSaleTicketApi.mockReset();
     spyOnNotifyPaymentFailureApi.mockReset();
 
-    jest.useFakeTimers();
-    jest.clearAllMocks();
+    vi.useFakeTimers();
+    vi.clearAllMocks();
 
     snsTicketsStore.reset();
     icpAccountsStore.resetForTesting();
 
     spyOnNewSaleTicketApi.mockResolvedValue(testSnsTicket.ticket);
     spyOnNotifyPaymentFailureApi.mockResolvedValue(undefined);
-    jest.spyOn(console, "error").mockReturnValue();
+    vi.spyOn(console, "error").mockReturnValue();
     spyOnQueryBalance.mockResolvedValue(newBalanceE8s);
 
     setUpMockSnsProjectStore({ rootCanisterId: testSnsTicket.rootCanisterId });
@@ -183,7 +181,7 @@ describe("sns-api", () => {
       certified: true,
     });
 
-    (importSnsWasmCanister as jest.Mock).mockResolvedValue({
+    (importSnsWasmCanister as vi.Mock).mockResolvedValue({
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       create: (options: SnsWasmCanisterOptions) => ({
         listSnses: () => Promise.resolve(deployedSnsMock),
@@ -193,7 +191,7 @@ describe("sns-api", () => {
     spyOnNotifyParticipation.mockResolvedValue({
       icp_accepted_participation_e8s: 666n,
     });
-    (importInitSnsWrapper as jest.Mock).mockResolvedValue(() =>
+    (importInitSnsWrapper as Mock).mockResolvedValue(() =>
       Promise.resolve({
         canisterIds: {
           rootCanisterId: rootCanisterIdMock,
@@ -211,13 +209,11 @@ describe("sns-api", () => {
     );
 
     // `getOpenTicket` is mocked from the SnsSwapCanister not the wrapper
-    jest
-      .spyOn(SnsSwapCanister, "create")
-      .mockImplementation((): SnsSwapCanister => snsSwapCanister);
+    vi.spyOn(SnsSwapCanister, "create").mockImplementation(
+      (): SnsSwapCanister => snsSwapCanister
+    );
 
-    jest
-      .spyOn(authStore, "subscribe")
-      .mockImplementation(mockAuthStoreSubscribe);
+    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
   });
 
   describe("loadOpenTicket", () => {
@@ -227,9 +223,9 @@ describe("sns-api", () => {
 
     describe("when polling is enabled", () => {
       beforeEach(() => {
-        jest.clearAllTimers();
+        vi.clearAllTimers();
         const now = Date.now();
-        jest.useFakeTimers().setSystemTime(now);
+        vi.useFakeTimers().setSystemTime(now);
       });
 
       it("should call api and load ticket in the store", async () => {
@@ -473,9 +469,9 @@ describe("sns-api", () => {
 
     describe("when disabling polling", () => {
       beforeEach(() => {
-        jest.clearAllTimers();
+        vi.clearAllTimers();
         const now = Date.now();
-        jest.useFakeTimers().setSystemTime(now);
+        vi.useFakeTimers().setSystemTime(now);
       });
 
       it("should stop retrying", async () => {
@@ -511,7 +507,7 @@ describe("sns-api", () => {
         expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(expectedCalls);
       });
 
-      it("should hide toast when stop retrying", async () => {
+      it.only("should hide toast when stop retrying", async () => {
         snsSwapCanister.getOpenTicket.mockRejectedValue(
           new Error("network error")
         );
@@ -522,7 +518,10 @@ describe("sns-api", () => {
           maxAttempts: 10,
         });
 
+        expect(spyOnToastsShow).toBeCalledTimes(0);
         await runResolvedPromises();
+        expect(spyOnToastsShow).toBeCalledTimes(1);
+
         let expectedCalls = 1;
         expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(expectedCalls);
 
@@ -547,9 +546,9 @@ describe("sns-api", () => {
 
   describe("loadNewSaleTicket ", () => {
     beforeEach(() => {
-      jest.clearAllTimers();
+      vi.clearAllTimers();
       const now = Date.now();
-      jest.useFakeTimers().setSystemTime(now);
+      vi.useFakeTimers().setSystemTime(now);
     });
     it("should call newSaleTicket  api", async () => {
       await loadNewSaleTicket({
@@ -809,8 +808,8 @@ describe("sns-api", () => {
   describe("restoreSnsSaleParticipation", () => {
     it("should perform successful participation flow if open ticket", async () => {
       snsSwapCanister.getOpenTicket.mockResolvedValue(testSnsTicket.ticket);
-      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
-      const updateProgressSpy = jest.fn().mockResolvedValue(undefined);
+      const postprocessSpy = vi.fn().mockResolvedValue(undefined);
+      const updateProgressSpy = vi.fn().mockResolvedValue(undefined);
 
       await restoreSnsSaleParticipation({
         rootCanisterId: rootCanisterIdMock,
@@ -834,11 +833,11 @@ describe("sns-api", () => {
 
     it("should not start flow if no open ticket", async () => {
       snsSwapCanister.getOpenTicket.mockResolvedValue(undefined);
-      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
-      const updateProgressSpy = jest.fn().mockResolvedValue(undefined);
-      const startBusySpy = jest
+      const postprocessSpy = vi.fn().mockResolvedValue(undefined);
+      const updateProgressSpy = vi.fn().mockResolvedValue(undefined);
+      const startBusySpy = vi
         .spyOn(busyStore, "startBusy")
-        .mockImplementation(jest.fn());
+        .mockImplementation(vi.fn());
 
       await restoreSnsSaleParticipation({
         rootCanisterId: rootCanisterIdMock,
@@ -863,8 +862,8 @@ describe("sns-api", () => {
       });
 
       snsSwapCanister.getOpenTicket.mockResolvedValue(testSnsTicket.ticket);
-      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
-      const updateProgressSpy = jest.fn().mockResolvedValue(undefined);
+      const postprocessSpy = vi.fn().mockResolvedValue(undefined);
+      const updateProgressSpy = vi.fn().mockResolvedValue(undefined);
 
       await restoreSnsSaleParticipation({
         rootCanisterId: rootCanisterIdMock,
@@ -890,8 +889,8 @@ describe("sns-api", () => {
       });
 
       snsSwapCanister.getOpenTicket.mockResolvedValue(testSnsTicket.ticket);
-      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
-      const updateProgressSpy = jest.fn().mockResolvedValue(undefined);
+      const postprocessSpy = vi.fn().mockResolvedValue(undefined);
+      const updateProgressSpy = vi.fn().mockResolvedValue(undefined);
 
       await restoreSnsSaleParticipation({
         rootCanisterId: rootCanisterIdMock,
@@ -919,8 +918,8 @@ describe("sns-api", () => {
           token: ICPToken,
         }),
       };
-      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
-      const updateProgressSpy = jest.fn().mockResolvedValue(undefined);
+      const postprocessSpy = vi.fn().mockResolvedValue(undefined);
+      const updateProgressSpy = vi.fn().mockResolvedValue(undefined);
 
       await initiateSnsSaleParticipation({
         rootCanisterId: rootCanisterIdMock,
@@ -958,9 +957,9 @@ describe("sns-api", () => {
 
     it("should handle errors", async () => {
       // remove the sns-project
-      jest
-        .spyOn(snsProjectsStore, "subscribe")
-        .mockImplementation(mockProjectSubscribe([]));
+      vi.spyOn(snsProjectsStore, "subscribe").mockImplementation(
+        mockProjectSubscribe([])
+      );
 
       const account = {
         ...mockMainAccount,
@@ -978,8 +977,8 @@ describe("sns-api", () => {
         }),
         account,
         userCommitment: 0n,
-        postprocess: jest.fn().mockResolvedValue(undefined),
-        updateProgress: jest.fn().mockResolvedValue(undefined),
+        postprocess: vi.fn().mockResolvedValue(undefined),
+        updateProgress: vi.fn().mockResolvedValue(undefined),
       });
 
       expect(spyOnNewSaleTicketApi).not.toBeCalled();
@@ -991,16 +990,16 @@ describe("sns-api", () => {
 
   describe("participateInSnsSale", () => {
     beforeEach(() => {
-      jest.clearAllTimers();
+      vi.clearAllTimers();
       const now = Date.now();
-      jest.useFakeTimers().setSystemTime(now);
+      vi.useFakeTimers().setSystemTime(now);
     });
     it("should call postprocess and APIs", async () => {
       icpAccountsStore.setForTesting({
         main: mockMainAccount,
       });
-      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
-      const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
+      const postprocessSpy = vi.fn().mockResolvedValue(undefined);
+      const upgradeProgressSpy = vi.fn().mockResolvedValue(undefined);
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
@@ -1026,8 +1025,8 @@ describe("sns-api", () => {
       icpAccountsStore.setForTesting({
         main: mockMainAccount,
       });
-      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
-      const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
+      const postprocessSpy = vi.fn().mockResolvedValue(undefined);
+      const upgradeProgressSpy = vi.fn().mockResolvedValue(undefined);
 
       expect(get(icpAccountsStore).main.balanceE8s).not.toEqual(newBalanceE8s);
 
@@ -1053,8 +1052,8 @@ describe("sns-api", () => {
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
       });
-      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
-      const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
+      const postprocessSpy = vi.fn().mockResolvedValue(undefined);
+      const upgradeProgressSpy = vi.fn().mockResolvedValue(undefined);
 
       expect(get(icpAccountsStore).main.balanceE8s).not.toEqual(newBalanceE8s);
 
@@ -1085,8 +1084,8 @@ describe("sns-api", () => {
         .mockResolvedValue({
           icp_accepted_participation_e8s: 666n,
         });
-      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
-      const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
+      const postprocessSpy = vi.fn().mockResolvedValue(undefined);
+      const upgradeProgressSpy = vi.fn().mockResolvedValue(undefined);
 
       participateInSnsSale({
         rootCanisterId: testRootCanisterId,
@@ -1130,8 +1129,8 @@ describe("sns-api", () => {
         confirmationText,
       });
 
-      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
-      const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
+      const postprocessSpy = vi.fn().mockResolvedValue(undefined);
+      const upgradeProgressSpy = vi.fn().mockResolvedValue(undefined);
 
       participateInSnsSale({
         rootCanisterId: testRootCanisterId,
@@ -1158,8 +1157,8 @@ describe("sns-api", () => {
         confirmationText,
       });
 
-      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
-      const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
+      const postprocessSpy = vi.fn().mockResolvedValue(undefined);
+      const upgradeProgressSpy = vi.fn().mockResolvedValue(undefined);
 
       participateInSnsSale({
         rootCanisterId: testRootCanisterId,
@@ -1185,8 +1184,8 @@ describe("sns-api", () => {
           "The token amount can only be refreshed when the canister is in the OPEN state"
         )
       );
-      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
-      const updateProgressSpy = jest.fn().mockResolvedValue(undefined);
+      const postprocessSpy = vi.fn().mockResolvedValue(undefined);
+      const updateProgressSpy = vi.fn().mockResolvedValue(undefined);
 
       participateInSnsSale({
         rootCanisterId: testRootCanisterId,
@@ -1220,7 +1219,7 @@ describe("sns-api", () => {
         ticket: testTicket,
       });
       // corrupt the current identity principal
-      jest.spyOn(authStore, "subscribe").mockImplementation((run) => {
+      vi.spyOn(authStore, "subscribe").mockImplementation((run) => {
         run({
           identity: {
             ...mockIdentity,
@@ -1234,8 +1233,8 @@ describe("sns-api", () => {
         rootCanisterId: testRootCanisterId,
         swapCanisterId,
         userCommitment: 0n,
-        postprocess: jest.fn().mockResolvedValue(undefined),
-        updateProgress: jest.fn().mockResolvedValue(undefined),
+        postprocess: vi.fn().mockResolvedValue(undefined),
+        updateProgress: vi.fn().mockResolvedValue(undefined),
         ticket: testTicket,
       });
 
@@ -1251,8 +1250,8 @@ describe("sns-api", () => {
     });
 
     it("should poll transfer during unknown issues or TxCreatedInFutureError", async () => {
-      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
-      const updateProgressSpy = jest.fn().mockResolvedValue(undefined);
+      const postprocessSpy = vi.fn().mockResolvedValue(undefined);
+      const updateProgressSpy = vi.fn().mockResolvedValue(undefined);
 
       // Success on the fourth try
       const callsUntilSuccess = 4;
@@ -1301,8 +1300,8 @@ describe("sns-api", () => {
         rootCanisterId: testRootCanisterId,
         swapCanisterId,
         userCommitment: 0n,
-        postprocess: jest.fn().mockResolvedValue(undefined),
-        updateProgress: jest.fn().mockResolvedValue(undefined),
+        postprocess: vi.fn().mockResolvedValue(undefined),
+        updateProgress: vi.fn().mockResolvedValue(undefined),
         ticket: testTicket,
       });
 
@@ -1323,8 +1322,8 @@ describe("sns-api", () => {
         rootCanisterId: testRootCanisterId,
         swapCanisterId,
         userCommitment: 0n,
-        postprocess: jest.fn().mockResolvedValue(undefined),
-        updateProgress: jest.fn().mockResolvedValue(undefined),
+        postprocess: vi.fn().mockResolvedValue(undefined),
+        updateProgress: vi.fn().mockResolvedValue(undefined),
         ticket: testTicket,
       });
 
@@ -1347,8 +1346,8 @@ describe("sns-api", () => {
           rootCanisterId: testRootCanisterId,
           swapCanisterId,
           userCommitment: 0n,
-          postprocess: jest.fn().mockResolvedValue(undefined),
-          updateProgress: jest.fn().mockResolvedValue(undefined),
+          postprocess: vi.fn().mockResolvedValue(undefined),
+          updateProgress: vi.fn().mockResolvedValue(undefined),
           ticket: testTicket,
         });
 
@@ -1381,8 +1380,8 @@ describe("sns-api", () => {
           rootCanisterId: testRootCanisterId,
           swapCanisterId,
           userCommitment: 0n,
-          postprocess: jest.fn().mockResolvedValue(undefined),
-          updateProgress: jest.fn().mockResolvedValue(undefined),
+          postprocess: vi.fn().mockResolvedValue(undefined),
+          updateProgress: vi.fn().mockResolvedValue(undefined),
           ticket: testTicket,
         });
 
@@ -1409,8 +1408,8 @@ describe("sns-api", () => {
         rootCanisterId: testRootCanisterId,
         swapCanisterId,
         userCommitment: 0n,
-        postprocess: jest.fn().mockResolvedValue(undefined),
-        updateProgress: jest.fn().mockResolvedValue(undefined),
+        postprocess: vi.fn().mockResolvedValue(undefined),
+        updateProgress: vi.fn().mockResolvedValue(undefined),
         ticket: testTicket,
       });
 
@@ -1431,8 +1430,8 @@ describe("sns-api", () => {
         rootCanisterId: testRootCanisterId,
         swapCanisterId,
         userCommitment: 0n,
-        postprocess: jest.fn().mockResolvedValue(undefined),
-        updateProgress: jest.fn().mockResolvedValue(undefined),
+        postprocess: vi.fn().mockResolvedValue(undefined),
+        updateProgress: vi.fn().mockResolvedValue(undefined),
         ticket,
       });
 
@@ -1457,8 +1456,8 @@ describe("sns-api", () => {
         rootCanisterId: testRootCanisterId,
         swapCanisterId,
         userCommitment: 0n,
-        postprocess: jest.fn().mockResolvedValue(undefined),
-        updateProgress: jest.fn().mockResolvedValue(undefined),
+        postprocess: vi.fn().mockResolvedValue(undefined),
+        updateProgress: vi.fn().mockResolvedValue(undefined),
         ticket,
       });
 
@@ -1481,8 +1480,8 @@ describe("sns-api", () => {
         rootCanisterId: testRootCanisterId,
         swapCanisterId,
         userCommitment: 7n,
-        postprocess: jest.fn().mockResolvedValue(undefined),
-        updateProgress: jest.fn().mockResolvedValue(undefined),
+        postprocess: vi.fn().mockResolvedValue(undefined),
+        updateProgress: vi.fn().mockResolvedValue(undefined),
         ticket,
       });
 
@@ -1496,8 +1495,8 @@ describe("sns-api", () => {
     it("should show 'high load' toast after 6 failures", async () => {
       const expectFailuresBeforeToast = 6;
       spyOnNotifyParticipation.mockRejectedValue(new Error("network error"));
-      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
-      const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
+      const postprocessSpy = vi.fn().mockResolvedValue(undefined);
+      const upgradeProgressSpy = vi.fn().mockResolvedValue(undefined);
       participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         swapCanisterId,
@@ -1535,8 +1534,8 @@ describe("sns-api", () => {
     it("transfer should show 'high load' toast after 6 failures", async () => {
       const expectFailuresBeforeToast = 6;
       spyOnSendICP.mockRejectedValue(new Error("network error"));
-      const postprocessSpy = jest.fn().mockResolvedValue(undefined);
-      const upgradeProgressSpy = jest.fn().mockResolvedValue(undefined);
+      const postprocessSpy = vi.fn().mockResolvedValue(undefined);
+      const upgradeProgressSpy = vi.fn().mockResolvedValue(undefined);
       participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         swapCanisterId,


### PR DESCRIPTION
# Motivation

Migrate sns-sale services to vitest.

# Changes

* Normal migration changes. Plus an extra `spyOnToastsShow.mockReturnValue(Symbol("toast-id"));` on beforeEach because the services rely on the return value of `toastsShow`. And with vi it was `undefined`.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
