### PR TITLE
Fix: Finalizing status in ProjectCard

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -33,6 +33,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Separators in project page appearing without data inside.
 * Cycles displayed as T Cycles on canister detail page.
+* Add "Finalizing" status in projects of the Launchpad.
 
 #### Security
 

--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -12,6 +12,9 @@
   import { nonNullish } from "@dfinity/utils";
   import { onMount } from "svelte";
   import { loadSnsFinalizationStatus } from "$lib/services/sns-finalization.services";
+  import type { Readable } from "svelte/store";
+  import { createIsSnsFinalizingStore } from "$lib/stores/sns-finalization-status.store";
+  import type { Principal } from "@dfinity/principal";
 
   export let project: SnsFullProject;
 
@@ -21,7 +24,8 @@
 
   let summary: SnsSummary;
   let swapCommitment: SnsSwapCommitment | undefined;
-  $: ({ summary, swapCommitment } = project);
+  let rootCanisterId: Principal;
+  $: ({ summary, swapCommitment, rootCanisterId } = project);
 
   let logo: string;
   let name: string;
@@ -39,6 +43,9 @@
 
   let href: string;
   $: href = `${AppPath.Project}/?project=${project.rootCanisterId.toText()}`;
+
+  let isFinalizingStore: Readable<boolean>;
+  $: isFinalizingStore = createIsSnsFinalizingStore(rootCanisterId);
 </script>
 
 <Card
@@ -53,7 +60,7 @@
 
   <p class="value description">{description}</p>
 
-  <ProjectCardSwapInfo {project} />
+  <ProjectCardSwapInfo isFinalizing={$isFinalizingStore} {project} />
 
   <SignedInOnly>
     <!-- TODO L2-751: handle fetching errors -->

--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -10,8 +10,14 @@
   import { getCommitmentE8s } from "$lib/utils/sns.utils";
   import SignedInOnly from "$lib/components/common/SignedInOnly.svelte";
   import { nonNullish } from "@dfinity/utils";
+  import { onMount } from "svelte";
+  import { loadSnsFinalizationStatus } from "$lib/services/sns-finalization.services";
 
   export let project: SnsFullProject;
+
+  onMount(() => {
+    loadSnsFinalizationStatus(project.rootCanisterId);
+  });
 
   let summary: SnsSummary;
   let swapCommitment: SnsSwapCommitment | undefined;

--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -16,7 +16,7 @@
   export let project: SnsFullProject;
 
   onMount(() => {
-    loadSnsFinalizationStatus(project.rootCanisterId);
+    loadSnsFinalizationStatus({ rootCanisterId: project.rootCanisterId });
   });
 
   let summary: SnsSummary;

--- a/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
@@ -17,17 +17,15 @@
   import ProjectUserCommitmentLabel from "$lib/components/project-detail/ProjectUserCommitmentLabel.svelte";
   import { getCommitmentE8s } from "$lib/utils/sns.utils";
   import { nonNullish } from "@dfinity/utils";
-  import type { Readable } from "svelte/store";
-  import { createIsSnsFinalizingStore } from "$lib/stores/sns-finalization-status.store";
-  import type { Principal } from "@dfinity/principal";
   import TestIdWrapper from "../common/TestIdWrapper.svelte";
 
   export let project: SnsFullProject;
+  // The data to know whether it's finalizing or not is not in the SnsFullProject.
+  export let isFinalizing: boolean;
 
   let summary: SnsSummary;
   let swapCommitment: SnsSwapCommitment | undefined;
-  let rootCanisterId: Principal;
-  $: ({ summary, swapCommitment, rootCanisterId } = project);
+  $: ({ summary, swapCommitment } = project);
 
   let swap: SnsSummarySwap;
   $: ({ swap } = summary);
@@ -42,9 +40,6 @@
 
   let durationTillStart: bigint | undefined;
   $: durationTillStart = durationTillSwapStart(swap);
-
-  let isFinalizingStore: Readable<boolean>;
-  $: isFinalizingStore = createIsSnsFinalizingStore(rootCanisterId);
 
   let myCommitment: TokenAmount | undefined = undefined;
   $: {
@@ -64,7 +59,7 @@
     {#if lifecycle === SnsSwapLifecycle.Committed}
       <dt class="label">{$i18n.sns_project_detail.status_completed}</dt>
       <!-- is finalizing is not a lifecycle, it can be Committed and Finalizing or Not Finalizing -->
-      {#if $isFinalizingStore}
+      {#if isFinalizing}
         <dd class="value">{$i18n.sns_project_detail.status_finalizing}</dd>
       {:else}
         <dd class="value">{$i18n.sns_project_detail.completed}</dd>

--- a/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
@@ -20,6 +20,7 @@
   import type { Readable } from "svelte/store";
   import { createIsSnsFinalizingStore } from "$lib/stores/sns-finalization-status.store";
   import type { Principal } from "@dfinity/principal";
+  import TestIdWrapper from "../common/TestIdWrapper.svelte";
 
   export let project: SnsFullProject;
 
@@ -58,28 +59,30 @@
 </script>
 
 <dl data-tid="project-card-swap-info-component">
-  <!-- Sale is committed -->
-  {#if lifecycle === SnsSwapLifecycle.Committed}
-    <dt class="label">{$i18n.sns_project_detail.status_completed}</dt>
-    <!-- is finalizing is not a lifecycle, it can be Committed and Finalizing or Not Finalizing -->
-    {#if $isFinalizingStore}
-      <dd class="value">{$i18n.sns_project_detail.status_finalizing}</dd>
-    {:else}
-      <dd class="value">{$i18n.sns_project_detail.completed}</dd>
+  <TestIdWrapper testId="project-status-text">
+    <!-- Sale is committed -->
+    {#if lifecycle === SnsSwapLifecycle.Committed}
+      <dt class="label">{$i18n.sns_project_detail.status_completed}</dt>
+      <!-- is finalizing is not a lifecycle, it can be Committed and Finalizing or Not Finalizing -->
+      {#if $isFinalizingStore}
+        <dd class="value">{$i18n.sns_project_detail.status_finalizing}</dd>
+      {:else}
+        <dd class="value">{$i18n.sns_project_detail.completed}</dd>
+      {/if}
     {/if}
-  {/if}
 
-  <!-- Sale is adopted -->
-  {#if lifecycle === SnsSwapLifecycle.Adopted && durationTillStart !== undefined}
-    <dt class="label">{$i18n.sns_project_detail.starts}</dt>
-    <dd class="value">{secondsToDuration(durationTillStart)}</dd>
-  {/if}
+    <!-- Sale is adopted -->
+    {#if lifecycle === SnsSwapLifecycle.Adopted && durationTillStart !== undefined}
+      <dt class="label">{$i18n.sns_project_detail.starts}</dt>
+      <dd class="value">{secondsToDuration(durationTillStart)}</dd>
+    {/if}
 
-  <!-- Sale is open -->
-  {#if lifecycle === SnsSwapLifecycle.Open && durationTillDeadline !== undefined}
-    <dt class="label">{$i18n.sns_project_detail.deadline}</dt>
-    <dd class="value">{secondsToDuration(durationTillDeadline)}</dd>
-  {/if}
+    <!-- Sale is open -->
+    {#if lifecycle === SnsSwapLifecycle.Open && durationTillDeadline !== undefined}
+      <dt class="label">{$i18n.sns_project_detail.deadline}</dt>
+      <dd class="value">{secondsToDuration(durationTillDeadline)}</dd>
+    {/if}
+  </TestIdWrapper>
 
   {#if myCommitment !== undefined}
     <dt><ProjectUserCommitmentLabel {summary} {swapCommitment} /></dt>

--- a/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
@@ -17,12 +17,16 @@
   import ProjectUserCommitmentLabel from "$lib/components/project-detail/ProjectUserCommitmentLabel.svelte";
   import { getCommitmentE8s } from "$lib/utils/sns.utils";
   import { nonNullish } from "@dfinity/utils";
+  import type { Readable } from "svelte/store";
+  import { createIsSnsFinalizingStore } from "$lib/stores/sns-finalization-status.store";
+  import type { Principal } from "@dfinity/principal";
 
   export let project: SnsFullProject;
 
   let summary: SnsSummary;
   let swapCommitment: SnsSwapCommitment | undefined;
-  $: ({ summary, swapCommitment } = project);
+  let rootCanisterId: Principal;
+  $: ({ summary, swapCommitment, rootCanisterId } = project);
 
   let swap: SnsSummarySwap;
   $: ({ swap } = summary);
@@ -37,6 +41,9 @@
 
   let durationTillStart: bigint | undefined;
   $: durationTillStart = durationTillSwapStart(swap);
+
+  let isFinalizingStore: Readable<boolean>;
+  $: isFinalizingStore = createIsSnsFinalizingStore(rootCanisterId);
 
   let myCommitment: TokenAmount | undefined = undefined;
   $: {
@@ -54,7 +61,12 @@
   <!-- Sale is committed -->
   {#if lifecycle === SnsSwapLifecycle.Committed}
     <dt class="label">{$i18n.sns_project_detail.status_completed}</dt>
-    <dd class="value">{$i18n.sns_project_detail.completed}</dd>
+    <!-- is finalizing is not a lifecycle, it can be Committed and Finalizing or Not Finalizing -->
+    {#if $isFinalizingStore}
+      <dd class="value">{$i18n.sns_project_detail.status_finalizing}</dd>
+    {:else}
+      <dd class="value">{$i18n.sns_project_detail.completed}</dd>
+    {/if}
   {/if}
 
   <!-- Sale is adopted -->

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -77,7 +77,10 @@
         },
         forceFetch: true,
       }),
-      loadSnsFinalizationStatus(Principal.fromText(rootCanisterId)),
+      loadSnsFinalizationStatus({
+        rootCanisterId: Principal.fromText(rootCanisterId),
+        forceFetch: true,
+      }),
     ]);
   };
 
@@ -173,7 +176,9 @@
     nonNullish(rootCanisterId) &&
     $projectDetailStore.summary?.swap.lifecycle === SnsSwapLifecycle.Committed
   ) {
-    loadSnsFinalizationStatus(Principal.fromText(rootCanisterId));
+    loadSnsFinalizationStatus({
+      rootCanisterId: Principal.fromText(rootCanisterId),
+    });
   }
 
   let derivedStateHasBuyersCount: boolean | undefined;

--- a/frontend/src/lib/services/sns-finalization.services.ts
+++ b/frontend/src/lib/services/sns-finalization.services.ts
@@ -1,12 +1,34 @@
 import { queryFinalizationStatus } from "$lib/api/sns-sale.api";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { getOrCreateSnsFinalizationStatusStore } from "$lib/stores/sns-finalization-status.store";
+import { snsSummariesStore } from "$lib/stores/sns.store";
+import { nowInSeconds } from "$lib/utils/date.utils";
+import { swapEndedMoreThanOneWeekAgo } from "$lib/utils/sns.utils";
 import type { Principal } from "@dfinity/principal";
-import type { SnsGetAutoFinalizationStatusResponse } from "@dfinity/sns";
-import { nonNullish } from "@dfinity/utils";
+import {
+  SnsSwapLifecycle,
+  type SnsGetAutoFinalizationStatusResponse,
+} from "@dfinity/sns";
+import { isNullish, nonNullish } from "@dfinity/utils";
+import { get } from "svelte/store";
 import { queryAndUpdate } from "./utils.services";
 
 export const loadSnsFinalizationStatus = async (rootCanisterId: Principal) => {
+  const summaries = get(snsSummariesStore);
+  const summary = summaries.find(
+    (s) => s.rootCanisterId.toText() === rootCanisterId.toText()
+  );
+  // We don't want to do calls that we know are unnecessary.
+  // The project starts finalizing right after the sale ends.
+  // It might take a few hours.
+  // Waiting one week ensures that the project is not finalizing anymore.
+  if (
+    isNullish(summary) ||
+    summary.swap.lifecycle !== SnsSwapLifecycle.Committed ||
+    swapEndedMoreThanOneWeekAgo({ summary, nowInSeconds: nowInSeconds() })
+  ) {
+    return;
+  }
   await queryAndUpdate<
     SnsGetAutoFinalizationStatusResponse | undefined,
     unknown

--- a/frontend/src/lib/services/sns-finalization.services.ts
+++ b/frontend/src/lib/services/sns-finalization.services.ts
@@ -13,7 +13,13 @@ import { isNullish, nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { queryAndUpdate } from "./utils.services";
 
-export const loadSnsFinalizationStatus = async (rootCanisterId: Principal) => {
+export const loadSnsFinalizationStatus = async ({
+  rootCanisterId,
+  forceFetch = false,
+}: {
+  rootCanisterId: Principal;
+  forceFetch?: boolean;
+}) => {
   const summaries = get(snsSummariesStore);
   const summary = summaries.find(
     (s) => s.rootCanisterId.toText() === rootCanisterId.toText()
@@ -23,9 +29,10 @@ export const loadSnsFinalizationStatus = async (rootCanisterId: Principal) => {
   // It might take a few hours.
   // Waiting one week ensures that the project is not finalizing anymore.
   if (
-    isNullish(summary) ||
-    summary.swap.lifecycle !== SnsSwapLifecycle.Committed ||
-    swapEndedMoreThanOneWeekAgo({ summary, nowInSeconds: nowInSeconds() })
+    !forceFetch &&
+    (isNullish(summary) ||
+      summary.swap.lifecycle !== SnsSwapLifecycle.Committed ||
+      swapEndedMoreThanOneWeekAgo({ summary, nowInSeconds: nowInSeconds() }))
   ) {
     return;
   }

--- a/frontend/src/lib/stores/sns-finalization-status.store.ts
+++ b/frontend/src/lib/stores/sns-finalization-status.store.ts
@@ -10,7 +10,7 @@ interface SnsFinalizationStatusData {
 }
 
 export interface SnsFinalizationStatusStore
-  extends Readable<SnsFinalizationStatusData> {
+  extends Readable<SnsFinalizationStatusData | undefined> {
   setData: (data: SnsFinalizationStatusData) => void;
 }
 
@@ -22,7 +22,9 @@ export const resetSnsFinalizationStatusStore = () => {
 };
 
 const initStore = (): SnsFinalizationStatusStore => {
-  const { subscribe, set } = writable<SnsFinalizationStatusData>(undefined);
+  const { subscribe, set } = writable<SnsFinalizationStatusData | undefined>(
+    undefined
+  );
 
   const store = {
     subscribe,

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -1,6 +1,7 @@
+import { SECONDS_IN_DAY } from "$lib/constants/constants";
 import type { SnsTicketsStoreData } from "$lib/stores/sns-tickets.store";
 import type { TicketStatus } from "$lib/types/sale";
-import type { SnsSwapCommitment } from "$lib/types/sns";
+import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
 import { AccountIdentifier, SubAccount } from "@dfinity/ledger-icp";
 import type { Principal } from "@dfinity/principal";
 import type {
@@ -155,4 +156,18 @@ export const convertDerivedStateResponseToDerivedState = (
     sns_tokens_per_icp,
     buyer_total_icp_e8s,
   };
+};
+
+/**
+ * Returns true if the swap has ended more than one week ago.
+ */
+export const swapEndedMoreThanOneWeekAgo = ({
+  summary,
+  nowInSeconds,
+}: {
+  summary: SnsSummary;
+  nowInSeconds: number;
+}) => {
+  const oneWeekAgoInSeconds = BigInt(nowInSeconds - SECONDS_IN_DAY * 7);
+  return oneWeekAgoInSeconds > summary.swap.params.swap_due_timestamp_seconds;
 };

--- a/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
@@ -1,4 +1,6 @@
+import * as saleApi from "$lib/api/sns-sale.api";
 import ProjectCard from "$lib/components/launchpad/ProjectCard.svelte";
+import { SECONDS_IN_DAY } from "$lib/constants/constants";
 import { authStore } from "$lib/stores/auth.store";
 import {
   authStoreMock,
@@ -6,17 +8,33 @@ import {
   mutableMockAuthStoreSubscribe,
 } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { createFinalizationStatusMock } from "$tests/mocks/sns-finalization-status.mock";
 import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
 import { ProjectCardPo } from "$tests/page-objects/ProjectCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { render } from "@testing-library/svelte";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { runResolvedPromises } from "$vitests/utils/timers.test-utils";
+import { SnsSwapLifecycle } from "@dfinity/sns";
+import { render, waitFor } from "@testing-library/svelte";
 
 describe("ProjectCard", () => {
   vitest
     .spyOn(authStore, "subscribe")
     .mockImplementation(mutableMockAuthStoreSubscribe);
 
-  afterEach(() => vitest.clearAllMocks());
+  const now = Date.now();
+  const nowInSeconds = Math.floor(now / 1000);
+  const yesterdayInSeconds = nowInSeconds - SECONDS_IN_DAY;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setSnsProjects([
+      {
+        rootCanisterId: mockSnsFullProject.rootCanisterId,
+        lifecycle: SnsSwapLifecycle.Committed,
+        swapDueTimestampSeconds: yesterdayInSeconds,
+      },
+    ]);
+  });
 
   describe("signed in", () => {
     beforeAll(() =>
@@ -131,6 +149,38 @@ describe("ProjectCard", () => {
       expect(
         getByText(en.sns_project_detail.user_current_commitment)
       ).toBeInTheDocument();
+    });
+
+    it("should render finalizing status if swap is finalizing", async () => {
+      vi.spyOn(saleApi, "queryFinalizationStatus").mockResolvedValue(
+        createFinalizationStatusMock(true)
+      );
+
+      const { container } = render(ProjectCard, {
+        props: {
+          project: {
+            ...mockSnsFullProject,
+            summary: {
+              ...mockSnsFullProject.summary,
+              swap: {
+                ...mockSnsFullProject.summary.swap,
+                lifecycle: SnsSwapLifecycle.Committed,
+                params: {
+                  ...mockSnsFullProject.summary.swap.params,
+                  swap_due_timestamp_seconds: BigInt(yesterdayInSeconds),
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const po = ProjectCardPo.under(new JestPageObjectElement(container));
+      await runResolvedPromises();
+
+      await waitFor(async () =>
+        expect(await po.getStatus()).toBe("Status Finalizing")
+      );
     });
   });
 

--- a/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
@@ -19,7 +19,7 @@ import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
-import { render, waitFor } from "@testing-library/svelte";
+import { render } from "@testing-library/svelte";
 
 describe("ProjectCard", () => {
   vitest
@@ -198,9 +198,7 @@ describe("ProjectCard", () => {
       const po = ProjectCardPo.under(new JestPageObjectElement(container));
       await runResolvedPromises();
 
-      await waitFor(async () =>
-        expect(await po.getStatus()).toBe("Status Finalizing")
-      );
+      expect(await po.getStatus()).toBe("Status Finalizing");
     });
   });
 

--- a/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
@@ -13,7 +13,7 @@ import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
 import { ProjectCardPo } from "$tests/page-objects/ProjectCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
-import { runResolvedPromises } from "$vitests/utils/timers.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
 

--- a/frontend/src/tests/lib/components/launchpad/ProjectCardSwapInfo.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCardSwapInfo.spec.ts
@@ -1,15 +1,22 @@
 import ProjectCardSwapInfo from "$lib/components/launchpad/ProjectCardSwapInfo.svelte";
 import { SECONDS_IN_DAY } from "$lib/constants/constants";
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
+import {
+  getOrCreateSnsFinalizationStatusStore,
+  resetSnsFinalizationStatusStore,
+} from "$lib/stores/sns-finalization-status.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
 import { secondsToDuration } from "$lib/utils/date.utils";
 import { getCommitmentE8s } from "$lib/utils/sns.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import en from "$tests/mocks/i18n.mock";
+import { createFinalizationStatusMock } from "$tests/mocks/sns-finalization-status.mock";
 import {
   mockSnsFullProject,
   summaryForLifecycle,
 } from "$tests/mocks/sns-projects.mock";
+import { ProjectCardSwapInfoPo } from "$tests/page-objects/ProjectCardSwapInfo.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
@@ -23,6 +30,7 @@ describe("ProjectCardSwapInfo", () => {
   const now = Date.now();
   beforeEach(() => {
     vitest.useFakeTimers().setSystemTime(now);
+    resetSnsFinalizationStatusStore();
   });
 
   afterAll(() => {
@@ -119,5 +127,27 @@ describe("ProjectCardSwapInfo", () => {
     });
 
     expect(getByText(en.sns_project_detail.completed)).toBeInTheDocument();
+  });
+
+  it("should render finalizing", async () => {
+    const finalizingData = createFinalizationStatusMock(true);
+    const store = getOrCreateSnsFinalizationStatusStore(
+      mockSnsFullProject.rootCanisterId
+    );
+    store.setData({ data: finalizingData, certified: true });
+    const { container } = render(ProjectCardSwapInfo, {
+      props: {
+        project: {
+          ...mockSnsFullProject,
+          summary: summaryForLifecycle(SnsSwapLifecycle.Committed),
+        },
+      },
+    });
+
+    const po = ProjectCardSwapInfoPo.under(
+      new JestPageObjectElement(container)
+    );
+
+    expect(await po.getStatus()).toBe("Status Finalizing");
   });
 });

--- a/frontend/src/tests/lib/components/launchpad/ProjectCardSwapInfo.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCardSwapInfo.spec.ts
@@ -1,16 +1,11 @@
 import ProjectCardSwapInfo from "$lib/components/launchpad/ProjectCardSwapInfo.svelte";
 import { SECONDS_IN_DAY } from "$lib/constants/constants";
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
-import {
-  getOrCreateSnsFinalizationStatusStore,
-  resetSnsFinalizationStatusStore,
-} from "$lib/stores/sns-finalization-status.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
 import { secondsToDuration } from "$lib/utils/date.utils";
 import { getCommitmentE8s } from "$lib/utils/sns.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import en from "$tests/mocks/i18n.mock";
-import { createFinalizationStatusMock } from "$tests/mocks/sns-finalization-status.mock";
 import {
   mockSnsFullProject,
   summaryForLifecycle,
@@ -20,17 +15,10 @@ import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
-vitest.mock("$lib/services/sns.services", () => {
-  return {
-    loadSnsSwapStateStore: vitest.fn().mockResolvedValue(Promise.resolve()),
-  };
-});
-
 describe("ProjectCardSwapInfo", () => {
   const now = Date.now();
   beforeEach(() => {
     vitest.useFakeTimers().setSystemTime(now);
-    resetSnsFinalizationStatusStore();
   });
 
   afterAll(() => {
@@ -41,6 +29,7 @@ describe("ProjectCardSwapInfo", () => {
     const { getByText } = render(ProjectCardSwapInfo, {
       props: {
         project: mockSnsFullProject,
+        isFinalizing: false,
       },
     });
 
@@ -70,6 +59,7 @@ describe("ProjectCardSwapInfo", () => {
     const { getByText } = render(ProjectCardSwapInfo, {
       props: {
         project,
+        isFinalizing: false,
       },
     });
 
@@ -84,6 +74,7 @@ describe("ProjectCardSwapInfo", () => {
     const { getByText } = render(ProjectCardSwapInfo, {
       props: {
         project: mockSnsFullProject,
+        isFinalizing: false,
       },
     });
 
@@ -107,6 +98,7 @@ describe("ProjectCardSwapInfo", () => {
             myCommitment: undefined,
           },
         },
+        isFinalizing: false,
       },
     });
 
@@ -123,6 +115,7 @@ describe("ProjectCardSwapInfo", () => {
           ...mockSnsFullProject,
           summary: summaryForLifecycle(SnsSwapLifecycle.Committed),
         },
+        isFinalizing: false,
       },
     });
 
@@ -130,17 +123,13 @@ describe("ProjectCardSwapInfo", () => {
   });
 
   it("should render finalizing", async () => {
-    const finalizingData = createFinalizationStatusMock(true);
-    const store = getOrCreateSnsFinalizationStatusStore(
-      mockSnsFullProject.rootCanisterId
-    );
-    store.setData({ data: finalizingData, certified: true });
     const { container } = render(ProjectCardSwapInfo, {
       props: {
         project: {
           ...mockSnsFullProject,
           summary: summaryForLifecycle(SnsSwapLifecycle.Committed),
         },
+        isFinalizing: true,
       },
     });
 

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -3,6 +3,7 @@ import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import * as snsSaleApi from "$lib/api/sns-sale.api";
 import * as snsMetricsApi from "$lib/api/sns-swap-metrics.api";
 import * as snsApi from "$lib/api/sns.api";
+import { SECONDS_IN_DAY } from "$lib/constants/constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { WATCH_SALE_STATE_EVERY_MILLISECONDS } from "$lib/constants/sns.constants";
 import { NOT_LOADED } from "$lib/constants/stores.constants";
@@ -76,6 +77,8 @@ describe("ProjectDetail", () => {
 # TYPE sale_buyer_count gauge
 sale_buyer_count ${saleBuyerCount} 1677707139456
 # HELP sale_cf_participants_count`;
+  const now = Date.now();
+  const nowInSeconds = Math.floor(now / 1000);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -86,7 +89,6 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
     userCountryStore.set(NOT_LOADED);
 
     vi.clearAllTimers();
-    const now = Date.now();
     vi.useFakeTimers().setSystemTime(now);
 
     vi.spyOn(ledgerApi, "sendICP").mockResolvedValue(undefined);
@@ -263,6 +265,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
             lifecycle: SnsSwapLifecycle.Committed,
             directParticipantCount: [30n],
             certified: true,
+            swapDueTimestampSeconds: nowInSeconds - SECONDS_IN_DAY,
           },
         ]);
       });

--- a/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
@@ -1,4 +1,5 @@
 import * as saleApi from "$lib/api/sns-sale.api";
+import { SECONDS_IN_DAY, SECONDS_IN_MONTH } from "$lib/constants/constants";
 import { loadSnsFinalizationStatus } from "$lib/services/sns-finalization.services";
 import {
   getOrCreateSnsFinalizationStatusStore,
@@ -7,6 +8,8 @@ import {
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { snsFinalizationStatusResponseMock } from "$tests/mocks/sns-finalization-status.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("sns-finalization-services", () => {
@@ -16,36 +19,94 @@ describe("sns-finalization-services", () => {
 
   describe("loadSnsFinalizationStatus", () => {
     const rootCanisterId = principal(0);
+    const now = Date.now();
+    const nowInSeconds = Math.floor(now / 1000);
+    const yesterdayInSeconds = nowInSeconds - SECONDS_IN_DAY;
     afterEach(() => {
+      vi.useFakeTimers().setSystemTime(now);
       vi.clearAllMocks();
+      resetSnsProjects();
       resetSnsFinalizationStatusStore();
     });
 
-    it("should call api.queryFinalizationStatus and load finalization status in store", async () => {
-      const spyQuery = vi
-        .spyOn(saleApi, "queryFinalizationStatus")
-        .mockResolvedValue(snsFinalizationStatusResponseMock);
-
-      await loadSnsFinalizationStatus(rootCanisterId);
-
-      const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
-      expect(get(store)).toEqual({
-        data: snsFinalizationStatusResponseMock,
-        certified: false,
+    describe("if swap finished less than a week ago", () => {
+      beforeEach(() => {
+        setSnsProjects([
+          {
+            rootCanisterId,
+            lifecycle: SnsSwapLifecycle.Committed,
+            swapDueTimestampSeconds: yesterdayInSeconds,
+          },
+        ]);
       });
-      expect(spyQuery).toBeCalled();
+
+      it("should call api.queryFinalizationStatus and load finalization status in store", async () => {
+        vi.spyOn(saleApi, "queryFinalizationStatus").mockResolvedValue(
+          snsFinalizationStatusResponseMock
+        );
+
+        expect(saleApi.queryFinalizationStatus).not.toBeCalled();
+        await loadSnsFinalizationStatus(rootCanisterId);
+
+        const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+        expect(get(store)).toEqual({
+          data: snsFinalizationStatusResponseMock,
+          certified: false,
+        });
+        expect(saleApi.queryFinalizationStatus).toBeCalled();
+      });
+
+      it("should call api.queryFinalizationStatus but not load finalization status in store if response is `undefined`", async () => {
+        vi.spyOn(saleApi, "queryFinalizationStatus").mockResolvedValue(
+          undefined
+        );
+
+        expect(saleApi.queryFinalizationStatus).not.toBeCalled();
+        await loadSnsFinalizationStatus(rootCanisterId);
+
+        const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+        expect(get(store)).toBeUndefined();
+        expect(saleApi.queryFinalizationStatus).toBeCalled();
+      });
     });
 
-    it("should call api.queryFinalizationStatus but not load finalization status in store if response is `undefined`", async () => {
-      const spyQuery = vi
-        .spyOn(saleApi, "queryFinalizationStatus")
-        .mockResolvedValue(undefined);
+    describe("if swap is open", () => {
+      beforeEach(() => {
+        setSnsProjects([
+          {
+            rootCanisterId,
+            lifecycle: SnsSwapLifecycle.Open,
+          },
+        ]);
+      });
 
-      await loadSnsFinalizationStatus(rootCanisterId);
+      it("should call not load finalization status in store nor call api", async () => {
+        await loadSnsFinalizationStatus(rootCanisterId);
 
-      const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
-      expect(get(store)).toBeUndefined();
-      expect(spyQuery).toBeCalled();
+        const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+        expect(get(store)).toBeUndefined();
+        expect(saleApi.queryFinalizationStatus).not.toBeCalled();
+      });
+    });
+
+    describe("if swap is committed more than a week ago", () => {
+      beforeEach(() => {
+        setSnsProjects([
+          {
+            rootCanisterId,
+            lifecycle: SnsSwapLifecycle.Open,
+            swapDueTimestampSeconds: nowInSeconds - SECONDS_IN_MONTH,
+          },
+        ]);
+      });
+
+      it("should call not load finalization status in store nor call api", async () => {
+        await loadSnsFinalizationStatus(rootCanisterId);
+
+        const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+        expect(get(store)).toBeUndefined();
+        expect(saleApi.queryFinalizationStatus).not.toBeCalled();
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
@@ -123,6 +123,22 @@ describe("sns-finalization-services", () => {
         expect(get(store)).toBeUndefined();
         expect(saleApi.queryFinalizationStatus).not.toBeCalled();
       });
+
+      it("should call api.queryFinalizationStatus and load finalization status in store if forced to fetch", async () => {
+        vi.spyOn(saleApi, "queryFinalizationStatus").mockResolvedValue(
+          snsFinalizationStatusResponseMock
+        );
+
+        expect(saleApi.queryFinalizationStatus).not.toBeCalled();
+        await loadSnsFinalizationStatus({ rootCanisterId, forceFetch: true });
+
+        const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+        expect(get(store)).toEqual({
+          data: snsFinalizationStatusResponseMock,
+          certified: false,
+        });
+        expect(saleApi.queryFinalizationStatus).toBeCalled();
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
@@ -46,7 +46,7 @@ describe("sns-finalization-services", () => {
         );
 
         expect(saleApi.queryFinalizationStatus).not.toBeCalled();
-        await loadSnsFinalizationStatus(rootCanisterId);
+        await loadSnsFinalizationStatus({ rootCanisterId });
 
         const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
         expect(get(store)).toEqual({
@@ -62,7 +62,7 @@ describe("sns-finalization-services", () => {
         );
 
         expect(saleApi.queryFinalizationStatus).not.toBeCalled();
-        await loadSnsFinalizationStatus(rootCanisterId);
+        await loadSnsFinalizationStatus({ rootCanisterId });
 
         const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
         expect(get(store)).toBeUndefined();
@@ -81,11 +81,27 @@ describe("sns-finalization-services", () => {
       });
 
       it("should call not load finalization status in store nor call api", async () => {
-        await loadSnsFinalizationStatus(rootCanisterId);
+        await loadSnsFinalizationStatus({ rootCanisterId });
 
         const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
         expect(get(store)).toBeUndefined();
         expect(saleApi.queryFinalizationStatus).not.toBeCalled();
+      });
+
+      it("should call api.queryFinalizationStatus and load finalization status in store if forced to fetch", async () => {
+        vi.spyOn(saleApi, "queryFinalizationStatus").mockResolvedValue(
+          snsFinalizationStatusResponseMock
+        );
+
+        expect(saleApi.queryFinalizationStatus).not.toBeCalled();
+        await loadSnsFinalizationStatus({ rootCanisterId, forceFetch: true });
+
+        const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
+        expect(get(store)).toEqual({
+          data: snsFinalizationStatusResponseMock,
+          certified: false,
+        });
+        expect(saleApi.queryFinalizationStatus).toBeCalled();
       });
     });
 
@@ -101,7 +117,7 @@ describe("sns-finalization-services", () => {
       });
 
       it("should call not load finalization status in store nor call api", async () => {
-        await loadSnsFinalizationStatus(rootCanisterId);
+        await loadSnsFinalizationStatus({ rootCanisterId });
 
         const store = getOrCreateSnsFinalizationStatusStore(rootCanisterId);
         expect(get(store)).toBeUndefined();

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -22,9 +22,9 @@ import {
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { snsTicketMock } from "$tests/mocks/sns.mock";
 import { AccountIdentifier } from "@dfinity/ledger-icp";
-import {
-  type SnsGetAutoFinalizationStatusResponse,
-  type SnsGetDerivedStateResponse,
+import type {
+  SnsGetAutoFinalizationStatusResponse,
+  SnsGetDerivedStateResponse,
 } from "@dfinity/sns";
 import { get } from "svelte/store";
 

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -68,6 +68,7 @@ export const aggregatorSnsMockWith = ({
   tokenMetadata,
   index,
   nervousFunctions,
+  swapDueTimestampSeconds,
 }: {
   rootCanisterId?: string;
   lifecycle?: SnsSwapLifecycle;
@@ -78,6 +79,7 @@ export const aggregatorSnsMockWith = ({
   tokenMetadata?: Partial<IcrcTokenMetadata>;
   index?: number;
   nervousFunctions?: SnsNervousSystemFunction[];
+  swapDueTimestampSeconds?: number;
 }): CachedSnsDto => ({
   index: index ?? aggregatorSnsMockDto.index,
   ...aggregatorSnsMockDto,
@@ -99,6 +101,13 @@ export const aggregatorSnsMockWith = ({
         restricted_countries: nonNullish(restrictedCountries)
           ? { iso_codes: restrictedCountries }
           : aggregatorSnsMockDto.swap_state.swap.init.restricted_countries,
+      },
+      params: {
+        ...aggregatorSnsMockDto.swap_state.swap.params,
+        swap_due_timestamp_seconds:
+          swapDueTimestampSeconds ??
+          aggregatorSnsMockDto.swap_state.swap.params
+            .swap_due_timestamp_seconds,
       },
     },
     derived: {
@@ -124,6 +133,17 @@ export const aggregatorSnsMockWith = ({
       restricted_countries: nonNullish(restrictedCountries)
         ? { iso_codes: restrictedCountries }
         : aggregatorSnsMockDto.swap_state.swap.init.restricted_countries,
+      swap_due_timestamp_seconds:
+        swapDueTimestampSeconds ??
+        aggregatorSnsMockDto.swap_state.swap.params.swap_due_timestamp_seconds,
+    },
+  },
+  swap_params: {
+    params: {
+      ...aggregatorSnsMockDto.swap_params.params,
+      swap_due_timestamp_seconds:
+        swapDueTimestampSeconds ??
+        aggregatorSnsMockDto.swap_state.swap.params.swap_due_timestamp_seconds,
     },
   },
   derived_state: {

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -300,6 +300,23 @@ export const summaryForLifecycle = (
   },
 });
 
+type SnsSummaryParams = {
+  lifecycle?: SnsSwapLifecycle;
+  confirmationText?: string | undefined;
+  restrictedCountries?: string[] | undefined;
+  minParticipants?: number;
+  buyersCount?: bigint | null;
+  tokensDistributed?: bigint;
+  minParticipantCommitment?: bigint;
+  maxParticipantCommitment?: bigint;
+  swapDueTimestampSeconds?: bigint;
+  minTotalCommitment?: bigint;
+  maxTotalCommitment?: bigint;
+  currentTotalCommitment?: bigint;
+  neuronsFundCommitment?: bigint;
+  directCommitment?: bigint;
+};
+
 export const createSummary = ({
   lifecycle = SnsSwapLifecycle.Open,
   confirmationText = undefined,
@@ -315,22 +332,7 @@ export const createSummary = ({
   currentTotalCommitment,
   neuronsFundCommitment,
   directCommitment,
-}: {
-  lifecycle?: SnsSwapLifecycle;
-  confirmationText?: string | undefined;
-  restrictedCountries?: string[] | undefined;
-  minParticipants?: number;
-  buyersCount?: bigint | null;
-  tokensDistributed?: bigint;
-  minParticipantCommitment?: bigint;
-  maxParticipantCommitment?: bigint;
-  swapDueTimestampSeconds?: bigint;
-  minTotalCommitment?: bigint;
-  maxTotalCommitment?: bigint;
-  currentTotalCommitment?: bigint;
-  neuronsFundCommitment?: bigint;
-  directCommitment?: bigint;
-}): SnsSummary => {
+}: SnsSummaryParams): SnsSummary => {
   const init: SnsSwapInit = {
     ...mockInit,
     swap_due_timestamp_seconds: [swapDueTimestampSeconds],
@@ -368,6 +370,18 @@ export const createSummary = ({
     derived,
   };
 };
+
+export const createMockSnsFullProject = ({
+  summaryParams,
+  rootCanisterId,
+}: {
+  rootCanisterId: Principal;
+  summaryParams: SnsSummaryParams;
+}) => ({
+  rootCanisterId,
+  summary: createSummary(summaryParams),
+  mockSwapCommitment: mockSnsSwapCommitment(rootCanisterId),
+});
 
 export const mockQueryMetadataResponse: SnsGetMetadataResponse = {
   url: [`https://my.url/`],

--- a/frontend/src/tests/page-objects/ProjectCard.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectCard.page-object.ts
@@ -1,5 +1,6 @@
 import { CardPo } from "$tests/page-objects/Card.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { ProjectCardSwapInfoPo } from "./ProjectCardSwapInfo.page-object";
 
 export class ProjectCardPo extends CardPo {
   private static readonly TID = "project-card-component";
@@ -16,5 +17,9 @@ export class ProjectCardPo extends CardPo {
 
   getProjectName(): Promise<string> {
     return this.getText("project-name");
+  }
+
+  getStatus(): Promise<string> {
+    return ProjectCardSwapInfoPo.under(this.root).getStatus();
   }
 }

--- a/frontend/src/tests/page-objects/ProjectCardSwapInfo.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectCardSwapInfo.page-object.ts
@@ -1,0 +1,16 @@
+import { CardPo } from "$tests/page-objects/Card.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ProjectCardSwapInfoPo extends CardPo {
+  private static readonly TID = "project-card-swap-info-component";
+
+  static under(element: PageObjectElement): ProjectCardSwapInfoPo {
+    return new ProjectCardSwapInfoPo(
+      element.byTestId(ProjectCardSwapInfoPo.TID)
+    );
+  }
+
+  async getStatus(): Promise<string> {
+    return (await this.getText("project-status-text")).trim();
+  }
+}

--- a/frontend/src/tests/utils/sns.test-utils.ts
+++ b/frontend/src/tests/utils/sns.test-utils.ts
@@ -17,6 +17,7 @@ export const setSnsProjects = (
     projectName?: string;
     tokenMetadata?: Partial<IcrcTokenMetadata>;
     nervousFunctions?: SnsNervousSystemFunction[];
+    swapDueTimestampSeconds?: number;
   }[]
 ) => {
   const aggregatorProjects = params.map((params, index) => {
@@ -29,6 +30,7 @@ export const setSnsProjects = (
       projectName: params.projectName,
       tokenMetadata: params.tokenMetadata,
       nervousFunctions: params.nervousFunctions,
+      swapDueTimestampSeconds: params.swapDueTimestampSeconds,
     });
   });
   snsLifecycleStore.reset();


### PR DESCRIPTION
# Motivation

Issue reported by a user: https://forum.dfinity.org/t/bug-projectpage-sns-launchpad-direct-url/23029/7?u=lmuntaner

Add the "Finalizing" status in the Launchpad, when we show all the SNSes.

Yet, to do that, we need to fetch the finalizing status of all the projects.

To not make unnecessary calls, I added a check that the project has finished within the last week. This way we don't make calls to for open or old projects.

# Changes

* Changes in `loadSnsFinalizationStatus` to not call the API unless it's possible that the project is finalizing. Also change the argument to accept another parameter `forceFetch`.
* Call `loadSnsFinalizationStatus` on mounting the ProjectDetailCard.
* Use `createIsSnsFinalizingStore` on ProjectCardSwap to render "Finalizing" instead of "Completed" when needed.
* Force fetching autofinalization after a participation. At that moment the project might not be loaded as Committed locally yet, but it might be Committed already.
* Fix the `SnsFinalizationStatusStore` that might be `undefined`.
* New sns util `swapEndedMoreThanOneWeekAgo` for convenience.

# Tests

* Add `swapDueTimestampSeconds` parameter when creating an SNS.
* Add `getStatus` to ProjectCardPo.
* New ProjectCardSwapInfoPo.
* Add a test case in ProjectCard that shows the Finalizing status. Also adapt it so that it has SNS setup. Until now it was not needed because it was using the props only.
* Add a test case in ProjectCardSwapInfo for the Finalizing status.
* Fix the swap ending time in ProjectDetail so that it triggers the call to get finalizing data.
* Edit tests in sns-finalization.services.spec after the changes in `loadSnsFinalizationStatus`.
* Test new sns util `swapEndedMoreThanOneWeekAgo`.

# Todos

- [x] Add entry to changelog (if necessary).
