### PR TITLE
GIX-1937: Use min max direct participation fields from aggregator

### DIFF
--- a/frontend/src/lib/types/sns-aggregator.ts
+++ b/frontend/src/lib/types/sns-aggregator.ts
@@ -59,6 +59,8 @@ export type CachedSwapParamsDto = {
     dissolve_delay_interval_seconds: number;
   };
   sale_delay_seconds?: number;
+  min_direct_participation_icp_e8s?: number | null;
+  max_direct_participation_icp_e8s?: number | null;
 };
 
 interface CachedLinearScalingCoefficient {
@@ -116,6 +118,8 @@ export type CachedSwapInitParamsDto = {
   confirmation_text?: string | undefined;
   restricted_countries?: CachedCountriesDto | undefined;
   neurons_fund_participation_constraints?: CachedNeuronsFundParticipationConstraints | null;
+  min_direct_participation_icp_e8s?: number | null;
+  max_direct_participation_icp_e8s?: number | null;
 };
 
 export type CachedSnsSwapDto = {

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -210,8 +210,12 @@ const convertSwapInitParams = (
               )
             )
           : [],
-        min_direct_participation_icp_e8s: [],
-        max_direct_participation_icp_e8s: [],
+        min_direct_participation_icp_e8s: toNullable(
+          convertOptionalNumToBigInt(init.min_direct_participation_icp_e8s)
+        ),
+        max_direct_participation_icp_e8s: toNullable(
+          convertOptionalNumToBigInt(init.max_direct_participation_icp_e8s)
+        ),
       }
     : undefined;
 
@@ -233,8 +237,12 @@ const convertSwapParams = (params: CachedSwapParamsDto): SnsParams => ({
   sale_delay_seconds: toNullable(
     convertOptionalNumToBigInt(params.sale_delay_seconds)
   ),
-  min_direct_participation_icp_e8s: [],
-  max_direct_participation_icp_e8s: [],
+  min_direct_participation_icp_e8s: toNullable(
+    convertOptionalNumToBigInt(params.min_direct_participation_icp_e8s)
+  ),
+  max_direct_participation_icp_e8s: toNullable(
+    convertOptionalNumToBigInt(params.max_direct_participation_icp_e8s)
+  ),
 });
 
 const convertSwap = ({

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -475,7 +475,7 @@ describe("sns aggregator converters utils", () => {
       ).toBeUndefined();
     });
 
-    it("converts fields related to NF participation", () => {
+    it("converts fields related to NF participation enhancements", () => {
       const aggregatorNFAndDirectParticipationFields: CachedSnsDto = {
         ...mockData,
         swap_state: {
@@ -484,6 +484,11 @@ describe("sns aggregator converters utils", () => {
             ...mockData.swap_state.swap,
             direct_participation_icp_e8s: 300000000000000,
             neurons_fund_participation_icp_e8s: 100000000000000,
+            params: {
+              ...mockData.swap_state.swap.params,
+              min_direct_participation_icp_e8s: 300000000000,
+              max_direct_participation_icp_e8s: 3000000000000,
+            },
             init: {
               ...mockData.swap_state.swap.init,
               neurons_fund_participation_constraints: {
@@ -499,6 +504,8 @@ describe("sns aggregator converters utils", () => {
                 max_neurons_fund_participation_icp_e8s: 300000000000,
                 min_direct_participation_threshold_icp_e8s: 10000000000,
               },
+              min_direct_participation_icp_e8s: 300000000000,
+              max_direct_participation_icp_e8s: 3000000000000,
             },
           },
           derived: {
@@ -512,6 +519,13 @@ describe("sns aggregator converters utils", () => {
           direct_participation_icp_e8s: 300000000000000,
           neurons_fund_participation_icp_e8s: 100000000000000,
         },
+        init: {
+          init: {
+            ...mockData.init.init,
+            min_direct_participation_icp_e8s: 300000000000,
+            max_direct_participation_icp_e8s: 3000000000000,
+          },
+        },
       };
 
       const summaryMockData = convertDtoToSnsSummary(mockData);
@@ -521,6 +535,11 @@ describe("sns aggregator converters utils", () => {
         ...summaryMockData,
         swap: {
           ...summaryMockData.swap,
+          params: {
+            ...summaryMockData.swap.params,
+            min_direct_participation_icp_e8s: [300000000000n],
+            max_direct_participation_icp_e8s: [3000000000000n],
+          },
           init: [
             {
               ...summaryMockData.swap.init[0],
@@ -539,6 +558,8 @@ describe("sns aggregator converters utils", () => {
                   min_direct_participation_threshold_icp_e8s: [10000000000n],
                 },
               ],
+              min_direct_participation_icp_e8s: [300000000000n],
+              max_direct_participation_icp_e8s: [3000000000000n],
             },
           ],
           direct_participation_icp_e8s: [300000000000000n],
@@ -548,6 +569,11 @@ describe("sns aggregator converters utils", () => {
           ...summaryMockData.derived,
           direct_participation_icp_e8s: [300000000000000n],
           neurons_fund_participation_icp_e8s: [100000000000000n],
+        },
+        init: {
+          ...summaryMockData.init,
+          min_direct_participation_icp_e8s: [300000000000n],
+          max_direct_participation_icp_e8s: [3000000000000n],
         },
       });
     });


### PR DESCRIPTION
# Motivation

Add functionality after Neurons' Fund enhancements.

In this PR, we use the new fields from the SNS Aggregator when we convert the data to SnsSummary.

# Changes

* Populate new fields `min_direct_participation_icp_e8s` and `max_direct_participation_icp_e8s` from the different places into the SnsSummary. Those fields are in the `Init` from `get_init`, but they are also in the `init` inside the `swap` and also in the `params` of the `swap`.

# Tests

* Add the fields in the test case for the NF's enhancements fields. The other tests have those fields not populated and are converted to `[]` as it was hardcoded before.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet necessary.