### PR TITLE
GIX-1962: Proof Of Concept for My Tokens page

### DIFF
--- a/frontend/src/lib/pages/MyTokens.svelte
+++ b/frontend/src/lib/pages/MyTokens.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import {
+    createFavoriteAction,
+    createOpenModalAction,
+  } from "$lib/types/actions";
+  import { createEventDispatcher } from "svelte";
+
+  export let data: { name: string; balance: string; id: string }[] = [];
+
+  const dispatcher = createEventDispatcher();
+</script>
+
+<div>
+  <h1>My Tokens</h1>
+
+  <div>
+    {#each data as { name, balance, id }}
+      <div>
+        <div>{name}</div>
+        <div>{balance}</div>
+        <button
+          class="secondary"
+          on:click={() => {
+            dispatcher("nnsAction", createFavoriteAction({ id }));
+          }}>Add to favorite</button
+        >
+        <button
+          class="secondary"
+          on:click={() => {
+            dispatcher(
+              "nnsAction",
+              createOpenModalAction({ id, fromAccount: name })
+            );
+          }}>Send Tokens</button
+        >
+      </div>
+    {/each}
+  </div>
+</div>

--- a/frontend/src/lib/types/actions.ts
+++ b/frontend/src/lib/types/actions.ts
@@ -1,0 +1,42 @@
+export type Action = FavoriteAction | OpenSendModalAction;
+
+export enum ActionTypes {
+  TOGGLE_FAVORITE = "TOGGLE_FAVORITE",
+  OPEN_SEND_MODAL = "OPEN_SEND_MODAL",
+}
+
+type BaseAction = {
+  type: ActionTypes;
+};
+
+type FavoriteAction = BaseAction & {
+  type: ActionTypes.TOGGLE_FAVORITE;
+  id: string;
+};
+
+type OpenSendModalAction = BaseAction & {
+  type: ActionTypes.OPEN_SEND_MODAL;
+  id: string;
+  fromAccount: string;
+};
+
+export const createFavoriteAction = ({
+  id,
+}: {
+  id: string;
+}): FavoriteAction => ({
+  type: ActionTypes.TOGGLE_FAVORITE,
+  id,
+});
+
+export const createOpenModalAction = ({
+  id,
+  fromAccount,
+}: {
+  id: string;
+  fromAccount: string;
+}): OpenSendModalAction => ({
+  type: ActionTypes.OPEN_SEND_MODAL,
+  id,
+  fromAccount,
+});

--- a/frontend/src/routes/(app)/(nns)/my-tokens/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/my-tokens/+layout.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import Layout from "$lib/components/layout/Layout.svelte";
+  import Content from "$lib/components/layout/Content.svelte";
+  import LayoutList from "$lib/components/layout/LayoutList.svelte";
+  import { i18n } from "$lib/stores/i18n";
+</script>
+
+<LayoutList title={$i18n.sns_launchpad.header}>
+  <Layout>
+    <Content>
+      <slot />
+    </Content>
+  </Layout>
+</LayoutList>

--- a/frontend/src/routes/(app)/(nns)/my-tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/my-tokens/+page.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import MyTokens from "$lib/pages/MyTokens.svelte";
+  import { ActionTypes, type Action } from "$lib/types/actions";
+
+  // Call services to load necessary data. Maybe one service to rule them all?
+
+  // This would be a derived store.
+  const data = [
+    { name: "ICP", balance: "3.14", id: "1" },
+    { name: "Open Chat", balance: "1.2311", id: "2" },
+  ];
+
+  const manageActions = ({ detail: action }: CustomEvent<Action>) => {
+    switch (action.type) {
+      case ActionTypes.TOGGLE_FAVORITE: {
+        console.log(action.id);
+        console.log("call service to toggle favorite");
+        return;
+      }
+      case ActionTypes.OPEN_SEND_MODAL: {
+        console.log(action.fromAccount);
+        console.log("open modal");
+        return;
+      }
+      default: {
+        console.log("Unknown action");
+      }
+    }
+  };
+</script>
+
+<MyTokens {data} on:nnsAction={manageActions} />

--- a/frontend/src/routes/static/my-tokens/+page.svelte
+++ b/frontend/src/routes/static/my-tokens/+page.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import MyTokens from "$lib/pages/MyTokens.svelte";
+
+  // This is rendered in `/static/my-tokens/`.
+
+  // This would be a mocked data. Or we could put the mocked data in stores and use the same derived store.
+  const data = [
+    { name: "ICP", balance: "3.14", id: "1" },
+    { name: "Open Chat", balance: "1.2311", id: "2" },
+  ];
+</script>
+
+<MyTokens {data} />


### PR DESCRIPTION
# Motivation

This is a proof of concept for a new idea on how to split the page with functionality and UI components.

Main idea: Be able to render the whole page for designers to work only with CSS.

The route component will load all the stores with initial data with the related services.

All subsequent data and actions is dispatched from components as custom events, then handled from the parent.

# Changes

* Route component that renders a Page component.
* Page component and children do not interact directly with the API. (IMPORTANT)
* Page component and children do not read from the store or the context.

# Tests

* We could easily do screenshot testing of the static pages.

# Todos

- [ ] Add entry to changelog (if necessary).
