### PR TITLE
GIX-1937: Use fields in min/max participation getters

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -25,6 +25,7 @@ proposal is successful, the changes it released will be moved from this file to
 * New Tag style. Used in followees topic and project status.
 * New header UI in the wallet pages.
 * Integrated library `marked` within dependencies instead of shipping it as a static asset.
+* Detailed values of the Neurons' Fund and direct participation in the project detai page.
 
 #### Deprecated
 #### Removed

--- a/frontend/src/lib/getters/sns-summary.ts
+++ b/frontend/src/lib/getters/sns-summary.ts
@@ -16,12 +16,12 @@ export const getNeuronsFundParticipation = ({
 }: SnsSummary): bigint | undefined =>
   fromNullable(derived.neurons_fund_participation_icp_e8s);
 
-// TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-export const getMinDirectParticipation = (
-  _summary: SnsSummary
-): bigint | undefined => undefined;
+export const getMinDirectParticipation = ({
+  init,
+}: SnsSummary): bigint | undefined =>
+  fromNullable(init?.min_direct_participation_icp_e8s ?? []);
 
-// TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-export const getMaxDirectParticipation = (
-  _summary: SnsSummary
-): bigint | undefined => undefined;
+export const getMaxDirectParticipation = ({
+  init,
+}: SnsSummary): bigint | undefined =>
+  fromNullable(init?.max_direct_participation_icp_e8s ?? []);

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -1,5 +1,4 @@
 import ProjectCommitment from "$lib/components/project-detail/ProjectCommitment.svelte";
-import * as summaryGetters from "$lib/getters/sns-summary";
 import { snsSwapMetricsStore } from "$lib/stores/sns-swap-metrics.store";
 import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
 import {
@@ -89,17 +88,8 @@ describe("ProjectCommitment", () => {
       currentTotalCommitment: directCommitment + nfCommitment,
       directCommitment,
       neuronsFundCommitment: nfCommitment,
-    });
-
-    beforeEach(() => {
-      // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-      vi.spyOn(summaryGetters, "getMinDirectParticipation").mockImplementation(
-        () => 10000000000n
-      );
-      // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-      vi.spyOn(summaryGetters, "getMaxDirectParticipation").mockImplementation(
-        () => 100000000000n
-      );
+      minDirectParticipation: 10000000000n,
+      maxDirectParticipation: 100000000000n,
     });
 
     it("should render a progress bar with direct participation", async () => {
@@ -122,23 +112,14 @@ describe("ProjectCommitment", () => {
   });
 
   describe("when Neurons' Fund enhancements fields are available and NF commitment is 0", () => {
-    beforeEach(() => {
-      // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-      vi.spyOn(summaryGetters, "getMinDirectParticipation").mockImplementation(
-        () => 10000000000n
-      );
-      // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-      vi.spyOn(summaryGetters, "getMaxDirectParticipation").mockImplementation(
-        () => 100000000000n
-      );
-    });
-
     it("should render detailed participation if neurons fund participation is zero", async () => {
       const directCommitment = 20000000000n;
       const summary = createSummary({
         currentTotalCommitment: directCommitment,
         neuronsFundCommitment: 0n,
         directCommitment,
+        minDirectParticipation: 10000000000n,
+        maxDirectParticipation: 100000000000n,
       });
       const po = renderComponent(summary);
       expect(await po.getNeuronsFundParticipation()).toEqual("0 ICP");
@@ -152,17 +133,8 @@ describe("ProjectCommitment", () => {
       currentTotalCommitment: overallCommitment,
       neuronsFundCommitment: undefined,
       directCommitment: undefined,
-    });
-
-    beforeEach(() => {
-      // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-      vi.spyOn(summaryGetters, "getMinDirectParticipation").mockImplementation(
-        () => undefined
-      );
-      // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-      vi.spyOn(summaryGetters, "getMaxDirectParticipation").mockImplementation(
-        () => undefined
-      );
+      minDirectParticipation: undefined,
+      maxDirectParticipation: undefined,
     });
 
     it("should render a progress bar with overall participation", async () => {

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1,6 +1,5 @@
 import { NOT_LOADED } from "$lib/constants/stores.constants";
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
-import * as summaryGetters from "$lib/getters/sns-summary";
 import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import {
@@ -1276,63 +1275,49 @@ describe("project-utils", () => {
   describe("getProjectCommitmentSplit", () => {
     const nfCommitment = 10000000000n;
     const directCommitment = 20000000000n;
-    const summary = createSummary({
-      currentTotalCommitment: directCommitment + nfCommitment,
-      directCommitment,
-      neuronsFundCommitment: nfCommitment,
-    });
 
     describe("when NF participation is present", () => {
       it("returns the commitments split if min-max direct participations are present", () => {
         const minDirectParticipation = 10000000000n;
         const maxDirectParticipation = 100000000000n;
-        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-        vi.spyOn(
-          summaryGetters,
-          "getMinDirectParticipation"
-        ).mockImplementation(() => minDirectParticipation);
-        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-        vi.spyOn(
-          summaryGetters,
-          "getMaxDirectParticipation"
-        ).mockImplementation(() => maxDirectParticipation);
+        const summary = createSummary({
+          currentTotalCommitment: directCommitment + nfCommitment,
+          directCommitment,
+          neuronsFundCommitment: nfCommitment,
+          minDirectParticipation,
+          maxDirectParticipation,
+        });
 
         expect(getProjectCommitmentSplit(summary)).toEqual({
-          totalCommitmentE8s: 30000000000n,
-          directCommitmentE8s: 20000000000n,
-          nfCommitmentE8s: 10000000000n,
+          totalCommitmentE8s: directCommitment + nfCommitment,
+          directCommitmentE8s: directCommitment,
+          nfCommitmentE8s: nfCommitment,
           minDirectCommitmentE8s: minDirectParticipation,
           maxDirectCommitmentE8s: maxDirectParticipation,
         });
       });
 
       it("returns the full commitment if min direct participation is not present", () => {
-        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-        vi.spyOn(
-          summaryGetters,
-          "getMinDirectParticipation"
-        ).mockImplementation(() => undefined);
-        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-        vi.spyOn(
-          summaryGetters,
-          "getMaxDirectParticipation"
-        ).mockImplementation(() => 100000000000n);
+        const summary = createSummary({
+          currentTotalCommitment: directCommitment + nfCommitment,
+          directCommitment,
+          neuronsFundCommitment: nfCommitment,
+          minDirectParticipation: undefined,
+          maxDirectParticipation: 100000000000n,
+        });
         expect(getProjectCommitmentSplit(summary)).toEqual({
           totalCommitmentE8s: 30000000000n,
         });
       });
 
       it("returns the full commitment if max direct participation is not present", () => {
-        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-        vi.spyOn(
-          summaryGetters,
-          "getMinDirectParticipation"
-        ).mockImplementation(() => 100000000000n);
-        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-        vi.spyOn(
-          summaryGetters,
-          "getMaxDirectParticipation"
-        ).mockImplementation(() => undefined);
+        const summary = createSummary({
+          currentTotalCommitment: directCommitment + nfCommitment,
+          directCommitment,
+          neuronsFundCommitment: nfCommitment,
+          minDirectParticipation: 100000000000n,
+          maxDirectParticipation: undefined,
+        });
         expect(getProjectCommitmentSplit(summary)).toEqual({
           totalCommitmentE8s: 30000000000n,
         });
@@ -1344,20 +1329,12 @@ describe("project-utils", () => {
         const directCommitment = 20000000000n;
         const minDirectParticipation = 10000000000n;
         const maxDirectParticipation = 100000000000n;
-        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-        vi.spyOn(
-          summaryGetters,
-          "getMinDirectParticipation"
-        ).mockImplementation(() => minDirectParticipation);
-        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-        vi.spyOn(
-          summaryGetters,
-          "getMaxDirectParticipation"
-        ).mockImplementation(() => maxDirectParticipation);
         const summary = createSummary({
           currentTotalCommitment: directCommitment,
           directCommitment,
           neuronsFundCommitment: 0n,
+          minDirectParticipation,
+          maxDirectParticipation,
         });
         expect(getProjectCommitmentSplit(summary)).toEqual({
           totalCommitmentE8s: 20000000000n,
@@ -1376,17 +1353,9 @@ describe("project-utils", () => {
           currentTotalCommitment,
           directCommitment: undefined,
           neuronsFundCommitment: undefined,
+          minDirectParticipation: 100000000000n,
+          maxDirectParticipation: 1000000000000n,
         });
-        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-        vi.spyOn(
-          summaryGetters,
-          "getMinDirectParticipation"
-        ).mockImplementation(() => 100000000000n);
-        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-        vi.spyOn(
-          summaryGetters,
-          "getMaxDirectParticipation"
-        ).mockImplementation(() => 1000000000000n);
         expect(getProjectCommitmentSplit(summary)).toEqual({
           totalCommitmentE8s: currentTotalCommitment,
         });
@@ -1397,22 +1366,14 @@ describe("project-utils", () => {
       it("returns the overall commitments even if nf commitment and min-max direct participations are present", () => {
         const minDirectParticipation = 10000000000n;
         const maxDirectParticipation = 100000000000n;
-        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-        vi.spyOn(
-          summaryGetters,
-          "getMinDirectParticipation"
-        ).mockImplementation(() => minDirectParticipation);
-        // TODO: https://dfinity.atlassian.net/browse/GIX-1936 use min direct field when present
-        vi.spyOn(
-          summaryGetters,
-          "getMaxDirectParticipation"
-        ).mockImplementation(() => maxDirectParticipation);
 
         const currentTotalCommitment = 30000000000n;
         const summary = createSummary({
           currentTotalCommitment,
           directCommitment: undefined,
           neuronsFundCommitment: 10n,
+          minDirectParticipation,
+          maxDirectParticipation,
         });
 
         expect(getProjectCommitmentSplit(summary)).toEqual({

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -127,8 +127,8 @@ export const mockInit: SnsSwapInit = {
   restricted_countries: [],
   min_icp_e8s: [1_500_000_000n],
   neurons_fund_participation_constraints: [],
-  min_direct_participation_icp_e8s: [],
-  max_direct_participation_icp_e8s: [],
+  min_direct_participation_icp_e8s: [1_000_000_000n],
+  max_direct_participation_icp_e8s: [3_000_000_000n],
 };
 
 export const mockSwap: SnsSummarySwap = {
@@ -315,6 +315,8 @@ type SnsSummaryParams = {
   currentTotalCommitment?: bigint;
   neuronsFundCommitment?: bigint;
   directCommitment?: bigint;
+  minDirectParticipation?: bigint;
+  maxDirectParticipation?: bigint;
 };
 
 export const createSummary = ({
@@ -332,11 +334,15 @@ export const createSummary = ({
   currentTotalCommitment,
   neuronsFundCommitment,
   directCommitment,
+  minDirectParticipation,
+  maxDirectParticipation,
 }: SnsSummaryParams): SnsSummary => {
   const init: SnsSwapInit = {
     ...mockInit,
     swap_due_timestamp_seconds: [swapDueTimestampSeconds],
     confirmation_text: toNullable(confirmationText),
+    min_direct_participation_icp_e8s: toNullable(minDirectParticipation),
+    max_direct_participation_icp_e8s: toNullable(maxDirectParticipation),
     restricted_countries: nonNullish(restrictedCountries)
       ? [{ iso_codes: restrictedCountries }]
       : [],
@@ -368,6 +374,7 @@ export const createSummary = ({
       params,
     },
     derived,
+    init,
   };
 };
 


### PR DESCRIPTION
# Motivation

Add support for the new Neurons' Fund enhancements.

In this PR, the getters `getMinDirectParticipation` and `getMaxDirectParticipation` return the actual value from the SNS project.

# Changes

* Return the values in the `init` field of the SnsSummary.

# Tests

* Add two fields to createSummary helper.
* Remove the mocks of the getters and instead create a summary with the desired values.

# Todos

- [x] Add entry to changelog (if necessary).
