### PR TITLE
fix: Rm exit step

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -19,12 +19,3 @@ jobs:
         run: |
           git tag -f tip
           git push origin tags/tip -f
-  tag_pass:
-    needs: ["tag_tip"]
-    if: ${{ always() }}
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/needs_success
-        with:
-          needs: '${{ toJson(needs) }}'

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,7 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
-* Detailed values of the Neurons' Fund and direct participation in the project detai page.
+* Detailed values of the Neurons' Fund and direct participation in the project detail page.
 
 #### Deprecated
 #### Removed
@@ -36,6 +36,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * E2E test for ckBTC.
+* Fix erroneous failures in the `tip` tagging workflow when a PR is closed without merging.
 
 #### Changed
 


### PR DESCRIPTION
# Motivation
There is a GitHub action that tags the tip of master, so that there is an unstable release called `tip` that always has the latest artefacts.  This _should_ be run whenever a PR is merged to `main`.

Unfortunately GitHub does not have workflow triggers that correspond to "PR merged to main".  It _does_ have a trigger for when a PR to main is closed, so we use that and then tag main if the PR was closed by merging.  So far, so good.  All that works fine.

However there is a final job in the workflow that checks that all (one) previous jobs have succeeded.  That has no conditional, so it runs and fails if a PR was closed without merging.  [Example.](https://github.com/dfinity/nns-dapp/pull/3552)

We can either make that final job conditional in the same way as the tagging step or - just delete it.  It aggregates the exit codes of just one step.  So it isn't needed.  Why spin up a VM just for that?

# Changes
- Delete the exit code aggregation step in the tagging workflow.

# Tests
- [x] Open this PR against main, then close it and see what happens.  Looks good.  No code, no problem.

# Todos

- [x] Add entry to changelog (if necessary).
