### PR TITLE
GIX-1986: Make SnsTransactionModal page agnostic

### DIFF
--- a/frontend/src/lib/components/accounts/SnsAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/SnsAccountsFooter.svelte
@@ -8,6 +8,9 @@
   import { isNullish, nonNullish } from "@dfinity/utils";
   import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { toastsError } from "$lib/stores/toasts.store";
+  import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
+  import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
+  import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
 
   // TODO: Support adding subaccounts
   let modal: "NewTransaction" | undefined = undefined;
@@ -27,7 +30,12 @@
 </script>
 
 {#if modal === "NewTransaction"}
-  <SnsTransactionModal on:nnsClose={closeModal} />
+  <SnsTransactionModal
+    rootCanisterId={$selectedUniverseIdStore}
+    token={$snsTokenSymbolSelectedStore}
+    transactionFee={$snsSelectedTransactionFeeStore}
+    on:nnsClose={closeModal}
+  />
 {/if}
 
 {#if nonNullish($snsProjectAccountsStore)}

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -8,7 +8,7 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { snsTransferTokens } from "$lib/services/sns-accounts.services";
   import type { Account } from "$lib/types/account";
-  import { Spinner, Modal, type WizardStep } from "@dfinity/gix-components";
+  import { Modal, Spinner, type WizardStep } from "@dfinity/gix-components";
   import type { TransactionInit } from "$lib/types/transaction";
   import { TokenAmount, nonNullish, type Token } from "@dfinity/utils";
   import type { Principal } from "@dfinity/principal";

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -5,20 +5,21 @@
   import { toastsSuccess } from "$lib/stores/toasts.store";
   import type { NewTransaction } from "$lib/types/transaction";
   import TransactionModal from "$lib/modals/transaction/TransactionModal.svelte";
-  import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
-  import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { snsTransferTokens } from "$lib/services/sns-accounts.services";
-  import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
   import type { Account } from "$lib/types/account";
-  import { Modal, Spinner, type WizardStep } from "@dfinity/gix-components";
+  import { Spinner, Modal, type WizardStep } from "@dfinity/gix-components";
   import type { TransactionInit } from "$lib/types/transaction";
-  import { nonNullish } from "@dfinity/utils";
+  import { TokenAmount, nonNullish, type Token } from "@dfinity/utils";
+  import type { Principal } from "@dfinity/principal";
 
   // TODO: Refactor to expect as props the rootCanisterId, transactionFee and token.
   // This way we can reuse this component in a dashboard page.
   export let selectedAccount: Account | undefined = undefined;
   export let loadTransactions = false;
+  export let rootCanisterId: Principal;
+  export let token: Token | undefined;
+  export let transactionFee: TokenAmount | undefined;
 
   let transactionInit: TransactionInit = {
     sourceAccount: selectedAccount,
@@ -46,7 +47,7 @@
       destinationAddress,
       amount,
       loadTransactions,
-      rootCanisterId: $selectedUniverseIdStore,
+      rootCanisterId,
     });
 
     stopBusy("accounts");
@@ -58,14 +59,14 @@
   };
 </script>
 
-{#if $snsSelectedTransactionFeeStore !== undefined}
+{#if nonNullish(transactionFee) && nonNullish(token)}
   <TransactionModal
-    rootCanisterId={$selectedUniverseIdStore}
+    {rootCanisterId}
     on:nnsSubmit={transfer}
     on:nnsClose
     bind:currentStep
-    token={$snsTokenSymbolSelectedStore}
-    transactionFee={$snsSelectedTransactionFeeStore}
+    {token}
+    {transactionFee}
     {transactionInit}
   >
     <svelte:fragment slot="title"
@@ -73,7 +74,7 @@
     >
     <p slot="description" class="value no-margin">
       {replacePlaceholders($i18n.accounts.sns_transaction_description, {
-        $token: $snsTokenSymbolSelectedStore?.symbol ?? "",
+        $token: token.symbol,
       })}
     </p>
   </TransactionModal>

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -33,6 +33,7 @@
   import SnsBalancesObserver from "$lib/components/accounts/SnsBalancesObserver.svelte";
   import WalletPageHeader from "$lib/components/accounts/WalletPageHeader.svelte";
   import WalletPageHeading from "$lib/components/accounts/WalletPageHeading.svelte";
+  import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
 
   let showModal: "send" | undefined = undefined;
 
@@ -179,11 +180,14 @@
   </Footer>
 </Island>
 
-{#if showModal}
+{#if showModal && nonNullish($snsOnlyProjectStore) && nonNullish(token)}
   <SnsTransactionModal
     on:nnsClose={() => (showModal = undefined)}
     selectedAccount={$selectedAccountStore.account}
+    rootCanisterId={$snsOnlyProjectStore}
     loadTransactions
+    {token}
+    transactionFee={$snsSelectedTransactionFeeStore}
   />
 {/if}
 

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -180,7 +180,7 @@
   </Footer>
 </Island>
 
-{#if showModal && nonNullish($snsOnlyProjectStore) && nonNullish(token)}
+{#if showModal && nonNullish($snsOnlyProjectStore)}
   <SnsTransactionModal
     on:nnsClose={() => (showModal = undefined)}
     selectedAccount={$selectedAccountStore.account}

--- a/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
@@ -35,6 +35,7 @@ describe("SnsTransactionModal", () => {
 
   beforeEach(() => {
     resetIdentity();
+    snsAccountsStore.reset();
   });
 
   it("should transfer tokens", async () => {

--- a/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
@@ -1,25 +1,16 @@
-import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
-import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
 import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";
 import { snsTransferTokens } from "$lib/services/sns-accounts.services";
-import { authStore } from "$lib/stores/auth.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import type { Account } from "$lib/types/account";
-import { page } from "$mocks/$app/stores";
-import {
-  mockAuthStoreSubscribe,
-  mockPrincipal,
-} from "$tests/mocks/auth.store.mock";
+import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import {
   mockSnsAccountsStoreSubscribe,
   mockSnsMainAccount,
 } from "$tests/mocks/sns-accounts.mock";
-import { mockSnsSelectedTransactionFeeStoreSubscribe } from "$tests/mocks/transaction-fee.mock";
 import { testTransferTokens } from "$tests/utils/transaction-modal.test-utils";
-import type { Principal } from "@dfinity/principal";
+import { TokenAmount } from "@dfinity/utils";
 import { waitFor } from "@testing-library/svelte";
-import type { Subscriber } from "svelte/store";
 
 vi.mock("$lib/services/sns-accounts.services", () => {
   return {
@@ -28,33 +19,28 @@ vi.mock("$lib/services/sns-accounts.services", () => {
 });
 
 describe("SnsTransactionModal", () => {
+  const rootCanisterId = mockPrincipal;
+  const token = { name: "Test", symbol: "TST" };
+  const transactionFee = TokenAmount.fromE8s({
+    amount: BigInt(10_000),
+    token,
+  });
   const renderTransactionModal = (selectedAccount?: Account) =>
     renderModal({
       component: SnsTransactionModal,
       props: {
         selectedAccount,
+        rootCanisterId,
+        transactionFee,
+        token,
       },
     });
 
-  beforeAll(() =>
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe)
-  );
-
   beforeEach(() => {
+    resetIdentity();
     vi.spyOn(snsAccountsStore, "subscribe").mockImplementation(
-      mockSnsAccountsStoreSubscribe(mockPrincipal)
+      mockSnsAccountsStoreSubscribe(rootCanisterId)
     );
-    vi.spyOn(snsSelectedTransactionFeeStore, "subscribe").mockImplementation(
-      mockSnsSelectedTransactionFeeStoreSubscribe()
-    );
-    vi.spyOn(selectedUniverseIdStore, "subscribe").mockImplementation(
-      (run: Subscriber<Principal>): (() => void) => {
-        run(mockPrincipal);
-        return () => undefined;
-      }
-    );
-
-    page.mock({ data: { universe: mockPrincipal.toText() } });
   });
 
   it("should transfer tokens", async () => {

--- a/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
@@ -4,10 +4,7 @@ import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import type { Account } from "$lib/types/account";
 import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
-import {
-  mockSnsAccountsStoreSubscribe,
-  mockSnsMainAccount,
-} from "$tests/mocks/sns-accounts.mock";
+import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { testTransferTokens } from "$tests/utils/transaction-modal.test-utils";
 import { TokenAmount } from "@dfinity/utils";
 import { waitFor } from "@testing-library/svelte";
@@ -38,12 +35,15 @@ describe("SnsTransactionModal", () => {
 
   beforeEach(() => {
     resetIdentity();
-    vi.spyOn(snsAccountsStore, "subscribe").mockImplementation(
-      mockSnsAccountsStoreSubscribe(rootCanisterId)
-    );
   });
 
   it("should transfer tokens", async () => {
+    // Used to choose the source account
+    snsAccountsStore.setAccounts({
+      rootCanisterId,
+      accounts: [mockSnsMainAccount],
+      certified: true,
+    });
     const result = await renderTransactionModal();
 
     await testTransferTokens({ result });

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -24,6 +24,8 @@ import {
   mockSummary,
 } from "$tests/mocks/sns-projects.mock";
 import { mockSnsSelectedTransactionFeeStoreSubscribe } from "$tests/mocks/transaction-fee.mock";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { fireEvent, waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
 import WalletTest from "../pages/AccountsTest.svelte";
@@ -127,6 +129,7 @@ describe("Accounts", () => {
     });
 
     icpAccountsStore.setForTesting(mockAccountsStoreData);
+    resetSnsProjects();
   });
 
   it("should render NnsAccounts by default", () => {
@@ -207,6 +210,12 @@ describe("Accounts", () => {
     page.mock({
       data: { universe: mockSnsFullProject.rootCanisterId.toText() },
     });
+    setSnsProjects([
+      {
+        rootCanisterId: mockSnsFullProject.rootCanisterId,
+        lifecycle: SnsSwapLifecycle.Committed,
+      },
+    ]);
 
     transactionsFeesStore.setFee({
       rootCanisterId: mockSnsFullProject.rootCanisterId,

--- a/frontend/src/tests/utils/transaction-modal.test-utils.ts
+++ b/frontend/src/tests/utils/transaction-modal.test-utils.ts
@@ -74,6 +74,7 @@ export const testTransferTokens = async ({
     result,
     selectedNetwork,
     destinationAddress,
+    amount,
   });
 
   await waitFor(() => expect(getByTestId("transaction-step-2")).toBeTruthy());


### PR DESCRIPTION
# Motivation

Implement the MyTokens page.

In this PR, the SnsTransactionModal is decoupled from the page it is rendered. Instead, it receives the data needed as props.

# Changes

* Add props `rootCanisterId`, `token` and `transactionFee` to SnsTransactionModal.
* Pass the new props where the modal was used: SnsWallet and SnsAccountsFooter.

# Tests

* Pass props in the SnsTransactionModal and remove related mocks.
* Add sns setup in routes/Accounts.spec

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
