### PR TITLE
Bump ic-js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -569,9 +569,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "1.0.1-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-10-11.2.tgz",
-      "integrity": "sha512-Piv09LKmJbn2AJSpTOtReObcQPFGXWQ10fte8LjY3kCMm++uie8CeJmnQ87wVzDHbsOGDZYfSsl6LB70CMVKZw==",
+      "version": "1.0.1-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-10-17.1.tgz",
+      "integrity": "sha512-6KAWHhkvz8+EFTdvgqqZFjgl445DxOsko+os5qiBnIkYpgHrchiV6/ssEy1pkNnmdIkVyYR6lLXnN7ArDPoJow==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "1.0.0-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-11.2.tgz",
-      "integrity": "sha512-4jNCpYpdUEn5+OZueoPeAb9uraXaqW88qNsPHqUHWoNOVdT7/n+s8D3Hi4pOnxgzRn9CzQ+v+ZoRuRlKLSoPnw==",
+      "version": "1.0.0-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-17.1.tgz",
+      "integrity": "sha512-/8SzzwEjktsSsxCTfrGoI8e5oMh6GHD39eX4BKJEEKBdF3tEdGUSsjCW4vKvczpH/rzb37iACpabftyWo1VEgw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -610,9 +610,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "1.0.0-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-11.2.tgz",
-      "integrity": "sha512-ewr6Q0r06MmTVhvF+s4OiNCDjHJ+T3FBpKtwWn+Og96zud7naBXwMHPbNciTjUHQO5GoZ2kHg5CcoEPQ/8CEfA==",
+      "version": "1.0.0-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-17.1.tgz",
+      "integrity": "sha512-d2CM2yZJynWjGUYtZOh5KxsxPAuGYhUCDh6IYFWaSpZk2486NAl/8JkeL4r8mdK3zXZ8oGLHFA1lm93MHh6NDw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -636,9 +636,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "1.0.0-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-10-11.2.tgz",
-      "integrity": "sha512-wF1jaM3Ykmeh+R6X5znkc4Zo1ofqV+Ates9oJHqQAZszs600w/PpYinOROrDV2xL2LV6ROPhSECjkHYVYago1Q==",
+      "version": "1.0.0-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-10-17.1.tgz",
+      "integrity": "sha512-7CdJsINsAJCyqjTqtlUzS5iVhKTBGe0BogIxB45nDO/PtjhMhUg2AR4JJ2SJPxJ6Th1EgU0OVk/2arvHjY4L4w==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "1.0.0-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-10-11.2.tgz",
-      "integrity": "sha512-bATHdRW47FKBm34SjibIehrOpoddsaZCalBqmSHU50mt3SzGFac/fQkK0WTNyvlqvB3hYYdcqN5c+E0AOC1Olg==",
+      "version": "1.0.0-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-10-17.1.tgz",
+      "integrity": "sha512-6T3m7RDsPT/wWKTfYXwkekjDsI0o8xsoxvrPsV/YRgEYJdCm3IBeEAQDDsvx/YHzzZPpjn+kopT2nlWAWd304Q==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -659,9 +659,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "2.0.0-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-10-11.2.tgz",
-      "integrity": "sha512-AGwRTAXLFXDj86/+qfr7ZsPVENb1h+5BAoQ5tHDdRcHtH6ZojGM8VAOtmd1yuySlsgC9WTElWPOpVinTjy3Qpw==",
+      "version": "2.0.0-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-10-17.1.tgz",
+      "integrity": "sha512-038eMxjXK2Z8oLPWA/imkOGwGiNMCTIMncl6v4XiB4CntKsOjAa9P/HNIxFWX/ddhOll2vhFOcX8BzhLQiMKDw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -676,9 +676,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.0-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-11.2.tgz",
-      "integrity": "sha512-sCARWq+ZVF0ezThw4a2UnRH9C+v/RQ11B3owc0yrI1cMgUIHwnpqWTTzlMXljupSlkvTC4fmwjhRGNYh2Div4Q==",
+      "version": "1.0.0-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-17.1.tgz",
+      "integrity": "sha512-CWyfW/vKciCKNf0xdzp8f+b3pEJ3dg2zVSjZqwTrBRXXEP2HtjFvlioSolMQASmGoLqf+cp2nn+wXG1jlkmptA==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -692,9 +692,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "1.0.1-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-10-11.2.tgz",
-      "integrity": "sha512-QjVy36o4KAcmEif0pY801S9puHvOD/FWxdz7Jmi0gbBQnFe/wdnDpNO/FvsIkZHbsc0LSWvK95RpgIX9Z4I6Mg==",
+      "version": "1.0.1-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-10-17.1.tgz",
+      "integrity": "sha512-WW9TagKYbbG9X4wLMLq38q33jJW39O4sYRZuZx+lk3SuTfJqaieF3LQ+dsYwxO1Q8bP4qQg4q/2pA5lXCYKT1g==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -707,9 +707,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "1.0.0-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-11.2.tgz",
-      "integrity": "sha512-HhzC4x4F8r06WDZLy99/A1p+GKuQSpNGvZMf6V8Q2WpDAs8t5Mit5mn/eFmCQoSazOcW/ifAM64lWaAW3C5e2A==",
+      "version": "1.0.0-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-17.1.tgz",
+      "integrity": "sha512-cEr8RWK/jKqp4jQKBd3DknzjzJo0I8vDX7GDjTDg4++JH/qO+124Dh4Ga2bAmF0/LK/3789u87/5DTiM3uS/Cw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7361,9 +7361,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "1.0.1-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-10-11.2.tgz",
-      "integrity": "sha512-Piv09LKmJbn2AJSpTOtReObcQPFGXWQ10fte8LjY3kCMm++uie8CeJmnQ87wVzDHbsOGDZYfSsl6LB70CMVKZw==",
+      "version": "1.0.1-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-10-17.1.tgz",
+      "integrity": "sha512-6KAWHhkvz8+EFTdvgqqZFjgl445DxOsko+os5qiBnIkYpgHrchiV6/ssEy1pkNnmdIkVyYR6lLXnN7ArDPoJow==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7371,9 +7371,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "1.0.0-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-11.2.tgz",
-      "integrity": "sha512-4jNCpYpdUEn5+OZueoPeAb9uraXaqW88qNsPHqUHWoNOVdT7/n+s8D3Hi4pOnxgzRn9CzQ+v+ZoRuRlKLSoPnw==",
+      "version": "1.0.0-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-17.1.tgz",
+      "integrity": "sha512-/8SzzwEjktsSsxCTfrGoI8e5oMh6GHD39eX4BKJEEKBdF3tEdGUSsjCW4vKvczpH/rzb37iACpabftyWo1VEgw==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7387,9 +7387,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "1.0.0-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-11.2.tgz",
-      "integrity": "sha512-ewr6Q0r06MmTVhvF+s4OiNCDjHJ+T3FBpKtwWn+Og96zud7naBXwMHPbNciTjUHQO5GoZ2kHg5CcoEPQ/8CEfA==",
+      "version": "1.0.0-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-17.1.tgz",
+      "integrity": "sha512-d2CM2yZJynWjGUYtZOh5KxsxPAuGYhUCDh6IYFWaSpZk2486NAl/8JkeL4r8mdK3zXZ8oGLHFA1lm93MHh6NDw==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7403,30 +7403,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "1.0.0-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-10-11.2.tgz",
-      "integrity": "sha512-wF1jaM3Ykmeh+R6X5znkc4Zo1ofqV+Ates9oJHqQAZszs600w/PpYinOROrDV2xL2LV6ROPhSECjkHYVYago1Q==",
+      "version": "1.0.0-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-10-17.1.tgz",
+      "integrity": "sha512-7CdJsINsAJCyqjTqtlUzS5iVhKTBGe0BogIxB45nDO/PtjhMhUg2AR4JJ2SJPxJ6Th1EgU0OVk/2arvHjY4L4w==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "1.0.0-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-10-11.2.tgz",
-      "integrity": "sha512-bATHdRW47FKBm34SjibIehrOpoddsaZCalBqmSHU50mt3SzGFac/fQkK0WTNyvlqvB3hYYdcqN5c+E0AOC1Olg==",
+      "version": "1.0.0-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-10-17.1.tgz",
+      "integrity": "sha512-6T3m7RDsPT/wWKTfYXwkekjDsI0o8xsoxvrPsV/YRgEYJdCm3IBeEAQDDsvx/YHzzZPpjn+kopT2nlWAWd304Q==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "2.0.0-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-10-11.2.tgz",
-      "integrity": "sha512-AGwRTAXLFXDj86/+qfr7ZsPVENb1h+5BAoQ5tHDdRcHtH6ZojGM8VAOtmd1yuySlsgC9WTElWPOpVinTjy3Qpw==",
+      "version": "2.0.0-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-10-17.1.tgz",
+      "integrity": "sha512-038eMxjXK2Z8oLPWA/imkOGwGiNMCTIMncl6v4XiB4CntKsOjAa9P/HNIxFWX/ddhOll2vhFOcX8BzhLQiMKDw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.0-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-11.2.tgz",
-      "integrity": "sha512-sCARWq+ZVF0ezThw4a2UnRH9C+v/RQ11B3owc0yrI1cMgUIHwnpqWTTzlMXljupSlkvTC4fmwjhRGNYh2Div4Q==",
+      "version": "1.0.0-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-17.1.tgz",
+      "integrity": "sha512-CWyfW/vKciCKNf0xdzp8f+b3pEJ3dg2zVSjZqwTrBRXXEP2HtjFvlioSolMQASmGoLqf+cp2nn+wXG1jlkmptA==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7440,17 +7440,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "1.0.1-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-10-11.2.tgz",
-      "integrity": "sha512-QjVy36o4KAcmEif0pY801S9puHvOD/FWxdz7Jmi0gbBQnFe/wdnDpNO/FvsIkZHbsc0LSWvK95RpgIX9Z4I6Mg==",
+      "version": "1.0.1-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-10-17.1.tgz",
+      "integrity": "sha512-WW9TagKYbbG9X4wLMLq38q33jJW39O4sYRZuZx+lk3SuTfJqaieF3LQ+dsYwxO1Q8bP4qQg4q/2pA5lXCYKT1g==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "1.0.0-next-2023-10-11.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-11.2.tgz",
-      "integrity": "sha512-HhzC4x4F8r06WDZLy99/A1p+GKuQSpNGvZMf6V8Q2WpDAs8t5Mit5mn/eFmCQoSazOcW/ifAM64lWaAW3C5e2A==",
+      "version": "1.0.0-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-17.1.tgz",
+      "integrity": "sha512-cEr8RWK/jKqp4jQKBd3DknzjzJo0I8vDX7GDjTDg4++JH/qO+124Dh4Ga2bAmF0/LK/3789u87/5DTiM3uS/Cw==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/lib/utils/anonymize.utils.ts
+++ b/frontend/src/lib/utils/anonymize.utils.ts
@@ -134,6 +134,7 @@ export const anonymizeNeuronInfo = async (
     votingPower,
     ageSeconds,
     fullNeuron,
+    isGenesis,
   } = neuron;
 
   return {
@@ -147,6 +148,7 @@ export const anonymizeNeuronInfo = async (
     votingPower: await anonymizeAmount(votingPower),
     ageSeconds,
     fullNeuron: await anonymizeFullNeuron(fullNeuron),
+    isGenesis,
   };
 };
 
@@ -191,6 +193,7 @@ export const anonymizeFullNeuron = async (
     dissolveState,
     followees,
     spawnAtTimesSeconds,
+    isGenesis,
   } = neuron;
 
   return {
@@ -214,6 +217,7 @@ export const anonymizeFullNeuron = async (
     spawnAtTimesSeconds,
     dissolveState,
     followees: await mapPromises(followees, anonymizeFollowees),
+    isGenesis,
   };
 };
 


### PR DESCRIPTION
# Motivation

We want to be able to use `retrieveBTCWithApproval` on the ckBTC minter canister, which was added to ic-js in https://github.com/dfinity/ic-js/pull/454.

# Changes

1. Updated `frontend/package-lock.json` by running `npm run upgrade:next`.
2. In `frontend/src/lib/utils/anonymize.utils.ts` added `isGenesis` field to return value of `anonymizeNeuronInfo` and `anonymizeFullNeuron` to match the new types for `Neuron` and `NeuronInfo`, changed in https://github.com/dfinity/ic-js/pull/453.

# Tests

Manually created an anonymized log by clicking 6 times and typing `c`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary