### PR TITLE
Feat: change SnsWallet

### DIFF
--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -87,6 +87,7 @@ describe("SnsWallet", () => {
     let resolve;
 
     beforeEach(() => {
+      resolve = undefined;
       vi.spyOn(snsLedgerApi, "getSnsAccounts").mockImplementation(() => {
         return new Promise<Account[]>((r) => {
           resolve = r;

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -99,7 +99,7 @@ describe("SnsWallet", () => {
 
       expect(queryByTestId("spinner")).toBeInTheDocument();
 
-      await waitFor(() => expect(resolve).not.toBeUndefined());
+      await waitFor(() => expect(resolve).toBeDefined());
 
       resolve([mockSnsMainAccount]);
       await runResolvedPromises();


### PR DESCRIPTION
# Motivation

Remove services and store mocks in SnsWallet test to improve testing.

This will allow me to then test a transaction and check that the desired data is passed to the api.

# Changes

* Remove all services and store mocks in SnsWallet.spec. Instead, mock the api layer.

# Tests

* Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
