### PR TITLE
GIX-1991: Fix low commitment progress bar

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -25,6 +25,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Add "Finalizing" status in projects of the Launchpad.
+* Fix UI bug when commitment was very low.
 
 #### Security
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -596,9 +596,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "2.7.0-next-2023-10-16.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.7.0-next-2023-10-16.2.tgz",
-      "integrity": "sha512-VT23zT5W10AF/touBYJhSqYE7NLvXSLVIn4JCE8WuGOGB8AfVUnP2UuZDVohPB6RuB7WHAlv3NkBh8GBVDax+w==",
+      "version": "2.7.0-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.7.0-next-2023-10-17.1.tgz",
+      "integrity": "sha512-Dl5AuhHDe7pRKiWAsDiDawXKkOX3i8KC/ZTpX5+mzV8XEMPnKMkKQqwF37qoLDf+RwtZWt87pwAON/L4aKeQ1A==",
       "dependencies": {
         "dompurify": "^3.0.4",
         "html5-qrcode": "^2.3.8",
@@ -7377,9 +7377,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "2.7.0-next-2023-10-16.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.7.0-next-2023-10-16.2.tgz",
-      "integrity": "sha512-VT23zT5W10AF/touBYJhSqYE7NLvXSLVIn4JCE8WuGOGB8AfVUnP2UuZDVohPB6RuB7WHAlv3NkBh8GBVDax+w==",
+      "version": "2.7.0-next-2023-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-2.7.0-next-2023-10-17.1.tgz",
+      "integrity": "sha512-Dl5AuhHDe7pRKiWAsDiDawXKkOX3i8KC/ZTpX5+mzV8XEMPnKMkKQqwF37qoLDf+RwtZWt87pwAON/L4aKeQ1A==",
       "requires": {
         "dompurify": "^3.0.4",
         "html5-qrcode": "^2.3.8",


### PR DESCRIPTION
# Motivation

There was a UI bug when the commitment was very low.

This was fixed in https://github.com/dfinity/gix-components/pull/312

# Changes

## Automatic changes

* Changes in package.lock.json by running `npm run update:gix`.

# Tests

Still passing.

# Todos

- [x] Add entry to changelog (if necessary).
