### PR TITLE
List playwright results

### DIFF
--- a/.github/actions/test-e2e/action.yml
+++ b/.github/actions/test-e2e/action.yml
@@ -51,6 +51,14 @@ runs:
         export PLAYWRIGHT_BASE_URL="$(../scripts/dfx-canister-url nns-dapp)"
         PLAYWRIGHT_FILES="$(ls src/tests/e2e/${{ inputs.test_filter }} | cat | split -n r/${{ inputs.shard_number }}/${{ inputs.shard_count }})"
         npm run test-e2e -- --update-snapshots ${PLAYWRIGHT_FILES:-}
+    - name: List Playwright results
+      if: ${{ failure() }}
+      shell: bash
+      # The playwright-failure-results artifact often ends up containing nothing
+      # but index.html. List the files we expect to be there to pin down what's
+      # going wrong.
+      run: |
+        find frontend/playwright-*
     - name: Upload Playwright results
       uses: actions/upload-artifact@v3
       if: ${{ failure() }}


### PR DESCRIPTION
# Motivation

I've noticed many times that the playwright-failure-results artifact contains only an index.html file and nothing else, which makes it useless for debugging.
When deliberately making an e2e fail, I was not able to reproduce this.
I'm not sure if Playwright fails to generate the right files or if GitHub fails to upload them.

# Changes

List the files generated by Playwright, so that we compare the logs with the artifact to see if the problem is with Playwright or with Github.

# Tests

I made a test fail deliberately and checked the GitHub Actions log.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary