### PR TITLE
Spellcheck changelog

### DIFF
--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -29,3 +29,5 @@ subaccount
 snsdemo
 AMD64
 Zondax
+E2E
+Vitest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,6 +46,8 @@ jobs:
           cargo install --target x86_64-unknown-linux-gnu cargo-spellcheck
       - name: Spellcheck Rust
         run: cargo spellcheck
+      - name: Spellcheck changelog
+        run: scripts/spellcheck-changelog
   cargo-tests:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,7 +18,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Detailed values of the Neurons' Fund and direct participation in the project detail page.
 * Update proposal info icons position to improve the UX.
-* Detailed values of the Neurons' Fund and direct participation in the project detai page.
 * Improve the indicator of the minimum commitment in the project status.
 
 #### Deprecated

--- a/scripts/spellcheck-changelog
+++ b/scripts/spellcheck-changelog
@@ -23,9 +23,8 @@ source "$(clap.build)"
 cargo spellcheck check CHANGELOG-Nns-Dapp-unreleased.md
 
 # For the aggregator, check everything before the first proposal:
-for file in CHANGELOG-Sns_Aggregator.md; do
-  unreleased="$(mktemp --suffix=.md)" # File with unreleased changelog entries.
-  sed -E '/^#+.*Proposal/q' "$file" >"$unreleased"
-  cargo spellcheck check "$unreleased" | awk -v tmp="$unreleased" -v orig="$file" '{gsub(tmp,orig,$0);print}'
-  rm "$unreleased"
-done
+file=CHANGELOG-Sns_Aggregator.md
+unreleased="$(mktemp --suffix=.md)" # File with unreleased changelog entries.
+sed -E '/^#+.*Proposal/q' "$file" >"$unreleased"
+cargo spellcheck check "$unreleased" | awk -v tmp="$unreleased" -v orig="$file" '{gsub(tmp,orig,$0);print}'
+rm "$unreleased"

--- a/scripts/spellcheck-changelog
+++ b/scripts/spellcheck-changelog
@@ -19,9 +19,13 @@ source "$SOURCE_DIR/clap.bash"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-for file in CHANGELOG-*; do
+# For NNS-dapp, check the 'unreleased' file:
+cargo spellcheck check CHANGELOG-Nns-Dapp-unreleased.md
+
+# For the aggregator, check everything before the first proposal:
+for file in CHANGELOG-Sns_Aggregator.md; do
   unreleased="$(mktemp --suffix=.md)" # File with unreleased changelog entries.
-  sed -E '/^#+ *Proposal/q' "$file" >"$unreleased"
+  sed -E '/^#+.*Proposal/q' "$file" >"$unreleased"
   cargo spellcheck check "$unreleased" | awk -v tmp="$unreleased" -v orig="$file" '{gsub(tmp,orig,$0);print}'
   rm "$unreleased"
 done


### PR DESCRIPTION
# Motivation
Fixing a typo in a changelog entry can cause the line to be duplicated.  Better to get it right first time, every time.

# Changes
* Update the `spellcheck-changelog` so that it runs against the new "unreleased" NNS-dapp changelog file.
* Run `spellcheck-changelog` in CI.
* Make corrections and add dictionary entries as required for the test to pass.

# Tests
See CI

# Todos

- [x] Add entry to changelog (if necessary).
