### PR TITLE
Add approveTransfer to icrc-ledger API

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -14,6 +14,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+* Added `approveTransfer` in icrc-ledger API.
+
 #### Changed
 
 * Detailed values of the Neurons' Fund and direct participation in the project detail page.

--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -136,6 +136,51 @@ export const executeIcrcTransfer = async ({
     ...rest,
   });
 
+export const approveTransfer = async ({
+  identity,
+  canisterId,
+  amount,
+  spender,
+  fromSubaccount,
+  fee,
+  expiresAt,
+  createdAt,
+  expectedAllowance,
+}: {
+  identity: Identity;
+  canisterId: Principal;
+  amount: bigint;
+  spender: Principal;
+  fromSubaccount?: Uint8Array;
+  fee?: bigint;
+  expiresAt?: bigint;
+  createdAt?: bigint;
+  expectedAllowance?: bigint;
+}): Promise<IcrcBlockIndex> => {
+  logWithTimestamp("Approving transfer: call...");
+
+  const {
+    canister: { approve },
+  } = await icrcLedgerCanister({ identity, canisterId });
+
+  const blockIndex = await approve({
+    amount,
+    spender: {
+      owner: spender,
+      subaccount: [],
+    },
+    from_subaccount: fromSubaccount,
+    fee,
+    expires_at: expiresAt,
+    created_at_time: createdAt ?? nowInBigIntNanoSeconds(),
+    expected_allowance: expectedAllowance,
+  });
+
+  logWithTimestamp("Approving transfer: call...");
+
+  return blockIndex;
+};
+
 export const icrcLedgerCanister = async ({
   identity,
   canisterId,

--- a/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
@@ -1,5 +1,6 @@
 import * as agent from "$lib/api/agent.api";
 import {
+  approveTransfer,
   executeIcrcTransfer,
   getIcrcAccount,
   getIcrcToken,
@@ -13,12 +14,14 @@ import {
 } from "$tests/mocks/sns-projects.mock";
 import type { HttpAgent } from "@dfinity/agent";
 import { IcrcLedgerCanister } from "@dfinity/ledger-icrc";
+import { Principal } from "@dfinity/principal";
 import { mock } from "vitest-mock-extended";
 
 describe("icrc-ledger api", () => {
   const ledgerCanisterMock = mock<IcrcLedgerCanister>();
 
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.spyOn(IcrcLedgerCanister, "create").mockImplementation(
       () => ledgerCanisterMock
     );
@@ -127,6 +130,80 @@ describe("icrc-ledger api", () => {
       });
 
       expect(transferSpy).toBeCalled();
+    });
+  });
+
+  describe("approveTransfer", () => {
+    it("successfully calls approve api", async () => {
+      const expectedBlockIndex = BigInt(123456);
+      const approveSpy =
+        ledgerCanisterMock.approve.mockResolvedValue(expectedBlockIndex);
+      const spenderPrincipal = Principal.fromHex("123abc");
+      const amount = BigInt(13_000_000);
+      const nowMillis = 123456789;
+      vi.setSystemTime(nowMillis);
+
+      const actualBlockIndex = await approveTransfer({
+        identity: mockIdentity,
+        canisterId: CKBTC_LEDGER_CANISTER_ID,
+        amount,
+        spender: spenderPrincipal,
+      });
+
+      expect(actualBlockIndex).toEqual(expectedBlockIndex);
+      expect(approveSpy).toBeCalledTimes(1);
+      expect(approveSpy).toBeCalledWith({
+        amount,
+        spender: {
+          owner: spenderPrincipal,
+          subaccount: [],
+        },
+        expected_allowance: undefined,
+        expires_at: undefined,
+        created_at_time: BigInt(nowMillis * 1_000_000),
+        fee: undefined,
+        from_subaccount: undefined,
+      });
+    });
+
+    it("successfully passes optional params", async () => {
+      const expectedBlockIndex = BigInt(123456);
+      const approveSpy =
+        ledgerCanisterMock.approve.mockResolvedValue(expectedBlockIndex);
+      const spenderPrincipal = Principal.fromHex("123abc");
+      const amount = BigInt(13_000_000);
+      const expectedAllowance = BigInt(135_000_000);
+      const expiresAt = BigInt(123999000000);
+      const createdAt = BigInt(123456000000);
+      const fee = BigInt(17_000);
+      const fromSubaccount = new Uint8Array([1, 9, 3]);
+
+      const actualBlockIndex = await approveTransfer({
+        identity: mockIdentity,
+        canisterId: CKBTC_LEDGER_CANISTER_ID,
+        amount,
+        spender: spenderPrincipal,
+        expectedAllowance,
+        expiresAt,
+        createdAt,
+        fee,
+        fromSubaccount,
+      });
+
+      expect(actualBlockIndex).toEqual(expectedBlockIndex);
+      expect(approveSpy).toBeCalledTimes(1);
+      expect(approveSpy).toBeCalledWith({
+        amount,
+        spender: {
+          owner: spenderPrincipal,
+          subaccount: [],
+        },
+        expected_allowance: expectedAllowance,
+        expires_at: expiresAt,
+        created_at_time: createdAt,
+        fee,
+        from_subaccount: fromSubaccount,
+      });
     });
   });
 });


### PR DESCRIPTION
# Motivation

We want to use ICRC-2 (transfer approval) for ckBTC withdrawals.

# Changes

Add `approveTransfer` to the ICRC ledger API layer.

# Tests

Added unit tests with and without optional params.
Manually tested in another branch for actual ckBTC withdrawal to mock bitcoin canister.

# Todos

- [x] Add entry to changelog (if necessary).
