### PR TITLE
Add --host to scripts/dfx-snapshot-start

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -42,6 +42,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Documentation for the proposals payload renderer.
 * E2E test for ckBTC.
 * Fix erroneous failures in the `tip` tagging workflow when a PR is closed without merging.
+* Add --host flag to dfx-snapshot-start.
 
 #### Changed
 

--- a/scripts/dfx-snapshot-start
+++ b/scripts/dfx-snapshot-start
@@ -22,6 +22,7 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=s long=snapshot desc="The snapshot .zip or .tar.xz file" variable=SNAPSHOT_ARCHIVE default="snapshot.tar.xz"
 clap.define short=c long=clean desc="Extract a clean state from the .zip file, even if a directory with extracted state exists" variable=CLEAN nargs=0 default="false"
+clap.define long=host desc="Passed to dfx start as --host" variable=DFX_HOST
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -62,6 +63,10 @@ echo "*  If the state was generated on a different type of machine, then  *"
 echo "*  starting the replica may just hang after a panic.                *"
 echo "*                                                                   *"
 echo "*********************************************************************"
-dfx start
+
+if [ "${DFX_HOST:-}" ]; then
+  DFX_ARGS=("--host" "$DFX_HOST")
+fi
+dfx start "${DFX_ARGS[@]}"
 
 # The trap set above will restore the state before this script exits.


### PR DESCRIPTION
# Motivation

We are considering using DevEnv instead of testnet to test release candidates.
To make a local replica accessible remotely, one needs to pass `--host 0.0.0.0:8080` to `dfx`.

# Changes

Add flag `--host` to `dfx-snapshot-start`. If set, the flag is passed on to `dfx`.

# Tests

I ran `scripts/dfx-snapshot-start -s ~/snapshots/pinned-2023-10-05.tar.xz --host 0.0.0.0:8080` on my DevEnv, and it is accessible from https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/
If I don't pass the flag, it gives "502 Bad Gateway".

# Todos

- [x] Add entry to changelog (if necessary).
