### PR TITLE
Fix: Changelog entry

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,7 +16,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
-* Detailed values of the Neurons' Fund and direct participation in the project detail page.
 * Update proposal info icons position to improve the UX.
 * Improve the indicator of the minimum commitment in the project status.
 
@@ -33,6 +32,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Not Published
 
 * New feature flag `ENABLE_MY_TOKENS`.
+* Detailed values of the Neurons' Fund and direct participation in the project detail page.
 
 ### Operations
 


### PR DESCRIPTION
# Motivation

There is an entry in the "Changed" section, but it hasn't yet been released from the backend.

Therefore, I'm moving it to "Unreleased".

# Changes

* Changelog.

# Tests

Only docs changes.

# Todos

- [ ] Add entry to changelog (if necessary).
