### PR TITLE
GIX-1992: SnsReceiveModal page agnostic

### DIFF
--- a/frontend/src/lib/components/accounts/ReceiveAddressQRCode.svelte
+++ b/frontend/src/lib/components/accounts/ReceiveAddressQRCode.svelte
@@ -42,8 +42,10 @@
   </article>
 
   {#if addressSelected && qrCodeRendered}
-    <div class="address-block">
-      <p class="label no-margin"><slot name="address-label" /></p>
+    <div data-tid="qr-address-label" class="address-block">
+      <p class="label no-margin">
+        <slot name="address-label" />
+      </p>
       <div class="address">
         <span class="value" data-tid="qrcode-display-address">{address}</span>
         <Copy value={address ?? ""} />

--- a/frontend/src/lib/components/accounts/ReceiveAddressQRCode.svelte
+++ b/frontend/src/lib/components/accounts/ReceiveAddressQRCode.svelte
@@ -43,9 +43,7 @@
 
   {#if addressSelected && qrCodeRendered}
     <div data-tid="qr-address-label" class="address-block">
-      <p class="label no-margin">
-        <slot name="address-label" />
-      </p>
+      <p class="label no-margin"><slot name="address-label" /></p>
       <div class="address">
         <span class="value" data-tid="qrcode-display-address">{address}</span>
         <Copy value={address ?? ""} />

--- a/frontend/src/lib/modals/accounts/AccountsModals.svelte
+++ b/frontend/src/lib/modals/accounts/AccountsModals.svelte
@@ -7,6 +7,9 @@
   import NnsReceiveModal from "$lib/modals/accounts/NnsReceiveModal.svelte";
   import { nonNullish } from "@dfinity/utils";
   import SnsReceiveModal from "$lib/modals/accounts/SnsReceiveModal.svelte";
+  import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
+  import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
+  import IC_LOGO from "$lib/assets/icp.svg";
 
   let modal: AccountsModal | undefined;
   const close = () => (modal = undefined);
@@ -25,5 +28,11 @@
 {/if}
 
 {#if type === "sns-receive" && nonNullish(data)}
-  <SnsReceiveModal on:nnsClose={close} {data} />
+  <SnsReceiveModal
+    on:nnsClose={close}
+    {data}
+    universeId={$snsOnlyProjectStore}
+    logo={$selectedUniverseStore?.summary?.metadata.logo ?? IC_LOGO}
+    tokenSymbol={$selectedUniverseStore?.summary?.token.symbol}
+  />
 {/if}

--- a/frontend/src/lib/modals/accounts/SnsReceiveModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsReceiveModal.svelte
@@ -3,29 +3,20 @@
   import type { Account } from "$lib/types/account";
   import ReceiveModal from "$lib/modals/accounts/ReceiveModal.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import IC_LOGO from "$lib/assets/icp.svg";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
   import type { UniverseCanisterId } from "$lib/types/universe";
-  import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { nonNullish } from "@dfinity/utils";
 
   export let data: AccountsReceiveModalData;
+  export let universeId: UniverseCanisterId | undefined;
+  export let tokenSymbol: string | undefined;
+  export let logo: string;
 
   let account: Account | undefined;
   let reload: (() => Promise<void>) | undefined;
   let canSelectAccount: boolean;
 
   $: ({ account, reload, canSelectAccount } = data);
-
-  let universeId: UniverseCanisterId | undefined;
-  $: universeId = $snsOnlyProjectStore;
-
-  let logo: string;
-  $: logo = $selectedUniverseStore?.summary?.metadata.logo ?? IC_LOGO;
-
-  let tokenSymbol: string | undefined;
-  $: tokenSymbol = $selectedUniverseStore?.summary?.token.symbol;
 </script>
 
 {#if nonNullish(universeId) && nonNullish(tokenSymbol)}

--- a/frontend/src/tests/lib/modals/accounts/SnsReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/SnsReceiveModal.spec.ts
@@ -3,7 +3,6 @@ import type { Account } from "$lib/types/account";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
-import { waitFor } from "@testing-library/svelte";
 
 describe("SnsReceiveModal", () => {
   const reloadSpy = vi.fn();
@@ -39,9 +38,7 @@ describe("SnsReceiveModal", () => {
       tokenSymbol,
     });
 
-    await waitFor(() =>
-      expect(getByTestId("logo").getAttribute("alt")).toEqual(tokenSymbol)
-    );
+    expect(getByTestId("logo").getAttribute("alt")).toEqual(tokenSymbol);
   });
 
   it("should render the address label of the sns account", async () => {

--- a/frontend/src/tests/lib/modals/accounts/SnsReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/SnsReceiveModal.spec.ts
@@ -1,0 +1,57 @@
+import SnsReceiveModal from "$lib/modals/accounts/SnsReceiveModal.svelte";
+import type { Account } from "$lib/types/account";
+import { renderModal } from "$tests/mocks/modal.mock";
+import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { waitFor } from "@testing-library/svelte";
+
+describe("SnsReceiveModal", () => {
+  const reloadSpy = vi.fn();
+  const tokenSymbol = "TST";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderReceiveModal = ({
+    account = mockSnsMainAccount,
+    tokenSymbol,
+  }: {
+    account?: Account;
+    tokenSymbol: string;
+  }) =>
+    renderModal({
+      component: SnsReceiveModal,
+      props: {
+        data: {
+          account,
+          reload: reloadSpy,
+          canSelectAccount: false,
+        },
+        universeId: rootCanisterIdMock,
+        tokenSymbol,
+        logo: "logo.svg",
+      },
+    });
+
+  it("should render the sns logo", async () => {
+    const { getByTestId } = await renderReceiveModal({
+      tokenSymbol,
+    });
+
+    await waitFor(() =>
+      expect(getByTestId("logo").getAttribute("alt")).toEqual(tokenSymbol)
+    );
+  });
+
+  it("should render the address label of the sns account", async () => {
+    const { queryByTestId } = await renderReceiveModal({
+      tokenSymbol,
+      account: mockSnsMainAccount,
+    });
+
+    expect(queryByTestId("qr-address-label").textContent.trim()).toBe(
+      `${tokenSymbol} Address ${mockSnsMainAccount.identifier}`
+    );
+  });
+});

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -64,6 +64,7 @@ describe("SnsWallet", () => {
   const rootCanisterId = rootCanisterIdMock;
   const rootCanisterIdText = rootCanisterId.toText();
   const fee = 10_000n;
+  const projectName = "Tetris";
 
   beforeEach(() => {
     resetIdentity();
@@ -82,6 +83,7 @@ describe("SnsWallet", () => {
       {
         rootCanisterId,
         lifecycle: SnsSwapLifecycle.Committed,
+        projectName,
       },
     ]);
     page.mock({ data: { universe: rootCanisterIdText } });
@@ -127,7 +129,7 @@ describe("SnsWallet", () => {
 
       const titleRow = getByTestId("universe-page-summary-component");
 
-      expect(titleRow.textContent.trim()).toBe("Catalyze");
+      expect(titleRow.textContent.trim()).toBe(projectName);
     });
 
     it("should render transactions", async () => {
@@ -224,7 +226,7 @@ describe("SnsWallet", () => {
       testComponent: SnsWallet,
     };
 
-    it("should open receive modal", async () => {
+    it("should open receive modal with sns logo", async () => {
       const result = render(AccountsTest, { props: modalProps });
 
       await runResolvedPromises();
@@ -234,6 +236,10 @@ describe("SnsWallet", () => {
       const { getByTestId } = result;
 
       expect(getByTestId("receive-modal")).not.toBeNull();
+
+      expect(getByTestId("logo").getAttribute("alt")).toEqual(
+        `${projectName} project logo`
+      );
     });
 
     it("should reload account after finish receiving tokens", async () => {

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -252,6 +252,10 @@ describe("Accounts", () => {
     await waitFor(() =>
       expect(container.querySelector("div.modal")).not.toBeNull()
     );
+
+    expect(getByTestId("logo").getAttribute("alt")).toEqual(
+      `${mockSnsFullProject.summary.metadata.name} project logo`
+    );
   });
 
   it("should load Sns accounts balances", async () => {


### PR DESCRIPTION
# Motivation

Create a page for all tokens.

In this PR, make the SnsReceiveModal agnostic of the page where it's rendered.

# Changes

* Add props to SnsReceiveModal instead of relying stores that rely in the pageStore.
* Pass those props from AccountsModal, which is coupled with the page where it's rendered.

# Tests

* Add a test in SnsWallet and Accounts route that the receive modal renders the logo of the project.
* Add missing test file for SnsReceiveModal.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.

