### PR TITLE
Add retrieveBtcWithApproval to ckbtc-minter API

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -14,8 +14,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
-* Added `approveTransfer` in icrc-ledger API.
-
 #### Changed
 
 * Update proposal info icons position to improve the UX.
@@ -35,6 +33,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 * New feature flag `ENABLE_MY_TOKENS`.
 * Detailed values of the Neurons' Fund and direct participation in the project detail page.
+* Added `approveTransfer` in icrc-ledger API.
+* Added `retrieveBtcWithApproval` in ckbtc-minter API.
 
 ### Operations
 

--- a/frontend/src/lib/api/ckbtc-minter.api.ts
+++ b/frontend/src/lib/api/ckbtc-minter.api.ts
@@ -101,6 +101,30 @@ export const retrieveBtc = async ({
   return result;
 };
 
+export const retrieveBtcWithApproval = async ({
+  identity,
+  canisterId,
+  ...params
+}: {
+  identity: Identity;
+  canisterId: Principal;
+  address: string;
+  amount: bigint;
+  fromSubaccount?: Uint8Array;
+}): Promise<RetrieveBtcOk> => {
+  logWithTimestamp("Retrieve BTC with approval: call...");
+
+  const {
+    canister: { retrieveBtcWithApproval: retrieveBtcWithApprovalApi },
+  } = await ckBTCMinterCanister({ identity, canisterId });
+
+  const result = await retrieveBtcWithApprovalApi(params);
+
+  logWithTimestamp("Retrieve BTC with approval: done");
+
+  return result;
+};
+
 export const estimateFee = async ({
   identity,
   canisterId,

--- a/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
+++ b/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
@@ -182,10 +182,11 @@ describe("ckbtc-minter api", () => {
         }
       );
 
-      const call = () => retrieveBtcWithApproval({
-        ...params,
-        ...retrieveWithApprovalParams,
-      });
+      const call = () =>
+        retrieveBtcWithApproval({
+          ...params,
+          ...retrieveWithApprovalParams,
+        });
 
       expect(call).rejects.toThrowError();
     });

--- a/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
+++ b/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
@@ -5,6 +5,7 @@ import {
   getWithdrawalAccount,
   minterInfo,
   retrieveBtc,
+  retrieveBtcWithApproval,
   updateBalance,
 } from "$lib/api/ckbtc-minter.api";
 import { CKBTC_MINTER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
@@ -142,6 +143,46 @@ describe("ckbtc-minter api", () => {
       });
 
       const call = () => retrieveBtc(retrieveParams);
+
+      expect(call).rejects.toThrowError();
+    });
+  });
+
+  describe("retrieveBtcWithApproval", () => {
+    const retrieveWithApprovalParams = {
+      address: mockBTCAddressTestnet,
+      amount: 123n,
+    };
+
+    it("returns successfully when btc are retrieved", async () => {
+      const ok: RetrieveBtcOk = {
+        block_index: 1n,
+      };
+
+      const retrieveBtcWithApprovalSpy =
+        minterCanisterMock.retrieveBtcWithApproval.mockResolvedValue(ok);
+
+      const result = await retrieveBtcWithApproval({
+        ...params,
+        ...retrieveWithApprovalParams,
+      });
+
+      expect(result).toEqual(ok);
+
+      expect(retrieveBtcWithApprovalSpy).toBeCalledTimes(1);
+      expect(retrieveBtcWithApprovalSpy).toBeCalledWith(
+        retrieveWithApprovalParams
+      );
+    });
+
+    it("bubble errors", () => {
+      minterCanisterMock.retrieveBtcWithApproval.mockImplementation(
+        async () => {
+          throw new Error();
+        }
+      );
+
+      const call = () => retrieveBtcWithApproval(retrieveWithApprovalParams);
 
       expect(call).rejects.toThrowError();
     });

--- a/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
+++ b/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
@@ -182,7 +182,10 @@ describe("ckbtc-minter api", () => {
         }
       );
 
-      const call = () => retrieveBtcWithApproval(retrieveWithApprovalParams);
+      const call = () => retrieveBtcWithApproval({
+        ...params,
+        ...retrieveWithApprovalParams,
+      });
 
       expect(call).rejects.toThrowError();
     });


### PR DESCRIPTION
# Motivation

We want to support ICRC-2 (transfer approval) for BTC withdrawal.

# Changes

Add `retrieveBtcWithApproval` to the ckbtc-minter API.

# Tests

Unit tests are added.
The code was also test manually in another branch which has a proof of concept of the full flow.

# Todos

- [x] Add entry to changelog (if necessary).
