### PR TITLE
GIX-1960: Upgrade next dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -569,9 +569,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "1.0.1-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-10-18.1.tgz",
-      "integrity": "sha512-K/RGzv85DMdIZMDn2Cy+F4BDCnhnn7lBH8gCTsQF1qP7JFoUfrhIZG9H7f2og10b/gRdwn9VXFTULztDgqEKFQ==",
+      "version": "1.0.1-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-10-19.1.tgz",
+      "integrity": "sha512-hXIoGtIH1hl+UDAi85eAKuMA3Cn165kLiK+hcbNcAAQa5//xMUOXxOX2qlmQSelc/53HEBEuQMUThDnGWoePmQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "1.0.0-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-18.1.tgz",
-      "integrity": "sha512-4peTBth/X6MEKv7vcETaKHBNlVowwAm9YrlxfnOgF6poatP2oXH+wx1ZEjVcWzucCNI5ZZmGt9+t0FyiFSK++Q==",
+      "version": "1.0.0-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-19.1.tgz",
+      "integrity": "sha512-GNTIhp6fUZLEbyXHp/po+MKwU6JCLjWutQbqQcn4BZRy1/e+evy4S3JtUvkNjlMAQ6zOXf9JX8GrmdYfDFQihA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -610,9 +610,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "1.0.0-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-18.1.tgz",
-      "integrity": "sha512-iNkZc/pZC3Rwul5k/TMc1CnFKVCD4o4Vkg3LbqyoWLzZGvOiSqtwNNlTyRLnsxbORcEdJuhdwoyIGnbHoq/UMg==",
+      "version": "1.0.0-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-19.1.tgz",
+      "integrity": "sha512-vPPN/evquAfPDjQqq8c40tufkITLR6Tg8qUKk62C0cOOtKqM0zfRd3clcU19hiJO2ufenOzcSujXlhecyQTYyw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -636,9 +636,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "1.0.0-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-10-18.1.tgz",
-      "integrity": "sha512-p0uFL0UEbLOksMuR/KtjW3eW9XsYzELOS+jeojYMJIYcnSCXH7EXAY6KVo+Mg+IWqp+UaIPoYSjVqNQd4j2pPQ==",
+      "version": "1.0.0-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-10-19.1.tgz",
+      "integrity": "sha512-13UMYbxn5NQHwckAcMt19mpuUQDe9wi99Pwa+4gtWna7Ogtwolo9DszWCu5gc52iYYjq/8SjFBkPVd/ZUbSqcg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "1.0.0-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-10-18.1.tgz",
-      "integrity": "sha512-kwqP9JMWZuYDjbLZ671fHFE8f6qnBDI0AJWf66tWeDO9h3JtphCthQA4AreY5GmxO6iq7/HthWLg+CjA90KJxQ==",
+      "version": "1.0.0-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-10-19.1.tgz",
+      "integrity": "sha512-HQ+hOjfgcCfb5Jdicpm+K1cHeY8gLhQJqsnKhtq5J74TOyS1PbN6IoMwRDfw1OPLwXiGtbNIujZW/Ea4H1ZECA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -659,9 +659,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "2.0.0-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-10-18.1.tgz",
-      "integrity": "sha512-wyDDUqucgDNqGuGVURAEglTJ9Wh0ygc85iC0Py7IUAOlZeKcXqffqMGZ5uSHP6yWIAtxGSUPlPdEaQOqajkbKg==",
+      "version": "2.0.0-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-10-19.1.tgz",
+      "integrity": "sha512-eiRE4ykeCGY6f3v6tPGpoe6fFqPJIf1cQDJNOVGjZ6GgxIf630iLyWRtgykF/6lL5miVnouP/HD0dUPN2HFjXQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -676,9 +676,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.0-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-18.1.tgz",
-      "integrity": "sha512-qK7UxNEQudIRTrdYSAOgwETdiVYNeZ18exst8M47iv8CPB0eQfEvSwm3PoTmU77ZSZleXmK3VQfiDX45WORtyA==",
+      "version": "1.0.0-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-19.1.tgz",
+      "integrity": "sha512-UStorOiLYQqfQQR3xh2+feMIYACXrCuNfVCPSlOVfzbe9RJlk09nugVRCTDghUcTxBk7Y/MzjAZu/xCOvhYh2g==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -692,9 +692,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "1.0.1-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-10-18.1.tgz",
-      "integrity": "sha512-3mDwJKTxrHl03BSIDDYjnTuTCOopV6Y7LOOlub+KDOGix2amqniT00FHbbRrNqWQEQujNapdARS1ItAn6XiHgQ==",
+      "version": "1.0.1-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-10-19.1.tgz",
+      "integrity": "sha512-/KKBKwaViXNoUOOMrLFz6ZNk0z72cbVHspsTW0Z19s2Za3QlrfTYop+iJfgOd4xiD4eatD7l2uWWUPaSLeUwxQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -707,9 +707,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "1.0.0-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-18.1.tgz",
-      "integrity": "sha512-DNYEHOEUE9m9ewR0Lv8ytms5zFkOAwXkTywCVKm2xaziKMkEmlkKMDA2YJpgM/c/F55XBK81G71l1Xugg8mAXg==",
+      "version": "1.0.0-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-19.1.tgz",
+      "integrity": "sha512-brgGhqmXgIEwmKF3W8rPru3u1je+Qomn4xDkRF8S+iBLQUWFxV1ISm27boU+QTI6pwYmd9V/x/z+9ZAJ0Zb6TA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7361,9 +7361,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "1.0.1-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-10-18.1.tgz",
-      "integrity": "sha512-K/RGzv85DMdIZMDn2Cy+F4BDCnhnn7lBH8gCTsQF1qP7JFoUfrhIZG9H7f2og10b/gRdwn9VXFTULztDgqEKFQ==",
+      "version": "1.0.1-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-10-19.1.tgz",
+      "integrity": "sha512-hXIoGtIH1hl+UDAi85eAKuMA3Cn165kLiK+hcbNcAAQa5//xMUOXxOX2qlmQSelc/53HEBEuQMUThDnGWoePmQ==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7371,9 +7371,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "1.0.0-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-18.1.tgz",
-      "integrity": "sha512-4peTBth/X6MEKv7vcETaKHBNlVowwAm9YrlxfnOgF6poatP2oXH+wx1ZEjVcWzucCNI5ZZmGt9+t0FyiFSK++Q==",
+      "version": "1.0.0-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-19.1.tgz",
+      "integrity": "sha512-GNTIhp6fUZLEbyXHp/po+MKwU6JCLjWutQbqQcn4BZRy1/e+evy4S3JtUvkNjlMAQ6zOXf9JX8GrmdYfDFQihA==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7387,9 +7387,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "1.0.0-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-18.1.tgz",
-      "integrity": "sha512-iNkZc/pZC3Rwul5k/TMc1CnFKVCD4o4Vkg3LbqyoWLzZGvOiSqtwNNlTyRLnsxbORcEdJuhdwoyIGnbHoq/UMg==",
+      "version": "1.0.0-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-19.1.tgz",
+      "integrity": "sha512-vPPN/evquAfPDjQqq8c40tufkITLR6Tg8qUKk62C0cOOtKqM0zfRd3clcU19hiJO2ufenOzcSujXlhecyQTYyw==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7403,30 +7403,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "1.0.0-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-10-18.1.tgz",
-      "integrity": "sha512-p0uFL0UEbLOksMuR/KtjW3eW9XsYzELOS+jeojYMJIYcnSCXH7EXAY6KVo+Mg+IWqp+UaIPoYSjVqNQd4j2pPQ==",
+      "version": "1.0.0-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-10-19.1.tgz",
+      "integrity": "sha512-13UMYbxn5NQHwckAcMt19mpuUQDe9wi99Pwa+4gtWna7Ogtwolo9DszWCu5gc52iYYjq/8SjFBkPVd/ZUbSqcg==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "1.0.0-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-10-18.1.tgz",
-      "integrity": "sha512-kwqP9JMWZuYDjbLZ671fHFE8f6qnBDI0AJWf66tWeDO9h3JtphCthQA4AreY5GmxO6iq7/HthWLg+CjA90KJxQ==",
+      "version": "1.0.0-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-10-19.1.tgz",
+      "integrity": "sha512-HQ+hOjfgcCfb5Jdicpm+K1cHeY8gLhQJqsnKhtq5J74TOyS1PbN6IoMwRDfw1OPLwXiGtbNIujZW/Ea4H1ZECA==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "2.0.0-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-10-18.1.tgz",
-      "integrity": "sha512-wyDDUqucgDNqGuGVURAEglTJ9Wh0ygc85iC0Py7IUAOlZeKcXqffqMGZ5uSHP6yWIAtxGSUPlPdEaQOqajkbKg==",
+      "version": "2.0.0-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-10-19.1.tgz",
+      "integrity": "sha512-eiRE4ykeCGY6f3v6tPGpoe6fFqPJIf1cQDJNOVGjZ6GgxIf630iLyWRtgykF/6lL5miVnouP/HD0dUPN2HFjXQ==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.0-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-18.1.tgz",
-      "integrity": "sha512-qK7UxNEQudIRTrdYSAOgwETdiVYNeZ18exst8M47iv8CPB0eQfEvSwm3PoTmU77ZSZleXmK3VQfiDX45WORtyA==",
+      "version": "1.0.0-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-19.1.tgz",
+      "integrity": "sha512-UStorOiLYQqfQQR3xh2+feMIYACXrCuNfVCPSlOVfzbe9RJlk09nugVRCTDghUcTxBk7Y/MzjAZu/xCOvhYh2g==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7440,17 +7440,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "1.0.1-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-10-18.1.tgz",
-      "integrity": "sha512-3mDwJKTxrHl03BSIDDYjnTuTCOopV6Y7LOOlub+KDOGix2amqniT00FHbbRrNqWQEQujNapdARS1ItAn6XiHgQ==",
+      "version": "1.0.1-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-10-19.1.tgz",
+      "integrity": "sha512-/KKBKwaViXNoUOOMrLFz6ZNk0z72cbVHspsTW0Z19s2Za3QlrfTYop+iJfgOd4xiD4eatD7l2uWWUPaSLeUwxQ==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "1.0.0-next-2023-10-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-18.1.tgz",
-      "integrity": "sha512-DNYEHOEUE9m9ewR0Lv8ytms5zFkOAwXkTywCVKm2xaziKMkEmlkKMDA2YJpgM/c/F55XBK81G71l1Xugg8mAXg==",
+      "version": "1.0.0-next-2023-10-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-19.1.tgz",
+      "integrity": "sha512-brgGhqmXgIEwmKF3W8rPru3u1je+Qomn4xDkRF8S+iBLQUWFxV1ISm27boU+QTI6pwYmd9V/x/z+9ZAJ0Zb6TA==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/lib/utils/anonymize.utils.ts
+++ b/frontend/src/lib/utils/anonymize.utils.ts
@@ -452,6 +452,7 @@ const anonymizeBuyer = async ([buyer, state]: [
           (await anonymizeAmount(state.icp[0]?.amount_e8s)) ?? BigInt(0),
       } as SnsTransferableAmount,
     ],
+    has_created_neuron_recipes: state.has_created_neuron_recipes,
   },
 ];
 
@@ -518,6 +519,8 @@ export const anonymizeSnsSwapCommitment = async (
                 },
               ]
             : [],
+        has_created_neuron_recipes:
+          originalSwapCommitment.myCommitment.has_created_neuron_recipes,
       },
     };
   }

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -174,6 +174,7 @@ const convertSwapInitParams = (
                         // CfNeuron
                         nns_neuron_id: BigInt(nns_neuron_id),
                         amount_icp_e8s: BigInt(amount_icp_e8s),
+                        has_created_neuron_recipes: [],
                       })
                     ),
                   })
@@ -216,6 +217,7 @@ const convertSwapInitParams = (
         max_direct_participation_icp_e8s: toNullable(
           convertOptionalNumToBigInt(init.max_direct_participation_icp_e8s)
         ),
+        neurons_fund_participation: [],
       }
     : undefined;
 

--- a/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
@@ -103,6 +103,7 @@ describe("ProjectCard", () => {
                     transfer_success_timestamp_seconds: BigInt(5443554),
                   },
                 ],
+                has_created_neuron_recipes: [],
               },
             },
           },

--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -288,6 +288,7 @@ describe("ParticipateButton", () => {
             icp: [
               createTransferableAmount(mockSnsParams.max_participant_icp_e8s),
             ],
+            has_created_neuron_recipes: [],
           },
         },
         Component: ParticipateButton,

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -363,6 +363,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
                 amount_transferred_e8s: [],
               },
             ],
+            has_created_neuron_recipes: [],
           },
         });
         const { queryByTestId } = render(ProjectDetail, props);
@@ -449,6 +450,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
               transfer_success_timestamp_seconds: BigInt(123445),
             },
           ],
+          has_created_neuron_recipes: [],
         };
 
         beforeEach(() => {
@@ -559,7 +561,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
       });
 
       it("should participate without user interaction if there is an open ticket.", async () => {
-        const initialCommitment = { icp: [] };
+        const initialCommitment = { icp: [], has_created_neuron_recipes: [] };
         const finalCommitment = {
           icp: [
             {
@@ -568,6 +570,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
               transfer_success_timestamp_seconds: BigInt(123445),
             },
           ],
+          has_created_neuron_recipes: [],
         };
         vi.spyOn(snsApi, "querySnsSwapCommitment")
           // Query call
@@ -628,6 +631,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
           rootCanisterId,
           myCommitment: {
             icp: [],
+            has_created_neuron_recipes: [],
           },
         });
       });
@@ -673,6 +677,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
                 amount_transferred_e8s: [],
               },
             ],
+            has_created_neuron_recipes: [],
           },
         });
       });

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -276,6 +276,7 @@ describe("project-utils", () => {
               icp: [
                 createTransferableAmount(mockSnsParams.max_participant_icp_e8s),
               ],
+              has_created_neuron_recipes: [],
             },
           },
         })
@@ -414,6 +415,7 @@ describe("project-utils", () => {
               icp: [
                 createTransferableAmount(mockSnsParams.max_participant_icp_e8s),
               ],
+              has_created_neuron_recipes: [],
             },
           },
           loggedIn: true,
@@ -455,6 +457,7 @@ describe("project-utils", () => {
             ...mockSwapCommitment,
             myCommitment: {
               icp: [],
+              has_created_neuron_recipes: [],
             },
           },
         })
@@ -525,6 +528,7 @@ describe("project-utils", () => {
           ...(mockSnsFullProject.swapCommitment as SnsSwapCommitment),
           myCommitment: {
             icp: [createTransferableAmount(userCommitment)],
+            has_created_neuron_recipes: [],
           },
         },
       };
@@ -599,6 +603,7 @@ describe("project-utils", () => {
           ...(mockSnsFullProject.swapCommitment as SnsSwapCommitment),
           myCommitment: {
             icp: [createTransferableAmount(userCommitment)],
+            has_created_neuron_recipes: [],
           },
         },
       };
@@ -669,6 +674,7 @@ describe("project-utils", () => {
         ...(mockSnsFullProject.swapCommitment as SnsSwapCommitment),
         myCommitment: {
           icp: [createTransferableAmount(BigInt(0))],
+          has_created_neuron_recipes: [],
         },
       },
     };
@@ -766,6 +772,7 @@ describe("project-utils", () => {
           ...(validProject.swapCommitment as SnsSwapCommitment),
           myCommitment: {
             icp: [createTransferableAmount(validAmountE8s)],
+            has_created_neuron_recipes: [],
           },
         },
       };
@@ -849,6 +856,7 @@ describe("project-utils", () => {
           ...(validProject.swapCommitment as SnsSwapCommitment),
           myCommitment: {
             icp: [createTransferableAmount(currentUserParticipation)],
+            has_created_neuron_recipes: [],
           },
         },
       };
@@ -910,6 +918,7 @@ describe("project-utils", () => {
         ...(mockSnsFullProject.swapCommitment as SnsSwapCommitment),
         myCommitment: {
           icp: [createTransferableAmount(initialAmountUser)],
+          has_created_neuron_recipes: [],
         },
       };
 
@@ -1163,6 +1172,7 @@ describe("project-utils", () => {
               summary.swap.params.max_participant_icp_e8s + BigInt(1)
             ),
           ],
+          has_created_neuron_recipes: [],
         },
       };
       expect(

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -345,6 +345,7 @@ describe("sns aggregator converters utils", () => {
               neurons_fund_participation_constraints: [],
               max_direct_participation_icp_e8s: [],
               min_direct_participation_icp_e8s: [],
+              neurons_fund_participation: [],
             },
           ],
           lifecycle: 2,
@@ -412,6 +413,7 @@ describe("sns aggregator converters utils", () => {
           neurons_fund_participation_constraints: [],
           max_direct_participation_icp_e8s: [],
           min_direct_participation_icp_e8s: [],
+          neurons_fund_participation: [],
         },
         swapParams: {
           min_participant_icp_e8s: 100000000n,

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -58,6 +58,7 @@ describe("sns-utils", () => {
         rootCanisterId: mockPrincipal,
         myCommitment: {
           icp: [],
+          has_created_neuron_recipes: [],
         },
       };
       expect(getCommitmentE8s(commitment)).toEqual(BigInt(0));

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -57,6 +57,7 @@ export const createTransferableAmount = (
 });
 export const createBuyersState = (amount: bigint): SnsSwapBuyerState => ({
   icp: [createTransferableAmount(amount)],
+  has_created_neuron_recipes: [],
 });
 
 export const mockSnsSwapCommitment = (
@@ -129,6 +130,7 @@ export const mockInit: SnsSwapInit = {
   neurons_fund_participation_constraints: [],
   min_direct_participation_icp_e8s: [1_000_000_000n],
   max_direct_participation_icp_e8s: [3_000_000_000n],
+  neurons_fund_participation: [],
 };
 
 export const mockSwap: SnsSummarySwap = {


### PR DESCRIPTION
# Motivation

Use new field for NF enhancements.

In this PR, upgrade ic-js dependencies.

# Changes

## Automatic changes

* In package.lock.json with `npm run upgrade:next`.

## Manual changes

* Fix mocks and converters with new fields.

# Tests

* Add new field in expected value of the sns aggregator converters.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
