### PR TITLE
Chore: Remove generic

### DIFF
--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -7,11 +7,24 @@
   import { onMount } from "svelte";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { isNullish } from "@dfinity/utils";
+  import type {
+    SnsProposalDecisionStatus,
+    SnsProposalRewardStatus,
+  } from "@dfinity/sns";
+  import type {
+    ProposalRewardStatus,
+    ProposalStatus,
+    Topic,
+  } from "@dfinity/nns";
 
-  // Source: https://github.com/dummdidumm/rfcs/blob/ts-typedefs-within-svelte-components/text/ts-typing-props-slots-events.md#solution
-  type T = $$Generic;
+  type FiltersData =
+    | SnsProposalRewardStatus
+    | Topic
+    | ProposalRewardStatus
+    | ProposalStatus
+    | SnsProposalDecisionStatus;
   // `undefined` means the filters are not loaded yet.
-  export let filters: Filter<T>[] | undefined;
+  export let filters: Filter<FiltersData>[] | undefined;
   export let visible = true;
 
   let loading: boolean;


### PR DESCRIPTION
# Motivation

Migrate to svelte 4.

In this PR, I remove the usage of `$$Generics` which is not supported in Svelte 4.

# Changes

* Change the generic type in FilterModal for all the possible allowed types.

# Tests

* Still passing.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
