### PR TITLE
Proposal status tag

### DIFF
--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -48,11 +48,10 @@
 </script>
 
 <TestIdWrapper testId="nns-proposal-component">
-  {#if $store?.proposal?.id !== undefined}
+  {#if $store?.proposal?.id !== undefined && nonNullish(statusString) && nonNullish(status)}
     {#if $referrerPathStore !== AppPath.Launchpad}
       <ProposalNavigation
         currentProposalId={$store.proposal.id}
-        currentProposalStatus={$store.proposal.status}
         {proposalIds}
         selectProposal={navigateToProposal}
       >

--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -21,7 +21,9 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import { ENABLE_FULL_WIDTH_PROPOSAL } from "$lib/stores/feature-flags.store";
   import { SplitBlock } from "@dfinity/gix-components";
+  import ProposalStatusTag from "$lib/components/ui/ProposalStatusTag.svelte";
   import { nonNullish } from "@dfinity/utils";
+  import { ProposalStatus } from "@dfinity/nns";
 
   const { store } = getContext<SelectedProposalContext>(
     SELECTED_PROPOSAL_CONTEXT_KEY
@@ -30,22 +32,32 @@
   let proposalIds: bigint[] | undefined;
   $: proposalIds = $filteredProposals.proposals?.map(({ id }) => id as bigint);
 
-  let proposalStatusString: string | undefined;
-  $: if (nonNullish($store.proposal)) {
-    ({ statusString: proposalStatusString } = mapProposalInfo($store.proposal));
-    console.log("proposalStatusString", proposalStatusString);
+  let statusString: string | undefined;
+  let status: string | undefined;
+  $: if (nonNullish($store?.proposal)) {
+    ({ statusString } = mapProposalInfo($store.proposal));
+    status = {
+      [ProposalStatus.Unknown]: "unknown",
+      [ProposalStatus.Open]: "open",
+      [ProposalStatus.Rejected]: "rejected",
+      [ProposalStatus.Accepted]: "adopted",
+      [ProposalStatus.Executed]: "executed",
+      [ProposalStatus.Failed]: "failed",
+    }[$store.proposal.status];
   }
 </script>
 
 <TestIdWrapper testId="nns-proposal-component">
-  {#if $store?.proposal?.id !== undefined && nonNullish(proposalStatusString)}
+  {#if $store?.proposal?.id !== undefined}
     {#if $referrerPathStore !== AppPath.Launchpad}
       <ProposalNavigation
         currentProposalId={$store.proposal.id}
-        currentProposalStatusString={proposalStatusString}
+        currentProposalStatus={$store.proposal.status}
         {proposalIds}
         selectProposal={navigateToProposal}
-      />
+      >
+        <ProposalStatusTag slot="status" statusLabel={statusString} {status} />
+      </ProposalNavigation>
     {/if}
 
     <TestIdWrapper testId="proposal-details-grid">

--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -12,12 +12,16 @@
   import NnsProposalProposerActionsEntry from "./NnsProposalProposerActionsEntry.svelte";
   import NnsProposalProposerPayloadEntry from "./NnsProposalProposerPayloadEntry.svelte";
   import { filteredProposals } from "$lib/derived/proposals.derived";
-  import { navigateToProposal } from "$lib/utils/proposals.utils";
+  import {
+    mapProposalInfo,
+    navigateToProposal,
+  } from "$lib/utils/proposals.utils";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { referrerPathStore } from "$lib/stores/routes.store";
   import { AppPath } from "$lib/constants/routes.constants";
   import { ENABLE_FULL_WIDTH_PROPOSAL } from "$lib/stores/feature-flags.store";
   import { SplitBlock } from "@dfinity/gix-components";
+  import { nonNullish } from "@dfinity/utils";
 
   const { store } = getContext<SelectedProposalContext>(
     SELECTED_PROPOSAL_CONTEXT_KEY
@@ -25,13 +29,20 @@
 
   let proposalIds: bigint[] | undefined;
   $: proposalIds = $filteredProposals.proposals?.map(({ id }) => id as bigint);
+
+  let proposalStatusString: string | undefined;
+  $: if (nonNullish($store.proposal)) {
+    ({ statusString: proposalStatusString } = mapProposalInfo($store.proposal));
+    console.log("proposalStatusString", proposalStatusString);
+  }
 </script>
 
 <TestIdWrapper testId="nns-proposal-component">
-  {#if $store?.proposal?.id !== undefined}
+  {#if $store?.proposal?.id !== undefined && nonNullish(proposalStatusString)}
     {#if $referrerPathStore !== AppPath.Launchpad}
       <ProposalNavigation
         currentProposalId={$store.proposal.id}
+        currentProposalStatusString={proposalStatusString}
         {proposalIds}
         selectProposal={navigateToProposal}
       />

--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -13,7 +13,7 @@
   import NnsProposalProposerPayloadEntry from "./NnsProposalProposerPayloadEntry.svelte";
   import { filteredProposals } from "$lib/derived/proposals.derived";
   import {
-    mapProposalInfo,
+    getUniversalProposalStatus,
     navigateToProposal,
   } from "$lib/utils/proposals.utils";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
@@ -23,7 +23,7 @@
   import { SplitBlock } from "@dfinity/gix-components";
   import ProposalStatusTag from "$lib/components/ui/ProposalStatusTag.svelte";
   import { nonNullish } from "@dfinity/utils";
-  import { ProposalStatus } from "@dfinity/nns";
+  import type { UniversalProposalStatus } from "$lib/types/proposals";
 
   const { store } = getContext<SelectedProposalContext>(
     SELECTED_PROPOSAL_CONTEXT_KEY
@@ -32,30 +32,19 @@
   let proposalIds: bigint[] | undefined;
   $: proposalIds = $filteredProposals.proposals?.map(({ id }) => id as bigint);
 
-  let statusString: string | undefined;
-  let status: string | undefined;
-  $: if (nonNullish($store?.proposal)) {
-    ({ statusString } = mapProposalInfo($store.proposal));
-    status = {
-      [ProposalStatus.Unknown]: "unknown",
-      [ProposalStatus.Open]: "open",
-      [ProposalStatus.Rejected]: "rejected",
-      [ProposalStatus.Accepted]: "adopted",
-      [ProposalStatus.Executed]: "executed",
-      [ProposalStatus.Failed]: "failed",
-    }[$store.proposal.status];
-  }
+  let status: UniversalProposalStatus | undefined;
+  $: status = $store?.proposal && getUniversalProposalStatus($store.proposal);
 </script>
 
 <TestIdWrapper testId="nns-proposal-component">
-  {#if $store?.proposal?.id !== undefined && nonNullish(statusString) && nonNullish(status)}
+  {#if $store?.proposal?.id !== undefined && nonNullish(status)}
     {#if $referrerPathStore !== AppPath.Launchpad}
       <ProposalNavigation
         currentProposalId={$store.proposal.id}
         {proposalIds}
         selectProposal={navigateToProposal}
       >
-        <ProposalStatusTag slot="status" statusLabel={statusString} {status} />
+        <ProposalStatusTag slot="status" {status} />
       </ProposalNavigation>
     {/if}
 

--- a/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
@@ -11,8 +11,10 @@
   import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
   import UniverseLogo from "$lib/components/universe/UniverseLogo.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import ProposalStatusTag from "$lib/components/ui/ProposalStatusTag.svelte";
 
   export let currentProposalId: bigint;
+  export let currentProposalStatusString: string;
   export let proposalIds: bigint[] = [];
   export let selectProposal: (proposalId: bigint) => void;
 
@@ -46,8 +48,7 @@
 {#if $ENABLE_FULL_WIDTH_PROPOSAL}
   <div class="proposal-nav" role="toolbar" data-tid="proposal-nav">
     <span class="status">
-      TBD: Status
-      <!-- TODO(GIX-1971): render proposal status component -->
+      <ProposalStatusTag statusString={currentProposalStatusString} />
     </span>
     <h2 class="title">
       <div class="universe-logo">

--- a/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
@@ -11,10 +11,8 @@
   import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
   import UniverseLogo from "$lib/components/universe/UniverseLogo.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
-  import ProposalStatusTag from "$lib/components/ui/ProposalStatusTag.svelte";
 
   export let currentProposalId: bigint;
-  export let currentProposalStatusString: string;
   export let proposalIds: bigint[] = [];
   export let selectProposal: (proposalId: bigint) => void;
 
@@ -47,9 +45,7 @@
 
 {#if $ENABLE_FULL_WIDTH_PROPOSAL}
   <div class="proposal-nav" role="toolbar" data-tid="proposal-nav">
-    <span class="status">
-      <ProposalStatusTag statusString={currentProposalStatusString} />
-    </span>
+    <div class="status"><slot name="status" /></div>
     <h2 class="title">
       <div class="universe-logo">
         <UniverseLogo

--- a/frontend/src/lib/components/ui/ProposalStatusTag.svelte
+++ b/frontend/src/lib/components/ui/ProposalStatusTag.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  // TODO: switch to ids
+  export let statusString: string;
+
+  let statusClass: string;
+  $: statusClass = statusString.toLowerCase();
+
+  let label: string;
+  $: label = statusString;
+</script>
+
+<span data-tid="proposal-status" class={`tag ${statusClass}`}>{label}</span>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+
+  .tag {
+    &.unknown {
+      color: var(--disable-contrast);
+      background-color: var(--disable);
+    }
+    &.open {
+      color: var(--green);
+      background-color: var(--green-tint);
+
+      @include media.dark-theme {
+        background-color: var(--green-dark);
+      }
+    }
+    &.rejected {
+      color: var(--pink);
+      background-color: var(--pink-tint);
+    }
+    &.adopted,
+    &.accepted {
+      color: var(--blue);
+      background-color: var(--blue-tint);
+    }
+    &.executed {
+      color: var(--orchid);
+      background-color: var(--indigo-tint);
+    }
+    &.failed {
+      color: var(--orange);
+      background-color: var(--orange-tint);
+    }
+  }
+</style>

--- a/frontend/src/lib/components/ui/ProposalStatusTag.svelte
+++ b/frontend/src/lib/components/ui/ProposalStatusTag.svelte
@@ -5,7 +5,7 @@
   export let status: UniversalProposalStatus;
 
   let label: string;
-  $: label = $i18n.proposal_status[status];
+  $: label = $i18n.universal_proposal_status[status];
 </script>
 
 <span data-tid="proposal-status" class={`tag ${status}`}>{label}</span>

--- a/frontend/src/lib/components/ui/ProposalStatusTag.svelte
+++ b/frontend/src/lib/components/ui/ProposalStatusTag.svelte
@@ -8,7 +8,7 @@
   $: label = $i18n.universal_proposal_status[status];
 </script>
 
-<span data-tid="proposal-status" class={`tag ${status}`}>{label}</span>
+<span data-tid="proposal-status-tag" class={`tag ${status}`}>{label}</span>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";

--- a/frontend/src/lib/components/ui/ProposalStatusTag.svelte
+++ b/frontend/src/lib/components/ui/ProposalStatusTag.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-  // TODO: switch to ids
-  export let statusString: string;
-
-  let statusClass: string;
-  $: statusClass = statusString.toLowerCase();
-
-  let label: string;
-  $: label = statusString;
+  export let statusLabel: string;
+  export let status:
+    | "unknown"
+    | "open"
+    | "rejected"
+    | "adopted"
+    | "executed"
+    | "failed";
 </script>
 
-<span data-tid="proposal-status" class={`tag ${statusClass}`}>{label}</span>
+<span data-tid="proposal-status" class={`tag ${status}`}>{statusLabel}</span>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";
@@ -31,8 +31,7 @@
       color: var(--pink);
       background-color: var(--pink-tint);
     }
-    &.adopted,
-    &.accepted {
+    &.adopted {
       color: var(--blue);
       background-color: var(--blue-tint);
     }

--- a/frontend/src/lib/components/ui/ProposalStatusTag.svelte
+++ b/frontend/src/lib/components/ui/ProposalStatusTag.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
-  export let statusLabel: string;
-  export let status:
-    | "unknown"
-    | "open"
-    | "rejected"
-    | "adopted"
-    | "executed"
-    | "failed";
+  import type { UniversalProposalStatus } from "$lib/types/proposals";
+  import { i18n } from "$lib/stores/i18n";
+
+  export let status: UniversalProposalStatus;
+
+  let label: string;
+  $: label = $i18n.proposal_status[status];
 </script>
 
-<span data-tid="proposal-status" class={`tag ${status}`}>{statusLabel}</span>
+<span data-tid="proposal-status" class={`tag ${status}`}>{label}</span>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -924,6 +924,14 @@
     "4": "Executed",
     "5": "Failed"
   },
+  "proposal_status": {
+    "unknown": "Unknown",
+    "open": "Open",
+    "rejected": "Rejected",
+    "adopted": "Adopted",
+    "executed": "Executed",
+    "failed": "Failed"
+  },
   "sns_status_description": {
     "0": "",
     "1": "A decision has not yet been made to adopt or reject the proposal.",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -924,7 +924,7 @@
     "4": "Executed",
     "5": "Failed"
   },
-  "proposal_status": {
+  "universal_proposal_status": {
     "unknown": "Unknown",
     "open": "Open",
     "rejected": "Rejected",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -29,7 +29,8 @@
     "done": "Done",
     "this_may_take_a_few_minutes": "This may take a few minutes",
     "do_not_close": "Please do not close your browser tab",
-    "finish": "Finish"
+    "finish": "Finish",
+    "unknown": "Unknown"
   },
   "error": {
     "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser.",

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -214,16 +214,12 @@
       [SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_FAILED]: "failed",
     }[proposalMap.status];
   }
-
-  let a: SnsProposalDecisionStatus | undefined;
-  $: a = nonNullish(proposal) && snsDecisionStatus(proposal);
 </script>
 
 <TestIdWrapper testId="sns-proposal-details-grid">
-  {#if nonNullish(proposalIdText) && !updating && nonNullish(proposal) && nonNullish(universeCanisterId) && nonNullish(statusString)}
+  {#if nonNullish(proposalIdText) && !updating && nonNullish(proposal) && nonNullish(universeCanisterId) && nonNullish(statusString) && nonNullish(status)}
     <ProposalNavigation
       currentProposalId={BigInt(proposalIdText)}
-      currentProposalStatus={statusString}
       {proposalIds}
       selectProposal={navigateToProposal}
     >

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -33,6 +33,7 @@ interface I18nCore {
   this_may_take_a_few_minutes: string;
   do_not_close: string;
   finish: string;
+  unknown: string;
 }
 
 interface I18nError {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -969,6 +969,15 @@ interface I18nSns_status {
   5: string;
 }
 
+interface I18nProposal_status {
+  unknown: string;
+  open: string;
+  rejected: string;
+  adopted: string;
+  executed: string;
+  failed: string;
+}
+
 interface I18nSns_status_description {
   0: string;
   1: string;
@@ -1300,6 +1309,7 @@ interface I18n {
   sns_rewards_status: I18nSns_rewards_status;
   sns_rewards_description: I18nSns_rewards_description;
   sns_status: I18nSns_status;
+  proposal_status: I18nProposal_status;
   sns_status_description: I18nSns_status_description;
   metrics: I18nMetrics;
   ckbtc: I18nCkbtc;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -969,7 +969,7 @@ interface I18nSns_status {
   5: string;
 }
 
-interface I18nProposal_status {
+interface I18nUniversal_proposal_status {
   unknown: string;
   open: string;
   rejected: string;
@@ -1309,7 +1309,7 @@ interface I18n {
   sns_rewards_status: I18nSns_rewards_status;
   sns_rewards_description: I18nSns_rewards_description;
   sns_status: I18nSns_status;
-  proposal_status: I18nProposal_status;
+  universal_proposal_status: I18nUniversal_proposal_status;
   sns_status_description: I18nSns_status_description;
   metrics: I18nMetrics;
   ckbtc: I18nCkbtc;

--- a/frontend/src/lib/types/proposals.ts
+++ b/frontend/src/lib/types/proposals.ts
@@ -5,6 +5,14 @@ export type ProposalsFilters =
   | typeof ProposalRewardStatus
   | typeof ProposalStatus;
 
+export type UniversalProposalStatus =
+  | "unknown"
+  | "open"
+  | "rejected"
+  | "adopted"
+  | "executed"
+  | "failed";
+
 export interface ProposalsFilterModalProps {
   category: "topics" | "rewards" | "status";
   filters: ProposalsFilters;

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -7,7 +7,10 @@ import { pageStore } from "$lib/derived/page.derived";
 import { i18n } from "$lib/stores/i18n";
 import type { ProposalsFiltersStore } from "$lib/stores/proposals.store";
 import type { VoteRegistrationStoreEntry } from "$lib/stores/vote-registration.store";
-import type { VotingNeuron } from "$lib/types/proposals";
+import type {
+  UniversalProposalStatus,
+  VotingNeuron,
+} from "$lib/types/proposals";
 import { buildProposalUrl } from "$lib/utils/navigation.utils";
 import type { Identity } from "@dfinity/agent";
 import type {
@@ -28,7 +31,7 @@ import {
   Vote,
 } from "@dfinity/nns";
 import type { SnsVote } from "@dfinity/sns";
-import { nonNullish } from "@dfinity/utils";
+import { isNullish, nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { nowInSeconds } from "./date.utils";
 import { errorToString } from "./error.utils";
@@ -611,3 +614,22 @@ export const navigateToProposal = (proposalId: ProposalId): Promise<void> =>
       proposalId,
     })
   );
+
+export const getUniversalProposalStatus = (
+  proposal: ProposalInfo
+): UniversalProposalStatus => {
+  const statusType = {
+    [ProposalStatus.Unknown]: "unknown",
+    [ProposalStatus.Open]: "open",
+    [ProposalStatus.Rejected]: "rejected",
+    [ProposalStatus.Accepted]: "adopted",
+    [ProposalStatus.Executed]: "executed",
+    [ProposalStatus.Failed]: "failed",
+  }[proposal.status];
+
+  if (isNullish(statusType)) {
+    throw new Error(`Unknown proposal status: ${proposal.status}`);
+  }
+
+  return statusType as UniversalProposalStatus;
+};

--- a/frontend/src/lib/utils/sns-proposals.utils.ts
+++ b/frontend/src/lib/utils/sns-proposals.utils.ts
@@ -4,7 +4,10 @@ import {
   SNS_PROPOSAL_COLOR,
 } from "$lib/constants/sns-proposals.constants";
 import { i18n } from "$lib/stores/i18n";
-import type { VotingNeuron } from "$lib/types/proposals";
+import type {
+  UniversalProposalStatus,
+  VotingNeuron,
+} from "$lib/types/proposals";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import type { Vote } from "@dfinity/nns";
 import type {
@@ -22,7 +25,7 @@ import {
   SnsProposalDecisionStatus,
   SnsProposalRewardStatus,
 } from "@dfinity/sns";
-import { fromDefinedNullable, fromNullable } from "@dfinity/utils";
+import { fromDefinedNullable, fromNullable, isNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { nowInSeconds } from "./date.utils";
 import { keyOfOptional } from "./utils";
@@ -389,3 +392,24 @@ export const toNnsVote = (vote: SnsVote | Vote): Vote =>
 /** To have the logic in one place */
 export const toSnsVote = (vote: SnsVote | Vote): SnsVote =>
   vote as unknown as SnsVote;
+
+export const getUniversalProposalStatus = (
+  proposalData: SnsProposalData
+): UniversalProposalStatus => {
+  const status = snsDecisionStatus(proposalData);
+
+  const statusType = {
+    [SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_UNSPECIFIED]: "unknown",
+    [SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN]: "open",
+    [SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_REJECTED]: "rejected",
+    [SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED]: "adopted",
+    [SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_EXECUTED]: "executed",
+    [SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_FAILED]: "failed",
+  }[status];
+
+  if (isNullish(statusType)) {
+    throw new Error(`Unknown sns proposal status: ${status}`);
+  }
+
+  return statusType as UniversalProposalStatus;
+};

--- a/frontend/src/tests/lib/components/ui/ProposalStatusTag.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ProposalStatusTag.spec.ts
@@ -1,0 +1,51 @@
+import ProposalStatusTag from "$lib/components/ui/ProposalStatusTag.svelte";
+import type { UniversalProposalStatus } from "$lib/types/proposals";
+import { ProposalStatusTagPo } from "$tests/page-objects/ProposalStatusTag.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("ProposalStatusTag", () => {
+  const renderComponent = (status: UniversalProposalStatus) => {
+    const { container } = render(ProposalStatusTag, {
+      props: { status },
+    });
+
+    return ProposalStatusTagPo.under(new JestPageObjectElement(container));
+  };
+
+  it('should render status "unknown"', async () => {
+    const po = await renderComponent("unknown");
+    expect(await po.getText()).toEqual("Unknown");
+    expect(await po.hasStatusClass("unknown")).toBe(true);
+  });
+
+  it('should render status "open"', async () => {
+    const po = await renderComponent("open");
+    expect(await po.getText()).toEqual("Open");
+    expect(await po.hasStatusClass("open")).toBe(true);
+  });
+
+  it('should render status "rejected"', async () => {
+    const po = await renderComponent("rejected");
+    expect(await po.getText()).toEqual("Rejected");
+    expect(await po.hasStatusClass("rejected")).toBe(true);
+  });
+
+  it('should render status "adopted"', async () => {
+    const po = await renderComponent("adopted");
+    expect(await po.getText()).toEqual("Adopted");
+    expect(await po.hasStatusClass("adopted")).toBe(true);
+  });
+
+  it('should render status "executed"', async () => {
+    const po = await renderComponent("executed");
+    expect(await po.getText()).toEqual("Executed");
+    expect(await po.hasStatusClass("executed")).toBe(true);
+  });
+
+  it('should render status "failed"', async () => {
+    const po = await renderComponent("failed");
+    expect(await po.getText()).toEqual("Failed");
+    expect(await po.hasStatusClass("failed")).toBe(true);
+  });
+});

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -7,6 +7,7 @@ import {
   concatenateUniqueProposals,
   excludeProposals,
   getNnsFunctionKey,
+  getUniversalProposalStatus,
   getVotingBallot,
   getVotingPower,
   hasMatchingProposals,
@@ -1310,6 +1311,31 @@ describe("proposals-utils", () => {
         neuronIdString: `${neuronId}`,
         votingPower: votingPower,
       });
+    });
+  });
+
+  describe("getUniversalProposalStatus", () => {
+    it("should return UniversalProposalStatus", () => {
+      const proposalWithStatus = (status: ProposalStatus): ProposalInfo => ({
+        ...mockProposalInfo,
+        status,
+      });
+
+      expect(
+        getUniversalProposalStatus(proposalWithStatus(ProposalStatus.Unknown))
+      ).toBe("unknown");
+      expect(
+        getUniversalProposalStatus(proposalWithStatus(ProposalStatus.Open))
+      ).toBe("open");
+      expect(
+        getUniversalProposalStatus(proposalWithStatus(ProposalStatus.Rejected))
+      ).toBe("rejected");
+      expect(
+        getUniversalProposalStatus(proposalWithStatus(ProposalStatus.Accepted))
+      ).toBe("adopted");
+      expect(
+        getUniversalProposalStatus(proposalWithStatus(ProposalStatus.Failed))
+      ).toBe("failed");
     });
   });
 });

--- a/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
@@ -2,6 +2,7 @@ import { nowInSeconds } from "$lib/utils/date.utils";
 import { enumValues } from "$lib/utils/enum.utils";
 import {
   ballotVotingPower,
+  getUniversalProposalStatus,
   isAccepted,
   lastProposalId,
   mapProposalInfo,
@@ -586,6 +587,67 @@ describe("sns-proposals utils", () => {
         neuronIdString: "010203",
         votingPower: 250n,
       });
+    });
+  });
+
+  describe("getUniversalProposalStatus", () => {
+    it("should return UniversalProposalStatus", () => {
+      const acceptedProposal = {
+        ...mockSnsProposal,
+        latest_tally: [
+          {
+            yes: BigInt(2),
+            no: BigInt(0),
+          },
+        ],
+      } as SnsProposalData;
+      const rejectedProposal = {
+        ...mockSnsProposal,
+        latest_tally: [
+          {
+            yes: BigInt(0),
+            no: BigInt(2),
+          },
+        ],
+      } as SnsProposalData;
+      expect(
+        getUniversalProposalStatus({
+          ...acceptedProposal,
+          decided_timestamp_seconds: 0n,
+          executed_timestamp_seconds: 0n,
+          failed_timestamp_seconds: 0n,
+        } as SnsProposalData)
+      ).toBe("open");
+      expect(
+        getUniversalProposalStatus({
+          ...acceptedProposal,
+          decided_timestamp_seconds: 1n,
+          executed_timestamp_seconds: 1n,
+          failed_timestamp_seconds: 0n,
+        } as SnsProposalData)
+      ).toBe("executed");
+      expect(
+        getUniversalProposalStatus({
+          ...acceptedProposal,
+          decided_timestamp_seconds: 1n,
+          executed_timestamp_seconds: 0n,
+          failed_timestamp_seconds: 1n,
+        } as SnsProposalData)
+      ).toBe("failed");
+      expect(
+        getUniversalProposalStatus({
+          ...acceptedProposal,
+          decided_timestamp_seconds: 1n,
+          executed_timestamp_seconds: 0n,
+          failed_timestamp_seconds: 0n,
+        } as SnsProposalData)
+      ).toBe("adopted");
+      expect(
+        getUniversalProposalStatus({
+          ...rejectedProposal,
+          decided_timestamp_seconds: 1n,
+        } as SnsProposalData)
+      ).toBe("rejected");
     });
   });
 });

--- a/frontend/src/tests/page-objects/ProposalStatusTag.page-object.ts
+++ b/frontend/src/tests/page-objects/ProposalStatusTag.page-object.ts
@@ -1,0 +1,16 @@
+import type { UniversalProposalStatus } from "$lib/types/proposals";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ProposalStatusTagPo extends BasePageObject {
+  private static readonly TID = "proposal-status-tag";
+
+  static under(element: PageObjectElement): ProposalStatusTagPo {
+    return new ProposalStatusTagPo(element.byTestId(ProposalStatusTagPo.TID));
+  }
+
+  async hasStatusClass(className: UniversalProposalStatus): Promise<boolean> {
+    const classNames = await this.root.getClasses();
+    return classNames.includes(className);
+  }
+}


### PR DESCRIPTION
# Motivation

Display proposal status on proposal detail pages using tag component.

# Changes

- `UniversalProposalStatus` to propose an agnostic-to-universes proposal status (+converter helpers).
- `universal_proposal_status` labels (currently all statuses match nns == sns)
- `ProposalStatusTag` component.

# Tests

- ProposalStatusTag
- getUniversalProposalStatus

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary
