### PR TITLE
Use props instead of Context CkBTCWallet

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCWalletFooter.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWalletFooter.svelte
@@ -1,10 +1,6 @@
 <script lang="ts">
   import { isNullish, nonNullish } from "@dfinity/utils";
-  import {
-    WALLET_CONTEXT_KEY,
-    type CkBTCWalletContext,
-  } from "$lib/types/wallet.context";
-  import { getContext } from "svelte";
+  import type { WalletStore } from "$lib/types/wallet.context";
   import { busy } from "@dfinity/gix-components";
   import Footer from "$lib/components/layout/Footer.svelte";
   import { selectedCkBTCUniverseIdStore } from "$lib/derived/selected-universe.derived";
@@ -12,11 +8,11 @@
   import { CKBTC_ADDITIONAL_CANISTERS } from "$lib/constants/ckbtc-additional-canister-ids.constants";
   import CkBTCReceiveButton from "$lib/components/accounts/CkBTCReceiveButton.svelte";
   import CkBTCSendButton from "$lib/components/accounts/CkBTCSendButton.svelte";
+  import type { Writable } from "svelte/store";
 
-  const context: CkBTCWalletContext =
-    getContext<CkBTCWalletContext>(WALLET_CONTEXT_KEY);
-  const { store, reloadAccount, reloadAccountFromStore }: CkBTCWalletContext =
-    context;
+  export let store: Writable<WalletStore>;
+  export let reloadAccount: () => Promise<void>;
+  export let reloadAccountFromStore: () => void;
 
   let canisters: CkBTCAdditionalCanisters | undefined = undefined;
   $: canisters = nonNullish($selectedCkBTCUniverseIdStore)

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -2,13 +2,8 @@
   import { Island, Spinner } from "@dfinity/gix-components";
   import Separator from "$lib/components/ui/Separator.svelte";
   import { writable } from "svelte/store";
-  import {
-    WALLET_CONTEXT_KEY,
-    type CkBTCWalletContext,
-    type WalletStore,
-  } from "$lib/types/wallet.context";
+  import type { WalletStore } from "$lib/types/wallet.context";
   import { debugSelectedAccountStore } from "$lib/derived/debug.derived";
-  import { setContext } from "svelte";
   import { findAccount, hasAccounts } from "$lib/utils/accounts.utils";
   import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
   import { TokenAmount, isNullish, nonNullish } from "@dfinity/utils";
@@ -77,12 +72,6 @@
   // However, the UI displays skeletons while loading and the user can proceed with other operations during this time.
   // That is why we do not need to wait for the promise to resolve here.
   const reloadTransactions = () => transactions?.reloadTransactions();
-
-  setContext<CkBTCWalletContext>(WALLET_CONTEXT_KEY, {
-    store: selectedAccountStore,
-    reloadAccount,
-    reloadAccountFromStore,
-  });
 
   const goBack = (): Promise<void> => goto(AppPath.Accounts);
 
@@ -238,7 +227,11 @@
   </main>
 
   {#if canMakeTransactions}
-    <CkBTCWalletFooter />
+    <CkBTCWalletFooter
+      store={selectedAccountStore}
+      {reloadAccount}
+      {reloadAccountFromStore}
+    />
   {/if}
 </Island>
 

--- a/frontend/src/lib/types/wallet.context.ts
+++ b/frontend/src/lib/types/wallet.context.ts
@@ -21,9 +21,4 @@ export interface WalletContext {
   store: Writable<WalletStore>;
 }
 
-export interface CkBTCWalletContext extends WalletContext {
-  reloadAccount: () => Promise<void>;
-  reloadAccountFromStore: () => void;
-}
-
 export const WALLET_CONTEXT_KEY = Symbol("wallet");

--- a/frontend/src/tests/lib/components/accounts/CkBTCWalletContextTest.svelte
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWalletContextTest.svelte
@@ -1,10 +1,6 @@
 <script lang="ts">
-  import { setContext, SvelteComponent } from "svelte";
-  import {
-    WALLET_CONTEXT_KEY,
-    CkBTCWalletContext,
-    WalletStore,
-  } from "$lib/types/wallet.context";
+  import { SvelteComponent } from "svelte";
+  import { WalletStore } from "$lib/types/wallet.context";
   import type { Account } from "$lib/types/account";
   import { writable } from "svelte/store";
   import CkBTCAccountsModals from "$lib/modals/accounts/CkBTCAccountsModals.svelte";
@@ -17,15 +13,17 @@
     neurons: [],
   });
 
-  setContext<CkBTCWalletContext>(WALLET_CONTEXT_KEY, {
-    store: walletStore,
-    reloadAccount: () => Promise.resolve(),
-    reloadAccountFromStore: () => {
-      // Do nothing here
-    },
-  });
+  const reloadAccount = () => Promise.resolve();
+  const reloadAccountFromStore = () => {
+    // Do nothing here
+  };
 </script>
 
-<svelte:component this={testComponent} />
+<svelte:component
+  this={testComponent}
+  store={walletStore}
+  {reloadAccount}
+  {reloadAccountFromStore}
+/>
 
 <CkBTCAccountsModals />


### PR DESCRIPTION
# Motivation

Using a context makes it difficult to see what is used where.
Some of these props might not be necessary and when we stop using them it should be clear that we can remove them completely.

# Changes

1. Remove `CkBTCWalletContext`.
2. Pass `store, reloadAccount, reloadAccountFromStore` directly as props from `CkBTCWallet` to `CkBTCWalletFooter`

# Tests

`CkBTCWalletContextTest.svelte` has been updated to make the existing test pass again.
Manual testing seems to work.
You can try it here: https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary