### PR TITLE
Fix: Allow robots to crawl

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -29,6 +29,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Add "Finalizing" status in projects of the Launchpad.
 * Fix UI bug when commitment was very low.
+* Remove robots metatag to allow search engines to crawl NNS Dapp.
 
 #### Security
 

--- a/config.sh
+++ b/config.sh
@@ -95,7 +95,7 @@ local_deployment_data="$(
   export TVL_CANISTER_ID
 
   : "Define the robots text, if any"
-  if [[ "$DFX_NETWORK" == "local" ]] || [[ "$DFX_NETWORK" == "testnet" ]]; then
+  if [[ "$DFX_NETWORK" == "mainnet" ]]; then
     ROBOTS=''
   else
     # shellcheck disable=SC2089 # yes, we really want the backslash

--- a/scripts/nns-dapp/test-config-assets/mainnet/arg.did
+++ b/scripts/nns-dapp/test-config-assets/mainnet/arg.did
@@ -13,7 +13,7 @@
     record{ 0="IDENTITY_SERVICE_URL"; 1="https://identity.internetcomputer.org/" };
     record{ 0="LEDGER_CANISTER_ID"; 1="ryjl3-tyaaa-aaaaa-aaaba-cai" };
     record{ 0="OWN_CANISTER_ID"; 1="qoctq-giaaa-aaaaa-aaaea-cai" };
-    record{ 0="ROBOTS"; 1="<meta name=\"robots\" content=\"noindex, nofollow\" />" };
+    record{ 0="ROBOTS"; 1="" };
     record{ 0="SNS_AGGREGATOR_URL"; 1="https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io" };
     record{ 0="STATIC_HOST"; 1="https://icp0.io" };
     record{ 0="TVL_CANISTER_ID"; 1="ewh3f-3qaaa-aaaap-aazjq-cai" };


### PR DESCRIPTION
# Motivation

We want search engines to crawl the NNS Dapp.

There was a bug with the logic of the robots confused. We only want them to crawl mainnet.

# Changes

* Change the `config.sh` to set as ROBOTS `""` on mainnet.

# Tests

* Change the config test expected value for mainnet.

# Todos

- [x] Add entry to changelog (if necessary).
