### PR TITLE
GIX-1982: Tokens page layout

### DIFF
--- a/frontend/src/lib/components/tokens/MainWrapper.svelte
+++ b/frontend/src/lib/components/tokens/MainWrapper.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  export let testId: string;
+</script>
+
+<main data-tid={testId}>
+  <div class="content">
+    <slot />
+  </div>
+</main>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+
+  // TODO: Confirm spacings https://dfinity.atlassian.net/browse/GIX-2005
+  main {
+    display: flex;
+    align-items: stretch;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
+
+    padding: var(--padding-2x) var(--padding-2x) var(--padding)
+      var(--padding-2x);
+
+    @include media.min-width(large) {
+      padding: var(--padding-4x) 0 0 0;
+    }
+
+    & .content {
+      width: 100%;
+      height: 100%;
+
+      overflow-x: hidden;
+      overflow-y: auto;
+
+      @include media.min-width(large) {
+        width: var(--island-width);
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1008,5 +1008,8 @@
     "status_idle_detailed": "Synchronization is currently idle.",
     "status_error_detailed": "An error occurred while synchronizing data. Please try reloading the page. If the problem persists, please contact support for further assistance.",
     "status_in_progress_detailed": "Checking for new transactions."
+  },
+  "tokens": {
+    "title": "Tokens"
   }
 }

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -1,2 +1,8 @@
+<script>
+  import MainWrapper from "$lib/components/tokens/MainWrapper.svelte";
+</script>
+
 <!-- TODO: GIX-1976 Render Tokens table with data -->
-<div data-tid="tokens-page-component">My Tokens</div>
+<MainWrapper testId="tokens-page-component">
+  <div>My Tokens</div>
+</MainWrapper>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1061,6 +1061,10 @@ interface I18nSync {
   status_in_progress_detailed: string;
 }
 
+interface I18nTokens {
+  title: string;
+}
+
 interface I18nNeuron_state {
   Unspecified: string;
   Locked: string;
@@ -1306,6 +1310,7 @@ interface I18n {
   feature_flags_prompt: I18nFeature_flags_prompt;
   settings: I18nSettings;
   sync: I18nSync;
+  tokens: I18nTokens;
   neuron_state: I18nNeuron_state;
   topics: I18nTopics;
   topics_description: I18nTopics_description;

--- a/frontend/src/routes/(app)/(nns)/tokens/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+layout.svelte
@@ -5,7 +5,7 @@
   import { i18n } from "$lib/stores/i18n";
 </script>
 
-<LayoutList title={$i18n.sns_launchpad.header}>
+<LayoutList title={$i18n.tokens.title}>
   <Layout>
     <Content>
       <slot />

--- a/frontend/src/tests/routes/app/tokens/layout.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/layout.spec.ts
@@ -1,0 +1,19 @@
+import { layoutTitleStore } from "$lib/stores/layout.store";
+import TokensLayout from "$routes/(app)/(nns)/tokens/+layout.svelte";
+import { render } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+describe("Tokens layout", () => {
+  beforeEach(() => {
+    layoutTitleStore.set({ title: "" });
+  });
+
+  it("should set title and header layout to 'Tokens'", () => {
+    render(TokensLayout);
+
+    expect(get(layoutTitleStore)).toEqual({
+      title: "Tokens",
+      header: "Tokens",
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

Implement the new Tokens page.

In this PR, setup the layout as expected in Figma.

This is the first time for this layout, but it seems to follow the rules of the current detail pages. Therefore, I applied the same rules and created a ticket to confirm them with Artem once he's back.

# Changes

* New component `MainWrapper.svelte`. For now used only in the Tokens page and therefore only in `components/tokens`. It might be moved in the future.
* New i18n key for the Tokens page title.
* New `MainWrapper` in the `Tokens` page.
* Use the new i18n key for LayoutList in tokens layout.

# Tests

* Add test for tokens layout.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
