### PR TITLE
E2E: Wait for content loaded before getting account names

### DIFF
--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -29,7 +29,7 @@ test("Test accounts requirements", async ({ page, context }) => {
   expect(await accountNames()).toEqual([mainAccountName, subAccountName]);
 
   // The linked account should still be present after refresh
-  page.reload();
+  await page.reload({ waitUntil: "load" });
   expect(await accountNames()).toEqual([mainAccountName, subAccountName]);
 
   // Get some ICP to be able to transfer

--- a/frontend/src/tests/page-objects/BaseAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/BaseAccounts.page-object.ts
@@ -1,5 +1,6 @@
 import { AccountCardPo } from "$tests/page-objects/AccountCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 
 export class BaseAccountsPo extends BasePageObject {
   getMainAccountCardPo(): AccountCardPo {
@@ -7,7 +8,8 @@ export class BaseAccountsPo extends BasePageObject {
     return AccountCardPo.under(this.root);
   }
 
-  getAccountCardPos(): Promise<AccountCardPo[]> {
+  async getAccountCardPos(): Promise<AccountCardPo[]> {
+    await this.waitForContentLoaded();
     return AccountCardPo.allUnder(this.root);
   }
 
@@ -21,6 +23,15 @@ export class BaseAccountsPo extends BasePageObject {
       );
     }
     return cards[index];
+  }
+
+  getSkeletonCardPo(): SkeletonCardPo {
+    return SkeletonCardPo.under(this.root);
+  }
+
+  async waitForContentLoaded(): Promise<void> {
+    await this.waitFor();
+    await this.getSkeletonCardPo().waitForAbsent();
   }
 
   async openAccount(accountName: string): Promise<void> {

--- a/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
@@ -1,6 +1,5 @@
 import { BaseAccountsPo } from "$tests/page-objects/BaseAccounts.page-object";
 import { NnsAddAccountPo } from "$tests/page-objects/NnsAddAccount.page-object";
-import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsAccountsPo extends BaseAccountsPo {
@@ -10,20 +9,11 @@ export class NnsAccountsPo extends BaseAccountsPo {
     return new NnsAccountsPo(element.byTestId(NnsAccountsPo.TID));
   }
 
-  getSkeletonCardPo(): SkeletonCardPo {
-    return SkeletonCardPo.under(this.root);
-  }
-
   getNnsAddAccountPo(): NnsAddAccountPo {
     return NnsAddAccountPo.under(this.root);
   }
 
   addAccount(name: string): Promise<void> {
     return this.getNnsAddAccountPo().addAccount(name);
-  }
-
-  async waitForContentLoaded(): Promise<void> {
-    await this.waitFor();
-    await this.getSkeletonCardPo().waitForAbsent();
   }
 }


### PR DESCRIPTION
# Motivation

We noticed some flakiness in the account e2e test when checking the account names after reloading the page.

# Changes

1. Await the reload and wait for the window load event.
2. Wait for the component content to be loaded before getting the account names.

# Tests

1. I applied these changes to branch `build/svelte-v4`
2. I added a loop around around lines 32-33 in `accounts.spec.ts`.
3. Without the changes, the loop would fail after a couple of times.
4. With the changes the loop would pass 20 iterations without failing.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary