### PR TITLE
Upgrade ic-js to next-2023-10-23.1 version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -569,9 +569,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "1.0.1-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-10-19.1.tgz",
-      "integrity": "sha512-hXIoGtIH1hl+UDAi85eAKuMA3Cn165kLiK+hcbNcAAQa5//xMUOXxOX2qlmQSelc/53HEBEuQMUThDnGWoePmQ==",
+      "version": "1.0.1-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-10-23.1.tgz",
+      "integrity": "sha512-zHrFs/dk+cNlGhefKLX6tCUx0dJQu0Li9UbdSJDKPsmDIRo5d5glyE9w1FeNPYOFzm7C3vTF8HCzXgrW0l9pBg==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "1.0.0-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-19.1.tgz",
-      "integrity": "sha512-GNTIhp6fUZLEbyXHp/po+MKwU6JCLjWutQbqQcn4BZRy1/e+evy4S3JtUvkNjlMAQ6zOXf9JX8GrmdYfDFQihA==",
+      "version": "1.0.0-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-23.1.tgz",
+      "integrity": "sha512-Jx7NcTsRRZCQAtu68DNVQUCmAuqmHNVqbF4ODIPlE+eIXJ4P6c7Rod8TNDKEwdGgmGw4OjaTqPRsy/kYkUdHLw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -610,9 +610,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "1.0.0-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-19.1.tgz",
-      "integrity": "sha512-vPPN/evquAfPDjQqq8c40tufkITLR6Tg8qUKk62C0cOOtKqM0zfRd3clcU19hiJO2ufenOzcSujXlhecyQTYyw==",
+      "version": "1.0.0-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-23.1.tgz",
+      "integrity": "sha512-tANQ7jYf9vauv6XQUXtcmpHOzv6ROmEQ1rEdlKrOKISma03NhvjF23zCTxkbJB4k8w9oF+CJUyr77706yoczBA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -636,9 +636,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "1.0.0-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-10-19.1.tgz",
-      "integrity": "sha512-13UMYbxn5NQHwckAcMt19mpuUQDe9wi99Pwa+4gtWna7Ogtwolo9DszWCu5gc52iYYjq/8SjFBkPVd/ZUbSqcg==",
+      "version": "1.0.0-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-10-23.1.tgz",
+      "integrity": "sha512-82R1qcq4WYEYF/ZNDQLzEUcqKkiVxdOGdzTdTxLFIhc5ZXRz6pjvmZtjuGUUzoAzp/4r1bu0yKdWFkFzgtDZ6w==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "1.0.0-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-10-19.1.tgz",
-      "integrity": "sha512-HQ+hOjfgcCfb5Jdicpm+K1cHeY8gLhQJqsnKhtq5J74TOyS1PbN6IoMwRDfw1OPLwXiGtbNIujZW/Ea4H1ZECA==",
+      "version": "1.0.0-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-10-23.1.tgz",
+      "integrity": "sha512-PmvH3mJFGRMY8YHfv8G/sGtVUrUt4SgHEUH3zZqW4YP1o0uCA8gByyNGtJ8ooTuXsOasnLTbKkoo74gKJfhYRw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -659,9 +659,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "2.0.0-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-10-19.1.tgz",
-      "integrity": "sha512-eiRE4ykeCGY6f3v6tPGpoe6fFqPJIf1cQDJNOVGjZ6GgxIf630iLyWRtgykF/6lL5miVnouP/HD0dUPN2HFjXQ==",
+      "version": "2.0.0-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-10-23.1.tgz",
+      "integrity": "sha512-ZvpabZt9TgRa1qhMr/22RD639KLBEi3bD9jKWvaGGNOuW8lADrZRmOVuYa0o4yVayxYVi3Ur0IOYwK8GVya5XA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -676,9 +676,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.0-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-19.1.tgz",
-      "integrity": "sha512-UStorOiLYQqfQQR3xh2+feMIYACXrCuNfVCPSlOVfzbe9RJlk09nugVRCTDghUcTxBk7Y/MzjAZu/xCOvhYh2g==",
+      "version": "1.0.0-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-23.1.tgz",
+      "integrity": "sha512-Hn+JN0szjAbQR0NPiH2UNEAxJgG0yH+SyryNyjs0VgtjTnWaS0xWp7nVd5aQNUmzpRCcKmGvRbkPS58sUXfdww==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -692,9 +692,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "1.0.1-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-10-19.1.tgz",
-      "integrity": "sha512-/KKBKwaViXNoUOOMrLFz6ZNk0z72cbVHspsTW0Z19s2Za3QlrfTYop+iJfgOd4xiD4eatD7l2uWWUPaSLeUwxQ==",
+      "version": "1.0.1-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-10-23.1.tgz",
+      "integrity": "sha512-2As7oQNpoBkcMcyaShXaUU7m1o3almXMTFsHAgzwPM9ek2o2V/ucpsu52us5JoCOspP8apMD32t3gyjVFSj3ng==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -707,9 +707,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "1.0.0-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-19.1.tgz",
-      "integrity": "sha512-brgGhqmXgIEwmKF3W8rPru3u1je+Qomn4xDkRF8S+iBLQUWFxV1ISm27boU+QTI6pwYmd9V/x/z+9ZAJ0Zb6TA==",
+      "version": "1.0.0-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-23.1.tgz",
+      "integrity": "sha512-eNE39DqJg5PIvpWOI+bwbLLNlZBCERlxFst1Dn5NAp2ZR2H9WH2Eeo9lWCZHc1oTwfiJ0KfFCvvrtO2QA3QnqQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7590,9 +7590,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "1.0.1-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-10-19.1.tgz",
-      "integrity": "sha512-hXIoGtIH1hl+UDAi85eAKuMA3Cn165kLiK+hcbNcAAQa5//xMUOXxOX2qlmQSelc/53HEBEuQMUThDnGWoePmQ==",
+      "version": "1.0.1-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-10-23.1.tgz",
+      "integrity": "sha512-zHrFs/dk+cNlGhefKLX6tCUx0dJQu0Li9UbdSJDKPsmDIRo5d5glyE9w1FeNPYOFzm7C3vTF8HCzXgrW0l9pBg==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7600,9 +7600,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "1.0.0-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-19.1.tgz",
-      "integrity": "sha512-GNTIhp6fUZLEbyXHp/po+MKwU6JCLjWutQbqQcn4BZRy1/e+evy4S3JtUvkNjlMAQ6zOXf9JX8GrmdYfDFQihA==",
+      "version": "1.0.0-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-10-23.1.tgz",
+      "integrity": "sha512-Jx7NcTsRRZCQAtu68DNVQUCmAuqmHNVqbF4ODIPlE+eIXJ4P6c7Rod8TNDKEwdGgmGw4OjaTqPRsy/kYkUdHLw==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7616,9 +7616,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "1.0.0-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-19.1.tgz",
-      "integrity": "sha512-vPPN/evquAfPDjQqq8c40tufkITLR6Tg8qUKk62C0cOOtKqM0zfRd3clcU19hiJO2ufenOzcSujXlhecyQTYyw==",
+      "version": "1.0.0-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-10-23.1.tgz",
+      "integrity": "sha512-tANQ7jYf9vauv6XQUXtcmpHOzv6ROmEQ1rEdlKrOKISma03NhvjF23zCTxkbJB4k8w9oF+CJUyr77706yoczBA==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7632,30 +7632,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "1.0.0-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-10-19.1.tgz",
-      "integrity": "sha512-13UMYbxn5NQHwckAcMt19mpuUQDe9wi99Pwa+4gtWna7Ogtwolo9DszWCu5gc52iYYjq/8SjFBkPVd/ZUbSqcg==",
+      "version": "1.0.0-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-10-23.1.tgz",
+      "integrity": "sha512-82R1qcq4WYEYF/ZNDQLzEUcqKkiVxdOGdzTdTxLFIhc5ZXRz6pjvmZtjuGUUzoAzp/4r1bu0yKdWFkFzgtDZ6w==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "1.0.0-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-10-19.1.tgz",
-      "integrity": "sha512-HQ+hOjfgcCfb5Jdicpm+K1cHeY8gLhQJqsnKhtq5J74TOyS1PbN6IoMwRDfw1OPLwXiGtbNIujZW/Ea4H1ZECA==",
+      "version": "1.0.0-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-10-23.1.tgz",
+      "integrity": "sha512-PmvH3mJFGRMY8YHfv8G/sGtVUrUt4SgHEUH3zZqW4YP1o0uCA8gByyNGtJ8ooTuXsOasnLTbKkoo74gKJfhYRw==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "2.0.0-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-10-19.1.tgz",
-      "integrity": "sha512-eiRE4ykeCGY6f3v6tPGpoe6fFqPJIf1cQDJNOVGjZ6GgxIf630iLyWRtgykF/6lL5miVnouP/HD0dUPN2HFjXQ==",
+      "version": "2.0.0-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-10-23.1.tgz",
+      "integrity": "sha512-ZvpabZt9TgRa1qhMr/22RD639KLBEi3bD9jKWvaGGNOuW8lADrZRmOVuYa0o4yVayxYVi3Ur0IOYwK8GVya5XA==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.0-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-19.1.tgz",
-      "integrity": "sha512-UStorOiLYQqfQQR3xh2+feMIYACXrCuNfVCPSlOVfzbe9RJlk09nugVRCTDghUcTxBk7Y/MzjAZu/xCOvhYh2g==",
+      "version": "1.0.0-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-10-23.1.tgz",
+      "integrity": "sha512-Hn+JN0szjAbQR0NPiH2UNEAxJgG0yH+SyryNyjs0VgtjTnWaS0xWp7nVd5aQNUmzpRCcKmGvRbkPS58sUXfdww==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7669,17 +7669,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "1.0.1-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-10-19.1.tgz",
-      "integrity": "sha512-/KKBKwaViXNoUOOMrLFz6ZNk0z72cbVHspsTW0Z19s2Za3QlrfTYop+iJfgOd4xiD4eatD7l2uWWUPaSLeUwxQ==",
+      "version": "1.0.1-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-10-23.1.tgz",
+      "integrity": "sha512-2As7oQNpoBkcMcyaShXaUU7m1o3almXMTFsHAgzwPM9ek2o2V/ucpsu52us5JoCOspP8apMD32t3gyjVFSj3ng==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "1.0.0-next-2023-10-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-19.1.tgz",
-      "integrity": "sha512-brgGhqmXgIEwmKF3W8rPru3u1je+Qomn4xDkRF8S+iBLQUWFxV1ISm27boU+QTI6pwYmd9V/x/z+9ZAJ0Zb6TA==",
+      "version": "1.0.0-next-2023-10-23.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-10-23.1.tgz",
+      "integrity": "sha512-eNE39DqJg5PIvpWOI+bwbLLNlZBCERlxFst1Dn5NAp2ZR2H9WH2Eeo9lWCZHc1oTwfiJ0KfFCvvrtO2QA3QnqQ==",
       "requires": {}
     },
     "@esbuild/android-arm": {


### PR DESCRIPTION
# Motivation

Upgrade `ic-js` version to make new proposals ([40&41](https://github.com/dfinity/ic-js/pull/413)) available.

# Changes

- `npm run upgrade:next`

# Tests

Proposals tested manually against the testnet.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary
