### PR TITLE
Do not reload transactions twice after BTC withdrawal

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCSendButton.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCSendButton.svelte
@@ -10,7 +10,6 @@
 
   export let account: Account | undefined = undefined;
   export let disableButton: boolean;
-  export let reloadAccountFromStore: (() => void) | undefined = undefined;
   export let canisters: CkBTCAdditionalCanisters | undefined = undefined;
   export let loadTransactions = false;
 
@@ -29,7 +28,6 @@
         type: "ckbtc-transaction",
         data: {
           account,
-          reloadAccountFromStore,
           universeId: $selectedCkBTCUniverseIdStore,
           canisters,
           loadTransactions,

--- a/frontend/src/lib/components/accounts/CkBTCWalletFooter.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWalletFooter.svelte
@@ -12,7 +12,6 @@
 
   export let store: Writable<WalletStore>;
   export let reloadAccount: () => Promise<void>;
-  export let reloadAccountFromStore: () => void;
 
   let canisters: CkBTCAdditionalCanisters | undefined = undefined;
   $: canisters = nonNullish($selectedCkBTCUniverseIdStore)
@@ -32,7 +31,6 @@
     {disableButton}
     {canisters}
     account={$store.account}
-    {reloadAccountFromStore}
     loadTransactions
   />
 

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionTokenModal.svelte
@@ -18,15 +18,13 @@
   let canisters: CkBTCAdditionalCanisters;
   let universeId: UniverseCanisterId;
   let account: Account | undefined;
-  let reloadAccountFromStore: (() => void) | undefined;
   let loadTransactions: boolean;
 
-  $: ({ account, reloadAccountFromStore, universeId, canisters } = data);
+  $: ({ account, universeId, canisters } = data);
 
   const dispatcher = createEventDispatcher();
 
-  const onTransferReloadSelectedAccount = async () => {
-    reloadAccountFromStore?.();
+  const onTransfer = async () => {
     dispatcher("nnsClose");
   };
 
@@ -40,7 +38,7 @@
 {#if nonNullish(token) && nonNullish(transactionFee)}
   <CkBTCTransactionModal
     on:nnsClose
-    on:nnsTransfer={onTransferReloadSelectedAccount}
+    on:nnsTransfer={onTransfer}
     selectedAccount={account}
     {loadTransactions}
     token={token.token}

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -60,12 +60,6 @@
     reloadTransactions();
   };
 
-  // e.g. when a function such as a transfer is called and which also reload the data and populate the stores after execution
-  const reloadAccountFromStore = () => {
-    setSelectedAccount();
-    reloadTransactions();
-  };
-
   const reloadOnlyAccountFromStore = () => setSelectedAccount();
 
   // transactions?.reloadTransactions?.() returns a promise.
@@ -227,11 +221,7 @@
   </main>
 
   {#if canMakeTransactions}
-    <CkBTCWalletFooter
-      store={selectedAccountStore}
-      {reloadAccount}
-      {reloadAccountFromStore}
-    />
+    <CkBTCWalletFooter store={selectedAccountStore} {reloadAccount} />
   {/if}
 </Island>
 


### PR DESCRIPTION
# Motivation

When making a ckBTC -> BTC withdrawal, the last step in the modal reloads transactions ([here](https://github.com/dfinity/nns-dapp/blob/04b511c634d027a59fdd7965fb7ad605c67af17d/frontend/src/lib/services/ckbtc-convert.services.ts#L208)), but right when the modal closes, transactions are reloaded again ([here](https://github.com/dfinity/nns-dapp/blob/main/frontend/src/lib/modals/accounts/CkBTCTransactionTokenModal.svelte#L29)).
The name (`reloadAccountFromStore`) and the comment ([here](https://github.com/dfinity/nns-dapp/blob/main/frontend/src/lib/pages/CkBTCWallet.svelte#L63)) suggest the function expects transaction to have been reloaded into the store such that the function can load the transactions just from the store, but that doesn't seem to be what it does. And after removing the line, the new transaction is still immediately visible when the window closes.

So I don't fully understand what was intended here so please review carefully.

# Changes

1. Don't call `reloadAccountFromStore` in `frontend/src/lib/modals/accounts/CkBTCTransactionTokenModal.svelte` before closing the window.
2. Remove now unused code/props.

# Tests

Tested manually here: https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [x] Add entry to changelog (if necessary).
