### PR TITLE
GIX-1960: Add new field from SNS Aggregator

### DIFF
--- a/frontend/src/lib/types/sns-aggregator.ts
+++ b/frontend/src/lib/types/sns-aggregator.ts
@@ -120,6 +120,7 @@ export type CachedSwapInitParamsDto = {
   neurons_fund_participation_constraints?: CachedNeuronsFundParticipationConstraints | null;
   min_direct_participation_icp_e8s?: number | null;
   max_direct_participation_icp_e8s?: number | null;
+  neurons_fund_participation?: boolean | null;
 };
 
 export type CachedSnsSwapDto = {

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -217,7 +217,7 @@ const convertSwapInitParams = (
         max_direct_participation_icp_e8s: toNullable(
           convertOptionalNumToBigInt(init.max_direct_participation_icp_e8s)
         ),
-        neurons_fund_participation: [],
+        neurons_fund_participation: toNullable(init.neurons_fund_participation),
       }
     : undefined;
 

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -508,6 +508,7 @@ describe("sns aggregator converters utils", () => {
               },
               min_direct_participation_icp_e8s: 300000000000,
               max_direct_participation_icp_e8s: 3000000000000,
+              neurons_fund_participation: true,
             },
           },
           derived: {
@@ -526,6 +527,7 @@ describe("sns aggregator converters utils", () => {
             ...mockData.init.init,
             min_direct_participation_icp_e8s: 300000000000,
             max_direct_participation_icp_e8s: 3000000000000,
+            neurons_fund_participation: true,
           },
         },
       };
@@ -562,6 +564,7 @@ describe("sns aggregator converters utils", () => {
               ],
               min_direct_participation_icp_e8s: [300000000000n],
               max_direct_participation_icp_e8s: [3000000000000n],
+              neurons_fund_participation: [true],
             },
           ],
           direct_participation_icp_e8s: [300000000000000n],
@@ -576,6 +579,7 @@ describe("sns aggregator converters utils", () => {
           ...summaryMockData.init,
           min_direct_participation_icp_e8s: [300000000000n],
           max_direct_participation_icp_e8s: [3000000000000n],
+          neurons_fund_participation: [true],
         },
       });
     });


### PR DESCRIPTION
# Motivation

Support the new Neurons' Enhancements features.

In this PR, support the field `neurons_fund_participation` from the aggretagor.

# Changes

* Add field `neurons_fund_participation` to SNS aggregator type.
* Support new field in the converter.

# Tests

* Add a test where the field is present with `true`.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet necessary.
