### PR TITLE
GIX-1939: Use NF participation field to show N/A

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TokenAmount, ICPToken, isNullish } from "@dfinity/utils";
+  import { TokenAmount, ICPToken } from "@dfinity/utils";
   import type { SnsSummary } from "$lib/types/sns";
   import { i18n } from "$lib/stores/i18n";
   import AmountDisplay from "../ic/AmountDisplay.svelte";

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TokenAmount, ICPToken } from "@dfinity/utils";
+  import { TokenAmount, ICPToken, isNullish } from "@dfinity/utils";
   import type { SnsSummary } from "$lib/types/sns";
   import { i18n } from "$lib/stores/i18n";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
@@ -109,9 +109,7 @@
         </div>
 
         <svelte:fragment slot="value">
-          {#if projectCommitments.nfCommitmentE8s === null}
-            <span>{$i18n.sns_project_detail.not_participating}</span>
-          {:else}
+          {#if projectCommitments.isNFParticipating && nonNullish(projectCommitments.nfCommitmentE8s)}
             <AmountDisplay
               amount={TokenAmount.fromE8s({
                 amount: projectCommitments.nfCommitmentE8s,
@@ -119,6 +117,8 @@
               })}
               singleLine
             />
+          {:else}
+            <span>{$i18n.sns_project_detail.not_participating}</span>
           {/if}
         </svelte:fragment>
       </KeyValuePairInfo>

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -108,14 +108,19 @@
           />
         </div>
 
-        <AmountDisplay
-          slot="value"
-          amount={TokenAmount.fromE8s({
-            amount: projectCommitments.nfCommitmentE8s,
-            token: ICPToken,
-          })}
-          singleLine
-        />
+        <svelte:fragment slot="value">
+          {#if projectCommitments.nfCommitmentE8s === null}
+            <span>{$i18n.core.not_applicable}</span>
+          {:else}
+            <AmountDisplay
+              amount={TokenAmount.fromE8s({
+                amount: projectCommitments.nfCommitmentE8s,
+                token: ICPToken,
+              })}
+              singleLine
+            />
+          {/if}
+        </svelte:fragment>
       </KeyValuePairInfo>
     </div>
   {/if}

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -110,7 +110,7 @@
 
         <svelte:fragment slot="value">
           {#if projectCommitments.nfCommitmentE8s === null}
-            <span>{$i18n.core.not_applicable}</span>
+            <span>{$i18n.sns_project_detail.not_participating}</span>
           {:else}
             <AmountDisplay
               amount={TokenAmount.fromE8s({

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -30,7 +30,6 @@
     "this_may_take_a_few_minutes": "This may take a few minutes",
     "do_not_close": "Please do not close your browser tab",
     "finish": "Finish",
-    "not_applicable": "N/A",
     "unknown": "Unknown"
   },
   "error": {
@@ -705,6 +704,7 @@
     "min_participants": "Minimum Participants",
     "current_overall_commitment": "Overall Commitment",
     "current_nf_commitment": "Neurons' Fund Commitment",
+    "not_participating": "Not Participating",
     "current_direct_commitment": "Direct Commitment",
     "current_sale_buyer_count": "Direct Participants",
     "min_commitment_goal": "Minimum Commitment Goal",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -30,6 +30,7 @@
     "this_may_take_a_few_minutes": "This may take a few minutes",
     "do_not_close": "Please do not close your browser tab",
     "finish": "Finish",
+    "not_applicable": "N/A",
     "unknown": "Unknown"
   },
   "error": {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -33,7 +33,6 @@ interface I18nCore {
   this_may_take_a_few_minutes: string;
   do_not_close: string;
   finish: string;
-  not_applicable: string;
   unknown: string;
 }
 
@@ -730,6 +729,7 @@ interface I18nSns_project_detail {
   min_participants: string;
   current_overall_commitment: string;
   current_nf_commitment: string;
+  not_participating: string;
   current_direct_commitment: string;
   current_sale_buyer_count: string;
   min_commitment_goal: string;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -33,6 +33,7 @@ interface I18nCore {
   this_may_take_a_few_minutes: string;
   do_not_close: string;
   finish: string;
+  not_applicable: string;
   unknown: string;
 }
 

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -412,10 +412,10 @@ export const differentSummaries = (
 export type FullProjectCommitmentSplit = {
   totalCommitmentE8s: bigint;
   directCommitmentE8s: bigint;
-  // `null` means that the NF is not participating
-  nfCommitmentE8s: bigint | null;
+  nfCommitmentE8s?: bigint;
   minDirectCommitmentE8s: bigint;
   maxDirectCommitmentE8s: bigint;
+  isNFParticipating: boolean;
 };
 export type ProjectCommitmentSplit =
   | { totalCommitmentE8s: bigint }
@@ -443,7 +443,8 @@ export const getProjectCommitmentSplit = (
     return {
       totalCommitmentE8s: summary.derived.buyer_total_icp_e8s,
       directCommitmentE8s,
-      nfCommitmentE8s: isNFParticipating ? nfCommitmentE8s : null,
+      nfCommitmentE8s: isNFParticipating ? nfCommitmentE8s : undefined,
+      isNFParticipating,
       minDirectCommitmentE8s,
       maxDirectCommitmentE8s,
     };

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -412,7 +412,8 @@ export const differentSummaries = (
 export type FullProjectCommitmentSplit = {
   totalCommitmentE8s: bigint;
   directCommitmentE8s: bigint;
-  nfCommitmentE8s: bigint;
+  // `null` means that the NF is not participating
+  nfCommitmentE8s: bigint | null;
   minDirectCommitmentE8s: bigint;
   maxDirectCommitmentE8s: bigint;
 };
@@ -429,8 +430,12 @@ export const getProjectCommitmentSplit = (
   );
   const minDirectCommitmentE8s = getMinDirectParticipation(summary);
   const maxDirectCommitmentE8s = getMaxDirectParticipation(summary);
+  const isNFParticipating = fromNullable(
+    summary.init?.neurons_fund_participation ?? []
+  );
+
   if (
-    nonNullish(nfCommitmentE8s) &&
+    nonNullish(isNFParticipating) &&
     nonNullish(directCommitmentE8s) &&
     nonNullish(minDirectCommitmentE8s) &&
     nonNullish(maxDirectCommitmentE8s)
@@ -438,7 +443,7 @@ export const getProjectCommitmentSplit = (
     return {
       totalCommitmentE8s: summary.derived.buyer_total_icp_e8s,
       directCommitmentE8s,
-      nfCommitmentE8s,
+      nfCommitmentE8s: isNFParticipating ? nfCommitmentE8s : null,
       minDirectCommitmentE8s,
       maxDirectCommitmentE8s,
     };

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -139,7 +139,9 @@ describe("ProjectCommitment", () => {
         neuronsFundIsParticipating: [false],
       });
       const po = renderComponent(summary);
-      expect(await po.getNeuronsFundParticipation()).toEqual("N/A");
+      expect(await po.getNeuronsFundParticipation()).toEqual(
+        "Not Participating"
+      );
       expect(await po.getDirectParticipation()).toEqual("200.00 ICP");
     });
   });

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -127,6 +127,23 @@ describe("ProjectCommitment", () => {
     });
   });
 
+  describe("when Neurons' Fund enhancements fields are available and NF is not participating", () => {
+    it("should render detailed participation with NF participation not applicable", async () => {
+      const directCommitment = 20000000000n;
+      const summary = createSummary({
+        currentTotalCommitment: directCommitment,
+        neuronsFundCommitment: undefined,
+        directCommitment,
+        minDirectParticipation: 10000000000n,
+        maxDirectParticipation: 100000000000n,
+        neuronsFundIsParticipating: [false],
+      });
+      const po = renderComponent(summary);
+      expect(await po.getNeuronsFundParticipation()).toEqual("N/A");
+      expect(await po.getDirectParticipation()).toEqual("200.00 ICP");
+    });
+  });
+
   describe("when Neurons' Fund enhancements fields are not available", () => {
     const overallCommitment = 30000000000n;
     const summary = createSummary({

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1372,7 +1372,7 @@ describe("project-utils", () => {
       });
     });
 
-    describe("when direct participation is present", () => {
+    describe("when direct participation is not present", () => {
       it("returns the overall commitments even if nf commitment and min-max direct participations are present", () => {
         const minDirectParticipation = 10000000000n;
         const maxDirectParticipation = 100000000000n;
@@ -1388,6 +1388,49 @@ describe("project-utils", () => {
 
         expect(getProjectCommitmentSplit(summary)).toEqual({
           totalCommitmentE8s: currentTotalCommitment,
+        });
+      });
+    });
+
+    describe("when neurons fund participation is not present", () => {
+      it("returns the overall commitments even if nf commitment and min-max direct participations are present", () => {
+        const minDirectParticipation = 10000000000n;
+        const maxDirectParticipation = 100000000000n;
+
+        const summary = createSummary({
+          currentTotalCommitment: nfCommitment + directCommitment,
+          directCommitment: directCommitment,
+          neuronsFundCommitment: nfCommitment,
+          minDirectParticipation,
+          maxDirectParticipation,
+          neuronsFundIsParticipating: [],
+        });
+
+        expect(getProjectCommitmentSplit(summary)).toEqual({
+          totalCommitmentE8s: nfCommitment + directCommitment,
+        });
+      });
+    });
+
+    describe("when NF enhancement fields are present, but NF is not participating", () => {
+      it("returns the commitments split with NF as `null`", () => {
+        const minDirectParticipation = 10000000000n;
+        const maxDirectParticipation = 100000000000n;
+        const summary = createSummary({
+          currentTotalCommitment: directCommitment,
+          directCommitment,
+          neuronsFundCommitment: undefined,
+          minDirectParticipation,
+          maxDirectParticipation,
+          neuronsFundIsParticipating: [false],
+        });
+
+        expect(getProjectCommitmentSplit(summary)).toEqual({
+          totalCommitmentE8s: directCommitment,
+          directCommitmentE8s: directCommitment,
+          nfCommitmentE8s: null,
+          minDirectCommitmentE8s: minDirectParticipation,
+          maxDirectCommitmentE8s: maxDirectParticipation,
         });
       });
     });

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1304,6 +1304,7 @@ describe("project-utils", () => {
           nfCommitmentE8s: nfCommitment,
           minDirectCommitmentE8s: minDirectParticipation,
           maxDirectCommitmentE8s: maxDirectParticipation,
+          isNFParticipating: true,
         });
       });
 
@@ -1352,22 +1353,7 @@ describe("project-utils", () => {
           nfCommitmentE8s: 0n,
           minDirectCommitmentE8s: minDirectParticipation,
           maxDirectCommitmentE8s: maxDirectParticipation,
-        });
-      });
-    });
-
-    describe("when NF participation is not present", () => {
-      it("returns the full commitment even if min-max direct participation are present", () => {
-        const currentTotalCommitment = 30000000000n;
-        const summary = createSummary({
-          currentTotalCommitment,
-          directCommitment: undefined,
-          neuronsFundCommitment: undefined,
-          minDirectParticipation: 100000000000n,
-          maxDirectParticipation: 1000000000000n,
-        });
-        expect(getProjectCommitmentSplit(summary)).toEqual({
-          totalCommitmentE8s: currentTotalCommitment,
+          isNFParticipating: true,
         });
       });
     });
@@ -1428,9 +1414,10 @@ describe("project-utils", () => {
         expect(getProjectCommitmentSplit(summary)).toEqual({
           totalCommitmentE8s: directCommitment,
           directCommitmentE8s: directCommitment,
-          nfCommitmentE8s: null,
+          nfCommitmentE8s: undefined,
           minDirectCommitmentE8s: minDirectParticipation,
           maxDirectCommitmentE8s: maxDirectParticipation,
+          isNFParticipating: false,
         });
       });
     });

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -320,6 +320,7 @@ type SnsSummaryParams = {
   minDirectParticipation?: bigint;
   maxDirectParticipation?: bigint;
   maxNFParticipation?: bigint;
+  neuronsFundIsParticipating?: [boolean] | [];
 };
 
 export const createSummary = ({
@@ -340,6 +341,7 @@ export const createSummary = ({
   minDirectParticipation,
   maxDirectParticipation,
   maxNFParticipation,
+  neuronsFundIsParticipating,
 }: SnsSummaryParams): SnsSummary => {
   const init: SnsSwapInit = {
     ...mockInit,
@@ -347,6 +349,10 @@ export const createSummary = ({
     confirmation_text: toNullable(confirmationText),
     min_direct_participation_icp_e8s: toNullable(minDirectParticipation),
     max_direct_participation_icp_e8s: toNullable(maxDirectParticipation),
+    neurons_fund_participation:
+      neuronsFundIsParticipating ??
+      // If `neuronsFundCommitment` is set, it means that the neurons fund is participating
+      toNullable(nonNullish(neuronsFundCommitment)),
     restricted_countries: nonNullish(restrictedCountries)
       ? [{ iso_codes: restrictedCountries }]
       : [],


### PR DESCRIPTION
# Motivation

If the participation of the NF is not requested in a swap, we want to display a suited message.

# Changes

* Change the field `nfCommitment` in `FullProjectCommitmentSplit` to also accept a `null`.
* Change logic in project util `getProjectCommitmentSplit` to return `null` for `nfCommitment` when NF participation is not requested.
* In ProjectCommitment, check whether `nfCommitmentE8s` is `null` to show "N/A".
* Add i18n key for "N/A".

# Tests

* Add a test in ProjectCommitment for new case.
* Add two tests in `getProjectCommitmentSplit` that use the new field and logic.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet published. Part of another entry.