### PR TITLE
Test that nns-dapp has a consistent version

### DIFF
--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -31,3 +31,4 @@ AMD64
 Zondax
 E2E
 Vitest
+npm

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -356,8 +356,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Backend and frontend have the same version
         run: |
-          backend_version = "$(cargo metadata | jq -r '.packages[] | select(.name == "nns-dapp").version')"
-          frontend_version = "$(jq -r .version frontend/package.json)"
+          backend_version="$(cargo metadata | jq -r '.packages[] | select(.name == "nns-dapp").version')"
+          frontend_version="$(jq -r .version frontend/package.json)"
           [[ "${backend_version}" == "${frontend_version}" ]] || {
                   echo "ERROR: The nns-dapp frontend and backend should have the same version but:"
                   echo "Backend:  $backend_version"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -349,8 +349,23 @@ jobs:
           fetch-depth: 0
       - run: scripts/past-changelog-test
       - run: scripts/past-changelog-test.test
+  version-match:
+    name: The nns-dapp npm and cargo versions should match
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Backend and frontend have the same version
+        run: |
+          backend_version = "$(cargo metadata | jq -r '.packages[] | select(.name == "nns-dapp").version')"
+          frontend_version = "$(jq -r .version frontend/package.json)"
+          [[ "${backend_version}" == "${frontend_version}" ]] || {
+                  echo "ERROR: The nns-dapp frontend and backend should have the same version but:"
+                  echo "Backend:  $backend_version"
+                  echo "Frontend: $frontend_version"
+                  exit 1
+          } >&2
   checks-pass:
-    needs: ["formatting", "spelling", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "split-changelog", "past-changelog", "minor-version-bump-works"]
+    needs: ["formatting", "spelling", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "ic-commit-consistency", "release-templating-works", "config-check", "sns-aggregator-patches", "asset-chunking-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "split-changelog", "past-changelog", "minor-version-bump-works", "version-match"]
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -22,7 +22,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Update proposal info icons position to improve the UX.
 * Improve the indicator of the minimum commitment in the project status.
-* Dapp upgraded to Svelte v4.
+* Dapp upgraded to Svelte `v4`.
 
 #### Deprecated
 #### Removed
@@ -31,7 +31,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Add "Finalizing" status in projects of the Launchpad.
 * Fix UI bug when commitment was very low.
-* Remove robots metatag to allow search engines to crawl NNS Dapp.
+* Remove robots meta tag to allow search engines to crawl NNS Dapp.
 
 #### Security
 
@@ -50,6 +50,7 @@ proposal is successful, the changes it released will be moved from this file to
 * E2E test for ckBTC.
 * Fix erroneous failures in the `tip` tagging workflow when a PR is closed without merging.
 * Add --host flag to dfx-snapshot-start.
+* Add test to check that the nns-dapp cargo and npm versions match.
 
 #### Changed
 


### PR DESCRIPTION
# Motivation
The NNS Dapp frontend npm version should match the backend cargo version.  This should be enforced in CI.

# Changes
- Add a github check that the versions match.

# Tests
See CI

- Here CI failed when the versions did not match: https://github.com/dfinity/nns-dapp/actions/runs/6614628537/job/17965039428
- CI should succeed now that they do match.

# Todos

- [x] Add entry to changelog (if necessary).
