### PR TITLE
fix: Join URLs with spaces

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -41,6 +41,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Join npm audit URLs with spaces instead of commas.
 * Add traits with a dedicated command rather than with patch files.
 
 #### Deprecated

--- a/scripts/nns-dapp/release-sop
+++ b/scripts/nns-dapp/release-sop
@@ -289,7 +289,7 @@ is_release_sop_script_newest_version() {
 npm_audit() {
   local audit
   pushd "$TOP_DIR/frontend" >&2
-  audit="$(npm audit --json | jq --slurp -r '[.. | .via? | .[]? | .url?] | join(",")')"
+  audit="$(npm audit --json | jq --slurp -r '[.. | .via? | .[]? | .url?] | join(" ")')"
   if [ "$audit" ]; then
     echo "$audit"
     exit


### PR DESCRIPTION
# Motivation
NPM audit provides issues as links.  Joining links with commas makes them into a single, long URL to a non-existent location.

# Changes
- Join npm audit URLs with spaces

# Tests
None: It doesn't appear to be possible to run the npm audit step without running everything before it in the release command.

# Todos

- [x] Add entry to changelog (if necessary).
