### PR TITLE
Chore: Refactor ProjectCard and ProjectCardSwapInfo tests

### DIFF
--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -58,7 +58,7 @@
     <h3 data-tid="project-name">{name}</h3>
   </div>
 
-  <p class="value description">{description}</p>
+  <p data-tid="project-description" class="value description">{description}</p>
 
   <ProjectCardSwapInfo isFinalizing={$isFinalizingStore} {project} />
 

--- a/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
@@ -75,7 +75,9 @@
     <!-- Sale is open -->
     {#if lifecycle === SnsSwapLifecycle.Open && durationTillDeadline !== undefined}
       <dt class="label">{$i18n.sns_project_detail.deadline}</dt>
-      <dd class="value">{secondsToDuration(durationTillDeadline)}</dd>
+      <dd class="value" data-tid="project-deadline">
+        {secondsToDuration(durationTillDeadline)}
+      </dd>
     {/if}
   </TestIdWrapper>
 

--- a/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
@@ -18,11 +18,12 @@ import { render } from "@testing-library/svelte";
 
 describe("ProjectCard", () => {
   const rootCanisterId = rootCanisterIdMock;
-  const now = 1698139468065;
+  const now = 1698139468000;
   const nowInSeconds = Math.round(now / 1000);
   const yesterdayInSeconds = nowInSeconds - SECONDS_IN_DAY;
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers().setSystemTime(now);
     setSnsProjects([
       {
         rootCanisterId: mockSnsFullProject.rootCanisterId,

--- a/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
@@ -18,9 +18,8 @@ import { render } from "@testing-library/svelte";
 
 describe("ProjectCard", () => {
   const rootCanisterId = rootCanisterIdMock;
-  const now = Date.now();
-  // Round up to the next second to avoid flaky tests
-  const nowInSeconds = Math.ceil(now / 1000);
+  const now = 1698139468065;
+  const nowInSeconds = Math.round(now / 1000);
   const yesterdayInSeconds = nowInSeconds - SECONDS_IN_DAY;
   beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
@@ -1,13 +1,8 @@
 import * as saleApi from "$lib/api/sns-sale.api";
 import ProjectCard from "$lib/components/launchpad/ProjectCard.svelte";
 import { SECONDS_IN_DAY, SECONDS_IN_MONTH } from "$lib/constants/constants";
-import { authStore } from "$lib/stores/auth.store";
-import {
-  authStoreMock,
-  mockIdentity,
-  mutableMockAuthStoreSubscribe,
-} from "$tests/mocks/auth.store.mock";
-import en from "$tests/mocks/i18n.mock";
+import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
+import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { createFinalizationStatusMock } from "$tests/mocks/sns-finalization-status.mock";
 import {
   createMockSnsFullProject,
@@ -22,12 +17,10 @@ import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
 describe("ProjectCard", () => {
-  vitest
-    .spyOn(authStore, "subscribe")
-    .mockImplementation(mutableMockAuthStoreSubscribe);
-
+  const rootCanisterId = rootCanisterIdMock;
   const now = Date.now();
-  const nowInSeconds = Math.floor(now / 1000);
+  // Round up to the next second to avoid flaky tests
+  const nowInSeconds = Math.ceil(now / 1000);
   const yesterdayInSeconds = nowInSeconds - SECONDS_IN_DAY;
   beforeEach(() => {
     vi.clearAllMocks();
@@ -40,120 +33,97 @@ describe("ProjectCard", () => {
     ]);
   });
 
+  const renderCard = async (project: SnsFullProject) => {
+    const { container } = render(ProjectCard, {
+      props: {
+        project,
+      },
+    });
+
+    await runResolvedPromises();
+
+    return ProjectCardPo.under(new JestPageObjectElement(container));
+  };
+
   describe("signed in", () => {
-    beforeAll(() =>
-      authStoreMock.next({
-        identity: mockIdentity,
-      })
-    );
+    beforeEach(() => {
+      resetIdentity();
+    });
 
-    it("should render a logo", () => {
-      const { container } = render(ProjectCard, {
-        props: {
-          project: mockSnsFullProject,
-        },
-      });
+    it("should render a logo", async () => {
+      const po = await renderCard(mockSnsFullProject);
 
-      const img = container.querySelector("img");
-
-      expect(img).toBeInTheDocument();
-      expect(img?.getAttribute("src")).toBe(
+      expect(await po.getLogoSrc()).toBe(
         mockSnsFullProject.summary.metadata.logo
       );
     });
 
     it("should render a title", async () => {
-      const { container } = render(ProjectCard, {
-        props: {
-          project: mockSnsFullProject,
-        },
-      });
-
-      const po = ProjectCardPo.under(new JestPageObjectElement(container));
+      const po = await renderCard(mockSnsFullProject);
 
       expect(await po.getProjectName()).toBe(
         mockSnsFullProject.summary.metadata.name
       );
     });
 
-    it("should render a description", () => {
-      const { getByText } = render(ProjectCard, {
-        props: {
-          project: mockSnsFullProject,
-        },
-      });
+    it("should render a description", async () => {
+      const po = await renderCard(mockSnsFullProject);
 
-      expect(
-        getByText(mockSnsFullProject.summary.metadata.description)
-      ).toBeInTheDocument();
+      expect(await po.getDescription()).toBe(
+        mockSnsFullProject.summary.metadata.description
+      );
     });
 
-    it("should be highlighted", async () => {
-      const { container } = render(ProjectCard, {
-        props: {
-          project: {
-            ...mockSnsFullProject,
-            swapCommitment: {
-              rootCanisterId: mockSnsFullProject.rootCanisterId,
-              myCommitment: {
-                icp: [
-                  {
-                    transfer_start_timestamp_seconds: BigInt(123132),
-                    amount_e8s: BigInt(100_000_000),
-                    transfer_success_timestamp_seconds: BigInt(5443554),
-                  },
-                ],
-                has_created_neuron_recipes: [],
-              },
-            },
-          },
+    it("should be highlighted with user commitment", async () => {
+      const project = createMockSnsFullProject({
+        rootCanisterId,
+        summaryParams: {
+          lifecycle: SnsSwapLifecycle.Open,
         },
+        icpCommitment: 100_000_000n,
       });
 
-      const po = ProjectCardPo.under(new JestPageObjectElement(container));
+      const po = await renderCard(project);
 
       expect(await po.isHighlighted()).toBe(true);
     });
 
     it("should not be highlighted without commitment", async () => {
-      const { container } = render(ProjectCard, {
-        props: {
-          project: {
-            ...mockSnsFullProject,
-            swapCommitment: {
-              rootCanisterId: mockSnsFullProject.rootCanisterId,
-              myCommitment: undefined,
-            },
-          },
+      const project = createMockSnsFullProject({
+        rootCanisterId,
+        summaryParams: {
+          lifecycle: SnsSwapLifecycle.Open,
         },
+        icpCommitment: undefined,
       });
-
-      const po = ProjectCardPo.under(new JestPageObjectElement(container));
+      const po = await renderCard(project);
 
       expect(await po.isHighlighted()).toBe(false);
     });
 
-    it("should display a spinner when the swapCommitment is not loaded", () => {
-      const { getByTestId } = render(ProjectCard, {
-        props: {
-          project: { ...mockSnsFullProject, swapCommitment: undefined },
-        },
+    it("should display a spinner when the swapCommitment is not loaded", async () => {
+      const po = await renderCard({
+        ...mockSnsFullProject,
+        swapCommitment: undefined,
       });
 
-      expect(getByTestId("spinner")).toBeInTheDocument();
+      expect(await po.hasSpinner()).toBe(true);
     });
 
-    it("should render swap info", () => {
-      const { getByText } = render(ProjectCard, {
-        props: {
-          project: mockSnsFullProject,
+    it("should render swap info", async () => {
+      const project = createMockSnsFullProject({
+        rootCanisterId,
+        summaryParams: {
+          lifecycle: SnsSwapLifecycle.Open,
+          swapDueTimestampSeconds: BigInt(nowInSeconds + SECONDS_IN_DAY),
         },
+        icpCommitment: 314000000n,
       });
 
-      expect(getByText(en.sns_project_detail.deadline)).toBeInTheDocument();
-      expect(
-        getByText(en.sns_project_detail.user_current_commitment)
-      ).toBeInTheDocument();
+      const po = await renderCard(project);
+
+      expect(await po.getUserCommitment()).toBe("3.14 ICP");
+      expect(await po.getDeadline()).toBe("1 day");
     });
 
     it("should render complete status if swap is Committed", async () => {
@@ -166,13 +136,8 @@ describe("ProjectCard", () => {
         },
       });
 
-      const { container } = render(ProjectCard, {
-        props: {
-          project: snsFulProject,
-        },
-      });
+      const po = await renderCard(snsFulProject);
 
-      const po = ProjectCardPo.under(new JestPageObjectElement(container));
       await runResolvedPromises();
 
       expect(await po.getStatus()).toBe("Status Completed");
@@ -190,34 +155,24 @@ describe("ProjectCard", () => {
         },
       });
 
-      const { container } = render(ProjectCard, {
-        props: {
-          project: snsFulProject,
-        },
-      });
-
-      const po = ProjectCardPo.under(new JestPageObjectElement(container));
-      await runResolvedPromises();
+      const po = await renderCard(snsFulProject);
 
       expect(await po.getStatus()).toBe("Status Finalizing");
     });
   });
 
   describe("not signed in", () => {
-    beforeAll(() =>
-      authStoreMock.next({
-        identity: undefined,
-      })
-    );
+    beforeAll(() => {
+      setNoIdentity();
+    });
 
-    it("should not display a spinner when the swapCommitment is not loaded", () => {
-      const { getByTestId } = render(ProjectCard, {
-        props: {
-          project: { ...mockSnsFullProject, swapCommitment: undefined },
-        },
+    it("should not display a spinner when the swapCommitment is not loaded", async () => {
+      const po = await renderCard({
+        ...mockSnsFullProject,
+        swapCommitment: undefined,
       });
 
-      expect(() => getByTestId("spinner")).toThrow();
+      expect(await po.hasSpinner()).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
@@ -138,8 +138,6 @@ describe("ProjectCard", () => {
 
       const po = await renderCard(snsFulProject);
 
-      await runResolvedPromises();
-
       expect(await po.getStatus()).toBe("Status Completed");
     });
 

--- a/frontend/src/tests/lib/components/launchpad/ProjectCardSwapInfo.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCardSwapInfo.spec.ts
@@ -10,8 +10,8 @@ import { render } from "@testing-library/svelte";
 
 describe("ProjectCardSwapInfo", () => {
   const rootCanisterId = rootCanisterIdMock;
-  const now = Date.now();
-  const nowInSeconds = Math.ceil(now / 1000);
+  const now = 1698139468000;
+  const nowInSeconds = Math.round(now / 1000);
 
   const renderCard = (props: {
     project: SnsFullProject;

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -321,6 +321,7 @@ type SnsSummaryParams = {
   maxDirectParticipation?: bigint;
   maxNFParticipation?: bigint;
   neuronsFundIsParticipating?: [boolean] | [];
+  swapOpenTimestampSeconds?: bigint;
 };
 
 export const createSummary = ({
@@ -342,6 +343,7 @@ export const createSummary = ({
   maxDirectParticipation,
   maxNFParticipation,
   neuronsFundIsParticipating,
+  swapOpenTimestampSeconds,
 }: SnsSummaryParams): SnsSummary => {
   const init: SnsSwapInit = {
     ...mockInit,
@@ -392,6 +394,7 @@ export const createSummary = ({
       ...summary.swap,
       init: [init],
       params,
+      decentralization_sale_open_timestamp_seconds: swapOpenTimestampSeconds,
     },
     derived,
     init,
@@ -401,13 +404,20 @@ export const createSummary = ({
 export const createMockSnsFullProject = ({
   summaryParams,
   rootCanisterId,
+  icpCommitment,
 }: {
   rootCanisterId: Principal;
   summaryParams: SnsSummaryParams;
-}) => ({
+  icpCommitment?: bigint;
+}): SnsFullProject => ({
   rootCanisterId,
   summary: createSummary(summaryParams),
-  mockSwapCommitment: mockSnsSwapCommitment(rootCanisterId),
+  swapCommitment: {
+    rootCanisterId,
+    myCommitment: nonNullish(icpCommitment)
+      ? createBuyersState(icpCommitment)
+      : undefined,
+  },
 });
 
 export const mockQueryMetadataResponse: SnsGetMetadataResponse = {

--- a/frontend/src/tests/page-objects/ProjectCard.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectCard.page-object.ts
@@ -19,7 +19,31 @@ export class ProjectCardPo extends CardPo {
     return this.getText("project-name");
   }
 
+  getSwapInfoPo(): ProjectCardSwapInfoPo {
+    return ProjectCardSwapInfoPo.under(this.root);
+  }
+
   getStatus(): Promise<string> {
-    return ProjectCardSwapInfoPo.under(this.root).getStatus();
+    return this.getSwapInfoPo().getStatus();
+  }
+
+  async getLogoSrc(): Promise<string> {
+    return this.root.querySelector("img")?.getAttribute("src") ?? "";
+  }
+
+  getDescription(): Promise<string> {
+    return this.getText("project-description");
+  }
+
+  hasSpinner(): Promise<boolean> {
+    return this.isPresent("spinner");
+  }
+
+  getDeadline(): Promise<string> {
+    return this.getSwapInfoPo().getSwapDeadline();
+  }
+
+  getUserCommitment(): Promise<string> {
+    return this.getSwapInfoPo().getUserCommitment();
   }
 }

--- a/frontend/src/tests/page-objects/ProjectCardSwapInfo.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectCardSwapInfo.page-object.ts
@@ -13,4 +13,18 @@ export class ProjectCardSwapInfoPo extends CardPo {
   async getStatus(): Promise<string> {
     return (await this.getText("project-status-text")).trim();
   }
+
+  hasUserCommitment(): Promise<boolean> {
+    return this.isPresent("commitment-token-value");
+  }
+
+  async getUserCommitment(): Promise<string | null> {
+    return (await this.hasUserCommitment())
+      ? this.getText("commitment-token-value")
+      : null;
+  }
+
+  getSwapDeadline(): Promise<string> {
+    return this.getText("project-deadline");
+  }
 }


### PR DESCRIPTION
# Motivation

Improve testing.

In this PR, migrate the test files for ProjectCard and ProjectCardSwapInfo to use page objects.

# Changes

* Add a couple of data-tid to elements in ProjectCard and ProjectCardSwapInfo.
* Add methods to ProjectCardPo and ProjectCardSwapInfoPo.
* Add new fields to test helper `createMockSnsFullProject`.
* Rewrite tests that weren't using PO and the helper.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
