### PR TITLE
Bump stable structures

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -21,6 +21,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Stable structures updated to `0.6.0`.
 * Dapp upgraded to Svelte v4.
 
 #### Deprecated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,7 +1645,7 @@ dependencies = [
  "crc32fast",
  "ic-crypto-sha 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
- "ic-stable-structures",
+ "ic-stable-structures 0.5.6",
  "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "prost",
  "serde",
@@ -1666,7 +1666,7 @@ dependencies = [
  "crc32fast",
  "ic-crypto-sha 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
  "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-stable-structures",
+ "ic-stable-structures 0.5.6",
  "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
  "prost",
  "serde",
@@ -1687,7 +1687,7 @@ dependencies = [
  "crc32fast",
  "ic-crypto-sha2",
  "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-stable-structures",
+ "ic-stable-structures 0.5.6",
  "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
  "prost",
  "serde",
@@ -2763,7 +2763,7 @@ dependencies = [
  "ic-metrics-encoder",
  "ic-nervous-system-runtime",
  "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-stable-structures",
+ "ic-stable-structures 0.5.6",
  "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
  "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
  "json5",
@@ -3260,7 +3260,7 @@ dependencies = [
  "ic-nervous-system-root 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-sns-governance",
- "ic-stable-structures",
+ "ic-stable-structures 0.5.6",
  "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "itertools",
@@ -3312,6 +3312,12 @@ name = "ic-stable-structures"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95dce29e3ceb0e6da3e78b305d95365530f2efd2146ca18590c0ef3aa6038568"
+
+[[package]]
+name = "ic-stable-structures"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4867a1d9f232e99ca68682161d1fc67dff9501f4f1bf42d69a9358289ad0f8"
 
 [[package]]
 name = "ic-sys"
@@ -4017,7 +4023,7 @@ dependencies = [
  "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "ic-nns-governance",
  "ic-sns-swap",
- "ic-stable-structures",
+ "ic-stable-structures 0.6.0",
  "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "itertools",
  "lazy_static",

--- a/rs/backend/Cargo.toml
+++ b/rs/backend/Cargo.toml
@@ -42,7 +42,7 @@ ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "89129b8212791d7e
 ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "89129b8212791d7e05cab62ff08eece2888a86e0" }
 ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "89129b8212791d7e05cab62ff08eece2888a86e0" }
 ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "89129b8212791d7e05cab62ff08eece2888a86e0" }
-ic-stable-structures = "0.5.6"
+ic-stable-structures = "0.6.0"
 icp-ledger = { git = "https://github.com/dfinity/ic", rev = "89129b8212791d7e05cab62ff08eece2888a86e0" }
 on_wire = { git = "https://github.com/dfinity/ic", rev = "89129b8212791d7e05cab62ff08eece2888a86e0" }
 

--- a/rs/backend/src/accounts_store/schema/accounts_in_stable_memory.rs
+++ b/rs/backend/src/accounts_store/schema/accounts_in_stable_memory.rs
@@ -25,7 +25,7 @@
 
 use crate::accounts_store::Account;
 use dfn_candid::Candid;
-use ic_stable_structures::storable::{BoundedStorable, Storable};
+use ic_stable_structures::storable::{Bound, Storable};
 use on_wire::{FromWire, IntoWire};
 use std::borrow::Cow;
 use std::convert::TryInto;
@@ -157,6 +157,10 @@ pub struct AccountStorageKey {
     bytes: [u8; AccountStorageKey::SIZE],
 }
 impl Storable for AccountStorageKey {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: Self::MAX_SIZE,
+        is_fixed_size: Self::IS_FIXED_SIZE,
+    };
     fn to_bytes(&self) -> Cow<'_, [u8]> {
         self.bytes[..].into()
     }
@@ -170,11 +174,9 @@ impl Storable for AccountStorageKey {
         }
     }
 }
-impl BoundedStorable for AccountStorageKey {
+impl AccountStorageKey {
     const MAX_SIZE: u32 = Self::SIZE as u32;
     const IS_FIXED_SIZE: bool = true;
-}
-impl AccountStorageKey {
     /// Location of the account identifier length in the key bytes.
     ///
     /// Note: Account identifiers typically consume 32 bytes, however some are shorter.
@@ -243,6 +245,10 @@ pub struct AccountStoragePage {
     bytes: [u8; AccountStoragePage::SIZE as usize],
 }
 impl Storable for AccountStoragePage {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: Self::MAX_SIZE,
+        is_fixed_size: Self::IS_FIXED_SIZE,
+    };
     fn to_bytes(&self) -> Cow<'_, [u8]> {
         self.bytes[..].into()
     }
@@ -256,11 +262,9 @@ impl Storable for AccountStoragePage {
         }
     }
 }
-impl BoundedStorable for AccountStoragePage {
+impl AccountStoragePage {
     const MAX_SIZE: u32 = AccountStoragePage::SIZE as u32;
     const IS_FIXED_SIZE: bool = true;
-}
-impl AccountStoragePage {
     /// The size of a page in bytes.
     pub const SIZE: u16 = 1024;
     /// The offset of the length header


### PR DESCRIPTION
# Motivation
We would like to use the variable memory sizes introduced in `ic-stable-structures 0.6.0`

# Changes
- Update `stable-structures` to version `0.6.0`
- Update the code to match:
  - Instead of having a separate `BoundedStorable` trait, `stable-structures` now has a `BOUND` in the `Storable` trait.

# Tests
Existing tests should suffice.

# Todos

- [x] Add entry to changelog (if necessary).
