### PR TITLE
Fix: Dissolve Delay Max

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -24,6 +24,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Stable structures updated to `0.6.0`.
 * Dapp upgraded to Svelte `v4`.
 * New Proposal Card.
+* Change the slider in dissolve delay for a read-only progress bar.
 
 #### Deprecated
 #### Removed
@@ -35,6 +36,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Remove robots meta tag to allow search engines to crawl NNS Dapp.
 * Fix i18n key in merge neurons summary screen.
 * Display `TransferFrom` as a normal receive instead of failing to load transactions.
+* Fix issue with setting max dissolve delay when max is not a whole day.
 
 #### Security
 

--- a/frontend/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -16,7 +16,7 @@
   import { valueSpan } from "$lib/utils/utils";
   import { Html, busy } from "@dfinity/gix-components";
 
-  export let delayInSeconds: number;
+  export let delayInSeconds: bigint;
   export let neuron: NeuronInfo;
   export let confirmButtonText: string;
 
@@ -29,8 +29,9 @@
 
     const neuronId = await updateDelay({
       neuronId: neuron.neuronId,
-      dissolveDelayInSeconds:
-        delayInSeconds - Number(neuron.dissolveDelaySeconds),
+      dissolveDelayInSeconds: Number(
+        delayInSeconds - neuron.dissolveDelaySeconds
+      ),
     });
 
     stopBusy("update-delay");
@@ -43,7 +44,7 @@
 
 <div class="wrapper" data-tid="confirm-dissolve-delay-container">
   <div class="main-info">
-    <h3>{secondsToDuration(BigInt(delayInSeconds))}</h3>
+    <h3>{secondsToDuration(delayInSeconds)}</h3>
   </div>
   <div>
     <p class="label">{$i18n.neurons.neuron_id}</p>
@@ -65,7 +66,7 @@
       {formatVotingPower(
         neuronVotingPower({
           neuron,
-          newDissolveDelayInSeconds: BigInt(delayInSeconds),
+          newDissolveDelayInSeconds: delayInSeconds,
         })
       )}
     </p>

--- a/frontend/src/lib/components/neurons/InputRangeDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/InputRangeDissolveDelay.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { daysToDuration, secondsToDays } from "$lib/utils/date.utils";
+  import { formatVotingPower } from "$lib/utils/neuron.utils";
+  import { InputRange } from "@dfinity/gix-components";
+
+  export let delayInSeconds: number;
+  export let maxDelayInSeconds: number;
+  export let onRangeInput: () => void;
+  export let votingPower: number;
+
+  let delayInDays: number;
+  $: delayInDays = secondsToDays(delayInSeconds);
+</script>
+
+<InputRange
+  ariaLabel={$i18n.neuron_detail.dissolve_delay_range}
+  min={0}
+  max={maxDelayInSeconds}
+  bind:value={delayInSeconds}
+  handleInput={onRangeInput}
+/>
+<div class="details">
+  <div>
+    <p class="label">
+      {formatVotingPower(votingPower)}
+    </p>
+    <p>{$i18n.neurons.voting_power}</p>
+  </div>
+  <div>
+    {#if delayInSeconds > 0}
+      <p class="label">{daysToDuration(delayInDays)}</p>
+    {:else}
+      <p class="label">{$i18n.neurons.no_delay}</p>
+    {/if}
+    <p>{$i18n.neurons.dissolve_delay_title}</p>
+  </div>
+</div>
+
+<style lang="scss">
+  .details {
+    margin-top: var(--padding);
+    display: flex;
+    justify-content: space-around;
+  }
+</style>

--- a/frontend/src/lib/components/neurons/RangeDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/RangeDissolveDelay.svelte
@@ -2,24 +2,17 @@
   import { i18n } from "$lib/stores/i18n";
   import { daysToDuration, secondsToDays } from "$lib/utils/date.utils";
   import { formatVotingPower } from "$lib/utils/neuron.utils";
-  import { InputRange } from "@dfinity/gix-components";
+  import { ProgressBar } from "@dfinity/gix-components";
 
   export let delayInSeconds: number;
   export let maxDelayInSeconds: number;
-  export let onRangeInput: () => void;
   export let votingPower: number;
 
   let delayInDays: number;
   $: delayInDays = secondsToDays(delayInSeconds);
 </script>
 
-<InputRange
-  ariaLabel={$i18n.neuron_detail.dissolve_delay_range}
-  min={0}
-  max={maxDelayInSeconds}
-  bind:value={delayInSeconds}
-  handleInput={onRangeInput}
-/>
+<ProgressBar max={maxDelayInSeconds} value={delayInSeconds} />
 <div class="details">
   <div>
     <p class="label">

--- a/frontend/src/lib/components/neurons/RangeDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/RangeDissolveDelay.svelte
@@ -3,6 +3,7 @@
   import { daysToDuration, secondsToDays } from "$lib/utils/date.utils";
   import { formatVotingPower } from "$lib/utils/neuron.utils";
   import { ProgressBar } from "@dfinity/gix-components";
+  import TestIdWrapper from "../common/TestIdWrapper.svelte";
 
   export let delayInSeconds: number;
   export let maxDelayInSeconds: number;
@@ -12,23 +13,29 @@
   $: delayInDays = secondsToDays(delayInSeconds);
 </script>
 
-<ProgressBar max={maxDelayInSeconds} value={delayInSeconds} />
-<div class="details">
-  <div>
-    <p class="label">
-      {formatVotingPower(votingPower)}
-    </p>
-    <p>{$i18n.neurons.voting_power}</p>
+<TestIdWrapper testId="range-dissolve-delay-component">
+  <ProgressBar
+    testId="range-dissolve-delay-progress-bar"
+    max={maxDelayInSeconds}
+    value={delayInSeconds}
+  />
+  <div class="details">
+    <div>
+      <p class="label">
+        {formatVotingPower(votingPower)}
+      </p>
+      <p>{$i18n.neurons.voting_power}</p>
+    </div>
+    <div>
+      {#if delayInSeconds > 0}
+        <p class="label">{daysToDuration(delayInDays)}</p>
+      {:else}
+        <p class="label">{$i18n.neurons.no_delay}</p>
+      {/if}
+      <p>{$i18n.neurons.dissolve_delay_title}</p>
+    </div>
   </div>
-  <div>
-    {#if delayInSeconds > 0}
-      <p class="label">{daysToDuration(delayInDays)}</p>
-    {:else}
-      <p class="label">{$i18n.neurons.no_delay}</p>
-    {/if}
-    <p>{$i18n.neurons.dissolve_delay_title}</p>
-  </div>
-</div>
+</TestIdWrapper>
 
 <style lang="scss">
   .details {

--- a/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -29,32 +29,11 @@
   let disableUpdate: boolean;
   $: disableUpdate = shouldUpdateBeDisabled(delayInSeconds);
 
-  const keepDelaysInBounds = () => {
-    if (delayInSeconds < Number(neuronDissolveDelaySeconds)) {
-      delayInSeconds = Number(neuronDissolveDelaySeconds);
-    }
-
-    if (delayInSeconds > maxDelayInSeconds) {
-      delayInSeconds = maxDelayInSeconds;
-    }
-  };
-
-  const setMin = () => {
-    delayInSeconds = Math.max(
-      Number(neuronDissolveDelaySeconds),
-      minProjectDelayInSeconds
-    );
-  };
-
-  const setMax = () => {
-    delayInSeconds = maxDelayInSeconds;
-  };
-
   const getInputError = (delayInSeconds: number) => {
     if (delayInSeconds > maxDelayInSeconds) {
       return $i18n.neurons.dissolve_delay_above_maximum;
     }
-    if (delayInSeconds < neuronDissolveDelaySeconds) {
+    if (delayInSeconds <= neuronDissolveDelaySeconds) {
       return $i18n.neurons.dissolve_delay_below_current;
     }
     if (delayInSeconds < minProjectDelayInSeconds) {
@@ -70,10 +49,6 @@
     return (
       nonNullish(error) && error !== $i18n.neurons.dissolve_delay_below_minimum
     );
-  };
-
-  const onRangeInput = () => {
-    keepDelaysInBounds();
   };
 
   const cancel = () => dispatch("nnsCancel");
@@ -121,8 +96,10 @@
       <DayInput
         bind:seconds={delayInSeconds}
         maxInSeconds={maxDelayInSeconds}
-        on:nnsMin={setMin}
-        on:nnsMax={setMax}
+        minInSeconds={Math.max(
+          Number(neuronDissolveDelaySeconds),
+          minProjectDelayInSeconds
+        )}
         placeholderLabelKey="neurons.dissolve_delay_placeholder"
         name="dissolve_delay"
         {getInputError}

--- a/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -9,7 +9,7 @@
   import DayInput from "$lib/components/ui/DayInput.svelte";
   import type { NeuronState } from "@dfinity/nns";
   import { type TokenAmount, nonNullish } from "@dfinity/utils";
-  import InputRangeDissolveDelay from "./InputRangeDissolveDelay.svelte";
+  import RangeDissolveDelay from "./RangeDissolveDelay.svelte";
 
   export let neuronState: NeuronState;
   export let neuronDissolveDelaySeconds: bigint;
@@ -129,12 +129,7 @@
       />
     </div>
     <div class="range">
-      <InputRangeDissolveDelay
-        {maxDelayInSeconds}
-        bind:delayInSeconds
-        {onRangeInput}
-        {votingPower}
-      />
+      <RangeDissolveDelay {maxDelayInSeconds} {delayInSeconds} {votingPower} />
     </div>
   </div>
 

--- a/frontend/src/lib/components/neurons/SetNnsDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/SetNnsDissolveDelay.svelte
@@ -25,7 +25,7 @@
     Number(
       neuronVotingPower({
         neuron,
-        newDissolveDelayInSeconds: BigInt(delayInSeconds),
+        newDissolveDelayInSeconds: BigInt(Math.round(delayInSeconds)),
       })
     );
 </script>

--- a/frontend/src/lib/components/sns-neurons/SetSnsDissolveDelay.svelte
+++ b/frontend/src/lib/components/sns-neurons/SetSnsDissolveDelay.svelte
@@ -45,7 +45,7 @@
     isNullish(snsParameters)
       ? 0
       : snsNeuronVotingPower({
-          newDissolveDelayInSeconds: BigInt(delayInSeconds),
+          newDissolveDelayInSeconds: BigInt(Math.round(delayInSeconds)),
           neuron,
           snsParameters,
         });

--- a/frontend/src/lib/components/ui/DayInput.svelte
+++ b/frontend/src/lib/components/ui/DayInput.svelte
@@ -7,7 +7,7 @@
   import { nonNullish } from "@dfinity/utils";
 
   export let seconds: number;
-  export let maxInSeconds: number | undefined = undefined;
+  export let maxInSeconds: number;
   export let placeholderLabelKey = "core.amount";
   export let name = "amount";
   export let getInputError: (value: number) => string | undefined;
@@ -31,7 +31,7 @@
   {placeholderLabelKey}
   {name}
   bind:value={days}
-  max={nonNullish(maxInSeconds) ? secondsToDays(maxInSeconds) : undefined}
+  max={secondsToDays(maxInSeconds)}
   inputType="number"
   {errorMessage}
   on:nnsInput={update}

--- a/frontend/src/lib/components/ui/DayInput.svelte
+++ b/frontend/src/lib/components/ui/DayInput.svelte
@@ -25,7 +25,7 @@
 
   let errorMessage: string | undefined;
   const showError = () => {
-    // This is called with before we update the `seconds` variable
+    // This is called before we update the `seconds` variable
     // The seconds variable is update a line above: `$: seconds = daysToSeconds(days);`
     errorMessage = getInputError(daysToSeconds(days));
   };

--- a/frontend/src/lib/components/ui/DayInput.svelte
+++ b/frontend/src/lib/components/ui/DayInput.svelte
@@ -12,12 +12,16 @@
   export let getInputError: (value: number) => string | undefined;
 
   // Round up the first time to not show a lot of decimal places.
-  let days: number = Math.min(Math.ceil(secondsToDays(seconds)), maxInSeconds);
+  let days: number = Math.min(
+    Math.ceil(secondsToDays(seconds)),
+    secondsToDays(maxInSeconds)
+  );
   $: seconds = daysToSeconds(days);
 
   let errorMessage: string | undefined;
   const showError = () => {
-    // This is called with before `$: seconds = daysToSeconds(days);`
+    // This is called with before we update the `seconds` variable
+    // The seconds variable is update a line above: `$: seconds = daysToSeconds(days);`
     errorMessage = getInputError(daysToSeconds(days));
   };
 

--- a/frontend/src/lib/components/ui/DayInput.svelte
+++ b/frontend/src/lib/components/ui/DayInput.svelte
@@ -3,12 +3,24 @@
   import MaxButton from "$lib/components/common/MaxButton.svelte";
   import InputWithError from "./InputWithError.svelte";
   import MinButton from "$lib/components/common/MinButton.svelte";
+  import { daysToSeconds, secondsToDays } from "$lib/utils/date.utils";
+  import { nonNullish } from "@dfinity/utils";
 
-  export let days: number | undefined = undefined;
-  export let max: number | undefined = undefined;
-  export let errorMessage: string | undefined = undefined;
+  export let seconds: number;
+  export let maxInSeconds: number | undefined = undefined;
   export let placeholderLabelKey = "core.amount";
   export let name = "amount";
+  export let getInputError: (value: number) => string | undefined;
+
+  let days: number;
+  $: days = secondsToDays(seconds);
+
+  let errorMessage: string | undefined;
+  $: errorMessage = getInputError(seconds);
+
+  const update = () => {
+    seconds = daysToSeconds(days);
+  };
 
   const dispatch = createEventDispatcher();
   const setMin = () => dispatch("nnsMin");
@@ -19,11 +31,11 @@
   {placeholderLabelKey}
   {name}
   bind:value={days}
-  {max}
+  max={nonNullish(maxInSeconds) ? secondsToDays(maxInSeconds) : undefined}
   inputType="number"
   {errorMessage}
-  on:nnsInput
-  on:blur
+  on:nnsInput={update}
+  on:blur={update}
 >
   <MinButton on:click={setMin} slot="start" />
   <MaxButton on:click={setMax} slot="end" />

--- a/frontend/src/lib/components/ui/DayInput.svelte
+++ b/frontend/src/lib/components/ui/DayInput.svelte
@@ -44,6 +44,7 @@
   inputType="number"
   {errorMessage}
   on:nnsInput={showError}
+  on:blur={showError}
 >
   <MinButton on:click={setMin} slot="start" />
   <MaxButton on:click={setMax} slot="end" />

--- a/frontend/src/lib/components/ui/DayInput.svelte
+++ b/frontend/src/lib/components/ui/DayInput.svelte
@@ -9,6 +9,11 @@
   export let minInSeconds: number;
   export let placeholderLabelKey = "core.amount";
   export let name = "amount";
+  // We don't want to trigger an error message until the input changes.
+  // We need to trigger the error on:nnsInput
+  // Yet, on:nnsInput is triggered before `seconds` change.
+  // And we don't want to expose days outside.
+  // That's why we expect the error function, instead of relying on the parent to calculate it based on `seconds`.
   export let getInputError: (value: number) => string | undefined;
 
   // Round up the first time to not show a lot of decimal places.

--- a/frontend/src/lib/components/ui/DayInput.svelte
+++ b/frontend/src/lib/components/ui/DayInput.svelte
@@ -43,7 +43,6 @@
   max={secondsToDays(maxInSeconds)}
   inputType="number"
   {errorMessage}
-  on:blur={showError}
   on:nnsInput={showError}
 >
   <MinButton on:click={setMin} slot="start" />

--- a/frontend/src/lib/components/ui/DayInput.svelte
+++ b/frontend/src/lib/components/ui/DayInput.svelte
@@ -1,30 +1,35 @@
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
   import MaxButton from "$lib/components/common/MaxButton.svelte";
   import InputWithError from "./InputWithError.svelte";
   import MinButton from "$lib/components/common/MinButton.svelte";
   import { daysToSeconds, secondsToDays } from "$lib/utils/date.utils";
-  import { nonNullish } from "@dfinity/utils";
 
   export let seconds: number;
   export let maxInSeconds: number;
+  export let minInSeconds: number;
   export let placeholderLabelKey = "core.amount";
   export let name = "amount";
   export let getInputError: (value: number) => string | undefined;
 
-  let days: number;
-  $: days = secondsToDays(seconds);
+  // Round up the first time to not show a lot of decimal places.
+  let days: number = Math.min(Math.ceil(secondsToDays(seconds)), maxInSeconds);
+  $: seconds = daysToSeconds(days);
 
   let errorMessage: string | undefined;
-  $: errorMessage = getInputError(seconds);
-
-  const update = () => {
-    seconds = daysToSeconds(days);
+  const showError = () => {
+    // This is called with before `$: seconds = daysToSeconds(days);`
+    errorMessage = getInputError(daysToSeconds(days));
   };
 
-  const dispatch = createEventDispatcher();
-  const setMin = () => dispatch("nnsMin");
-  const setMax = () => dispatch("nnsMax");
+  const setMin = () => {
+    seconds = minInSeconds;
+    days = secondsToDays(seconds);
+  };
+
+  const setMax = () => {
+    seconds = maxInSeconds;
+    days = secondsToDays(seconds);
+  };
 </script>
 
 <InputWithError
@@ -34,8 +39,8 @@
   max={secondsToDays(maxInSeconds)}
   inputType="number"
   {errorMessage}
-  on:nnsInput={update}
-  on:blur={update}
+  on:blur={showError}
+  on:nnsInput={showError}
 >
   <MinButton on:click={setMin} slot="start" />
   <MaxButton on:click={setMax} slot="end" />

--- a/frontend/src/lib/modals/neurons/IncreaseDissolveDelayModal.svelte
+++ b/frontend/src/lib/modals/neurons/IncreaseDissolveDelayModal.svelte
@@ -62,7 +62,7 @@
     <ConfirmDissolveDelay
       confirmButtonText={$i18n.neurons.confirm_update_delay}
       {neuron}
-      {delayInSeconds}
+      delayInSeconds={BigInt(Math.round(delayInSeconds))}
       on:nnsUpdated={closeModal}
       on:nnsBack={modal.back}
     />

--- a/frontend/src/lib/modals/neurons/NnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/NnsStakeNeuronModal.svelte
@@ -208,7 +208,7 @@
       <ConfirmDissolveDelay
         confirmButtonText={$i18n.neurons.confirm_set_delay}
         neuron={newNeuron}
-        {delayInSeconds}
+        delayInSeconds={BigInt(Math.round(delayInSeconds))}
         on:nnsUpdated={goNext}
         on:nnsBack={modal.back}
       />

--- a/frontend/src/lib/utils/date.utils.ts
+++ b/frontend/src/lib/utils/date.utils.ts
@@ -158,7 +158,8 @@ export const secondsToTime = (seconds: number): string => {
 
 export const secondsToDays = (seconds: number): number =>
   seconds / SECONDS_IN_DAY;
-export const daysToSeconds = (days: number): number => days * SECONDS_IN_DAY;
+export const daysToSeconds = (days: number): number =>
+  Math.round(days * SECONDS_IN_DAY);
 
 export const nowInSeconds = (): number => Math.round(Date.now() / 1000);
 export const nowInBigIntNanoSeconds = (): bigint =>

--- a/frontend/src/lib/utils/date.utils.ts
+++ b/frontend/src/lib/utils/date.utils.ts
@@ -90,7 +90,7 @@ export const secondsToDuration = (seconds: bigint): string => {
  * @param days
  */
 export const daysToDuration = (days: number): string =>
-  secondsToDuration(BigInt(days) * BigInt(SECONDS_IN_DAY));
+  secondsToDuration(BigInt(Math.ceil(days * SECONDS_IN_DAY)));
 
 /**
  * Displays years, months and days.
@@ -157,9 +157,7 @@ export const secondsToTime = (seconds: number): string => {
 };
 
 export const secondsToDays = (seconds: number): number =>
-  Math.ceil(seconds / SECONDS_IN_DAY);
-export const secondsToDaysRoundedDown = (seconds: number): number =>
-  Math.floor(seconds / SECONDS_IN_DAY);
+  seconds / SECONDS_IN_DAY;
 export const daysToSeconds = (days: number): number => days * SECONDS_IN_DAY;
 
 export const nowInSeconds = (): number => Math.round(Date.now() / 1000);

--- a/frontend/src/tests/lib/components/neurons/ConfirmDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/ConfirmDissolveDelay.spec.ts
@@ -8,7 +8,7 @@ describe("ConfirmDissolveDelay", () => {
     render(ConfirmDisolveDelay, {
       props: {
         neuron: mockNeuron,
-        delayInSeconds: 10_000,
+        delayInSeconds: 10_000n,
         confirmButtonText: "confirm",
       },
     });

--- a/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
@@ -57,7 +57,7 @@ describe("SetDissolveDelay", () => {
     });
   });
 
-  it("should initialize text and slider correctly", async () => {
+  it("should initialize text", async () => {
     const neuronDissolveDelaySeconds = 90 * SECONDS_IN_DAY;
     const po = renderComponent({
       neuronDissolveDelaySeconds: BigInt(neuronDissolveDelaySeconds),
@@ -65,7 +65,6 @@ describe("SetDissolveDelay", () => {
     });
 
     expect(await po.getDays()).toBe(90);
-    expect(await po.getSliderDays()).toBe(90);
   });
 
   it("fractional days get rounded up", async () => {
@@ -77,31 +76,18 @@ describe("SetDissolveDelay", () => {
     });
 
     expect(await po.getDays()).toBe(91);
-    expect(await po.getSliderDays()).toBe(91);
   });
 
   it("should update slider on text input", async () => {
     const po = renderComponent();
     await po.enterDays(1);
-    expect(await po.getSliderDays()).toBe(1);
+    expect(await po.getProgressBarSeconds()).toBe(1 * SECONDS_IN_DAY);
 
     await po.enterDays(1000);
-    expect(await po.getSliderDays()).toBe(1000);
+    expect(await po.getProgressBarSeconds()).toBe(1000 * SECONDS_IN_DAY);
 
     await po.enterDays(0);
-    expect(await po.getSliderDays()).toBe(0);
-  });
-
-  it("should update text on slider input", async () => {
-    const po = renderComponent();
-    await po.setSliderDays(1);
-    expect(await po.getDays()).toBe(1);
-
-    await po.setSliderDays(1000);
-    expect(await po.getDays()).toBe(1000);
-
-    await po.setSliderDays(0);
-    expect(await po.getDays()).toBe(0);
+    expect(await po.getProgressBarSeconds()).toBe(0);
   });
 
   describe("should update error message and button state", () => {
@@ -174,58 +160,6 @@ describe("SetDissolveDelay", () => {
         en.neurons.dissolve_delay_above_maximum
       );
     });
-
-    it("when slider input below or equal to current delay", async () => {
-      const neuronDays = 365;
-      const neuronDissolveDelaySeconds = neuronDays * SECONDS_IN_DAY;
-      const projectMinDays = 183;
-
-      const po = renderComponent({
-        neuronDissolveDelaySeconds: BigInt(neuronDissolveDelaySeconds),
-        minProjectDelayInSeconds: projectMinDays * SECONDS_IN_DAY,
-        delayInSeconds: neuronDissolveDelaySeconds,
-        maxDelayInSeconds: SECONDS_IN_EIGHT_YEARS,
-      });
-
-      expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
-      expect(await po.getErrorMessage()).toBe(null);
-
-      await po.setSliderDays(neuronDays);
-      expect(await po.getErrorMessage()).toBe(
-        en.neurons.dissolve_delay_below_current
-      );
-      expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
-
-      await po.setSliderDays(neuronDays + 1);
-      expect(await po.getErrorMessage()).toBe(null);
-      expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
-    });
-
-    it("when slider input below min project delay", async () => {
-      const neuronDays = 0;
-      const neuronDissolveDelaySeconds = neuronDays * SECONDS_IN_DAY;
-      const projectMinDays = 183;
-
-      const po = renderComponent({
-        neuronDissolveDelaySeconds: BigInt(neuronDissolveDelaySeconds),
-        minProjectDelayInSeconds: projectMinDays * SECONDS_IN_DAY,
-        delayInSeconds: neuronDissolveDelaySeconds,
-        maxDelayInSeconds: SECONDS_IN_EIGHT_YEARS,
-      });
-
-      expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
-      expect(await po.getErrorMessage()).toBe(null);
-
-      await po.setSliderDays(projectMinDays - 1);
-      expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
-      expect(await po.getErrorMessage()).toBe(
-        en.neurons.dissolve_delay_below_minimum
-      );
-
-      await po.setSliderDays(projectMinDays);
-      expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
-      expect(await po.getErrorMessage()).toBe(null);
-    });
   });
 
   it("can set same number of days when current number of days is fractional", async () => {
@@ -237,7 +171,7 @@ describe("SetDissolveDelay", () => {
     });
 
     expect(await po.getDays()).toBe(1001);
-    expect(await po.getSliderDays()).toBe(1001);
+    expect(await po.getProgressBarSeconds()).toBe(1001 * SECONDS_IN_DAY);
 
     expect(await po.getErrorMessage()).toBe(null);
     expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
@@ -270,20 +204,7 @@ describe("SetDissolveDelay", () => {
     expect(getDelayInSeconds(component)).toBe(200 * SECONDS_IN_DAY);
   });
 
-  it("should update prop on slider input", async () => {
-    const { container, component } = render(SetDissolveDelay, {
-      props: defaultComponentProps,
-    });
-    const po = SetDissolveDelayPo.under(new JestPageObjectElement(container));
-
-    await po.setSliderDays(100);
-    expect(getDelayInSeconds(component)).toBe(100 * SECONDS_IN_DAY);
-
-    await po.setSliderDays(200);
-    expect(getDelayInSeconds(component)).toBe(200 * SECONDS_IN_DAY);
-  });
-
-  it("should update prop, text and slider on Min/Max", async () => {
+  it("should update prop, text, progress bar on Min/Max", async () => {
     const minProjectDelayInDays = 50;
     const maxDelayInDays = 500;
     const minProjectDelayInSeconds = minProjectDelayInDays * SECONDS_IN_DAY;
@@ -305,17 +226,23 @@ describe("SetDissolveDelay", () => {
     await po.clickMin();
     expect(getDelayInSeconds(component)).toBe(minProjectDelayInSeconds);
     expect(await po.getDays()).toBe(minProjectDelayInDays);
-    expect(await po.getSliderDays()).toBe(minProjectDelayInDays);
+    expect(await po.getProgressBarSeconds()).toBe(
+      minProjectDelayInDays * SECONDS_IN_DAY
+    );
 
     await po.clickMax();
     expect(getDelayInSeconds(component)).toBe(maxDelayInSeconds);
     expect(await po.getDays()).toBe(maxDelayInDays);
-    expect(await po.getSliderDays()).toBe(maxDelayInDays);
+    expect(await po.getProgressBarSeconds()).toBe(
+      maxDelayInDays * SECONDS_IN_DAY
+    );
 
     // Clicking "Min" can decrease the delay to the minimum.
     await po.clickMin();
     expect(getDelayInSeconds(component)).toBe(minProjectDelayInSeconds);
     expect(await po.getDays()).toBe(minProjectDelayInDays);
-    expect(await po.getSliderDays()).toBe(minProjectDelayInDays);
+    expect(await po.getProgressBarSeconds()).toBe(
+      minProjectDelayInDays * SECONDS_IN_DAY
+    );
   });
 });

--- a/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
@@ -65,6 +65,7 @@ describe("SetDissolveDelay", () => {
     });
 
     expect(await po.getDays()).toBe(90);
+    expect(await po.getProgressBarSeconds()).toBe(90 * SECONDS_IN_DAY);
   });
 
   it("fractional days get rounded up", async () => {
@@ -76,9 +77,10 @@ describe("SetDissolveDelay", () => {
     });
 
     expect(await po.getDays()).toBe(91);
+    expect(await po.getProgressBarSeconds()).toBe(91 * SECONDS_IN_DAY);
   });
 
-  it("should update slider on text input", async () => {
+  it("should update progress bar on text input", async () => {
     const po = renderComponent();
     await po.enterDays(1);
     expect(await po.getProgressBarSeconds()).toBe(1 * SECONDS_IN_DAY);
@@ -107,6 +109,12 @@ describe("SetDissolveDelay", () => {
       expect(await po.getErrorMessage()).toBe(null);
 
       await po.enterDays(neuronDays);
+      expect(await po.getErrorMessage()).toBe(
+        en.neurons.dissolve_delay_below_current
+      );
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
+
+      await po.enterDays(neuronDays - 1.5);
       expect(await po.getErrorMessage()).toBe(
         en.neurons.dissolve_delay_below_current
       );

--- a/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
@@ -234,7 +234,7 @@ describe("SetDissolveDelay", () => {
     { min: 50.1, max: 500 },
   ];
   for (const { min, max } of minMaxDaysPairs) {
-    it("should update prop, text, progress bar on Min/Max", async () => {
+    it(`should update prop, text, progress bar on Min ${min} and Max ${max}`, async () => {
       const minProjectDelayInDays = min;
       const maxDelayInDays = max;
       const minProjectDelayInSeconds = minProjectDelayInDays * SECONDS_IN_DAY;

--- a/frontend/src/tests/lib/components/ui/DayInput.spec.ts
+++ b/frontend/src/tests/lib/components/ui/DayInput.spec.ts
@@ -39,6 +39,18 @@ describe("DayInput", () => {
     ).toEqual(en.core.amount);
   });
 
+  it("should render an error message after changing value", async () => {
+    const { queryByText, container } = render(DayInput, {
+      props: {
+        ...defaultProps,
+        getInputError: () => "error",
+      },
+    });
+    expect(queryByText("error")).toBeNull();
+    await fireEvent.input(container.querySelector("input"), { target: "12" });
+    expect(queryByText("error")).toBeInTheDocument();
+  });
+
   it("should render a custom placeholder attribute", () => {
     const { container } = render(DayInput, {
       props: {

--- a/frontend/src/tests/lib/components/ui/DayInput.spec.ts
+++ b/frontend/src/tests/lib/components/ui/DayInput.spec.ts
@@ -1,24 +1,39 @@
 import DayInput from "$lib/components/ui/DayInput.svelte";
+import { SECONDS_IN_DAY, SECONDS_IN_YEAR } from "$lib/constants/constants";
 import en from "$tests/mocks/i18n.mock";
-import { render } from "@testing-library/svelte";
+import { fireEvent, render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import DayInputTest from "./DayInputTest.svelte";
 
 describe("DayInput", () => {
+  const defaultProps = {
+    seconds: 10,
+    maxInSeconds: 100,
+    minInSeconds: 5,
+    getInputError: () => undefined,
+  };
+
   it("should render a default name attribute", () => {
-    const { container } = render(DayInput);
+    const { container } = render(DayInput, { props: defaultProps });
     expect(container.querySelector("input")?.getAttribute("name")).toEqual(
       "amount"
     );
   });
 
   it("should render a custom name attribute", () => {
-    const { container } = render(DayInput, { props: { name: "custom" } });
+    const { container } = render(DayInput, {
+      props: {
+        name: "custom",
+        ...defaultProps,
+      },
+    });
     expect(container.querySelector("input")?.getAttribute("name")).toEqual(
       "custom"
     );
   });
 
   it("should render a default placeholder attribute", () => {
-    const { container } = render(DayInput);
+    const { container } = render(DayInput, { props: defaultProps });
     expect(
       container.querySelector("input")?.getAttribute("placeholder")
     ).toEqual(en.core.amount);
@@ -26,10 +41,91 @@ describe("DayInput", () => {
 
   it("should render a custom placeholder attribute", () => {
     const { container } = render(DayInput, {
-      props: { placeholderLabelKey: "neurons.dissolve_delay_placeholder" },
+      props: {
+        placeholderLabelKey: "neurons.dissolve_delay_placeholder",
+        ...defaultProps,
+      },
     });
     expect(
       container.querySelector("input")?.getAttribute("placeholder")
     ).toEqual(en.neurons.dissolve_delay_placeholder);
+  });
+
+  it("should render days inside the input", async () => {
+    const days = 6;
+
+    const { container } = render(DayInput, {
+      props: {
+        ...defaultProps,
+        seconds: SECONDS_IN_DAY * days,
+      },
+    });
+
+    expect(container.querySelector("input").value).toBe(days.toString());
+  });
+
+  it("should update seconds when days are changed", async () => {
+    const initialSeconds = SECONDS_IN_DAY;
+
+    const { queryByTestId, container } = render(DayInputTest, {
+      props: {
+        ...defaultProps,
+        seconds: initialSeconds,
+      },
+    });
+
+    expect(queryByTestId("seconds")?.textContent).toBe(
+      initialSeconds.toString()
+    );
+    const inputElement = container.querySelector("input");
+    const days = 2;
+
+    await fireEvent.input(inputElement, {
+      target: { value: days },
+    });
+
+    await tick();
+    expect(queryByTestId("seconds")?.textContent).toBe(
+      String(SECONDS_IN_DAY * days)
+    );
+  });
+
+  it("shuold update seconds and input on Min/Max click", async () => {
+    const initialSeconds = SECONDS_IN_DAY;
+    const minInSeconds = SECONDS_IN_DAY * 30;
+    const maxInSeconds = SECONDS_IN_YEAR;
+
+    const { container, queryByTestId } = render(DayInputTest, {
+      props: {
+        seconds: initialSeconds,
+        maxInSeconds,
+        minInSeconds,
+        getInputError: () => null,
+      },
+    });
+
+    const minButton = queryByTestId("min-button");
+    const maxButton = queryByTestId("max-button");
+    const inputElement = container.querySelector("input");
+
+    expect(queryByTestId("seconds")?.textContent).toBe(
+      initialSeconds.toString()
+    );
+    expect(inputElement.value).toBe("1");
+
+    await fireEvent.click(minButton);
+
+    expect(queryByTestId("seconds")?.textContent).toBe(minInSeconds.toString());
+    expect(inputElement.value).toBe("30");
+
+    await fireEvent.click(maxButton);
+
+    expect(queryByTestId("seconds")?.textContent).toBe(maxInSeconds.toString());
+    expect(inputElement.value).toBe("365.25");
+
+    await fireEvent.click(minButton);
+
+    expect(queryByTestId("seconds")?.textContent).toBe(minInSeconds.toString());
+    expect(inputElement.value).toBe("30");
   });
 });

--- a/frontend/src/tests/lib/components/ui/DayInput.spec.ts
+++ b/frontend/src/tests/lib/components/ui/DayInput.spec.ts
@@ -58,6 +58,7 @@ describe("DayInput", () => {
       props: {
         ...defaultProps,
         seconds: SECONDS_IN_DAY * days,
+        maxInSeconds: SECONDS_IN_YEAR,
       },
     });
 
@@ -70,6 +71,7 @@ describe("DayInput", () => {
     const { queryByTestId, container } = render(DayInputTest, {
       props: {
         ...defaultProps,
+        maxInSeconds: SECONDS_IN_YEAR,
         seconds: initialSeconds,
       },
     });
@@ -90,7 +92,7 @@ describe("DayInput", () => {
     );
   });
 
-  it("shuold update seconds and input on Min/Max click", async () => {
+  it("should update seconds and input on Min/Max click", async () => {
     const initialSeconds = SECONDS_IN_DAY;
     const minInSeconds = SECONDS_IN_DAY * 30;
     const maxInSeconds = SECONDS_IN_YEAR;
@@ -127,5 +129,26 @@ describe("DayInput", () => {
 
     expect(queryByTestId("seconds")?.textContent).toBe(minInSeconds.toString());
     expect(inputElement.value).toBe("30");
+  });
+
+  it("should take into accout the max when rounding up", async () => {
+    // This is a fraction that if rounded up would be 366 days.
+    const initialSeconds = SECONDS_IN_DAY * 365 + 10;
+    // But the max is 365.5 days
+    const maxInSeconds = SECONDS_IN_DAY * 365 + SECONDS_IN_DAY / 2;
+    const minInSeconds = SECONDS_IN_DAY * 30;
+
+    const { container } = render(DayInput, {
+      props: {
+        seconds: initialSeconds,
+        maxInSeconds,
+        minInSeconds,
+        getInputError: () => null,
+      },
+    });
+
+    const inputElement = container.querySelector("input");
+
+    expect(inputElement.value).toBe("365.5");
   });
 });

--- a/frontend/src/tests/lib/components/ui/DayInputTest.svelte
+++ b/frontend/src/tests/lib/components/ui/DayInputTest.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import DayInput from "$lib/components/ui/DayInput.svelte";
+
+  export let seconds: number;
+  export let maxInSeconds: number;
+  export let minInSeconds: number;
+  export let getInputError: (value: number) => string | undefined;
+</script>
+
+<DayInput bind:seconds {maxInSeconds} {getInputError} {minInSeconds} />
+
+<p data-tid="seconds">{seconds}</p>

--- a/frontend/src/tests/lib/modals/neurons/IncreaseDissolveDelayModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/IncreaseDissolveDelayModal.spec.ts
@@ -63,13 +63,17 @@ describe("IncreaseDissolveDelayModal", () => {
     const { container } = await renderIncreaseDelayModal(editableNeuron);
 
     await waitFor(() =>
-      expect(container.querySelector('input[type="range"]')).not.toBeNull()
+      expect(
+        container.querySelector("input[name='dissolve_delay']")
+      ).not.toBeNull()
     );
-    const inputRange = container.querySelector('input[type="range"]');
-    expect(inputRange).not.toBeNull();
+    const inputElement = container.querySelector(
+      "input[name='dissolve_delay']"
+    );
+    expect(inputElement).not.toBeNull();
 
-    inputRange &&
-      (await fireEvent.input(inputRange, {
+    inputElement &&
+      (await fireEvent.input(inputElement, {
         target: { value: 365 * 2 },
       }));
 
@@ -107,15 +111,17 @@ describe("IncreaseDissolveDelayModal", () => {
     const { container } = await renderIncreaseDelayModal(editableNeuron);
 
     await waitFor(() =>
-      expect(container.querySelector('input[type="range"]')).not.toBeNull()
+      expect(
+        container.querySelector("input[name='dissolve_delay']")
+      ).not.toBeNull()
     );
-    const inputRange = container.querySelector<HTMLInputElement>(
-      'input[type="range"]'
+    const inputElement = container.querySelector<HTMLInputElement>(
+      "input[name='dissolve_delay']"
     );
-    expect(inputRange).not.toBeNull();
+    expect(inputElement).not.toBeNull();
 
-    inputRange &&
-      (await fireEvent.input(inputRange, {
+    inputElement &&
+      (await fireEvent.input(inputElement, {
         target: { value: currentNeuronDissoveDelayDays / 2 },
       }));
 
@@ -123,12 +129,6 @@ describe("IncreaseDissolveDelayModal", () => {
       '[data-tid="go-confirm-delay-button"]'
     );
 
-    await waitFor(() =>
-      expect(goToConfirmDelayButton?.getAttribute("disabled")).not.toBeNull()
-    );
-    inputRange &&
-      (await waitFor(() =>
-        expect(inputRange.value).toBe(String(currentNeuronDissoveDelayDays))
-      ));
+    expect(goToConfirmDelayButton?.getAttribute("disabled")).not.toBeNull();
   });
 });

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -228,13 +228,17 @@ describe("NnsStakeNeuronModal", () => {
       createButton && (await fireEvent.click(createButton));
 
       await waitFor(() =>
-        expect(container.querySelector('input[type="range"]')).not.toBeNull()
+        expect(
+          container.querySelector("input[name='dissolve_delay']")
+        ).not.toBeNull()
       );
-      const inputRange = container.querySelector('input[type="range"]');
+      const inputElement = container.querySelector(
+        "input[name='dissolve_delay']"
+      );
 
       const FIVE_MONTHS = 30 * 5;
-      inputRange &&
-        (await fireEvent.input(inputRange, {
+      inputElement &&
+        (await fireEvent.input(inputElement, {
           target: { value: FIVE_MONTHS },
         }));
 
@@ -260,7 +264,9 @@ describe("NnsStakeNeuronModal", () => {
       createButton && (await fireEvent.click(createButton));
 
       await waitFor(() =>
-        expect(container.querySelector('input[type="range"]')).not.toBeNull()
+        expect(
+          container.querySelector("input[name='dissolve_delay']")
+        ).not.toBeNull()
       );
 
       expect(
@@ -319,9 +325,13 @@ describe("NnsStakeNeuronModal", () => {
       createButton && (await fireEvent.click(createButton));
 
       await waitFor(() =>
-        expect(container.querySelector('input[type="range"]')).not.toBeNull()
+        expect(
+          container.querySelector("input[name='dissolve_delay']")
+        ).not.toBeNull()
       );
-      const inputRange = container.querySelector('input[type="range"]');
+      const inputRange = container.querySelector(
+        "input[name='dissolve_delay']"
+      );
 
       const ONE_YEAR = 365;
       inputRange &&
@@ -371,7 +381,9 @@ describe("NnsStakeNeuronModal", () => {
 
       // SCREEN: Set Dissolve Delay
       await waitFor(() =>
-        expect(container.querySelector('input[type="range"]')).not.toBeNull()
+        expect(
+          container.querySelector("input[name='dissolve_delay']")
+        ).not.toBeNull()
       );
 
       const skipButton = queryByTestId("cancel-neuron-delay");
@@ -477,9 +489,13 @@ describe("NnsStakeNeuronModal", () => {
       expect(addHotkeyForHardwareWalletNeuron).toBeCalled();
 
       await waitFor(() =>
-        expect(container.querySelector('input[type="range"]')).not.toBeNull()
+        expect(
+          container.querySelector("input[name='dissolve_delay']")
+        ).not.toBeNull()
       );
-      const inputRange = container.querySelector('input[type="range"]');
+      const inputRange = container.querySelector(
+        "input[name='dissolve_delay']"
+      );
 
       const ONE_YEAR = 365;
       inputRange &&

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -329,13 +329,13 @@ describe("NnsStakeNeuronModal", () => {
           container.querySelector("input[name='dissolve_delay']")
         ).not.toBeNull()
       );
-      const inputRange = container.querySelector(
+      const inputElement = container.querySelector(
         "input[name='dissolve_delay']"
       );
 
       const ONE_YEAR = 365;
-      inputRange &&
-        (await fireEvent.input(inputRange, {
+      inputElement &&
+        (await fireEvent.input(inputElement, {
           target: { value: ONE_YEAR },
         }));
 
@@ -493,13 +493,13 @@ describe("NnsStakeNeuronModal", () => {
           container.querySelector("input[name='dissolve_delay']")
         ).not.toBeNull()
       );
-      const inputRange = container.querySelector(
+      const inputElement = container.querySelector(
         "input[name='dissolve_delay']"
       );
 
       const ONE_YEAR = 365;
-      inputRange &&
-        (await fireEvent.input(inputRange, {
+      inputElement &&
+        (await fireEvent.input(inputElement, {
           target: { value: ONE_YEAR },
         }));
 

--- a/frontend/src/tests/lib/modals/sns/IncreaseSnsDissolveDelayModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/IncreaseSnsDissolveDelayModal.spec.ts
@@ -30,9 +30,6 @@ vi.mock("$lib/services/sns-parameters.services");
 
 const testIdentity = createMockIdentity(10023);
 
-const roundUpSecondsToWholeDays = (seconds: number): number =>
-  daysToSeconds(secondsToDays(seconds));
-
 describe("IncreaseSnsDissolveDelayModal", () => {
   const nowInSeconds = 1689063315;
   const now = nowInSeconds * 1000;

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -190,6 +190,11 @@ describe("daysToDuration", () => {
       });
     }
   });
+
+  it("should return fractions of day", () => {
+    expect(daysToDuration(1.5)).toBe("");
+    expect(daysToDuration(365.125)).toBe("1 year");
+  });
 });
 
 describe("secondsToDissolveDelayDuration", () => {

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -192,8 +192,8 @@ describe("daysToDuration", () => {
   });
 
   it("should return fractions of day", () => {
-    expect(daysToDuration(1.5)).toBe("");
-    expect(daysToDuration(365.125)).toBe("1 year");
+    expect(daysToDuration(1.5)).toBe("1 day, 12 hours");
+    expect(daysToDuration(365.125)).toBe("1 year, 3 hours");
   });
 });
 

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -326,7 +326,7 @@ describe("daysToSeconds", () => {
   });
 
   it("returns integers only", () => {
-    expect(daysToSeconds(1.11)).not.toBe(SECONDS_IN_DAY * 1.11);
-    expect(daysToSeconds(1.11)).toBe(95904);
+    expect(daysToSeconds(1.123456)).not.toBe(SECONDS_IN_DAY * 1.123456);
+    expect(daysToSeconds(1.123456)).toBe(97067);
   });
 });

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -1,6 +1,7 @@
 import { SECONDS_IN_DAY, SECONDS_IN_MONTH } from "$lib/constants/constants";
 import {
   daysToDuration,
+  daysToSeconds,
   nanoSecondsToDateTime,
   secondsToDate,
   secondsToDateTime,
@@ -314,5 +315,18 @@ describe("secondsToTime", () => {
     date.setMinutes(45);
     date.setSeconds(59);
     expect(secondsToTime(+date / 1000)).toContain("9:45");
+  });
+});
+
+describe("daysToSeconds", () => {
+  it("returns the days in seconds", () => {
+    expect(daysToSeconds(1)).toBe(SECONDS_IN_DAY);
+    expect(daysToSeconds(2)).toBe(SECONDS_IN_DAY * 2);
+    expect(daysToSeconds(3)).toBe(SECONDS_IN_DAY * 3);
+  });
+
+  it("returns integers only", () => {
+    expect(daysToSeconds(1.11)).not.toBe(SECONDS_IN_DAY * 1.11);
+    expect(daysToSeconds(1.11)).toBe(95904);
   });
 });

--- a/frontend/src/tests/page-objects/RangeDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/RangeDissolveDelay.page-object.ts
@@ -1,0 +1,16 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class RangeDissolveDelayPo extends BasePageObject {
+  private static readonly TID = "range-dissolve-delay-component";
+
+  static under(element: PageObjectElement): RangeDissolveDelayPo {
+    return new RangeDissolveDelayPo(element.byTestId(RangeDissolveDelayPo.TID));
+  }
+
+  async getProgressBarValue(): Promise<number> {
+    return Number(
+      await this.root.querySelector("progress").getAttribute("value")
+    );
+  }
+}

--- a/frontend/src/tests/page-objects/RangeDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/RangeDissolveDelay.page-object.ts
@@ -8,7 +8,7 @@ export class RangeDissolveDelayPo extends BasePageObject {
     return new RangeDissolveDelayPo(element.byTestId(RangeDissolveDelayPo.TID));
   }
 
-  async getProgressBarValue(): Promise<number> {
+  async getProgressBarSeconds(): Promise<number> {
     return Number(
       await this.root.querySelector("progress").getAttribute("value")
     );

--- a/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
@@ -79,6 +79,6 @@ export class SetDissolveDelayPo extends BasePageObject {
   }
 
   async getProgressBarSeconds(): Promise<number> {
-    return this.getRangeDissolveDelayPo().getProgressBarValue();
+    return this.getRangeDissolveDelayPo().getProgressBarSeconds();
   }
 }

--- a/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
@@ -1,8 +1,8 @@
 import { ButtonPo } from "$tests/page-objects/Button.page-object";
-import { InputRangePo } from "$tests/page-objects/InputRange.page-object";
 import { InputWithErrorPo } from "$tests/page-objects/InputWithError.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { RangeDissolveDelayPo } from "./RangeDissolveDelay.page-object";
 
 export class SetDissolveDelayPo extends BasePageObject {
   private static readonly TID = "set-dissolve-delay-component";
@@ -33,8 +33,8 @@ export class SetDissolveDelayPo extends BasePageObject {
     });
   }
 
-  getInputRangePo(): InputRangePo {
-    return InputRangePo.under(this.root);
+  getRangeDissolveDelayPo(): RangeDissolveDelayPo {
+    return RangeDissolveDelayPo.under(this.root);
   }
 
   clickUpdate(): Promise<void> {
@@ -78,11 +78,7 @@ export class SetDissolveDelayPo extends BasePageObject {
     return this.getInputWithErrorPo().getErrorMessage();
   }
 
-  async getSliderDays(): Promise<number> {
-    return this.getInputRangePo().getValue();
-  }
-
-  setSliderDays(days: number): Promise<void> {
-    return this.getInputRangePo().setValue(days);
+  async getProgressBarSeconds(): Promise<number> {
+    return this.getRangeDissolveDelayPo().getProgressBarValue();
   }
 }


### PR DESCRIPTION
# Motivation

There is a bug raised in the [forum](https://forum.dfinity.org/t/changing-future-max-lock-up-for-sns-1-dkp/23576/34).

This screen has already been fixed with other bugs. The source of the bugs is the duality of seconds and days and synchronizing the slider with the input.

In this PR, we remove the slider and show a read-only progress bar instead.

We use days to be user friendly, but the code uses the values in seconds.

# Changes

* New component RangeDissolveDelay instead of the InputRange.
* Days are not managed in SetDissolveDelay, instead in the child components DayInput and RangeDissolveDelay.
* New props and functionality in DayInput, like managing Min and Max buttons.
* Change delayInSeconds of ConfirmDissolveDelay to `bigint` to avoid issues with decimals.
* Remove rounding in `secondsToDays`.

# Tests

* SetDissolveDelay.spec. Remove tests regarding slider and check progress bar instead.
* DayInput.spec. Add new test cases for new functionality.
* IncreaseDissolveDelayModal.spec. Use the input instead of range to set delay.
* NnsStakeNeuronModal.spec. Use the input instead of range to set delay.
* IncreaseSnsDissolveDelayModal.spec. Use the input instead of range to set delay. Remove test for slider.
* New PO RangeDissolveDelayPo
* Edit SetDissolveDelayPo accordingly

# Todos

- [x] Add entry to changelog (if necessary).
