### PR TITLE
Fix: Merge neurons label

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,6 +30,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Remove robots meta tag to allow search engines to crawl NNS Dapp.
+* Fix i18n key in merge neurons summary screen.
 
 #### Security
 

--- a/frontend/src/lib/components/neurons/NnsNeuronDetailCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronDetailCard.svelte
@@ -2,6 +2,7 @@
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import { i18n } from "$lib/stores/i18n";
   import { secondsToDuration } from "$lib/utils/date.utils";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import {
     formatVotingPower,
     formattedStakedMaturity,
@@ -29,7 +30,11 @@
     <span class="value" slot="value">{neuron.neuronId}</span>
   </KeyValuePair>
   <KeyValuePair testId="stake">
-    <span class="label" slot="key">{$i18n.neurons.ic_stake}</span>
+    <span class="label" slot="key"
+      >{replacePlaceholders($i18n.neurons.ic_stake, {
+        $token: ICPToken.symbol,
+      })}</span
+    >
     <span class="value" slot="value"
       ><AmountDisplay inline singleLine amount={stake} /></span
     >

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronDetailCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronDetailCard.spec.ts
@@ -32,6 +32,7 @@ describe("NnsNeuronDetailCard", () => {
     });
 
     expect(await po.getStake()).toBe("20.00 ICP");
+    expect(await po.getStakeLabel()).toBe("ICP staked");
   });
 
   it("should render neuron dissolve delay", async () => {

--- a/frontend/src/tests/page-objects/NnsNeuronDetailCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetailCard.page-object.ts
@@ -25,6 +25,15 @@ export class NnsNeuronDetailCardPo extends BasePageObject {
     return (await this.getValue("stake")).trim();
   }
 
+  async getStakeLabel(): Promise<string> {
+    return (
+      await KeyValuePairPo.under({
+        element: this.root,
+        testId: "stake",
+      }).getKeyText()
+    ).trim();
+  }
+
   getDissolveDelay(): Promise<string> {
     return this.getValue("dissolve-delay");
   }


### PR DESCRIPTION
# Motivation

A i18n key was changed to replace a value instead of concatenating strings.

A usage of this key was forgotten and didn't replace the value.

# Changes

* Use `replacePlaceholders` for key "neurons.ic_stake" in NnsNeuronDetailCard.svelte.

# Tests

* Add a check of the key in the related test case in NnsNeuronDetailCard.spec.
* Add a method in NnsNeuronDetailCardPo to get the neuron stake key.

# Todos

- [x] Add entry to changelog (if necessary).
