### PR TITLE
Remove debounce on deriving network from BTC address

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -27,6 +27,8 @@ proposal is successful, the changes it released will be moved from this file to
 #### Deprecated
 #### Removed
 
+* Removed debounce on deriving Network from ckBTC send address.
+
 #### Fixed
 
 * Remove robots meta tag to allow search engines to crawl NNS Dapp.

--- a/frontend/src/lib/components/accounts/SelectNetworkDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectNetworkDropdown.svelte
@@ -2,7 +2,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { Dropdown, DropdownItem } from "@dfinity/gix-components";
   import { TransactionNetwork } from "$lib/types/transaction";
-  import { debounce, isNullish, nonNullish } from "@dfinity/utils";
+  import { isNullish, nonNullish } from "@dfinity/utils";
   import type { UniverseCanisterId } from "$lib/types/universe";
   import { isUniverseCkTESTBTC } from "$lib/utils/universe.utils";
   import {
@@ -19,7 +19,7 @@
   let ckTESTBTC = false;
   $: ckTESTBTC = isUniverseCkTESTBTC(universeId);
 
-  const onDestinationAddressInput = debounce(() => {
+  const onDestinationAddressInput = () => {
     if (nonNullish(selectedNetwork)) {
       // If the network does not match the address an error "Please enter a valid address." is displayed next to the input.
       return;
@@ -48,7 +48,7 @@
         ? TransactionNetwork.BTC_TESTNET
         : TransactionNetwork.BTC_MAINNET;
     }
-  });
+  };
 
   $: selectedDestinationAddress, onDestinationAddressInput();
 </script>


### PR DESCRIPTION
# Motivation

When sending ckBTC you can enter either a ckBTC address or a BTC address.
We derive the "network" (Internet Computer/Bitcoin) from the address.
This is debounced so there is a small delay.
The derivation does not require any network requests, and once the network is derived we don't change it (if you later change to an address to a different network, we consider it invalid unless you change the network manually), so this delay does not prevent any jarring experience.
So I see no reason to have the debounce there.
Additionally it makes unit testing slightly harder so there is a benefit in removing the debounce.

# Changes

Remove the debounce on deriving the network from the address.

# Tests

Removing it didn't cause any tests to fail so it wasn't tested before.
Manual testing looks good and can be tried here: 

# Todos

- [x] Add entry to changelog (if necessary).
