### PR TITLE
Use page objects in CkBTCWallet.spec.ts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -276,9 +276,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "3.0.0-next-2023-10-19",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-3.0.0-next-2023-10-19.tgz",
-      "integrity": "sha512-OHMOrNGeJwDZvzayjZa2vgPWe8BF69RzMvvNohwfA292MlWWwmN4g4JHI7IhoAI+CqmsSzRteCLuzydQWvxK9w==",
+      "version": "3.0.0-next-2023-10-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-3.0.0-next-2023-10-25.1.tgz",
+      "integrity": "sha512-jDiMsmKRWXSPMsuLLPlF+hhw4scsAB1Q/4lqeG4TvfMh5kj2AwADilEnjhCPeUB+rBGjceAxsJj3QMn8urAa1A==",
       "dependencies": {
         "dompurify": "^3.0.6",
         "html5-qrcode": "^2.3.8",
@@ -7053,9 +7053,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "3.0.0-next-2023-10-19",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-3.0.0-next-2023-10-19.tgz",
-      "integrity": "sha512-OHMOrNGeJwDZvzayjZa2vgPWe8BF69RzMvvNohwfA292MlWWwmN4g4JHI7IhoAI+CqmsSzRteCLuzydQWvxK9w==",
+      "version": "3.0.0-next-2023-10-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-3.0.0-next-2023-10-25.1.tgz",
+      "integrity": "sha512-jDiMsmKRWXSPMsuLLPlF+hhw4scsAB1Q/4lqeG4TvfMh5kj2AwADilEnjhCPeUB+rBGjceAxsJj3QMn8urAa1A==",
       "requires": {
         "dompurify": "^3.0.6",
         "html5-qrcode": "^2.3.8",

--- a/frontend/src/lib/components/accounts/CkBTCWalletFooter.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWalletFooter.svelte
@@ -27,7 +27,7 @@
     $busy;
 </script>
 
-<Footer>
+<Footer testId="ckbtc-wallet-footer-component">
   <CkBTCSendButton
     {disableButton}
     {canisters}

--- a/frontend/src/lib/components/layout/Footer.svelte
+++ b/frontend/src/lib/components/layout/Footer.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import { Toolbar } from "@dfinity/gix-components";
 
+  export let testId: string | undefined = undefined;
   export let columns = 2;
 </script>
 
-<footer style={`--footer-columns: ${columns}`}>
+<footer data-tid={testId} style={`--footer-columns: ${columns}`}>
   <Toolbar>
     <slot />
   </Toolbar>

--- a/frontend/src/lib/modals/accounts/CkBTCReceiveModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCReceiveModal.svelte
@@ -124,8 +124,10 @@
 
   <div class="receive">
     <Segment bind:selectedSegmentId bind:this={segment}>
-      <SegmentButton segmentId={ckBTCSegmentId}>{segmentLabel}</SegmentButton>
-      <SegmentButton segmentId={bitcoinSegmentId}
+      <SegmentButton testId="receive-ckbtc" segmentId={ckBTCSegmentId}
+        >{segmentLabel}</SegmentButton
+      >
+      <SegmentButton testId="receive-bitcoin" segmentId={bitcoinSegmentId}
         >{bitcoinSegmentLabel}</SegmentButton
       >
     </Segment>

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -178,6 +178,7 @@
 </script>
 
 <TransactionModal
+  testId="ckbtc-transaction-modal-component"
   rootCanisterId={universeId}
   bind:this={modal}
   on:nnsSubmit={transfer}

--- a/frontend/src/tests/page-objects/CkBTCReceiveModal.page-object.ts
+++ b/frontend/src/tests/page-objects/CkBTCReceiveModal.page-object.ts
@@ -1,0 +1,18 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class CkBTCReceiveModalPo extends BasePageObject {
+  private static readonly TID = "ckbtc-receive-modal";
+
+  static under(element: PageObjectElement): CkBTCReceiveModalPo {
+    return new CkBTCReceiveModalPo(element.byTestId(CkBTCReceiveModalPo.TID));
+  }
+
+  selectBitcoin(): Promise<void> {
+    return this.click("receive-bitcoin");
+  }
+
+  clickFinish(): Promise<void> {
+    return this.click("reload-receive-account");
+  }
+}

--- a/frontend/src/tests/page-objects/CkBTCTransactionModal.page-object.ts
+++ b/frontend/src/tests/page-objects/CkBTCTransactionModal.page-object.ts
@@ -1,0 +1,12 @@
+import { TransactionModalBasePo } from "$tests/page-objects/TransactionModal.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class CkBTCTransactionModalPo extends TransactionModalBasePo {
+  private static readonly TID = "ckbtc-transaction-modal-component";
+
+  static under(element: PageObjectElement): CkBTCTransactionModalPo {
+    return new CkBTCTransactionModalPo(
+      element.byTestId(CkBTCTransactionModalPo.TID)
+    );
+  }
+}

--- a/frontend/src/tests/page-objects/CkBTCWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/CkBTCWallet.page-object.ts
@@ -1,5 +1,8 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { CkBTCWalletFooterPo } from "$tests/page-objects/CkBTCWalletFooter.page-object";
 import { IcrcTransactionsListPo } from "$tests/page-objects/IcrcTransactionsList.page-object";
+import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-object";
+import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class CkBTCWalletPo extends BasePageObject {
@@ -13,7 +16,23 @@ export class CkBTCWalletPo extends BasePageObject {
     return IcrcTransactionsListPo.under(this.root);
   }
 
+  getWalletPageHeaderPo(): WalletPageHeaderPo {
+    return WalletPageHeaderPo.under(this.root);
+  }
+
+  getWalletPageHeadingPo(): WalletPageHeadingPo {
+    return WalletPageHeadingPo.under(this.root);
+  }
+
+  getCkBTCWalletFooterPo(): CkBTCWalletFooterPo {
+    return CkBTCWalletFooterPo.under(this.root);
+  }
+
   clickRefreshBalance(): Promise<void> {
     return this.click("manual-refresh-balance");
+  }
+
+  hasSpinner(): Promise<boolean> {
+    return this.isPresent("spinner");
   }
 }

--- a/frontend/src/tests/page-objects/CkBTCWalletFooter.page-object.ts
+++ b/frontend/src/tests/page-objects/CkBTCWalletFooter.page-object.ts
@@ -1,0 +1,18 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class CkBTCWalletFooterPo extends BasePageObject {
+  private static readonly TID = "ckbtc-wallet-footer-component";
+
+  static under(element: PageObjectElement): CkBTCWalletFooterPo {
+    return new CkBTCWalletFooterPo(element.byTestId(CkBTCWalletFooterPo.TID));
+  }
+
+  clickSendButton(): Promise<void> {
+    return this.click("open-ckbtc-transaction");
+  }
+
+  clickReceiveButton(): Promise<void> {
+    return this.click("receive-ckbtc");
+  }
+}

--- a/frontend/src/tests/page-objects/SelectDestinationAddress.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectDestinationAddress.page-object.ts
@@ -30,11 +30,15 @@ export class SelectDestinationAddressPo extends BasePageObject {
   }
 
   async enableSelect(): Promise<void> {
-    return this.getTogglePo().setDisabled();
+    if (!(await this.getDropdownPo().isPresent())) {
+      await this.getTogglePo().setDisabled();
+    }
   }
 
   async enableTextInput(): Promise<void> {
-    return this.getTogglePo().setEnabled();
+    if (await this.getDropdownPo().isPresent()) {
+      await this.getTogglePo().setEnabled();
+    }
   }
 
   async selectAccount(accountName: string): Promise<void> {

--- a/frontend/src/tests/page-objects/TransactionForm.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionForm.page-object.ts
@@ -55,4 +55,16 @@ export class TransactionFormPo extends BasePageObject {
     await this.enterAmount(amount);
     await this.clickContinue();
   }
+
+  async transferToAddress({
+    destinationAddress,
+    amount,
+  }: {
+    destinationAddress: string;
+    amount: number;
+  }): Promise<void> {
+    await this.getSelectDestinationAddressPo().enterAddress(destinationAddress);
+    await this.enterAmount(amount);
+    await this.clickContinue();
+  }
 }

--- a/frontend/src/tests/page-objects/TransactionModal.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionModal.page-object.ts
@@ -1,6 +1,6 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { TransactionFormPo } from "$tests/page-objects/TransactionForm.page-object";
 import { TransactionReviewPo } from "$tests/page-objects/TransactionReview.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 // This should not be used directly but rather as a base class for specific
@@ -32,6 +32,28 @@ export class TransactionModalBasePo extends BasePageObject {
     if (destinationAddress.trim() !== expectedAccountAddress.trim()) {
       throw new Error(
         `Destination address should be ${expectedAccountAddress} but was ${destinationAddress}.`
+      );
+    }
+    await review.clickSend();
+  }
+
+  async transferToAddress({
+    destinationAddress,
+    amount,
+  }: {
+    destinationAddress: string;
+    amount: number;
+  }): Promise<void> {
+    await this.getTransactionFormPo().transferToAddress({
+      destinationAddress,
+      amount,
+    });
+    const review = this.getTransactionReviewPo();
+    await review.waitFor();
+    const address = await review.getDestinationAddress();
+    if (address.trim() !== destinationAddress.trim()) {
+      throw new Error(
+        `Destination address should be ${destinationAddress} but was ${address}.`
       );
     }
     await review.clickSend();

--- a/frontend/src/tests/page-objects/WalletPageHeader.page-object.ts
+++ b/frontend/src/tests/page-objects/WalletPageHeader.page-object.ts
@@ -10,11 +10,11 @@ export class WalletPageHeaderPo extends BasePageObject {
     return new WalletPageHeaderPo(element.byTestId(WalletPageHeaderPo.TID));
   }
 
-  getUniverse() {
+  getUniverse(): Promise<string> {
     return UniversePageSummaryPo.under(this.root).getTitle();
   }
 
-  getWalletAddress() {
+  getWalletAddress(): Promise<string> {
     return HashPo.under(this.root).getText();
   }
 }

--- a/frontend/src/tests/page-objects/jest.page-object.ts
+++ b/frontend/src/tests/page-objects/jest.page-object.ts
@@ -175,4 +175,9 @@ export class JestPageObjectElement implements PageObjectElement {
     await this.waitFor();
     await fireEvent.blur(this.element);
   }
+
+  async innerHtmlForDebugging(): Promise<string> {
+    await this.waitFor();
+    return this.element?.innerHTML ?? "";
+  }
 }

--- a/frontend/src/tests/page-objects/playwright.page-object.ts
+++ b/frontend/src/tests/page-objects/playwright.page-object.ts
@@ -119,4 +119,8 @@ export class PlaywrightPageObjectElement implements PageObjectElement {
   async blur(): Promise<void> {
     throw new Error("Not implement");
   }
+
+  async innerHtmlForDebugging(): Promise<string> {
+    return "not implemeneted";
+  }
 }

--- a/frontend/src/tests/types/page-object.types.ts
+++ b/frontend/src/tests/types/page-object.types.ts
@@ -35,4 +35,5 @@ export interface PageObjectElement {
   getValue(): Promise<string>;
   isVisible(): Promise<boolean>;
   blur(): Promise<void>;
+  innerHtmlForDebugging(): Promise<string>;
 }


### PR DESCRIPTION
# Motivation

Making the test more readable.

# Changes

1. Use page objects in `CkBTCWallet.spec.ts`.
2. Add test IDs where necessary.
3. Add necessary methods to exiting page objects.
4. Add new page objects.
5. In `frontend/src/tests/page-objects/SelectDestinationAddress.page-object.ts` check whether the dropdown input is present before trying to check the state of the checkbox. In some contexts there is no checkbox and if the input is already the type of input we need (dropdown vs. text), this is fine.
6. Add missing types to `frontend/src/tests/page-objects/WalletPageHeader.page-object.ts`
7. Add `innerHtmlForDebugging` to PageObjectElement to help probe the state of an element when debugging.

# Tests

yes

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary