### PR TITLE
fix: zero approve workaround

### DIFF
--- a/rs/backend/src/ledger_sync.rs
+++ b/rs/backend/src/ledger_sync.rs
@@ -2,11 +2,11 @@ use crate::canisters::ledger;
 use crate::state::STATE;
 use candid::Principal;
 use dfn_core::CanisterId;
-use ic_ledger_core::Tokens;
 use ic_ledger_core::block::BlockType;
+use ic_ledger_core::Tokens;
 use ic_nns_constants::LEDGER_CANISTER_ID;
 use icp_ledger::protobuf::ArchiveIndexEntry;
-use icp_ledger::{Block, BlockIndex, TimeStamp, Transaction, Memo, Operation, AccountIdentifier};
+use icp_ledger::{AccountIdentifier, Block, BlockIndex, Memo, Operation, TimeStamp, Transaction};
 use lazy_static::lazy_static;
 use std::cmp::{max, min};
 use std::ops::RangeInclusive;
@@ -79,26 +79,36 @@ async fn get_blocks(from: BlockIndex, tip_of_chain: BlockIndex) -> Result<Vec<(B
     let results: Vec<_> = blocks
         .into_iter()
         .enumerate()
-        .map(|(index, block)| (range.start() + (index as u64), match Block::decode(block) {
-            Ok(block) => block,
-            Err(err)  => {
-                let dummy = Block {
-                    parent_hash: None,
-                    timestamp: TimeStamp::new(0, 0),
-                    transaction: Transaction {
-                        memo: Memo(64),
-                        created_at_time: None,
-                        icrc1_memo: None,
-                        operation: Operation::Burn {
-                            from: AccountIdentifier::new(Principal::management_canister().into(), None),
-                            amount: Tokens::from_e8s(1234),
-                        },
-                    },
-                };
-                ic_cdk::println!("Replacing block {} with dummy block {:?} because of error: {}", range.start() + (index as u64), &dummy, err);
-                dummy
-            }
-        }))
+        .map(|(index, block)| {
+            (
+                range.start() + (index as u64),
+                match Block::decode(block) {
+                    Ok(block) => block,
+                    Err(err) => {
+                        let dummy = Block {
+                            parent_hash: None,
+                            timestamp: TimeStamp::new(0, 0),
+                            transaction: Transaction {
+                                memo: Memo(64),
+                                created_at_time: None,
+                                icrc1_memo: None,
+                                operation: Operation::Burn {
+                                    from: AccountIdentifier::new(Principal::management_canister().into(), None),
+                                    amount: Tokens::from_e8s(1234),
+                                },
+                            },
+                        };
+                        ic_cdk::println!(
+                            "Replacing block {} with dummy block {:?} because of error: {}",
+                            range.start() + (index as u64),
+                            &dummy,
+                            err
+                        );
+                        dummy
+                    }
+                },
+            )
+        })
         .collect();
 
     Ok(results)

--- a/rs/backend/src/ledger_sync.rs
+++ b/rs/backend/src/ledger_sync.rs
@@ -80,7 +80,7 @@ async fn get_blocks(from: BlockIndex, tip_of_chain: BlockIndex) -> Result<Vec<(B
         .flat_map(|(index, block)| match Block::decode(block) {
             Ok(block) => Some((range.start() + (index as u64), block)),
             Err(err)  => {
-                println!("Ignoring block {}: {}", range.start() + (index as u64), err);
+                ic_cdk::println!("Ignoring block {}: {}", range.start() + (index as u64), err);
                 None
             }
         })

--- a/rs/backend/src/ledger_sync.rs
+++ b/rs/backend/src/ledger_sync.rs
@@ -77,7 +77,11 @@ async fn get_blocks(from: BlockIndex, tip_of_chain: BlockIndex) -> Result<Vec<(B
     let results: Vec<_> = blocks
         .into_iter()
         .enumerate()
-        .map(|(index, block)| (range.start() + (index as u64), Block::decode(block).unwrap()))
+        .flat_map(|(index, block)| match Block::decode(block) {
+            Ok(block) => Some((range.start() + (index as u64), block)),
+            Err(err) if err.contains("SignedToken") => None,
+            Err(err) => panic!("{}", err),
+        })
         .collect();
 
     Ok(results)

--- a/rs/backend/src/ledger_sync.rs
+++ b/rs/backend/src/ledger_sync.rs
@@ -79,8 +79,10 @@ async fn get_blocks(from: BlockIndex, tip_of_chain: BlockIndex) -> Result<Vec<(B
         .enumerate()
         .flat_map(|(index, block)| match Block::decode(block) {
             Ok(block) => Some((range.start() + (index as u64), block)),
-            Err(err) if err.contains("SignedToken") => None,
-            Err(err) => panic!("{}", err),
+            Err(err)  => {
+                println!("Ignoring block {}: {}", range.start() + (index as u64), err);
+                None
+            }
         })
         .collect();
 


### PR DESCRIPTION
# Motivation

There was a bug when we have an approve transaction with amount zero.

In this PR, we catch errors decoding blocks and ignoring when an error is found.

# Changes

* Identify if there is an error decoding blocks and ignore if so.

# Tests

No tests.

# Todos

- [x] Add entry to changelog (if necessary).
