### PR TITLE
Keep a list of exceptional transactions

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Added `approveTransfer` in icrc-ledger API.
 * Add `UpdateElectedHostosVersions` and `UpdateNodesHostosVersion` proposals support.
 * Show the maximum participation of the Neurons' Fund when present.
+* A list of exceptional (not-rendered, zero value) transactions.
 
 #### Changed
 

--- a/rs/backend/src/ledger_sync.rs
+++ b/rs/backend/src/ledger_sync.rs
@@ -104,6 +104,11 @@ async fn get_blocks(from: BlockIndex, tip_of_chain: BlockIndex) -> Result<Vec<(B
                             &dummy,
                             err
                         );
+                        STATE.with(|s| {
+                            s.performance
+                                .borrow_mut()
+                                .record_exceptional_transaction_id(range.start() + (index as u64))
+                        });
                         dummy
                     }
                 },

--- a/rs/backend/src/perf.rs
+++ b/rs/backend/src/perf.rs
@@ -34,6 +34,7 @@ impl PerformanceCount {
 #[derive(CandidType, Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 pub struct PerformanceCounts {
     pub instruction_counts: VecDeque<PerformanceCount>,
+    pub exceptional_transactions: Option<VecDeque<u64>>,
 }
 
 impl PerformanceCounts {
@@ -47,6 +48,19 @@ impl PerformanceCounts {
 
     pub fn get_stats(&self, stats: &mut Stats) {
         stats.performance_counts = self.instruction_counts.iter().cloned().collect();
+    }
+
+    /// The maximum number of exceptional transaction IDs we store.
+    const MAX_EXCEPTIONAL_TRANSACTIONS: usize = 1000;
+    /// Saves an exceptional transaction ID
+    pub fn record_exceptional_transaction_id(&mut self, transaction_id: u64) {
+        if self.exceptional_transactions.is_none() {
+            self.exceptional_transactions = Some(VecDeque::new());
+        }
+        if let Some(exceptional_transactions) = &mut self.exceptional_transactions {
+            exceptional_transactions.push_front(transaction_id);
+            exceptional_transactions.truncate(Self::MAX_EXCEPTIONAL_TRANSACTIONS);
+        }
     }
 
     /// Generates sample data for use in tests

--- a/rs/backend/src/perf/tests.rs
+++ b/rs/backend/src/perf/tests.rs
@@ -25,3 +25,26 @@ fn perf_stable_memory_never_fails() {
         PerformanceCounts::decode(data).expect("Failed to decode perf counters");
     }
 }
+
+/// When truncating the most recent exceptional transactions are kept
+#[test]
+fn most_recent_exceptional_transactions_are_retained() {
+    let mut perf = PerformanceCounts::default();
+    let num_inserted = PerformanceCounts::MAX_EXCEPTIONAL_TRANSACTIONS + 20;
+    for i in 0..num_inserted {
+        perf.record_exceptional_transaction_id(i as u64);
+    }
+    assert_eq!(
+        perf.exceptional_transactions.as_ref().unwrap().len(),
+        PerformanceCounts::MAX_EXCEPTIONAL_TRANSACTIONS
+    );
+    let first_id = perf
+        .exceptional_transactions
+        .as_ref()
+        .unwrap()
+        .iter()
+        .next()
+        .copied()
+        .unwrap();
+    assert_eq!(first_id, num_inserted as u64 - 1, "Expected to have the most recent ID");
+}


### PR DESCRIPTION
# Motivation
Some special, zero-value, transaction types currently fail to parse.  We would like visibility of which transactions fail to parse.

# Changes
* Keep a bounded vector of exceptional transaction IDs.

# Tests
There is a unit test that verifies that the list does not exceed the limit and that it retains the most recent transactions.

# Todos

- [x] Add entry to changelog (if necessary).
