### PR TITLE
API to get exceptional transactions

### DIFF
--- a/rs/backend/nns-dapp-exports-production.txt
+++ b/rs/backend/nns-dapp-exports-production.txt
@@ -5,6 +5,7 @@ canister_post_upgrade
 canister_pre_upgrade
 canister_query get_account
 canister_query get_canisters
+canister_query get_exceptional_transactions
 canister_query get_histogram
 canister_query get_stats
 canister_query get_transactions

--- a/rs/backend/nns-dapp-exports-test.txt
+++ b/rs/backend/nns-dapp-exports-test.txt
@@ -5,6 +5,7 @@ canister_post_upgrade
 canister_pre_upgrade
 canister_query get_account
 canister_query get_canisters
+canister_query get_exceptional_transactions
 canister_query get_histogram
 canister_query get_stats
 canister_query get_toy_account

--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -281,6 +281,7 @@ service: (opt Config) -> {
     get_proposal_payload: (nat64) -> (GetProposalPayloadResponse);
     get_stats: () -> (Stats) query;
     get_histogram: () -> (Histogram) query;
+    get_exceptional_transactions: () -> (vec nat64) query;
     add_pending_notify_swap: (AddPendingNotifySwapRequest) -> (AddPendingTransactionResponse);
 
     http_request: (request: HttpRequest) -> (HttpResponse) query;

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -395,6 +395,20 @@ pub fn get_toy_account() {
     })
 }
 
+#[export_name = "canister_query get_exceptional_transactions"]
+pub fn get_exceptional_transactions() {
+    over(candid, |()| get_exceptional_transactions_impl());
+}
+fn get_exceptional_transactions_impl() -> Option<Vec<u64>> {
+    STATE.with(|s| {
+        s.performance
+            .borrow()
+            .exceptional_transactions
+            .as_ref()
+            .map(|transactions| transactions.iter().cloned().collect::<Vec<u64>>())
+    })
+}
+
 #[derive(CandidType)]
 pub enum GetAccountResponse {
     Ok(AccountDetails),


### PR DESCRIPTION
# Motivation
We keep a list of exceptional transactions; we would like to be able to access it.

# Changes
* Add a query method to get the list.

# Tests
There is a PR to add the NNS Dapp ledger candid to the repo.  When that has been merged it will be possible to write meaningful tests.

# Todos

- [x] Add entry to changelog (if necessary).
  - Covered sufficiently by an existing changelog entry about storing this data.
