### PR TITLE
Include exceptional transactions in stats

### DIFF
--- a/rs/backend/src/perf.rs
+++ b/rs/backend/src/perf.rs
@@ -48,6 +48,12 @@ impl PerformanceCounts {
 
     pub fn get_stats(&self, stats: &mut Stats) {
         stats.performance_counts = self.instruction_counts.iter().cloned().collect();
+        stats.exceptional_transactions_count = Some(
+            self.exceptional_transactions
+                .as_ref()
+                .map(|x| x.len() as u32)
+                .unwrap_or(0),
+        );
     }
 
     /// The maximum number of exceptional transaction IDs we store.

--- a/rs/backend/src/stats.rs
+++ b/rs/backend/src/stats.rs
@@ -50,6 +50,7 @@ pub struct Stats {
     pub wasm_memory_size_bytes: Option<u64>,
     pub schema: Option<u32>,              // The numeric form of a SchemaLabel.
     pub migration_countdown: Option<u32>, // When non-zero, a migration is in progress.
+    pub exceptional_transactions_count: Option<u32>,
 }
 
 pub fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
@@ -108,6 +109,11 @@ pub fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         "nns_dapp_migration_countdown",
         stats.migration_countdown.unwrap_or(0) as f64,
         "When non-zero, a migration is in progress.",
+    )?;
+    w.encode_gauge(
+        "exceptional_transactions_count",
+        stats.exceptional_transactions_count.unwrap_or(0) as f64,
+        "The number of exceptional transactions in the canister log.",
     )?;
     Ok(())
 }

--- a/scripts/nns-dapp/e2e-test-metrics-present.keys
+++ b/scripts/nns-dapp/e2e-test-metrics-present.keys
@@ -1,4 +1,5 @@
 accounts_count
+exceptional_transactions_count
 hardware_wallet_accounts_count
 neurons_created_count
 neurons_topped_up_count


### PR DESCRIPTION
# Motivation
We would like to have visibility of the number of exceptional transactions and potentially alerts for their number.

# Changes
Provide a metric with a count of the number of stored exceptional transactions.

Note: If the exceptional transactions log ever becomes full, this metric will plateau.  If that happens before we switch to the index canister we may need revise this statistic, e.g. with a dedicated counter.

# Tests
Awaiting #3629 to write an e2e test.

# Todos

- [ ] Add entry to changelog (if necessary).
  - Covered by an existing changelog entry