### PR TITLE
Remove wrong CHANGELOG entry

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -15,7 +15,6 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Added provenance information to .did files and derived rust code.
-* Added `approveTransfer` in icrc-ledger API.
 * Add `UpdateElectedHostosVersions` and `UpdateNodesHostosVersion` proposals support.
 * Show the maximum participation of the Neurons' Fund when present.
 * A list of exceptional (not-rendered, zero value) transactions.


### PR DESCRIPTION
# Motivation

The entry "Added approveTransfer in icrc-ledger API." is already in the release CHANGELOG, [here](https://github.com/dfinity/nns-dapp/blob/bf1eeaf0f49b5002a3c68b95d068de03a1f72a19/CHANGELOG-Nns-Dapp.md?plain=1#L38).
But [this commit](https://github.com/dfinity/nns-dapp/commit/c6a5f4d3262b914368278bd16a7c0d825a026282) put it back into the the unrelease CHANGELOG as well, probably by accident.

# Changes

Remove the unwanted entry.

# Tests

no

# Todos

- [x] Add entry to changelog (if necessary).
