### PR TITLE
Use transaction type Transfer for Send/Receive derived from TransferFrom

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -34,6 +34,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Remove robots meta tag to allow search engines to crawl NNS Dapp.
 * Fix i18n key in merge neurons summary screen.
+* Display `TransferFrom` as a normal receive instead of failing to load transactions.
 
 #### Security
 

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -783,6 +783,13 @@ impl AccountsStore {
             .take(request.page_size as usize)
             .map(|transaction_index| {
                 let transaction = self.get_transaction(*transaction_index).unwrap();
+                let transaction_type = transaction.transaction_type;
+                let used_transaction_type = if let Some(TransactionType::TransferFrom) = transaction_type {
+                    Some(TransactionType::Transfer)
+                } else {
+                    transaction_type
+                };
+
                 TransactionResult {
                     block_height: transaction.block_height,
                     timestamp: transaction.timestamp,
@@ -818,7 +825,7 @@ impl AccountsStore {
                             fee,
                         },
                     },
-                    transaction_type: transaction.transaction_type,
+                    transaction_type: used_transaction_type,
                 }
             })
             .collect();
@@ -1710,7 +1717,7 @@ pub struct TransactionResult {
     transaction_type: Option<TransactionType>,
 }
 
-#[derive(CandidType)]
+#[derive(CandidType, Debug, PartialEq)]
 pub enum TransferResult {
     Burn {
         amount: Tokens,


### PR DESCRIPTION
# Motivation

[Here](https://github.com/dfinity/nns-dapp/blob/5642420e1cadc0fe4c80c11ed2be9d34293c8630/rs/backend/src/accounts_store.rs#L794) we treat TransferFrom the same as Transfer and turn into a `Send` or a `Receive`. But [here](https://github.com/dfinity/nns-dapp/blob/5642420e1cadc0fe4c80c11ed2be9d34293c8630/rs/backend/src/accounts_store.rs#L821) we pass the transaction type which might be TransferFrom . But [in the frontend](https://github.com/dfinity/nns-dapp/blob/5642420e1cadc0fe4c80c11ed2be9d34293c8630/frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js#L87), we don't know TransactionType TransferFrom and thus it fails to decode the transaction.

# Changes

Use transaction type `Transfer` on the `Send` or `Receive` created from a `TransferFrom`.

# Tests

Added a test with a `TransferFrom` and check that it get transaction type `Transfer`.

# Todos

- [x] Add entry to changelog (if necessary).
