### PR TITLE
GIX-2018: Add proposal card project detail

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectProposal.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectProposal.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import type { SnsSummary } from "$lib/types/sns";
+  import type { ProposalInfo } from "@dfinity/nns";
+  import { nonNullish } from "@dfinity/utils";
+  import NnsProposalCard from "../proposals/NnsProposalCard.svelte";
+  import { getProjectProposal } from "$lib/getters/sns-summary";
+  import { loadProposal } from "$lib/services/$public/proposals.services";
+  import { i18n } from "$lib/stores/i18n";
+
+  export let summary: SnsSummary;
+
+  let proposalInfo: ProposalInfo | undefined;
+
+  $: {
+    let proposalId = getProjectProposal(summary);
+    if (nonNullish(proposalId)) {
+      loadProposal({
+        proposalId,
+        setProposal: (proposal: ProposalInfo) => {
+          // User might navigate quickly between proposals - previous / next.
+          // e.g. the update call of previous proposal id 3n might be fetched after user has navigated to next proposal id 2n
+          if (proposal.id !== proposalId) {
+            return;
+          }
+          proposalInfo = proposal;
+        },
+        silentUpdateErrorMessages: true,
+      });
+    }
+  }
+</script>
+
+{#if nonNullish(proposalInfo)}
+  <h3>{$i18n.sns_project_detail.swap_proposal}</h3>
+  <NnsProposalCard {proposalInfo} />
+{/if}

--- a/frontend/src/lib/components/project-detail/ProjectProposal.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectProposal.svelte
@@ -12,7 +12,7 @@
   let proposalInfo: ProposalInfo | undefined;
 
   $: {
-    let proposalId = getProjectProposal(summary);
+    const proposalId = getProjectProposal(summary);
     if (nonNullish(proposalId)) {
       loadProposal({
         proposalId,

--- a/frontend/src/lib/components/project-detail/ProjectProposal.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectProposal.svelte
@@ -19,7 +19,7 @@
         setProposal: (proposal: ProposalInfo) => {
           // User might navigate quickly between proposals - previous / next.
           // e.g. the update call of previous proposal id 3n might be fetched after user has navigated to next proposal id 2n
-          if (proposal.id !== proposalId) {
+          if (proposal.id !== getProjectProposal(summary)) {
             return;
           }
           proposalInfo = proposal;

--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -85,8 +85,12 @@
   @use "@dfinity/gix-components/dist/styles/mixins/card";
   @use "@dfinity/gix-components/dist/styles/mixins/media";
 
-  li.hidden {
-    visibility: hidden;
+  li {
+    list-style: none;
+
+    &.hidden {
+      visibility: hidden;
+    }
   }
 
   .stretch-wrapper {

--- a/frontend/src/lib/getters/sns-summary.ts
+++ b/frontend/src/lib/getters/sns-summary.ts
@@ -1,5 +1,6 @@
 import type { CountryCode } from "$lib/types/location";
 import type { SnsSummary } from "$lib/types/sns";
+import type { ProposalId } from "@dfinity/nns";
 import { fromNullable } from "@dfinity/utils";
 
 export const getDeniedCountries = (_summary: SnsSummary): CountryCode[] =>
@@ -33,3 +34,8 @@ export const getMaxNeuronsFundParticipation = ({
     fromNullable(init?.neurons_fund_participation_constraints ?? [])
       ?.max_neurons_fund_participation_icp_e8s ?? []
   );
+
+// TODO: Hardcode the project ids for initial projects
+export const getProjectProposal = (
+  summary: SnsSummary
+): ProposalId | undefined => fromNullable(summary.init?.nns_proposal_id ?? []);

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -695,6 +695,7 @@
     "no_proposals": "There are no decentralisation swap proposals open at the moment."
   },
   "sns_project_detail": {
+    "swap_proposal": "Swap Proposal",
     "token_name": "Token Name",
     "token_symbol": "Token Symbol",
     "total_tokens": "Tokens Distributed to Participants",

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -43,6 +43,7 @@
   import { loadUserCountry } from "$lib/services/user-country.services";
   import { hasBuyersCount } from "$lib/utils/sns-swap.utils";
   import { loadSnsFinalizationStatus } from "$lib/services/sns-finalization.services";
+  import ProjectProposal from "$lib/components/project-detail/ProjectProposal.svelte";
 
   export let rootCanisterId: string | undefined | null;
 
@@ -300,17 +301,20 @@
 <TestIdWrapper testId="project-detail-component">
   <main>
     <div class="stretch-mobile">
+      <ProjectMetadataSection />
       <div class="content-grid">
         <div class="content-a">
-          <ProjectMetadataSection />
-        </div>
-
-        <div class="content-c">
           <ProjectInfoSection />
         </div>
-        <div class="content-d">
+        <div class="content-b">
           <ProjectStatusSection />
         </div>
+
+        {#if nonNullish($projectDetailStore.summary)}
+          <div class="content-c">
+            <ProjectProposal summary={$projectDetailStore.summary} />
+          </div>
+        {/if}
       </div>
     </div>
   </main>
@@ -327,9 +331,7 @@
 
     display: flex;
     align-items: stretch;
-
-    @include media.min-width(large) {
-      display: block;
-    }
+    flex-direction: column;
+    gap: var(--row-gap);
   }
 </style>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -720,6 +720,7 @@ interface I18nSns_launchpad {
 }
 
 interface I18nSns_project_detail {
+  swap_proposal: string;
   token_name: string;
   token_symbol: string;
   total_tokens: string;

--- a/frontend/src/tests/lib/components/project-detail/ProjectProposal.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectProposal.spec.ts
@@ -1,0 +1,46 @@
+import * as proposalsApi from "$lib/api/proposals.api";
+import ProjectProposal from "$lib/components/project-detail/ProjectProposal.svelte";
+import { mockProposalInfo } from "$tests/mocks/proposal.mock";
+import { createSummary } from "$tests/mocks/sns-projects.mock";
+import { blockAllCallsTo } from "$tests/utils/module.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { render } from "@testing-library/svelte";
+
+vi.mock("$lib/api/proposals.api");
+
+const blockedApiPaths = ["$lib/api/proposals.api"];
+describe("ProjectProposal", () => {
+  blockAllCallsTo(blockedApiPaths);
+
+  beforeEach(() => {
+    vi.spyOn(proposalsApi, "queryProposal").mockResolvedValue(mockProposalInfo);
+  });
+
+  it("should show a proposal card from the proposal id", async () => {
+    const { queryByTestId } = render(ProjectProposal, {
+      props: {
+        summary: createSummary({
+          nnsProposalId: mockProposalInfo.id,
+        }),
+      },
+    });
+
+    await runResolvedPromises();
+
+    expect(queryByTestId("proposal-card")).toBeInTheDocument();
+  });
+
+  it("should not show a proposal card if no nns proposal id", async () => {
+    const { queryByTestId } = render(ProjectProposal, {
+      props: {
+        summary: createSummary({
+          nnsProposalId: undefined,
+        }),
+      },
+    });
+
+    await runResolvedPromises();
+
+    expect(queryByTestId("proposal-card")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -67,6 +67,7 @@ export const aggregatorSnsMockWith = ({
   index,
   nervousFunctions,
   swapDueTimestampSeconds,
+  nnsProposalId,
 }: {
   rootCanisterId?: string;
   lifecycle?: SnsSwapLifecycle;
@@ -78,6 +79,7 @@ export const aggregatorSnsMockWith = ({
   index?: number;
   nervousFunctions?: SnsNervousSystemFunction[];
   swapDueTimestampSeconds?: number;
+  nnsProposalId?: number;
 }): CachedSnsDto => ({
   index: index ?? aggregatorSnsMockDto.index,
   ...aggregatorSnsMockDto,
@@ -134,6 +136,8 @@ export const aggregatorSnsMockWith = ({
       swap_due_timestamp_seconds:
         swapDueTimestampSeconds ??
         aggregatorSnsMockDto.swap_state.swap.params.swap_due_timestamp_seconds,
+      nns_proposal_id:
+        nnsProposalId ?? aggregatorSnsMockDto.init.init.nns_proposal_id,
     },
   },
   swap_params: {

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -322,6 +322,7 @@ type SnsSummaryParams = {
   maxNFParticipation?: bigint;
   neuronsFundIsParticipating?: [boolean] | [];
   swapOpenTimestampSeconds?: bigint;
+  nnsProposalId?: bigint;
 };
 
 export const createSummary = ({
@@ -344,6 +345,7 @@ export const createSummary = ({
   maxNFParticipation,
   neuronsFundIsParticipating,
   swapOpenTimestampSeconds,
+  nnsProposalId,
 }: SnsSummaryParams): SnsSummary => {
   const init: SnsSwapInit = {
     ...mockInit,
@@ -368,6 +370,7 @@ export const createSummary = ({
           },
         ]
       : [],
+    nns_proposal_id: toNullable(nnsProposalId),
   };
   const params: SnsParams = {
     ...mockSnsParams,

--- a/frontend/src/tests/utils/sns.test-utils.ts
+++ b/frontend/src/tests/utils/sns.test-utils.ts
@@ -18,6 +18,7 @@ export const setSnsProjects = (
     tokenMetadata?: Partial<IcrcTokenMetadata>;
     nervousFunctions?: SnsNervousSystemFunction[];
     swapDueTimestampSeconds?: number;
+    nnsProposalId?: number;
   }[]
 ) => {
   const aggregatorProjects = params.map((params, index) => {
@@ -31,6 +32,7 @@ export const setSnsProjects = (
       tokenMetadata: params.tokenMetadata,
       nervousFunctions: params.nervousFunctions,
       swapDueTimestampSeconds: params.swapDueTimestampSeconds,
+      nnsProposalId: params.nnsProposalId,
     });
   });
   snsLifecycleStore.reset();


### PR DESCRIPTION
# Motivation

Users can easily find the proposal that opened a swap.

# Changes

* A new ProjectProposal component
* Move the ProjectMetadataSection outside of the grid in ProjectDetail. The grid is used for the other sections.
* Render the new component `ProjectProposal` in ProjectDetail below the `ProjectInfoSection`.
* Add getters `getProjectProposal` to get the proposal id or a summary. This will be useful because we might want to hardcode the proposals before 1-Proposal was deployed.

# Tests

* Test the new component ProjectProposal.
* Add a test to ProjectDetail when the project has a related NNS proposal id in the information it renders a proposal card.
* Add nnsProposalId to helpers.

# Todos

- [ ] Add entry to changelog (if necessary).
