### PR TITLE
Update E2E tests to new version of Internet Identity

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -57,6 +57,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Join npm audit URLs with spaces instead of commas.
 * Add traits with a dedicated command rather than with patch files.
+* Use snsdemo snapshot with Internet Identity version 2023-10-27.
 
 #### Deprecated
 #### Removed

--- a/dfx.json
+++ b/dfx.json
@@ -642,7 +642,7 @@
         "BINSTALL_VERSION": "1.3.0",
         "DIDC_VERSION": "2023-09-27",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2023-10-19",
+        "SNSDEMO_RELEASE": "release-2023-10-30",
         "IC_COMMIT": "dd51544944987556c978e774aa7a1992e5c11542"
       },
       "packtool": ""

--- a/frontend/src/tests/utils/e2e.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.test-utils.ts
@@ -59,9 +59,8 @@ export const signInWithNewUser = async ({
   const iiPage = await iiPagePromise;
   await expect(iiPage).toHaveTitle("Internet Identity");
 
-  await iiPage.getByRole("button", { name: "Create an Anchor" }).click();
-  await iiPage.getByPlaceholder("Example: my phone").fill("my phone");
-  await iiPage.getByRole("button", { name: "Next" }).click();
+  await iiPage.getByRole("button", { name: "Create Internet Identity" }).click();
+  await iiPage.getByRole("button", { name: "Create Passkey" }).click();
   step("Sign in > creating identity");
 
   await iiPage.locator("input#captchaInput").fill("a");
@@ -69,10 +68,6 @@ export const signInWithNewUser = async ({
   step("Sign in > verifying captcha");
 
   await iiPage.getByRole("button", { name: "Continue" }).click();
-  await iiPage.getByText("Choose a Recovery Method").waitFor();
-  await iiPage.getByRole("button", { name: /Skip/ }).click();
-  await iiPage.getByRole("button", { name: "Add another device" }).waitFor();
-  await iiPage.getByRole("button", { name: /Skip/ }).click();
 
   step("Sign in > finalizing authentication");
   await iiPage.waitForEvent("close");

--- a/frontend/src/tests/utils/e2e.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.test-utils.ts
@@ -59,7 +59,9 @@ export const signInWithNewUser = async ({
   const iiPage = await iiPagePromise;
   await expect(iiPage).toHaveTitle("Internet Identity");
 
-  await iiPage.getByRole("button", { name: "Create Internet Identity" }).click();
+  await iiPage
+    .getByRole("button", { name: "Create Internet Identity" })
+    .click();
   await iiPage.getByRole("button", { name: "Create Passkey" }).click();
   step("Sign in > creating identity");
 


### PR DESCRIPTION
# Motivation

The current used version of Internet Identity is from April. It has a bug where it tries to connect to mainnet when it doesn't recognize the FE URL. This prevents us from using it on a DevEnv.

# Changes

1. Use the latest snsdemo snapshot which uses version 2023-10-27 of Internet Identity.
2. Update `signInWithNewUser` to the new ii UI.

# Tests

Pass on CI

# Todos

- [x] Add entry to changelog (if necessary).
