### PR TITLE
Mock API layer in CkBTCWallet.spec.ts

### DIFF
--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -7,16 +7,12 @@ import { CKBTC_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/ckbtc.constants"
 import { AppPath } from "$lib/constants/routes.constants";
 import CkBTCWallet from "$lib/pages/CkBTCWallet.svelte";
 import * as services from "$lib/services/ckbtc-accounts.services";
-import { authStore } from "$lib/stores/auth.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { Account } from "$lib/types/account";
 import { page } from "$mocks/$app/stores";
 import CkBTCAccountsTest from "$tests/lib/components/accounts/CkBTCAccountsTest.svelte";
-import {
-  mockAuthStoreSubscribe,
-  resetIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockCkBTCMainAccount,
   mockCkBTCToken,
@@ -26,7 +22,6 @@ import { CkBTCReceiveModalPo } from "$tests/page-objects/CkBTCReceiveModal.page-
 import { CkBTCTransactionModalPo } from "$tests/page-objects/CkBTCTransactionModal.page-object";
 import { CkBTCWalletPo } from "$tests/page-objects/CkBTCWallet.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { allowLoggingInOneTestForDebugging } from "$tests/utils/console.test-utils";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import {
   advanceTime,
@@ -112,8 +107,6 @@ describe("CkBTCWallet", () => {
   };
 
   beforeEach(() => {
-    allowLoggingInOneTestForDebugging();
-
     vi.clearAllMocks();
     vi.clearAllTimers();
     tokensStore.reset();
@@ -174,10 +167,6 @@ describe("CkBTCWallet", () => {
     beforeEach(() => {
       afterTransfer = false;
       vi.useFakeTimers().setSystemTime(new Date());
-
-      vi.spyOn(authStore, "subscribe").mockImplementation(
-        mockAuthStoreSubscribe
-      );
 
       icrcAccountsStore.set({
         accounts: {

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -1,4 +1,5 @@
 import * as ckbtcLedgerApi from "$lib/api/ckbtc-ledger.api";
+import * as ckbtcMinterApi from "$lib/api/ckbtc-minter.api";
 import * as icrcIndexApi from "$lib/api/icrc-index.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
@@ -35,12 +36,6 @@ import { render, waitFor } from "@testing-library/svelte";
 import { mockBTCAddressTestnet } from "../../mocks/ckbtc-accounts.mock";
 
 const expectedBalanceAfterTransfer = 11_111n;
-
-vi.mock("$lib/api/ckbtc-minter.api", () => {
-  return {
-    getBTCAddress: vi.fn().mockImplementation(() => mockBTCAddressTestnet),
-  };
-});
 
 vi.mock("$lib/services/ckbtc-minter.services", async () => {
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -87,11 +82,13 @@ vi.mock("$lib/services/worker-transactions.services", () => ({
 }));
 
 vi.mock("$lib/api/ckbtc-ledger.api");
+vi.mock("$lib/api/ckbtc-minter.api");
 vi.mock("$lib/api/icrc-ledger.api");
 vi.mock("$lib/api/icrc-index.api");
 
 const blockedApiPaths = [
   "$lib/api/ckbtc-ledger.api",
+  "$lib/api/ckbtc-minter.api",
   "$lib/api/icrc-ledger.api",
   "$lib/api/icrc-index.api",
 ];
@@ -162,6 +159,9 @@ describe("CkBTCWallet", () => {
         });
       });
       vi.mocked(ckbtcLedgerApi.getCkBTCToken).mockResolvedValue(mockCkBTCToken);
+      vi.mocked(ckbtcMinterApi.getBTCAddress).mockResolvedValue(
+        mockBTCAddressTestnet
+      );
     });
 
     it("should render a spinner while loading", async () => {

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -154,8 +154,6 @@ describe("CkBTCWallet", () => {
 
     it("should call to load ckBTC accounts", async () => {
       await renderWallet();
-
-      await runResolvedPromises();
       expect(ckbtcLedgerApi.getCkBTCAccount).toBeCalled();
       expect(ckbtcLedgerApi.getCkBTCToken).toBeCalled();
     });

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -37,18 +37,6 @@ import { mockBTCAddressTestnet } from "../../mocks/ckbtc-accounts.mock";
 
 const expectedBalanceAfterTransfer = 11_111n;
 
-vi.mock("$lib/services/ckbtc-minter.services", async () => {
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  const actual = await vi.importActual<any>(
-    "$lib/services/ckbtc-minter.services"
-  );
-  return {
-    ...actual,
-    updateBalance: vi.fn().mockResolvedValue([]),
-    depositFee: vi.fn().mockResolvedValue(789n),
-  };
-});
-
 vi.mock("$lib/services/ckbtc-info.services", () => {
   return {
     loadCkBTCInfo: vi.fn().mockResolvedValue(undefined),
@@ -208,7 +196,6 @@ describe("CkBTCWallet", () => {
       });
 
       vi.mocked(icrcLedgerApi.icrcTransfer).mockImplementation(() => {
-        console.log("dskloetx mock icrcTransfer");
         afterTransfer = true;
         return Promise.resolve(BigInt(1));
       });

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -115,6 +115,14 @@ describe("CkBTCWallet", () => {
     vi.mocked(icrcIndexApi.getTransactions).mockResolvedValue({
       transactions: [],
     });
+    vi.mocked(ckbtcMinterApi.getBTCAddress).mockResolvedValue(
+      mockBTCAddressTestnet
+    );
+    vi.mocked(ckbtcMinterApi.minterInfo).mockResolvedValue({
+      retrieve_btc_min_amount: 80_000n,
+      min_confirmations: 12,
+      kyt_fee: 7_000n,
+    });
   });
 
   describe("accounts not loaded", () => {
@@ -134,14 +142,6 @@ describe("CkBTCWallet", () => {
         });
       });
       vi.mocked(ckbtcLedgerApi.getCkBTCToken).mockResolvedValue(mockCkBTCToken);
-      vi.mocked(ckbtcMinterApi.getBTCAddress).mockResolvedValue(
-        mockBTCAddressTestnet
-      );
-      vi.mocked(ckbtcMinterApi.minterInfo).mockResolvedValue({
-        retrieve_btc_min_amount: 80_000n,
-        min_confirmations: 12,
-        kyt_fee: 7_000n,
-      });
     });
 
     it("should render a spinner while loading", async () => {

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -7,6 +7,8 @@ import { CKBTC_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/ckbtc.constants"
 import { AppPath } from "$lib/constants/routes.constants";
 import CkBTCWallet from "$lib/pages/CkBTCWallet.svelte";
 import * as services from "$lib/services/ckbtc-accounts.services";
+import { bitcoinAddressStore } from "$lib/stores/bitcoin.store";
+import { ckBTCInfoStore } from "$lib/stores/ckbtc-info.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { Account } from "$lib/types/account";
@@ -110,6 +112,8 @@ describe("CkBTCWallet", () => {
     vi.clearAllMocks();
     vi.clearAllTimers();
     tokensStore.reset();
+    ckBTCInfoStore.reset();
+    bitcoinAddressStore.reset();
     resetIdentity();
 
     vi.mocked(icrcIndexApi.getTransactions).mockResolvedValue({

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -37,12 +37,6 @@ import { mockBTCAddressTestnet } from "../../mocks/ckbtc-accounts.mock";
 
 const expectedBalanceAfterTransfer = 11_111n;
 
-vi.mock("$lib/services/ckbtc-info.services", () => {
-  return {
-    loadCkBTCInfo: vi.fn().mockResolvedValue(undefined),
-  };
-});
-
 vi.mock("$lib/services/worker-balances.services", () => ({
   initBalancesWorker: vi.fn(() =>
     Promise.resolve({
@@ -150,6 +144,11 @@ describe("CkBTCWallet", () => {
       vi.mocked(ckbtcMinterApi.getBTCAddress).mockResolvedValue(
         mockBTCAddressTestnet
       );
+      vi.mocked(ckbtcMinterApi.minterInfo).mockResolvedValue({
+        retrieve_btc_min_amount: 80_000n,
+        min_confirmations: 12,
+        kyt_fee: 7_000n,
+      });
     });
 
     it("should render a spinner while loading", async () => {

--- a/frontend/src/tests/utils/module.test-utils.ts
+++ b/frontend/src/tests/utils/module.test-utils.ts
@@ -56,9 +56,7 @@ export const installImplAndBlockRest = ({
       // jest.mock() can't be done here because jest does some magic to move all
       // those calls to the top of test to make sure they happen before any
       // import.
-      throw new Error(
-        `You must add 'jest.mock("${modulePath}");' to your test.`
-      );
+      throw new Error(`You must add 'vi.mock("${modulePath}");' to your test.`);
     }
     for (const fn in implementedFunctions) {
       if (!module[fn]?.mock) {


### PR DESCRIPTION
# Motivation

It's easier to refactor code if the test mocks lower layers because we don't care which service calls the API.

# Changes

1. Stop mocking several services in `CkBTCWallet.spec.ts`
2. Instead mock the necessary APIs and block non-mocked calls to those APIs
3. In `beforeEach`, reset stores that are filled by the service layer
4. Use `resetIdentity` instead of `mockAuthStoreSubscribe`
5. Merge the tests that the spinner is visible/not visible into one test where the spinner starts visible and then goes away
6. Fix an error message about using `jest.mock` to say `vi.mock` instead

# Tests

Pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary