### PR TITLE
fix: expandObject to respect arrays

### DIFF
--- a/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerPayloadEntry.svelte
@@ -9,10 +9,8 @@
   // `null` means that the payload was not found
   // `object` means that the payload is an object
   export let payload: object | undefined | null;
-  let expandedPayload: object | undefined | null;
-  $: expandedPayload = isNullish(payload)
-    ? payload
-    : expandObject(payload as Record<string, unknown>);
+  let expandedPayload: unknown;
+  $: expandedPayload = isNullish(payload) ? payload : expandObject(payload);
 </script>
 
 <div class="content-cell-island">

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -378,7 +378,7 @@ export const expandObject = (value: unknown): unknown => {
   if (typeof value === "string") {
     try {
       return JSON.parse(value);
-    } catch (e) {
+    } catch (e: unknown) {
       return value;
     }
   }

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -386,12 +386,15 @@ export const expandObject = (value: unknown): unknown => {
     return value.map(expandObject);
   }
   if (typeof value === "object") {
-    Object.keys(value).forEach(
+    // to avoid mutating original object
+    const result = { ...value };
+    Object.keys(result).forEach(
       (key) =>
-        ((value as Record<string, unknown>)[key] = expandObject(
-          (value as Record<string, unknown>)[key]
+        ((result as Record<string, unknown>)[key] = expandObject(
+          (result as Record<string, unknown>)[key]
         ))
     );
+    return result;
   }
   return value;
 };

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -371,30 +371,30 @@ export const isPngAsset = (
  * @param obj
  * @returns parsed object
  */
-export const expandObject = (
-  obj: Record<string, unknown>
-): Record<string, unknown> =>
-  Object.keys(obj).reduce(
-    (acc, key) => {
-      const value = obj[key];
-      if (typeof value === "string") {
-        try {
-          acc[key] = JSON.parse(value);
-        } catch (e) {
-          acc[key] = value;
-        }
-      } else if (typeof value === "object") {
-        acc[key] =
-          value !== null
-            ? expandObject(value as Record<string, unknown>)
-            : value;
-      } else {
-        acc[key] = value;
-      }
-      return acc;
-    },
-    {} as Record<string, unknown>
-  );
+export const expandObject = (value: unknown): unknown => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value);
+    } catch (e) {
+      return value;
+    }
+  }
+  if (Array.isArray(value)) {
+    return value.map(expandObject);
+  }
+  if (typeof value === "object") {
+    Object.keys(value).forEach(
+      (key) =>
+        ((value as Record<string, unknown>)[key] = expandObject(
+          (value as Record<string, unknown>)[key]
+        ))
+    );
+  }
+  return value;
+};
 
 export const sameBufferData = (
   buffer1: ArrayBuffer,

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -24,6 +24,7 @@ import {
 } from "$tests/utils/timers.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { get } from "svelte/store";
+import { beforeEach } from "vitest";
 
 describe("utils", () => {
   beforeEach(() => {
@@ -835,6 +836,16 @@ describe("utils", () => {
     it("should parse JSON strings", () => {
       const obj = { a: JSON.stringify({ b: "c" }) };
       expect(expandObject(obj)).toEqual({ a: { b: "c" } });
+    });
+
+    it("should respect arrays (not convert into objects)", () => {
+      const obj = { a: [1, 2, 3] };
+      expect(expandObject(obj)).toEqual({ a: [1, 2, 3] });
+    });
+
+    it("should parse JSON strings from arrays", () => {
+      const obj = { a: [1, JSON.stringify({ b: 2 }), 3] };
+      expect(expandObject(obj)).toEqual({ a: [1, { b: 2 }, 3] });
     });
   });
 


### PR DESCRIPTION
# Motivation

Add array support to `expandObject` util.

# Changes

- Returns array as array, not an object.

# Tests

Extended.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

# Screenshots

## Before
<img width="313" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/5d11e87b-70e0-4bcf-8df5-0334df9a7fd8">

## After
<img width="336" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/521f9660-59b9-414d-a094-302115b5082a">

