### PR TITLE
Don't call global.fetch from unit tests.

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -56,6 +56,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Formatting for `Cargo.toml` files.
 * Add test to check that the nns-dapp cargo and npm versions match.
 * Script to deploy nns-dapp on `DevEnv`.
+* Try to prevent calls to global.fetch in unit tests.
 
 #### Changed
 

--- a/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/ProjectCard.spec.ts
@@ -11,19 +11,30 @@ import {
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { ProjectCardPo } from "$tests/page-objects/ProjectCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
+vi.mock("$lib/api/sns-sale.api");
+
+const blockedApiPaths = ["$lib/api/sns-sale.api"];
+
 describe("ProjectCard", () => {
+  blockAllCallsTo(blockedApiPaths);
+
   const rootCanisterId = rootCanisterIdMock;
   const now = 1698139468000;
   const nowInSeconds = Math.round(now / 1000);
   const yesterdayInSeconds = nowInSeconds - SECONDS_IN_DAY;
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers().setSystemTime(now);
+    vi.spyOn(saleApi, "queryFinalizationStatus").mockResolvedValue(
+      createFinalizationStatusMock(false)
+    );
     setSnsProjects([
       {
         rootCanisterId: mockSnsFullProject.rootCanisterId,

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -74,17 +74,20 @@ setDefaultTestConstants({
 
 failTestsThatLogToConsole();
 
-// Avoid using fetch in tests
-let usedFetch = false;
+// Avoid using fetch in tests.
+// NOTE: This doesn't seem to work when all tests are run but works when
+// individual tests are run. Not sure why. Still it seems better to have it than
+// not to have it.
+let usedGlobalFetch = false;
 beforeEach(() => {
-  usedFetch = false;
+  usedGlobalFetch = false;
 });
 afterEach(async () => {
-  expect(usedFetch).toBe(false);
+  expect(usedGlobalFetch).toBe(false);
 });
 vi.spyOn(global, "fetch").mockImplementation(() => {
-  usedFetch = true;
-  throw new Error("fetch is not allowed in tests");
+  usedGlobalFetch = true;
+  throw new Error("global.fetch is not allowed in tests");
 });
 
 // testing-library setup

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -74,6 +74,19 @@ setDefaultTestConstants({
 
 failTestsThatLogToConsole();
 
+// Avoid using fetch in tests
+let usedFetch = false;
+beforeEach(() => {
+  usedFetch = false;
+});
+afterEach(async () => {
+  expect(usedFetch).toBe(false);
+});
+vi.spyOn(global, "fetch").mockImplementation(() => {
+  usedFetch = true;
+  throw new Error("fetch is not allowed in tests");
+});
+
 // testing-library setup
 configure({
   testIdAttribute: "data-tid",


### PR DESCRIPTION
# Motivation

This [test failure](https://github.com/dfinity/nns-dapp/actions/runs/6730359901/job/18292918007) seems to be the result of a unit test making a real request:
```
Server returned an error:
   ❯ src/tests/lib/components/launchpad/ProjectCard.spec.ts > ProjectCard > not signed in > should not display a spinner when the swapCommitment is not loaded
  Code: 400 (Bad Request)
  Body: Specified ingress_expiry not within expected range: Minimum allowed expiry: 2023-11-02 09:03:58.649355448 UTC, Maximum allowed expiry: 2023-11-02 09:09:28.649355448 UTC, Provided expiry:        2023-10-24 09:28:28 UTC
  Retrying request.
  ```
Unit test should never (try to) make actual network requests.
This PR tries to catch it when a unit test tries to call `global.fetch`. Strangely there seems to be some interference between tests that makes it so that the check doesn't work when all tests are run together. Even though individual test files should be isolated from each other.
Still it seems better to have the check than not to have it.

# Changes

1. Add code in `vitest.setup.ts` to disallow calling `global.fetch`.
2. Mock `sns-sale.api` in `ProjectCard.spec.ts` so it doesn't try to make actual requests.

# Tests

pass

# Todos

- [x] Add entry to changelog (if necessary).
