### PR TITLE
Don't automatically update the aggregator rust types when the NNS can…

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -69,6 +69,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Removed
 
 * Delete nightly `GitHub` job to update II used in tests; we now use the II that comes with `snsdemo`.
+* No longer update rust bindings when NNS canister interfaces are updated.
 
 #### Fixed
 

--- a/scripts/update_ic_commit
+++ b/scripts/update_ic_commit
@@ -2,8 +2,9 @@
 set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 print_help() {
-  cat <<-EOF
-	Gets stable data from an sns_aggregator.
+  cat <<-"EOF"
+
+	Fetches the candid for NNS canisters.
 	EOF
 }
 # Source the clap.bash file ---------------------------------------------------
@@ -53,9 +54,6 @@ source "$(clap.build)"
   did_curl sns_wasm /rs/nns/sns-wasm/canister/sns-wasm.did
   did_curl sns_ledger /rs/rosetta-api/icrc1/ledger/ledger.did
 }
-
-: "Derive Rust types from candid interfaces"
-time scripts/mk_nns_types.sh
 
 : "All done"
 echo FIN


### PR DESCRIPTION
# Motivation
The maintenance plan calls for updates to be broken down into small units.

# Changes
- Don't automatically update the aggregator rust types when the NNS canister declarations are updated
- Update the help text to match.

# Tests
None.

# Todos

- [x] Add entry to changelog (if necessary).
