### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+        # These are peer deps of Cargo and should not be automatically bumped
+        - dependency-name: "semver"
+        - dependency-name: "crates-io"
+    rebase-strategy: "disabled"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-        # These are peer deps of Cargo and should not be automatically bumped
-        - dependency-name: "semver"
-        - dependency-name: "crates-io"
+      # These are peer deps of Cargo and should not be automatically bumped
+      - dependency-name: "semver"
+      - dependency-name: "crates-io"
     rebase-strategy: "disabled"

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -55,6 +55,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+* Enable dependabot for Rust updates.
 * Import candid for NNS ledger.
 * Formatting for `Cargo.toml` files.
 * Add test to check that the nns-dapp cargo and npm versions match.


### PR DESCRIPTION
# Motivation
We would like to keep the Rust dependencies up to date.  Some are simple to manage, third party packages with semantic versions and these can be taken care of by dependabot.  Others, in particular updates of crates in the IC repo, require a tailored approach.  This PR addresses simple third party packages.

Note: Dependabot opens PRs when updates are available.

### References
- https://dfinity.atlassian.net/browse/GIX-1964
- https://dfinity.atlassian.net/browse/GIX-1967

# Changes
- Enable dependabot for rust crate updates.

# Tests

# Todos

- [x] Add entry to changelog (if necessary).
