### PR TITLE
Support ICRC-2 in ConvertBtcInProgress.svelte

### DIFF
--- a/frontend/src/lib/components/accounts/ConvertBtcInProgress.svelte
+++ b/frontend/src/lib/components/accounts/ConvertBtcInProgress.svelte
@@ -6,22 +6,33 @@
 
   export let progressStep: ConvertBtcStep;
   export let transferToLedgerStep = true;
+  export let useIcrc2 = false;
 
   let steps: [ProgressStep, ...ProgressStep[]] = [
-    {
-      step: ConvertBtcStep.INITIALIZATION,
-      text: $i18n.ckbtc.step_initialization,
-      state: "next",
-    } as ProgressStep,
-    ...(transferToLedgerStep
+    ...(useIcrc2
       ? [
           {
-            step: ConvertBtcStep.LOCKING_CKBTC,
-            text: $i18n.ckbtc.step_locking_ckbtc,
+            step: ConvertBtcStep.APPROVE_TRANSFER,
+            text: $i18n.ckbtc.step_approve_transfer,
             state: "next",
           } as ProgressStep,
         ]
-      : []),
+      : [
+          {
+            step: ConvertBtcStep.INITIALIZATION,
+            text: $i18n.ckbtc.step_initialization,
+            state: "next",
+          } as ProgressStep,
+          ...(transferToLedgerStep
+            ? [
+                {
+                  step: ConvertBtcStep.LOCKING_CKBTC,
+                  text: $i18n.ckbtc.step_locking_ckbtc,
+                  state: "next",
+                } as ProgressStep,
+              ]
+            : []),
+        ]),
     {
       step: ConvertBtcStep.SEND_BTC,
       text: $i18n.ckbtc.step_send_btc,

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -974,6 +974,7 @@
     "ckbtc_balance_updated": "Updated available ckBTC : New confirmed BTC.",
     "step_initialization": "Initializing transaction",
     "step_locking_ckbtc": "Confirming ckBTC",
+    "step_approve_transfer": "Approving transfer",
     "step_send_btc": "Sending BTC",
     "step_reload": "Refreshing UI Balances",
     "sending_ckbtc_to_btc": "Sending ckBTC —> BTC",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1022,6 +1022,7 @@ interface I18nCkbtc {
   ckbtc_balance_updated: string;
   step_initialization: string;
   step_locking_ckbtc: string;
+  step_approve_transfer: string;
   step_send_btc: string;
   step_reload: string;
   sending_ckbtc_to_btc: string;

--- a/frontend/src/tests/lib/components/accounts/ConvertBtcInProgress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ConvertBtcInProgress.spec.ts
@@ -245,4 +245,113 @@ describe("ConvertBtcInProgress", () => {
       status: "In progress",
     });
   });
+
+  describe("with ICRC-2 transfer approval", () => {
+    it("should render steps while approving transfer", () => {
+      const result = render(ConvertBtcInProgress, {
+        props: {
+          useIcrc2: true,
+          progressStep: ConvertBtcStep.APPROVE_TRANSFER,
+        },
+      });
+
+      testProgress({
+        result,
+        position: 1,
+        label: en.ckbtc.step_approve_transfer,
+        status: "In progress",
+      });
+
+      expect(result.container.querySelectorAll(".step").length).toEqual(3);
+    });
+
+    it("should render steps while sending btc", () => {
+      const result = render(ConvertBtcInProgress, {
+        props: {
+          useIcrc2: true,
+          progressStep: ConvertBtcStep.SEND_BTC,
+        },
+      });
+
+      testProgress({
+        result,
+        position: 1,
+        label: en.ckbtc.step_approve_transfer,
+        status: "Completed",
+      });
+
+      testProgress({
+        result,
+        position: 2,
+        label: en.ckbtc.step_send_btc,
+        status: "In progress",
+      });
+
+      expect(result.container.querySelectorAll(".step").length).toEqual(3);
+    });
+
+    it("should render steps while reloading", () => {
+      const result = render(ConvertBtcInProgress, {
+        props: {
+          useIcrc2: true,
+          progressStep: ConvertBtcStep.RELOAD,
+        },
+      });
+
+      testProgress({
+        result,
+        position: 1,
+        label: en.ckbtc.step_approve_transfer,
+        status: "Completed",
+      });
+
+      testProgress({
+        result,
+        position: 2,
+        label: en.ckbtc.step_send_btc,
+        status: "Completed",
+      });
+
+      testProgress({
+        result,
+        position: 3,
+        label: en.ckbtc.step_reload,
+        status: "In progress",
+      });
+
+      expect(result.container.querySelectorAll(".step").length).toEqual(3);
+    });
+
+    it("should render steps when done", () => {
+      const result = render(ConvertBtcInProgress, {
+        props: {
+          useIcrc2: true,
+          progressStep: ConvertBtcStep.DONE,
+        },
+      });
+
+      testProgress({
+        result,
+        position: 1,
+        label: en.ckbtc.step_approve_transfer,
+        status: "Completed",
+      });
+
+      testProgress({
+        result,
+        position: 2,
+        label: en.ckbtc.step_send_btc,
+        status: "Completed",
+      });
+
+      testProgress({
+        result,
+        position: 3,
+        label: en.ckbtc.step_reload,
+        status: "Completed",
+      });
+
+      expect(result.container.querySelectorAll(".step").length).toEqual(3);
+    });
+  });
 });


### PR DESCRIPTION
# Motivation

We want to use ICRC-2 transfer approval for BTC withdrawal.
During BTC withdrawal we show a progress screen with a list of steps.
The ICRC-2 flow has somewhat different steps.

# Changes

1. Add a prop `useIcrc2` to `ConvertBtcInProgress.svelte` to indicate using the different steps.
2. Use steps depending on the prop.

# Tests

Unit tests are added.
Tested manually in a branch that has the full ICRC-2 flow working.

# Todos

- [ ] Add entry to changelog (if necessary).
will add when used in another PR