### PR TITLE
Use ICRC-2 in BTC withdrawal

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -35,6 +35,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Not Published
 
+* Use ICRC-2 for BTC withdrawal when `ENABLE_CKBTC_ICRC2` is enabled.
+
 ### Operations
 
 #### Added


### PR DESCRIPTION
# Motivation

By using ICRC-2 for BTC withdrawal we can't transfer to the wrong account because it's the minter itself that makes the transfer.

# Changes

When `ENABLE_CKBTC_ICRC2` is enabled use `convertCkBTCToBtcIcrc2` instead of `convertCkBTCToBtc` and tell the `ConvertBtcInProgress` component to use the ICRC-2 steps.

# Tests

1. In `frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts` duplicate the tests that expect a call to `convertCkBTCToBtc` and expect a call to `convertCkBTCToBtcIcrc2` instead if `ENABLE_CKBTC_ICRC2` is enabled.
2. In `frontend/src/tests/lib/pages/CkBTCWallet.spec.ts` duplicate the tests that expect a call to `icrcLedgerApi.icrcTransfer` and expect calls to `icrcLedgerApi.approveTransfer` and `ckbtcMinterApi.retrieveBtcWithApproval` instead if `ENABLE_CKBTC_ICRC2` is enabled.

Also tested manually [here](https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/) by sending some ckBTC to `1ASLxsAMbbt4gcrNc6v6qDBW4JkeWAtTeh`.

# Todos

- [x] Add entry to changelog (if necessary).
