### PR TITLE
Remove unused parameter loadTransactions

### DIFF
--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -36,7 +36,6 @@
   } from "$lib/stores/ckbtc-info.store";
 
   export let selectedAccount: Account | undefined = undefined;
-  export let loadTransactions = false;
 
   export let canisters: CkBTCAdditionalCanisters;
   export let universeId: UniverseCanisterId;
@@ -99,7 +98,6 @@
       source: sourceAccount,
       destinationAddress,
       amount,
-      loadTransactions,
       universeId,
       indexCanisterId: canisters.indexCanisterId,
     });

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionTokenModal.svelte
@@ -19,7 +19,6 @@
   let universeId: UniverseCanisterId;
   let account: Account | undefined;
   let reloadAccountFromStore: (() => void) | undefined;
-  let loadTransactions: boolean;
 
   $: ({ account, reloadAccountFromStore, universeId, canisters } = data);
 
@@ -42,7 +41,6 @@
     on:nnsClose
     on:nnsTransfer={onTransferReloadSelectedAccount}
     selectedAccount={account}
-    {loadTransactions}
     token={token.token}
     {transactionFee}
     {universeId}

--- a/frontend/src/lib/services/ckbtc-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts.services.ts
@@ -5,7 +5,6 @@ import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
 import { getCkBTCAccounts } from "$lib/services/ckbtc-accounts-loader.services";
 import { loadCkBTCToken } from "$lib/services/ckbtc-tokens.services";
-import { loadCkBTCAccountTransactions } from "$lib/services/ckbtc-transactions.services";
 import { transferTokens } from "$lib/services/icrc-accounts.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
@@ -71,12 +70,10 @@ export const syncCkBTCAccounts = async (params: {
 
 export const ckBTCTransferTokens = async ({
   source,
-  loadTransactions,
   universeId,
   indexCanisterId,
   ...rest
 }: IcrcTransferTokensUserParams & {
-  loadTransactions: boolean;
   universeId: UniverseCanisterId;
 } & Pick<CkBTCAdditionalCanisters, "indexCanisterId">): Promise<{
   blockIndex: IcrcBlockIndex | undefined;
@@ -97,13 +94,6 @@ export const ckBTCTransferTokens = async ({
         canisterId: universeId,
       }),
     reloadAccounts: async () => await loadCkBTCAccounts({ universeId }),
-    reloadTransactions: async () =>
-      await (loadTransactions
-        ? loadCkBTCAccountTransactions({
-            account: source,
-            canisterId: universeId,
-            indexCanisterId,
-          })
-        : Promise.resolve()),
+    reloadTransactions: async () => Promise.resolve(),
   });
 };

--- a/frontend/src/lib/services/ckbtc-convert.services.ts
+++ b/frontend/src/lib/services/ckbtc-convert.services.ts
@@ -170,7 +170,6 @@ export const convertCkBTCToBtc = async ({
     source,
     amount,
     destinationAddress: ledgerAddress,
-    loadTransactions: false,
     universeId,
     indexCanisterId,
   });

--- a/frontend/src/tests/lib/services/ckbtc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts.services.spec.ts
@@ -8,7 +8,6 @@ import {
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
 import * as services from "$lib/services/ckbtc-accounts.services";
 import { loadCkBTCAccounts } from "$lib/services/ckbtc-accounts.services";
-import { loadCkBTCAccountTransactions } from "$lib/services/ckbtc-transactions.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import * as toastsStore from "$lib/stores/toasts.store";
@@ -177,7 +176,6 @@ describe("ckbtc-accounts-services", () => {
         source: mockCkBTCMainAccount,
         destinationAddress: "aaaaa-aa",
         amount: 1,
-        loadTransactions: false,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
         indexCanisterId: CKBTC_INDEX_CANISTER_ID,
       });
@@ -185,28 +183,6 @@ describe("ckbtc-accounts-services", () => {
       expect(blockIndex).toEqual(456n);
       expect(spyTransfer).toBeCalled();
       expect(spyAccounts).toBeCalled();
-    });
-
-    it("should load transactions if flag is passed", async () => {
-      tokensStore.setTokens(mockTokens);
-
-      const spyTransfer = vi
-        .spyOn(icrcLedgerApi, "icrcTransfer")
-        .mockResolvedValue(456n);
-
-      const { blockIndex } = await services.ckBTCTransferTokens({
-        source: mockCkBTCMainAccount,
-        destinationAddress: "aaaaa-aa",
-        amount: 1,
-        loadTransactions: true,
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
-        indexCanisterId: CKBTC_INDEX_CANISTER_ID,
-      });
-
-      expect(blockIndex).toEqual(456n);
-      expect(spyTransfer).toBeCalled();
-      expect(spyAccounts).toBeCalled();
-      expect(loadCkBTCAccountTransactions).toBeCalled();
     });
 
     it("should show toast and return success false if transfer fails", async () => {
@@ -223,7 +199,6 @@ describe("ckbtc-accounts-services", () => {
         source: mockCkBTCMainAccount,
         destinationAddress: "aaaaa-aa",
         amount: 1,
-        loadTransactions: false,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
         indexCanisterId: CKBTC_INDEX_CANISTER_ID,
       });
@@ -247,7 +222,6 @@ describe("ckbtc-accounts-services", () => {
         source: mockCkBTCMainAccount,
         destinationAddress: "aaaaa-aa",
         amount: 1,
-        loadTransactions: false,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
         indexCanisterId: CKBTC_INDEX_CANISTER_ID,
       });


### PR DESCRIPTION
# Motivation

Parameter `loadTransactions` of `ckBTCTransferTokens` only ever gets the value `false` so it's less confusing to just remove the parameter.

# Changes

Remove the `loadTransactions` parameter from `ckBTCTransferTokens` and all the places where it is passed from.

# Tests

Removed a test where `true` is passed and updated other tests to no longer pass the value.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary