### PR TITLE
Use a human readable timestamp in the snapshot restore dir

### DIFF
--- a/scripts/dfx-snapshot-start
+++ b/scripts/dfx-snapshot-start
@@ -37,7 +37,7 @@ if pgrep replica || [ "$SCRIPT_COUNT" -gt 2 ]; then
   exit 1
 fi
 
-BACKUP_DIR="$HOME/dfx-state-backup-$(date +%s)"
+BACKUP_DIR="$HOME/dfx-state-backup-$(date +"%Y%m%d_%H%M%S")"
 
 RESTORE_BACKUP_SCRIPT_FILE="$BACKUP_DIR/restore.sh"
 


### PR DESCRIPTION
# Motivation

When you start a snapshot with `scripts/dfx-snapshot-start` your current `dfx` configuration is moved into a backup directory. The name of this directory contains a timestamp. But this timestamp is not very useful in figuring out when the backup was made because it is in seconds instead of a human readable date format.
The similar script `dfx-snapshot-install`, does use a human readable date format [here](https://github.com/dfinity/nns-dapp/blob/d92dc292e86eb73f02a2954488e1c099613563ba/scripts/dfx-snapshot-install#L85).

# Changes

Use a human readable date format in `scripts/dfx-snapshot-start`.

# Tests

Ran the script manually and checked the restore directory.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary