### PR TITLE
fix: Correct IC candid updater PR title

### DIFF
--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -83,7 +83,7 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-ic-update
           delete-branch: true
-          title: 'Update didc release'
+          title: 'Update IC candid files'
           body: |
             # Motivation
             A newer release of the internet computer is available.


### PR DESCRIPTION
# Motivation
There is a bot that updates the IC candid files.  The PR title, however, states that it updates `didc`.

# Changes
* Corerct the PR title.

# Tests
None

# Todos

- [x] Add entry to changelog (if necessary).
  - Already covered by the existing changelog entry for creating the bot.
