### PR TITLE
Feat: Improve text for NF commitment

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -748,7 +748,7 @@
     "max_user_commitment_reached": "Maximum commitment reached",
     "not_eligible_to_participate": "You are not eligible to participate in this swap.",
     "getting_sns_open_ticket": "We're connecting with the SNS swap. This might take more than a minute.",
-    "current_nf_commitment_description": "The NF commitment increases based on direct participation. <a href=\"https://internetcomputer.org/docs/current/tokenomics/nns/neurons-fund\" rel=\"noopener noreferrer\" aria-label=\"more info about neurons' fund\" target=\"_blank\">Learn more</a>.",
+    "current_nf_commitment_description": "The Neurons' Fund commitment increases based on direct participation. The exact amount is computed at the end of the swap. <a href=\"https://internetcomputer.org/docs/current/tokenomics/nns/neurons-fund\" rel=\"noopener noreferrer\" aria-label=\"more info about neurons' fund\" target=\"_blank\">Learn more</a>.",
     "sign_in": "Sign in to participate"
   },
   "sns_sale": {


### PR DESCRIPTION
# Motivation

Improve the text that explains the new Neurons' Fund commitment.

# Changes

* Edit the value of an i18n key.

# Tests

Not necessary.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary. Not seen by any user yet.
