### PR TITLE
Fix: Canister title when not controller

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -31,6 +31,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Show canister title in details when user is not the controller.
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/canisters/ic-management/ic-management.errors.ts
+++ b/frontend/src/lib/canisters/ic-management/ic-management.errors.ts
@@ -7,14 +7,12 @@ export function mapError(error: Error | unknown): Error | unknown {
   const statusLine =
     error instanceof Error
       ? error.message
-      : ""
           .split("\n")
           .map((l) => l.trim().toLowerCase())
-          .find(
-            (l) => l.startsWith("code:") || l.startsWith("http status code:")
-          );
+          .find((l) => l.startsWith('"error code"'))
+      : "";
 
-  if (statusLine?.includes("403")) {
+  if (statusLine?.includes("ic0512")) {
     return new UserNotTheControllerError();
   }
   return error;

--- a/frontend/src/lib/canisters/ic-management/ic-management.errors.ts
+++ b/frontend/src/lib/canisters/ic-management/ic-management.errors.ts
@@ -4,6 +4,8 @@
  * @throws UserNotTheControllerError and Error.
  */
 export function mapError(error: Error | unknown): Error | unknown {
+  // As per IC Specification: https://internetcomputer.org/docs/current/references/ic-interface-spec#error-codes
+  // Specification might change and then we might need to change this as well.
   const statusLine =
     error instanceof Error
       ? error.message

--- a/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
@@ -52,7 +52,7 @@ describe("ICManagementCanister", () => {
       );
     });
 
-    it("throws UserNotTheControllerError", async () => {
+    it('throws UserNotTheControllerError if "Error Code" is "IC0512"', async () => {
       const error = new Error(`Call failed:
       Canister: aaaaa-aa
       Method: canister_status (update)

--- a/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
@@ -71,7 +71,7 @@ describe("ICManagementCanister", () => {
       expect(call).rejects.toThrowError(UserNotTheControllerError);
     });
 
-    it("throws Error if code is in request id", async () => {
+    it('throws Error if "IC0512" is present, but not as "Error Code"', async () => {
       const error = new Error(`Call failed:
       Canister: aaaaa-aa
       Method: canister_status (update)

--- a/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
@@ -137,7 +137,13 @@ describe("ICManagementCanister", () => {
     });
 
     it("throws UserNotTheControllerError", async () => {
-      const error = new Error("code: 403");
+      const error = new Error(`Call failed:
+      Canister: aaaaa-aa
+      Method: canister_status (update)
+      "Request ID": "9dac7652f94de82d72f00ee492c132defc48da8dd6043516312275ab0fa5b5e1"
+      "Error code": "IC0512"
+      "Reject code": "5"
+      "Reject message": "Only controllers of canister mwewp-s4aaa-aaaaa-qabjq-cai can call ic00 method canister_status"`);
       const service = mock<IcManagementService>();
       service.update_settings.mockRejectedValue(error);
 

--- a/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
@@ -53,7 +53,13 @@ describe("ICManagementCanister", () => {
     });
 
     it("throws UserNotTheControllerError", async () => {
-      const error = new Error("code: 403");
+      const error = new Error(`Call failed:
+      Canister: aaaaa-aa
+      Method: canister_status (update)
+      "Request ID": "9dac7652f94de82d72f00ee492c132defc48da8dd6043516312275ab0fa5b5e1"
+      "Error code": "IC0512"
+      "Reject code": "5"
+      "Reject message": "Only controllers of canister mwewp-s4aaa-aaaaa-qabjq-cai can call ic00 method canister_status"`);
       const service = mock<IcManagementService>();
       service.canister_status.mockRejectedValue(error);
 
@@ -63,6 +69,25 @@ describe("ICManagementCanister", () => {
         icManagement.getCanisterDetails(Principal.fromText("aaaaa-aa"));
 
       expect(call).rejects.toThrowError(UserNotTheControllerError);
+    });
+
+    it("throws Error if code is in request id", async () => {
+      const error = new Error(`Call failed:
+      Canister: aaaaa-aa
+      Method: canister_status (update)
+      "Request ID": "IC0512"
+      "Error code": "Another code"
+      "Reject code": "5"
+      "Reject message": "..."`);
+      const service = mock<IcManagementService>();
+      service.canister_status.mockRejectedValue(error);
+
+      const icManagement = await createICManagement(service);
+
+      const call = () =>
+        icManagement.getCanisterDetails(Principal.fromText("aaaaa-aa"));
+
+      expect(call).rejects.toThrowError(Error);
     });
 
     it("throws Error", async () => {

--- a/frontend/src/tests/lib/canisters/ic-management.errors.spec.ts
+++ b/frontend/src/tests/lib/canisters/ic-management.errors.spec.ts
@@ -5,15 +5,27 @@ import {
 
 describe("IC Management Error utils", () => {
   describe("mapError", () => {
-    it("returns error based on code", () => {
-      expect(mapError(new Error("code: 403"))).toBeInstanceOf(
+    it("returns error based on error code", () => {
+      const notControllerError = new Error(`Call failed:
+      Canister: aaaaa-aa
+      Method: canister_status (update)
+      "Request ID": "9dac7652f94de82d72f00ee492c132defc48da8dd6043516312275ab0fa5b5e1"
+      "Error code": "IC0512"
+      "Reject code": "5"
+      "Reject message": "Only controllers of canister mwewp-s4aaa-aaaaa-qabjq-cai can call ic00 method canister_status"`);
+      expect(mapError(notControllerError)).toBeInstanceOf(
         UserNotTheControllerError
       );
+      expect(mapError(new Error("code: 403"))).toBeInstanceOf(Error);
       expect(
-        mapError(new Error("This is an error message with\ncode: 514"))
+        mapError(
+          new Error(`This is an error message with\n"Error code": "IC0511"`)
+        )
       ).toBeInstanceOf(Error);
       expect(
-        mapError(new Error("And this is yet another one with\ncode: 509"))
+        mapError(
+          new Error(`And this is yet another one with\n"Error code": "IC2512"`)
+        )
       ).toBeInstanceOf(Error);
     });
 
@@ -22,7 +34,7 @@ describe("IC Management Error utils", () => {
         Error
       );
       expect(
-        mapError(new Error("erro message with code: 509 in the same line"))
+        mapError(new Error("erro message with code: IC2512 in the same line"))
       ).toBeInstanceOf(Error);
     });
   });


### PR DESCRIPTION
# Motivation

There was a bug where the user would see a loading skeleton instead of the canister name when they were not the controllers.

The cause of this bug was a change in the error message from the IC Management canister when the caller is not the controller.

The error message is parsed and expects a certain structure and wording.

I also changed splitting the error message to get the error code line. This was not the cause of the bug, because the code checked whether 403 was in the error message. But that would not be accurate because 403 could be part of a request id.

# Changes

* Change the `mapError` function for the IC Management canister.

# Tests

* Added a test with an up to date error message.

# Todos

- [x] Add entry to changelog (if necessary).
