### PR TITLE
fix: Make the prod releases public

### DIFF
--- a/.github/actions/release_nns_dapp/action.yaml
+++ b/.github/actions/release_nns_dapp/action.yaml
@@ -28,8 +28,8 @@ runs:
           then gh release upload --repo dfinity/nns-dapp --clobber "$tag" "${artefacts[@]}" || true
           else gh release create --title "Release for tags/$tag" --draft --notes "$("$GITHUB_ACTION_PATH/template" --tag "$tag" --dir .)" "$tag" "${artefacts[@]}"
           fi
-          : If the tag is for a proposal or nightly, make it public
-          [[ "$tag" != proposal-* ]] && [[ "$tag" != nightly-* ]] || { echo "Making release public" ; gh release edit "$tag" --draft=false ; }
+          : If the tag is for a proposal, prod or nightly, make it public
+          [[ "$tag" != proposal-* ]] && [[ "$tag" != nightly-* ]] && [[ "$tag" != "aggregator-prod" ]] && [[ "$tag" != "prod" ]] || { echo "Making release public" ; gh release edit "$tag" --draft=false ; }
         done
       env:
         GITHUB_TOKEN: ${{ inputs.token }}

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -47,6 +47,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Factor out the `snsdemo` installation.
+* Add `prod` and `aggregator-prod` to the list of public releases.
 
 #### Deprecated
 


### PR DESCRIPTION
# Motivation
The `prod` releases should be public.  In particular, CI expects the `aggregator-prod` to be public.

# Changes
- Add the two `prod` releases to the set  of releases that should be public.

# Tests
None

# Todos

- [x] Add entry to changelog (if necessary).
