### PR TITLE
Json tree view optimization

### DIFF
--- a/frontend/src/lib/components/common/JsonPreview.svelte
+++ b/frontend/src/lib/components/common/JsonPreview.svelte
@@ -45,7 +45,7 @@
     </button>
   {/if}
   <div class="json-container">
-    <TestIdWrapper dataTid="json-wrapper">
+    <TestIdWrapper testId="json-wrapper">
       {#if $jsonRepresentationModeStore === "tree"}
         <div in:fade>
           <TreeJson

--- a/frontend/src/lib/components/common/JsonPreview.svelte
+++ b/frontend/src/lib/components/common/JsonPreview.svelte
@@ -23,25 +23,27 @@
 </script>
 
 <div class="content-cell-island markdown-container">
-  {#if $jsonRepresentationModeStore === "tree"}
-    <div class="json" data-tid="json-wrapper" in:fade>
-      {#if !expandAll}
-        <button class="ghost expand-all" on:click={toggleExpanded}
-          ><IconExpandAll /><span class="expand-all-label"
-            >{$i18n.core.expand_all}</span
-          ></button
-        >
-      {/if}
-      <TreeJson
-        json={expandedData}
-        defaultExpandedLevel={expandAll ? Number.MAX_SAFE_INTEGER : 1}
-      />
-    </div>
-  {:else}
-    <div in:fade>
-      <RawJson {json} />
-    </div>
+  {#if !expandAll}
+    <button class="ghost expand-all" on:click={toggleExpanded}
+      ><IconExpandAll /><span class="expand-all-label"
+        >{$i18n.core.expand_all}</span
+      ></button
+    >
   {/if}
+  <div class="json-container">
+    <div class="json" data-tid="json-wrapper" in:fade>
+      {#if $jsonRepresentationModeStore === "tree"}
+        <TreeJson
+          json={expandedData}
+          defaultExpandedLevel={expandAll ? Number.MAX_SAFE_INTEGER : 1}
+        />
+      {:else}
+        <div in:fade>
+          <RawJson {json} />
+        </div>
+      {/if}
+    </div>
+  </div>
 </div>
 
 <style lang="scss">
@@ -50,8 +52,8 @@
   .expand-all {
     padding: 0;
     position: absolute;
-    right: var(--padding-0_5x);
-    top: var(--padding-0_5x);
+    right: var(--padding-2x);
+    top: var(--padding-2x);
 
     display: flex;
     align-items: center;
@@ -66,10 +68,11 @@
     }
   }
 
-  .json {
-    // needs for the expand all button
-    position: relative;
-    word-break: break-word;
+  .json-container {
+    // json content scrolling
+    overflow-x: auto;
+    // same as "content-cell-island"
+    padding: var(--padding-2x);
   }
 
   // TODO(max): rename and move to gix-components
@@ -77,5 +80,10 @@
     // custom island styles
     background: var(--card-background-disabled);
     color: var(--description-color);
+
+    // reset "content-cell-island" padding
+    padding: 0;
+    // to place expand-all button
+    position: relative;
   }
 </style>

--- a/frontend/src/lib/components/common/JsonPreview.svelte
+++ b/frontend/src/lib/components/common/JsonPreview.svelte
@@ -23,7 +23,7 @@
 </script>
 
 <div class="content-cell-island markdown-container">
-  {#if !expandAll}
+  {#if $jsonRepresentationModeStore === "tree" && !expandAll}
     <button class="ghost expand-all" on:click={toggleExpanded}
       ><IconExpandAll /><span class="expand-all-label"
         >{$i18n.core.expand_all}</span

--- a/frontend/src/lib/components/common/JsonPreview.svelte
+++ b/frontend/src/lib/components/common/JsonPreview.svelte
@@ -7,6 +7,7 @@
   import RawJson from "$lib/components/common/RawJson.svelte";
   import { fade } from "svelte/transition";
   import { jsonRepresentationModeStore } from "$lib/derived/json-representation.derived";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   const DEFAULT_EXPANDED_LEVEL = 1;
 
@@ -44,7 +45,7 @@
     </button>
   {/if}
   <div class="json-container">
-    <div class="json" data-tid="json-wrapper">
+    <TestIdWrapper dataTid="json-wrapper">
       {#if $jsonRepresentationModeStore === "tree"}
         <div in:fade>
           <TreeJson
@@ -57,7 +58,7 @@
           <RawJson {json} />
         </div>
       {/if}
-    </div>
+    </TestIdWrapper>
   </div>
 </div>
 

--- a/frontend/src/lib/components/common/RawJson.svelte
+++ b/frontend/src/lib/components/common/RawJson.svelte
@@ -17,7 +17,6 @@
 
   pre {
     margin: 0;
-    overflow-x: auto;
     @include fonts.small;
   }
 </style>

--- a/frontend/src/lib/components/common/TreeJson.svelte
+++ b/frontend/src/lib/components/common/TreeJson.svelte
@@ -4,6 +4,7 @@
   import TreeJsonValue from "$lib/components/common/TreeJsonValue.svelte";
   import { getTreeJsonValueRenderType } from "$lib/utils/json.utils";
   import { fade } from "svelte/transition";
+  import { isLikeANumber } from "$lib/utils/utils";
 
   export let json: unknown | undefined = undefined;
   export let defaultExpandedLevel = Infinity;
@@ -38,7 +39,7 @@
     _collapsed === undefined ? _level >= defaultExpandedLevel : _collapsed;
 
   let keyIsIndex = false;
-  $: keyIsIndex = !isNaN(Number(_key));
+  $: keyIsIndex = isLikeANumber(_key);
 
   const toggle = () => (collapsed = !collapsed);
 </script>

--- a/frontend/src/lib/components/common/TreeJson.svelte
+++ b/frontend/src/lib/components/common/TreeJson.svelte
@@ -7,7 +7,7 @@
     type TreeJsonValueType,
   } from "$lib/utils/json.utils";
   import { fade } from "svelte/transition";
-  import { isLikeANumber } from "$lib/utils/utils";
+  import { typeOfLikeANumber } from "$lib/utils/utils";
 
   export let json: unknown | undefined = undefined;
   export let defaultExpandedLevel = Infinity;
@@ -44,7 +44,7 @@
   $: collapsed = _level >= defaultExpandedLevel;
 
   let keyIsIndex = false;
-  $: keyIsIndex = isLikeANumber(_key) || (_isArrayEntry ?? false);
+  $: keyIsIndex = typeOfLikeANumber(_key) || (_isArrayEntry ?? false);
 
   const toggle = () => (collapsed = !collapsed);
 </script>

--- a/frontend/src/lib/components/common/TreeJsonValue.svelte
+++ b/frontend/src/lib/components/common/TreeJsonValue.svelte
@@ -11,6 +11,12 @@
     if (valueType === "base64Encoding") {
       return (data as { [key: string]: unknown })["base64Encoding"] as string;
     }
+    if (valueType === "basisPoints") {
+      return `${data.basisPoints}`;
+    }
+    if (valueType === "seconds") {
+      return `${data.seconds}`;
+    }
     if (
       (
         [
@@ -20,8 +26,6 @@
           "bigint",
           "boolean",
           "object",
-          "basisPoints",
-          "seconds",
         ] as Array<TreeJsonValueType>
       ).includes(valueType)
     ) {

--- a/frontend/src/lib/components/common/TreeJsonValue.svelte
+++ b/frontend/src/lib/components/common/TreeJsonValue.svelte
@@ -5,9 +5,11 @@
   import { i18n } from "$lib/stores/i18n";
 
   // To avoid having quotes around all the value types
-  const formatData = (value: unknown) => {
+  const formatE8s = (data: unknown): string[] =>
+    splitE8sIntoChunks((data as Record<"e8s", unknown>)?.e8s);
+  const formatData = (value: unknown): string => {
     if (valueType === "base64Encoding") {
-      return (data as { [key: string]: unknown })["base64Encoding"];
+      return (data as { [key: string]: unknown })["base64Encoding"] as string;
     }
     if (
       (
@@ -18,6 +20,8 @@
           "bigint",
           "boolean",
           "object",
+          "basisPoints",
+          "seconds",
         ] as Array<TreeJsonValueType>
       ).includes(valueType)
     ) {
@@ -31,6 +35,9 @@
   export let key: string | undefined = undefined;
   export let valueType: TreeJsonValueType;
 
+  let value: string | undefined;
+  $: value = formatData(data);
+
   let title: string | undefined;
   $: title = valueType === "hash" ? (data as number[]).join() : undefined;
 </script>
@@ -38,30 +45,28 @@
 {#if valueType === "base64Encoding"}
   <!-- base64 encoded image (use <Html> to sanitize the content from XSS) -->
   <Html
-    text={`<img class="value ${valueType}" alt="${key}" src="${formatData(
-      data
-    )}" loading="lazy" />`}
+    text={`<img class="value ${valueType}" alt="${key}" src="${value}" loading="lazy" />`}
   />
 {:else if valueType === "seconds"}
   <span class="value {valueType}" {title}
-    >{data?.seconds}
+    >{value}
     <span class="unit">{$i18n.proposal_detail.json_unit_seconds}</span>
   </span>
 {:else if valueType === "e8s"}
   <span class="value {valueType}" {title}>
-    {#each splitE8sIntoChunks(data?.e8s) as chunk}
+    {#each formatE8s(data) as chunk}
       <span>{chunk}</span>
     {/each}
     <span class="unit">{$i18n.proposal_detail.json_unit_e8s}</span>
   </span>
 {:else if valueType === "basisPoints"}
   <span class="value {valueType}" {title}
-    >{data?.basisPoints}
+    >{value}
     <span class="unit">{$i18n.proposal_detail.json_unit_basis_points}</span
     ></span
   >
 {:else}
-  <span class="value {valueType}" {title}>{formatData(data)}</span>
+  <span class="value {valueType}" {title}>{value}</span>
 {/if}
 
 <style lang="scss">

--- a/frontend/src/lib/components/common/TreeJsonValue.svelte
+++ b/frontend/src/lib/components/common/TreeJsonValue.svelte
@@ -67,34 +67,9 @@
 {/if}
 
 <style lang="scss">
-  @use "@dfinity/gix-components/dist/styles/mixins/media";
   @use "@dfinity/gix-components/dist/styles/mixins/fonts";
 
-  .key {
-    display: flex;
-    align-items: center;
-    margin-right: var(--padding-2x);
-
-    @include fonts.standard(true);
-    color: var(--content-color);
-
-    &.root {
-      @include fonts.h4();
-    }
-    &.key--expandable {
-      margin-right: 0;
-      // no icon gap compensation
-      margin-left: 0;
-    }
-    &.key--is-index {
-      // monospace for array indexes to avoid different widths
-      font-family: monospace;
-    }
-  }
-
   .value {
-    // better shrink the value than the key
-    flex: 1 1 0;
     color: var(--description-color);
 
     // for chunks and units
@@ -102,10 +77,8 @@
     align-items: center;
     gap: var(--padding-0_5x);
 
-    @include media.min-width(medium) {
-      // We want to break the value, so that the keys stay on the same line.
-      word-break: break-all;
-    }
+    // keep lines (scroll horizontally)
+    white-space: nowrap;
 
     .unit {
       margin-left: var(--padding-0_5x);

--- a/frontend/src/lib/components/common/TreeJsonValue.svelte
+++ b/frontend/src/lib/components/common/TreeJsonValue.svelte
@@ -11,6 +11,7 @@
     if (valueType === "base64Encoding") {
       return (data as { [key: string]: unknown })["base64Encoding"] as string;
     }
+    // TODO(max): think about moving to a separate component
     if (valueType === "basisPoints") {
       return `${data.basisPoints}`;
     }

--- a/frontend/src/lib/components/common/TreeJsonValue.svelte
+++ b/frontend/src/lib/components/common/TreeJsonValue.svelte
@@ -30,9 +30,7 @@
 
   export let data: unknown | undefined = undefined;
   export let key: string | undefined = undefined;
-
-  let valueType: TreeJsonValueType;
-  $: valueType = getTreeJsonValueRenderType(data);
+  export let valueType: TreeJsonValueType;
 
   let title: string | undefined;
   $: title = valueType === "hash" ? (data as number[]).join() : undefined;

--- a/frontend/src/lib/components/common/TreeJsonValue.svelte
+++ b/frontend/src/lib/components/common/TreeJsonValue.svelte
@@ -2,6 +2,7 @@
   import { Html } from "@dfinity/gix-components";
   import type { TreeJsonValueType } from "$lib/utils/json.utils";
   import { splitE8sIntoChunks, stringifyJson } from "$lib/utils/utils.js";
+  import { i18n } from "$lib/stores/i18n";
 
   // To avoid having quotes around all the value types
   const formatData = (value: unknown) => {
@@ -44,19 +45,20 @@
 {:else if valueType === "seconds"}
   <span class="value {valueType}" {title}
     >{data?.seconds}
-    <span class="unit">seconds</span>
+    <span class="unit">{$i18n.proposal_detail.json_unit_seconds}</span>
   </span>
 {:else if valueType === "e8s"}
   <span class="value {valueType}" {title}>
     {#each splitE8sIntoChunks(data?.e8s) as chunk}
       <span>{chunk}</span>
     {/each}
-    <span class="unit">e8s</span>
+    <span class="unit">{$i18n.proposal_detail.json_unit_e8s}</span>
   </span>
 {:else if valueType === "basisPoints"}
   <span class="value {valueType}" {title}
     >{data?.basisPoints}
-    <span class="unit">basis points</span></span
+    <span class="unit">{$i18n.proposal_detail.json_unit_basis_points}</span
+    ></span
   >
 {:else}
   <span class="value {valueType}" {title}>{formatData(data)}</span>

--- a/frontend/src/lib/components/common/TreeJsonValue.svelte
+++ b/frontend/src/lib/components/common/TreeJsonValue.svelte
@@ -13,10 +13,10 @@
     }
     // TODO(max): think about moving to a separate component
     if (valueType === "basisPoints") {
-      return `${data.basisPoints}`;
+      return `${(data as { [basisPoints: string]: unknown }).basisPoints}`;
     }
     if (valueType === "seconds") {
-      return `${data.seconds}`;
+      return `${(data as { [seconds: string]: unknown }).seconds}`;
     }
     if (
       (

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
@@ -69,6 +69,11 @@
     @include text.clamp(1);
   }
 
+  .toggle {
+    // compensate toggle and toggle inner buttons padding. Is important when cols wrap on mobile.
+    margin: 0 calc(var(--padding-0_5x) * -2);
+  }
+
   .header {
     display: flex;
     justify-content: space-between;

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
@@ -59,7 +59,6 @@
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/fonts";
   @use "@dfinity/gix-components/dist/styles/mixins/text";
-  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .header-text {
     display: flex;

--- a/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalProposerActionsEntry.svelte
@@ -28,7 +28,9 @@
         </h2>
         <Copy value={copyContent} />
       </div>
-      <TreeRawToggle />
+      <div class="toggle">
+        <TreeRawToggle />
+      </div>
     </div>
 
     <div
@@ -56,17 +58,24 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+  @use "@dfinity/gix-components/dist/styles/mixins/text";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .header-text {
     display: flex;
     align-items: center;
     @include fonts.h3;
+
+    @include text.clamp(1);
   }
 
   .header {
     display: flex;
     justify-content: space-between;
     align-items: center;
+
+    flex-wrap: wrap;
+    row-gap: var(--padding);
 
     .title-copy {
       display: flex;

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -534,6 +534,9 @@
     "toggle_lable": "Switch between user-friendly and raw data representation",
     "toggle_tree": "Tree",
     "toggle_raw": "Raw",
+    "json_unit_basis_points": "basis points",
+    "json_unit_seconds": "seconds",
+    "json_unit_e8s": "e8s",
     "id": "ID"
   },
   "proposal_detail__vote": {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -554,6 +554,9 @@ interface I18nProposal_detail {
   toggle_lable: string;
   toggle_tree: string;
   toggle_raw: string;
+  json_unit_basis_points: string;
+  json_unit_seconds: string;
+  json_unit_e8s: string;
   id: string;
 }
 

--- a/frontend/src/lib/utils/json.utils.ts
+++ b/frontend/src/lib/utils/json.utils.ts
@@ -43,7 +43,6 @@ export const getTreeJsonValueRenderType = (
     if (keys.length === 1) {
       const key = keys[0];
       const keyValue = (value as Record<string, unknown>)[key];
-      console.log(key, keyValue);
       if (
         ["e8s", "seconds", "basisPoints"].includes(key) &&
         isLikeANumber(keyValue)

--- a/frontend/src/lib/utils/json.utils.ts
+++ b/frontend/src/lib/utils/json.utils.ts
@@ -1,4 +1,4 @@
-import { isHash, isLikeANumber, isPrincipal } from "$lib/utils/utils";
+import { isHash, isPrincipal, typeOfLikeANumber } from "$lib/utils/utils";
 
 export type TreeJsonValueType =
   | "bigint"
@@ -35,7 +35,7 @@ export const getTreeJsonValueRenderType = (
   if (typeof value === "object") {
     const keys = Object.keys(value);
 
-    if (Object.keys(value as object)[0] === "base64Encoding") {
+    if (keys[0] === "base64Encoding") {
       return "base64Encoding";
     }
 
@@ -45,7 +45,7 @@ export const getTreeJsonValueRenderType = (
       const keyValue = (value as Record<string, unknown>)[key];
       if (
         ["e8s", "seconds", "basisPoints"].includes(key) &&
-        isLikeANumber(keyValue)
+        typeOfLikeANumber(keyValue)
       ) {
         return key as TreeJsonValueType;
       }

--- a/frontend/src/lib/utils/json.utils.ts
+++ b/frontend/src/lib/utils/json.utils.ts
@@ -1,4 +1,4 @@
-import { isHash, isPrincipal } from "$lib/utils/utils";
+import { isHash, isLikeANumber, isPrincipal } from "$lib/utils/utils";
 
 export type TreeJsonValueType =
   | "bigint"
@@ -12,7 +12,14 @@ export type TreeJsonValueType =
   | "string"
   | "symbol"
   | "base64Encoding"
-  | "undefined";
+  | "undefined"
+  // units-only nodes
+  // sample: { "seconds": 1000000000 }
+  | "seconds"
+  // sample: { "e8s": 1000000000 }
+  | "e8s"
+  // sample: { "basisPoints": 1000000000 }
+  | "basisPoints";
 
 /**
  * Returns the type of the value for the TreeJson&TreeJsonValue components.
@@ -25,10 +32,25 @@ export const getTreeJsonValueRenderType = (
   if (isPrincipal(value)) return "principal";
   if (Array.isArray(value) && isHash(value)) return "hash";
   // not null was already checked above
-  if (
-    typeof value === "object" &&
-    Object.keys(value as object)[0] === "base64Encoding"
-  )
-    return "base64Encoding";
+  if (typeof value === "object") {
+    const keys = Object.keys(value);
+
+    if (Object.keys(value as object)[0] === "base64Encoding") {
+      return "base64Encoding";
+    }
+
+    // check for unit-only nodes (e.g. { "e8s": 1000000000 })
+    if (keys.length === 1) {
+      const key = keys[0];
+      const keyValue = (value as Record<string, unknown>)[key];
+      console.log(key, keyValue);
+      if (
+        ["e8s", "seconds", "basisPoints"].includes(key) &&
+        isLikeANumber(keyValue)
+      ) {
+        return key as TreeJsonValueType;
+      }
+    }
+  }
   return typeof value;
 };

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -453,14 +453,16 @@ export const isLikeANumber = (value: unknown): boolean =>
 export const splitE8sIntoChunks = (value: unknown): string[] => {
   if (!isLikeANumber(value)) {
     console.error("splitE8sIntoChunks: value is not a number");
-    return [`${value}`];
+    return [`${stringifyJson(value)}`];
   }
 
   const chars = `${value}`.split("");
   const chunks: string[] = [];
-  for (let i = chars.length; i >= 0; i -= 8) {
+  for (let i = chars.length; i > 0; i -= 8) {
     const chunk = chars.slice(Math.max(i - 8, 0), i);
+    // if (chunk.length > 0) {
     chunks.unshift(chunk.join(""));
+    // }
   }
 
   return chunks;

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -439,3 +439,8 @@ export const getObjMaxDepth = (obj: unknown): number => {
 
   return 1 + childrenMaxDepth; // Add 1 for the current level.
 };
+
+export const isLikeANumber = (value: unknown): boolean =>
+  typeof value === "number" ||
+  typeof value === "bigint" ||
+  (typeof value === "string" && value.length > 0 && !isNaN(Number(value)));

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -444,3 +444,24 @@ export const isLikeANumber = (value: unknown): boolean =>
   typeof value === "number" ||
   typeof value === "bigint" ||
   (typeof value === "string" && value.length > 0 && !isNaN(Number(value)));
+
+/**
+ * Split a value into 8 characters chunks
+ * @example
+ * 00001111222233334444 --> ["0000", "11112222", "33334444"]
+ */
+export const splitE8sIntoChunks = (value: unknown): string[] => {
+  if (!isLikeANumber(value)) {
+    console.error("splitE8sIntoChunks: value is not a number");
+    return [`${value}`];
+  }
+
+  const chars = `${value}`.split("");
+  const chunks: string[] = [];
+  for (let i = chars.length; i >= 0; i -= 8) {
+    const chunk = chars.slice(Math.max(i - 8, 0), i);
+    chunks.unshift(chunk.join(""));
+  }
+
+  return chunks;
+};

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -440,7 +440,7 @@ export const getObjMaxDepth = (obj: unknown): number => {
   return 1 + childrenMaxDepth; // Add 1 for the current level.
 };
 
-export const isLikeANumber = (value: unknown): boolean =>
+export const typeOfLikeANumber = (value: unknown): boolean =>
   typeof value === "number" ||
   typeof value === "bigint" ||
   (typeof value === "string" && value.length > 0 && !isNaN(Number(value)));
@@ -451,7 +451,7 @@ export const isLikeANumber = (value: unknown): boolean =>
  * 00001111222233334444 --> ["0000", "11112222", "33334444"]
  */
 export const splitE8sIntoChunks = (value: unknown): string[] => {
-  if (!isLikeANumber(value)) {
+  if (!typeOfLikeANumber(value)) {
     console.error("splitE8sIntoChunks: value is not a number");
     return [`${stringifyJson(value)}`];
   }

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -460,9 +460,7 @@ export const splitE8sIntoChunks = (value: unknown): string[] => {
   const chunks: string[] = [];
   for (let i = chars.length; i > 0; i -= 8) {
     const chunk = chars.slice(Math.max(i - 8, 0), i);
-    // if (chunk.length > 0) {
     chunks.unshift(chunk.join(""));
-    // }
   }
 
   return chunks;

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -9,6 +9,7 @@ import {
   hexStringToBytes,
   isDefined,
   isHash,
+  isLikeANumber,
   isPngAsset,
   poll,
   removeKeys,
@@ -912,6 +913,40 @@ describe("utils", () => {
       expect(getObjMaxDepth(null)).toBe(0);
       expect(getObjMaxDepth("hello")).toBe(0);
       expect(getObjMaxDepth(0)).toBe(0);
+    });
+  });
+
+  describe("isLikeANumber", () => {
+    it("returns true for numbers", () => {
+      expect(isLikeANumber(1)).toBe(true);
+      expect(isLikeANumber(0)).toBe(true);
+      expect(isLikeANumber(0.001)).toBe(true);
+      expect(isLikeANumber(-1)).toBe(true);
+    });
+
+    it("returns true for bigint", () => {
+      expect(isLikeANumber(99999999999999999999999999999999999999999999n)).toBe(
+        true
+      );
+    });
+
+    it("returns true for stringified number", () => {
+      expect(isLikeANumber("1")).toBe(true);
+      expect(isLikeANumber("0")).toBe(true);
+      expect(isLikeANumber("0.001")).toBe(true);
+      expect(isLikeANumber("-1")).toBe(true);
+      expect(isLikeANumber("+1")).toBe(true);
+    });
+
+    it("returns false for empty string", () => {
+      expect(isLikeANumber("")).toBe(false);
+    });
+
+    it("returns false for not numbers", () => {
+      expect(isLikeANumber("test")).toBe(false);
+      expect(isLikeANumber("123sec")).toBe(false);
+      expect(isLikeANumber([])).toBe(false);
+      expect(isLikeANumber({})).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -978,6 +978,7 @@ describe("utils", () => {
     it("should split bigints", () => {
       expect(splitE8sIntoChunks(12345678n)).toStrictEqual(["12345678"]);
       expect(splitE8sIntoChunks(1234567890n)).toStrictEqual(["12", "34567890"]);
+      expect(splitE8sIntoChunks(123456789n)).toStrictEqual(["1", "23456789"]);
       expect(splitE8sIntoChunks(12345678901234567890n)).toStrictEqual([
         "1234",
         "56789012",

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -15,6 +15,7 @@ import {
   removeKeys,
   sameBufferData,
   smallerVersion,
+  splitE8sIntoChunks,
   stringifyJson,
   uniqueObjects,
 } from "$lib/utils/utils";
@@ -947,6 +948,55 @@ describe("utils", () => {
       expect(isLikeANumber("123sec")).toBe(false);
       expect(isLikeANumber([])).toBe(false);
       expect(isLikeANumber({})).toBe(false);
+    });
+  });
+
+  describe("splitE8sIntoChunks", () => {
+    it("should split strings", () => {
+      expect(splitE8sIntoChunks("12345678")).toStrictEqual(["12345678"]);
+      expect(splitE8sIntoChunks("1234567890")).toStrictEqual([
+        "12",
+        "34567890",
+      ]);
+      expect(splitE8sIntoChunks("12345678901234567890")).toStrictEqual([
+        "1234",
+        "56789012",
+        "34567890",
+      ]);
+    });
+
+    it("should split number", () => {
+      expect(splitE8sIntoChunks(12345678)).toStrictEqual(["12345678"]);
+      expect(splitE8sIntoChunks(1234567890)).toStrictEqual(["12", "34567890"]);
+      expect(splitE8sIntoChunks(45678901234567890)).toStrictEqual([
+        "4",
+        "56789012",
+        "34567890",
+      ]);
+    });
+
+    it("should split bigints", () => {
+      expect(splitE8sIntoChunks(12345678n)).toStrictEqual(["12345678"]);
+      expect(splitE8sIntoChunks(1234567890n)).toStrictEqual(["12", "34567890"]);
+      expect(splitE8sIntoChunks(12345678901234567890n)).toStrictEqual([
+        "1234",
+        "56789012",
+        "34567890",
+      ]);
+    });
+
+    it("should not split short values", () => {
+      expect(splitE8sIntoChunks(0)).toStrictEqual(["0"]);
+      expect(splitE8sIntoChunks(12345678)).toStrictEqual(["12345678"]);
+    });
+
+    it("should not split not numbers", () => {
+      expect(splitE8sIntoChunks(NaN)).toStrictEqual(["NaN"]);
+      expect(splitE8sIntoChunks("")).toStrictEqual([`""`]);
+      expect(splitE8sIntoChunks(null)).toStrictEqual(["null"]);
+      expect(splitE8sIntoChunks(undefined)).toStrictEqual(["undefined"]);
+      expect(splitE8sIntoChunks([])).toStrictEqual(["[]"]);
+      expect(splitE8sIntoChunks({})).toStrictEqual(["{}"]);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -9,7 +9,6 @@ import {
   hexStringToBytes,
   isDefined,
   isHash,
-  isLikeANumber,
   isPngAsset,
   poll,
   removeKeys,
@@ -17,6 +16,7 @@ import {
   smallerVersion,
   splitE8sIntoChunks,
   stringifyJson,
+  typeOfLikeANumber,
   uniqueObjects,
 } from "$lib/utils/utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
@@ -917,37 +917,37 @@ describe("utils", () => {
     });
   });
 
-  describe("isLikeANumber", () => {
+  describe("typeOfLikeANumber", () => {
     it("returns true for numbers", () => {
-      expect(isLikeANumber(1)).toBe(true);
-      expect(isLikeANumber(0)).toBe(true);
-      expect(isLikeANumber(0.001)).toBe(true);
-      expect(isLikeANumber(-1)).toBe(true);
+      expect(typeOfLikeANumber(1)).toBe(true);
+      expect(typeOfLikeANumber(0)).toBe(true);
+      expect(typeOfLikeANumber(0.001)).toBe(true);
+      expect(typeOfLikeANumber(-1)).toBe(true);
     });
 
     it("returns true for bigint", () => {
-      expect(isLikeANumber(99999999999999999999999999999999999999999999n)).toBe(
-        true
-      );
+      expect(
+        typeOfLikeANumber(99999999999999999999999999999999999999999999n)
+      ).toBe(true);
     });
 
     it("returns true for stringified number", () => {
-      expect(isLikeANumber("1")).toBe(true);
-      expect(isLikeANumber("0")).toBe(true);
-      expect(isLikeANumber("0.001")).toBe(true);
-      expect(isLikeANumber("-1")).toBe(true);
-      expect(isLikeANumber("+1")).toBe(true);
+      expect(typeOfLikeANumber("1")).toBe(true);
+      expect(typeOfLikeANumber("0")).toBe(true);
+      expect(typeOfLikeANumber("0.001")).toBe(true);
+      expect(typeOfLikeANumber("-1")).toBe(true);
+      expect(typeOfLikeANumber("+1")).toBe(true);
     });
 
     it("returns false for empty string", () => {
-      expect(isLikeANumber("")).toBe(false);
+      expect(typeOfLikeANumber("")).toBe(false);
     });
 
     it("returns false for not numbers", () => {
-      expect(isLikeANumber("test")).toBe(false);
-      expect(isLikeANumber("123sec")).toBe(false);
-      expect(isLikeANumber([])).toBe(false);
-      expect(isLikeANumber({})).toBe(false);
+      expect(typeOfLikeANumber("test")).toBe(false);
+      expect(typeOfLikeANumber("123sec")).toBe(false);
+      expect(typeOfLikeANumber([])).toBe(false);
+      expect(typeOfLikeANumber({})).toBe(false);
     });
   });
 


### PR DESCRIPTION
# Motivation

This is the second iteration of json tree improvement.

# Changes

- mobile layout for actions (header and horizontal scroll)
- values with known units

# Tests

- for utils

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

# Screenshots

### Section header
| Before | After |
|--------|--------|
| <img width="390" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/3902c72c-ace1-4e7b-a149-089ece2215ac"> | <img width="388" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/9d1691fa-3a44-4c7c-a044-c7c269706eb6"> | 

### Values with units and e8s (gaps)
<img width="828" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/4a000d86-70e8-4b22-af12-e36857afb2e5">



