### PR TITLE
GIX-1982: Render mobile or desktop tokens component

### DIFF
--- a/frontend/src/lib/components/tokens/MobileTokensList/MobileTokensList.svelte
+++ b/frontend/src/lib/components/tokens/MobileTokensList/MobileTokensList.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  /* eslint-disable-next-line */
+  export let userTokensData: UserTokenData[];
+</script>
+
+<div data-tid="mobile-tokens-list-component">Mobile List</div>

--- a/frontend/src/lib/components/tokens/MobileTokensList/MobileTokensList.svelte
+++ b/frontend/src/lib/components/tokens/MobileTokensList/MobileTokensList.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
+  import type { UserTokenData } from "$lib/types/tokens-page";
+
   /* eslint-disable-next-line */
   export let userTokensData: UserTokenData[];
 </script>
 
-<div data-tid="mobile-tokens-list-component">Mobile List</div>
+<div data-tid="mobile-tokens-list-component">
+  {`Mobile List: ${userTokensData.length}`}
+</div>

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -1,13 +1,26 @@
 <script lang="ts">
   import MainWrapper from "$lib/components/tokens/MainWrapper.svelte";
   import DesktopTokensTable from "$lib/components/tokens/DesktopTokensTable/DesktopTokensTable.svelte";
+  import MobileTokensList from "$lib/components/tokens/MobileTokensList/MobileTokensList.svelte";
   import type { UserTokenData } from "$lib/types/tokens-page";
 
   export let userTokensData: UserTokenData[];
+
+  let innerWidth = 0;
+
+  let isMobileWidth = false;
+  // TODO: Use constant from gix-components
+  const BREAKPOINT_MEDIUM = 768;
+  $: isMobileWidth = innerWidth < BREAKPOINT_MEDIUM;
 </script>
 
+<svelte:window bind:innerWidth />
+
 <MainWrapper testId="tokens-page-component">
-  <!-- TODO: GIX-1982 Render desktop or mobile component -->
-  <DesktopTokensTable {userTokensData} on:nnsAction />
+  {#if isMobileWidth}
+    <MobileTokensList {userTokensData} on:nnsAction />
+  {:else}
+    <DesktopTokensTable {userTokensData} on:nnsAction />
+  {/if}
   <!-- TODO: GIX-1977 Mobile component -->
 </MainWrapper>

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -10,6 +10,9 @@ import { TokensPagePo } from "$tests/page-objects/TokensPage.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 
+// TODO: Use constant from gix-components
+const BREAKPOINT_MEDIUM = 768;
+
 describe("Tokens page", () => {
   const renderPage = (userTokensData: UserTokenData[]) => {
     const { container } = render(TokensPage, {
@@ -18,9 +21,15 @@ describe("Tokens page", () => {
     return TokensPagePo.under(new JestPageObjectElement(container));
   };
 
+  // TODO: Move within a describe block
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).innerWidth = BREAKPOINT_MEDIUM + 10;
+  });
+
   it("should render the tokens table", async () => {
     const po = renderPage(userTokensPageMock);
-    expect(await po.hasTokensTable()).toBeDefined();
+    expect(await po.hasDesktopTokensTable()).toBeDefined();
   });
 
   it("should render a row per token", async () => {
@@ -31,6 +40,18 @@ describe("Tokens page", () => {
       universeId: principal(0),
     });
     const po = renderPage([token1, token2]);
-    expect(await po.getTokensTable().getRows()).toHaveLength(2);
+    expect(await po.getDesktopTokensTable().getRows()).toHaveLength(2);
+  });
+
+  describe("Mobile device", () => {
+    beforeEach(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).innerWidth = BREAKPOINT_MEDIUM - 10;
+    });
+
+    it("should render the mobile tokens list", () => {
+      const po = renderPage(userTokensPageMock);
+      expect(po.hasMobileTokensList()).toBe(true);
+    });
   });
 });

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -49,9 +49,9 @@ describe("Tokens page", () => {
       (window as any).innerWidth = BREAKPOINT_MEDIUM - 10;
     });
 
-    it("should render the mobile tokens list", () => {
+    it("should render the mobile tokens list", async () => {
       const po = renderPage(userTokensPageMock);
-      expect(po.hasMobileTokensList()).toBe(true);
+      expect(await po.hasMobileTokensList()).toBe(true);
     });
   });
 });

--- a/frontend/src/tests/page-objects/MobileTokensList.page-object.ts
+++ b/frontend/src/tests/page-objects/MobileTokensList.page-object.ts
@@ -1,0 +1,10 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { BasePageObject } from "./base.page-object";
+
+export class MobileTokensListPo extends BasePageObject {
+  private static readonly TID = "mobile-tokens-list-component";
+
+  static under(element: PageObjectElement): MobileTokensListPo {
+    return new MobileTokensListPo(element.byTestId(MobileTokensListPo.TID));
+  }
+}

--- a/frontend/src/tests/page-objects/TokensPage.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensPage.page-object.ts
@@ -1,6 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { DesktopTokensTablePo } from "./DesktopTokensTable.page-object";
+import { MobileTokensListPo } from "./MobileTokensList.page-object";
 
 export class TokensPagePo extends BasePageObject {
   private static readonly TID = "tokens-page-component";
@@ -9,11 +10,19 @@ export class TokensPagePo extends BasePageObject {
     return new TokensPagePo(element.byTestId(TokensPagePo.TID));
   }
 
-  getTokensTable(): DesktopTokensTablePo {
+  getDesktopTokensTable(): DesktopTokensTablePo {
     return DesktopTokensTablePo.under(this.root);
   }
 
-  hasTokensTable(): Promise<boolean> {
-    return this.getTokensTable().isPresent();
+  hasDesktopTokensTable(): Promise<boolean> {
+    return this.getDesktopTokensTable().isPresent();
+  }
+
+  getMobileTokensList(): MobileTokensListPo {
+    return MobileTokensListPo.under(this.root);
+  }
+
+  hasMobileTokensList(): Promise<boolean> {
+    return this.getMobileTokensList().isPresent();
   }
 }


### PR DESCRIPTION
# Motivation

Current tokens list is only for desktop devices. The mobile devices will use a different UI.

In this PR, the Tokens page renders either the Desktop or the Mobile component based no window's width.

# Changes

* Add svelte:window to watch window's with in Tokens page and render a different component.
* Setup new component MobileTokensList.

# Tests

* Test that Tokens page renders one or ther other based on window's width.
* Rename TokensPagePO methods.
* Setup MobileTokensListPo.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary yet. Part of bigger feature.
