### PR TITLE
Chore: Add devenv llorenc

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -48,6 +48,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Enable dependabot for Rust updates.
 * Workflow to get the latest NNS and SNS canister candid files.
 * Try to prevent calls to global.fetch in unit tests.
+* Add `devenv_llorenc` to list of networks.
 
 #### Changed
 

--- a/dfx.json
+++ b/dfx.json
@@ -254,6 +254,19 @@
       ],
       "type": "persistent"
     },
+    "devenv-llorenc": {
+      "config": {
+        "HOST": "https://llorenc-ingress.devenv.dfinity.network",
+        "FEATURE_FLAGS": {
+          "ENABLE_CKBTC": true,
+          "ENABLE_CKTESTBTC": false
+        }
+      },
+      "providers": [
+        "https://llorenc-ingress.devenv.dfinity.network"
+      ],
+      "type": "persistent"
+    },
     "nnsdapp": {
       "providers": [
         "http://[2a00:fb01:400:42:5000:d1ff:fefe:987e]:8080"

--- a/dfx.json
+++ b/dfx.json
@@ -254,7 +254,7 @@
       ],
       "type": "persistent"
     },
-    "devenv-llorenc": {
+    "devenv_llorenc": {
       "config": {
         "HOST": "https://llorenc-ingress.devenv.dfinity.network",
         "FEATURE_FLAGS": {


### PR DESCRIPTION
# Motivation

Use the `--network` tag and variable `DFX_NETWORK` also for the dev environments.

Alloes us:
* `dfx` calls with `--network`.
* Use `./deploy.sh` script.
* Point locally to a devenv with `DFX_NETWORK=devenv_llorenc ./config.sh`.

Examples:
```
DFX_NETWORK=devenv_llorenc ./config.sh
./deploy.sh --nns-dapp devenv_llorenc
dfx canister create nns-dapp --network devenv_llorenc
dfx canister id nns-dapp --network devenv_llorenc
dfx canister install --network devenv_llorenc ...
```

This should allow to run the SOP script from local machine more easily.

In this PR, I added my dev environment. This show how each of us can add their dev environment.

# Changes

* Add a new network in dfx.json

# Tests

The release candidate of 2023-11-09 was deployed using this network.

# Todos

- [x] Add entry to changelog (if necessary).
