### PR TITLE
Chore: Upgrade gix-components

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -276,9 +276,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "3.1.0-next-2023-11-08.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-3.1.0-next-2023-11-08.1.tgz",
-      "integrity": "sha512-LLjei215BpuTZL/DfViY+2o6l2h7+7GcxbNmUUCCZC5kUDa13nwjcoqbX01VBSgdIZrUSGPchN6PdZSIkHXhoQ==",
+      "version": "3.1.0-next-2023-11-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-3.1.0-next-2023-11-09.1.tgz",
+      "integrity": "sha512-pQPWkS7FP4NgGc+w/6dVe+Pj5NW7QYNrUmy0wsK4dS2cR70xxAWK0IDYPrx1dsLTUaLgVK1MURlKvjfHU6K4fQ==",
       "dependencies": {
         "dompurify": "^3.0.6",
         "html5-qrcode": "^2.3.8",
@@ -7053,9 +7053,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "3.1.0-next-2023-11-08.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-3.1.0-next-2023-11-08.1.tgz",
-      "integrity": "sha512-LLjei215BpuTZL/DfViY+2o6l2h7+7GcxbNmUUCCZC5kUDa13nwjcoqbX01VBSgdIZrUSGPchN6PdZSIkHXhoQ==",
+      "version": "3.1.0-next-2023-11-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-3.1.0-next-2023-11-09.1.tgz",
+      "integrity": "sha512-pQPWkS7FP4NgGc+w/6dVe+Pj5NW7QYNrUmy0wsK4dS2cR70xxAWK0IDYPrx1dsLTUaLgVK1MURlKvjfHU6K4fQ==",
       "requires": {
         "dompurify": "^3.0.6",
         "html5-qrcode": "^2.3.8",


### PR DESCRIPTION
# Motivation

Fix the background in the new tokens table. The new colors are in a new version of gix-components.

In this PR, I upgrade gix-components.

# Changes

## Automatic changes

* Changes in `package.lock.json` with `npm run update:gix`.

# Tests

Still passing.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.