### PR TITLE
Use page objects in IcrcTransactionCard and -List tests

### DIFF
--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
@@ -1,10 +1,7 @@
 import IcrcTransactionCard from "$lib/components/accounts/IcrcTransactionCard.svelte";
 import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import type { Account } from "$lib/types/account";
-import { replacePlaceholders } from "$lib/utils/i18n.utils";
-import { formatToken } from "$lib/utils/token.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
-import en from "$tests/mocks/i18n.mock";
 import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
 import { createIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import {
@@ -16,6 +13,8 @@ import {
   mockSnsFullProject,
   mockSnsToken,
 } from "$tests/mocks/sns-projects.mock";
+import { TransactionCardPo } from "$tests/page-objects/TransactionCard.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { normalizeWhitespace } from "$tests/utils/utils.test-utils";
 import type { IcrcTransactionWithId } from "@dfinity/ledger-icrc";
 import type { Principal } from "@dfinity/principal";
@@ -23,7 +22,7 @@ import type { Token } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
 describe("IcrcTransactionCard", () => {
-  const renderTransactionCard = ({
+  const renderComponent = ({
     account,
     transactionWithId,
     governanceCanisterId = undefined,
@@ -33,8 +32,8 @@ describe("IcrcTransactionCard", () => {
     transactionWithId: IcrcTransactionWithId;
     governanceCanisterId?: Principal;
     token: Token | undefined;
-  }) =>
-    render(IcrcTransactionCard, {
+  }) => {
+    const { container } = render(IcrcTransactionCard, {
       props: {
         account,
         transactionWithId,
@@ -43,22 +42,24 @@ describe("IcrcTransactionCard", () => {
         token,
       },
     });
+    return TransactionCardPo.under(new JestPageObjectElement(container));
+  };
 
-  const to = {
+  const subaccount = {
     owner: mockPrincipal,
     subaccount: [Uint8Array.from(mockSubAccountArray)] as [Uint8Array],
   };
-  const from = {
+  const mainAccount = {
     owner: mockPrincipal,
     subaccount: [] as [],
   };
   const transactionFromMainToSubaccount = createIcrcTransactionWithId({
-    to,
-    from,
+    to: subaccount,
+    from: mainAccount,
   });
   const transactionToMainFromSubaccount = createIcrcTransactionWithId({
-    to: from,
-    from: to,
+    to: mainAccount,
+    from: subaccount,
   });
 
   beforeEach(() => {
@@ -67,144 +68,130 @@ describe("IcrcTransactionCard", () => {
     );
   });
 
-  it("renders received headline", () => {
-    const { getByText } = renderTransactionCard({
+  it("renders received headline", async () => {
+    const po = renderComponent({
       account: mockSnsSubAccount,
       transactionWithId: transactionFromMainToSubaccount,
       token: mockSnsToken,
     });
 
-    const expectedText = replacePlaceholders(en.transaction_names.receive, {
-      $tokenSymbol: mockSnsToken.symbol,
-    });
-    expect(getByText(expectedText)).toBeInTheDocument();
+    expect(await po.getHeadline()).toBe("Received");
   });
 
-  it("renders sent headline", () => {
-    const { getByText } = renderTransactionCard({
+  it("renders sent headline", async () => {
+    const po = renderComponent({
       account: mockSnsMainAccount,
       transactionWithId: transactionFromMainToSubaccount,
       token: mockSnsToken,
     });
 
-    const expectedText = replacePlaceholders(en.transaction_names.send, {
-      $tokenSymbol: mockSnsToken.symbol,
-    });
-    expect(getByText(expectedText)).toBeInTheDocument();
+    expect(await po.getHeadline()).toBe("Sent");
   });
 
-  it("renders stake neuron headline", () => {
+  it("renders stake neuron headline", async () => {
     const toGov = {
       owner: mockSnsFullProject.summary.governanceCanisterId,
       subaccount: [Uint8Array.from([0, 0, 1])] as [Uint8Array],
     };
     const stakeNeuronTransaction = createIcrcTransactionWithId({
       to: toGov,
-      from,
+      from: mainAccount,
     });
     stakeNeuronTransaction.transaction.transfer[0].memo = [new Uint8Array()];
-    const { getByText } = renderTransactionCard({
+    const po = renderComponent({
       account: mockSnsMainAccount,
       transactionWithId: stakeNeuronTransaction,
       governanceCanisterId: mockSnsFullProject.summary.governanceCanisterId,
       token: mockSnsToken,
     });
 
-    const expectedText = replacePlaceholders(en.transaction_names.stakeNeuron, {
-      $tokenSymbol: mockSnsToken.symbol,
-    });
-    expect(getByText(expectedText)).toBeInTheDocument();
+    expect(await po.getHeadline()).toBe("Stake Neuron");
   });
 
-  it("renders transaction Token symbol with - sign", () => {
+  it("renders transaction Token symbol with - sign", async () => {
     const account = mockSnsMainAccount;
-    const transaction = transactionFromMainToSubaccount;
-    const { getByTestId } = renderTransactionCard({
+    const po = renderComponent({
       account,
-      transactionWithId: transaction,
+      transactionWithId: createIcrcTransactionWithId({
+        from: mainAccount,
+        to: subaccount,
+        amount: 123_000_000n,
+        fee: 10_000n,
+      }),
       token: mockSnsToken,
     });
 
-    const fee = transaction.transaction.transfer[0]?.fee[0];
-    const amount = transaction.transaction.transfer[0]?.amount;
-    expect(getByTestId("token-value")?.textContent).toBe(
-      `-${formatToken({
-        value: amount + fee,
-        detailed: true,
-      })}`
-    );
+    expect(await po.getAmount()).toBe("-1.2301");
   });
 
-  it("renders transaction Tokens with + sign", () => {
+  it("renders transaction Tokens with + sign", async () => {
     const account = mockSnsSubAccount;
-    const transaction = transactionFromMainToSubaccount;
-    const { getByTestId } = renderTransactionCard({
+    const po = renderComponent({
       account,
-      transactionWithId: transaction,
+      transactionWithId: createIcrcTransactionWithId({
+        from: mainAccount,
+        to: subaccount,
+        amount: 123_000_000n,
+        fee: 10_000n,
+      }),
       token: mockSnsToken,
     });
 
-    const amount = transaction.transaction.transfer[0]?.amount;
-    expect(getByTestId("token-value")?.textContent).toBe(
-      `+${formatToken({ value: amount, detailed: true })}`
-    );
+    expect(await po.getAmount()).toBe("+1.23");
   });
 
-  it("displays transaction date and time", () => {
-    const { getByTestId } = renderTransactionCard({
+  it("displays transaction date and time", async () => {
+    const po = renderComponent({
       account: mockSnsMainAccount,
       transactionWithId: transactionFromMainToSubaccount,
       token: mockSnsToken,
     });
 
-    const div = getByTestId("transaction-date");
-
-    expect(div?.textContent).toContain("Jan 1, 1970");
-    expect(normalizeWhitespace(div?.textContent)).toContain("12:00 AM");
+    expect(normalizeWhitespace(await po.getDate())).toBe(
+      "Jan 1, 1970 12:00 AM"
+    );
   });
 
-  it("displays identifier for received", () => {
-    const { getByTestId } = renderTransactionCard({
+  it("displays identifier for received", async () => {
+    const po = renderComponent({
       account: mockSnsSubAccount,
       transactionWithId: transactionFromMainToSubaccount,
       token: mockSnsToken,
     });
-    const identifier = getByTestId("identifier")?.textContent;
+    const identifier = await po.getIdentifier();
 
-    expect(identifier).toContain(mockSnsMainAccount.identifier);
-    expect(identifier).toContain(en.wallet.direction_from);
+    expect(identifier).toBe(`Source: ${mockSnsMainAccount.identifier}`);
   });
 
-  it("displays identifier for sent for main sns account", () => {
-    const { getByTestId } = renderTransactionCard({
+  it("displays identifier for sent for main sns account", async () => {
+    const po = renderComponent({
       account: mockSnsMainAccount,
       transactionWithId: transactionFromMainToSubaccount,
       token: mockSnsToken,
     });
-    const identifier = getByTestId("identifier")?.textContent;
+    const identifier = await po.getIdentifier();
 
-    expect(identifier).toContain(mockSnsMainAccount.identifier);
-    expect(identifier).toContain(en.wallet.direction_to);
+    expect(identifier).toBe(`To: ${mockSnsSubAccount.identifier}`);
   });
 
-  it("displays identifier for sent for sub sns account", () => {
-    const { getByTestId } = renderTransactionCard({
-      account: mockSnsMainAccount,
+  it("displays identifier for sent for sub sns account", async () => {
+    const po = renderComponent({
+      account: mockSnsSubAccount,
       transactionWithId: transactionToMainFromSubaccount,
       token: mockSnsToken,
     });
-    const identifier = getByTestId("identifier")?.textContent;
+    const identifier = await po.getIdentifier();
 
-    expect(identifier).toContain(mockSnsSubAccount.identifier);
+    expect(identifier).toBe(`To: ${mockSnsMainAccount.identifier}`);
   });
 
-  it("renders no transaction card if token is unlikely undefined", () => {
-    const { getByTestId } = renderTransactionCard({
+  it("renders no transaction card if token is unlikely undefined", async () => {
+    const po = renderComponent({
       account: mockSnsSubAccount,
       transactionWithId: transactionFromMainToSubaccount,
       token: undefined,
     });
 
-    expect(() => getByTestId("transaction-card")).toThrow();
+    expect(await po.isPresent()).toBe(false);
   });
 });

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionsList.spec.ts
@@ -2,17 +2,18 @@ import IcrcTransactionsList from "$lib/components/accounts/IcrcTransactionsList.
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import type { Account } from "$lib/types/account";
 import type { IcrcTransactionData } from "$lib/types/transaction";
-import en from "$tests/mocks/i18n.mock";
 import {
   mockIcrcTransactionsStoreSubscribe,
   mockIcrcTransactionWithId,
 } from "$tests/mocks/icrc-transactions.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
-import { render, waitFor } from "@testing-library/svelte";
+import { IcrcTransactionsListPo } from "$tests/page-objects/IcrcTransactionsList.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
 
 describe("IcrcTransactionList", () => {
-  const renderIcrcTransactionList = ({
+  const renderComponent = ({
     account,
     transactions,
     loading,
@@ -22,8 +23,8 @@ describe("IcrcTransactionList", () => {
     transactions: IcrcTransactionData[];
     loading?: boolean;
     completed?: boolean;
-  }) =>
-    render(IcrcTransactionsList, {
+  }) => {
+    const { container } = render(IcrcTransactionsList, {
       props: {
         account,
         transactions,
@@ -32,6 +33,8 @@ describe("IcrcTransactionList", () => {
         token: mockSnsToken,
       },
     });
+    return IcrcTransactionsListPo.under(new JestPageObjectElement(container));
+  };
 
   afterEach(() => {
     vi.clearAllMocks();
@@ -42,13 +45,13 @@ describe("IcrcTransactionList", () => {
       mockIcrcTransactionsStoreSubscribe({})
     );
 
-    const { queryAllByTestId } = renderIcrcTransactionList({
+    const po = renderComponent({
       account: mockSnsMainAccount,
       transactions: [],
       loading: true,
     });
 
-    expect(queryAllByTestId("skeleton-card").length).toBeGreaterThan(0);
+    expect(await po.getSkeletonCardPo().isPresent()).toBe(true);
   });
 
   it("should display no-transactions message", async () => {
@@ -56,22 +59,18 @@ describe("IcrcTransactionList", () => {
       mockIcrcTransactionsStoreSubscribe({})
     );
 
-    const { getByText } = renderIcrcTransactionList({
+    const po = renderComponent({
       account: mockSnsMainAccount,
       transactions: [],
       loading: false,
       completed: true,
     });
 
-    await waitFor(() => {
-      expect(
-        getByText(en.wallet.no_transactions, { exact: false })
-      ).toBeInTheDocument();
-    });
+    expect(await po.getText()).toBe("No transactions");
   });
 
-  it("should render transactions", () => {
-    const { queryAllByTestId } = renderIcrcTransactionList({
+  it("should render transactions", async () => {
+    const po = renderComponent({
       account: mockSnsMainAccount,
       transactions: [
         {
@@ -83,6 +82,6 @@ describe("IcrcTransactionList", () => {
       completed: true,
     });
 
-    expect(queryAllByTestId("transaction-card").length).toBe(1);
+    expect(await po.getTransactionCardPos()).toHaveLength(1);
   });
 });

--- a/frontend/src/tests/mocks/icrc-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icrc-transactions.mock.ts
@@ -1,4 +1,6 @@
 import type { IcrcTransactionsStoreData } from "$lib/stores/icrc-transactions.store";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
 import type {
   IcrcTransaction,
   IcrcTransactionWithId,
@@ -14,9 +16,13 @@ export interface IcrcCandidAccount {
 export const createIcrcTransactionWithId = ({
   from,
   to,
+  fee,
+  amount,
 }: {
-  to: IcrcCandidAccount;
-  from: IcrcCandidAccount;
+  to?: IcrcCandidAccount;
+  from?: IcrcCandidAccount;
+  fee?: bigint;
+  amount?: bigint;
 }): IcrcTransactionWithId => ({
   id: BigInt(123),
   transaction: {
@@ -26,12 +32,18 @@ export const createIcrcTransactionWithId = ({
     mint: [],
     transfer: [
       {
-        to,
-        from,
+        to: to ?? {
+          owner: mockPrincipal,
+          subaccount: [Uint8Array.from(mockSubAccountArray)],
+        },
+        from: from ?? {
+          owner: mockPrincipal,
+          subaccount: [] as [],
+        },
         memo: [],
         created_at_time: [BigInt(123)],
-        amount: BigInt(33),
-        fee: [BigInt(1)],
+        amount: amount ?? BigInt(33),
+        fee: [fee ?? BigInt(1)],
         spender: [],
       },
     ],

--- a/frontend/src/tests/page-objects/TransactionCard.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionCard.page-object.ts
@@ -5,6 +5,10 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class TransactionCardPo extends BasePageObject {
   private static readonly TID = "transaction-card";
 
+  static under(element: PageObjectElement): TransactionCardPo {
+    return new TransactionCardPo(element.byTestId(TransactionCardPo.TID));
+  }
+
   static async allUnder(
     element: PageObjectElement
   ): Promise<TransactionCardPo[]> {
@@ -13,12 +17,20 @@ export class TransactionCardPo extends BasePageObject {
     );
   }
 
+  getHeadline(): Promise<string> {
+    return this.getText("headline");
+  }
+
   getIdentifier(): Promise<string> {
     return this.getText("identifier");
   }
 
   getDescription(): Promise<string> {
     return this.getText("transaction-description");
+  }
+
+  getDate(): Promise<string> {
+    return this.getText("transaction-date");
   }
 
   getAmountDisplayPo(): AmountDisplayPo {


### PR DESCRIPTION
# Motivation

Tests with page objects are easier to read and maintain.
I will be changing these tests when making UI changes for ckBTC transactions.

# Changes

1. Extend `createIcrcTransactionWithId` to make `to` and `from` params optional and accept additional optional `amount` and `fee` params.
2. Add `getHeadline` and `getDate` and static `under` to `TransactionCardPo` page object.
3. Use page objects in `IcrcTransactionCard` and `IcrcTransactionsList`.
4. Fix `"displays identifier for sent for main sns account"` to expect the destination to be the subaccount rather than the main account. It didn't fail because the main account identifier is a substring of the subaccount identifier (for ICRC-1) and the test used `toContain` instead of `toBe`.
5. Fix `"displays identifier for sent for sub sns account"` such that the transaction is actually a sent transaction as the test description suggests. Also test that it's a sent transaction which the test didn't test before.

# Tests

Only tests

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary
