### PR TITLE
mapTransaction prop on IcrcTransactionsList

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -12,6 +12,7 @@
   import {
     getSortedTransactionsFromStore,
     isIcrcTransactionsCompleted,
+    mapIcrcTransaction,
   } from "$lib/utils/icrc-transactions.utils";
   import IcrcTransactionsList from "$lib/components/accounts/IcrcTransactionsList.svelte";
   import type { UniverseCanisterId } from "$lib/types/universe";
@@ -106,5 +107,6 @@
     {completed}
     {descriptions}
     {token}
+    mapTransaction={mapIcrcTransaction}
   />
 </CkBTCWalletTransactionsObserver>

--- a/frontend/src/lib/components/accounts/IcrcTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Account } from "$lib/types/account";
-  import { mapIcrcTransaction } from "$lib/utils/icrc-transactions.utils";
+  import type { mapIcrcTransactionType } from "$lib/utils/icrc-transactions.utils";
   import type { Principal } from "@dfinity/principal";
   import type { IcrcTransactionWithId } from "@dfinity/ledger-icrc";
   import TransactionCard from "./TransactionCard.svelte";
@@ -14,9 +14,10 @@
   export let governanceCanisterId: Principal | undefined = undefined;
   export let descriptions: Record<string, string> | undefined = undefined;
   export let token: IcrcTokenMetadata | undefined;
+  export let mapTransaction: mapIcrcTransactionType;
 
   let transactionData: Transaction | undefined;
-  $: transactionData = mapIcrcTransaction({
+  $: transactionData = mapTransaction({
     transaction: transactionWithId,
     account,
     toSelfTransaction,

--- a/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
@@ -7,6 +7,7 @@
   import SkeletonCard from "../ui/SkeletonCard.svelte";
   import type { IcrcTransactionData } from "$lib/types/transaction";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
+  import type { mapIcrcTransactionType } from "$lib/utils/icrc-transactions.utils";
   import { flip } from "svelte/animate";
 
   export let account: Account;
@@ -16,6 +17,7 @@
   export let completed = false;
   export let descriptions: Record<string, string> | undefined = undefined;
   export let token: IcrcTokenMetadata | undefined;
+  export let mapTransaction: mapIcrcTransactionType;
 </script>
 
 <div data-tid="transactions-list" class="container">
@@ -35,6 +37,7 @@
             {governanceCanisterId}
             {descriptions}
             {token}
+            {mapTransaction}
           />
         </div>
       {/each}

--- a/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
@@ -10,6 +10,7 @@
   import {
     getSortedTransactionsFromStore,
     isIcrcTransactionsCompleted,
+    mapIcrcTransaction,
   } from "$lib/utils/icrc-transactions.utils";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import SnsWalletTransactionsObserver from "$lib/components/accounts/SnsWalletTransactionsObserver.svelte";
@@ -70,5 +71,6 @@
     {governanceCanisterId}
     {completed}
     {token}
+    mapTransaction={mapIcrcTransaction}
   />
 </SnsWalletTransactionsObserver>

--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -167,6 +167,8 @@ export const mapIcrcTransaction = ({
   }
 };
 
+export type mapIcrcTransactionType = typeof mapIcrcTransaction;
+
 // TODO: use `oldestTxId` instead of sorting and getting the oldest element's id.
 // It seems that the `Index` canister has a bug.
 /**

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
@@ -1,6 +1,10 @@
 import IcrcTransactionCard from "$lib/components/accounts/IcrcTransactionCard.svelte";
 import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import type { Account } from "$lib/types/account";
+import {
+  mapIcrcTransaction,
+  type mapIcrcTransactionType,
+} from "$lib/utils/icrc-transactions.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
 import { createIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
@@ -27,11 +31,13 @@ describe("IcrcTransactionCard", () => {
     transactionWithId,
     governanceCanisterId = undefined,
     token,
+    mapTransaction,
   }: {
     account: Account;
     transactionWithId: IcrcTransactionWithId;
     governanceCanisterId?: Principal;
     token: Token | undefined;
+    mapTransaction?: mapIcrcTransactionType;
   }) => {
     const { container } = render(IcrcTransactionCard, {
       props: {
@@ -40,6 +46,7 @@ describe("IcrcTransactionCard", () => {
         toSelfTransaction: false,
         governanceCanisterId,
         token,
+        mapTransaction: mapTransaction ?? mapIcrcTransaction,
       },
     });
     return TransactionCardPo.under(new JestPageObjectElement(container));
@@ -193,5 +200,23 @@ describe("IcrcTransactionCard", () => {
     });
 
     expect(await po.isPresent()).toBe(false);
+  });
+
+  it("uses mapTransaction", async () => {
+    const customIdentifier = "custom identifier";
+    const customMapTransaction = (params) => ({
+      ...mapIcrcTransaction(params),
+      to: customIdentifier,
+    });
+
+    const po = renderComponent({
+      account: mockSnsMainAccount,
+      transactionWithId: transactionFromMainToSubaccount,
+      token: mockSnsToken,
+      mapTransaction: customMapTransaction,
+    });
+    const identifier = await po.getIdentifier();
+
+    expect(identifier).toBe(`To: ${customIdentifier}`);
   });
 });


### PR DESCRIPTION
# Motivation

For ckBTC withdrawal transactions we want to render the BTC address as the "To:" address.
This address is encoded in the memo of burn transactions and we want to place it in the `to:` of the transaction rendered in the `TransactionCard`.
This can be done in `mapIcrcTransaction` but the logic is specific to ckBTC so shouldn't be applied to all tokens.
My solution is to be able to pass a different `mapTransaction` function per token.

This PR only makes it possible to pass a `mapTransaction` to `IcrcTransactionsList` but does not use it for any custom mapping for ckBTC.

# Changes

1. Add `mapTransaction` prop to `IcrcTransactionsList` and pass it on to `IcrcTransactionCard` which will call the passed function instead of `mapIcrcTransaction`.
2. Pass `mapIcrcTransaction` from `CkBTCTransactionsList` and `SnsTransactionsList`. This is for now. In a future PR we'll pass a custom function from `CkBTCTransactionsList`.

# Tests

Add tests for `IcrcTransactionsList` and `IcrcTransactionCard` that the passed in mapping function is used.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary
