### PR TITLE
Use a unique branch name for snsdemo updates

### DIFF
--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -63,6 +63,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-snsdemo-update
+          branch-suffix: timestamp
           add-paths: .github/*/*ml
           delete-branch: true
           title: 'Update snsdemo to ${{ steps.update.outputs.release }}'

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -55,6 +55,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Update `ic-wasm` to the latest version.
 * Factor out the `snsdemo` installation.
 * Add `prod` and `aggregator-prod` to the list of public releases.
+* Use a unique branch when updating the snsdemo release.
 
 #### Deprecated
 


### PR DESCRIPTION
# Motivation

If the update workflow runs again while we are still considering a previous update, we don't want the previous update to be overwritten.
It might have additional manual changes or a custom PR description that we don't want to lose.
By using a fixed branch name, we might lose these changes, so we want to use a unique branch name.
The GitHub action to create a PR already supports this out of the box:
https://github.com/peter-evans/create-pull-request#alternative-strategy---always-create-a-new-pull-request-branch
Note that the documentation does mention the follow:
> This strategy is not recommended because if not used carefully it could result in multiple pull requests being created unnecessarily.

Since this workflow runs only once a week or when triggered manually, I don't think creating multiple pull requests is a concern.

Here is an example PR created this way: https://github.com/dfinity/nns-dapp/pull/3702

This PR is just for the snsdemo update flow but when it is working as expected we should update the other update flows as well.

# Changes

Add `branch-suffix: timestamp` to the inputs of the `create-pull-request` action.

# Tests

Ran manually and it created this PR: https://github.com/dfinity/nns-dapp/pull/3702

# Todos

- [x] Add entry to changelog (if necessary).
