### PR TITLE
Fix: Add Rename button to subaccount page

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -33,6 +33,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Show canister title in details when user is not the controller.
+* Add missing "Rename" button in the subaccount page.
 
 #### Security
 

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -160,7 +160,7 @@
   $: isHardwareWallet = isAccountHardwareWallet($selectedAccountStore.account);
 
   let isSubaccount: boolean;
-  $: isSubaccount = nonNullish($selectedAccountStore.account?.subAccount);
+  $: isSubaccount = $selectedAccountStore.account?.type === "subAccount";
 </script>
 
 <TestIdWrapper testId="nns-wallet-component">

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -45,6 +45,7 @@
   import { NNS_UNIVERSE } from "$lib/derived/selectable-universes.derived";
   import HardwareWalletListNeuronsButton from "$lib/components/accounts/HardwareWalletListNeuronsButton.svelte";
   import HardwareWalletShowActionButton from "$lib/components/accounts/HardwareWalletShowActionButton.svelte";
+    import RenameSubAccountButton from "$lib/components/accounts/RenameSubAccountButton.svelte";
 
   onMount(() => {
     pollAccounts();
@@ -157,6 +158,9 @@
 
   let isHardwareWallet: boolean;
   $: isHardwareWallet = isAccountHardwareWallet($selectedAccountStore.account);
+
+  let isSubaccount: boolean;
+  $: isSubaccount = nonNullish($selectedAccountStore.account?.subAccount);
 </script>
 
 <TestIdWrapper testId="nns-wallet-component">
@@ -181,6 +185,8 @@
             {#if isHardwareWallet}
               <HardwareWalletListNeuronsButton />
               <HardwareWalletShowActionButton />
+            {:else if isSubaccount}
+              <RenameSubAccountButton />
             {/if}
           </WalletPageHeading>
 

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -45,7 +45,7 @@
   import { NNS_UNIVERSE } from "$lib/derived/selectable-universes.derived";
   import HardwareWalletListNeuronsButton from "$lib/components/accounts/HardwareWalletListNeuronsButton.svelte";
   import HardwareWalletShowActionButton from "$lib/components/accounts/HardwareWalletShowActionButton.svelte";
-    import RenameSubAccountButton from "$lib/components/accounts/RenameSubAccountButton.svelte";
+  import RenameSubAccountButton from "$lib/components/accounts/RenameSubAccountButton.svelte";
 
   onMount(() => {
     pollAccounts();

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -234,7 +234,6 @@ describe("NnsWallet", () => {
       icpAccountsStore.setForTesting({
         ...mockAccountsStoreData,
         subAccounts: [mockSubAccount],
-        hardwareWallets: [mockHardwareWalletAccount],
       });
     });
 

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -15,6 +15,7 @@ import {
   mockAccountsStoreData,
   mockHardwareWalletAccount,
   mockMainAccount,
+  mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
 import {
   modalToolbarSelector,
@@ -225,6 +226,27 @@ describe("NnsWallet", () => {
         expect(accountsApi.getTransactions).toBeCalledTimes(4)
       );
       expect(ledgerApi.queryAccountBalance).toBeCalledTimes(2);
+    });
+  });
+
+  describe("accounts loaded (Subaccount)", () => {
+    beforeEach(() => {
+      icpAccountsStore.setForTesting({
+        ...mockAccountsStoreData,
+        subAccounts: [mockSubAccount],
+        hardwareWallets: [mockHardwareWalletAccount],
+      });
+    });
+
+    const props = {
+      accountIdentifier: mockSubAccount.identifier,
+    };
+
+    it("should Rename button", async () => {
+      const { queryByTestId } = render(NnsWallet, props);
+      expect(
+        queryByTestId("open-rename-subaccount-button")
+      ).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
# Motivation

Bug: Rename subaccount button is not available.

# Changes

* Add the RenameSubAccountButton in the PageHeading when the account is a Subaccount.

# Tests

* Add a test to check that the button is there if the account is a subaccount.

# Todos

- [x] Add entry to changelog (if necessary).
