### PR TITLE
Fix: TokensTable background colors

### DIFF
--- a/frontend/src/lib/components/tokens/DesktopTokensTable/DesktopTokensTable.svelte
+++ b/frontend/src/lib/components/tokens/DesktopTokensTable/DesktopTokensTable.svelte
@@ -27,7 +27,7 @@
 
     th {
       color: var(--text-description);
-      background-color: var(--input-background);
+      background-color: var(--table-header-background);
 
       font-weight: normal;
       font-size: var(--font-size-small);

--- a/frontend/src/lib/components/tokens/DesktopTokensTable/DesktopTokensTableRow.svelte
+++ b/frontend/src/lib/components/tokens/DesktopTokensTable/DesktopTokensTableRow.svelte
@@ -76,11 +76,10 @@
   tr {
     @include interaction.tappable;
 
-    // background-color: var(--input-focus-background);
-    background-color: var(--purple-75);
+    background-color: var(--table-row-background);
 
     &:hover {
-      background-color: var(--input-background);
+      background-color: var(--table-row-background-hover);
     }
   }
 


### PR DESCRIPTION
# Motivation

TokensTable background color was not themed.

In this PR, we use the new colors introduced for the table in gix-components

# Changes

* Use new variables for colors in Tokens table headers and row.

# Tests

Only styling changes. No new tests needed.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.