### PR TITLE
Fix: Aggregator with devenv

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -66,4 +66,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Aggregator url doesn't use raw for devenv environments.
+
 #### Security

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -12,7 +12,7 @@ const snsAggregatorUrlEnv = envVars.snsAggregatorUrl ?? "";
 const snsAggregatorUrl = (url: string) => {
   try {
     const { hostname } = new URL(url);
-    if (isLocalhost(hostname)) {
+    if (isLocalhost(hostname) || hostname.includes("devenv")) {
       return url;
     }
 

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -12,7 +12,12 @@ const snsAggregatorUrlEnv = envVars.snsAggregatorUrl ?? "";
 const snsAggregatorUrl = (url: string) => {
   try {
     const { hostname } = new URL(url);
-    if (isLocalhost(hostname) || hostname.includes("devenv")) {
+    if (isLocalhost(hostname)) {
+      return url;
+    }
+
+    // We don't want to add `raw` to the URL if we are running against a devenv environment.
+    if (url.includes("devenv")) {
       return url;
     }
 


### PR DESCRIPTION
# Motivation

When connecting to `devenv`, we can't use the `raw` in the url.

# Changes

* Add an extra check in the environments constants to build the aggregator url.

# Tests

Only dev environment, this is not tested.

# Todos

- [x] Add entry to changelog (if necessary).
