### PR TITLE
Update sent/received icons

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -25,6 +25,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Read schema version from stable memory.
+* New icons for sent/received transactions.
 
 #### Deprecated
 

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -6,7 +6,7 @@
   import type { Token } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
   import { transactionName } from "$lib/utils/transactions.utils";
-  import { Html, IconNorthEast, KeyValuePair } from "@dfinity/gix-components";
+  import { Html, IconNorthEast, IconUp, IconDown, KeyValuePair } from "@dfinity/gix-components";
   import type {
     Transaction,
     AccountTransactionType,
@@ -57,7 +57,11 @@
 
 <article data-tid="transaction-card" transition:fade|global>
   <div class="icon" class:send={!isReceive}>
-    <IconNorthEast size="24px" />
+    {#if isReceive}
+      <IconDown size="24px" />
+    {:else}
+      <IconUp size="24px" />
+    {/if}
   </div>
 
   <div class="transaction">
@@ -138,8 +142,6 @@
     justify-content: center;
     align-items: center;
 
-    transform: rotate(90deg);
-
     background: var(--positive-emphasis-light);
     color: var(--positive-emphasis);
 
@@ -151,7 +153,6 @@
     margin: var(--padding-0_5x) 0;
 
     &.send {
-      transform: rotate(270deg);
       background: var(--background);
       color: var(--disable-contrast);
     }

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -6,7 +6,12 @@
   import type { Token } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
   import { transactionName } from "$lib/utils/transactions.utils";
-  import { Html, IconNorthEast, IconUp, IconDown, KeyValuePair } from "@dfinity/gix-components";
+  import {
+    Html,
+    IconUp,
+    IconDown,
+    KeyValuePair,
+  } from "@dfinity/gix-components";
   import type {
     Transaction,
     AccountTransactionType,


### PR DESCRIPTION
# Motivation

We have new icons for sent/received transactions in the [ckBTC UI update design](https://www.figma.com/file/x8dk5axQUf8Bi43uUsqCHc/NNS-Production-%26-Hand-over?type=design&node-id=475-5782&mode=design&t=DZsyUIvKZoKJmlPj-4).
I asked Artem if these icons are specific to ckBTC or if we should use them everywhere and he said we should use them everywhere.

# Changes

1. Replace the diagonal arrows for sent/received transaction with up/down arrows.
2. The diagonal arrows were the same icons but differently rotated so I also removed the rotation.

# Tests

Old:
<img width="206" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/5982fb36-b1ba-4040-9525-9b7ac6b21c12">

New:
<img width="289" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/e763c9c2-ed1b-4a96-ac57-35b5a7ab8c26">


# Todos

- [x] Add entry to changelog (if necessary).
