### PR TITLE
GIX-1979: Load ckBTC tokens

### DIFF
--- a/frontend/src/lib/services/ckbtc-tokens.services.ts
+++ b/frontend/src/lib/services/ckbtc-tokens.services.ts
@@ -62,13 +62,16 @@ export const loadCkBTCToken = async ({
       if (!certified && notForceCallStrategy()) {
         return;
       }
+
       // Explicitly handle only UPDATE errors
       toastsError({
         labelKey: "error.token_not_found",
         err,
       });
+
       // Hide unproven data
       tokensStore.resetUniverse(universeId);
+
       handleError?.();
     },
   });

--- a/frontend/src/lib/services/ckbtc-tokens.services.ts
+++ b/frontend/src/lib/services/ckbtc-tokens.services.ts
@@ -45,7 +45,7 @@ export const loadCkBTCToken = async ({
 
   return queryAndUpdate<IcrcTokenMetadata, unknown>({
     strategy: FORCE_CALL_STRATEGY,
-    identityType: "anonymous",
+    identityType: "current",
     request: ({ certified, identity }) =>
       getCkBTCToken({
         identity,

--- a/frontend/src/lib/services/ckbtc-tokens.services.ts
+++ b/frontend/src/lib/services/ckbtc-tokens.services.ts
@@ -1,12 +1,33 @@
 import { getCkBTCToken } from "$lib/api/ckbtc-ledger.api";
+import {
+  CKBTC_UNIVERSE_CANISTER_ID,
+  CKTESTBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
-import { queryAndUpdate } from "$lib/services/utils.services";
+import {
+  ENABLE_CKBTC,
+  ENABLE_CKTESTBTC,
+} from "$lib/stores/feature-flags.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import type { UniverseCanisterId } from "$lib/types/universe";
 import { notForceCallStrategy } from "$lib/utils/env.utils";
 import { get } from "svelte/store";
+import { queryAndUpdate } from "./utils.services";
+
+export const loadCkBTCTokens = async () => {
+  const enableCkBTC = get(ENABLE_CKBTC);
+  const enableCkBTCTest = get(ENABLE_CKTESTBTC);
+  return Promise.all([
+    enableCkBTC
+      ? loadCkBTCToken({ universeId: CKBTC_UNIVERSE_CANISTER_ID })
+      : undefined,
+    enableCkBTCTest
+      ? loadCkBTCToken({ universeId: CKTESTBTC_UNIVERSE_CANISTER_ID })
+      : undefined,
+  ]);
+};
 
 export const loadCkBTCToken = async ({
   handleError,
@@ -24,32 +45,31 @@ export const loadCkBTCToken = async ({
 
   return queryAndUpdate<IcrcTokenMetadata, unknown>({
     strategy: FORCE_CALL_STRATEGY,
+    identityType: "anonymous",
     request: ({ certified, identity }) =>
       getCkBTCToken({
         identity,
         certified,
         canisterId: universeId,
       }),
-    onLoad: async ({ response: token, certified }) =>
+    onLoad: async ({ response: token, certified }) => {
       tokensStore.setToken({
         certified,
         canisterId: universeId,
         token,
-      }),
+      });
+    },
     onError: ({ error: err, certified }) => {
       if (!certified && notForceCallStrategy()) {
         return;
       }
-
       // Explicitly handle only UPDATE errors
       toastsError({
         labelKey: "error.token_not_found",
         err,
       });
-
       // Hide unproven data
-      tokensStore.resetUniverse(universeId);
-
+      // tokensStore.resetUniverse(universeId);
       handleError?.();
     },
   });

--- a/frontend/src/lib/services/ckbtc-tokens.services.ts
+++ b/frontend/src/lib/services/ckbtc-tokens.services.ts
@@ -52,13 +52,12 @@ export const loadCkBTCToken = async ({
         certified,
         canisterId: universeId,
       }),
-    onLoad: async ({ response: token, certified }) => {
+    onLoad: async ({ response: token, certified }) =>
       tokensStore.setToken({
         certified,
         canisterId: universeId,
         token,
-      });
-    },
+      }),
     onError: ({ error: err, certified }) => {
       if (!certified && notForceCallStrategy()) {
         return;
@@ -69,7 +68,7 @@ export const loadCkBTCToken = async ({
         err,
       });
       // Hide unproven data
-      // tokensStore.resetUniverse(universeId);
+      tokensStore.resetUniverse(universeId);
       handleError?.();
     },
   });

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -15,11 +15,14 @@
   import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
   import type { Action } from "$lib/types/actions";
   import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+  import { loadCkBTCTokens } from "$lib/services/ckbtc-tokens.services";
+  import { tokensListBaseStore } from "$lib/derived/tokens-list-base.derived";
 
   onMount(() => {
     if (!$ENABLE_MY_TOKENS) {
       goto(AppPath.Accounts);
     }
+    loadCkBTCTokens();
   });
 
   const data: UserTokenData[] = [
@@ -49,6 +52,6 @@
   {#if $authSignedInStore}
     <Tokens userTokensData={data} on:nnsAction={handleAction} />
   {:else}
-    <SignInTokens />
+    <SignInTokens userTokensData={$tokensListBaseStore} />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -15,7 +15,6 @@
   import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
   import type { Action } from "$lib/types/actions";
   import { UnavailableTokenAmount } from "$lib/utils/token.utils";
-  import { tokensListBaseStore } from "$lib/derived/tokens-list-base.derived";
 
   onMount(() => {
     if (!$ENABLE_MY_TOKENS) {
@@ -50,6 +49,6 @@
   {#if $authSignedInStore}
     <Tokens userTokensData={data} on:nnsAction={handleAction} />
   {:else}
-    <SignInTokens userTokensData={$tokensListBaseStore} />
+    <SignInTokens />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -15,14 +15,12 @@
   import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
   import type { Action } from "$lib/types/actions";
   import { UnavailableTokenAmount } from "$lib/utils/token.utils";
-  import { loadCkBTCTokens } from "$lib/services/ckbtc-tokens.services";
   import { tokensListBaseStore } from "$lib/derived/tokens-list-base.derived";
 
   onMount(() => {
     if (!$ENABLE_MY_TOKENS) {
       goto(AppPath.Accounts);
     }
-    loadCkBTCTokens();
   });
 
   const data: UserTokenData[] = [

--- a/frontend/src/tests/lib/services/ckbtc-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-tokens.services.spec.ts
@@ -1,25 +1,28 @@
 import * as ledgerApi from "$lib/api/ckbtc-ledger.api";
-import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import {
+  CKBTC_UNIVERSE_CANISTER_ID,
+  CKTESTBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
 import * as services from "$lib/services/ckbtc-tokens.services";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
+vi.mock("$lib/api/ckbtc-ledger.api");
+
 describe("ckbtc-tokens-services", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     resetIdentity();
   });
 
-  describe("loadCkBTCTokens", () => {
+  describe("loadCkBTCToken", () => {
     beforeEach(() => {
       tokensStore.reset();
-    });
-
-    afterEach(() => {
-      vi.clearAllMocks();
     });
 
     it("should load token in the store", async () => {
@@ -50,17 +53,13 @@ describe("ckbtc-tokens-services", () => {
     });
   });
 
-  describe("already loaded", () => {
+  describe("loadCkBTCToken already loaded", () => {
     beforeEach(() => {
       tokensStore.setToken({
         canisterId: CKBTC_UNIVERSE_CANISTER_ID,
         token: mockCkBTCToken,
         certified: true,
       });
-    });
-
-    afterEach(() => {
-      vi.clearAllMocks();
     });
 
     it("should not reload token if already loaded", async () => {
@@ -71,6 +70,97 @@ describe("ckbtc-tokens-services", () => {
       await services.loadCkBTCToken({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
 
       expect(spyGetToken).not.toBeCalled();
+    });
+  });
+
+  describe("loadCkBTCTokens", () => {
+    const mockCkTestBTCToken = {
+      ...mockCkBTCToken,
+      symbol: "ckTESTBTC",
+    };
+    beforeEach(() => {
+      tokensStore.reset();
+      vi.spyOn(ledgerApi, "getCkBTCToken").mockImplementation(
+        async ({ canisterId }) => {
+          if (canisterId.toText() === CKBTC_UNIVERSE_CANISTER_ID.toText()) {
+            return mockCkBTCToken;
+          } else {
+            return mockCkTestBTCToken;
+          }
+        }
+      );
+    });
+
+    describe("no ckBTC enabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_CKBTC", false);
+        overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", false);
+      });
+
+      it("should load the ckTESTBTC token if enabled", async () => {
+        await services.loadCkBTCTokens();
+
+        expect(
+          get(tokensStore)[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]
+        ).toBeUndefined();
+        expect(
+          get(tokensStore)[CKBTC_UNIVERSE_CANISTER_ID.toText()]
+        ).toBeUndefined();
+      });
+    });
+
+    describe("CKBTC enabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_CKBTC", true);
+        overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", false);
+      });
+
+      it("should load the ckBTC token if enabled", async () => {
+        await services.loadCkBTCTokens();
+
+        expect(
+          get(tokensStore)[CKBTC_UNIVERSE_CANISTER_ID.toText()]?.token
+        ).toEqual(mockCkBTCToken);
+        expect(
+          get(tokensStore)[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]
+        ).toBeUndefined();
+      });
+    });
+
+    describe("CKBTCTest enabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_CKBTC", false);
+        overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", true);
+      });
+
+      it("should load the ckTESTBTC token if enabled", async () => {
+        await services.loadCkBTCTokens();
+
+        expect(
+          get(tokensStore)[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]?.token
+        ).toEqual(mockCkTestBTCToken);
+        expect(
+          get(tokensStore)[CKBTC_UNIVERSE_CANISTER_ID.toText()]
+        ).toBeUndefined();
+      });
+    });
+
+    describe("both ckbtc enabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_CKBTC", true);
+        overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", true);
+      });
+
+      it("should load the ckTESTBTC token if enabled", async () => {
+        await services.loadCkBTCTokens();
+
+        expect(
+          get(tokensStore)[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]?.token
+        ).toEqual(mockCkTestBTCToken);
+        expect(
+          get(tokensStore)[CKBTC_UNIVERSE_CANISTER_ID.toText()]?.token
+        ).toEqual(mockCkBTCToken);
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/services/ckbtc-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-tokens.services.spec.ts
@@ -97,7 +97,7 @@ describe("ckbtc-tokens-services", () => {
         overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", false);
       });
 
-      it("should load the ckTESTBTC token if enabled", async () => {
+      it("should not load the ckBTC related tokens", async () => {
         await services.loadCkBTCTokens();
 
         expect(
@@ -115,7 +115,7 @@ describe("ckbtc-tokens-services", () => {
         overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", false);
       });
 
-      it("should load the ckBTC token if enabled", async () => {
+      it("should load the ckBTC token", async () => {
         await services.loadCkBTCTokens();
 
         expect(
@@ -133,7 +133,7 @@ describe("ckbtc-tokens-services", () => {
         overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", true);
       });
 
-      it("should load the ckTESTBTC token if enabled", async () => {
+      it("should load the ckTESTBTC token", async () => {
         await services.loadCkBTCTokens();
 
         expect(
@@ -151,7 +151,7 @@ describe("ckbtc-tokens-services", () => {
         overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", true);
       });
 
-      it("should load the ckTESTBTC token if enabled", async () => {
+      it("should load both ckBTC tokes", async () => {
         await services.loadCkBTCTokens();
 
         expect(


### PR DESCRIPTION
# Motivation

We want to show the tokens table also for non-logged in users.

Therefore, we need to fetch the token information about CkBTC.

In this PR, I introduce a service `loadCkBTCTokens` that will be used for the tokens route to load the token data.

# Changes

* New ckBTC token service `loadCkBTCTokens`.

# Tests

* Test new service

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.