### PR TITLE
Remove irrelevant TODOs from update-snsdemo PR description

### DIFF
--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -76,8 +76,7 @@ jobs:
             * Ensured that the `dfx` version and IC commit in `dfx.json` match `snsdemo`.
 
             # Tests
-              - [ ] Please check the API updates for any breaking changes that affect our code.
-              - [ ] Please check for new proposal types.
+            CI should pass.
           # Since the this is a scheduled job, a failure won't be shown on any
           # PR status. To notify the team, we send a message to our Slack channel on failure.
       - name: Notify Slack on failure


### PR DESCRIPTION
# Motivation

The update-snsdemo workflow used to also update candid files and rust types.
Now it only updates the snsdemo release that we use for test environment scripts and snapshot.
The TODOs in the automated PR description no longer apply to this workflow.

# Changes

Remove the TODOs that no longer apply to the update-snsdemo workflow.

# Tests

Not tested. Fingers crossed that the workflow will work correctly next week.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary.