### PR TITLE
Use page objects in TransactionCard.spec.ts

### DIFF
--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -3,46 +3,45 @@ import {
   AccountTransactionType,
   type Transaction,
 } from "$lib/types/transaction";
-import { replacePlaceholders } from "$lib/utils/i18n.utils";
-import { formatToken } from "$lib/utils/token.utils";
 import en from "$tests/mocks/i18n.mock";
 import {
   mockTransactionReceiveDataFromMain,
   mockTransactionSendDataFromMain,
 } from "$tests/mocks/transaction.mock";
+import { TransactionCardPo } from "$tests/page-objects/TransactionCard.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { normalizeWhitespace } from "$tests/utils/utils.test-utils";
 import { ICPToken } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
 describe("TransactionCard", () => {
-  const renderTransactionCard = ({
+  const renderComponent = ({
     transaction = mockTransactionSendDataFromMain,
     descriptions,
   }: {
     transaction?: Transaction;
     descriptions?: Record<string, string>;
-  }) =>
-    render(TransactionCard, {
+  }) => {
+    const { container } = render(TransactionCard, {
       props: {
         transaction,
         token: ICPToken,
         descriptions,
       },
     });
+    return TransactionCardPo.under(new JestPageObjectElement(container));
+  };
 
-  it("renders received headline", () => {
-    const { getByText } = renderTransactionCard({
+  it("renders received headline", async () => {
+    const po = renderComponent({
       transaction: mockTransactionReceiveDataFromMain,
     });
 
-    const expectedText = replacePlaceholders(en.transaction_names.receive, {
-      $tokenSymbol: ICPToken.symbol,
-    });
-    expect(getByText(expectedText)).toBeInTheDocument();
+    expect(await po.getHeadline()).toBe("Received");
   });
 
-  it("renders received description", () => {
-    const { getByText, getByTestId } = renderTransactionCard({
+  it("renders burn description", async () => {
+    const po = renderComponent({
       transaction: {
         ...mockTransactionReceiveDataFromMain,
         type: AccountTransactionType.Burn,
@@ -53,82 +52,67 @@ describe("TransactionCard", () => {
       >,
     });
 
-    const expectedText = replacePlaceholders(en.transaction_names.burn, {
-      $tokenSymbol: ICPToken.symbol,
-    });
-    expect(getByText(expectedText)).toBeInTheDocument();
-
-    expect(getByTestId("transaction-description")?.textContent).toEqual(
-      "To: BTC Network"
-    );
+    expect(await po.getHeadline()).toBe("Sent");
+    expect(await po.getDescription()).toBe("To: BTC Network");
   });
 
-  it("renders sent headline", () => {
-    const { getByText } = renderTransactionCard({
+  it("renders sent headline", async () => {
+    const po = renderComponent({
       transaction: mockTransactionSendDataFromMain,
     });
 
-    const expectedText = replacePlaceholders(en.transaction_names.send, {
-      $tokenSymbol: ICPToken.symbol,
-    });
-    expect(getByText(expectedText)).toBeInTheDocument();
+    expect(await po.getHeadline()).toBe("Sent");
   });
 
-  it("renders transaction ICPs with - sign", () => {
-    const { getByTestId } = renderTransactionCard({
+  it("renders transaction ICPs with - sign", async () => {
+    const po = renderComponent({
+      transaction: {
+        ...mockTransactionSendDataFromMain,
+        displayAmount: 123_000_000n,
+      },
+    });
+
+    expect(await po.getAmount()).toBe("-1.23");
+  });
+
+  it("renders transaction ICPs with + sign", async () => {
+    const po = renderComponent({
+      transaction: {
+        ...mockTransactionReceiveDataFromMain,
+        displayAmount: 345_000_000n,
+      },
+    });
+
+    expect(await po.getAmount()).toBe("+3.45");
+  });
+
+  it("displays transaction date and time", async () => {
+    const po = renderComponent({
       transaction: mockTransactionSendDataFromMain,
     });
 
-    expect(getByTestId("token-value")?.textContent).toBe(
-      `-${formatToken({
-        value: mockTransactionSendDataFromMain.displayAmount,
-        detailed: true,
-      })}`
+    expect(normalizeWhitespace(await po.getDate())).toBe(
+      "Mar 14, 2021 12:00 AM"
     );
   });
 
-  it("renders transaction ICPs with + sign", () => {
-    const { getByTestId } = renderTransactionCard({
+  it("displays identifier for received", async () => {
+    const po = renderComponent({
       transaction: mockTransactionReceiveDataFromMain,
     });
 
-    expect(getByTestId("token-value")?.textContent).toBe(
-      `+${formatToken({
-        value: mockTransactionReceiveDataFromMain.displayAmount,
-        detailed: true,
-      })}`
+    expect(await po.getIdentifier()).toBe(
+      `Source: ${mockTransactionReceiveDataFromMain.from}`
     );
   });
 
-  it("displays transaction date and time", () => {
-    const { getByTestId } = renderTransactionCard({
+  it("displays identifier for sent", async () => {
+    const po = renderComponent({
       transaction: mockTransactionSendDataFromMain,
     });
 
-    const div = getByTestId("transaction-date");
-
-    const textContent = normalizeWhitespace(div?.textContent);
-    expect(textContent).toContain("Mar 14, 2021 12:00 AM");
-    expect(textContent).toContain("12:00 AM");
-  });
-
-  it("displays identifier for received", () => {
-    const { getByTestId } = renderTransactionCard({
-      transaction: mockTransactionReceiveDataFromMain,
-    });
-    const identifier = getByTestId("identifier")?.textContent;
-
-    expect(identifier).toContain(mockTransactionReceiveDataFromMain.from);
-    expect(identifier).toContain(en.wallet.direction_from);
-  });
-
-  it("displays identifier for sent", () => {
-    const { getByTestId } = renderTransactionCard({
-      transaction: mockTransactionSendDataFromMain,
-    });
-    const identifier = getByTestId("identifier")?.textContent;
-
-    expect(identifier).toContain(mockTransactionSendDataFromMain.to);
-    expect(identifier).toContain(en.wallet.direction_to);
+    expect(await po.getIdentifier()).toBe(
+      `To: ${mockTransactionSendDataFromMain.to}`
+    );
   });
 });


### PR DESCRIPTION
# Motivation

More readable and maintainable.

# Changes

Use page objects in `frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts`

# Tests

yes

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary