### PR TITLE
Consistent e-mail address for the GIX bot

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -248,7 +248,7 @@ jobs:
         run: ./scripts/nns-dapp/bump-patch.test
       - name: Set git user
         run: |
-          git config --global user.email "gix-bot@dfinity.org"
+          git config --global user.email "gix-bot@users.noreply.github.com"
           git config --global user.name "GIX bot"
       - name: Command creates commits
         run: |

--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -51,7 +51,7 @@ jobs:
           ./scripts/update-snsdemo --dir ./snsdemo --release "${{ steps.update.outputs.release }}" --verbose
           echo "Changes:"
           git diff
-          git config --global user.email "gix-bot@dfinity.org"
+          git config --global user.email "gix-bot@users.noreply.github.com"
           git config --global user.name "GIX bot"
           git commit -a -m "Update snsdemo to ${{ steps.update.outputs.release }}"
       - name: Create Pull Request


### PR DESCRIPTION
# Motivation
The GIX bot uses two different e-mail addresses.  This makes tracking it in scripts unnecessarily complicated.  It also makes it mess up the insights stats, for example by having its commits split over two columns here:

![Screenshot from 2023-11-11 13-11-22](https://github.com/dfinity/nns-dapp/assets/5982633/60b209df-ca35-4a03-b592-19b8ca99b23d)



# Changes
- Use one e-mail address consistently for GIX bot.  Of the options, I picked the github "noreply" email address.  I'd be surprised if we reply to the other e-mail address.

Update:  I e-mailed gix-bot@dfinity.org and got this reply:

> 550 5.1.1 The email account that you tried to reach does not exist. Please try double-checking the recipient's email address for typos or unnecessary spaces. Learn more at https://support.google.com/mail/?p=NoSuchUser c10-20020a50f60a000000b0053f8411973esor240121edn.4 - gsmtp

# Tests
None

# Todos

- [ ] Add entry to changelog (if necessary).
  - Not worth a mention, I think.