### PR TITLE
build: fix for prettier-plugin-organize-imports which deletes imports in WebStorm 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -50,7 +50,7 @@
         "node-fetch": "^3.3.2",
         "postcss": "^8.4.31",
         "prettier": "^3.0.3",
-        "prettier-plugin-organize-imports": "^3.2.3",
+        "prettier-plugin-organize-imports": "^3.2.4",
         "prettier-plugin-svelte": "^3.0.3",
         "sass": "^1.69.4",
         "svelte": "^4.2.1",
@@ -5239,9 +5239,9 @@
       }
     },
     "node_modules/prettier-plugin-organize-imports": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.3.tgz",
-      "integrity": "sha512-KFvk8C/zGyvUaE3RvxN2MhCLwzV6OBbFSkwZ2OamCrs9ZY4i5L77jQ/w4UmUr+lqX8qbaqVq6bZZkApn+IgJSg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.4.tgz",
+      "integrity": "sha512-6m8WBhIp0dfwu0SkgfOxJqh+HpdyfqSSLfKKRZSFbDuEQXDDndb8fTpRWkUrX/uBenkex3MgnVk0J3b3Y5byog==",
       "dev": true,
       "peerDependencies": {
         "@volar/vue-language-plugin-pug": "^1.0.4",
@@ -10507,9 +10507,9 @@
       "dev": true
     },
     "prettier-plugin-organize-imports": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.3.tgz",
-      "integrity": "sha512-KFvk8C/zGyvUaE3RvxN2MhCLwzV6OBbFSkwZ2OamCrs9ZY4i5L77jQ/w4UmUr+lqX8qbaqVq6bZZkApn+IgJSg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.4.tgz",
+      "integrity": "sha512-6m8WBhIp0dfwu0SkgfOxJqh+HpdyfqSSLfKKRZSFbDuEQXDDndb8fTpRWkUrX/uBenkex3MgnVk0J3b3Y5byog==",
       "dev": true,
       "requires": {}
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,7 @@
     "node-fetch": "^3.3.2",
     "postcss": "^8.4.31",
     "prettier": "^3.0.3",
-    "prettier-plugin-organize-imports": "^3.2.3",
+    "prettier-plugin-organize-imports": "^3.2.4",
     "prettier-plugin-svelte": "^3.0.3",
     "sass": "^1.69.4",
     "svelte": "^4.2.1",


### PR DESCRIPTION
# Motivation

The "Refactoring" feature of Webstorm had for results to remove all imports when code was moved between modules.

https://youtrack.jetbrains.com/issue/WEB-50178#focus=Comments-27-8352541.0-0

https://github.com/simonhaenisch/prettier-plugin-organize-imports/issues/110#issuecomment-1804775453

# Changes

- bump `prettier-plugin-organize-imports`