### PR TITLE
feat: Separate branches everywhere

### DIFF
--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -46,6 +46,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-didc-update
+          branch-suffix: timestamp
           delete-branch: true
           title: 'Update didc release'
           body: |

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -82,6 +82,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-ic-update
+          branch-suffix: timestamp
           delete-branch: true
           title: 'Update IC candid files'
           body: |

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -35,6 +35,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-proposals-update
+          branch-suffix: timestamp
           add-paths: .github/*/*ml
           delete-branch: true
           title: 'Update proposal rendering'

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -59,6 +59,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-rust-update
+          branch-suffix: timestamp
           delete-branch: true
           title: 'Update rust version'
           # Since the this is a scheduled job, a failure won't be shown on any

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -57,7 +57,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Update `ic-wasm` to the latest version.
 * Factor out the `snsdemo` installation.
 * Add `prod` and `aggregator-prod` to the list of public releases.
-* Use a unique branch when updating the snsdemo release.
+* Use a unique branch when updating the snsdemo release, didc, IC candid files or rust.
 
 #### Deprecated
 


### PR DESCRIPTION
# Motivation
Keep bots consistent.  In #3703, one bot was changed to create a separate branch and PR every time the bot was run.

Note: I am concerned that this will make the bots spammier, which in turn will want developers to run the bots less frequently, which in turn will increase the time between e.g. a new proposal type appearing in the nns and being supported in the nns-dapp.  But we can see and revert if necessary.

# Changes
- Convert all the nns-dapp bots to branch-per-run.

# Tests
None

# Todos

- [x] Add entry to changelog (if necessary).
