### PR TITLE
Stop relying on duplicate transactions from index

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -25,6 +25,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Add missing "Rename" button in the subaccount page.
+* Fix disappearing "Received" half of to-self transactions.
 
 #### Security
 

--- a/frontend/src/lib/stores/icrc-transactions.store.ts
+++ b/frontend/src/lib/stores/icrc-transactions.store.ts
@@ -4,6 +4,7 @@ import type {
   UniverseCanisterId,
   UniverseCanisterIdText,
 } from "$lib/types/universe";
+import { getUniqueTransactions } from "$lib/utils/icrc-transactions.utils";
 import { removeKeys } from "$lib/utils/utils";
 import type { IcrcTransactionWithId } from "@dfinity/ledger-icrc";
 import type { Principal } from "@dfinity/principal";
@@ -74,12 +75,10 @@ const initIcrcTransactionsStore = (): IcrcTransactionsStore => {
       update((currentState: IcrcTransactionsStoreData) => {
         const projectState = currentState[canisterId.toText()];
         const accountState = projectState?.[accountIdentifier];
-        const uniquePreviousTransactions = (
-          accountState?.transactions ?? []
-        ).filter(
-          ({ id: oldTxId }) =>
-            !transactions.some(({ id: newTxId }) => newTxId === oldTxId)
-        );
+        const allTransactions = getUniqueTransactions([
+          ...(accountState?.transactions ?? []),
+          ...transactions,
+        ]);
         // Ids are in increasing order. We want to keep the oldest id.
         const newOldestTxId =
           oldestTxId === undefined
@@ -92,7 +91,7 @@ const initIcrcTransactionsStore = (): IcrcTransactionsStore => {
           [canisterId.toText()]: {
             ...projectState,
             [accountIdentifier]: {
-              transactions: [...uniquePreviousTransactions, ...transactions],
+              transactions: allTransactions,
               oldestTxId: newOldestTxId,
               completed,
             },

--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -50,24 +50,14 @@ const mapToSelfTransactions = (
   transactions: IcrcTransactionWithId[]
 ): { transaction: IcrcTransactionWithId; toSelfTransaction: boolean }[] => {
   const resultTransactions = transactions.flatMap((transaction) => {
+    const tx = {
+      transaction: { ...transaction },
+      toSelfTransaction: false,
+    };
     if (isToSelf(transaction.transaction)) {
-      return [
-        {
-          transaction: { ...transaction },
-          toSelfTransaction: true,
-        },
-        {
-          transaction: { ...transaction },
-          toSelfTransaction: false,
-        },
-      ];
+      return [{ ...tx, toSelfTransaction: true }, tx];
     }
-    return [
-      {
-        transaction: { ...transaction },
-        toSelfTransaction: false,
-      },
-    ];
+    return [tx];
   });
   return resultTransactions;
 };

--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -15,14 +15,67 @@ import type {
 } from "@dfinity/ledger-icrc";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
 import type { Principal } from "@dfinity/principal";
-import { fromNullable, nonNullish } from "@dfinity/utils";
-import { mapToSelfTransaction, showTransactionFee } from "./transactions.utils";
+import {
+  fromNullable,
+  isNullish,
+  nonNullish,
+  uint8ArrayToHexString,
+} from "@dfinity/utils";
+import { showTransactionFee } from "./transactions.utils";
+
+const isToSelf = (transaction: IcrcTransaction): boolean => {
+  if (transaction.transfer.length !== 1) {
+    return false;
+  }
+  const { from, to } = transaction.transfer[0];
+  if (from.owner.toText() !== to.owner.toText()) {
+    return false;
+  }
+  const fromSub = fromNullable(from.subaccount);
+  const toSub = fromNullable(to.subaccount);
+  if (isNullish(fromSub)) {
+    return isNullish(toSub);
+  }
+  return (
+    nonNullish(toSub) &&
+    uint8ArrayToHexString(fromSub) === uint8ArrayToHexString(toSub)
+  );
+};
 
 /**
- * Returns transactions of an SNS account sorted by date (newest first).
- * Filters out duplicated transactions.
- * A duplicated transaction is normally one made to itself.
- * The data of the duplicated transaction is the same in both transactions. No need to show it twice.
+ * Duplicates transactions made from and to the same account such that one of
+ * the transactions has toSelfTransaction set to true and the other to false.
+ */
+const mapToSelfTransactions = (
+  transactions: IcrcTransactionWithId[]
+): { transaction: IcrcTransactionWithId; toSelfTransaction: boolean }[] => {
+  const resultTransactions = transactions.flatMap((transaction) => {
+    if (isToSelf(transaction.transaction)) {
+      return [
+        {
+          transaction: { ...transaction },
+          toSelfTransaction: true,
+        },
+        {
+          transaction: { ...transaction },
+          toSelfTransaction: false,
+        },
+      ];
+    }
+    return [
+      {
+        transaction: { ...transaction },
+        toSelfTransaction: false,
+      },
+    ];
+  });
+  return resultTransactions;
+};
+
+/**
+ * Returns transactions of an ICRC-1 account sorted by date (newest first).
+ * Duplicates transactions made from and to the same account such that one of
+ * the transactions has toSelfTransaction set to true and the other to false.
  *
  * @param params
  * @param {Account} params.account
@@ -39,7 +92,7 @@ export const getSortedTransactionsFromStore = ({
   canisterId: UniverseCanisterId;
   account: Account;
 }): IcrcTransactionData[] =>
-  mapToSelfTransaction(
+  mapToSelfTransactions(
     store[canisterId.toText()]?.[account.identifier]?.transactions ?? []
   ).sort(({ transaction: txA }, { transaction: txB }) =>
     Number(txB.transaction.timestamp - txA.transaction.timestamp)
@@ -214,3 +267,17 @@ export const isIcrcTransactionsCompleted = ({
   account: Account;
 }): boolean =>
   Boolean(store[canisterId.toText()]?.[account.identifier]?.completed);
+
+export const getUniqueTransactions = (
+  transactions: IcrcTransactionWithId[]
+): IcrcTransactionWithId[] => {
+  const txIds = new Set<bigint>();
+  const result: IcrcTransactionWithId[] = [];
+  for (const tx of transactions) {
+    if (!txIds.has(tx.id)) {
+      txIds.add(tx.id);
+      result.push(tx);
+    }
+  }
+  return result;
+};

--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -258,6 +258,9 @@ export const isIcrcTransactionsCompleted = ({
 }): boolean =>
   Boolean(store[canisterId.toText()]?.[account.identifier]?.completed);
 
+/**
+ * Dedupe transactions based on ID.
+ */
 export const getUniqueTransactions = (
   transactions: IcrcTransactionWithId[]
 ): IcrcTransactionWithId[] => {

--- a/frontend/src/lib/utils/transactions.utils.ts
+++ b/frontend/src/lib/utils/transactions.utils.ts
@@ -192,9 +192,9 @@ export const transactionName = ({
   );
 
 /** (from==to workaround) Set `mapToSelfNnsTransaction: true` when sender and receiver are the same account (e.g. transmitting from `main` to `main` account) */
-export const mapToSelfTransaction = <T>(
-  transactions: T[]
-): { transaction: T; toSelfTransaction: boolean }[] => {
+export const mapToSelfTransaction = (
+  transactions: NnsTransaction[]
+): { transaction: NnsTransaction; toSelfTransaction: boolean }[] => {
   const resultTransactions = transactions.map((transaction) => ({
     transaction: { ...transaction },
     toSelfTransaction: false,

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -11,6 +11,7 @@ import {
   mockIcrcTransactionBurn,
   mockIcrcTransactionMint,
   mockIcrcTransactionWithId,
+  mockIcrcTransactionWithIdToSelf,
   mockIcrcTransactionsStoreSubscribe,
 } from "$tests/mocks/icrc-transactions.mock";
 import { IcrcTransactionsListPo } from "$tests/page-objects/IcrcTransactionsList.page-object";
@@ -123,6 +124,26 @@ describe("CkBTCTransactionList", () => {
     const { po } = renderComponent();
 
     expect(await po.getTransactionCardPos()).toHaveLength(1);
+  });
+
+  it("should render to-self transactions from store as duplicate", async () => {
+    const store = {
+      [CKBTC_UNIVERSE_CANISTER_ID.toText()]: {
+        [mockCkBTCMainAccount.identifier]: {
+          transactions: [mockIcrcTransactionWithIdToSelf],
+          completed: false,
+          oldestTxId: BigInt(0),
+        },
+      },
+    };
+
+    vi.spyOn(icrcTransactionsStore, "subscribe").mockImplementation(
+      mockIcrcTransactionsStoreSubscribe(store)
+    );
+
+    const { po } = renderComponent();
+
+    expect(await po.getTransactionCardPos()).toHaveLength(2);
   });
 
   it("should render description burn to btc network", async () => {

--- a/frontend/src/tests/lib/stores/icrc-transactions.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icrc-transactions.store.spec.ts
@@ -57,4 +57,35 @@ describe("icrc-transactions", () => {
       ]
     ).toBeUndefined();
   });
+
+  it("should dedupe transactions", () => {
+    const canisterId = CKTESTBTC_UNIVERSE_CANISTER_ID;
+    const identifier = mockCkBTCMainAccount.identifier;
+
+    icrcTransactionsStore.addTransactions({
+      canisterId,
+      transactions: [mockIcrcTransactionWithId],
+      accountIdentifier: identifier,
+      oldestTxId: BigInt(10),
+      completed: false,
+    });
+
+    expect(
+      get(icrcTransactionsStore)[canisterId.toText()][identifier].transactions
+        .length
+    ).toBe(1);
+
+    icrcTransactionsStore.addTransactions({
+      canisterId,
+      transactions: [mockIcrcTransactionWithId, mockIcrcTransactionWithId],
+      accountIdentifier: identifier,
+      oldestTxId: BigInt(10),
+      completed: false,
+    });
+
+    expect(
+      get(icrcTransactionsStore)[canisterId.toText()][identifier].transactions
+        .length
+    ).toBe(1);
+  });
 });

--- a/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
@@ -3,6 +3,7 @@ import { AccountTransactionType } from "$lib/types/transaction";
 import {
   getOldestTxIdFromStore,
   getSortedTransactionsFromStore,
+  getUniqueTransactions,
   isIcrcTransactionsCompleted,
   mapIcrcTransaction,
 } from "$lib/utils/icrc-transactions.utils";
@@ -83,11 +84,11 @@ describe("icrc-transaction utils", () => {
       });
     });
 
-    it("should set selfTransaction to true", () => {
+    it("should duplicate selfTransaction", () => {
       const store: IcrcTransactionsStoreData = {
         [mockSnsMainAccount.principal.toText()]: {
           [mockSnsMainAccount.identifier]: {
-            transactions: [selfTransaction, selfTransaction],
+            transactions: [selfTransaction],
             completed: false,
             oldestTxId: BigInt(1234),
           },
@@ -335,6 +336,56 @@ describe("icrc-transaction utils", () => {
           account: mockSnsSubAccount,
         })
       ).toBe(true);
+    });
+  });
+
+  describe("getUniqueTransactions", () => {
+    const mainAccount = {
+      owner: mockPrincipal,
+      subaccount: [] as [] | [Uint8Array],
+    };
+    const subAccount = {
+      owner: mockPrincipal,
+      subaccount: [new Uint8Array([1, 2, 3])] as [] | [Uint8Array],
+    };
+    const txA = createIcrcTransactionWithId({
+      id: 1n,
+      from: mainAccount,
+      to: subAccount,
+    });
+    const txB = createIcrcTransactionWithId({
+      id: 2n,
+      from: subAccount,
+      to: mainAccount,
+    });
+    const txC = createIcrcTransactionWithId({
+      id: 3n,
+      from: mainAccount,
+      to: mainAccount,
+    });
+
+    it("empty array", () => {
+      expect(getUniqueTransactions([])).toEqual([]);
+    });
+
+    it("singleton array", () => {
+      const transactions = [txA];
+      expect(getUniqueTransactions(transactions)).toEqual(transactions);
+    });
+
+    it("duplicate transactions", () => {
+      const transactions = [txA, txA];
+      expect(getUniqueTransactions(transactions)).toEqual([txA]);
+    });
+
+    it("multiple different transactions", () => {
+      const transactions = [txA, txB, txC];
+      expect(getUniqueTransactions(transactions)).toEqual(transactions);
+    });
+
+    it("non-consecutive duplicate transactions", () => {
+      const transactions = [txA, txB, txC, txA, txC, txB, txA, txC];
+      expect(getUniqueTransactions(transactions)).toEqual([txA, txB, txC]);
     });
   });
 });

--- a/frontend/src/tests/mocks/icrc-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icrc-transactions.mock.ts
@@ -14,17 +14,19 @@ export interface IcrcCandidAccount {
 }
 
 export const createIcrcTransactionWithId = ({
+  id,
   from,
   to,
   fee,
   amount,
 }: {
+  id?: bigint;
   to?: IcrcCandidAccount;
   from?: IcrcCandidAccount;
   fee?: bigint;
   amount?: bigint;
 }): IcrcTransactionWithId => ({
-  id: BigInt(123),
+  id: id ?? 123n,
   transaction: {
     kind: "transfer",
     timestamp: BigInt(12354),

--- a/frontend/src/tests/mocks/icrc-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icrc-transactions.mock.ts
@@ -58,7 +58,31 @@ const fakeAccount = {
   subaccount: [] as [],
 };
 
+const fakeSubAccount = {
+  owner: Principal.fromText("aaaaa-aa"),
+  subaccount: [new Uint8Array([2, 3, 4])] as [Uint8Array],
+};
+
 const mockIcrcTransactionTransfer: IcrcTransaction = {
+  kind: "transfer",
+  timestamp: BigInt(12354),
+  burn: [],
+  mint: [],
+  transfer: [
+    {
+      to: fakeSubAccount,
+      from: fakeAccount,
+      memo: [],
+      created_at_time: [BigInt(123)],
+      amount: BigInt(33),
+      fee: [BigInt(1)],
+      spender: [],
+    },
+  ],
+  approve: [],
+};
+
+const mockIcrcTransactionTransferToSelf: IcrcTransaction = {
   kind: "transfer",
   timestamp: BigInt(12354),
   burn: [],
@@ -113,6 +137,11 @@ export const mockIcrcTransactionMint: IcrcTransaction = {
 export const mockIcrcTransactionWithId: IcrcTransactionWithId = {
   id: BigInt(123),
   transaction: mockIcrcTransactionTransfer,
+};
+
+export const mockIcrcTransactionWithIdToSelf: IcrcTransactionWithId = {
+  id: BigInt(124),
+  transaction: mockIcrcTransactionTransferToSelf,
 };
 
 export const mockIcrcTransactionsStoreSubscribe =


### PR DESCRIPTION
# Motivation

When you make a transaction where the "from" and "to" are the same (sub)account we render this as 2 transactions: 1 sent and 1 received.
To do this we rely on the index canister returning 2 copies of this transaction as well.
But this is a bug in the index canister that might be fixed at some point and also it makes our code fragile.
For example, in the transactions works, we [dedupe transaction](https://github.com/dfinity/nns-dapp/blob/d4a4d206db95027b58653ccd7ab0da6014497939/frontend/src/lib/worker-services/icrc-transactions.worker-services.ts#L63) which means that actually most of the time we fail to render 2 transactions.

# Changes

1. Add a utility function `getUniqueTransactions` to dedupe transactions.
2. In `icrcTransactionsStore` always dedupe all transactions instead of only removing existing transaction from new transactions.
3. In `getSortedTransactionsFromStore`, duplicate self-transactions instead of depending on them to already be duplicated and just marking them.
4. Add an optional `id` param to `createIcrcTransactionWithId` for convenience.
5. Removed template parameter from `mapToSelfTransaction` as it is no longer used for ICRC transactions.

# Tests

Added unit tests for:
1. `getUniqueTransactions`
2. `icrcTransactionsStore`
3. `getSortedTransactionsFromStore`
4. `CkBTCTransactionsList`

Tested manually at: https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [x] Add entry to changelog (if necessary).
