### PR TITLE
GIX-1979: Render table visitors

### DIFF
--- a/frontend/src/lib/components/tokens/DesktopTokensTable/DesktopTokensTableRow.svelte
+++ b/frontend/src/lib/components/tokens/DesktopTokensTable/DesktopTokensTableRow.svelte
@@ -49,7 +49,7 @@
         size="medium"
         framed
       />
-      <span>{userTokenData.title}</span>
+      <span data-tid="project-name">{userTokenData.title}</span>
     </div>
     <div class="title-actions actions mobile-only">
       {#each userTokenData.actions as action}

--- a/frontend/src/lib/pages/SignInTokens.svelte
+++ b/frontend/src/lib/pages/SignInTokens.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import SignIn from "$lib/components/common/SignIn.svelte";
+  import DesktopTokensTable from "$lib/components/tokens/DesktopTokensTable/DesktopTokensTable.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import type { UserTokenData } from "$lib/types/tokens-page";
   import { PageBanner, IconAccountsPage } from "@dfinity/gix-components";
+
+  export let userTokensData: UserTokenData[];
 </script>
 
 <main class="sign-in" data-tid="sign-in-tokens-page-component">
@@ -14,7 +18,7 @@
       <SignIn slot="actions" />
     </PageBanner>
 
-    <!-- TODO: GIX-1979 Add Tokens table no balances -->
+    <DesktopTokensTable {userTokensData} />
   </div>
 </main>
 

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -15,6 +15,7 @@
   import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
   import type { Action } from "$lib/types/actions";
   import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+  import { tokensListBaseStore } from "$lib/derived/tokens-list-base.derived";
 
   onMount(() => {
     if (!$ENABLE_MY_TOKENS) {
@@ -49,6 +50,6 @@
   {#if $authSignedInStore}
     <Tokens userTokensData={data} on:nnsAction={handleAction} />
   {:else}
-    <SignInTokens />
+    <SignInTokens userTokensData={$tokensListBaseStore} />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/tests/page-objects/DesktopTokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/DesktopTokensTableRow.page-object.ts
@@ -12,6 +12,10 @@ export class DesktopTokensTableRowPo extends BasePageObject {
     ).map((el) => new DesktopTokensTableRowPo(el));
   }
 
+  getProjectName(): Promise<string> {
+    return this.getText("project-name");
+  }
+
   getBalance(): Promise<string> {
     return this.getText("token-value-label");
   }

--- a/frontend/src/tests/page-objects/SignInTokens.page-object.ts
+++ b/frontend/src/tests/page-objects/SignInTokens.page-object.ts
@@ -1,10 +1,20 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { DesktopTokensTablePo } from "./DesktopTokensTable.page-object";
 
 export class SignInTokensPagePo extends BasePageObject {
   private static readonly TID = "sign-in-tokens-page-component";
 
   static under(element: PageObjectElement): SignInTokensPagePo {
     return new SignInTokensPagePo(element.byTestId(SignInTokensPagePo.TID));
+  }
+
+  getTokensTablePo() {
+    return DesktopTokensTablePo.under(this.root);
+  }
+
+  async getTokenNames(): Promise<string[]> {
+    const rows = await this.getTokensTablePo().getRows();
+    return Promise.all(rows.map((row) => row.getProjectName()));
   }
 }

--- a/frontend/src/tests/page-objects/TokensRoute.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensRoute.page-object.ts
@@ -10,8 +10,12 @@ export class TokensRoutePo extends BasePageObject {
     return new TokensRoutePo(element.byTestId(TokensRoutePo.TID));
   }
 
+  getSignInTokensPagePo(): SignInTokensPagePo {
+    return SignInTokensPagePo.under(this.root);
+  }
+
   hasLoginPage(): Promise<boolean> {
-    return SignInTokensPagePo.under(this.root).isPresent();
+    return this.getSignInTokensPagePo().isPresent();
   }
 
   hasTokensPage(): Promise<boolean> {

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -1,10 +1,11 @@
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
 import TokensRoute from "$routes/(app)/(nns)/tokens/+page.svelte";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
-import { principal } from "$tests/mocks/sns-projects.mock";
+import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { TokensRoutePo } from "$tests/page-objects/TokensRoute.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -26,18 +27,28 @@ describe("Tokens route", () => {
   describe("when feature flag enabled", () => {
     beforeEach(() => {
       overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
+      const rootCanisterId1 = rootCanisterIdMock;
+      const rootCanisterId2 = principal(1);
       setSnsProjects([
         {
-          rootCanisterId: rootCanisterIdMock,
+          rootCanisterId: rootCanisterId1,
           projectName: "Tetris",
           lifecycle: SnsSwapLifecycle.Committed,
         },
         {
-          rootCanisterId: principal(1),
+          rootCanisterId: rootCanisterId2,
           projectName: "Pacman",
           lifecycle: SnsSwapLifecycle.Committed,
         },
       ]);
+      tokensStore.setTokens({
+        [rootCanisterId1.toText()]: {
+          token: mockSnsToken,
+        },
+        [rootCanisterId2.toText()]: {
+          token: mockSnsToken,
+        },
+      });
     });
 
     describe("when logged in", () => {

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -4,14 +4,21 @@ import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { page } from "$mocks/$app/stores";
 import TokensRoute from "$routes/(app)/(nns)/tokens/+page.svelte";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { TokensRoutePo } from "$tests/page-objects/TokensRoute.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Tokens route", () => {
-  const renderPage = () => {
+  const renderPage = async () => {
     const { container } = render(TokensRoute);
+
+    await runResolvedPromises();
 
     return TokensRoutePo.under(new JestPageObjectElement(container));
   };
@@ -19,6 +26,18 @@ describe("Tokens route", () => {
   describe("when feature flag enabled", () => {
     beforeEach(() => {
       overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
+      setSnsProjects([
+        {
+          rootCanisterId: rootCanisterIdMock,
+          projectName: "Tetris",
+          lifecycle: SnsSwapLifecycle.Committed,
+        },
+        {
+          rootCanisterId: principal(1),
+          projectName: "Pacman",
+          lifecycle: SnsSwapLifecycle.Committed,
+        },
+      ]);
     });
 
     describe("when logged in", () => {
@@ -27,7 +46,7 @@ describe("Tokens route", () => {
       });
 
       it("should render my tokens page", async () => {
-        const po = renderPage();
+        const po = await renderPage();
 
         expect(await po.hasLoginPage()).toBe(false);
         expect(await po.hasTokensPage()).toBe(true);
@@ -40,10 +59,21 @@ describe("Tokens route", () => {
       });
 
       it("should render sign-in if not logged in", async () => {
-        const po = renderPage();
+        const po = await renderPage();
 
         expect(await po.hasLoginPage()).toBe(true);
         expect(await po.hasTokensPage()).toBe(false);
+      });
+
+      it("should render ICP and SNS tokens", async () => {
+        const po = await renderPage();
+
+        const signInPo = po.getSignInTokensPagePo();
+        expect(await signInPo.getTokenNames()).toEqual([
+          "Internet Computer",
+          "Tetris",
+          "Pacman",
+        ]);
       });
     });
   });
@@ -57,7 +87,7 @@ describe("Tokens route", () => {
     it("should redirect to accounts page", async () => {
       expect(get(pageStore).path).toEqual(AppPath.Tokens);
 
-      renderPage();
+      await renderPage();
 
       expect(get(pageStore).path).toEqual(AppPath.Accounts);
     });


### PR DESCRIPTION
# Motivation

Show the tokens table without balance to the non logged in user.

In this PR, render the table in the SignInTokens using the derived store with base data.

In the upcoming PRs I will improve the UX. I will add a "goToDetail" action and logic that will redirect the user to login on row click.

# Changes

* Render `DesktopTokensTable` in `SignInTokens`.
* Expect `userTokensData` in `SignInTokens`.
* Pass `tokensListBaseStore` to `SignInTokens` in the route.

# Tests

* Add methods to get the name of the project of the row.
* Add a test in the route component to check that there are tokens when the user is not logged in.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.