### PR TITLE
refactor: Move snsdemo outside repo

### DIFF
--- a/.github/actions/build_nns_dapp/action.yaml
+++ b/.github/actions/build_nns_dapp/action.yaml
@@ -45,9 +45,10 @@ runs:
       uses: ./.github/actions/checkout_snsdemo
       with:
         token: ${{ inputs.token }}
+        path: ../snsdemo # Next to, not inside, the nns-dapp repo.
     - name: Add SNS scripts to the path
       shell: bash
-      run: echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
+      run: echo "$PWD/../snsdemo/bin" >> $GITHUB_PATH
     - name: Install tools
       shell: bash
       run: |

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -51,7 +51,7 @@ runs:
     - name: Add snsdemo scripts to the path
       shell: bash
       run: |
-        echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
+        echo "$PWD/../snsdemo/bin" >> $GITHUB_PATH
     - name: Install cargo binstall
       uses: ./.github/actions/install_binstall
     - name: Install SNS script dependencies

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -60,12 +60,13 @@ jobs:
         uses: ./.github/actions/checkout_snsdemo
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          path: ../snsdemo
       - name: Set up SNS scripts
         run: |
           : Install more
           sudo apt-get update -yy && sudo apt-get install -yy moreutils
           : Add scripts to the path
-          echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
+          echo "$PWD/../snsdemo/bin" >> $GITHUB_PATH
       - name: Verify identity
         run: |
           dfx identity whoami

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Add SNS scripts to the path
         if: ${{ steps.update.outputs.updated == '1' }}
         shell: bash
-        run: echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
+        run: echo "$PWD/../snsdemo/bin" >> $GITHUB_PATH
       - name: Install sponge
         if: ${{ steps.update.outputs.updated == '1' }}
         run: sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
@@ -69,7 +69,7 @@ jobs:
         if: ${{ steps.update.outputs.updated == '1' }}
         run: |
           # Install didc
-          snsdemo/bin/dfx-software-didc-install --release "$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+          dfx-software-didc-install --release "$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
           # Update didc
           scripts/update_ic_commit -c "${{ steps.update.outputs.release }}"
       - name: Create Pull Request

--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -31,20 +31,11 @@ jobs:
               echo "release=$latest_release"
             fi
           } >> "$GITHUB_OUTPUT"
-      - name: Get snsdemo repo
-        uses: actions/checkout@v3
-        if: ${{ steps.update.outputs.updated == '1' }}
-        with:
-          repository: 'dfinity/snsdemo'
-          path: 'snsdemo'
-          ref: ${{ steps.update.outputs.release }}
       - name: Update snsdemo
         if: ${{ steps.update.outputs.updated == '1' }}
         run: |
           set -x
           echo snsdemo needs an update
-          # Install didc
-          snsdemo/bin/dfx-software-didc-install --release "$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
           # Install sponge
           sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
           # Update


### PR DESCRIPTION
# Motivation
The snsdemo is currently  checked out inside the nns-dapp repo.  This has caused a number of problems including, most recently, the snsdemo accidentally being committed.

# Changes
- Move the snsdemo so that it is checked out next to, not inside, the nns-dapp repo.

# Tests
- See CI
- For bots, they will be triggered manually but this may not exercise all interesting paths if there are no changes

# Todos

- [ ] Add entry to changelog (if necessary).
