### PR TITLE
Fix add-paths lines

### DIFF
--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main
+          # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: dfx.json
           commit-message: Update didc release
           committer: GitHub <noreply@github.com>

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main
+          add-paths: dfx.json
           commit-message: Update ic candid files
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main
+          # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
             dfx.json
             declarations/*/*.did

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main
-          add-paths: dfx.json
+          add-paths: dfx.json declarations/*/*.did
           commit-message: Update ic candid files
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -78,7 +78,9 @@ jobs:
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main
-          add-paths: dfx.json declarations/*/*.did
+          add-paths: |
+            dfx.json
+            declarations/*/*.did
           commit-message: Update ic candid files
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -36,7 +36,7 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-proposals-update
           branch-suffix: timestamp
-          add-paths: .github/*/*ml
+          add-paths: rs/proposals/src/canisters/*/api.rs
           delete-branch: true
           title: 'Update proposal rendering'
           body: |

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -36,6 +36,7 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-proposals-update
           branch-suffix: timestamp
+          # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: rs/proposals/src/canisters/*/api.rs
           delete-branch: true
           title: 'Update proposal rendering'

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main
+          # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: ./rust-toolchain.toml
           commit-message: Update rust version
           committer: GitHub <noreply@github.com>

--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -64,6 +64,7 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-snsdemo-update
           branch-suffix: timestamp
+          # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: dfx.json
           delete-branch: true
           title: 'Update snsdemo to ${{ steps.update.outputs.release }}'

--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -64,7 +64,7 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-snsdemo-update
           branch-suffix: timestamp
-          add-paths: .github/*/*ml
+          add-paths: dfx.json
           delete-branch: true
           title: 'Update snsdemo to ${{ steps.update.outputs.release }}'
           body: |

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -58,4 +58,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Remove accidentally committed (empty) directory and fix commit patterns.
+
 #### Security


### PR DESCRIPTION
# Motivation
The snsdemo repo was added accidentally.  (Not the whole repo but as a link.)

This looks as if it was caused by an incorrect pattern.

# Changes
- Remove the spurious directory.
- Fix incorrect patterns.

# Tests
We can trigger workflows but given that the workflows do nothing most of the time, the only real test will be to wait for changes that cause non-trivial changes and check whether the bot creates correct outputs.

# Todos

- [x] Add entry to changelog (if necessary).
