### PR TITLE
GIX-1979: Render ckBTC token

### DIFF
--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -16,11 +16,13 @@
   import type { Action } from "$lib/types/actions";
   import { UnavailableTokenAmount } from "$lib/utils/token.utils";
   import { tokensListBaseStore } from "$lib/derived/tokens-list-base.derived";
+  import { loadCkBTCTokens } from "$lib/services/ckbtc-tokens.services";
 
   onMount(() => {
     if (!$ENABLE_MY_TOKENS) {
       goto(AppPath.Accounts);
     }
+    loadCkBTCTokens();
   });
 
   const data: UserTokenData[] = [


### PR DESCRIPTION
# Motivation

Tokens page should also render the ckBTC token.

It was missing before before it wasn't loading the token in the tokensStore.

# Changes

* Call service to load the enabled ckBTC tokens in the store in the Tokens route.

# Tests

* Add tests to the route to check for ckBTC tokens.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.