### PR TITLE
Update proposal rendering

### DIFF
--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,3 +1,5 @@
+//! Rust code created from candid by: scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-08_23-01/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
@@ -263,13 +265,16 @@ pub struct Countries {
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SwapParameters {
     pub minimum_participants: Option<u64>,
+    pub neurons_fund_participation: Option<bool>,
     pub duration: Option<Duration>,
     pub neuron_basket_construction_parameters: Option<NeuronBasketConstructionParameters>,
     pub confirmation_text: Option<String>,
     pub maximum_participant_icp: Option<Tokens>,
     pub minimum_icp: Option<Tokens>,
+    pub minimum_direct_participation_icp: Option<Tokens>,
     pub minimum_participant_icp: Option<Tokens>,
     pub start_time: Option<GlobalTimeOfDay>,
+    pub maximum_direct_participation_icp: Option<Tokens>,
     pub maximum_icp: Option<Tokens>,
     pub neurons_fund_investment_icp: Option<Tokens>,
     pub restricted_countries: Option<Countries>,
@@ -366,7 +371,9 @@ pub struct Params {
     pub sns_token_e8s: u64,
     pub sale_delay_seconds: Option<u64>,
     pub max_participant_icp_e8s: u64,
+    pub min_direct_participation_icp_e8s: Option<u64>,
     pub min_icp_e8s: u64,
+    pub max_direct_participation_icp_e8s: Option<u64>,
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
@@ -527,6 +534,16 @@ pub struct NeuronStakeTransfer {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct Followers {
+    pub followers: Vec<NeuronId>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct FollowersMap {
+    pub followers_map: Vec<(u64, Followers)>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
 pub enum Progress {
     LastNeuronId(NeuronId),
 }
@@ -552,6 +569,7 @@ pub struct GovernanceError {
 
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct CfNeuron {
+    pub has_created_neuron_recipes: Option<bool>,
     pub nns_neuron_id: u64,
     pub amount_icp_e8s: u64,
 }
@@ -566,6 +584,52 @@ pub struct CfParticipant {
 pub struct Ballot {
     pub vote: i32,
     pub voting_power: u64,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct SwapParticipationLimits {
+    pub min_participant_icp_e8s: Option<u64>,
+    pub max_participant_icp_e8s: Option<u64>,
+    pub min_direct_participation_icp_e8s: Option<u64>,
+    pub max_direct_participation_icp_e8s: Option<u64>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct NeuronsFundNeuronPortion {
+    pub hotkey_principal: Option<Principal>,
+    pub is_capped: Option<bool>,
+    pub maturity_equivalent_icp_e8s: Option<u64>,
+    pub nns_neuron_id: Option<NeuronId>,
+    pub amount_icp_e8s: Option<u64>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct NeuronsFundSnapshot {
+    pub neurons_fund_neuron_portions: Vec<NeuronsFundNeuronPortion>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct IdealMatchedParticipationFunction {
+    pub serialized_representation: Option<String>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct NeuronsFundParticipation {
+    pub total_maturity_equivalent_icp_e8s: Option<u64>,
+    pub intended_neurons_fund_participation_icp_e8s: Option<u64>,
+    pub direct_participation_icp_e8s: Option<u64>,
+    pub swap_participation_limits: Option<SwapParticipationLimits>,
+    pub max_neurons_fund_swap_participation_icp_e8s: Option<u64>,
+    pub neurons_fund_reserves: Option<NeuronsFundSnapshot>,
+    pub ideal_matched_participation_function: Option<IdealMatchedParticipationFunction>,
+    pub allocated_neurons_fund_participation_icp_e8s: Option<u64>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct NeuronsFundData {
+    pub final_neurons_fund_participation: Option<NeuronsFundParticipation>,
+    pub initial_neurons_fund_participation: Option<NeuronsFundParticipation>,
+    pub neurons_fund_refunds: Option<NeuronsFundSnapshot>,
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
@@ -624,6 +688,7 @@ pub struct ProposalData {
     pub proposal_timestamp_seconds: u64,
     pub reward_event_round: u64,
     pub failed_timestamp_seconds: u64,
+    pub neurons_fund_data: Option<NeuronsFundData>,
     pub reject_cost_e8s: u64,
     pub derived_proposal_information: Option<DerivedProposalInformation>,
     pub latest_tally: Option<Tally>,
@@ -707,6 +772,7 @@ pub struct Governance {
     pub latest_reward_event: Option<RewardEvent>,
     pub to_claim_transfers: Vec<NeuronStakeTransfer>,
     pub short_voting_period_seconds: u64,
+    pub topic_followee_index: Vec<(i32, FollowersMap)>,
     pub migrations: Option<Migrations>,
     pub proposals: Vec<(u64, ProposalData)>,
     pub in_flight_commands: Vec<(u64, NeuronInFlightCommand)>,
@@ -770,7 +836,35 @@ pub enum Result5 {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct GetNeuronsFundAuditInfoRequest {
+    pub nns_proposal_id: Option<NeuronId>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct NeuronsFundAuditInfo {
+    pub final_neurons_fund_participation: Option<NeuronsFundParticipation>,
+    pub initial_neurons_fund_participation: Option<NeuronsFundParticipation>,
+    pub neurons_fund_refunds: Option<NeuronsFundSnapshot>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct Ok {
+    pub neurons_fund_audit_info: Option<NeuronsFundAuditInfo>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
 pub enum Result6 {
+    Ok(Ok),
+    Err(GovernanceError),
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct GetNeuronsFundAuditInfoResponse {
+    pub result: Option<Result6>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub enum Result7 {
     Ok(NodeProvider),
     Err(GovernanceError),
 }
@@ -904,15 +998,58 @@ pub struct Committed {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
-pub enum Result7 {
+pub enum Result8 {
     Committed(Committed),
     Aborted(EmptyRecord),
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SettleCommunityFundParticipation {
-    pub result: Option<Result7>,
+    pub result: Option<Result8>,
     pub open_sns_token_swap_proposal_id: Option<u64>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct Committed1 {
+    pub total_direct_participation_icp_e8s: Option<u64>,
+    pub total_neurons_fund_participation_icp_e8s: Option<u64>,
+    pub sns_governance_canister_id: Option<Principal>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub enum Result9 {
+    Committed(Committed1),
+    Aborted(EmptyRecord),
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct SettleNeuronsFundParticipationRequest {
+    pub result: Option<Result9>,
+    pub nns_proposal_id: Option<u64>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct NeuronsFundNeuron {
+    pub hotkey_principal: Option<String>,
+    pub is_capped: Option<bool>,
+    pub nns_neuron_id: Option<u64>,
+    pub amount_icp_e8s: Option<u64>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct Ok1 {
+    pub neurons_fund_neuron_portions: Vec<NeuronsFundNeuron>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub enum Result10 {
+    Ok(Ok1),
+    Err(GovernanceError),
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct SettleNeuronsFundParticipationResponse {
+    pub result: Option<Result10>,
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
@@ -966,7 +1103,13 @@ impl Service {
     pub async fn get_neuron_info_by_id_or_subaccount(&self, arg0: NeuronIdOrSubaccount) -> CallResult<(Result5,)> {
         ic_cdk::call(self.0, "get_neuron_info_by_id_or_subaccount", (arg0,)).await
     }
-    pub async fn get_node_provider_by_caller(&self, arg0: ()) -> CallResult<(Result6,)> {
+    pub async fn get_neurons_fund_audit_info(
+        &self,
+        arg0: GetNeuronsFundAuditInfoRequest,
+    ) -> CallResult<(GetNeuronsFundAuditInfoResponse,)> {
+        ic_cdk::call(self.0, "get_neurons_fund_audit_info", (arg0,)).await
+    }
+    pub async fn get_node_provider_by_caller(&self, arg0: ()) -> CallResult<(Result7,)> {
         ic_cdk::call(self.0, "get_node_provider_by_caller", (arg0,)).await
     }
     pub async fn get_pending_proposals(&self) -> CallResult<(Vec<ProposalInfo>,)> {
@@ -995,6 +1138,12 @@ impl Service {
         arg0: SettleCommunityFundParticipation,
     ) -> CallResult<(Result_,)> {
         ic_cdk::call(self.0, "settle_community_fund_participation", (arg0,)).await
+    }
+    pub async fn settle_neurons_fund_participation(
+        &self,
+        arg0: SettleNeuronsFundParticipationRequest,
+    ) -> CallResult<(SettleNeuronsFundParticipationResponse,)> {
+        ic_cdk::call(self.0, "settle_neurons_fund_participation", (arg0,)).await
     }
     pub async fn simulate_manage_neuron(&self, arg0: ManageNeuron) -> CallResult<(ManageNeuronResponse,)> {
         ic_cdk::call(self.0, "simulate_manage_neuron", (arg0,)).await

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,3 +1,5 @@
+//! Rust code created from candid by: scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-08_23-01/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
@@ -13,6 +15,13 @@ pub struct EmptyRecord {}
 // #![allow(dead_code, unused_imports)]
 // use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
 // use ic_cdk::api::call::CallResult as Result;
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct AddApiBoundaryNodePayload {
+    pub node_id: Principal,
+    pub domain: String,
+    pub version: String,
+}
 
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum FirewallRulesScope {
@@ -47,6 +56,7 @@ pub struct AddNodePayload {
     pub http_endpoint: String,
     pub idkg_dealing_encryption_pk: Option<serde_bytes::ByteBuf>,
     pub xnet_endpoint: String,
+    pub chip_id: Option<serde_bytes::ByteBuf>,
     pub committee_signing_pk: serde_bytes::ByteBuf,
     pub node_signing_pk: serde_bytes::ByteBuf,
     pub transport_tls_cert: serde_bytes::ByteBuf,
@@ -288,6 +298,11 @@ pub struct RecoverSubnetPayload {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct RemoveApiBoundaryNodesPayload {
+    pub node_ids: Vec<Principal>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct RemoveFirewallRulesPayload {
     pub expected_hash: String,
     pub scope: FirewallRulesScope,
@@ -326,6 +341,18 @@ pub struct SetFirewallConfigPayload {
     pub ipv4_prefixes: Vec<String>,
     pub firewall_config: String,
     pub ipv6_prefixes: Vec<String>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct UpdateApiBoundaryNodeDomainPayload {
+    pub node_id: Principal,
+    pub domain: String,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct UpdateApiBoundaryNodesVersionPayload {
+    pub version: String,
+    pub node_ids: Vec<Principal>,
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
@@ -447,6 +474,9 @@ pub struct UpdateUnassignedNodesConfigPayload {
 
 pub struct Service(pub Principal);
 impl Service {
+    pub async fn add_api_boundary_node(&self, arg0: AddApiBoundaryNodePayload) -> CallResult<()> {
+        ic_cdk::call(self.0, "add_api_boundary_node", (arg0,)).await
+    }
     pub async fn add_firewall_rules(&self, arg0: AddFirewallRulesPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "add_firewall_rules", (arg0,)).await
     }
@@ -498,6 +528,9 @@ impl Service {
     pub async fn recover_subnet(&self, arg0: RecoverSubnetPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "recover_subnet", (arg0,)).await
     }
+    pub async fn remove_api_boundary_nodes(&self, arg0: RemoveApiBoundaryNodesPayload) -> CallResult<()> {
+        ic_cdk::call(self.0, "remove_api_boundary_nodes", (arg0,)).await
+    }
     pub async fn remove_firewall_rules(&self, arg0: RemoveFirewallRulesPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "remove_firewall_rules", (arg0,)).await
     }
@@ -521,6 +554,15 @@ impl Service {
     }
     pub async fn set_firewall_config(&self, arg0: SetFirewallConfigPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "set_firewall_config", (arg0,)).await
+    }
+    pub async fn update_api_boundary_node_domain(&self, arg0: UpdateApiBoundaryNodeDomainPayload) -> CallResult<()> {
+        ic_cdk::call(self.0, "update_api_boundary_node_domain", (arg0,)).await
+    }
+    pub async fn update_api_boundary_nodes_version(
+        &self,
+        arg0: UpdateApiBoundaryNodesVersionPayload,
+    ) -> CallResult<()> {
+        ic_cdk::call(self.0, "update_api_boundary_nodes_version", (arg0,)).await
     }
     pub async fn update_elected_hostos_versions(&self, arg0: UpdateElectedHostosVersionsPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "update_elected_hostos_versions", (arg0,)).await

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,3 +1,5 @@
+//! Rust code created from candid by: scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-08_23-01/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
@@ -75,14 +77,21 @@ pub struct LinearScalingCoefficient {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct IdealMatchedParticipationFunction {
+    pub serialized_representation: Option<String>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronsFundParticipationConstraints {
     pub coefficient_intervals: Vec<LinearScalingCoefficient>,
     pub max_neurons_fund_participation_icp_e8s: Option<u64>,
     pub min_direct_participation_threshold_icp_e8s: Option<u64>,
+    pub ideal_matched_participation_function: Option<IdealMatchedParticipationFunction>,
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct CfNeuron {
+    pub has_created_neuron_recipes: Option<bool>,
     pub nns_neuron_id: u64,
     pub amount_icp_e8s: u64,
 }
@@ -152,6 +161,7 @@ pub struct SnsInitPayload {
     pub max_dissolve_delay_seconds: Option<u64>,
     pub max_dissolve_delay_bonus_percentage: Option<u64>,
     pub nns_proposal_id: Option<u64>,
+    pub neurons_fund_participation: Option<bool>,
     pub min_participant_icp_e8s: Option<u64>,
     pub neuron_basket_construction_parameters: Option<NeuronBasketConstructionParameters>,
     pub fallback_controller_principal_ids: Vec<String>,
@@ -181,9 +191,11 @@ pub struct SnsInitPayload {
     pub token_logo: Option<String>,
     pub token_name: Option<String>,
     pub max_participant_icp_e8s: Option<u64>,
+    pub min_direct_participation_icp_e8s: Option<u64>,
     pub proposal_reject_cost_e8s: Option<u64>,
     pub restricted_countries: Option<Countries>,
     pub min_icp_e8s: Option<u64>,
+    pub max_direct_participation_icp_e8s: Option<u64>,
 }
 
 #[derive(Serialize, CandidType, Deserialize)]


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.

# Changes
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.
  * Note: The candid files under `declarations/nns-$CANISTER` are used as inputs.

# Tests
  - [x] Please check the API updates for any breaking changes that affect our code.
  - [x] Please check for new proposal types and add tests for them.
    - Created an issue: https://dfinity.atlassian.net/browse/GIX-2050
    - Before deployment, there are tests in prod so we should see recent proposals rendered correctly.