### PR TITLE
Better logging for update actions

### DIFF
--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -29,11 +29,16 @@ jobs:
             sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
             DIDC_RELEASE="$latest_didc_release" jq '.defaults.build.config.DIDC_VERSION=(env.DIDC_RELEASE)' dfx.json  | sponge dfx.json
             echo "updated=1" >> "$GITHUB_OUTPUT"
+            echo "version=$latest_didc_release" >> "$GITHUB_OUTPUT"
           else
             echo "updated=0" >> "$GITHUB_OUTPUT"
           fi
 
           jq '.defaults.build.config.DIDC_VERSION' dfx.json
+          echo "Git status:"
+          git status
+          echo "Changes:"
+          git diff
         # If `dfx.json` was updated, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
@@ -49,7 +54,7 @@ jobs:
           branch: bot-didc-update
           branch-suffix: timestamp
           delete-branch: true
-          title: 'Update didc release'
+          title: 'Update didc release to ${{ steps.update.outputs.version }}'
           body: |
             # Motivation
             A newer version of `didc` is available.

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           if test -d snsdemo
           then echo have_snsdemo=true >> "$GITHUB_OUTPUT"
-          else have_snsdemo=false >> "$GITHUB_OUTPUT"
+          else echo have_snsdemo=false >> "$GITHUB_OUTPUT"
           fi
       - name: Determine snsdemo ref
         if: ${{ steps.have_snsdemo.outputs.have_snsdemo }} == 'false'
@@ -72,6 +72,10 @@ jobs:
           snsdemo/bin/dfx-software-didc-install --release "$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
           # Update didc
           scripts/update_ic_commit -c "${{ steps.update.outputs.release }}"
+          # Show changes
+          echo "Git status:"
+          git status
+          echo "Note: The git diff is likely to be long so is not logged.  Please see the PR."
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
         uses: peter-evans/create-pull-request@v4
@@ -88,7 +92,7 @@ jobs:
           branch: bot-ic-update
           branch-suffix: timestamp
           delete-branch: true
-          title: 'Update IC candid files'
+          title: 'Update IC candid files to ${{ steps.update.outputs.release }}'
           body: |
             # Motivation
             A newer release of the internet computer is available.

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -25,12 +25,12 @@ jobs:
       - name: Update to the latest declared APIs
         id: update
         run: |
-                # Derive rust files
-                ./scripts/proposals/did2rs
-                # Show changes
-                echo "Git status:"
-                git status
-                echo "Note: The git diff may be long so is not logged.  Please see the PR."
+          # Derive rust files
+          ./scripts/proposals/did2rs
+          # Show changes
+          echo "Git status:"
+          git status
+          echo "Note: The git diff may be long so is not logged.  Please see the PR."
       - name: Create Pull Request
         id: cpr
         # Note: If there were no changes, this step creates no PR.

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -24,7 +24,13 @@ jobs:
           curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
       - name: Update to the latest declared APIs
         id: update
-        run: ./scripts/proposals/did2rs
+        run: |
+                # Derive rust files
+                ./scripts/proposals/did2rs
+                # Show changes
+                echo "Git status:"
+                git status
+                echo "Note: The git diff may be long so is not logged.  Please see the PR."
       - name: Create Pull Request
         id: cpr
         # Note: If there were no changes, this step creates no PR.
@@ -40,6 +46,8 @@ jobs:
           add-paths: rs/proposals/src/canisters/*/api.rs
           delete-branch: true
           title: 'Update proposal rendering'
+          # Note: It is _likely_ but not guaranteed that the .did files match the IC_COMMIT in dfx.json.  The files in the PR have a header that give this information reliably.
+          #       We do _not_ put a commit in the PR title as it could be misleading.
           body: |
             # Motivation
             We would like to render all the latest proposal types.

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -44,9 +44,15 @@ jobs:
             echo "updated=1" >> "$GITHUB_OUTPUT"
           else
             echo "updated=0" >> "$GITHUB_OUTPUT"
+            echo "version=$latest_rust_version" >> "$GITHUB_OUTPUT"
           fi
 
           cat ./rust-toolchain.toml
+          # Show changes
+          echo "Git status:"
+          git status
+          echo "Git diff:"
+          git diff
         # If the rust-toolchain was updated, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
@@ -62,7 +68,7 @@ jobs:
           branch: bot-rust-update
           branch-suffix: timestamp
           delete-branch: true
-          title: 'Update rust version'
+          title: 'Update rust version to ${{ steps.update.outputs.version }}'
           # Since the this is a scheduled job, a failure won't be shown on any
           # PR status. To notify the team, we send a message to our Slack channel on failure.
       - name: Notify Slack on failure

--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -49,17 +49,17 @@ jobs:
           sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
           # Update
           ./scripts/update-snsdemo --dir ./snsdemo --release "${{ steps.update.outputs.release }}" --verbose
+          # Show changes
+          echo "Git status:"
+          git status
           echo "Changes:"
           git diff
-          git config --global user.email "gix-bot@users.noreply.github.com"
-          git config --global user.name "GIX bot"
-          git commit -a -m "Update snsdemo to ${{ steps.update.outputs.release }}"
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
-          commit-message: Update snsdemo
+          commit-message: Update snsdemo to ${{ steps.update.outputs.release }}
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-snsdemo-update


### PR DESCRIPTION
# Motivation
Update actions have insufficient logging for rapid debugging.

# Changes
- Log the git status, so that the log can be compared with the the PR generated by the action.
- Include the version being updated to in the PR title, where applicable, to make it easier to find.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [x] Add entry to changelog (if necessary).
