### PR TITLE
GIX-1979: Login action visitors

### DIFF
--- a/frontend/src/lib/derived/tokens-list-visitors.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-visitors.derived.ts
@@ -1,0 +1,13 @@
+import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
+import { derived, type Readable } from "svelte/store";
+import { tokensListBaseStore } from "./tokens-list-base.derived";
+
+const addVisitorActions = (data: UserTokenData): UserTokenData => ({
+  ...data,
+  actions: [UserTokenAction.GoToDetail],
+});
+
+export const tokensListVisitorsStore = derived<
+  Readable<UserTokenData[]>,
+  UserTokenData[]
+>(tokensListBaseStore, (tokensData) => tokensData.map(addVisitorActions));

--- a/frontend/src/lib/pages/SignInTokens.svelte
+++ b/frontend/src/lib/pages/SignInTokens.svelte
@@ -18,7 +18,7 @@
       <SignIn slot="actions" />
     </PageBanner>
 
-    <TokensTable {userTokensData} />
+    <TokensTable on:nnsAction {userTokensData} />
   </div>
 </main>
 

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -15,8 +15,9 @@
   import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
   import type { Action } from "$lib/types/actions";
   import { UnavailableTokenAmount } from "$lib/utils/token.utils";
-  import { tokensListBaseStore } from "$lib/derived/tokens-list-base.derived";
   import { loadCkBTCTokens } from "$lib/services/ckbtc-tokens.services";
+  import { tokensListVisitorsStore } from "$lib/derived/tokens-list-visitors.derived";
+  import { login } from "$lib/services/auth.services";
 
   onMount(() => {
     if (!$ENABLE_MY_TOKENS) {
@@ -42,9 +43,11 @@
     },
   ];
 
-  const handleAction = ({ detail }: { detail: Action }) => {
-    console.log("action", detail.type);
-    console.log(detail.data);
+  const handleAction = ({ detail: _ }: { detail: Action }) => {
+    // Any action from non-signed in user should be trigger a login
+    if (!$authSignedInStore) {
+      login();
+    }
   };
 </script>
 
@@ -52,6 +55,9 @@
   {#if $authSignedInStore}
     <Tokens userTokensData={data} on:nnsAction={handleAction} />
   {:else}
-    <SignInTokens userTokensData={$tokensListBaseStore} />
+    <SignInTokens
+      on:nnsAction={handleAction}
+      userTokensData={$tokensListVisitorsStore}
+    />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/tests/lib/derived/tokens-list-visitors.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-visitors.derived.spec.ts
@@ -1,0 +1,72 @@
+import {
+  CKBTC_UNIVERSE_CANISTER_ID,
+  CKTESTBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
+import { tokensListVisitorsStore } from "$lib/derived/tokens-list-visitors.derived";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { UserTokenAction } from "$lib/types/tokens-page";
+import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
+import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { SnsSwapLifecycle } from "@dfinity/sns";
+import { get } from "svelte/store";
+
+describe("tokens-list-base.derived", () => {
+  const snsTetrisToken = mockSnsToken;
+  const snsTetris = {
+    rootCanisterId: rootCanisterIdMock,
+    projectName: "Tetris",
+    lifecycle: SnsSwapLifecycle.Committed,
+    tokenMetadata: snsTetrisToken,
+  };
+  const snsPackmanToken = {
+    ...mockSnsToken,
+    symbol: "PAC",
+  };
+  const snsPacman = {
+    rootCanisterId: principal(1),
+    projectName: "Pacman",
+    lifecycle: SnsSwapLifecycle.Committed,
+    tokenMetadata: snsPackmanToken,
+  };
+  const mockCkTESTBTCToken = {
+    ...mockCkBTCToken,
+    symbol: "ckTESTBTC",
+    name: "ckTESTBTC",
+  };
+
+  describe("tokensListVisitorsStore", () => {
+    beforeEach(() => {
+      resetSnsProjects();
+      tokensStore.reset();
+    });
+
+    it("should return universes with action GoToDetail", () => {
+      setSnsProjects([snsTetris, snsPacman]);
+      tokensStore.setTokens({
+        [CKBTC_UNIVERSE_CANISTER_ID.toText()]: {
+          token: mockCkBTCToken,
+          certified: true,
+        },
+        [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: {
+          token: mockCkTESTBTCToken,
+          certified: true,
+        },
+        [snsTetris.rootCanisterId.toText()]: {
+          token: snsTetrisToken,
+          certified: true,
+        },
+        [snsPacman.rootCanisterId.toText()]: {
+          token: snsPackmanToken,
+          certified: true,
+        },
+      });
+      const universeTokens = get(tokensListVisitorsStore);
+
+      universeTokens.forEach((token) => {
+        expect(token.actions).toEqual([UserTokenAction.GoToDetail]);
+      });
+    });
+  });
+});

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -13,7 +13,7 @@ import { TokensRoutePo } from "$tests/page-objects/TokensRoute.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import type { AuthClient } from "@dfinity/auth-client";
+import { AuthClient } from "@dfinity/auth-client";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -39,6 +39,9 @@ describe("Tokens route", () => {
       overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
       vi.spyOn(ckBTCLedgerApi, "getCkBTCToken").mockResolvedValue(
         mockCkBTCToken
+      );
+      vi.spyOn(AuthClient, "create").mockImplementation(
+        async (): Promise<AuthClient> => mockAuthClient
       );
       const rootCanisterId1 = rootCanisterIdMock;
       const rootCanisterId2 = principal(1);


### PR DESCRIPTION
# Motivation

Tokens table is also interactive for non logged in users.

The requirement was to send them to login.

# Changes

* New derived store for the tokens table: `tokensListVisitorsStore`.
* Listen for the event `nnsAction` in the Tokens route and SignInTokens.
* Trigger a login in any `nnsAction` if the user is not logged in.

# Tests

* Add a test in the tokens route that the user is sent to login when clicking in a row.
* Test new store `tokensListVisitorsStore`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.