### PR TITLE
Render BTC withdrawal address

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -14,6 +14,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+* Render withdrawal address on ckBTC burn transactions.
+
 #### Changed
 
 * New icons for sent/received transactions.

--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -12,7 +12,7 @@
   import {
     getSortedTransactionsFromStore,
     isIcrcTransactionsCompleted,
-    mapIcrcTransaction,
+    mapCkbtcTransaction,
   } from "$lib/utils/icrc-transactions.utils";
   import IcrcTransactionsList from "$lib/components/accounts/IcrcTransactionsList.svelte";
   import type { UniverseCanisterId } from "$lib/types/universe";
@@ -107,6 +107,6 @@
     {completed}
     {descriptions}
     {token}
-    mapTransaction={mapIcrcTransaction}
+    mapTransaction={mapCkbtcTransaction}
   />
 </CkBTCWalletTransactionsObserver>

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -84,12 +84,10 @@
 
     <ColumnRow>
       <div slot="start" class="identifier">
-        {#if nonNullish(description)}
-          <p data-tid="transaction-description"><Html text={description} /></p>
-        {/if}
-
         {#if nonNullish(identifier)}
           <Identifier size="medium" {label} {identifier} />
+        {:else if nonNullish(description)}
+          <p data-tid="transaction-description"><Html text={description} /></p>
         {/if}
       </div>
 

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -40,10 +40,30 @@ describe("TransactionCard", () => {
     expect(await po.getHeadline()).toBe("Received");
   });
 
-  it("renders burn description", async () => {
+  it("renders ckBTC approve description", async () => {
     const po = renderComponent({
       transaction: {
         ...mockTransactionReceiveDataFromMain,
+        type: AccountTransactionType.Approve,
+        from: undefined,
+        to: undefined,
+      },
+      descriptions: en.ckbtc_transaction_names as unknown as Record<
+        string,
+        string
+      >,
+    });
+
+    expect(await po.getHeadline()).toBe("Approve transfer");
+    // Approve transfer transactions don't have a description but we render a
+    // zero-width space to keep the layout consistent.
+    expect(await po.getDescription()).toBe("​");
+  });
+
+  it("renders ckBTC burn To:", async () => {
+    const po = renderComponent({
+      transaction: {
+        ...mockTransactionSendDataFromMain,
         type: AccountTransactionType.Burn,
       },
       descriptions: en.ckbtc_transaction_names as unknown as Record<
@@ -53,7 +73,9 @@ describe("TransactionCard", () => {
     });
 
     expect(await po.getHeadline()).toBe("Sent");
-    expect(await po.getDescription()).toBe("To: BTC Network");
+    expect(await po.getIdentifier()).toBe(
+      `To: ${mockTransactionSendDataFromMain.to}`
+    );
   });
 
   it("renders sent headline", async () => {

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -40,11 +40,11 @@ describe("TransactionCard", () => {
     expect(await po.getHeadline()).toBe("Received");
   });
 
-  it("renders ckBTC approve description", async () => {
+  it("renders burn description", async () => {
     const po = renderComponent({
       transaction: {
-        ...mockTransactionReceiveDataFromMain,
-        type: AccountTransactionType.Approve,
+        ...mockTransactionSendDataFromMain,
+        type: AccountTransactionType.Burn,
         from: undefined,
         to: undefined,
       },
@@ -54,10 +54,9 @@ describe("TransactionCard", () => {
       >,
     });
 
-    expect(await po.getHeadline()).toBe("Approve transfer");
-    // Approve transfer transactions don't have a description but we render a
-    // zero-width space to keep the layout consistent.
-    expect(await po.getDescription()).toBe("​");
+    expect(await po.getHeadline()).toBe("Sent");
+    expect(await po.getDescription()).toBe("To: BTC Network");
+    expect(await po.getIdentifier()).toBe(null);
   });
 
   it("renders ckBTC burn To:", async () => {
@@ -76,6 +75,7 @@ describe("TransactionCard", () => {
     expect(await po.getIdentifier()).toBe(
       `To: ${mockTransactionSendDataFromMain.to}`
     );
+    expect(await po.getDescription()).toBe(null);
   });
 
   it("renders sent headline", async () => {


### PR DESCRIPTION
# Motivation

For ckBTC -> BTC withdrawals we want to list the withdrawal address in the "To:" of the transactions.
The withdrawals address in encoded in the memo of the ckBTC burn transaction.
We already have a custom `mapCkbtcTransaction` function which can be used instead of `mapIcrcTransaction` to map the transaction such that if it is a burn transaction with a memo, the decoded address will be set in the "To:".

In `TransactionCard.svelte` we render either To/Source for a Transfer or a custom description for either transaction types. We never render both, but technically `TransactionCard` currently supports rendering both, even though it doesn't look right in the UI.

# Changes

1. Pass `mapCkbtcTransaction` instead of `mapIcrcTransaction` to `IcrcTransactionsList` from `fCkBTCTransactionsList.svelte` to take care of decoding the withdrawal address.
2. In `TransactionCard.svelte`, only render a description if no "To:/Source:" identifier is present.

# Tests

1. Test that ckBTC burn transactions without memo render as before.
2. Test that ckBTC burn transactions with correctly encoded memo render the encoded withdrawal address.
3. Test that a generic burn transaction without to/from is rendered with the given description.
4. Test that a generic burn transaction with a `to` gets rendered with the "To:"

Manually at: https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [x] Add entry to changelog (if necessary).
