### PR TITLE
Fix_debug-store

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,6 +26,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Add missing "Rename" button in the subaccount page.
 * Fix disappearing "Received" half of to-self transactions.
+* Fix debug store that wasn't working.
 
 #### Security
 

--- a/frontend/src/lib/derived/debug.derived.ts
+++ b/frontend/src/lib/derived/debug.derived.ts
@@ -32,7 +32,10 @@ import { derived, readable, writable, type Readable } from "svelte/store";
 const createDerivedStore = <T>(store: Readable<T>): Readable<T> =>
   derived(store, (store) => store);
 
-let addAccountStore: Readable<AddAccountStore>;
+let addAccountStore: Readable<AddAccountStore> = readable({
+  type: undefined,
+  hardwareWalletName: undefined,
+});
 export const debugAddAccountStore = (store: Readable<AddAccountStore>) =>
   (addAccountStore = createDerivedStore(store));
 


### PR DESCRIPTION
# Motivation

There is a bug with the debug store and the command "fo" isn't working.

The issue is that a specific store was `undefined` by default.

# Changes

* Add a default store for `addAccountStore` in debug.derived.

# Tests

Not tested.

# Todos

- [ ] Add entry to changelog (if necessary).