### PR TITLE
Bump ic-js next

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -249,9 +249,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "1.0.1-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-11-09.1.tgz",
-      "integrity": "sha512-srC2Lc6ShwsDFfHfFCuUPrRacbCGDUDNJCVi5u0IHSPeMGodgWw1G1d+j3YgDtCPwPi1NNtGdt/oW+RljktHBg==",
+      "version": "1.1.0-next-2023-11-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.1.0-next-2023-11-15.tgz",
+      "integrity": "sha512-nrRjXdNw1cu7fDcfeSbD7ftHJ0AMNXwhzRilc0RV4qo2nCvjd9VAw1wJzhaxzdSguAP5Iftr0t6ZRRRvDfO6Dw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -265,9 +265,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "1.0.0-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-11-09.1.tgz",
-      "integrity": "sha512-q3rKzqrB+9CdvwNHfRaWbGbPk6du0k9++lptqSmNgoqbLfehlRWy5PyWOoGNed3MIxIpy/6EZ/mu18sc1/8YIw==",
+      "version": "1.0.0-next-2023-11-15.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-11-15.1.tgz",
+      "integrity": "sha512-JdSnQ/anJyZi8lpvEPqBm5E+vRFse7xHEaXF59nC3upt93AEShHv3XUwfulkhOKq0jG1hpNwXYTY7NDtAdyChg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -290,9 +290,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "1.0.0-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-11-09.1.tgz",
-      "integrity": "sha512-I7JayxvB/7WEXLVTxh/0iAdMjk8yJbgOb8+B4nVmlGko/8RVTKySWdhUSEaWUQaoFbjUS7yr6Jd88Iycy2O+eQ==",
+      "version": "1.0.0-next-2023-11-15.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-11-15.1.tgz",
+      "integrity": "sha512-sjOOjFc146PvY6oZQ4kQdD3mv2SllswHflkCRQU9LgmsLDpB3mLgXa07VOsOvUFI8aUsNNdWcCjGuNvbrQas5Q==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -316,9 +316,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "1.0.0-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-11-09.1.tgz",
-      "integrity": "sha512-MV4OGhxQ8xs6SWFzNzm1qaD/xO9QSku3LmOCsOv/2jXsy48JRj3YT6c37hgLbV4xaEiQAUB8Sc7tJD29F5mkvg==",
+      "version": "1.1.0-next-2023-11-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.1.0-next-2023-11-15.tgz",
+      "integrity": "sha512-rVayDzYFlqt2eppqIpqK4EjDLFy/jiVjBAti4q96JmOzd6k8j58P/CQ/CLOzPASFekA3mklewEOZYVqv9QfBuQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -328,9 +328,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "1.0.0-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-11-09.1.tgz",
-      "integrity": "sha512-K+PXfWxQIRM2dLMljcWgWYTRQa1Ce/D3LyAmLN0itph06bIUDHE+MhrRic+Wi4BRiuizm44yVLgqtgVAN5GkTw==",
+      "version": "1.0.1-next-2023-11-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.1-next-2023-11-15.tgz",
+      "integrity": "sha512-Wq5nKp20NicNFS8kl4Dpe9o+r01JClCino+1yrE+E+hrqsSNdoU1zCNL23GfZT9SjWiTrcbZchmpgnseQMqO4g==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -339,9 +339,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "2.0.0-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-11-09.1.tgz",
-      "integrity": "sha512-bAJ7UZITElzzma6ONrOfZ3VXxvCQAJU09g4ekEEWxjhsIdv2HXMFcpi/MQSQAy/6i6b4rfSuAyOfJhURO9hnVQ==",
+      "version": "2.1.0-next-2023-11-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.1.0-next-2023-11-15.tgz",
+      "integrity": "sha512-dE2BBHyz8J28+h//dMmr9hu3+8HGNFyYk4YxMHWWg429ZNUENXRhbwOanhLXby3shDjYYUPqIoAeggrFHk20Pw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -356,9 +356,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.0-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-11-09.1.tgz",
-      "integrity": "sha512-VP3NuwSuKC6/jN2vfbTbQvJMOAdReSCCdREYgnIsEagG5QWSaosdr+ievpuSkLP0Rw7EKI2VUhPYrzIQBilIRQ==",
+      "version": "1.0.0-next-2023-11-15.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-11-15.1.tgz",
+      "integrity": "sha512-OKeoYsF5yGhdhlnTcZrCiZqCSGqX8R5X8Mylkqk9Rgcc5FsEe8aR1vOEU4tfJ7gPUfcUyW7osJzgs6DwVYu4UA==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -372,9 +372,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "1.0.1-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-11-09.1.tgz",
-      "integrity": "sha512-N4W9fFUCFunAk297lDQb4JfAQSFwMHUxbyMFGGLF3x7qYFA60RIT4oHd0/KdfoiuHCnBxhEloAjC8+fQRwxVRQ==",
+      "version": "1.0.2-next-2023-11-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.2-next-2023-11-15.tgz",
+      "integrity": "sha512-h8ylVGyGf1FbIPoKDai8r/BdHeym5RpLP49MLshxXkqn90z82Q1xq6qb6nFRWHYKTHZ7Ri9ofan899LWIjIWdA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -387,9 +387,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "1.0.0-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-11-09.1.tgz",
-      "integrity": "sha512-4s6lnrQKvLqZiimHauGtwTGA6hKuXFhjFxEzu667cBBtsVv9R3ctPtEn9hNXlylEpnYJckwU2+BCaWzyH3NnzQ==",
+      "version": "1.1.0-next-2023-11-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.1.0-next-2023-11-15.tgz",
+      "integrity": "sha512-XMTg+HQYOeZZpQp5CJ1lu1qDCXbEXVJXxnF2T6pvjlQHi9Ck2N1p6pHQW9/mLzIhTF9r567tjQV04JO6I+DfhQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7037,9 +7037,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "1.0.1-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.0.1-next-2023-11-09.1.tgz",
-      "integrity": "sha512-srC2Lc6ShwsDFfHfFCuUPrRacbCGDUDNJCVi5u0IHSPeMGodgWw1G1d+j3YgDtCPwPi1NNtGdt/oW+RljktHBg==",
+      "version": "1.1.0-next-2023-11-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-1.1.0-next-2023-11-15.tgz",
+      "integrity": "sha512-nrRjXdNw1cu7fDcfeSbD7ftHJ0AMNXwhzRilc0RV4qo2nCvjd9VAw1wJzhaxzdSguAP5Iftr0t6ZRRRvDfO6Dw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7047,9 +7047,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "1.0.0-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-11-09.1.tgz",
-      "integrity": "sha512-q3rKzqrB+9CdvwNHfRaWbGbPk6du0k9++lptqSmNgoqbLfehlRWy5PyWOoGNed3MIxIpy/6EZ/mu18sc1/8YIw==",
+      "version": "1.0.0-next-2023-11-15.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-1.0.0-next-2023-11-15.1.tgz",
+      "integrity": "sha512-JdSnQ/anJyZi8lpvEPqBm5E+vRFse7xHEaXF59nC3upt93AEShHv3XUwfulkhOKq0jG1hpNwXYTY7NDtAdyChg==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7063,9 +7063,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "1.0.0-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-11-09.1.tgz",
-      "integrity": "sha512-I7JayxvB/7WEXLVTxh/0iAdMjk8yJbgOb8+B4nVmlGko/8RVTKySWdhUSEaWUQaoFbjUS7yr6Jd88Iycy2O+eQ==",
+      "version": "1.0.0-next-2023-11-15.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-1.0.0-next-2023-11-15.1.tgz",
+      "integrity": "sha512-sjOOjFc146PvY6oZQ4kQdD3mv2SllswHflkCRQU9LgmsLDpB3mLgXa07VOsOvUFI8aUsNNdWcCjGuNvbrQas5Q==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7079,30 +7079,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "1.0.0-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.0.0-next-2023-11-09.1.tgz",
-      "integrity": "sha512-MV4OGhxQ8xs6SWFzNzm1qaD/xO9QSku3LmOCsOv/2jXsy48JRj3YT6c37hgLbV4xaEiQAUB8Sc7tJD29F5mkvg==",
+      "version": "1.1.0-next-2023-11-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-1.1.0-next-2023-11-15.tgz",
+      "integrity": "sha512-rVayDzYFlqt2eppqIpqK4EjDLFy/jiVjBAti4q96JmOzd6k8j58P/CQ/CLOzPASFekA3mklewEOZYVqv9QfBuQ==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "1.0.0-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.0-next-2023-11-09.1.tgz",
-      "integrity": "sha512-K+PXfWxQIRM2dLMljcWgWYTRQa1Ce/D3LyAmLN0itph06bIUDHE+MhrRic+Wi4BRiuizm44yVLgqtgVAN5GkTw==",
+      "version": "1.0.1-next-2023-11-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-1.0.1-next-2023-11-15.tgz",
+      "integrity": "sha512-Wq5nKp20NicNFS8kl4Dpe9o+r01JClCino+1yrE+E+hrqsSNdoU1zCNL23GfZT9SjWiTrcbZchmpgnseQMqO4g==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "2.0.0-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.0.0-next-2023-11-09.1.tgz",
-      "integrity": "sha512-bAJ7UZITElzzma6ONrOfZ3VXxvCQAJU09g4ekEEWxjhsIdv2HXMFcpi/MQSQAy/6i6b4rfSuAyOfJhURO9hnVQ==",
+      "version": "2.1.0-next-2023-11-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-2.1.0-next-2023-11-15.tgz",
+      "integrity": "sha512-dE2BBHyz8J28+h//dMmr9hu3+8HGNFyYk4YxMHWWg429ZNUENXRhbwOanhLXby3shDjYYUPqIoAeggrFHk20Pw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.0-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-11-09.1.tgz",
-      "integrity": "sha512-VP3NuwSuKC6/jN2vfbTbQvJMOAdReSCCdREYgnIsEagG5QWSaosdr+ievpuSkLP0Rw7EKI2VUhPYrzIQBilIRQ==",
+      "version": "1.0.0-next-2023-11-15.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-11-15.1.tgz",
+      "integrity": "sha512-OKeoYsF5yGhdhlnTcZrCiZqCSGqX8R5X8Mylkqk9Rgcc5FsEe8aR1vOEU4tfJ7gPUfcUyW7osJzgs6DwVYu4UA==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7116,17 +7116,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "1.0.1-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.1-next-2023-11-09.1.tgz",
-      "integrity": "sha512-N4W9fFUCFunAk297lDQb4JfAQSFwMHUxbyMFGGLF3x7qYFA60RIT4oHd0/KdfoiuHCnBxhEloAjC8+fQRwxVRQ==",
+      "version": "1.0.2-next-2023-11-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-1.0.2-next-2023-11-15.tgz",
+      "integrity": "sha512-h8ylVGyGf1FbIPoKDai8r/BdHeym5RpLP49MLshxXkqn90z82Q1xq6qb6nFRWHYKTHZ7Ri9ofan899LWIjIWdA==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "1.0.0-next-2023-11-09.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.0.0-next-2023-11-09.1.tgz",
-      "integrity": "sha512-4s6lnrQKvLqZiimHauGtwTGA6hKuXFhjFxEzu667cBBtsVv9R3ctPtEn9hNXlylEpnYJckwU2+BCaWzyH3NnzQ==",
+      "version": "1.1.0-next-2023-11-15",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.1.0-next-2023-11-15.tgz",
+      "integrity": "sha512-XMTg+HQYOeZZpQp5CJ1lu1qDCXbEXVJXxnF2T6pvjlQHi9Ck2N1p6pHQW9/mLzIhTF9r567tjQV04JO6I+DfhQ==",
       "requires": {}
     },
     "@esbuild/android-arm": {


### PR DESCRIPTION
# Motivation

A new version of ic-js has been released ([Release 2023.10.15-0600Z](https://github.com/dfinity/ic-js/releases/tag/2023.10.15-0600Z)) following which I triggered a next version to integrate the new version number. This PR bump the libs to those next versions.

