### PR TITLE
GIX-1981_LM_new-derived-store-user-tokens

### DIFF
--- a/frontend/src/lib/derived/tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-user.derived.ts
@@ -1,0 +1,61 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import {
+  tokensStore,
+  type TokensStore,
+  type TokensStoreData,
+} from "$lib/stores/tokens.store";
+import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
+import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+import { isNullish, TokenAmount } from "@dfinity/utils";
+import { derived, type Readable } from "svelte/store";
+import { tokensListBaseStore } from "./tokens-list-base.derived";
+import {
+  universesAccountsBalance,
+  type UniversesAccountsBalanceReadableStore,
+} from "./universes-accounts-balance.derived";
+
+const addBalance =
+  ({
+    balances,
+    tokens,
+  }: {
+    balances: UniversesAccountsBalanceReadableStore;
+    tokens: TokensStoreData;
+  }) =>
+  (userTokenData: UserTokenData): UserTokenData => {
+    const balanceE8s = balances[userTokenData.universeId.toText()]?.balanceE8s;
+    const token = tokens[userTokenData.universeId.toText()]?.token;
+    if (isNullish(token) || isNullish(balanceE8s)) {
+      return userTokenData;
+    }
+    const balance = TokenAmount.fromE8s({ amount: balanceE8s, token });
+    return {
+      ...userTokenData,
+      balance,
+    };
+  };
+
+const addActions = (userTokenData: UserTokenData): UserTokenData => ({
+  ...userTokenData,
+  actions:
+    userTokenData.balance instanceof UnavailableTokenAmount
+      ? []
+      : [
+          ...(userTokenData.universeId.toText() === OWN_CANISTER_ID_TEXT
+            ? [UserTokenAction.GoToDetail]
+            : [UserTokenAction.Receive, UserTokenAction.Send]),
+        ],
+});
+
+export const tokensListUserStore = derived<
+  [
+    Readable<UserTokenData[]>,
+    Readable<UniversesAccountsBalanceReadableStore>,
+    TokensStore,
+  ],
+  UserTokenData[]
+>(
+  [tokensListBaseStore, universesAccountsBalance, tokensStore],
+  ([tokensList, balances, tokens]) =>
+    tokensList.map(addBalance({ balances, tokens })).map(addActions)
+);

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -1,0 +1,209 @@
+import CKBTC_LOGO from "$lib/assets/ckBTC.svg";
+import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
+import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
+import { tokensListUserStore } from "$lib/derived/tokens-list-user.derived";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
+import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
+import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+import {
+  mockCkBTCMainAccount,
+  mockCkBTCToken,
+} from "$tests/mocks/ckbtc-accounts.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
+import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
+import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { SnsSwapLifecycle } from "@dfinity/sns";
+import { TokenAmount } from "@dfinity/utils";
+import { get } from "svelte/store";
+
+describe("tokens-list-user.derived", () => {
+  const icpTokenBase: UserTokenData = {
+    universeId: OWN_CANISTER_ID,
+    title: "Internet Computer",
+    logo: IC_LOGO_ROUNDED,
+    balance: new UnavailableTokenAmount(NNS_TOKEN_DATA),
+    actions: [],
+  };
+  const icpUserToken: UserTokenData = {
+    ...icpTokenBase,
+    balance: TokenAmount.fromE8s({
+      amount: mockMainAccount.balanceE8s,
+      token: NNS_TOKEN_DATA,
+    }),
+    actions: [UserTokenAction.GoToDetail],
+  };
+  const snsTetrisToken = mockSnsToken;
+  const snsTetris = {
+    rootCanisterId: rootCanisterIdMock,
+    projectName: "Tetris",
+    lifecycle: SnsSwapLifecycle.Committed,
+    tokenMetadata: snsTetrisToken,
+  };
+  const snsPackmanToken = {
+    ...mockSnsToken,
+    symbol: "PAC",
+  };
+  const snsPacman = {
+    rootCanisterId: principal(1),
+    projectName: "Pacman",
+    lifecycle: SnsSwapLifecycle.Committed,
+    tokenMetadata: snsPackmanToken,
+  };
+  const tetrisTokenBase: UserTokenData = {
+    universeId: snsTetris.rootCanisterId,
+    title: snsTetris.projectName,
+    logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/g3pce-2iaae/logo.png",
+    balance: new UnavailableTokenAmount(snsTetris.tokenMetadata),
+    actions: [],
+  };
+  const tetrisUserToken: UserTokenData = {
+    ...tetrisTokenBase,
+    balance: TokenAmount.fromE8s({
+      amount: mockSnsMainAccount.balanceE8s,
+      token: snsTetrisToken,
+    }),
+    actions: [UserTokenAction.Receive, UserTokenAction.Send],
+  };
+  const pacmanTokenBase: UserTokenData = {
+    universeId: snsPacman.rootCanisterId,
+    title: snsPacman.projectName,
+    logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/f7crg-kabae/logo.png",
+    balance: new UnavailableTokenAmount(snsPacman.tokenMetadata),
+    actions: [],
+  };
+  const pacmanUserToken: UserTokenData = {
+    ...pacmanTokenBase,
+    balance: TokenAmount.fromE8s({
+      amount: mockSnsMainAccount.balanceE8s,
+      token: snsPackmanToken,
+    }),
+    actions: [UserTokenAction.Receive, UserTokenAction.Send],
+  };
+  const ckBTCTokenBase: UserTokenData = {
+    universeId: CKBTC_UNIVERSE_CANISTER_ID,
+    title: "ckBTC",
+    logo: CKBTC_LOGO,
+    balance: new UnavailableTokenAmount(mockCkBTCToken),
+    actions: [],
+  };
+  const ckBTCUserToken: UserTokenData = {
+    ...ckBTCTokenBase,
+    balance: TokenAmount.fromE8s({
+      amount: mockCkBTCMainAccount.balanceE8s,
+      token: mockCkBTCToken,
+    }),
+    actions: [UserTokenAction.Receive, UserTokenAction.Send],
+  };
+
+  describe("tokensListBaseStore", () => {
+    beforeEach(() => {
+      icpAccountsStore.resetForTesting();
+      icrcAccountsStore.reset();
+      snsAccountsStore.reset();
+      tokensStore.reset();
+
+      setSnsProjects([snsTetris, snsPacman]);
+      tokensStore.setTokens({
+        [CKBTC_UNIVERSE_CANISTER_ID.toText()]: {
+          token: mockCkBTCToken,
+          certified: true,
+        },
+        [snsTetris.rootCanisterId.toText()]: {
+          token: snsTetrisToken,
+          certified: true,
+        },
+        [snsPacman.rootCanisterId.toText()]: {
+          token: snsPackmanToken,
+          certified: true,
+        },
+      });
+    });
+
+    it("should return UnavailableBalance and no actions if no balance", () => {
+      expect(get(tokensListUserStore)).toEqual([
+        icpTokenBase,
+        ckBTCTokenBase,
+        tetrisTokenBase,
+        pacmanTokenBase,
+      ]);
+    });
+
+    it("should return balance and goToDetail action if ICP balance is present", () => {
+      icpAccountsStore.setForTesting({
+        main: mockMainAccount,
+      });
+      expect(get(tokensListUserStore)).toEqual([
+        icpUserToken,
+        ckBTCTokenBase,
+        tetrisTokenBase,
+        pacmanTokenBase,
+      ]);
+    });
+
+    it("should return balance and Send and Receive actions if ckBTC balance is present", () => {
+      icrcAccountsStore.set({
+        accounts: {
+          accounts: [mockCkBTCMainAccount],
+          certified: true,
+        },
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+      });
+      expect(get(tokensListUserStore)).toEqual([
+        icpTokenBase,
+        ckBTCUserToken,
+        tetrisTokenBase,
+        pacmanTokenBase,
+      ]);
+    });
+
+    it("should return balance and Send and Receive actions if SNS project balance is present", () => {
+      snsAccountsStore.setAccounts({
+        accounts: [mockSnsMainAccount],
+        certified: true,
+        rootCanisterId: snsTetris.rootCanisterId,
+      });
+      expect(get(tokensListUserStore)).toEqual([
+        icpTokenBase,
+        ckBTCTokenBase,
+        tetrisUserToken,
+        pacmanTokenBase,
+      ]);
+    });
+
+    it("should return all balances and actoins if all balances are present", () => {
+      icpAccountsStore.setForTesting({
+        main: mockMainAccount,
+      });
+      icrcAccountsStore.set({
+        accounts: {
+          accounts: [mockCkBTCMainAccount],
+          certified: true,
+        },
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+      });
+      snsAccountsStore.setAccounts({
+        accounts: [mockSnsMainAccount],
+        certified: true,
+        rootCanisterId: snsTetris.rootCanisterId,
+      });
+      snsAccountsStore.setAccounts({
+        accounts: [mockSnsMainAccount],
+        certified: true,
+        rootCanisterId: snsPacman.rootCanisterId,
+      });
+      expect(get(tokensListUserStore)).toEqual([
+        icpUserToken,
+        ckBTCUserToken,
+        tetrisUserToken,
+        pacmanUserToken,
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

We want to render the tokens page with the logged in user data.

In this PR, I add a new derived store with the user balances.

# Changes

* New derived store `tokensListUserStore`.

# Tests

* Test new derived store `tokensListUserStore`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.