### PR TITLE
Change Source: to From:

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -484,7 +484,7 @@
     "title": "Account",
     "address": "Address",
     "principal": "Principal",
-    "direction_from": "Source:",
+    "direction_from": "From:",
     "direction_to": "To:",
     "no_transactions": "No transactions",
     "icp_qrcode_aria_label": "A QR code that renders the address to receive ICP",

--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -72,8 +72,6 @@ test("Test accounts requirements", async ({ page, context }) => {
   expect(transactions).toHaveLength(1);
   const transaction = transactions[0];
 
-  expect(await transaction.getIdentifier()).toBe(
-    `Source: ${mainAccountAddress}`
-  );
+  expect(await transaction.getIdentifier()).toBe(`From: ${mainAccountAddress}`);
   expect(await transaction.getAmount()).toBe("+5.00");
 });

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
@@ -167,7 +167,7 @@ describe("IcrcTransactionCard", () => {
     });
     const identifier = await po.getIdentifier();
 
-    expect(identifier).toBe(`Source: ${mockSnsMainAccount.identifier}`);
+    expect(identifier).toBe(`From: ${mockSnsMainAccount.identifier}`);
   });
 
   it("displays identifier for sent for main sns account", async () => {

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionsList.spec.ts
@@ -114,6 +114,6 @@ describe("IcrcTransactionList", () => {
 
     const cards = await po.getTransactionCardPos();
     expect(cards).toHaveLength(1);
-    expect(await cards[0].getIdentifier()).toBe(`Source: ${customIdentifier}`);
+    expect(await cards[0].getIdentifier()).toBe(`From: ${customIdentifier}`);
   });
 });

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -124,7 +124,7 @@ describe("TransactionCard", () => {
     });
 
     expect(await po.getIdentifier()).toBe(
-      `Source: ${mockTransactionReceiveDataFromMain.from}`
+      `From: ${mockTransactionReceiveDataFromMain.from}`
     );
   });
 


### PR DESCRIPTION
# Motivation

The opposite of "To" is "From".
The opposite of "Source" is "Destination".
Currently we write "To: address" for Sent transaction but "Source: address" to Received transactions.
But we also write "From: BTC Network" rather than "Source: BTC Network" for ckBTC mint transactions.
And new UI mocks (here) use "From:" everywhere.

# Changes

Change "Source:" to "From:" for consistency.

# Tests

Existing tests are updated.

# Todos

- [x] Add entry to changelog (if necessary).
