### PR TITLE
Fix: Adapt tokens table border radius

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -32,6 +32,10 @@
     display: flex;
     flex-direction: column;
 
+    border-radius: var(--border-radius);
+    // Otherwise the non-rounded corners of the header and last row would be visible.
+    overflow: hidden;
+
     @include media.min-width(medium) {
       display: grid;
       grid-template-columns: 1fr max-content max-content;


### PR DESCRIPTION
# Motivation

Tokens table design has a rounded border radius.

# Changes

* Add rounded border radius to TokensTable.

# Tests

Only UI changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.