### PR TITLE
Set block height 0 on mock BTC UTXO

### DIFF
--- a/frontend/src/lib/api/dev.api.ts
+++ b/frontend/src/lib/api/dev.api.ts
@@ -325,10 +325,16 @@ export const receiveMockBtc = async ({
   }
   await actor.push_utxo_to_address({
     utxo: {
-      // The height defines the number of confirmations. > 12 should mean the
-      // amount can be credited although the current mock bitcoin canister does
-      // not even seem to check this.
-      height: 15,
+      // We need >= 12 confirmations to get the ckBTC credited by the minter.
+      // We have 1 confirmation as soon as the UTXO is included in a block.
+      // Each block mined after that first block, in the same chain, counts as
+      // an additional confirmation.
+      // So the smaller the height of the block with the utxo, the more
+      // confirmations it has (given a fixed height of the latest block).
+      // The mock bitcoin canister starts out assuming that the latest block is
+      // at height 12. So giving our UTXO height 0 will make sure that it has
+      // the required 12 confirmations.
+      height: 0,
       value: amountE8s,
       outpoint: {
         txid,


### PR DESCRIPTION
# Motivation

When requesting UTXOs from the Bitcoin canister ([bitcoin_get_utxos](https://github.com/dfinity/bitcoin-canister/blob/dad22c128e0c9a0d8d9b03c7f3d87ba2f4fbd207/canister/candid.did#L99C3-L99C20)), you can specify a minimum number of confirmations that the returned UTXOs should have.
The mock bitcoin canister ignores this but this is about to change in [this MR](https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/16099/diffs#ed6c0c0d68949b83bb908ba47bda66d9dd732861).
And the assumption based on which we currently set a height of 15 is incorrect but this didn't matter before.
Now we need to set a lower block height on our mock UTXOs to keep the "Get BTC" button working.

# Changes

Set 0 block height on mock UTXOs.

# Tests

I built and installed a new mock bitcoin canister from the GitLab branch and tested manually.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary