### PR TITLE
fix: stuck loading of the sns proposal

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,6 +30,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Add missing "Rename" button in the subaccount page.
 * Fix disappearing "Received" half of to-self transactions.
 * Fix debug store that wasn't working.
+* Fix the stuck loading issue with the Sns proposal.
 
 #### Security
 

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -41,6 +41,7 @@
   import type { Readable } from "svelte/store";
   import type { SnsNervousSystemFunction } from "@dfinity/sns";
   import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
+  import { tick } from "svelte";
 
   export let proposalIdText: string | undefined | null = undefined;
 
@@ -60,7 +61,11 @@
   let proposal: SnsProposalData | undefined;
   let updating = false;
 
-  const setProposal = (value: typeof proposal) => {
+  const setProposal = async (value: typeof proposal) => {
+    // TODO: recheck if this workaround is still needed after next svelte update
+    // workaround to fix not triggering the subscriptions ($:...) after "proposal" changes.
+    // Because the update is ignored if the value is changed before onMount.
+    await tick();
     proposal = value;
     debugSnsProposalStore(value);
   };


### PR DESCRIPTION
# Motivation

Fix sns proposal initial update. For undiscovered reason data changes in `SnsProposalDetail` don't trigger auto-subsribers (maybe the lazy loading of the component on slow internet provokes this behaviour)

# Changes

- wait for component finished current updates before applying new data changes.

# Tests

Manually tested with network throttling.

# Todos

- [x] Add entry to changelog (if necessary).
