### PR TITLE
Refactor: Use Universe title and logo fields

### DIFF
--- a/frontend/src/lib/derived/tokens-list-base.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-base.derived.ts
@@ -6,7 +6,6 @@ import {
 import type { UserTokenData } from "$lib/types/tokens-page";
 import type { Universe } from "$lib/types/universe";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
-import { getUniverseLogo, getUniverseTitle } from "$lib/utils/universe.utils";
 import { Principal } from "@dfinity/principal";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
@@ -15,19 +14,16 @@ import { universesStore } from "./universes.derived";
 const convertUniverseToBaseTokenData =
   (tokensData: TokensStoreData) =>
   (universe: Universe): UserTokenData | undefined => {
-    const universeId = Principal.fromText(universe.canisterId);
-    const title = getUniverseTitle(universe);
     const token = tokensData[universe.canisterId]?.token;
-    const logo = getUniverseLogo(universe);
 
-    if (isNullish(token) || isNullish(title) || isNullish(logo)) {
+    if (isNullish(token)) {
       return undefined;
     }
     return {
-      universeId,
-      title,
+      universeId: Principal.fromText(universe.canisterId),
+      title: universe.title,
       balance: new UnavailableTokenAmount(token),
-      logo,
+      logo: universe.logo,
       actions: [],
     };
   };

--- a/frontend/src/lib/utils/universe.utils.ts
+++ b/frontend/src/lib/utils/universe.utils.ts
@@ -1,6 +1,3 @@
-import CKBTC_LOGO from "$lib/assets/ckBTC.svg";
-import CKTESTBTC_LOGO from "$lib/assets/ckTESTBTC.svg";
-import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import {
   CKBTC_UNIVERSE_CANISTER_ID,
@@ -12,7 +9,7 @@ import { i18n } from "$lib/stores/i18n";
 import type { SnsSummary } from "$lib/types/sns";
 import type { Universe } from "$lib/types/universe";
 import { isSelectedPath } from "$lib/utils/navigation.utils";
-import { Principal } from "@dfinity/principal";
+import type { Principal } from "@dfinity/principal";
 import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
@@ -57,29 +54,6 @@ export const universeLogoAlt = ({ summary, canisterId }: Universe): string => {
   }
 
   return i18nObj.auth.ic_logo;
-};
-
-export const getUniverseTitle = (universe: Universe): string | undefined => {
-  const i18nKeys = get(i18n);
-  const universeId = Principal.fromText(universe.canisterId);
-  return isUniverseNns(universeId)
-    ? i18nKeys.core.ic
-    : isUniverseCkTESTBTC(universeId)
-    ? i18nKeys.ckbtc.test_title
-    : isUniverseRealCkBTC(universeId)
-    ? i18nKeys.ckbtc.title
-    : universe.summary?.metadata.name;
-};
-
-export const getUniverseLogo = (universe: Universe): string | undefined => {
-  const universeId = Principal.fromText(universe.canisterId);
-  return isUniverseNns(universeId)
-    ? IC_LOGO_ROUNDED
-    : isUniverseCkTESTBTC(universeId)
-    ? CKTESTBTC_LOGO
-    : isUniverseRealCkBTC(universeId)
-    ? CKBTC_LOGO
-    : universe.summary?.metadata.logo;
 };
 
 export const createUniverse = (summary: SnsSummary): Universe => ({


### PR DESCRIPTION
# Motivation

Simplify universes code.

In this PR, use the fields `title` and `logo` of the Universe instead of using a helper.

# Changes

* In `convertUniverseToBaseTokenData` use the universe `logo` and `title`.
* Remove unused helpers `getUniverseTitle` and `getUniverseLogo`.

# Tests

Tests still passing. Helpers didn't have tests of their own.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.