### PR TITLE
GIX-2005_LM_fix-tablet-horizontal-spacing

### DIFF
--- a/frontend/src/lib/components/tokens/MainWrapper.svelte
+++ b/frontend/src/lib/components/tokens/MainWrapper.svelte
@@ -11,7 +11,6 @@
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";
 
-  // TODO: Confirm spacings https://dfinity.atlassian.net/browse/GIX-2005
   main {
     display: flex;
     align-items: stretch;
@@ -23,7 +22,7 @@
       var(--padding-2x);
 
     @include media.min-width(large) {
-      padding: var(--padding-4x) 0 0 0;
+      padding-top: var(--padding-4x);
     }
 
     & .content {

--- a/frontend/src/lib/components/tokens/MainWrapper.svelte
+++ b/frontend/src/lib/components/tokens/MainWrapper.svelte
@@ -22,7 +22,7 @@
       var(--padding-2x);
 
     @include media.min-width(large) {
-      padding-top: var(--padding-4x);
+      padding: var(--padding-4x) 0 0 0;
     }
 
     & .content {
@@ -34,6 +34,7 @@
 
       @include media.min-width(large) {
         width: var(--island-width);
+        max-width: var(--island-max-width);
       }
     }
   }


### PR DESCRIPTION
# Motivation

Width on tablet was too wide.

Instead, use the logic of the `Island` to set the max-width. This has been agreed with design, although it's open to change.

# Changes

* Add a max-width on the token page `MainWrapper`.

# Tests

Only UI changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary