### PR TITLE
Fix deploy to app

### DIFF
--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -90,6 +90,16 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           network: ${{ env.DFX_NETWORK }}
+      - name: Log the current state of the canisters
+        run: |
+          for canister in nns-dapp sns_aggregator ; do
+            echo "==== $canister ===="
+            set -x
+            dfx canister id --network app "$canister"
+            dfx canister info --network app "$canister"
+            dfx canister status --network app "$canister"
+            set +x
+          done
       - name: Deploy nns-dapp
         if: (inputs.canisters == 'all') || (inputs.canisters == 'nns-dapp') || ( github.event_name != 'workflow_dispatch' )
         run: |

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -49,8 +49,8 @@ proposal is successful, the changes it released will be moved from this file to
 * Make the location of the snsdemo checkout configurable.
 * Add `prod` and `aggregator-prod` to the list of public releases.
 * Update `dfx` to `v0.15.1`.
+* Update the URL of the app subnet to what dfx v15 expects.
 * Use a unique branch when updating the snsdemo release, didc, IC candid files or rust.
-* Use a unique branch when updating the snsdemo release.
 
 #### Deprecated
 

--- a/dfx.json
+++ b/dfx.json
@@ -213,7 +213,7 @@
         }
       },
       "providers": [
-        "https://icp-api.io/"
+        "https://icp0.io"
       ],
       "type": "persistent"
     },

--- a/dfx.json
+++ b/dfx.json
@@ -228,7 +228,7 @@
         }
       },
       "providers": [
-        "https://icp-api.io/"
+        "https://icp0.io"
       ],
       "type": "persistent"
     },


### PR DESCRIPTION
# Motivation
Test deployments to the app subnet currently fail.

# Changes
- Add logging
- Change provider to match what dfx 15 expects.  See [this thread on the forum](https://forum.dfinity.org/t/replica-error-not-allowed-to-call-ic00-method-provisional-create-canister-with-cycles/23709/6) for details.

# Tests
- See this deployment: https://github.com/dfinity/nns-dapp/actions/runs/6879490121

# Todos

- [x] Add entry to changelog (if necessary).
