### PR TITLE
feat: do not hide voting buttons after voting

### DIFF
--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingCard.svelte
@@ -61,10 +61,7 @@
   ).find(({ proposalIdString }) => `${proposalInfo.id}` === proposalIdString);
 
   $: $definedNeuronsStore,
-    (visible =
-      voteRegistration !== undefined ||
-      (votableNeurons().length > 0 &&
-        isProposalDeadlineInTheFuture(proposalInfo)));
+    (visible = isProposalDeadlineInTheFuture(proposalInfo));
 
   const updateVotingNeuronSelectedStore = () => {
     if (!initialSelectionDone) {

--- a/frontend/src/lib/components/sns-proposals/SnsVotingCard.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsVotingCard.svelte
@@ -80,9 +80,7 @@
   let visible = false;
   $: $snsOnlyProjectStore,
     $voteRegistrationStore,
-    (visible =
-      voteRegistration !== undefined ||
-      (votableNeurons.length > 0 && snsProposalAcceptingVotes(proposal)));
+    (visible = snsProposalAcceptingVotes(proposal));
 
   let neuronsReady = false;
   $: neuronsReady =


### PR DESCRIPTION
# Motivation

Keep adapt/reject buttons visible but disabled after voting. Part of voting section redesign.

# Changes

- update visibility logic for nns and sns proposals

# Tests

Works

# Todos

- [ ] Add entry to changelog (if necessary).

# Screenshots

<img width="1326" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/51b12d42-1f3e-4205-9858-15114f5e533e">
