### PR TITLE
Error if network is defined but not exported

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -58,6 +58,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Update `dfx` to `v0.15.1`.
 * Update the URL of the app subnet to what dfx v15 expects.
 * Use a unique branch when updating the snsdemo release, didc, IC candid files or rust.
+* Better checks that the network is defined.
 
 #### Deprecated
 

--- a/scripts/network-config
+++ b/scripts/network-config
@@ -15,6 +15,10 @@ assert_dfx_network_var_is_set() {
     echo "ERROR: DFX_NETWORK is not defined."
     return 1
   } >&2
+  [[ "${DFX_NETWORK@a}" == *x* ]] || {
+    echo "ERROR: DFX_NETWORK is not exported."
+    return 1
+  }
 }
 # Gets the global network configuration.  If missing, the answer is null and the return-value 1.
 global_network_config() {
@@ -33,6 +37,7 @@ local_network_config() {
 }
 # Checks that the DFX_NETWORK is configured
 assert_dfx_network_var_is_configured() {
+  assert_dfx_network_var_is_set || return
   local_network_config >/dev/null || global_network_config >/dev/null || {
     echo "ERROR: DFX_NETWORK '$DFX_NETWORK' is not defined in dfx.json or $GLOBAL_NETWORK_CONFIG_FILE"
     echo "Available networks are:"

--- a/scripts/network-config
+++ b/scripts/network-config
@@ -15,7 +15,10 @@ assert_dfx_network_var_is_set() {
     echo "ERROR: DFX_NETWORK is not defined."
     return 1
   } >&2
-  # Note: ${var@a} gets variable attributes.  It has been available in bash since 2020, so is as old as Node14.
+  # Note: ${var@a} gets variable attributes.  It has been available in bash since bash 5.1, so is as old as Node14.
+  #       'x' is the export attribute.
+  #       If we find that we need to support older systems, please use this instead:
+  #         bash -c 'test -n "${DFX_NETWORK:-}"' || { ...
   [[ "${DFX_NETWORK@a}" == *x* ]] || {
     echo "ERROR: DFX_NETWORK is not exported."
     return 1

--- a/scripts/network-config
+++ b/scripts/network-config
@@ -15,6 +15,7 @@ assert_dfx_network_var_is_set() {
     echo "ERROR: DFX_NETWORK is not defined."
     return 1
   } >&2
+  # Note: ${var@a} gets variable attributes.  It has been available in bash since 2020, so is as old as Node14.
   [[ "${DFX_NETWORK@a}" == *x* ]] || {
     echo "ERROR: DFX_NETWORK is not exported."
     return 1

--- a/scripts/network-config.test
+++ b/scripts/network-config.test
@@ -170,19 +170,41 @@ title() {
     } >&2
   fi
 )
-(
-  title "assert_dfx_network_var_is_set should fail when the network is unset"
-  mk_env
-  unset DFX_NETWORK
-  if assert_dfx_network_var_is_set 2>/dev/null; then
-    {
-      echo "FAIL"
+for command in assert_dfx_network_var_is_set assert_dfx_network_var_is_configured global_network_config local_network_config network_config; do
+  (
+    title "$command should fail when the network is unset"
+    mk_env
+    unset DFX_NETWORK
+    if "$command" 2>/dev/null; then
+      {
+        echo "FAIL"
+        exit 1
+      } >&2
+    else
+      echo OK
+    fi
+  )
+  (
+    title "$command should fail when the network is defined but not exported"
+    mk_env
+    DFX_NETWORK=gobbeldygook
+    if actual_stderr="$("$command" 2>&1)"; then
+      {
+        echo "FAIL: $command should have returned non-zero."
+        exit 1
+      } >&2
+    else
+      echo OK
+    fi
+    expected_stderr="ERROR: DFX_NETWORK is not exported."
+    [[ "${expected_stderr}" == "${actual_stderr}" ]] || {
+      echo "FAIL: The error emitted by $command should state explicitly that DFX_NETWORK should be exported."
+      echo "Expected: $expected_stderr"
+      echo "Actual:   $actual_stderr"
       exit 1
     } >&2
-  else
-    echo OK
-  fi
-)
+  )
+done
 (
   title "global_network_config should be able to get a globally defined network"
   mk_env


### PR DESCRIPTION
# Motivation
`DFX_NETWORK` is typically provided to dfx build commands as an exported environment variable.  When checking that `DFX_NETWORK` is provided, we need to check specifically that it is exported as otherwise it is possible to get very confusing behaviour in which the network is defined in one part of the deployment but not another.

# Changes
- Check that `DFX_NETWORK` is exported.

# Tests
- Tests have been added that the error message specifically mentions `DFX_NETWORK` not being exported.

# Todos

- [x] Add entry to changelog (if necessary).
