### PR TITLE
Fix local deployments

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -59,5 +59,6 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Remove accidentally committed (empty) directory and fix commit patterns.
+* Fix local deployments with `dfx 0.15.1`.
 
 #### Security

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,6 +31,7 @@ help_text() {
 }
 
 #
+export DFX_NETWORK
 DFX_NETWORK=local # which network to deploy to
 
 # Whether to run each action:


### PR DESCRIPTION
# Motivation
With dfx 0.15.1 this fails with a confusing error message:
```
./deploy.sh --nns-dapp local
```
This is due to the network being defined but not exported.

# Changes
- Export `DFX_NETWORK`.

# Tests
* Tested locally.  CI tests are underway but I am unlikely to get them finished this morning so this is to unblock developers.
* Fixes and tests for appropriate error messages are in #3771 

# Todos

- [x] Add entry to changelog (if necessary).
