### PR TITLE
GIX-1980: Setup icp accounts with tokens table

### DIFF
--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -24,11 +24,12 @@
     cancelPollAccounts();
   });
 
-  export let userTokensData: UserTokenData[];
+  // TODO: Remove default value when we remove the feature flag
+  export let userTokensData: UserTokenData[] = [];
 </script>
 
 {#if $ENABLE_MY_TOKENS}
-  <MainWrapper testId="nns-accounts-component">
+  <MainWrapper testId="accounts-body">
     <TokensTable {userTokensData} />
   </MainWrapper>
 {:else}

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -17,7 +17,9 @@
   import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
 
   onMount(() => {
-    pollAccounts();
+    if (!$ENABLE_MY_TOKENS) {
+      pollAccounts();
+    }
   });
 
   onDestroy(() => {

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -11,6 +11,10 @@
     pollAccounts,
   } from "$lib/services/icp-accounts.services";
   import { ICPToken } from "@dfinity/utils";
+  import type { UserTokenData } from "$lib/types/tokens-page";
+  import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
+  import MainWrapper from "$lib/components/tokens/MainWrapper.svelte";
+  import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
 
   onMount(() => {
     pollAccounts();
@@ -19,29 +23,37 @@
   onDestroy(() => {
     cancelPollAccounts();
   });
+
+  export let userTokensData: UserTokenData[];
 </script>
 
-<div class="card-grid" data-tid="accounts-body">
-  {#if nonNullish($icpAccountsStore?.main)}
-    <!-- Workaround: Type checker does not get $accountsStore.main is defined here -->
-    {@const mainAccount = $icpAccountsStore.main}
+{#if $ENABLE_MY_TOKENS}
+  <MainWrapper testId="nns-accounts-component">
+    <TokensTable {userTokensData} />
+  </MainWrapper>
+{:else}
+  <div class="card-grid" data-tid="accounts-body">
+    {#if nonNullish($icpAccountsStore?.main)}
+      <!-- Workaround: Type checker does not get $accountsStore.main is defined here -->
+      {@const mainAccount = $icpAccountsStore.main}
 
-    <AccountCard account={mainAccount} token={ICPToken}
-      >{$i18n.accounts.main}</AccountCard
-    >
-    {#each $icpAccountsStore.subAccounts ?? [] as subAccount}
-      <AccountCard account={subAccount} token={ICPToken}
-        >{subAccount.name}</AccountCard
+      <AccountCard account={mainAccount} token={ICPToken}
+        >{$i18n.accounts.main}</AccountCard
       >
-    {/each}
-    {#each $icpAccountsStore.hardwareWallets ?? [] as walletAccount}
-      <AccountCard account={walletAccount} token={ICPToken}
-        >{walletAccount.name}</AccountCard
-      >
-    {/each}
+      {#each $icpAccountsStore.subAccounts ?? [] as subAccount}
+        <AccountCard account={subAccount} token={ICPToken}
+          >{subAccount.name}</AccountCard
+        >
+      {/each}
+      {#each $icpAccountsStore.hardwareWallets ?? [] as walletAccount}
+        <AccountCard account={walletAccount} token={ICPToken}
+          >{walletAccount.name}</AccountCard
+        >
+      {/each}
 
-    <NnsAddAccount />
-  {:else}
-    <SkeletonCard size="medium" />
-  {/if}
-</div>
+      <NnsAddAccount />
+    {:else}
+      <SkeletonCard size="medium" />
+    {/if}
+  </div>
+{/if}

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -14,7 +14,7 @@
     snsProjectsCommittedStore,
     type SnsFullProject,
   } from "$lib/derived/sns/sns-projects.derived";
-  import { nonNullish } from "@dfinity/utils";
+  import { TokenAmount, nonNullish } from "@dfinity/utils";
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { uncertifiedLoadCkBTCAccountsBalance } from "$lib/services/ckbtc-accounts-balance.services";
   import CkBTCAccounts from "$lib/pages/CkBTCAccounts.svelte";
@@ -25,6 +25,10 @@
   import { isArrayEmpty } from "$lib/utils/utils";
   import AccountsModals from "$lib/modals/accounts/AccountsModals.svelte";
   import CkBTCAccountsModals from "$lib/modals/accounts/CkBTCAccountsModals.svelte";
+  import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
+  import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+  import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
+  import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
 
   // TODO: This component is mounted twice. Understand why and fix it.
 
@@ -77,6 +81,20 @@
       loadSnsAccountsBalances($snsProjectsCommittedStore),
       loadCkBTCAccountsBalances($ckBTCUniversesStore),
     ]))();
+
+  // TODO: Use derived store https://dfinity.atlassian.net/browse/GIX-2083
+  const data: UserTokenData[] = [
+    {
+      universeId: OWN_CANISTER_ID,
+      title: "Main",
+      balance: TokenAmount.fromE8s({
+        amount: 314000000n,
+        token: NNS_TOKEN_DATA,
+      }),
+      logo: IC_LOGO_ROUNDED,
+      actions: [UserTokenAction.Send, UserTokenAction.Receive],
+    },
+  ];
 </script>
 
 <TestIdWrapper testId="accounts-component">
@@ -84,7 +102,7 @@
     <SummaryUniverse />
 
     {#if $isNnsUniverseStore}
-      <NnsAccounts />
+      <NnsAccounts userTokensData={data} />
     {:else if $isCkBTCUniverseStore}
       <CkBTCAccounts />
     {:else if nonNullish($snsProjectSelectedStore)}

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -41,14 +41,6 @@ describe("NnsAccounts", () => {
   describe("when tokens flag is enabled", () => {
     beforeEach(() => {
       overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
-      // TODO: Return from mocked api layer instead of setting store directly
-      icpAccountsStore.setForTesting({
-        main: mockMainAccount,
-        subAccounts: [],
-        hardwareWallets: [],
-        certified: true,
-      });
-      cancelPollAccounts();
     });
 
     it("should render tokens table", async () => {

--- a/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
@@ -1,12 +1,21 @@
 import { BaseAccountsPo } from "$tests/page-objects/BaseAccounts.page-object";
 import { NnsAddAccountPo } from "$tests/page-objects/NnsAddAccount.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { TokensTablePo } from "./TokensTable.page-object";
 
 export class NnsAccountsPo extends BaseAccountsPo {
   private static readonly TID = "accounts-body";
 
   static under(element: PageObjectElement): NnsAccountsPo {
     return new NnsAccountsPo(element.byTestId(NnsAccountsPo.TID));
+  }
+
+  getTokensTablePo() {
+    return TokensTablePo.under(this.root);
+  }
+
+  hasTokensTable(): Promise<boolean> {
+    return this.getTokensTablePo().isPresent();
   }
 
   getNnsAddAccountPo(): NnsAddAccountPo {

--- a/frontend/src/tests/routes/app/accounts/page.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/page.spec.ts
@@ -1,29 +1,71 @@
-import { authStore } from "$lib/stores/auth.store";
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { AppPath } from "$lib/constants/routes.constants";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import { page } from "$mocks/$app/stores";
 import AccountsPage from "$routes/(app)/(u)/(accounts)/accounts/+page.svelte";
-import {
-  authStoreMock,
-  mutableMockAuthStoreSubscribe,
-} from "$tests/mocks/auth.store.mock";
+import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
+import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 
+vi.mock("$lib/api/ckbtc-ledger.api");
+vi.mock("$lib/api/sns-ledger.api");
+
 describe("Accounts page", () => {
-  vi.spyOn(authStore, "subscribe").mockImplementation(
-    mutableMockAuthStoreSubscribe
-  );
+  const renderComponent = () => {
+    const { container } = render(AccountsPage);
+    return AccountsPo.under(new JestPageObjectElement(container));
+  };
 
-  beforeAll(() => {
-    authStoreMock.next({
-      identity: undefined,
-    });
-  });
-
-  afterAll(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("should render sign-in if not logged in", () => {
-    const { getByTestId } = render(AccountsPage);
+  describe("not logged in", () => {
+    beforeEach(() => {
+      setNoIdentity();
+    });
 
-    expect(getByTestId("login-button")).not.toBeNull();
+    it("should render sign-in if not logged in", () => {
+      const { getByTestId } = render(AccountsPage);
+
+      expect(getByTestId("login-button")).not.toBeNull();
+    });
+  });
+
+  describe("logged in NNS Accounts", () => {
+    beforeEach(() => {
+      resetIdentity();
+      page.mock({
+        routeId: AppPath.Accounts,
+        data: { universe: OWN_CANISTER_ID_TEXT },
+      });
+    });
+
+    describe("tokens flag enabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
+      });
+
+      it("renders tokens table for NNS accounts", async () => {
+        const po = renderComponent();
+
+        const pagePo = po.getNnsAccountsPo();
+        expect(await pagePo.hasTokensTable()).toBe(true);
+      });
+    });
+
+    describe("tokens flag disabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", false);
+      });
+
+      it("does not render tokens table for NNS accounts", async () => {
+        const po = renderComponent();
+
+        const pagePo = po.getNnsAccountsPo();
+        expect(await pagePo.hasTokensTable()).toBe(false);
+      });
+    });
   });
 });


### PR DESCRIPTION
# Motivation

When we migrate to the tokens page, we also want a similar view for the ICP accounts, subaccounts and hardware wallet accounts.

In this PR, I introduce the TokensTable for NNS Accounts.

# Changes

* Render `TokensTable` in `NnsAccounts` depending on feature flag.
* Expect an optional list of `UserTokenData` in `NnsAccounts`.
* Hard code a list of `UserTokenData` in the Accounts route and pass it to `NnsAccounts`.

# Tests

* Add test in NnsAccounts.spec that the tokens table is there if feature flag is enabled. I added myself some TODOs comments to remember improving the test before adding more features here.
* Add methods to NnsAccountsPo.
* Add test in Accounts route to check that tokens table is rendered if flag is enabled.

# Todos

- [ ] Add entry to changelog (if necessary).
