### PR TITLE
GIX-2082: Add subtitle to TokensTable

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
@@ -12,6 +12,7 @@
   import { ActionType } from "$lib/types/actions";
   import { UnavailableTokenAmount } from "$lib/utils/token.utils";
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
+  import { nonNullish } from "@dfinity/utils";
 
   export let userTokenData: UserTokenData;
   export let index: number;
@@ -42,14 +43,21 @@
   data-tid="tokens-table-row-component"
 >
   <div role="cell" class="title-cell">
-    <div class="title">
+    <div class="title-logo-wrapper">
       <Logo
         src={userTokenData.logo}
         alt={userTokenData.title}
         size="medium"
         framed
       />
-      <span data-tid="project-name">{userTokenData.title}</span>
+      <div class="title-wrapper">
+        <span data-tid="project-name">{userTokenData.title}</span>
+        {#if nonNullish(userTokenData.subtitle)}
+          <span data-tid="project-subtitle" class="description"
+            >{userTokenData.subtitle}</span
+          >
+        {/if}
+      </div>
     </div>
     <div class="title-actions actions mobile-only">
       {#each userTokenData.actions as action}
@@ -157,10 +165,16 @@
     }
   }
 
-  .title {
+  .title-logo-wrapper {
     display: flex;
     align-items: center;
     gap: var(--padding);
+
+    .title-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: var(--padding-0_5x);
+    }
   }
 
   .actions {

--- a/frontend/src/lib/types/tokens-page.ts
+++ b/frontend/src/lib/types/tokens-page.ts
@@ -11,6 +11,7 @@ export enum UserTokenAction {
 export type UserTokenData = {
   universeId: Principal;
   title: string;
+  subtitle?: string;
   balance: TokenAmount | UnavailableTokenAmount;
   logo: string;
   actions: UserTokenAction[];

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -70,6 +70,30 @@ describe("TokensTable", () => {
     expect(await row2Po.getBalance()).toBe("1.14 TETRIS");
   });
 
+  it("should render the subtitle if present", async () => {
+    const subtitle = "Hardware Wallet";
+    const token1 = createUserToken({
+      universeId: OWN_CANISTER_ID,
+      balance: TokenAmount.fromE8s({ amount: 314000000n, token: ICPToken }),
+      subtitle,
+    });
+    const token2 = createUserToken({
+      universeId: principal(0),
+      balance: TokenAmount.fromE8s({
+        amount: 114000000n,
+        token: { name: "Tetris", symbol: "TETRIS" },
+      }),
+    });
+    const po = renderTable({ userTokensData: [token1, token2] });
+
+    const rows = await po.getRows();
+    const row1Po = rows[0];
+    const row2Po = rows[1];
+
+    expect(await row1Po.getSubtitle()).toBe(subtitle);
+    expect(await row2Po.getSubtitle()).toBeNull();
+  });
+
   it("should render specific text if balance not available", async () => {
     const token1 = createUserToken({
       universeId: OWN_CANISTER_ID,

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -25,6 +25,10 @@ export class TokensTableRowPo extends BasePageObject {
     return this.getText("token-value-label");
   }
 
+  getSubtitle(): Promise<string | null> {
+    return this.getText("project-subtitle");
+  }
+
   async getData(): Promise<TokensTableRowData> {
     const projectName = await this.getProjectName();
     const balance = await this.getBalance();


### PR DESCRIPTION
# Motivation

The view of the ICP accounts includes subaccounts and hardware wallets. Those are identified with a subtitle.

See design [here](https://www.figma.com/file/x8dk5axQUf8Bi43uUsqCHc/NNS-Production-%26-Hand-over?type=design&node-id=408-2886&mode=design&t=96zreK0AABYejpwI-0).

# Changes

* Add new optional field `subtitle` to `UserTokenData`.
* Render new field (if present) and adapt styles in `TokensTableRow`.

# Tests

* Add test in TokensTable.spec for the new field.
* Add method to TokensTableRow page object to get subtitle.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
