### PR TITLE
Remove dead code to place token symbol in transactions

### DIFF
--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -39,7 +39,6 @@
     type,
     isReceive: isReceive || toSelfTransaction,
     labels: $i18n.transaction_names,
-    tokenSymbol: token.symbol,
   });
 
   let label: string | undefined;

--- a/frontend/src/lib/utils/transactions.utils.ts
+++ b/frontend/src/lib/utils/transactions.utils.ts
@@ -9,7 +9,6 @@ import {
   TransactionNetwork,
 } from "$lib/types/transaction";
 import { isNullish } from "@dfinity/utils";
-import { replacePlaceholders } from "./i18n.utils";
 import { stringifyJson } from "./utils";
 
 export const transactionType = ({
@@ -175,21 +174,16 @@ export const transactionName = ({
   type,
   isReceive,
   labels,
-  tokenSymbol,
 }: {
   type: AccountTransactionType;
   isReceive: boolean;
   labels: I18nTransaction_names;
-  tokenSymbol: string;
 }): string =>
-  replacePlaceholders(
-    type === AccountTransactionType.Send
-      ? isReceive
-        ? labels.receive
-        : labels.send
-      : labels[type] ?? type,
-    { $tokenSymbol: tokenSymbol }
-  );
+  type === AccountTransactionType.Send
+    ? isReceive
+      ? labels.receive
+      : labels.send
+    : labels[type] ?? type;
 
 /** (from==to workaround) Set `mapToSelfNnsTransaction: true` when sender and receiver are the same account (e.g. transmitting from `main` to `main` account) */
 export const mapToSelfTransaction = (

--- a/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
@@ -1,7 +1,6 @@
 import type { Transaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import NnsTransactionCard from "$lib/components/accounts/NnsTransactionCard.svelte";
 import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
-import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { getSwapCanisterAccount } from "$lib/utils/sns.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import { mapNnsTransaction } from "$lib/utils/transactions.utils";
@@ -17,7 +16,6 @@ import {
   mockSentToSubAccountTransaction,
 } from "$tests/mocks/transaction.mock";
 import { normalizeWhitespace } from "$tests/utils/utils.test-utils";
-import { ICPToken } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
 describe("NnsTransactionCard", () => {
@@ -38,9 +36,7 @@ describe("NnsTransactionCard", () => {
       mockReceivedFromMainAccountTransaction
     );
 
-    const expectedText = replacePlaceholders(en.transaction_names.receive, {
-      $tokenSymbol: ICPToken.symbol,
-    });
+    const expectedText = en.transaction_names.receive;
     expect(getByText(expectedText)).toBeInTheDocument();
   });
 
@@ -82,9 +78,7 @@ describe("NnsTransactionCard", () => {
       mockSentToSubAccountTransaction
     );
 
-    const expectedText = replacePlaceholders(en.transaction_names.send, {
-      $tokenSymbol: ICPToken.symbol,
-    });
+    const expectedText = en.transaction_names.send;
     expect(getByText(expectedText)).toBeInTheDocument();
   });
 

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -4,7 +4,6 @@ import {
   TransactionNetwork,
 } from "$lib/types/transaction";
 import { enumKeys } from "$lib/utils/enum.utils";
-import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { getSwapCanisterAccount } from "$lib/utils/sns.utils";
 import {
   isTransactionNetworkBtc,
@@ -26,7 +25,6 @@ import {
   mockReceivedFromMainAccountTransaction,
   mockSentToSubAccountTransaction,
 } from "$tests/mocks/transaction.mock";
-import { ICPToken } from "@dfinity/utils";
 
 describe("transactions-utils", () => {
   describe("showTransactionFee", () => {
@@ -462,14 +460,8 @@ describe("transactions-utils", () => {
             type: key as AccountTransactionType,
             isReceive: false,
             labels: en.transaction_names,
-            tokenSymbol: ICPToken.symbol,
           })
-        ).toBe(
-          replacePlaceholders(
-            en.transaction_names[key as AccountTransactionType],
-            { $tokenSymbol: ICPToken.symbol }
-          )
-        );
+        ).toBe(en.transaction_names[key as AccountTransactionType]);
       }
     });
 
@@ -479,13 +471,8 @@ describe("transactions-utils", () => {
           type: AccountTransactionType.Send,
           isReceive: true,
           labels: en.transaction_names,
-          tokenSymbol: ICPToken.symbol,
         })
-      ).toBe(
-        replacePlaceholders(en.transaction_names.receive, {
-          $tokenSymbol: ICPToken.symbol,
-        })
-      );
+      ).toBe(en.transaction_names.receive);
     });
 
     it("returns raw type if not label", () => {
@@ -494,7 +481,6 @@ describe("transactions-utils", () => {
           type: "test" as AccountTransactionType,
           isReceive: true,
           labels: en.transaction_names,
-          tokenSymbol: ICPToken.symbol,
         })
       ).toBe("test");
     });


### PR DESCRIPTION
# Motivation

We used to have tokens symbols in transaction headlines, like "Received $token".
We no longer do, but we still try to replace the placeholder that's no longer there.
The code died in https://github.com/dfinity/nns-dapp/pull/2164

# Changes

Stop trying to replace the token symbol in transaction headlines.

# Tests

Existing (updated) tests pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary