### PR TITLE
Pass a single prop to TransactionCard

### DIFF
--- a/frontend/src/lib/components/accounts/IcrcTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionCard.svelte
@@ -6,7 +6,7 @@
   import type { IcrcTransactionWithId } from "@dfinity/ledger-icrc";
   import TransactionCard from "./TransactionCard.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import type { Transaction } from "$lib/types/transaction";
+  import type { Transaction, UiTransaction } from "$lib/types/transaction";
   import { nonNullish } from "@dfinity/utils";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
 
@@ -26,16 +26,19 @@
     governanceCanisterId,
   });
 
-  let uiTransaction: UiTransaction;
-  $: uiTransaction = toUiTransaction({
-    transaction: transactionData,
-    toSelfTransaction,
-    token,
-    transactionNames: $i18n.transaction_names,
-    fallbackDescriptions: descriptions,
-  });
+  let uiTransaction: UiTransaction | undefined;
+  $: uiTransaction =
+    transactionData &&
+    token &&
+    toUiTransaction({
+      transaction: transactionData,
+      toSelfTransaction,
+      token,
+      transactionNames: $i18n.transaction_names,
+      fallbackDescriptions: descriptions,
+    });
 </script>
 
-{#if nonNullish(transactionData) && nonNullish(token)}
+{#if nonNullish(uiTransaction) && nonNullish(token)}
   <TransactionCard transaction={uiTransaction} />
 {/if}

--- a/frontend/src/lib/components/accounts/IcrcTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionCard.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import type { Account } from "$lib/types/account";
+  import { toUiTransaction } from "$lib/utils/transactions.utils";
   import type { mapIcrcTransactionType } from "$lib/utils/icrc-transactions.utils";
   import type { Principal } from "@dfinity/principal";
   import type { IcrcTransactionWithId } from "@dfinity/ledger-icrc";
   import TransactionCard from "./TransactionCard.svelte";
+  import { i18n } from "$lib/stores/i18n";
   import type { Transaction } from "$lib/types/transaction";
   import { nonNullish } from "@dfinity/utils";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
@@ -23,13 +25,17 @@
     toSelfTransaction,
     governanceCanisterId,
   });
+
+  let uiTransaction: UiTransaction;
+  $: uiTransaction = toUiTransaction({
+    transaction: transactionData,
+    toSelfTransaction,
+    token,
+    transactionNames: $i18n.transaction_names,
+    fallbackDescriptions: descriptions,
+  });
 </script>
 
 {#if nonNullish(transactionData) && nonNullish(token)}
-  <TransactionCard
-    {toSelfTransaction}
-    transaction={transactionData}
-    {token}
-    {descriptions}
-  />
+  <TransactionCard transaction={uiTransaction} />
 {/if}

--- a/frontend/src/lib/components/accounts/NnsTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/NnsTransactionCard.svelte
@@ -9,7 +9,7 @@
   import { toastsError } from "$lib/stores/toasts.store";
   import TransactionCard from "./TransactionCard.svelte";
   import { ICPToken } from "@dfinity/utils";
-  import type { Transaction } from "$lib/types/transaction";
+  import type { UiTransaction } from "$lib/types/transaction";
   import { createSwapCanisterAccountsStore } from "$lib/derived/sns-swap-canisters-accounts.derived";
   import type { Principal } from "@dfinity/principal";
   import type { Readable } from "svelte/store";

--- a/frontend/src/lib/components/accounts/NnsTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/NnsTransactionCard.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import type { Account } from "$lib/types/account";
   import type { Transaction as NnsTransaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
-  import { mapNnsTransaction } from "$lib/utils/transactions.utils";
+  import {
+    mapNnsTransaction,
+    toUiTransaction,
+  } from "$lib/utils/transactions.utils";
+  import { i18n } from "$lib/stores/i18n";
   import { toastsError } from "$lib/stores/toasts.store";
   import TransactionCard from "./TransactionCard.svelte";
   import { ICPToken } from "@dfinity/utils";
@@ -25,20 +29,26 @@
   $: swapCanisterAccountsStore =
     createSwapCanisterAccountsStore(accountPrincipal);
 
-  let transactionData: Transaction | undefined;
+  let uiTransaction: UiTransaction | undefined;
 
   $: account,
     transaction,
     (() => {
       try {
-        transactionData = mapNnsTransaction({
+        const transactionData = mapNnsTransaction({
           transaction,
           toSelfTransaction,
           account,
           swapCanisterAccounts: $swapCanisterAccountsStore,
         });
+        uiTransaction = toUiTransaction({
+          transaction: transactionData,
+          toSelfTransaction,
+          token: ICPToken,
+          transactionNames: $i18n.transaction_names,
+        });
       } catch (err: unknown) {
-        transactionData = undefined;
+        uiTransaction = undefined;
         toastsError(
           err instanceof Error
             ? { labelKey: err.message }
@@ -48,10 +58,6 @@
     })();
 </script>
 
-{#if transactionData !== undefined}
-  <TransactionCard
-    transaction={transactionData}
-    {toSelfTransaction}
-    token={ICPToken}
-  />
+{#if uiTransaction !== undefined}
+  <TransactionCard transaction={uiTransaction} />
 {/if}

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -3,7 +3,6 @@
   import DateSeconds from "$lib/components/ui/DateSeconds.svelte";
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import Identifier from "$lib/components/ui/Identifier.svelte";
-  import type { Token } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
   import {
     Html,
@@ -12,23 +11,20 @@
     KeyValuePair,
   } from "@dfinity/gix-components";
   import type { UiTransaction } from "$lib/types/transaction";
-  import { nonNullish } from "@dfinity/utils";
-  import { TokenAmount } from "@dfinity/utils";
+  import { nonNullish, type TokenAmount } from "@dfinity/utils";
   import { fade } from "svelte/transition";
 
   export let transaction: UiTransaction;
 
   let headline: string;
-  let amount: bigint;
-  let token: Token;
+  let tokenAmount: TokenAmount;
   let isIncoming: boolean;
   let otherParty: string | undefined;
   let fallbackDescription: string | undefined;
   let timestamp: Date;
   $: ({
     headline,
-    amount,
-    token,
+    tokenAmount,
     isIncoming,
     otherParty,
     fallbackDescription,
@@ -59,7 +55,7 @@
 
       <AmountDisplay
         slot="value"
-        amount={TokenAmount.fromE8s({ amount, token })}
+        amount={tokenAmount}
         sign={isIncoming ? "+" : "-"}
         detailed
         inline

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -6,20 +6,12 @@
   import type { Token } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
   import {
-    transactionName,
-    toUiTransaction,
-  } from "$lib/utils/transactions.utils";
-  import {
     Html,
     IconUp,
     IconDown,
     KeyValuePair,
   } from "@dfinity/gix-components";
-  import type {
-    Transaction,
-    UiTransaction,
-    AccountTransactionType,
-  } from "$lib/types/transaction";
+  import type { UiTransaction } from "$lib/types/transaction";
   import { nonNullish } from "@dfinity/utils";
   import { TokenAmount } from "@dfinity/utils";
   import { fade } from "svelte/transition";
@@ -31,6 +23,7 @@
   let token: Token;
   let isIncoming: boolean;
   let otherParty: string | undefined;
+  let fallbackDescription: string | undefined;
   let timestamp: Date;
   $: ({
     headline,

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -5,7 +5,10 @@
   import Identifier from "$lib/components/ui/Identifier.svelte";
   import type { Token } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
-  import { transactionName } from "$lib/utils/transactions.utils";
+  import {
+    transactionName,
+    toUiTransaction,
+  } from "$lib/utils/transactions.utils";
   import {
     Html,
     IconUp,
@@ -14,54 +17,43 @@
   } from "@dfinity/gix-components";
   import type {
     Transaction,
+    UiTransaction,
     AccountTransactionType,
   } from "$lib/types/transaction";
   import { nonNullish } from "@dfinity/utils";
   import { TokenAmount } from "@dfinity/utils";
   import { fade } from "svelte/transition";
 
-  export let transaction: Transaction;
-  export let toSelfTransaction = false;
-  export let token: Token;
-  export let descriptions: Record<string, string> | undefined = undefined;
-
-  let type: AccountTransactionType;
-  let isReceive: boolean;
-  let isSend: boolean;
-  let from: string | undefined;
-  let to: string | undefined;
-  let displayAmount: bigint;
-  let date: Date;
-  $: ({ type, isReceive, isSend, from, to, displayAmount, date } = transaction);
+  export let transaction: UiTransaction;
 
   let headline: string;
-  $: headline = transactionName({
-    type,
-    isReceive: isReceive || toSelfTransaction,
-    labels: $i18n.transaction_names,
-  });
+  let amount: bigint;
+  let token: Token;
+  let isIncoming: boolean;
+  let otherParty: string | undefined;
+  let timestamp: Date;
+  $: ({
+    headline,
+    amount,
+    token,
+    isIncoming,
+    otherParty,
+    fallbackDescription,
+    timestamp,
+  } = transaction);
 
-  let label: string | undefined;
-  $: label =
-    isReceive || toSelfTransaction
-      ? $i18n.wallet.direction_from
-      : isSend
-      ? $i18n.wallet.direction_to
-      : undefined;
-
-  let description: string | undefined;
-  $: description = descriptions?.[type];
-
-  let identifier: string | undefined;
-  $: identifier = isReceive ? from : to;
+  let label: string;
+  $: label = isIncoming
+    ? $i18n.wallet.direction_from
+    : $i18n.wallet.direction_to;
 
   let seconds: number;
-  $: seconds = date.getTime() / 1000;
+  $: seconds = timestamp.getTime() / 1000;
 </script>
 
 <article data-tid="transaction-card" transition:fade|global>
-  <div class="icon" class:send={!isReceive}>
-    {#if isReceive}
+  <div class="icon" class:send={!isIncoming}>
+    {#if isIncoming}
       <IconDown size="24px" />
     {:else}
       <IconUp size="24px" />
@@ -74,8 +66,8 @@
 
       <AmountDisplay
         slot="value"
-        amount={TokenAmount.fromE8s({ amount: displayAmount, token })}
-        sign={isReceive || toSelfTransaction ? "+" : "-"}
+        amount={TokenAmount.fromE8s({ amount, token })}
+        sign={isIncoming ? "+" : "-"}
         detailed
         inline
       />
@@ -83,10 +75,12 @@
 
     <ColumnRow>
       <div slot="start" class="identifier">
-        {#if nonNullish(identifier)}
-          <Identifier size="medium" {label} {identifier} />
-        {:else if nonNullish(description)}
-          <p data-tid="transaction-description"><Html text={description} /></p>
+        {#if nonNullish(otherParty)}
+          <Identifier size="medium" {label} identifier={otherParty} />
+        {:else if nonNullish(fallbackDescription)}
+          <p data-tid="transaction-description">
+            <Html text={fallbackDescription} />
+          </p>
         {/if}
       </div>
 

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -84,7 +84,7 @@ export interface UiTransaction {
   isIncoming: boolean;
   headline: string;
   // Where the amount is going to or coming from.
-  otherParty: string;
+  otherParty?: string;
   // TODO: Remove fallbackDescription and always use otherParty.
   fallbackDescription?: string;
   // Always positive.

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -83,11 +83,11 @@ export interface Transaction {
 export interface UiTransaction {
   isIncoming: boolean;
   headline: string;
-  // Where to amount is going to or coming from.
+  // Where the amount is going to or coming from.
   otherParty: string;
   // TODO: Remove fallbackDescription and always use otherParty.
   fallbackDescription?: string;
-  // Positing for incoming, negative for outgoing.
+  // Always positive.
   amount: bigint;
   token: Token;
   timestamp: Date;

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -1,4 +1,5 @@
 import type { IcrcTransactionWithId } from "@dfinity/ledger-icrc";
+import type { Token } from "@dfinity/utils";
 import type { Account } from "./account";
 
 export type NewTransaction = {
@@ -77,6 +78,19 @@ export interface Transaction {
   to: string | undefined;
   displayAmount: bigint;
   date: Date;
+}
+
+export interface UiTransaction {
+  isIncoming: boolean;
+  headline: string;
+  // Where to amount is going to or coming from.
+  otherParty: string;
+  // TODO: Remove fallbackDescription and always use otherParty.
+  fallbackDescription?: string;
+  // Positing for incoming, negative for outgoing.
+  amount: bigint;
+  token: Token;
+  timestamp: Date;
 }
 
 export enum TransactionNetwork {

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -1,5 +1,5 @@
 import type { IcrcTransactionWithId } from "@dfinity/ledger-icrc";
-import type { Token } from "@dfinity/utils";
+import type { TokenAmount } from "@dfinity/utils";
 import type { Account } from "./account";
 
 export type NewTransaction = {
@@ -88,8 +88,7 @@ export interface UiTransaction {
   // TODO: Remove fallbackDescription and always use otherParty.
   fallbackDescription?: string;
   // Always positive.
-  amount: bigint;
-  token: Token;
+  tokenAmount: TokenAmount;
   timestamp: Date;
 }
 

--- a/frontend/src/lib/utils/transactions.utils.ts
+++ b/frontend/src/lib/utils/transactions.utils.ts
@@ -175,10 +175,10 @@ export const toUiTransaction = ({
   fallbackDescriptions,
 }: {
   transaction: Transaction;
-  toSelfTransaction?: boolean;
+  toSelfTransaction: boolean;
   token: Token;
   transactionNames: I18nTransaction_names;
-  fallbackDescriptions?: I18nCkbtc_transaction_names;
+  fallbackDescriptions?: Record<string, string>;
 }): UiTransaction => {
   const isIncoming = transaction.isReceive || toSelfTransaction;
   const headline = transactionName({

--- a/frontend/src/lib/utils/transactions.utils.ts
+++ b/frontend/src/lib/utils/transactions.utils.ts
@@ -9,7 +9,7 @@ import {
   TransactionNetwork,
 } from "$lib/types/transaction";
 import type { Token } from "@dfinity/utils";
-import { isNullish } from "@dfinity/utils";
+import { TokenAmount, isNullish } from "@dfinity/utils";
 import { stringifyJson } from "./utils";
 
 export const transactionType = ({
@@ -196,8 +196,10 @@ export const toUiTransaction = ({
     headline,
     otherParty,
     fallbackDescription,
-    amount: transaction.displayAmount,
-    token,
+    tokenAmount: TokenAmount.fromE8s({
+      amount: transaction.displayAmount,
+      token,
+    }),
     timestamp: transaction.date,
   };
 };

--- a/frontend/src/lib/utils/transactions.utils.ts
+++ b/frontend/src/lib/utils/transactions.utils.ts
@@ -3,11 +3,12 @@ import type {
   Transaction as NnsTransaction,
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import type { Account } from "$lib/types/account";
-import type { Transaction } from "$lib/types/transaction";
+import type { Transaction, UiTransaction } from "$lib/types/transaction";
 import {
   AccountTransactionType,
   TransactionNetwork,
 } from "$lib/types/transaction";
+import type { Token } from "@dfinity/utils";
 import { isNullish } from "@dfinity/utils";
 import { stringifyJson } from "./utils";
 
@@ -163,6 +164,41 @@ export const mapNnsTransaction = ({
     to,
     displayAmount,
     date,
+  };
+};
+
+export const toUiTransaction = ({
+  transaction,
+  toSelfTransaction,
+  token,
+  transactionNames,
+  fallbackDescriptions,
+}: {
+  transaction: Transaction;
+  toSelfTransaction?: boolean;
+  token: Token;
+  transactionNames: I18nTransaction_names;
+  fallbackDescriptions?: I18nCkbtc_transaction_names;
+}): UiTransaction => {
+  const isIncoming = transaction.isReceive || toSelfTransaction;
+  const headline = transactionName({
+    type: transaction.type,
+    isReceive: isIncoming,
+    labels: transactionNames,
+  });
+  const otherParty = isIncoming ? transaction.from : transaction.to;
+  const fallbackDescription = isNullish(otherParty)
+    ? fallbackDescriptions?.[transaction.type]
+    : undefined;
+
+  return {
+    isIncoming,
+    headline,
+    otherParty,
+    fallbackDescription,
+    amount: transaction.displayAmount,
+    token,
+    timestamp: transaction.date,
   };
 };
 

--- a/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
@@ -4,7 +4,6 @@ import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
 import { getSwapCanisterAccount } from "$lib/utils/sns.utils";
 import { formatToken } from "$lib/utils/token.utils";
 import { mapNnsTransaction } from "$lib/utils/transactions.utils";
-import en from "$tests/mocks/i18n.mock";
 import {
   mockMainAccount,
   mockSubAccount,
@@ -12,13 +11,30 @@ import {
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import {
+  createMockReceiveTransaction,
+  createMockSendTransaction,
   mockReceivedFromMainAccountTransaction,
   mockSentToSubAccountTransaction,
 } from "$tests/mocks/transaction.mock";
+import { TransactionCardPo } from "$tests/page-objects/TransactionCard.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { normalizeWhitespace } from "$tests/utils/utils.test-utils";
 import { render } from "@testing-library/svelte";
 
 describe("NnsTransactionCard", () => {
+  const renderComponent = (
+    account = mockMainAccount,
+    transaction = mockReceivedFromMainAccountTransaction
+  ) => {
+    const { container } = render(NnsTransactionCard, {
+      props: {
+        account,
+        transaction,
+      },
+    });
+    return TransactionCardPo.under(new JestPageObjectElement(container));
+  };
+
   const renderTransactionCard = (
     account = mockMainAccount,
     transaction = mockReceivedFromMainAccountTransaction
@@ -30,17 +46,16 @@ describe("NnsTransactionCard", () => {
       },
     });
 
-  it("renders received headline", () => {
-    const { getByText } = renderTransactionCard(
+  it("renders received headline", async () => {
+    const po = renderComponent(
       mockSubAccount,
       mockReceivedFromMainAccountTransaction
     );
 
-    const expectedText = en.transaction_names.receive;
-    expect(getByText(expectedText)).toBeInTheDocument();
+    expect(await po.getHeadline()).toBe("Received");
   });
 
-  it("renders participate in swap transaction type", () => {
+  it("renders participate in swap transaction type", async () => {
     const swapCanisterId = principal(0);
     const aggregatorData = {
       ...aggregatorSnsMockDto,
@@ -64,33 +79,30 @@ describe("NnsTransactionCard", () => {
         },
       },
     };
-    const { queryByTestId } = renderTransactionCard(
-      mockMainAccount,
-      swapTransaction
-    );
+    const po = renderComponent(mockMainAccount, swapTransaction);
 
-    expect(queryByTestId("headline").textContent).toBe("Decentralization Swap");
+    expect(await po.getHeadline()).toBe("Decentralization Swap");
   });
 
-  it("renders sent headline", () => {
-    const { getByText } = renderTransactionCard(
+  it("renders sent headline", async () => {
+    const po = renderComponent(
       mockMainAccount,
       mockSentToSubAccountTransaction
     );
 
-    const expectedText = en.transaction_names.send;
-    expect(getByText(expectedText)).toBeInTheDocument();
+    expect(await po.getHeadline()).toBe("Sent");
   });
 
-  it("renders transaction ICPs with - sign", () => {
+  it("renders transaction ICPs with - sign", async () => {
     const account = mockMainAccount;
-    const transaction = mockSentToSubAccountTransaction;
-    const { getByTestId } = renderTransactionCard(account, transaction);
-    const { displayAmount } = mapNnsTransaction({ account, transaction });
+    const transaction = createMockSendTransaction({
+      amount: 123_000_000n,
+      fee: 10_000n,
+      to: mockSubAccount.identifier,
+    });
+    const po = renderComponent(account, transaction);
 
-    expect(getByTestId("token-value")?.textContent).toBe(
-      `-${formatToken({ value: displayAmount, detailed: true })}`
-    );
+    expect(await po.getAmount()).toBe("-1.2301");
   });
 
   it("renders transaction ICPs with + sign", () => {
@@ -104,37 +116,44 @@ describe("NnsTransactionCard", () => {
     );
   });
 
-  it("displays transaction date and time", () => {
-    const { getByTestId } = renderTransactionCard(
+  it("renders transaction ICPs with + sign", async () => {
+    const account = mockSubAccount;
+    const transaction = createMockReceiveTransaction({
+      from: mockMainAccount.identifier,
+      amount: 125_000_000n,
+      fee: 20_000n,
+    });
+    const po = renderComponent(account, transaction);
+
+    expect(await po.getAmount()).toBe("+1.25");
+  });
+
+  it("displays transaction date and time", async () => {
+    const po = renderComponent(
       mockMainAccount,
       mockSentToSubAccountTransaction
     );
 
-    const div = getByTestId("transaction-date");
-
-    expect(div?.textContent).toContain("Jan 1, 1970");
-    expect(normalizeWhitespace(div?.textContent)).toContain("12:00 AM");
+    expect(normalizeWhitespace(await po.getDate())).toBe(
+      "Jan 1, 1970 12:00 AM"
+    );
   });
 
-  it("displays identifier for received", () => {
-    const { getByTestId } = renderTransactionCard(
+  it("displays identifier for received", async () => {
+    const po = renderComponent(
       mockSubAccount,
       mockReceivedFromMainAccountTransaction
     );
-    const identifier = getByTestId("identifier")?.textContent;
-
-    expect(identifier).toContain(mockMainAccount.identifier);
-    expect(identifier).toContain(en.wallet.direction_from);
+    expect(await po.getIdentifier()).toBe(
+      `From: ${mockMainAccount.identifier}`
+    );
   });
 
-  it("displays identifier for sent", () => {
-    const { getByTestId } = renderTransactionCard(
+  it("displays identifier for sent", async () => {
+    const po = renderComponent(
       mockMainAccount,
       mockSentToSubAccountTransaction
     );
-    const identifier = getByTestId("identifier")?.textContent;
-
-    expect(identifier).toContain(mockSubAccount.identifier);
-    expect(identifier).toContain(en.wallet.direction_to);
+    expect(await po.getIdentifier()).toBe(`To: ${mockSubAccount.identifier}`);
   });
 });

--- a/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
@@ -35,17 +35,6 @@ describe("NnsTransactionCard", () => {
     return TransactionCardPo.under(new JestPageObjectElement(container));
   };
 
-  const renderTransactionCard = (
-    account = mockMainAccount,
-    transaction = mockReceivedFromMainAccountTransaction
-  ) =>
-    render(NnsTransactionCard, {
-      props: {
-        account,
-        transaction,
-      },
-    });
-
   it("renders received headline", async () => {
     const po = renderComponent(
       mockSubAccount,
@@ -103,17 +92,6 @@ describe("NnsTransactionCard", () => {
     const po = renderComponent(account, transaction);
 
     expect(await po.getAmount()).toBe("-1.2301");
-  });
-
-  it("renders transaction ICPs with + sign", () => {
-    const account = mockSubAccount;
-    const transaction = mockReceivedFromMainAccountTransaction;
-    const { getByTestId } = renderTransactionCard(account, transaction);
-    const { displayAmount } = mapNnsTransaction({ account, transaction });
-
-    expect(getByTestId("token-value")?.textContent).toBe(
-      `+${formatToken({ value: displayAmount, detailed: true })}`
-    );
   });
 
   it("renders transaction ICPs with + sign", async () => {

--- a/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
@@ -2,8 +2,6 @@ import type { Transaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import NnsTransactionCard from "$lib/components/accounts/NnsTransactionCard.svelte";
 import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
 import { getSwapCanisterAccount } from "$lib/utils/sns.utils";
-import { formatToken } from "$lib/utils/token.utils";
-import { mapNnsTransaction } from "$lib/utils/transactions.utils";
 import {
   mockMainAccount,
   mockSubAccount,

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -1,6 +1,5 @@
 import TransactionCard from "$lib/components/accounts/TransactionCard.svelte";
-import type { Transaction, UiTransaction } from "$lib/types/transaction";
-import { mockTransactionSendDataFromMain } from "$tests/mocks/transaction.mock";
+import type { UiTransaction } from "$lib/types/transaction";
 import { TransactionCardPo } from "$tests/page-objects/TransactionCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { normalizeWhitespace } from "$tests/utils/utils.test-utils";
@@ -8,21 +7,6 @@ import { ICPToken } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
 describe("TransactionCard", () => {
-  const renderComponent = ({
-    transaction = mockTransactionSendDataFromMain,
-    descriptions,
-  }: {
-    transaction?: Transaction | UiTransaction;
-    descriptions?: Record<string, string>;
-  }) => {
-    const { container } = render(TransactionCard, {
-      props: {
-        transaction,
-      },
-    });
-    return TransactionCardPo.under(new JestPageObjectElement(container));
-  };
-
   const defaultTransaction = {
     isIncoming: false,
     icon: "outgoing",
@@ -33,13 +17,22 @@ describe("TransactionCard", () => {
     timestamp: new Date("2021-03-14T00:00:00.000Z"),
   } as UiTransaction;
 
+  const renderComponent = (transaction: Partial<UiTransaction>) => {
+    const { container } = render(TransactionCard, {
+      props: {
+        transaction: {
+          ...defaultTransaction,
+          ...transaction,
+        },
+      },
+    });
+    return TransactionCardPo.under(new JestPageObjectElement(container));
+  };
+
   it("renders received headline", async () => {
     const headline = "Received";
     const po = renderComponent({
-      transaction: {
-        ...defaultTransaction,
-        headline,
-      },
+      headline,
     });
 
     expect(await po.getHeadline()).toBe(headline);
@@ -47,12 +40,9 @@ describe("TransactionCard", () => {
 
   it("renders burn description", async () => {
     const po = renderComponent({
-      transaction: {
-        ...defaultTransaction,
-        headline: "Sent",
-        fallbackDescription: "To: BTC Network",
-        otherParty: undefined,
-      },
+      headline: "Sent",
+      fallbackDescription: "To: BTC Network",
+      otherParty: undefined,
     });
 
     expect(await po.getHeadline()).toBe("Sent");
@@ -62,12 +52,9 @@ describe("TransactionCard", () => {
 
   it("renders ckBTC burn To:", async () => {
     const po = renderComponent({
-      transaction: {
-        ...defaultTransaction,
-        isIncoming: false,
-        headline: "Sent",
-        otherParty: "withdrwala-address",
-      },
+      isIncoming: false,
+      headline: "Sent",
+      otherParty: "withdrwala-address",
     });
 
     expect(await po.getHeadline()).toBe("Sent");
@@ -78,10 +65,7 @@ describe("TransactionCard", () => {
   it("renders sent headline", async () => {
     const headline = "Sent";
     const po = renderComponent({
-      transaction: {
-        ...defaultTransaction,
-        headline,
-      },
+      headline,
     });
 
     expect(await po.getHeadline()).toBe(headline);
@@ -89,11 +73,8 @@ describe("TransactionCard", () => {
 
   it("renders transaction ICPs with - sign", async () => {
     const po = renderComponent({
-      transaction: {
-        ...defaultTransaction,
-        isIncoming: false,
-        amount: 123_000_000n,
-      },
+      isIncoming: false,
+      amount: 123_000_000n,
     });
 
     expect(await po.getAmount()).toBe("-1.23");
@@ -101,11 +82,8 @@ describe("TransactionCard", () => {
 
   it("renders transaction ICPs with + sign", async () => {
     const po = renderComponent({
-      transaction: {
-        ...defaultTransaction,
-        isIncoming: true,
-        amount: 345_000_000n,
-      },
+      isIncoming: true,
+      amount: 345_000_000n,
     });
 
     expect(await po.getAmount()).toBe("+3.45");
@@ -113,10 +91,7 @@ describe("TransactionCard", () => {
 
   it("displays transaction date and time", async () => {
     const po = renderComponent({
-      transaction: {
-        ...defaultTransaction,
-        timestamp: new Date("2021-03-14T00:00:00.000Z"),
-      },
+      timestamp: new Date("2021-03-14T00:00:00.000Z"),
     });
 
     expect(normalizeWhitespace(await po.getDate())).toBe(
@@ -126,11 +101,8 @@ describe("TransactionCard", () => {
 
   it("displays identifier for received", async () => {
     const po = renderComponent({
-      transaction: {
-        ...defaultTransaction,
-        isIncoming: true,
-        otherParty: "from-address",
-      },
+      isIncoming: true,
+      otherParty: "from-address",
     });
 
     expect(await po.getIdentifier()).toBe("From: from-address");
@@ -138,11 +110,8 @@ describe("TransactionCard", () => {
 
   it("displays identifier for sent", async () => {
     const po = renderComponent({
-      transaction: {
-        ...defaultTransaction,
-        isIncoming: false,
-        otherParty: "to-address",
-      },
+      isIncoming: false,
+      otherParty: "to-address",
     });
 
     expect(await po.getIdentifier()).toBe("To: to-address");

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -3,7 +3,7 @@ import type { UiTransaction } from "$lib/types/transaction";
 import { TransactionCardPo } from "$tests/page-objects/TransactionCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { normalizeWhitespace } from "$tests/utils/utils.test-utils";
-import { ICPToken } from "@dfinity/utils";
+import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
 describe("TransactionCard", () => {
@@ -12,8 +12,7 @@ describe("TransactionCard", () => {
     icon: "outgoing",
     headline: "Sent",
     otherParty: "some-address",
-    amount: 123_000_000n,
-    token: ICPToken,
+    tokenAmount: TokenAmount.fromE8s({ amount: 123_000_000n, token: ICPToken }),
     timestamp: new Date("2021-03-14T00:00:00.000Z"),
   } as UiTransaction;
 
@@ -74,7 +73,10 @@ describe("TransactionCard", () => {
   it("renders transaction ICPs with - sign", async () => {
     const po = renderComponent({
       isIncoming: false,
-      amount: 123_000_000n,
+      tokenAmount: TokenAmount.fromE8s({
+        amount: 123_000_000n,
+        token: ICPToken,
+      }),
     });
 
     expect(await po.getAmount()).toBe("-1.23");
@@ -83,7 +85,10 @@ describe("TransactionCard", () => {
   it("renders transaction ICPs with + sign", async () => {
     const po = renderComponent({
       isIncoming: true,
-      amount: 345_000_000n,
+      tokenAmount: TokenAmount.fromE8s({
+        amount: 345_000_000n,
+        token: ICPToken,
+      }),
     });
 
     expect(await po.getAmount()).toBe("+3.45");

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -520,26 +520,6 @@ describe("transactions-utils", () => {
       });
     });
 
-    it("should convert an approve transaction", () => {
-      expect(
-        toUiTransaction({
-          ...defaultParams,
-          transaction: {
-            ...defaultTransaction,
-            type: AccountTransactionType.Approve,
-            isSend: false,
-            isReceive: false,
-            from: undefined,
-            to: undefined,
-          },
-        })
-      ).toEqual({
-        ...defaultExpectedUiTransaction,
-        headline: "Approve transfer",
-        otherParty: undefined,
-      });
-    });
-
     it("should use fallbackDescriptions", () => {
       expect(
         toUiTransaction({

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -1,7 +1,9 @@
-import type { Transaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import type { Transaction as NnsTransaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import {
   AccountTransactionType,
   TransactionNetwork,
+  type Transaction,
+  type UiTransaction,
 } from "$lib/types/transaction";
 import { enumKeys } from "$lib/utils/enum.utils";
 import { getSwapCanisterAccount } from "$lib/utils/sns.utils";
@@ -10,6 +12,7 @@ import {
   mapNnsTransaction,
   mapToSelfTransaction,
   showTransactionFee,
+  toUiTransaction,
   transactionDisplayAmount,
   transactionName,
   transactionType,
@@ -20,11 +23,12 @@ import {
   mockMainAccount,
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
-import { principal } from "$tests/mocks/sns-projects.mock";
+import { mockToken, principal } from "$tests/mocks/sns-projects.mock";
 import {
   mockReceivedFromMainAccountTransaction,
   mockSentToSubAccountTransaction,
 } from "$tests/mocks/transaction.mock";
+import { ICPToken, TokenAmount } from "@dfinity/utils";
 
 describe("transactions-utils", () => {
   describe("showTransactionFee", () => {
@@ -148,7 +152,7 @@ describe("transactions-utils", () => {
         controller: mockMainAccount.principal,
         swapCanisterId,
       });
-      const swapTransaction: Transaction = {
+      const swapTransaction: NnsTransaction = {
         ...mockReceivedFromMainAccountTransaction,
         transfer: {
           Send: {
@@ -172,7 +176,7 @@ describe("transactions-utils", () => {
         controller: mockMainAccount.principal,
         swapCanisterId,
       });
-      const swapTransaction: Transaction = {
+      const swapTransaction: NnsTransaction = {
         ...mockReceivedFromMainAccountTransaction,
         transfer: {
           Receive: {
@@ -205,7 +209,7 @@ describe("transactions-utils", () => {
             ...mockSentToSubAccountTransaction,
             Burn: null,
             transaction_type: [],
-          } as unknown as Transaction,
+          } as unknown as NnsTransaction,
         })
       ).toBe(AccountTransactionType.Burn);
       expect(
@@ -214,7 +218,7 @@ describe("transactions-utils", () => {
             ...mockSentToSubAccountTransaction,
             Mint: null,
             transaction_type: [],
-          } as unknown as Transaction,
+          } as unknown as NnsTransaction,
         })
       ).toBe(AccountTransactionType.Mint);
     });
@@ -375,7 +379,7 @@ describe("transactions-utils", () => {
         controller: mockMainAccount.principal,
         swapCanisterId,
       });
-      const swapTransaction: Transaction = {
+      const swapTransaction: NnsTransaction = {
         ...mockReceivedFromMainAccountTransaction,
         transfer: {
           Send: {
@@ -400,7 +404,7 @@ describe("transactions-utils", () => {
         controller: mockMainAccount.principal,
         swapCanisterId,
       });
-      const swapTransaction: Transaction = {
+      const swapTransaction: NnsTransaction = {
         ...mockReceivedFromMainAccountTransaction,
         transfer: {
           Receive: {
@@ -417,6 +421,209 @@ describe("transactions-utils", () => {
         swapCanisterAccounts: new Set([swapCanisterAccount.toHex()]),
       });
       expect(type).toBe(AccountTransactionType.RefundSwap);
+    });
+  });
+
+  describe("toUiTransaction", () => {
+    const defaultDate = new Date("2021-01-01 00:00:00");
+    const defaultAmount = 100_000_000n;
+    const defaultFrom = "from-address";
+    const defaultTo = "to-address";
+
+    const defaultTransaction: Transaction = {
+      type: AccountTransactionType.Send,
+      isReceive: false,
+      isSend: true,
+      from: defaultFrom,
+      to: defaultTo,
+      displayAmount: defaultAmount,
+      date: defaultDate,
+    };
+
+    const defaultParams = {
+      transaction: defaultTransaction,
+      toSelfTransaction: false,
+      token: ICPToken,
+      transactionNames: en.transaction_names,
+    };
+
+    const defaultExpectedUiTransaction: UiTransaction = {
+      isIncoming: false,
+      headline: "Sent",
+      otherParty: defaultTo,
+      tokenAmount: TokenAmount.fromE8s({
+        amount: defaultAmount,
+        token: ICPToken,
+      }),
+      timestamp: defaultDate,
+    };
+
+    it("should convert the default transaction", () => {
+      expect(toUiTransaction(defaultParams)).toEqual(
+        defaultExpectedUiTransaction
+      );
+    });
+
+    it("should convert a sent transaction", () => {
+      expect(
+        toUiTransaction({
+          ...defaultParams,
+          transaction: {
+            ...defaultTransaction,
+            isSend: true,
+            isReceive: false,
+          },
+        })
+      ).toEqual({
+        ...defaultExpectedUiTransaction,
+        isIncoming: false,
+        headline: "Sent",
+        otherParty: defaultTo,
+      });
+    });
+
+    it("should convert a received transaction", () => {
+      expect(
+        toUiTransaction({
+          ...defaultParams,
+          transaction: {
+            ...defaultTransaction,
+            isReceive: true,
+            isSend: false,
+          },
+        })
+      ).toEqual({
+        ...defaultExpectedUiTransaction,
+        isIncoming: true,
+        headline: "Received",
+        otherParty: defaultFrom,
+      });
+    });
+
+    it("should convert an approve transaction", () => {
+      expect(
+        toUiTransaction({
+          ...defaultParams,
+          transaction: {
+            ...defaultTransaction,
+            type: AccountTransactionType.Approve,
+            isSend: false,
+            isReceive: false,
+            from: undefined,
+            to: undefined,
+          },
+        })
+      ).toEqual({
+        ...defaultExpectedUiTransaction,
+        headline: "Approve transfer",
+        otherParty: undefined,
+      });
+    });
+
+    it("should convert an approve transaction", () => {
+      expect(
+        toUiTransaction({
+          ...defaultParams,
+          transaction: {
+            ...defaultTransaction,
+            type: AccountTransactionType.Approve,
+            isSend: false,
+            isReceive: false,
+            from: undefined,
+            to: undefined,
+          },
+        })
+      ).toEqual({
+        ...defaultExpectedUiTransaction,
+        headline: "Approve transfer",
+        otherParty: undefined,
+      });
+    });
+
+    it("should use fallbackDescriptions", () => {
+      expect(
+        toUiTransaction({
+          ...defaultParams,
+          transaction: {
+            ...defaultTransaction,
+            type: AccountTransactionType.Burn,
+            isSend: false,
+            isReceive: false,
+            from: undefined,
+            to: undefined,
+          },
+          fallbackDescriptions: en.ckbtc_transaction_names as unknown as Record<
+            string,
+            string
+          >,
+        })
+      ).toEqual({
+        ...defaultExpectedUiTransaction,
+        headline: "Sent",
+        otherParty: undefined,
+        fallbackDescription: 'To: <span class="value">BTC Network</span>',
+      });
+    });
+
+    it("should convert a to-self transaction", () => {
+      expect(
+        toUiTransaction({
+          ...defaultParams,
+          toSelfTransaction: true,
+        })
+      ).toEqual({
+        ...defaultExpectedUiTransaction,
+        isIncoming: true,
+        headline: "Received",
+        otherParty: defaultFrom,
+      });
+    });
+
+    it("should convert amount", () => {
+      const amount = 728_000_000n;
+      expect(
+        toUiTransaction({
+          ...defaultParams,
+          transaction: {
+            ...defaultTransaction,
+            displayAmount: amount,
+          },
+        })
+      ).toEqual({
+        ...defaultExpectedUiTransaction,
+        tokenAmount: TokenAmount.fromE8s({ amount, token: ICPToken }),
+      });
+    });
+
+    it("should convert token", () => {
+      expect(
+        toUiTransaction({
+          ...defaultParams,
+          token: mockToken,
+        })
+      ).toEqual({
+        ...defaultExpectedUiTransaction,
+        tokenAmount: TokenAmount.fromE8s({
+          amount: defaultAmount,
+          token: mockToken,
+        }),
+      });
+    });
+
+    it("should convert timestamp", () => {
+      const timestamp = new Date("2021-03-04 12:56:47");
+      expect(
+        toUiTransaction({
+          ...defaultParams,
+          transaction: {
+            ...defaultTransaction,
+            date: timestamp,
+          },
+        })
+      ).toEqual({
+        ...defaultExpectedUiTransaction,
+        timestamp,
+      });
     });
   });
 

--- a/frontend/src/tests/mocks/transaction.mock.ts
+++ b/frontend/src/tests/mocks/transaction.mock.ts
@@ -3,33 +3,56 @@ import type { Transaction } from "$lib/types/transaction";
 import { AccountTransactionType } from "$lib/types/transaction";
 import { mockMainAccount, mockSubAccount } from "./icp-accounts.store.mock";
 
-export const mockSentToSubAccountTransaction = {
+export const createMockSendTransaction = ({
+  amount = 110000023n,
+  fee = 10000n,
+  to = mockSubAccount.identifier,
+}: {
+  amount?: bigint;
+  fee?: bigint;
+  to?: string;
+}): NnsTransaction => ({
   transaction_type: [{ Transfer: null }],
   memo: BigInt(0),
   timestamp: { timestamp_nanos: BigInt("0") },
   block_height: BigInt(208),
   transfer: {
     Send: {
-      to: mockSubAccount.identifier,
-      fee: { e8s: BigInt(10000) },
-      amount: { e8s: BigInt(110000023) },
+      to,
+      fee: { e8s: fee },
+      amount: { e8s: amount },
     },
   },
-} as NnsTransaction;
+});
 
-export const mockReceivedFromMainAccountTransaction = {
+export const mockSentToSubAccountTransaction = createMockSendTransaction({
+  to: mockSubAccount.identifier,
+});
+
+export const createMockReceiveTransaction = ({
+  amount = 110000000n,
+  fee = 10000n,
+  from = mockMainAccount.identifier,
+}: {
+  amount?: bigint;
+  fee?: bigint;
+  from?: string;
+}): NnsTransaction => ({
   transaction_type: [{ Transfer: null }],
   memo: BigInt(0),
   timestamp: { timestamp_nanos: BigInt("1652121288218078256") },
   block_height: BigInt(208),
   transfer: {
     Receive: {
-      fee: { e8s: BigInt(10000) },
-      from: mockMainAccount.identifier,
-      amount: { e8s: BigInt(110000000) },
+      fee: { e8s: fee },
+      from,
+      amount: { e8s: amount },
     },
   },
-} as NnsTransaction;
+});
+
+export const mockReceivedFromMainAccountTransaction =
+  createMockReceiveTransaction({ from: mockMainAccount.identifier });
 
 const displayAmount = 11000000000000000n;
 


### PR DESCRIPTION
# Motivation

We currently pass `mapTransaction` from `CkbtcTransactionsList` to `IcrcTransactionsList` to `IcrcTransactionCard` and then we apply the mapping and pass a lot of props to `TransactionCard`.
My goal is to simplify this and give the higher level component more direct control over how the transactions are rendered.

In this PR I introduce the `UiTransaction` type which contains all information necessary to render the `TransactionCard` component. This allows us to pass a single prop to `TransactionCard`.
My goal is to eventually return `UiTransaction` from `mapTransaction` and possibly retire the intermediate `Transaction` type.
Also, I want to map all the transactions in the higher level component to avoid sending down all these different props.

This is the first step.

# Changes

1. Introduce a new type `UiTransaction` which has the information needed to render a transaction in the transaction list.
2. Change `TransactionCard` to accept 1 prop of type `UiTransaction` and remove the logic that is made obsolete by that.
3. Add `toUiTransaction` which converts `Transaction`, plus some extra params, to a `UiTransaction`.
4. Change `IcrcTransactionCard` and `NnsTransactionCard` to pass a `UiTransaction` to `TransactionCard` instead of a collection of props.

# Tests

Unit tests updated and pass.
Manually at: https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary