### PR TITLE
Refactor: New mandatory SnsSummary fields

### DIFF
--- a/frontend/src/lib/types/sns.ts
+++ b/frontend/src/lib/types/sns.ts
@@ -79,17 +79,17 @@ export interface SnsSummary {
   /**
    * Data from `get_init` call.
    */
-  init?: SnsSwapInit;
+  init: SnsSwapInit;
 
   /**
    * Data from `get_sale_parameters` call.
    */
-  swapParams?: SnsParams;
+  swapParams: SnsParams;
 
   /**
    * Data from `get_lifecycle` call.
    */
-  lifecycle?: SnsGetLifecycleResponse;
+  lifecycle: SnsGetLifecycleResponse;
 }
 
 export interface SnsSwapCommitment {

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -388,16 +388,23 @@ const convertDtoToLifecycle = (
   lifecycle: toNullable(data.lifecycle),
 });
 
-type PartialSummary = Omit<SnsSummary, "metadata" | "token" | "swap"> & {
+type PartialSummary = Omit<
+  SnsSummary,
+  "metadata" | "token" | "swap" | "init" | "swapParams"
+> & {
   metadata?: SnsSummaryMetadata;
   token?: IcrcTokenMetadata;
   swap?: SnsSummarySwap;
+  init?: SnsSwapInit;
+  swapParams?: SnsParams;
 };
 
 const isValidSummary = (entry: PartialSummary): entry is SnsSummary =>
   nonNullish(entry.metadata) &&
   nonNullish(entry.token) &&
-  nonNullish(entry.swap);
+  nonNullish(entry.swap) &&
+  nonNullish(entry.init) &&
+  nonNullish(entry.swapParams);
 
 export const convertDtoToSnsSummary = ({
   canister_ids: {

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -203,6 +203,11 @@ export const mockToken: IcrcTokenMetadata = {
   fee: BigInt(0),
 };
 
+export const mockLifecycleResponse: SnsGetLifecycleResponse = {
+  lifecycle: [SnsSwapLifecycle.Open],
+  decentralization_sale_open_timestamp_seconds: [],
+};
+
 export const mockSnsSummaryList: SnsSummary[] = [
   {
     rootCanisterId: principal(0),
@@ -214,6 +219,9 @@ export const mockSnsSummaryList: SnsSummary[] = [
     token: mockToken,
     swap: mockSwap,
     derived: mockDerived,
+    init: mockInit,
+    swapParams: mockSnsParams,
+    lifecycle: mockLifecycleResponse,
   },
   {
     rootCanisterId: principal(1),
@@ -235,6 +243,9 @@ export const mockSnsSummaryList: SnsSummary[] = [
     },
     swap: mockSwap,
     derived: mockDerived,
+    init: mockInit,
+    swapParams: mockSnsParams,
+    lifecycle: mockLifecycleResponse,
   },
   {
     rootCanisterId: principal(2),
@@ -256,6 +267,9 @@ export const mockSnsSummaryList: SnsSummary[] = [
     },
     swap: mockSwap,
     derived: mockDerived,
+    init: mockInit,
+    swapParams: mockSnsParams,
+    lifecycle: mockLifecycleResponse,
   },
   {
     rootCanisterId: principal(3),
@@ -277,6 +291,9 @@ export const mockSnsSummaryList: SnsSummary[] = [
     },
     swap: mockSwap,
     derived: mockDerived,
+    init: mockInit,
+    swapParams: mockSnsParams,
+    lifecycle: mockLifecycleResponse,
   },
 ];
 
@@ -473,9 +490,4 @@ export const mockUniverse: Universe = {
   summary: mockSnsFullProject.summary,
   title: mockSnsFullProject.summary.metadata.name,
   logo: mockSnsFullProject.summary.metadata.logo,
-};
-
-export const mockLifecycleResponse: SnsGetLifecycleResponse = {
-  lifecycle: [SnsSwapLifecycle.Open],
-  decentralization_sale_open_timestamp_seconds: [],
 };


### PR DESCRIPTION
# Motivation

To better start using the new fields in SnsSummary, we should make them mandatory.

In this PR, make `init`, `swapParams` and `lifecycle` mandatory in SnsSummary.

# Changes

* Make `init`, `swapParams` and `lifecycle` mandatory in SnsSummary type.
* Add checks in `isValidSummary` for those fields except `lifecycle` which already couldn't be `undefined`.

# Tests

* Add mandaotry fields to mocks.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary