### PR TITLE
Fix: SignIn Tokens width page

### DIFF
--- a/frontend/src/lib/components/tokens/MainWrapper.svelte
+++ b/frontend/src/lib/components/tokens/MainWrapper.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  export let testId: string;
+  export let testId: string | undefined = undefined;
 </script>
 
 <main data-tid={testId}>

--- a/frontend/src/lib/pages/SignInTokens.svelte
+++ b/frontend/src/lib/pages/SignInTokens.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import SignIn from "$lib/components/common/SignIn.svelte";
+  import MainWrapper from "$lib/components/tokens/MainWrapper.svelte";
   import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
   import { i18n } from "$lib/stores/i18n";
   import type { UserTokenData } from "$lib/types/tokens-page";
@@ -8,7 +9,7 @@
   export let userTokensData: UserTokenData[];
 </script>
 
-<main class="sign-in" data-tid="sign-in-tokens-page-component">
+<MainWrapper testId="sign-in-tokens-page-component">
   <div class="content">
     <PageBanner>
       <IconAccountsPage slot="image" />
@@ -20,7 +21,7 @@
 
     <TokensTable on:nnsAction {userTokensData} />
   </div>
-</main>
+</MainWrapper>
 
 <style lang="scss">
   .content {

--- a/frontend/src/lib/pages/SignInTokens.svelte
+++ b/frontend/src/lib/pages/SignInTokens.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import SignIn from "$lib/components/common/SignIn.svelte";
-  import MainWrapper from "$lib/components/tokens/MainWrapper.svelte";
   import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
   import { i18n } from "$lib/stores/i18n";
   import type { UserTokenData } from "$lib/types/tokens-page";
@@ -9,19 +8,16 @@
   export let userTokensData: UserTokenData[];
 </script>
 
-<MainWrapper testId="sign-in-tokens-page-component">
-  <div class="content">
-    <PageBanner>
-      <IconAccountsPage slot="image" />
-      <svelte:fragment slot="title">{$i18n.auth_accounts.title}</svelte:fragment
-      >
-      <p class="description" slot="description">{$i18n.auth_accounts.text}</p>
-      <SignIn slot="actions" />
-    </PageBanner>
+<div class="content" data-tid="sign-in-tokens-page-component">
+  <PageBanner>
+    <IconAccountsPage slot="image" />
+    <svelte:fragment slot="title">{$i18n.auth_accounts.title}</svelte:fragment>
+    <p class="description" slot="description">{$i18n.auth_accounts.text}</p>
+    <SignIn slot="actions" />
+  </PageBanner>
 
-    <TokensTable on:nnsAction {userTokensData} />
-  </div>
-</MainWrapper>
+  <TokensTable on:nnsAction {userTokensData} />
+</div>
 
 <style lang="scss">
   .content {

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import MainWrapper from "$lib/components/tokens/MainWrapper.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
   import type { UserTokenData } from "$lib/types/tokens-page";
 
   export let userTokensData: UserTokenData[];
 </script>
 
-<MainWrapper testId="tokens-page-component">
+<TestIdWrapper testId="tokens-page-component">
   <TokensTable {userTokensData} on:nnsAction />
-</MainWrapper>
+</TestIdWrapper>

--- a/frontend/src/routes/(app)/(nns)/tokens/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+layout.svelte
@@ -3,12 +3,15 @@
   import Content from "$lib/components/layout/Content.svelte";
   import LayoutList from "$lib/components/layout/LayoutList.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import MainWrapper from "$lib/components/tokens/MainWrapper.svelte";
 </script>
 
 <LayoutList title={$i18n.tokens.title}>
   <Layout>
     <Content>
-      <slot />
+      <MainWrapper>
+        <slot />
+      </MainWrapper>
     </Content>
   </Layout>
 </LayoutList>


### PR DESCRIPTION
# Motivation

Width of tokens page for logged and non-logged in visitors was different.

Solution, move the wrapper to the layout.

# Changes

* Make `testId` optional in MainWrapper. Only used in NnsAccounts.
* Remove `<main>` wrapper in `SignInTokens`.
* Remove `MainWrapper` from Tokens page.
* Add `MainWrapper` in the tokens layout.

# Tests

No new tests. Only UI changes reshuffling some elements.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.