### PR TITLE
Update rust workflow text

### DIFF
--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -1,6 +1,6 @@
 # A GitHub Actions workflow that regularly checks for new Rust toolchain release
 # and creates a PR on new versions.
-name: Rust Update
+name: Update rust
 on:
   schedule:
     # check for new rust versions weekly
@@ -36,6 +36,7 @@ jobs:
           fi
 
           echo "latest rust version '$latest_rust_version'"
+          echo "version=$latest_rust_version" >> "$GITHUB_OUTPUT"
 
           if [ "$current_rust_version" != "$latest_rust_version" ]
           then
@@ -44,7 +45,6 @@ jobs:
             echo "updated=1" >> "$GITHUB_OUTPUT"
           else
             echo "updated=0" >> "$GITHUB_OUTPUT"
-            echo "version=$latest_rust_version" >> "$GITHUB_OUTPUT"
           fi
 
           cat ./rust-toolchain.toml
@@ -69,9 +69,19 @@ jobs:
           branch-suffix: timestamp
           delete-branch: true
           title: 'Update rust version to ${{ steps.update.outputs.version }}'
-          # Since the this is a scheduled job, a failure won't be shown on any
-          # PR status. To notify the team, we send a message to our Slack channel on failure.
+          body: |
+            # Motivation
+            A new verion of Rust is available.
+
+            # Automated changes
+            * Update Rust version.
+
+            # Manual changes
+            [ ] Fix clippy lints (if necessary)
+            [ ] Write a changelog entry.
       - name: Notify Slack on failure
+        # Since the this is a scheduled job, a failure won't be shown on any
+        # PR status. To notify the team, we send a message to our Slack channel on failure.
         uses: dfinity/internet-identity/.github/actions/slack@release-2023-08-28
         if: ${{ failure() }}
         with:

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -77,8 +77,8 @@ jobs:
             * Update Rust version.
 
             # Manual changes
-            [ ] Fix clippy lints (if necessary)
-            [ ] Write a changelog entry.
+            - [ ] Fix clippy lints (if necessary)
+            - [ ] Write a changelog entry.
       - name: Notify Slack on failure
         # Since the this is a scheduled job, a failure won't be shown on any
         # PR status. To notify the team, we send a message to our Slack channel on failure.

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -59,6 +59,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Update the URL of the app subnet to what dfx v15 expects.
 * Use a unique branch when updating the snsdemo release, didc, IC candid files or rust.
 * Better checks that the network is defined.
+* Better text for rust update PRs.
 
 #### Deprecated
 


### PR DESCRIPTION
# Motivation
The title and body of PRs created by the Rust update action are bad.  [Example](https://github.com/dfinity/nns-dapp/pull/3781)

- Title tries to declare which version is updated to but the version number is missing
- The PR has no meaningful body

# Changes
- Fix the title (by making the version number available unconditionally)
- Add a body

# Tests
This PR was generated by this action: #3788

# Todos

- [x] Add entry to changelog (if necessary).
