### PR TITLE
Update snsdemo to release-2023-11-17

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.15.1",
+  "dfx": "0.14.4",
   "canisters": {
     "nns-governance": {
       "type": "custom",
@@ -301,7 +301,7 @@
         "BINSTALL_VERSION": "1.3.0",
         "DIDC_VERSION": "2023-11-16",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2023-11-15",
+        "SNSDEMO_RELEASE": "release-2023-11-17",
         "IC_COMMIT": "release-2023-11-08_23-01"
       },
       "packtool": ""


### PR DESCRIPTION
# Motivation
We would like to keep the testing environment, provided by snsdemo, up to date.

# Changes
* Updated `snsdemo` version in `dfx.json`.
* Ensured that the `dfx` version and IC commit in `dfx.json` match `snsdemo`.

# Tests
CI should pass.