### PR TITLE
Chore: Revert upgrade dfx

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -62,6 +62,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Use a unique branch when updating the snsdemo release, didc, IC candid files or rust.
 * Better checks that the network is defined.
 * Better text for rust update PRs.
+* Revert `dfx` to `v0.14.4`.
 
 #### Deprecated
 


### PR DESCRIPTION
# Motivation

There are problems to connect to the dev environments using dfx 0.15.

In this PR, revert back to 0.14

# Changes

* Change dfx and snsdemo versions.

# Tests

Still passing.

# Todos

- [x] Add entry to changelog (if necessary).
