### PR TITLE
Create UiTransactions in IcrcTransactionsList

### DIFF
--- a/frontend/src/lib/components/accounts/IcrcTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionCard.svelte
@@ -1,44 +1,11 @@
 <script lang="ts">
-  import type { Account } from "$lib/types/account";
-  import { toUiTransaction } from "$lib/utils/transactions.utils";
-  import type { mapIcrcTransactionType } from "$lib/utils/icrc-transactions.utils";
-  import type { Principal } from "@dfinity/principal";
-  import type { IcrcTransactionWithId } from "@dfinity/ledger-icrc";
   import TransactionCard from "./TransactionCard.svelte";
-  import { i18n } from "$lib/stores/i18n";
-  import type { Transaction, UiTransaction } from "$lib/types/transaction";
+  import type { UiTransaction } from "$lib/types/transaction";
   import { nonNullish } from "@dfinity/utils";
-  import type { IcrcTokenMetadata } from "$lib/types/icrc";
 
-  export let transactionWithId: IcrcTransactionWithId;
-  export let account: Account;
-  export let toSelfTransaction: boolean;
-  export let governanceCanisterId: Principal | undefined = undefined;
-  export let descriptions: Record<string, string> | undefined = undefined;
-  export let token: IcrcTokenMetadata | undefined;
-  export let mapTransaction: mapIcrcTransactionType;
-
-  let transactionData: Transaction | undefined;
-  $: transactionData = mapTransaction({
-    transaction: transactionWithId,
-    account,
-    toSelfTransaction,
-    governanceCanisterId,
-  });
-
-  let uiTransaction: UiTransaction | undefined;
-  $: uiTransaction =
-    transactionData &&
-    token &&
-    toUiTransaction({
-      transaction: transactionData,
-      toSelfTransaction,
-      token,
-      transactionNames: $i18n.transaction_names,
-      fallbackDescriptions: descriptions,
-    });
+  export let transaction: UiTransaction | undefined;
 </script>
 
-{#if nonNullish(uiTransaction) && nonNullish(token)}
-  <TransactionCard transaction={uiTransaction} />
+{#if nonNullish(transaction)}
+  <TransactionCard {transaction} />
 {/if}

--- a/frontend/src/lib/components/accounts/NnsTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/NnsTransactionCard.svelte
@@ -43,6 +43,7 @@
         });
         uiTransaction = toUiTransaction({
           transaction: transactionData,
+          transactionId: transaction.block_height,
           toSelfTransaction,
           token: ICPToken,
           transactionNames: $i18n.transaction_names,

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -81,6 +81,8 @@ export interface Transaction {
 }
 
 export interface UiTransaction {
+  // Used in forEach for consistent rendering.
+  domKey: string;
   isIncoming: boolean;
   headline: string;
   // Where the amount is going to or coming from.

--- a/frontend/src/lib/utils/transactions.utils.ts
+++ b/frontend/src/lib/utils/transactions.utils.ts
@@ -169,12 +169,14 @@ export const mapNnsTransaction = ({
 
 export const toUiTransaction = ({
   transaction,
+  transactionId,
   toSelfTransaction,
   token,
   transactionNames,
   fallbackDescriptions,
 }: {
   transaction: Transaction;
+  transactionId: bigint;
   toSelfTransaction: boolean;
   token: Token;
   transactionNames: I18nTransaction_names;
@@ -192,6 +194,7 @@ export const toUiTransaction = ({
     : undefined;
 
   return {
+    domKey: `${transactionId}-${toSelfTransaction ? "0" : "1"}`,
     isIncoming,
     headline,
     otherParty,

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionCard.spec.ts
@@ -1,222 +1,52 @@
 import IcrcTransactionCard from "$lib/components/accounts/IcrcTransactionCard.svelte";
-import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
-import type { Account } from "$lib/types/account";
-import {
-  mapIcrcTransaction,
-  type mapIcrcTransactionType,
-} from "$lib/utils/icrc-transactions.utils";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
-import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
-import { createIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
-import {
-  mockSnsMainAccount,
-  mockSnsSubAccount,
-} from "$tests/mocks/sns-accounts.mock";
-import {
-  mockProjectSubscribe,
-  mockSnsFullProject,
-  mockSnsToken,
-} from "$tests/mocks/sns-projects.mock";
+import type { UiTransaction } from "$lib/types/transaction";
 import { TransactionCardPo } from "$tests/page-objects/TransactionCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { normalizeWhitespace } from "$tests/utils/utils.test-utils";
-import type { IcrcTransactionWithId } from "@dfinity/ledger-icrc";
-import type { Principal } from "@dfinity/principal";
-import type { Token } from "@dfinity/utils";
+import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
 describe("IcrcTransactionCard", () => {
-  const renderComponent = ({
-    account,
-    transactionWithId,
-    governanceCanisterId = undefined,
-    token,
-    mapTransaction,
-  }: {
-    account: Account;
-    transactionWithId: IcrcTransactionWithId;
-    governanceCanisterId?: Principal;
-    token: Token | undefined;
-    mapTransaction?: mapIcrcTransactionType;
-  }) => {
+  const renderComponent = (transaction: UiTransaction | undefined) => {
     const { container } = render(IcrcTransactionCard, {
       props: {
-        account,
-        transactionWithId,
-        toSelfTransaction: false,
-        governanceCanisterId,
-        token,
-        mapTransaction: mapTransaction ?? mapIcrcTransaction,
+        transaction,
       },
     });
     return TransactionCardPo.under(new JestPageObjectElement(container));
   };
 
-  const subaccount = {
-    owner: mockPrincipal,
-    subaccount: [Uint8Array.from(mockSubAccountArray)] as [Uint8Array],
-  };
-  const mainAccount = {
-    owner: mockPrincipal,
-    subaccount: [] as [],
-  };
-  const transactionFromMainToSubaccount = createIcrcTransactionWithId({
-    to: subaccount,
-    from: mainAccount,
-  });
-  const transactionToMainFromSubaccount = createIcrcTransactionWithId({
-    to: mainAccount,
-    from: subaccount,
-  });
+  const defaultTransaction = {
+    domKey: "123-0",
+    isIncoming: false,
+    icon: "outgoing",
+    headline: "Sent",
+    otherParty: "some-address",
+    tokenAmount: TokenAmount.fromE8s({ amount: 123_000_000n, token: ICPToken }),
+    timestamp: new Date("2021-03-14T00:00:00.000Z"),
+  } as UiTransaction;
 
-  beforeEach(() => {
-    vi.spyOn(snsProjectsStore, "subscribe").mockImplementation(
-      mockProjectSubscribe([mockSnsFullProject])
-    );
-  });
-
-  it("renders received headline", async () => {
-    const po = renderComponent({
-      account: mockSnsSubAccount,
-      transactionWithId: transactionFromMainToSubaccount,
-      token: mockSnsToken,
-    });
-
-    expect(await po.getHeadline()).toBe("Received");
-  });
-
-  it("renders sent headline", async () => {
-    const po = renderComponent({
-      account: mockSnsMainAccount,
-      transactionWithId: transactionFromMainToSubaccount,
-      token: mockSnsToken,
-    });
-
-    expect(await po.getHeadline()).toBe("Sent");
-  });
-
-  it("renders stake neuron headline", async () => {
-    const toGov = {
-      owner: mockSnsFullProject.summary.governanceCanisterId,
-      subaccount: [Uint8Array.from([0, 0, 1])] as [Uint8Array],
-    };
-    const stakeNeuronTransaction = createIcrcTransactionWithId({
-      to: toGov,
-      from: mainAccount,
-    });
-    stakeNeuronTransaction.transaction.transfer[0].memo = [new Uint8Array()];
-    const po = renderComponent({
-      account: mockSnsMainAccount,
-      transactionWithId: stakeNeuronTransaction,
-      governanceCanisterId: mockSnsFullProject.summary.governanceCanisterId,
-      token: mockSnsToken,
-    });
-
-    expect(await po.getHeadline()).toBe("Stake Neuron");
-  });
-
-  it("renders transaction Token symbol with - sign", async () => {
-    const account = mockSnsMainAccount;
-    const po = renderComponent({
-      account,
-      transactionWithId: createIcrcTransactionWithId({
-        from: mainAccount,
-        to: subaccount,
-        amount: 123_000_000n,
-        fee: 10_000n,
-      }),
-      token: mockSnsToken,
-    });
-
-    expect(await po.getAmount()).toBe("-1.2301");
-  });
-
-  it("renders transaction Tokens with + sign", async () => {
-    const account = mockSnsSubAccount;
-    const po = renderComponent({
-      account,
-      transactionWithId: createIcrcTransactionWithId({
-        from: mainAccount,
-        to: subaccount,
-        amount: 123_000_000n,
-        fee: 10_000n,
-      }),
-      token: mockSnsToken,
-    });
-
-    expect(await po.getAmount()).toBe("+1.23");
-  });
-
-  it("displays transaction date and time", async () => {
-    const po = renderComponent({
-      account: mockSnsMainAccount,
-      transactionWithId: transactionFromMainToSubaccount,
-      token: mockSnsToken,
-    });
-
-    expect(normalizeWhitespace(await po.getDate())).toBe(
-      "Jan 1, 1970 12:00 AM"
-    );
-  });
-
-  it("displays identifier for received", async () => {
-    const po = renderComponent({
-      account: mockSnsSubAccount,
-      transactionWithId: transactionFromMainToSubaccount,
-      token: mockSnsToken,
-    });
-    const identifier = await po.getIdentifier();
-
-    expect(identifier).toBe(`From: ${mockSnsMainAccount.identifier}`);
-  });
-
-  it("displays identifier for sent for main sns account", async () => {
-    const po = renderComponent({
-      account: mockSnsMainAccount,
-      transactionWithId: transactionFromMainToSubaccount,
-      token: mockSnsToken,
-    });
-    const identifier = await po.getIdentifier();
-
-    expect(identifier).toBe(`To: ${mockSnsSubAccount.identifier}`);
-  });
-
-  it("displays identifier for sent for sub sns account", async () => {
-    const po = renderComponent({
-      account: mockSnsSubAccount,
-      transactionWithId: transactionToMainFromSubaccount,
-      token: mockSnsToken,
-    });
-    const identifier = await po.getIdentifier();
-
-    expect(identifier).toBe(`To: ${mockSnsMainAccount.identifier}`);
-  });
-
-  it("renders no transaction card if token is unlikely undefined", async () => {
-    const po = renderComponent({
-      account: mockSnsSubAccount,
-      transactionWithId: transactionFromMainToSubaccount,
-      token: undefined,
-    });
-
+  it("renders nothing for undefined", async () => {
+    const po = renderComponent(undefined);
     expect(await po.isPresent()).toBe(false);
   });
 
-  it("uses mapTransaction", async () => {
-    const customIdentifier = "custom identifier";
-    const customMapTransaction = (params) => ({
-      ...mapIcrcTransaction(params),
-      to: customIdentifier,
-    });
-
+  it("renders sent headline", async () => {
+    const headline = "Sent";
     const po = renderComponent({
-      account: mockSnsMainAccount,
-      transactionWithId: transactionFromMainToSubaccount,
-      token: mockSnsToken,
-      mapTransaction: customMapTransaction,
+      ...defaultTransaction,
+      headline,
     });
-    const identifier = await po.getIdentifier();
 
-    expect(identifier).toBe(`To: ${customIdentifier}`);
+    expect(await po.getHeadline()).toBe(headline);
+  });
+
+  it("renders received headline", async () => {
+    const headline = "Received";
+    const po = renderComponent({
+      ...defaultTransaction,
+      headline,
+    });
+
+    expect(await po.getHeadline()).toBe(headline);
   });
 });

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionsList.spec.ts
@@ -95,7 +95,7 @@ describe("IcrcTransactionList", () => {
     expect(await po.getTransactionCardPos()).toHaveLength(1);
   });
 
-  it.only("should not render transactions without token", async () => {
+  it("should not render transactions without token", async () => {
     const po = renderComponent({
       account: mockSnsMainAccount,
       transactions: [

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionsList.spec.ts
@@ -1,6 +1,7 @@
 import IcrcTransactionsList from "$lib/components/accounts/IcrcTransactionsList.svelte";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import type { Account } from "$lib/types/account";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import type { IcrcTransactionData } from "$lib/types/transaction";
 import {
   mapIcrcTransaction,
@@ -23,12 +24,14 @@ describe("IcrcTransactionList", () => {
     loading,
     completed = false,
     mapTransaction,
+    token = mockSnsToken,
   }: {
     account: Account;
     transactions: IcrcTransactionData[];
     loading?: boolean;
     completed?: boolean;
     mapTransaction?: mapIcrcTransactionType;
+    token?: IcrcTokenMetadata;
   }) => {
     const { container } = render(IcrcTransactionsList, {
       props: {
@@ -36,7 +39,7 @@ describe("IcrcTransactionList", () => {
         transactions,
         loading,
         completed,
-        token: mockSnsToken,
+        token,
         mapTransaction: mapTransaction ?? mapIcrcTransaction,
       },
     });
@@ -90,6 +93,23 @@ describe("IcrcTransactionList", () => {
     });
 
     expect(await po.getTransactionCardPos()).toHaveLength(1);
+  });
+
+  it.only("should not render transactions without token", async () => {
+    const po = renderComponent({
+      account: mockSnsMainAccount,
+      transactions: [
+        {
+          transaction: mockIcrcTransactionWithId,
+          toSelfTransaction: false,
+        },
+      ],
+      loading: false,
+      completed: true,
+      token: null,
+    });
+
+    expect(await po.getTransactionCardPos()).toHaveLength(0);
   });
 
   it("uses mapTransaction", async () => {

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -8,6 +8,7 @@ import { render } from "@testing-library/svelte";
 
 describe("TransactionCard", () => {
   const defaultTransaction = {
+    domKey: "234-0",
     isIncoming: false,
     icon: "outgoing",
     headline: "Sent",

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -442,12 +442,14 @@ describe("transactions-utils", () => {
 
     const defaultParams = {
       transaction: defaultTransaction,
+      transactionId: 123n,
       toSelfTransaction: false,
       token: ICPToken,
       transactionNames: en.transaction_names,
     };
 
     const defaultExpectedUiTransaction: UiTransaction = {
+      domKey: "123-1",
       isIncoming: false,
       headline: "Sent",
       otherParty: defaultTo,
@@ -549,10 +551,12 @@ describe("transactions-utils", () => {
       expect(
         toUiTransaction({
           ...defaultParams,
+          transactionId: 129n,
           toSelfTransaction: true,
         })
       ).toEqual({
         ...defaultExpectedUiTransaction,
+        domKey: "129-0",
         isIncoming: true,
         headline: "Received",
         otherParty: defaultFrom,


### PR DESCRIPTION
# Motivation

To simplify transactions list rendering and give the higher level components more control over it, I'm moving the conversion to `UiTransaction` up the component chain.
The ultimate goal is to create the list of `UiTransaction`s directly from the list of `TransactionWithId`s without intermediate `IcrcTransactionData` or `Transaction`. Then it will also be easier to render multiple transactions as 1 (to hide the approval step) or 1 as multiple (such as with a to-self transaction).

In this PR we move creation of `UiTransactions` from the IcrcTransactionCard` to the `IcrcTransactionsList`.

# Changes

1. Add a field `domKey` to `UiTransaction` to keep consistent list rendering.
2. Pass transaction ID to `toUiTransaction` to use for the `domKey`.
3. Remove all props from `IcrcTransactionCard` and keep only 1 prop: `transaction: UiTransaction`.
4. In `IcrcTransactionsList` convert the entire list of transactions to a list of `UiTransaction`s before rendering.

# Tests

1. Remove most tests from `IcrcTransactionCard.spec.ts` because the component became a very simple pass-through components.
2. Add a test that was missing that no transactions are rendered when `token` is not available yet.
3. Add `domKey` to unit tests.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary