### PR TITLE
GIX-2085: AccountsPlusPagePo

### DIFF
--- a/frontend/src/routes/(app)/(u)/(accounts)/+page.svelte
+++ b/frontend/src/routes/(app)/(u)/(accounts)/+page.svelte
@@ -2,10 +2,13 @@
   import SignInAccounts from "$lib/pages/SignInAccounts.svelte";
   import Accounts from "$lib/routes/Accounts.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 </script>
 
-{#if $authSignedInStore}
-  <Accounts />
-{:else}
-  <SignInAccounts />
-{/if}
+<TestIdWrapper testId="accounts-plus-page-component">
+  {#if $authSignedInStore}
+    <Accounts />
+  {:else}
+    <SignInAccounts />
+  {/if}
+</TestIdWrapper>

--- a/frontend/src/routes/(app)/(u)/(accounts)/accounts/+page.svelte
+++ b/frontend/src/routes/(app)/(u)/(accounts)/accounts/+page.svelte
@@ -2,10 +2,13 @@
   import SignInAccounts from "$lib/pages/SignInAccounts.svelte";
   import Accounts from "$lib/routes/Accounts.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 </script>
 
-{#if $authSignedInStore}
-  <Accounts />
-{:else}
-  <SignInAccounts />
-{/if}
+<TestIdWrapper testId="accounts-plus-page-component">
+  {#if $authSignedInStore}
+    <Accounts />
+  {:else}
+    <SignInAccounts />
+  {/if}
+</TestIdWrapper>

--- a/frontend/src/tests/page-objects/AccountsPlusPage.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountsPlusPage.page-object.ts
@@ -1,7 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AccountsPo } from "./Accounts.page-object";
-import { SignInAccountsPo } from "./SignInAccounts.page-object";
 
 export class AccountsPlusPagePo extends BasePageObject {
   private static readonly TID = "accounts-plus-page-component";
@@ -12,9 +11,5 @@ export class AccountsPlusPagePo extends BasePageObject {
 
   getAccountsPo(): AccountsPo {
     return AccountsPo.under(this.root);
-  }
-
-  getSignInAccountsPo(): SignInAccountsPo {
-    return SignInAccountsPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/AccountsPlusPage.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountsPlusPage.page-object.ts
@@ -1,0 +1,20 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { AccountsPo } from "./Accounts.page-object";
+import { SignInAccountsPo } from "./SignInAccounts.page-object";
+
+export class AccountsPlusPagePo extends BasePageObject {
+  private static readonly TID = "accounts-plus-page-component";
+
+  static under(element: PageObjectElement): AccountsPlusPagePo {
+    return new AccountsPlusPagePo(element.byTestId(AccountsPlusPagePo.TID));
+  }
+
+  getAccountsPo(): AccountsPo {
+    return AccountsPo.under(this.root);
+  }
+
+  getSignInAccountsPo(): SignInAccountsPo {
+    return SignInAccountsPo.under(this.root);
+  }
+}

--- a/frontend/src/tests/routes/app/accounts/page.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/page.spec.ts
@@ -4,7 +4,7 @@ import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { page } from "$mocks/$app/stores";
 import AccountsPage from "$routes/(app)/(u)/(accounts)/accounts/+page.svelte";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
-import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
+import { AccountsPlusPagePo } from "$tests/page-objects/AccountsPlusPage.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 
@@ -14,7 +14,7 @@ vi.mock("$lib/api/sns-ledger.api");
 describe("Accounts page", () => {
   const renderComponent = () => {
     const { container } = render(AccountsPage);
-    return AccountsPo.under(new JestPageObjectElement(container));
+    return AccountsPlusPagePo.under(new JestPageObjectElement(container));
   };
 
   beforeEach(() => {
@@ -50,7 +50,7 @@ describe("Accounts page", () => {
       it("renders tokens table for NNS accounts", async () => {
         const po = renderComponent();
 
-        const pagePo = po.getNnsAccountsPo();
+        const pagePo = po.getAccountsPo().getNnsAccountsPo();
         expect(await pagePo.hasTokensTable()).toBe(true);
       });
     });
@@ -63,7 +63,7 @@ describe("Accounts page", () => {
       it("does not render tokens table for NNS accounts", async () => {
         const po = renderComponent();
 
-        const pagePo = po.getNnsAccountsPo();
+        const pagePo = po.getAccountsPo().getNnsAccountsPo();
         expect(await pagePo.hasTokensTable()).toBe(false);
       });
     });


### PR DESCRIPTION
# Motivation

There was a mismatch with the PO used in one test and the actual component being tested.

The spec for the `+page` in the accounts route was using the PO for the `routes/Accounts.svelte`. Which is really a child of that component.

In this PR, I add a new PO `AccountsPlusPagePo`. I added the `PlusPage` in reference to `+page` used in the route. I hope this will help with the misconcenption.

# Changes

* New PO AccountsPlusPagePo
* Use the new PO in `routes/app/accounts/page.spec.ts`

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.