### PR TITLE
GIX-2058: Derived store ICP Tokens visitor

### DIFF
--- a/frontend/src/lib/derived/icp-tokens-list-visitors.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-visitors.derived.ts
@@ -1,0 +1,20 @@
+import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
+import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
+import type { Universe } from "$lib/types/universe";
+import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+import { Principal } from "@dfinity/principal";
+import { derived, type Readable } from "svelte/store";
+import { nnsUniverseStore } from "./nns-universe.derived";
+
+export const icpTokensListVisitors = derived<
+  Readable<Universe>,
+  UserTokenData[]
+>(nnsUniverseStore, (nnsUniverse) => [
+  {
+    universeId: Principal.fromText(nnsUniverse.canisterId),
+    title: nnsUniverse.title,
+    balance: new UnavailableTokenAmount(NNS_TOKEN_DATA),
+    logo: nnsUniverse.logo,
+    actions: [UserTokenAction.GoToDetail],
+  },
+]);

--- a/frontend/src/tests/lib/derived/icp-tokens-list-visitors.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-visitors.derived.spec.ts
@@ -1,0 +1,28 @@
+import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
+import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
+import { icpTokensListVisitors } from "$lib/derived/icp-tokens-list-visitors.derived";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
+import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+import { get } from "svelte/store";
+
+describe("icp-tokens-list-visitors.derived", () => {
+  const icpTokenBase: UserTokenData = {
+    universeId: OWN_CANISTER_ID,
+    title: "Internet Computer",
+    logo: IC_LOGO_ROUNDED,
+    balance: new UnavailableTokenAmount(NNS_TOKEN_DATA),
+    actions: [UserTokenAction.GoToDetail],
+  };
+
+  describe("icpTokensListVisitors", () => {
+    beforeEach(() => {
+      tokensStore.reset();
+    });
+
+    it("should return ICP with unavailable balance", () => {
+      expect(get(icpTokensListVisitors)).toEqual([icpTokenBase]);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

The user might arrive directly to the accounts page of the ICP without going through tokens.

The route is the current `/accounts` page. Although for now, it will be available only when `u=OWN_CANISTER`.

In case a non-logged in user lands there, they should see a table like in `/tokens` but with only ICP main account.

In this PR, I introduce the derived store for those visitors.

# Changes

* New derived store `icpTokensListVisitors`.

# Tests

* Test new derived store.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
