### PR TITLE
Remove unnecessary showTransactionFee

### DIFF
--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -22,7 +22,6 @@ import {
   nonNullish,
   uint8ArrayToHexString,
 } from "@dfinity/utils";
-import { showTransactionFee } from "./transactions.utils";
 
 const isToSelf = (transaction: IcrcTransaction): boolean => {
   if (transaction.transfer.length !== 1) {
@@ -183,10 +182,7 @@ export const mapIcrcTransaction = ({
     const isReceive =
       toSelfTransaction === true || txInfo.from !== account.identifier;
     const isSend = nonNullish(txInfo.to) && txInfo.to !== account.identifier;
-    const useFee =
-      toSelfTransaction === true
-        ? false
-        : showTransactionFee({ type, isReceive });
+    const useFee = !isReceive;
     const feeApplied =
       useFee && txInfo.fee !== undefined ? txInfo.fee : BigInt(0);
 

--- a/frontend/src/lib/utils/transactions.utils.ts
+++ b/frontend/src/lib/utils/transactions.utils.ts
@@ -70,25 +70,6 @@ export const transactionType = ({
   );
 };
 
-export const showTransactionFee = ({
-  type,
-  isReceive,
-}: {
-  type: AccountTransactionType;
-  isReceive: boolean;
-}): boolean => {
-  if (isReceive) {
-    return false;
-  }
-  switch (type) {
-    case AccountTransactionType.Mint:
-    case AccountTransactionType.Burn:
-      return false;
-    default:
-      return true;
-  }
-};
-
 export const transactionDisplayAmount = ({
   useFee,
   amount,
@@ -149,11 +130,7 @@ export const mapNnsTransaction = ({
   const date = new Date(Number(timestamp.timestamp_nanos / BigInt(1e6)));
   const isReceive = toSelfTransaction === true || from !== account.identifier;
   const isSend = to !== account.identifier;
-  // (from==to workaround) in case of transaction duplication we replace one of the transaction to `Received`, and it doesn't need to show fee because paid fee is already shown in the `Send` one.
-  const useFee =
-    toSelfTransaction === true
-      ? false
-      : showTransactionFee({ type, isReceive });
+  const useFee = !isReceive;
   const displayAmount = transactionDisplayAmount({ useFee, amount, fee });
 
   return {

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -11,7 +11,6 @@ import {
   isTransactionNetworkBtc,
   mapNnsTransaction,
   mapToSelfTransaction,
-  showTransactionFee,
   toUiTransaction,
   transactionDisplayAmount,
   transactionName,
@@ -31,53 +30,6 @@ import {
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 
 describe("transactions-utils", () => {
-  describe("showTransactionFee", () => {
-    it("should be false for received transactions", () => {
-      expect(
-        showTransactionFee({
-          type: AccountTransactionType.Send,
-          isReceive: true,
-        })
-      ).toBe(false);
-      expect(
-        showTransactionFee({
-          type: AccountTransactionType.Mint,
-          isReceive: true,
-        })
-      ).toBe(false);
-    });
-
-    it("should be false for sent Mint and Burn", () => {
-      expect(
-        showTransactionFee({
-          type: AccountTransactionType.Mint,
-          isReceive: false,
-        })
-      ).toBe(false);
-      expect(
-        showTransactionFee({
-          type: AccountTransactionType.Burn,
-          isReceive: false,
-        })
-      ).toBe(false);
-    });
-
-    it("should be true for Sent", () => {
-      expect(
-        showTransactionFee({
-          type: AccountTransactionType.Send,
-          isReceive: false,
-        })
-      ).toBeTruthy();
-      expect(
-        showTransactionFee({
-          type: AccountTransactionType.StakeNeuron,
-          isReceive: false,
-        })
-      ).toBeTruthy();
-    });
-  });
-
   describe("transactionType", () => {
     it("determines type by transaction_type value", () => {
       expect(


### PR DESCRIPTION
# Motivation

The logic in `showTransactionFee` is unnecessary.
Burn and Mint transactions don't have a fee so even if we tried to add it, there's nothing to add.
If `toSelfTransaction` is true, then `isReceive` is also true, so there's no need to check `toSelfTransaction` separately.

# Changes

1. Remove `showTransactionFee` and just use `!isReceive` instead.
2. Remove test for `showTransactionFee`.

# Tests

Existing unit tests pass.
Transaction list, including Burn, Mint, Approve and TransferFrom, looks correct.
I also changed `transactionDisplayAmount` to add a fee when it shouldn't or not add a fee when it should and in both cases there was a failing test so that confirms there is test coverage.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary