### PR TITLE
Fix: global config fallback

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -28,6 +28,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Fix docker builds when there is no global config.
 * Add missing "Rename" button in the subaccount page.
 * Fix disappearing "Received" half of to-self transactions.
 * Fix debug store that wasn't working.

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -84,7 +84,7 @@ GLOBAL_NETWORK_CONFIG_PATH="$HOME/.config/dfx/networks.json"
 if test -e "$GLOBAL_NETWORK_CONFIG_PATH"; then
   cp "$GLOBAL_NETWORK_CONFIG_PATH" global-config.json # Docker cannot access files outside the local directory.
 else
-  echo "{}" >.global-config.json
+  echo "{}" >global-config.json
 fi
 
 if DOCKER_BUILDKIT=1 docker build \

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -81,10 +81,12 @@ set -x
 docker build --target check-environment .
 
 GLOBAL_NETWORK_CONFIG_PATH="$HOME/.config/dfx/networks.json"
+# Docker cannot access files outside the local directory.
+LOCAL_COPY_OF_GLOBAL_CONFIG="global-config.json"
 if test -e "$GLOBAL_NETWORK_CONFIG_PATH"; then
-  cp "$GLOBAL_NETWORK_CONFIG_PATH" global-config.json # Docker cannot access files outside the local directory.
+  cp "$GLOBAL_NETWORK_CONFIG_PATH" "$LOCAL_COPY_OF_GLOBAL_CONFIG"
 else
-  echo "{}" >global-config.json
+  echo "{}" >"$LOCAL_COPY_OF_GLOBAL_CONFIG"
 fi
 
 if DOCKER_BUILDKIT=1 docker build \


### PR DESCRIPTION
# Motivation
There is a typo in the global config fallback, causing docker builds to fail on machines that have never set a global config.

Note: Local configs have been deprecated since February 2022, so most active developers will have a global config, but not all.

Note: In CI we call docker directly so that we can cache builds use the buildx action.  Maybe we could have tests that are run only when the `release-candidate` tag is pushed.  That way we could test the docker build script pre-release without slowing down every PR.

# Changes
- Fix the typo - with a var so that the same filename is used on both branches.

# Tests
- Built locally with and without a global config.

# Todos

- [x] Add entry to changelog (if necessary).
