### PR TITLE
GIX-2085: Use TokensTable in SignInAccounts

### DIFF
--- a/frontend/src/lib/components/common/EmptyCards.svelte
+++ b/frontend/src/lib/components/common/EmptyCards.svelte
@@ -2,7 +2,7 @@
   import { Card } from "@dfinity/gix-components";
 </script>
 
-<div class="card-grid">
+<div class="card-grid" data-tid="empty-cards-component">
   <Card disabled>
     <div class="card-item" />
   </Card>

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -13,8 +13,8 @@
   import { ICPToken } from "@dfinity/utils";
   import type { UserTokenData } from "$lib/types/tokens-page";
   import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
-  import MainWrapper from "$lib/components/tokens/MainWrapper.svelte";
   import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   onMount(() => {
     if (!$ENABLE_MY_TOKENS) {
@@ -31,9 +31,9 @@
 </script>
 
 {#if $ENABLE_MY_TOKENS}
-  <MainWrapper testId="accounts-body">
+  <TestIdWrapper testId="accounts-body">
     <TokensTable {userTokensData} />
-  </MainWrapper>
+  </TestIdWrapper>
 {:else}
   <div class="card-grid" data-tid="accounts-body">
     {#if nonNullish($icpAccountsStore?.main)}

--- a/frontend/src/lib/pages/SignInAccounts.svelte
+++ b/frontend/src/lib/pages/SignInAccounts.svelte
@@ -2,14 +2,17 @@
   import EmptyCards from "$lib/components/common/EmptyCards.svelte";
   import SignIn from "$lib/components/common/SignIn.svelte";
   import SummaryUniverse from "$lib/components/summary/SummaryUniverse.svelte";
+  import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
+  import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
+  import type { UserTokenData } from "$lib/types/tokens-page";
   import { PageBanner, IconAccountsPage } from "@dfinity/gix-components";
+
+  export let userTokensData: UserTokenData[] = [];
 </script>
 
-<main data-tid="accounts-landing-page">
-  <SummaryUniverse />
-
-  <div class="content">
+{#if $ENABLE_MY_TOKENS}
+  <div class="content" data-tid="accounts-landing-page">
     <PageBanner>
       <IconAccountsPage slot="image" />
       <svelte:fragment slot="title">{$i18n.auth_accounts.title}</svelte:fragment
@@ -18,9 +21,28 @@
       <SignIn slot="actions" />
     </PageBanner>
 
-    <EmptyCards />
+    {#if userTokensData.length > 0}
+      <TokensTable {userTokensData} />
+    {/if}
   </div>
-</main>
+{:else}
+  <main data-tid="accounts-landing-page">
+    <SummaryUniverse />
+
+    <div class="content">
+      <PageBanner>
+        <IconAccountsPage slot="image" />
+        <svelte:fragment slot="title"
+          >{$i18n.auth_accounts.title}</svelte:fragment
+        >
+        <p class="description" slot="description">{$i18n.auth_accounts.text}</p>
+        <SignIn slot="actions" />
+      </PageBanner>
+
+      <EmptyCards />
+    </div>
+  </main>
+{/if}
 
 <style lang="scss">
   .content {

--- a/frontend/src/routes/(app)/(u)/(accounts)/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(accounts)/+layout.svelte
@@ -3,12 +3,23 @@
   import UniverseSplitContent from "$lib/components/layout/UniverseSplitContent.svelte";
   import { i18n } from "$lib/stores/i18n";
   import LayoutList from "$lib/components/layout/LayoutList.svelte";
+  import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
+  import MainWrapper from "$lib/components/tokens/MainWrapper.svelte";
+  import Content from "$lib/components/layout/Content.svelte";
 </script>
 
 <LayoutList title={$i18n.navigation.tokens}>
   <Layout>
-    <UniverseSplitContent>
-      <slot />
-    </UniverseSplitContent>
+    {#if $ENABLE_MY_TOKENS}
+      <Content>
+        <MainWrapper>
+          <slot />
+        </MainWrapper>
+      </Content>
+    {:else}
+      <UniverseSplitContent>
+        <slot />
+      </UniverseSplitContent>
+    {/if}
   </Layout>
 </LayoutList>

--- a/frontend/src/routes/(app)/(u)/(accounts)/+page.svelte
+++ b/frontend/src/routes/(app)/(u)/(accounts)/+page.svelte
@@ -3,12 +3,13 @@
   import Accounts from "$lib/routes/Accounts.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import { icpTokensListVisitors } from "$lib/derived/icp-tokens-list-visitors.derived";
 </script>
 
 <TestIdWrapper testId="accounts-plus-page-component">
   {#if $authSignedInStore}
     <Accounts />
   {:else}
-    <SignInAccounts />
+    <SignInAccounts userTokensData={$icpTokensListVisitors} />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/routes/(app)/(u)/(accounts)/accounts/+page.svelte
+++ b/frontend/src/routes/(app)/(u)/(accounts)/accounts/+page.svelte
@@ -9,6 +9,7 @@
   {#if $authSignedInStore}
     <Accounts />
   {:else}
+    <!-- TODO: New derived store accounts visitors https://dfinity.atlassian.net/browse/GIX-2058 -->
     <SignInAccounts />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/routes/(app)/(u)/(accounts)/accounts/+page.svelte
+++ b/frontend/src/routes/(app)/(u)/(accounts)/accounts/+page.svelte
@@ -3,13 +3,13 @@
   import Accounts from "$lib/routes/Accounts.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import { icpTokensListVisitors } from "$lib/derived/icp-tokens-list-visitors.derived";
 </script>
 
 <TestIdWrapper testId="accounts-plus-page-component">
   {#if $authSignedInStore}
     <Accounts />
   {:else}
-    <!-- TODO: New derived store accounts visitors https://dfinity.atlassian.net/browse/GIX-2058 -->
-    <SignInAccounts />
+    <SignInAccounts userTokensData={$icpTokensListVisitors} />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/routes/(app)/(u)/(detail)/wallet/+page.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/wallet/+page.svelte
@@ -13,6 +13,5 @@
 {#if $authSignedInStore}
   <Wallet {accountIdentifier} />
 {:else}
-  <!-- TODO: New derived store accounts visitors https://dfinity.atlassian.net/browse/GIX-2058 -->
   <SignInAccounts />
 {/if}

--- a/frontend/src/routes/(app)/(u)/(detail)/wallet/+page.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/wallet/+page.svelte
@@ -13,5 +13,6 @@
 {#if $authSignedInStore}
   <Wallet {accountIdentifier} />
 {:else}
+  <!-- TODO: New derived store accounts visitors https://dfinity.atlassian.net/browse/GIX-2058 -->
   <SignInAccounts />
 {/if}

--- a/frontend/src/tests/page-objects/AccountsPlusPage.page-object.ts
+++ b/frontend/src/tests/page-objects/AccountsPlusPage.page-object.ts
@@ -1,6 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AccountsPo } from "./Accounts.page-object";
+import { SignInAccountsPo } from "./SignInAccounts.page-object";
 
 export class AccountsPlusPagePo extends BasePageObject {
   private static readonly TID = "accounts-plus-page-component";
@@ -11,5 +12,9 @@ export class AccountsPlusPagePo extends BasePageObject {
 
   getAccountsPo(): AccountsPo {
     return AccountsPo.under(this.root);
+  }
+
+  getSignInAccountsPo(): SignInAccountsPo {
+    return SignInAccountsPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/SignInAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/SignInAccounts.page-object.ts
@@ -1,0 +1,15 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SignInAccountsPo extends BasePageObject {
+  static readonly TID = "accounts-landing-page";
+
+  static under(element: PageObjectElement): SignInAccountsPo {
+    return new SignInAccountsPo(element.byTestId(SignInAccountsPo.TID));
+  }
+
+  // TODO: Remove with ENABLE_MY_TOKENS flag
+  hasEmptyCards(): Promise<boolean> {
+    return this.isPresent("empty-cards-component");
+  }
+}

--- a/frontend/src/tests/page-objects/SignInAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/SignInAccounts.page-object.ts
@@ -1,5 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { TokensTablePo } from "./TokensTable.page-object";
 
 export class SignInAccountsPo extends BasePageObject {
   static readonly TID = "accounts-landing-page";
@@ -11,5 +12,9 @@ export class SignInAccountsPo extends BasePageObject {
   // TODO: Remove with ENABLE_MY_TOKENS flag
   hasEmptyCards(): Promise<boolean> {
     return this.isPresent("empty-cards-component");
+  }
+
+  hasTokensTable(): Promise<boolean> {
+    return TokensTablePo.under(this.root).isPresent();
   }
 }

--- a/frontend/src/tests/page-objects/SignInAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/SignInAccounts.page-object.ts
@@ -14,7 +14,15 @@ export class SignInAccountsPo extends BasePageObject {
     return this.isPresent("empty-cards-component");
   }
 
+  getTokensTablePo(): TokensTablePo {
+    return TokensTablePo.under(this.root);
+  }
+
   hasTokensTable(): Promise<boolean> {
     return TokensTablePo.under(this.root).isPresent();
+  }
+
+  async getTokenNames(): Promise<string[]> {
+    return TokensTablePo.under(this.root).getTokenNames();
   }
 }

--- a/frontend/src/tests/routes/app/accounts/layout.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/layout.spec.ts
@@ -1,3 +1,4 @@
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import AccountsLayout from "$routes/(app)/(u)/(accounts)/+layout.svelte";
 import { render } from "@testing-library/svelte";
@@ -14,6 +15,32 @@ describe("Accounts layout", () => {
     expect(get(layoutTitleStore)).toEqual({
       title: "My Tokens",
       header: "My Tokens",
+    });
+  });
+
+  describe("when tokens flag is enabled", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
+    });
+
+    it("should not show the split content navigation", () => {
+      const { queryByTestId } = render(AccountsLayout);
+
+      expect(
+        queryByTestId("select-universe-nav-title")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when tokens flag is enabled", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", false);
+    });
+
+    it("should not show the split content navigation", () => {
+      const { queryByTestId } = render(AccountsLayout);
+
+      expect(queryByTestId("select-universe-nav-title")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/tests/routes/app/accounts/page.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/page.spec.ts
@@ -41,7 +41,7 @@ describe("Accounts page", () => {
         const po = renderComponent();
 
         const pagePo = po.getSignInAccountsPo();
-        expect(await pagePo.getTokenNames()).toBe(["Internet Computer"]);
+        expect(await pagePo.getTokenNames()).toEqual(["Internet Computer"]);
         expect(await pagePo.hasEmptyCards()).toBe(false);
       });
     });

--- a/frontend/src/tests/routes/app/accounts/page.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/page.spec.ts
@@ -31,6 +31,33 @@ describe("Accounts page", () => {
 
       expect(getByTestId("login-button")).not.toBeNull();
     });
+
+    describe("tokens flag enabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
+      });
+
+      it("renders tokens table for NNS accounts", async () => {
+        const po = renderComponent();
+
+        // TODO: Test that the tokens table is rendered when we implement the derived store for visitors
+        const pagePo = po.getSignInAccountsPo();
+        expect(await pagePo.hasEmptyCards()).toBe(false);
+      });
+    });
+
+    describe("tokens flag disabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", false);
+      });
+
+      it("renders tokens empty cards", async () => {
+        const po = renderComponent();
+
+        const pagePo = po.getSignInAccountsPo();
+        expect(await pagePo.hasEmptyCards()).toBe(true);
+      });
+    });
   });
 
   describe("logged in NNS Accounts", () => {

--- a/frontend/src/tests/routes/app/accounts/page.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/page.spec.ts
@@ -41,7 +41,7 @@ describe("Accounts page", () => {
         const po = renderComponent();
 
         const pagePo = po.getSignInAccountsPo();
-        expect(await pagePo.hasTokensTable()).toBe(true);
+        expect(await pagePo.getTokenNames()).toBe(["Internet Computer"]);
         expect(await pagePo.hasEmptyCards()).toBe(false);
       });
     });

--- a/frontend/src/tests/routes/app/accounts/page.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/page.spec.ts
@@ -40,8 +40,8 @@ describe("Accounts page", () => {
       it("renders tokens table for NNS accounts", async () => {
         const po = renderComponent();
 
-        // TODO: Test that the tokens table is rendered when we implement the derived store for visitors
         const pagePo = po.getSignInAccountsPo();
+        expect(await pagePo.hasTokensTable()).toBe(true);
         expect(await pagePo.hasEmptyCards()).toBe(false);
       });
     });
@@ -55,6 +55,7 @@ describe("Accounts page", () => {
         const po = renderComponent();
 
         const pagePo = po.getSignInAccountsPo();
+        expect(await pagePo.hasTokensTable()).toBe(false);
         expect(await pagePo.hasEmptyCards()).toBe(true);
       });
     });


### PR DESCRIPTION
# Motivation

The accounts page for non-logged in users should be similar to the logged-in page.

Therefore, we use the TokensTable in SignInAccounts when flag is enabled.

# Changes

* Move the `MainWrapper` to the layout of the route accounts and apply it when flag is enabled.
* Add logic in the `SignInAccounts` to render different components depending on flag value.
* Use the `icpTokensListVisitors` when rendering `SignInAccounts` in the accounts route pages.

# Tests

* New SignInAccountsPo.
* Add methods to PO
* Add a test in the routes layout spec to check that token navigation is present or not depending on the flag.
* Add tests in the routes page to check that either tokens table or empty cards are present depending on the flag.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.