### PR TITLE
GIX-2058: IcpTokensListUser derived store

### DIFF
--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -1,0 +1,63 @@
+import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
+import { i18n } from "$lib/stores/i18n";
+import {
+  icpAccountsStore,
+  type IcpAccountsStore,
+} from "$lib/stores/icp-accounts.store";
+import type { Account, AccountType } from "$lib/types/account";
+import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
+import type { Universe } from "$lib/types/universe";
+import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+import { Principal } from "@dfinity/principal";
+import { isNullish, nonNullish, TokenAmount } from "@dfinity/utils";
+import { derived, type Readable } from "svelte/store";
+import { nnsUniverseStore } from "./nns-universe.derived";
+
+const convertAccountToUserTokenData =
+  ({ nnsUniverse, i18nKeys }: { nnsUniverse: Universe; i18nKeys: I18n }) =>
+  (account?: Account): UserTokenData => {
+    const subtitleMap: Record<AccountType, string | undefined> = {
+      main: undefined,
+      subAccount: i18nKeys.accounts.subAccount,
+      hardwareWallet: i18nKeys.accounts.hardwareWallet,
+      // This is not used in the UI, but it's here for completeness
+      withdrawalAccount: i18nKeys.accounts.withdrawalAccount,
+    };
+    const title: string = isNullish(account)
+      ? i18nKeys.core.ic
+      : account.type === "main"
+      ? i18nKeys.accounts.main
+      : account.name ?? "";
+    return {
+      universeId: Principal.fromText(nnsUniverse.canisterId),
+      title,
+      subtitle: nonNullish(account) ? subtitleMap[account.type] : undefined,
+      // TODO: Add loading balance state
+      balance: nonNullish(account)
+        ? TokenAmount.fromE8s({
+            amount: account.balanceE8s,
+            token: NNS_TOKEN_DATA,
+          })
+        : new UnavailableTokenAmount(NNS_TOKEN_DATA),
+      logo: nnsUniverse.logo,
+      actions: nonNullish(account)
+        ? [UserTokenAction.Receive, UserTokenAction.Send]
+        : [],
+    };
+  };
+
+export const icpTokensListUser = derived<
+  [Readable<Universe>, IcpAccountsStore, Readable<I18n>],
+  UserTokenData[]
+>(
+  [nnsUniverseStore, icpAccountsStore, i18n],
+  ([nnsUniverse, icpAccounts, i18nKeys]) => [
+    convertAccountToUserTokenData({ nnsUniverse, i18nKeys })(icpAccounts.main),
+    ...(icpAccounts.subAccounts ?? []).map(
+      convertAccountToUserTokenData({ nnsUniverse, i18nKeys })
+    ),
+    ...(icpAccounts.hardwareWallets ?? []).map(
+      convertAccountToUserTokenData({ nnsUniverse, i18nKeys })
+    ),
+  ]
+);

--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -22,7 +22,13 @@ const convertAccountToUserTokenData = ({
   i18nObj: I18n;
   account?: Account;
 }): UserTokenData => {
-  const subtitleMap: Record<AccountType, string | undefined> = i18nObj.accounts;
+  const subtitleMap: Record<AccountType, string | undefined> = {
+    main: undefined,
+    subAccount: i18nObj.accounts.subAccount,
+    hardwareWallet: i18nObj.accounts.hardwareWallet,
+    // This is not used in the UI, but it's here for completeness
+    withdrawalAccount: i18nObj.accounts.withdrawalAccount,
+  };
   const title: string = isNullish(account)
     ? i18nObj.core.ic
     : account.type === "main"

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -1,0 +1,98 @@
+import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
+import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
+import { icpTokensListUser } from "$lib/derived/icp-tokens-list-user.derived";
+import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
+import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+import {
+  mockHardwareWalletAccount,
+  mockMainAccount,
+  mockSubAccount,
+} from "$tests/mocks/icp-accounts.store.mock";
+import { TokenAmount } from "@dfinity/utils";
+import { get } from "svelte/store";
+
+describe("icp-tokens-list-user.derived", () => {
+  const icpTokenBase: UserTokenData = {
+    universeId: OWN_CANISTER_ID,
+    title: "Internet Computer",
+    logo: IC_LOGO_ROUNDED,
+    balance: new UnavailableTokenAmount(NNS_TOKEN_DATA),
+    actions: [UserTokenAction.Receive, UserTokenAction.Send],
+  };
+  const emptyUserTokenData: UserTokenData = {
+    ...icpTokenBase,
+    title: "Internet Computer",
+    subtitle: undefined,
+    actions: [],
+  };
+  const mainUserTokenData: UserTokenData = {
+    ...icpTokenBase,
+    balance: TokenAmount.fromE8s({
+      amount: mockMainAccount.balanceE8s,
+      token: NNS_TOKEN_DATA,
+    }),
+    title: "Main",
+    subtitle: undefined,
+  };
+  const subaccountUserTokenData: UserTokenData = {
+    ...icpTokenBase,
+    balance: TokenAmount.fromE8s({
+      amount: mockSubAccount.balanceE8s,
+      token: NNS_TOKEN_DATA,
+    }),
+    title: mockSubAccount.name,
+    subtitle: "Linked Account",
+  };
+  const hardwareWalletUserTokenData: UserTokenData = {
+    ...icpTokenBase,
+    balance: TokenAmount.fromE8s({
+      amount: mockHardwareWalletAccount.balanceE8s,
+      token: NNS_TOKEN_DATA,
+    }),
+    title: mockHardwareWalletAccount.name,
+    subtitle: "Hardware Wallet",
+  };
+
+  describe("icpTokensListVisitors", () => {
+    beforeEach(() => {
+      icpAccountsStore.resetForTesting();
+    });
+
+    it("should return empty if no accounts", () => {
+      expect(get(icpTokensListUser)).toEqual([emptyUserTokenData]);
+    });
+
+    it("should return only main if no subaccounts and no subaccounts", () => {
+      icpAccountsStore.setForTesting({
+        main: mockMainAccount,
+      });
+      expect(get(icpTokensListUser)).toEqual([mainUserTokenData]);
+    });
+
+    it("should return subaccounts and main", () => {
+      icpAccountsStore.setForTesting({
+        main: mockMainAccount,
+        subAccounts: [mockSubAccount],
+      });
+      expect(get(icpTokensListUser)).toEqual([
+        mainUserTokenData,
+        subaccountUserTokenData,
+      ]);
+    });
+
+    it("should return hardware wallets, subaccounts and main", () => {
+      icpAccountsStore.setForTesting({
+        main: mockMainAccount,
+        subAccounts: [mockSubAccount],
+        hardwareWallets: [mockHardwareWalletAccount],
+      });
+      expect(get(icpTokensListUser)).toEqual([
+        mainUserTokenData,
+        subaccountUserTokenData,
+        hardwareWalletUserTokenData,
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

Render the tokens table with ICP accounts.

In this PR, introduce the derived store that combines the NNS universe and the icp accounts to return  the data for the TokensTable.

# Changes

* New derived store `icpTokensListUser`.

# Tests

* Test new store `icpTokensListUser`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.