### PR TITLE
Map directly to UiTransaction

### DIFF
--- a/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
@@ -3,7 +3,7 @@
   import type { Principal } from "@dfinity/principal";
   import { InfiniteScroll, Spinner } from "@dfinity/gix-components";
   import type { IcrcTransactionWithId } from "@dfinity/ledger-icrc";
-  import { isNullish } from "@dfinity/utils";
+  import { nonNullish } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
   import IcrcTransactionCard from "./IcrcTransactionCard.svelte";
   import SkeletonCard from "../ui/SkeletonCard.svelte";
@@ -26,38 +26,26 @@
   export let mapTransaction: mapIcrcTransactionType;
 
   let uiTransactions: UiTransaction[] = [];
-  $: uiTransactions = transactions.flatMap(
-    ({
-      transaction,
-      toSelfTransaction,
-    }: {
-      transaction: IcrcTransactionWithId;
-      toSelfTransaction: boolean;
-    }) => {
-      if (isNullish(token)) {
-        return [];
-      }
-      const mappedTransaction = mapTransaction({
+  $: uiTransactions = transactions
+    .map(
+      ({
         transaction,
-        account,
         toSelfTransaction,
-        governanceCanisterId,
-      });
-      if (isNullish(mappedTransaction)) {
-        return [];
-      }
-      return [
-        toUiTransaction({
-          transaction: mappedTransaction,
-          transactionId: transaction.id,
+      }: {
+        transaction: IcrcTransactionWithId;
+        toSelfTransaction: boolean;
+      }) =>
+        mapTransaction({
+          transaction,
+          account,
           toSelfTransaction,
+          governanceCanisterId,
           token,
           transactionNames: $i18n.transaction_names,
           fallbackDescriptions: descriptions,
-        }),
-      ];
-    }
-  );
+        })
+    )
+    .filter(nonNullish);
 </script>
 
 <div data-tid="transactions-list" class="container">

--- a/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
@@ -13,7 +13,6 @@
   } from "$lib/types/transaction";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import type { mapIcrcTransactionType } from "$lib/utils/icrc-transactions.utils";
-  import { toUiTransaction } from "$lib/utils//transactions.utils";
   import { flip } from "svelte/animate";
 
   export let account: Account;

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionsList.spec.ts
@@ -116,7 +116,7 @@ describe("IcrcTransactionList", () => {
     const customIdentifier = "custom identifier";
     const customMapTransaction = (params) => ({
       ...mapIcrcTransaction(params),
-      from: customIdentifier,
+      otherParty: customIdentifier,
     });
 
     const po = renderComponent({

--- a/frontend/src/tests/mocks/icrc-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icrc-transactions.mock.ts
@@ -1,3 +1,4 @@
+import { NANO_SECONDS_IN_MILLISECOND } from "$lib/constants/constants";
 import type { IcrcTransactionsStoreData } from "$lib/stores/icrc-transactions.store";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
@@ -20,17 +21,22 @@ export const createIcrcTransactionWithId = ({
   to,
   fee,
   amount,
+  timestamp = new Date(0),
+  memo,
 }: {
   id?: bigint;
   to?: IcrcCandidAccount;
   from?: IcrcCandidAccount;
   fee?: bigint;
   amount?: bigint;
+  timestamp?: Date;
+  memo?: Uint8Array;
 }): IcrcTransactionWithId => ({
   id: id ?? 123n,
   transaction: {
     kind: "transfer",
-    timestamp: BigInt(12354),
+    timestamp:
+      BigInt(timestamp.getTime()) * BigInt(NANO_SECONDS_IN_MILLISECOND),
     burn: [],
     mint: [],
     transfer: [
@@ -43,7 +49,7 @@ export const createIcrcTransactionWithId = ({
           owner: mockPrincipal,
           subaccount: [] as [],
         },
-        memo: [],
+        memo: toNullable(memo),
         created_at_time: [BigInt(123)],
         amount: amount ?? BigInt(33),
         fee: [fee ?? BigInt(1)],


### PR DESCRIPTION
# Motivation

In `IcrcTransactionsList` we map `IcrcTransactionData`s to `Transaction`s and then to `UiTransaction`s.
This is not necessary and by doing it in 1 step we can give the custom `mapTransaction` function more control over the rendering of the transactions.
This will make it easier to implement ckBTC UI improvements.

# Changes

1. Change `mapIcrcTransaction` and `mapCkbtcTransaction` to return `UiTransaction` instead of `Transaction`.
2. In `IcrcTransactionsList` map transactions with the new single mapping function. Then filter out `undefined` transactions.
3. 

# Tests

1. Accept optional `timestamp` and `memo` params to `createIcrcTransactionWithId`.
2. Change unit tests for `mapTransaction` to expect the full result instead of just a few properties. Define default values so we still only have to specify the properties relevant to the test.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary