### PR TITLE
Remove the fallbackDescription slot from TransactionCard

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -85,12 +85,6 @@
     canisterId: universeId,
     account,
   });
-
-  let descriptions: Record<string, string>;
-  $: descriptions = $i18n.ckbtc_transaction_names as unknown as Record<
-    string,
-    string
-  >;
 </script>
 
 <CkBTCWalletTransactionsObserver
@@ -105,7 +99,6 @@
     {transactions}
     {loading}
     {completed}
-    {descriptions}
     {token}
     mapTransaction={mapCkbtcTransaction}
   />

--- a/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
@@ -20,7 +20,6 @@
   export let loading: boolean;
   export let governanceCanisterId: Principal | undefined = undefined;
   export let completed = false;
-  export let descriptions: Record<string, string> | undefined = undefined;
   export let token: IcrcTokenMetadata | undefined;
   export let mapTransaction: mapIcrcTransactionType;
 
@@ -40,8 +39,7 @@
           toSelfTransaction,
           governanceCanisterId,
           token,
-          transactionNames: $i18n.transaction_names,
-          fallbackDescriptions: descriptions,
+          i18n: $i18n,
         })
     )
     .filter(nonNullish);

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -66,10 +66,6 @@
       <div slot="start" class="identifier">
         {#if nonNullish(otherParty)}
           <Identifier size="medium" {label} identifier={otherParty} />
-        {:else if nonNullish(fallbackDescription)}
-          <p data-tid="transaction-description">
-            <Html text={fallbackDescription} />
-          </p>
         {/if}
       </div>
 

--- a/frontend/src/lib/components/ui/ColumnRow.svelte
+++ b/frontend/src/lib/components/ui/ColumnRow.svelte
@@ -21,6 +21,7 @@
     @include media.min-width(small) {
       @include display.space-between;
       flex-direction: row;
+      align-items: normal;
 
       margin: 0 0 var(--padding);
     }

--- a/frontend/src/lib/components/ui/ColumnRow.svelte
+++ b/frontend/src/lib/components/ui/ColumnRow.svelte
@@ -9,7 +9,6 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";
-  @use "@dfinity/gix-components/dist/styles/mixins/display";
 
   div {
     display: flex;
@@ -19,9 +18,8 @@
     column-gap: var(--padding-2x);
 
     @include media.min-width(small) {
-      @include display.space-between;
+      justify-content: space-between;
       flex-direction: row;
-      align-items: normal;
 
       margin: 0 0 var(--padding);
     }

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -475,11 +475,6 @@
     "participateSwap": "Decentralization Swap",
     "approve": "Approve transfer"
   },
-  "ckbtc_transaction_names": {
-    "burn": "To: <span class=\"value\">BTC Network</span>",
-    "mint": "From: <span class=\"value\">BTC Network</span>",
-    "approve": "&ZeroWidthSpace;"
-  },
   "wallet": {
     "title": "Account",
     "address": "Address",
@@ -995,7 +990,8 @@
     "warning_transaction_description": "When sending your ckBTC to a BTC address, your transaction got stuck in the redeeming account. Visit the ckBTC accounts page to continue.",
     "checking_incomplete_btc_transfers": "Checking for incomplete BTC transfers",
     "all_btc_transfers_complete": "All transfers are complete",
-    "click_to_complete_btc_transfers": "Click here to complete BTC transfer for $amount ckBTC"
+    "click_to_complete_btc_transfers": "Click here to complete BTC transfer for $amount ckBTC",
+    "btc_network": "BTC Network"
   },
   "error__ckbtc": {
     "already_process": "The minter has already been notified and updating the balance is in progress.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -492,12 +492,6 @@ interface I18nTransaction_names {
   approve: string;
 }
 
-interface I18nCkbtc_transaction_names {
-  burn: string;
-  mint: string;
-  approve: string;
-}
-
 interface I18nWallet {
   title: string;
   address: string;
@@ -1044,6 +1038,7 @@ interface I18nCkbtc {
   checking_incomplete_btc_transfers: string;
   all_btc_transfers_complete: string;
   click_to_complete_btc_transfers: string;
+  btc_network: string;
 }
 
 interface I18nError__ckbtc {
@@ -1310,7 +1305,6 @@ interface I18n {
   canisters: I18nCanisters;
   canister_detail: I18nCanister_detail;
   transaction_names: I18nTransaction_names;
-  ckbtc_transaction_names: I18nCkbtc_transaction_names;
   wallet: I18nWallet;
   busy_screen: I18nBusy_screen;
   proposal_detail: I18nProposal_detail;

--- a/frontend/src/lib/utils/transactions.utils.ts
+++ b/frontend/src/lib/utils/transactions.utils.ts
@@ -150,14 +150,12 @@ export const toUiTransaction = ({
   toSelfTransaction,
   token,
   transactionNames,
-  fallbackDescriptions,
 }: {
   transaction: Transaction;
   transactionId: bigint;
   toSelfTransaction: boolean;
   token: Token;
   transactionNames: I18nTransaction_names;
-  fallbackDescriptions?: Record<string, string>;
 }): UiTransaction => {
   const isIncoming = transaction.isReceive || toSelfTransaction;
   const headline = transactionName({
@@ -166,16 +164,12 @@ export const toUiTransaction = ({
     labels: transactionNames,
   });
   const otherParty = isIncoming ? transaction.from : transaction.to;
-  const fallbackDescription = isNullish(otherParty)
-    ? fallbackDescriptions?.[transaction.type]
-    : undefined;
 
   return {
     domKey: `${transactionId}-${toSelfTransaction ? "0" : "1"}`,
     isIncoming,
     headline,
     otherParty,
-    fallbackDescription,
     tokenAmount: TokenAmount.fromE8s({
       amount: transaction.displayAmount,
       token,

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -182,7 +182,7 @@ describe("CkBTCTransactionList", () => {
 
     expect(cards).toHaveLength(1);
     expect(await cards[0].getHeadline()).toEqual("Sent");
-    expect(await cards[0].getDescription()).toEqual("To: BTC Network");
+    expect(await cards[0].getIdentifier()).toEqual("To: BTC Network");
     expect(errorLog).toEqual(["Failed to decode ckBTC burn memo"]);
   });
 
@@ -250,6 +250,6 @@ describe("CkBTCTransactionList", () => {
     const { po } = renderComponent();
     const cards = await po.getTransactionCardPos();
 
-    expect(await cards[0].getDescription()).toEqual("From: BTC Network");
+    expect(await cards[0].getIdentifier()).toEqual("From: BTC Network");
   });
 });

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -41,13 +41,11 @@ describe("TransactionCard", () => {
   it("renders burn description", async () => {
     const po = renderComponent({
       headline: "Sent",
-      fallbackDescription: "To: BTC Network",
-      otherParty: undefined,
+      otherParty: "BTC Network",
     });
 
     expect(await po.getHeadline()).toBe("Sent");
-    expect(await po.getDescription()).toBe("To: BTC Network");
-    expect(await po.getIdentifier()).toBe(null);
+    expect(await po.getIdentifier()).toBe("To: BTC Network");
   });
 
   it("renders ckBTC burn To:", async () => {
@@ -59,7 +57,6 @@ describe("TransactionCard", () => {
 
     expect(await po.getHeadline()).toBe("Sent");
     expect(await po.getIdentifier()).toBe("To: withdrwala-address");
-    expect(await po.getDescription()).toBe(null);
   });
 
   it("renders sent headline", async () => {

--- a/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
@@ -138,7 +138,7 @@ describe("icrc-transaction utils", () => {
       account: mockSnsMainAccount,
       toSelfTransaction: false,
       token: ICPToken,
-      transactionNames: en.transaction_names,
+      i18n: en,
     };
     const defaultExpectedData = {
       domKey: "112-1",
@@ -343,7 +343,7 @@ describe("icrc-transaction utils", () => {
         account: mockCkBTCMainAccount,
         toSelfTransaction: false,
         token: ICPToken,
-        transactionNames: en.transaction_names,
+        i18n: en,
       });
       expect(data).toEqual({
         domKey: "1234-1",
@@ -381,7 +381,7 @@ describe("icrc-transaction utils", () => {
         account: mockCkBTCMainAccount,
         toSelfTransaction: false,
         token: ICPToken,
-        transactionNames: en.transaction_names,
+        i18n: en,
       });
       expect(data).toEqual({
         domKey: "1234-1",
@@ -418,14 +418,14 @@ describe("icrc-transaction utils", () => {
         account: mockCkBTCMainAccount,
         toSelfTransaction: false,
         token: ICPToken,
-        transactionNames: en.transaction_names,
+        i18n: en,
       });
 
       expect(data).toEqual({
         domKey: "1234-1",
         headline: "Sent",
         isIncoming: false,
-        otherParty: undefined,
+        otherParty: "BTC Network",
         timestamp: new Date(0),
         tokenAmount: TokenAmount.fromE8s({
           amount,

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -474,31 +474,6 @@ describe("transactions-utils", () => {
       });
     });
 
-    it("should use fallbackDescriptions", () => {
-      expect(
-        toUiTransaction({
-          ...defaultParams,
-          transaction: {
-            ...defaultTransaction,
-            type: AccountTransactionType.Burn,
-            isSend: false,
-            isReceive: false,
-            from: undefined,
-            to: undefined,
-          },
-          fallbackDescriptions: en.ckbtc_transaction_names as unknown as Record<
-            string,
-            string
-          >,
-        })
-      ).toEqual({
-        ...defaultExpectedUiTransaction,
-        headline: "Sent",
-        otherParty: undefined,
-        fallbackDescription: 'To: <span class="value">BTC Network</span>',
-      });
-    });
-
     it("should convert a to-self transaction", () => {
       expect(
         toUiTransaction({

--- a/frontend/src/tests/page-objects/TransactionCard.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionCard.page-object.ts
@@ -25,10 +25,6 @@ export class TransactionCardPo extends BasePageObject {
     return this.getText("identifier");
   }
 
-  getDescription(): Promise<string> {
-    return this.getText("transaction-description");
-  }
-
   getDate(): Promise<string> {
     return this.getText("transaction-date");
   }


### PR DESCRIPTION
# Motivation

We use the `fallbackDescription` on `UiTransaction` only to render "From: BTC Network" on ckBTC mint transactions.
We can accomplish the same thing by setting `otherParty` to "BTC Network".

# Changes

1. Remove the `fallbackDescription` field from `UiTransaction`.
2. Remove the description slot from `TransactionCard`.
3. Stop passing `$i18n.ckbtc_transaction_names` from `CkBTCTransactionList` to `IcrcTransactionsList` and to `mapTransaction`.
4. Pass the full `i18n` object to `mapTransaction` instead of just `transaction_names`. This gives it additional access to `ckbtc.btc_network` to use as `otherParty`.
5. In `ColumnRow` use `justify-content: space-between` instead of `@include display.space-between` on larger screens.  [@include display.space-between](https://github.com/dfinity/gix-components/blob/ff7f9beb27b15f91fdee2bbe640d6c7dba28d1e2/src/lib/styles/mixins/_display.scss#L1) comes additionally with `display: inline-flex` and `width: 100%`. We don't need these extra styles and the `display: inline-flex` has the strange effect that the transaction row containing the To/From and date gets taller when the To/From slot isn't there. You can see it in the video in [this comment](https://github.com/dfinity/nns-dapp/pull/3645#discussion_r1378616357). I spent several hours debugging this and I still don't understand why this happens. But removing the include seems cleaner than rendering a zero-width space when there is no To/From. `ColumnRow` is only use in `TransactionCard` and in `CardInfo`. `CardInfo` is used in many places but as far as I can tell, the `ColumnRow` is only relevant to it when it has an `end` slot, which it only has in `NeuronCardContainer` and in `SkeletonCard`. But `NeuronCardContainer` itself isn't used anywhere with an `end` slot. I've looked at `SkeletonCard` and it still looks fine to me.
6. Remove now unused `"ckbtc_transaction_names"` from `i18n`.
7. Set `uiTransaction.otherParty` to "BTC Network" in `mapCkbtcTransaction` for Mint and Burn transactions.
8. Remove `getDescription` from the page object and only check `getIdentifier` in tests.

# Tests

Updated and passing.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary