### PR TITLE
Fix proposal details for small devices

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -24,6 +24,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Fix docker builds when there is no global config.
 * Fix "Expiration date" countdown label visibility.
+* Optimize nns proposal rendering for small devices.
 
 #### Security
 

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoProposerEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoProposerEntry.svelte
@@ -11,12 +11,6 @@
 
   let modalOpen = false;
   // TODO: For simplicity reason, currently we do not display the proposer details if not signed-in. We might want to improve the display of these information in the future.
-
-  const showVotingHistoryModal = () => {
-    if ($authSignedInStore) {
-      modalOpen = true;
-    }
-  };
 </script>
 
 <TestIdWrapper testId="proposal-system-info-proposer-entry-component">
@@ -34,7 +28,8 @@
           showCopy
           splitLength={6}
           tooltipTop
-          on:nnsHash={showVotingHistoryModal}
+          isClickable={$authSignedInStore}
+          on:nnsHash={() => (modalOpen = true)}
         />
       </svelte:fragment>
 

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoProposerEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoProposerEntry.svelte
@@ -12,7 +12,7 @@
   let modalOpen = false;
   // TODO: For simplicity reason, currently we do not display the proposer details if not signed-in. We might want to improve the display of these information in the future.
 
-  const click = () => {
+  const showVotingHistoryModal = () => {
     if ($authSignedInStore) {
       modalOpen = true;
     }
@@ -34,7 +34,7 @@
           showCopy
           splitLength={6}
           tooltipTop
-          on:nnsTextClick={click}
+          on:nnsHash={showVotingHistoryModal}
         />
       </svelte:fragment>
 

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoProposerEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoProposerEntry.svelte
@@ -2,15 +2,21 @@
   import { i18n } from "$lib/stores/i18n";
   import type { NeuronId } from "@dfinity/nns";
   import VotingHistoryModal from "$lib/modals/neurons/VotingHistoryModal.svelte";
-  import { Html, KeyValuePairInfo } from "@dfinity/gix-components";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import Hash from "$lib/components/ui/Hash.svelte";
+  import { Html, KeyValuePairInfo } from "@dfinity/gix-components";
 
   export let proposer: NeuronId | undefined;
 
   let modalOpen = false;
-
   // TODO: For simplicity reason, currently we do not display the proposer details if not signed-in. We might want to improve the display of these information in the future.
+
+  const click = () => {
+    if ($authSignedInStore) {
+      modalOpen = true;
+    }
+  };
 </script>
 
 <TestIdWrapper testId="proposal-system-info-proposer-entry-component">
@@ -21,20 +27,15 @@
       >
 
       <svelte:fragment slot="value">
-        {#if $authSignedInStore}
-          <button
-            class="text"
-            on:click|stopPropagation={() => (modalOpen = true)}
-          >
-            <span class="value" data-tid="proposal-system-info-proposer-value"
-              >{proposer}</span
-            >
-          </button>
-        {:else}
-          <span class="value" data-tid="proposal-system-info-proposer-value"
-            >{proposer}</span
-          >
-        {/if}
+        <Hash
+          id="proposer-id"
+          text={`${proposer}`}
+          tagName="span"
+          showCopy
+          splitLength={6}
+          tooltipTop
+          on:nnsTextClick={click}
+        />
       </svelte:fragment>
 
       <svelte:fragment slot="info">
@@ -50,11 +51,3 @@
     {/if}
   {/if}
 </TestIdWrapper>
-
-<style lang="scss">
-  button {
-    margin: 0;
-    padding: 0;
-    font-size: inherit;
-  }
-</style>

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoProposerEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoProposerEntry.svelte
@@ -22,7 +22,8 @@
 
       <svelte:fragment slot="value">
         <Hash
-          id="proposer-id"
+          id="proposal-system-info-proposer-value"
+          testId="proposal-system-info-proposer-value"
           text={`${proposer}`}
           tagName="span"
           showCopy

--- a/frontend/src/lib/components/proposals/ProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/ProposalCard.svelte
@@ -144,7 +144,7 @@
 
     span,
     output {
-      @include text.truncate;
+      @include text.clamp(1);
     }
   }
 </style>

--- a/frontend/src/lib/components/ui/Hash.svelte
+++ b/frontend/src/lib/components/ui/Hash.svelte
@@ -12,6 +12,7 @@
   export let className: string | undefined = undefined;
   export let splitLength: number | undefined = undefined;
   export let tooltipTop: boolean | undefined = undefined;
+  export let isClickable: boolean | undefined = undefined;
 
   const dispatcher = createEventDispatcher();
 
@@ -25,7 +26,8 @@
       this={tagName}
       data-tid={testId}
       class={className}
-      on:click|stopPropagation={() => dispatcher("nnsHash")}
+      role={isClickable ? "button" : undefined}
+      on:click|stopPropagation={() => isClickable && dispatcher("nnsHash")}
     >
       {shortenText}</svelte:element
     >

--- a/frontend/src/lib/components/ui/Hash.svelte
+++ b/frontend/src/lib/components/ui/Hash.svelte
@@ -2,6 +2,7 @@
   import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
   import { Copy } from "@dfinity/gix-components";
   import Tooltip from "./Tooltip.svelte";
+  import { createEventDispatcher } from "svelte";
 
   export let tagName: "h3" | "p" | "span" | "h5" = "h3";
   export let testId: string | undefined = undefined;
@@ -10,14 +11,24 @@
   export let showCopy = false;
   export let className: string | undefined = undefined;
   export let splitLength: number | undefined = undefined;
+  export let tooltipTop: boolean | undefined = undefined;
+
+  const dispatcher = createEventDispatcher();
 
   let shortenText: string;
   $: shortenText = shortenWithMiddleEllipsis(text, splitLength);
+
+  $: console.log("text", text, shortenText);
 </script>
 
 <span data-tid="hash-component">
-  <Tooltip {id} {text}>
-    <svelte:element this={tagName} data-tid={testId} class={className}>
+  <Tooltip top={tooltipTop} {id} {text}>
+    <svelte:element
+      this={tagName}
+      data-tid={testId}
+      class={className}
+      on:click|stopPropagation={() => dispatcher("nnsTextClick")}
+    >
       {shortenText}</svelte:element
     >
   </Tooltip>

--- a/frontend/src/lib/components/ui/Hash.svelte
+++ b/frontend/src/lib/components/ui/Hash.svelte
@@ -17,8 +17,6 @@
 
   let shortenText: string;
   $: shortenText = shortenWithMiddleEllipsis(text, splitLength);
-
-  $: console.log("text", text, shortenText);
 </script>
 
 <span data-tid="hash-component">
@@ -27,7 +25,7 @@
       this={tagName}
       data-tid={testId}
       class={className}
-      on:click|stopPropagation={() => dispatcher("nnsTextClick")}
+      on:click|stopPropagation={() => dispatcher("nnsHash")}
     >
       {shortenText}</svelte:element
     >

--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -1,3 +1,4 @@
+import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
@@ -178,7 +179,7 @@ test("Test neuron voting", async ({ page, context }) => {
     "Accepting Votes"
   );
   expect(await systemInfoSectionPo.getProposalProposerNeuronIdText()).toBe(
-    proposerNeuronId
+    shortenWithMiddleEllipsis(proposerNeuronId, 6)
   );
 
   // Votes result

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalSystemInfoProposerEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalSystemInfoProposerEntry.spec.ts
@@ -30,12 +30,12 @@ describe("ProposalMeta", () => {
   // Proposer description display in tested in ProposalSystemInfoSection.spec.ts
 
   it("should render proposer id", () => {
-    const { getByText } = render(ProposalSystemInfoProposerEntry, {
+    const { queryByTestId } = render(ProposalSystemInfoProposerEntry, {
       props,
     });
     expect(
-      getByText(new RegExp(`${mockProposalInfo.proposer?.toString()}$`))
-    ).toBeInTheDocument();
+      queryByTestId("proposal-system-info-proposer-value").textContent
+    ).toBe(`${mockProposalInfo.proposer?.toString().substring(0, 7)}`);
   });
 
   describe("signed in", () => {
@@ -46,11 +46,14 @@ describe("ProposalMeta", () => {
     });
 
     it("should open proposer modal", async () => {
-      const { container } = render(ProposalSystemInfoProposerEntry, {
-        props,
-      });
+      const { container, getByTestId } = render(
+        ProposalSystemInfoProposerEntry,
+        {
+          props,
+        }
+      );
 
-      const button = container.querySelector("button.text");
+      const button = getByTestId("proposal-system-info-proposer-value");
       expect(button).not.toBeNull();
       button && (await fireEvent.click(button));
 


### PR DESCRIPTION
# Motivation

Optimise nns proposals for middle-size android devices (eg.Galaxy S21).

# Changes

- apply sns proposer UI for nns proposer
- fix broken ellipsis in proposal card

# Tests

| Before | After |
|--------|--------|
| <img width="390" alt="Screenshot 2023-11-22 at 10 58 12" src="https://github.com/dfinity/nns-dapp/assets/98811342/8a094ee9-e59f-449f-80ec-4a70f4893b26"> | <img width="364" alt="Screenshot 2023-11-22 at 10 59 29" src="https://github.com/dfinity/nns-dapp/assets/98811342/f259c75e-6017-452f-a1b3-aa63140b1917"> |
| <img width="310" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/7ebe642e-2e02-45f2-805d-5a77b103c299"> | <img width="312" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/6257e584-6f4f-424f-827e-39da00fafc37"> | 

# Todos

- [x] Add entry to changelog (if necessary).
