### PR TITLE
GIX-1983: Add SnsTransaction functionality

### DIFF
--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -82,7 +82,7 @@
 {:else}
   <!-- A toast error is shown if there is an error fetching the transaction fee -->
   <!-- TODO: replace with busy spinner pattern as in <SnsIncreateStakeNeuronModal /> -->
-  <Modal on:nnsClose>
+  <Modal testId="sns-transaction-modal-component" on:nnsClose>
     <svelte:fragment slot="title"
       >{title ?? $i18n.accounts.send}</svelte:fragment
     ><Spinner /></Modal

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -61,6 +61,7 @@
 
 {#if nonNullish(transactionFee) && nonNullish(token)}
   <TransactionModal
+    testId="sns-transaction-modal-component"
     {rootCanisterId}
     on:nnsSubmit={transfer}
     on:nnsClose

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -24,7 +24,6 @@
   import { isUniverseCkBTC, isUniverseNns } from "$lib/utils/universe.utils";
   import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";
   import type { UserTokenData } from "$lib/types/tokens-page";
-  import { TokenAmount } from "@dfinity/utils";
 
   onMount(() => {
     if (!$ENABLE_MY_TOKENS) {

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -7,7 +7,7 @@
   import SignInTokens from "$lib/pages/SignInTokens.svelte";
   import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
   import { onMount } from "svelte";
-  import type { Action } from "$lib/types/actions";
+  import { ActionType, type Action } from "$lib/types/actions";
   import { tokensListVisitorsStore } from "$lib/derived/tokens-list-visitors.derived";
   import { login } from "$lib/services/auth.services";
   import { loadCkBTCTokens } from "$lib/services/ckbtc-tokens.services";
@@ -21,6 +21,10 @@
   import { isArrayEmpty } from "$lib/utils/utils";
   import { uncertifiedLoadCkBTCAccountsBalance } from "$lib/services/ckbtc-accounts-balance.services";
   import { ckBTCUniversesStore } from "$lib/derived/ckbtc-universes.derived";
+  import { isUniverseCkBTC, isUniverseNns } from "$lib/utils/universe.utils";
+  import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";
+  import type { UserTokenData } from "$lib/types/tokens-page";
+  import { TokenAmount } from "@dfinity/utils";
 
   onMount(() => {
     if (!$ENABLE_MY_TOKENS) {
@@ -79,10 +83,27 @@
     }
   })();
 
-  const handleAction = ({ detail: _ }: { detail: Action }) => {
+  let modal:
+    | { type: "sns-send" | "nns-send" | "ckbtc-send"; data: UserTokenData }
+    | undefined;
+  const closeModal = () => {
+    modal = undefined;
+  };
+
+  const handleAction = ({ detail }: { detail: Action }) => {
     // Any action from non-signed in user should be trigger a login
     if (!$authSignedInStore) {
       login();
+    }
+    if (detail.type === ActionType.Send) {
+      if (isUniverseNns(detail.data.universeId)) {
+        modal = { type: "nns-send", data: detail.data };
+      } else if (isUniverseCkBTC(detail.data.universeId)) {
+        modal = { type: "ckbtc-send", data: detail.data };
+      } else {
+        // Default to SNS, this might change when we have more universe sources
+        modal = { type: "sns-send", data: detail.data };
+      }
     }
   };
 </script>
@@ -94,6 +115,18 @@
     <SignInTokens
       on:nnsAction={handleAction}
       userTokensData={$tokensListVisitorsStore}
+    />
+  {/if}
+
+  {#if modal?.type === "sns-send"}
+    <SnsTransactionModal
+      rootCanisterId={modal.data.universeId}
+      token={modal.data.token}
+      transactionFee={TokenAmount.fromE8s({
+        amount: modal.data.feeE8s,
+        token: modal.data.token,
+      })}
+      on:nnsClose={closeModal}
     />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -122,10 +122,7 @@
     <SnsTransactionModal
       rootCanisterId={modal.data.universeId}
       token={modal.data.token}
-      transactionFee={TokenAmount.fromE8s({
-        amount: modal.data.feeE8s,
-        token: modal.data.token,
-      })}
+      transactionFee={modal.data.fee}
       on:nnsClose={closeModal}
     />
   {/if}

--- a/frontend/src/tests/page-objects/SnsTransactionModal.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsTransactionModal.page-object.ts
@@ -1,0 +1,12 @@
+import { TransactionModalBasePo } from "$tests/page-objects/TransactionModal.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SnsTransactionModalPo extends TransactionModalBasePo {
+  private static readonly TID = "sns-transaction-modal-component";
+
+  static under(element: PageObjectElement): SnsTransactionModalPo {
+    return new SnsTransactionModalPo(
+      element.byTestId(SnsTransactionModalPo.TID)
+    );
+  }
+}

--- a/frontend/src/tests/page-objects/TokensPage.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensPage.page-object.ts
@@ -25,4 +25,8 @@ export class TokensPagePo extends BasePageObject {
   getRowsData(): Promise<TokensTableRowData[]> {
     return this.getTokensTable().getRowsData();
   }
+
+  clickSendOnRow(index: number): Promise<void> {
+    return this.getTokensTable().clickSendOnRow(index);
+  }
 }

--- a/frontend/src/tests/page-objects/TokensPage.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensPage.page-object.ts
@@ -26,7 +26,7 @@ export class TokensPagePo extends BasePageObject {
     return this.getTokensTable().getRowsData();
   }
 
-  clickSendOnRow(index: number): Promise<void> {
-    return this.getTokensTable().clickSendOnRow(index);
+  clickSendOnRow(projectName: string): Promise<void> {
+    return this.getTokensTable().clickSendOnRow(projectName);
   }
 }

--- a/frontend/src/tests/page-objects/TokensRoute.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensRoute.page-object.ts
@@ -1,6 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { SignInTokensPagePo } from "./SignInTokens.page-object";
+import { SnsTransactionModalPo } from "./SnsTransactionModal.page-object";
 import { TokensPagePo } from "./TokensPage.page-object";
 
 export class TokensRoutePo extends BasePageObject {
@@ -24,5 +25,16 @@ export class TokensRoutePo extends BasePageObject {
 
   hasTokensPage(): Promise<boolean> {
     return this.getTokensPagePo().isPresent();
+  }
+
+  getSnsTransactionModalPo(): SnsTransactionModalPo {
+    return SnsTransactionModalPo.under(this.root);
+  }
+
+  transferSnsTokens(params: {
+    destinationAddress: string;
+    amount: number;
+  }): Promise<void> {
+    return this.getSnsTransactionModalPo().transferToAddress(params);
   }
 }

--- a/frontend/src/tests/page-objects/TokensTable.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTable.page-object.ts
@@ -25,4 +25,9 @@ export class TokensTablePo extends BasePageObject {
     const rows = await this.getRows();
     return Promise.all(rows.map((row) => row.getData()));
   }
+
+  async clickSendOnRow(index: number): Promise<void> {
+    const rows = await this.getRows();
+    return rows[index].click("send-button-component");
+  }
 }

--- a/frontend/src/tests/page-objects/TokensTable.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTable.page-object.ts
@@ -1,4 +1,5 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { isNullish } from "@dfinity/utils";
 import {
   TokensTableRowPo,
   type TokensTableRowData,
@@ -26,8 +27,24 @@ export class TokensTablePo extends BasePageObject {
     return Promise.all(rows.map((row) => row.getData()));
   }
 
-  async clickSendOnRow(index: number): Promise<void> {
+  async findRowByName(
+    projectName: string
+  ): Promise<TokensTableRowPo | undefined> {
     const rows = await this.getRows();
-    return rows[index].click("send-button-component");
+    for (const row of rows) {
+      const name = await row.getProjectName();
+      if (name === projectName) {
+        return row;
+      }
+    }
+    return undefined;
+  }
+
+  async clickSendOnRow(projectName: string): Promise<void> {
+    const row = await this.findRowByName(projectName);
+    if (isNullish(row)) {
+      throw new Error(`Row with project name ${projectName} not found`);
+    }
+    return row.click("send-button-component");
   }
 }

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -180,8 +180,7 @@ describe("Tokens route", () => {
 
           const tokensPagePo = po.getTokensPagePo();
 
-          // The the first two rows are ICP and ckBTC.
-          await tokensPagePo.clickSendOnRow(2);
+          await tokensPagePo.clickSendOnRow("Tetris");
 
           expect(await po.getSnsTransactionModalPo().isPresent()).toBe(true);
 


### PR DESCRIPTION
# Motivation

Users can make SNS transactions from the tokens view.

# Changes

* Add a `modal` local variable in the Tokens route +page to control whether a modal should be open or not.
* Populate `modal` when an action is triggered.
* Render the SnsTransactionModal when `modal.type` matches an SNS transaction.

# Tests

* Add test id in SnsTransactionModal.svelte
* New PO for SnsTransactionModal.
* New methods in TokensTable, TokensPage and TokensRoute POs.
* Add a test case in the Tokens route page that user can transfer SNS tokens.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
