### PR TITLE
GIX-2102: Add column headers to ICP TokensTable

### DIFF
--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -32,7 +32,13 @@
 
 {#if $ENABLE_MY_TOKENS}
   <TestIdWrapper testId="accounts-body">
-    <TokensTable {userTokensData} />
+    <TokensTable
+      {userTokensData}
+      columnHeaders={[
+        $i18n.tokens.accounts_header,
+        $i18n.tokens.balance_header,
+      ]}
+    />
   </TestIdWrapper>
 {:else}
   <div class="card-grid" data-tid="accounts-body">

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -34,10 +34,7 @@
   <TestIdWrapper testId="accounts-body">
     <TokensTable
       {userTokensData}
-      columnHeaders={[
-        $i18n.tokens.accounts_header,
-        $i18n.tokens.balance_header,
-      ]}
+      firstColumnHeader={$i18n.tokens.accounts_header}
     />
   </TestIdWrapper>
 {:else}

--- a/frontend/src/lib/pages/SignInAccounts.svelte
+++ b/frontend/src/lib/pages/SignInAccounts.svelte
@@ -22,7 +22,13 @@
     </PageBanner>
 
     {#if userTokensData.length > 0}
-      <TokensTable {userTokensData} />
+      <TokensTable
+        {userTokensData}
+        columnHeaders={[
+          $i18n.tokens.accounts_header,
+          $i18n.tokens.balance_header,
+        ]}
+      />
     {/if}
   </div>
 {:else}

--- a/frontend/src/lib/pages/SignInAccounts.svelte
+++ b/frontend/src/lib/pages/SignInAccounts.svelte
@@ -24,10 +24,7 @@
     {#if userTokensData.length > 0}
       <TokensTable
         {userTokensData}
-        columnHeaders={[
-          $i18n.tokens.accounts_header,
-          $i18n.tokens.balance_header,
-        ]}
+        firstColumnHeader={$i18n.tokens.accounts_header}
       />
     {/if}
   </div>

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -52,6 +52,13 @@ describe("NnsAccounts", () => {
       overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
     });
 
+    it("renders 'Accounts' as tokens table first column", async () => {
+      const po = renderComponent();
+
+      const tablePo = po.getTokensTablePo();
+      expect(await tablePo.getFirstColumnHeader()).toEqual("Accounts");
+    });
+
     it("should render tokens table with rows", async () => {
       const mainTokenData = createUserToken({
         title: "Main",

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -419,6 +419,13 @@ describe("Accounts", () => {
           },
         ]);
       });
+
+      it("renders 'Accounts' as tokens table first column", async () => {
+        const po = renderComponent();
+
+        const tablePo = po.getNnsAccountsPo().getTokensTablePo();
+        expect(await tablePo.getFirstColumnHeader()).toEqual("Accounts");
+      });
     });
   });
 });

--- a/frontend/src/tests/routes/app/accounts/page.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/page.spec.ts
@@ -54,6 +54,13 @@ describe("Accounts page", () => {
         expect(await pagePo.getTokenNames()).toEqual(["Internet Computer"]);
         expect(await pagePo.hasEmptyCards()).toBe(false);
       });
+
+      it("renders 'Accounts' as tokens first column", async () => {
+        const po = renderComponent();
+
+        const tablePo = po.getSignInAccountsPo().getTokensTablePo();
+        expect(await tablePo.getFirstColumnHeader()).toEqual("Accounts");
+      });
     });
 
     describe("tokens flag disabled", () => {
@@ -90,6 +97,16 @@ describe("Accounts page", () => {
 
         const pagePo = po.getAccountsPo().getNnsAccountsPo();
         expect(await pagePo.hasTokensTable()).toBe(true);
+      });
+
+      it("renders 'Accounts' as tokens table first column", async () => {
+        const po = renderComponent();
+
+        const tablePo = po
+          .getAccountsPo()
+          .getNnsAccountsPo()
+          .getTokensTablePo();
+        expect(await tablePo.getFirstColumnHeader()).toEqual("Accounts");
       });
     });
 


### PR DESCRIPTION
# Motivation

The tokens table for ICP accounts has a different header than for all tokens view.

In this PR, the new prop `firstColumnHeader` is used to change the column header for ICP accounts.

# Changes

* Use `firstColumnHeader` in NnsAcconts.
* Use `firstColumnHeader` in SignInAccounts.

# Tests

* Add a test in the Accounts route (the one that renders NnsAccounts).
* Add a test in NnsAccounts.spec
* Add a test in routes/app/accounts/page.spec (the one that renders SignInAccounts, and tests its logic).

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary
