### PR TITLE
Pass UiTransaction[] to IcrcTransactionList

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -24,6 +24,7 @@
   import { CKBTC_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/ckbtc.constants";
   import { waitForMilliseconds } from "$lib/utils/utils";
   import { nonNullish } from "@dfinity/utils";
+  import type { UiTransaction } from "$lib/types/transaction";
 
   export let indexCanisterId: CanisterId;
   export let universeId: UniverseCanisterId;

--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -9,6 +9,7 @@
   } from "$lib/services/ckbtc-transactions.services";
   import type { IcrcTransactionData } from "$lib/types/transaction";
   import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
+  import { i18n } from "$lib/stores/i18n";
   import {
     getSortedTransactionsFromStore,
     isIcrcTransactionsCompleted,
@@ -22,6 +23,7 @@
   import CkBTCWalletTransactionsObserver from "$lib/components/accounts/CkBTCWalletTransactionsObserver.svelte";
   import { CKBTC_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/ckbtc.constants";
   import { waitForMilliseconds } from "$lib/utils/utils";
+  import { nonNullish } from "@dfinity/utils";
 
   export let indexCanisterId: CanisterId;
   export let universeId: UniverseCanisterId;
@@ -84,6 +86,18 @@
     canisterId: universeId,
     account,
   });
+
+  let uiTransactions: UiTransaction[];
+  $: uiTransactions = transactions
+    .map((transaction: IcrcTransactionData) =>
+      mapCkbtcTransaction({
+        ...transaction,
+        account,
+        token,
+        i18n: $i18n,
+      })
+    )
+    .filter(nonNullish);
 </script>
 
 <CkBTCWalletTransactionsObserver
@@ -94,11 +108,8 @@
 >
   <IcrcTransactionsList
     on:nnsIntersect={loadNextTransactions}
-    {account}
-    {transactions}
+    transactions={uiTransactions}
     {loading}
     {completed}
-    {token}
-    mapTransaction={mapCkbtcTransaction}
   />
 </CkBTCWalletTransactionsObserver>

--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -3,6 +3,7 @@
 
 <script lang="ts">
   import type { Account } from "$lib/types/account";
+  import type { UiTransaction } from "$lib/types/transaction";
   import {
     loadCkBTCAccountNextTransactions,
     loadCkBTCAccountTransactions,
@@ -24,7 +25,6 @@
   import { CKBTC_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/ckbtc.constants";
   import { waitForMilliseconds } from "$lib/utils/utils";
   import { nonNullish } from "@dfinity/utils";
-  import type { UiTransaction } from "$lib/types/transaction";
 
   export let indexCanisterId: CanisterId;
   export let universeId: UniverseCanisterId;

--- a/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
@@ -1,18 +1,9 @@
 <script lang="ts">
-  import type { Account } from "$lib/types/account";
-  import type { Principal } from "@dfinity/principal";
   import { InfiniteScroll, Spinner } from "@dfinity/gix-components";
-  import type { IcrcTransactionWithId } from "@dfinity/ledger-icrc";
-  import { nonNullish } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
   import IcrcTransactionCard from "./IcrcTransactionCard.svelte";
   import SkeletonCard from "../ui/SkeletonCard.svelte";
-  import type {
-    IcrcTransactionData,
-    UiTransaction,
-  } from "$lib/types/transaction";
-  import type { IcrcTokenMetadata } from "$lib/types/icrc";
-  import type { mapIcrcTransactionType } from "$lib/utils/icrc-transactions.utils";
+  import type { UiTransaction } from "$lib/types/transaction";
   import { flip } from "svelte/animate";
 
   export let transactions: UiTransaction[];

--- a/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTransactionsList.svelte
@@ -15,34 +15,9 @@
   import type { mapIcrcTransactionType } from "$lib/utils/icrc-transactions.utils";
   import { flip } from "svelte/animate";
 
-  export let account: Account;
-  export let transactions: IcrcTransactionData[];
+  export let transactions: UiTransaction[];
   export let loading: boolean;
-  export let governanceCanisterId: Principal | undefined = undefined;
   export let completed = false;
-  export let token: IcrcTokenMetadata | undefined;
-  export let mapTransaction: mapIcrcTransactionType;
-
-  let uiTransactions: UiTransaction[] = [];
-  $: uiTransactions = transactions
-    .map(
-      ({
-        transaction,
-        toSelfTransaction,
-      }: {
-        transaction: IcrcTransactionWithId;
-        toSelfTransaction: boolean;
-      }) =>
-        mapTransaction({
-          transaction,
-          account,
-          toSelfTransaction,
-          governanceCanisterId,
-          token,
-          i18n: $i18n,
-        })
-    )
-    .filter(nonNullish);
 </script>
 
 <div data-tid="transactions-list" class="container">
@@ -53,7 +28,7 @@
     <SkeletonCard cardType="info" />
   {:else}
     <InfiniteScroll on:nnsIntersect disabled={loading || completed}>
-      {#each uiTransactions as transaction (transaction.domKey)}
+      {#each transactions as transaction (transaction.domKey)}
         <div animate:flip={{ duration: 250 }}>
           <IcrcTransactionCard {transaction} />
         </div>

--- a/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
@@ -3,7 +3,9 @@
   import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
   import { i18n } from "$lib/stores/i18n";
   import type { Account } from "$lib/types/account";
+  import type { UiTransaction } from "$lib/types/transaction";
   import type { Principal } from "@dfinity/principal";
+  import { nonNullish } from "@dfinity/utils";
   import { onMount } from "svelte";
   import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
   import type { IcrcTransactionData } from "$lib/types/transaction";
@@ -15,8 +17,6 @@
   } from "$lib/utils/icrc-transactions.utils";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import SnsWalletTransactionsObserver from "$lib/components/accounts/SnsWalletTransactionsObserver.svelte";
-  import { nonNullish } from "@dfinity/utils";
-  import type { UiTransaction } from "$lib/types/transaction";
 
   export let account: Account;
   export let rootCanisterId: Principal;

--- a/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { loadSnsAccountNextTransactions } from "$lib/services/sns-transactions.services";
   import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
+  import { i18n } from "$lib/stores/i18n";
   import type { Account } from "$lib/types/account";
   import type { Principal } from "@dfinity/principal";
   import { onMount } from "svelte";
@@ -14,6 +15,7 @@
   } from "$lib/utils/icrc-transactions.utils";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import SnsWalletTransactionsObserver from "$lib/components/accounts/SnsWalletTransactionsObserver.svelte";
+  import { nonNullish } from "@dfinity/utils";
 
   export let account: Account;
   export let rootCanisterId: Principal;
@@ -60,17 +62,26 @@
     ({ rootCanisterId: currentId }) =>
       currentId.toText() === rootCanisterId.toText()
   )?.summary.governanceCanisterId;
+
+  let uiTransactions: UiTransaction[];
+  $: uiTransactions = transactions
+    .map((transaction: IcrcTransactionData) =>
+      mapIcrcTransaction({
+        ...transaction,
+        account,
+        governanceCanisterId,
+        token,
+        i18n: $i18n,
+      })
+    )
+    .filter(nonNullish);
 </script>
 
 <SnsWalletTransactionsObserver {account} {completed}>
   <IcrcTransactionsList
     on:nnsIntersect={loadMore}
-    {account}
-    {transactions}
+    transactions={uiTransactions}
     {loading}
-    {governanceCanisterId}
     {completed}
-    {token}
-    mapTransaction={mapIcrcTransaction}
   />
 </SnsWalletTransactionsObserver>

--- a/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/SnsTransactionsList.svelte
@@ -16,6 +16,7 @@
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import SnsWalletTransactionsObserver from "$lib/components/accounts/SnsWalletTransactionsObserver.svelte";
   import { nonNullish } from "@dfinity/utils";
+  import type { UiTransaction } from "$lib/types/transaction";
 
   export let account: Account;
   export let rootCanisterId: Principal;

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -87,8 +87,6 @@ export interface UiTransaction {
   headline: string;
   // Where the amount is going to or coming from.
   otherParty?: string;
-  // TODO: Remove fallbackDescription and always use otherParty.
-  fallbackDescription?: string;
   // Always positive.
   tokenAmount: TokenAmount;
   timestamp: Date;

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionsList.spec.ts
@@ -1,46 +1,29 @@
 import IcrcTransactionsList from "$lib/components/accounts/IcrcTransactionsList.svelte";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
-import type { Account } from "$lib/types/account";
-import type { IcrcTokenMetadata } from "$lib/types/icrc";
-import type { IcrcTransactionData } from "$lib/types/transaction";
+import type { UiTransaction } from "$lib/types/transaction";
 import {
-  mapIcrcTransaction,
-  type mapIcrcTransactionType,
-} from "$lib/utils/icrc-transactions.utils";
-import {
-  mockIcrcTransactionWithId,
   mockIcrcTransactionsStoreSubscribe,
+  mockUiTransaction,
 } from "$tests/mocks/icrc-transactions.mock";
-import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
-import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import { IcrcTransactionsListPo } from "$tests/page-objects/IcrcTransactionsList.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 
 describe("IcrcTransactionList", () => {
   const renderComponent = ({
-    account,
     transactions,
     loading,
     completed = false,
-    mapTransaction,
-    token = mockSnsToken,
   }: {
-    account: Account;
-    transactions: IcrcTransactionData[];
+    transactions: UiTransaction[];
     loading?: boolean;
     completed?: boolean;
-    mapTransaction?: mapIcrcTransactionType;
-    token?: IcrcTokenMetadata;
   }) => {
     const { container } = render(IcrcTransactionsList, {
       props: {
-        account,
         transactions,
         loading,
         completed,
-        token,
-        mapTransaction: mapTransaction ?? mapIcrcTransaction,
       },
     });
     return IcrcTransactionsListPo.under(new JestPageObjectElement(container));
@@ -56,7 +39,6 @@ describe("IcrcTransactionList", () => {
     );
 
     const po = renderComponent({
-      account: mockSnsMainAccount,
       transactions: [],
       loading: true,
     });
@@ -70,7 +52,6 @@ describe("IcrcTransactionList", () => {
     );
 
     const po = renderComponent({
-      account: mockSnsMainAccount,
       transactions: [],
       loading: false,
       completed: true,
@@ -81,59 +62,20 @@ describe("IcrcTransactionList", () => {
 
   it("should render transactions", async () => {
     const po = renderComponent({
-      account: mockSnsMainAccount,
       transactions: [
         {
-          transaction: mockIcrcTransactionWithId,
-          toSelfTransaction: false,
+          ...mockUiTransaction,
+          domKey: "1-1",
+        },
+        {
+          ...mockUiTransaction,
+          domKey: "2-1",
         },
       ],
       loading: false,
       completed: true,
     });
 
-    expect(await po.getTransactionCardPos()).toHaveLength(1);
-  });
-
-  it("should not render transactions without token", async () => {
-    const po = renderComponent({
-      account: mockSnsMainAccount,
-      transactions: [
-        {
-          transaction: mockIcrcTransactionWithId,
-          toSelfTransaction: false,
-        },
-      ],
-      loading: false,
-      completed: true,
-      token: null,
-    });
-
-    expect(await po.getTransactionCardPos()).toHaveLength(0);
-  });
-
-  it("uses mapTransaction", async () => {
-    const customIdentifier = "custom identifier";
-    const customMapTransaction = (params) => ({
-      ...mapIcrcTransaction(params),
-      otherParty: customIdentifier,
-    });
-
-    const po = renderComponent({
-      account: mockSnsMainAccount,
-      transactions: [
-        {
-          transaction: mockIcrcTransactionWithId,
-          toSelfTransaction: false,
-        },
-      ],
-      loading: false,
-      completed: true,
-      mapTransaction: customMapTransaction,
-    });
-
-    const cards = await po.getTransactionCardPos();
-    expect(cards).toHaveLength(1);
-    expect(await cards[0].getIdentifier()).toBe(`From: ${customIdentifier}`);
+    expect(await po.getTransactionCardPos()).toHaveLength(2);
   });
 });

--- a/frontend/src/tests/lib/components/accounts/IcrcTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTransactionsList.spec.ts
@@ -1,10 +1,8 @@
 import IcrcTransactionsList from "$lib/components/accounts/IcrcTransactionsList.svelte";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import type { UiTransaction } from "$lib/types/transaction";
-import {
-  mockIcrcTransactionsStoreSubscribe,
-  mockUiTransaction,
-} from "$tests/mocks/icrc-transactions.mock";
+import { mockIcrcTransactionsStoreSubscribe } from "$tests/mocks/icrc-transactions.mock";
+import { createMockUiTransaction } from "$tests/mocks/transaction.mock";
 import { IcrcTransactionsListPo } from "$tests/page-objects/IcrcTransactionsList.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
@@ -63,14 +61,8 @@ describe("IcrcTransactionList", () => {
   it("should render transactions", async () => {
     const po = renderComponent({
       transactions: [
-        {
-          ...mockUiTransaction,
-          domKey: "1-1",
-        },
-        {
-          ...mockUiTransaction,
-          domKey: "2-1",
-        },
+        createMockUiTransaction({ domKey: "1-1" }),
+        createMockUiTransaction({ domKey: "2-1" }),
       ],
       loading: false,
       completed: true,

--- a/frontend/src/tests/mocks/icrc-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icrc-transactions.mock.ts
@@ -7,7 +7,7 @@ import type {
   IcrcTransactionWithId,
 } from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
-import { ICPToken, TokenAmount, toNullable } from "@dfinity/utils";
+import { toNullable } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
 
 export interface IcrcCandidAccount {
@@ -208,12 +208,3 @@ export const mockIcrcTransactionsStoreSubscribe =
 
     return () => undefined;
   };
-
-export const mockUiTransaction = {
-  domKey: "123-1",
-  isIncoming: false,
-  headline: "Sent",
-  otherParty: "aaaaa-aa",
-  tokenAmount: TokenAmount.fromE8s({ amount: 330_000_000n, token: ICPToken }),
-  timestamp: new Date("2021-08-01T15:00:00.000Z"),
-};

--- a/frontend/src/tests/mocks/icrc-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icrc-transactions.mock.ts
@@ -7,7 +7,7 @@ import type {
   IcrcTransactionWithId,
 } from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
-import { toNullable } from "@dfinity/utils";
+import { ICPToken, TokenAmount, toNullable } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
 
 export interface IcrcCandidAccount {
@@ -208,3 +208,12 @@ export const mockIcrcTransactionsStoreSubscribe =
 
     return () => undefined;
   };
+
+export const mockUiTransaction = {
+  domKey: "123-1",
+  isIncoming: false,
+  headline: "Sent",
+  otherParty: "aaaaa-aa",
+  tokenAmount: TokenAmount.fromE8s({ amount: 330_000_000n, token: ICPToken }),
+  timestamp: new Date("2021-08-01T15:00:00.000Z"),
+};

--- a/frontend/src/tests/mocks/transaction.mock.ts
+++ b/frontend/src/tests/mocks/transaction.mock.ts
@@ -1,7 +1,9 @@
 import type { Transaction as NnsTransaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
-import type { Transaction } from "$lib/types/transaction";
+import type { Transaction, UiTransaction } from "$lib/types/transaction";
 import { AccountTransactionType } from "$lib/types/transaction";
+import { TokenAmount } from "@dfinity/utils";
 import { mockMainAccount, mockSubAccount } from "./icp-accounts.store.mock";
+import { mockSnsToken } from "./sns-projects.mock";
 
 export const createMockSendTransaction = ({
   amount = 110000023n,
@@ -75,3 +77,22 @@ export const mockTransactionSendDataFromMain: Transaction = {
   displayAmount,
   date: new Date("03-14-2021"),
 };
+
+export const createMockUiTransaction = ({
+  domKey = "123-1",
+  isIncoming = false,
+  headline = "Sent",
+  otherParty = "aaaaa-aa",
+  tokenAmount = TokenAmount.fromE8s({
+    amount: 330_000_000n,
+    token: mockSnsToken,
+  }),
+  timestamp = new Date("2021-08-01T15:00:00.000Z"),
+}: Partial<UiTransaction>): UiTransaction => ({
+  domKey,
+  isIncoming,
+  headline,
+  otherParty,
+  tokenAmount,
+  timestamp,
+});


### PR DESCRIPTION
# Motivation

In CkBTCTransactions list I want to render multiple transactions (such as Approve + transfer) as a single transaction.
This is easier if the conversion from `IcrcTransactionData` to `UiTransaction` happens closer to the CkBTCTransactionsList.

In this PR I move the conversion from `IcrcTransactionData[]` to `UiTransaction[]` from `IcrcTransactionsList` to `CkBTCTransactionsList` and `SnsTransactionsList`.

# Changes

1. In `CkBTCTransactionsList` convert `IcrcTransactionData[]` to `UiTransaction[]` and pass that to `IcrcTransactionsList`. No longer pass `account` and `token` which were only passed to do the conversion.
2. In `SnsTransactionsList` convert `IcrcTransactionData[]` to `UiTransaction[]` and pass that to `IcrcTransactionsList`. No longer pass `governanceCanisterId`, `account` and `token` which were only passed to do the conversion.
3. Remove the conversion step an unused props from `IcrcTransactionsList`.
4. Drive-by: Remove `fallbackDescription` from `UiTransaction`, which I thought I did in a previous PR.

# Tests

1. Removed irrelevant tests from `frontend/src/tests/lib/components/accounts/IcrcTransactionsList.spec.ts`.
2. Added `createMockUiTransaction` for convenience.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary