### PR TITLE
GIX-2102: Remove default firstColumnHeader

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -4,7 +4,7 @@
   import Row from "./TokensTableRow.svelte";
 
   export let userTokensData: UserTokenData[];
-  export let firstColumnHeader: string = $i18n.tokens.projects_header;
+  export let firstColumnHeader: string;
 </script>
 
 <div role="table" data-tid="tokens-table-component">

--- a/frontend/src/lib/pages/SignInTokens.svelte
+++ b/frontend/src/lib/pages/SignInTokens.svelte
@@ -16,7 +16,11 @@
     <SignIn slot="actions" />
   </PageBanner>
 
-  <TokensTable on:nnsAction {userTokensData} />
+  <TokensTable
+    on:nnsAction
+    {userTokensData}
+    firstColumnHeader={$i18n.tokens.projects_header}
+  />
 </div>
 
 <style lang="scss">

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
+  import { i18n } from "$lib/stores/i18n";
   import type { UserTokenData } from "$lib/types/tokens-page";
 
   export let userTokensData: UserTokenData[];
 </script>
 
 <TestIdWrapper testId="tokens-page-component">
-  <TokensTable {userTokensData} on:nnsAction />
+  <TokensTable
+    {userTokensData}
+    on:nnsAction
+    firstColumnHeader={$i18n.tokens.projects_header}
+  />
 </TestIdWrapper>

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -50,15 +50,6 @@ describe("TokensTable", () => {
     expect(await po.getRows()).toHaveLength(2);
   });
 
-  it("should render the column header 'Projects' by default", async () => {
-    const token1 = createUserToken({
-      universeId: OWN_CANISTER_ID,
-    });
-    const po = renderTable({ userTokensData: [token1] });
-
-    expect(await po.getFirstColumnHeader()).toEqual("Projects");
-  });
-
   it("should render the first column headers from props", async () => {
     const firstColumnHeader = "Accounts";
     const token1 = createUserToken({

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -145,7 +145,7 @@ describe("Tokens route", () => {
         expect(await po.hasTokensPage()).toBe(true);
       });
 
-      it("renders 'Accounts' as tokens table first column", async () => {
+      it("renders 'Projects' as tokens table first column", async () => {
         const po = await renderPage();
 
         const tablePo = po.getTokensPagePo().getTokensTable();
@@ -228,7 +228,7 @@ describe("Tokens route", () => {
         expect(await po.hasTokensPage()).toBe(false);
       });
 
-      it("renders 'Accounts' as tokens table first column", async () => {
+      it("renders 'Projects' as tokens table first column", async () => {
         const po = await renderPage();
 
         const tablePo = po.getSignInTokensPagePo().getTokensTablePo();

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -145,6 +145,13 @@ describe("Tokens route", () => {
         expect(await po.hasTokensPage()).toBe(true);
       });
 
+      it("renders 'Accounts' as tokens table first column", async () => {
+        const po = await renderPage();
+
+        const tablePo = po.getTokensPagePo().getTokensTable();
+        expect(await tablePo.getFirstColumnHeader()).toEqual("Projects");
+      });
+
       describe("when ckBTC is enabled", () => {
         beforeEach(() => {
           overrideFeatureFlagsStore.setFlag("ENABLE_CKBTC", true);
@@ -219,6 +226,13 @@ describe("Tokens route", () => {
 
         expect(await po.hasLoginPage()).toBe(true);
         expect(await po.hasTokensPage()).toBe(false);
+      });
+
+      it("renders 'Accounts' as tokens table first column", async () => {
+        const po = await renderPage();
+
+        const tablePo = po.getSignInTokensPagePo().getTokensTablePo();
+        expect(await tablePo.getFirstColumnHeader()).toEqual("Projects");
       });
 
       describe("when ckBTC is enabled", () => {


### PR DESCRIPTION
# Motivation

Remove default value for `firstColumnHeader` to make it configurable from outside always.

# Changes

* Remove default value from `firstColumnHeader` in TokensTable.svelte
* Add the old default value in the usages of TokensTable without the prop `firstColumnHeader`.

# Tests

* Remove a test for the default column header in TokensTable.
* Add tests in the tokens route to check the header's title, both logged in and out.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary
