### PR TITLE
GIX-2062: Add loading balance

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -3,13 +3,8 @@
   import type { UserTokenData, UserTokenLoading } from "$lib/types/tokens-page";
   import Row from "./TokensTableRow.svelte";
 
-<<<<<<< HEAD
-  export let userTokensData: UserTokenData[];
-  export let firstColumnHeader: string;
-=======
   export let userTokensData: Array<UserTokenData | UserTokenLoading>;
-  export let firstColumnHeader: string = $i18n.tokens.projects_header;
->>>>>>> 48ff8d063 (Untitled commit)
+  export let firstColumnHeader: string;
 </script>
 
 <div role="table" data-tid="tokens-table-component">

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import type { UserTokenData } from "$lib/types/tokens-page";
+  import type { UserTokenData, UserTokenLoading } from "$lib/types/tokens-page";
   import Row from "./TokensTableRow.svelte";
 
+<<<<<<< HEAD
   export let userTokensData: UserTokenData[];
   export let firstColumnHeader: string;
+=======
+  export let userTokensData: Array<UserTokenData | UserTokenLoading>;
+  export let firstColumnHeader: string = $i18n.tokens.projects_header;
+>>>>>>> 48ff8d063 (Untitled commit)
 </script>
 
 <div role="table" data-tid="tokens-table-component">

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
+  import {
+    UserTokenAction,
+    type UserTokenData,
+    type UserTokenLoading,
+  } from "$lib/types/tokens-page";
   import {
     SvelteComponent,
     createEventDispatcher,
@@ -15,8 +19,9 @@
   import { nonNullish } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
   import { Spinner } from "@dfinity/gix-components";
+  import { isUserTokenData } from "$lib/utils/user-token.utils";
 
-  export let userTokenData: UserTokenData;
+  export let userTokenData: UserTokenData | UserTokenLoading;
   export let index: number;
 
   const dispatcher = createEventDispatcher();
@@ -30,11 +35,18 @@
     [UserTokenAction.Send]: SendButton,
   };
 
-  const handleClick = () =>
-    dispatcher("nnsAction", {
-      type: ActionType.GoToTokenDetail,
-      data: userTokenData,
-    });
+  let userToken: UserTokenData | undefined;
+  $: userToken = isUserTokenData(userTokenData) ? userTokenData : undefined;
+
+  const handleClick = () => {
+    if (nonNullish(userToken)) {
+      // Actions can only be dispatched with `UserTokenData`
+      dispatcher("nnsAction", {
+        type: ActionType.GoToTokenDetail,
+        data: userToken,
+      });
+    }
+  };
 </script>
 
 <div
@@ -62,13 +74,15 @@
       </div>
     </div>
     <div class="title-actions actions mobile-only">
-      {#each userTokenData.actions as action}
-        <svelte:component
-          this={actionMapper[action]}
-          userToken={userTokenData}
-          on:nnsAction
-        />
-      {/each}
+      {#if nonNullish(userToken)}
+        {#each userToken.actions as action}
+          <svelte:component
+            this={actionMapper[action]}
+            {userToken}
+            on:nnsAction
+          />
+        {/each}
+      {/if}
     </div>
   </div>
   <div role="cell" class="mobile-row-cell left-cell">
@@ -86,13 +100,15 @@
     {/if}
   </div>
   <div role="cell" class="actions-cell actions">
-    {#each userTokenData.actions as action}
-      <svelte:component
-        this={actionMapper[action]}
-        userToken={userTokenData}
-        on:nnsAction
-      />
-    {/each}
+    {#if nonNullish(userToken)}
+      {#each userToken.actions as action}
+        <svelte:component
+          this={actionMapper[action]}
+          {userToken}
+          on:nnsAction
+        />
+      {/each}
+    {/if}
   </div>
 </div>
 

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
@@ -14,6 +14,7 @@
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import { nonNullish } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
+  import { Spinner } from "@dfinity/gix-components";
 
   export let userTokenData: UserTokenData;
   export let index: number;
@@ -75,6 +76,10 @@
     {#if userTokenData.balance instanceof UnavailableTokenAmount}
       <span data-tid="token-value-label"
         >{`-/- ${userTokenData.balance.token.symbol}`}</span
+      >
+    {:else if userTokenData.balance === "loading"}
+      <span data-tid="token-value-label" class="balance-spinner"
+        ><Spinner inline size="tiny" /></span
       >
     {:else}
       <AmountDisplay singleLine amount={userTokenData.balance} />
@@ -176,6 +181,11 @@
       flex-direction: column;
       gap: var(--padding-0_5x);
     }
+  }
+
+  .balance-spinner {
+    display: flex;
+    align-items: center;
   }
 
   .actions {

--- a/frontend/src/lib/components/tokens/TokensTable/actions/GoToDetailButton.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/actions/GoToDetailButton.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <button
-  class="icon"
+  class="icon-only"
   data-tid="go-to-detail-button-component"
   on:click|stopPropagation={() => {
     dispatcher("nnsAction", {

--- a/frontend/src/lib/types/tokens-page.ts
+++ b/frontend/src/lib/types/tokens-page.ts
@@ -12,7 +12,7 @@ export type UserTokenData = {
   universeId: Principal;
   title: string;
   subtitle?: string;
-  balance: TokenAmount | UnavailableTokenAmount;
+  balance: TokenAmount | UnavailableTokenAmount | "loading";
   token: Token;
   // Fees are included in the metadata of ICRC tokens, but this is not a list of only ICRC tokens
   fee: TokenAmount;

--- a/frontend/src/lib/types/tokens-page.ts
+++ b/frontend/src/lib/types/tokens-page.ts
@@ -29,7 +29,7 @@ export type UserTokenLoading = UserTokenBase & {
 };
 
 export type UserTokenData = UserTokenBase & {
-  balance: TokenAmount | UnavailableTokenAmount | "loading";
+  balance: TokenAmount | UnavailableTokenAmount;
   token: Token;
   // Fees are included in the metadata of ICRC tokens, but this is not a list of only ICRC tokens
   fee: TokenAmount;

--- a/frontend/src/lib/types/tokens-page.ts
+++ b/frontend/src/lib/types/tokens-page.ts
@@ -8,14 +8,29 @@ export enum UserTokenAction {
   Receive = "receive",
 }
 
-export type UserTokenData = {
+export type UserTokenBase = {
   universeId: Principal;
   title: string;
   subtitle?: string;
+  logo: string;
+  actions: UserTokenAction[];
+};
+
+/**
+ * By using two types, we can keep `token` and `fee` mandatory in `UserTokenData`.
+ *
+ * This makes it easy to manage opening modals and managing actions where those fields are mandatory
+ * but they are not present while loading because the data is not yet there.
+ *
+ */
+export type UserTokenLoading = UserTokenBase & {
+  balance: "loading";
+  actions: [];
+};
+
+export type UserTokenData = UserTokenBase & {
   balance: TokenAmount | UnavailableTokenAmount | "loading";
   token: Token;
   // Fees are included in the metadata of ICRC tokens, but this is not a list of only ICRC tokens
   fee: TokenAmount;
-  logo: string;
-  actions: UserTokenAction[];
 };

--- a/frontend/src/lib/utils/user-token.utils.ts
+++ b/frontend/src/lib/utils/user-token.utils.ts
@@ -1,0 +1,7 @@
+import type { UserTokenData, UserTokenLoading } from "$lib/types/tokens-page";
+
+export const isUserTokenData = (
+  userToken: UserTokenData | UserTokenLoading
+): userToken is UserTokenData => {
+  return userToken.balance !== "loading";
+};

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -119,6 +119,20 @@ describe("TokensTable", () => {
     expect(await row1Po.getBalance()).toBe("-/- ckBTC");
   });
 
+  it("should render balance spinner if balance is loading", async () => {
+    const token1 = createUserToken({
+      universeId: OWN_CANISTER_ID,
+      balance: "loading",
+    });
+    const po = renderTable({ userTokensData: [token1] });
+
+    const rows = await po.getRows();
+    const row1Po = rows[0];
+
+    expect(await row1Po.getBalance()).toBe("");
+    expect(await row1Po.hasBalanceSpinner()).toBe(true);
+  });
+
   it("should render a button Send action", async () => {
     const po = renderTable({
       userTokensData: [

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -1,11 +1,16 @@
 import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { ActionType } from "$lib/types/actions";
-import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
+import {
+  UserTokenAction,
+  type UserTokenData,
+  type UserTokenLoading,
+} from "$lib/types/tokens-page";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import {
   createUserToken,
+  createUserTokenLoading,
   userTokenPageMock,
 } from "$tests/mocks/tokens-page.mock";
 import { TokensTablePo } from "$tests/page-objects/TokensTable.page-object";
@@ -21,7 +26,7 @@ describe("TokensTable", () => {
     firstColumnHeader,
     onAction,
   }: {
-    userTokensData: UserTokenData[];
+    userTokensData: Array<UserTokenData | UserTokenLoading>;
     firstColumnHeader?: string;
     onAction?: Mock;
   }) => {
@@ -120,10 +125,7 @@ describe("TokensTable", () => {
   });
 
   it("should render balance spinner if balance is loading", async () => {
-    const token1 = createUserToken({
-      universeId: OWN_CANISTER_ID,
-      balance: "loading",
-    });
+    const token1 = createUserTokenLoading();
     const po = renderTable({ userTokensData: [token1] });
 
     const rows = await po.getRows();

--- a/frontend/src/tests/mocks/tokens-page.mock.ts
+++ b/frontend/src/tests/mocks/tokens-page.mock.ts
@@ -7,7 +7,11 @@ import {
   CKTESTBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
-import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
+import {
+  UserTokenAction,
+  type UserTokenData,
+  type UserTokenLoading,
+} from "$lib/types/tokens-page";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { TokenAmount } from "@dfinity/utils";
 import { mockCkBTCToken, mockCkTESTBTCToken } from "./ckbtc-accounts.mock";
@@ -120,5 +124,20 @@ export const createUserToken = (params: Partial<UserTokenData> = {}) => ({
 
 export const createIcpUserToken = (params: Partial<UserTokenData> = {}) => ({
   ...icpTokenBase,
+  ...params,
+});
+
+export const defaultUserTokenLoading: UserTokenLoading = {
+  universeId: principal(0),
+  title: "Test SNS",
+  balance: "loading",
+  logo: "sns-logo.svg",
+  actions: [],
+};
+
+export const createUserTokenLoading = (
+  params: Partial<UserTokenLoading> = {}
+) => ({
+  ...defaultUserTokenLoading,
   ...params,
 });

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -25,6 +25,11 @@ export class TokensTableRowPo extends BasePageObject {
     return this.getText("token-value-label");
   }
 
+  hasBalanceSpinner(): Promise<boolean> {
+    const balanceElement = this.root.byTestId("token-value-label");
+    return balanceElement.byTestId("spinner").isPresent();
+  }
+
   getSubtitle(): Promise<string | null> {
     return this.getText("project-subtitle");
   }


### PR DESCRIPTION
# Motivation

Give a better user experience in the tokens table pages.

In this PR, I introduce two new types `UserTokenBase` and `UserTokenLoading`. Both are accepted in the props of TokenTable. But only the initial one `UserTokenData` can be used to dispatch actions.

I guess the loading could also dispatch events, but we should use another event name, not `nnsAction`. This way, we know for certain that when `nnsAction` is triggered, it has the token and fee available. This is important to open modals at the moment, but could be important for other actions in the future.

# Changes

* Add two new types `UserTokenBase` and `UserTokenLoading`.
* Render a Spinner if UserTokenLoading in TokensTableRow.
* Support a union of `UserTokenLoading` and `UserTokenData` in TokensTable and TokensTableRow

# Tests

* Add a test in TokensTable.spec for the new loading value

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
