### PR TITLE
Draft Migration test

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -33,6 +33,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+* Experimental tests for schema migration.
+
 #### Changed
 
 * Update Rust to the latest stable version (1.74.0).

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -19,8 +19,8 @@ help_text() {
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/../clap.bash"
 # Define options
-clap.define short=w long=wasm1 desc="A test build of the first wasm.  May be a .wasm.gz file or a named release." variable=FIRST_WASM default="out/nns-dapp_test.wasm.gz"
-clap.define short=W long=wasm2 desc="A test build of the second wasm.  May be a .wasm.gz file or a named release." variable=SECOND_WASM default="prod"
+clap.define short=w long=wasm1 desc="A test build of the first wasm.  May be a _test.wasm.gz file or a named release." variable=FIRST_WASM default="out/nns-dapp_test.wasm.gz"
+clap.define short=W long=wasm2 desc="A test build of the second wasm.  May be a _test.wasm.gz file or a named release." variable=SECOND_WASM default="prod"
 clap.define short=a long=args1 desc="A file containing the first init arguments." variable=FIRST_ARGFILE default="out/nns-dapp-arg-local.did"
 clap.define short=A long=args2 desc="A file containing the second init arguments." variable=SECOND_ARGFILE default="out/nns-dapp-arg-local.did"
 clap.define short=s long=schema1 desc="The schema for the first deployment.  Overrides the value in the argument file." variable=FIRST_SCHEMA default=""
@@ -48,10 +48,88 @@ on_exit() {
 }
 trap on_exit EXIT
 
+# Checks that the configuration number is valid.
+lint_configuration_num() {
+  local configuration_num
+  configuration_num="${1:-}"
+  [[ "${configuration_num:-}" == 1 ]] || [[ "${configuration_num:-}" == 2 ]] || {
+    echo "ERROR: configuration_num is invalid."
+    echo "Expected: 1 or 2 (corresponding to the initial deployment and the upgrade respectively)"
+    echo "Actual:  '${configuration_num:-}'"
+    exit 1
+  } >&2
+}
+
+# Checks that a local path points to a plausible _test.wasm.gz file.
+lint_wasm_path() {
+  local wasm_path
+  wasm_path="${1:-}"
+  [[ "${wasm_path:-}" = *_test.wasm.gz ]] || {
+    echo "ERROR: Invalid wasm path."
+    echo "Expected:  A path ending in _test.wasm.gz"
+    echo "Actual:    '${wasm_path:-}'"
+    exit 1
+  } >&2
+  test -e "${wasm_path:-1}" || {
+    echo "ERROR: Wasm file does not exist."
+    echo "Path: '${wasm_path:-}'"
+    exit 1
+  } >&2
+  data_type="$(file "${wasm_path:-}")"
+  [[ "${data_type:-}" = *gzip\ compressed\ data* ]]
+}
+
+# Checks that the release name is valid
+lint_release_name() {
+  local release_name
+  release_name="${1:-}"
+  git check-ref-format "refs/tags/${release_name:-}" || {
+    echo "ERROR: Invalid release name"
+    echo "Expected: A valid git tag name"
+    echo "Actual:   '${release_name:-}'"
+    exit 1
+  } >&2
+}
+
+# Downloads a released Wasm into the temporary working directory.
+download_wasm() {
+  local release_name destination
+  release_name="$1"
+  destination="$2"
+  curl -sSLf "https://github.com/dfinity/nns-dapp/releases/download/${release_name}/nns-dapp_test.wasm.gz" | sponge "$destination"
+}
+
+# The path to the local copy of the wasm used in the test.
+working_wasm() {
+  local configuration_num
+  lint_configuration_num "${configuration_num:-}"
+  echo "$WORKDIR/nns-dapp-${configuration_num}_test.wasm.gz"
+}
+
+# The path to the arguments used in the test
+working_arguments() {
+  local configuration_num
+  lint_configuration_num "${configuration_num:-}"
+  echo "$WORKDIR/nns-dapp-args-${configuration_num}.did"
+}
+
+
+# Gets a local copy of a wasm from a path or GitHub release
 get_wasm() {
-  local wasm_num path_or_release
+  local configuration_num destination
+  path_or_release="${1:-}"
+  destination="${2:-}"
+  lint_wasm_path "$destination"
 
-
+  if [[ "${wasm_path:-}" = *.wasm.gz ]]; then
+    lint_wasm_path "${path_or_release:-}"
+    cp "${path_or_release}" "$destination"
+  else
+    lint_release_name "${path_or_release:-}"
+    download_wasm "${path_or_release}" "$destination"
+  fi
+  : Final sanity check
+  lint_wasm_path "$destination"
 }
 
 exit 1

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -51,16 +51,16 @@ function print_stack() {
   # If, as we do, set -euo pipefail is set, the line number is typically 1 for the top entry in the stack (index 2)
   # which is not very helpful but I guess it is worth keeping that stack entry.
   # Entries further down the stack look OK.
-  for ((i = 2; i < $stack_size; i++)); do
+  for ((i = 2; i < stack_size; i++)); do
     func="${FUNCNAME[$((i))]}"
-    [ x$func = x ] && func=MAIN
+    func="${func:-MAIN}"
     if ((i == 2)); then
       linen="??" # Better nothing than misleading data.  BASH_LINENO is typically 1 in this case, which is wrong.
     else
       linen="${BASH_LINENO[$((i - 1))]}"
     fi
     src="${BASH_SOURCE[$i]}"
-    [ x"$src" = x ] && src=non_file_source
+    src="${src:-non_file_source}"
     # Note: This line format is compatible with MS Code's format.  Clicking on the filename+linenumber jumps to that location.
     printf "   at: %s:%s: %s\n" "$src" "$linen" "$func"
   done
@@ -111,7 +111,7 @@ get_assets() {
     get_wasm "${!WASM}" "$(working_wasm "$config")"
     get_argfile "${!ARGFILE}" "$(working_arguments "$config")"
     test -z "${!SCHEMA}" || {
-      set_schema "${!SCHEMA}" < "$(working_arguments "$config")" | sponge "$(working_arguments "$config")"
+      set_schema "${!SCHEMA}" <"$(working_arguments "$config")" | sponge "$(working_arguments "$config")"
     }
   done
 }

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -28,9 +28,9 @@ help_text() {
 source "$SOURCE_DIR/../clap.bash"
 # Define options
 clap.define short=w long=wasm1 desc="A test build of the first wasm.  May be a _test.wasm.gz file or a named release." variable=WASM1 default="out/nns-dapp_test.wasm.gz"
-clap.define short=W long=wasm2 desc="A test build of the second wasm.  May be a _test.wasm.gz file or a named release." variable=WASM2 default="prod"
+clap.define short=W long=wasm2 desc="A test build of the second wasm.  May be a _test.wasm.gz file or a named release." variable=WASM2 default="out/nns-dapp_test.wasm.gz"
 clap.define short=a long=args1 desc="A file containing the first init arguments." variable=ARGFILE1 default="out/nns-dapp-arg-local.did"
-clap.define short=A long=args2 desc="A file containing the second init arguments." variable=ARGFILE2 default="prod"
+clap.define short=A long=args2 desc="A file containing the second init arguments." variable=ARGFILE2 default="out/nns-dapp-arg-local.did"
 clap.define short=s long=schema1 desc="The schema for the first deployment.  Overrides the value in the argument file." variable=SCHEMA1 default=""
 clap.define short=S long=schema2 desc="The schema for the second deployment.  Overrides the value in the argument file." variable=SCHEMA2 default=""
 clap.define short=a long=accounts desc="Accounts will be created until there are at least this many." variable=NUM_TOY_ACCOUNTS default="220000"
@@ -107,8 +107,12 @@ get_assets() {
   for config in 1 2; do
     WASM="WASM$config"
     ARGFILE="ARGFILE$config"
+    SCHEMA="SCHEMA$config"
     get_wasm "${!WASM}" "$(working_wasm "$config")"
     get_argfile "${!ARGFILE}" "$(working_arguments "$config")"
+    test -z "${!SCHEMA}" || {
+      set_schema "${!SCHEMA}" < "$(working_arguments "$config")" | sponge "$(working_arguments "$config")"
+    }
   done
 }
 

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -47,14 +47,22 @@ source "$(clap.build)"
 function print_stack() {
   local i stack_size func linen src
   stack_size=${#FUNCNAME[@]}
-  # to avoid noise we start with 1 to skip the get_stack function
+  # Skip print_stack (index 0) and on_exit (index 1), so start at index 2.
+  # If, as we do, set -euo pipefail is set, the line number is typically 1 for the top entry in the stack (index 2)
+  # which is not very helpful but I guess it is worth keeping that stack entry.
+  # Entries further down the stack look OK.
   for ((i = 2; i < $stack_size; i++)); do
     func="${FUNCNAME[$((i))]}"
     [ x$func = x ] && func=MAIN
-    linen="${BASH_LINENO[$((i - 1))]}"
+    if ((i == 2)); then
+      linen="??" # Better nothing than misleading data.  BASH_LINENO is typically 1 in this case, which is wrong.
+    else
+      linen="${BASH_LINENO[$((i - 1))]}"
+    fi
     src="${BASH_SOURCE[$i]}"
     [ x"$src" = x ] && src=non_file_source
-    printf "   at: %s %s %s\n" "$func" "$src" "$linen"
+    # Note: This line format is compatible with MS Code's format.  Clicking on the filename+linenumber jumps to that location.
+    printf "   at: %s:%s: %s\n" "$src" "$linen" "$func"
   done
 }
 

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -19,12 +19,12 @@ help_text() {
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/../clap.bash"
 # Define options
-clap.define short=w long=wasm1 desc="A test build of the first wasm.  May be a _test.wasm.gz file or a named release." variable=FIRST_WASM default="out/nns-dapp_test.wasm.gz"
-clap.define short=W long=wasm2 desc="A test build of the second wasm.  May be a _test.wasm.gz file or a named release." variable=SECOND_WASM default="prod"
-clap.define short=a long=args1 desc="A file containing the first init arguments." variable=FIRST_ARGFILE default="out/nns-dapp-arg-local.did"
-clap.define short=A long=args2 desc="A file containing the second init arguments." variable=SECOND_ARGFILE default="out/nns-dapp-arg-local.did"
-clap.define short=s long=schema1 desc="The schema for the first deployment.  Overrides the value in the argument file." variable=FIRST_SCHEMA default=""
-clap.define short=S long=schema2 desc="The schema for the second deployment.  Overrides the value in the argument file." variable=FIRST_SCHEMA default=""
+clap.define short=w long=wasm1 desc="A test build of the first wasm.  May be a _test.wasm.gz file or a named release." variable=WASM1 default="out/nns-dapp_test.wasm.gz"
+clap.define short=W long=wasm2 desc="A test build of the second wasm.  May be a _test.wasm.gz file or a named release." variable=WASM2 default="prod"
+clap.define short=a long=args1 desc="A file containing the first init arguments." variable=ARGFILE1 default="out/nns-dapp-arg-local.did"
+clap.define short=A long=args2 desc="A file containing the second init arguments." variable=ARGFILE2 default="out/nns-dapp-arg-local.did"
+clap.define short=s long=schema1 desc="The schema for the first deployment.  Overrides the value in the argument file." variable=SCHEMA1 default=""
+clap.define short=S long=schema2 desc="The schema for the second deployment.  Overrides the value in the argument file." variable=SCHEMA2 default=""
 clap.define short=a long=accounts desc="Accounts will be created until there are at least this many." variable=NUM_TOY_ACCOUNTS default="220000"
 clap.define short=c long=chunk desc="The accounts are created in chunks of this size." variable=TOY_ACCOUNT_CHUNK_SIZE default="10000"
 # Source the output file ----------------------------------------------------------
@@ -130,6 +130,10 @@ get_wasm() {
   fi
   : Final sanity check
   lint_wasm_path "$destination"
+}
+
+get_config() {
+
 }
 
 exit 1

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -49,8 +49,8 @@ function print_stack() {
   stack_size=${#FUNCNAME[@]}
   # Skip print_stack (index 0) and on_exit (index 1), so start at index 2.
   # If, as we do, set -euo pipefail is set, the line number is typically 1 for the top entry in the stack (index 2)
-  # which is not very helpful but I guess it is worth keeping that stack entry.
-  # Entries further down the stack look OK.
+  # which is not very helpful but it is worth keeping the filename and function name.
+  # Entries further down the stack are accurate.
   for ((i = 2; i < stack_size; i++)); do
     func="${FUNCNAME[$((i))]}"
     func="${func:-MAIN}"

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -20,6 +20,7 @@ help_text() {
 	  - idl2json
 	  - wasm files for the two deployments.
 	  - candid argument files (optional)
+	  - a running replica
 	EOF
 }
 
@@ -37,10 +38,12 @@ clap.define short=c long=chunk desc="The accounts are created in chunks of this 
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
+# Gets helper functions
 . "${BASH_SOURCE[0]}.linters"
 . "${BASH_SOURCE[0]}.getters"
-WORKDIR="$(realpath "$(mktemp -d nns-dapp-test-XXXXXX)")"
-# Print a stack trace
+. "${BASH_SOURCE[0]}.canister"
+
+# Prints a stack trace
 function print_stack() {
   local i stack_size func linen src
   stack_size=${#FUNCNAME[@]}
@@ -54,6 +57,8 @@ function print_stack() {
     printf "   at: %s %s %s\n" "$func" "$src" "$linen"
   done
 }
+
+# Clean up on exit - or print error details.
 on_exit() {
   exit_code=$?
   if ((exit_code == 0)); then
@@ -99,176 +104,28 @@ get_assets() {
   done
 }
 
-get_assets
-find "$WORKDIR"
+test_upgrade_downgrade() {
+  WORKDIR="$(realpath "$(mktemp -d nns-dapp-test-XXXXXX)")"
+  get_assets
+  find "$WORKDIR"
 
-exit 1
-
-verify_healthy() {
-  dfx canister call nns-dapp get_stats
-  dfx canister call nns-dapp get_canisters
-}
-
-get_current_wasm() {
-  ./scripts/docker-build --network local
-}
-
-get_prod_wasm() {
-  # Note: Using the test build allows us to get arbitrary test accounts from the canister.
-  if test -n "${PROD_WASM:-}"; then
-    test -f "${PROD_WASM}" || {
-      echo "ERROR: The specified production wasm file does not exist at: '$PROD_WASM'"
-      exit 1
-    } >&2
-  else
-    PROD_WASM="$(mktemp nns-dapp-prod-XXXXXX --suffix .wasm.gz)"
-    curl -sL https://github.com/dfinity/nns-dapp/releases/download/prod/nns-dapp_test.wasm.gz >"$PROD_WASM"
-  fi
-}
-
-# Gets the number of transactions; this list may be pruned so is not invariant.
-get_transactions_count() {
-  dfx canister call nns-dapp get_stats | idl2json | jq -r '.transactions_count'
-}
-# Gets stats that should be invariant across upgrades
-get_upgrade_invariant_stats() {
-  dfx canister call nns-dapp get_stats | idl2json | jq '{accounts_count, neurons_created_count, neurons_topped_up_count, sub_accounts_count}'
-}
-# Gets some sample accounts
-sample_toy_accounts() {
-  seq 0 "$TOY_ACCOUNT_CHUNK_SIZE" "$((NUM_TOY_ACCOUNTS - 1))" | xargs -I{} dfx canister call nns-dapp get_toy_account "({})" --query
-}
-# Gets data that should be invariant across upgrades
-get_upgrade_invariants() {
-  echo "==== UPGRADE INVARIANT STATS ===="
-  get_upgrade_invariant_stats
-  echo "==== END ===="
-  echo "==== SAMPLE INVARIANT STATS ===="
-  sample_toy_accounts
-  echo "==== END ===="
-}
-
-# Verifies that the state is at least as large as expected.
-check_state_size() {
-  local invariants accounts_count expected_min_accounts
-  expected_min_accounts="$NUM_TOY_ACCOUNTS"
-  invariants="$(get_upgrade_invariant_stats)"
-  accounts_count="$(jq .accounts_count <<<"$invariants")"
-  if ((accounts_count < expected_min_accounts)); then
-    {
-      echo "ERROR: 'accounts_count' is smaller than expected."
-      printf "  Expected at least: %10d\n" "$expected_min_accounts"
-      printf "  Actual:            %10d\n" "$accounts_count"
-      printf "  State:\n%s\n" "$invariants"
-      exit 1
-    } >&2
-  fi
-}
-
-# Verifies that the number of transactions is reasonable.  Some may be pruned, but not a lot.
-check_num_transactions() {
-  # The toy state creates 3 transactions per account; see TRANSACTIONS_PER_ACCOUNT
-  # in: rs/backend/src/accounts_store/toy_data.rs
-  toy_transactions="$((NUM_TOY_ACCOUNTS * 3))"
-  # Note: Transactions MAY be pruned if the state is large enough, however in tests
-  # we should not make the state so large that, say, half the transactions are pruned.
-  # If that many are pruned, either the test is unrealistic or we should increase the
-  # amount of storage available.
-  expected_min_transactions="$((toy_transactions / 2))"
-  transactions_count="$(get_transactions_count)"
-  if ((transactions_count < expected_min_transactions)); then
-    {
-      echo "ERROR: 'transactions_count' is smaller than expected."
-      printf "  Expected at least: %10d\n" "$expected_min_transactions"
-      printf "  Actual:            %10d\n" "$transactions_count"
-      printf "  Note: Transactions MAY be pruned but if a lot are being pruned, there is insufficient memory."
-      exit 1
-    } >&2
-  fi
-}
-
-# Wait for the migration countdown to complete.
-wait_for_migration() {
-  local migration_countdown
-  for ((i = 0; i < 120; i++)); do
-    migration_countdown="$(dfx canister call nns-dapp get_stats --query | idl2json | jq '.migration_countdown[0] // 0')" # TODO: Remove the default when prod has migration countdown stats
-    echo "Migration countdown: $migration_countdown"
-    if ((migration_countdown == 0)); then
-      return
-    fi
-    sleep 1
+  echo "Installing $(working_wasm 1)..."
+  install_nnsdapp "$(working_wasm 1)" "$(working_arguments 1)"
+  echo "Installing state..."
+  while (("$(dfx canister call nns-dapp get_stats | idl2json | jq -r .accounts_count)" < NUM_TOY_ACCOUNTS)); do
+    dfx canister call nns-dapp create_toy_accounts "($TOY_ACCOUNT_CHUNK_SIZE: nat)"
   done
-  {
-    echo "ERROR: Migration did not complete within the expected time."
-    echo "       For a migration to be considered complete, the migration_countdown should reach zero."
-    echo "       Here are the current stats:"
-    dfx canister call nns-dapp get_stats
-    exit 1
-  } >&2
+  verify_healthy
+  check_state_size
+  check_num_transactions
+  echo "Upgrading to $(working_wasm 2)..."
+  upgrade_nnsdapp "$(working_wasm 2)" "$(working_arguments 2)"
+  check_num_transactions
+  echo "Reverting to $(working_wasm 1)..."
+  upgrade_nnsdapp "$(working_wasm 1)" "$(working_arguments 1)"
+  verify_healthy
+  check_num_transactions
+  echo SUCCESS
 }
 
-# Installs the current build of nns-dapp
-# TODO: Record upgrade time
-# TODO: Record upgrade cycles
-# TODO: Record state size
-upgrade_nnsdapp() {
-  local prestate poststate
-  prestate="$(get_upgrade_invariants | tee /dev/stderr)"
-  # Check that the data is plausible
-  # TODO: Check that the prestate is not empty; first we need to populate the state.
-  # TODO: Consider storing all accounts data in a merkle tree so that we can check just the root hash.
-  dfx canister install --upgrade-unchanged nns-dapp --wasm "$1" --mode upgrade --argument "$(cat nns-dapp-arg-local.did)" --yes
-  scripts/dfx-canister-check-wasm-hash --wasm "$1" --canister nns-dapp
-  wait_for_migration
-  poststate="$(get_upgrade_invariants)"
-  if [[ "$prestate" != "$poststate" ]]; then
-    {
-      echo "ERROR: The upgrade changed the state of the canister."
-      echo "Prestate: $prestate"
-      echo "Poststate: $poststate"
-      echo "Diff:"
-      diff -u <(echo "$prestate") <(echo "$poststate") || true
-      exit 1
-    } >&2
-  fi
-}
-
-echo "Getting or building the wasm..."
-test -n "${CURRENT_WASM:-}" || {
-  CURRENT_WASM="out/nns-dapp_test.wasm.gz"
-  echo "Building $CURRENT_WASM..."
-  ./scripts/docker-build --network local
-}
-test -e "$CURRENT_WASM" || {
-  echo "ERROR: Wasm file not found at '$CURRENT_WASM'."
-  exit 1
-} >&2
-echo "Installing $CURRENT_WASM..."
-if dfx canister id nns-dapp >/dev/null 2>/dev/null; then
-  upgrade_nnsdapp "$CURRENT_WASM"
-else
-  dfx canister create nns-dapp
-  dfx canister install nns-dapp --wasm "$CURRENT_WASM" --argument "$(cat nns-dapp-arg-local.did)" --yes
-fi
-scripts/dfx-canister-check-wasm-hash --wasm "$CURRENT_WASM" --canister nns-dapp
-echo "Checking that the current wasm is healthy..."
-verify_healthy
-echo "Installing state"
-while (("$(dfx canister call nns-dapp get_stats | idl2json | jq -r .accounts_count)" < NUM_TOY_ACCOUNTS)); do
-  dfx canister call nns-dapp create_toy_accounts "($TOY_ACCOUNT_CHUNK_SIZE: nat)"
-done
-verify_healthy
-check_state_size
-check_num_transactions
-echo "Downloading and installing the prod wasm..."
-get_prod_wasm
-upgrade_nnsdapp "$PROD_WASM"
-echo "Checking that the rollback is healthy..."
-verify_healthy
-check_num_transactions
-echo "Rolling forwards..."
-upgrade_nnsdapp "$CURRENT_WASM"
-echo "Checking that the upgrade is healthy..."
-verify_healthy
-check_num_transactions
-echo SUCCESS
+test_upgrade_downgrade

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -18,8 +18,8 @@ help_text() {
 	  - dfx
 	  - ic-wasm
 	  - idl2json
-	  - wasm files for the two deployments.
-	  - candid argument files (optional)
+	  - wasm files for the two deployments
+	  - candid argument files
 	  - a running replica
 	EOF
 }

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PATH="$SOURCE_DIR:$PATH"
+
+help_text() {
+  cat <<-EOF
+	Tests:
+	  - Populating a given schema with large scale data
+	  - Migrating from one wasm+schema to another wasm+schema and back.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/../clap.bash"
+# Define options
+clap.define short=w long=wasm desc="The wasm built from the local code." variable=CURRENT_WASM default=""
+clap.define short=p long=prod desc="A test build of the production wasm" variable=PROD_WASM default=""
+clap.define short=a long=accounts desc="Accounts will be created until there are at least this many." variable=NUM_TOY_ACCOUNTS default="220000"
+clap.define short=c long=chunk desc="The accounts are created in chunks of this size." variable=TOY_ACCOUNT_CHUNK_SIZE default="10000"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+verify_healthy() {
+  dfx canister call nns-dapp get_stats
+  dfx canister call nns-dapp get_canisters
+}
+
+get_current_wasm() {
+  ./scripts/docker-build --network local
+}
+
+get_prod_wasm() {
+  # Note: Using the test build allows us to get arbitrary test accounts from the canister.
+  if test -n "${PROD_WASM:-}"; then
+    test -f "${PROD_WASM}" || {
+      echo "ERROR: The specified production wasm file does not exist at: '$PROD_WASM'"
+      exit 1
+    } >&2
+  else
+    PROD_WASM="$(mktemp nns-dapp-prod-XXXXXX --suffix .wasm.gz)"
+    curl -sL https://github.com/dfinity/nns-dapp/releases/download/prod/nns-dapp_test.wasm.gz >"$PROD_WASM"
+  fi
+}
+
+# Gets the number of transactions; this list may be pruned so is not invariant.
+get_transactions_count() {
+  dfx canister call nns-dapp get_stats | idl2json | jq -r '.transactions_count'
+}
+# Gets stats that should be invariant across upgrades
+get_upgrade_invariant_stats() {
+  dfx canister call nns-dapp get_stats | idl2json | jq '{accounts_count, neurons_created_count, neurons_topped_up_count, sub_accounts_count}'
+}
+# Gets some sample accounts
+sample_toy_accounts() {
+  seq 0 "$TOY_ACCOUNT_CHUNK_SIZE" "$((NUM_TOY_ACCOUNTS - 1))" | xargs -I{} dfx canister call nns-dapp get_toy_account "({})" --query
+}
+# Gets data that should be invariant across upgrades
+get_upgrade_invariants() {
+  echo "==== UPGRADE INVARIANT STATS ===="
+  get_upgrade_invariant_stats
+  echo "==== END ===="
+  echo "==== SAMPLE INVARIANT STATS ===="
+  sample_toy_accounts
+  echo "==== END ===="
+}
+
+# Verifies that the state is at least as large as expected.
+check_state_size() {
+  local invariants accounts_count expected_min_accounts
+  expected_min_accounts="$NUM_TOY_ACCOUNTS"
+  invariants="$(get_upgrade_invariant_stats)"
+  accounts_count="$(jq .accounts_count <<<"$invariants")"
+  if ((accounts_count < expected_min_accounts)); then
+    {
+      echo "ERROR: 'accounts_count' is smaller than expected."
+      printf "  Expected at least: %10d\n" "$expected_min_accounts"
+      printf "  Actual:            %10d\n" "$accounts_count"
+      printf "  State:\n%s\n" "$invariants"
+      exit 1
+    } >&2
+  fi
+}
+
+# Verifies that the number of transactions is reasonable.  Some may be pruned, but not a lot.
+check_num_transactions() {
+  # The toy state creates 3 transactions per account; see TRANSACTIONS_PER_ACCOUNT
+  # in: rs/backend/src/accounts_store/toy_data.rs
+  toy_transactions="$((NUM_TOY_ACCOUNTS * 3))"
+  # Note: Transactions MAY be pruned if the state is large enough, however in tests
+  # we should not make the state so large that, say, half the transactions are pruned.
+  # If that many are pruned, either the test is unrealistic or we should increase the
+  # amount of storage available.
+  expected_min_transactions="$((toy_transactions / 2))"
+  transactions_count="$(get_transactions_count)"
+  if ((transactions_count < expected_min_transactions)); then
+    {
+      echo "ERROR: 'transactions_count' is smaller than expected."
+      printf "  Expected at least: %10d\n" "$expected_min_transactions"
+      printf "  Actual:            %10d\n" "$transactions_count"
+      printf "  Note: Transactions MAY be pruned but if a lot are being pruned, there is insufficient memory."
+      exit 1
+    } >&2
+  fi
+}
+
+# Wait for the migration countdown to complete.
+wait_for_migration() {
+  local migration_countdown
+  for ((i = 0; i < 120; i++)); do
+    migration_countdown="$(dfx canister call nns-dapp get_stats --query | idl2json | jq '.migration_countdown[0] // 0')" # TODO: Remove the default when prod has migration countdown stats
+    echo "Migration countdown: $migration_countdown"
+    if ((migration_countdown == 0)); then
+      return
+    fi
+    sleep 1
+  done
+  {
+    echo "ERROR: Migration did not complete within the expected time."
+    echo "       For a migration to be considered complete, the migration_countdown should reach zero."
+    echo "       Here are the current stats:"
+    dfx canister call nns-dapp get_stats
+    exit 1
+  } >&2
+}
+
+# Installs the current build of nns-dapp
+# TODO: Record upgrade time
+# TODO: Record upgrade cycles
+# TODO: Record state size
+upgrade_nnsdapp() {
+  local prestate poststate
+  prestate="$(get_upgrade_invariants | tee /dev/stderr)"
+  # Check that the data is plausible
+  # TODO: Check that the prestate is not empty; first we need to populate the state.
+  # TODO: Consider storing all accounts data in a merkle tree so that we can check just the root hash.
+  dfx canister install --upgrade-unchanged nns-dapp --wasm "$1" --mode upgrade --argument "$(cat nns-dapp-arg-local.did)" --yes
+  scripts/dfx-canister-check-wasm-hash --wasm "$1" --canister nns-dapp
+  wait_for_migration
+  poststate="$(get_upgrade_invariants)"
+  if [[ "$prestate" != "$poststate" ]]; then
+    {
+      echo "ERROR: The upgrade changed the state of the canister."
+      echo "Prestate: $prestate"
+      echo "Poststate: $poststate"
+      echo "Diff:"
+      diff -u <(echo "$prestate") <(echo "$poststate") || true
+      exit 1
+    } >&2
+  fi
+}
+
+echo "Getting or building the wasm..."
+test -n "${CURRENT_WASM:-}" || {
+  CURRENT_WASM="out/nns-dapp_test.wasm.gz"
+  echo "Building $CURRENT_WASM..."
+  ./scripts/docker-build --network local
+}
+test -e "$CURRENT_WASM" || {
+  echo "ERROR: Wasm file not found at '$CURRENT_WASM'."
+  exit 1
+} >&2
+echo "Installing $CURRENT_WASM..."
+if dfx canister id nns-dapp >/dev/null 2>/dev/null; then
+  upgrade_nnsdapp "$CURRENT_WASM"
+else
+  dfx canister create nns-dapp
+  dfx canister install nns-dapp --wasm "$CURRENT_WASM" --argument "$(cat nns-dapp-arg-local.did)" --yes
+fi
+scripts/dfx-canister-check-wasm-hash --wasm "$CURRENT_WASM" --canister nns-dapp
+echo "Checking that the current wasm is healthy..."
+verify_healthy
+echo "Installing state"
+while (("$(dfx canister call nns-dapp get_stats | idl2json | jq -r .accounts_count)" < NUM_TOY_ACCOUNTS)); do
+  dfx canister call nns-dapp create_toy_accounts "($TOY_ACCOUNT_CHUNK_SIZE: nat)"
+done
+verify_healthy
+check_state_size
+check_num_transactions
+echo "Downloading and installing the prod wasm..."
+get_prod_wasm
+upgrade_nnsdapp "$PROD_WASM"
+echo "Checking that the rollback is healthy..."
+verify_healthy
+check_num_transactions
+echo "Rolling forwards..."
+upgrade_nnsdapp "$CURRENT_WASM"
+echo "Checking that the upgrade is healthy..."
+verify_healthy
+check_num_transactions
+echo SUCCESS

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -18,6 +18,8 @@ help_text() {
 	  - dfx
 	  - ic-wasm
 	  - idl2json
+	  - wasm files for the two deployments.
+	  - candid argument files (optional)
 	EOF
 }
 
@@ -27,7 +29,7 @@ source "$SOURCE_DIR/../clap.bash"
 clap.define short=w long=wasm1 desc="A test build of the first wasm.  May be a _test.wasm.gz file or a named release." variable=WASM1 default="out/nns-dapp_test.wasm.gz"
 clap.define short=W long=wasm2 desc="A test build of the second wasm.  May be a _test.wasm.gz file or a named release." variable=WASM2 default="prod"
 clap.define short=a long=args1 desc="A file containing the first init arguments." variable=ARGFILE1 default="out/nns-dapp-arg-local.did"
-clap.define short=A long=args2 desc="A file containing the second init arguments." variable=ARGFILE2 default="out/nns-dapp-arg-local.did"
+clap.define short=A long=args2 desc="A file containing the second init arguments." variable=ARGFILE2 default="prod"
 clap.define short=s long=schema1 desc="The schema for the first deployment.  Overrides the value in the argument file." variable=SCHEMA1 default=""
 clap.define short=S long=schema2 desc="The schema for the second deployment.  Overrides the value in the argument file." variable=SCHEMA2 default=""
 clap.define short=a long=accounts desc="Accounts will be created until there are at least this many." variable=NUM_TOY_ACCOUNTS default="220000"
@@ -38,12 +40,28 @@ source "$(clap.build)"
 . "${BASH_SOURCE[0]}.linters"
 . "${BASH_SOURCE[0]}.getters"
 WORKDIR="$(realpath "$(mktemp -d nns-dapp-test-XXXXXX)")"
+# Print a stack trace
+function print_stack() {
+  local i stack_size func linen src
+  stack_size=${#FUNCNAME[@]}
+  # to avoid noise we start with 1 to skip the get_stack function
+  for ((i = 2; i < $stack_size; i++)); do
+    func="${FUNCNAME[$((i))]}"
+    [ x$func = x ] && func=MAIN
+    linen="${BASH_LINENO[$((i - 1))]}"
+    src="${BASH_SOURCE[$i]}"
+    [ x"$src" = x ] && src=non_file_source
+    printf "   at: %s %s %s\n" "$func" "$src" "$linen"
+  done
+}
 on_exit() {
   exit_code=$?
   if ((exit_code == 0)); then
     rm -fr "$WORKDIR"
   else
     {
+      echo =============================================
+      print_stack
       printf "\n\nERROR: exiting with code %s\n\n" $exit_code
       printf "       %s\n" \
         "The temporary working directory may assist with debugging:" \
@@ -58,6 +76,7 @@ trap on_exit EXIT
 # The path to the local copy of the wasm used in the test.
 working_wasm() {
   local configuration_num
+  configuration_num="${1:-}"
   lint_configuration_num "${configuration_num:-}"
   echo "$WORKDIR/nns-dapp-${configuration_num}_test.wasm.gz"
 }
@@ -70,6 +89,18 @@ working_arguments() {
   echo "$WORKDIR/nns-dapp-args-${configuration_num}.did"
 }
 
+# Get the assets we need for the tests
+get_assets() {
+  for config in 1 2; do
+    WASM="WASM$config"
+    ARGFILE="ARGFILE$config"
+    get_wasm "${!WASM}" "$(working_wasm "$config")"
+    get_argfile "${!ARGFILE}" "$(working_arguments "$config")"
+  done
+}
+
+get_assets
+find "$WORKDIR"
 
 exit 1
 

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -55,6 +55,22 @@ on_exit() {
 }
 trap on_exit EXIT
 
+# The path to the local copy of the wasm used in the test.
+working_wasm() {
+  local configuration_num
+  lint_configuration_num "${configuration_num:-}"
+  echo "$WORKDIR/nns-dapp-${configuration_num}_test.wasm.gz"
+}
+
+# The path to the arguments used in the test
+working_arguments() {
+  local configuration_num
+  configuration_num="${1:-}"
+  lint_configuration_num "${configuration_num:-}"
+  echo "$WORKDIR/nns-dapp-args-${configuration_num}.did"
+}
+
+
 exit 1
 
 verify_healthy() {

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -13,6 +13,11 @@ help_text() {
 	  - This test is primarily experimental at this time.
 	  - This test is based on the 'downgrade-upgrade' test.
 	  - Some or all of these changes may be migrated into the downgrade-upgrade test.
+
+	Needs:
+	  - dfx
+	  - ic-wasm
+	  - idl2json
 	EOF
 }
 
@@ -30,6 +35,8 @@ clap.define short=c long=chunk desc="The accounts are created in chunks of this 
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
+. "${BASH_SOURCE[0]}.linters"
+. "${BASH_SOURCE[0]}.getters"
 WORKDIR="$(realpath "$(mktemp -d nns-dapp-test-XXXXXX)")"
 on_exit() {
   exit_code=$?
@@ -47,143 +54,6 @@ on_exit() {
   fi
 }
 trap on_exit EXIT
-
-# Checks that the configuration number is valid.
-lint_configuration_num() {
-  local configuration_num
-  configuration_num="${1:-}"
-  [[ "${configuration_num:-}" == 1 ]] || [[ "${configuration_num:-}" == 2 ]] || {
-    echo "ERROR: configuration_num is invalid."
-    echo "Expected: 1 or 2 (corresponding to the initial deployment and the upgrade respectively)"
-    echo "Actual:  '${configuration_num:-}'"
-    exit 1
-  } >&2
-}
-
-# Checks that a Wasm filename has the expected form.
-lint_wasm_path() {
-  local wasm_path
-  wasm_path="${1:-}"
-  [[ "${wasm_path:-}" = *.wasm.gz ]] || {
-    echo "ERROR: Invalid wasm path."
-    echo "Expected:  A path ending in .wasm.gz"
-    echo "Actual:    '${wasm_path:-}'"
-    exit 1
-  } >&2
-}
-
-# Gets the information, including exported methods, from a gzipped Wasm file.
-get_wasm_info() {
-  local wasm_path
-  wasm_path="${1:-}"
-  lint_wasm_path "${wasm_path:-}"
-  ic-wasm <(gunzip <"$wasm_path") info || {
-    echo "ERROR: Wasm file cannot be parsed"
-    echo "Expected: ic-wasm should be able to get the Wasm info"
-    echo "Actual:   See error messages above."
-    exit 1
-  } >&2
-}
-
-# Checks that a Wasm file appears to be well formed.
-lint_wasm_file() {
-  local wasm_path wasm_info
-  wasm_path="${1:-}"
-  test -e "${wasm_path:-1}" || {
-    echo "ERROR: Wasm file does not exist."
-    echo "Path: '${wasm_path:-}'"
-    exit 1
-  } >&2
-  data_type="$(file "${wasm_path:-}")"
-  [[ "${data_type:-}" = *gzip\ compressed\ data* ]] || {
-    echo "ERROR: Wasm file is not compressed"
-    echo "Expected:  gzip compressed data"
-    echo "Actual:    '${data_type:-}'"
-    exit 1
-  } >&2
-  wasm_info="$(get_wasm_info "$wasm_path")"
-  test_method="get_toy_account"
-  echo "${wasm_info:-}" | grep -q "$test_method" || {
-    echo "ERROR: This test needs test builds of the Wasm."
-    echo "Expected: Test methods including '$test_method'."
-    echo "Actual:   The exported methods do not include '$test_method':"
-    echo "$wasm_info" | sed 's/^/wasm_info:  /g'
-    exit 1
-  } >&2
-}
-
-# Checks that the release name is valid
-lint_release_name() {
-  local release_name
-  release_name="${1:-}"
-  git check-ref-format "refs/tags/${release_name:-}" || {
-    echo "ERROR: Invalid release name"
-    echo "Expected: A valid git tag name"
-    echo "Actual:   '${release_name:-}'"
-    exit 1
-  } >&2
-}
-
-# Downloads a released asset
-download_asset() {
-  local release_name asset destination
-  release_name="$1"
-  asset="$2"
-  destination="$3"
-  curl -sSLf "https://github.com/dfinity/nns-dapp/releases/download/${release_name}/${asset}" | sponge "$destination" || {
-    echo "ERROR: Failed to download asset '${asset:-}' for release '${release_name}'."
-    exit 1
-  } >&2
-}
-
-# The path to the local copy of the wasm used in the test.
-working_wasm() {
-  local configuration_num
-  lint_configuration_num "${configuration_num:-}"
-  echo "$WORKDIR/nns-dapp-${configuration_num}_test.wasm.gz"
-}
-
-# The path to the arguments used in the test
-working_arguments() {
-  local configuration_num
-  lint_configuration_num "${configuration_num:-}"
-  echo "$WORKDIR/nns-dapp-args-${configuration_num}.did"
-}
-
-# Gets a local copy of a wasm from a path or GitHub release
-get_wasm() {
-  local configuration_num destination
-  path_or_release="${1:-}"
-  destination="${2:-}"
-  lint_wasm_path "$destination"
-
-  if [[ "${path_or_release:-}" = *.wasm.gz ]]; then
-    lint_wasm_path "${path_or_release:-}"
-    cp "${path_or_release}" "$destination"
-  else
-    lint_release_name "${path_or_release:-}"
-    download_asset "${path_or_release}" nns-dapp_test.wasm.gz "$destination"
-  fi
-  : Final sanity check
-  lint_wasm_file "$destination"
-}
-
-get_argfile() {
-  local configuration_num destination
-  path_or_release="${1:-}"
-  destination="${2:-}"
-  lint_argfile_path "$destination"
-
-  if [[ "${path_or_release:-}" = *.did ]]; then
-    lint_argfile_path "${path_or_release:-}"
-    cp "${path_or_release}" "$destination"
-  else
-    lint_release_name "${path_or_release:-}"
-    download_asset "${path_or_release}" nns-dapp_test.wasm.gz "$destination"
-  fi
-  : Final sanity check
-  lint_wasm_path "$destination"
-}
 
 exit 1
 

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -19,8 +19,8 @@ help_text() {
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/../clap.bash"
 # Define options
-clap.define short=w long=wasm1 desc="A test build of the first wasm.  May be a path or a named release." variable=FIRST_WASM default="out/nns-dapp_test.wasm.gz"
-clap.define short=W long=wasm2 desc="A test build of the second wasm.  May be a path or a named release." variable=SECOND_WASM default="prod"
+clap.define short=w long=wasm1 desc="A test build of the first wasm.  May be a .wasm.gz file or a named release." variable=FIRST_WASM default="out/nns-dapp_test.wasm.gz"
+clap.define short=W long=wasm2 desc="A test build of the second wasm.  May be a .wasm.gz file or a named release." variable=SECOND_WASM default="prod"
 clap.define short=a long=args1 desc="A file containing the first init arguments." variable=FIRST_ARGFILE default="out/nns-dapp-arg-local.did"
 clap.define short=A long=args2 desc="A file containing the second init arguments." variable=SECOND_ARGFILE default="out/nns-dapp-arg-local.did"
 clap.define short=s long=schema1 desc="The schema for the first deployment.  Overrides the value in the argument file." variable=FIRST_SCHEMA default=""
@@ -47,6 +47,12 @@ on_exit() {
   fi
 }
 trap on_exit EXIT
+
+get_wasm() {
+  local wasm_num path_or_release
+
+
+}
 
 exit 1
 

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -30,6 +30,26 @@ clap.define short=c long=chunk desc="The accounts are created in chunks of this 
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
+WORKDIR="$(realpath "$(mktemp -d nns-dapp-test-XXXXXX)")"
+on_exit() {
+  exit_code=$?
+  if ((exit_code == 0)); then
+    rm -fr "$WORKDIR"
+  else
+    {
+      printf "\n\nERROR: exiting with code %s\n\n" $exit_code
+      printf "       %s\n" \
+        "The temporary working directory may assist with debugging:" \
+        "  '$WORKDIR'"
+      echo
+      exit $exit_code
+    } >&2
+  fi
+}
+trap on_exit EXIT
+
+exit 1
+
 verify_healthy() {
   dfx canister call nns-dapp get_stats
   dfx canister call nns-dapp get_canisters

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -60,23 +60,56 @@ lint_configuration_num() {
   } >&2
 }
 
-# Checks that a local path points to a plausible _test.wasm.gz file.
+# Checks that a Wasm filename has the expected form.
 lint_wasm_path() {
   local wasm_path
   wasm_path="${1:-}"
-  [[ "${wasm_path:-}" = *_test.wasm.gz ]] || {
+  [[ "${wasm_path:-}" = *.wasm.gz ]] || {
     echo "ERROR: Invalid wasm path."
-    echo "Expected:  A path ending in _test.wasm.gz"
+    echo "Expected:  A path ending in .wasm.gz"
     echo "Actual:    '${wasm_path:-}'"
     exit 1
   } >&2
+}
+
+# Gets the information, including exported methods, from a gzipped Wasm file.
+get_wasm_info() {
+  local wasm_path
+  wasm_path="${1:-}"
+  lint_wasm_path "${wasm_path:-}"
+  ic-wasm <(gunzip <"$wasm_path") info || {
+    echo "ERROR: Wasm file cannot be parsed"
+    echo "Expected: ic-wasm should be able to get the Wasm info"
+    echo "Actual:   See error messages above."
+    exit 1
+  } >&2
+}
+
+# Checks that a Wasm file appears to be well formed.
+lint_wasm_file() {
+  local wasm_path wasm_info
+  wasm_path="${1:-}"
   test -e "${wasm_path:-1}" || {
     echo "ERROR: Wasm file does not exist."
     echo "Path: '${wasm_path:-}'"
     exit 1
   } >&2
   data_type="$(file "${wasm_path:-}")"
-  [[ "${data_type:-}" = *gzip\ compressed\ data* ]]
+  [[ "${data_type:-}" = *gzip\ compressed\ data* ]] || {
+    echo "ERROR: Wasm file is not compressed"
+    echo "Expected:  gzip compressed data"
+    echo "Actual:    '${data_type:-}'"
+    exit 1
+  } >&2
+  wasm_info="$(get_wasm_info "$wasm_path")"
+  test_method="get_toy_account"
+  echo "${wasm_info:-}" | grep -q "$test_method" || {
+    echo "ERROR: This test needs test builds of the Wasm."
+    echo "Expected: Test methods including '$test_method'."
+    echo "Actual:   The exported methods do not include '$test_method':"
+    echo "$wasm_info" | sed 's/^/wasm_info:  /g'
+    exit 1
+  } >&2
 }
 
 # Checks that the release name is valid
@@ -91,12 +124,16 @@ lint_release_name() {
   } >&2
 }
 
-# Downloads a released Wasm into the temporary working directory.
-download_wasm() {
-  local release_name destination
+# Downloads a released asset
+download_asset() {
+  local release_name asset destination
   release_name="$1"
-  destination="$2"
-  curl -sSLf "https://github.com/dfinity/nns-dapp/releases/download/${release_name}/nns-dapp_test.wasm.gz" | sponge "$destination"
+  asset="$2"
+  destination="$3"
+  curl -sSLf "https://github.com/dfinity/nns-dapp/releases/download/${release_name}/${asset}" | sponge "$destination" || {
+    echo "ERROR: Failed to download asset '${asset:-}' for release '${release_name}'."
+    exit 1
+  } >&2
 }
 
 # The path to the local copy of the wasm used in the test.
@@ -113,7 +150,6 @@ working_arguments() {
   echo "$WORKDIR/nns-dapp-args-${configuration_num}.did"
 }
 
-
 # Gets a local copy of a wasm from a path or GitHub release
 get_wasm() {
   local configuration_num destination
@@ -121,19 +157,32 @@ get_wasm() {
   destination="${2:-}"
   lint_wasm_path "$destination"
 
-  if [[ "${wasm_path:-}" = *.wasm.gz ]]; then
+  if [[ "${path_or_release:-}" = *.wasm.gz ]]; then
     lint_wasm_path "${path_or_release:-}"
     cp "${path_or_release}" "$destination"
   else
     lint_release_name "${path_or_release:-}"
-    download_wasm "${path_or_release}" "$destination"
+    download_asset "${path_or_release}" nns-dapp_test.wasm.gz "$destination"
+  fi
+  : Final sanity check
+  lint_wasm_file "$destination"
+}
+
+get_argfile() {
+  local configuration_num destination
+  path_or_release="${1:-}"
+  destination="${2:-}"
+  lint_argfile_path "$destination"
+
+  if [[ "${path_or_release:-}" = *.did ]]; then
+    lint_argfile_path "${path_or_release:-}"
+    cp "${path_or_release}" "$destination"
+  else
+    lint_release_name "${path_or_release:-}"
+    download_asset "${path_or_release}" nns-dapp_test.wasm.gz "$destination"
   fi
   : Final sanity check
   lint_wasm_path "$destination"
-}
-
-get_config() {
-
 }
 
 exit 1

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -4,18 +4,27 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
 help_text() {
-  cat <<-EOF
+  cat <<-"EOF"
 	Tests:
 	  - Populating a given schema with large scale data
-	  - Migrating from one wasm+schema to another wasm+schema and back.
+	  - Migrating from one Wasm+schema to another Wasm+schema and back.
+
+	Note:
+	  - This test is primarily experimental at this time.
+	  - This test is based on the 'downgrade-upgrade' test.
+	  - Some or all of these changes may be migrated into the downgrade-upgrade test.
 	EOF
 }
 
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/../clap.bash"
 # Define options
-clap.define short=w long=wasm desc="The wasm built from the local code." variable=CURRENT_WASM default=""
-clap.define short=p long=prod desc="A test build of the production wasm" variable=PROD_WASM default=""
+clap.define short=w long=wasm1 desc="A test build of the first wasm.  May be a path or a named release." variable=FIRST_WASM default="out/nns-dapp_test.wasm.gz"
+clap.define short=W long=wasm2 desc="A test build of the second wasm.  May be a path or a named release." variable=SECOND_WASM default="prod"
+clap.define short=a long=args1 desc="A file containing the first init arguments." variable=FIRST_ARGFILE default="out/nns-dapp-arg-local.did"
+clap.define short=A long=args2 desc="A file containing the second init arguments." variable=SECOND_ARGFILE default="out/nns-dapp-arg-local.did"
+clap.define short=s long=schema1 desc="The schema for the first deployment.  Overrides the value in the argument file." variable=FIRST_SCHEMA default=""
+clap.define short=S long=schema2 desc="The schema for the second deployment.  Overrides the value in the argument file." variable=FIRST_SCHEMA default=""
 clap.define short=a long=accounts desc="Accounts will be created until there are at least this many." variable=NUM_TOY_ACCOUNTS default="220000"
 clap.define short=c long=chunk desc="The accounts are created in chunks of this size." variable=TOY_ACCOUNT_CHUNK_SIZE default="10000"
 # Source the output file ----------------------------------------------------------

--- a/scripts/nns-dapp/migration-test.canister
+++ b/scripts/nns-dapp/migration-test.canister
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+verify_healthy() {
+  dfx canister call nns-dapp get_stats
+  dfx canister call nns-dapp get_canisters
+}
+
+# Gets the number of transactions; this list may be pruned so is not invariant.
+get_transactions_count() {
+  dfx canister call nns-dapp get_stats | idl2json | jq -r '.transactions_count'
+}
+# Gets stats that should be invariant across upgrades
+get_upgrade_invariant_stats() {
+  dfx canister call nns-dapp get_stats | idl2json | jq '{accounts_count, neurons_created_count, neurons_topped_up_count, sub_accounts_count}'
+}
+# Gets some sample accounts
+sample_toy_accounts() {
+  seq 0 "$TOY_ACCOUNT_CHUNK_SIZE" "$((NUM_TOY_ACCOUNTS - 1))" | xargs -I{} dfx canister call nns-dapp get_toy_account "({})" --query
+}
+# Gets data that should be invariant across upgrades
+get_upgrade_invariants() {
+  echo "==== UPGRADE INVARIANT STATS ===="
+  get_upgrade_invariant_stats
+  echo "==== END ===="
+  echo "==== SAMPLE INVARIANT STATS ===="
+  sample_toy_accounts
+  echo "==== END ===="
+}
+
+# Verifies that the state is at least as large as expected.
+check_state_size() {
+  local invariants accounts_count expected_min_accounts
+  expected_min_accounts="$NUM_TOY_ACCOUNTS"
+  invariants="$(get_upgrade_invariant_stats)"
+  accounts_count="$(jq .accounts_count <<<"$invariants")"
+  if ((accounts_count < expected_min_accounts)); then
+    {
+      echo "ERROR: 'accounts_count' is smaller than expected."
+      printf "  Expected at least: %10d\n" "$expected_min_accounts"
+      printf "  Actual:            %10d\n" "$accounts_count"
+      printf "  State:\n%s\n" "$invariants"
+      exit 1
+    } >&2
+  fi
+}
+
+# Verifies that the number of transactions is reasonable.  Some may be pruned, but not a lot.
+check_num_transactions() {
+  # The toy state creates 3 transactions per account; see TRANSACTIONS_PER_ACCOUNT
+  # in: rs/backend/src/accounts_store/toy_data.rs
+  toy_transactions="$((NUM_TOY_ACCOUNTS * 3))"
+  # Note: Transactions MAY be pruned if the state is large enough, however in tests
+  # we should not make the state so large that, say, half the transactions are pruned.
+  # If that many are pruned, either the test is unrealistic or we should increase the
+  # amount of storage available.
+  expected_min_transactions="$((toy_transactions / 2))"
+  transactions_count="$(get_transactions_count)"
+  if ((transactions_count < expected_min_transactions)); then
+    {
+      echo "ERROR: 'transactions_count' is smaller than expected."
+      printf "  Expected at least: %10d\n" "$expected_min_transactions"
+      printf "  Actual:            %10d\n" "$transactions_count"
+      printf "  Note: Transactions MAY be pruned but if a lot are being pruned, there is insufficient memory."
+      exit 1
+    } >&2
+  fi
+}
+
+# Wait for the migration countdown to complete.
+wait_for_migration() {
+  local migration_countdown
+  for ((i = 0; i < 120; i++)); do
+    migration_countdown="$(dfx canister call nns-dapp get_stats --query | idl2json | jq '.migration_countdown[0] // 0')" # TODO: Remove the default when prod has migration countdown stats
+    echo "Migration countdown: $migration_countdown"
+    if ((migration_countdown == 0)); then
+      return
+    fi
+    sleep 1
+  done
+  {
+    echo "ERROR: Migration did not complete within the expected time."
+    echo "       For a migration to be considered complete, the migration_countdown should reach zero."
+    echo "       Here are the current stats:"
+    dfx canister call nns-dapp get_stats
+    exit 1
+  } >&2
+}
+
+# Installs the nns-dapp canister
+# - Creates the canister if it doesn't exist
+# - Installs the canister even if the wasm is the same
+install_nnsdapp() {
+  local wasm argfile
+  wasm="$1"
+  argfile="$2"
+  if dfx canister id nns-dapp >/dev/null 2>/dev/null; then
+    upgrade_nnsdapp "$wasm" "$argfile"
+  else
+    dfx canister create nns-dapp
+    dfx canister install nns-dapp --wasm "$wasm" --argument "$(cat "$argfile")" --yes
+    scripts/dfx-canister-check-wasm-hash --wasm "$wasm" --canister nns-dapp
+    verify_healthy
+  fi
+}
+
+# Installs the current build of nns-dapp
+# TODO: Record upgrade time
+# TODO: Record upgrade cycles
+# TODO: Record state size
+upgrade_nnsdapp() {
+  local wasm argfile
+  wasm="$1"
+  argfile="$2"
+  local prestate poststate
+  prestate="$(get_upgrade_invariants | tee /dev/stderr)"
+  # Check that the data is plausible
+  # TODO: Check that the prestate is not empty; first we need to populate the state.
+  # TODO: Consider storing all accounts data in a merkle tree so that we can check just the root hash.
+  dfx canister install --upgrade-unchanged nns-dapp --wasm "$wasm" --mode upgrade --argument "$(cat "$argfile")" --yes
+  scripts/dfx-canister-check-wasm-hash --wasm "$wasm" --canister nns-dapp
+  verify_healthy
+  wait_for_migration
+  verify_healthy
+  poststate="$(get_upgrade_invariants)"
+  if [[ "$prestate" != "$poststate" ]]; then
+    {
+      echo "ERROR: The upgrade changed the state of the canister."
+      echo "Prestate: $prestate"
+      echo "Poststate: $poststate"
+      echo "Diff:"
+      diff -u <(echo "$prestate") <(echo "$poststate") || true
+      exit 1
+    } >&2
+  fi
+}
+
+# This file is intended to be sourced, but if called directly, offer some help
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  if (($# == 0)) || [[ "${1:-}" == "--help" ]]; then
+    cat <<-EOF
+		A library of methods for getting and manipulating the nns-canister state.
+
+		Usage:
+		- Source this file from your code.
+		- You can also call this file directly.  Pass the function name
+		  you want to call and arguments.  This may be useful for
+		  ad-hoc runs but is not intended for production use.
+
+		A list of functions:
+		EOF
+    declare -F
+    exit 0
+  fi
+  "${@}"
+fi

--- a/scripts/nns-dapp/migration-test.canister
+++ b/scripts/nns-dapp/migration-test.canister
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Verifies that the nns-dapp canister is healthy
 verify_healthy() {
   dfx canister call nns-dapp get_stats
   dfx canister call nns-dapp get_canisters
@@ -10,14 +11,17 @@ verify_healthy() {
 get_transactions_count() {
   dfx canister call nns-dapp get_stats | idl2json | jq -r '.transactions_count'
 }
+
 # Gets stats that should be invariant across upgrades
 get_upgrade_invariant_stats() {
   dfx canister call nns-dapp get_stats | idl2json | jq '{accounts_count, neurons_created_count, neurons_topped_up_count, sub_accounts_count}'
 }
+
 # Gets some sample accounts
 sample_toy_accounts() {
   seq 0 "$TOY_ACCOUNT_CHUNK_SIZE" "$((NUM_TOY_ACCOUNTS - 1))" | xargs -I{} dfx canister call nns-dapp get_toy_account "({})" --query
 }
+
 # Gets data that should be invariant across upgrades
 get_upgrade_invariants() {
   echo "==== UPGRADE INVARIANT STATS ===="
@@ -46,6 +50,7 @@ check_state_size() {
 }
 
 # Verifies that the number of transactions is reasonable.  Some may be pruned, but not a lot.
+# TODO: Unit Test
 check_num_transactions() {
   # The toy state creates 3 transactions per account; see TRANSACTIONS_PER_ACCOUNT
   # in: rs/backend/src/accounts_store/toy_data.rs

--- a/scripts/nns-dapp/migration-test.canister
+++ b/scripts/nns-dapp/migration-test.canister
@@ -151,8 +151,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 		- You can also call this file directly.  This may be useful for
 		  ad-hoc runs but is not intended for production use.
 
-      Usage: scripts/nns-dapp/migration-test.getters <function> [arguments..]
-      e.g.:  scripts/nns-dapp/migration-test.getters verify_healthy
+      Usage: scripts/nns-dapp/migration-test.canister <function> [arguments..]
+      e.g.:  scripts/nns-dapp/migration-test.canister verify_healthy
 
       A list of functions:
 		EOF

--- a/scripts/nns-dapp/migration-test.canister
+++ b/scripts/nns-dapp/migration-test.canister
@@ -148,13 +148,15 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 
 		Usage:
 		- Source this file from your code.
-		- You can also call this file directly.  Pass the function name
-		  you want to call and arguments.  This may be useful for
+		- You can also call this file directly.  This may be useful for
 		  ad-hoc runs but is not intended for production use.
 
-		A list of functions:
+      Usage: scripts/nns-dapp/migration-test.getters <function> [arguments..]
+      e.g.:  scripts/nns-dapp/migration-test.getters verify_healthy
+
+      A list of functions:
 		EOF
-    declare -F
+    declare -F | awk '{print "        " $3}'
     exit 0
   fi
   "${@}"

--- a/scripts/nns-dapp/migration-test.getters
+++ b/scripts/nns-dapp/migration-test.getters
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Downloads a released asset
+download_asset() {
+  local release_name asset destination
+  release_name="$1"
+  asset="$2"
+  destination="$3"
+  curl -sSLf "https://github.com/dfinity/nns-dapp/releases/download/${release_name}/${asset}" | sponge "$destination" || {
+    echo "ERROR: Failed to download asset '${asset:-}' for release '${release_name}'."
+    exit 1
+  } >&2
+}
+
+# The path to the local copy of the wasm used in the test.
+working_wasm() {
+  local configuration_num
+  lint_configuration_num "${configuration_num:-}"
+  echo "$WORKDIR/nns-dapp-${configuration_num}_test.wasm.gz"
+}
+
+# The path to the arguments used in the test
+working_arguments() {
+  local configuration_num
+  configuration_num="${1:-}"
+  lint_configuration_num "${configuration_num:-}"
+  echo "$WORKDIR/nns-dapp-args-${configuration_num}.did"
+}
+
+# Gets a local copy of a Wasm from a path or GitHub release
+get_wasm() {
+  local configuration_num destination
+  path_or_release="${1:-}"
+  destination="${2:-}"
+  lint_wasm_path "$destination"
+
+  if [[ "${path_or_release:-}" = *.wasm.gz ]]; then
+    lint_wasm_path "${path_or_release:-}"
+    cp "${path_or_release}" "$destination"
+  else
+    lint_release_name "${path_or_release:-}"
+    download_asset "${path_or_release}" nns-dapp_test.wasm.gz "$destination"
+  fi
+  : Final sanity check
+  lint_wasm "$destination"
+}
+
+# Gets a local copy of an arguments file from a local path or GitHub release
+get_argfile() {
+  local configuration_num destination
+  path_or_release="${1:-}"
+  destination="${2:-}"
+  lint_argfile_path "$destination"
+
+  if [[ "${path_or_release:-}" = *.did ]]; then
+    lint_argfile_path "${path_or_release:-}"
+    cp "${path_or_release}" "$destination"
+  else
+    lint_release_name "${path_or_release:-}"
+    download_asset "${path_or_release}" nns-dapp-arg-local.did "$destination"
+  fi
+  : Final sanity check
+  lint_argfile "$destination"
+}

--- a/scripts/nns-dapp/migration-test.getters
+++ b/scripts/nns-dapp/migration-test.getters
@@ -63,3 +63,23 @@ get_argfile() {
   : Final sanity check
   lint_argfile "$destination"
 }
+
+# This file is intended to be sourced, but if called directly, offer some help
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  if (($# == 0)) || [[ "${1:-}" == "--help" ]]; then
+    cat <<-EOF
+		A library of methods for getting assets.
+
+		Usage:
+		- Source this file from your code.
+		- You can also call this file directly.  Pass the function name
+		  you want to call and arguments.  This may be useful for
+		  ad-hoc runs but is not intended for production use.
+
+		A list of functions:
+		EOF
+    declare -F
+    exit 0
+  fi
+  "${@}"
+fi

--- a/scripts/nns-dapp/migration-test.getters
+++ b/scripts/nns-dapp/migration-test.getters
@@ -64,6 +64,14 @@ get_argfile() {
   lint_argfile "$destination"
 }
 
+# Sets the schema of an argfile.
+# Reads from stdin and writes to stdout.
+set_schema() {
+  local schema="${1:-}"
+  # TODO: Finalize support for compound types in yaml2candid.  Then this line can be simplified, as we don't need to remove and replace the enclosing brackets.
+  echo '( opt '; idl2json | schema="$schema" jq '.[0] | .schema = (env.schema)' | yaml2candid --did rs/backend/nns-dapp.did  --typ Config ; echo ")"
+}
+
 # This file is intended to be sourced, but if called directly, offer some help
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   if (($# == 0)) || [[ "${1:-}" == "--help" ]]; then

--- a/scripts/nns-dapp/migration-test.getters
+++ b/scripts/nns-dapp/migration-test.getters
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 # Downloads a released asset
+# TODO: Unit Test
 download_asset() {
   local release_name asset destination
   release_name="$1"
@@ -14,6 +15,7 @@ download_asset() {
 }
 
 # The path to the local copy of the wasm used in the test.
+# TODO: Unit Test
 working_wasm() {
   local configuration_num
   lint_configuration_num "${configuration_num:-}" || exit 1
@@ -21,6 +23,7 @@ working_wasm() {
 }
 
 # The path to the arguments used in the test
+# TODO: Unit Test
 working_arguments() {
   local configuration_num
   configuration_num="${1:-}"
@@ -29,6 +32,7 @@ working_arguments() {
 }
 
 # Gets a local copy of a Wasm from a path or GitHub release
+# TODO: Unit Test
 get_wasm() {
   local path_or_release destination
   path_or_release="${1:-}"
@@ -47,6 +51,7 @@ get_wasm() {
 }
 
 # Gets a local copy of an arguments file from a local path or GitHub release
+# TODO: Unit Test
 get_argfile() {
   local path_or_release destination
   path_or_release="${1:-}"
@@ -66,10 +71,13 @@ get_argfile() {
 
 # Sets the schema of an argfile.
 # Reads from stdin and writes to stdout.
+# TODO: Unit Test
 set_schema() {
-  local schema="${1:-}"
-  # TODO: Finalize support for compound types in yaml2candid.  Then this line can be simplified, as we don't need to remove and replace the enclosing brackets.
-  echo '( opt '; idl2json | schema="$schema" jq '.[0] | .schema = (env.schema)' | yaml2candid --did rs/backend/nns-dapp.did  --typ Config ; echo ")"
+  local schema="${1}" # TODO: Add linter for schema.
+  # TODO: Finalize support for compound types in yaml2candid.  Then we can use something like this:
+  # idl2json | schema="$schema" jq '.[0].schema = (env.schema)' | yaml2candid --did rs/backend/nns-dapp.did  --typ 'opt Config'
+  # This is simple but can break if the format is not as expected:
+  awk -v schema="$schema" '/^ *schema *= *opt *variant/{ printf "  schema = opt variant { %s };\n", schema; next }{print}' out/nns-dapp-arg-local.did
 }
 
 # This file is intended to be sourced, but if called directly, offer some help

--- a/scripts/nns-dapp/migration-test.getters
+++ b/scripts/nns-dapp/migration-test.getters
@@ -16,7 +16,7 @@ download_asset() {
 # The path to the local copy of the wasm used in the test.
 working_wasm() {
   local configuration_num
-  lint_configuration_num "${configuration_num:-}"
+  lint_configuration_num "${configuration_num:-}" || exit 1
   echo "$WORKDIR/nns-dapp-${configuration_num}_test.wasm.gz"
 }
 
@@ -24,13 +24,13 @@ working_wasm() {
 working_arguments() {
   local configuration_num
   configuration_num="${1:-}"
-  lint_configuration_num "${configuration_num:-}"
+  lint_configuration_num "${configuration_num:-}" || exit 1
   echo "$WORKDIR/nns-dapp-args-${configuration_num}.did"
 }
 
 # Gets a local copy of a Wasm from a path or GitHub release
 get_wasm() {
-  local configuration_num destination
+  local path_or_release destination
   path_or_release="${1:-}"
   destination="${2:-}"
   lint_wasm_path "$destination"
@@ -48,7 +48,7 @@ get_wasm() {
 
 # Gets a local copy of an arguments file from a local path or GitHub release
 get_argfile() {
-  local configuration_num destination
+  local path_or_release destination
   path_or_release="${1:-}"
   destination="${2:-}"
   lint_argfile_path "$destination"

--- a/scripts/nns-dapp/migration-test.getters
+++ b/scripts/nns-dapp/migration-test.getters
@@ -82,19 +82,22 @@ set_schema() {
 
 # This file is intended to be sourced, but if called directly, offer some help
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  . "${0%.getters}.linters"
   if (($# == 0)) || [[ "${1:-}" == "--help" ]]; then
     cat <<-EOF
 		A library of methods for getting assets.
 
 		Usage:
 		- Source this file from your code.
-		- You can also call this file directly.  Pass the function name
-		  you want to call and arguments.  This may be useful for
+		- You can also call this file directly.  This may be useful for
 		  ad-hoc runs but is not intended for production use.
 
-		A list of functions:
+      Usage: scripts/nns-dapp/migration-test.getters <function> [arguments..]
+      e.g.:  scripts/nns-dapp/migration-test.getters get_wasm prod ./prod.wasm.gz
+
+      A list of functions:
 		EOF
-    declare -F
+    declare -F | awk '{print "        " $3}'
     exit 0
   fi
   "${@}"

--- a/scripts/nns-dapp/migration-test.linters
+++ b/scripts/nns-dapp/migration-test.linters
@@ -128,13 +128,18 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 
 		Usage:
 		- Source this file from your code.
-		- You can also call this file directly.  Pass the function name
-		  you want to call and arguments.  This may be useful for
+		- You can also call this file directly.  This may be useful for
 		  ad-hoc runs but is not intended for production use.
 
-		A list of functions:
+      Usage: scripts/nns-dapp/migration-test.linters <function> [arguments..]
+      e.g.:  scripts/nns-dapp/migration-test.linters lint_release_name 'fox trot'
+             ERROR: Invalid release name
+             Expected: A valid git tag name
+             Actual:   'fox trot'
+
+      A list of functions:
 		EOF
-    declare -F
+    declare -F | awk '{print "        " $3}'
     exit 0
   fi
   "${@}"

--- a/scripts/nns-dapp/migration-test.linters
+++ b/scripts/nns-dapp/migration-test.linters
@@ -98,3 +98,23 @@ lint_argfile() {
     exit 1
   } >&2
 }
+
+# This file is intended to be sourced, but if called directly, offer some help
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  if (($# == 0)) || [[ "${1:-}" == "--help" ]]; then
+    cat <<-EOF
+		A library of methods for linting wasms and argument files.
+
+		Usage:
+		- Source this file from your code.
+		- You can also call this file directly.  Pass the function name
+		  you want to call and arguments.  This may be useful for
+		  ad-hoc runs but is not intended for production use.
+
+		A list of functions:
+		EOF
+    declare -F
+    exit 0
+  fi
+  "${@}"
+fi

--- a/scripts/nns-dapp/migration-test.linters
+++ b/scripts/nns-dapp/migration-test.linters
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Checks that the configuration number is valid.
+lint_configuration_num() {
+  local configuration_num
+  configuration_num="${1:-}"
+  [[ "${configuration_num:-}" == 1 ]] || [[ "${configuration_num:-}" == 2 ]] || {
+    echo "ERROR: configuration_num is invalid."
+    echo "Expected: 1 or 2 (corresponding to the initial deployment and the upgrade respectively)"
+    echo "Actual:  '${configuration_num:-}'"
+    exit 1
+  } >&2
+}
+
+# Checks that a Wasm filename has the expected form.
+lint_wasm_path() {
+  local wasm_path
+  wasm_path="${1:-}"
+  [[ "${wasm_path:-}" = *.wasm.gz ]] || {
+    echo "ERROR: Invalid wasm path."
+    echo "Expected:  A path ending in .wasm.gz"
+    echo "Actual:    '${wasm_path:-}'"
+    exit 1
+  } >&2
+}
+
+# Gets the information, including exported methods, from a gzipped Wasm file.
+get_wasm_info() {
+  local wasm_path
+  wasm_path="${1:-}"
+  lint_wasm_path "${wasm_path:-}"
+  ic-wasm <(gunzip <"$wasm_path") info || {
+    echo "ERROR: Wasm file cannot be parsed"
+    echo "Expected: ic-wasm should be able to get the Wasm info"
+    echo "Actual:   See error messages above."
+    exit 1
+  } >&2
+}
+
+# Checks that a Wasm file appears to be well formed.
+lint_wasm() {
+  local wasm_path wasm_info
+  wasm_path="${1:-}"
+  test -e "${wasm_path:-1}" || {
+    echo "ERROR: Wasm file does not exist."
+    echo "Path: '${wasm_path:-}'"
+    exit 1
+  } >&2
+  data_type="$(file "${wasm_path:-}")"
+  [[ "${data_type:-}" = *gzip\ compressed\ data* ]] || {
+    echo "ERROR: Wasm file is not compressed"
+    echo "Expected:  gzip compressed data"
+    echo "Actual:    '${data_type:-}'"
+    exit 1
+  } >&2
+  wasm_info="$(get_wasm_info "$wasm_path")"
+  test_method="get_toy_account"
+  echo "${wasm_info:-}" | grep -q "$test_method" || {
+    echo "ERROR: This test needs test builds of the Wasm."
+    echo "Expected: Test methods including '$test_method'."
+    echo "Actual:   The exported methods do not include '$test_method':"
+    echo "$wasm_info" | sed 's/^/wasm_info:  /g'
+    exit 1
+  } >&2
+}
+
+# Checks that the release name is valid
+lint_release_name() {
+  local release_name
+  release_name="${1:-}"
+  git check-ref-format "refs/tags/${release_name:-}" || {
+    echo "ERROR: Invalid release name"
+    echo "Expected: A valid git tag name"
+    echo "Actual:   '${release_name:-}'"
+    exit 1
+  } >&2
+}
+
+# Checks that an argument is well formed candid
+lint_argfile() {
+  local argfile_path
+  argfile_path="${1:-}"
+  test -e "${argfile_path:-1}" || {
+    echo "ERROR: Arguments candid file does not exist."
+    echo "Path: '${argfile_path:-}'"
+    exit 1
+  } >&2
+  data_type="$(file "${argfile_path:-}")"
+  [[ "${data_type:-}" = *text* ]] || {
+    echo "ERROR: Arguments file should be ASCII or UTF8 text."
+    echo "Expected:  text"
+    echo "Actual:    '${data_type:-}'"
+    exit 1
+  } >&2
+  idl2json <"$argfile_path" >/dev/null || {
+    echo "ERROR: Failed to parse arguments as candid."
+    exit 1
+  } >&2
+}

--- a/scripts/nns-dapp/migration-test.linters
+++ b/scripts/nns-dapp/migration-test.linters
@@ -15,12 +15,24 @@ lint_configuration_num() {
 
 # Checks that a Wasm filename has the expected form.
 lint_wasm_path() {
-  local wasm_path
-  wasm_path="${1:-}"
-  [[ "${wasm_path:-}" = *.wasm.gz ]] || {
+  local path
+  path="${1:-}"
+  [[ "${path:-}" = *.wasm.gz ]] || {
     echo "ERROR: Invalid wasm path."
     echo "Expected:  A path ending in .wasm.gz"
-    echo "Actual:    '${wasm_path:-}'"
+    echo "Actual:    '${path:-}'"
+    exit 1
+  } >&2
+}
+
+# Checks that an arguments filename has the expected form.
+lint_argfile_path() {
+  local path
+  path="${1:-}"
+  [[ "${path:-}" = *.did ]] || {
+    echo "ERROR: Invalid argfile path."
+    echo "Expected:  A path ending in .did"
+    echo "Actual:    '${path:-}'"
     exit 1
   } >&2
 }
@@ -60,7 +72,8 @@ lint_wasm() {
     echo "ERROR: This test needs test builds of the Wasm."
     echo "Expected: Test methods including '$test_method'."
     echo "Actual:   The exported methods do not include '$test_method':"
-    echo "$wasm_info" | sed 's/^/wasm_info:  /g'
+    #shellcheck disable=SC2001
+    echo "${wasm_info}" | sed 's/^/wasm_info:  /g'
     exit 1
   } >&2
 }

--- a/scripts/nns-dapp/migration-test.linters
+++ b/scripts/nns-dapp/migration-test.linters
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 # Checks that the configuration number is valid.
+# TODO: Unit Test
 lint_configuration_num() {
   local configuration_num
   configuration_num="${1:-}"
@@ -14,6 +15,7 @@ lint_configuration_num() {
 }
 
 # Checks that a Wasm filename has the expected form.
+# TODO: Unit Test
 lint_wasm_path() {
   local path
   path="${1:-}"
@@ -26,6 +28,7 @@ lint_wasm_path() {
 }
 
 # Checks that an arguments filename has the expected form.
+# TODO: Unit Test
 lint_argfile_path() {
   local path
   path="${1:-}"
@@ -38,6 +41,7 @@ lint_argfile_path() {
 }
 
 # Gets the information, including exported methods, from a gzipped Wasm file.
+# TODO: Unit Test
 get_wasm_info() {
   local wasm_path
   wasm_path="${1:-}"
@@ -51,6 +55,7 @@ get_wasm_info() {
 }
 
 # Checks that a Wasm file appears to be well formed.
+# TODO: Unit Test
 lint_wasm() {
   local wasm_path wasm_info
   wasm_path="${1:-}"
@@ -79,6 +84,7 @@ lint_wasm() {
 }
 
 # Checks that the release name is valid
+# TODO: Unit Test
 lint_release_name() {
   local release_name
   release_name="${1:-}"
@@ -91,6 +97,7 @@ lint_release_name() {
 }
 
 # Checks that an argument is well formed candid
+# TODO: Unit Test
 lint_argfile() {
   local argfile_path
   argfile_path="${1:-}"
@@ -113,6 +120,7 @@ lint_argfile() {
 }
 
 # This file is intended to be sourced, but if called directly, offer some help
+# TODO: Unit Test
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   if (($# == 0)) || [[ "${1:-}" == "--help" ]]; then
     cat <<-EOF


### PR DESCRIPTION
# Motivation
Testing migration is very similar to the downgrade-upgrade test.  The downgrade-upgrade test can almost certainly be expanded to make it appropriate for this use case.  However the schema change tests are likely to need a lot of modification over the next few weeks, so I would prefer to have a separate test for schema changes that can "move fast and experiment" and then migrate useful code back into the original, eventually deleting the experimental code.

Why not keep the test in a branch?  Most development is on Rust code.  Importing tests into every rust development branch has been a real pain.

# Changes
* Make a copy of the downgrade upgrade test dedicated to schema changes:
  * Copy the test script
  * Mark the new test as unstable.
  * Split the test into small chunks, as the file is huge!
  * Add argument linters & backtraces to help with debugging.
* Adapt the command line arguments to make them suitable for schema migration tests:
  * Previously the downgrade-upgrade test was always between the default current build and prod.  Added flags to allow the downgrade-upgrade test to work against any pair of wasms and argfiles.  This way, we can e.g. upgrade to self, just changing the schema in the schema.
  * Add flags to make it easy to change the schema without writing a new argfile.  We will need this a lot! :-)

# Tests
* Run locally.  Marked the most urgent missing unit tests with TODOs in the code.

# Todos

- [x] Add entry to changelog (if necessary).
