### PR TITLE
GIX-2116: New icrcCanistersStore

### DIFF
--- a/frontend/src/lib/stores/icrc-canisters.store.ts
+++ b/frontend/src/lib/stores/icrc-canisters.store.ts
@@ -1,0 +1,56 @@
+import type { UniverseCanisterIdText } from "$lib/types/universe";
+import type { Principal } from "@dfinity/principal";
+import type { Readable } from "svelte/store";
+import { writable } from "svelte/store";
+
+export interface IcrcCanisters {
+  ledgerCansisterId: Principal;
+  indexCanisterId: Principal;
+}
+
+export type IcrcCanistersStoreData = Record<
+  UniverseCanisterIdText,
+  IcrcCanisters
+>;
+
+export interface IcrcCanistersStore extends Readable<IcrcCanistersStoreData> {
+  setCanisters: (data: IcrcCanisters) => void;
+  reset: () => void;
+}
+
+/**
+ * A store that holds the sets of ICRC compatible canisters.
+ * The ledger canister id is used as the key and universe id.
+ *
+ * - setCanisters: set one set of canisters.
+ * - reset: reset all information.
+ *
+ */
+const initIcrcCanistersStore = (): IcrcCanistersStore => {
+  const initialIcrcCanistersStoreData: IcrcCanistersStoreData = {};
+
+  const { subscribe, update, set } = writable<IcrcCanistersStoreData>(
+    initialIcrcCanistersStoreData
+  );
+
+  return {
+    subscribe,
+
+    setCanisters({ ledgerCansisterId, indexCanisterId }: IcrcCanisters) {
+      update((state: IcrcCanistersStoreData) => ({
+        ...state,
+        [ledgerCansisterId.toText()]: {
+          ledgerCansisterId,
+          indexCanisterId,
+        },
+      }));
+    },
+
+    // Used in tests
+    reset() {
+      set(initialIcrcCanistersStoreData);
+    },
+  };
+};
+
+export const icrcCanistersStore = initIcrcCanistersStore();

--- a/frontend/src/tests/lib/stores/icrc-canisters.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icrc-canisters.store.spec.ts
@@ -1,0 +1,45 @@
+import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { get } from "svelte/store";
+
+describe("icrc canisters store", () => {
+  beforeEach(() => {
+    icrcCanistersStore.reset();
+  });
+
+  const ledgerCansisterId = principal(0);
+  const indexCanisterId = principal(1);
+
+  it("should store one set of canisters", () => {
+    icrcCanistersStore.setCanisters({ ledgerCansisterId, indexCanisterId });
+
+    const store = get(icrcCanistersStore);
+    expect(store[ledgerCansisterId.toText()]).toEqual({
+      ledgerCansisterId,
+      indexCanisterId,
+    });
+  });
+
+  it("should store multiple sets of canisters keyed by ledger canister id", () => {
+    const ledgerCansisterId2 = principal(2);
+    const indexCanisterId2 = principal(3);
+    icrcCanistersStore.setCanisters({
+      ledgerCansisterId,
+      indexCanisterId,
+    });
+    icrcCanistersStore.setCanisters({
+      ledgerCansisterId: ledgerCansisterId2,
+      indexCanisterId: indexCanisterId2,
+    });
+
+    const store = get(icrcCanistersStore);
+    expect(store[ledgerCansisterId.toText()]).toEqual({
+      ledgerCansisterId,
+      indexCanisterId,
+    });
+    expect(store[ledgerCansisterId2.toText()]).toEqual({
+      ledgerCansisterId: ledgerCansisterId2,
+      indexCanisterId: indexCanisterId2,
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

Support for ckETH.

In this PR, I introduce a store that will hold the canister ids of the ckETH set of canisters. It might be used for other ICRC compatible tokens.

# Changes

* New store `icrcCanistersStore`.

# Tests

* Test new store

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary yet.
