### PR TITLE
Add pending UTXOs store

### DIFF
--- a/frontend/src/lib/stores/ckbtc-pending-utxos.store.ts
+++ b/frontend/src/lib/stores/ckbtc-pending-utxos.store.ts
@@ -1,0 +1,52 @@
+import type {
+  UniverseCanisterId,
+  UniverseCanisterIdText,
+} from "$lib/types/universe";
+import type { PendingUtxo } from "@dfinity/ckbtc";
+import { writable, type Readable } from "svelte/store";
+
+type CkbtcPendingUtxosStoreData = Record<UniverseCanisterIdText, PendingUtxo[]>;
+
+export interface CkbtcPendingUtxosStore
+  extends Readable<CkbtcPendingUtxosStoreData> {
+  setUtxos: (params: {
+    universeId: UniverseCanisterId;
+    utxos: PendingUtxo[];
+  }) => void;
+  reset: () => void;
+}
+
+/**
+ * Intended to hold incoming BTC blockchain UTXOs that have at least 1
+ * confirmation but not the required number of confirmations to be credited by
+ * the ckBTC minter.
+ */
+const initCkbtcPendingUtxosStore = (): CkbtcPendingUtxosStore => {
+  const initialUtxos: CkbtcPendingUtxosStoreData = {};
+
+  const { subscribe, update, set } =
+    writable<CkbtcPendingUtxosStoreData>(initialUtxos);
+
+  return {
+    subscribe,
+
+    setUtxos: ({
+      universeId,
+      utxos,
+    }: {
+      universeId: UniverseCanisterId;
+      utxos: PendingUtxo[];
+    }) => {
+      utxos = [...utxos];
+      utxos.sort((a, b) => a.confirmations - b.confirmations);
+      update((currentState: CkbtcPendingUtxosStoreData) => ({
+        ...currentState,
+        [universeId.toText()]: utxos,
+      }));
+    },
+
+    reset: () => set(initialUtxos),
+  };
+};
+
+export const ckbtcPendingUtxosStore = initCkbtcPendingUtxosStore();

--- a/frontend/src/tests/lib/stores/ckbtc-pending-utxos.store.spec.ts
+++ b/frontend/src/tests/lib/stores/ckbtc-pending-utxos.store.spec.ts
@@ -1,0 +1,89 @@
+import { ckbtcPendingUtxosStore } from "$lib/stores/ckbtc-pending-utxos.store";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { get } from "svelte/store";
+
+describe("ckBTC pending UTXOs store", () => {
+  beforeEach(() => {
+    ckbtcPendingUtxosStore.reset();
+  });
+
+  const ckbtcUniverseId = principal(0);
+  const cktestbtcUniverseId = principal(1);
+
+  const pendingUtxo1 = {
+    outpoint: { txid: new Uint8Array([5, 7, 4]), vout: 0 },
+    value: 13_000_000n,
+    confirmations: 10,
+  };
+
+  const pendingUtxo2 = {
+    outpoint: { txid: new Uint8Array([7, 4, 1, 1]), vout: 1 },
+    value: 3_700_000n,
+    confirmations: 1,
+  };
+
+  it("should store a pending UTXO", () => {
+    ckbtcPendingUtxosStore.setUtxos({
+      universeId: ckbtcUniverseId,
+      utxos: [pendingUtxo1],
+    });
+
+    const store = get(ckbtcPendingUtxosStore);
+    expect(store[ckbtcUniverseId.toText()]).toEqual([pendingUtxo1]);
+  });
+
+  it("should override existing values", () => {
+    ckbtcPendingUtxosStore.setUtxos({
+      universeId: ckbtcUniverseId,
+      utxos: [pendingUtxo1],
+    });
+
+    ckbtcPendingUtxosStore.setUtxos({
+      universeId: ckbtcUniverseId,
+      utxos: [pendingUtxo2],
+    });
+
+    const store = get(ckbtcPendingUtxosStore);
+    expect(store[ckbtcUniverseId.toText()]).toEqual([pendingUtxo2]);
+  });
+
+  it("should store a different pending UTXOs in different universes", () => {
+    ckbtcPendingUtxosStore.setUtxos({
+      universeId: ckbtcUniverseId,
+      utxos: [pendingUtxo1],
+    });
+    ckbtcPendingUtxosStore.setUtxos({
+      universeId: cktestbtcUniverseId,
+      utxos: [pendingUtxo2],
+    });
+
+    const store = get(ckbtcPendingUtxosStore);
+    expect(store[ckbtcUniverseId.toText()]).toEqual([pendingUtxo1]);
+    expect(store[cktestbtcUniverseId.toText()]).toEqual([pendingUtxo2]);
+  });
+
+  it("should sort pending UTXOs by confirmations", () => {
+    ckbtcPendingUtxosStore.setUtxos({
+      universeId: ckbtcUniverseId,
+      utxos: [pendingUtxo1, pendingUtxo2],
+    });
+
+    const store = get(ckbtcPendingUtxosStore);
+    expect(store[ckbtcUniverseId.toText()]).toEqual([
+      pendingUtxo2,
+      pendingUtxo1,
+    ]);
+  });
+
+  it("should not change the input parameter", () => {
+    const originalInputArray = [pendingUtxo1, pendingUtxo2];
+    const inputArray = [...originalInputArray];
+
+    ckbtcPendingUtxosStore.setUtxos({
+      universeId: ckbtcUniverseId,
+      utxos: inputArray,
+    });
+
+    expect(inputArray).toEqual(originalInputArray);
+  });
+});


### PR DESCRIPTION
# Motivation

We want to show pending incoming BTC deposit transactions.
This PR just adds a store to store these transactions after we receive them from the minter so that we can display them in the wallet.

# Changes

1. Adds a store for pending UTXOs. There is a separate list per universeId (ckBTC vs. ckTESTBTC). UTXOs are sorted by number of confirmations so that they will be listed with newer transactions above older transactions.
2. Unit tests for the store.

# Tests

Unit tests pass.
Tested manually in a branch which uses the store.

# Todos

- [ ] Add entry to changelog (if necessary).
will add when it's used