### PR TITLE
Fix quoting

### DIFF
--- a/scripts/nns-dapp/migration-test.canister
+++ b/scripts/nns-dapp/migration-test.canister
@@ -37,7 +37,7 @@ check_state_size() {
   local invariants accounts_count expected_min_accounts
   expected_min_accounts="$NUM_TOY_ACCOUNTS"
   invariants="$(get_upgrade_invariant_stats)"
-  accounts_count="$(jq .accounts_count <<<"$invariants")"
+  accounts_count="$(jq -r .accounts_count <<<"$invariants")"
   if ((accounts_count < expected_min_accounts)); then
     {
       echo "ERROR: 'accounts_count' is smaller than expected."


### PR DESCRIPTION
# Motivation
When I create a lot of accounts in the migration tests IO get:
```
./scripts/nns-dapp/migration-test.canister: line 41: ((: "220000": syntax error: operand expected (error token is ""220000"")
ERROR: 'transactions_count' is smaller than expected.
  Expected at least:     330000
  Actual:                  1000
  Note: Transactions MAY be pruned but if a lot are being pruned, there is insufficient memory.=============================================
   at: ./scripts/nns-dapp/migration-test.canister:??: check_num_transactions
   at: ./scripts/nns-dapp/migration-test:132: test_upgrade_downgrade
   at: ./scripts/nns-dapp/migration-test:146: main
```
The error about transaction counts is expected, the syntax error is not.

It is caused by:
- `idl2json` expresses potentially large numbers as strings, as Javascript doesn't support large integers.
- the call to `jq` leaves the quotes in, so we get `"123"` instead of `123`

# Changes
- Use the `-r` flag to `jq` to skip the quotes.

Not changed: The existing downgrade-upgrade test.  I'm not sure why it hasn't been complaining and don't really want to spend time investigating or tinkering with it.  Once the migration test utilities are mature they will replace the relevant code in the downgrade upgrade test anyway.

# Tests
- Run locally, I now see only the expected error.

# Todos

- [x] Add entry to changelog (if necessary).
  - These tests are new and described in an existing changelog entry.
