### PR TITLE
Update IC candid files to release-2023-11-23_23-01

### DIFF
--- a/declarations/nns_governance/nns_governance.did
+++ b/declarations/nns_governance/nns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-15_23-00/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-23_23-01/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record { hash : vec nat8 };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;

--- a/declarations/nns_ledger/nns_ledger.did
+++ b/declarations/nns_ledger/nns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-15_23-00/rs/rosetta-api/icp_ledger/ledger.did>
+//! Candid for canister `nns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-23_23-01/rs/rosetta-api/icp_ledger/ledger.did>
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.

--- a/declarations/nns_registry/nns_registry.did
+++ b/declarations/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-15_23-00/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-23_23-01/rs/registry/canister/canister/registry.did>
 type AddApiBoundaryNodePayload = record {
   node_id : principal;
   domain : text;
@@ -196,17 +196,10 @@ type SetFirewallConfigPayload = record {
   firewall_config : text;
   ipv6_prefixes : vec text;
 };
-type SevFeatureStatus = variant {
-  SecureEnabled;
-  Disabled;
-  InsecureIntegrityEnabled;
-  SecureNoUpgradeEnabled;
-  InsecureEnabled;
-};
 type SubnetFeatures = record {
   canister_sandboxing : bool;
-  sev_status : opt SevFeatureStatus;
   http_requests : bool;
+  sev_enabled : opt bool;
 };
 type SubnetType = variant { application; verified_application; system };
 type UpdateApiBoundaryNodeDomainPayload = record {

--- a/declarations/sns_governance/sns_governance.did
+++ b/declarations/sns_governance/sns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-15_23-00/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-23_23-01/rs/sns/governance/canister/governance.did>
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
@@ -341,6 +341,7 @@ type ProposalData = record {
   proposal : opt Proposal;
   proposer : opt NeuronId;
   wait_for_quiet_state : opt WaitForQuietState;
+  minimum_yes_proportion_of_exercised : opt Percentage;
   is_eligible_for_rewards : bool;
   executed_timestamp_seconds : nat64;
 };
@@ -357,6 +358,7 @@ type RewardEvent = record {
   rounds_since_last_distribution : opt nat64;
   actual_timestamp_seconds : nat64;
   end_timestamp_seconds : opt nat64;
+  total_available_e8s_equivalent : opt nat64;
   distributed_e8s_equivalent : nat64;
   round : nat64;
   settled_proposals : vec ProposalId;

--- a/declarations/sns_ledger/sns_ledger.did
+++ b/declarations/sns_ledger/sns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-15_23-00/rs/rosetta-api/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-23_23-01/rs/rosetta-api/icrc1/ledger/ledger.did>
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.

--- a/declarations/sns_root/sns_root.did
+++ b/declarations/sns_root/sns_root.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-15_23-00/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-23_23-01/rs/sns/root/canister/root.did>
 type CanisterCallError = record { code : opt int32; description : text };
 type CanisterIdRecord = record { canister_id : principal };
 type CanisterInstallMode = variant { reinstall; upgrade; install };

--- a/declarations/sns_swap/sns_swap.did
+++ b/declarations/sns_swap/sns_swap.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-15_23-00/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-23_23-01/rs/sns/swap/canister/swap.did>
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;

--- a/declarations/sns_wasm/sns_wasm.did
+++ b/declarations/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-15_23-00/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-23_23-01/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record { hash : vec nat8; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
@@ -44,6 +44,14 @@ type FractionalDeveloperVotingPower = record {
 };
 type GetAllowedPrincipalsResponse = record {
   allowed_principals : vec principal;
+};
+type GetDeployedSnsByProposalIdRequest = record { proposal_id : nat64 };
+type GetDeployedSnsByProposalIdResponse = record {
+  get_deployed_sns_by_proposal_id_result : opt GetDeployedSnsByProposalIdResult;
+};
+type GetDeployedSnsByProposalIdResult = variant {
+  Error : SnsWasmError;
+  DeployedSns : DeployedSns;
 };
 type GetNextSnsVersionRequest = record {
   governance_canister_id : opt principal;
@@ -201,6 +209,9 @@ service : (SnsWasmCanisterInitPayload) -> {
   add_wasm : (AddWasmRequest) -> (AddWasmResponse);
   deploy_new_sns : (DeployNewSnsRequest) -> (DeployNewSnsResponse);
   get_allowed_principals : (record {}) -> (GetAllowedPrincipalsResponse) query;
+  get_deployed_sns_by_proposal_id : (GetDeployedSnsByProposalIdRequest) -> (
+      GetDeployedSnsByProposalIdResponse,
+    ) query;
   get_latest_sns_version_pretty : (null) -> (vec record { text; text }) query;
   get_next_sns_version : (GetNextSnsVersionRequest) -> (
       GetNextSnsVersionResponse,

--- a/dfx.json
+++ b/dfx.json
@@ -303,7 +303,7 @@
         "DIDC_VERSION": "2023-11-16",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2023-11-22",
-        "IC_COMMIT": "release-2023-11-15_23-00"
+        "IC_COMMIT": "release-2023-11-23_23-01"
       },
       "packtool": ""
     }


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.

# Changes
## Changes made by a bot triggered by github-merge-queue
- Update the version of `ic` specified in `dfx.json`.
- Update the NNS candid files to the versions in that commit.

## Changes made by a human (delete if inapplicable)

# Tests
- See CI
- [x] Check for breaking changes in the APIs and schedule any required follow-on work.