### PR TITLE
test on_exit

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -205,6 +205,15 @@ jobs:
       - uses: actions/checkout@v3
       - name: Test chunking
         run: scripts/nns-dapp/split-assets.test
+  migration-test-utils-work:
+    name: Migration test utilities work
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test migration utilities
+        run: |
+          set +x
+          scripts/nns-dapp/migration-test.on-exit.test
   dfx-nns-proposal-args-works:
     # TODO: Reenable (add it in line 338) once fixed, should it depend on mainnet?
     if: false
@@ -364,7 +373,27 @@ jobs:
       - name: Getting network config works
         run: scripts/network-config.test
   checks-pass:
-    needs: ["formatting", "spelling", "cargo-tests", "svelte-lint", "svelte-tests", "shell-checks", "ic-commit-consistency", "release-templating-works", "config-check", "asset-chunking-works", "docker-build-cli-flags", "download-nns-dapp-ci-wasm", "canister-ids-tool", "release-sop", "split-changelog", "past-changelog", "minor-version-bump-works", "version-match", "network-config"]
+    needs:
+      - formatting
+      - spelling
+      - cargo-tests
+      - svelte-lint
+      - svelte-tests
+      - shell-checks
+      - ic-commit-consistency
+      - release-templating-works
+      - config-check
+      - asset-chunking-works
+      - docker-build-cli-flags
+      - download-nns-dapp-ci-wasm
+      - canister-ids-tool
+      - release-sop
+      - split-changelog
+      - past-changelog
+      - minor-version-bump-works
+      - version-match
+      - network-config
+      - migration-test-utils-work
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -24,6 +24,12 @@ help_text() {
 	EOF
 }
 
+# Gets helper functions
+. "${BASH_SOURCE[0]}.linters"
+. "${BASH_SOURCE[0]}.getters"
+. "${BASH_SOURCE[0]}.canister"
+. "${BASH_SOURCE[0]}.on-exit"
+
 # Source the clap.bash file ---------------------------------------------------
 source "$SOURCE_DIR/../clap.bash"
 # Define options
@@ -37,11 +43,7 @@ clap.define short=a long=accounts desc="Accounts will be created until there are
 clap.define short=c long=chunk desc="The accounts are created in chunks of this size." variable=TOY_ACCOUNT_CHUNK_SIZE default="10000"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-
-# Gets helper functions
-. "${BASH_SOURCE[0]}.linters"
-. "${BASH_SOURCE[0]}.getters"
-. "${BASH_SOURCE[0]}.canister"
+trap on_exit EXIT
 
 # Prints a stack trace
 function print_stack() {
@@ -67,24 +69,14 @@ function print_stack() {
 }
 
 # Clean up on exit - or print error details.
-on_exit() {
-  exit_code=$?
-  if ((exit_code == 0)); then
-    rm -fr "$WORKDIR"
-  else
-    {
-      echo =============================================
-      print_stack
-      printf "\n\nERROR: exiting with code %s\n\n" $exit_code
-      printf "       %s\n" \
-        "The temporary working directory may assist with debugging:" \
-        "  '$WORKDIR'"
-      echo
-      exit $exit_code
-    } >&2
-  fi
+on_exit_ok() {
+  rm -fr "$WORKDIR"
 }
-trap on_exit EXIT
+on_exit_err() {
+  printf "       %s\n" \
+    "The temporary working directory may assist with debugging:" \
+    "  '$WORKDIR'"
+}
 
 # The path to the local copy of the wasm used in the test.
 working_wasm() {

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -45,29 +45,6 @@ clap.define short=c long=chunk desc="The accounts are created in chunks of this 
 source "$(clap.build)"
 trap on_exit EXIT
 
-# Prints a stack trace
-function print_stack() {
-  local i stack_size func linen src
-  stack_size=${#FUNCNAME[@]}
-  # Skip print_stack (index 0) and on_exit (index 1), so start at index 2.
-  # If, as we do, set -euo pipefail is set, the line number is typically 1 for the top entry in the stack (index 2)
-  # which is not very helpful but it is worth keeping the filename and function name.
-  # Entries further down the stack are accurate.
-  for ((i = 2; i < stack_size; i++)); do
-    func="${FUNCNAME[$((i))]}"
-    func="${func:-MAIN}"
-    if ((i == 2)); then
-      linen="??" # Better nothing than misleading data.  BASH_LINENO is typically 1 in this case, which is wrong.
-    else
-      linen="${BASH_LINENO[$((i - 1))]}"
-    fi
-    src="${BASH_SOURCE[$i]}"
-    src="${src:-non_file_source}"
-    # Note: This line format is compatible with MS Code's format.  Clicking on the filename+linenumber jumps to that location.
-    printf "   at: %s:%s: %s\n" "$src" "$linen" "$func"
-  done
-}
-
 # Clean up on exit - or print error details.
 on_exit_ok() {
   rm -fr "$WORKDIR"

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -43,12 +43,14 @@ clap.define short=a long=accounts desc="Accounts will be created until there are
 clap.define short=c long=chunk desc="The accounts are created in chunks of this size." variable=TOY_ACCOUNT_CHUNK_SIZE default="10000"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
-trap on_exit EXIT
 
 # Clean up on exit - or print error details.
+trap on_exit EXIT
+# Called by on_exit:
 on_exit_ok() {
   rm -fr "$WORKDIR"
 }
+# Called by on_exit:
 on_exit_err() {
   printf "       %s\n" \
     "The temporary working directory may assist with debugging:" \

--- a/scripts/nns-dapp/migration-test.on-exit
+++ b/scripts/nns-dapp/migration-test.on-exit
@@ -1,0 +1,36 @@
+# Prints a stack trace
+function print_stack() {
+  local skip i stack_size func linen src
+  skip="${1:-0}"
+  stack_size=${#FUNCNAME[@]}
+  for ((i = skip; i < stack_size; i++)); do
+    func="${FUNCNAME[$((i))]}"
+    func="${func:-MAIN}"
+    linen="${BASH_LINENO[$((i - 1))]}"
+    ((linen != 0)) || linen="??" # 0 is an invalid linenumber.  Happens when -euo pipefail is set and the line number of the exit is unrelated to where the code was running.
+    src="${BASH_SOURCE[$i]}"
+    src="${src:-non_file_source}"
+    # Note: This line format is compatible with MS Code's format.  Clicking on the filename+linenumber jumps to that location.
+    printf "   at: %s:%s: %s\n" "$src" "$linen" "$func"
+  done
+}
+
+# Clean up on exit - or print error details.
+# Usage:
+# - Optionally define on_exit_ok
+# - Optionally define on_exit_err
+# - After parsing arguments, run: trap on_exit EXIT
+on_exit() {
+  exit_code=$?
+  if ((exit_code == 0)); then
+    [[ $(type -t on_exit_ok) != function ]] || on_exit_ok
+  else
+    {
+      echo =============================================
+      print_stack 2 # Skip print_stack (index 0) and on_exit (index 1), so start at index 2.
+      printf "\n\nERROR: exiting with code %s\n\n" $exit_code
+      [[ $(type -t on_exit_err) != function ]] || on_exit_err
+      exit $exit_code
+    } >&2
+  fi
+}

--- a/scripts/nns-dapp/migration-test.on-exit.test
+++ b/scripts/nns-dapp/migration-test.on-exit.test
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2030,SC2031,SC2001
+# Note regarding shellcheck: These tests create subshells with variables, it is intentional that the variables are not set globally.
 #
 # WARNING: This file tests backtraces including linenums.  If you change the line numbers in this file, you may need to update the expected stacktrace.
 set -euo pipefail
@@ -47,10 +49,10 @@ title() {
   EXPECTED_STACKTRACE="$(
     cat <<-EOF
 	   at: scripts/nns-dapp/migration-test.on-exit:??: print_stack
-	   at: scripts/nns-dapp/migration-test.on-exit.test:14: bat
-	   at: scripts/nns-dapp/migration-test.on-exit.test:11: bar
-	   at: scripts/nns-dapp/migration-test.on-exit.test:8: foo
-	   at: scripts/nns-dapp/migration-test.on-exit.test:56: main
+	   at: scripts/nns-dapp/migration-test.on-exit.test:16: bat
+	   at: scripts/nns-dapp/migration-test.on-exit.test:13: bar
+	   at: scripts/nns-dapp/migration-test.on-exit.test:10: foo
+	   at: scripts/nns-dapp/migration-test.on-exit.test:58: main
 	EOF
   )"
   foo bar bat
@@ -60,9 +62,9 @@ title() {
   title "Backtrace should skip the expected number of entries"
   EXPECTED_STACKTRACE="$(
     cat <<-EOF
-	   at: scripts/nns-dapp/migration-test.on-exit.test:11: bar
-	   at: scripts/nns-dapp/migration-test.on-exit.test:8: foo
-	   at: scripts/nns-dapp/migration-test.on-exit.test:68: main
+	   at: scripts/nns-dapp/migration-test.on-exit.test:13: bar
+	   at: scripts/nns-dapp/migration-test.on-exit.test:10: foo
+	   at: scripts/nns-dapp/migration-test.on-exit.test:70: main
 	EOF
   )"
   foo bar bat 2
@@ -73,10 +75,10 @@ title() {
   EXPECTED="$(
     cat <<-EOF
 	=============================================
-	   at: scripts/nns-dapp/migration-test.on-exit.test:32: bail
-	   at: scripts/nns-dapp/migration-test.on-exit.test:11: bar
-	   at: scripts/nns-dapp/migration-test.on-exit.test:8: foo
-	   at: scripts/nns-dapp/migration-test.on-exit.test:85: main
+	   at: scripts/nns-dapp/migration-test.on-exit.test:34: bail
+	   at: scripts/nns-dapp/migration-test.on-exit.test:13: bar
+	   at: scripts/nns-dapp/migration-test.on-exit.test:10: foo
+	   at: scripts/nns-dapp/migration-test.on-exit.test:87: main
 
 
 	ERROR: exiting with code 1

--- a/scripts/nns-dapp/migration-test.on-exit.test
+++ b/scripts/nns-dapp/migration-test.on-exit.test
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# WARNING: This file tests backtraces including linenums.  If you change the line numbers in this file, you may need to update the expected stacktrace.
+set -euo pipefail
+. "${0%.test}"
+# Toy functions to test the backtrace
+foo() {
+  "$@"
+}
+bar() {
+  "$@"
+}
+bat() {
+  ACTUAL_STACKTRACE="$(print_stack "$@")"
+  [[ "${ACTUAL_STACKTRACE:-}" == "${EXPECTED_STACKTRACE:-}" ]] || {
+    echo "ERROR: Actual stacktrace did not match expected stacktrace."
+    echo "Expected:"
+    echo "----------------------------------------------"
+    echo "$EXPECTED_STACKTRACE"
+    echo "----------------------------------------------"
+    echo "Actual:"
+    echo "----------------------------------------------"
+    echo "$ACTUAL_STACKTRACE"
+    echo "----------------------------------------------"
+    echo "Diff:"
+    diff -u <(echo "$EXPECTED_STACKTRACE") <(echo "$ACTUAL_STACKTRACE")
+    exit 1
+  } >&2
+}
+bail() {
+  false
+  on_exit
+}
+
+# Prints a section title
+title() {
+  cat <<-EOF
+
+	=============================================================================
+	   $*
+	=============================================================================
+	EOF
+}
+
+(
+  title "Should print a correct backtrace"
+  EXPECTED_STACKTRACE="$(
+    cat <<-EOF
+	   at: scripts/nns-dapp/migration-test.on-exit:??: print_stack
+	   at: scripts/nns-dapp/migration-test.on-exit.test:14: bat
+	   at: scripts/nns-dapp/migration-test.on-exit.test:11: bar
+	   at: scripts/nns-dapp/migration-test.on-exit.test:8: foo
+	   at: scripts/nns-dapp/migration-test.on-exit.test:56: main
+	EOF
+  )"
+  foo bar bat
+)
+
+(
+  title "Backtrace should skip the expected number of entries"
+  EXPECTED_STACKTRACE="$(
+    cat <<-EOF
+	   at: scripts/nns-dapp/migration-test.on-exit.test:11: bar
+	   at: scripts/nns-dapp/migration-test.on-exit.test:8: foo
+	   at: scripts/nns-dapp/migration-test.on-exit.test:68: main
+	EOF
+  )"
+  foo bar bat 2
+)
+
+(
+  title "on_exit should work"
+  EXPECTED="$(
+    cat <<-EOF
+	=============================================
+	   at: scripts/nns-dapp/migration-test.on-exit.test:32: bail
+	   at: scripts/nns-dapp/migration-test.on-exit.test:11: bar
+	   at: scripts/nns-dapp/migration-test.on-exit.test:8: foo
+	   at: scripts/nns-dapp/migration-test.on-exit.test:85: main
+
+
+	ERROR: exiting with code 1
+	EOF
+  )"
+  if ACTUAL="$(foo bar bail 2>&1)"; then
+    echo "ERROR: Expected exit 1"
+    exit 1
+  fi
+  [[ "${ACTUAL:-}" == "${EXPECTED:-}" ]] || {
+    echo "ERROR: Actual output did not match expected output."
+    echo "Expected:"
+    echo "----------------------------------------------"
+    echo "$EXPECTED"
+    echo "----------------------------------------------"
+    echo "Actual:"
+    echo "----------------------------------------------"
+    echo "$ACTUAL"
+    echo "----------------------------------------------"
+    echo "Diff:"
+    diff -u <(echo "$EXPECTED") <(echo "$ACTUAL")
+    exit 1
+  } >&2
+)
+
+echo "$(basename "$0") PASSED"


### PR DESCRIPTION
# Motivation
The migration test has an `on_exit` handler and a backtrace printing function.  These lack tests.

# Changes
* Move the functions out into utilities (as I found myself using them in other code as well).
* Add tests

# Tests
This PR consists primarily of unit tests.

# Todos

- [x] Add entry to changelog (if necessary).
   - Covered by an existing changelog entry