### PR TITLE
Update aggregator

### DIFF
--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: scripts/did2rs.sh --canister sns_governance --out ic_sns_governance.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-15_23-00/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-23_23-01/rs/sns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -134,6 +134,7 @@ pub struct RewardEvent {
     pub rounds_since_last_distribution: Option<u64>,
     pub actual_timestamp_seconds: u64,
     pub end_timestamp_seconds: Option<u64>,
+    pub total_available_e8s_equivalent: Option<u64>,
     pub distributed_e8s_equivalent: u64,
     pub round: u64,
     pub settled_proposals: Vec<ProposalId>,
@@ -274,6 +275,7 @@ pub struct ProposalData {
     pub proposal: Option<Proposal>,
     pub proposer: Option<NeuronId>,
     pub wait_for_quiet_state: Option<WaitForQuietState>,
+    pub minimum_yes_proportion_of_exercised: Option<Percentage>,
     pub is_eligible_for_rewards: bool,
     pub executed_timestamp_seconds: u64,
 }

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: scripts/did2rs.sh --canister sns_ledger --out ic_sns_ledger.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-15_23-00/rs/rosetta-api/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-23_23-01/rs/rosetta-api/icrc1/ledger/ledger.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: scripts/did2rs.sh --canister sns_root --out ic_sns_root.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-15_23-00/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-23_23-01/rs/sns/root/canister/root.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: scripts/did2rs.sh --canister sns_swap --out ic_sns_swap.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-15_23-00/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-23_23-01/rs/sns/swap/canister/swap.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: scripts/did2rs.sh --canister sns_wasm --out ic_sns_wasm.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-15_23-00/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-23_23-01/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -235,6 +235,31 @@ pub struct GetAllowedPrincipalsResponse {
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct GetDeployedSnsByProposalIdRequest {
+    pub proposal_id: u64,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]
+pub struct DeployedSns {
+    pub root_canister_id: Option<Principal>,
+    pub governance_canister_id: Option<Principal>,
+    pub index_canister_id: Option<Principal>,
+    pub swap_canister_id: Option<Principal>,
+    pub ledger_canister_id: Option<Principal>,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub enum GetDeployedSnsByProposalIdResult {
+    Error(SnsWasmError),
+    DeployedSns(DeployedSns),
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct GetDeployedSnsByProposalIdResponse {
+    pub get_deployed_sns_by_proposal_id_result: Option<GetDeployedSnsByProposalIdResult>,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SnsVersion {
     pub archive_wasm_hash: serde_bytes::ByteBuf,
     pub root_wasm_hash: serde_bytes::ByteBuf,
@@ -292,15 +317,6 @@ pub struct InsertUpgradePathEntriesResponse {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListDeployedSnsesArg {}
-
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]
-pub struct DeployedSns {
-    pub root_canister_id: Option<Principal>,
-    pub governance_canister_id: Option<Principal>,
-    pub index_canister_id: Option<Principal>,
-    pub swap_canister_id: Option<Principal>,
-    pub ledger_canister_id: Option<Principal>,
-}
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListDeployedSnsesResponse {
@@ -376,6 +392,12 @@ impl Service {
         arg0: GetAllowedPrincipalsArg,
     ) -> CallResult<(GetAllowedPrincipalsResponse,)> {
         ic_cdk::call(self.0, "get_allowed_principals", (arg0,)).await
+    }
+    pub async fn get_deployed_sns_by_proposal_id(
+        &self,
+        arg0: GetDeployedSnsByProposalIdRequest,
+    ) -> CallResult<(GetDeployedSnsByProposalIdResponse,)> {
+        ic_cdk::call(self.0, "get_deployed_sns_by_proposal_id", (arg0,)).await
     }
     pub async fn get_latest_sns_version_pretty(&self, arg0: ()) -> CallResult<(Vec<(String, String)>,)> {
         ic_cdk::call(self.0, "get_latest_sns_version_pretty", (arg0,)).await


### PR DESCRIPTION
# Motivation
We would like to parse all the latest SNS data.

# Changes
* Updated the Rust code derived from `.did` files in the aggregator.
  * Note: The candid files under `declarations/nns-$CANISTER` are used as inputs.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.