### PR TITLE
Update proposal rendering

### DIFF
--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-15_23-00/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-23_23-01/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-15_23-00/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-23_23-01/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
@@ -145,19 +145,10 @@ pub enum Result1 {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
-pub enum SevFeatureStatus {
-    SecureEnabled,
-    Disabled,
-    InsecureIntegrityEnabled,
-    SecureNoUpgradeEnabled,
-    InsecureEnabled,
-}
-
-#[derive(Serialize, CandidType, Deserialize)]
 pub struct SubnetFeatures {
     pub canister_sandboxing: bool,
-    pub sev_status: Option<SevFeatureStatus>,
     pub http_requests: bool,
+    pub sev_enabled: Option<bool>,
 }
 
 #[derive(Serialize, CandidType, Deserialize)]

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-15_23-00/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-23_23-01/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
@@ -236,6 +236,31 @@ pub struct GetAllowedPrincipalsResponse {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct GetDeployedSnsByProposalIdRequest {
+    pub proposal_id: u64,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct DeployedSns {
+    pub root_canister_id: Option<Principal>,
+    pub governance_canister_id: Option<Principal>,
+    pub index_canister_id: Option<Principal>,
+    pub swap_canister_id: Option<Principal>,
+    pub ledger_canister_id: Option<Principal>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub enum GetDeployedSnsByProposalIdResult {
+    Error(SnsWasmError),
+    DeployedSns(DeployedSns),
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct GetDeployedSnsByProposalIdResponse {
+    pub get_deployed_sns_by_proposal_id_result: Option<GetDeployedSnsByProposalIdResult>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct SnsVersion {
     pub archive_wasm_hash: serde_bytes::ByteBuf,
     pub root_wasm_hash: serde_bytes::ByteBuf,
@@ -293,15 +318,6 @@ pub struct InsertUpgradePathEntriesResponse {
 
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ListDeployedSnsesArg {}
-
-#[derive(Serialize, CandidType, Deserialize)]
-pub struct DeployedSns {
-    pub root_canister_id: Option<Principal>,
-    pub governance_canister_id: Option<Principal>,
-    pub index_canister_id: Option<Principal>,
-    pub swap_canister_id: Option<Principal>,
-    pub ledger_canister_id: Option<Principal>,
-}
 
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ListDeployedSnsesResponse {
@@ -377,6 +393,12 @@ impl Service {
         arg0: GetAllowedPrincipalsArg,
     ) -> CallResult<(GetAllowedPrincipalsResponse,)> {
         ic_cdk::call(self.0, "get_allowed_principals", (arg0,)).await
+    }
+    pub async fn get_deployed_sns_by_proposal_id(
+        &self,
+        arg0: GetDeployedSnsByProposalIdRequest,
+    ) -> CallResult<(GetDeployedSnsByProposalIdResponse,)> {
+        ic_cdk::call(self.0, "get_deployed_sns_by_proposal_id", (arg0,)).await
     }
     pub async fn get_latest_sns_version_pretty(&self, arg0: ()) -> CallResult<(Vec<(String, String)>,)> {
         ic_cdk::call(self.0, "get_latest_sns_version_pretty", (arg0,)).await


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.

# Changes
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.
  * Note: The candid files under `declarations/nns-$CANISTER` are used as inputs.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.