### PR TITLE
Chore: Fix typo icrcCansitersStore

### DIFF
--- a/frontend/src/lib/stores/icrc-canisters.store.ts
+++ b/frontend/src/lib/stores/icrc-canisters.store.ts
@@ -4,7 +4,7 @@ import type { Readable } from "svelte/store";
 import { writable } from "svelte/store";
 
 export interface IcrcCanisters {
-  ledgerCansisterId: Principal;
+  ledgerCanisterId: Principal;
   indexCanisterId: Principal;
 }
 
@@ -36,11 +36,11 @@ const initIcrcCanistersStore = (): IcrcCanistersStore => {
   return {
     subscribe,
 
-    setCanisters({ ledgerCansisterId, indexCanisterId }: IcrcCanisters) {
+    setCanisters({ ledgerCanisterId, indexCanisterId }: IcrcCanisters) {
       update((state: IcrcCanistersStoreData) => ({
         ...state,
-        [ledgerCansisterId.toText()]: {
-          ledgerCansisterId,
+        [ledgerCanisterId.toText()]: {
+          ledgerCanisterId,
           indexCanisterId,
         },
       }));

--- a/frontend/src/tests/lib/stores/icrc-canisters.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icrc-canisters.store.spec.ts
@@ -7,15 +7,15 @@ describe("icrc canisters store", () => {
     icrcCanistersStore.reset();
   });
 
-  const ledgerCansisterId = principal(0);
+  const ledgerCanisterId = principal(0);
   const indexCanisterId = principal(1);
 
   it("should store one set of canisters", () => {
-    icrcCanistersStore.setCanisters({ ledgerCansisterId, indexCanisterId });
+    icrcCanistersStore.setCanisters({ ledgerCanisterId, indexCanisterId });
 
     const store = get(icrcCanistersStore);
-    expect(store[ledgerCansisterId.toText()]).toEqual({
-      ledgerCansisterId,
+    expect(store[ledgerCanisterId.toText()]).toEqual({
+      ledgerCanisterId,
       indexCanisterId,
     });
   });
@@ -24,21 +24,21 @@ describe("icrc canisters store", () => {
     const ledgerCansisterId2 = principal(2);
     const indexCanisterId2 = principal(3);
     icrcCanistersStore.setCanisters({
-      ledgerCansisterId,
+      ledgerCanisterId,
       indexCanisterId,
     });
     icrcCanistersStore.setCanisters({
-      ledgerCansisterId: ledgerCansisterId2,
+      ledgerCanisterId: ledgerCansisterId2,
       indexCanisterId: indexCanisterId2,
     });
 
     const store = get(icrcCanistersStore);
-    expect(store[ledgerCansisterId.toText()]).toEqual({
-      ledgerCansisterId,
+    expect(store[ledgerCanisterId.toText()]).toEqual({
+      ledgerCanisterId,
       indexCanisterId,
     });
     expect(store[ledgerCansisterId2.toText()]).toEqual({
-      ledgerCansisterId: ledgerCansisterId2,
+      ledgerCanisterId: ledgerCansisterId2,
       indexCanisterId: indexCanisterId2,
     });
   });


### PR DESCRIPTION
# Motivation

There was a typo in the IcrcCanistersStore: "ledgerCansisterId" instead of "ledgerCanisterId".

# Changes

* Fix typo.

# Tests

* Also in tests.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.