### PR TITLE
Map PendingUtxo to UiTransaction

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -999,7 +999,8 @@
     "checking_incomplete_btc_transfers": "Checking for incomplete BTC transfers",
     "all_btc_transfers_complete": "All transfers are complete",
     "click_to_complete_btc_transfers": "Click here to complete BTC transfer for $amount ckBTC",
-    "btc_network": "BTC Network"
+    "btc_network": "BTC Network",
+    "receiving_btc": "Receiving BTC"
   },
   "error__ckbtc": {
     "already_process": "The minter has already been notified and updating the balance is in progress.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1047,6 +1047,7 @@ interface I18nCkbtc {
   all_btc_transfers_complete: string;
   click_to_complete_btc_transfers: string;
   btc_network: string;
+  receiving_btc: string;
 }
 
 interface I18nError__ckbtc {

--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -11,6 +11,7 @@ import { AccountTransactionType } from "$lib/types/transaction";
 import type { UniverseCanisterId } from "$lib/types/universe";
 import { transactionName } from "$lib/utils/transactions.utils";
 import { Cbor } from "@dfinity/agent";
+import type { PendingUtxo } from "@dfinity/ckbtc";
 import type {
   IcrcTransaction,
   IcrcTransactionWithId,
@@ -263,6 +264,32 @@ export const mapCkbtcTransaction = (params: {
     }
   }
   return mappedTransaction;
+};
+
+export const mapCkbtcPendingUtxo = ({
+  utxo,
+  token,
+  kytFee,
+  i18n,
+}: {
+  utxo: PendingUtxo;
+  token: Token;
+  kytFee: bigint;
+  i18n: I18n;
+}): UiTransaction => {
+  return {
+    domKey: `${uint8ArrayToHexString(Uint8Array.from(utxo.outpoint.txid))}-${
+      utxo.outpoint.vout
+    }`,
+    isIncoming: true,
+    isPending: true,
+    headline: i18n.ckbtc.receiving_btc,
+    otherParty: i18n.ckbtc.btc_network,
+    tokenAmount: TokenAmount.fromE8s({
+      amount: utxo.value - kytFee,
+      token: token,
+    }),
+  };
 };
 
 // TODO: use `oldestTxId` instead of sorting and getting the oldest element's id.

--- a/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
@@ -5,12 +5,16 @@ import {
   getSortedTransactionsFromStore,
   getUniqueTransactions,
   isIcrcTransactionsCompleted,
+  mapCkbtcPendingUtxo,
   mapCkbtcTransaction,
   mapIcrcTransaction,
   type mapIcrcTransactionType,
 } from "$lib/utils/icrc-transactions.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
-import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
+import {
+  mockCkBTCMainAccount,
+  mockCkBTCToken,
+} from "$tests/mocks/ckbtc-accounts.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
 import {
@@ -383,7 +387,7 @@ describe("icrc-transaction utils", () => {
         },
         account: mockCkBTCMainAccount,
         toSelfTransaction: false,
-        token: ICPToken,
+        token: mockCkBTCToken,
         i18n: en,
       });
       expect(data).toEqual({
@@ -395,7 +399,7 @@ describe("icrc-transaction utils", () => {
         timestamp: new Date(0),
         tokenAmount: TokenAmount.fromE8s({
           amount,
-          token: ICPToken,
+          token: mockCkBTCToken,
         }),
       });
     });
@@ -421,7 +425,7 @@ describe("icrc-transaction utils", () => {
         },
         account: mockCkBTCMainAccount,
         toSelfTransaction: false,
-        token: ICPToken,
+        token: mockCkBTCToken,
         i18n: en,
       });
 
@@ -434,7 +438,7 @@ describe("icrc-transaction utils", () => {
         timestamp: new Date(0),
         tokenAmount: TokenAmount.fromE8s({
           amount,
-          token: ICPToken,
+          token: mockCkBTCToken,
         }),
       });
 
@@ -454,7 +458,7 @@ describe("icrc-transaction utils", () => {
         },
         account: mockCkBTCMainAccount,
         toSelfTransaction: false,
-        token: ICPToken,
+        token: mockCkBTCToken,
         i18n: en,
       });
       expect(data).toEqual({
@@ -466,7 +470,39 @@ describe("icrc-transaction utils", () => {
         timestamp: new Date(0),
         tokenAmount: TokenAmount.fromE8s({
           amount,
-          token: ICPToken,
+          token: mockCkBTCToken,
+        }),
+      });
+    });
+  });
+
+  describe("mapCkbtcPendingUtxo", () => {
+    it("maps PendingUtxo to uiTransaction ", () => {
+      const amount = 23_000_000n;
+      const kytFee = 5_000n;
+      const utxo = {
+        outpoint: {
+          txid: new Uint8Array([2, 3, 2]),
+          vout: 2,
+        },
+        value: amount,
+        confirmations: 3,
+      };
+      const uiTransaction = mapCkbtcPendingUtxo({
+        utxo,
+        token: mockCkBTCToken,
+        kytFee,
+        i18n: en,
+      });
+      expect(uiTransaction).toEqual({
+        domKey: "020302-2",
+        isIncoming: true,
+        isPending: true,
+        headline: "Receiving BTC",
+        otherParty: "BTC Network",
+        tokenAmount: TokenAmount.fromE8s({
+          amount: amount - kytFee,
+          token: mockCkBTCToken,
         }),
       });
     });


### PR DESCRIPTION
# Motivation

When converting BTC to ckBTC, the minter only credits the ckBTC account when the incoming BTC transaction has 12 confirmations. When a UTXO has fewer than 12 confirmations, we consider it "pending" and we want to render it as a pending transaction.

In this PR I add a function to convert `PendingUtxo` to `UiTransaction` so that we can use `TransactionCard` to render it (already implemented in https://github.com/dfinity/nns-dapp/pull/3839).
The mapping function will be used in a future PR.

# Changes

1. Add `mapCkbtcPendingUtxo` which converts a `PendingUtxo` to a `UiTransaction`.
2. Add a unit test. The conversion is so straightforward that a single test seemed sufficient, but let me know if you agree.
3. Drive-by: Use a ckBTC token instead of `ICPToken` in another ckBTC related unit test. This doesn't matter to the test but it might be confusing to use ICP instead of ckBTC.

# Tests

Unit tests pass.
Tested manually in another branch which has the working code to rendering pending UTXOs.

# Todos

- [ ] Add entry to changelog (if necessary).
will add when it's used
