### PR TITLE
GIX-2117: Add ledger api endpoints

### DIFF
--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -74,6 +74,9 @@ export const getIcrcToken = async ({
   return token;
 };
 
+/**
+ * Similar to `getIcrcToken` but it expects the canister id instead of the function that queries the metada.
+ */
 export const queryIcrcToken = async ({
   certified,
   identity,

--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -74,6 +74,48 @@ export const getIcrcToken = async ({
   return token;
 };
 
+export const queryIcrcToken = async ({
+  certified,
+  identity,
+  canisterId,
+}: {
+  certified: boolean;
+  identity: Identity;
+  canisterId: Principal;
+}): Promise<IcrcTokenMetadata> => {
+  const {
+    canister: { metadata },
+  } = await icrcLedgerCanister({ identity, canisterId });
+
+  const tokenData = await metadata({ certified });
+
+  const token = mapOptionalToken(tokenData);
+
+  if (isNullish(token)) {
+    throw new LedgerErrorKey("error.icrc_token_load");
+  }
+
+  return token;
+};
+
+export const queryIcrcBalance = async ({
+  identity,
+  certified,
+  canisterId,
+  account,
+}: {
+  identity: Identity;
+  certified: boolean;
+  canisterId: Principal;
+  account: IcrcAccount;
+}): Promise<bigint> => {
+  const {
+    canister: { balance },
+  } = await icrcLedgerCanister({ identity, canisterId });
+
+  return balance({ ...account, certified });
+};
+
 export interface IcrcTransferParams {
   to: IcrcAccount;
   amount: bigint;

--- a/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
@@ -5,15 +5,18 @@ import {
   getIcrcAccount,
   getIcrcToken,
   icrcTransfer,
+  queryIcrcBalance,
+  queryIcrcToken,
 } from "$lib/api/icrc-ledger.api";
 import { CKBTC_LEDGER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockQueryTokenResponse,
   mockSnsToken,
+  principal,
 } from "$tests/mocks/sns-projects.mock";
-import type { HttpAgent } from "@dfinity/agent";
-import { IcrcLedgerCanister } from "@dfinity/ledger-icrc";
+import { AnonymousIdentity, type HttpAgent } from "@dfinity/agent";
+import { IcrcLedgerCanister, type IcrcAccount } from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
 import { mock } from "vitest-mock-extended";
 
@@ -21,6 +24,7 @@ describe("icrc-ledger api", () => {
   const ledgerCanisterMock = mock<IcrcLedgerCanister>();
 
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.useFakeTimers();
     vi.spyOn(IcrcLedgerCanister, "create").mockImplementation(
       () => ledgerCanisterMock
@@ -205,6 +209,49 @@ describe("icrc-ledger api", () => {
         created_at_time: createdAt,
         fee,
         from_subaccount: fromSubaccount,
+      });
+    });
+  });
+
+  describe("queryIcrcToken", () => {
+    it("successfully calls metadata endpoint and transforms response", async () => {
+      ledgerCanisterMock.metadata.mockResolvedValue(mockQueryTokenResponse);
+
+      const metadata = await queryIcrcToken({
+        certified: true,
+        identity: new AnonymousIdentity(),
+        canisterId: principal(0),
+      });
+
+      expect(metadata).toEqual(mockSnsToken);
+      expect(ledgerCanisterMock.metadata).toBeCalledTimes(1);
+      expect(ledgerCanisterMock.metadata).toBeCalledWith({
+        certified: true,
+      });
+    });
+  });
+
+  describe("queryIcrcBalance", () => {
+    it("successfully calls balance endpoint", async () => {
+      const balanceE8s = 314000000n;
+      ledgerCanisterMock.balance.mockResolvedValue(balanceE8s);
+
+      const account: IcrcAccount = {
+        owner: mockIdentity.getPrincipal(),
+      };
+
+      const balance = await queryIcrcBalance({
+        certified: true,
+        identity: new AnonymousIdentity(),
+        canisterId: principal(0),
+        account,
+      });
+
+      expect(balance).toEqual(balanceE8s);
+      expect(ledgerCanisterMock.balance).toBeCalledTimes(1);
+      expect(ledgerCanisterMock.balance).toBeCalledWith({
+        certified: true,
+        ...account,
       });
     });
   });


### PR DESCRIPTION
# Motivation

Get token data and balance of ICRC tokens easily.

Add new icrc ledger api functions: `queryIcrcToken` and `queryIcrcBalance`. This make a call to the endpoint of the ledger canister passed.

# Changes

* New icrc ledger functions `queryIcrcToken` and `queryIcrcBalance`.

# Tests

* Test new functions.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
