### PR TITLE
GIX-2118: Add ckETH universe derived

### DIFF
--- a/frontend/src/lib/derived/icrc-universes.derived.ts
+++ b/frontend/src/lib/derived/icrc-universes.derived.ts
@@ -1,7 +1,7 @@
 import CKBTC_LOGO from "$lib/assets/ckBTC.svg";
 import CKTESTBTC_LOGO from "$lib/assets/ckTESTBTC.svg";
 import {
-  CKETHTEST_UNIVERSE_CANISTER_ID,
+  CKETHSEPOLIA_UNIVERSE_CANISTER_ID,
   CKETH_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/cketh-canister-ids.constants";
 import {
@@ -27,7 +27,7 @@ const convertIcrcCanistersToUniverse = ({
   const logo =
     universeId === CKETH_UNIVERSE_CANISTER_ID.toText()
       ? CKBTC_LOGO
-      : universeId === CKETHTEST_UNIVERSE_CANISTER_ID.toText()
+      : universeId === CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText()
       ? CKTESTBTC_LOGO
       : undefined;
   if (isNullish(token) || isNullish(logo)) {

--- a/frontend/src/lib/derived/icrc-universes.derived.ts
+++ b/frontend/src/lib/derived/icrc-universes.derived.ts
@@ -1,0 +1,51 @@
+import CKBTC_LOGO from "$lib/assets/ckBTC.svg";
+import CKTESTBTC_LOGO from "$lib/assets/ckTESTBTC.svg";
+import {
+  CKETHTEST_UNIVERSE_CANISTER_ID,
+  CKETH_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/cketh-canister-ids.constants";
+import {
+  icrcCanistersStore,
+  type IcrcCanisters,
+} from "$lib/stores/icrc-canisters.store";
+import { tokensStore, type TokensStoreData } from "$lib/stores/tokens.store";
+import type { Universe } from "$lib/types/universe";
+import { isNullish, nonNullish } from "@dfinity/utils";
+import { derived, type Readable } from "svelte/store";
+
+const convertIcrcCanistersToUniverse = ({
+  canisters,
+  tokensData,
+}: {
+  canisters: IcrcCanisters;
+  tokensData: TokensStoreData;
+}): Universe | undefined => {
+  const universeId = canisters.ledgerCanisterId.toText();
+  const token = tokensData[universeId];
+  // TODO: Read logo from token https://dfinity.atlassian.net/browse/GIX-2140
+  // TODO: Add ckETH and ckETHTEST logos
+  const logo =
+    universeId === CKETH_UNIVERSE_CANISTER_ID.toText()
+      ? CKBTC_LOGO
+      : universeId === CKETHTEST_UNIVERSE_CANISTER_ID.toText()
+      ? CKTESTBTC_LOGO
+      : undefined;
+  if (isNullish(token) || isNullish(logo)) {
+    return;
+  }
+  return {
+    canisterId: universeId,
+    title: token.token.name,
+    logo,
+  };
+};
+
+export const icrcTokensUniversesStore: Readable<Universe[]> = derived(
+  [icrcCanistersStore, tokensStore],
+  ([icrcCanisters, tokensData]) =>
+    Object.values(icrcCanisters)
+      .map((canisters: IcrcCanisters) =>
+        convertIcrcCanistersToUniverse({ canisters, tokensData })
+      )
+      .filter((universe): universe is Universe => nonNullish(universe))
+);

--- a/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
@@ -1,8 +1,9 @@
 import {
-  CKETHTEST_UNIVERSE_CANISTER_ID,
+  CKETHSEPOLIA_INDEX_CANISTER_ID,
+  CKETHSEPOLIA_LEDGER_CANISTER_ID,
+  CKETHSEPOLIA_UNIVERSE_CANISTER_ID,
   CKETH_INDEX_CANISTER_ID,
   CKETH_UNIVERSE_CANISTER_ID,
-  CKTESTETH_INDEX_CANISTER_ID,
 } from "$lib/constants/cketh-canister-ids.constants";
 import { icrcTokensUniversesStore } from "$lib/derived/icrc-universes.derived";
 import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
@@ -13,7 +14,7 @@ import {
 } from "$tests/mocks/cketh-accounts.mock";
 import { mockToken, principal } from "$tests/mocks/sns-projects.mock";
 import {
-  ckETHTESTUniverseMock,
+  ckETHSEPOLIAUniverseMock,
   ckETHUniverseMock,
 } from "$tests/mocks/universe.mock";
 import { get } from "svelte/store";
@@ -38,7 +39,7 @@ describe("icrcTokensUniversesStore", () => {
         certified: true,
         token: mockCkETHToken,
       },
-      [CKETHTEST_UNIVERSE_CANISTER_ID.toText()]: {
+      [CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText()]: {
         certified: true,
         token: mockCkETHTESTToken,
       },
@@ -52,7 +53,7 @@ describe("icrcTokensUniversesStore", () => {
         certified: true,
         token: mockCkETHToken,
       },
-      [CKETHTEST_UNIVERSE_CANISTER_ID.toText()]: {
+      [CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText()]: {
         certified: true,
         token: mockCkETHTESTToken,
       },
@@ -62,12 +63,12 @@ describe("icrcTokensUniversesStore", () => {
       indexCanisterId: CKETH_INDEX_CANISTER_ID,
     });
     icrcCanistersStore.setCanisters({
-      ledgerCanisterId: CKETHTEST_UNIVERSE_CANISTER_ID,
-      indexCanisterId: CKTESTETH_INDEX_CANISTER_ID,
+      ledgerCanisterId: CKETHSEPOLIA_LEDGER_CANISTER_ID,
+      indexCanisterId: CKETHSEPOLIA_INDEX_CANISTER_ID,
     });
     expect(get(icrcTokensUniversesStore)).toEqual([
       ckETHUniverseMock,
-      ckETHTESTUniverseMock,
+      ckETHSEPOLIAUniverseMock,
     ]);
   });
 

--- a/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
@@ -47,7 +47,7 @@ describe("icrcTokensUniversesStore", () => {
     expect(get(icrcTokensUniversesStore)).toEqual([]);
   });
 
-  it("returns cket universes if present in icrcCanistersStore", () => {
+  it("returns ckETH universe if present in icrcCanistersStore", () => {
     tokensStore.setTokens({
       [CKETH_UNIVERSE_CANISTER_ID.toText()]: {
         certified: true,
@@ -62,7 +62,7 @@ describe("icrcTokensUniversesStore", () => {
   });
 
   // TODO: Enable when we have ckETH mainnet canister ids
-  it.skip("returns cketh universes if present in icrcCanistersStore", () => {
+  it.skip("returns ckETH and ckSEPOLIA universes if present in icrcCanistersStore", () => {
     tokensStore.setTokens({
       [CKETH_UNIVERSE_CANISTER_ID.toText()]: {
         certified: true,

--- a/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
@@ -47,7 +47,22 @@ describe("icrcTokensUniversesStore", () => {
     expect(get(icrcTokensUniversesStore)).toEqual([]);
   });
 
-  it("returns cketh universes if present in icrcCanistersStore", () => {
+  it("returns cket universes if present in icrcCanistersStore", () => {
+    tokensStore.setTokens({
+      [CKETH_UNIVERSE_CANISTER_ID.toText()]: {
+        certified: true,
+        token: mockCkETHToken,
+      },
+    });
+    icrcCanistersStore.setCanisters({
+      ledgerCanisterId: CKETH_UNIVERSE_CANISTER_ID,
+      indexCanisterId: CKETH_INDEX_CANISTER_ID,
+    });
+    expect(get(icrcTokensUniversesStore)).toEqual([ckETHUniverseMock]);
+  });
+
+  // TODO: Enable when we have ckETH mainnet canister ids
+  it.skip("returns cketh universes if present in icrcCanistersStore", () => {
     tokensStore.setTokens({
       [CKETH_UNIVERSE_CANISTER_ID.toText()]: {
         certified: true,

--- a/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
@@ -1,0 +1,90 @@
+import {
+  CKETHTEST_UNIVERSE_CANISTER_ID,
+  CKETH_INDEX_CANISTER_ID,
+  CKETH_UNIVERSE_CANISTER_ID,
+  CKTESTETH_INDEX_CANISTER_ID,
+} from "$lib/constants/cketh-canister-ids.constants";
+import { icrcTokensUniversesStore } from "$lib/derived/icrc-universes.derived";
+import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
+import { tokensStore } from "$lib/stores/tokens.store";
+import {
+  mockCkETHTESTToken,
+  mockCkETHToken,
+} from "$tests/mocks/cketh-accounts.mock";
+import { mockToken, principal } from "$tests/mocks/sns-projects.mock";
+import {
+  ckETHTESTUniverseMock,
+  ckETHUniverseMock,
+} from "$tests/mocks/universe.mock";
+import { get } from "svelte/store";
+
+describe("icrcTokensUniversesStore", () => {
+  beforeEach(() => {
+    tokensStore.reset();
+    icrcCanistersStore.reset();
+  });
+
+  it("returns empty array if no tokens are present", () => {
+    icrcCanistersStore.setCanisters({
+      ledgerCanisterId: CKETH_UNIVERSE_CANISTER_ID,
+      indexCanisterId: CKETH_INDEX_CANISTER_ID,
+    });
+    expect(get(icrcTokensUniversesStore)).toEqual([]);
+  });
+
+  it("returns empty array if no canister ids are present", () => {
+    tokensStore.setTokens({
+      [CKETH_UNIVERSE_CANISTER_ID.toText()]: {
+        certified: true,
+        token: mockCkETHToken,
+      },
+      [CKETHTEST_UNIVERSE_CANISTER_ID.toText()]: {
+        certified: true,
+        token: mockCkETHTESTToken,
+      },
+    });
+    expect(get(icrcTokensUniversesStore)).toEqual([]);
+  });
+
+  it("returns cketh universes if present in icrcCanistersStore", () => {
+    tokensStore.setTokens({
+      [CKETH_UNIVERSE_CANISTER_ID.toText()]: {
+        certified: true,
+        token: mockCkETHToken,
+      },
+      [CKETHTEST_UNIVERSE_CANISTER_ID.toText()]: {
+        certified: true,
+        token: mockCkETHTESTToken,
+      },
+    });
+    icrcCanistersStore.setCanisters({
+      ledgerCanisterId: CKETH_UNIVERSE_CANISTER_ID,
+      indexCanisterId: CKETH_INDEX_CANISTER_ID,
+    });
+    icrcCanistersStore.setCanisters({
+      ledgerCanisterId: CKETHTEST_UNIVERSE_CANISTER_ID,
+      indexCanisterId: CKTESTETH_INDEX_CANISTER_ID,
+    });
+    expect(get(icrcTokensUniversesStore)).toEqual([
+      ckETHUniverseMock,
+      ckETHTESTUniverseMock,
+    ]);
+  });
+
+  // TODO: https://dfinity.atlassian.net/browse/GIX-2140
+  it("doesn't return non-cketh universes", () => {
+    // For not it's because the logo is not yet parsed in the token.
+    const ledgerCanisterId = principal(1);
+    tokensStore.setTokens({
+      [ledgerCanisterId.toText()]: {
+        certified: true,
+        token: mockToken,
+      },
+    });
+    icrcCanistersStore.setCanisters({
+      ledgerCanisterId: ledgerCanisterId,
+      indexCanisterId: principal(2),
+    });
+    expect(get(icrcTokensUniversesStore)).toEqual([]);
+  });
+});

--- a/frontend/src/tests/mocks/cketh-accounts.mock.ts
+++ b/frontend/src/tests/mocks/cketh-accounts.mock.ts
@@ -1,0 +1,13 @@
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
+
+export const mockCkETHToken: IcrcTokenMetadata = {
+  name: "ckETH",
+  symbol: "ckETH",
+  fee: 10_000n,
+};
+
+export const mockCkETHTESTToken: IcrcTokenMetadata = {
+  symbol: "ckETHTEST",
+  name: "ckETHTEST",
+  fee: 10_000n,
+};

--- a/frontend/src/tests/mocks/universe.mock.ts
+++ b/frontend/src/tests/mocks/universe.mock.ts
@@ -7,7 +7,7 @@ import {
   CKTESTBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import {
-  CKETHTEST_UNIVERSE_CANISTER_ID,
+  CKETHSEPOLIA_UNIVERSE_CANISTER_ID,
   CKETH_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/cketh-canister-ids.constants";
 import type { Universe } from "$lib/types/universe";
@@ -36,8 +36,8 @@ export const ckETHUniverseMock: Universe = {
   logo: CKBTC_LOGO,
 };
 
-export const ckETHTESTUniverseMock: Universe = {
-  canisterId: CKETHTEST_UNIVERSE_CANISTER_ID.toText(),
+export const ckETHSEPOLIAUniverseMock: Universe = {
+  canisterId: CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText(),
   title: "ckETHTEST",
   logo: CKTESTBTC_LOGO,
 };

--- a/frontend/src/tests/mocks/universe.mock.ts
+++ b/frontend/src/tests/mocks/universe.mock.ts
@@ -6,6 +6,10 @@ import {
   CKBTC_UNIVERSE_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
+import {
+  CKETHTEST_UNIVERSE_CANISTER_ID,
+  CKETH_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/cketh-canister-ids.constants";
 import type { Universe } from "$lib/types/universe";
 
 export const nnsUniverseMock: Universe = {
@@ -23,5 +27,17 @@ export const ckBTCUniverseMock: Universe = {
 export const ckTESTBTCUniverseMock: Universe = {
   canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID.toText(),
   title: "ckTESTBTC",
+  logo: CKTESTBTC_LOGO,
+};
+
+export const ckETHUniverseMock: Universe = {
+  canisterId: CKETH_UNIVERSE_CANISTER_ID.toText(),
+  title: "ckETH",
+  logo: CKBTC_LOGO,
+};
+
+export const ckETHTESTUniverseMock: Universe = {
+  canisterId: CKETHTEST_UNIVERSE_CANISTER_ID.toText(),
+  title: "ckETHTEST",
   logo: CKTESTBTC_LOGO,
 };


### PR DESCRIPTION
# Motivation

Convert the ICRC tokens stored in `icrcCanistersStore` into a `Universe`.

# Changes

* New derived store `icrcTokensUniversesStore`. For now, it works only for ckETH canisters.

# Tests

* Add mocks for ckETH universes and tokens.
* Add test for new derived store `icrcTokensUniversesStore`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
