### PR TITLE
Update release-sop for DevEnv

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -38,6 +38,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Adapt `release-sop` script to work with DevEnv instead of staging.
+
 #### Deprecated
 
 #### Removed

--- a/scripts/nns-dapp/release-sop
+++ b/scripts/nns-dapp/release-sop
@@ -355,6 +355,7 @@ post_rc_on_slack() {
     echo "WASM hash: $WASM_HASH"
     echo "Change log: https://github.com/dfinity/nns-dapp/blob/release-candidate/CHANGELOG-Nns-Dapp-unreleased.md"
     echo "[QR Code](https://api.qrserver.com/v1/create-qr-code/?size=500x500&data=$RC_URL)"
+    echo "[Use a VPN](https://www.notion.so/dfinityorg/NNS-dapp-on-DevEnv-2882138a87fa45c39bf0966591c3dd73#929a5ccd7edd4b428efbc765aedf4d84) to test on mobile."
     echo "Please try it out."
     echo
     echo -n "Then enter the Slack link: "

--- a/scripts/nns-dapp/release-sop
+++ b/scripts/nns-dapp/release-sop
@@ -27,6 +27,8 @@ source "$SOURCE_DIR/../clap.bash"
 clap.define long=new desc="Start a new release branch" variable=IS_NEW_RELEASE nargs=0 default="false"
 clap.define long=continue desc="Continue with an existing release branch" variable=CONTINUE nargs=0 default="false"
 clap.define long=name desc="The name of the new release branch" variable=BRANCH_NAME default=""
+clap.define long=test_network desc="The dfx network to deploy the release candidate to for testing" variable=TEST_NETWORK default="devenv_$USER"
+clap.define long=test_domain desc="The domain to use for the Release candidate URL" variable=TEST_DOMAIN default="${USER}-ingress.devenv.dfinity.network"
 clap.define long=mock-json desc="A json file with mock responses for commands during testing" variable=MOCK_JSON default=""
 # Source the output file ------------------------------------------------------
 source "$(clap.build)"
@@ -333,20 +335,6 @@ get_dfx_identity() {
   echo "$(dfx identity whoami): $(dfx identity get-principal)"
 }
 
-remove_staging_nns_dapp_from_canister_ids_json() {
-  old_canister_id="$(jq -r '."nns-dapp".staging' canister_ids.json)"
-  if ! [ "$old_canister_id" ]; then
-    checklist_add "$label" "Was already not there"
-    return
-  fi
-
-  new_name="staging-before-$(execute date +%Y%m%d-%H%M%S)"
-  jq --arg new_name "$new_name" '."nns-dapp"[$new_name] = ."nns-dapp".staging | del(."nns-dapp".staging)' canister_ids.json >canister_ids.json.new
-  mv canister_ids.json.new canister_ids.json
-
-  #checklist_add "$label" "\"$new_name\": \"$old_canister_id\""
-}
-
 get_module_hash_from_network() {
   local network
   network="$1"
@@ -355,18 +343,18 @@ get_module_hash_from_network() {
 }
 
 post_rc_on_slack() {
-  STAGING_URL="$(checklist_must_get "Staging URL")"
+  RC_URL="$(checklist_must_get "Release candidate URL")"
   COMMIT="$(checklist_must_get "Release commit")"
   WASM_HASH="$(checklist_must_get "CI NNS-dapp WASM hash")"
   (
     echo
     echo "Post the following on #eng-gix-private:"
     echo
-    echo ":rocket: *New RC ${BRANCH_NAME}* : $STAGING_URL"
+    echo ":rocket: *New RC ${BRANCH_NAME}* : $RC_URL"
     echo "Commit: $COMMIT"
     echo "WASM hash: $WASM_HASH"
     echo "Change log: https://github.com/dfinity/nns-dapp/blob/release-candidate/CHANGELOG-Nns-Dapp-unreleased.md"
-    echo "[QR Code](https://api.qrserver.com/v1/create-qr-code/?size=500x500&data=$STAGING_URL)"
+    echo "[QR Code](https://api.qrserver.com/v1/create-qr-code/?size=500x500&data=$RC_URL)"
     echo "Please try it out."
     echo
     echo -n "Then enter the Slack link: "
@@ -454,21 +442,21 @@ record "Security test: no HTML in templates" no_html_in_templates
 confirm_cmd "$SOURCE_DIR/download-ci-wasm" --commit tags/release-candidate --dir "$TOP_DIR/release/ci" --wasm-filename nns-dapp.wasm.gz
 record "CI NNS-dapp WASM hash" "$SOURCE_DIR/get-hash-from-ci-log" --commit tags/release-candidate
 verify "CI NNS-dapp WASM hash" "Local WASM hash" sha256 "$TOP_DIR/release/ci/nns-dapp.wasm.gz"
-confirm_cmd scripts/canister_ids --remove --network staging --canister nns-dapp
+confirm_cmd scripts/canister_ids --remove --network "$TEST_NETWORK" --canister nns-dapp
 record "dfx identity" get_dfx_identity
-confirm_cmd dfx canister create nns-dapp --network staging --no-wallet
-record "NNS-dapp staging canister ID" dfx canister id nns-dapp --network staging
-verify "NNS-dapp staging canister ID" "Current NNS-dapp staging canister ID" dfx canister id nns-dapp --network staging
-CANISTER_ID="$(checklist_must_get "NNS-dapp staging canister ID")"
-confirm_cmd DFX_NETWORK=staging ./config.sh
-confirm_cmd dfx canister install nns-dapp --argument "$(execute cat nns-dapp-arg-staging.did)" --network staging --wasm ./release/ci/nns-dapp.wasm.gz
-record "Staging URL" echo "https://$CANISTER_ID.nnsdapp.dfinity.network/"
-verify "CI NNS-dapp WASM hash" "Staging WASM hash" get_module_hash_from_network staging
+confirm_cmd dfx canister create nns-dapp --network "$TEST_NETWORK" --no-wallet
+record "NNS-dapp $TEST_NETWORK canister ID" dfx canister id nns-dapp --network "$TEST_NETWORK"
+verify "NNS-dapp $TEST_NETWORK canister ID" "Current NNS-dapp $TEST_NETWORK canister ID" dfx canister id nns-dapp --network "$TEST_NETWORK"
+CANISTER_ID="$(checklist_must_get "NNS-dapp $TEST_NETWORK canister ID")"
+confirm_cmd DFX_NETWORK="$TEST_NETWORK" ./config.sh
+confirm_cmd dfx canister install nns-dapp --argument "$(execute cat "nns-dapp-arg-${TEST_NETWORK}.did")" --network "$TEST_NETWORK" --wasm ./release/ci/nns-dapp.wasm.gz
+record "Release candidate URL" echo "https://$CANISTER_ID.${TEST_DOMAIN}/"
+verify "CI NNS-dapp WASM hash" "RC WASM hash" get_module_hash_from_network "$TEST_NETWORK"
 record "Post RC on Slack" post_rc_on_slack
-confirm_manual "Update playground" printf 'Update the "Playground" bookmark on the #eng-nns-dapp Slack channel to point to the new release candidate.\n\nSlack channel: https://dfinity.slack.com/channels/eng-nns-dapp\nNew Playground bookmark:  %s\n' "$(checklist_must_get "Staging URL")"
+confirm_manual "Update playground" printf 'Update the "Playground" bookmark on the #eng-nns-dapp Slack channel to point to the new release candidate.\n\nSlack channel: https://dfinity.slack.com/channels/eng-nns-dapp\nNew Playground bookmark:  %s\n' "$(checklist_must_get "Release candidate URL")"
 
 # Release
-record "Canister IDs" "$SOURCE_DIR/../canister_ids" --export --network staging
+record "Canister IDs" "$SOURCE_DIR/../canister_ids" --export --network "$TEST_NETWORK"
 record "Build hashes" verify_build
 confirm_cmd "$SOURCE_DIR/release-template"
 confirm_cmd "$SOURCE_DIR/release-check"

--- a/scripts/nns-dapp/release-sop-test-continue-after-success.json
+++ b/scripts/nns-dapp/release-sop-test-continue-after-success.json
@@ -1,6 +1,10 @@
 {
   "args": [
-    "--continue"
+    "--continue",
+    "--test_network",
+    "devenv_user",
+    "--test_domain",
+    "user-ingress.devenv.dfinity.network"
   ],
   "behavior": [
     {
@@ -34,19 +38,19 @@
       "exitCode": 0
     },
     {
-      "command": "dfx canister id nns-dapp --network staging",
+      "command": "dfx canister id nns-dapp --network devenv_user",
       "stdout": "jefp3-bqaaa-aaaaa-aacyq-cai",
       "stderr": "",
       "exitCode": 0
     },
     {
-      "command": "cat nns-dapp-arg-staging.did",
+      "command": "cat nns-dapp-arg-devenv_user.did",
       "stdout": "(record{})",
       "stderr": "",
       "exitCode": 0
     },
     {
-      "command": "get_module_hash_from_network staging",
+      "command": "get_module_hash_from_network devenv_user",
       "stdout": "6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4",
       "stderr": "",
       "exitCode": 0
@@ -74,18 +78,18 @@
     "scripts/nns-dapp/download-ci-wasm --commit tags/release-candidate --dir /home/runner/work/nns-dapp/release/ci --wasm-filename nns-dapp.wasm.gz: Was already done. Skipping.",
     "CI NNS-dapp WASM hash: Was already: \u001b[35m6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4\u001b[0m",
     "Local WASM hash: 6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4",
-    "scripts/canister_ids --remove --network staging --canister nns-dapp: Was already done. Skipping.",
+    "scripts/canister_ids --remove --network devenv_user --canister nns-dapp: Was already done. Skipping.",
     "dfx identity: Was already: \u001b[35mdefault: s2dw5-fmktb-knrnq-772tr-ca3g7-me224-st35j-f3eli-xx2vf-aoesd-2qe\u001b[0m",
-    "dfx canister create nns-dapp --network staging --no-wallet: Was already done. Skipping.",
-    "NNS-dapp staging canister ID: Was already: \u001b[35mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
-    "Current NNS-dapp staging canister ID: jefp3-bqaaa-aaaaa-aacyq-cai",
-    "DFX_NETWORK=staging ./config.sh: Was already done. Skipping.",
-    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network staging --wasm ./release/ci/nns-dapp.wasm.gz: Was already done. Skipping.",
-    "Staging URL: Was already: \u001b[35mhttps://jefp3-bqaaa-aaaaa-aacyq-cai.nnsdapp.dfinity.network/\u001b[0m",
-    "Staging WASM hash: 6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4",
+    "dfx canister create nns-dapp --network devenv_user --no-wallet: Was already done. Skipping.",
+    "NNS-dapp devenv_user canister ID: Was already: \u001b[35mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
+    "Current NNS-dapp devenv_user canister ID: jefp3-bqaaa-aaaaa-aacyq-cai",
+    "DFX_NETWORK=devenv_user ./config.sh: Was already done. Skipping.",
+    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network devenv_user --wasm ./release/ci/nns-dapp.wasm.gz: Was already done. Skipping.",
+    "Release candidate URL: Was already: \u001b[35mhttps://jefp3-bqaaa-aaaaa-aacyq-cai.user-ingress.devenv.dfinity.network/\u001b[0m",
+    "RC WASM hash: 6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4",
     "Post RC on Slack: Was already: \u001b[35mhttps://dfinity.slack.com/archives/C03HZERHBT3/p1687962898467509\u001b[0m",
     "Update playground: Was already done. Skipping.",
-    "Canister IDs: Was already: \u001b[35m{ \"internet_identity\": { \"staging\": \"wqmuk-5qaaa-aaaaa-aaaqq-cai\" } }\u001b[0m",
+    "Canister IDs: Was already: \u001b[35m{ \"internet_identity\": { \"devenv_user\": \"wqmuk-5qaaa-aaaaa-aaaqq-cai\" } }\u001b[0m",
     "Build hashes: Was already: \u001b[35m41ed48445882e6cff25f14c10ca1fb5c34b2df04c4c2b4d77a6244a0baa0e5ca  assets.tar.xz",
     "6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4  nns-dapp.wasm.gz",
     "bf2a1d0abe03272358245d5fa25f5b24ba32aa8eb7fd0367e3e68e975a2771ff  sns_aggregator.wasm.gz",

--- a/scripts/nns-dapp/release-sop-test-continue-different-staging-canister.json
+++ b/scripts/nns-dapp/release-sop-test-continue-different-staging-canister.json
@@ -1,6 +1,10 @@
 {
   "args": [
-    "--continue"
+    "--continue",
+    "--test_network",
+    "devenv_user",
+    "--test_domain",
+    "user-ingress.devenv.dfinity.network"
   ],
   "behavior": [
     {
@@ -34,7 +38,7 @@
       "exitCode": 0
     },
     {
-      "command": "dfx canister id nns-dapp --network staging",
+      "command": "dfx canister id nns-dapp --network devenv_user",
       "stdout": "aaaaa-aa",
       "stderr": "",
       "exitCode": 0
@@ -62,13 +66,13 @@
     "scripts/nns-dapp/download-ci-wasm --commit tags/release-candidate --dir /home/runner/work/nns-dapp/release/ci --wasm-filename nns-dapp.wasm.gz: Was already done. Skipping.",
     "CI NNS-dapp WASM hash: Was already: \u001b[35m6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4\u001b[0m",
     "Local WASM hash: 6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4",
-    "scripts/canister_ids --remove --network staging --canister nns-dapp: Was already done. Skipping.",
+    "scripts/canister_ids --remove --network devenv_user --canister nns-dapp: Was already done. Skipping.",
     "dfx identity: Was already: \u001b[35mdefault: s2dw5-fmktb-knrnq-772tr-ca3g7-me224-st35j-f3eli-xx2vf-aoesd-2qe\u001b[0m",
-    "dfx canister create nns-dapp --network staging --no-wallet: Was already done. Skipping.",
-    "NNS-dapp staging canister ID: Was already: \u001b[35mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
+    "dfx canister create nns-dapp --network devenv_user --no-wallet: Was already done. Skipping.",
+    "NNS-dapp devenv_user canister ID: Was already: \u001b[35mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
     "Values don't match!",
-    "NNS-dapp staging canister ID: jefp3-bqaaa-aaaaa-aacyq-cai",
-    "Current NNS-dapp staging canister ID: aaaaa-aa"
+    "NNS-dapp devenv_user canister ID: jefp3-bqaaa-aaaaa-aacyq-cai",
+    "Current NNS-dapp devenv_user canister ID: aaaaa-aa"
   ],
   "expectedExitCode": 1
 }

--- a/scripts/nns-dapp/release-sop-test-different-built-args-hash.json
+++ b/scripts/nns-dapp/release-sop-test-different-built-args-hash.json
@@ -1,6 +1,10 @@
 {
   "args": [
-    "--new"
+    "--new",
+    "--test_network",
+    "devenv_user",
+    "--test_domain",
+    "user-ingress.devenv.dfinity.network"
   ],
   "behavior": [
     {
@@ -88,19 +92,19 @@
       "exitCode": 0
     },
     {
-      "command": "dfx canister id nns-dapp --network staging",
+      "command": "dfx canister id nns-dapp --network devenv_user",
       "stdout": "jefp3-bqaaa-aaaaa-aacyq-cai",
       "stderr": "",
       "exitCode": 0
     },
     {
-      "command": "cat nns-dapp-arg-staging.did",
+      "command": "cat nns-dapp-arg-devenv_user.did",
       "stdout": "(record{})",
       "stderr": "",
       "exitCode": 0
     },
     {
-      "command": "get_module_hash_from_network staging",
+      "command": "get_module_hash_from_network devenv_user",
       "stdout": "6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4",
       "stderr": "",
       "exitCode": 0
@@ -112,8 +116,8 @@
       "exitCode": 0
     },
     {
-      "command": "scripts/nns-dapp/../canister_ids --export --network staging",
-      "stdout": "{ \"internet_identity\": { \"staging\": \"wqmuk-5qaaa-aaaaa-aaaqq-cai\" } }",
+      "command": "scripts/nns-dapp/../canister_ids --export --network devenv_user",
+      "stdout": "{ \"internet_identity\": { \"devenv_user\": \"wqmuk-5qaaa-aaaaa-aaaqq-cai\" } }",
       "stderr": "",
       "exitCode": 0
     },
@@ -202,38 +206,38 @@
     "Local WASM hash: \u001b[32m6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4\u001b[0m",
     "👇 Press enter to run the following command:",
     "",
-    "scripts/canister_ids --remove --network staging --canister nns-dapp",
+    "scripts/canister_ids --remove --network devenv_user --canister nns-dapp",
     "",
-    "scripts/canister_ids --remove --network staging --canister nns-dapp: \u001b[32mDone\u001b[0m",
+    "scripts/canister_ids --remove --network devenv_user --canister nns-dapp: \u001b[32mDone\u001b[0m",
     "dfx identity: \u001b[32mdefault: s2dw5-fmktb-knrnq-772tr-ca3g7-me224-st35j-f3eli-xx2vf-aoesd-2qe\u001b[0m",
     "👇 Press enter to run the following command:",
     "",
-    "dfx canister create nns-dapp --network staging --no-wallet",
+    "dfx canister create nns-dapp --network devenv_user --no-wallet",
     "",
-    "dfx canister create nns-dapp --network staging --no-wallet: \u001b[32mDone\u001b[0m",
-    "NNS-dapp staging canister ID: \u001b[32mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
-    "Current NNS-dapp staging canister ID: \u001b[32mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
+    "dfx canister create nns-dapp --network devenv_user --no-wallet: \u001b[32mDone\u001b[0m",
+    "NNS-dapp devenv_user canister ID: \u001b[32mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
+    "Current NNS-dapp devenv_user canister ID: \u001b[32mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
     "👇 Press enter to run the following command:",
     "",
-    "DFX_NETWORK=staging ./config.sh",
+    "DFX_NETWORK=devenv_user ./config.sh",
     "",
-    "DFX_NETWORK=staging ./config.sh: \u001b[32mDone\u001b[0m",
+    "DFX_NETWORK=devenv_user ./config.sh: \u001b[32mDone\u001b[0m",
     "👇 Press enter to run the following command:",
     "",
-    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network staging --wasm ./release/ci/nns-dapp.wasm.gz",
+    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network devenv_user --wasm ./release/ci/nns-dapp.wasm.gz",
     "",
-    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network staging --wasm ./release/ci/nns-dapp.wasm.gz: \u001b[32mDone\u001b[0m",
-    "Staging URL: \u001b[32mhttps://jefp3-bqaaa-aaaaa-aacyq-cai.nnsdapp.dfinity.network/\u001b[0m",
-    "Staging WASM hash: \u001b[32m6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4\u001b[0m",
+    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network devenv_user --wasm ./release/ci/nns-dapp.wasm.gz: \u001b[32mDone\u001b[0m",
+    "Release candidate URL: \u001b[32mhttps://jefp3-bqaaa-aaaaa-aacyq-cai.user-ingress.devenv.dfinity.network/\u001b[0m",
+    "RC WASM hash: \u001b[32m6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4\u001b[0m",
     "Post RC on Slack: \u001b[32mhttps://dfinity.slack.com/archives/C03HZERHBT3/p1687962898467509\u001b[0m",
     "Update the \"Playground\" bookmark on the #eng-nns-dapp Slack channel to point to the new release candidate.",
     "",
     "Slack channel: https://dfinity.slack.com/channels/eng-nns-dapp",
-    "New Playground bookmark:  https://jefp3-bqaaa-aaaaa-aacyq-cai.nnsdapp.dfinity.network/",
+    "New Playground bookmark:  https://jefp3-bqaaa-aaaaa-aacyq-cai.user-ingress.devenv.dfinity.network/",
     "",
     "When you've done that ☝️  confirm by entering 'y':",
     "Update playground: \u001b[32mDone\u001b[0m",
-    "Canister IDs: \u001b[32m{ \"internet_identity\": { \"staging\": \"wqmuk-5qaaa-aaaaa-aaaqq-cai\" } }\u001b[0m",
+    "Canister IDs: \u001b[32m{ \"internet_identity\": { \"devenv_user\": \"wqmuk-5qaaa-aaaaa-aaaqq-cai\" } }\u001b[0m",
     "Build hashes: \u001b[32m41ed48445882e6cff25f14c10ca1fb5c34b2df04c4c2b4d77a6244a0baa0e5ca  assets.tar.xz",
     "6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4  nns-dapp.wasm.gz",
     "bf2a1d0abe03272358245d5fa25f5b24ba32aa8eb7fd0367e3e68e975a2771ff  sns_aggregator.wasm.gz",

--- a/scripts/nns-dapp/release-sop-test-different-built-wasm-hash.json
+++ b/scripts/nns-dapp/release-sop-test-different-built-wasm-hash.json
@@ -1,6 +1,10 @@
 {
   "args": [
-    "--new"
+    "--new",
+    "--test_network",
+    "devenv_user",
+    "--test_domain",
+    "user-ingress.devenv.dfinity.network"
   ],
   "behavior": [
     {
@@ -88,19 +92,19 @@
       "exitCode": 0
     },
     {
-      "command": "dfx canister id nns-dapp --network staging",
+      "command": "dfx canister id nns-dapp --network devenv_user",
       "stdout": "jefp3-bqaaa-aaaaa-aacyq-cai",
       "stderr": "",
       "exitCode": 0
     },
     {
-      "command": "cat nns-dapp-arg-staging.did",
+      "command": "cat nns-dapp-arg-devenv_user.did",
       "stdout": "(record{})",
       "stderr": "",
       "exitCode": 0
     },
     {
-      "command": "get_module_hash_from_network staging",
+      "command": "get_module_hash_from_network devenv_user",
       "stdout": "6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4",
       "stderr": "",
       "exitCode": 0
@@ -112,8 +116,8 @@
       "exitCode": 0
     },
     {
-      "command": "scripts/nns-dapp/../canister_ids --export --network staging",
-      "stdout": "{ \"internet_identity\": { \"staging\": \"wqmuk-5qaaa-aaaaa-aaaqq-cai\" } }",
+      "command": "scripts/nns-dapp/../canister_ids --export --network devenv_user",
+      "stdout": "{ \"internet_identity\": { \"devenv_user\": \"wqmuk-5qaaa-aaaaa-aaaqq-cai\" } }",
       "stderr": "",
       "exitCode": 0
     },
@@ -172,38 +176,38 @@
     "Local WASM hash: \u001b[32m6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4\u001b[0m",
     "👇 Press enter to run the following command:",
     "",
-    "scripts/canister_ids --remove --network staging --canister nns-dapp",
+    "scripts/canister_ids --remove --network devenv_user --canister nns-dapp",
     "",
-    "scripts/canister_ids --remove --network staging --canister nns-dapp: \u001b[32mDone\u001b[0m",
+    "scripts/canister_ids --remove --network devenv_user --canister nns-dapp: \u001b[32mDone\u001b[0m",
     "dfx identity: \u001b[32mdefault: s2dw5-fmktb-knrnq-772tr-ca3g7-me224-st35j-f3eli-xx2vf-aoesd-2qe\u001b[0m",
     "👇 Press enter to run the following command:",
     "",
-    "dfx canister create nns-dapp --network staging --no-wallet",
+    "dfx canister create nns-dapp --network devenv_user --no-wallet",
     "",
-    "dfx canister create nns-dapp --network staging --no-wallet: \u001b[32mDone\u001b[0m",
-    "NNS-dapp staging canister ID: \u001b[32mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
-    "Current NNS-dapp staging canister ID: \u001b[32mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
+    "dfx canister create nns-dapp --network devenv_user --no-wallet: \u001b[32mDone\u001b[0m",
+    "NNS-dapp devenv_user canister ID: \u001b[32mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
+    "Current NNS-dapp devenv_user canister ID: \u001b[32mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
     "👇 Press enter to run the following command:",
     "",
-    "DFX_NETWORK=staging ./config.sh",
+    "DFX_NETWORK=devenv_user ./config.sh",
     "",
-    "DFX_NETWORK=staging ./config.sh: \u001b[32mDone\u001b[0m",
+    "DFX_NETWORK=devenv_user ./config.sh: \u001b[32mDone\u001b[0m",
     "👇 Press enter to run the following command:",
     "",
-    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network staging --wasm ./release/ci/nns-dapp.wasm.gz",
+    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network devenv_user --wasm ./release/ci/nns-dapp.wasm.gz",
     "",
-    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network staging --wasm ./release/ci/nns-dapp.wasm.gz: \u001b[32mDone\u001b[0m",
-    "Staging URL: \u001b[32mhttps://jefp3-bqaaa-aaaaa-aacyq-cai.nnsdapp.dfinity.network/\u001b[0m",
-    "Staging WASM hash: \u001b[32m6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4\u001b[0m",
+    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network devenv_user --wasm ./release/ci/nns-dapp.wasm.gz: \u001b[32mDone\u001b[0m",
+    "Release candidate URL: \u001b[32mhttps://jefp3-bqaaa-aaaaa-aacyq-cai.user-ingress.devenv.dfinity.network/\u001b[0m",
+    "RC WASM hash: \u001b[32m6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4\u001b[0m",
     "Post RC on Slack: \u001b[32mhttps://dfinity.slack.com/archives/C03HZERHBT3/p1687962898467509\u001b[0m",
     "Update the \"Playground\" bookmark on the #eng-nns-dapp Slack channel to point to the new release candidate.",
     "",
     "Slack channel: https://dfinity.slack.com/channels/eng-nns-dapp",
-    "New Playground bookmark:  https://jefp3-bqaaa-aaaaa-aacyq-cai.nnsdapp.dfinity.network/",
+    "New Playground bookmark:  https://jefp3-bqaaa-aaaaa-aacyq-cai.user-ingress.devenv.dfinity.network/",
     "",
     "When you've done that ☝️  confirm by entering 'y':",
     "Update playground: \u001b[32mDone\u001b[0m",
-    "Canister IDs: \u001b[32m{ \"internet_identity\": { \"staging\": \"wqmuk-5qaaa-aaaaa-aaaqq-cai\" } }\u001b[0m",
+    "Canister IDs: \u001b[32m{ \"internet_identity\": { \"devenv_user\": \"wqmuk-5qaaa-aaaaa-aaaqq-cai\" } }\u001b[0m",
     "Build hashes: \u001b[32m41ed48445882e6cff25f14c10ca1fb5c34b2df04c4c2b4d77a6244a0baa0e5ca  assets.tar.xz",
     "4444444444444444444444444444444444444444444444444444444444444444  nns-dapp.wasm.gz",
     "bf2a1d0abe03272358245d5fa25f5b24ba32aa8eb7fd0367e3e68e975a2771ff  sns_aggregator.wasm.gz",

--- a/scripts/nns-dapp/release-sop-test-different-staging-wasm-hash.json
+++ b/scripts/nns-dapp/release-sop-test-different-staging-wasm-hash.json
@@ -1,6 +1,10 @@
 {
   "args": [
-    "--new"
+    "--new",
+    "--test_network",
+    "devenv_user",
+    "--test_domain",
+    "user-ingress.devenv.dfinity.network"
   ],
   "behavior": [
     {
@@ -88,19 +92,19 @@
       "exitCode": 0
     },
     {
-      "command": "dfx canister id nns-dapp --network staging",
+      "command": "dfx canister id nns-dapp --network devenv_user",
       "stdout": "jefp3-bqaaa-aaaaa-aacyq-cai",
       "stderr": "",
       "exitCode": 0
     },
     {
-      "command": "cat nns-dapp-arg-staging.did",
+      "command": "cat nns-dapp-arg-devenv_user.did",
       "stdout": "(record{})",
       "stderr": "",
       "exitCode": 0
     },
     {
-      "command": "get_module_hash_from_network staging",
+      "command": "get_module_hash_from_network devenv_user",
       "stdout": "8888888888888888888888888888888888888888888888888888888888888888",
       "stderr": "",
       "exitCode": 0
@@ -154,31 +158,31 @@
     "Local WASM hash: \u001b[32m6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4\u001b[0m",
     "👇 Press enter to run the following command:",
     "",
-    "scripts/canister_ids --remove --network staging --canister nns-dapp",
+    "scripts/canister_ids --remove --network devenv_user --canister nns-dapp",
     "",
-    "scripts/canister_ids --remove --network staging --canister nns-dapp: \u001b[32mDone\u001b[0m",
+    "scripts/canister_ids --remove --network devenv_user --canister nns-dapp: \u001b[32mDone\u001b[0m",
     "dfx identity: \u001b[32mdefault: s2dw5-fmktb-knrnq-772tr-ca3g7-me224-st35j-f3eli-xx2vf-aoesd-2qe\u001b[0m",
     "👇 Press enter to run the following command:",
     "",
-    "dfx canister create nns-dapp --network staging --no-wallet",
+    "dfx canister create nns-dapp --network devenv_user --no-wallet",
     "",
-    "dfx canister create nns-dapp --network staging --no-wallet: \u001b[32mDone\u001b[0m",
-    "NNS-dapp staging canister ID: \u001b[32mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
-    "Current NNS-dapp staging canister ID: \u001b[32mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
+    "dfx canister create nns-dapp --network devenv_user --no-wallet: \u001b[32mDone\u001b[0m",
+    "NNS-dapp devenv_user canister ID: \u001b[32mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
+    "Current NNS-dapp devenv_user canister ID: \u001b[32mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
     "👇 Press enter to run the following command:",
     "",
-    "DFX_NETWORK=staging ./config.sh",
+    "DFX_NETWORK=devenv_user ./config.sh",
     "",
-    "DFX_NETWORK=staging ./config.sh: \u001b[32mDone\u001b[0m",
+    "DFX_NETWORK=devenv_user ./config.sh: \u001b[32mDone\u001b[0m",
     "👇 Press enter to run the following command:",
     "",
-    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network staging --wasm ./release/ci/nns-dapp.wasm.gz",
+    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network devenv_user --wasm ./release/ci/nns-dapp.wasm.gz",
     "",
-    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network staging --wasm ./release/ci/nns-dapp.wasm.gz: \u001b[32mDone\u001b[0m",
-    "Staging URL: \u001b[32mhttps://jefp3-bqaaa-aaaaa-aacyq-cai.nnsdapp.dfinity.network/\u001b[0m",
+    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network devenv_user --wasm ./release/ci/nns-dapp.wasm.gz: \u001b[32mDone\u001b[0m",
+    "Release candidate URL: \u001b[32mhttps://jefp3-bqaaa-aaaaa-aacyq-cai.user-ingress.devenv.dfinity.network/\u001b[0m",
     "Values don't match!",
     "CI NNS-dapp WASM hash: 6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4",
-    "Staging WASM hash: 8888888888888888888888888888888888888888888888888888888888888888"
+    "RC WASM hash: 8888888888888888888888888888888888888888888888888888888888888888"
   ],
   "expectedExitCode": 1
 }

--- a/scripts/nns-dapp/release-sop-test-successful-release.json
+++ b/scripts/nns-dapp/release-sop-test-successful-release.json
@@ -1,6 +1,10 @@
 {
   "args": [
-    "--new"
+    "--new",
+    "--test_network",
+    "devenv_user",
+    "--test_domain",
+    "user-ingress.devenv.dfinity.network"
   ],
   "behavior": [
     {
@@ -88,19 +92,19 @@
       "exitCode": 0
     },
     {
-      "command": "dfx canister id nns-dapp --network staging",
+      "command": "dfx canister id nns-dapp --network devenv_user",
       "stdout": "jefp3-bqaaa-aaaaa-aacyq-cai",
       "stderr": "",
       "exitCode": 0
     },
     {
-      "command": "cat nns-dapp-arg-staging.did",
+      "command": "cat nns-dapp-arg-devenv_user.did",
       "stdout": "(record{})",
       "stderr": "",
       "exitCode": 0
     },
     {
-      "command": "get_module_hash_from_network staging",
+      "command": "get_module_hash_from_network devenv_user",
       "stdout": "6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4",
       "stderr": "",
       "exitCode": 0
@@ -112,8 +116,8 @@
       "exitCode": 0
     },
     {
-      "command": "scripts/nns-dapp/../canister_ids --export --network staging",
-      "stdout": "{ \"internet_identity\": { \"staging\": \"wqmuk-5qaaa-aaaaa-aaaqq-cai\" } }",
+      "command": "scripts/nns-dapp/../canister_ids --export --network devenv_user",
+      "stdout": "{ \"internet_identity\": { \"devenv_user\": \"wqmuk-5qaaa-aaaaa-aaaqq-cai\" } }",
       "stderr": "",
       "exitCode": 0
     },
@@ -202,38 +206,38 @@
     "Local WASM hash: \u001b[32m6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4\u001b[0m",
     "👇 Press enter to run the following command:",
     "",
-    "scripts/canister_ids --remove --network staging --canister nns-dapp",
+    "scripts/canister_ids --remove --network devenv_user --canister nns-dapp",
     "",
-    "scripts/canister_ids --remove --network staging --canister nns-dapp: \u001b[32mDone\u001b[0m",
+    "scripts/canister_ids --remove --network devenv_user --canister nns-dapp: \u001b[32mDone\u001b[0m",
     "dfx identity: \u001b[32mdefault: s2dw5-fmktb-knrnq-772tr-ca3g7-me224-st35j-f3eli-xx2vf-aoesd-2qe\u001b[0m",
     "👇 Press enter to run the following command:",
     "",
-    "dfx canister create nns-dapp --network staging --no-wallet",
+    "dfx canister create nns-dapp --network devenv_user --no-wallet",
     "",
-    "dfx canister create nns-dapp --network staging --no-wallet: \u001b[32mDone\u001b[0m",
-    "NNS-dapp staging canister ID: \u001b[32mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
-    "Current NNS-dapp staging canister ID: \u001b[32mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
+    "dfx canister create nns-dapp --network devenv_user --no-wallet: \u001b[32mDone\u001b[0m",
+    "NNS-dapp devenv_user canister ID: \u001b[32mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
+    "Current NNS-dapp devenv_user canister ID: \u001b[32mjefp3-bqaaa-aaaaa-aacyq-cai\u001b[0m",
     "👇 Press enter to run the following command:",
     "",
-    "DFX_NETWORK=staging ./config.sh",
+    "DFX_NETWORK=devenv_user ./config.sh",
     "",
-    "DFX_NETWORK=staging ./config.sh: \u001b[32mDone\u001b[0m",
+    "DFX_NETWORK=devenv_user ./config.sh: \u001b[32mDone\u001b[0m",
     "👇 Press enter to run the following command:",
     "",
-    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network staging --wasm ./release/ci/nns-dapp.wasm.gz",
+    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network devenv_user --wasm ./release/ci/nns-dapp.wasm.gz",
     "",
-    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network staging --wasm ./release/ci/nns-dapp.wasm.gz: \u001b[32mDone\u001b[0m",
-    "Staging URL: \u001b[32mhttps://jefp3-bqaaa-aaaaa-aacyq-cai.nnsdapp.dfinity.network/\u001b[0m",
-    "Staging WASM hash: \u001b[32m6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4\u001b[0m",
+    "dfx canister install nns-dapp --argument \\(record\\{\\}\\) --network devenv_user --wasm ./release/ci/nns-dapp.wasm.gz: \u001b[32mDone\u001b[0m",
+    "Release candidate URL: \u001b[32mhttps://jefp3-bqaaa-aaaaa-aacyq-cai.user-ingress.devenv.dfinity.network/\u001b[0m",
+    "RC WASM hash: \u001b[32m6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4\u001b[0m",
     "Post RC on Slack: \u001b[32mhttps://dfinity.slack.com/archives/C03HZERHBT3/p1687962898467509\u001b[0m",
     "Update the \"Playground\" bookmark on the #eng-nns-dapp Slack channel to point to the new release candidate.",
     "",
     "Slack channel: https://dfinity.slack.com/channels/eng-nns-dapp",
-    "New Playground bookmark:  https://jefp3-bqaaa-aaaaa-aacyq-cai.nnsdapp.dfinity.network/",
+    "New Playground bookmark:  https://jefp3-bqaaa-aaaaa-aacyq-cai.user-ingress.devenv.dfinity.network/",
     "",
     "When you've done that ☝️  confirm by entering 'y':",
     "Update playground: \u001b[32mDone\u001b[0m",
-    "Canister IDs: \u001b[32m{ \"internet_identity\": { \"staging\": \"wqmuk-5qaaa-aaaaa-aaaqq-cai\" } }\u001b[0m",
+    "Canister IDs: \u001b[32m{ \"internet_identity\": { \"devenv_user\": \"wqmuk-5qaaa-aaaaa-aaaqq-cai\" } }\u001b[0m",
     "Build hashes: \u001b[32m41ed48445882e6cff25f14c10ca1fb5c34b2df04c4c2b4d77a6244a0baa0e5ca  assets.tar.xz",
     "6fbaddd1b8fde76de97ca1b03a356f01741878d6210cd9b7c6753ae80ae374a4  nns-dapp.wasm.gz",
     "bf2a1d0abe03272358245d5fa25f5b24ba32aa8eb7fd0367e3e68e975a2771ff  sns_aggregator.wasm.gz",


### PR DESCRIPTION
# Motivation

Staging testnet is dead. We now use DevEnv to stage our release candidate for testing.

# Changes

1. Add two new flags to `release-sop`: `--test_network` (defaults to `devenv_$USER`) and `--test_domain` (defaults to `${USER}-ingress.devenv.dfinity.network`).
2. Replace all occurrences of "staging" with more appropriate replacements. Mostly `$TEST_NETWORK`.
3. Drive-by change: Remove `remove_staging_nns_dapp_from_canister_ids_json` which is no longer used.

# Tests

1. In the test vectors, pass parameters to make the test network/domain not depend on the user running the test.
2. Update the mock behavior and expected output.

# Todos

- [x] Add entry to changelog (if necessary).
