### PR TITLE
Chore: Rename pathSupportsCkBTC

### DIFF
--- a/frontend/src/lib/derived/selectable-universes.derived.ts
+++ b/frontend/src/lib/derived/selectable-universes.derived.ts
@@ -1,6 +1,9 @@
 import { pageStore, type Page } from "$lib/derived/page.derived";
 import type { Universe } from "$lib/types/universe";
-import { isUniverseCkBTC, pathSupportsCkBTC } from "$lib/utils/universe.utils";
+import {
+  isUniverseCkBTC,
+  pathSupportsIcrcToken,
+} from "$lib/utils/universe.utils";
 import { derived, type Readable } from "svelte/store";
 import { universesStore } from "./universes.derived";
 
@@ -9,6 +12,7 @@ export const selectableUniversesStore = derived<
   Universe[]
 >([universesStore, pageStore], ([universes, page]: [Universe[], Page]) =>
   universes.filter(
-    ({ canisterId }) => pathSupportsCkBTC(page) || !isUniverseCkBTC(canisterId)
+    ({ canisterId }) =>
+      pathSupportsIcrcToken(page) || !isUniverseCkBTC(canisterId)
   )
 );

--- a/frontend/src/lib/derived/selectable-universes.derived.ts
+++ b/frontend/src/lib/derived/selectable-universes.derived.ts
@@ -1,8 +1,8 @@
 import { pageStore, type Page } from "$lib/derived/page.derived";
 import type { Universe } from "$lib/types/universe";
 import {
+  isNonGovernanceTokenPath,
   isUniverseCkBTC,
-  pathSupportsIcrcToken,
 } from "$lib/utils/universe.utils";
 import { derived, type Readable } from "svelte/store";
 import { universesStore } from "./universes.derived";
@@ -13,6 +13,6 @@ export const selectableUniversesStore = derived<
 >([universesStore, pageStore], ([universes, page]: [Universe[], Page]) =>
   universes.filter(
     ({ canisterId }) =>
-      pathSupportsIcrcToken(page) || !isUniverseCkBTC(canisterId)
+      isNonGovernanceTokenPath(page) || !isUniverseCkBTC(canisterId)
   )
 );

--- a/frontend/src/lib/derived/selected-universe.derived.ts
+++ b/frontend/src/lib/derived/selected-universe.derived.ts
@@ -11,10 +11,10 @@ import {
 } from "$lib/stores/feature-flags.store";
 import type { Universe, UniverseCanisterId } from "$lib/types/universe";
 import {
+  isNonGovernanceTokenPath,
   isUniverseCkBTC,
   isUniverseCkTESTBTC,
   isUniverseNns,
-  pathSupportsIcrcToken,
 } from "$lib/utils/universe.utils";
 import { Principal } from "@dfinity/principal";
 import { derived, type Readable } from "svelte/store";
@@ -48,7 +48,7 @@ export const selectedUniverseIdStore: Readable<Principal> = derived<
   [pageUniverseIdStore, pageStore, ENABLE_CKBTC, ENABLE_CKTESTBTC],
   ([canisterId, page, $ENABLE_CKBTC, $ENABLE_CKTESTBTC]) => {
     // ckBTC is only available on Accounts therefore we fallback to Nns if selected and user switch to another view
-    if (isUniverseCkBTC(canisterId) && !pathSupportsIcrcToken(page)) {
+    if (isUniverseCkBTC(canisterId) && !isNonGovernanceTokenPath(page)) {
       return OWN_CANISTER_ID;
     }
     if (

--- a/frontend/src/lib/derived/selected-universe.derived.ts
+++ b/frontend/src/lib/derived/selected-universe.derived.ts
@@ -14,7 +14,7 @@ import {
   isUniverseCkBTC,
   isUniverseCkTESTBTC,
   isUniverseNns,
-  pathSupportsCkBTC,
+  pathSupportsIcrcToken,
 } from "$lib/utils/universe.utils";
 import { Principal } from "@dfinity/principal";
 import { derived, type Readable } from "svelte/store";
@@ -48,7 +48,7 @@ export const selectedUniverseIdStore: Readable<Principal> = derived<
   [pageUniverseIdStore, pageStore, ENABLE_CKBTC, ENABLE_CKTESTBTC],
   ([canisterId, page, $ENABLE_CKBTC, $ENABLE_CKTESTBTC]) => {
     // ckBTC is only available on Accounts therefore we fallback to Nns if selected and user switch to another view
-    if (isUniverseCkBTC(canisterId) && !pathSupportsCkBTC(page)) {
+    if (isUniverseCkBTC(canisterId) && !pathSupportsIcrcToken(page)) {
       return OWN_CANISTER_ID;
     }
     if (

--- a/frontend/src/lib/utils/universe.utils.ts
+++ b/frontend/src/lib/utils/universe.utils.ts
@@ -13,7 +13,7 @@ import type { Principal } from "@dfinity/principal";
 import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
-export const pathSupportsIcrcToken = ({ path }: Page): boolean =>
+export const isNonGovernanceTokenPath = ({ path }: Page): boolean =>
   isSelectedPath({
     currentPath: path,
     paths: [AppPath.Accounts, AppPath.Wallet],

--- a/frontend/src/lib/utils/universe.utils.ts
+++ b/frontend/src/lib/utils/universe.utils.ts
@@ -13,7 +13,7 @@ import type { Principal } from "@dfinity/principal";
 import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
-export const pathSupportsCkBTC = ({ path }: Page): boolean =>
+export const pathSupportsIcrcToken = ({ path }: Page): boolean =>
   isSelectedPath({
     currentPath: path,
     paths: [AppPath.Accounts, AppPath.Wallet],

--- a/frontend/src/tests/lib/utils/universes.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/universes.utils.spec.ts
@@ -9,9 +9,9 @@ import {
 import { AppPath } from "$lib/constants/routes.constants";
 import {
   createUniverse,
+  isNonGovernanceTokenPath,
   isUniverseCkBTC,
   isUniverseNns,
-  pathSupportsIcrcToken,
   universeLogoAlt,
 } from "$lib/utils/universe.utils";
 import en from "$tests/mocks/i18n.mock";
@@ -24,17 +24,17 @@ import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { Principal } from "@dfinity/principal";
 
 describe("universes-utils", () => {
-  describe("pathSupportsIcrcToken", () => {
+  describe("isNonGovernanceTokenPath", () => {
     it("should support ICRC token", () => {
       expect(
-        pathSupportsIcrcToken({
+        isNonGovernanceTokenPath({
           universe: "not used here",
           path: AppPath.Accounts,
         })
       ).toBeTruthy();
 
       expect(
-        pathSupportsIcrcToken({
+        isNonGovernanceTokenPath({
           universe: "not used here",
           path: AppPath.Wallet,
         })
@@ -43,14 +43,14 @@ describe("universes-utils", () => {
 
     it("should not support ICRC Token", () => {
       expect(
-        pathSupportsIcrcToken({
+        isNonGovernanceTokenPath({
           universe: "not used here",
           path: AppPath.Neurons,
         })
       ).toBe(false);
 
       expect(
-        pathSupportsIcrcToken({
+        isNonGovernanceTokenPath({
           universe: "not used here",
           path: AppPath.Proposal,
         })

--- a/frontend/src/tests/lib/utils/universes.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/universes.utils.spec.ts
@@ -11,7 +11,7 @@ import {
   createUniverse,
   isUniverseCkBTC,
   isUniverseNns,
-  pathSupportsCkBTC,
+  pathSupportsIcrcToken,
   universeLogoAlt,
 } from "$lib/utils/universe.utils";
 import en from "$tests/mocks/i18n.mock";
@@ -24,33 +24,33 @@ import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { Principal } from "@dfinity/principal";
 
 describe("universes-utils", () => {
-  describe("pathSupportsCkBTC", () => {
-    it("should support ckBTC", () => {
+  describe("pathSupportsIcrcToken", () => {
+    it("should support ICRC token", () => {
       expect(
-        pathSupportsCkBTC({
+        pathSupportsIcrcToken({
           universe: "not used here",
           path: AppPath.Accounts,
         })
       ).toBeTruthy();
 
       expect(
-        pathSupportsCkBTC({
+        pathSupportsIcrcToken({
           universe: "not used here",
           path: AppPath.Wallet,
         })
       ).toBeTruthy();
     });
 
-    it("should not support ckBTC", () => {
+    it("should not support ICRC Token", () => {
       expect(
-        pathSupportsCkBTC({
+        pathSupportsIcrcToken({
           universe: "not used here",
           path: AppPath.Neurons,
         })
       ).toBe(false);
 
       expect(
-        pathSupportsCkBTC({
+        pathSupportsIcrcToken({
           universe: "not used here",
           path: AppPath.Proposal,
         })


### PR DESCRIPTION
# Motivation

Util `pathSupportsCkBTC` can also be used for ckETH and other ICRC tokens.

# Changes

* Rename `pathSupportsCkBTC` to `pathSupportsIcrcToken`.

# Tests

* Rename tests

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
