### PR TITLE
GIX-2117: Load ckETH on Accounts page

### DIFF
--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -26,6 +26,13 @@
   import AccountsModals from "$lib/modals/accounts/AccountsModals.svelte";
   import CkBTCAccountsModals from "$lib/modals/accounts/CkBTCAccountsModals.svelte";
   import { icpTokensListUser } from "$lib/derived/icp-tokens-list-user.derived";
+  import {
+    icrcCanistersStore,
+    type IcrcCanistersStoreData,
+  } from "$lib/stores/icrc-canisters.store";
+  import { loadIcrcAccounts } from "$lib/services/icrc-accounts.services";
+  import { onMount } from "svelte";
+  import { loadCkETHCanisters } from "$lib/services/cketh-canisters.services";
 
   // TODO: This component is mounted twice. Understand why and fix it.
 
@@ -34,6 +41,10 @@
 
   let loadSnsAccountsBalancesRequested = false;
   let loadCkBTCAccountsBalancesRequested = false;
+
+  onMount(() => {
+    loadCkETHCanisters();
+  });
 
   const loadSnsAccountsBalances = async (projects: SnsFullProject[]) => {
     // We start when the projects are fetched
@@ -73,10 +84,19 @@
     });
   };
 
+  const loadIcrcs = (icrcCanisters: IcrcCanistersStoreData) => {
+    const ledgerCanisterIds = Object.values(icrcCanisters).map(
+      ({ ledgerCanisterId }) => ledgerCanisterId
+    );
+
+    loadIcrcAccounts({ ledgerCanisterIds, certified: false });
+  };
+
   $: (async () =>
     await Promise.allSettled([
       loadSnsAccountsBalances($snsProjectsCommittedStore),
       loadCkBTCAccountsBalances($ckBTCUniversesStore),
+      loadIcrcs($icrcCanistersStore),
     ]))();
 </script>
 

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -84,7 +84,7 @@
     });
   };
 
-  const loadIcrcs = (icrcCanisters: IcrcCanistersStoreData) => {
+  const loadIcrcTokenAccounts = (icrcCanisters: IcrcCanistersStoreData) => {
     const ledgerCanisterIds = Object.values(icrcCanisters).map(
       ({ ledgerCanisterId }) => ledgerCanisterId
     );
@@ -96,7 +96,7 @@
     await Promise.allSettled([
       loadSnsAccountsBalances($snsProjectsCommittedStore),
       loadCkBTCAccountsBalances($ckBTCUniversesStore),
-      loadIcrcs($icrcCanistersStore),
+      loadIcrcTokenAccounts($icrcCanistersStore),
     ]))();
 </script>
 

--- a/frontend/src/lib/services/cketh-canisters.services.ts
+++ b/frontend/src/lib/services/cketh-canisters.services.ts
@@ -9,16 +9,26 @@ import {
   ENABLE_CKTESTBTC,
 } from "$lib/stores/feature-flags.store";
 import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
+import { isNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 export const loadCkETHCanisters = async () => {
-  if (get(ENABLE_CKETH)) {
+  const storeData = get(icrcCanistersStore);
+  // To avoid rerendering the UI and possibly triggering new requests
+  // We don't change the store if it's already filled.
+  if (
+    get(ENABLE_CKETH) &&
+    isNullish(storeData[CKETH_LEDGER_CANISTER_ID.toText()])
+  ) {
     icrcCanistersStore.setCanisters({
       ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
       indexCanisterId: CKETH_INDEX_CANISTER_ID,
     });
   }
-  if (get(ENABLE_CKTESTBTC)) {
+  if (
+    get(ENABLE_CKTESTBTC) &&
+    isNullish(storeData[CKETHSEPOLIA_LEDGER_CANISTER_ID.toText()])
+  ) {
     icrcCanistersStore.setCanisters({
       ledgerCanisterId: CKETHSEPOLIA_LEDGER_CANISTER_ID,
       indexCanisterId: CKETHSEPOLIA_INDEX_CANISTER_ID,

--- a/frontend/src/lib/services/cketh-canisters.services.ts
+++ b/frontend/src/lib/services/cketh-canisters.services.ts
@@ -14,6 +14,8 @@ import { get } from "svelte/store";
 
 export const loadCkETHCanisters = async () => {
   const storeData = get(icrcCanistersStore);
+  // To avoid rerendering the UI and possibly triggering new requests
+  // We don't change the store if it's already filled.
   if (
     get(ENABLE_CKETH) &&
     isNullish(storeData[CKETH_LEDGER_CANISTER_ID.toText()])

--- a/frontend/src/lib/services/cketh-canisters.services.ts
+++ b/frontend/src/lib/services/cketh-canisters.services.ts
@@ -9,26 +9,16 @@ import {
   ENABLE_CKTESTBTC,
 } from "$lib/stores/feature-flags.store";
 import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
-import { isNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 export const loadCkETHCanisters = async () => {
-  const storeData = get(icrcCanistersStore);
-  // To avoid rerendering the UI and possibly triggering new requests
-  // We don't change the store if it's already filled.
-  if (
-    get(ENABLE_CKETH) &&
-    isNullish(storeData[CKETH_LEDGER_CANISTER_ID.toText()])
-  ) {
+  if (get(ENABLE_CKETH)) {
     icrcCanistersStore.setCanisters({
       ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
       indexCanisterId: CKETH_INDEX_CANISTER_ID,
     });
   }
-  if (
-    get(ENABLE_CKTESTBTC) &&
-    isNullish(storeData[CKETHSEPOLIA_LEDGER_CANISTER_ID.toText()])
-  ) {
+  if (get(ENABLE_CKTESTBTC)) {
     icrcCanistersStore.setCanisters({
       ledgerCanisterId: CKETHSEPOLIA_LEDGER_CANISTER_ID,
       indexCanisterId: CKETHSEPOLIA_INDEX_CANISTER_ID,

--- a/frontend/src/lib/services/cketh-canisters.services.ts
+++ b/frontend/src/lib/services/cketh-canisters.services.ts
@@ -9,19 +9,25 @@ import {
   ENABLE_CKTESTBTC,
 } from "$lib/stores/feature-flags.store";
 import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
+import { isNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 export const loadCkETHCanisters = async () => {
+  const storeData = get(icrcCanistersStore);
   if (get(ENABLE_CKETH)) {
-    icrcCanistersStore.setCanisters({
-      ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
-      indexCanisterId: CKETH_INDEX_CANISTER_ID,
-    });
+    if (isNullish(storeData[CKETH_LEDGER_CANISTER_ID.toText()])) {
+      icrcCanistersStore.setCanisters({
+        ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
+        indexCanisterId: CKETH_INDEX_CANISTER_ID,
+      });
+    }
   }
   if (get(ENABLE_CKTESTBTC)) {
-    icrcCanistersStore.setCanisters({
-      ledgerCanisterId: CKETHSEPOLIA_LEDGER_CANISTER_ID,
-      indexCanisterId: CKETHSEPOLIA_INDEX_CANISTER_ID,
-    });
+    if (isNullish(storeData[CKETHSEPOLIA_LEDGER_CANISTER_ID.toText()])) {
+      icrcCanistersStore.setCanisters({
+        ledgerCanisterId: CKETHSEPOLIA_LEDGER_CANISTER_ID,
+        indexCanisterId: CKETHSEPOLIA_INDEX_CANISTER_ID,
+      });
+    }
   }
 };

--- a/frontend/src/lib/services/cketh-canisters.services.ts
+++ b/frontend/src/lib/services/cketh-canisters.services.ts
@@ -14,20 +14,22 @@ import { get } from "svelte/store";
 
 export const loadCkETHCanisters = async () => {
   const storeData = get(icrcCanistersStore);
-  if (get(ENABLE_CKETH)) {
-    if (isNullish(storeData[CKETH_LEDGER_CANISTER_ID.toText()])) {
-      icrcCanistersStore.setCanisters({
-        ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
-        indexCanisterId: CKETH_INDEX_CANISTER_ID,
-      });
-    }
+  if (
+    get(ENABLE_CKETH) &&
+    isNullish(storeData[CKETH_LEDGER_CANISTER_ID.toText()])
+  ) {
+    icrcCanistersStore.setCanisters({
+      ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
+      indexCanisterId: CKETH_INDEX_CANISTER_ID,
+    });
   }
-  if (get(ENABLE_CKTESTBTC)) {
-    if (isNullish(storeData[CKETHSEPOLIA_LEDGER_CANISTER_ID.toText()])) {
-      icrcCanistersStore.setCanisters({
-        ledgerCanisterId: CKETHSEPOLIA_LEDGER_CANISTER_ID,
-        indexCanisterId: CKETHSEPOLIA_INDEX_CANISTER_ID,
-      });
-    }
+  if (
+    get(ENABLE_CKTESTBTC) &&
+    isNullish(storeData[CKETHSEPOLIA_LEDGER_CANISTER_ID.toText()])
+  ) {
+    icrcCanistersStore.setCanisters({
+      ledgerCanisterId: CKETHSEPOLIA_LEDGER_CANISTER_ID,
+      indexCanisterId: CKETHSEPOLIA_INDEX_CANISTER_ID,
+    });
   }
 };

--- a/frontend/src/tests/lib/services/cketh-canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/cketh-canisters.services.spec.ts
@@ -39,17 +39,6 @@ describe("cketh-canisters.services", () => {
           },
         });
       });
-
-      it("should not load cketh canisters if already present", async () => {
-        vi.spyOn(icrcCanistersStore, "setCanisters");
-        icrcCanistersStore.setCanisters({
-          ledgerCanisterId: CKETH_UNIVERSE_CANISTER_ID,
-          indexCanisterId: CKETH_INDEX_CANISTER_ID,
-        });
-        expect(icrcCanistersStore.setCanisters).toHaveBeenCalledTimes(1);
-        await loadCkETHCanisters();
-        expect(icrcCanistersStore.setCanisters).toHaveBeenCalledTimes(1);
-      });
     });
 
     describe("if cketh is enabled", () => {

--- a/frontend/src/tests/lib/services/cketh-canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/cketh-canisters.services.spec.ts
@@ -39,6 +39,17 @@ describe("cketh-canisters.services", () => {
           },
         });
       });
+
+      it("should not load cketh canisters if already present", async () => {
+        vi.spyOn(icrcCanistersStore, "setCanisters");
+        icrcCanistersStore.setCanisters({
+          ledgerCanisterId: CKETH_UNIVERSE_CANISTER_ID,
+          indexCanisterId: CKETH_INDEX_CANISTER_ID,
+        });
+        expect(icrcCanistersStore.setCanisters).toHaveBeenCalledTimes(1);
+        await loadCkETHCanisters();
+        expect(icrcCanistersStore.setCanisters).toHaveBeenCalledTimes(1);
+      });
     });
 
     describe("if cketh is enabled", () => {


### PR DESCRIPTION
# Motivation

Load ckETH and ckETHSepolia (if needed) in Accounts page.

# Changes

* Use services `loadCkETHCanisters` and `loadIcrcAccounts` in Accounts page.

# Tests

* Test that the store is filled with proper data in Accounts route.

I added this test because the Accounts page doesn't render the token selector sidebar. Therefore, I can't test that the token is present in the UI from that component.

This will change with the new Tokens page. Therefore, there is no need to improve it for now.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary
