### PR TITLE
nybble: Pass new schema to post_upgrade hook

### DIFF
--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -91,11 +91,11 @@ impl State {
     /// - Deploy a release with a parser for the new schema.
     /// - Then, deploy a release that writes the new schema.
     /// This way it is possible to roll back after deploying the new schema.
-    pub fn post_upgrade() -> Self {
-        match Self::schema_version_from_stable_memory() {
-            None => Self::post_upgrade_unversioned(),
-            Some(version) => {
-                trap_with(&format!("Unknown schema version: {version:?}"));
+    pub fn post_upgrade(args_schema: Option<SchemaLabel>) -> Self {
+        match (Self::schema_version_from_stable_memory(), args_schema) {
+            (None, _) => Self::post_upgrade_unversioned(),
+            other => {
+                trap_with(&format!("Unsupported schema pair: {other:?}"));
                 unreachable!();
             }
         }


### PR DESCRIPTION
# Motivation
The state `post_upgrade` function will not be able to migrate data if the new schema is not provided.

# Changes
- Pass the schema provided in the upgrade arguments (if any) to the state `post_upgrade` hook.

# Tests
None.  Existing behaviour is unchanged.

# Todos

- [ ] Add entry to changelog (if necessary).
  - Too small to warrant a changelog entry.  There will be an entry when the post-upgrade hook performs migrations!
