### PR TITLE
GIX-2118: Add ckETH to universesStore

### DIFF
--- a/frontend/src/lib/derived/universes.derived.ts
+++ b/frontend/src/lib/derived/universes.derived.ts
@@ -6,20 +6,33 @@ import {
 import type { Universe } from "$lib/types/universe";
 import { createUniverse } from "$lib/utils/universe.utils";
 import { derived, type Readable } from "svelte/store";
+import { icrcTokensUniversesStore } from "./icrc-universes.derived";
 import { nnsUniverseStore } from "./nns-universe.derived";
 
 export const universesStore = derived<
-  [Readable<Universe>, Readable<SnsFullProject[]>, Readable<Universe[]>],
+  [
+    Readable<Universe>,
+    Readable<SnsFullProject[]>,
+    Readable<Universe[]>,
+    Readable<Universe[]>,
+  ],
   Universe[]
 >(
-  [nnsUniverseStore, snsProjectsCommittedStore, ckBTCUniversesStore],
-  ([nnsUniverse, projects, ckBTCUniverses]: [
+  [
+    nnsUniverseStore,
+    snsProjectsCommittedStore,
+    ckBTCUniversesStore,
+    icrcTokensUniversesStore,
+  ],
+  ([nnsUniverse, projects, ckBTCUniverses, icrcUniverses]: [
     Universe,
     SnsFullProject[],
+    Universe[],
     Universe[],
   ]) => [
     nnsUniverse,
     ...ckBTCUniverses,
+    ...icrcUniverses,
     ...(projects.map(({ summary }) => createUniverse(summary)) ?? []),
   ]
 );

--- a/frontend/src/tests/lib/derived/universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes.derived.spec.ts
@@ -1,12 +1,26 @@
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import {
+  CKETHSEPOLIA_INDEX_CANISTER_ID,
+  CKETHSEPOLIA_LEDGER_CANISTER_ID,
+  CKETH_INDEX_CANISTER_ID,
+  CKETH_LEDGER_CANISTER_ID,
+} from "$lib/constants/cketh-canister-ids.constants";
 import { universesStore } from "$lib/derived/universes.derived";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
+import { tokensStore } from "$lib/stores/tokens.store";
 import { aggregatorCanisterLogoPath } from "$lib/utils/sns-aggregator-converters.utils";
+import {
+  mockCkETHTESTToken,
+  mockCkETHToken,
+} from "$tests/mocks/cketh-accounts.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import {
   ckBTCUniverseMock,
+  ckETHSEPOLIAUniverseMock,
+  ckETHUniverseMock,
   ckTESTBTCUniverseMock,
   nnsUniverseMock,
 } from "$tests/mocks/universe.mock";
@@ -18,6 +32,8 @@ describe("universes derived stores", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     resetSnsProjects();
+    icrcCanistersStore.reset();
+    tokensStore.reset();
   });
 
   describe("ckBTC both enabled", () => {
@@ -34,7 +50,7 @@ describe("universes derived stores", () => {
       expect(store[2]).toEqual(ckTESTBTCUniverseMock);
     });
 
-    it("should return Nns, ckBTC, ckTESTBTC and SNS projects", () => {
+    it("should return Nns, ckBTC, ckTESTBTC, ckETH and SNS projects", () => {
       const snsRootCanisterId = rootCanisterIdMock;
       const projectName = "Tetris";
       setSnsProjects([
@@ -44,12 +60,22 @@ describe("universes derived stores", () => {
           projectName,
         },
       ]);
+      icrcCanistersStore.setCanisters({
+        ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
+        indexCanisterId: CKETH_INDEX_CANISTER_ID,
+      });
+      tokensStore.setTokens({
+        [CKETH_LEDGER_CANISTER_ID.toText()]: {
+          certified: true,
+          token: mockCkETHToken,
+        },
+      });
       const store = get(universesStore);
-      expect(store.length).toEqual(4);
-      expect(store[3].summary).not.toBeUndefined();
-      expect(store[3].canisterId).toEqual(snsRootCanisterId.toText());
-      expect(store[3].title).toBe(projectName);
-      expect(store[3].logo).toBe(
+      expect(store.length).toEqual(5);
+      expect(store[4].summary).not.toBeUndefined();
+      expect(store[4].canisterId).toEqual(snsRootCanisterId.toText());
+      expect(store[4].title).toBe(projectName);
+      expect(store[4].logo).toBe(
         aggregatorCanisterLogoPath(snsRootCanisterId.toText())
       );
     });
@@ -68,6 +94,56 @@ describe("universes derived stores", () => {
       expect(store[0].canisterId).toEqual(OWN_CANISTER_ID.toText());
       expect(store[1].summary).toBeUndefined();
       expect(store[1].canisterId).toEqual(CKBTC_UNIVERSE_CANISTER_ID.toText());
+    });
+
+    it("should return Nns, ckBTC and ckETH", () => {
+      icrcCanistersStore.setCanisters({
+        ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
+        indexCanisterId: CKETH_INDEX_CANISTER_ID,
+      });
+      tokensStore.setTokens({
+        [CKETH_LEDGER_CANISTER_ID.toText()]: {
+          certified: true,
+          token: mockCkETHToken,
+        },
+      });
+      const store = get(universesStore);
+      expect(store.length).toEqual(3);
+      expect(store[0].summary).toBeUndefined();
+      expect(store[0].canisterId).toEqual(OWN_CANISTER_ID.toText());
+      expect(store[1].summary).toBeUndefined();
+      expect(store[1].canisterId).toEqual(CKBTC_UNIVERSE_CANISTER_ID.toText());
+      expect(store[2]).toEqual(ckETHUniverseMock);
+    });
+
+    // TODO: Enable when we have the ckETH canister ids in env vars
+    it.skip("should return Nns, ckBTC, ckETH and ckETHSEPOLIA", () => {
+      icrcCanistersStore.setCanisters({
+        ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
+        indexCanisterId: CKETH_INDEX_CANISTER_ID,
+      });
+      icrcCanistersStore.setCanisters({
+        ledgerCanisterId: CKETHSEPOLIA_LEDGER_CANISTER_ID,
+        indexCanisterId: CKETHSEPOLIA_INDEX_CANISTER_ID,
+      });
+      tokensStore.setTokens({
+        [CKETH_LEDGER_CANISTER_ID.toText()]: {
+          certified: true,
+          token: mockCkETHToken,
+        },
+        [CKETHSEPOLIA_LEDGER_CANISTER_ID.toText()]: {
+          certified: true,
+          token: mockCkETHTESTToken,
+        },
+      });
+      const store = get(universesStore);
+      expect(store.length).toEqual(4);
+      expect(store[0].summary).toBeUndefined();
+      expect(store[0].canisterId).toEqual(OWN_CANISTER_ID.toText());
+      expect(store[1].summary).toBeUndefined();
+      expect(store[1].canisterId).toEqual(CKBTC_UNIVERSE_CANISTER_ID.toText());
+      expect(store[2]).toEqual(ckETHUniverseMock);
+      expect(store[3]).toEqual(ckETHSEPOLIAUniverseMock);
     });
   });
 

--- a/frontend/src/tests/lib/derived/universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes.derived.spec.ts
@@ -50,7 +50,7 @@ describe("universes derived stores", () => {
       expect(store[2]).toEqual(ckTESTBTCUniverseMock);
     });
 
-    it("should return Nns, ckBTC, ckTESTBTC, ckETH and SNS projects", () => {
+    it("should return Nns, ckBTC, ckTESTBTC and SNS projects", () => {
       const snsRootCanisterId = rootCanisterIdMock;
       const projectName = "Tetris";
       setSnsProjects([
@@ -60,22 +60,12 @@ describe("universes derived stores", () => {
           projectName,
         },
       ]);
-      icrcCanistersStore.setCanisters({
-        ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
-        indexCanisterId: CKETH_INDEX_CANISTER_ID,
-      });
-      tokensStore.setTokens({
-        [CKETH_LEDGER_CANISTER_ID.toText()]: {
-          certified: true,
-          token: mockCkETHToken,
-        },
-      });
       const store = get(universesStore);
-      expect(store.length).toEqual(5);
-      expect(store[4].summary).not.toBeUndefined();
-      expect(store[4].canisterId).toEqual(snsRootCanisterId.toText());
-      expect(store[4].title).toBe(projectName);
-      expect(store[4].logo).toBe(
+      expect(store.length).toEqual(4);
+      expect(store[3].summary).not.toBeUndefined();
+      expect(store[3].canisterId).toEqual(snsRootCanisterId.toText());
+      expect(store[3].title).toBe(projectName);
+      expect(store[3].logo).toBe(
         aggregatorCanisterLogoPath(snsRootCanisterId.toText())
       );
     });

--- a/frontend/src/tests/lib/derived/universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes.derived.spec.ts
@@ -116,7 +116,7 @@ describe("universes derived stores", () => {
       expect(store[2]).toEqual(ckETHUniverseMock);
     });
 
-    // TODO: Enable when we have the ckETH canister ids in env vars
+    // TODO: GIX-2137 Enable when we have the ckETH canister ids in env vars
     it.skip("should return Nns, ckBTC, ckETH and ckETHSEPOLIA", () => {
       icrcCanistersStore.setCanisters({
         ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,


### PR DESCRIPTION
# Motivation

Add the ICRC Tokens universes to the main `universesStore`.

After this, the token appears in the token selector (if present)

# Changes

* Add `icrcTokensUniversesStore` as part of the `universesStore`.

# Tests

* Test that `universesStore` includes ICRC Tokens when present.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessay.
