### PR TITLE
GIX-2121: Add ICRC Token universe selected store

### DIFF
--- a/frontend/src/lib/derived/selected-universe.derived.ts
+++ b/frontend/src/lib/derived/selected-universe.derived.ts
@@ -9,6 +9,10 @@ import {
   ENABLE_CKBTC,
   ENABLE_CKTESTBTC,
 } from "$lib/stores/feature-flags.store";
+import {
+  icrcCanistersStore,
+  type IcrcCanistersStoreData,
+} from "$lib/stores/icrc-canisters.store";
 import type { Universe, UniverseCanisterId } from "$lib/types/universe";
 import {
   isNonGovernanceTokenPath,
@@ -78,6 +82,23 @@ export const isNnsUniverseStore = derived(
 export const isCkBTCUniverseStore = derived(
   selectedUniverseIdStore,
   ($selectedProjectId: Principal) => isUniverseCkBTC($selectedProjectId)
+);
+
+/**
+ * Is the selected an ICRC Token?
+ */
+export const isIcrcTokenUniverseStore = derived(
+  [pageUniverseIdStore, pageStore, icrcCanistersStore],
+  ([canisterId, page, icrcTokensCanisters]: [
+    Principal,
+    Page,
+    IcrcCanistersStoreData,
+  ]) =>
+    isNonGovernanceTokenPath(page) &&
+    Object.values(icrcTokensCanisters).some(
+      ({ ledgerCanisterId }) =>
+        ledgerCanisterId.toText() === canisterId.toText()
+    )
 );
 
 export const selectedUniverseStore: Readable<Universe> = derived(

--- a/frontend/src/lib/derived/selected-universe.derived.ts
+++ b/frontend/src/lib/derived/selected-universe.derived.ts
@@ -21,6 +21,7 @@ import {
   isUniverseNns,
 } from "$lib/utils/universe.utils";
 import { Principal } from "@dfinity/principal";
+import { nonNullish } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 import { nnsUniverseStore } from "./nns-universe.derived";
 
@@ -85,7 +86,7 @@ export const isCkBTCUniverseStore = derived(
 );
 
 /**
- * Is the selected an ICRC Token?
+ * Is the selected universe an ICRC Token?
  */
 export const isIcrcTokenUniverseStore = derived(
   [pageUniverseIdStore, pageStore, icrcCanistersStore],
@@ -95,10 +96,7 @@ export const isIcrcTokenUniverseStore = derived(
     IcrcCanistersStoreData,
   ]) =>
     isNonGovernanceTokenPath(page) &&
-    Object.values(icrcTokensCanisters).some(
-      ({ ledgerCanisterId }) =>
-        ledgerCanisterId.toText() === canisterId.toText()
-    )
+    nonNullish(icrcTokensCanisters[canisterId.toText()])
 );
 
 export const selectedUniverseStore: Readable<Universe> = derived(


### PR DESCRIPTION
# Motivation

New derived store `isIcrcTokenUniverseStore` to be used when rendering the component for a specific universe.

Similar to `isCkBTCUniverseStore` or `isNnsUniverseStore`, which are used to render NnsAccounts or CkBTCAccounts components in Accounts.svelte

# Changes

* New derived store `isIcrcTokenUniverseStore`.

# Tests

* Test new derived store

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
