### PR TITLE
GIX-2118: Add ckETH logos to universe

### DIFF
--- a/frontend/src/lib/derived/icrc-universes.derived.ts
+++ b/frontend/src/lib/derived/icrc-universes.derived.ts
@@ -1,5 +1,5 @@
-import CKBTC_LOGO from "$lib/assets/ckBTC.svg";
-import CKTESTBTC_LOGO from "$lib/assets/ckTESTBTC.svg";
+import CKETH_LOGO from "$lib/assets/ckETH.svg";
+import CKSEPOLIAETH_LOGO from "$lib/assets/ckSepoliaETH.svg";
 import {
   CKETHSEPOLIA_UNIVERSE_CANISTER_ID,
   CKETH_UNIVERSE_CANISTER_ID,
@@ -23,12 +23,11 @@ const convertIcrcCanistersToUniverse = ({
   const universeId = canisters.ledgerCanisterId.toText();
   const token = tokensData[universeId];
   // TODO: Read logo from token https://dfinity.atlassian.net/browse/GIX-2140
-  // TODO: Add ckETH and ckETHTEST logos
   const logo =
     universeId === CKETH_UNIVERSE_CANISTER_ID.toText()
-      ? CKBTC_LOGO
+      ? CKETH_LOGO
       : universeId === CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText()
-      ? CKTESTBTC_LOGO
+      ? CKSEPOLIAETH_LOGO
       : undefined;
   if (isNullish(token) || isNullish(logo)) {
     return;

--- a/frontend/src/tests/mocks/universe.mock.ts
+++ b/frontend/src/tests/mocks/universe.mock.ts
@@ -1,4 +1,6 @@
 import CKBTC_LOGO from "$lib/assets/ckBTC.svg";
+import CKETH_LOGO from "$lib/assets/ckETH.svg";
+import CKSEPOLIAETH_LOGO from "$lib/assets/ckSepoliaETH.svg";
 import CKTESTBTC_LOGO from "$lib/assets/ckTESTBTC.svg";
 import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
@@ -33,11 +35,11 @@ export const ckTESTBTCUniverseMock: Universe = {
 export const ckETHUniverseMock: Universe = {
   canisterId: CKETH_UNIVERSE_CANISTER_ID.toText(),
   title: "ckETH",
-  logo: CKBTC_LOGO,
+  logo: CKETH_LOGO,
 };
 
 export const ckETHSEPOLIAUniverseMock: Universe = {
   canisterId: CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText(),
   title: "ckETHTEST",
-  logo: CKTESTBTC_LOGO,
+  logo: CKSEPOLIAETH_LOGO,
 };


### PR DESCRIPTION
# Motivation

Use the new ETH logos for ckETH related universes.

# Changes

* Import and use the ckETH logos in the icrc-universes derived store.

# Tests

* Change the mocks to use the new logos. Those are used in test expects.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
