### PR TITLE
Include ckETH canisters in env config

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -37,6 +37,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Experimental tests for schema migration.
 * Add optional version support to the storage records.
+* Include ckETH when generating args.did and .env.
 
 #### Changed
 

--- a/config.sh
+++ b/config.sh
@@ -81,6 +81,14 @@ local_deployment_data="$(
   export CKBTC_MINTER_CANISTER_ID
   test -n "${CKBTC_MINTER_CANISTER_ID:-}" || unset CKBTC_MINTER_CANISTER_ID
 
+  : "Try to find the ckETH canister IDs"
+  CKETH_LEDGER_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id cketh_ledger 2>/dev/null || true)"
+  export CKETH_LEDGER_CANISTER_ID
+  test -n "${CKETH_LEDGER_CANISTER_ID:-}" || unset CKETH_LEDGER_CANISTER_ID
+  CKETH_INDEX_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id cketh_index 2>/dev/null || true)"
+  export CKETH_INDEX_CANISTER_ID
+  test -n "${CKETH_INDEX_CANISTER_ID:-}" || unset CKETH_INDEX_CANISTER_ID
+
   : "Get the governance canister ID - it should be defined"
   GOVERNANCE_CANISTER_ID="$(dfx canister --network "$DFX_NETWORK" id nns-governance)"
   export GOVERNANCE_CANISTER_ID
@@ -128,6 +136,8 @@ local_deployment_data="$(
     CKBTC_LEDGER_CANISTER_ID: env.CKBTC_LEDGER_CANISTER_ID,
     CKBTC_MINTER_CANISTER_ID: env.CKBTC_MINTER_CANISTER_ID,
     CKBTC_INDEX_CANISTER_ID: env.CKBTC_INDEX_CANISTER_ID,
+    CKETH_LEDGER_CANISTER_ID: env.CKETH_LEDGER_CANISTER_ID,
+    CKETH_INDEX_CANISTER_ID: env.CKETH_INDEX_CANISTER_ID,
     CYCLES_MINTING_CANISTER_ID: env.CYCLES_MINTING_CANISTER_ID,
     ROBOTS: env.ROBOTS,
     STATIC_HOST: env.STATIC_HOST,
@@ -171,6 +181,8 @@ aggregatorCanisterUrl=$(echo "$json" | jq -r '.SNS_AGGREGATOR_URL // ""')
 ckbtcLedgerCanisterId=$(echo "$json" | jq -r '.CKBTC_LEDGER_CANISTER_ID // ""')
 ckbtcMinterCanisterId=$(echo "$json" | jq -r '.CKBTC_MINTER_CANISTER_ID // ""')
 ckbtcIndexCanisterId=$(echo "$json" | jq -r '.CKBTC_INDEX_CANISTER_ID // ""')
+ckethLedgerCanisterId=$(echo "$json" | jq -r '.CKETH_LEDGER_CANISTER_ID // ""')
+ckethIndexCanisterId=$(echo "$json" | jq -r '.CKETH_INDEX_CANISTER_ID // ""')
 
 echo "VITE_DFX_NETWORK=$dfxNetwork
 VITE_CYCLES_MINTING_CANISTER_ID=$cmcCanisterId
@@ -186,7 +198,9 @@ VITE_IDENTITY_SERVICE_URL=$identityServiceUrl
 VITE_AGGREGATOR_CANISTER_URL=${aggregatorCanisterUrl:-}
 VITE_CKBTC_LEDGER_CANISTER_ID=${ckbtcLedgerCanisterId:-}
 VITE_CKBTC_MINTER_CANISTER_ID=${ckbtcMinterCanisterId:-}
-VITE_CKBTC_INDEX_CANISTER_ID=${ckbtcIndexCanisterId:-}" | tee "$ENV_FILE"
+VITE_CKBTC_INDEX_CANISTER_ID=${ckbtcIndexCanisterId:-}
+VITE_CKETH_LEDGER_CANISTER_ID=${ckethLedgerCanisterId:-}
+VITE_CKETH_INDEX_CANISTER_ID=${ckethIndexCanisterId:-}" | tee "$ENV_FILE"
 
 echo "$json" >"$JSON_OUT"
 {
@@ -218,6 +232,11 @@ CKBTC_MINTER_CANISTER_ID="${ckbtcMinterCanisterId:-}"
 export CKBTC_MINTER_CANISTER_ID
 CKBTC_INDEX_CANISTER_ID="${ckbtcIndexCanisterId:-}"
 export CKBTC_INDEX_CANISTER_ID
+
+CKETH_LEDGER_CANISTER_ID="${ckethLedgerCanisterId:-}"
+export CKETH_LEDGER_CANISTER_ID
+CKETH_INDEX_CANISTER_ID="${ckethIndexCanisterId:-}"
+export CKETH_INDEX_CANISTER_ID
 
 GOVERNANCE_CANISTER_ID="$governanceCanisterId"
 export GOVERNANCE_CANISTER_ID

--- a/dfx.json
+++ b/dfx.json
@@ -194,8 +194,7 @@
       "wasm": "target/ic/ckbtc_ledger.wasm",
       "type": "custom",
       "remote": {
-        "id": {
-        }
+        "id": {}
       }
     },
     "cketh_index": {
@@ -206,8 +205,7 @@
       "wasm": "target/ic/ckbtc_index.wasm",
       "type": "custom",
       "remote": {
-        "id": {
-        }
+        "id": {}
       }
     },
     "tvl": {

--- a/dfx.json
+++ b/dfx.json
@@ -186,6 +186,30 @@
         }
       }
     },
+    "cketh_ledger": {
+      "build": [
+        "true"
+      ],
+      "candid": "target/ic/cketh_ledger.did",
+      "wasm": "target/ic/ckbtc_ledger.wasm",
+      "type": "custom",
+      "remote": {
+        "id": {
+        }
+      }
+    },
+    "cketh_index": {
+      "build": [
+        "true"
+      ],
+      "candid": "target/ic/ckbtc_index.did",
+      "wasm": "target/ic/ckbtc_index.wasm",
+      "type": "custom",
+      "remote": {
+        "id": {
+        }
+      }
+    },
     "tvl": {
       "build": [
         "true"

--- a/scripts/nns-dapp/test-config-assets/app/env
+++ b/scripts/nns-dapp/test-config-assets/app/env
@@ -13,3 +13,5 @@ VITE_AGGREGATOR_CANISTER_URL=https://otgyv-wyaaa-aaaak-qcgba-cai.icp0.io
 VITE_CKBTC_LEDGER_CANISTER_ID=mxzaz-hqaaa-aaaar-qaada-cai
 VITE_CKBTC_MINTER_CANISTER_ID=mqygn-kiaaa-aaaar-qaadq-cai
 VITE_CKBTC_INDEX_CANISTER_ID=n5wcd-faaaa-aaaar-qaaea-cai
+VITE_CKETH_LEDGER_CANISTER_ID=
+VITE_CKETH_INDEX_CANISTER_ID=

--- a/scripts/nns-dapp/test-config-assets/mainnet/env
+++ b/scripts/nns-dapp/test-config-assets/mainnet/env
@@ -13,3 +13,5 @@ VITE_AGGREGATOR_CANISTER_URL=https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io
 VITE_CKBTC_LEDGER_CANISTER_ID=mxzaz-hqaaa-aaaar-qaada-cai
 VITE_CKBTC_MINTER_CANISTER_ID=mqygn-kiaaa-aaaar-qaadq-cai
 VITE_CKBTC_INDEX_CANISTER_ID=n5wcd-faaaa-aaaar-qaaea-cai
+VITE_CKETH_LEDGER_CANISTER_ID=
+VITE_CKETH_INDEX_CANISTER_ID=


### PR DESCRIPTION
# Motivation

The NNS dapp needs to be aware of the ckETH ledger and index canister IDs.

# Changes

1. Include entries for `cketh_ledger` and `cketh_index` in `dfx.json`. The don't have mainnet IDs yet.
2. Update `./config.sh` to include entries for ckETH similar as for ckBTC but without minter.

# Tests

Ran `scripts/nns-dapp/test-config --update` to update golden files.

# Todos

- [x] Add entry to changelog (if necessary).
