### PR TITLE
GIX-2121: Setup IcrcTokenAccounts

### DIFF
--- a/frontend/src/lib/pages/IcrcTokenAccounts.svelte
+++ b/frontend/src/lib/pages/IcrcTokenAccounts.svelte
@@ -1,0 +1,4 @@
+<script lang="ts">
+</script>
+
+<div class="card-grid" data-tid="icrc-token-accounts-component">TBD</div>

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -4,6 +4,7 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import {
     isCkBTCUniverseStore,
+    isIcrcTokenUniverseStore,
     isNnsUniverseStore,
     selectedUniverseIdStore,
   } from "$lib/derived/selected-universe.derived";
@@ -33,6 +34,7 @@
   import { loadIcrcAccounts } from "$lib/services/icrc-accounts.services";
   import { onMount } from "svelte";
   import { loadCkETHCanisters } from "$lib/services/cketh-canisters.services";
+  import IcrcTokenAccounts from "$lib/pages/IcrcTokenAccounts.svelte";
 
   // TODO: This component is mounted twice. Understand why and fix it.
 
@@ -108,6 +110,8 @@
       <NnsAccounts userTokensData={$icpTokensListUser} />
     {:else if $isCkBTCUniverseStore}
       <CkBTCAccounts />
+    {:else if $isIcrcTokenUniverseStore}
+      <IcrcTokenAccounts />
     {:else if nonNullish($snsProjectSelectedStore)}
       <SnsAccounts />
     {/if}

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -126,6 +126,13 @@ vi.mock("$lib/services/worker-balances.services", () => ({
 
 describe("Accounts", () => {
   const balanceIcrcToken = 314000000n;
+
+  const renderComponent = () => {
+    const { container } = render(Accounts);
+
+    return AccountsPo.under(new JestPageObjectElement(container));
+  };
+
   beforeAll(() => {
     vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
   });
@@ -370,6 +377,19 @@ describe("Accounts", () => {
     expect(icrcLedgerApi.queryIcrcBalance).toHaveBeenCalledTimes(1);
   });
 
+  it("should render IcrcTokenAccounts component with ckETH enabled and universe ckETH", async () => {
+    overrideFeatureFlagsStore.setFlag("ENABLE_CKETH", true);
+
+    page.mock({
+      data: { universe: CKETH_UNIVERSE_CANISTER_ID.toText() },
+      routeId: AppPath.Accounts,
+    });
+
+    const po = renderComponent();
+
+    expect(await po.getIcrcTokenAccountsPo().isPresent()).toBe(true);
+  });
+
   it("should render sns project name", () => {
     page.mock({
       data: { universe: mockSnsFullProject.rootCanisterId.toText() },
@@ -439,12 +459,6 @@ describe("Accounts", () => {
   });
 
   describe("when NNS universe", () => {
-    const renderComponent = () => {
-      const { container } = render(Accounts);
-
-      return AccountsPo.under(new JestPageObjectElement(container));
-    };
-
     beforeEach(() => {
       page.mock({
         data: { universe: OWN_CANISTER_ID_TEXT },

--- a/frontend/src/tests/page-objects/Accounts.page-object.ts
+++ b/frontend/src/tests/page-objects/Accounts.page-object.ts
@@ -5,6 +5,7 @@ import { SnsAccountsPo } from "$tests/page-objects/SnsAccounts.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { BuyICPModalPo } from "./BuyICPModal.page-object";
+import { IcrcTokenAccountsPo } from "./IcrcTokenAccounts.page-object";
 
 export class AccountsPo extends BasePageObject {
   private static readonly TID = "accounts-component";
@@ -19,6 +20,10 @@ export class AccountsPo extends BasePageObject {
 
   getCkBTCAccountsPo(): CkBTCAccountsPo {
     return CkBTCAccountsPo.under(this.root);
+  }
+
+  getIcrcTokenAccountsPo(): IcrcTokenAccountsPo {
+    return IcrcTokenAccountsPo.under(this.root);
   }
 
   getSnsAccountsPo(): SnsAccountsPo {

--- a/frontend/src/tests/page-objects/IcrcTokenAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/IcrcTokenAccounts.page-object.ts
@@ -1,0 +1,10 @@
+import { BaseAccountsPo } from "$tests/page-objects/BaseAccounts.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class IcrcTokenAccountsPo extends BaseAccountsPo {
+  private static readonly TID = "icrc-token-accounts-component";
+
+  static under(element: PageObjectElement): IcrcTokenAccountsPo {
+    return new IcrcTokenAccountsPo(element.byTestId(IcrcTokenAccountsPo.TID));
+  }
+}


### PR DESCRIPTION
# Motivation

Render a specific Accounts page when the selected universe is an ICRC Token.

# Changes

* Setup empty IcrcTokenAccounts.svelte
* In Accounts.svelte, render IcrcTokenAccounts for ICRC Token universes.

# Tests

* Add new PO IcrcTokenAccountsPo.
* Add method to get the new accounts page in AccountsPo
* Test in Accounts.spec to check that the new component is rendered.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessay.
