### PR TITLE
Refactor ckbtc index / transactions -> wallet

### DIFF
--- a/frontend/src/lib/api/icrc-index.api.ts
+++ b/frontend/src/lib/api/icrc-index.api.ts
@@ -23,6 +23,9 @@ export interface GetTransactionsResponse
   oldestTxId?: bigint;
 }
 
+/**
+ * @deprecated to be replaced with similar function from wallet-index.api
+ */
 export const getTransactions = async ({
   maxResults: max_results,
   start,

--- a/frontend/src/lib/api/wallet-index.api.ts
+++ b/frontend/src/lib/api/wallet-index.api.ts
@@ -10,18 +10,21 @@ import type { Agent, Identity } from "@dfinity/agent";
 import { IcrcIndexCanister } from "@dfinity/ledger-icrc";
 import type { Principal } from "@dfinity/principal";
 
-export const getCkBTCTransactions = async ({
+/**
+ * TODO: move to icrc-index once Sns migrated to icrcStore
+ */
+export const getTransactions = async ({
   identity,
   indexCanisterId: canisterId,
   ...rest
 }: Omit<GetTransactionsParams, "getTransactions" | "canisterId"> & {
   indexCanisterId: Principal;
 }): Promise<GetTransactionsResponse> => {
-  logWithTimestamp("Getting ckBTC accounts transactions: call...");
+  logWithTimestamp("Getting wallet transactions: call...");
 
   const {
     canister: { getTransactions },
-  } = await ckBTCIndexCanister({ identity, canisterId });
+  } = await indexCanister({ identity, canisterId });
 
   const results = await getIcrcTransactions({
     identity,
@@ -29,12 +32,12 @@ export const getCkBTCTransactions = async ({
     getTransactions,
   });
 
-  logWithTimestamp("Getting ckBTC account transactions: done");
+  logWithTimestamp("Getting wallet transactions: done");
 
   return results;
 };
 
-const ckBTCIndexCanister = async ({
+const indexCanister = async ({
   identity,
   canisterId,
 }: {

--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -5,9 +5,9 @@
   import type { Account } from "$lib/types/account";
   import type { UiTransaction } from "$lib/types/transaction";
   import {
-    loadCkBTCAccountNextTransactions,
-    loadCkBTCAccountTransactions,
-  } from "$lib/services/ckbtc-transactions.services";
+    loadWalletNextTransactions,
+    loadWalletTransactions,
+  } from "$lib/services/wallet-transactions.services";
   import type { IcrcTransactionData } from "$lib/types/transaction";
   import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
   import { i18n } from "$lib/stores/i18n";
@@ -22,7 +22,7 @@
   import { onMount } from "svelte";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import IcrcWalletTransactionsObserver from "$lib/components/accounts/IcrcWalletTransactionsObserver.svelte";
-  import { CKBTC_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/ckbtc.constants";
+  import { WALLET_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/wallet.constants";
   import { waitForMilliseconds } from "$lib/utils/utils";
   import { nonNullish } from "@dfinity/utils";
 
@@ -36,7 +36,7 @@
 
   const loadNextTransactions = async () => {
     loading = true;
-    await loadCkBTCAccountNextTransactions({
+    await loadWalletNextTransactions({
       account,
       canisterId: universeId,
       indexCanisterId,
@@ -61,9 +61,9 @@
     });
 
     // We optimistically try to fetch the new transaction the user just transferred by delaying the reload of the transactions.
-    await waitForMilliseconds(CKBTC_TRANSACTIONS_RELOAD_DELAY);
+    await waitForMilliseconds(WALLET_TRANSACTIONS_RELOAD_DELAY);
 
-    await loadCkBTCAccountTransactions({
+    await loadWalletTransactions({
       account,
       canisterId: universeId,
       indexCanisterId,

--- a/frontend/src/lib/constants/wallet.constants.ts
+++ b/frontend/src/lib/constants/wallet.constants.ts
@@ -1,4 +1,4 @@
 // On mainnet, the ckBTC Index canister polls new transactions event two seconds.
 // By delaying such an action as reloading the transactions, we can optimistically try to fetch the last transaction(s).
 // Useful for example when a user send ckBTC to ckBTC.
-export const CKBTC_TRANSACTIONS_RELOAD_DELAY = 4000;
+export const WALLET_TRANSACTIONS_RELOAD_DELAY = 4000;

--- a/frontend/src/lib/services/ckbtc-convert.services.ts
+++ b/frontend/src/lib/services/ckbtc-convert.services.ts
@@ -39,8 +39,8 @@ import {
   ckBTCTransferTokens,
   loadCkBTCAccounts,
 } from "./ckbtc-accounts.services";
-import { loadCkBTCAccountTransactions } from "./ckbtc-transactions.services";
 import type { IcrcTransferTokensUserParams } from "./icrc-accounts.services";
+import { loadWalletTransactions } from "./wallet-transactions.services";
 
 export type ConvertCkBTCToBtcParams = Omit<
   IcrcTransferTokensUserParams,
@@ -302,7 +302,7 @@ const reload = async ({
     ...(loadAccounts ? [loadCkBTCAccounts({ universeId })] : []),
     ...(nonNullish(source)
       ? [
-          loadCkBTCAccountTransactions({
+          loadWalletTransactions({
             account: source,
             canisterId: universeId,
             indexCanisterId,

--- a/frontend/src/lib/services/ckbtc-minter.services.ts
+++ b/frontend/src/lib/services/ckbtc-minter.services.ts
@@ -3,7 +3,7 @@ import {
   getBTCAddress as getBTCAddressAPI,
   updateBalance as updateBalanceAPI,
 } from "$lib/api/ckbtc-minter.api";
-import { CKBTC_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/ckbtc.constants";
+import { WALLET_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/wallet.constants";
 import { getAuthenticatedIdentity } from "$lib/services/auth.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import { bitcoinAddressStore } from "$lib/stores/bitcoin.store";
@@ -122,7 +122,7 @@ export const updateBalance = async ({
 
     // Workaround. Ultimately we want to poll to update balance and list of transactions
     await waitForMilliseconds(
-      deferReload ? CKBTC_TRANSACTIONS_RELOAD_DELAY : 0
+      deferReload ? WALLET_TRANSACTIONS_RELOAD_DELAY : 0
     );
 
     uiIndicators &&

--- a/frontend/src/lib/services/wallet-transactions.services.ts
+++ b/frontend/src/lib/services/wallet-transactions.services.ts
@@ -1,8 +1,8 @@
-import { getCkBTCTransactions } from "$lib/api/ckbtc-index.api";
 import type {
   GetTransactionsParams,
   GetTransactionsResponse,
 } from "$lib/api/icrc-index.api";
+import { getTransactions as getWalletTransactions } from "$lib/api/wallet-index.api";
 import {
   loadIcrcAccountNextTransactions,
   loadIcrcAccountTransactions,
@@ -11,7 +11,7 @@ import {
 } from "$lib/services/icrc-transactions.services";
 import type { CkBTCAdditionalCanisters } from "$lib/types/ckbtc-canisters";
 
-export const loadCkBTCAccountTransactions = async ({
+export const loadWalletTransactions = async ({
   indexCanisterId,
   ...params
 }: Pick<LoadIcrcAccountTransactionsParams, "account" | "start" | "canisterId"> &
@@ -21,10 +21,10 @@ export const loadCkBTCAccountTransactions = async ({
     getTransactions: (
       params: Omit<GetTransactionsParams, "getTransactions" | "canisterId">
     ): Promise<GetTransactionsResponse> =>
-      getCkBTCTransactions({ ...params, indexCanisterId }),
+      getWalletTransactions({ ...params, indexCanisterId }),
   });
 
-export const loadCkBTCAccountNextTransactions = async ({
+export const loadWalletNextTransactions = async ({
   indexCanisterId,
   ...params
 }: Pick<LoadIcrcAccountNextTransactions, "account" | "canisterId"> &
@@ -34,7 +34,7 @@ export const loadCkBTCAccountNextTransactions = async ({
     loadAccountTransactions: (
       params: Omit<LoadIcrcAccountTransactionsParams, "getTransactions">
     ) =>
-      loadCkBTCAccountTransactions({
+      loadWalletTransactions({
         ...params,
         indexCanisterId,
       }),

--- a/frontend/src/tests/lib/api/wallet-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/wallet-index.api.spec.ts
@@ -1,12 +1,12 @@
 import * as agent from "$lib/api/agent.api";
-import { getCkBTCTransactions } from "$lib/api/ckbtc-index.api";
+import { getTransactions } from "$lib/api/wallet-index.api";
 import { CKBTC_INDEX_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
 import type { HttpAgent } from "@dfinity/agent";
 import { IcrcIndexCanister, type IcrcTransaction } from "@dfinity/ledger-icrc";
 import { mock } from "vitest-mock-extended";
 
-describe("ckbtc-index api", () => {
+describe("wallet-index api", () => {
   const indexCanisterMock = mock<IcrcIndexCanister>();
 
   beforeAll(() => {
@@ -36,7 +36,7 @@ describe("ckbtc-index api", () => {
     burn: [],
   } as unknown as IcrcTransaction;
 
-  describe("getCkBTCTransactions", () => {
+  describe("getTransactions", () => {
     it("should returns transactions", async () => {
       const id = BigInt(1);
 
@@ -46,7 +46,7 @@ describe("ckbtc-index api", () => {
           oldest_tx_id: [],
         });
 
-      const results = await getCkBTCTransactions(params);
+      const results = await getTransactions(params);
 
       expect(results.transactions.length).toBeGreaterThan(0);
 
@@ -63,7 +63,7 @@ describe("ckbtc-index api", () => {
         throw new Error();
       });
 
-      const call = () => getCkBTCTransactions(params);
+      const call = () => getTransactions(params);
 
       expect(call).rejects.toThrowError();
     });

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -23,7 +23,7 @@ import {
 import { Cbor } from "@dfinity/agent";
 import { render } from "@testing-library/svelte";
 
-vi.mock("$lib/services/ckbtc-transactions.services", () => {
+vi.mock("$lib/services/wallet-transactions.services", () => {
   return {
     loadCkBTCAccountNextTransactions: vi.fn().mockResolvedValue(undefined),
     loadCkBTCAccountTransactions: vi.fn().mockResolvedValue(undefined),

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -25,8 +25,8 @@ import { render } from "@testing-library/svelte";
 
 vi.mock("$lib/services/wallet-transactions.services", () => {
   return {
-    loadCkBTCAccountNextTransactions: vi.fn().mockResolvedValue(undefined),
-    loadCkBTCAccountTransactions: vi.fn().mockResolvedValue(undefined),
+    loadWalletNextTransactions: vi.fn().mockResolvedValue(undefined),
+    loadWalletTransactions: vi.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -1,6 +1,6 @@
 import CkBTCTransactionsList from "$lib/components/accounts/CkBTCTransactionsList.svelte";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
-import * as services from "$lib/services/ckbtc-transactions.services";
+import * as services from "$lib/services/wallet-transactions.services";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { mockCkBTCAdditionalCanisters } from "$tests/mocks/canisters.mock";
 import {
@@ -69,7 +69,7 @@ describe("CkBTCTransactionList", () => {
   });
 
   it("should call service to load transactions", () => {
-    const spy = vi.spyOn(services, "loadCkBTCAccountNextTransactions");
+    const spy = vi.spyOn(services, "loadWalletNextTransactions");
 
     renderComponent();
 
@@ -77,8 +77,8 @@ describe("CkBTCTransactionList", () => {
   });
 
   it("should call service to load transactions on imperative function call", async () => {
-    const spy = vi.spyOn(services, "loadCkBTCAccountNextTransactions");
-    const spyReload = vi.spyOn(services, "loadCkBTCAccountTransactions");
+    const spy = vi.spyOn(services, "loadWalletNextTransactions");
+    const spyReload = vi.spyOn(services, "loadWalletTransactions");
 
     let resolveLoadNext;
     spy.mockImplementation(

--- a/frontend/src/tests/lib/components/accounts/CkBTCWalletActions.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWalletActions.spec.ts
@@ -4,8 +4,8 @@ import {
   CKTESTBTC_MINTER_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
-import { CKBTC_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/ckbtc.constants";
 import { AppPath } from "$lib/constants/routes.constants";
+import { WALLET_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/wallet.constants";
 import { page } from "$mocks/$app/stores";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
@@ -59,7 +59,7 @@ describe("CkBTCWalletActions", () => {
     await fireEvent.click(button as HTMLButtonElement);
 
     // wait for 4 seconds
-    await advanceTime(CKBTC_TRANSACTIONS_RELOAD_DELAY);
+    await advanceTime(WALLET_TRANSACTIONS_RELOAD_DELAY);
 
     await waitFor(() => expect(spyUpdateBalance).toHaveBeenCalledTimes(1));
   });
@@ -81,7 +81,7 @@ describe("CkBTCWalletActions", () => {
     await fireEvent.click(button as HTMLButtonElement);
 
     // wait for 4 seconds
-    await advanceTime(CKBTC_TRANSACTIONS_RELOAD_DELAY);
+    await advanceTime(WALLET_TRANSACTIONS_RELOAD_DELAY);
 
     await waitFor(() => expect(spyReload).toHaveBeenCalled());
   });

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -6,8 +6,8 @@ import {
   CKTESTBTC_MINTER_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
-import { CKBTC_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/ckbtc.constants";
 import { AppPath } from "$lib/constants/routes.constants";
+import { WALLET_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/wallet.constants";
 import CkBTCWallet from "$lib/pages/CkBTCWallet.svelte";
 import * as services from "$lib/services/ckbtc-accounts.services";
 import { bitcoinAddressStore } from "$lib/stores/bitcoin.store";
@@ -301,7 +301,7 @@ describe("CkBTCWallet", () => {
       await runResolvedPromises();
       expect(icrcLedgerApi.icrcTransfer).toBeCalledTimes(1);
 
-      await advanceTime(CKBTC_TRANSACTIONS_RELOAD_DELAY + 1000);
+      await advanceTime(WALLET_TRANSACTIONS_RELOAD_DELAY + 1000);
 
       expect(icrcIndexApi.getTransactions).toBeCalledTimes(2);
     });
@@ -361,7 +361,7 @@ describe("CkBTCWallet", () => {
 
         expect(icrcIndexApi.getTransactions).toBeCalledTimes(2);
 
-        await advanceTime(CKBTC_TRANSACTIONS_RELOAD_DELAY + 1000);
+        await advanceTime(WALLET_TRANSACTIONS_RELOAD_DELAY + 1000);
 
         // This additional loading of transactions is not necessary.
         // TODO: Remove the double reloading and change the expected number of
@@ -425,7 +425,7 @@ describe("CkBTCWallet", () => {
 
         expect(icrcIndexApi.getTransactions).toBeCalledTimes(2);
 
-        await advanceTime(CKBTC_TRANSACTIONS_RELOAD_DELAY + 1000);
+        await advanceTime(WALLET_TRANSACTIONS_RELOAD_DELAY + 1000);
 
         // This additional loading of transactions is not necessary.
         // TODO: Remove the double reloading and change the expected number of

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -24,7 +24,7 @@ vi.mock("$lib/services/ckbtc-accounts.services", () => {
   };
 });
 
-vi.mock("$lib/services/ckbtc-transactions.services", () => {
+vi.mock("$lib/services/wallet-transactions.services", () => {
   return {
     loadCkBTCAccountNextTransactions: vi.fn().mockResolvedValue(undefined),
     loadCkBTCAccountTransactions: vi.fn().mockResolvedValue(undefined),

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -26,8 +26,8 @@ vi.mock("$lib/services/ckbtc-accounts.services", () => {
 
 vi.mock("$lib/services/wallet-transactions.services", () => {
   return {
-    loadCkBTCAccountNextTransactions: vi.fn().mockResolvedValue(undefined),
-    loadCkBTCAccountTransactions: vi.fn().mockResolvedValue(undefined),
+    loadWalletNextTransactions: vi.fn().mockResolvedValue(undefined),
+    loadWalletTransactions: vi.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/frontend/src/tests/lib/services/ckbtc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts.services.spec.ts
@@ -21,7 +21,7 @@ import { mockTokens } from "$tests/mocks/tokens.mock";
 import { tick } from "svelte";
 import { get } from "svelte/store";
 
-vi.mock("$lib/services/ckbtc-transactions.services", () => {
+vi.mock("$lib/services/wallet-transactions.services", () => {
   return {
     loadCkBTCAccountTransactions: vi.fn().mockResolvedValue(undefined),
   };

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -9,8 +9,8 @@ import {
   convertCkBTCToBtcIcrc2,
   retrieveBtc,
 } from "$lib/services/ckbtc-convert.services";
-import { loadCkBTCAccountTransactions } from "$lib/services/ckbtc-transactions.services";
 import { loadCkBTCWithdrawalAccount } from "$lib/services/ckbtc-withdrawal-accounts.services";
+import { loadWalletTransactions } from "$lib/services/wallet-transactions.services";
 import { bitcoinConvertBlockIndexes } from "$lib/stores/bitcoin.store";
 import { ckBTCWithdrawalAccountsStore } from "$lib/stores/ckbtc-withdrawal-accounts.store";
 import * as toastsStore from "$lib/stores/toasts.store";
@@ -221,14 +221,14 @@ describe("ckbtc-convert-services", () => {
           it("should load transactions and withdrawal account", async () => {
             const updateProgressSpy = vi.fn();
             expect(loadCkBTCAccountsSpy).toBeCalledTimes(0);
-            expect(loadCkBTCAccountTransactions).toBeCalledTimes(0);
+            expect(loadWalletTransactions).toBeCalledTimes(0);
             expect(loadCkBTCWithdrawalAccount).toBeCalledTimes(0);
 
             await convert(updateProgressSpy);
 
             // We only test that the call is made here. Test should be covered by its respective service.
             expect(loadCkBTCAccountsSpy).not.toBeCalled();
-            expect(loadCkBTCAccountTransactions).toBeCalledTimes(1);
+            expect(loadWalletTransactions).toBeCalledTimes(1);
             expect(loadCkBTCWithdrawalAccount).toBeCalledTimes(1);
 
             expectAllStepsPerformed(updateProgressSpy);
@@ -421,7 +421,7 @@ describe("ckbtc-convert-services", () => {
       });
 
       // We only test that the call is made here. Test should be covered by its respective service.
-      expect(loadCkBTCAccountTransactions).not.toBeCalled();
+      expect(loadWalletTransactions).not.toBeCalled();
       expect(loadCkBTCWithdrawalAccount).toBeCalled();
 
       expectStepsPerformed({
@@ -476,7 +476,7 @@ describe("ckbtc-convert-services", () => {
         updateProgress: vi.fn(),
       });
 
-      expect(loadCkBTCAccountTransactions).not.toBeCalled();
+      expect(loadWalletTransactions).not.toBeCalled();
     });
 
     it("should reload withdrawal account on retrieve btc error too", async () => {
@@ -502,7 +502,7 @@ describe("ckbtc-convert-services", () => {
         updateProgress: vi.fn(),
       });
 
-      expect(loadCkBTCAccountTransactions).not.toBeCalled();
+      expect(loadWalletTransactions).not.toBeCalled();
     });
   });
 
@@ -573,7 +573,7 @@ describe("ckbtc-convert-services", () => {
       expect(approveTransferSpy).toBeCalledTimes(1);
       expect(retrieveBtcSpy).toBeCalledTimes(0);
       expect(loadCkBTCWithdrawalAccount).toBeCalledTimes(0);
-      expect(loadCkBTCAccountTransactions).toBeCalledTimes(0);
+      expect(loadWalletTransactions).toBeCalledTimes(0);
       expect(loadCkBTCAccountsSpy).toBeCalledTimes(0);
     });
 
@@ -605,7 +605,7 @@ describe("ckbtc-convert-services", () => {
       expect(approveTransferSpy).toBeCalledTimes(1);
       expect(retrieveBtcSpy).toBeCalledTimes(1);
       expect(loadCkBTCWithdrawalAccount).toBeCalledTimes(0);
-      expect(loadCkBTCAccountTransactions).toBeCalledTimes(0);
+      expect(loadWalletTransactions).toBeCalledTimes(0);
       expect(loadCkBTCAccountsSpy).toBeCalledTimes(0);
     });
 
@@ -637,7 +637,7 @@ describe("ckbtc-convert-services", () => {
         universeId: params.universeId,
       });
 
-      expect(loadCkBTCAccountTransactions).toBeCalledWith({
+      expect(loadWalletTransactions).toBeCalledWith({
         account: params.source,
         canisterId: params.universeId,
         indexCanisterId: mockCkBTCAdditionalCanisters.indexCanisterId,
@@ -650,7 +650,7 @@ describe("ckbtc-convert-services", () => {
       expect(approveTransferSpy).toBeCalledTimes(1);
       expect(retrieveBtcSpy).toBeCalledTimes(1);
       expect(loadCkBTCWithdrawalAccount).toBeCalledTimes(1);
-      expect(loadCkBTCAccountTransactions).toBeCalledTimes(1);
+      expect(loadWalletTransactions).toBeCalledTimes(1);
       expect(loadCkBTCAccountsSpy).toBeCalledTimes(1);
     });
 
@@ -683,7 +683,7 @@ describe("ckbtc-convert-services", () => {
       expect(approveTransferSpy).toBeCalledTimes(1);
       expect(retrieveBtcSpy).toBeCalledTimes(1);
       expect(loadCkBTCWithdrawalAccount).toBeCalledTimes(1);
-      expect(loadCkBTCAccountTransactions).toBeCalledTimes(1);
+      expect(loadWalletTransactions).toBeCalledTimes(1);
       expect(loadCkBTCAccountsSpy).toBeCalledTimes(1);
 
       expect(await convertPromise).toEqual({ success: true });
@@ -718,7 +718,7 @@ describe("ckbtc-convert-services", () => {
       expect(approveTransferSpy).toBeCalledTimes(1);
       expect(retrieveBtcSpy).toBeCalledTimes(1);
       expect(loadCkBTCWithdrawalAccount).toBeCalledTimes(1);
-      expect(loadCkBTCAccountTransactions).toBeCalledTimes(1);
+      expect(loadWalletTransactions).toBeCalledTimes(1);
 
       expect(await convertPromise).toEqual({ success: false });
       expect(spyOnToastsError).toBeCalledTimes(1);

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -47,7 +47,7 @@ import {
 import type { Mock } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-vi.mock("$lib/services/ckbtc-transactions.services");
+vi.mock("$lib/services/wallet-transactions.services");
 vi.mock("$lib/services/ckbtc-withdrawal-accounts.services");
 
 describe("ckbtc-convert-services", () => {

--- a/frontend/src/tests/lib/services/wallet-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-transactions.services.spec.ts
@@ -1,10 +1,10 @@
-import * as indexApi from "$lib/api/ckbtc-index.api";
+import * as indexApi from "$lib/api/wallet-index.api";
 import {
   CKBTC_INDEX_CANISTER_ID,
   CKBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
-import * as services from "$lib/services/ckbtc-transactions.services";
+import * as services from "$lib/services/wallet-transactions.services";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
@@ -12,7 +12,7 @@ import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
-describe("ckbtc-transactions-services", () => {
+describe("wallet-transactions-services", () => {
   beforeEach(() => {
     resetIdentity();
     icrcTransactionsStore.reset();
@@ -22,17 +22,17 @@ describe("ckbtc-transactions-services", () => {
     vi.clearAllMocks();
   });
 
-  describe("loadCkBTCAccountTransactions", () => {
+  describe("loadWalletTransactions", () => {
     it("loads transactions in the store", async () => {
       const spyGetTransactions = vi
-        .spyOn(indexApi, "getCkBTCTransactions")
+        .spyOn(indexApi, "getTransactions")
         .mockResolvedValue({
           oldestTxId: BigInt(1234),
           transactions: [mockIcrcTransactionWithId],
         });
       const start = BigInt(1234);
 
-      await services.loadCkBTCAccountTransactions({
+      await services.loadWalletTransactions({
         account: mockCkBTCMainAccount,
         start,
         indexCanisterId: CKBTC_INDEX_CANISTER_ID,
@@ -63,16 +63,16 @@ describe("ckbtc-transactions-services", () => {
     });
   });
 
-  describe("loadCkBTCAccountNextTransactions", () => {
+  describe("loadWalletNextTransactions", () => {
     it("loads transactions in the store", async () => {
       const spyGetTransactions = vi
-        .spyOn(indexApi, "getCkBTCTransactions")
+        .spyOn(indexApi, "getTransactions")
         .mockResolvedValue({
           oldestTxId: BigInt(1234),
           transactions: [mockIcrcTransactionWithId],
         });
 
-      await services.loadCkBTCAccountNextTransactions({
+      await services.loadWalletNextTransactions({
         account: mockCkBTCMainAccount,
         indexCanisterId: CKBTC_INDEX_CANISTER_ID,
         canisterId: CKBTC_UNIVERSE_CANISTER_ID,
@@ -102,7 +102,7 @@ describe("ckbtc-transactions-services", () => {
 
     it("uses store oldest transaction to set the start", async () => {
       const spyGetTransactions = vi
-        .spyOn(indexApi, "getCkBTCTransactions")
+        .spyOn(indexApi, "getTransactions")
         .mockResolvedValue({
           oldestTxId: BigInt(1234),
           transactions: [mockIcrcTransactionWithId],
@@ -118,7 +118,7 @@ describe("ckbtc-transactions-services", () => {
         completed: false,
       });
 
-      await services.loadCkBTCAccountNextTransactions({
+      await services.loadWalletNextTransactions({
         account: mockCkBTCMainAccount,
         indexCanisterId: CKBTC_INDEX_CANISTER_ID,
         canisterId: CKBTC_UNIVERSE_CANISTER_ID,


### PR DESCRIPTION
# Changes

- rename `ckbtc-index.api` -> `wallet-index.api` + add TODO to ultimately migrate the function to `icrc-index.api`
- rename `ckbtc-transactions.services` -> `wallet-transactions.services`
- rename ckbtc constant to wallet
