### PR TITLE
Chore: Add ckETHSEPOLIA index canister id

### DIFF
--- a/frontend/src/lib/constants/cketh-canister-ids.constants.ts
+++ b/frontend/src/lib/constants/cketh-canister-ids.constants.ts
@@ -4,7 +4,6 @@ import { Principal } from "@dfinity/principal";
 const MAINNET_CKETH_LEDGER_CANISTER_ID = "apia6-jaaaa-aaaar-qabma-cai";
 const MAINNET_CKETH_INDEX_CANISTER_ID = "sh5u2-cqaaa-aaaar-qacna-cai";
 
-// TODO: Add ckETHTEST canister IDs on env vars https://dfinity.atlassian.net/browse/GIX-2137
 export const CKETHSEPOLIA_LEDGER_CANISTER_ID = Principal.fromText(
   "apia6-jaaaa-aaaar-qabma-cai"
 );

--- a/frontend/src/lib/constants/cketh-canister-ids.constants.ts
+++ b/frontend/src/lib/constants/cketh-canister-ids.constants.ts
@@ -2,7 +2,6 @@ import { Principal } from "@dfinity/principal";
 
 // TODO: Fallback to ckETH canister IDs on mainnet. These are Sepolia canister IDs.
 const MAINNET_CKETH_LEDGER_CANISTER_ID = "apia6-jaaaa-aaaar-qabma-cai";
-// TODO: Change to Sepolia index canister
 const MAINNET_CKETH_INDEX_CANISTER_ID = "sh5u2-cqaaa-aaaar-qacna-cai";
 
 // TODO: Add ckETHTEST canister IDs on env vars https://dfinity.atlassian.net/browse/GIX-2137

--- a/frontend/src/lib/constants/cketh-canister-ids.constants.ts
+++ b/frontend/src/lib/constants/cketh-canister-ids.constants.ts
@@ -3,7 +3,7 @@ import { Principal } from "@dfinity/principal";
 // TODO: Fallback to ckETH canister IDs on mainnet. These are Sepolia canister IDs.
 const MAINNET_CKETH_LEDGER_CANISTER_ID = "apia6-jaaaa-aaaar-qabma-cai";
 // TODO: Change to Sepolia index canister
-const MAINNET_CKETH_INDEX_CANISTER_ID = "apia6-jaaaa-aaaar-qabma-cai";
+const MAINNET_CKETH_INDEX_CANISTER_ID = "sh5u2-cqaaa-aaaar-qacna-cai";
 
 // TODO: Add ckETHTEST canister IDs on env vars https://dfinity.atlassian.net/browse/GIX-2137
 export const CKETHSEPOLIA_LEDGER_CANISTER_ID = Principal.fromText(
@@ -11,7 +11,7 @@ export const CKETHSEPOLIA_LEDGER_CANISTER_ID = Principal.fromText(
 );
 
 export const CKETHSEPOLIA_INDEX_CANISTER_ID = Principal.fromText(
-  "apia6-jaaaa-aaaar-qabma-cai"
+  "sh5u2-cqaaa-aaaar-qacna-cai"
 );
 
 // TODO: Add ckETH canister IDs on env vars https://dfinity.atlassian.net/browse/GIX-2137


### PR DESCRIPTION
# Motivation

ckETHSEPOLIA Index is already present in mainnet.

In this PR, I add the mainnet canister id for that canister.

# Changes

* Changes in `cketh-canister-ids.constants`.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
