### PR TITLE
GIX-2121: Render accounts in IcrcTokenAccounts

### DIFF
--- a/frontend/src/lib/pages/IcrcTokenAccounts.svelte
+++ b/frontend/src/lib/pages/IcrcTokenAccounts.svelte
@@ -1,4 +1,39 @@
 <script lang="ts">
+  import AccountCard from "$lib/components/accounts/AccountCard.svelte";
+  import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
+  import { selectedIcrcTokenUniverseIdStore } from "$lib/derived/selected-universe.derived";
+  import { i18n } from "$lib/stores/i18n";
+  import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
+  import { tokensStore } from "$lib/stores/tokens.store";
+  import type { Account } from "$lib/types/account";
+  import type { IcrcTokenMetadata } from "$lib/types/icrc";
+  import { isNullish, nonNullish } from "@dfinity/utils";
+
+  let loading: boolean;
+  $: loading =
+    isNullish($selectedIcrcTokenUniverseIdStore) ||
+    isNullish($icrcAccountsStore[$selectedIcrcTokenUniverseIdStore.toText()]);
+
+  let accounts: Account[] = [];
+  $: accounts = nonNullish($selectedIcrcTokenUniverseIdStore)
+    ? $icrcAccountsStore[$selectedIcrcTokenUniverseIdStore.toText()]
+        ?.accounts ?? []
+    : [];
+
+  let token: IcrcTokenMetadata | undefined;
+  $: token = nonNullish($selectedIcrcTokenUniverseIdStore)
+    ? $tokensStore[$selectedIcrcTokenUniverseIdStore.toText()]?.token
+    : undefined;
 </script>
 
-<div class="card-grid" data-tid="icrc-token-accounts-component">TBD</div>
+<div class="card-grid" data-tid="icrc-token-accounts-component">
+  {#if loading}
+    <SkeletonCard size="medium" />
+  {:else}
+    {#each accounts as account}
+      <AccountCard {account} {token}
+        >{account.name ?? $i18n.accounts.main}</AccountCard
+      >
+    {/each}
+  {/if}
+</div>

--- a/frontend/src/tests/lib/pages/IcrcTokenAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcTokenAccounts.spec.ts
@@ -1,0 +1,60 @@
+import { AppPath } from "$lib/constants/routes.constants";
+import IcrcTokenAccounts from "$lib/pages/IcrcTokenAccounts.svelte";
+import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
+import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { page } from "$mocks/$app/stores";
+import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
+import { mockIcrcMainAccount } from "$tests/mocks/icrc-accounts.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { IcrcTokenAccountsPo } from "$tests/page-objects/IcrcTokenAccounts.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("IcrcTokenAccounts", () => {
+  const ledgerCanisterId = principal(0);
+
+  const renderComponent = () => {
+    const { container } = render(IcrcTokenAccounts);
+
+    return IcrcTokenAccountsPo.under(new JestPageObjectElement(container));
+  };
+
+  beforeEach(() => {
+    icrcAccountsStore.reset();
+    tokensStore.reset();
+    icrcCanistersStore.setCanisters({
+      ledgerCanisterId,
+      indexCanisterId: principal(1),
+    });
+    tokensStore.setTokens({
+      [ledgerCanisterId.toText()]: {
+        certified: true,
+        token: mockCkETHToken,
+      },
+    });
+    page.mock({
+      data: { universe: ledgerCanisterId.toText() },
+      routeId: AppPath.Accounts,
+    });
+  });
+
+  it("renders Skeleton card while universe's store is undefined", async () => {
+    const po = renderComponent();
+
+    expect(await po.hasSkeleton()).toBe(true);
+  });
+
+  it("renders AccountCard with balance", async () => {
+    icrcAccountsStore.set({
+      universeId: ledgerCanisterId,
+      accounts: {
+        accounts: [mockIcrcMainAccount],
+        certified: true,
+      },
+    });
+    const po = renderComponent();
+
+    expect(await po.getAccountCardPos()).toHaveLength(1);
+  });
+});

--- a/frontend/src/tests/lib/pages/IcrcTokenAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcTokenAccounts.spec.ts
@@ -39,7 +39,8 @@ describe("IcrcTokenAccounts", () => {
     });
   });
 
-  it("renders Skeleton card while universe's store is undefined", async () => {
+  it("renders Skeleton card while the accounts are undefined", async () => {
+    icrcAccountsStore.reset();
     const po = renderComponent();
 
     expect(await po.hasSkeleton()).toBe(true);

--- a/frontend/src/tests/mocks/icrc-accounts.mock.ts
+++ b/frontend/src/tests/mocks/icrc-accounts.mock.ts
@@ -1,0 +1,12 @@
+import type { Account } from "$lib/types/account";
+import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
+import { mockPrincipal } from "./auth.store.mock";
+
+export const mockIcrcMainAccount: Account = {
+  identifier: encodeIcrcAccount({
+    owner: mockPrincipal,
+  }),
+  balanceE8s: 890156712340000n,
+  principal: mockPrincipal,
+  type: "main",
+};

--- a/frontend/src/tests/page-objects/IcrcTokenAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/IcrcTokenAccounts.page-object.ts
@@ -1,10 +1,24 @@
 import { BaseAccountsPo } from "$tests/page-objects/BaseAccounts.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { AccountCardPo } from "./AccountCard.page-object";
+import { SkeletonCardPo } from "./SkeletonCard.page-object";
 
 export class IcrcTokenAccountsPo extends BaseAccountsPo {
   private static readonly TID = "icrc-token-accounts-component";
 
   static under(element: PageObjectElement): IcrcTokenAccountsPo {
     return new IcrcTokenAccountsPo(element.byTestId(IcrcTokenAccountsPo.TID));
+  }
+
+  getSkeletonCardPo(): SkeletonCardPo {
+    return SkeletonCardPo.under(this.root);
+  }
+
+  hasSkeleton(): Promise<boolean> {
+    return this.getSkeletonCardPo().isPresent();
+  }
+
+  getAccountsCardPos(): Promise<AccountCardPo[]> {
+    return AccountCardPo.allUnder(this.root);
   }
 }


### PR DESCRIPTION
# Motivation

Render the Main account when the user selects a ckETH universe.

# Changes

* Implement the IcrcTokenAccounts logic to render AccountCard from the accounts store.

# Tests

* New IcrcTokenAcconuts.spec: test that AccountCard or SkeletonCard are rendered accordingly.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary yet.
