### PR TITLE
fix: warning "Void function return value is used"

### DIFF
--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -86,12 +86,12 @@
     });
   };
 
-  const loadIcrcTokenAccounts = (icrcCanisters: IcrcCanistersStoreData) => {
+  const loadIcrcTokenAccounts = (icrcCanisters: IcrcCanistersStoreData): Promise<void> => {
     const ledgerCanisterIds = Object.values(icrcCanisters).map(
       ({ ledgerCanisterId }) => ledgerCanisterId
     );
 
-    loadIcrcAccounts({ ledgerCanisterIds, certified: false });
+    return loadIcrcAccounts({ ledgerCanisterIds, certified: false });
   };
 
   $: (async () =>

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -86,7 +86,9 @@
     });
   };
 
-  const loadIcrcTokenAccounts = (icrcCanisters: IcrcCanistersStoreData): Promise<void> => {
+  const loadIcrcTokenAccounts = (
+    icrcCanisters: IcrcCanistersStoreData
+  ): Promise<void> => {
     const ledgerCanisterIds = Object.values(icrcCanisters).map(
       ({ ledgerCanisterId }) => ledgerCanisterId
     );


### PR DESCRIPTION
# Motivation

Editor throw a warning "Void function return value is used " because the function is not a promise.
