### PR TITLE
ckETH canisters in envVars

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Enable ICRC-2 flow for BTC withdrawal.
 * Add ENABLE_CKETH feature flag.
+* Get ckETH canister IDs from environment/configuration.
 
 #### Changed
 

--- a/frontend/src/lib/constants/cketh-canister-ids.constants.ts
+++ b/frontend/src/lib/constants/cketh-canister-ids.constants.ts
@@ -1,4 +1,7 @@
+import { getEnvVars } from "$lib/utils/env-vars.utils";
 import { Principal } from "@dfinity/principal";
+
+const envVars = getEnvVars();
 
 // TODO: Fallback to ckETH canister IDs on mainnet. These are Sepolia canister IDs.
 const MAINNET_CKETH_LEDGER_CANISTER_ID = "apia6-jaaaa-aaaar-qabma-cai";
@@ -16,10 +19,10 @@ export const CKETHSEPOLIA_INDEX_CANISTER_ID = Principal.fromText(
 
 // TODO: Add ckETH canister IDs on env vars https://dfinity.atlassian.net/browse/GIX-2137
 export const CKETH_LEDGER_CANISTER_ID = Principal.fromText(
-  MAINNET_CKETH_LEDGER_CANISTER_ID
+  envVars.ckethLedgerCanisterId ?? MAINNET_CKETH_LEDGER_CANISTER_ID
 );
 export const CKETH_INDEX_CANISTER_ID = Principal.fromText(
-  MAINNET_CKETH_INDEX_CANISTER_ID
+  envVars.ckethIndexCanisterId ?? MAINNET_CKETH_INDEX_CANISTER_ID
 );
 
 // Universes: the universe === the ledger canister ID

--- a/frontend/src/lib/utils/env-vars.utils.ts
+++ b/frontend/src/lib/utils/env-vars.utils.ts
@@ -8,6 +8,8 @@ type EnvironmentVars = {
   ckbtcIndexCanisterId?: string;
   ckbtcLedgerCanisterId?: string;
   ckbtcMinterCanisterId?: string;
+  ckethIndexCanisterId?: string;
+  ckethLedgerCanisterId?: string;
   cyclesMintingCanisterId: string;
   dfxNetwork: string;
   featureFlags: string;
@@ -93,6 +95,12 @@ const getBuildEnvVars = (): EnvironmentVars => {
     ),
     ckbtcMinterCanisterId: convertEmtpyStringToUndefined(
       import.meta.env.VITE_CKBTC_MINTER_CANISTER_ID
+    ),
+    ckethIndexCanisterId: convertEmtpyStringToUndefined(
+      import.meta.env.VITE_CKETH_INDEX_CANISTER_ID
+    ),
+    ckethLedgerCanisterId: convertEmtpyStringToUndefined(
+      import.meta.env.VITE_CKETH_LEDGER_CANISTER_ID
     ),
     cyclesMintingCanisterId: convertEmtpyStringToUndefined(
       import.meta.env.VITE_CYCLES_MINTING_CANISTER_ID


### PR DESCRIPTION
# Motivation

We want to use ckETH canister IDs from the environment/configuration.

# Changes

1. Add `ckethLedgerCanisterId` and `ckethIndexCanisterId` fields to `EnvironmentVars` type.
2. Set the fields in `getBuildEnvVars`.
3. Use the fields in `frontend/src/lib/constants/cketh-canister-ids.constants.ts`.

# Tests

Tested manually on `http://localhost:5173/` and `http://qsgjb-riaaa-aaaaa-aaaga-cai.localhost:8080/`

# Todos

- [x] Add entry to changelog (if necessary).
