### PR TITLE
Refactor ckBTC loading services and api -> wallet

### DIFF
--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -30,6 +30,9 @@ import {
   uint8ArrayToArrayOfNumber,
 } from "@dfinity/utils";
 
+/**
+ * @deprecated replace with getAccount function of wallet-ledger.api
+ */
 export const getIcrcAccount = async ({
   owner,
   subaccount,

--- a/frontend/src/lib/api/wallet-ledger.api.ts
+++ b/frontend/src/lib/api/wallet-ledger.api.ts
@@ -10,7 +10,10 @@ import type { Identity } from "@dfinity/agent";
 import type { IcrcAccount } from "@dfinity/ledger-icrc";
 import type { Principal } from "@dfinity/principal";
 
-export const getCkBTCAccount = async ({
+/**
+ * TODO: move to icrc-index once Sns migrated to icrcStore
+ */
+export const getAccount = async ({
   identity,
   certified,
   canisterId,
@@ -21,7 +24,7 @@ export const getCkBTCAccount = async ({
   canisterId: Principal;
   type: AccountType;
 } & IcrcAccount): Promise<Account> => {
-  logWithTimestamp("Getting ckBTC account: call...");
+  logWithTimestamp("Getting account: call...");
 
   const {
     canister: { balance },
@@ -37,12 +40,15 @@ export const getCkBTCAccount = async ({
     ...callParams,
   });
 
-  logWithTimestamp("Getting ckBTC account: done");
+  logWithTimestamp("Getting account: done");
 
   return account;
 };
 
-export const getCkBTCToken = async (params: {
+/**
+ * TODO: replace with icrc-index queryIcrcToken once Sns migrated to icrcStore
+ */
+export const getToken = async (params: {
   identity: Identity;
   certified: boolean;
   canisterId: Principal;

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -17,7 +17,7 @@
   } from "$lib/derived/sns/sns-projects.derived";
   import { nonNullish } from "@dfinity/utils";
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
-  import { uncertifiedLoadCkBTCAccountsBalance } from "$lib/services/ckbtc-accounts-balance.services";
+  import { uncertifiedLoadAccountsBalance } from "$lib/services/wallet-accounts.services";
   import CkBTCAccounts from "$lib/pages/CkBTCAccounts.svelte";
   import SummaryUniverse from "$lib/components/summary/SummaryUniverse.svelte";
   import CkBTCAccountsFooter from "$lib/components/accounts/CkBTCAccountsFooter.svelte";
@@ -80,7 +80,7 @@
 
     loadCkBTCAccountsBalancesRequested = true;
 
-    await uncertifiedLoadCkBTCAccountsBalance({
+    await uncertifiedLoadAccountsBalance({
       universeIds: universes.map(({ canisterId }) => canisterId),
       excludeUniverseIds: [selectedUniverseId.toText()],
     });

--- a/frontend/src/lib/services/ckbtc-accounts-loader.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts-loader.services.ts
@@ -1,18 +1,16 @@
-import { getCkBTCAccount } from "$lib/api/ckbtc-ledger.api";
+import { getAccount } from "$lib/api/wallet-ledger.api";
 import { CKBTC_ADDITIONAL_CANISTERS } from "$lib/constants/ckbtc-additional-canister-ids.constants";
 import { getWithdrawalAccount as getWithdrawalAccountServices } from "$lib/services/ckbtc-minter.services";
 import type { CkBTCBTCWithdrawalAccount } from "$lib/stores/ckbtc-withdrawal-accounts.store";
 import { ckBTCWithdrawalAccountsStore } from "$lib/stores/ckbtc-withdrawal-accounts.store";
 import { i18n } from "$lib/stores/i18n";
 import { toastsError } from "$lib/stores/toasts.store";
-import type { Account, AccountType } from "$lib/types/account";
 import type { CkBTCAdditionalCanisters } from "$lib/types/ckbtc-canisters";
 import type { UniverseCanisterId } from "$lib/types/universe";
 import { toToastError } from "$lib/utils/error.utils";
 import type { Identity } from "@dfinity/agent";
 import type { IcrcAccount } from "@dfinity/ledger-icrc";
 import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
-import type { Principal } from "@dfinity/principal";
 import {
   assertNonNullish,
   fromNullable,
@@ -20,31 +18,6 @@ import {
   nonNullish,
 } from "@dfinity/utils";
 import { get } from "svelte/store";
-
-export const getCkBTCAccounts = async ({
-  identity,
-  certified,
-  universeId,
-}: {
-  identity: Identity;
-  certified: boolean;
-  universeId: Principal;
-}): Promise<Account[]> => {
-  // TODO: Support subaccounts
-  const mainAccount: { owner: Principal; type: AccountType } = {
-    owner: identity.getPrincipal(),
-    type: "main",
-  };
-
-  const account = await getCkBTCAccount({
-    identity,
-    certified,
-    canisterId: universeId,
-    ...mainAccount,
-  });
-
-  return [account];
-};
 
 /**
  * 1. If not yet loaded, get the ckBTC withdrawal account from the minter, otherwise use the existing value in store.
@@ -111,7 +84,7 @@ export const getCkBTCWithdrawalAccount = async ({
     : await getWithdrawalAccount();
 
   try {
-    const account = await getCkBTCAccount({
+    const account = await getAccount({
       identity,
       certified,
       canisterId: universeId,

--- a/frontend/src/lib/services/ckbtc-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts.services.ts
@@ -3,10 +3,10 @@ import { icrcTransfer } from "$lib/api/icrc-ledger.api";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
-import { getCkBTCAccounts } from "$lib/services/ckbtc-accounts-loader.services";
 import { loadCkBTCToken } from "$lib/services/ckbtc-tokens.services";
 import { transferTokens } from "$lib/services/icrc-accounts.services";
 import { queryAndUpdate } from "$lib/services/utils.services";
+import { getAccounts } from "$lib/services/wallet-loader.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { toastsError } from "$lib/stores/toasts.store";
@@ -29,7 +29,7 @@ export const loadCkBTCAccounts = async ({
   return queryAndUpdate<Account[], unknown>({
     strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
-      getCkBTCAccounts({ identity, certified, universeId }),
+      getAccounts({ identity, certified, universeId }),
     onLoad: ({ response: accounts, certified }) =>
       icrcAccountsStore.set({
         universeId,

--- a/frontend/src/lib/services/ckbtc-tokens.services.ts
+++ b/frontend/src/lib/services/ckbtc-tokens.services.ts
@@ -1,4 +1,4 @@
-import { getCkBTCToken } from "$lib/api/ckbtc-ledger.api";
+import { getToken } from "$lib/api/wallet-ledger.api";
 import {
   CKBTC_UNIVERSE_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
@@ -47,7 +47,7 @@ export const loadCkBTCToken = async ({
     strategy: FORCE_CALL_STRATEGY,
     identityType: "current",
     request: ({ certified, identity }) =>
-      getCkBTCToken({
+      getToken({
         identity,
         certified,
         canisterId: universeId,

--- a/frontend/src/lib/services/wallet-loader.services.ts
+++ b/frontend/src/lib/services/wallet-loader.services.ts
@@ -3,15 +3,20 @@ import type { Account, AccountType } from "$lib/types/account";
 import type { Identity } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
 
-export const getAccounts = async ({
-  identity,
-  certified,
-  universeId,
-}: {
-  identity: Identity;
-  certified: boolean;
-  universeId: Principal;
-}): Promise<Account[]> => {
+/**
+ * TODO: This function is called `getAccounts` because it was originally refactored from a `getCkBtcAccounts` function. It can be renamed to something more suitable given that this services is a loader that load that from the API to the store.
+ */
+export const getAccounts = async (
+  {
+    identity,
+    certified,
+    universeId,
+  }: {
+    identity: Identity;
+    certified: boolean;
+    universeId: Principal;
+  }
+): Promise<Account[]> => {
   // TODO: Support subaccounts
   const mainAccount: { owner: Principal; type: AccountType } = {
     owner: identity.getPrincipal(),

--- a/frontend/src/lib/services/wallet-loader.services.ts
+++ b/frontend/src/lib/services/wallet-loader.services.ts
@@ -6,17 +6,15 @@ import type { Principal } from "@dfinity/principal";
 /**
  * TODO: This function is called `getAccounts` because it was originally refactored from a `getCkBtcAccounts` function. It can be renamed to something more suitable given that this services is a loader that load that from the API to the store.
  */
-export const getAccounts = async (
-  {
-    identity,
-    certified,
-    universeId,
-  }: {
-    identity: Identity;
-    certified: boolean;
-    universeId: Principal;
-  }
-): Promise<Account[]> => {
+export const getAccounts = async ({
+  identity,
+  certified,
+  universeId,
+}: {
+  identity: Identity;
+  certified: boolean;
+  universeId: Principal;
+}): Promise<Account[]> => {
   // TODO: Support subaccounts
   const mainAccount: { owner: Principal; type: AccountType } = {
     owner: identity.getPrincipal(),

--- a/frontend/src/lib/services/wallet-loader.services.ts
+++ b/frontend/src/lib/services/wallet-loader.services.ts
@@ -1,0 +1,29 @@
+import { getAccount } from "$lib/api/wallet-ledger.api";
+import type { Account, AccountType } from "$lib/types/account";
+import type { Identity } from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+
+export const getAccounts = async ({
+  identity,
+  certified,
+  universeId,
+}: {
+  identity: Identity;
+  certified: boolean;
+  universeId: Principal;
+}): Promise<Account[]> => {
+  // TODO: Support subaccounts
+  const mainAccount: { owner: Principal; type: AccountType } = {
+    owner: identity.getPrincipal(),
+    type: "main",
+  };
+
+  const account = await getAccount({
+    identity,
+    certified,
+    canisterId: universeId,
+    ...mainAccount,
+  });
+
+  return [account];
+};

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -19,7 +19,7 @@
   import { uncertifiedLoadSnsAccountsBalances } from "$lib/services/sns-accounts-balance.services";
   import type { Universe } from "$lib/types/universe";
   import { isArrayEmpty } from "$lib/utils/utils";
-  import { uncertifiedLoadCkBTCAccountsBalance } from "$lib/services/ckbtc-accounts-balance.services";
+  import { uncertifiedLoadAccountsBalance } from "$lib/services/wallet-accounts.services";
   import { ckBTCUniversesStore } from "$lib/derived/ckbtc-universes.derived";
   import { isUniverseCkBTC, isUniverseNns } from "$lib/utils/universe.utils";
   import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";
@@ -67,7 +67,7 @@
 
     loadCkBTCAccountsBalancesRequested = true;
 
-    await uncertifiedLoadCkBTCAccountsBalance({
+    await uncertifiedLoadAccountsBalance({
       universeIds: universes.map(({ canisterId }) => canisterId),
       excludeUniverseIds: [],
     });

--- a/frontend/src/tests/lib/api/wallet-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/wallet-ledger.api.spec.ts
@@ -1,5 +1,5 @@
 import * as agent from "$lib/api/agent.api";
-import { getCkBTCAccount, getCkBTCToken } from "$lib/api/ckbtc-ledger.api";
+import { getAccount, getToken } from "$lib/api/wallet-ledger.api";
 import { CKBTC_LEDGER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import {
@@ -10,7 +10,7 @@ import type { HttpAgent } from "@dfinity/agent";
 import { IcrcLedgerCanister } from "@dfinity/ledger-icrc";
 import { mock } from "vitest-mock-extended";
 
-describe("ckbtc-ledger api", () => {
+describe("wallet-ledger api", () => {
   const ledgerCanisterMock = mock<IcrcLedgerCanister>();
 
   beforeAll(() => {
@@ -27,13 +27,13 @@ describe("ckbtc-ledger api", () => {
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
-  describe("getCkBTCAccount", () => {
+  describe("getAccount", () => {
     it("returns main account with balance", async () => {
       const balance = BigInt(10_000_000);
 
       const balanceSpy = ledgerCanisterMock.balance.mockResolvedValue(balance);
 
-      const account = await getCkBTCAccount({
+      const account = await getAccount({
         certified: true,
         identity: mockIdentity,
         canisterId: CKBTC_LEDGER_CANISTER_ID,
@@ -54,7 +54,7 @@ describe("ckbtc-ledger api", () => {
       );
 
       const call = () =>
-        getCkBTCAccount({
+        getAccount({
           certified: true,
           identity: mockIdentity,
           canisterId: CKBTC_LEDGER_CANISTER_ID,
@@ -66,13 +66,13 @@ describe("ckbtc-ledger api", () => {
     });
   });
 
-  describe("getCkBTCToken", () => {
+  describe("getToken", () => {
     it("returns token metadata", async () => {
       const metadataSpy = ledgerCanisterMock.metadata.mockResolvedValue(
         mockQueryTokenResponse
       );
 
-      const token = await getCkBTCToken({
+      const token = await getToken({
         certified: true,
         identity: mockIdentity,
         canisterId: CKBTC_LEDGER_CANISTER_ID,
@@ -87,7 +87,7 @@ describe("ckbtc-ledger api", () => {
       ledgerCanisterMock.metadata.mockResolvedValue([]);
 
       const call = () =>
-        getCkBTCToken({
+        getToken({
           certified: true,
           identity: mockIdentity,
           canisterId: CKBTC_LEDGER_CANISTER_ID,

--- a/frontend/src/tests/lib/components/accounts/CkBTCWithdrawalAccount.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWithdrawalAccount.spec.ts
@@ -1,5 +1,5 @@
-import * as ledgerApi from "$lib/api/ckbtc-ledger.api";
 import * as minterApi from "$lib/api/ckbtc-minter.api";
+import * as ledgerApi from "$lib/api/wallet-ledger.api";
 import CkBTCWithdrawalAccount from "$lib/components/accounts/CkBTCWithdrawalAccount.svelte";
 import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
@@ -64,7 +64,7 @@ describe("CkBTCWithdrawalAccount", () => {
 
     beforeEach(() => {
       spyGetCkBTCAccount = vi
-        .spyOn(ledgerApi, "getCkBTCAccount")
+        .spyOn(ledgerApi, "getAccount")
         .mockResolvedValue(mockCkBTCWithdrawalAccount);
     });
 
@@ -209,7 +209,7 @@ describe("CkBTCWithdrawalAccount", () => {
           subaccount: [mockCkBTCWithdrawalIcrcAccount.subaccount],
         });
 
-        vi.spyOn(ledgerApi, "getCkBTCAccount").mockResolvedValue({
+        vi.spyOn(ledgerApi, "getAccount").mockResolvedValue({
           ...mockCkBTCWithdrawalAccount,
           balanceE8s: balanceZero,
         });
@@ -291,7 +291,7 @@ describe("CkBTCWithdrawalAccount", () => {
     let spyUpdateBalance;
 
     beforeEach(() => {
-      vi.spyOn(ledgerApi, "getCkBTCAccount").mockResolvedValue(
+      vi.spyOn(ledgerApi, "getAccount").mockResolvedValue(
         mockCkBTCWithdrawalAccount
       );
 

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -1,7 +1,7 @@
-import * as ckbtcLedgerApi from "$lib/api/ckbtc-ledger.api";
 import * as ckbtcMinterApi from "$lib/api/ckbtc-minter.api";
 import * as icrcIndexApi from "$lib/api/icrc-index.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
+import * as ckbtcLedgerApi from "$lib/api/wallet-ledger.api";
 import {
   CKTESTBTC_MINTER_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
@@ -157,12 +157,12 @@ describe("CkBTCWallet", () => {
         routeId: AppPath.Wallet,
       });
 
-      vi.mocked(ckbtcLedgerApi.getCkBTCAccount).mockImplementation(() => {
+      vi.mocked(ckbtcLedgerApi.getAccount).mockImplementation(() => {
         return new Promise<Account>((resolve) => {
           resolveAccounts = resolve;
         });
       });
-      vi.mocked(ckbtcLedgerApi.getCkBTCToken).mockResolvedValue(mockCkBTCToken);
+      vi.mocked(ckbtcLedgerApi.getToken).mockResolvedValue(mockCkBTCToken);
     });
 
     it("should render a spinner while loading", async () => {
@@ -175,8 +175,8 @@ describe("CkBTCWallet", () => {
 
     it("should call to load ckBTC accounts", async () => {
       await renderWallet();
-      expect(ckbtcLedgerApi.getCkBTCAccount).toBeCalled();
-      expect(ckbtcLedgerApi.getCkBTCToken).toBeCalled();
+      expect(ckbtcLedgerApi.getAccount).toBeCalled();
+      expect(ckbtcLedgerApi.getToken).toBeCalled();
     });
   });
 
@@ -215,7 +215,7 @@ describe("CkBTCWallet", () => {
           return Promise.resolve({ block_index: 3n });
         }
       );
-      vi.mocked(ckbtcLedgerApi.getCkBTCAccount).mockImplementation(() => {
+      vi.mocked(ckbtcLedgerApi.getAccount).mockImplementation(() => {
         return Promise.resolve({
           ...mockCkBTCMainAccount,
           ...(afterTransfer

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -65,7 +65,7 @@ vi.mock("$lib/services/worker-transactions.services", () => ({
   ),
 }));
 
-vi.mock("$lib/api/ckbtc-ledger.api");
+vi.mock("$lib/api/wallet-ledger.api");
 vi.mock("$lib/api/ckbtc-minter.api");
 vi.mock("$lib/api/icrc-ledger.api");
 vi.mock("$lib/api/icrc-index.api");

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -71,7 +71,7 @@ vi.mock("$lib/api/icrc-ledger.api");
 vi.mock("$lib/api/icrc-index.api");
 
 const blockedApiPaths = [
-  "$lib/api/ckbtc-ledger.api",
+  "$lib/api/wallet-ledger.api",
   "$lib/api/ckbtc-minter.api",
   "$lib/api/icrc-ledger.api",
   "$lib/api/icrc-index.api",

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -13,8 +13,8 @@ import {
 } from "$lib/derived/sns/sns-projects.derived";
 import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
 import Accounts from "$lib/routes/Accounts.svelte";
-import { uncertifiedLoadCkBTCAccountsBalance } from "$lib/services/ckbtc-accounts-balance.services";
 import { uncertifiedLoadSnsAccountsBalances } from "$lib/services/sns-accounts-balance.services";
+import { uncertifiedLoadAccountsBalance } from "$lib/services/wallet-accounts.services";
 import { authStore } from "$lib/stores/auth.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
@@ -312,7 +312,7 @@ describe("Accounts", () => {
     render(Accounts);
 
     await waitFor(() =>
-      expect(uncertifiedLoadCkBTCAccountsBalance).toHaveBeenCalled()
+      expect(uncertifiedLoadAccountsBalance).toHaveBeenCalled()
     );
   });
 
@@ -325,7 +325,7 @@ describe("Accounts", () => {
     render(Accounts);
 
     await waitFor(() =>
-      expect(uncertifiedLoadCkBTCAccountsBalance).toHaveBeenCalled()
+      expect(uncertifiedLoadAccountsBalance).toHaveBeenCalled()
     );
   });
 

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -74,9 +74,9 @@ vi.mock("$lib/services/sns-accounts-balance.services", () => {
   };
 });
 
-vi.mock("$lib/services/ckbtc-accounts-balance.services", () => {
+vi.mock("$lib/services/wallet-accounts.services", () => {
   return {
-    uncertifiedLoadCkBTCAccountsBalance: vi.fn().mockResolvedValue(undefined),
+    uncertifiedLoadAccountsBalance: vi.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/frontend/src/tests/lib/services/ckbtc-accounts-loader.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts-loader.services.spec.ts
@@ -3,12 +3,10 @@ import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { getCkBTCWithdrawalAccount } from "$lib/services/ckbtc-accounts-loader.services";
 import * as minterServices from "$lib/services/ckbtc-minter.services";
-import { getAccounts } from "$lib/services/wallet-loader.services";
 import { ckBTCWithdrawalAccountsStore } from "$lib/stores/ckbtc-withdrawal-accounts.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import {
-  mockCkBTCMainAccount,
   mockCkBTCToken,
   mockCkBTCWithdrawalAccount,
   mockCkBTCWithdrawalIcrcAccount,
@@ -20,30 +18,6 @@ import { waitFor } from "@testing-library/svelte";
 describe("ckbtc-accounts-loader-services", () => {
   afterEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe("getCkBTCAccounts", () => {
-    it("should call get CkBTC account", async () => {
-      const spyGetCkBTCAccount = vi
-        .spyOn(ledgerApi, "getAccount")
-        .mockResolvedValue(mockCkBTCMainAccount);
-
-      await getAccounts({
-        identity: mockIdentity,
-        certified: true,
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
-      });
-
-      await waitFor(() =>
-        expect(spyGetCkBTCAccount).toBeCalledWith({
-          identity: mockIdentity,
-          certified: true,
-          canisterId: CKBTC_UNIVERSE_CANISTER_ID,
-          owner: mockIdentity.getPrincipal(),
-          type: "main",
-        })
-      );
-    });
   });
 
   describe("getCkBTCWithdrawalAccount", () => {

--- a/frontend/src/tests/lib/services/ckbtc-accounts-loader.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts-loader.services.spec.ts
@@ -1,9 +1,9 @@
-import * as ledgerApi from "$lib/api/ckbtc-ledger.api";
+import * as ledgerApi from "$lib/api/wallet-ledger.api";
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
-import * as services from "$lib/services/ckbtc-accounts-loader.services";
 import { getCkBTCWithdrawalAccount } from "$lib/services/ckbtc-accounts-loader.services";
 import * as minterServices from "$lib/services/ckbtc-minter.services";
+import { getAccounts } from "$lib/services/wallet-loader.services";
 import { ckBTCWithdrawalAccountsStore } from "$lib/stores/ckbtc-withdrawal-accounts.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
@@ -25,10 +25,10 @@ describe("ckbtc-accounts-loader-services", () => {
   describe("getCkBTCAccounts", () => {
     it("should call get CkBTC account", async () => {
       const spyGetCkBTCAccount = vi
-        .spyOn(ledgerApi, "getCkBTCAccount")
+        .spyOn(ledgerApi, "getAccount")
         .mockResolvedValue(mockCkBTCMainAccount);
 
-      await services.getCkBTCAccounts({
+      await getAccounts({
         identity: mockIdentity,
         certified: true,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
@@ -89,7 +89,7 @@ describe("ckbtc-accounts-loader-services", () => {
 
       beforeEach(() => {
         spyGetCkBTCAccount = vi
-          .spyOn(ledgerApi, "getCkBTCAccount")
+          .spyOn(ledgerApi, "getAccount")
           .mockResolvedValue({
             ...mockCkBTCWithdrawalAccount,
             balanceE8s: mockAccountBalance.toE8s(),
@@ -198,7 +198,7 @@ describe("ckbtc-accounts-loader-services", () => {
 
       beforeEach(() => {
         vi.spyOn(console, "error").mockImplementation(() => undefined);
-        vi.spyOn(ledgerApi, "getCkBTCAccount").mockRejectedValue(new Error());
+        vi.spyOn(ledgerApi, "getAccount").mockRejectedValue(new Error());
 
         spyOnToastsError = vi.spyOn(toastsStore, "toastsError");
       });

--- a/frontend/src/tests/lib/services/ckbtc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts.services.spec.ts
@@ -1,5 +1,5 @@
-import * as ckbtcLedgerApi from "$lib/api/ckbtc-ledger.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
+import * as ckbtcLedgerApi from "$lib/api/wallet-ledger.api";
 import {
   CKBTC_UNIVERSE_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
@@ -41,7 +41,7 @@ describe("ckbtc-accounts-services", () => {
 
     it("should call api.getCkBTCAccount and load neurons in store", async () => {
       const spyQuery = vi
-        .spyOn(ckbtcLedgerApi, "getCkBTCAccount")
+        .spyOn(ckbtcLedgerApi, "getAccount")
         .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
 
       await loadCkBTCAccounts({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
@@ -60,7 +60,7 @@ describe("ckbtc-accounts-services", () => {
 
     it("should call error callback", async () => {
       const spyQuery = vi
-        .spyOn(ckbtcLedgerApi, "getCkBTCAccount")
+        .spyOn(ckbtcLedgerApi, "getAccount")
         .mockRejectedValue(new Error());
 
       const spy = vi.fn();
@@ -92,7 +92,7 @@ describe("ckbtc-accounts-services", () => {
         completed: false,
       });
 
-      vi.spyOn(ckbtcLedgerApi, "getCkBTCAccount").mockImplementation(() =>
+      vi.spyOn(ckbtcLedgerApi, "getAccount").mockImplementation(() =>
         Promise.reject(undefined)
       );
 
@@ -116,11 +116,11 @@ describe("ckbtc-accounts-services", () => {
 
     it("should call ckBTC accounts and token and load them in store", async () => {
       const spyAccountsQuery = vi
-        .spyOn(ckbtcLedgerApi, "getCkBTCAccount")
+        .spyOn(ckbtcLedgerApi, "getAccount")
         .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
 
       const spyTokenQuery = vi
-        .spyOn(ckbtcLedgerApi, "getCkBTCToken")
+        .spyOn(ckbtcLedgerApi, "getToken")
         .mockImplementation(() => Promise.resolve(mockCkBTCToken));
 
       await services.syncCkBTCAccounts({
@@ -156,7 +156,7 @@ describe("ckbtc-accounts-services", () => {
       icrcAccountsStore.reset();
 
       spyAccounts = vi
-        .spyOn(ckbtcLedgerApi, "getCkBTCAccount")
+        .spyOn(ckbtcLedgerApi, "getAccount")
         .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
     });
 

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -1,7 +1,7 @@
 import * as agent from "$lib/api/agent.api";
-import * as ledgerApi from "$lib/api/ckbtc-ledger.api";
 import * as minterApi from "$lib/api/ckbtc-minter.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
+import * as ledgerApi from "$lib/api/wallet-ledger.api";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import * as ckbtcAccountsServices from "$lib/services/ckbtc-accounts.services";
 import {
@@ -153,7 +153,7 @@ describe("ckbtc-convert-services", () => {
           minterCanisterMock.retrieveBtc.mockReset();
           tokensStore.setTokens(mockTokens);
           transferSpy.mockResolvedValue(123n);
-          vi.spyOn(ledgerApi, "getCkBTCAccount").mockImplementation(() =>
+          vi.spyOn(ledgerApi, "getAccount").mockImplementation(() =>
             Promise.resolve(mockCkBTCMainAccount)
           );
         });

--- a/frontend/src/tests/lib/services/ckbtc-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-tokens.services.spec.ts
@@ -12,7 +12,7 @@ import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
-vi.mock("$lib/api/ckbtc-ledger.api");
+vi.mock("$lib/api/wallet-ledger.api");
 
 describe("ckbtc-tokens-services", () => {
   beforeEach(() => {

--- a/frontend/src/tests/lib/services/ckbtc-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-tokens.services.spec.ts
@@ -1,4 +1,4 @@
-import * as ledgerApi from "$lib/api/ckbtc-ledger.api";
+import * as ledgerApi from "$lib/api/wallet-ledger.api";
 import {
   CKBTC_UNIVERSE_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
@@ -27,7 +27,7 @@ describe("ckbtc-tokens-services", () => {
 
     it("should load token in the store", async () => {
       const spyGetToken = vi
-        .spyOn(ledgerApi, "getCkBTCToken")
+        .spyOn(ledgerApi, "getToken")
         .mockResolvedValue(mockCkBTCToken);
 
       await services.loadCkBTCToken({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
@@ -64,7 +64,7 @@ describe("ckbtc-tokens-services", () => {
 
     it("should not reload token if already loaded", async () => {
       const spyGetToken = vi
-        .spyOn(ledgerApi, "getCkBTCToken")
+        .spyOn(ledgerApi, "getToken")
         .mockResolvedValue(mockCkBTCToken);
 
       await services.loadCkBTCToken({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
@@ -80,7 +80,7 @@ describe("ckbtc-tokens-services", () => {
     };
     beforeEach(() => {
       tokensStore.reset();
-      vi.spyOn(ledgerApi, "getCkBTCToken").mockImplementation(
+      vi.spyOn(ledgerApi, "getToken").mockImplementation(
         async ({ canisterId }) => {
           if (canisterId.toText() === CKBTC_UNIVERSE_CANISTER_ID.toText()) {
             return mockCkBTCToken;

--- a/frontend/src/tests/lib/services/ckbtc-withdrawal-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-withdrawal-accounts.services.spec.ts
@@ -1,4 +1,4 @@
-import * as ledgerApi from "$lib/api/ckbtc-ledger.api";
+import * as ledgerApi from "$lib/api/wallet-ledger.api";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import * as minterServices from "$lib/services/ckbtc-minter.services";
 import { loadCkBTCWithdrawalAccount } from "$lib/services/ckbtc-withdrawal-accounts.services";
@@ -37,7 +37,7 @@ describe("ckbtc-withdrawal-accounts.services", () => {
 
     it("should call api.getCkBTCAccount and load neurons in store", async () => {
       const spyGetCkBTCAccount = vi
-        .spyOn(ledgerApi, "getCkBTCAccount")
+        .spyOn(ledgerApi, "getAccount")
         .mockResolvedValue(mockCkBTCWithdrawalAccount);
 
       await loadCkBTCWithdrawalAccount({
@@ -61,7 +61,7 @@ describe("ckbtc-withdrawal-accounts.services", () => {
     it("should not be affected by FORCE_CALL_STRATEGY", async () => {
       mockedConstants.FORCE_CALL_STRATEGY = "query";
       const spyGetCkBTCAccount = vi
-        .spyOn(ledgerApi, "getCkBTCAccount")
+        .spyOn(ledgerApi, "getAccount")
         .mockResolvedValue(mockCkBTCWithdrawalAccount);
 
       await loadCkBTCWithdrawalAccount({
@@ -91,7 +91,7 @@ describe("ckbtc-withdrawal-accounts.services", () => {
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       });
 
-      vi.spyOn(ledgerApi, "getCkBTCAccount").mockImplementation(() =>
+      vi.spyOn(ledgerApi, "getAccount").mockImplementation(() =>
         Promise.reject(undefined)
       );
 

--- a/frontend/src/tests/lib/services/wallet-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-accounts.services.spec.ts
@@ -1,11 +1,11 @@
-import * as ledgerApi from "$lib/api/ckbtc-ledger.api";
+import * as ledgerApi from "$lib/api/wallet-ledger.api";
 import {
   CKBTC_UNIVERSE_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { universesAccountsBalance } from "$lib/derived/universes-accounts-balance.derived";
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
-import * as services from "$lib/services/ckbtc-accounts-balance.services";
+import * as services from "$lib/services/wallet-accounts.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
@@ -23,7 +23,7 @@ vi.mock("$lib/stores/toasts.store", () => {
   };
 });
 
-describe("ckbtc-accounts-balance.services", () => {
+describe("wallet-accounts.services", () => {
   beforeEach(() => {
     resetIdentity();
   });
@@ -42,16 +42,16 @@ describe("ckbtc-accounts-balance.services", () => {
     ],
   };
 
-  it("should call api.getCkBTCAccounts and load balance in store", async () => {
-    vi.spyOn(ledgerApi, "getCkBTCToken").mockImplementation(() =>
+  it("should call api.getAccounts and load balance in store", async () => {
+    vi.spyOn(ledgerApi, "getToken").mockImplementation(() =>
       Promise.resolve(mockCkBTCToken)
     );
 
     const spyQuery = vi
-      .spyOn(ledgerApi, "getCkBTCAccount")
+      .spyOn(ledgerApi, "getAccount")
       .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
 
-    await services.uncertifiedLoadCkBTCAccountsBalance(params);
+    await services.uncertifiedLoadAccountsBalance(params);
 
     await tick();
 
@@ -64,16 +64,16 @@ describe("ckbtc-accounts-balance.services", () => {
     expect(spyQuery).toBeCalled();
   });
 
-  it("should call api.getCkBTCToken and load token in store", async () => {
+  it("should call api.getToken and load token in store", async () => {
     const spyQuery = vi
-      .spyOn(ledgerApi, "getCkBTCToken")
+      .spyOn(ledgerApi, "getToken")
       .mockImplementation(() => Promise.resolve(mockCkBTCToken));
 
-    vi.spyOn(ledgerApi, "getCkBTCAccount").mockImplementation(() =>
+    vi.spyOn(ledgerApi, "getAccount").mockImplementation(() =>
       Promise.resolve(mockCkBTCMainAccount)
     );
 
-    await services.uncertifiedLoadCkBTCAccountsBalance(params);
+    await services.uncertifiedLoadAccountsBalance(params);
 
     await tick();
 
@@ -92,9 +92,9 @@ describe("ckbtc-accounts-balance.services", () => {
 
   it("should toast error", async () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.spyOn(ledgerApi, "getCkBTCAccount").mockRejectedValue(new Error());
+    vi.spyOn(ledgerApi, "getAccount").mockRejectedValue(new Error());
 
-    await services.uncertifiedLoadCkBTCAccountsBalance(params);
+    await services.uncertifiedLoadAccountsBalance(params);
 
     expect(toastsError).toHaveBeenCalled();
   });

--- a/frontend/src/tests/lib/services/wallet-loader.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-loader.services.spec.ts
@@ -1,0 +1,36 @@
+import * as ledgerApi from "$lib/api/wallet-ledger.api";
+import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { getAccounts } from "$lib/services/wallet-loader.services";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
+import { waitFor } from "@testing-library/svelte";
+
+describe("wallet-loader-services", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getAccounts", () => {
+    it("should call get CkBTC account", async () => {
+      const spyGetCkBTCAccount = vi
+        .spyOn(ledgerApi, "getAccount")
+        .mockResolvedValue(mockCkBTCMainAccount);
+
+      await getAccounts({
+        identity: mockIdentity,
+        certified: true,
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+      });
+
+      await waitFor(() =>
+        expect(spyGetCkBTCAccount).toBeCalledWith({
+          identity: mockIdentity,
+          certified: true,
+          canisterId: CKBTC_UNIVERSE_CANISTER_ID,
+          owner: mockIdentity.getPrincipal(),
+          type: "main",
+        })
+      );
+    });
+  });
+});

--- a/frontend/src/tests/routes/app/accounts/page.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/page.spec.ts
@@ -13,7 +13,7 @@ import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { render } from "@testing-library/svelte";
 
-vi.mock("$lib/api/ckbtc-ledger.api");
+vi.mock("$lib/api/wallet-ledger.api");
 vi.mock("$lib/api/icp-ledger.api");
 vi.mock("$lib/api/nns-dapp.api");
 vi.mock("$lib/api/sns-ledger.api");

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -33,7 +33,7 @@ import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 import { mock } from "vitest-mock-extended";
 
-vi.mock("$lib/api/ckbtc-ledger.api");
+vi.mock("$lib/api/wallet-ledger.api");
 vi.mock("$lib/api/sns-ledger.api");
 
 describe("Tokens route", () => {

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -1,5 +1,5 @@
-import * as ckBTCLedgerApi from "$lib/api/ckbtc-ledger.api";
 import * as snsLedgerApi from "$lib/api/sns-ledger.api";
+import * as ckBTCLedgerApi from "$lib/api/wallet-ledger.api";
 import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
@@ -64,13 +64,11 @@ describe("Tokens route", () => {
     beforeEach(() => {
       vi.clearAllMocks();
       overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
-      vi.spyOn(ckBTCLedgerApi, "getCkBTCToken").mockResolvedValue(
-        mockCkBTCToken
-      );
+      vi.spyOn(ckBTCLedgerApi, "getToken").mockResolvedValue(mockCkBTCToken);
       vi.spyOn(AuthClient, "create").mockImplementation(
         async (): Promise<AuthClient> => mockAuthClient
       );
-      vi.spyOn(ckBTCLedgerApi, "getCkBTCAccount").mockResolvedValue({
+      vi.spyOn(ckBTCLedgerApi, "getAccount").mockResolvedValue({
         ...mockCkBTCMainAccount,
         balanceE8s: ckBTCBalanceE8s,
       });


### PR DESCRIPTION
# Motivation

We need more generic api and services to implement the Icrc wallet page without duplication and I also want ultimately to improve the loading the accounts because with current implementation we duplicate code and calls.

# Changes

- `ckbtc-ledger.api` -> `wallet-ledger.api`
- `ckbtc-accounts-balance.servies` -> `wallet-accounts.services`
- `ckbtc-accounts-loader` -> `wallet-loader.services`
- remove `ckBTC` from various function name - e.g. `getCkBtcToken` -> `getToken`

No functional changes in this PR.