### PR TITLE
GIX-2123: Setup IcrcTokenAccountsFooter

### DIFF
--- a/frontend/src/lib/components/accounts/IcrcTokenAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTokenAccountsFooter.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import Footer from "$lib/components/layout/Footer.svelte";
+  import { nonNullish } from "@dfinity/utils";
+  import { selectedIcrcTokenUniverseIdStore } from "$lib/derived/selected-universe.derived";
+</script>
+
+{#if nonNullish($selectedIcrcTokenUniverseIdStore)}
+  <Footer testId="icrc-token-accounts-footer-component">
+    <!-- TODO: Implement Send modal GIX-2120 -->
+    <button
+      class="primary full-width"
+      data-tid="open-new-icrc-token-transaction">{$i18n.accounts.send}</button
+    >
+    <!-- TODO: Add Receive button GIX-2124 -->
+  </Footer>
+{/if}

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -35,6 +35,7 @@
   import { onMount } from "svelte";
   import { loadCkETHCanisters } from "$lib/services/cketh-canisters.services";
   import IcrcTokenAccounts from "$lib/pages/IcrcTokenAccounts.svelte";
+  import IcrcTokenAccountsFooter from "$lib/components/accounts/IcrcTokenAccountsFooter.svelte";
 
   // TODO: This component is mounted twice. Understand why and fix it.
 
@@ -121,6 +122,8 @@
     <NnsAccountsFooter />
   {:else if $isCkBTCUniverseStore}
     <CkBTCAccountsFooter />
+  {:else if $isIcrcTokenUniverseStore}
+    <IcrcTokenAccountsFooter />
   {:else if nonNullish($snsProjectSelectedStore)}
     <SnsAccountsFooter />
   {/if}

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -370,7 +370,7 @@ describe("Accounts", () => {
     expect(icrcLedgerApi.queryIcrcBalance).toHaveBeenCalledTimes(1);
   });
 
-  it("should render IcrcTokenAccounts component with ckETH enabled and universe ckETH", async () => {
+  it("should render IcrcTokenAccounts and IcrcTokenAccountsFooter component with ckETH enabled and universe ckETH", async () => {
     overrideFeatureFlagsStore.setFlag("ENABLE_CKETH", true);
 
     page.mock({
@@ -381,6 +381,7 @@ describe("Accounts", () => {
     const po = renderComponent();
 
     expect(await po.getIcrcTokenAccountsPo().isPresent()).toBe(true);
+    expect(await po.getIcrcTokenAccountsFooterPo().isPresent()).toBe(true);
   });
 
   it("should render sns project name", () => {

--- a/frontend/src/tests/page-objects/Accounts.page-object.ts
+++ b/frontend/src/tests/page-objects/Accounts.page-object.ts
@@ -6,6 +6,7 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { BuyICPModalPo } from "./BuyICPModal.page-object";
 import { IcrcTokenAccountsPo } from "./IcrcTokenAccounts.page-object";
+import { IcrcTokenAccountsFooterPo } from "./IcrcTokenAccountsFooter.page-object";
 
 export class AccountsPo extends BasePageObject {
   private static readonly TID = "accounts-component";
@@ -24,6 +25,10 @@ export class AccountsPo extends BasePageObject {
 
   getIcrcTokenAccountsPo(): IcrcTokenAccountsPo {
     return IcrcTokenAccountsPo.under(this.root);
+  }
+
+  getIcrcTokenAccountsFooterPo(): IcrcTokenAccountsFooterPo {
+    return IcrcTokenAccountsFooterPo.under(this.root);
   }
 
   getSnsAccountsPo(): SnsAccountsPo {

--- a/frontend/src/tests/page-objects/IcrcTokenAccountsFooter.page-object.ts
+++ b/frontend/src/tests/page-objects/IcrcTokenAccountsFooter.page-object.ts
@@ -1,0 +1,12 @@
+import { BaseAccountsPo } from "$tests/page-objects/BaseAccounts.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class IcrcTokenAccountsFooterPo extends BaseAccountsPo {
+  private static readonly TID = "icrc-token-accounts-footer-component";
+
+  static under(element: PageObjectElement): IcrcTokenAccountsFooterPo {
+    return new IcrcTokenAccountsFooterPo(
+      element.byTestId(IcrcTokenAccountsFooterPo.TID)
+    );
+  }
+}


### PR DESCRIPTION
# Motivation

Users can Send and Receive ICRC tokens such as ckETH.

In this PR, I setup the IcrcTokenAccontsFooter

# Changes

* Render the IcrcTokenAccontsFooter in Accounts accordingly.

# Tests

* Add an expect in the test for ckETH universe in Accounts.spec
* New IcrcTokenAccontsFooterPo
* New methods in AccountsPo 

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary
