### PR TITLE
Include cketh canisters when importing IDs from URL

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -37,6 +37,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Experimental tests for schema migration.
 * Add optional version support to the storage records.
+* Include ckETH canister IDs when importing from URL with `scripts/canister_ids`.
 
 #### Changed
 

--- a/scripts/canister_ids
+++ b/scripts/canister_ids
@@ -117,7 +117,7 @@ get_value_from_html() {
   pattern="$key=\"([^\"]+)\""
   # E.g. find a line like `data-own-canister-id="lf43c-fyaaa-aaaaa-aacva-cai"`
   # and outputs the value between quotes.
-  grep -oE "$pattern" "$file" | sed -E "s/$pattern/\\1/" | head -1
+  grep -oE "$pattern" "$file" | sed -E "s/$pattern/\\1/" | head -1 || true
 }
 
 canister_id_from_url() {
@@ -145,6 +145,8 @@ if [ "$command" = "import-from-index-html" ]; then
   ckbtcIndex="$(get_value_from_html data-ckbtc-index-canister-id "$tmp_index_html")"
   ckbtcLedger="$(get_value_from_html data-ckbtc-ledger-canister-id "$tmp_index_html")"
   ckbtcMinter="$(get_value_from_html data-ckbtc-minter-canister-id "$tmp_index_html")"
+  ckethIndex="$(get_value_from_html data-cketh-index-canister-id "$tmp_index_html")"
+  ckethLedger="$(get_value_from_html data-cketh-ledger-canister-id "$tmp_index_html")"
   snsWasm="$(get_value_from_html data-wasm-canister-id "$tmp_index_html")"
   nnsDapp="$(get_value_from_html data-own-canister-id "$tmp_index_html")"
 
@@ -153,6 +155,8 @@ if [ "$command" = "import-from-index-html" ]; then
     .ckbtc_index[$network] = $ckbtcIndex |
     .ckbtc_ledger[$network] = $ckbtcLedger |
     .ckbtc_minter[$network] = $ckbtcMinter |
+    .cketh_index[$network] = $ckethIndex |
+    .cketh_ledger[$network] = $ckethLedger |
     .["nns-sns-wasm"][$network] = $snsWasm |
     .internet_identity[$network] = $internetIdentity |
     .["nns-dapp"][$network] = $nnsDapp |
@@ -161,6 +165,8 @@ if [ "$command" = "import-from-index-html" ]; then
     --arg ckbtcIndex "$ckbtcIndex" \
     --arg ckbtcLedger "$ckbtcLedger" \
     --arg ckbtcMinter "$ckbtcMinter" \
+    --arg ckethIndex "$ckethIndex" \
+    --arg ckethLedger "$ckethLedger" \
     --arg snsWasm "$snsWasm" \
     --arg internetIdentity "$internetIdentity" \
     --arg nnsDapp "$nnsDapp" \

--- a/scripts/canister_ids.test
+++ b/scripts/canister_ids.test
@@ -35,6 +35,8 @@ cat >"$test_index_html" <<-EOF
         data-ckbtc-index-canister-id="tqtu6-byaaa-aaaaa-aaana-cai"
         data-ckbtc-ledger-canister-id="st75y-vaaaa-aaaaa-aaalq-cai"
         data-ckbtc-minter-canister-id="t6rzw-2iaaa-aaaaa-aaama-cai"
+        data-cketh-index-canister-id="of3vp-2eaaa-aaaaa-qabha-cai"
+        data-cketh-ledger-canister-id="omy6t-mmaaa-aaaaa-qabgq-cai"
         data-cycles-minting-canister-id="rkp4c-7iaaa-aaaaa-aaaca-cai"
         data-dfx-network="staging"
         data-feature-flags="{&quot;ENABLE_CKBTC&quot;:true,&quot;ENABLE_CKTESTBTC&quot;:false,&quot;ENABLE_ICP_ICRC&quot;:false,&quot;ENABLE_INSTANT_UNLOCK&quot;:false,&quot;ENABLE_NEURON_SETTINGS&quot;:true}"
@@ -152,6 +154,12 @@ if ! diff "$test_json_file" <(
   },
   "ckbtc_minter": {
     "staging": "t6rzw-2iaaa-aaaaa-aaama-cai"
+  },
+  "cketh_index": {
+    "staging": "of3vp-2eaaa-aaaaa-qabha-cai"
+  },
+  "cketh_ledger": {
+    "staging": "omy6t-mmaaa-aaaaa-qabgq-cai"
   },
   "nns-sns-wasm": {
     "staging": "qaa6y-5yaaa-aaaaa-aaafa-cai"


### PR DESCRIPTION
# Motivation

When staging a release, one of the steps is importing canister IDs from a URL so they can be used to deploy the release candidate.

# Changes

1. Include ckETH canister IDs when importing from URL in `scripts/canister_ids`.
2. Output empty string instead of failing when a field is not present in the `index.html`.

# Tests

Test was updated.

# Todos

- [x] Add entry to changelog (if necessary).
