### PR TITLE
GIX-2121: Fix snsOnlyProjectStore

### DIFF
--- a/frontend/src/lib/derived/sns/sns-selected-project.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-selected-project.derived.ts
@@ -1,13 +1,14 @@
-import {
-  isIcrcTokenUniverseStore,
-  selectedUniverseIdStore,
-} from "$lib/derived/selected-universe.derived";
+import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
 import {
   snsProjectsCommittedStore,
   snsProjectsStore,
   type SnsFullProject,
 } from "$lib/derived/sns/sns-projects.derived";
-import { isUniverseCkBTC, isUniverseNns } from "$lib/utils/universe.utils";
+import {
+  snsAggregatorStore,
+  type SnsAggregatorData,
+  type SnsAggregatorStore,
+} from "$lib/stores/sns-aggregator.store";
 import type { Principal } from "@dfinity/principal";
 import { derived, type Readable } from "svelte/store";
 
@@ -15,16 +16,20 @@ import { derived, type Readable } from "svelte/store";
  * Returns undefined if the selected project is NNS or ckBTC, otherwise returns the selected project principal.
  */
 export const snsOnlyProjectStore = derived<
-  [Readable<Principal>, Readable<boolean>],
+  [Readable<Principal>, SnsAggregatorStore],
   Principal | undefined
 >(
-  [selectedUniverseIdStore, isIcrcTokenUniverseStore],
-  ([$selectedUniverseIdStore, isIcrcTokenUniverse]: [Principal, boolean]) =>
-    isUniverseNns($selectedUniverseIdStore) ||
-    isUniverseCkBTC($selectedUniverseIdStore) ||
-    isIcrcTokenUniverse
-      ? undefined
-      : $selectedUniverseIdStore
+  [selectedUniverseIdStore, snsAggregatorStore],
+  ([$selectedUniverseIdStore, snsAggreagatorData]: [
+    Principal,
+    SnsAggregatorData,
+  ]) =>
+    snsAggreagatorData.data?.some(
+      ({ canister_ids: { root_canister_id } }) =>
+        root_canister_id === $selectedUniverseIdStore.toText()
+    )
+      ? $selectedUniverseIdStore
+      : undefined
 );
 
 export const snsProjectSelectedStore: Readable<SnsFullProject | undefined> =

--- a/frontend/src/lib/derived/sns/sns-selected-project.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-selected-project.derived.ts
@@ -1,4 +1,7 @@
-import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
+import {
+  isIcrcTokenUniverseStore,
+  selectedUniverseIdStore,
+} from "$lib/derived/selected-universe.derived";
 import {
   snsProjectsCommittedStore,
   snsProjectsStore,
@@ -12,13 +15,16 @@ import { derived, type Readable } from "svelte/store";
  * Returns undefined if the selected project is NNS or ckBTC, otherwise returns the selected project principal.
  */
 export const snsOnlyProjectStore = derived<
-  Readable<Principal>,
+  [Readable<Principal>, Readable<boolean>],
   Principal | undefined
->(selectedUniverseIdStore, ($selectedUniverseIdStore: Principal) =>
-  isUniverseNns($selectedUniverseIdStore) ||
-  isUniverseCkBTC($selectedUniverseIdStore)
-    ? undefined
-    : $selectedUniverseIdStore
+>(
+  [selectedUniverseIdStore, isIcrcTokenUniverseStore],
+  ([$selectedUniverseIdStore, isIcrcTokenUniverse]: [Principal, boolean]) =>
+    isUniverseNns($selectedUniverseIdStore) ||
+    isUniverseCkBTC($selectedUniverseIdStore) ||
+    isIcrcTokenUniverse
+      ? undefined
+      : $selectedUniverseIdStore
 );
 
 export const snsProjectSelectedStore: Readable<SnsFullProject | undefined> =

--- a/frontend/src/tests/lib/components/accounts/SnsTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsTransactionsList.spec.ts
@@ -1,5 +1,4 @@
 import SnsTransactionList from "$lib/components/accounts/SnsTransactionsList.svelte";
-import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import * as services from "$lib/services/sns-transactions.services";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { page } from "$mocks/$app/stores";
@@ -10,10 +9,11 @@ import {
 } from "$tests/mocks/icrc-transactions.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import {
-  mockProjectSubscribe,
   mockSnsFullProject,
   mockSnsToken,
 } from "$tests/mocks/sns-projects.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
 vi.mock("$lib/services/sns-transactions.services", () => {
@@ -51,9 +51,12 @@ describe("SnsTransactionList", () => {
       data: { universe: mockSnsFullProject.rootCanisterId.toText() },
     });
 
-    vi.spyOn(snsProjectsStore, "subscribe").mockImplementation(
-      mockProjectSubscribe([mockSnsFullProject])
-    );
+    setSnsProjects([
+      {
+        rootCanisterId: mockSnsFullProject.rootCanisterId,
+        lifecycle: SnsSwapLifecycle.Committed,
+      },
+    ]);
   });
 
   it("should call service to load transactions", () => {

--- a/frontend/src/tests/lib/components/accounts/SnsWalletTransactionsObserver.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsWalletTransactionsObserver.spec.ts
@@ -1,5 +1,4 @@
 import { AppPath } from "$lib/constants/routes.constants";
-import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { syncStore } from "$lib/stores/sync.store";
 import type { PostMessageDataResponseSync } from "$lib/types/post-message.sync";
@@ -16,11 +15,9 @@ import {
 } from "$tests/mocks/icrc-transactions.mock";
 import { PostMessageMock } from "$tests/mocks/post-message.mocks";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
-import {
-  mockProjectSubscribe,
-  mockSnsFullProject,
-} from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { jsonReplacer } from "@dfinity/utils";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -43,14 +40,12 @@ describe("SnsWalletTransactionsObserver", () => {
   };
 
   beforeEach(() => {
-    vi.spyOn(snsProjectsStore, "subscribe").mockImplementation(
-      mockProjectSubscribe([
-        {
-          ...mockSnsFullProject,
-          rootCanisterId: rootCanisterIdMock,
-        },
-      ])
-    );
+    setSnsProjects([
+      {
+        rootCanisterId: rootCanisterIdMock,
+        lifecycle: SnsSwapLifecycle.Committed,
+      },
+    ]);
 
     icrcTransactionsStore.addTransactions(transaction);
 

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
@@ -18,12 +18,14 @@ import {
 } from "$tests/mocks/sns-neurons.mock";
 import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { mockSnsCanisterId } from "$tests/mocks/sns.api.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { NeuronState, Vote } from "@dfinity/nns";
 import type { SnsNeuron, SnsProposalData } from "@dfinity/sns";
 import {
   SnsNeuronPermissionType,
   SnsProposalDecisionStatus,
   SnsProposalRewardStatus,
+  SnsSwapLifecycle,
   SnsVote,
   type SnsBallot,
 } from "@dfinity/sns";
@@ -120,6 +122,13 @@ describe("SnsVotingCard", () => {
     spyRegisterVote.mockClear();
 
     page.mock({ data: { universe: mockSnsCanisterId.toText() } });
+
+    setSnsProjects([
+      {
+        rootCanisterId: mockSnsCanisterId,
+        lifecycle: SnsSwapLifecycle.Committed,
+      },
+    ]);
 
     snsParametersStore.setParameters({
       rootCanisterId: mockSnsCanisterId,

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
@@ -8,7 +8,6 @@ import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
 import { snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
-import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
 import {
   mockSnsSwapCommitment,
   principal,
@@ -26,8 +25,6 @@ describe("selected sns project derived stores", () => {
   });
 
   describe("snsOnlyProjectStore", () => {
-    const ledgerCanisterId = principal(0);
-
     beforeEach(() => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
       setSnsProjects([
@@ -40,7 +37,8 @@ describe("selected sns project derived stores", () => {
       tokensStore.reset();
     });
 
-    it("should be set by default undefined", () => {
+    it("should be set to undefined if NNS Universe", () => {
+      page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
       const $store = get(snsOnlyProjectStore);
 
       expect($store).toBeUndefined();
@@ -65,18 +63,8 @@ describe("selected sns project derived stores", () => {
       expect($store2).toBeUndefined();
     });
 
-    it("should return undefined if ICRC Token universe is selected", () => {
-      icrcCanistersStore.setCanisters({
-        ledgerCanisterId: ledgerCanisterId,
-        indexCanisterId: principal(3),
-      });
-      tokensStore.setTokens({
-        [ledgerCanisterId.toText()]: {
-          certified: true,
-          token: mockCkETHToken,
-        },
-      });
-      page.mock({ data: { universe: ledgerCanisterId.toText() } });
+    it("should return undefined if universe not valid SNS root canister id", () => {
+      page.mock({ data: { universe: principal(1).toText() } });
 
       expect(get(snsOnlyProjectStore)).toBeUndefined();
     });

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project.derived.spec.ts
@@ -4,8 +4,11 @@ import {
   snsOnlyProjectStore,
   snsProjectSelectedStore,
 } from "$lib/derived/sns/sns-selected-project.derived";
+import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
 import { snsSwapCommitmentsStore } from "$lib/stores/sns.store";
+import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
+import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
 import {
   mockSnsSwapCommitment,
   principal,
@@ -23,6 +26,8 @@ describe("selected sns project derived stores", () => {
   });
 
   describe("snsOnlyProjectStore", () => {
+    const ledgerCanisterId = principal(0);
+
     beforeEach(() => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
       setSnsProjects([
@@ -31,6 +36,8 @@ describe("selected sns project derived stores", () => {
           lifecycle: SnsSwapLifecycle.Committed,
         },
       ]);
+      icrcCanistersStore.reset();
+      tokensStore.reset();
     });
 
     it("should be set by default undefined", () => {
@@ -56,6 +63,22 @@ describe("selected sns project derived stores", () => {
 
       const $store2 = get(snsOnlyProjectStore);
       expect($store2).toBeUndefined();
+    });
+
+    it("should return undefined if ICRC Token universe is selected", () => {
+      icrcCanistersStore.setCanisters({
+        ledgerCanisterId: ledgerCanisterId,
+        indexCanisterId: principal(3),
+      });
+      tokensStore.setTokens({
+        [ledgerCanisterId.toText()]: {
+          certified: true,
+          token: mockCkETHToken,
+        },
+      });
+      page.mock({ data: { universe: ledgerCanisterId.toText() } });
+
+      expect(get(snsOnlyProjectStore)).toBeUndefined();
     });
   });
 

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -18,12 +18,14 @@ import {
 } from "$tests/mocks/sns-proposals.mock";
 import { SnsProposalDetailPo } from "$tests/page-objects/SnsProposalDetail.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { AnonymousIdentity } from "@dfinity/agent";
 import {
   SnsNeuronPermissionType,
   SnsProposalDecisionStatus,
   SnsProposalRewardStatus,
+  SnsSwapLifecycle,
   SnsVote,
 } from "@dfinity/sns";
 import { render, waitFor } from "@testing-library/svelte";
@@ -55,6 +57,12 @@ describe("SnsProposalDetail", () => {
       authStore.setForTesting(undefined);
       snsFunctionsStore.reset();
       page.mock({ data: { universe: rootCanisterId.toText() } });
+      setSnsProjects([
+        {
+          rootCanisterId,
+          lifecycle: SnsSwapLifecycle.Committed,
+        },
+      ]);
     });
 
     it("should show skeleton while loading proposal", async () => {

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -11,11 +11,14 @@ import {
   mockPrincipal,
 } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
 import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { AnonymousIdentity } from "@dfinity/agent";
 import {
   SnsProposalDecisionStatus,
   SnsProposalRewardStatus,
+  SnsSwapLifecycle,
   type SnsProposalData,
 } from "@dfinity/sns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
@@ -33,6 +36,8 @@ describe("SnsProposals", () => {
     )[0];
 
   const rootCanisterId = mockPrincipal;
+  const functionName = "test_function";
+  const functionId = BigInt(3);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -41,17 +46,23 @@ describe("SnsProposals", () => {
     snsFiltersStore.reset();
     // Reset to default value
     page.mock({ data: { universe: rootCanisterId.toText() } });
+    setSnsProjects([
+      {
+        rootCanisterId,
+        lifecycle: SnsSwapLifecycle.Committed,
+        nervousFunctions: [
+          {
+            ...nervousSystemFunctionMock,
+            name: functionName,
+            id: functionId,
+          },
+        ],
+      },
+    ]);
   });
 
   describe("logged in user", () => {
-    const functionName = "test_function";
-    const functionId = BigInt(3);
     beforeEach(() => {
-      fakeSnsGovernanceApi.addNervousSystemFunctionWith({
-        rootCanisterId,
-        name: functionName,
-        id: functionId,
-      });
       vi.spyOn(authStore, "subscribe").mockImplementation(
         mockAuthStoreSubscribe
       );
@@ -141,9 +152,6 @@ describe("SnsProposals", () => {
         identity: new AnonymousIdentity(),
         rootCanisterId,
       });
-      fakeSnsGovernanceApi.addNervousSystemFunctionWith({
-        rootCanisterId,
-      });
     });
 
     describe("Matching results", () => {
@@ -189,10 +197,6 @@ describe("SnsProposals", () => {
         rootCanisterId,
         ...proposals[1],
         action: functionId,
-      });
-      fakeSnsGovernanceApi.addNervousSystemFunctionWith({
-        rootCanisterId,
-        id: functionId,
       });
     });
 

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -45,7 +45,7 @@ import {
 import { mockSnsSelectedTransactionFeeStoreSubscribe } from "$tests/mocks/transaction-fee.mock";
 import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { SnsSwapLifecycle } from "@dfinity/sns";
@@ -158,6 +158,13 @@ describe("Accounts", () => {
       mockSnsSelectedTransactionFeeStoreSubscribe()
     );
 
+    setSnsProjects([
+      {
+        rootCanisterId: mockSnsFullProject.rootCanisterId,
+        lifecycle: SnsSwapLifecycle.Committed,
+      },
+    ]);
+
     // Reset to default value
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT },
@@ -171,7 +178,6 @@ describe("Accounts", () => {
     });
 
     icpAccountsStore.setForTesting(mockAccountsStoreData);
-    resetSnsProjects();
   });
 
   it("should render NnsAccounts by default", () => {


### PR DESCRIPTION
# Motivation

snsOnlyProjectStore should not return universes of ICRC Tokens. It's used in specifically SNS only places.

# Changes

* Fix `snsOnlyProjectStore` to check whether the current universe is an ICRC Token universe.

I know that SNS universes are actually ICRC Tokens. But in our current code, that is not the case, and until we refactor to use the same, we consider them differently.

# Tests

* Add a test case for `snsOnlyProjectStore`.

Test was failing without the fix.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary yet.
