### PR TITLE
Refactor ckBTC sync/load tokens and accounts to wallet

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCAccountsFooter.svelte
@@ -13,8 +13,8 @@
   import { busy } from "@dfinity/gix-components";
   import CkBTCReceiveButton from "$lib/components/accounts/CkBTCReceiveButton.svelte";
   import CkBTCSendButton from "$lib/components/accounts/CkBTCSendButton.svelte";
-  import { syncCkBTCAccounts } from "$lib/services/ckbtc-accounts.services";
   import { toastsError } from "$lib/stores/toasts.store";
+  import { syncAccounts } from "$lib/services/wallet-accounts.services";
 
   let canMakeTransactions = false;
   $: canMakeTransactions =
@@ -38,7 +38,7 @@
       return;
     }
 
-    await syncCkBTCAccounts({ universeId: $selectedCkBTCUniverseIdStore });
+    await syncAccounts({ universeId: $selectedCkBTCUniverseIdStore });
   };
 </script>
 

--- a/frontend/src/lib/derived/selected-universe.derived.ts
+++ b/frontend/src/lib/derived/selected-universe.derived.ts
@@ -87,13 +87,13 @@ export const isCkBTCUniverseStore = derived(
 
 export const selectedIcrcTokenUniverseIdStore = derived(
   [pageUniverseIdStore, pageStore, icrcCanistersStore],
-  ([canisterId, page, icrcTokensCanisters]: [
+  ([$pageUniverseIdStore, $page, $icrcCanistersStore]: [
     Principal,
     Page,
     IcrcCanistersStoreData,
   ]) =>
-    isNonGovernanceTokenPath(page)
-      ? icrcTokensCanisters[canisterId.toText()]?.ledgerCanisterId
+    isNonGovernanceTokenPath($page)
+      ? $icrcCanistersStore[$pageUniverseIdStore.toText()]?.ledgerCanisterId
       : undefined
 );
 
@@ -102,7 +102,8 @@ export const selectedIcrcTokenUniverseIdStore = derived(
  */
 export const isIcrcTokenUniverseStore = derived(
   selectedIcrcTokenUniverseIdStore,
-  (canisterId) => nonNullish(canisterId)
+  ($selectedIcrcTokenUniverseIdStore) =>
+    nonNullish($selectedIcrcTokenUniverseIdStore)
 );
 
 export const selectedUniverseStore: Readable<Universe> = derived(

--- a/frontend/src/lib/pages/CkBTCAccounts.svelte
+++ b/frontend/src/lib/pages/CkBTCAccounts.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
-  import { syncCkBTCAccounts } from "$lib/services/ckbtc-accounts.services";
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
   import AccountCard from "$lib/components/accounts/AccountCard.svelte";
   import { i18n } from "$lib/stores/i18n";
@@ -16,6 +15,7 @@
   import { CKBTC_ADDITIONAL_CANISTERS } from "$lib/constants/ckbtc-additional-canister-ids.constants";
   import { loadCkBTCInfo } from "$lib/services/ckbtc-info.services";
   import IcrcBalancesObserver from "$lib/components/accounts/IcrcBalancesObserver.svelte";
+  import { syncAccounts as syncWalletAccounts } from "$lib/services/wallet-accounts.services";
 
   let loading = false;
 
@@ -37,7 +37,7 @@
     }
 
     loading = true;
-    await syncCkBTCAccounts({ universeId: selectedCkBTCUniverseId });
+    await syncWalletAccounts({ universeId: selectedCkBTCUniverseId });
     loading = false;
   };
 

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -7,10 +7,6 @@
   import { findAccount, hasAccounts } from "$lib/utils/accounts.utils";
   import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
   import { TokenAmount, isNullish, nonNullish } from "@dfinity/utils";
-  import {
-    loadCkBTCAccounts,
-    syncCkBTCAccounts,
-  } from "$lib/services/ckbtc-accounts.services";
   import { toastsError } from "$lib/stores/toasts.store";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { i18n } from "$lib/stores/i18n";
@@ -36,6 +32,10 @@
   import IcrcBalancesObserver from "$lib/components/accounts/IcrcBalancesObserver.svelte";
   import WalletPageHeader from "$lib/components/accounts/WalletPageHeader.svelte";
   import WalletPageHeading from "$lib/components/accounts/WalletPageHeading.svelte";
+  import {
+    loadAccounts,
+    syncAccounts,
+  } from "$lib/services/wallet-accounts.services";
 
   export let accountIdentifier: string | undefined | null = undefined;
 
@@ -54,7 +54,7 @@
       return;
     }
 
-    await loadCkBTCAccounts({ universeId: $selectedCkBTCUniverseIdStore });
+    await loadAccounts({ universeId: $selectedCkBTCUniverseIdStore });
     await loadAccount($selectedCkBTCUniverseIdStore);
 
     reloadTransactions();
@@ -136,7 +136,7 @@
     }
 
     // Maybe the accounts were just not loaded yet in store, so we try to load the accounts in store
-    await syncCkBTCAccounts({ universeId });
+    await syncAccounts({ universeId });
 
     // And finally try to set the account again
     await loadAccount(universeId);

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -17,7 +17,7 @@
   } from "$lib/derived/sns/sns-projects.derived";
   import { nonNullish } from "@dfinity/utils";
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
-  import { uncertifiedLoadAccountsBalance } from "$lib/services/wallet-accounts.services";
+  import { uncertifiedLoadAccountsBalance } from "$lib/services/wallet-uncertified-accounts.services";
   import CkBTCAccounts from "$lib/pages/CkBTCAccounts.svelte";
   import SummaryUniverse from "$lib/components/summary/SummaryUniverse.svelte";
   import CkBTCAccountsFooter from "$lib/components/accounts/CkBTCAccountsFooter.svelte";

--- a/frontend/src/lib/services/ckbtc-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts.services.ts
@@ -9,6 +9,11 @@ import type { IcrcBlockIndex } from "@dfinity/ledger-icrc";
 import { get } from "svelte/store";
 import type { IcrcTransferTokensUserParams } from "./icrc-accounts.services";
 
+export const loadCkBTCAccounts = async (params: {
+  handleError?: () => void;
+  universeId: UniverseCanisterId;
+}): Promise<void> => loadAccounts(params);
+
 export const ckBTCTransferTokens = async ({
   source,
   universeId,

--- a/frontend/src/lib/services/ckbtc-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts.services.ts
@@ -1,71 +1,13 @@
 import type { IcrcTransferParams } from "$lib/api/icrc-ledger.api";
 import { icrcTransfer } from "$lib/api/icrc-ledger.api";
-import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
-import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
-import { loadCkBTCToken } from "$lib/services/ckbtc-tokens.services";
 import { transferTokens } from "$lib/services/icrc-accounts.services";
-import { queryAndUpdate } from "$lib/services/utils.services";
-import { getAccounts } from "$lib/services/wallet-loader.services";
-import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
-import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
-import { toastsError } from "$lib/stores/toasts.store";
-import type { Account } from "$lib/types/account";
+import { loadAccounts } from "$lib/services/wallet-accounts.services";
 import type { UniverseCanisterId } from "$lib/types/universe";
-import { notForceCallStrategy } from "$lib/utils/env.utils";
-import { toToastError } from "$lib/utils/error.utils";
 import type { Identity } from "@dfinity/agent";
 import type { IcrcBlockIndex } from "@dfinity/ledger-icrc";
 import { get } from "svelte/store";
 import type { IcrcTransferTokensUserParams } from "./icrc-accounts.services";
-
-export const loadCkBTCAccounts = async ({
-  handleError,
-  universeId,
-}: {
-  handleError?: () => void;
-  universeId: UniverseCanisterId;
-}): Promise<void> => {
-  return queryAndUpdate<Account[], unknown>({
-    strategy: FORCE_CALL_STRATEGY,
-    request: ({ certified, identity }) =>
-      getAccounts({ identity, certified, universeId }),
-    onLoad: ({ response: accounts, certified }) =>
-      icrcAccountsStore.set({
-        universeId,
-        accounts: {
-          accounts,
-          certified,
-        },
-      }),
-    onError: ({ error: err, certified }) => {
-      console.error(err);
-
-      if (!certified && notForceCallStrategy()) {
-        return;
-      }
-
-      // hide unproven data
-      icrcAccountsStore.reset();
-      icrcTransactionsStore.resetUniverse(CKBTC_UNIVERSE_CANISTER_ID);
-
-      toastsError(
-        toToastError({
-          err,
-          fallbackErrorLabelKey: "error.accounts_load",
-        })
-      );
-
-      handleError?.();
-    },
-    logMessage: "Syncing ckBTC Accounts",
-  });
-};
-
-export const syncCkBTCAccounts = async (params: {
-  handleError?: () => void;
-  universeId: UniverseCanisterId;
-}) => await Promise.all([loadCkBTCAccounts(params), loadCkBTCToken(params)]);
 
 export const ckBTCTransferTokens = async ({
   source,
@@ -91,7 +33,7 @@ export const ckBTCTransferTokens = async ({
         ...params,
         canisterId: universeId,
       }),
-    reloadAccounts: async () => await loadCkBTCAccounts({ universeId }),
+    reloadAccounts: async () => await loadAccounts({ universeId }),
     reloadTransactions: async () => Promise.resolve(),
   });
 };

--- a/frontend/src/lib/services/ckbtc-convert.services.ts
+++ b/frontend/src/lib/services/ckbtc-convert.services.ts
@@ -35,10 +35,7 @@ import { approveTransfer } from "../api/icrc-ledger.api";
 import { toastsError } from "../stores/toasts.store";
 import { numberToE8s } from "../utils/token.utils";
 import { getAuthenticatedIdentity } from "./auth.services";
-import {
-  ckBTCTransferTokens,
-  loadCkBTCAccounts,
-} from "./ckbtc-accounts.services";
+import { ckBTCTransferTokens } from "./ckbtc-accounts.services";
 import type { IcrcTransferTokensUserParams } from "./icrc-accounts.services";
 import { loadWalletTransactions } from "./wallet-transactions.services";
 
@@ -299,7 +296,7 @@ const reload = async ({
   // - if provided, the transactions of the account for which the transfer was executed
   // - the balance of the withdrawal account to display an information if some funds - from this transaction or another - are stuck and not been converted yet
   await Promise.all([
-    ...(loadAccounts ? [loadCkBTCAccounts({ universeId })] : []),
+    ...(loadAccounts ? [loadAccounts({ universeId })] : []),
     ...(nonNullish(source)
       ? [
           loadWalletTransactions({

--- a/frontend/src/lib/services/ckbtc-convert.services.ts
+++ b/frontend/src/lib/services/ckbtc-convert.services.ts
@@ -37,6 +37,7 @@ import { numberToE8s } from "../utils/token.utils";
 import { getAuthenticatedIdentity } from "./auth.services";
 import { ckBTCTransferTokens } from "./ckbtc-accounts.services";
 import type { IcrcTransferTokensUserParams } from "./icrc-accounts.services";
+import { loadAccounts as loadCkBTCAccounts } from "./wallet-accounts.services";
 import { loadWalletTransactions } from "./wallet-transactions.services";
 
 export type ConvertCkBTCToBtcParams = Omit<
@@ -296,7 +297,7 @@ const reload = async ({
   // - if provided, the transactions of the account for which the transfer was executed
   // - the balance of the withdrawal account to display an information if some funds - from this transaction or another - are stuck and not been converted yet
   await Promise.all([
-    ...(loadAccounts ? [loadAccounts({ universeId })] : []),
+    ...(loadAccounts ? [loadCkBTCAccounts({ universeId })] : []),
     ...(nonNullish(source)
       ? [
           loadWalletTransactions({

--- a/frontend/src/lib/services/ckbtc-convert.services.ts
+++ b/frontend/src/lib/services/ckbtc-convert.services.ts
@@ -35,9 +35,11 @@ import { approveTransfer } from "../api/icrc-ledger.api";
 import { toastsError } from "../stores/toasts.store";
 import { numberToE8s } from "../utils/token.utils";
 import { getAuthenticatedIdentity } from "./auth.services";
-import { ckBTCTransferTokens } from "./ckbtc-accounts.services";
+import {
+  ckBTCTransferTokens,
+  loadCkBTCAccounts,
+} from "./ckbtc-accounts.services";
 import type { IcrcTransferTokensUserParams } from "./icrc-accounts.services";
-import { loadAccounts as loadCkBTCAccounts } from "./wallet-accounts.services";
 import { loadWalletTransactions } from "./wallet-transactions.services";
 
 export type ConvertCkBTCToBtcParams = Omit<

--- a/frontend/src/lib/services/ckbtc-tokens.services.ts
+++ b/frontend/src/lib/services/ckbtc-tokens.services.ts
@@ -1,78 +1,23 @@
-import { getToken } from "$lib/api/wallet-ledger.api";
 import {
   CKBTC_UNIVERSE_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
-import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
+import { loadToken } from "$lib/services/wallet-tokens.services";
 import {
   ENABLE_CKBTC,
   ENABLE_CKTESTBTC,
 } from "$lib/stores/feature-flags.store";
-import { toastsError } from "$lib/stores/toasts.store";
-import { tokensStore } from "$lib/stores/tokens.store";
-import type { IcrcTokenMetadata } from "$lib/types/icrc";
-import type { UniverseCanisterId } from "$lib/types/universe";
-import { notForceCallStrategy } from "$lib/utils/env.utils";
 import { get } from "svelte/store";
-import { queryAndUpdate } from "./utils.services";
 
 export const loadCkBTCTokens = async () => {
   const enableCkBTC = get(ENABLE_CKBTC);
   const enableCkBTCTest = get(ENABLE_CKTESTBTC);
   return Promise.all([
     enableCkBTC
-      ? loadCkBTCToken({ universeId: CKBTC_UNIVERSE_CANISTER_ID })
+      ? loadToken({ universeId: CKBTC_UNIVERSE_CANISTER_ID })
       : undefined,
     enableCkBTCTest
-      ? loadCkBTCToken({ universeId: CKTESTBTC_UNIVERSE_CANISTER_ID })
+      ? loadToken({ universeId: CKTESTBTC_UNIVERSE_CANISTER_ID })
       : undefined,
   ]);
-};
-
-export const loadCkBTCToken = async ({
-  handleError,
-  universeId,
-}: {
-  handleError?: () => void;
-  universeId: UniverseCanisterId;
-}) => {
-  // Currently we assume the token metadata does not change that often and might never change while the session is active
-  // That's why, we load the token for a project only once as long as its data is already certified
-  const storeData = get(tokensStore);
-  if (storeData[universeId.toText()]?.certified) {
-    return;
-  }
-
-  return queryAndUpdate<IcrcTokenMetadata, unknown>({
-    strategy: FORCE_CALL_STRATEGY,
-    identityType: "current",
-    request: ({ certified, identity }) =>
-      getToken({
-        identity,
-        certified,
-        canisterId: universeId,
-      }),
-    onLoad: async ({ response: token, certified }) =>
-      tokensStore.setToken({
-        certified,
-        canisterId: universeId,
-        token,
-      }),
-    onError: ({ error: err, certified }) => {
-      if (!certified && notForceCallStrategy()) {
-        return;
-      }
-
-      // Explicitly handle only UPDATE errors
-      toastsError({
-        labelKey: "error.token_not_found",
-        err,
-      });
-
-      // Hide unproven data
-      tokensStore.resetUniverse(universeId);
-
-      handleError?.();
-    },
-  });
 };

--- a/frontend/src/lib/services/wallet-accounts.services.ts
+++ b/frontend/src/lib/services/wallet-accounts.services.ts
@@ -1,22 +1,28 @@
-import { getToken } from "$lib/api/wallet-ledger.api";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { queryAndUpdate } from "$lib/services/utils.services";
 import { getAccounts } from "$lib/services/wallet-loader.services";
+import { loadToken } from "$lib/services/wallet-tokens.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
+import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { toastsError } from "$lib/stores/toasts.store";
-import { tokensStore } from "$lib/stores/tokens.store";
 import type { Account } from "$lib/types/account";
-import type { IcrcTokenMetadata } from "$lib/types/icrc";
-import type {
-  UniverseCanisterId,
-  UniverseCanisterIdText,
-} from "$lib/types/universe";
-import { Principal } from "@dfinity/principal";
+import type { UniverseCanisterId } from "$lib/types/universe";
+import { notForceCallStrategy } from "$lib/utils/env.utils";
+import { toToastError } from "$lib/utils/error.utils";
 
 /**
- * This function performs only an insecure "query" and does not toast the error but throw it so that all errors are collected by its caller.
+ * TODO: once sns are migrated to store this module can probably be reused and renamed to icrc-accounts.services
  */
-const loadAccountsBalance = (universeId: UniverseCanisterId): Promise<void> => {
+
+export const loadAccounts = async ({
+  handleError,
+  universeId,
+}: {
+  handleError?: () => void;
+  universeId: UniverseCanisterId;
+}): Promise<void> => {
   return queryAndUpdate<Account[], unknown>({
+    strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       getAccounts({ identity, certified, universeId }),
     onLoad: ({ response: accounts, certified }) =>
@@ -27,70 +33,31 @@ const loadAccountsBalance = (universeId: UniverseCanisterId): Promise<void> => {
           certified,
         },
       }),
-    onError: ({ error: err }) => {
+    onError: ({ error: err, certified }) => {
       console.error(err);
-      throw err;
+
+      if (!certified && notForceCallStrategy()) {
+        return;
+      }
+
+      // hide unproven data
+      icrcAccountsStore.reset();
+      icrcTransactionsStore.resetUniverse(universeId);
+
+      toastsError(
+        toToastError({
+          err,
+          fallbackErrorLabelKey: "error.accounts_load",
+        })
+      );
+
+      handleError?.();
     },
-    logMessage: "Syncing Accounts Balance",
-    strategy: "query",
+    logMessage: "Syncing Accounts",
   });
 };
 
-/**
- * This function performs only an insecure "query" and does not toast the error but throw it so that all errors are collected by its caller.
- */
-const loadToken = (universeId: UniverseCanisterId): Promise<void> => {
-  return queryAndUpdate<IcrcTokenMetadata, unknown>({
-    request: ({ certified, identity }) =>
-      getToken({ identity, certified, canisterId: universeId }),
-    onLoad: ({ response: token, certified }) =>
-      tokensStore.setToken({
-        canisterId: universeId,
-        token,
-        certified,
-      }),
-    onError: ({ error: err }) => {
-      console.error(err);
-      throw err;
-    },
-    logMessage: "Syncing token",
-    strategy: "query",
-  });
-};
-
-/**
- * Load Icrc accounts balances and token
- *
- * ⚠️ WARNING: this feature only performs "query" calls. Effective "update" is performed when the universe is manually selected either through the token navigation switcher or accessed directly via the browser url.
- *
- * @param {universeIds: UniverseCanisterId[]; excludeUniverseIds: RootCanisterIdText[] | undefined} params
- * @param {UniverseCanisterId[]} params.universeIds The Icrc environment for which the balances should be loaded.
- * @param {RootCanisterIdText[] | undefined} params.excludeUniverseIds As the balance is also loaded by loadSnsAccounts() - to perform query and UPDATE call - this variable can be used to avoid to perform unnecessary query and per extension to override data in the balance store.
- */
-export const uncertifiedLoadAccountsBalance = async ({
-  universeIds,
-  excludeUniverseIds = [],
-}: {
-  universeIds: UniverseCanisterIdText[];
-  excludeUniverseIds?: UniverseCanisterIdText[] | undefined;
-}): Promise<void> => {
-  const results: PromiseSettledResult<[void, void]>[] =
-    await Promise.allSettled(
-      (
-        universeIds.filter(
-          (universeId) => !excludeUniverseIds.includes(universeId)
-        ) ?? []
-      ).map((universeId) =>
-        Promise.all([
-          loadAccountsBalance(Principal.fromText(universeId)),
-          loadToken(Principal.fromText(universeId)),
-        ])
-      )
-    );
-
-  const error: boolean =
-    results.find(({ status }) => status === "rejected") !== undefined;
-  if (error) {
-    toastsError({ labelKey: "error.sns_accounts_balance_load" });
-  }
-};
+export const syncAccounts = async (params: {
+  handleError?: () => void;
+  universeId: UniverseCanisterId;
+}) => await Promise.all([loadAccounts(params), loadToken(params)]);

--- a/frontend/src/lib/services/wallet-tokens.services.ts
+++ b/frontend/src/lib/services/wallet-tokens.services.ts
@@ -1,0 +1,57 @@
+import { getToken } from "$lib/api/wallet-ledger.api";
+import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
+import { queryAndUpdate } from "$lib/services/utils.services";
+import { toastsError } from "$lib/stores/toasts.store";
+import { tokensStore } from "$lib/stores/tokens.store";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
+import type { UniverseCanisterId } from "$lib/types/universe";
+import { notForceCallStrategy } from "$lib/utils/env.utils";
+import { get } from "svelte/store";
+
+export const loadToken = async ({
+  handleError,
+  universeId,
+}: {
+  handleError?: () => void;
+  universeId: UniverseCanisterId;
+}) => {
+  // Currently we assume the token metadata does not change that often and might never change while the session is active
+  // That's why, we load the token for a project only once as long as its data is already certified
+  const storeData = get(tokensStore);
+  if (storeData[universeId.toText()]?.certified) {
+    return;
+  }
+
+  return queryAndUpdate<IcrcTokenMetadata, unknown>({
+    strategy: FORCE_CALL_STRATEGY,
+    identityType: "current",
+    request: ({ certified, identity }) =>
+      getToken({
+        identity,
+        certified,
+        canisterId: universeId,
+      }),
+    onLoad: async ({ response: token, certified }) =>
+      tokensStore.setToken({
+        certified,
+        canisterId: universeId,
+        token,
+      }),
+    onError: ({ error: err, certified }) => {
+      if (!certified && notForceCallStrategy()) {
+        return;
+      }
+
+      // Explicitly handle only UPDATE errors
+      toastsError({
+        labelKey: "error.token_not_found",
+        err,
+      });
+
+      // Hide unproven data
+      tokensStore.resetUniverse(universeId);
+
+      handleError?.();
+    },
+  });
+};

--- a/frontend/src/lib/services/wallet-uncertified-accounts.services.ts
+++ b/frontend/src/lib/services/wallet-uncertified-accounts.services.ts
@@ -1,0 +1,96 @@
+import { getToken } from "$lib/api/wallet-ledger.api";
+import { queryAndUpdate } from "$lib/services/utils.services";
+import { getAccounts } from "$lib/services/wallet-loader.services";
+import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
+import { toastsError } from "$lib/stores/toasts.store";
+import { tokensStore } from "$lib/stores/tokens.store";
+import type { Account } from "$lib/types/account";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
+import type {
+  UniverseCanisterId,
+  UniverseCanisterIdText,
+} from "$lib/types/universe";
+import { Principal } from "@dfinity/principal";
+
+/**
+ * This function performs only an insecure "query" and does not toast the error but throw it so that all errors are collected by its caller.
+ */
+const loadAccountsBalance = (universeId: UniverseCanisterId): Promise<void> => {
+  return queryAndUpdate<Account[], unknown>({
+    request: ({ certified, identity }) =>
+      getAccounts({ identity, certified, universeId }),
+    onLoad: ({ response: accounts, certified }) =>
+      icrcAccountsStore.set({
+        universeId,
+        accounts: {
+          accounts,
+          certified,
+        },
+      }),
+    onError: ({ error: err }) => {
+      console.error(err);
+      throw err;
+    },
+    logMessage: "Syncing Accounts Balance",
+    strategy: "query",
+  });
+};
+
+/**
+ * This function performs only an insecure "query" and does not toast the error but throw it so that all errors are collected by its caller.
+ */
+const loadToken = (universeId: UniverseCanisterId): Promise<void> => {
+  return queryAndUpdate<IcrcTokenMetadata, unknown>({
+    request: ({ certified, identity }) =>
+      getToken({ identity, certified, canisterId: universeId }),
+    onLoad: ({ response: token, certified }) =>
+      tokensStore.setToken({
+        canisterId: universeId,
+        token,
+        certified,
+      }),
+    onError: ({ error: err }) => {
+      console.error(err);
+      throw err;
+    },
+    logMessage: "Syncing token",
+    strategy: "query",
+  });
+};
+
+/**
+ * Load Icrc accounts balances and token
+ *
+ * ⚠️ WARNING: this feature only performs "query" calls. Effective "update" is performed when the universe is manually selected either through the token navigation switcher or accessed directly via the browser url.
+ *
+ * @param {universeIds: UniverseCanisterId[]; excludeUniverseIds: RootCanisterIdText[] | undefined} params
+ * @param {UniverseCanisterId[]} params.universeIds The Icrc environment for which the balances should be loaded.
+ * @param {RootCanisterIdText[] | undefined} params.excludeUniverseIds As the balance is also loaded by loadSnsAccounts() - to perform query and UPDATE call - this variable can be used to avoid to perform unnecessary query and per extension to override data in the balance store.
+ */
+export const uncertifiedLoadAccountsBalance = async ({
+  universeIds,
+  excludeUniverseIds = [],
+}: {
+  universeIds: UniverseCanisterIdText[];
+  excludeUniverseIds?: UniverseCanisterIdText[] | undefined;
+}): Promise<void> => {
+  const results: PromiseSettledResult<[void, void]>[] =
+    await Promise.allSettled(
+      (
+        universeIds.filter(
+          (universeId) => !excludeUniverseIds.includes(universeId)
+        ) ?? []
+      ).map((universeId) =>
+        Promise.all([
+          loadAccountsBalance(Principal.fromText(universeId)),
+          loadToken(Principal.fromText(universeId)),
+        ])
+      )
+    );
+
+  const error: boolean =
+    results.find(({ status }) => status === "rejected") !== undefined;
+  if (error) {
+    toastsError({ labelKey: "error.sns_accounts_balance_load" });
+  }
+};

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -19,7 +19,7 @@
   import { uncertifiedLoadSnsAccountsBalances } from "$lib/services/sns-accounts-balance.services";
   import type { Universe } from "$lib/types/universe";
   import { isArrayEmpty } from "$lib/utils/utils";
-  import { uncertifiedLoadAccountsBalance } from "$lib/services/wallet-accounts.services";
+  import { uncertifiedLoadAccountsBalance } from "$lib/services/wallet-uncertified-accounts.services";
   import { ckBTCUniversesStore } from "$lib/derived/ckbtc-universes.derived";
   import { isUniverseCkBTC, isUniverseNns } from "$lib/utils/universe.utils";
   import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";

--- a/frontend/src/tests/lib/components/accounts/CkBTCAccountsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCAccountsFooter.spec.ts
@@ -26,7 +26,7 @@ vi.mock("$lib/services/ckbtc-minter.services", async () => {
   };
 });
 
-vi.mock("$lib/services/wallet-accounts.services", () => {
+vi.mock("$lib/services/wallet-uncertified-accounts.services", () => {
   return {
     syncAccounts: vi.fn().mockResolvedValue(undefined),
   };

--- a/frontend/src/tests/lib/components/accounts/CkBTCAccountsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCAccountsFooter.spec.ts
@@ -1,7 +1,7 @@
 import CkBTCAccountsFooter from "$lib/components/accounts/CkBTCAccountsFooter.svelte";
 import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
-import * as services from "$lib/services/ckbtc-accounts.services";
+import * as services from "$lib/services/wallet-accounts.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
@@ -26,9 +26,9 @@ vi.mock("$lib/services/ckbtc-minter.services", async () => {
   };
 });
 
-vi.mock("$lib/services/ckbtc-accounts.services", () => {
+vi.mock("$lib/services/wallet-accounts.services", () => {
   return {
-    syncCkBTCAccounts: vi.fn().mockResolvedValue(undefined),
+    syncAccounts: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -135,7 +135,7 @@ describe("CkBTCAccountsFooter", () => {
 
       await selectSegmentBTC(container);
 
-      const spy = vi.spyOn(services, "syncCkBTCAccounts");
+      const spy = vi.spyOn(services, "syncAccounts");
 
       fireEvent.click(
         getByTestId("reload-receive-account") as HTMLButtonElement

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -36,7 +36,7 @@ import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import { SvelteComponent, tick } from "svelte";
 import { get } from "svelte/store";
 
-vi.mock("$lib/services/ckbtc-accounts.services");
+vi.mock("$lib/services/wallet-accounts.services");
 vi.mock("$lib/services/ckbtc-convert.services");
 
 describe("CkBTCTransactionModal", () => {

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -36,6 +36,7 @@ import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import { SvelteComponent, tick } from "svelte";
 import { get } from "svelte/store";
 
+vi.mock("$lib/services/ckbtc-accounts.services");
 vi.mock("$lib/services/wallet-accounts.services");
 vi.mock("$lib/services/ckbtc-convert.services");
 

--- a/frontend/src/tests/lib/pages/CkBTCAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCAccounts.spec.ts
@@ -17,9 +17,9 @@ import {
 } from "$tests/mocks/tokens.mock";
 import { render, waitFor } from "@testing-library/svelte";
 
-vi.mock("$lib/services/ckbtc-accounts.services", () => {
+vi.mock("$lib/services/wallet-accounts.services", () => {
   return {
-    syncCkBTCAccounts: vi.fn().mockResolvedValue(undefined),
+    syncAccounts: vi.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/frontend/src/tests/lib/pages/CkBTCAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCAccounts.spec.ts
@@ -1,7 +1,7 @@
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import CkBTCAccounts from "$lib/pages/CkBTCAccounts.svelte";
-import { syncCkBTCAccounts } from "$lib/services/ckbtc-accounts.services";
+import { syncAccounts } from "$lib/services/wallet-accounts.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { formatToken } from "$lib/utils/token.utils";
@@ -81,7 +81,7 @@ describe("CkBTCAccounts", () => {
     it("should not load ckBTC accounts", () => {
       render(CkBTCAccounts);
 
-      expect(syncCkBTCAccounts).not.toHaveBeenCalled();
+      expect(syncAccounts).not.toHaveBeenCalled();
     });
 
     it("should render a main Account", async () => {
@@ -123,7 +123,7 @@ describe("CkBTCAccounts", () => {
     it("should call load ckBTC accounts", () => {
       render(CkBTCAccounts);
 
-      expect(syncCkBTCAccounts).toHaveBeenCalled();
+      expect(syncAccounts).toHaveBeenCalled();
     });
 
     it("should render skeletons while loading", () => {

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -9,7 +9,7 @@ import {
 import { AppPath } from "$lib/constants/routes.constants";
 import { WALLET_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/wallet.constants";
 import CkBTCWallet from "$lib/pages/CkBTCWallet.svelte";
-import * as services from "$lib/services/ckbtc-accounts.services";
+import * as services from "$lib/services/wallet-accounts.services";
 import { bitcoinAddressStore } from "$lib/stores/bitcoin.store";
 import { ckBTCInfoStore } from "$lib/stores/ckbtc-info.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
@@ -451,7 +451,7 @@ describe("CkBTCWallet", () => {
 
       await receiveModalPo.selectBitcoin();
 
-      const spy = vi.spyOn(services, "loadCkBTCAccounts");
+      const spy = vi.spyOn(services, "loadAccounts");
 
       await receiveModalPo.clickFinish();
 

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -14,7 +14,7 @@ import {
 import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
 import Accounts from "$lib/routes/Accounts.svelte";
 import { uncertifiedLoadSnsAccountsBalances } from "$lib/services/sns-accounts-balance.services";
-import { uncertifiedLoadAccountsBalance } from "$lib/services/wallet-accounts.services";
+import { uncertifiedLoadAccountsBalance } from "$lib/services/wallet-uncertified-accounts.services";
 import { authStore } from "$lib/stores/auth.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -74,7 +74,7 @@ vi.mock("$lib/services/sns-accounts-balance.services", () => {
   };
 });
 
-vi.mock("$lib/services/wallet-accounts.services", () => {
+vi.mock("$lib/services/wallet-uncertified-accounts.services", () => {
   return {
     uncertifiedLoadAccountsBalance: vi.fn().mockResolvedValue(undefined),
   };

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -62,9 +62,9 @@ vi.mock("$lib/services/sns-accounts.services", () => {
   };
 });
 
-vi.mock("$lib/services/ckbtc-accounts.services", () => {
+vi.mock("$lib/services/wallet-accounts.services", () => {
   return {
-    syncCkBTCAccounts: vi.fn().mockResolvedValue(undefined),
+    syncAccounts: vi.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -18,9 +18,9 @@ vi.mock("$lib/services/sns-accounts.services", () => {
   };
 });
 
-vi.mock("$lib/services/ckbtc-accounts.services", () => {
+vi.mock("$lib/services/wallet-accounts.services", () => {
   return {
-    syncCkBTCAccounts: vi.fn().mockResolvedValue(undefined),
+    syncAccounts: vi.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/frontend/src/tests/lib/services/ckbtc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts.services.spec.ts
@@ -1,25 +1,13 @@
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import * as ckbtcLedgerApi from "$lib/api/wallet-ledger.api";
-import {
-  CKBTC_UNIVERSE_CANISTER_ID,
-  CKTESTBTC_UNIVERSE_CANISTER_ID,
-} from "$lib/constants/ckbtc-canister-ids.constants";
-import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
+import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import * as services from "$lib/services/ckbtc-accounts.services";
-import { loadCkBTCAccounts } from "$lib/services/ckbtc-accounts.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
-import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
-import {
-  mockCkBTCMainAccount,
-  mockCkBTCToken,
-} from "$tests/mocks/ckbtc-accounts.mock";
-import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
+import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
 import { mockTokens } from "$tests/mocks/tokens.mock";
-import { tick } from "svelte";
-import { get } from "svelte/store";
 
 vi.mock("$lib/services/wallet-transactions.services", () => {
   return {
@@ -30,122 +18,6 @@ vi.mock("$lib/services/wallet-transactions.services", () => {
 describe("ckbtc-accounts-services", () => {
   beforeEach(() => {
     resetIdentity();
-  });
-
-  describe("loadCkBTCAccounts", () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
-      icrcAccountsStore.reset();
-      vi.spyOn(console, "error").mockImplementation(() => undefined);
-    });
-
-    it("should call api.getCkBTCAccount and load neurons in store", async () => {
-      const spyQuery = vi
-        .spyOn(ckbtcLedgerApi, "getAccount")
-        .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
-
-      await loadCkBTCAccounts({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
-
-      await tick();
-
-      const store = get(icrcAccountsStore);
-
-      expect(store[CKBTC_UNIVERSE_CANISTER_ID.toText()].accounts).toHaveLength(
-        1
-      );
-      expect(spyQuery).toBeCalled();
-
-      spyQuery.mockClear();
-    });
-
-    it("should call error callback", async () => {
-      const spyQuery = vi
-        .spyOn(ckbtcLedgerApi, "getAccount")
-        .mockRejectedValue(new Error());
-
-      const spy = vi.fn();
-
-      await loadCkBTCAccounts({
-        handleError: spy,
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
-      });
-
-      expect(spy).toBeCalled();
-
-      spyQuery.mockClear();
-    });
-
-    it("should empty store if update call fails", async () => {
-      icrcAccountsStore.set({
-        accounts: {
-          accounts: [mockCkBTCMainAccount],
-          certified: true,
-        },
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
-      });
-
-      icrcTransactionsStore.addTransactions({
-        canisterId: CKBTC_UNIVERSE_CANISTER_ID,
-        accountIdentifier: mockCkBTCMainAccount.identifier,
-        transactions: [mockIcrcTransactionWithId],
-        oldestTxId: undefined,
-        completed: false,
-      });
-
-      vi.spyOn(ckbtcLedgerApi, "getAccount").mockImplementation(() =>
-        Promise.reject(undefined)
-      );
-
-      await loadCkBTCAccounts({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
-
-      const store = get(icrcAccountsStore);
-      expect(store[CKBTC_UNIVERSE_CANISTER_ID.toText()]).toBeUndefined();
-
-      const transactionsStore = get(icrcTransactionsStore);
-      expect(
-        transactionsStore[CKBTC_UNIVERSE_CANISTER_ID.toText()]
-      ).toBeUndefined();
-    });
-  });
-
-  describe("syncCkBTCAccounts", () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
-      icrcAccountsStore.reset();
-    });
-
-    it("should call ckBTC accounts and token and load them in store", async () => {
-      const spyAccountsQuery = vi
-        .spyOn(ckbtcLedgerApi, "getAccount")
-        .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
-
-      const spyTokenQuery = vi
-        .spyOn(ckbtcLedgerApi, "getToken")
-        .mockImplementation(() => Promise.resolve(mockCkBTCToken));
-
-      await services.syncCkBTCAccounts({
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
-      });
-
-      await tick();
-
-      expect(spyAccountsQuery).toBeCalled();
-      expect(spyTokenQuery).toBeCalled();
-
-      const accountsStore = get(icrcAccountsStore);
-      expect(
-        accountsStore[CKBTC_UNIVERSE_CANISTER_ID.toText()].accounts
-      ).toHaveLength(1);
-
-      const tokenStore = get(ckBTCTokenStore);
-      expect(tokenStore).toEqual({
-        [CKBTC_UNIVERSE_CANISTER_ID.toText()]: {
-          token: mockCkBTCToken,
-          certified: true,
-        },
-        [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: undefined,
-      });
-    });
   });
 
   describe("ckBTCTransferTokens", () => {

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -3,13 +3,13 @@ import * as minterApi from "$lib/api/ckbtc-minter.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import * as ledgerApi from "$lib/api/wallet-ledger.api";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import * as ckbtcAccountsServices from "$lib/services/ckbtc-accounts.services";
 import {
   convertCkBTCToBtc,
   convertCkBTCToBtcIcrc2,
   retrieveBtc,
 } from "$lib/services/ckbtc-convert.services";
 import { loadCkBTCWithdrawalAccount } from "$lib/services/ckbtc-withdrawal-accounts.services";
-import * as walletAccountsServices from "$lib/services/wallet-accounts.services";
 import { loadWalletTransactions } from "$lib/services/wallet-transactions.services";
 import { bitcoinConvertBlockIndexes } from "$lib/stores/bitcoin.store";
 import { ckBTCWithdrawalAccountsStore } from "$lib/stores/ckbtc-withdrawal-accounts.store";
@@ -109,7 +109,7 @@ describe("ckbtc-convert-services", () => {
 
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     loadCkBTCAccountsSpy = vi
-      .spyOn(walletAccountsServices, "loadAccounts")
+      .spyOn(ckbtcAccountsServices, "loadCkBTCAccounts")
       .mockResolvedValue(undefined);
 
     vi.useFakeTimers().setSystemTime(now);

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -3,13 +3,13 @@ import * as minterApi from "$lib/api/ckbtc-minter.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import * as ledgerApi from "$lib/api/wallet-ledger.api";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
-import * as ckbtcAccountsServices from "$lib/services/ckbtc-accounts.services";
 import {
   convertCkBTCToBtc,
   convertCkBTCToBtcIcrc2,
   retrieveBtc,
 } from "$lib/services/ckbtc-convert.services";
 import { loadCkBTCWithdrawalAccount } from "$lib/services/ckbtc-withdrawal-accounts.services";
+import * as walletAccountsServices from "$lib/services/wallet-accounts.services";
 import { loadWalletTransactions } from "$lib/services/wallet-transactions.services";
 import { bitcoinConvertBlockIndexes } from "$lib/stores/bitcoin.store";
 import { ckBTCWithdrawalAccountsStore } from "$lib/stores/ckbtc-withdrawal-accounts.store";
@@ -109,7 +109,7 @@ describe("ckbtc-convert-services", () => {
 
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     loadCkBTCAccountsSpy = vi
-      .spyOn(ckbtcAccountsServices, "loadCkBTCAccounts")
+      .spyOn(walletAccountsServices, "loadAccounts")
       .mockResolvedValue(undefined);
 
     vi.useFakeTimers().setSystemTime(now);

--- a/frontend/src/tests/lib/services/ckbtc-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-tokens.services.spec.ts
@@ -3,13 +3,11 @@ import {
   CKBTC_UNIVERSE_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
-import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
 import * as services from "$lib/services/ckbtc-tokens.services";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { tokensStore } from "$lib/stores/tokens.store";
-import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
-import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 vi.mock("$lib/api/wallet-ledger.api");
@@ -18,59 +16,6 @@ describe("ckbtc-tokens-services", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetIdentity();
-  });
-
-  describe("loadCkBTCToken", () => {
-    beforeEach(() => {
-      tokensStore.reset();
-    });
-
-    it("should load token in the store", async () => {
-      const spyGetToken = vi
-        .spyOn(ledgerApi, "getToken")
-        .mockResolvedValue(mockCkBTCToken);
-
-      await services.loadCkBTCToken({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
-
-      await waitFor(() =>
-        expect(spyGetToken).toBeCalledWith({
-          identity: mockIdentity,
-          certified: true,
-          canisterId: CKBTC_UNIVERSE_CANISTER_ID,
-        })
-      );
-
-      const storeData = get(ckBTCTokenStore);
-
-      const token = {
-        token: mockCkBTCToken,
-        certified: true,
-      };
-
-      expect(storeData).toEqual({
-        [CKBTC_UNIVERSE_CANISTER_ID.toText()]: token,
-      });
-    });
-  });
-
-  describe("loadCkBTCToken already loaded", () => {
-    beforeEach(() => {
-      tokensStore.setToken({
-        canisterId: CKBTC_UNIVERSE_CANISTER_ID,
-        token: mockCkBTCToken,
-        certified: true,
-      });
-    });
-
-    it("should not reload token if already loaded", async () => {
-      const spyGetToken = vi
-        .spyOn(ledgerApi, "getToken")
-        .mockResolvedValue(mockCkBTCToken);
-
-      await services.loadCkBTCToken({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
-
-      expect(spyGetToken).not.toBeCalled();
-    });
   });
 
   describe("loadCkBTCTokens", () => {

--- a/frontend/src/tests/lib/services/wallet-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-accounts.services.spec.ts
@@ -1,101 +1,148 @@
-import * as ledgerApi from "$lib/api/wallet-ledger.api";
+import * as ckbtcLedgerApi from "$lib/api/wallet-ledger.api";
 import {
   CKBTC_UNIVERSE_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
-import { universesAccountsBalance } from "$lib/derived/universes-accounts-balance.derived";
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
-import * as services from "$lib/services/wallet-accounts.services";
+import {
+  loadAccounts,
+  syncAccounts,
+} from "$lib/services/wallet-accounts.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
-import { toastsError } from "$lib/stores/toasts.store";
-import { tokensStore } from "$lib/stores/tokens.store";
+import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockCkBTCMainAccount,
   mockCkBTCToken,
 } from "$tests/mocks/ckbtc-accounts.mock";
+import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import { tick } from "svelte";
 import { get } from "svelte/store";
 
-vi.mock("$lib/stores/toasts.store", () => {
+vi.mock("$lib/services/wallet-transactions.services", () => {
   return {
-    toastsError: vi.fn(),
+    loadCkBTCAccountTransactions: vi.fn().mockResolvedValue(undefined),
   };
 });
 
-describe("wallet-accounts.services", () => {
+describe("wallet-accounts-services", () => {
   beforeEach(() => {
     resetIdentity();
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-
-    icrcAccountsStore.reset();
-    tokensStore.reset();
-  });
-
-  const params = {
-    universeIds: [
-      CKBTC_UNIVERSE_CANISTER_ID.toText(),
-      CKTESTBTC_UNIVERSE_CANISTER_ID.toText(),
-    ],
-  };
-
-  it("should call api.getAccounts and load balance in store", async () => {
-    vi.spyOn(ledgerApi, "getToken").mockImplementation(() =>
-      Promise.resolve(mockCkBTCToken)
-    );
-
-    const spyQuery = vi
-      .spyOn(ledgerApi, "getAccount")
-      .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
-
-    await services.uncertifiedLoadAccountsBalance(params);
-
-    await tick();
-
-    const store = get(universesAccountsBalance);
-    // Nns + ckBTC + ckTESTBTC
-    expect(Object.keys(store)).toHaveLength(3);
-    expect(store[CKBTC_UNIVERSE_CANISTER_ID.toText()].balanceE8s).toEqual(
-      mockCkBTCMainAccount.balanceE8s
-    );
-    expect(spyQuery).toBeCalled();
-  });
-
-  it("should call api.getToken and load token in store", async () => {
-    const spyQuery = vi
-      .spyOn(ledgerApi, "getToken")
-      .mockImplementation(() => Promise.resolve(mockCkBTCToken));
-
-    vi.spyOn(ledgerApi, "getAccount").mockImplementation(() =>
-      Promise.resolve(mockCkBTCMainAccount)
-    );
-
-    await services.uncertifiedLoadAccountsBalance(params);
-
-    await tick();
-
-    const store = get(ckBTCTokenStore);
-    const token = {
-      token: mockCkBTCToken,
-      certified: false,
-    };
-    expect(store).toEqual({
-      [CKBTC_UNIVERSE_CANISTER_ID.toText()]: token,
-      [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: token,
+  describe("loadAccounts", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      icrcAccountsStore.reset();
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
     });
 
-    expect(spyQuery).toBeCalled();
+    it("should call api.getCkBTCAccount and load neurons in store", async () => {
+      const spyQuery = vi
+        .spyOn(ckbtcLedgerApi, "getAccount")
+        .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
+
+      await loadAccounts({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
+
+      await tick();
+
+      const store = get(icrcAccountsStore);
+
+      expect(store[CKBTC_UNIVERSE_CANISTER_ID.toText()].accounts).toHaveLength(
+        1
+      );
+      expect(spyQuery).toBeCalled();
+
+      spyQuery.mockClear();
+    });
+
+    it("should call error callback", async () => {
+      const spyQuery = vi
+        .spyOn(ckbtcLedgerApi, "getAccount")
+        .mockRejectedValue(new Error());
+
+      const spy = vi.fn();
+
+      await loadAccounts({
+        handleError: spy,
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+      });
+
+      expect(spy).toBeCalled();
+
+      spyQuery.mockClear();
+    });
+
+    it("should empty store if update call fails", async () => {
+      icrcAccountsStore.set({
+        accounts: {
+          accounts: [mockCkBTCMainAccount],
+          certified: true,
+        },
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+      });
+
+      icrcTransactionsStore.addTransactions({
+        canisterId: CKBTC_UNIVERSE_CANISTER_ID,
+        accountIdentifier: mockCkBTCMainAccount.identifier,
+        transactions: [mockIcrcTransactionWithId],
+        oldestTxId: undefined,
+        completed: false,
+      });
+
+      vi.spyOn(ckbtcLedgerApi, "getAccount").mockImplementation(() =>
+        Promise.reject(undefined)
+      );
+
+      await loadAccounts({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
+
+      const store = get(icrcAccountsStore);
+      expect(store[CKBTC_UNIVERSE_CANISTER_ID.toText()]).toBeUndefined();
+
+      const transactionsStore = get(icrcTransactionsStore);
+      expect(
+        transactionsStore[CKBTC_UNIVERSE_CANISTER_ID.toText()]
+      ).toBeUndefined();
+    });
   });
 
-  it("should toast error", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.spyOn(ledgerApi, "getAccount").mockRejectedValue(new Error());
+  describe("syncAccounts", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      icrcAccountsStore.reset();
+    });
 
-    await services.uncertifiedLoadAccountsBalance(params);
+    it("should call ckBTC accounts and token and load them in store", async () => {
+      const spyAccountsQuery = vi
+        .spyOn(ckbtcLedgerApi, "getAccount")
+        .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
 
-    expect(toastsError).toHaveBeenCalled();
+      const spyTokenQuery = vi
+        .spyOn(ckbtcLedgerApi, "getToken")
+        .mockImplementation(() => Promise.resolve(mockCkBTCToken));
+
+      await syncAccounts({
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+      });
+
+      await tick();
+
+      expect(spyAccountsQuery).toBeCalled();
+      expect(spyTokenQuery).toBeCalled();
+
+      const accountsStore = get(icrcAccountsStore);
+      expect(
+        accountsStore[CKBTC_UNIVERSE_CANISTER_ID.toText()].accounts
+      ).toHaveLength(1);
+
+      const tokenStore = get(ckBTCTokenStore);
+      expect(tokenStore).toEqual({
+        [CKBTC_UNIVERSE_CANISTER_ID.toText()]: {
+          token: mockCkBTCToken,
+          certified: true,
+        },
+        [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: undefined,
+      });
+    });
   });
 });

--- a/frontend/src/tests/lib/services/wallet-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-tokens.services.spec.ts
@@ -1,0 +1,71 @@
+import * as ledgerApi from "$lib/api/wallet-ledger.api";
+import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
+import { loadToken } from "$lib/services/wallet-tokens.services";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
+import { waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+vi.mock("$lib/api/wallet-ledger.api");
+
+describe("wallet-tokens-services", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetIdentity();
+  });
+
+  describe("loadToken", () => {
+    beforeEach(() => {
+      tokensStore.reset();
+    });
+
+    it("should load token in the store", async () => {
+      const spyGetToken = vi
+        .spyOn(ledgerApi, "getToken")
+        .mockResolvedValue(mockCkBTCToken);
+
+      await loadToken({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
+
+      await waitFor(() =>
+        expect(spyGetToken).toBeCalledWith({
+          identity: mockIdentity,
+          certified: true,
+          canisterId: CKBTC_UNIVERSE_CANISTER_ID,
+        })
+      );
+
+      const storeData = get(ckBTCTokenStore);
+
+      const token = {
+        token: mockCkBTCToken,
+        certified: true,
+      };
+
+      expect(storeData).toEqual({
+        [CKBTC_UNIVERSE_CANISTER_ID.toText()]: token,
+      });
+    });
+  });
+
+  describe("loadToken already loaded", () => {
+    beforeEach(() => {
+      tokensStore.setToken({
+        canisterId: CKBTC_UNIVERSE_CANISTER_ID,
+        token: mockCkBTCToken,
+        certified: true,
+      });
+    });
+
+    it("should not reload token if already loaded", async () => {
+      const spyGetToken = vi
+        .spyOn(ledgerApi, "getToken")
+        .mockResolvedValue(mockCkBTCToken);
+
+      await loadToken({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
+
+      expect(spyGetToken).not.toBeCalled();
+    });
+  });
+});

--- a/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
@@ -1,0 +1,101 @@
+import * as ledgerApi from "$lib/api/wallet-ledger.api";
+import {
+  CKBTC_UNIVERSE_CANISTER_ID,
+  CKTESTBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
+import { universesAccountsBalance } from "$lib/derived/universes-accounts-balance.derived";
+import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
+import * as services from "$lib/services/wallet-uncertified-accounts.services";
+import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
+import { toastsError } from "$lib/stores/toasts.store";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import {
+  mockCkBTCMainAccount,
+  mockCkBTCToken,
+} from "$tests/mocks/ckbtc-accounts.mock";
+import { tick } from "svelte";
+import { get } from "svelte/store";
+
+vi.mock("$lib/stores/toasts.store", () => {
+  return {
+    toastsError: vi.fn(),
+  };
+});
+
+describe("wallet-uncertified-accounts.services", () => {
+  beforeEach(() => {
+    resetIdentity();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+
+    icrcAccountsStore.reset();
+    tokensStore.reset();
+  });
+
+  const params = {
+    universeIds: [
+      CKBTC_UNIVERSE_CANISTER_ID.toText(),
+      CKTESTBTC_UNIVERSE_CANISTER_ID.toText(),
+    ],
+  };
+
+  it("should call api.getAccounts and load balance in store", async () => {
+    vi.spyOn(ledgerApi, "getToken").mockImplementation(() =>
+      Promise.resolve(mockCkBTCToken)
+    );
+
+    const spyQuery = vi
+      .spyOn(ledgerApi, "getAccount")
+      .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
+
+    await services.uncertifiedLoadAccountsBalance(params);
+
+    await tick();
+
+    const store = get(universesAccountsBalance);
+    // Nns + ckBTC + ckTESTBTC
+    expect(Object.keys(store)).toHaveLength(3);
+    expect(store[CKBTC_UNIVERSE_CANISTER_ID.toText()].balanceE8s).toEqual(
+      mockCkBTCMainAccount.balanceE8s
+    );
+    expect(spyQuery).toBeCalled();
+  });
+
+  it("should call api.getToken and load token in store", async () => {
+    const spyQuery = vi
+      .spyOn(ledgerApi, "getToken")
+      .mockImplementation(() => Promise.resolve(mockCkBTCToken));
+
+    vi.spyOn(ledgerApi, "getAccount").mockImplementation(() =>
+      Promise.resolve(mockCkBTCMainAccount)
+    );
+
+    await services.uncertifiedLoadAccountsBalance(params);
+
+    await tick();
+
+    const store = get(ckBTCTokenStore);
+    const token = {
+      token: mockCkBTCToken,
+      certified: false,
+    };
+    expect(store).toEqual({
+      [CKBTC_UNIVERSE_CANISTER_ID.toText()]: token,
+      [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: token,
+    });
+
+    expect(spyQuery).toBeCalled();
+  });
+
+  it("should toast error", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(ledgerApi, "getAccount").mockRejectedValue(new Error());
+
+    await services.uncertifiedLoadAccountsBalance(params);
+
+    expect(toastsError).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Motivation

This PR allow us in #3894 to extract a common WalletPageContent that can be used by Icrc and ckBTC wallet pages without the need of duplicating any loading logic.

# Changes

- extract sync/load functions from `ckbtc-accounts.services` -> `wallet-accounts.services`
- extract load function from `ckbtc-token.services` -> `wallet-token.services` (I'm not sure here we do not have a duplicate but moving it was a must to be able to move above functions. we can clean up in another PR if duplicate)
- rename current `ckbtc-accounts.services` to `ckbtc-uncertified-accounts.services` to resolve name clashes
- remove ckBTC in function names - e.g. `syncCkBTCAccounts` -> `syncAccounts` (one of the function that will be use in the generic Wallet Page)

No functional changes.
