### PR TITLE
GIX-2122: Send CkETH Tokens

### DIFF
--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -22,6 +22,7 @@ declare namespace svelteHTML {
     "on:nnsWalletModal"?: CompositionEventHandler<T>;
     "on:nnsCkBTCAccountsModal"?: CompositionEventHandler<T>;
     "on:nnsAccountsModal"?: CompositionEventHandler<T>;
+    "on:nnsIcrcTokenModal"?: CompositionEventHandler<T>;
   }
 }
 

--- a/frontend/src/lib/components/accounts/IcrcTokenAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTokenAccountsFooter.svelte
@@ -4,28 +4,28 @@
   import { isNullish, nonNullish } from "@dfinity/utils";
   import { selectedIcrcTokenUniverseIdStore } from "$lib/derived/selected-universe.derived";
   import { openIcrcTokenModal } from "$lib/utils/modals.utils";
-  import type { Principal } from "@dfinity/principal";
   import { tokensStore } from "$lib/stores/tokens.store";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import { toastsError } from "$lib/stores/toasts.store";
+  import type { UniverseCanisterId } from "$lib/types/universe";
 
-  let ledgerCanisterId: Principal | undefined;
-  $: ledgerCanisterId = $selectedIcrcTokenUniverseIdStore;
+  let universeId: UniverseCanisterId | undefined;
+  $: universeId = $selectedIcrcTokenUniverseIdStore;
 
   let token: IcrcTokenMetadata | undefined;
-  $: token = nonNullish(ledgerCanisterId)
-    ? $tokensStore[ledgerCanisterId.toText()]?.token
+  $: token = nonNullish(universeId)
+    ? $tokensStore[universeId.toText()]?.token
     : undefined;
 
   const openSendModal = () => {
-    if (isNullish(ledgerCanisterId) || isNullish(token)) {
+    if (isNullish(universeId) || isNullish(token)) {
       toastsError({ labelKey: "error.icrc_token_load" });
       return;
     }
     openIcrcTokenModal({
       type: "icrc-send",
       data: {
-        universeId: ledgerCanisterId,
+        universeId,
         token,
         loadTransactions: false,
       },

--- a/frontend/src/lib/components/accounts/IcrcTokenAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTokenAccountsFooter.svelte
@@ -1,15 +1,43 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import Footer from "$lib/components/layout/Footer.svelte";
-  import { nonNullish } from "@dfinity/utils";
+  import { isNullish, nonNullish } from "@dfinity/utils";
   import { selectedIcrcTokenUniverseIdStore } from "$lib/derived/selected-universe.derived";
+  import { openIcrcTokenModal } from "$lib/utils/modals.utils";
+  import type { Principal } from "@dfinity/principal";
+  import { tokensStore } from "$lib/stores/tokens.store";
+  import type { IcrcTokenMetadata } from "$lib/types/icrc";
+  import { toastsError } from "$lib/stores/toasts.store";
+
+  let ledgerCanisterId: Principal | undefined;
+  $: ledgerCanisterId = $selectedIcrcTokenUniverseIdStore;
+
+  let token: IcrcTokenMetadata | undefined;
+  $: token = nonNullish(ledgerCanisterId)
+    ? $tokensStore[ledgerCanisterId.toText()]?.token
+    : undefined;
+
+  const openSendModal = () => {
+    if (isNullish(ledgerCanisterId) || isNullish(token)) {
+      toastsError({ labelKey: "error.icrc_token_load" });
+      return;
+    }
+    openIcrcTokenModal({
+      type: "icrc-send",
+      data: {
+        universeId: ledgerCanisterId,
+        token,
+        loadTransactions: false,
+      },
+    });
+  };
 </script>
 
 {#if nonNullish($selectedIcrcTokenUniverseIdStore)}
   <Footer testId="icrc-token-accounts-footer-component">
-    <!-- TODO: Implement Send modal GIX-2120 -->
     <button
       class="primary full-width"
+      on:click={openSendModal}
       data-tid="open-new-icrc-token-transaction">{$i18n.accounts.send}</button
     >
     <!-- TODO: Add Receive button GIX-2124 -->

--- a/frontend/src/lib/modals/accounts/IcrcTokenAccountsModals.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenAccountsModals.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { TokenAmount } from "@dfinity/utils";
+  import IcrcTokenTransactionModal from "./IcrcTokenTransactionModal.svelte";
+  import type { IcrcTokenModalProps } from "$lib/types/icrc-accounts.modal";
+
+  let modal: IcrcTokenModalProps | undefined = undefined;
+
+  const onNnsCkBTCAccountsModal = ({
+    detail,
+  }: CustomEvent<IcrcTokenModalProps>) => (modal = detail);
+</script>
+
+<svelte:window on:nnsCkBTCAccountsModal={onNnsCkBTCAccountsModal} />
+
+{#if modal?.type === "icrc-send"}
+  <IcrcTokenTransactionModal
+    ledgerCanisterId={modal.data.universeId}
+    token={modal.data.token}
+    transactionFee={TokenAmount.fromE8s({
+      amount: modal.data.token.fee,
+      token: modal.data.token,
+    })}
+  />
+{/if}

--- a/frontend/src/lib/modals/accounts/IcrcTokenAccountsModals.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenAccountsModals.svelte
@@ -5,15 +5,22 @@
 
   let modal: IcrcTokenModalProps | undefined = undefined;
 
-  const onNnsCkBTCAccountsModal = ({
+  const closeModal = () => {
+    modal = undefined;
+  };
+
+  const onIcrcTokenAccountsModal = ({
     detail,
-  }: CustomEvent<IcrcTokenModalProps>) => (modal = detail);
+  }: CustomEvent<IcrcTokenModalProps>) => {
+    modal = detail;
+  };
 </script>
 
-<svelte:window on:nnsCkBTCAccountsModal={onNnsCkBTCAccountsModal} />
+<svelte:window on:nnsIcrcTokenModal={onIcrcTokenAccountsModal} />
 
 {#if modal?.type === "icrc-send"}
   <IcrcTokenTransactionModal
+    on:nnsClose={closeModal}
     ledgerCanisterId={modal.data.universeId}
     token={modal.data.token}
     transactionFee={TokenAmount.fromE8s({

--- a/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
@@ -7,7 +7,7 @@
   import TransactionModal from "$lib/modals/transaction/TransactionModal.svelte";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import type { Account } from "$lib/types/account";
-  import { Modal, Spinner, type WizardStep } from "@dfinity/gix-components";
+  import type { WizardStep } from "@dfinity/gix-components";
   import type { TransactionInit } from "$lib/types/transaction";
   import { TokenAmount, nonNullish } from "@dfinity/utils";
   import type { Principal } from "@dfinity/principal";
@@ -19,7 +19,7 @@
   export let selectedAccount: Account | undefined = undefined;
   export let ledgerCanisterId: Principal;
   export let token: IcrcTokenMetadata;
-  export let transactionFee: TokenAmount | undefined;
+  export let transactionFee: TokenAmount;
 
   let transactionInit: TransactionInit = {
     sourceAccount: selectedAccount,
@@ -47,7 +47,7 @@
       destinationAddress,
       amount,
       ledgerCanisterId,
-      fee: token?.fee,
+      fee: token.fee,
     });
 
     stopBusy("accounts");
@@ -59,32 +59,20 @@
   };
 </script>
 
-{#if nonNullish(transactionFee) && nonNullish(token)}
-  <TransactionModal
-    testId="icrc-transaction-modal-component"
-    rootCanisterId={ledgerCanisterId}
-    on:nnsSubmit={transfer}
-    on:nnsClose
-    bind:currentStep
-    {token}
-    {transactionFee}
-    {transactionInit}
-  >
-    <svelte:fragment slot="title"
-      >{title ?? $i18n.accounts.send}</svelte:fragment
-    >
-    <p slot="description" class="value no-margin">
-      {replacePlaceholders($i18n.accounts.sns_transaction_description, {
-        $token: token.symbol,
-      })}
-    </p>
-  </TransactionModal>
-{:else}
-  <!-- A toast error is shown if there is an error fetching the transaction fee -->
-  <!-- TODO: replace with busy spinner pattern as in <SnsIncreateStakeNeuronModal /> -->
-  <Modal testId="sns-transaction-modal-component" on:nnsClose>
-    <svelte:fragment slot="title"
-      >{title ?? $i18n.accounts.send}</svelte:fragment
-    ><Spinner /></Modal
-  >
-{/if}
+<TransactionModal
+  testId="icrc-transaction-modal-component"
+  rootCanisterId={ledgerCanisterId}
+  on:nnsSubmit={transfer}
+  on:nnsClose
+  bind:currentStep
+  {token}
+  {transactionFee}
+  {transactionInit}
+>
+  <svelte:fragment slot="title">{title ?? $i18n.accounts.send}</svelte:fragment>
+  <p slot="description" class="value no-margin">
+    {replacePlaceholders($i18n.accounts.sns_transaction_description, {
+      $token: token.symbol,
+    })}
+  </p>
+</TransactionModal>

--- a/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import { startBusy, stopBusy } from "$lib/stores/busy.store";
+  import { i18n } from "$lib/stores/i18n";
+  import { toastsSuccess } from "$lib/stores/toasts.store";
+  import type { NewTransaction } from "$lib/types/transaction";
+  import TransactionModal from "$lib/modals/transaction/TransactionModal.svelte";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import type { Account } from "$lib/types/account";
+  import { Modal, Spinner, type WizardStep } from "@dfinity/gix-components";
+  import type { TransactionInit } from "$lib/types/transaction";
+  import { TokenAmount, nonNullish } from "@dfinity/utils";
+  import type { Principal } from "@dfinity/principal";
+  import { icrcTransferTokens } from "$lib/services/icrc-accounts.services";
+  import type { IcrcTokenMetadata } from "$lib/types/icrc";
+
+  // TODO: Refactor to expect as props the rootCanisterId, transactionFee and token.
+  // This way we can reuse this component in a dashboard page.
+  export let selectedAccount: Account | undefined = undefined;
+  export let ledgerCanisterId: Principal;
+  export let token: IcrcTokenMetadata;
+  export let transactionFee: TokenAmount | undefined;
+
+  let transactionInit: TransactionInit = {
+    sourceAccount: selectedAccount,
+  };
+
+  let currentStep: WizardStep | undefined;
+
+  $: title =
+    currentStep?.name === "Form"
+      ? $i18n.accounts.send
+      : currentStep?.name === "QRCode"
+      ? $i18n.accounts.scan_qr_code
+      : $i18n.accounts.you_are_sending;
+
+  const dispatcher = createEventDispatcher();
+  const transfer = async ({
+    detail: { sourceAccount, amount, destinationAddress },
+  }: CustomEvent<NewTransaction>) => {
+    startBusy({
+      initiator: "accounts",
+    });
+
+    const { blockIndex } = await icrcTransferTokens({
+      source: sourceAccount,
+      destinationAddress,
+      amount,
+      ledgerCanisterId,
+      fee: token?.fee,
+    });
+
+    stopBusy("accounts");
+
+    if (nonNullish(blockIndex)) {
+      toastsSuccess({ labelKey: "accounts.transaction_success" });
+      dispatcher("nnsClose");
+    }
+  };
+</script>
+
+{#if nonNullish(transactionFee) && nonNullish(token)}
+  <TransactionModal
+    testId="icrc-transaction-modal-component"
+    rootCanisterId={ledgerCanisterId}
+    on:nnsSubmit={transfer}
+    on:nnsClose
+    bind:currentStep
+    {token}
+    {transactionFee}
+    {transactionInit}
+  >
+    <svelte:fragment slot="title"
+      >{title ?? $i18n.accounts.send}</svelte:fragment
+    >
+    <p slot="description" class="value no-margin">
+      {replacePlaceholders($i18n.accounts.sns_transaction_description, {
+        $token: token.symbol,
+      })}
+    </p>
+  </TransactionModal>
+{:else}
+  <!-- A toast error is shown if there is an error fetching the transaction fee -->
+  <!-- TODO: replace with busy spinner pattern as in <SnsIncreateStakeNeuronModal /> -->
+  <Modal testId="sns-transaction-modal-component" on:nnsClose>
+    <svelte:fragment slot="title"
+      >{title ?? $i18n.accounts.send}</svelte:fragment
+    ><Spinner /></Modal
+  >
+{/if}

--- a/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
@@ -60,7 +60,7 @@
 </script>
 
 <TransactionModal
-  testId="icrc-transaction-modal-component"
+  testId="icrc-token-transaction-modal-component"
   rootCanisterId={ledgerCanisterId}
   on:nnsSubmit={transfer}
   on:nnsClose

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -37,7 +37,7 @@
   import { loadCkETHCanisters } from "$lib/services/cketh-canisters.services";
   import IcrcTokenAccounts from "$lib/pages/IcrcTokenAccounts.svelte";
   import IcrcTokenAccountsFooter from "$lib/components/accounts/IcrcTokenAccountsFooter.svelte";
-  import IcrcTokenTransactionModal from "$lib/modals/accounts/IcrcTokenTransactionModal.svelte";
+  import IcrcTokenAccountsModals from "$lib/modals/accounts/IcrcTokenAccountsModals.svelte";
 
   // TODO: This component is mounted twice. Understand why and fix it.
 
@@ -135,7 +135,7 @@
   {#if $isCkBTCUniverseStore}
     <CkBTCAccountsModals />
   {:else if $selectedIcrcTokenUniverseIdStore}
-    <IcrcTokenTransactionModal />
+    <IcrcTokenAccountsModals />
   {:else}
     <AccountsModals />
   {/if}

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -6,6 +6,7 @@
     isCkBTCUniverseStore,
     isIcrcTokenUniverseStore,
     isNnsUniverseStore,
+    selectedIcrcTokenUniverseIdStore,
     selectedUniverseIdStore,
   } from "$lib/derived/selected-universe.derived";
   import SnsAccounts from "$lib/pages/SnsAccounts.svelte";
@@ -36,6 +37,7 @@
   import { loadCkETHCanisters } from "$lib/services/cketh-canisters.services";
   import IcrcTokenAccounts from "$lib/pages/IcrcTokenAccounts.svelte";
   import IcrcTokenAccountsFooter from "$lib/components/accounts/IcrcTokenAccountsFooter.svelte";
+  import IcrcTokenTransactionModal from "$lib/modals/accounts/IcrcTokenTransactionModal.svelte";
 
   // TODO: This component is mounted twice. Understand why and fix it.
 
@@ -132,6 +134,8 @@
 
   {#if $isCkBTCUniverseStore}
     <CkBTCAccountsModals />
+  {:else if $selectedIcrcTokenUniverseIdStore}
+    <IcrcTokenTransactionModal />
   {:else}
     <AccountsModals />
   {/if}

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -164,6 +164,7 @@ export interface IcrcTransferTokensUserParams {
   amount: number;
 }
 
+// TODO: use `wallet-accounts.services`
 export const transferTokens = async ({
   source,
   destinationAddress,
@@ -240,7 +241,7 @@ export const icrcTransferTokens = async ({
       }),
     reloadAccounts: async () =>
       await loadIcrcAccount({ ledgerCanisterId, certified: true }),
-    // TODO: Reload transactions after transfer in Wallet page
+    // Web workders take care of refreshing transactions
     reloadTransactions: () => Promise.resolve(),
   });
 };

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -1,4 +1,5 @@
 import {
+  icrcTransfer,
   queryIcrcBalance,
   queryIcrcToken,
   type IcrcTransferParams,
@@ -211,4 +212,35 @@ export const transferTokens = async ({
 
     return { blockIndex: undefined };
   }
+};
+
+export const icrcTransferTokens = async ({
+  source,
+  destinationAddress,
+  amount,
+  fee,
+  ledgerCanisterId,
+}: IcrcTransferTokensUserParams & {
+  fee: bigint;
+  ledgerCanisterId: Principal;
+}): Promise<{ blockIndex: IcrcBlockIndex | undefined }> => {
+  return transferTokens({
+    source,
+    amount,
+    fee,
+    destinationAddress,
+    transfer: async (
+      params: {
+        identity: Identity;
+      } & IcrcTransferParams
+    ) =>
+      await icrcTransfer({
+        ...params,
+        canisterId: ledgerCanisterId,
+      }),
+    reloadAccounts: async () =>
+      await loadIcrcAccount({ ledgerCanisterId, certified: true }),
+    // TODO: Reload transactions after transfer in Wallet page
+    reloadTransactions: () => Promise.resolve(),
+  });
 };

--- a/frontend/src/lib/types/icrc-accounts.modal.ts
+++ b/frontend/src/lib/types/icrc-accounts.modal.ts
@@ -6,7 +6,6 @@ export type IcrcTokenModalType = "icrc-send";
 export type IcrcTokenTransactionModalData = {
   universeId: UniverseCanisterId;
   token: IcrcTokenMetadata;
-  reloadAccountFromStore: (() => void) | undefined;
   loadTransactions: boolean;
 };
 

--- a/frontend/src/lib/types/icrc-accounts.modal.ts
+++ b/frontend/src/lib/types/icrc-accounts.modal.ts
@@ -1,0 +1,16 @@
+import type { UniverseCanisterId } from "$lib/types/universe";
+import type { IcrcTokenMetadata } from "./icrc";
+
+export type IcrcTokenModalType = "icrc-send";
+
+export type IcrcTokenTransactionModalData = {
+  universeId: UniverseCanisterId;
+  token: IcrcTokenMetadata;
+  reloadAccountFromStore: (() => void) | undefined;
+  loadTransactions: boolean;
+};
+
+export interface IcrcTokenModalProps {
+  type: IcrcTokenModalType;
+  data: IcrcTokenTransactionModalData;
+}

--- a/frontend/src/lib/utils/modals.utils.ts
+++ b/frontend/src/lib/utils/modals.utils.ts
@@ -1,4 +1,5 @@
 import type { AccountsModal } from "$lib/types/accounts.modal";
+import type { IcrcTokenModalProps } from "$lib/types/icrc-accounts.modal";
 import type {
   NnsNeuronModal,
   NnsNeuronModalData,
@@ -30,5 +31,11 @@ export const openWalletModal = (detail: WalletModal) =>
 export const openAccountsModal = (detail: AccountsModal) =>
   emit<AccountsModal>({
     message: "nnsAccountsModal",
+    detail,
+  });
+
+export const openIcrcTokenModal = (detail: IcrcTokenModalProps) =>
+  emit<IcrcTokenModalProps>({
+    message: "nnsIcrcTokenModal",
     detail,
   });

--- a/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
@@ -1,0 +1,83 @@
+import * as ledgerApi from "$lib/api/icrc-ledger.api";
+import { E8S_PER_ICP } from "$lib/constants/icp.constants";
+import { AppPath } from "$lib/constants/routes.constants";
+import IcrcTokenTransactionModal from "$lib/modals/accounts/IcrcTokenTransactionModal.svelte";
+import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
+import { page } from "$mocks/$app/stores";
+import {
+  mockIdentity,
+  mockPrincipal,
+  resetIdentity,
+} from "$tests/mocks/auth.store.mock";
+import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
+import { mockIcrcMainAccount } from "$tests/mocks/icrc-accounts.mock";
+import { renderModal } from "$tests/mocks/modal.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { IcrcTokenTransactionModalPo } from "$tests/page-objects/IcrcTokenTransactionModal.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
+import { TokenAmount } from "@dfinity/utils";
+
+vi.mock("$lib/api/icrc-ledger.api");
+
+describe("IcrcTokenTransactionModal", () => {
+  const ledgerCanisterId = mockPrincipal;
+  const token = mockCkETHToken;
+  const transactionFee = TokenAmount.fromE8s({
+    amount: token.fee,
+    token,
+  });
+
+  beforeEach(() => {
+    resetIdentity();
+    page.mock({
+      data: { universe: ledgerCanisterId.toText() },
+      routeId: AppPath.Accounts,
+    });
+    icrcAccountsStore.reset();
+    vi.spyOn(ledgerApi, "icrcTransfer").mockResolvedValue(1234n);
+  });
+
+  it("should transfer tokens", async () => {
+    // Used to choose the source account
+    icrcAccountsStore.set({
+      universeId: ledgerCanisterId,
+      accounts: {
+        accounts: [mockIcrcMainAccount],
+        certified: true,
+      },
+    });
+
+    const { container } = await renderModal({
+      component: IcrcTokenTransactionModal,
+      props: {
+        ledgerCanisterId,
+        token,
+        transactionFee,
+      },
+    });
+
+    const po = IcrcTokenTransactionModalPo.under(
+      new JestPageObjectElement(container)
+    );
+
+    const toAccount = {
+      owner: principal(2),
+    };
+    const amount = 10;
+
+    await po.transferToAddress({
+      destinationAddress: encodeIcrcAccount(toAccount),
+      amount,
+    });
+
+    expect(ledgerApi.icrcTransfer).toHaveBeenCalledTimes(1);
+    expect(ledgerApi.icrcTransfer).toHaveBeenCalledWith({
+      identity: mockIdentity,
+      canisterId: ledgerCanisterId,
+      amount: BigInt(amount * E8S_PER_ICP),
+      to: toAccount,
+      fee: token.fee,
+    });
+  });
+});

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -1,6 +1,8 @@
 import * as ledgerApi from "$lib/api/icrc-ledger.api";
+import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import {
   getIcrcAccountIdentity,
+  icrcTransferTokens,
   loadIcrcAccount,
   loadIcrcAccounts,
   loadIcrcToken,
@@ -8,6 +10,8 @@ import {
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
+import { mockIcrcMainAccount } from "$tests/mocks/icrc-accounts.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { mockToken, principal } from "$tests/mocks/sns-projects.mock";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
@@ -209,6 +213,85 @@ describe("icrc-accounts-services", () => {
         certified: false,
         token: mockToken,
       });
+    });
+  });
+
+  describe("icrcTransferTokens", () => {
+    const amount = 10;
+    const amountE8s = BigInt(10 * E8S_PER_ICP);
+    const fee = 10_000n;
+    const destinationAccount = {
+      owner: principal(2),
+    };
+
+    it("calls icrcTransfer from icrc ledger api", async () => {
+      await icrcTransferTokens({
+        source: mockIcrcMainAccount,
+        amount,
+        destinationAddress: encodeIcrcAccount(destinationAccount),
+        fee,
+        ledgerCanisterId,
+      });
+
+      expect(ledgerApi.icrcTransfer).toHaveBeenCalledTimes(1);
+      expect(ledgerApi.icrcTransfer).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        amount: amountE8s,
+        fee,
+        canisterId: ledgerCanisterId,
+        to: destinationAccount,
+      });
+    });
+
+    it("calls transfers from subaccount", async () => {
+      await icrcTransferTokens({
+        source: {
+          ...mockIcrcMainAccount,
+          type: "subAccount",
+          subAccount: mockSubAccountArray,
+        },
+        amount,
+        destinationAddress: encodeIcrcAccount(destinationAccount),
+        fee,
+        ledgerCanisterId,
+      });
+
+      expect(ledgerApi.icrcTransfer).toHaveBeenCalledTimes(1);
+      expect(ledgerApi.icrcTransfer).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        amount: amountE8s,
+        fee,
+        canisterId: ledgerCanisterId,
+        to: destinationAccount,
+        fromSubAccount: mockSubAccountArray,
+      });
+    });
+
+    it("should load balance after transfer", async () => {
+      const initialAccount = {
+        ...mockIcrcMainAccount,
+        balanceE8s: balanceE8s + amountE8s,
+      };
+      icrcAccountsStore.set({
+        universeId: ledgerCanisterId,
+        accounts: {
+          accounts: [initialAccount],
+          certified: true,
+        },
+      });
+
+      await icrcTransferTokens({
+        source: mockIcrcMainAccount,
+        amount,
+        destinationAddress: encodeIcrcAccount(destinationAccount),
+        fee,
+        ledgerCanisterId,
+      });
+
+      const finalAccount =
+        get(icrcAccountsStore)[ledgerCanisterId.toText()]?.accounts[0];
+
+      expect(finalAccount.balanceE8s).toEqual(balanceE8s);
     });
   });
 });

--- a/frontend/src/tests/page-objects/Accounts.page-object.ts
+++ b/frontend/src/tests/page-objects/Accounts.page-object.ts
@@ -7,6 +7,7 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 import { BuyICPModalPo } from "./BuyICPModal.page-object";
 import { IcrcTokenAccountsPo } from "./IcrcTokenAccounts.page-object";
 import { IcrcTokenAccountsFooterPo } from "./IcrcTokenAccountsFooter.page-object";
+import { IcrcTokenTransactionModalPo } from "./IcrcTokenTransactionModal.page-object";
 
 export class AccountsPo extends BasePageObject {
   private static readonly TID = "accounts-component";
@@ -27,6 +28,10 @@ export class AccountsPo extends BasePageObject {
     return IcrcTokenAccountsPo.under(this.root);
   }
 
+  getIcrcTokenTransactionModalPo() {
+    return IcrcTokenTransactionModalPo.under(this.root);
+  }
+
   getIcrcTokenAccountsFooterPo(): IcrcTokenAccountsFooterPo {
     return IcrcTokenAccountsFooterPo.under(this.root);
   }
@@ -45,6 +50,10 @@ export class AccountsPo extends BasePageObject {
 
   clickSend(): Promise<void> {
     return this.getNnsAccountsFooterPo().clickSend();
+  }
+
+  clickCkETHSend(): Promise<void> {
+    return this.getIcrcTokenAccountsFooterPo().clickSend();
   }
 
   clickBuyICP(): Promise<void> {

--- a/frontend/src/tests/page-objects/IcrcTokenAccountsFooter.page-object.ts
+++ b/frontend/src/tests/page-objects/IcrcTokenAccountsFooter.page-object.ts
@@ -9,4 +9,8 @@ export class IcrcTokenAccountsFooterPo extends BaseAccountsPo {
       element.byTestId(IcrcTokenAccountsFooterPo.TID)
     );
   }
+
+  async clickSend(): Promise<void> {
+    return this.click("open-new-icrc-token-transaction");
+  }
 }

--- a/frontend/src/tests/page-objects/IcrcTokenTransactionModal.page-object.ts
+++ b/frontend/src/tests/page-objects/IcrcTokenTransactionModal.page-object.ts
@@ -1,0 +1,12 @@
+import { TransactionModalBasePo } from "$tests/page-objects/TransactionModal.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class IcrcTokenTransactionModalPo extends TransactionModalBasePo {
+  private static readonly TID = "icrc-token-transaction-modal-component";
+
+  static under(element: PageObjectElement): IcrcTokenTransactionModalPo {
+    return new IcrcTokenTransactionModalPo(
+      element.byTestId(IcrcTokenTransactionModalPo.TID)
+    );
+  }
+}


### PR DESCRIPTION
# Motivation

User can send ICRC Tokens

It's a fairly big PR, but the functionality was better tested once all was in.

# Changes

* Add new event name `nnsIcrcTokenModal` to HTMLAttributes.
* Implement the button to open the Send modal.
* New component IcrcTokenAccountsModals to render the Icrc Token modals. For now only `IcrcTokenTransactionModal`. The type of the data needed differes from ckBTC and SNS; therefore, I couldn't easily reuse any. I bet we can further improve this, but in another PR.
* New IcrcTokenTransactionModal that renders a TransactionModal and makes the ICRC Token transfer.
* Render IcrcTokenAccountsModals in Accounts
* New icrc accounts service `icrcTransferTokens`. There is some duplication with ckBTC. We can improve this further.
* New types for icrc-accounts modals.
* New modal util `openIcrcTokenModal`.

# Tests

* Test new IcrcTokenTransactionModal
* Test that users can perform transactions from Accounts.
* Test new ICRC service `icrcTransferTokens`.
* Add new PO IcrcTokenTransactionModalPo
* Add necessary methods to POs

# Todos

- [ ] Add entry to changelog (if necessary).
