### PR TITLE
GIX-2144: Load ckETH canisters on init public

### DIFF
--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -33,8 +33,6 @@
     type IcrcCanistersStoreData,
   } from "$lib/stores/icrc-canisters.store";
   import { loadIcrcAccounts } from "$lib/services/icrc-accounts.services";
-  import { onMount } from "svelte";
-  import { loadCkETHCanisters } from "$lib/services/cketh-canisters.services";
   import IcrcTokenAccounts from "$lib/pages/IcrcTokenAccounts.svelte";
   import IcrcTokenAccountsFooter from "$lib/components/accounts/IcrcTokenAccountsFooter.svelte";
   import IcrcTokenAccountsModals from "$lib/modals/accounts/IcrcTokenAccountsModals.svelte";
@@ -46,10 +44,6 @@
 
   let loadSnsAccountsBalancesRequested = false;
   let loadCkBTCAccountsBalancesRequested = false;
-
-  onMount(() => {
-    loadCkETHCanisters();
-  });
 
   const loadSnsAccountsBalances = async (projects: SnsFullProject[]) => {
     // We start when the projects are fetched

--- a/frontend/src/lib/services/$public/app.services.ts
+++ b/frontend/src/lib/services/$public/app.services.ts
@@ -11,15 +11,12 @@ import { loadCkETHCanisters } from "../cketh-canisters.services";
  * These data can be read by any users without being signed-in.
  */
 export const initAppPublicData = (): Promise<
-  [PromiseSettledResult<void[]>, PromiseSettledResult<void[]>]
+  [PromiseSettledResult<void>, PromiseSettledResult<void>]
 > => {
-  const initNns: Promise<void>[] = [loadCkETHCanisters()];
-  const initSns: Promise<void>[] = [loadSnsProjects()];
-
   /**
-   * If Nns load but Sns load fails it is "fine" to go on because Nns are core features.
+   * If one of the promises fails, we don't want to block the app.
    */
-  return Promise.allSettled([Promise.all(initNns), Promise.all(initSns)]);
+  return Promise.allSettled([loadCkETHCanisters(), loadSnsProjects()]);
 };
 
 const syncAuthStore = async () => {

--- a/frontend/src/lib/services/$public/app.services.ts
+++ b/frontend/src/lib/services/$public/app.services.ts
@@ -4,6 +4,7 @@ import { displayAndCleanLogoutMsg } from "$lib/services/auth.services";
 import { authStore } from "$lib/stores/auth.store";
 import { layoutAuthReady } from "$lib/stores/layout.store";
 import { toastsError } from "$lib/stores/toasts.store";
+import { loadCkETHCanisters } from "../cketh-canisters.services";
 
 /**
  * Load the application public data that are available globally ("global stores").
@@ -12,7 +13,7 @@ import { toastsError } from "$lib/stores/toasts.store";
 export const initAppPublicData = (): Promise<
   [PromiseSettledResult<void[]>, PromiseSettledResult<void[]>]
 > => {
-  const initNns: Promise<void>[] = [];
+  const initNns: Promise<void>[] = [loadCkETHCanisters()];
   const initSns: Promise<void>[] = [loadSnsProjects()];
 
   /**

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -2,7 +2,6 @@ import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import {
-  CKETH_INDEX_CANISTER_ID,
   CKETH_LEDGER_CANISTER_ID,
   CKETH_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/cketh-canister-ids.constants";
@@ -20,7 +19,6 @@ import { authStore } from "$lib/stores/auth.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
-import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
@@ -362,23 +360,6 @@ describe("Accounts", () => {
         accounts: [mockAccount],
       });
     });
-  });
-
-  it("should not refetch ckETH accounts if ckETH canisters are already loaded", async () => {
-    overrideFeatureFlagsStore.setFlag("ENABLE_CKETH", true);
-
-    icrcCanistersStore.setCanisters({
-      ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
-      indexCanisterId: CKETH_INDEX_CANISTER_ID,
-    });
-
-    render(Accounts);
-
-    await runResolvedPromises();
-
-    // It's called once when the component is mounted
-    expect(icrcLedgerApi.queryIcrcToken).toHaveBeenCalledTimes(1);
-    expect(icrcLedgerApi.queryIcrcBalance).toHaveBeenCalledTimes(1);
   });
 
   it("should make ckETH transactions from ckETH universe", async () => {

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -47,6 +47,7 @@ import {
 import { mockSnsSelectedTransactionFeeStoreSubscribe } from "$tests/mocks/transaction-fee.mock";
 import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
@@ -150,6 +151,7 @@ describe("Accounts", () => {
   beforeEach(() => {
     tokensStore.reset();
     icrcAccountsStore.reset();
+    setCkETHCanisters();
 
     vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockResolvedValue(mockCkETHToken);
     vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockResolvedValue(

--- a/frontend/src/tests/lib/services/_public/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/app.services.spec.ts
@@ -32,6 +32,18 @@ describe("$public/app-services", () => {
     await expect(loadSnsProjects).toHaveBeenCalledTimes(1);
   });
 
+  describe("when ENABLE_CKETH and ENABLE_CKTESTBTC are disabled", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_CKETH", false);
+      overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", false);
+    });
+    it("should not load ckETH canisters in store", async () => {
+      await initAppPublicData();
+
+      expect(get(icrcCanistersStore)).toEqual({});
+    });
+  });
+
   describe("when ENABLE_CKETH is enabled", () => {
     beforeEach(() => {
       overrideFeatureFlagsStore.setFlag("ENABLE_CKETH", true);

--- a/frontend/src/tests/lib/services/_public/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/app.services.spec.ts
@@ -1,5 +1,16 @@
+import {
+  CKETHSEPOLIA_INDEX_CANISTER_ID,
+  CKETHSEPOLIA_LEDGER_CANISTER_ID,
+  CKETHSEPOLIA_UNIVERSE_CANISTER_ID,
+  CKETH_INDEX_CANISTER_ID,
+  CKETH_LEDGER_CANISTER_ID,
+  CKETH_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/cketh-canister-ids.constants";
 import { initAppPublicData } from "$lib/services/$public/app.services";
 import { loadSnsProjects } from "$lib/services/$public/sns.services";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
+import { get } from "svelte/store";
 
 vi.mock("$lib/services/$public/sns.services", () => {
   return {
@@ -8,13 +19,48 @@ vi.mock("$lib/services/$public/sns.services", () => {
 });
 
 describe("$public/app-services", () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
+    icrcCanistersStore.reset();
+    overrideFeatureFlagsStore.setFlag("ENABLE_CKETH", false);
+    overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", false);
   });
 
   it("should init Sns", async () => {
     await initAppPublicData();
 
     await expect(loadSnsProjects).toHaveBeenCalledTimes(1);
+  });
+
+  describe("when ENABLE_CKETH is enabled", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_CKETH", true);
+    });
+    it("should load ckETH canisters in store", async () => {
+      await initAppPublicData();
+
+      expect(
+        get(icrcCanistersStore)[CKETH_UNIVERSE_CANISTER_ID.toText()]
+      ).toEqual({
+        ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
+        indexCanisterId: CKETH_INDEX_CANISTER_ID,
+      });
+    });
+  });
+
+  describe("when ENABLE_CKTESTBTC is enabled", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", true);
+    });
+    it("should load ckETHSEPOLIA canisters in store", async () => {
+      await initAppPublicData();
+
+      expect(
+        get(icrcCanistersStore)[CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText()]
+      ).toEqual({
+        ledgerCanisterId: CKETHSEPOLIA_LEDGER_CANISTER_ID,
+        indexCanisterId: CKETHSEPOLIA_INDEX_CANISTER_ID,
+      });
+    });
   });
 });

--- a/frontend/src/tests/utils/cketh.test-utils.ts
+++ b/frontend/src/tests/utils/cketh.test-utils.ts
@@ -1,0 +1,19 @@
+import {
+  CKETH_INDEX_CANISTER_ID,
+  CKETH_LEDGER_CANISTER_ID,
+  CKETH_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/cketh-canister-ids.constants";
+import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
+
+export const setCkETHCanisters = () => {
+  icrcCanistersStore.setCanisters({
+    ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
+    indexCanisterId: CKETH_INDEX_CANISTER_ID,
+  });
+  tokensStore.setToken({
+    canisterId: CKETH_UNIVERSE_CANISTER_ID,
+    token: mockCkETHToken,
+  });
+};


### PR DESCRIPTION
# Motivation

CkETH will also be visible for non-logged in users.

In this PR, load the ckETH canisters on public init along the SNS projects.

This is not enough. We also need to load the tokens. That will come in another PR.

# Changes

* Move `loadCkETHCanisters` to app.services and remove it from Accounts.svelte.

# Tests

* Add a test util `setCkETHCanisters`.
* The Accounts tests now need to ckETH set because it's not loading them.
* Add tests for `initAppPublicData` to check that loads the ckETH canisters accordingly.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
