### PR TITLE
Map the list of transactions instead of individual transactions

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -2,6 +2,7 @@
 <svelte:options accessors />
 
 <script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
   import type { Account } from "$lib/types/account";
   import { mapCkbtcTransaction } from "$lib/utils/icrc-transactions.utils";
   import type { UniverseCanisterId } from "$lib/types/universe";
@@ -17,6 +18,18 @@
   export const reloadTransactions = () => transactions?.reloadTransactions?.();
 
   let transactions: IcrcWalletTransactionsList;
+
+  const mapTransactions = (
+    transactionData: IcrcTransactionData[]
+  ): UiTransaction[] =>
+    transactionData.map((transaction: IcrcTransactionData) =>
+      mapCkbtcTransaction({
+        ...transaction,
+        account,
+        token,
+        i18n: $i18n,
+      })
+    );
 </script>
 
 <IcrcWalletTransactionsList
@@ -25,5 +38,5 @@
   {account}
   {universeId}
   {token}
-  mapTransaction={mapCkbtcTransaction}
+  {mapTransactions}
 />

--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -5,10 +5,15 @@
   import { i18n } from "$lib/stores/i18n";
   import type { Account } from "$lib/types/account";
   import { mapCkbtcTransaction } from "$lib/utils/icrc-transactions.utils";
+  import type {
+    UiTransaction,
+    IcrcTransactionData,
+  } from "$lib/types/transaction";
   import type { UniverseCanisterId } from "$lib/types/universe";
   import type { CanisterId } from "$lib/types/canister";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import IcrcWalletTransactionsList from "$lib/components/accounts/IcrcWalletTransactionsList.svelte";
+  import { nonNullish } from "@dfinity/utils";
 
   export let indexCanisterId: CanisterId;
   export let universeId: UniverseCanisterId;
@@ -22,14 +27,16 @@
   const mapTransactions = (
     transactionData: IcrcTransactionData[]
   ): UiTransaction[] =>
-    transactionData.map((transaction: IcrcTransactionData) =>
-      mapCkbtcTransaction({
-        ...transaction,
-        account,
-        token,
-        i18n: $i18n,
-      })
-    );
+    transactionData
+      .map((transaction: IcrcTransactionData) =>
+        mapCkbtcTransaction({
+          ...transaction,
+          account,
+          token,
+          i18n: $i18n,
+        })
+      )
+      .filter(nonNullish);
 </script>
 
 <IcrcWalletTransactionsList

--- a/frontend/src/lib/components/accounts/IcrcWalletTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletTransactionsList.svelte
@@ -3,19 +3,20 @@
 
 <script lang="ts">
   import type { Account } from "$lib/types/account";
-  import type { UiTransaction } from "$lib/types/transaction";
+  import type {
+    UiTransaction,
+    IcrcTransactionData,
+  } from "$lib/types/transaction";
   import {
     loadWalletNextTransactions,
     loadWalletTransactions,
   } from "$lib/services/wallet-transactions.services";
-  import type { IcrcTransactionData } from "$lib/types/transaction";
   import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
   import { i18n } from "$lib/stores/i18n";
   import {
     getSortedTransactionsFromStore,
     isIcrcTransactionsCompleted,
     mapIcrcTransaction,
-    type MapIcrcTransactionType,
   } from "$lib/utils/icrc-transactions.utils";
   import IcrcTransactionsList from "$lib/components/accounts/IcrcTransactionsList.svelte";
   import type { UniverseCanisterId } from "$lib/types/universe";
@@ -31,9 +32,9 @@
   export let universeId: UniverseCanisterId;
   export let account: Account;
   export let token: IcrcTokenMetadata | undefined;
-  export let mapTransactions: (IcrcTransactionData) => UiTransaction = (
-    transactions
-  ) =>
+  export let mapTransactions = (
+    transactions: IcrcTransactionData[]
+  ): UiTransaction[] =>
     transactions
       .map((transaction: IcrcTransactionData) =>
         mapIcrcTransaction({

--- a/frontend/src/lib/components/accounts/IcrcWalletTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletTransactionsList.svelte
@@ -31,7 +31,19 @@
   export let universeId: UniverseCanisterId;
   export let account: Account;
   export let token: IcrcTokenMetadata | undefined;
-  export let mapTransaction: MapIcrcTransactionType = mapIcrcTransaction;
+  export let mapTransactions: (IcrcTransactionData) => UiTransaction = (
+    transactions
+  ) =>
+    transactions
+      .map((transaction: IcrcTransactionData) =>
+        mapIcrcTransaction({
+          ...transaction,
+          account,
+          token,
+          i18n: $i18n,
+        })
+      )
+      .filter(nonNullish);
 
   // Expose for test purpose only
   export let loading = true;
@@ -91,16 +103,7 @@
   });
 
   let uiTransactions: UiTransaction[];
-  $: uiTransactions = transactions
-    .map((transaction: IcrcTransactionData) =>
-      mapTransaction({
-        ...transaction,
-        account,
-        token,
-        i18n: $i18n,
-      })
-    )
-    .filter(nonNullish);
+  $: uiTransactions = mapTransactions(transactions);
 </script>
 
 <IcrcWalletTransactionsObserver

--- a/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsList.spec.ts
@@ -2,6 +2,10 @@ import IcrcWalletTransactionsList from "$lib/components/accounts/IcrcWalletTrans
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import * as services from "$lib/services/wallet-transactions.services";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
+import type {
+  IcrcTransactionData,
+  UiTransaction,
+} from "$lib/types/transaction";
 import { mockCkBTCAdditionalCanisters } from "$tests/mocks/canisters.mock";
 import {
   mockCkBTCMainAccount,
@@ -18,6 +22,7 @@ import {
   advanceTime,
   runResolvedPromises,
 } from "$tests/utils/timers.test-utils";
+import { TokenAmount } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
 vi.mock("$lib/services/wallet-transactions.services", () => {
@@ -41,13 +46,18 @@ vi.mock("$lib/services/worker-transactions.services", () => ({
 }));
 
 describe("IcrcWalletTransactionList", () => {
-  const renderComponent = () => {
+  const renderComponent = (
+    mapTransactions?: (
+      txs: IcrcTransactionData[]
+    ) => UiTransaction[] | undefined
+  ) => {
     const { container, component } = render(IcrcWalletTransactionsList, {
       props: {
         account: mockCkBTCMainAccount,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
         indexCanisterId: mockCkBTCAdditionalCanisters.indexCanisterId,
         token: mockCkBTCToken,
+        mapTransactions,
       },
     });
     return {
@@ -142,5 +152,59 @@ describe("IcrcWalletTransactionList", () => {
     const { po } = renderComponent();
 
     expect(await po.getTransactionCardPos()).toHaveLength(2);
+  });
+
+  it("should use custom mapTransactions", async () => {
+    const store = {
+      [CKBTC_UNIVERSE_CANISTER_ID.toText()]: {
+        [mockCkBTCMainAccount.identifier]: {
+          transactions: [mockIcrcTransactionWithId],
+          completed: false,
+          oldestTxId: BigInt(0),
+        },
+      },
+    };
+
+    vi.spyOn(icrcTransactionsStore, "subscribe").mockImplementation(
+      mockIcrcTransactionsStoreSubscribe(store)
+    );
+
+    const fakeHeadline = "Fake transaction";
+    const fakeUiTransaction: UiTransaction = {
+      domKey: "1",
+      isIncoming: false,
+      isPending: false,
+      headline: fakeHeadline,
+      otherParty: "123",
+      tokenAmount: TokenAmount.fromE8s({
+        amount: 100_000_000n,
+        token: mockCkBTCToken,
+      }),
+      timestamp: new Date(),
+    };
+
+    // Ignores actual transacitons and returns 3 fake transactions.
+    const mapTransactions = (
+      transactionData: IcrcTransactionData[]
+    ): UiTransaction[] => [
+      fakeUiTransaction,
+      {
+        ...fakeUiTransaction,
+        domKey: "2",
+      },
+      {
+        ...fakeUiTransaction,
+        domKey: "3",
+      },
+    ];
+
+    const { po } = renderComponent(mapTransactions);
+
+    const cards = await po.getTransactionCardPos();
+
+    expect(cards).toHaveLength(3);
+    expect(await cards[0].getHeadline()).toBe(fakeHeadline);
+    expect(await cards[1].getHeadline()).toBe(fakeHeadline);
+    expect(await cards[2].getHeadline()).toBe(fakeHeadline);
   });
 });

--- a/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsList.spec.ts
@@ -184,9 +184,7 @@ describe("IcrcWalletTransactionList", () => {
     };
 
     // Ignores actual transacitons and returns 3 fake transactions.
-    const mapTransactions = (
-      transactionData: IcrcTransactionData[]
-    ): UiTransaction[] => [
+    const mapTransactions = (_: IcrcTransactionData[]): UiTransaction[] => [
       fakeUiTransaction,
       {
         ...fakeUiTransaction,


### PR DESCRIPTION
# Motivation

We want the ckBTC wallet component to have full control over the transactions list in order to:
1. Include pending transactions mapped from `PendingUtxo`s
2. Merge some transactions into a single transaction, such as Approve+Transfer or Failed+Reimbursed.

This control was accomplished with https://github.com/dfinity/nns-dapp/pull/3828 by passing a `UITransaction[]` from `CkBTCTransactionsList` to `IcrcTransactionsList`.

Unfortunately, before we could make use of this, the effort was reversed in https://github.com/dfinity/nns-dapp/pull/3884 by passing only `mapCkbtcTransaction` (which maps individual transactions) from `CkBTCTransactionsList` to `IcrcWalletTransactionsList`.

In this PR we, once again, give `CkBTCTransactionsList` control over the full list by passing a function that maps a list of transactions instead of passing a function that maps individual transactions.

This is a pure refactoring. The PR does not yet do anything other than mapping each individual transaction.

# Changes

1. In `IcrcWalletTransactionsList` remove the `mapTransaction` (singular) prop and add the `mapTransactions` (plural) prop. It gets a default value which does the mapping that was already the default in that component.
2. From `CkBTCTransactionsList`, pass a function which maps all transactions through `mapCkbtcTransaction`.

# Tests

Existing tests pass.
Added a unit test for `IcrcWalletTransactionsList` that tests that the custom mapping function is used. It previously did not have such a test for the singular mapping function.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary