### PR TITLE
GIX-2144: Do not request token data if present

### DIFF
--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -21,7 +21,8 @@ import {
   type IcrcBlockIndex,
 } from "@dfinity/ledger-icrc";
 import type { Principal } from "@dfinity/principal";
-import { isNullish } from "@dfinity/utils";
+import { isNullish, nonNullish } from "@dfinity/utils";
+import { get } from "svelte/store";
 import { queryAndUpdate } from "./utils.services";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -37,6 +38,12 @@ export const loadIcrcToken = ({
   ledgerCanisterId: Principal;
   certified: boolean;
 }) => {
+  const currentToken = get(tokensStore)[ledgerCanisterId.toText()];
+
+  if (nonNullish(currentToken) && (currentToken.certified || !certified)) {
+    return;
+  }
+
   return queryAndUpdate<IcrcTokenMetadata, unknown>({
     strategy: certified ? FORCE_CALL_STRATEGY : "query",
     request: ({ certified, identity }) =>

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -98,6 +98,62 @@ describe("icrc-accounts-services", () => {
       });
       expect(ledgerApi.queryIcrcToken).toHaveBeenCalledTimes(1);
     });
+
+    it("doesn't load token from api into store if requested certified false and already present", async () => {
+      tokensStore.setToken({
+        canisterId: ledgerCanisterId,
+        token: mockToken,
+        certified: false,
+      });
+      expect(ledgerApi.queryIcrcToken).not.toBeCalled();
+
+      await loadIcrcToken({ ledgerCanisterId, certified: false });
+
+      expect(ledgerApi.queryIcrcToken).not.toBeCalled();
+    });
+
+    it("doesn't load token from api into store if requested certified true and already store is loaded with certified data", async () => {
+      tokensStore.setToken({
+        canisterId: ledgerCanisterId,
+        token: mockToken,
+        certified: true,
+      });
+      expect(ledgerApi.queryIcrcToken).not.toBeCalled();
+
+      await loadIcrcToken({ ledgerCanisterId, certified: true });
+
+      expect(ledgerApi.queryIcrcToken).not.toBeCalled();
+    });
+
+    it("doesn't load token from api into store if requested certified false and already store is loaded with certified data", async () => {
+      tokensStore.setToken({
+        canisterId: ledgerCanisterId,
+        token: mockToken,
+        certified: true,
+      });
+      expect(ledgerApi.queryIcrcToken).not.toBeCalled();
+
+      await loadIcrcToken({ ledgerCanisterId, certified: false });
+
+      expect(ledgerApi.queryIcrcToken).not.toBeCalled();
+    });
+
+    it("loads token from api into store if requested certified true and store has certified false", async () => {
+      tokensStore.setToken({
+        canisterId: ledgerCanisterId,
+        token: mockToken,
+        certified: false,
+      });
+      expect(ledgerApi.queryIcrcToken).not.toBeCalled();
+
+      await loadIcrcToken({ ledgerCanisterId, certified: true });
+
+      expect(ledgerApi.queryIcrcToken).toHaveBeenCalledTimes(2);
+      expect(get(tokensStore)[ledgerCanisterId.toText()]).toEqual({
+        certified: true,
+        token: mockToken,
+      });
+    });
   });
 
   describe("loadIcrcAccount", () => {


### PR DESCRIPTION
# Motivation

Avoid unnecessary calls to data that almost never changes.

In this PR, add functionality in `loadIcrcToken` to not request data when already loaded.

This will help call `loadIcrcToken` whenever is needed and not worry about making unnecessary calls.

# Changes

* In `loadIcrcToken` do not fetch data if already present in store.

# Tests

* Test the new functionality in `loadIcrcToken`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary yet. This is not used in prod yet.
