### PR TITLE
Icrc receive modal

### DIFF
--- a/frontend/src/lib/components/accounts/IcrcTokenAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTokenAccountsFooter.svelte
@@ -2,12 +2,18 @@
   import { i18n } from "$lib/stores/i18n";
   import Footer from "$lib/components/layout/Footer.svelte";
   import { isNullish, nonNullish } from "@dfinity/utils";
-  import { selectedIcrcTokenUniverseIdStore } from "$lib/derived/selected-universe.derived";
+  import {
+    selectedIcrcTokenUniverseIdStore,
+    selectedUniverseStore,
+  } from "$lib/derived/selected-universe.derived";
   import { openIcrcTokenModal } from "$lib/utils/modals.utils";
   import { tokensStore } from "$lib/stores/tokens.store";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import { toastsError } from "$lib/stores/toasts.store";
   import type { UniverseCanisterId } from "$lib/types/universe";
+  import ReceiveButton from "$lib/components/accounts/ReceiveButton.svelte";
+  import { syncAccounts } from "$lib/services/wallet-accounts.services";
+  import IC_LOGO from "$lib/assets/icp.svg";
 
   let universeId: UniverseCanisterId | undefined;
   $: universeId = $selectedIcrcTokenUniverseIdStore;
@@ -31,15 +37,35 @@
       },
     });
   };
+
+  const reload = async () => {
+    if (isNullish(universeId)) {
+      toastsError({
+        labelKey: "error.icrc_no_universe",
+      });
+      return;
+    }
+
+    await syncAccounts({ universeId });
+  };
 </script>
 
-{#if nonNullish($selectedIcrcTokenUniverseIdStore)}
+{#if nonNullish($selectedIcrcTokenUniverseIdStore) && nonNullish(universeId)}
   <Footer testId="icrc-token-accounts-footer-component">
     <button
       class="primary full-width"
       on:click={openSendModal}
       data-tid="open-new-icrc-token-transaction">{$i18n.accounts.send}</button
     >
-    <!-- TODO: Add Receive button GIX-2124 -->
+
+    <ReceiveButton
+      type="icrc-receive"
+      canSelectAccount
+      testId="receive-icrc"
+      {reload}
+      {universeId}
+      logo={$selectedUniverseStore?.logo ?? IC_LOGO}
+      tokenSymbol={token?.symbol}
+    />
   </Footer>
 {/if}

--- a/frontend/src/lib/components/accounts/IcrcTokenAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTokenAccountsFooter.svelte
@@ -50,7 +50,7 @@
   };
 </script>
 
-{#if nonNullish($selectedIcrcTokenUniverseIdStore) && nonNullish(universeId)}
+{#if nonNullish($selectedIcrcTokenUniverseIdStore)}
   <Footer testId="icrc-token-accounts-footer-component">
     <button
       class="primary full-width"

--- a/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
@@ -9,6 +9,8 @@
   import { syncAccounts } from "$lib/services/icp-accounts.services";
   import { openAccountsModal } from "$lib/utils/modals.utils";
   import { IconAdd } from "@dfinity/gix-components";
+  import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+  import IC_LOGO from "$lib/assets/icp.svg";
 
   let modal: "NewTransaction" | undefined = undefined;
   const openNewTransaction = () => (modal = "NewTransaction");
@@ -42,7 +44,13 @@
         data-tid="open-new-transaction">{$i18n.accounts.send}</button
       >
 
-      <ReceiveButton type="nns-receive" canSelectAccount {reload} />
+      <ReceiveButton
+        type="nns-receive"
+        canSelectAccount
+        {reload}
+        universeId={OWN_CANISTER_ID}
+        logo={IC_LOGO}
+      />
 
       <button
         class="primary full-width with-icon"

--- a/frontend/src/lib/components/accounts/ReceiveButton.svelte
+++ b/frontend/src/lib/components/accounts/ReceiveButton.svelte
@@ -11,7 +11,7 @@
   export let account: Account | undefined = undefined;
   export let reload: (() => Promise<void>) | undefined = undefined;
   export let canSelectAccount = false;
-  export let universeId: UniverseCanisterId;
+  export let universeId: UniverseCanisterId | undefined;
   export let logo: string;
   export let tokenSymbol: string | undefined = undefined;
 

--- a/frontend/src/lib/components/accounts/ReceiveButton.svelte
+++ b/frontend/src/lib/components/accounts/ReceiveButton.svelte
@@ -4,12 +4,16 @@
   import { openAccountsModal } from "$lib/utils/modals.utils";
   import { busy } from "@dfinity/gix-components";
   import type { AccountsModalType } from "$lib/types/accounts.modal";
+  import type { UniverseCanisterId } from "$lib/types/universe";
 
   export let testId = "receive-icp";
   export let type: AccountsModalType;
   export let account: Account | undefined = undefined;
   export let reload: (() => Promise<void>) | undefined = undefined;
   export let canSelectAccount = false;
+  export let universeId: UniverseCanisterId;
+  export let logo: string;
+  export let tokenSymbol: string | undefined = undefined;
 
   const openModal = () =>
     openAccountsModal({
@@ -18,6 +22,9 @@
         account,
         reload,
         canSelectAccount,
+        universeId,
+        tokenSymbol,
+        logo,
       },
     });
 </script>

--- a/frontend/src/lib/components/accounts/SnsAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/SnsAccountsFooter.svelte
@@ -42,7 +42,7 @@
   />
 {/if}
 
-{#if nonNullish($snsProjectAccountsStore) && nonNullish($snsOnlyProjectStore)}
+{#if nonNullish($snsProjectAccountsStore)}
   <Footer>
     <button
       class="primary full-width"

--- a/frontend/src/lib/components/accounts/SnsAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/SnsAccountsFooter.svelte
@@ -8,9 +8,13 @@
   import { isNullish, nonNullish } from "@dfinity/utils";
   import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { toastsError } from "$lib/stores/toasts.store";
-  import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
+  import {
+    selectedUniverseIdStore,
+    selectedUniverseStore,
+  } from "$lib/derived/selected-universe.derived";
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
   import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
+  import IC_LOGO from "$lib/assets/icp.svg";
 
   // TODO: Support adding subaccounts
   let modal: "NewTransaction" | undefined = undefined;
@@ -38,7 +42,7 @@
   />
 {/if}
 
-{#if nonNullish($snsProjectAccountsStore)}
+{#if nonNullish($snsProjectAccountsStore) && nonNullish($snsOnlyProjectStore)}
   <Footer>
     <button
       class="primary full-width"
@@ -47,10 +51,13 @@
     >
 
     <ReceiveButton
-      type="sns-receive"
+      type="icrc-receive"
       canSelectAccount
       testId="receive-sns"
       {reload}
+      universeId={$snsOnlyProjectStore}
+      logo={$selectedUniverseStore?.summary?.metadata.logo ?? IC_LOGO}
+      tokenSymbol={$selectedUniverseStore?.summary?.token.symbol}
     />
   </Footer>
 {/if}

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -925,7 +925,8 @@
   "universe": {
     "select_token": "Select Token",
     "select_nervous_system": "Select Nervous System",
-    "select": "Select"
+    "select": "Select",
+    "universe_logo": "$universe logo"
   },
   "sns_rewards_status": {
     "0": "Unknown",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -490,7 +490,7 @@
     "direction_to": "To:",
     "no_transactions": "No transactions",
     "icp_qrcode_aria_label": "A QR code that renders the address to receive ICP",
-    "sns_qrcode_aria_label": "A QR code that renders the address to receive $tokenSymbol",
+    "icrc_qrcode_aria_label": "A QR code that renders the address to receive $tokenSymbol",
     "token_address": "$tokenSymbol Address",
     "pending_transaction_timestamp": "Pending..."
   },
@@ -1023,7 +1023,8 @@
     "deposit_fee": "Sorry, the Inter-network Fee cannot be fetched.",
     "retrieve_btc_min_amount": "The amount falls below the minimum of $amount ckBTC required for converting to BTC.",
     "retrieve_btc_min_amount_unknown": "The minimum amount of ckBTC required for converting to BTC is unknown.",
-    "wait_ckbtc_info_parameters_certified": "Please wait until the ckBTC parameters have been certified."
+    "wait_ckbtc_info_parameters_certified": "Please wait until the ckBTC parameters have been certified.",
+    "icrc_no_universe": "An Icrc environment should be provided to execute this feature"
   },
   "feature_flags_prompt": {
     "override_true": "Enter the number for the feature you want to enable.",

--- a/frontend/src/lib/modals/accounts/AccountsModals.svelte
+++ b/frontend/src/lib/modals/accounts/AccountsModals.svelte
@@ -6,10 +6,7 @@
   } from "$lib/types/accounts.modal";
   import NnsReceiveModal from "$lib/modals/accounts/NnsReceiveModal.svelte";
   import { nonNullish } from "@dfinity/utils";
-  import SnsReceiveModal from "$lib/modals/accounts/SnsReceiveModal.svelte";
-  import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
-  import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
-  import IC_LOGO from "$lib/assets/icp.svg";
+  import IcrcReceiveModal from "$lib/modals/accounts/IcrcReceiveModal.svelte";
   import BuyIcpModal from "./BuyIcpModal.svelte";
   import type { Account } from "$lib/types/account";
 
@@ -39,12 +36,6 @@
   <NnsReceiveModal on:nnsClose={close} {data} />
 {/if}
 
-{#if type === "sns-receive" && nonNullish(data)}
-  <SnsReceiveModal
-    on:nnsClose={close}
-    {data}
-    universeId={$snsOnlyProjectStore}
-    logo={$selectedUniverseStore?.summary?.metadata.logo ?? IC_LOGO}
-    tokenSymbol={$selectedUniverseStore?.summary?.token.symbol}
-  />
+{#if type === "icrc-receive" && nonNullish(data)}
+  <IcrcReceiveModal on:nnsClose={close} {data} />
 {/if}

--- a/frontend/src/lib/modals/accounts/AccountsModals.svelte
+++ b/frontend/src/lib/modals/accounts/AccountsModals.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type {
     AccountsModal,
+    AccountsModalData,
     AccountsModalType,
     AccountsReceiveModalData,
   } from "$lib/types/accounts.modal";
@@ -10,20 +11,27 @@
   import BuyIcpModal from "./BuyIcpModal.svelte";
   import type { Account } from "$lib/types/account";
 
-  let modal: AccountsModal | undefined;
+  let modal:
+    | AccountsModal<AccountsReceiveModalData | AccountsModalData>
+    | undefined;
   const close = () => (modal = undefined);
 
   let type: AccountsModalType | undefined;
   $: type = modal?.type;
 
   let data: AccountsReceiveModalData | undefined;
-  $: data = (modal as AccountsModal | undefined)?.data;
+  $: data = (modal as AccountsModal<AccountsReceiveModalData> | undefined)
+    ?.data;
 
   let account: Account | undefined;
-  $: account = (modal as AccountsModal | undefined)?.data?.account;
+  $: account = (modal as AccountsModal<AccountsModalData> | undefined)?.data
+    ?.account;
 
-  const onNnsAccountsModal = ({ detail }: CustomEvent<AccountsModal>) =>
-    (modal = detail);
+  const onNnsAccountsModal = ({
+    detail,
+  }: CustomEvent<
+    AccountsModal<AccountsReceiveModalData | AccountsModalData>
+  >) => (modal = detail);
 </script>
 
 <svelte:window on:nnsAccountsModal={onNnsAccountsModal} />

--- a/frontend/src/lib/modals/accounts/IcrcReceiveModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcReceiveModal.svelte
@@ -8,22 +8,23 @@
   import { nonNullish } from "@dfinity/utils";
 
   export let data: AccountsReceiveModalData;
-  export let universeId: UniverseCanisterId | undefined;
-  export let tokenSymbol: string | undefined;
-  export let logo: string;
 
+  let universeId: UniverseCanisterId;
+  let tokenSymbol: string | undefined;
+  let logo: string;
   let account: Account | undefined;
   let reload: (() => Promise<void>) | undefined;
   let canSelectAccount: boolean;
 
-  $: ({ account, reload, canSelectAccount } = data);
+  $: ({ account, reload, canSelectAccount, universeId, tokenSymbol, logo } =
+    data);
 </script>
 
 {#if nonNullish(universeId) && nonNullish(tokenSymbol)}
   <ReceiveModal
     {account}
     on:nnsClose
-    qrCodeLabel={replacePlaceholders($i18n.wallet.sns_qrcode_aria_label, {
+    qrCodeLabel={replacePlaceholders($i18n.wallet.icrc_qrcode_aria_label, {
       $tokenSymbol: tokenSymbol,
     })}
     {logo}

--- a/frontend/src/lib/modals/accounts/IcrcReceiveModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcReceiveModal.svelte
@@ -9,7 +9,7 @@
 
   export let data: AccountsReceiveModalData;
 
-  let universeId: UniverseCanisterId;
+  let universeId: UniverseCanisterId | undefined;
   let tokenSymbol: string | undefined;
   let logo: string;
   let account: Account | undefined;

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -46,6 +46,8 @@
   import HardwareWalletShowActionButton from "$lib/components/accounts/HardwareWalletShowActionButton.svelte";
   import RenameSubAccountButton from "$lib/components/accounts/RenameSubAccountButton.svelte";
   import { nnsUniverseStore } from "$lib/derived/nns-universe.derived";
+  import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+  import IC_LOGO from "$lib/assets/icp.svg";
 
   onMount(() => {
     pollAccounts();
@@ -211,6 +213,8 @@
         type="nns-receive"
         account={$selectedAccountStore.account}
         reload={reloadAccount}
+        universeId={OWN_CANISTER_ID}
+        logo={IC_LOGO}
       />
     </Footer>
   </Island>

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -33,6 +33,7 @@
   import WalletPageHeader from "$lib/components/accounts/WalletPageHeader.svelte";
   import WalletPageHeading from "$lib/components/accounts/WalletPageHeading.svelte";
   import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
+  import IC_LOGO from "$lib/assets/icp.svg";
 
   let showModal: "send" | undefined = undefined;
 
@@ -169,6 +170,9 @@
       account={$selectedAccountStore.account}
       reload={reloadAccount}
       testId="receive-sns"
+      universeId={$snsOnlyProjectStore}
+      logo={$selectedUniverseStore?.summary?.metadata.logo ?? IC_LOGO}
+      tokenSymbol={$selectedUniverseStore?.summary?.token.symbol}
     />
   </Footer>
 </Island>

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -165,7 +165,7 @@
     >
 
     <ReceiveButton
-      type="sns-receive"
+      type="icrc-receive"
       account={$selectedAccountStore.account}
       reload={reloadAccount}
       testId="receive-sns"

--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -134,9 +134,10 @@
 
   {#if $isCkBTCUniverseStore}
     <CkBTCAccountsModals />
-  {:else if $selectedIcrcTokenUniverseIdStore}
-    <IcrcTokenAccountsModals />
   {:else}
+    {#if $selectedIcrcTokenUniverseIdStore}
+      <IcrcTokenAccountsModals />
+    {/if}
     <AccountsModals />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/lib/types/accounts.modal.ts
+++ b/frontend/src/lib/types/accounts.modal.ts
@@ -1,6 +1,7 @@
 import type { Account } from "$lib/types/account";
+import type { UniverseCanisterId } from "$lib/types/universe";
 
-export type AccountsModalType = "nns-receive" | "sns-receive" | "buy-icp";
+export type AccountsModalType = "nns-receive" | "icrc-receive" | "buy-icp";
 
 export interface AccountsModal {
   type: AccountsModalType;
@@ -10,6 +11,9 @@ export interface AccountsReceiveModalData {
   account: Account | undefined;
   reload: (() => Promise<void>) | undefined;
   canSelectAccount: boolean;
+  universeId: UniverseCanisterId;
+  tokenSymbol: string | undefined;
+  logo: string;
 }
 
 export interface AccountsModal {

--- a/frontend/src/lib/types/accounts.modal.ts
+++ b/frontend/src/lib/types/accounts.modal.ts
@@ -3,20 +3,19 @@ import type { UniverseCanisterId } from "$lib/types/universe";
 
 export type AccountsModalType = "nns-receive" | "icrc-receive" | "buy-icp";
 
-export interface AccountsModal {
-  type: AccountsModalType;
-}
-
-export interface AccountsReceiveModalData {
+export interface AccountsModalData {
   account: Account | undefined;
   reload: (() => Promise<void>) | undefined;
   canSelectAccount: boolean;
-  universeId: UniverseCanisterId;
+}
+
+export interface AccountsReceiveModalData extends AccountsModalData {
+  universeId: UniverseCanisterId | undefined;
   tokenSymbol: string | undefined;
   logo: string;
 }
 
-export interface AccountsModal {
+export interface AccountsModal<T> {
   type: AccountsModalType;
-  data: AccountsReceiveModalData;
+  data: T;
 }

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -507,7 +507,7 @@ interface I18nWallet {
   direction_to: string;
   no_transactions: string;
   icp_qrcode_aria_label: string;
-  sns_qrcode_aria_label: string;
+  icrc_qrcode_aria_label: string;
   token_address: string;
   pending_transaction_timestamp: string;
 }
@@ -1072,6 +1072,7 @@ interface I18nError__ckbtc {
   retrieve_btc_min_amount: string;
   retrieve_btc_min_amount_unknown: string;
   wait_ckbtc_info_parameters_certified: string;
+  icrc_no_universe: string;
 }
 
 interface I18nFeature_flags_prompt {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -966,6 +966,7 @@ interface I18nUniverse {
   select_token: string;
   select_nervous_system: string;
   select: string;
+  universe_logo: string;
 }
 
 interface I18nSns_rewards_status {

--- a/frontend/src/lib/types/icrc-accounts.modal.ts
+++ b/frontend/src/lib/types/icrc-accounts.modal.ts
@@ -1,6 +1,10 @@
 import type { UniverseCanisterId } from "$lib/types/universe";
 import type { IcrcTokenMetadata } from "./icrc";
 
+// TODO: to be refactored:
+// 1. Integrate those types in accounts.modal.ts
+// 2. Remove and integrate IcrcTokenAccountsModal into AccountsModal
+// 3. Remove usage in Accounts.svelte and Wallet
 export type IcrcTokenModalType = "icrc-send";
 
 export type IcrcTokenTransactionModalData = {

--- a/frontend/src/lib/types/icrc-accounts.modal.ts
+++ b/frontend/src/lib/types/icrc-accounts.modal.ts
@@ -1,7 +1,7 @@
 import type { UniverseCanisterId } from "$lib/types/universe";
 import type { IcrcTokenMetadata } from "./icrc";
 
-// TODO: to be refactored:
+// TODO: https://dfinity.atlassian.net/browse/GIX-2150 to be refactored:
 // 1. Integrate those types in accounts.modal.ts
 // 2. Remove and integrate IcrcTokenAccountsModal into AccountsModal
 // 3. Remove usage in Accounts.svelte and Wallet

--- a/frontend/src/lib/utils/modals.utils.ts
+++ b/frontend/src/lib/utils/modals.utils.ts
@@ -28,8 +28,8 @@ export const openWalletModal = (detail: WalletModal) =>
     detail,
   });
 
-export const openAccountsModal = (detail: AccountsModal) =>
-  emit<AccountsModal>({
+export const openAccountsModal = <T>(detail: AccountsModal<T>) =>
+  emit<AccountsModal<T>>({
     message: "nnsAccountsModal",
     detail,
   });

--- a/frontend/src/lib/utils/universe.utils.ts
+++ b/frontend/src/lib/utils/universe.utils.ts
@@ -8,6 +8,7 @@ import type { Page } from "$lib/derived/page.derived";
 import { i18n } from "$lib/stores/i18n";
 import type { SnsSummary } from "$lib/types/sns";
 import type { Universe } from "$lib/types/universe";
+import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { isSelectedPath } from "$lib/utils/navigation.utils";
 import type { Principal } from "@dfinity/principal";
 import { nonNullish } from "@dfinity/utils";
@@ -38,7 +39,11 @@ export const isUniverseCkTESTBTC = (
   (typeof canisterId === "string" ? canisterId : canisterId.toText()) ===
     CKTESTBTC_UNIVERSE_CANISTER_ID.toText();
 
-export const universeLogoAlt = ({ summary, canisterId }: Universe): string => {
+export const universeLogoAlt = ({
+  summary,
+  canisterId,
+  title,
+}: Universe): string => {
   const i18nObj = get(i18n);
 
   if (nonNullish(summary?.metadata.name)) {
@@ -53,7 +58,9 @@ export const universeLogoAlt = ({ summary, canisterId }: Universe): string => {
     return i18nObj.ckbtc.logo;
   }
 
-  return i18nObj.auth.ic_logo;
+  return replacePlaceholders(i18nObj.universe.universe_logo, {
+    $universe: title,
+  });
 };
 
 export const createUniverse = (summary: SnsSummary): Universe => ({

--- a/frontend/src/tests/lib/components/accounts/IcrcTokenAccountsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcTokenAccountsFooter.spec.ts
@@ -1,0 +1,75 @@
+import * as walletLedgerApi from "$lib/api/wallet-ledger.api";
+import IcrcTokenAccountsFooter from "$lib/components/accounts/IcrcTokenAccountsFooter.svelte";
+import {
+  CKETH_INDEX_CANISTER_ID,
+  CKETH_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/cketh-canister-ids.constants";
+import { AppPath } from "$lib/constants/routes.constants";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { page } from "$mocks/$app/stores";
+import AccountsTest from "$tests/lib/pages/AccountsTest.svelte";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import {
+  mockCkETHMainAccount,
+  mockCkETHToken,
+} from "$tests/mocks/cketh-accounts.mock";
+import {
+  modalToolbarSelector,
+  waitModalIntroEnd,
+} from "$tests/mocks/modal.mock";
+import { mockTokens } from "$tests/mocks/tokens.mock";
+import { testAccountsModal } from "$tests/utils/accounts.test-utils";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+
+describe("IcrcTokenAccountsFooter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetIdentity();
+
+    vi.spyOn(walletLedgerApi, "getToken").mockResolvedValue(mockCkETHToken);
+    vi.spyOn(walletLedgerApi, "getAccount").mockResolvedValue(
+      mockCkETHMainAccount
+    );
+
+    icrcCanistersStore.setCanisters({
+      ledgerCanisterId: CKETH_UNIVERSE_CANISTER_ID,
+      indexCanisterId: CKETH_INDEX_CANISTER_ID,
+    });
+
+    overrideFeatureFlagsStore.setFlag("ENABLE_CKETH", true);
+
+    tokensStore.setTokens(mockTokens);
+
+    page.mock({
+      data: {
+        universe: CKETH_UNIVERSE_CANISTER_ID.toText(),
+        routeId: AppPath.Accounts,
+      },
+    });
+  });
+
+  const modalProps = {
+    testComponent: IcrcTokenAccountsFooter,
+  };
+
+  it("should sync accounts after finish receiving tokens", async () => {
+    const result = render(AccountsTest, { props: modalProps });
+
+    await testAccountsModal({ result, testId: "receive-icrc" });
+
+    const { getByTestId, container } = result;
+
+    await waitModalIntroEnd({ container, selector: modalToolbarSelector });
+
+    await waitFor(() => expect(getByTestId("receive-modal")).not.toBeNull());
+
+    expect(walletLedgerApi.getAccount).toBeCalledTimes(0);
+
+    fireEvent.click(getByTestId("reload-receive-account") as HTMLButtonElement);
+
+    // Query + Update calls
+    await waitFor(() => expect(walletLedgerApi.getAccount).toBeCalledTimes(2));
+  });
+});

--- a/frontend/src/tests/lib/modals/accounts/IcrcReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcrcReceiveModal.spec.ts
@@ -1,10 +1,10 @@
-import SnsReceiveModal from "$lib/modals/accounts/IcrcReceiveModal.svelte";
+import IcrcReceiveModal from "$lib/modals/accounts/IcrcReceiveModal.svelte";
 import type { Account } from "$lib/types/account";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 
-describe("SnsReceiveModal", () => {
+describe("IcrcReceiveModal", () => {
   const reloadSpy = vi.fn();
   const tokenSymbol = "TST";
 
@@ -20,7 +20,7 @@ describe("SnsReceiveModal", () => {
     tokenSymbol: string;
   }) =>
     renderModal({
-      component: SnsReceiveModal,
+      component: IcrcReceiveModal,
       props: {
         data: {
           account,

--- a/frontend/src/tests/lib/modals/accounts/IcrcReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcrcReceiveModal.spec.ts
@@ -12,13 +12,15 @@ describe("IcrcReceiveModal", () => {
     vi.clearAllMocks();
   });
 
-  const renderReceiveModal = ({
-    account = mockSnsMainAccount,
-    tokenSymbol,
-  }: {
-    account?: Account;
-    tokenSymbol: string;
-  }) =>
+  const renderReceiveModal = (
+    {
+      account = mockSnsMainAccount,
+      tokenSymbol,
+    }: {
+      account?: Account;
+      tokenSymbol: string;
+    }
+  ) =>
     renderModal({
       component: IcrcReceiveModal,
       props: {
@@ -26,10 +28,10 @@ describe("IcrcReceiveModal", () => {
           account,
           reload: reloadSpy,
           canSelectAccount: false,
+          universeId: rootCanisterIdMock,
+          tokenSymbol,
+          logo: "logo.svg",
         },
-        universeId: rootCanisterIdMock,
-        tokenSymbol,
-        logo: "logo.svg",
       },
     });
 

--- a/frontend/src/tests/lib/modals/accounts/IcrcReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcrcReceiveModal.spec.ts
@@ -12,15 +12,13 @@ describe("IcrcReceiveModal", () => {
     vi.clearAllMocks();
   });
 
-  const renderReceiveModal = (
-    {
-      account = mockSnsMainAccount,
-      tokenSymbol,
-    }: {
-      account?: Account;
-      tokenSymbol: string;
-    }
-  ) =>
+  const renderReceiveModal = ({
+    account = mockSnsMainAccount,
+    tokenSymbol,
+  }: {
+    account?: Account;
+    tokenSymbol: string;
+  }) =>
     renderModal({
       component: IcrcReceiveModal,
       props: {

--- a/frontend/src/tests/lib/modals/accounts/SnsReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/SnsReceiveModal.spec.ts
@@ -1,4 +1,4 @@
-import SnsReceiveModal from "$lib/modals/accounts/SnsReceiveModal.svelte";
+import SnsReceiveModal from "$lib/modals/accounts/IcrcReceiveModal.svelte";
 import type { Account } from "$lib/types/account";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";

--- a/frontend/src/tests/lib/pages/AccountsTest.svelte
+++ b/frontend/src/tests/lib/pages/AccountsTest.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import AccountsModals from "$lib/modals/accounts/AccountsModals.svelte";
-  import { SvelteComponent } from "svelte";
+  import type { SvelteComponent } from "svelte";
   import { nonNullish } from "@dfinity/utils";
 
   export let testComponent: typeof SvelteComponent;

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -626,6 +626,6 @@ describe("Accounts", () => {
       expect(container.querySelector("div.modal")).not.toBeNull()
     );
 
-    expect(getByTestId("logo").getAttribute("alt")).toEqual(`ckETHTEST logo`);
+    expect(getByTestId("logo").getAttribute("alt")).toEqual(`ckETH logo`);
   });
 });

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -181,6 +181,11 @@ describe("Accounts", () => {
     });
 
     icpAccountsStore.setForTesting(mockAccountsStoreData);
+
+    icrcCanistersStore.setCanisters({
+      ledgerCanisterId: CKETH_UNIVERSE_CANISTER_ID,
+      indexCanisterId: CKETH_INDEX_CANISTER_ID,
+    });
   });
 
   it("should render NnsAccounts by default", () => {
@@ -557,5 +562,28 @@ describe("Accounts", () => {
         expect(await tablePo.getFirstColumnHeader()).toEqual("Accounts");
       });
     });
+  });
+
+  it("should open icrc receive modal", async () => {
+    page.mock({
+      data: {
+        universe: CKETH_UNIVERSE_CANISTER_ID.toText(),
+        routeId: AppPath.Accounts,
+      },
+    });
+
+    const { getByTestId, container } = render(WalletTest, {
+      props: { testComponent: Accounts },
+    });
+
+    fireEvent.click(getByTestId("receive-icrc") as HTMLButtonElement);
+
+    await waitFor(() =>
+      expect(container.querySelector("div.modal")).not.toBeNull()
+    );
+
+    expect(getByTestId("logo").getAttribute("alt")).toEqual(
+      `ckETH project logo`
+    );
   });
 });

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -41,7 +41,7 @@ import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import {
   mockProjectSubscribe,
   mockSnsFullProject,
-  mockSummary,
+  mockSummary, mockToken,
   principal,
 } from "$tests/mocks/sns-projects.mock";
 import { mockSnsSelectedTransactionFeeStoreSubscribe } from "$tests/mocks/transaction-fee.mock";
@@ -55,6 +55,7 @@ import { fireEvent, waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 import WalletTest from "../pages/AccountsTest.svelte";
+import {mockTokens} from "$tests/mocks/tokens.mock";
 
 vi.mock("$lib/api/icrc-ledger.api");
 
@@ -151,7 +152,7 @@ describe("Accounts", () => {
     tokensStore.reset();
     icrcAccountsStore.reset();
 
-    vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockResolvedValue(mockCkETHToken);
+    vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockResolvedValue(mockToken);
     vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockResolvedValue(
       balanceIcrcToken
     );
@@ -565,6 +566,10 @@ describe("Accounts", () => {
   });
 
   it("should open icrc receive modal", async () => {
+    overrideFeatureFlagsStore.setFlag("ENABLE_CKETH", true);
+
+    tokensStore.setTokens(mockTokens);
+
     page.mock({
       data: {
         universe: CKETH_UNIVERSE_CANISTER_ID.toText(),

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -2,6 +2,7 @@ import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import {
+  CKETH_INDEX_CANISTER_ID,
   CKETH_LEDGER_CANISTER_ID,
   CKETH_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/cketh-canister-ids.constants";
@@ -19,6 +20,7 @@ import { authStore } from "$lib/stores/auth.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
+import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
@@ -39,9 +41,11 @@ import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import {
   mockProjectSubscribe,
   mockSnsFullProject,
-  mockSummary, mockToken,
+  mockSummary,
+  mockToken,
   principal,
 } from "$tests/mocks/sns-projects.mock";
+import { mockTokens } from "$tests/mocks/tokens.mock";
 import { mockSnsSelectedTransactionFeeStoreSubscribe } from "$tests/mocks/transaction-fee.mock";
 import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -54,7 +58,6 @@ import { fireEvent, waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 import WalletTest from "../pages/AccountsTest.svelte";
-import {mockTokens} from "$tests/mocks/tokens.mock";
 
 vi.mock("$lib/api/icrc-ledger.api");
 
@@ -570,8 +573,6 @@ describe("Accounts", () => {
       expect(container.querySelector("div.modal")).not.toBeNull()
     );
 
-    expect(getByTestId("logo").getAttribute("alt")).toEqual(
-      `ckETH project logo`
-    );
+    expect(getByTestId("logo").getAttribute("alt")).toEqual(`ckETHTEST logo`);
   });
 });

--- a/frontend/src/tests/lib/utils/universes.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/universes.utils.spec.ts
@@ -1,12 +1,10 @@
-import {
-  OWN_CANISTER_ID,
-  OWN_CANISTER_ID_TEXT,
-} from "$lib/constants/canister-ids.constants";
+import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import {
   CKBTC_UNIVERSE_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
+import { nnsUniverseStore } from "$lib/derived/nns-universe.derived";
 import {
   createUniverse,
   isNonGovernanceTokenPath,
@@ -22,6 +20,7 @@ import {
 } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { Principal } from "@dfinity/principal";
+import { get } from "svelte/store";
 
 describe("universes-utils", () => {
   describe("isNonGovernanceTokenPath", () => {
@@ -125,13 +124,9 @@ describe("universes-utils", () => {
     });
 
     it("should render alt NNS", () => {
-      expect(
-        universeLogoAlt({
-          canisterId: OWN_CANISTER_ID_TEXT,
-          title: "Tetris",
-          logo: "https://logo.png",
-        })
-      ).toEqual(en.auth.ic_logo);
+      const universe = get(nnsUniverseStore);
+
+      expect(universeLogoAlt(universe)).toEqual(en.auth.ic_logo);
     });
   });
 


### PR DESCRIPTION
# Motivation

Implement CkETH receive modal feature.

# Changes

- refactor and pass additional parameters to `ReceiveButton` and related modal to make the receive modal generic for icrc
- implement the parameters (either constant for ICRC or those of the universe)
- rename `SnsReceiveModal` to `IcrcReceiveModal`
- add modal for Icrc univeser on Accounts page
- adapt arial label for logo for icrc