### PR TITLE
GIX-2122: Send from Wallet

### DIFF
--- a/frontend/src/lib/components/accounts/IcrcTokenWalletFooter.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTokenWalletFooter.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { isNullish } from "@dfinity/utils";
+  import Footer from "$lib/components/layout/Footer.svelte";
+  import type { UniverseCanisterId } from "$lib/types/universe";
+  import { toastsError } from "$lib/stores/toasts.store";
+  import { openIcrcTokenModal } from "$lib/utils/modals.utils";
+  import type { IcrcTokenMetadata } from "$lib/types/icrc";
+  import { i18n } from "$lib/stores/i18n";
+  import type { Account } from "$lib/types/account";
+
+  export let universeId: UniverseCanisterId;
+  export let token: IcrcTokenMetadata;
+  export let account: Account;
+
+  const openSendModal = () => {
+    if (isNullish(universeId) || isNullish(token)) {
+      toastsError({ labelKey: "error.icrc_token_load" });
+      return;
+    }
+    openIcrcTokenModal({
+      type: "icrc-send",
+      data: {
+        universeId,
+        token,
+        loadTransactions: false,
+        sourceAccount: account,
+      },
+    });
+  };
+</script>
+
+<Footer testId="ckbtc-wallet-footer-component">
+  <button
+    class="primary full-width"
+    on:click={openSendModal}
+    data-tid="open-new-icrc-token-transaction">{$i18n.accounts.send}</button
+  >
+  <!-- TODO: Add Receive button GIX-2124 -->
+</Footer>

--- a/frontend/src/lib/modals/accounts/IcrcTokenAccountsModals.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenAccountsModals.svelte
@@ -27,5 +27,6 @@
       amount: modal.data.token.fee,
       token: modal.data.token,
     })}
+    selectedAccount={modal.data.sourceAccount}
   />
 {/if}

--- a/frontend/src/lib/pages/IcrcWallet.svelte
+++ b/frontend/src/lib/pages/IcrcWallet.svelte
@@ -9,6 +9,7 @@
   import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import { tokensStore } from "$lib/stores/tokens.store";
+  import IcrcTokenWalletFooter from "$lib/components/accounts/IcrcTokenWalletFooter.svelte";
 
   export let accountIdentifier: string | undefined | null = undefined;
 
@@ -42,6 +43,16 @@
         account={$selectedAccountStore.account}
         {indexCanisterId}
         universeId={$selectedIcrcTokenUniverseIdStore}
+        {token}
+      />
+    {/if}
+  </svelte:fragment>
+
+  <svelte:fragment slot="footer-actions">
+    {#if nonNullish($selectedAccountStore.account) && nonNullish(token) && nonNullish($selectedIcrcTokenUniverseIdStore)}
+      <IcrcTokenWalletFooter
+        universeId={$selectedIcrcTokenUniverseIdStore}
+        account={$selectedAccountStore.account}
         {token}
       />
     {/if}

--- a/frontend/src/lib/routes/Wallet.svelte
+++ b/frontend/src/lib/routes/Wallet.svelte
@@ -15,6 +15,7 @@
   import AccountsModals from "$lib/modals/accounts/AccountsModals.svelte";
   import CkBTCAccountsModals from "$lib/modals/accounts/CkBTCAccountsModals.svelte";
   import IcrcWallet from "$lib/pages/IcrcWallet.svelte";
+  import IcrcTokenAccountsModals from "$lib/modals/accounts/IcrcTokenAccountsModals.svelte";
 
   export let accountIdentifier: string | undefined | null = undefined;
 
@@ -36,6 +37,8 @@
 
   {#if $isCkBTCUniverseStore}
     <CkBTCAccountsModals />
+  {:else if $isIcrcTokenUniverseStore}
+    <IcrcTokenAccountsModals />
   {:else}
     <AccountsModals />
   {/if}

--- a/frontend/src/lib/types/icrc-accounts.modal.ts
+++ b/frontend/src/lib/types/icrc-accounts.modal.ts
@@ -1,4 +1,5 @@
 import type { UniverseCanisterId } from "$lib/types/universe";
+import type { Account } from "./account";
 import type { IcrcTokenMetadata } from "./icrc";
 
 // TODO: https://dfinity.atlassian.net/browse/GIX-2150 to be refactored:
@@ -11,6 +12,7 @@ export type IcrcTokenTransactionModalData = {
   universeId: UniverseCanisterId;
   token: IcrcTokenMetadata;
   loadTransactions: boolean;
+  sourceAccount?: Account;
 };
 
 export interface IcrcTokenModalProps {

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -1,19 +1,36 @@
+import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
-import { CKETH_UNIVERSE_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
+import {
+  CKETH_LEDGER_CANISTER_ID,
+  CKETH_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/cketh-canister-ids.constants";
+import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import Wallet from "$lib/routes/Wallet.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
+import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import {
+  mockAuthStoreSubscribe,
+  mockIdentity,
+} from "$tests/mocks/auth.store.mock";
+import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
 import { mockAccountsStoreData } from "$tests/mocks/icp-accounts.store.mock";
+import { mockIcrcMainAccount } from "$tests/mocks/icrc-accounts.mock";
 import { mockSnsFullProject, principal } from "$tests/mocks/sns-projects.mock";
+import { WalletPo } from "$tests/page-objects/Wallet.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
+
+vi.mock("$lib/api/icrc-ledger.api");
 
 vi.mock("$lib/services/sns-accounts.services", () => {
   return {
@@ -40,6 +57,32 @@ vi.mock("$lib/services/ckbtc-info.services", () => {
   };
 });
 
+vi.mock("$lib/services/worker-balances.services", () => ({
+  initBalancesWorker: vi.fn(() =>
+    Promise.resolve({
+      startBalancesTimer: () => {
+        // Do nothing
+      },
+      stopBalancesTimer: () => {
+        // Do nothing
+      },
+    })
+  ),
+}));
+
+vi.mock("$lib/services/worker-transactions.services", () => ({
+  initTransactionsWorker: vi.fn(() =>
+    Promise.resolve({
+      startTransactionsTimer: () => {
+        // Do nothing
+      },
+      stopTransactionsTimer: () => {
+        // Do nothing
+      },
+    })
+  ),
+}));
+
 describe("Wallet", () => {
   beforeEach(() => {
     setCkETHCanisters();
@@ -51,6 +94,7 @@ describe("Wallet", () => {
     ]);
     icpAccountsStore.setForTesting(mockAccountsStoreData);
     overrideFeatureFlagsStore.reset();
+    vi.spyOn(icrcLedgerApi, "icrcTransfer").mockResolvedValue(1234n);
   });
 
   beforeAll(() => {
@@ -114,5 +158,61 @@ describe("Wallet", () => {
       },
     });
     expect(getByTestId("icrc-wallet-component")).toBeInTheDocument();
+  });
+
+  // TODO: GIX-2150 Mock API layer instead of services for the setup
+  it("user can transfer ckETH tokens", async () => {
+    overrideFeatureFlagsStore.setFlag("ENABLE_CKETH", true);
+    page.mock({
+      data: { universe: CKETH_UNIVERSE_CANISTER_ID.toText() },
+      routeId: AppPath.Wallet,
+    });
+
+    icrcAccountsStore.set({
+      universeId: CKETH_UNIVERSE_CANISTER_ID,
+      accounts: {
+        accounts: [mockIcrcMainAccount],
+        certified: true,
+      },
+    });
+
+    tokensStore.setToken({
+      canisterId: CKETH_UNIVERSE_CANISTER_ID,
+      token: mockCkETHToken,
+      certified: true,
+    });
+
+    const { container } = render(Wallet, {
+      props: {
+        accountIdentifier: mockIcrcMainAccount.identifier,
+      },
+    });
+
+    const po = WalletPo.under(new JestPageObjectElement(container));
+
+    await po.clickSendCkETH();
+
+    const modalPo = po.getIcrcTokenTransactionModalPo();
+
+    expect(await modalPo.isPresent()).toBe(true);
+
+    const toAccount = {
+      owner: principal(2),
+    };
+    const amount = 2;
+
+    await modalPo.transferToAddress({
+      destinationAddress: encodeIcrcAccount(toAccount),
+      amount,
+    });
+
+    expect(icrcLedgerApi.icrcTransfer).toHaveBeenCalledTimes(1);
+    expect(icrcLedgerApi.icrcTransfer).toHaveBeenCalledWith({
+      identity: mockIdentity,
+      canisterId: CKETH_LEDGER_CANISTER_ID,
+      amount: BigInt(amount * E8S_PER_ICP),
+      to: toAccount,
+      fee: mockCkETHToken.fee,
+    });
   });
 });

--- a/frontend/src/tests/page-objects/Wallet.page-object.ts
+++ b/frontend/src/tests/page-objects/Wallet.page-object.ts
@@ -2,6 +2,7 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { CkBTCWalletPo } from "$tests/page-objects/CkBTCWallet.page-object";
 import { NnsWalletPo } from "$tests/page-objects/NnsWallet.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { IcrcTokenTransactionModalPo } from "./IcrcTokenTransactionModal.page-object";
 
 export class WalletPo extends BasePageObject {
   private static readonly TID = "wallet-component";
@@ -16,5 +17,14 @@ export class WalletPo extends BasePageObject {
 
   getCkBTCWalletPo(): CkBTCWalletPo {
     return CkBTCWalletPo.under(this.root);
+  }
+
+  // TODO: GIX-2150 Use POs all the levels
+  clickSendCkETH() {
+    return this.click("open-new-icrc-token-transaction");
+  }
+
+  getIcrcTokenTransactionModalPo() {
+    return IcrcTokenTransactionModalPo.under(this.root);
   }
 }


### PR DESCRIPTION
# Motivation

Users can send ckETH from the wallet page.

# Changes

* New IcrcTokenWalletFooter
* Add `sourceAccount` as optional field in `IcrcTokenTransactionModalData`.
* Pass the source account in IcrcTokenAccountsModal.
* Render IcrcTokenWalletFooter in IcrcWallet
* Render IcrcTokenAccountsModals accordingly in IcrcTokenWalletFooter

# Tests

* Add some methods to WalletPo.
* Add a test in Wallet route to check that user can send ckETH tokens.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
