### PR TITLE
Set ckETH canister IDs in dfx.json

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -194,7 +194,9 @@
       "wasm": "target/ic/ckbtc_ledger.wasm",
       "type": "custom",
       "remote": {
-        "id": {}
+        "id": {
+          "mainnet": "ss2fx-dyaaa-aaaar-qacoq-cai"
+        }
       }
     },
     "cketh_index": {
@@ -205,7 +207,9 @@
       "wasm": "target/ic/ckbtc_index.wasm",
       "type": "custom",
       "remote": {
-        "id": {}
+        "id": {
+          "mainnet": "s3zol-vqaaa-aaaar-qacpa-cai"
+        }
       }
     },
     "tvl": {

--- a/scripts/nns-dapp/test-config-assets/mainnet/arg.did
+++ b/scripts/nns-dapp/test-config-assets/mainnet/arg.did
@@ -4,6 +4,8 @@
     record{ 0="CKBTC_INDEX_CANISTER_ID"; 1="n5wcd-faaaa-aaaar-qaaea-cai" };
     record{ 0="CKBTC_LEDGER_CANISTER_ID"; 1="mxzaz-hqaaa-aaaar-qaada-cai" };
     record{ 0="CKBTC_MINTER_CANISTER_ID"; 1="mqygn-kiaaa-aaaar-qaadq-cai" };
+    record{ 0="CKETH_INDEX_CANISTER_ID"; 1="s3zol-vqaaa-aaaar-qacpa-cai" };
+    record{ 0="CKETH_LEDGER_CANISTER_ID"; 1="ss2fx-dyaaa-aaaar-qacoq-cai" };
     record{ 0="CYCLES_MINTING_CANISTER_ID"; 1="rkp4c-7iaaa-aaaaa-aaaca-cai" };
     record{ 0="DFX_NETWORK"; 1="mainnet" };
     record{ 0="FEATURE_FLAGS"; 1="{\"ENABLE_CKBTC\":true,\"ENABLE_CKBTC_ICRC2\":true,\"ENABLE_CKETH\":false,\"ENABLE_CKTESTBTC\":false,\"ENABLE_ICP_ICRC\":false,\"ENABLE_INSTANT_UNLOCK\":false,\"ENABLE_MY_TOKENS\":false,\"ENABLE_STAKE_NEURON_ICRC1\":false,\"ENABLE_SWAP_ICRC1\":false}" };

--- a/scripts/nns-dapp/test-config-assets/mainnet/env
+++ b/scripts/nns-dapp/test-config-assets/mainnet/env
@@ -13,5 +13,5 @@ VITE_AGGREGATOR_CANISTER_URL=https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io
 VITE_CKBTC_LEDGER_CANISTER_ID=mxzaz-hqaaa-aaaar-qaada-cai
 VITE_CKBTC_MINTER_CANISTER_ID=mqygn-kiaaa-aaaar-qaadq-cai
 VITE_CKBTC_INDEX_CANISTER_ID=n5wcd-faaaa-aaaar-qaaea-cai
-VITE_CKETH_LEDGER_CANISTER_ID=
-VITE_CKETH_INDEX_CANISTER_ID=
+VITE_CKETH_LEDGER_CANISTER_ID=ss2fx-dyaaa-aaaar-qacoq-cai
+VITE_CKETH_INDEX_CANISTER_ID=s3zol-vqaaa-aaaar-qacpa-cai


### PR DESCRIPTION
# Motivation

Include ckETH canister IDs in mainnet module args.

# Changes

1. Set mainnet canister IDs for ckETH canisters in `dfx.json`.
2. Run `scripts/nns-dapp/test-config --update`.

# Tests

Configs were updated by `scripts/nns-dapp/test-config --update` so the canister IDs were picked up.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary