### PR TITLE
Remove temporary loadCkETHCanisters

### DIFF
--- a/frontend/src/lib/routes/Wallet.svelte
+++ b/frontend/src/lib/routes/Wallet.svelte
@@ -15,13 +15,8 @@
   import AccountsModals from "$lib/modals/accounts/AccountsModals.svelte";
   import CkBTCAccountsModals from "$lib/modals/accounts/CkBTCAccountsModals.svelte";
   import IcrcWallet from "$lib/pages/IcrcWallet.svelte";
-  import { onMount } from "svelte";
-  import { loadCkETHCanisters } from "$lib/services/cketh-canisters.services";
 
   export let accountIdentifier: string | undefined | null = undefined;
-
-  // TODO: refactor this should not be loaded explicitely within this component or Accounts
-  onMount(loadCkETHCanisters);
 
   layoutTitleStore.set({
     title: $i18n.wallet.title,


### PR DESCRIPTION
# Motivation

`loadCkETHCanisters` are now loaded publically / globally. Therefore the temporary loader can be removed.
