### PR TITLE
Refactor ckBTCTransferTokens use icrcTransferTokens

### DIFF
--- a/frontend/src/lib/services/ckbtc-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts.services.ts
@@ -1,13 +1,13 @@
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
 import { icrcTransferTokens } from "$lib/services/icrc-accounts.services";
 import { loadAccounts } from "$lib/services/wallet-accounts.services";
+import { toastsError } from "$lib/stores/toasts.store";
 import type { UniverseCanisterId } from "$lib/types/universe";
+import { ledgerErrorToToastError } from "$lib/utils/sns-ledger.utils";
 import type { IcrcBlockIndex } from "@dfinity/ledger-icrc";
 import { isNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import type { IcrcTransferTokensUserParams } from "./icrc-accounts.services";
-import {toastsError} from "$lib/stores/toasts.store";
-import {ledgerErrorToToastError} from "$lib/utils/sns-ledger.utils";
 
 export const loadCkBTCAccounts = async (params: {
   handleError?: () => void;
@@ -26,10 +26,10 @@ export const ckBTCTransferTokens = async ({
 
   if (isNullish(fee)) {
     toastsError(
-        ledgerErrorToToastError({
-          fallbackErrorLabelKey: "error.transaction_error",
-          err: new Error("error.transaction_fee_not_found")
-        })
+      ledgerErrorToToastError({
+        fallbackErrorLabelKey: "error.transaction_error",
+        err: new Error("error.transaction_fee_not_found"),
+      })
     );
 
     return { blockIndex: undefined };

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -32,15 +32,13 @@ export const getIcrcAccountIdentity = (_: Account): Promise<Identity> => {
   return getAuthenticatedIdentity();
 };
 
-export const loadIcrcToken = (
-  {
-    ledgerCanisterId,
-    certified,
-  }: {
-    ledgerCanisterId: Principal;
-    certified: boolean;
-  }
-) => {
+export const loadIcrcToken = ({
+  ledgerCanisterId,
+  certified,
+}: {
+  ledgerCanisterId: Principal;
+  certified: boolean;
+}) => {
   const currentToken = get(tokensStore)[ledgerCanisterId.toText()];
 
   if (nonNullish(currentToken) && (currentToken.certified || !certified)) {
@@ -74,17 +72,15 @@ export const loadIcrcToken = (
   });
 };
 
-const getIcrcMainIdentityAccount = async (
-  {
-    ledgerCanisterId,
-    identity,
-    certified,
-  }: {
-    ledgerCanisterId: Principal;
-    identity: Identity;
-    certified: boolean;
-  }
-): Promise<Account> => {
+const getIcrcMainIdentityAccount = async ({
+  ledgerCanisterId,
+  identity,
+  certified,
+}: {
+  ledgerCanisterId: Principal;
+  identity: Identity;
+  certified: boolean;
+}): Promise<Account> => {
   const account: IcrcAccount = {
     owner: identity.getPrincipal(),
   };
@@ -104,15 +100,13 @@ const getIcrcMainIdentityAccount = async (
   };
 };
 
-export const loadIcrcAccount = (
-  {
-    ledgerCanisterId,
-    certified,
-  }: {
-    ledgerCanisterId: Principal;
-    certified: boolean;
-  }
-) => {
+export const loadIcrcAccount = ({
+  ledgerCanisterId,
+  certified,
+}: {
+  ledgerCanisterId: Principal;
+  certified: boolean;
+}) => {
   return queryAndUpdate<Account, unknown>({
     strategy: certified ? FORCE_CALL_STRATEGY : "query",
     request: ({ certified, identity }) =>
@@ -143,15 +137,13 @@ export const loadIcrcAccount = (
   });
 };
 
-export const loadIcrcAccounts = async (
-  {
-    ledgerCanisterIds,
-    certified,
-  }: {
-    ledgerCanisterIds: Principal[];
-    certified: boolean;
-  }
-) => {
+export const loadIcrcAccounts = async ({
+  ledgerCanisterIds,
+  certified,
+}: {
+  ledgerCanisterIds: Principal[];
+  certified: boolean;
+}) => {
   const results: PromiseSettledResult<[void, void]>[] =
     await Promise.allSettled(
       ledgerCanisterIds.map((ledgerCanisterId) =>
@@ -179,26 +171,24 @@ export interface IcrcTransferTokensUserParams {
   amount: number;
 }
 
-export const transferTokens = async (
-  {
-    source,
-    destinationAddress,
-    amount,
-    fee,
-    transfer,
-    reloadAccounts,
-    reloadTransactions,
-  }: IcrcTransferTokensUserParams & {
-    fee: bigint | undefined;
-    transfer: (
-      params: {
-        identity: Identity;
-      } & IcrcTransferParams
-    ) => Promise<IcrcBlockIndex>;
-    reloadAccounts: () => Promise<void>;
-    reloadTransactions: () => Promise<void>;
-  }
-): Promise<{ blockIndex: IcrcBlockIndex | undefined }> => {
+export const transferTokens = async ({
+  source,
+  destinationAddress,
+  amount,
+  fee,
+  transfer,
+  reloadAccounts,
+  reloadTransactions,
+}: IcrcTransferTokensUserParams & {
+  fee: bigint | undefined;
+  transfer: (
+    params: {
+      identity: Identity;
+    } & IcrcTransferParams
+  ) => Promise<IcrcBlockIndex>;
+  reloadAccounts: () => Promise<void>;
+  reloadTransactions: () => Promise<void>;
+}): Promise<{ blockIndex: IcrcBlockIndex | undefined }> => {
   try {
     if (isNullish(fee)) {
       throw new Error("error.transaction_fee_not_found");
@@ -231,15 +221,13 @@ export const transferTokens = async (
   }
 };
 
-export const icrcTransferTokens = async (
-  {
-    ledgerCanisterId,
-    ...rest
-  }: IcrcTransferTokensUserParams & {
-    fee: bigint;
-    ledgerCanisterId: Principal;
-  }
-): Promise<{ blockIndex: IcrcBlockIndex | undefined }> =>
+export const icrcTransferTokens = async ({
+  ledgerCanisterId,
+  ...rest
+}: IcrcTransferTokensUserParams & {
+  fee: bigint;
+  ledgerCanisterId: Principal;
+}): Promise<{ blockIndex: IcrcBlockIndex | undefined }> =>
   transferTokens({
     transfer: async (
       params: {

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -32,13 +32,15 @@ export const getIcrcAccountIdentity = (_: Account): Promise<Identity> => {
   return getAuthenticatedIdentity();
 };
 
-export const loadIcrcToken = ({
-  ledgerCanisterId,
-  certified,
-}: {
-  ledgerCanisterId: Principal;
-  certified: boolean;
-}) => {
+export const loadIcrcToken = (
+  {
+    ledgerCanisterId,
+    certified,
+  }: {
+    ledgerCanisterId: Principal;
+    certified: boolean;
+  }
+) => {
   const currentToken = get(tokensStore)[ledgerCanisterId.toText()];
 
   if (nonNullish(currentToken) && (currentToken.certified || !certified)) {
@@ -72,15 +74,17 @@ export const loadIcrcToken = ({
   });
 };
 
-const getIcrcMainIdentityAccount = async ({
-  ledgerCanisterId,
-  identity,
-  certified,
-}: {
-  ledgerCanisterId: Principal;
-  identity: Identity;
-  certified: boolean;
-}): Promise<Account> => {
+const getIcrcMainIdentityAccount = async (
+  {
+    ledgerCanisterId,
+    identity,
+    certified,
+  }: {
+    ledgerCanisterId: Principal;
+    identity: Identity;
+    certified: boolean;
+  }
+): Promise<Account> => {
   const account: IcrcAccount = {
     owner: identity.getPrincipal(),
   };
@@ -100,13 +104,15 @@ const getIcrcMainIdentityAccount = async ({
   };
 };
 
-export const loadIcrcAccount = ({
-  ledgerCanisterId,
-  certified,
-}: {
-  ledgerCanisterId: Principal;
-  certified: boolean;
-}) => {
+export const loadIcrcAccount = (
+  {
+    ledgerCanisterId,
+    certified,
+  }: {
+    ledgerCanisterId: Principal;
+    certified: boolean;
+  }
+) => {
   return queryAndUpdate<Account, unknown>({
     strategy: certified ? FORCE_CALL_STRATEGY : "query",
     request: ({ certified, identity }) =>
@@ -137,13 +143,15 @@ export const loadIcrcAccount = ({
   });
 };
 
-export const loadIcrcAccounts = async ({
-  ledgerCanisterIds,
-  certified,
-}: {
-  ledgerCanisterIds: Principal[];
-  certified: boolean;
-}) => {
+export const loadIcrcAccounts = async (
+  {
+    ledgerCanisterIds,
+    certified,
+  }: {
+    ledgerCanisterIds: Principal[];
+    certified: boolean;
+  }
+) => {
   const results: PromiseSettledResult<[void, void]>[] =
     await Promise.allSettled(
       ledgerCanisterIds.map((ledgerCanisterId) =>
@@ -171,25 +179,26 @@ export interface IcrcTransferTokensUserParams {
   amount: number;
 }
 
-// TODO: use `wallet-accounts.services`
-export const transferTokens = async ({
-  source,
-  destinationAddress,
-  amount,
-  fee,
-  transfer,
-  reloadAccounts,
-  reloadTransactions,
-}: IcrcTransferTokensUserParams & {
-  fee: bigint | undefined;
-  transfer: (
-    params: {
-      identity: Identity;
-    } & IcrcTransferParams
-  ) => Promise<IcrcBlockIndex>;
-  reloadAccounts: () => Promise<void>;
-  reloadTransactions: () => Promise<void>;
-}): Promise<{ blockIndex: IcrcBlockIndex | undefined }> => {
+export const transferTokens = async (
+  {
+    source,
+    destinationAddress,
+    amount,
+    fee,
+    transfer,
+    reloadAccounts,
+    reloadTransactions,
+  }: IcrcTransferTokensUserParams & {
+    fee: bigint | undefined;
+    transfer: (
+      params: {
+        identity: Identity;
+      } & IcrcTransferParams
+    ) => Promise<IcrcBlockIndex>;
+    reloadAccounts: () => Promise<void>;
+    reloadTransactions: () => Promise<void>;
+  }
+): Promise<{ blockIndex: IcrcBlockIndex | undefined }> => {
   try {
     if (isNullish(fee)) {
       throw new Error("error.transaction_fee_not_found");
@@ -222,21 +231,16 @@ export const transferTokens = async ({
   }
 };
 
-export const icrcTransferTokens = async ({
-  source,
-  destinationAddress,
-  amount,
-  fee,
-  ledgerCanisterId,
-}: IcrcTransferTokensUserParams & {
-  fee: bigint;
-  ledgerCanisterId: Principal;
-}): Promise<{ blockIndex: IcrcBlockIndex | undefined }> => {
-  return transferTokens({
-    source,
-    amount,
-    fee,
-    destinationAddress,
+export const icrcTransferTokens = async (
+  {
+    ledgerCanisterId,
+    ...rest
+  }: IcrcTransferTokensUserParams & {
+    fee: bigint;
+    ledgerCanisterId: Principal;
+  }
+): Promise<{ blockIndex: IcrcBlockIndex | undefined }> =>
+  transferTokens({
     transfer: async (
       params: {
         identity: Identity;
@@ -248,7 +252,7 @@ export const icrcTransferTokens = async ({
       }),
     reloadAccounts: async () =>
       await loadIcrcAccount({ ledgerCanisterId, certified: true }),
-    // Web workders take care of refreshing transactions
+    // Web workers take care of refreshing transactions
     reloadTransactions: () => Promise.resolve(),
+    ...rest,
   });
-};


### PR DESCRIPTION
# Motivation

We can refactor `ckBTCTransferTokens` the other way around that way it still remove duplication and does not introduce too many changes in the code.

# Changes

- use `icrcTransferTokens` in `ckBTCTransferTokens`
