### PR TITLE
GIX-2144: Watch new IcrcToken canisters load token data

### DIFF
--- a/frontend/src/lib/services/$public/app.services.ts
+++ b/frontend/src/lib/services/$public/app.services.ts
@@ -14,7 +14,7 @@ import { watchIcrcTokensLoadTokenData } from "../icrc-tokens.services";
 export const initAppPublicData = (): Promise<
   [PromiseSettledResult<void>, PromiseSettledResult<void>]
 > => {
-  watchIcrcTokensLoadTokenData({ certified: false });
+  watchIcrcTokensLoadTokenData();
   /**
    * If one of the promises fails, we don't want to block the app.
    */

--- a/frontend/src/lib/services/$public/app.services.ts
+++ b/frontend/src/lib/services/$public/app.services.ts
@@ -5,6 +5,7 @@ import { authStore } from "$lib/stores/auth.store";
 import { layoutAuthReady } from "$lib/stores/layout.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { loadCkETHCanisters } from "../cketh-canisters.services";
+import { watchIcrcTokensLoadTokenData } from "../icrc-tokens.services";
 
 /**
  * Load the application public data that are available globally ("global stores").
@@ -13,6 +14,7 @@ import { loadCkETHCanisters } from "../cketh-canisters.services";
 export const initAppPublicData = (): Promise<
   [PromiseSettledResult<void>, PromiseSettledResult<void>]
 > => {
+  watchIcrcTokensLoadTokenData({ certified: false });
   /**
    * If one of the promises fails, we don't want to block the app.
    */

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -47,6 +47,7 @@ export const loadIcrcToken = ({
 
   return queryAndUpdate<IcrcTokenMetadata, unknown>({
     strategy: certified ? FORCE_CALL_STRATEGY : "query",
+    identityType: "current",
     request: ({ certified, identity }) =>
       queryIcrcToken({
         identity,

--- a/frontend/src/lib/services/icrc-tokens.services.ts
+++ b/frontend/src/lib/services/icrc-tokens.services.ts
@@ -1,0 +1,15 @@
+import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
+import type { Unsubscriber } from "svelte/store";
+import { loadIcrcToken } from "./icrc-accounts.services";
+
+export const watchIcrcTokensLoadTokenData = ({
+  certified,
+}: {
+  certified: boolean;
+}): Unsubscriber => {
+  return icrcCanistersStore.subscribe((canistersData) => {
+    Object.values(canistersData).forEach(({ ledgerCanisterId }) => {
+      loadIcrcToken({ ledgerCanisterId, certified });
+    });
+  });
+};

--- a/frontend/src/lib/services/icrc-tokens.services.ts
+++ b/frontend/src/lib/services/icrc-tokens.services.ts
@@ -2,15 +2,11 @@ import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
 import type { Unsubscriber } from "svelte/store";
 import { loadIcrcToken } from "./icrc-accounts.services";
 
-export const watchIcrcTokensLoadTokenData = ({
-  certified,
-}: {
-  certified: boolean;
-}): Unsubscriber => {
+export const watchIcrcTokensLoadTokenData = (): Unsubscriber => {
   return icrcCanistersStore.subscribe((canistersData) => {
     Object.values(canistersData).forEach(({ ledgerCanisterId }) => {
       // `loadIcrcToken` does nothing if the token is already loaded.
-      loadIcrcToken({ ledgerCanisterId, certified });
+      loadIcrcToken({ ledgerCanisterId, certified: false });
     });
   });
 };

--- a/frontend/src/lib/services/icrc-tokens.services.ts
+++ b/frontend/src/lib/services/icrc-tokens.services.ts
@@ -9,6 +9,7 @@ export const watchIcrcTokensLoadTokenData = ({
 }): Unsubscriber => {
   return icrcCanistersStore.subscribe((canistersData) => {
     Object.values(canistersData).forEach(({ ledgerCanisterId }) => {
+      // `loadIcrcToken` does nothing if the token is already loaded.
       loadIcrcToken({ ledgerCanisterId, certified });
     });
   });

--- a/frontend/src/tests/lib/services/_public/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/app.services.spec.ts
@@ -1,3 +1,4 @@
+import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import {
   CKETHSEPOLIA_INDEX_CANISTER_ID,
   CKETHSEPOLIA_LEDGER_CANISTER_ID,
@@ -10,7 +11,11 @@ import { initAppPublicData } from "$lib/services/$public/app.services";
 import { loadSnsProjects } from "$lib/services/$public/sns.services";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
 import { get } from "svelte/store";
+
+vi.mock("$lib/api/icrc-ledger.api");
 
 vi.mock("$lib/services/$public/sns.services", () => {
   return {
@@ -22,6 +27,8 @@ describe("$public/app-services", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     icrcCanistersStore.reset();
+    tokensStore.reset();
+    vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockResolvedValue(mockCkETHToken);
     overrideFeatureFlagsStore.setFlag("ENABLE_CKETH", false);
     overrideFeatureFlagsStore.setFlag("ENABLE_CKTESTBTC", false);
   });
@@ -58,6 +65,15 @@ describe("$public/app-services", () => {
         indexCanisterId: CKETH_INDEX_CANISTER_ID,
       });
     });
+
+    it("should load token in store", async () => {
+      await initAppPublicData();
+
+      expect(get(tokensStore)[CKETH_UNIVERSE_CANISTER_ID.toText()]).toEqual({
+        token: mockCkETHToken,
+        certified: false,
+      });
+    });
   });
 
   describe("when ENABLE_CKTESTBTC is enabled", () => {
@@ -72,6 +88,17 @@ describe("$public/app-services", () => {
       ).toEqual({
         ledgerCanisterId: CKETHSEPOLIA_LEDGER_CANISTER_ID,
         indexCanisterId: CKETHSEPOLIA_INDEX_CANISTER_ID,
+      });
+    });
+
+    it("should load token in store", async () => {
+      await initAppPublicData();
+
+      expect(
+        get(tokensStore)[CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText()]
+      ).toEqual({
+        token: mockCkETHToken,
+        certified: false,
       });
     });
   });

--- a/frontend/src/tests/lib/services/icrc-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-tokens.services.spec.ts
@@ -2,7 +2,6 @@ import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import { watchIcrcTokensLoadTokenData } from "$lib/services/icrc-tokens.services";
 import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
 import { tokensStore } from "$lib/stores/tokens.store";
-import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockToken, principal } from "$tests/mocks/sns-projects.mock";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { get } from "svelte/store";
@@ -32,7 +31,7 @@ describe("icrc-tokens.services", () => {
     });
 
     it("should load tokens when icrcCanistersStore is updated", async () => {
-      watchIcrcTokensLoadTokenData({ certified: false });
+      watchIcrcTokensLoadTokenData();
 
       icrcCanistersStore.setCanisters({
         ledgerCanisterId: ledgerCanisterId1,
@@ -48,7 +47,7 @@ describe("icrc-tokens.services", () => {
     });
 
     it("should load multiple tokens when icrcCanistersStore is updated multiple times", async () => {
-      watchIcrcTokensLoadTokenData({ certified: false });
+      watchIcrcTokensLoadTokenData();
 
       icrcCanistersStore.setCanisters({
         ledgerCanisterId: ledgerCanisterId1,
@@ -70,23 +69,6 @@ describe("icrc-tokens.services", () => {
       expect(get(tokensStore)[ledgerCanisterId2.toText()]).toEqual({
         certified: false,
         token: token2,
-      });
-    });
-
-    it("should load tokens with certified data when logged in", async () => {
-      resetIdentity();
-      watchIcrcTokensLoadTokenData({ certified: true });
-
-      icrcCanistersStore.setCanisters({
-        ledgerCanisterId: ledgerCanisterId1,
-        indexCanisterId,
-      });
-
-      await runResolvedPromises();
-
-      expect(get(tokensStore)[ledgerCanisterId1.toText()]).toEqual({
-        certified: true,
-        token: token1,
       });
     });
   });

--- a/frontend/src/tests/lib/services/icrc-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-tokens.services.spec.ts
@@ -4,7 +4,7 @@ import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockToken, principal } from "$tests/mocks/sns-projects.mock";
-import { waitFor } from "@testing-library/svelte";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { get } from "svelte/store";
 
 vi.mock("$lib/api/icrc-ledger.api");
@@ -39,12 +39,12 @@ describe("icrc-tokens.services", () => {
         indexCanisterId,
       });
 
-      await waitFor(() =>
-        expect(get(tokensStore)[ledgerCanisterId1.toText()]).toEqual({
-          certified: false,
-          token: token1,
-        })
-      );
+      await runResolvedPromises();
+
+      expect(get(tokensStore)[ledgerCanisterId1.toText()]).toEqual({
+        certified: false,
+        token: token1,
+      });
     });
 
     it("should load multiple tokens when icrcCanistersStore is updated multiple times", async () => {
@@ -60,12 +60,12 @@ describe("icrc-tokens.services", () => {
         indexCanisterId,
       });
 
-      await waitFor(() =>
-        expect(get(tokensStore)[ledgerCanisterId1.toText()]).toEqual({
-          certified: false,
-          token: token1,
-        })
-      );
+      await runResolvedPromises();
+
+      expect(get(tokensStore)[ledgerCanisterId1.toText()]).toEqual({
+        certified: false,
+        token: token1,
+      });
 
       expect(get(tokensStore)[ledgerCanisterId2.toText()]).toEqual({
         certified: false,
@@ -73,7 +73,7 @@ describe("icrc-tokens.services", () => {
       });
     });
 
-    it.only("should load tokens with certified data when logged in", async () => {
+    it("should load tokens with certified data when logged in", async () => {
       resetIdentity();
       watchIcrcTokensLoadTokenData({ certified: true });
 
@@ -82,12 +82,12 @@ describe("icrc-tokens.services", () => {
         indexCanisterId,
       });
 
-      await waitFor(async () =>
-        expect(get(tokensStore)[ledgerCanisterId1.toText()]).toEqual({
-          certified: true,
-          token: token1,
-        })
-      );
+      await runResolvedPromises();
+
+      expect(get(tokensStore)[ledgerCanisterId1.toText()]).toEqual({
+        certified: true,
+        token: token1,
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/services/icrc-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-tokens.services.spec.ts
@@ -1,0 +1,93 @@
+import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
+import { watchIcrcTokensLoadTokenData } from "$lib/services/icrc-tokens.services";
+import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockToken, principal } from "$tests/mocks/sns-projects.mock";
+import { waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+vi.mock("$lib/api/icrc-ledger.api");
+
+describe("icrc-tokens.services", () => {
+  describe("watchIcrcTokensLoadTokenData", () => {
+    const ledgerCanisterId1 = principal(0);
+    const ledgerCanisterId2 = principal(1);
+    const indexCanisterId = principal(2);
+    const token1 = mockToken;
+    const token2 = { ...mockToken, name: "Token 2" };
+
+    beforeEach(() => {
+      icrcCanistersStore.reset();
+      tokensStore.reset();
+      vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockImplementation(
+        async ({ canisterId }) => {
+          if (canisterId.toText() === ledgerCanisterId1.toText()) {
+            return token1;
+          } else if (canisterId.toText() === ledgerCanisterId2.toText()) {
+            return token2;
+          }
+        }
+      );
+    });
+
+    it("should load tokens when icrcCanistersStore is updated", async () => {
+      watchIcrcTokensLoadTokenData({ certified: false });
+
+      icrcCanistersStore.setCanisters({
+        ledgerCanisterId: ledgerCanisterId1,
+        indexCanisterId,
+      });
+
+      await waitFor(() =>
+        expect(get(tokensStore)[ledgerCanisterId1.toText()]).toEqual({
+          certified: false,
+          token: token1,
+        })
+      );
+    });
+
+    it("should load multiple tokens when icrcCanistersStore is updated multiple times", async () => {
+      watchIcrcTokensLoadTokenData({ certified: false });
+
+      icrcCanistersStore.setCanisters({
+        ledgerCanisterId: ledgerCanisterId1,
+        indexCanisterId,
+      });
+
+      icrcCanistersStore.setCanisters({
+        ledgerCanisterId: ledgerCanisterId2,
+        indexCanisterId,
+      });
+
+      await waitFor(() =>
+        expect(get(tokensStore)[ledgerCanisterId1.toText()]).toEqual({
+          certified: false,
+          token: token1,
+        })
+      );
+
+      expect(get(tokensStore)[ledgerCanisterId2.toText()]).toEqual({
+        certified: false,
+        token: token2,
+      });
+    });
+
+    it.only("should load tokens with certified data when logged in", async () => {
+      resetIdentity();
+      watchIcrcTokensLoadTokenData({ certified: true });
+
+      icrcCanistersStore.setCanisters({
+        ledgerCanisterId: ledgerCanisterId1,
+        indexCanisterId,
+      });
+
+      await waitFor(async () =>
+        expect(get(tokensStore)[ledgerCanisterId1.toText()]).toEqual({
+          certified: true,
+          token: token1,
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

Non-logged in users should also have available the ICRC Tokens.

What was missing was loading the token metadata in the store.

To accomplish that, I added a listener on icrcCanistersStore that loads the tokensStore for each ledgerCanisterId added there.

# Changes

* New icrc token service `watchIcrcTokensLoadTokenData`.
* Set the watcher in the service `initAppPublicData`.
* Allow querying the token from `loadIcrcToken` for non logged in users.

# Tests

* Test that tokens are loaded in `initAppPublicData`.
* Test new service `watchIcrcTokensLoadTokenData`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
