### PR TITLE
Add pending UTXOs to store after updateBalance

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Enable ICRC-2 flow for BTC withdrawal.
 * Add ENABLE_CKETH feature flag.
 * Get ckETH canister IDs from environment/configuration.
+* Display BTC deposits with 1-11 confirmations as "pending".
 
 #### Changed
 

--- a/frontend/src/lib/components/accounts/BitcoinAddress.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinAddress.svelte
@@ -60,7 +60,7 @@
     $min: `${minConfirmations ?? ""}`,
   })}
 
-  <CkBTCWalletActions inline {minterCanisterId} {reload} />
+  <CkBTCWalletActions inline {universeId} {minterCanisterId} {reload} />
 
   {$i18n.ckbtc.incoming_bitcoin_network_part_2}
   <a

--- a/frontend/src/lib/components/accounts/CkBTCWalletActions.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWalletActions.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import type { CanisterId } from "$lib/types/canister";
+  import type { UniverseCanisterId } from "$lib/types/universe";
   import { updateBalance as updateBalanceService } from "$lib/services/ckbtc-minter.services";
 
+  export let universeId: UniverseCanisterId;
   export let minterCanisterId: CanisterId;
   export let reload: () => Promise<void>;
   export let inline = false;
@@ -10,6 +12,7 @@
   // TODO(GIX-1320): ckBTC - update_balance is an happy path, improve UX once track_balance implemented
   const updateBalance = async () =>
     await updateBalanceService({
+      universeId,
       minterCanisterId,
       reload,
       deferReload: true,

--- a/frontend/src/lib/components/accounts/CkBTCWithdrawalAccount.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWithdrawalAccount.svelte
@@ -31,7 +31,7 @@
       ? CKBTC_ADDITIONAL_CANISTERS[$selectedCkBTCUniverseIdStore.toText()]
       : undefined;
 
-    if (isNullish(canisters)) {
+    if (isNullish(canisters) || isNullish($selectedCkBTCUniverseIdStore)) {
       return;
     }
 

--- a/frontend/src/lib/components/accounts/CkBTCWithdrawalAccount.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWithdrawalAccount.svelte
@@ -41,6 +41,7 @@
 
     // Because updateBalance is not related to withdrawal account, we do not really care if the call succeed or not except displaying potential errors in a toast.
     await updateBalanceService({
+      universeId: $selectedCkBTCUniverseIdStore,
       minterCanisterId,
       reload: undefined,
       uiIndicators: false,

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -88,7 +88,7 @@
   bind:this={wallet}
 >
   <svelte:fragment slot="header-actions">
-    {#if nonNullish(canisters)}
+    {#if nonNullish(canisters) && nonNullish($selectedCkBTCUniverseIdStore)}
       <CkBTCWalletActions
         reload={reloadAccount}
         universeId={$selectedCkBTCUniverseIdStore}

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -91,6 +91,7 @@
     {#if nonNullish(canisters)}
       <CkBTCWalletActions
         reload={reloadAccount}
+        universeId={$selectedCkBTCUniverseIdStore}
         minterCanisterId={canisters.minterCanisterId}
       />
     {/if}

--- a/frontend/src/tests/lib/components/accounts/CkBTCWalletActions.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWalletActions.spec.ts
@@ -10,12 +10,9 @@ import { page } from "$mocks/$app/stores";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { advanceTime } from "$tests/utils/timers.test-utils";
+import { MinterNoNewUtxosError } from "@dfinity/ckbtc";
 import { waitFor } from "@testing-library/dom";
 import { fireEvent, render } from "@testing-library/svelte";
-
-vi.mock("$lib/api/ckbtc-minter.api", () => ({
-  updateBalance: vi.fn().mockResolvedValue(undefined),
-}));
 
 describe("CkBTCWalletActions", () => {
   const now = Date.now();
@@ -30,12 +27,19 @@ describe("CkBTCWalletActions", () => {
   beforeEach(() => {
     resetIdentity();
     vi.useFakeTimers().setSystemTime(now);
+    vi.spyOn(api, "updateBalance").mockRejectedValue(
+      new MinterNoNewUtxosError({
+        required_confirmations: 12,
+        pending_utxos: [],
+      })
+    );
   });
   afterEach(() => {
     vi.clearAllTimers();
   });
 
   const props = {
+    universeId: CKTESTBTC_UNIVERSE_CANISTER_ID,
     minterCanisterId: CKTESTBTC_MINTER_CANISTER_ID,
     reload: () => Promise.resolve(),
   };

--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -277,10 +277,17 @@ describe("ckbtc-minter-services", () => {
         .spyOn(minterApi, "updateBalance")
         .mockResolvedValue(mockUpdateBalanceOk);
 
+      const spyOnToastsSuccess = vi.spyOn(toastsStore, "toastsSuccess");
+
       const result = await services.updateBalance(params);
 
       expect(result).toEqual({ success: true });
       expect(updateBalanceSpy).toBeCalledTimes(3);
+
+      expect(spyOnToastsSuccess).toBeCalledTimes(1);
+      expect(spyOnToastsSuccess).toBeCalledWith({
+        labelKey: "ckbtc.ckbtc_balance_updated",
+      });
     });
 
     it("should return generic error even if no ui indicators", async () => {

--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -1,6 +1,7 @@
 import * as minterApi from "$lib/api/ckbtc-minter.api";
 import {
   CKBTC_MINTER_CANISTER_ID,
+  CKBTC_UNIVERSE_CANISTER_ID,
   CKTESTBTC_MINTER_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
@@ -8,6 +9,7 @@ import { AppPath } from "$lib/constants/routes.constants";
 import * as services from "$lib/services/ckbtc-minter.services";
 import { bitcoinAddressStore } from "$lib/stores/bitcoin.store";
 import * as busyStore from "$lib/stores/busy.store";
+import { ckbtcPendingUtxosStore } from "$lib/stores/ckbtc-pending-utxos.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { ApiErrorKey } from "$lib/types/api.errors";
 import { page } from "$mocks/$app/stores";
@@ -76,6 +78,7 @@ describe("ckbtc-minter-services", () => {
     });
 
     const params = {
+      universeId: CKBTC_UNIVERSE_CANISTER_ID,
       minterCanisterId: CKBTC_MINTER_CANISTER_ID,
       reload: undefined,
     };
@@ -202,8 +205,84 @@ describe("ckbtc-minter-services", () => {
 
       expect(result).toEqual({ success: true });
       expect(spyOnToastsSuccess).toHaveBeenCalledWith({
-        labelKey: en.error__ckbtc.no_new_confirmed_btc,
+        labelKey: "error__ckbtc.no_new_confirmed_btc",
       });
+
+      expect(get(ckbtcPendingUtxosStore)).toEqual({
+        [CKBTC_UNIVERSE_CANISTER_ID.toText()]: [],
+      });
+    });
+
+    it("should add pending UTXO to store", async () => {
+      const pendingUtxo = {
+        outpoint: { txid: new Uint8Array([3, 5, 7]), vout: 0 },
+        value: 760_000n,
+        confirmations: 10,
+      };
+      vi.spyOn(minterApi, "updateBalance").mockImplementation(async () => {
+        throw new MinterNoNewUtxosError({
+          required_confirmations: 12,
+          pending_utxos: [[pendingUtxo]],
+        });
+      });
+
+      const spyOnToastsSuccess = vi.spyOn(toastsStore, "toastsSuccess");
+
+      const result = await services.updateBalance(params);
+
+      expect(result).toEqual({ success: true });
+
+      expect(spyOnToastsSuccess).toBeCalledTimes(1);
+      expect(spyOnToastsSuccess).toBeCalledWith({
+        labelKey: "error__ckbtc.no_new_confirmed_btc",
+      });
+
+      expect(get(ckbtcPendingUtxosStore)).toEqual({
+        [CKBTC_UNIVERSE_CANISTER_ID.toText()]: [pendingUtxo],
+      });
+    });
+
+    it("should fetch pending UTXOs after success", async () => {
+      const pendingUtxo = {
+        outpoint: { txid: new Uint8Array([3, 5, 7]), vout: 0 },
+        value: 760_000n,
+        confirmations: 10,
+      };
+      vi.spyOn(minterApi, "updateBalance")
+        .mockResolvedValueOnce(mockUpdateBalanceOk)
+        .mockImplementation(async () => {
+          throw new MinterNoNewUtxosError({
+            required_confirmations: 12,
+            pending_utxos: [[pendingUtxo]],
+          });
+        });
+
+      const spyOnToastsSuccess = vi.spyOn(toastsStore, "toastsSuccess");
+
+      const result = await services.updateBalance(params);
+
+      expect(result).toEqual({ success: true });
+      expect(spyOnToastsSuccess).toBeCalledTimes(1);
+      expect(spyOnToastsSuccess).toBeCalledWith({
+        labelKey: "ckbtc.ckbtc_balance_updated",
+      });
+
+      expect(get(ckbtcPendingUtxosStore)).toEqual({
+        [CKBTC_UNIVERSE_CANISTER_ID.toText()]: [pendingUtxo],
+      });
+    });
+
+    it("should stop after 3 times success", async () => {
+      const updateBalanceSpy = vi
+        .spyOn(minterApi, "updateBalance")
+        .mockResolvedValue(mockUpdateBalanceOk);
+
+      const spyOnToastsSuccess = vi.spyOn(toastsStore, "toastsSuccess");
+
+      const result = await services.updateBalance(params);
+
+      expect(result).toEqual({ success: true });
+      expect(updateBalanceSpy).toBeCalledTimes(3);
     });
 
     it("should return generic error even if no ui indicators", async () => {

--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -277,8 +277,6 @@ describe("ckbtc-minter-services", () => {
         .spyOn(minterApi, "updateBalance")
         .mockResolvedValue(mockUpdateBalanceOk);
 
-      const spyOnToastsSuccess = vi.spyOn(toastsStore, "toastsSuccess");
-
       const result = await services.updateBalance(params);
 
       expect(result).toEqual({ success: true });


### PR DESCRIPTION
# Motivation

In order to get a BTC deposit credited as ckBTC, we need to call `update_balace` on the minter.
If (and only if!) there are no new deposits with enough confirmations, the minter returns (as an error) any deposits that do not yet have enough confirmations.
This means that if there are new completed deposits, we need to call `update_balace` again to know if there are also any pending deposits.

# Changes

1. In `frontend/src/lib/services/ckbtc-minter.services.ts` call `update_balance` until we get pending transactions (if there are any) and then put them in the store.
2. Pass `universeId` to `updateBalance` and to components that call `updateBalance` because it's used as a key in the store.

# Tests

Unit tests are added.
Test manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/accounts/?u=oq4ec-3maaa-aaaaa-qabeq-cai

# Todos

- [x] Add entry to changelog (if necessary).
