### PR TITLE
Smoothness universes list appearance

### DIFF
--- a/frontend/src/lib/components/universe/SelectUniverseList.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseList.svelte
@@ -4,6 +4,7 @@
   import SelectUniverseCard from "$lib/components/universe/SelectUniverseCard.svelte";
   import { createEventDispatcher } from "svelte";
   import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
+  import { blur } from "svelte/transition";
 
   export let role: "link" | "button" = "link";
 
@@ -15,11 +16,13 @@
 
 <TestIdWrapper testId="select-universe-list-component">
   {#each $selectableUniversesStore as universe (universe.canisterId)}
-    <SelectUniverseCard
-      {universe}
-      {role}
-      selected={universe.canisterId === selectedCanisterId}
-      on:click={() => dispatch("nnsSelectUniverse", universe.canisterId)}
-    />
+    <div in:blur>
+      <SelectUniverseCard
+              {universe}
+              {role}
+              selected={universe.canisterId === selectedCanisterId}
+              on:click={() => dispatch("nnsSelectUniverse", universe.canisterId)}
+      />
+    </div>
   {/each}
 </TestIdWrapper>

--- a/frontend/src/lib/components/universe/SelectUniverseList.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseList.svelte
@@ -18,10 +18,10 @@
   {#each $selectableUniversesStore as universe (universe.canisterId)}
     <div in:blur>
       <SelectUniverseCard
-              {universe}
-              {role}
-              selected={universe.canisterId === selectedCanisterId}
-              on:click={() => dispatch("nnsSelectUniverse", universe.canisterId)}
+        {universe}
+        {role}
+        selected={universe.canisterId === selectedCanisterId}
+        on:click={() => dispatch("nnsSelectUniverse", universe.canisterId)}
       />
     </div>
   {/each}


### PR DESCRIPTION
# Motivation

I find the appearance of the universes in the list a bit rough on the edges given that now not only Snses are displayed with a delay but also ckETH. Therefore I suggest to blur the appearance of the card.

# Changes

- `in:blur` in universe card

# Screenshots

Without blur

![without](https://github.com/dfinity/nns-dapp/assets/16886711/291408b2-bc3b-4b0c-b888-8dcdbca5422f)

With blur

![with](https://github.com/dfinity/nns-dapp/assets/16886711/bf44d1e9-f76d-4580-a263-766a1e347875)

