### PR TITLE
Fix non governance navigation with additional flag

### DIFF
--- a/frontend/src/lib/derived/ckbtc-universe.derived.ts
+++ b/frontend/src/lib/derived/ckbtc-universe.derived.ts
@@ -10,5 +10,6 @@ export const ckBTCUniverseStore: Readable<Universe> = derived(
     canisterId: CKBTC_UNIVERSE_CANISTER_ID.toText(),
     title: $i18n.ckbtc.title,
     logo: CKBTC_LOGO,
+    governance: false,
   })
 );

--- a/frontend/src/lib/derived/cktestbtc-universe.derived.ts
+++ b/frontend/src/lib/derived/cktestbtc-universe.derived.ts
@@ -10,5 +10,6 @@ export const ckTESTBTCUniverseStore: Readable<Universe> = derived(
     canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID.toText(),
     title: $i18n.ckbtc.test_title,
     logo: CKTESTBTC_LOGO,
+    governance: false,
   })
 );

--- a/frontend/src/lib/derived/icrc-universes.derived.ts
+++ b/frontend/src/lib/derived/icrc-universes.derived.ts
@@ -32,10 +32,12 @@ const convertIcrcCanistersToUniverse = ({
   if (isNullish(token) || isNullish(logo)) {
     return;
   }
+
   return {
     canisterId: universeId,
     title: token.token.name,
     logo,
+    governance: false,
   };
 };
 

--- a/frontend/src/lib/derived/icrc-universes.derived.ts
+++ b/frontend/src/lib/derived/icrc-universes.derived.ts
@@ -13,7 +13,10 @@ import type { Universe } from "$lib/types/universe";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 
-const convertIcrcCanistersToUniverse = ({
+/**
+ * Convert an icrc token provided in icrcCanisterStore to a non governance token universe.
+ */
+const convertIcrcCanistersToTokenUniverse = ({
   canisters,
   tokensData,
 }: {
@@ -46,7 +49,7 @@ export const icrcTokensUniversesStore: Readable<Universe[]> = derived(
   ([icrcCanisters, tokensData]) =>
     Object.values(icrcCanisters)
       .map((canisters: IcrcCanisters) =>
-        convertIcrcCanistersToUniverse({ canisters, tokensData })
+        convertIcrcCanistersToTokenUniverse({ canisters, tokensData })
       )
       .filter((universe): universe is Universe => nonNullish(universe))
 );

--- a/frontend/src/lib/derived/nns-universe.derived.ts
+++ b/frontend/src/lib/derived/nns-universe.derived.ts
@@ -8,4 +8,5 @@ export const nnsUniverseStore: Readable<Universe> = derived(i18n, ($i18n) => ({
   canisterId: OWN_CANISTER_ID_TEXT,
   title: $i18n.core.ic,
   logo: IC_LOGO_ROUNDED,
+  governance: true,
 }));

--- a/frontend/src/lib/derived/selectable-universes.derived.ts
+++ b/frontend/src/lib/derived/selectable-universes.derived.ts
@@ -1,9 +1,6 @@
 import { pageStore, type Page } from "$lib/derived/page.derived";
 import type { Universe } from "$lib/types/universe";
-import {
-  isNonGovernanceTokenPath,
-  isUniverseCkBTC,
-} from "$lib/utils/universe.utils";
+import { isNonGovernanceTokenPath } from "$lib/utils/universe.utils";
 import { derived, type Readable } from "svelte/store";
 import { universesStore } from "./universes.derived";
 
@@ -12,7 +9,6 @@ export const selectableUniversesStore = derived<
   Universe[]
 >([universesStore, pageStore], ([universes, page]: [Universe[], Page]) =>
   universes.filter(
-    ({ canisterId }) =>
-      isNonGovernanceTokenPath(page) || !isUniverseCkBTC(canisterId)
+    ({ governance }) => isNonGovernanceTokenPath(page) || governance
   )
 );

--- a/frontend/src/lib/derived/selected-universe.derived.ts
+++ b/frontend/src/lib/derived/selected-universe.derived.ts
@@ -11,6 +11,7 @@ import {
 } from "$lib/stores/feature-flags.store";
 import {
   icrcCanistersStore,
+  type IcrcCanistersStore,
   type IcrcCanistersStoreData,
 } from "$lib/stores/icrc-canisters.store";
 import type { Universe, UniverseCanisterId } from "$lib/types/universe";
@@ -47,13 +48,35 @@ const pageUniverseIdStore: Readable<Principal> = derived(
 );
 
 export const selectedUniverseIdStore: Readable<Principal> = derived<
-  [Readable<Principal>, Readable<Page>, Readable<boolean>, Readable<boolean>],
+  [
+    Readable<Principal>,
+    Readable<Page>,
+    Readable<boolean>,
+    Readable<boolean>,
+    IcrcCanistersStore,
+  ],
   Principal
 >(
-  [pageUniverseIdStore, pageStore, ENABLE_CKBTC, ENABLE_CKTESTBTC],
-  ([canisterId, page, $ENABLE_CKBTC, $ENABLE_CKTESTBTC]) => {
-    // ckBTC is only available on Accounts therefore we fallback to Nns if selected and user switch to another view
-    if (isUniverseCkBTC(canisterId) && !isNonGovernanceTokenPath(page)) {
+  [
+    pageUniverseIdStore,
+    pageStore,
+    ENABLE_CKBTC,
+    ENABLE_CKTESTBTC,
+    icrcCanistersStore,
+  ],
+  ([
+    canisterId,
+    page,
+    $ENABLE_CKBTC,
+    $ENABLE_CKTESTBTC,
+    $icrcCanistersStore,
+  ]) => {
+    // ckBTC and Icrc token are only available on Accounts therefore we fallback to Nns if selected and user switch to another view
+    if (
+      (isUniverseCkBTC(canisterId) ||
+        nonNullish($icrcCanistersStore[canisterId.toText()])) &&
+      !isNonGovernanceTokenPath(page)
+    ) {
       return OWN_CANISTER_ID;
     }
     if (

--- a/frontend/src/lib/derived/universes.derived.ts
+++ b/frontend/src/lib/derived/universes.derived.ts
@@ -4,7 +4,7 @@ import {
   type SnsFullProject,
 } from "$lib/derived/sns/sns-projects.derived";
 import type { Universe } from "$lib/types/universe";
-import { createUniverse } from "$lib/utils/universe.utils";
+import { createSnsUniverse } from "$lib/utils/universe.utils";
 import { derived, type Readable } from "svelte/store";
 import { icrcTokensUniversesStore } from "./icrc-universes.derived";
 import { nnsUniverseStore } from "./nns-universe.derived";
@@ -33,6 +33,6 @@ export const universesStore = derived<
     nnsUniverse,
     ...ckBTCUniverses,
     ...icrcUniverses,
-    ...(projects.map(({ summary }) => createUniverse(summary)) ?? []),
+    ...(projects.map(({ summary }) => createSnsUniverse(summary)) ?? []),
   ]
 );

--- a/frontend/src/lib/types/universe.ts
+++ b/frontend/src/lib/types/universe.ts
@@ -9,4 +9,5 @@ export interface Universe {
   summary?: SnsSummary;
   title: string;
   logo: string;
+  governance: boolean;
 }

--- a/frontend/src/lib/utils/universe.utils.ts
+++ b/frontend/src/lib/utils/universe.utils.ts
@@ -56,9 +56,10 @@ export const universeLogoAlt = ({ summary, canisterId }: Universe): string => {
   return i18nObj.auth.ic_logo;
 };
 
-export const createUniverse = (summary: SnsSummary): Universe => ({
+export const createSnsUniverse = (summary: SnsSummary): Universe => ({
   canisterId: summary.rootCanisterId.toText(),
   summary,
   title: summary.metadata.name,
   logo: summary.metadata.logo,
+  governance: true,
 });

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -3,7 +3,7 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import type { Universe } from "$lib/types/universe";
-import { createUniverse } from "$lib/utils/universe.utils";
+import { createSnsUniverse } from "$lib/utils/universe.utils";
 import { page } from "$mocks/$app/stores";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
@@ -20,7 +20,7 @@ import { render } from "@testing-library/svelte";
 
 describe("SelectUniverseCard", () => {
   const props = { universe: nnsUniverseMock, selected: false };
-  const mockSnsUniverse: Universe = createUniverse(mockSummary);
+  const mockSnsUniverse: Universe = createSnsUniverse(mockSummary);
 
   const renderComponent = (props) => {
     const { container } = render(SelectUniverseCard, props);

--- a/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
+++ b/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
@@ -6,7 +6,7 @@ import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { formatToken } from "$lib/utils/token.utils";
-import { createUniverse } from "$lib/utils/universe.utils";
+import { createSnsUniverse } from "$lib/utils/universe.utils";
 import { page } from "$mocks/$app/stores";
 import {
   mockCkBTCMainAccount,
@@ -53,7 +53,7 @@ describe("UniverseAccountsBalance", () => {
   });
 
   // Not the same sns canister id to test that the balance is not displayed
-  const universe = createUniverse(mockSnsFullProject.summary);
+  const universe = createSnsUniverse(mockSnsFullProject.summary);
 
   describe("no balance", () => {
     it("should render skeleton while loading", () => {

--- a/frontend/src/tests/lib/components/universe/UniversePageSummary.spec.ts
+++ b/frontend/src/tests/lib/components/universe/UniversePageSummary.spec.ts
@@ -1,5 +1,5 @@
 import UniversePageSummary from "$lib/components/universe/UniversePageSummary.svelte";
-import { createUniverse } from "$lib/utils/universe.utils";
+import { createSnsUniverse } from "$lib/utils/universe.utils";
 import { mockSummary } from "$tests/mocks/sns-projects.mock";
 import {
   ckBTCUniverseMock,
@@ -25,7 +25,7 @@ describe("UniversePageSummary", () => {
   });
 
   it("shout render sns", async () => {
-    const mockSnsUniverse = createUniverse(mockSummary);
+    const mockSnsUniverse = createSnsUniverse(mockSummary);
     const po = renderComponent(mockSnsUniverse);
     expect(await po.getTitle()).toEqual("Tetris");
   });

--- a/frontend/src/tests/lib/utils/universes.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/universes.utils.spec.ts
@@ -8,7 +8,7 @@ import {
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import {
-  createUniverse,
+  createSnsUniverse,
   isNonGovernanceTokenPath,
   isUniverseCkBTC,
   isUniverseNns,
@@ -146,7 +146,7 @@ describe("universes-utils", () => {
         logo,
       });
 
-      const universe = createUniverse(summary);
+      const universe = createSnsUniverse(summary);
       expect(universe).toEqual({
         canisterId: rootCanisterId.toText(),
         summary,


### PR DESCRIPTION
# Motivation

ckETH is displayed on governance pages because we know if a path support governance or not but, we don't if a universe is actually meant for governance or not. It works with ckBTC because we have some additional checks but, it is not generic.

```
// We know we are on Neurons page
// We know it is not ckBTC
// We don't know (in the future) if the Icrc universe is an Icrc token related to a Sns project or just token
isNonGovernanceTokenPath(page) || !isUniverseCkBTC(canisterId)
```

Moreover we face another problem when user select ckETH and switch to proposal. If we do nothing, the selected universe is not reseted and nothing is shown on proposal. For ckBTC we can detect this and fallback to NNS but, in case of generic Icrc token or Sns, we cannot know neither.

```
// Current code:
//
// ckBTC is only available on Accounts therefore we fallback to Nns if selected and user switch to another view
    if (isUniverseCkBTC(canisterId) && !isNonGovernanceTokenPath(page)) {
      return OWN_CANISTER_ID;
}
```

Therefore, I suggest to add a flag `governance` in the universe. Open to better idea!

# Changes

<!-- List the changes that have been developed -->

# Screenshot

Issue 1 - ckETH on neuron

<img width="1536" alt="Capture d’écran 2023-11-29 à 16 35 28" src="https://github.com/dfinity/nns-dapp/assets/16886711/a638098e-d928-4547-8f99-5ab44caa9408">

Issue 2 - empty proposal, no fallback

<img width="1536" alt="Capture d’écran 2023-11-29 à 16 51 17" src="https://github.com/dfinity/nns-dapp/assets/16886711/70ac3afa-c63b-45ab-b314-bfcd59f444e7">

