### PR TITLE
GIX-2151: Reload after transaction

### DIFF
--- a/frontend/src/lib/components/accounts/IcrcTokenWalletFooter.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTokenWalletFooter.svelte
@@ -14,7 +14,7 @@
   export let universeId: UniverseCanisterId;
   export let token: IcrcTokenMetadata;
   export let account: Account;
-  export let reloadAccount: () => Promise<void>;
+  export let reloadSourceAccount: (() => Promise<void>) | undefined = undefined;
 
   const openSendModal = () => {
     if (isNullish(universeId) || isNullish(token)) {
@@ -28,6 +28,7 @@
         token,
         loadTransactions: false,
         sourceAccount: account,
+        reloadSourceAccount,
       },
     });
   };
@@ -43,7 +44,7 @@
   <ReceiveButton
     type="icrc-receive"
     {account}
-    reload={reloadAccount}
+    reload={reloadSourceAccount}
     testId="receive-icrc"
     {universeId}
     logo={$selectedUniverseStore?.logo ?? IC_LOGO}

--- a/frontend/src/lib/components/accounts/IcrcTokenWalletFooter.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTokenWalletFooter.svelte
@@ -14,7 +14,13 @@
   export let universeId: UniverseCanisterId;
   export let token: IcrcTokenMetadata;
   export let account: Account;
-  export let reloadSourceAccount: (() => Promise<void>) | undefined = undefined;
+  export let reloadAccount: (() => Promise<void>) | undefined = undefined;
+  export let reloadTransactions: (() => Promise<void>) | undefined = undefined;
+
+  const reloadSourceAccount = async () => {
+    await reloadAccount?.();
+    await reloadTransactions?.();
+  };
 
   const openSendModal = () => {
     if (isNullish(universeId) || isNullish(token)) {
@@ -44,7 +50,7 @@
   <ReceiveButton
     type="icrc-receive"
     {account}
-    reload={reloadSourceAccount}
+    reload={reloadAccount}
     testId="receive-icrc"
     {universeId}
     logo={$selectedUniverseStore?.logo ?? IC_LOGO}

--- a/frontend/src/lib/components/accounts/IcrcTokenWalletFooter.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTokenWalletFooter.svelte
@@ -14,12 +14,12 @@
   export let universeId: UniverseCanisterId;
   export let token: IcrcTokenMetadata;
   export let account: Account;
-  export let reloadAccount: (() => Promise<void>) | undefined = undefined;
-  export let reloadTransactions: (() => Promise<void>) | undefined = undefined;
+  export let reloadAccount: () => Promise<void>;
+  export let reloadTransactions: () => Promise<void>;
 
   const reloadSourceAccount = async () => {
-    await reloadAccount?.();
-    await reloadTransactions?.();
+    await reloadAccount();
+    await reloadTransactions();
   };
 
   const openSendModal = () => {

--- a/frontend/src/lib/modals/accounts/IcrcTokenAccountsModals.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenAccountsModals.svelte
@@ -28,5 +28,6 @@
       token: modal.data.token,
     })}
     selectedAccount={modal.data.sourceAccount}
+    reloadSourceAccount={modal.data.reloadSourceAccount}
   />
 {/if}

--- a/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
@@ -20,6 +20,7 @@
   export let ledgerCanisterId: Principal;
   export let token: IcrcTokenMetadata;
   export let transactionFee: TokenAmount;
+  export let reloadSourceAccount: (() => void) | undefined = undefined;
 
   let transactionInit: TransactionInit = {
     sourceAccount: selectedAccount,
@@ -53,6 +54,7 @@
     stopBusy("accounts");
 
     if (nonNullish(blockIndex)) {
+      reloadSourceAccount?.();
       toastsSuccess({ labelKey: "accounts.transaction_success" });
       dispatcher("nnsClose");
     }

--- a/frontend/src/lib/pages/IcrcWallet.svelte
+++ b/frontend/src/lib/pages/IcrcWallet.svelte
@@ -13,13 +13,6 @@
 
   export let accountIdentifier: string | undefined | null = undefined;
 
-  let wallet: IcrcWalletPage;
-
-  // e.g. when a function such as a transfer is called and which also reload the data and populate the stores after execution
-  const reloadAccount = async () => {
-    wallet.setSelectedAccount();
-  };
-
   const selectedAccountStore = writable<WalletStore>({
     account: undefined,
     neurons: [],
@@ -37,6 +30,9 @@
     : undefined;
 
   let transactions: IcrcWalletTransactionsList;
+  let wallet: IcrcWalletPage;
+
+  const reloadAccount = async () => await wallet.reloadAccount?.();
   const reloadTransactions = () => transactions?.reloadTransactions?.();
 </script>
 
@@ -66,9 +62,9 @@
       <IcrcTokenWalletFooter
         universeId={$selectedIcrcTokenUniverseIdStore}
         account={$selectedAccountStore.account}
+        {token}
         {reloadAccount}
         {reloadTransactions}
-        {token}
       />
     {/if}
   </svelte:fragment>

--- a/frontend/src/lib/pages/IcrcWallet.svelte
+++ b/frontend/src/lib/pages/IcrcWallet.svelte
@@ -16,7 +16,7 @@
   let wallet: IcrcWalletPage;
 
   // e.g. when a function such as a transfer is called and which also reload the data and populate the stores after execution
-  const reloadAccount = () => {
+  const reloadAccount = async () => {
     wallet.setSelectedAccount();
   };
 
@@ -66,9 +66,9 @@
       <IcrcTokenWalletFooter
         universeId={$selectedIcrcTokenUniverseIdStore}
         account={$selectedAccountStore.account}
-        reloadSourceAccount={reloadAccount}
-        {token}
         {reloadAccount}
+        {reloadTransactions}
+        {token}
       />
     {/if}
   </svelte:fragment>

--- a/frontend/src/lib/pages/IcrcWallet.svelte
+++ b/frontend/src/lib/pages/IcrcWallet.svelte
@@ -13,6 +13,13 @@
 
   export let accountIdentifier: string | undefined | null = undefined;
 
+  let wallet: IcrcWalletPage;
+
+  // e.g. when a function such as a transfer is called and which also reload the data and populate the stores after execution
+  const reloadAccount = () => {
+    wallet.setSelectedAccount();
+  };
+
   const selectedAccountStore = writable<WalletStore>({
     account: undefined,
     neurons: [],
@@ -30,9 +37,6 @@
     : undefined;
 
   let transactions: IcrcWalletTransactionsList;
-  let wallet: IcrcWalletPage;
-
-  const reloadAccount = async () => await wallet.reloadAccount?.();
   const reloadTransactions = () => transactions?.reloadTransactions?.();
 </script>
 
@@ -62,6 +66,7 @@
       <IcrcTokenWalletFooter
         universeId={$selectedIcrcTokenUniverseIdStore}
         account={$selectedAccountStore.account}
+        reloadSourceAccount={reloadAccount}
         {token}
         {reloadAccount}
       />

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -224,7 +224,7 @@ export const icrcTransferTokens = async ({
         canisterId: ledgerCanisterId,
       }),
     reloadAccounts: async () =>
-      await loadIcrcAccount({ ledgerCanisterId, certified: true }),
+      loadIcrcAccount({ ledgerCanisterId, certified: true }),
     // Web workders take care of refreshing transactions
     reloadTransactions: () => Promise.resolve(),
   });

--- a/frontend/src/lib/types/icrc-accounts.modal.ts
+++ b/frontend/src/lib/types/icrc-accounts.modal.ts
@@ -13,6 +13,7 @@ export type IcrcTokenTransactionModalData = {
   token: IcrcTokenMetadata;
   loadTransactions: boolean;
   sourceAccount?: Account;
+  reloadSourceAccount?: () => void;
 };
 
 export interface IcrcTokenModalProps {

--- a/frontend/src/lib/types/icrc-accounts.modal.ts
+++ b/frontend/src/lib/types/icrc-accounts.modal.ts
@@ -13,7 +13,7 @@ export type IcrcTokenTransactionModalData = {
   token: IcrcTokenMetadata;
   loadTransactions: boolean;
   sourceAccount?: Account;
-  reloadSourceAccount?: () => void;
+  reloadSourceAccount?: () => Promise<void>;
 };
 
 export interface IcrcTokenModalProps {

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -171,7 +171,7 @@ describe("Wallet", () => {
   });
 
   // TODO: GIX-2150 Mock API layer instead of services for the setup
-  it.only("user can transfer ckETH tokens", async () => {
+  it("user can transfer ckETH tokens and balance is refreshed", async () => {
     overrideFeatureFlagsStore.setFlag("ENABLE_CKETH", true);
     page.mock({
       data: { universe: CKETH_UNIVERSE_CANISTER_ID.toText() },

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -101,7 +101,7 @@ describe("Wallet", () => {
     icpAccountsStore.setForTesting(mockAccountsStoreData);
     overrideFeatureFlagsStore.reset();
     vi.spyOn(icrcLedgerApi, "icrcTransfer").mockResolvedValue(1234n);
-    // Called only after a transfer (for now)
+    // Called only after a transfer (for now GIX-2150)
     vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockResolvedValue(
       balanceAfterTransfer
     );

--- a/frontend/src/tests/page-objects/Wallet.page-object.ts
+++ b/frontend/src/tests/page-objects/Wallet.page-object.ts
@@ -3,6 +3,7 @@ import { CkBTCWalletPo } from "$tests/page-objects/CkBTCWallet.page-object";
 import { NnsWalletPo } from "$tests/page-objects/NnsWallet.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { IcrcTokenTransactionModalPo } from "./IcrcTokenTransactionModal.page-object";
+import { IcrcWalletPo } from "./IcrcWallet.page-object";
 
 export class WalletPo extends BasePageObject {
   private static readonly TID = "wallet-component";
@@ -17,6 +18,10 @@ export class WalletPo extends BasePageObject {
 
   getCkBTCWalletPo(): CkBTCWalletPo {
     return CkBTCWalletPo.under(this.root);
+  }
+
+  getIcrcWalletPo() {
+    return IcrcWalletPo.under(this.root);
   }
 
   // TODO: GIX-2150 Use POs all the levels


### PR DESCRIPTION
# Motivation

User sees the updated balance after making a transaction from the Wallet page.

# Changes

* Add optional field `reloadSourceAccount` to the modal props.
* Add prop `reloadTransactions` to IcrcTokenWalletFooter. Pass a `reloadSourceAccount` when opening the `"icrc-send"` modal.
* Add same field to IcrcTokenTransactionModal props. Call it on transfer success.

# Tests

* Add expects to current test `"user can transfer ckETH tokens"`.
* Add method to WalletPo

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary yet.
