### PR TITLE
GIX-2152: ckETH not selected in governance

### DIFF
--- a/frontend/src/lib/derived/selected-universe.derived.ts
+++ b/frontend/src/lib/derived/selected-universe.derived.ts
@@ -11,6 +11,7 @@ import {
 } from "$lib/stores/feature-flags.store";
 import {
   icrcCanistersStore,
+  type IcrcCanistersStore,
   type IcrcCanistersStoreData,
 } from "$lib/stores/icrc-canisters.store";
 import type { Universe, UniverseCanisterId } from "$lib/types/universe";
@@ -47,13 +48,27 @@ const pageUniverseIdStore: Readable<Principal> = derived(
 );
 
 export const selectedUniverseIdStore: Readable<Principal> = derived<
-  [Readable<Principal>, Readable<Page>, Readable<boolean>, Readable<boolean>],
+  [
+    Readable<Principal>,
+    Readable<Page>,
+    IcrcCanistersStore,
+    Readable<boolean>,
+    Readable<boolean>,
+  ],
   Principal
 >(
-  [pageUniverseIdStore, pageStore, ENABLE_CKBTC, ENABLE_CKTESTBTC],
-  ([canisterId, page, $ENABLE_CKBTC, $ENABLE_CKTESTBTC]) => {
-    // ckBTC is only available on Accounts therefore we fallback to Nns if selected and user switch to another view
-    if (isUniverseCkBTC(canisterId) && !isNonGovernanceTokenPath(page)) {
+  [
+    pageUniverseIdStore,
+    pageStore,
+    icrcCanistersStore,
+    ENABLE_CKBTC,
+    ENABLE_CKTESTBTC,
+  ],
+  ([canisterId, page, icrcCanisters, $ENABLE_CKBTC, $ENABLE_CKTESTBTC]) => {
+    const isCkBTC = isUniverseCkBTC(canisterId);
+    const isIcrcToken = nonNullish(icrcCanisters[canisterId.toText()]);
+    // ckBTC and ICRC Tokens are only available on Accounts therefore we fallback to Nns if selected and user switch to another view
+    if ((isCkBTC || isIcrcToken) && !isNonGovernanceTokenPath(page)) {
       return OWN_CANISTER_ID;
     }
     if (

--- a/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selected-universe.derived.spec.ts
@@ -176,6 +176,103 @@ describe("selected universe derived stores", () => {
       expect($store2.toText()).toEqual(mockSnsCanisterIdText);
     });
 
+    const ckBTCTestData = [
+      {
+        universeName: "ckBTC",
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        expectedUniverseName: "ckBTC",
+        expectedUniverseId: CKBTC_UNIVERSE_CANISTER_ID,
+        routeId: AppPath.Accounts,
+      },
+      {
+        universeName: "ckBTC",
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        expectedUniverseName: "ckBTC",
+        expectedUniverseId: CKBTC_UNIVERSE_CANISTER_ID,
+        routeId: AppPath.Wallet,
+      },
+      {
+        universeName: "ckBTC",
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        expectedUniverseName: "NNS",
+        expectedUniverseId: OWN_CANISTER_ID,
+        routeId: AppPath.Neurons,
+      },
+      {
+        universeName: "ckBTC",
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        expectedUniverseName: "NNS",
+        expectedUniverseId: OWN_CANISTER_ID,
+        routeId: AppPath.Proposals,
+      },
+    ];
+
+    ckBTCTestData.forEach((data) => {
+      it(`should return ${data.expectedUniverseName} universe id for ${data.universeName} in ${data.routeId} page`, () => {
+        page.mock({
+          data: {
+            universe: data.universeId.toText(),
+          },
+          routeId: data.routeId,
+        });
+
+        expect(get(selectedUniverseIdStore).toText()).toEqual(
+          data.expectedUniverseId.toText()
+        );
+      });
+    });
+
+    const icrcCanisterId = principal(0);
+    const IcrcTokenTestData = [
+      {
+        universeName: "IcrcToken",
+        universeId: icrcCanisterId,
+        expectedUniverseName: "IcrcToken",
+        expectedUniverseId: icrcCanisterId,
+        routeId: AppPath.Accounts,
+      },
+      {
+        universeName: "IcrcToken",
+        universeId: icrcCanisterId,
+        expectedUniverseName: "IcrcToken",
+        expectedUniverseId: icrcCanisterId,
+        routeId: AppPath.Wallet,
+      },
+      {
+        universeName: "IcrcToken",
+        universeId: icrcCanisterId,
+        expectedUniverseName: "NNS",
+        expectedUniverseId: OWN_CANISTER_ID,
+        routeId: AppPath.Neurons,
+      },
+      {
+        universeName: "IcrcToken",
+        universeId: icrcCanisterId,
+        expectedUniverseName: "NNS",
+        expectedUniverseId: OWN_CANISTER_ID,
+        routeId: AppPath.Proposals,
+      },
+    ];
+
+    IcrcTokenTestData.forEach((data) => {
+      it(`should return ${data.expectedUniverseName} universe id for ${data.universeName} in ${data.routeId} page`, () => {
+        page.mock({
+          data: {
+            universe: data.universeId.toText(),
+          },
+          routeId: data.routeId,
+        });
+        icrcCanistersStore.setCanisters({
+          ledgerCanisterId: icrcCanisterId,
+          indexCanisterId: principal(1),
+        });
+
+        expect(get(selectedUniverseIdStore).toText()).toEqual(
+          data.expectedUniverseId.toText()
+        );
+      });
+    });
+
     it("returns OWN_CANISTER_ID if context is not a valid principal id", () => {
       const $store1 = get(selectedUniverseIdStore);
 


### PR DESCRIPTION
# Motivation

ckETH doesn't have neurons nor proposals. It should not be visible and the page should default to NNS.

In this PR, the page defaults to NNS, but the token is still selectable in the Token Selector. That will come in another PR.

# Changes

* Edit `selectedUniverseIdStore` to take into account the `icrcCanistersStore` when using NNS fallback or not.

# Tests

* Add tests for new functionality.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.

