### PR TITLE
GIX-2152: Non Selectable ICRC Tokens in Governance page

### DIFF
--- a/frontend/src/lib/derived/selectable-universes.derived.ts
+++ b/frontend/src/lib/derived/selectable-universes.derived.ts
@@ -1,18 +1,33 @@
 import { pageStore, type Page } from "$lib/derived/page.derived";
+import {
+  icrcCanistersStore,
+  type IcrcCanistersStore,
+  type IcrcCanistersStoreData,
+} from "$lib/stores/icrc-canisters.store";
 import type { Universe } from "$lib/types/universe";
 import {
   isNonGovernanceTokenPath,
   isUniverseCkBTC,
 } from "$lib/utils/universe.utils";
+import { isNullish } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 import { universesStore } from "./universes.derived";
 
 export const selectableUniversesStore = derived<
-  [Readable<Universe[]>, Readable<Page>],
+  [Readable<Universe[]>, Readable<Page>, IcrcCanistersStore],
   Universe[]
->([universesStore, pageStore], ([universes, page]: [Universe[], Page]) =>
-  universes.filter(
-    ({ canisterId }) =>
-      isNonGovernanceTokenPath(page) || !isUniverseCkBTC(canisterId)
-  )
+>(
+  [universesStore, pageStore, icrcCanistersStore],
+  ([universes, page, icrcCanisters]: [
+    Universe[],
+    Page,
+    IcrcCanistersStoreData,
+  ]) =>
+    // Non-governance paths show all universes
+    // The rest show all universes except for ckBTC, and ICRC Tokens
+    universes.filter(
+      ({ canisterId }) =>
+        isNonGovernanceTokenPath(page) ||
+        (!isUniverseCkBTC(canisterId) && isNullish(icrcCanisters[canisterId]))
+    )
 );

--- a/frontend/src/tests/lib/derived/selectable-universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selectable-universes.derived.spec.ts
@@ -1,5 +1,6 @@
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { CKETH_UNIVERSE_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
 import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
@@ -8,11 +9,16 @@ import {
   mockProjectSubscribe,
   mockSnsFullProject,
 } from "$tests/mocks/sns-projects.mock";
+import {
+  resetCkETHCanisters,
+  setCkETHCanisters,
+} from "$tests/utils/cketh.test-utils";
 import { get } from "svelte/store";
 
 describe("selectable universes derived stores", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    resetCkETHCanisters();
 
     page.mock({
       routeId: AppPath.Accounts,
@@ -29,11 +35,34 @@ describe("selectable universes derived stores", () => {
     expect(store[1].canisterId).toEqual(CKBTC_UNIVERSE_CANISTER_ID.toText());
   });
 
+  it("should return CkETH in Accounts page", () => {
+    setCkETHCanisters();
+    const store = get(selectableUniversesStore);
+    expect(store.length).toEqual(4);
+    expect(store[3].summary).toBeUndefined();
+    expect(store[3].canisterId).toEqual(CKETH_UNIVERSE_CANISTER_ID.toText());
+  });
+
   it("should not return ckBTC if path is not Account", () => {
     page.mock({
       routeId: AppPath.Neurons,
       data: { universe: OWN_CANISTER_ID.toText() },
     });
+
+    const store = get(selectableUniversesStore);
+    // 1 length = only NNS
+    expect(store.length).toEqual(1);
+    expect(store[0].canisterId).not.toEqual(
+      CKBTC_UNIVERSE_CANISTER_ID.toText()
+    );
+  });
+
+  it("should not return ckETH if path is not Account", () => {
+    page.mock({
+      routeId: AppPath.Neurons,
+      data: { universe: OWN_CANISTER_ID.toText() },
+    });
+    setCkETHCanisters();
 
     const store = get(selectableUniversesStore);
     // 1 length = only NNS

--- a/frontend/src/tests/utils/cketh.test-utils.ts
+++ b/frontend/src/tests/utils/cketh.test-utils.ts
@@ -17,3 +17,8 @@ export const setCkETHCanisters = () => {
     token: mockCkETHToken,
   });
 };
+
+export const resetCkETHCanisters = () => {
+  icrcCanistersStore.reset();
+  tokensStore.reset();
+};

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -34,6 +34,8 @@ vi.mock("./src/lib/utils/env-vars.utils.ts", () => ({
     ckbtcIndexCanisterId: "n5wcd-faaaa-aaaar-qaaea-cai",
     ckbtcLedgerCanisterId: "mxzaz-hqaaa-aaaar-qaada-cai",
     cyclesMintingCanisterId: "rkp4c-7iaaa-aaaaa-aaaca-cai",
+    ckethLedgerCanisterId: "ss2fx-dyaaa-aaaar-qacoq-cai",
+    ckethIndexCanisterId: "s3zol-vqaaa-aaaar-qacpa-cai",
     dfxNetwork: "testnet",
     featureFlags: JSON.stringify({
       ENABLE_CKBTC: true,


### PR DESCRIPTION
# Motivation

CkETH has no neurons or proposals.

In this PR, the CkETH universe is not selectable when the user is in Neurons or Proposals.

# Changes

* Use the `icrcCanistersStore` in `selectableUniversesStore` to determine whether ICRC Token universe is selectable based on the page.

# Tests

* Add tests for new functionality.
* Add a helper to reset after setting CkETH canisters.
* Add new env vars to vitest setup.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necesary.
