### PR TITLE
Chore: Enable CkETH for tests

### DIFF
--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -45,7 +45,7 @@ vi.mock("./src/lib/utils/env-vars.utils.ts", () => ({
       ENABLE_STAKE_NEURON_ICRC1: true,
       ENABLE_SWAP_ICRC1: true,
       ENABLE_MY_TOKENS: false,
-      ENABLE_CKETH: false,
+      ENABLE_CKETH: true,
       ENABLE_CKBTC_ICRC2: true,
       TEST_FLAG_EDITABLE: true,
       TEST_FLAG_NOT_EDITABLE: true,


### PR DESCRIPTION
# Motivation

We want to enable CkETH for mainnet.

In this PR, enable the feature flag only for tests as a first step.

# Changes

* Set `true` for `ENABLE_CKETH` in vitest.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet.
