### PR TITLE
Use themed colors instead of theme selector

### DIFF
--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -128,8 +128,8 @@
     justify-content: center;
     align-items: center;
 
-    background: var(--positive-emphasis-light);
-    color: var(--positive-emphasis);
+    background: var(--check-tint);
+    color: var(--check);
 
     border-radius: var(--border-radius);
 
@@ -146,18 +146,6 @@
     &.pending {
       color: var(--pending-color);
       background: var(--pending-background);
-    }
-  }
-
-  @include media.dark-theme {
-    .icon {
-      background: rgba(var(--positive-emphasis-rgb), 0.3);
-      color: var(--positive-emphasis);
-
-      &.send {
-        background: var(--background);
-        color: var(--disable-contrast);
-      }
     }
   }
 </style>


### PR DESCRIPTION
# Motivation

The icon for received transactions changes color based on light/dark theme.
This is done with a `@include media.dark-theme` selector which has a higher specificity than the `.pending` class for the orange icon for pending transactions.
Because of this, the pending transactions aren't orange in the dark them.

# Changes

Use themed color constants for the transaction icon instead of the `@include media.dark-theme` selector.

# Tests

Before:
<img width="778" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/f4e6612d-5865-47c7-a494-b8b02a54cecf">

After:
<img width="777" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/debec2b9-6fe5-4186-9c64-5d97fe39b8a6">


# Todos

- [ ] Add entry to changelog (if necessary).
Covered by existing entry about pending transactions.