### PR TITLE
GIX-2154: Support decimals numberToE8s

### DIFF
--- a/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
@@ -47,6 +47,7 @@
       source: sourceAccount,
       destinationAddress,
       amount,
+      token,
       ledgerCanisterId,
       fee: token.fee,
     });

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -22,7 +22,7 @@ import {
   type IcrcBlockIndex,
 } from "@dfinity/ledger-icrc";
 import type { Principal } from "@dfinity/principal";
-import { isNullish, nonNullish } from "@dfinity/utils";
+import { isNullish, nonNullish, type Token } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { queryAndUpdate } from "./utils.services";
 
@@ -146,6 +146,7 @@ export interface IcrcTransferTokensUserParams {
   source: Account;
   destinationAddress: string;
   amount: number;
+  token?: Token;
 }
 
 // TODO: use `wallet-accounts.services`
@@ -153,6 +154,7 @@ export const transferTokens = async ({
   source,
   destinationAddress,
   amount,
+  token,
   fee,
   transfer,
   reloadAccounts,
@@ -172,7 +174,7 @@ export const transferTokens = async ({
       throw new Error("error.transaction_fee_not_found");
     }
 
-    const amountE8s = numberToE8s(amount);
+    const amountE8s = numberToE8s(amount, token);
     const identity: Identity = await getIcrcAccountIdentity(source);
     const to = decodeIcrcAccount(destinationAddress);
 
@@ -203,6 +205,7 @@ export const icrcTransferTokens = async ({
   source,
   destinationAddress,
   amount,
+  token,
   fee,
   ledgerCanisterId,
 }: IcrcTransferTokensUserParams & {
@@ -212,6 +215,7 @@ export const icrcTransferTokens = async ({
   return transferTokens({
     source,
     amount,
+    token,
     fee,
     destinationAddress,
     transfer: async (

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -155,10 +155,11 @@ export const convertTCyclesToIcpNumber = ({
  * @returns {bigint}
  * @throws {Error} If the amount has more than 8 decimals.
  */
-export const numberToE8s = (amount: number): bigint =>
+// TODO: GIX-2150 Make `token` mandatory.
+export const numberToE8s = (amount: number, token: Token = ICPToken): bigint =>
   TokenAmount.fromNumber({
     amount,
-    token: ICPToken,
+    token,
   }).toE8s();
 
 export class UnavailableTokenAmount {

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -9,6 +9,7 @@ import {
   numberToE8s,
   sumAmountE8s,
 } from "$lib/utils/token.utils";
+import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 
 describe("token-utils", () => {
@@ -259,6 +260,19 @@ describe("token-utils", () => {
       expect(numberToE8s(1)).toBe(BigInt(100_000_000));
       expect(numberToE8s(3.14)).toBe(BigInt(314_000_000));
       expect(numberToE8s(0.14)).toBe(BigInt(14_000_000));
+    });
+
+    // TODO: Enable when we upgrade ic-js with TokenAmount supporting decimals.
+    it.skip("converts number to e8s with token", () => {
+      expect(numberToE8s(1.14, mockCkETHToken)).toBe(
+        BigInt(1_140_000_000_000_000_000)
+      );
+      expect(numberToE8s(1, mockCkETHToken)).toBe(
+        BigInt(1_000_000_000_000_000_000)
+      );
+      expect(numberToE8s(3.14, mockCkETHToken)).toBe(
+        BigInt(3_140_000_000_000_000_000)
+      );
     });
   });
 });

--- a/frontend/src/tests/mocks/cketh-accounts.mock.ts
+++ b/frontend/src/tests/mocks/cketh-accounts.mock.ts
@@ -7,12 +7,14 @@ export const mockCkETHToken: IcrcTokenMetadata = {
   name: "ckETH",
   symbol: "ckETH",
   fee: 10_000n,
+  decimals: 18n,
 };
 
 export const mockCkETHTESTToken: IcrcTokenMetadata = {
   symbol: "ckETHTEST",
   name: "ckETHTEST",
   fee: 10_000n,
+  decimals: 18n,
 };
 
 export const mockCkETHMainAccount: Account = {


### PR DESCRIPTION
# Motivation

Support tokens with different decimal precision.

In this PR, add optional parameter to helper `numberToE8s`.

# Changes

* Add new optional parameter `token` in `numberToE8s`.
* New optional param `token` in `IcrcTransferTokensUserParams`.
* New optional `token` param in the `transferTokens` icrc service
* Use new param in the IcrcTokenTransactionModal.

# Tests

* Add test in `numberToE8s` for the new functionality.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
