### PR TITLE
GIX-2154: numberToE8s mandatory token

### DIFF
--- a/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
@@ -11,8 +11,10 @@
     ckBTCInfoStore,
     type CkBTCInfoStoreUniverseData,
   } from "$lib/stores/ckbtc-info.store";
+  import type { IcrcTokenMetadata } from "$lib/types/icrc";
 
   export let amount: number | undefined = undefined;
+  export let ckBTCToken: IcrcTokenMetadata;
   export let bitcoinEstimatedFee: bigint | undefined | null = undefined;
   export let universeId: UniverseCanisterId;
 
@@ -31,10 +33,13 @@
   $: token = {
     symbol: $i18n.ckbtc.btc,
     name: bitcoinLabel,
+    decimals: ckBTCToken.decimals,
   };
 
   let amountE8s = BigInt(0);
-  $: amountE8s = nonNullish(amount) ? numberToE8s(amount) : BigInt(0);
+  $: amountE8s = nonNullish(amount)
+    ? numberToE8s({ amount, token: ckBTCToken })
+    : BigInt(0);
 
   let estimatedFee = BigInt(0);
   $: estimatedFee =

--- a/frontend/src/lib/components/accounts/BitcoinEstimatedFee.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinEstimatedFee.svelte
@@ -8,9 +8,11 @@
   import type { CanisterId } from "$lib/types/canister";
   import { isTransactionNetworkBtc } from "$lib/utils/transactions.utils";
   import type { EstimateWithdrawalFee } from "@dfinity/ckbtc";
+  import type { IcrcTokenMetadata } from "$lib/types/icrc";
 
   export let minterCanisterId: CanisterId;
   export let amount: number | undefined = undefined;
+  export let token: IcrcTokenMetadata;
   export let selectedNetwork: TransactionNetwork | undefined = undefined;
 
   export let bitcoinEstimatedFee: bigint | undefined | null = undefined;
@@ -30,7 +32,7 @@
     await estimateFeeService({
       minterCanisterId,
       params: {
-        amount: nonNullish(amount) ? numberToE8s(amount) : undefined,
+        amount: nonNullish(amount) ? numberToE8s({ amount, token }) : undefined,
         certified: false,
       },
       callback,

--- a/frontend/src/lib/derived/sns/sns-token-symbol-selected.store.ts
+++ b/frontend/src/lib/derived/sns/sns-token-symbol-selected.store.ts
@@ -1,24 +1,20 @@
 import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
 import { snsSummariesStore } from "$lib/stores/sns.store";
-import type { Token } from "@dfinity/utils";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import { derived, type Readable } from "svelte/store";
 
 /**
  * TODO: integrate ckBTC fee
  * @deprecated to be replaced with tokenStore (Token returned here does not contain fee)
  */
-export const snsTokenSymbolSelectedStore: Readable<Token | undefined> = derived(
+export const snsTokenSymbolSelectedStore: Readable<
+  IcrcTokenMetadata | undefined
+> = derived(
   [selectedUniverseIdStore, snsSummariesStore],
   ([selectedRootCanisterId, summaries]) => {
-    const selectedTokenMetadata = summaries.find(
+    return summaries.find(
       ({ rootCanisterId }) =>
         rootCanisterId.toText() === selectedRootCanisterId.toText()
     )?.token;
-    if (selectedTokenMetadata !== undefined) {
-      return {
-        symbol: selectedTokenMetadata.symbol,
-        name: selectedTokenMetadata.name,
-      };
-    }
   }
 );

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -100,6 +100,7 @@
       source: sourceAccount,
       destinationAddress,
       amount,
+      token,
       universeId,
     });
 
@@ -125,6 +126,7 @@
       amount,
       universeId,
       canisters,
+      token,
       updateProgress,
     };
 
@@ -182,6 +184,7 @@
       networkBtc,
       sourceAccount: selectedAccount,
       amount,
+      token,
       transactionFee: fee.toE8s(),
       infoData,
     });
@@ -217,6 +220,7 @@
   <svelte:fragment slot="additional-info-form">
     <BitcoinEstimatedFee
       {selectedNetwork}
+      {token}
       amount={userAmount}
       minterCanisterId={canisters.minterCanisterId}
       bind:bitcoinEstimatedFee
@@ -228,6 +232,7 @@
   <svelte:fragment slot="received-amount">
     {#if networkBtc}
       <BitcoinEstimatedAmountReceived
+        ckBTCToken={token}
         {bitcoinEstimatedFee}
         {universeId}
         amount={userAmount}

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -10,7 +10,12 @@
   import type { Account } from "$lib/types/account";
   import { Modal, Spinner, type WizardStep } from "@dfinity/gix-components";
   import type { TransactionInit } from "$lib/types/transaction";
-  import { TokenAmount, nonNullish, type Token } from "@dfinity/utils";
+  import {
+    TokenAmount,
+    nonNullish,
+    type Token,
+    assertNonNullish,
+  } from "@dfinity/utils";
   import type { Principal } from "@dfinity/principal";
 
   // TODO: Refactor to expect as props the rootCanisterId, transactionFee and token.
@@ -42,10 +47,13 @@
       initiator: "accounts",
     });
 
+    assertNonNullish(token);
+
     const { blockIndex } = await snsTransferTokens({
       source: sourceAccount,
       destinationAddress,
       amount,
+      token,
       loadTransactions,
       rootCanisterId,
     });

--- a/frontend/src/lib/modals/sns/neurons/AddMaturityModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/AddMaturityModal.svelte
@@ -8,8 +8,10 @@
   import { numberToE8s } from "$lib/utils/token.utils";
   import { addMaturity } from "$lib/services/sns-neurons-dev.services";
   import type { SnsNeuronId } from "@dfinity/sns";
+  import type { IcrcTokenMetadata } from "$lib/types/icrc";
 
   export let neuronId: SnsNeuronId;
+  export let token: IcrcTokenMetadata;
   export let rootCanisterId: Principal;
   export let reloadNeuron: () => Promise<void>;
 
@@ -35,7 +37,7 @@
     await addMaturity({
       rootCanisterId,
       neuronId,
-      amountE8s: numberToE8s(inputValue),
+      amountE8s: numberToE8s({ amount: inputValue, token }),
     });
     await reloadNeuron();
 

--- a/frontend/src/lib/modals/sns/neurons/NnsAddMaturityModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/NnsAddMaturityModal.svelte
@@ -7,6 +7,7 @@
   import { numberToE8s } from "$lib/utils/token.utils";
   import { addMaturity } from "$lib/services/nns-neurons-dev.services";
   import type { NeuronInfo } from "@dfinity/nns";
+  import { ICPToken } from "@dfinity/utils";
 
   export let neuron: NeuronInfo;
 
@@ -30,7 +31,7 @@
 
     await addMaturity({
       neuron,
-      amountE8s: numberToE8s(inputValue),
+      amountE8s: numberToE8s({ amount: inputValue, token: ICPToken }),
     });
 
     dispatcher("nnsClose");

--- a/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import SnsTransactionModal from "$lib/modals/sns/neurons/SnsTransactionModal.svelte";
-  import type { TokenAmount, Token } from "@dfinity/utils";
+  import type { TokenAmount } from "@dfinity/utils";
   import type { Principal } from "@dfinity/principal";
   import type { WizardStep } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
@@ -17,9 +17,10 @@
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import type { IcrcTokenMetadata } from "$lib/types/icrc";
 
   export let neuronId: SnsNeuronId;
-  export let token: Token;
+  export let token: IcrcTokenMetadata;
   export let rootCanisterId: Principal;
   export let reloadNeuron: () => Promise<void>;
 
@@ -58,6 +59,7 @@
     const { success } = await increaseStakeNeuron({
       rootCanisterId,
       amount,
+      token,
       account,
       neuronId,
     });

--- a/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte
@@ -7,7 +7,6 @@
   } from "$lib/types/sns-neuron-detail.context";
   import { isNullish, nonNullish } from "@dfinity/utils";
   import type { E8s } from "@dfinity/nns";
-  import type { Token } from "@dfinity/utils";
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
   import DisburseSnsNeuronModal from "$lib/modals/neurons/DisburseSnsNeuronModal.svelte";
   import DissolveSnsNeuronModal from "$lib/modals/sns/neurons/DissolveSnsNeuronModal.svelte";
@@ -34,6 +33,7 @@
   import SnsActiveDisbursementsModal from "$lib/modals/sns/neurons/SnsActiveDisbursementsModal.svelte";
   import SnsDisburseMaturityModal from "$lib/modals/sns/neurons/SnsDisburseMaturityModal.svelte";
   import AddMaturityModal from "$lib/modals/sns/neurons/AddMaturityModal.svelte";
+  import type { IcrcTokenMetadata } from "$lib/types/icrc";
 
   // Modal events
 
@@ -62,8 +62,8 @@
   let neuronState: NeuronState | undefined;
   $: neuronState = isNullish(neuron) ? undefined : getSnsNeuronState(neuron);
 
-  let token: Token;
-  $: token = $snsTokenSymbolSelectedStore as Token;
+  let token: IcrcTokenMetadata;
+  $: token = $snsTokenSymbolSelectedStore as IcrcTokenMetadata;
 
   let parameters: SnsNervousSystemParameters | undefined;
   $: parameters = nonNullish(rootCanisterId)
@@ -192,9 +192,10 @@
     />
   {/if}
 
-  {#if type === "dev-add-maturity" && IS_TESTNET && nonNullish(rootCanisterId) && nonNullish(neuronId)}
+  {#if type === "dev-add-maturity" && IS_TESTNET && nonNullish(rootCanisterId) && nonNullish(neuronId) && nonNullish(token)}
     <AddMaturityModal
       {rootCanisterId}
+      {token}
       {neuronId}
       {reloadNeuron}
       on:nnsClose={close}

--- a/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
@@ -76,6 +76,7 @@
     const { success } = await stakeNeuron({
       rootCanisterId,
       amount: detail.amount,
+      token,
       account: detail.sourceAccount,
     });
 

--- a/frontend/src/lib/services/ckbtc-convert.services.ts
+++ b/frontend/src/lib/services/ckbtc-convert.services.ts
@@ -62,6 +62,7 @@ export const convertCkBTCToBtcIcrc2 = async ({
   amount,
   source,
   universeId,
+  token,
   canisters: { minterCanisterId, indexCanisterId },
   updateProgress,
 }: ConvertCkBTCToBtcParams &
@@ -76,7 +77,7 @@ export const convertCkBTCToBtcIcrc2 = async ({
     await approveTransfer({
       identity,
       canisterId: universeId,
-      amount: numberToE8s(amount),
+      amount: numberToE8s({ amount, token }),
       // 5 minutes should be long enough to perform the transfer but if it
       // doesn't succeed we don't want the approval to remain valid
       // indefinitely.
@@ -90,7 +91,7 @@ export const convertCkBTCToBtcIcrc2 = async ({
       identity,
       canisterId: minterCanisterId,
       address: destinationAddress,
-      amount: numberToE8s(amount),
+      amount: numberToE8s({ amount, token }),
     });
   } catch (err: unknown) {
     toastsError(toastRetrieveBtcError(err));
@@ -122,6 +123,7 @@ export const convertCkBTCToBtcIcrc2 = async ({
 export const convertCkBTCToBtc = async ({
   destinationAddress,
   amount,
+  token,
   source,
   universeId,
   canisters: { minterCanisterId, indexCanisterId },
@@ -178,6 +180,7 @@ export const convertCkBTCToBtc = async ({
   const { blockIndex } = await ckBTCTransferTokens({
     source,
     amount,
+    token,
     destinationAddress: ledgerAddress,
     universeId,
   });
@@ -192,6 +195,7 @@ export const convertCkBTCToBtc = async ({
   return await retrieveBtcAndReload({
     destinationAddress,
     amount,
+    token,
     source,
     universeId,
     canisters: { minterCanisterId, indexCanisterId },
@@ -211,6 +215,7 @@ export const convertCkBTCToBtc = async ({
 export const retrieveBtc = async ({
   destinationAddress,
   amount,
+  token,
   universeId,
   canisters: { minterCanisterId, indexCanisterId },
   updateProgress,
@@ -222,6 +227,7 @@ export const retrieveBtc = async ({
   return await retrieveBtcAndReload({
     destinationAddress,
     amount,
+    token,
     universeId,
     canisters: { minterCanisterId, indexCanisterId },
     updateProgress,
@@ -233,6 +239,7 @@ const retrieveBtcAndReload = async ({
   amount,
   source,
   universeId,
+  token,
   canisters: { minterCanisterId, indexCanisterId },
   updateProgress,
   blockIndex,
@@ -253,7 +260,7 @@ const retrieveBtcAndReload = async ({
     await retrieveBtcAPI({
       identity,
       address: bitcoinAddress,
-      amount: numberToE8s(amount),
+      amount: numberToE8s({ amount, token }),
       canisterId: minterCanisterId,
     });
   } catch (err: unknown) {

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -146,7 +146,7 @@ export interface IcrcTransferTokensUserParams {
   source: Account;
   destinationAddress: string;
   amount: number;
-  token?: Token;
+  token: Token;
 }
 
 // TODO: use `wallet-accounts.services`
@@ -174,7 +174,7 @@ export const transferTokens = async ({
       throw new Error("error.transaction_fee_not_found");
     }
 
-    const amountE8s = numberToE8s(amount, token);
+    const amountE8s = numberToE8s({ amount, token });
     const identity: Identity = await getIcrcAccountIdentity(source);
     const to = decodeIcrcAccount(destinationAddress);
 

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -53,7 +53,7 @@ import { numberToE8s } from "$lib/utils/token.utils";
 import { AnonymousIdentity, type Identity } from "@dfinity/agent";
 import { Topic, type NeuronId, type NeuronInfo } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
-import { isNullish } from "@dfinity/utils";
+import { ICPToken, isNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { getAuthenticatedIdentity } from "./auth.services";
 import {
@@ -193,7 +193,7 @@ export const stakeNeuron = async ({
   loadNeuron?: boolean;
 }): Promise<NeuronId | undefined> => {
   try {
-    const stake = numberToE8s(amount);
+    const stake = numberToE8s({ amount, token: ICPToken });
     assertEnoughAccountFunds({
       account,
       amountE8s: stake,
@@ -623,7 +623,7 @@ export const splitNeuron = async ({
     }
 
     const feeE8s = get(mainTransactionFeeE8sStore);
-    const amountE8s = numberToE8s(amount) + feeE8s;
+    const amountE8s = numberToE8s({ amount, token: ICPToken }) + feeE8s;
 
     if (!isEnoughToStakeNeuron({ stakeE8s: amountE8s, feeE8s })) {
       throw new NotEnoughAmountError();

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -32,6 +32,7 @@ import { snsParametersStore } from "$lib/stores/sns-parameters.store";
 import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import type { Account } from "$lib/types/account";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import { notForceCallStrategy } from "$lib/utils/env.utils";
 import { toToastError } from "$lib/utils/error.utils";
@@ -62,6 +63,7 @@ import {
   fromNullable,
   isNullish,
   nonNullish,
+  type Token,
 } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { getAuthenticatedIdentity } from "./auth.services";
@@ -345,7 +347,7 @@ export const splitNeuron = async ({
     ]?.fee;
     assertNonNullish(transactionFee, "fee not defined");
 
-    const amountE8s = numberToE8s(amount);
+    const amountE8s = numberToE8s({ amount, token });
     const amountAndFee = amountE8s + transactionFee;
 
     // minimum validation
@@ -512,11 +514,13 @@ export const updateDelay = async ({
 export const increaseStakeNeuron = async ({
   rootCanisterId,
   amount,
+  token,
   account,
   neuronId,
 }: {
   rootCanisterId: Principal;
   amount: number;
+  token: IcrcTokenMetadata;
   account: Account;
   neuronId: SnsNeuronId;
 }): Promise<{ success: boolean }> => {
@@ -524,7 +528,7 @@ export const increaseStakeNeuron = async ({
     // TODO: Get identity depending on account to support HW accounts
     const identity = await getAuthenticatedIdentity();
 
-    const stakeE8s = numberToE8s(amount);
+    const stakeE8s = numberToE8s({ amount, token });
     await increaseStakeNeuronApi({
       // We can cast it because we already checked that the neuron id is not undefined
       neuronId,
@@ -551,16 +555,18 @@ export const increaseStakeNeuron = async ({
 export const stakeNeuron = async ({
   rootCanisterId,
   amount,
+  token,
   account,
 }: {
   rootCanisterId: Principal;
+  token: Token;
   amount: number;
   account: Account;
 }): Promise<{ success: boolean }> => {
   try {
     // TODO: Get identity depending on account to support HW accounts
     const identity = await getAuthenticatedIdentity();
-    const stakeE8s = numberToE8s(amount);
+    const stakeE8s = numberToE8s({ amount, token });
 
     const fee = get(transactionsFeesStore).projects[rootCanisterId.toText()]
       ?.fee;

--- a/frontend/src/lib/types/icrc.ts
+++ b/frontend/src/lib/types/icrc.ts
@@ -4,6 +4,7 @@ import type { Token } from "@dfinity/utils";
  * Token metadata are to some extension optional and provided in Candid in a way the frontend cannot really use.
  * That's why we have to map the data as well.
  */
+// GIX-2150 Unify `Token` and `IcrcTokenMetadata` types.
 export interface IcrcTokenMetadata extends Token {
   fee: bigint;
   decimals?: bigint;

--- a/frontend/src/lib/utils/ckbtc.utils.ts
+++ b/frontend/src/lib/utils/ckbtc.utils.ts
@@ -2,6 +2,7 @@ import type { CkBTCInfoStoreUniverseData } from "$lib/stores/ckbtc-info.store";
 import { i18n } from "$lib/stores/i18n";
 import type { Account } from "$lib/types/account";
 import { CkBTCErrorRetrieveBtcMinAmount } from "$lib/types/ckbtc.errors";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import { assertEnoughAccountFunds } from "$lib/utils/accounts.utils";
 import { notForceCallStrategy } from "$lib/utils/env.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -13,12 +14,14 @@ export const assertCkBTCUserInputAmount = ({
   networkBtc,
   sourceAccount,
   amount,
+  token,
   transactionFee,
   infoData,
 }: {
   networkBtc: boolean;
   sourceAccount: Account | undefined;
   amount: number | undefined;
+  token: IcrcTokenMetadata;
   transactionFee: bigint;
   infoData: CkBTCInfoStoreUniverseData | undefined;
 }) => {
@@ -36,7 +39,7 @@ export const assertCkBTCUserInputAmount = ({
     return;
   }
 
-  const amountE8s = numberToE8s(amount);
+  const amountE8s = numberToE8s({ amount, token });
 
   // No additional check if amount is zero because user might be entering a value such as 0.00000...
   if (amountE8s === BigInt(0)) {

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -155,8 +155,13 @@ export const convertTCyclesToIcpNumber = ({
  * @returns {bigint}
  * @throws {Error} If the amount has more than 8 decimals.
  */
-// TODO: GIX-2150 Make `token` mandatory.
-export const numberToE8s = (amount: number, token: Token = ICPToken): bigint =>
+export const numberToE8s = ({
+  amount,
+  token,
+}: {
+  amount: number;
+  token: Token;
+}): bigint =>
   TokenAmount.fromNumber({
     amount,
     token,

--- a/frontend/src/tests/lib/components/accounts/BitcoinEstimatedAmountReceived.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BitcoinEstimatedAmountReceived.spec.ts
@@ -3,6 +3,7 @@ import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.co
 import { ckBTCInfoStore } from "$lib/stores/ckbtc-info.store";
 import { formatEstimatedFee } from "$lib/utils/bitcoin.utils";
 import { formatToken } from "$lib/utils/token.utils";
+import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
 import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import en from "$tests/mocks/i18n.mock";
 import { render } from "@testing-library/svelte";
@@ -19,6 +20,7 @@ describe("BitcoinEstimatedAmountReceived", () => {
       const { getByTestId } = render(BitcoinEstimatedAmountReceived, {
         props: {
           amount: undefined,
+          ckBTCToken: mockCkBTCToken,
           bitcoinEstimatedFee: undefined,
           universeId: CKBTC_UNIVERSE_CANISTER_ID,
         },
@@ -32,6 +34,7 @@ describe("BitcoinEstimatedAmountReceived", () => {
       const { getByTestId } = render(BitcoinEstimatedAmountReceived, {
         props: {
           amount: undefined,
+          ckBTCToken: mockCkBTCToken,
           bitcoinEstimatedFee: 1_000n,
           universeId: CKBTC_UNIVERSE_CANISTER_ID,
         },
@@ -45,6 +48,7 @@ describe("BitcoinEstimatedAmountReceived", () => {
       const { getByTestId } = render(BitcoinEstimatedAmountReceived, {
         props: {
           amount: 10,
+          ckBTCToken: mockCkBTCToken,
           bitcoinEstimatedFee: undefined,
           universeId: CKBTC_UNIVERSE_CANISTER_ID,
         },
@@ -67,6 +71,7 @@ describe("BitcoinEstimatedAmountReceived", () => {
       const { getByTestId } = render(BitcoinEstimatedAmountReceived, {
         props: {
           amount: 0.0000099,
+          ckBTCToken: mockCkBTCToken,
           bitcoinEstimatedFee: 5_000n,
           universeId: CKBTC_UNIVERSE_CANISTER_ID,
         },
@@ -81,6 +86,7 @@ describe("BitcoinEstimatedAmountReceived", () => {
     const { getByText } = render(BitcoinEstimatedAmountReceived, {
       props: {
         amount: undefined,
+        ckBTCToken: mockCkBTCToken,
         bitcoinEstimatedFee: undefined,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       },
@@ -95,6 +101,7 @@ describe("BitcoinEstimatedAmountReceived", () => {
     const { getByText } = render(BitcoinEstimatedAmountReceived, {
       props: {
         amount: undefined,
+        ckBTCToken: mockCkBTCToken,
         bitcoinEstimatedFee: undefined,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       },
@@ -107,6 +114,7 @@ describe("BitcoinEstimatedAmountReceived", () => {
     const { getByText } = render(BitcoinEstimatedAmountReceived, {
       props: {
         amount: undefined,
+        ckBTCToken: mockCkBTCToken,
         bitcoinEstimatedFee: undefined,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       },
@@ -128,6 +136,7 @@ describe("BitcoinEstimatedAmountReceived", () => {
     const { getByTestId } = render(BitcoinEstimatedAmountReceived, {
       props: {
         amount: 0.0099,
+        ckBTCToken: mockCkBTCToken,
         bitcoinEstimatedFee: undefined,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       },
@@ -146,6 +155,7 @@ describe("BitcoinEstimatedAmountReceived", () => {
     const { getByTestId } = render(BitcoinEstimatedAmountReceived, {
       props: {
         amount: 0.0099,
+        ckBTCToken: mockCkBTCToken,
         bitcoinEstimatedFee: 1_000n,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       },
@@ -173,6 +183,7 @@ describe("BitcoinEstimatedAmountReceived", () => {
     const { getByTestId } = render(BitcoinEstimatedAmountReceived, {
       props: {
         amount: 0.0099,
+        ckBTCToken: mockCkBTCToken,
         bitcoinEstimatedFee: 1_000n,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       },

--- a/frontend/src/tests/lib/components/accounts/BitcoinEstimatedFee.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BitcoinEstimatedFee.spec.ts
@@ -5,7 +5,9 @@ import { TransactionNetwork } from "$lib/types/transaction";
 import { formatEstimatedFee } from "$lib/utils/bitcoin.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
 import en from "$tests/mocks/i18n.mock";
+import { ICPToken } from "@dfinity/utils";
 import { render, waitFor } from "@testing-library/svelte";
 
 describe("BitcoinEstimatedFee", () => {
@@ -23,6 +25,7 @@ describe("BitcoinEstimatedFee", () => {
 
   const props = {
     minterCanisterId: CKBTC_MINTER_CANISTER_ID,
+    token: mockCkBTCToken,
   };
 
   it("should not display estimated fee if no network selected", () => {
@@ -90,7 +93,7 @@ describe("BitcoinEstimatedFee", () => {
 
     await waitFor(() =>
       expect(spyEstimateFee).toHaveBeenCalledWith({
-        amount: numberToE8s(amount),
+        amount: numberToE8s({ amount, token: ICPToken }),
         certified: false,
         identity: mockIdentity,
         canisterId: CKBTC_MINTER_CANISTER_ID,

--- a/frontend/src/tests/lib/components/transaction/TransactionSummary.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionSummary.spec.ts
@@ -19,7 +19,7 @@ describe("TransactionSummary", () => {
     transactionFee,
   };
 
-  const e8s = numberToE8s(amount);
+  const e8s = numberToE8s({ amount, token });
 
   it("should render sending amount", () => {
     const { getByTestId } = render(TransactionSummary, {

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
@@ -29,10 +29,6 @@ describe("selected-project-new-transaction-data derived store", () => {
     });
 
     it("returns the data for the a new Tx from the current universe", () => {
-      const token = {
-        name: "name",
-        symbol: "symbol",
-      };
       snsSwapCommitmentsStore.setSwapCommitment({
         swapCommitment: mockSnsSwapCommitment(rootCanisterId),
         certified: true,
@@ -41,7 +37,7 @@ describe("selected-project-new-transaction-data derived store", () => {
         {
           rootCanisterId,
           lifecycle: SnsSwapLifecycle.Committed,
-          tokenMetadata: token,
+          tokenMetadata: mockSnsToken,
         },
       ]);
 
@@ -58,7 +54,7 @@ describe("selected-project-new-transaction-data derived store", () => {
       expect(storeData.rootCanisterId.toText()).toEqual(
         rootCanisterId.toText()
       );
-      expect(storeData.token).toEqual(token);
+      expect(storeData.token).toEqual(mockSnsToken);
       expect(storeData.transactionFee.toE8s()).toEqual(fee);
     });
 

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -47,6 +47,7 @@ import {
   runResolvedPromises,
 } from "$tests/utils/timers.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
+import { ICPToken } from "@dfinity/utils";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
@@ -471,7 +472,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
       describe("successful participation", () => {
         const formattedAmountICP = "5.00";
         const amountICP = 5;
-        const amountE8s = numberToE8s(amountICP);
+        const amountE8s = numberToE8s({ amount: amountICP, token: ICPToken });
         const finalCommitment = {
           icp: [
             {

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -31,6 +31,7 @@ import {
   createMockSnsNeuron,
   mockSnsNeuron,
 } from "$tests/mocks/sns-neurons.mock";
+import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { SnsNeuronDetailPo } from "$tests/page-objects/SnsNeuronDetail.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -111,7 +112,10 @@ describe("SnsNeuronDetail", () => {
       fakeSnsGovernanceApi.addNeuronWith({
         rootCanisterId,
         id: [validNeuronId],
-        cached_neuron_stake_e8s: numberToE8s(neuronStake),
+        cached_neuron_stake_e8s: numberToE8s({
+          amount: neuronStake,
+          token: mockSnsToken,
+        }),
       });
     });
 
@@ -145,7 +149,10 @@ describe("SnsNeuronDetail", () => {
       fakeSnsGovernanceApi.addNeuronWith({
         rootCanisterId,
         id: [validNeuronId],
-        cached_neuron_stake_e8s: numberToE8s(neuronStake),
+        cached_neuron_stake_e8s: numberToE8s({
+          amount: neuronStake,
+          token: mockSnsToken,
+        }),
       });
       const po = await renderComponent(props);
 
@@ -155,7 +162,10 @@ describe("SnsNeuronDetail", () => {
       fakeSnsGovernanceApi.setNeuronWith({
         rootCanisterId,
         id: [validNeuronId],
-        cached_neuron_stake_e8s: numberToE8s(neuronStake + amountToStake),
+        cached_neuron_stake_e8s: numberToE8s({
+          amount: neuronStake + amountToStake,
+          token: mockSnsToken,
+        }),
       });
 
       await po.increaseStake(amountToStake);
@@ -166,7 +176,7 @@ describe("SnsNeuronDetail", () => {
       expect(increaseStakeNeuron).toHaveBeenCalledTimes(1);
       expect(increaseStakeNeuron).toHaveBeenCalledWith({
         neuronId: validNeuronId,
-        stakeE8s: numberToE8s(amountToStake),
+        stakeE8s: numberToE8s({ amount: amountToStake, token: mockSnsToken }),
         rootCanisterId,
         identity: mockIdentity,
         source: mainAccount,
@@ -186,7 +196,10 @@ describe("SnsNeuronDetail", () => {
       fakeSnsGovernanceApi.addNeuronWith({
         rootCanisterId,
         id: [validNeuronId],
-        cached_neuron_stake_e8s: numberToE8s(neuronStake),
+        cached_neuron_stake_e8s: numberToE8s({
+          amount: neuronStake,
+          token: mockSnsToken,
+        }),
         permissions: [
           {
             principal: [mockIdentity.getPrincipal()],
@@ -205,7 +218,10 @@ describe("SnsNeuronDetail", () => {
       fakeSnsGovernanceApi.addNeuronWith({
         rootCanisterId,
         id: [validNeuronId],
-        cached_neuron_stake_e8s: numberToE8s(neuronStake),
+        cached_neuron_stake_e8s: numberToE8s({
+          amount: neuronStake,
+          token: mockSnsToken,
+        }),
         permissions: [
           {
             principal: [mockIdentity.getPrincipal()],
@@ -228,7 +244,10 @@ describe("SnsNeuronDetail", () => {
       fakeSnsGovernanceApi.addNeuronWith({
         rootCanisterId,
         id: [validNeuronId],
-        cached_neuron_stake_e8s: numberToE8s(neuronStake),
+        cached_neuron_stake_e8s: numberToE8s({
+          amount: neuronStake,
+          token: mockSnsToken,
+        }),
         permissions: [
           {
             principal: [mockIdentity.getPrincipal()],
@@ -254,7 +273,10 @@ describe("SnsNeuronDetail", () => {
       fakeSnsGovernanceApi.addNeuronWith({
         rootCanisterId,
         id: [validNeuronId],
-        cached_neuron_stake_e8s: numberToE8s(neuronStake),
+        cached_neuron_stake_e8s: numberToE8s({
+          amount: neuronStake,
+          token: mockSnsToken,
+        }),
         permissions: [
           {
             principal: [mockIdentity.getPrincipal()],

--- a/frontend/src/tests/lib/services/ckbtc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts.services.spec.ts
@@ -6,7 +6,10 @@ import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
-import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
+import {
+  mockCkBTCMainAccount,
+  mockCkBTCToken,
+} from "$tests/mocks/ckbtc-accounts.mock";
 import { mockTokens } from "$tests/mocks/tokens.mock";
 
 vi.mock("$lib/services/wallet-transactions.services", () => {
@@ -47,6 +50,7 @@ describe("ckbtc-accounts-services", () => {
         source: mockCkBTCMainAccount,
         destinationAddress: "aaaaa-aa",
         amount: 1,
+        token: mockCkBTCToken,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       });
 
@@ -69,6 +73,7 @@ describe("ckbtc-accounts-services", () => {
         source: mockCkBTCMainAccount,
         destinationAddress: "aaaaa-aa",
         amount: 1,
+        token: mockCkBTCToken,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       });
 
@@ -91,6 +96,7 @@ describe("ckbtc-accounts-services", () => {
         source: mockCkBTCMainAccount,
         destinationAddress: "aaaaa-aa",
         amount: 1,
+        token: mockCkBTCToken,
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       });
 

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -59,6 +59,7 @@ describe("ckbtc-convert-services", () => {
     source: mockCkBTCMainAccount,
     destinationAddress: mockBTCAddressTestnet,
     amount: 1,
+    token: mockCkBTCToken,
     universeId: CKBTC_UNIVERSE_CANISTER_ID,
     canisters: mockCkBTCAdditionalCanisters,
   };
@@ -147,7 +148,10 @@ describe("ckbtc-convert-services", () => {
 
       describe("transfer tokens succeed", () => {
         const transferSpy = ledgerCanisterMock.transfer;
-        const amountE8s = numberToE8s(params.amount);
+        const amountE8s = numberToE8s({
+          amount: params.amount,
+          token: params.token,
+        });
 
         beforeEach(() => {
           minterCanisterMock.retrieveBtc.mockReset();
@@ -417,7 +421,7 @@ describe("ckbtc-convert-services", () => {
 
       expect(retrieveBtcSpy).toBeCalledWith({
         address: mockBTCAddressTestnet,
-        amount: numberToE8s(params.amount),
+        amount: numberToE8s({ amount: params.amount, token: params.token }),
       });
 
       // We only test that the call is made here. Test should be covered by its respective service.
@@ -565,7 +569,7 @@ describe("ckbtc-convert-services", () => {
       expect(approveTransferSpy).toBeCalledWith({
         identity: mockIdentity,
         canisterId: params.universeId,
-        amount: numberToE8s(params.amount),
+        amount: numberToE8s({ amount: params.amount, token: params.token }),
         expiresAt: BigInt(now) * 1_000_000n + 5n * 60n * 1_000_000_000n,
         spender: mockCkBTCAdditionalCanisters.minterCanisterId,
       });
@@ -599,7 +603,7 @@ describe("ckbtc-convert-services", () => {
         identity: mockIdentity,
         canisterId: mockCkBTCAdditionalCanisters.minterCanisterId,
         address: params.destinationAddress,
-        amount: numberToE8s(params.amount),
+        amount: numberToE8s({ amount: params.amount, token: params.token }),
       });
 
       expect(approveTransferSpy).toBeCalledTimes(1);

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -215,6 +215,7 @@ describe("icrc-accounts-services", () => {
       await icrcTransferTokens({
         source: mockIcrcMainAccount,
         amount,
+        token: mockToken,
         destinationAddress: encodeIcrcAccount(destinationAccount),
         fee,
         ledgerCanisterId,
@@ -238,6 +239,7 @@ describe("icrc-accounts-services", () => {
           subAccount: mockSubAccountArray,
         },
         amount,
+        token: mockToken,
         destinationAddress: encodeIcrcAccount(destinationAccount),
         fee,
         ledgerCanisterId,
@@ -270,6 +272,7 @@ describe("icrc-accounts-services", () => {
       await icrcTransferTokens({
         source: mockIcrcMainAccount,
         amount,
+        token: mockToken,
         destinationAddress: encodeIcrcAccount(destinationAccount),
         fee,
         ledgerCanisterId,

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -41,6 +41,7 @@ import { toastsStore } from "@dfinity/gix-components";
 import { LedgerCanister } from "@dfinity/ledger-icp";
 import { Topic, type NeuronInfo } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
+import { ICPToken } from "@dfinity/utils";
 import { LedgerError, type ResponseVersion } from "@zondax/ledger-icp";
 import { tick } from "svelte";
 import { get } from "svelte/store";
@@ -1437,7 +1438,9 @@ describe("neurons-services", () => {
       });
 
       expect(spySplitNeuron).toBeCalledWith({
-        amount: numberToE8s(2.2) + BigInt(DEFAULT_TRANSACTION_FEE_E8S),
+        amount:
+          numberToE8s({ amount: 2.2, token: ICPToken }) +
+          BigInt(DEFAULT_TRANSACTION_FEE_E8S),
         identity: mockIdentity,
         neuronId: controlledNeuron.neuronId,
       });
@@ -1459,7 +1462,7 @@ describe("neurons-services", () => {
       expect(spySplitNeuron).toBeCalledWith({
         identity: mockIdentity,
         neuronId: controlledNeuron.neuronId,
-        amount: numberToE8s(amountWithFee),
+        amount: numberToE8s({ amount: amountWithFee, token: ICPToken }),
       });
     });
 

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -9,6 +9,7 @@ import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
+import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import type { HttpAgent } from "@dfinity/agent";
 import { waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
@@ -155,6 +156,7 @@ describe("sns-accounts-services", () => {
         source: mockSnsMainAccount,
         destinationAddress: "aaaaa-aa",
         amount: 1,
+        token: mockSnsToken,
         loadTransactions: false,
       });
 
@@ -178,6 +180,7 @@ describe("sns-accounts-services", () => {
         source: mockSnsMainAccount,
         destinationAddress: "aaaaa-aa",
         amount: 1,
+        token: mockSnsToken,
         loadTransactions: true,
       });
 
@@ -203,6 +206,7 @@ describe("sns-accounts-services", () => {
         source: mockSnsMainAccount,
         destinationAddress: "aaaaa-aa",
         amount: 1,
+        token: mockSnsToken,
         loadTransactions: false,
       });
 
@@ -224,6 +228,7 @@ describe("sns-accounts-services", () => {
         source: mockSnsMainAccount,
         destinationAddress: "aaaaa-aa",
         amount: 1,
+        token: mockSnsToken,
         loadTransactions: false,
       });
 

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -36,7 +36,7 @@ import {
   mockSnsNeuron,
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
-import { mockTokenStore } from "$tests/mocks/sns-projects.mock";
+import { mockSnsToken, mockTokenStore } from "$tests/mocks/sns-projects.mock";
 import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
 import {
@@ -676,6 +676,7 @@ describe("sns-neurons-services", () => {
       const { success } = await stakeNeuron({
         rootCanisterId: mockPrincipal,
         amount: 2,
+        token: mockSnsToken,
         account: mockSnsMainAccount,
       });
 
@@ -694,6 +695,7 @@ describe("sns-neurons-services", () => {
       const { success } = await stakeNeuron({
         rootCanisterId: mockPrincipal,
         amount: 2,
+        token: mockSnsToken,
         account: mockSnsMainAccount,
       });
 
@@ -710,6 +712,7 @@ describe("sns-neurons-services", () => {
 
       const rootCanisterId = mockPrincipal;
       const amount = 2;
+      const token = mockSnsToken;
       const identity = mockIdentity;
       const neuronId = mockSnsNeuron.id[0] as SnsNeuronId;
       const account = mockSnsMainAccount;
@@ -718,6 +721,7 @@ describe("sns-neurons-services", () => {
       const { success } = await increaseStakeNeuron({
         rootCanisterId,
         amount,
+        token,
         account,
         neuronId,
       });
@@ -727,7 +731,7 @@ describe("sns-neurons-services", () => {
       expect(spyOnIncreaseStakeNeuron).toBeCalledWith({
         neuronId,
         rootCanisterId,
-        stakeE8s: numberToE8s(amount),
+        stakeE8s: numberToE8s({ amount, token }),
         identity,
         source: identifier,
       });

--- a/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
@@ -4,6 +4,7 @@ import { NotEnoughAmountError } from "$lib/types/common.errors";
 import { assertCkBTCUserInputAmount } from "$lib/utils/ckbtc.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatToken } from "$lib/utils/token.utils";
+import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
 import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
@@ -19,6 +20,7 @@ describe("ckbtc.utils", () => {
     networkBtc: true,
     sourceAccount: mockMainAccount,
     amount: 0.002,
+    token: mockCkBTCToken,
     transactionFee: 1n,
     infoData: {
       info: {

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import {
   convertIcpToTCycles,
   convertTCyclesToIcpNumber,
@@ -255,22 +256,28 @@ describe("token-utils", () => {
   });
 
   describe("numberToE8s", () => {
-    it("converts number to e8s", () => {
-      expect(numberToE8s(1.14)).toBe(BigInt(114_000_000));
-      expect(numberToE8s(1)).toBe(BigInt(100_000_000));
-      expect(numberToE8s(3.14)).toBe(BigInt(314_000_000));
-      expect(numberToE8s(0.14)).toBe(BigInt(14_000_000));
+    it("converts number to e8s with 8 decimals", () => {
+      const token: IcrcTokenMetadata = {
+        name: "ICP",
+        symbol: "ICP",
+        fee: 10_000n,
+        decimals: 8n,
+      };
+      expect(numberToE8s({ amount: 1.14, token })).toBe(BigInt(114_000_000));
+      expect(numberToE8s({ amount: 1, token })).toBe(BigInt(100_000_000));
+      expect(numberToE8s({ amount: 3.14, token })).toBe(BigInt(314_000_000));
+      expect(numberToE8s({ amount: 0.14, token })).toBe(BigInt(14_000_000));
     });
 
     // TODO: Enable when we upgrade ic-js with TokenAmount supporting decimals.
     it.skip("converts number to e8s with token", () => {
-      expect(numberToE8s(1.14, mockCkETHToken)).toBe(
+      expect(numberToE8s({ amount: 1.14, token: mockCkETHToken })).toBe(
         BigInt(1_140_000_000_000_000_000)
       );
-      expect(numberToE8s(1, mockCkETHToken)).toBe(
+      expect(numberToE8s({ amount: 1, token: mockCkETHToken })).toBe(
         BigInt(1_000_000_000_000_000_000)
       );
-      expect(numberToE8s(3.14, mockCkETHToken)).toBe(
+      expect(numberToE8s({ amount: 3.14, token: mockCkETHToken })).toBe(
         BigInt(3_140_000_000_000_000_000)
       );
     });

--- a/frontend/src/tests/mocks/ckbtc-accounts.mock.ts
+++ b/frontend/src/tests/mocks/ckbtc-accounts.mock.ts
@@ -6,6 +6,7 @@ import { mockPrincipal } from "./auth.store.mock";
 export const mockCkBTCToken: IcrcTokenMetadata = {
   name: "Test account",
   symbol: "ckBTC",
+  decimals: 8n,
   fee: BigInt(1),
 };
 

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -25,7 +25,6 @@ import {
   type SnsSwapInit,
   type SnsTransferableAmount,
 } from "@dfinity/sns";
-import type { Token } from "@dfinity/utils";
 import { nonNullish, toNullable } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
 
@@ -483,7 +482,7 @@ export const mockQueryMetadata: QuerySnsMetadata = {
   token: mockQueryTokenResponse,
 };
 
-export const mockTokenStore = (run?: Subscriber<Token>) => {
+export const mockTokenStore = (run?: Subscriber<IcrcTokenMetadata>) => {
   run?.(mockSnsToken);
   return () => undefined;
 };

--- a/frontend/src/tests/mocks/sns.mock.ts
+++ b/frontend/src/tests/mocks/sns.mock.ts
@@ -5,7 +5,6 @@ import {
 } from "$lib/types/project-detail.context";
 import type { SnsSummary, SnsSwapCommitment, SnsTicket } from "$lib/types/sns";
 import { nowInSeconds } from "$lib/utils/date.utils";
-import { numberToE8s } from "$lib/utils/token.utils";
 import ContextWrapperTest from "$tests/lib/components/ContextWrapperTest.svelte";
 import type { Principal } from "@dfinity/principal";
 import type { TokenAmount } from "@dfinity/utils";
@@ -33,7 +32,7 @@ export const snsTicketMock = ({
         subaccount: toNullable(subaccount),
       },
     ],
-    amount_icp_e8s: numberToE8s(10),
+    amount_icp_e8s: 1000000000n,
   },
 });
 


### PR DESCRIPTION
# Motivation

Support tokens with different decimals than 8.

In this PR, change the signature of `numberToE8s` and make `token` mandatory.

# Changes

* Change signature of `numberToE8s`.
* Change calls to `numberToE8s`. Sometimes the `token` had to be passed from the parent component also.

# Tests

* Fix tests.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
