### PR TITLE
GIX-2154: New token util numberToUlps

### DIFF
--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -154,7 +154,6 @@ export const transferTokens = async ({
   source,
   destinationAddress,
   amount,
-  token,
   fee,
   transfer,
   reloadAccounts,
@@ -174,7 +173,8 @@ export const transferTokens = async ({
       throw new Error("error.transaction_fee_not_found");
     }
 
-    const amountE8s = numberToE8s(amount, token);
+    // TODO: Change to use `numberToUlps` instead.
+    const amountE8s = numberToE8s(amount);
     const identity: Identity = await getIcrcAccountIdentity(source);
     const to = decodeIcrcAccount(destinationAddress);
 

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -162,6 +162,23 @@ export const numberToE8s = (amount: number, token: Token = ICPToken): bigint =>
     token,
   }).toE8s();
 
+/**
+ * Returns the number of Ulps for the given amount.
+ *
+ * The precision is given by the token.
+ *
+ * @param {Object} params
+ * @param {number} parms.amount
+ * @param {token} params.token
+ * @returns {bigint}
+ * @throws {Error} If the amount has more than number of decimals in the token.
+ */
+// TODO: Use TokenAmountV2
+export const numberToUlps = (params: {
+  amount: number;
+  token: Token;
+}): bigint => TokenAmount.fromNumber(params).toE8s();
+
 export class UnavailableTokenAmount {
   public token: Token;
 

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -147,6 +147,7 @@ export const convertTCyclesToIcpNumber = ({
 }): number => tCycles / (Number(exchangeRate) / NUMBER_XDR_PER_ONE_ICP);
 
 /**
+ * @deprecated Use `numberToUlps` instead.
  * Returns the number of E8s for the given amount.
  *
  * E8s have a precision of 8 decimals. An error is thrown if the amount has more than 8 decimals.

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -156,11 +156,10 @@ export const convertTCyclesToIcpNumber = ({
  * @returns {bigint}
  * @throws {Error} If the amount has more than 8 decimals.
  */
-// TODO: GIX-2150 Make `token` mandatory.
-export const numberToE8s = (amount: number, token: Token = ICPToken): bigint =>
+export const numberToE8s = (amount: number): bigint =>
   TokenAmount.fromNumber({
     amount,
-    token,
+    token: ICPToken,
   }).toE8s();
 
 /**

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -7,6 +7,7 @@ import {
   formatToken,
   getMaxTransactionAmount,
   numberToE8s,
+  numberToUlps,
   sumAmountE8s,
 } from "$lib/utils/token.utils";
 import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
@@ -271,6 +272,38 @@ describe("token-utils", () => {
         BigInt(1_000_000_000_000_000_000)
       );
       expect(numberToE8s(3.14, mockCkETHToken)).toBe(
+        BigInt(3_140_000_000_000_000_000)
+      );
+    });
+  });
+
+  describe("numberToUlps", () => {
+    it("converts number to e8s", () => {
+      const token = {
+        decimals: 8n,
+        symbol: "TEST",
+        name: "Test",
+      };
+      expect(numberToUlps({ amount: 1.14, token })).toBe(BigInt(114_000_000));
+      expect(numberToUlps({ amount: 1, token })).toBe(BigInt(100_000_000));
+      expect(numberToUlps({ amount: 3.14, token })).toBe(BigInt(314_000_000));
+      expect(numberToUlps({ amount: 0.14, token })).toBe(BigInt(14_000_000));
+    });
+
+    // TODO: Enable when we upgrade ic-js with TokenAmountV2 supporting decimals.
+    it.skip("converts number to e8s with token", () => {
+      const token = {
+        decimals: 18n,
+        symbol: "TEST",
+        name: "Test",
+      };
+      expect(numberToUlps({ amount: 1.14, token })).toBe(
+        BigInt(1_140_000_000_000_000_000)
+      );
+      expect(numberToUlps({ amount: 1, token })).toBe(
+        BigInt(1_000_000_000_000_000_000)
+      );
+      expect(numberToUlps({ amount: 3.14, token })).toBe(
         BigInt(3_140_000_000_000_000_000)
       );
     });

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -10,7 +10,6 @@ import {
   numberToUlps,
   sumAmountE8s,
 } from "$lib/utils/token.utils";
-import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 
 describe("token-utils", () => {
@@ -261,19 +260,6 @@ describe("token-utils", () => {
       expect(numberToE8s(1)).toBe(BigInt(100_000_000));
       expect(numberToE8s(3.14)).toBe(BigInt(314_000_000));
       expect(numberToE8s(0.14)).toBe(BigInt(14_000_000));
-    });
-
-    // TODO: Enable when we upgrade ic-js with TokenAmount supporting decimals.
-    it.skip("converts number to e8s with token", () => {
-      expect(numberToE8s(1.14, mockCkETHToken)).toBe(
-        BigInt(1_140_000_000_000_000_000)
-      );
-      expect(numberToE8s(1, mockCkETHToken)).toBe(
-        BigInt(1_000_000_000_000_000_000)
-      );
-      expect(numberToE8s(3.14, mockCkETHToken)).toBe(
-        BigInt(3_140_000_000_000_000_000)
-      );
     });
   });
 


### PR DESCRIPTION
# Motivation

Support token with different decimals.

In this PR, I add a new token util `numberToUlps` that should substitute `numberToE8s` in the end.

# Changes

* Set `numberToE8s` as deprecated.
* Remove extra `token` param in `numberToE8s`.
* New token util `numberToUlps`. Not used yet.

# Tests

* Test new token util `numberToUlps` but skipping test with different decimals until TokenAmountV2 is available.
* Remove tests for numberToE8s with different decimals.

# Todos

- [ ] Add entry to changelog (if necessary).
