### PR TITLE
Make decimals number instead of bigint

### DIFF
--- a/frontend/src/lib/types/icrc.ts
+++ b/frontend/src/lib/types/icrc.ts
@@ -6,7 +6,7 @@ import type { Token } from "@dfinity/utils";
  */
 export interface IcrcTokenMetadata extends Token {
   fee: bigint;
-  decimals?: bigint;
+  decimals?: number;
   logo?: string;
   // TODO: integrate "decimals" to replace ICP_DISPLAYED_DECIMALS_DETAILED
 }

--- a/frontend/src/lib/utils/icrc-tokens.utils.ts
+++ b/frontend/src/lib/utils/icrc-tokens.utils.ts
@@ -24,7 +24,10 @@ export const mapOptionalToken = (
           acc = { ...acc, ...("Nat" in value && { fee: value.Nat }) };
           break;
         case IcrcMetadataResponseEntries.DECIMALS:
-          acc = { ...acc, ...("Nat" in value && { decimals: value.Nat }) };
+          acc = {
+            ...acc,
+            ...("Nat" in value && { decimals: Number(value.Nat) }),
+          };
           break;
         case IcrcMetadataResponseEntries.LOGO:
           acc = { ...acc, ...("Text" in value && { logo: value.Text }) };

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -305,7 +305,7 @@ describe("sns aggregator converters utils", () => {
             fee: 100000n,
             name: "CatalyzeDAO",
             symbol: "CAT",
-            decimals: 8n,
+            decimals: 8,
           },
           swap: {
             already_tried_to_auto_finalize: [],

--- a/frontend/src/tests/mocks/cketh-accounts.mock.ts
+++ b/frontend/src/tests/mocks/cketh-accounts.mock.ts
@@ -7,14 +7,14 @@ export const mockCkETHToken: IcrcTokenMetadata = {
   name: "ckETH",
   symbol: "ckETH",
   fee: 10_000n,
-  decimals: 18n,
+  decimals: 18,
 };
 
 export const mockCkETHTESTToken: IcrcTokenMetadata = {
   symbol: "ckETHTEST",
   name: "ckETHTEST",
   fee: 10_000n,
-  decimals: 18n,
+  decimals: 18,
 };
 
 export const mockCkETHMainAccount: Account = {

--- a/frontend/src/tests/mocks/icrc-tokens.utils.spec.ts
+++ b/frontend/src/tests/mocks/icrc-tokens.utils.spec.ts
@@ -46,7 +46,7 @@ describe("icrc-tokens.utils", () => {
       ]);
       expect(token).toEqual({
         ...mockSnsToken,
-        decimals: 8n,
+        decimals: 8,
         logo,
       });
     });

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -17,7 +17,7 @@ export const aggregatorTokenMock: IcrcTokenMetadata = {
   name: "CatalyzeDAO",
   symbol: "CAT",
   fee: 100000n,
-  decimals: 8n,
+  decimals: 8,
 };
 
 export const aggregatorSnsMockDto: CachedSnsDto = {

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -466,7 +466,7 @@ export const mockSnsToken: IcrcTokenMetadata = {
   symbol: "TST",
   name: "Tetris",
   fee: BigInt(40_000),
-  decimals: 8n,
+  decimals: 8,
 };
 
 export const mockQueryTokenResponse: IcrcTokenMetadataResponse = [


### PR DESCRIPTION
# Motivation

`Token.decimals` in the next version of `ic-js` is a `number`, so `IcrcTokenMetadata.decimals` needs to be a number too.

# Changes

Change `IcrcTokenMetadata.decimals` from `bigint` to `number`.

# Tests

Manual spot check.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary