### PR TITLE
Bump ic-js with Token.decimals

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -249,9 +249,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.0.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.0.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-zfhcdkBAj7e72oAqtjZQfBCP9gDwgsByJpb/DKB/DiPZjss5T5atHXwAzAWM+XoS8eqhRDrjv/it/DNxjwKT4A==",
+      "version": "2.0.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.0.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-wOgs+rN2KUgwskhwSnc63nTvkymuc3MjEw/avBEs9zhsoBFu2rQ/921R5JKZAnqgwPyVtIKaZqBELbc823Zlww==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -265,9 +265,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "2.0.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-2.0.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-cuQ+ZqMXNBibH2r78/0mlPCQH2xCBOAwHW812xZBLw+MzihGLFxlQ+b/BM5TDq2VIp1FsV1owOkvsL4UG3fmYQ==",
+      "version": "2.0.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-2.0.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-qSSuu2hGtPYLuQMLTdS3wzf3Epel8ijEaa/P4KoB6CcQl94dLYqdt2tZ4HiYKz+EdIs/nrdzvPDogZWwhHbb7w==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -290,9 +290,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "2.0.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.0.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-o2Wm5Mfkf8uj25oYNCf2rg4YRpkPZdQ9bIoRDYT9bZ00xZh7WVZNdxh6BsWwZ964qLr/6SN83yt+UMFK1nynvQ==",
+      "version": "2.0.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.0.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-F2NCebmIVZIWiBbE/jU9N29X4XeN78adJ5eNVxw7c2iyI0YX5yogeFludS2TX3gChevraA9qT6QmgNEuh/SORw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -316,9 +316,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.0.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.0.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-dKliP3b7U49o52S9ka7x9QE3DsGqhdhOJvn2i3aCGeEJTCxdmGJIK62+NtlfzdpIeWjHA0Es1qCp54pahZaQxQ==",
+      "version": "2.0.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.0.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-5WfAmmpXOUwkszqfPPdL0RE+LrNl+i9fKCNX1lJiyp6NrsLu4ACVV/zg8XZ/4xG6l9fgfbiCay7CN944zzlvnw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -328,9 +328,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.0.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.0.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-60/vQKImFb9uWOX8xwWNR9uUVi2qixB6dNcqnclzBxKvaa9oeTLnMDrRfT83qGKI0kGI2d/TiZHTpoHfpfalFw==",
+      "version": "2.0.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.0.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-cYQM2EVTEeA40AhzawYbEBlY3/vNMydRGnexoNrxPBKsAJgWvNd2ikuNmmYJf6WKVSCtJIU9u/SA77VbZtUEIQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -339,9 +339,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "3.0.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.0.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-kWoh/gWrHfVtwEEYgGS5ZVReDc/joYcvLPnoiQS/JU8/Y4KJct5vBSI/6vjkoi4PqQbKGN6tZUIQMCh1Fh/DJg==",
+      "version": "3.0.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.0.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-UdErYibtBv/6puZoYDAf0DYtSWQRhg8jdDhAO/Pj5WV5mzwO9Gt5pfHvY1RS6lZUjgnYOFV/n7gOLFvvuvzUGQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -356,9 +356,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-lR4u5Z2efY2URMMTI8BDKjCXhXmeSgLA9PJ5gteduALz0azc8Irr1On1odGwPKYVereu9ggvDFgKUKcLtF15+w==",
+      "version": "1.0.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-zwWKXR9BOC4zK9OR/l7E5b+YMlxlYnjdLtl1TsIAD2uY12aeVjgFDW25CeklMzR+gCPvvAkyWeOmyVcYH3aRVw==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -372,9 +372,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "2.0.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.0.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-r1eoMj2ZBQSvm3NqA2aYqCjXofck8eAZk9ejb7Gc3KkHCUQ9cO8MOCEwDg/k/saD+sHugH9bwN0naVBkrwp2Qw==",
+      "version": "2.0.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.0.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-88mvs05xiWEY05m5WZEm1VV86qwgOteyDpYgo8N+3WHbguu0qkospoUV91PHte3KPZ9WSmBB0mlflyu1/fo0Qw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -387,9 +387,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "1.1.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.1.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-1ZG+NUhQ2eDV1vgeKtS41K4RxzfJcKPicx5ZxEoAJ7sbuN3njTvdRVvfN9XK9aC+h+aPmnRZ1qR6RvTGA64soQ==",
+      "version": "1.1.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.1.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-/U/JY6NXuDXLzi7n2gfaI+nE8bLbR3yQWGZjOZvnog5Vj1hUa3qb26uHze5DsLz3bLZ47RoQtp3ddNBdxqgBBQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7037,9 +7037,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.0.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.0.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-zfhcdkBAj7e72oAqtjZQfBCP9gDwgsByJpb/DKB/DiPZjss5T5atHXwAzAWM+XoS8eqhRDrjv/it/DNxjwKT4A==",
+      "version": "2.0.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.0.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-wOgs+rN2KUgwskhwSnc63nTvkymuc3MjEw/avBEs9zhsoBFu2rQ/921R5JKZAnqgwPyVtIKaZqBELbc823Zlww==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7047,9 +7047,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "2.0.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-2.0.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-cuQ+ZqMXNBibH2r78/0mlPCQH2xCBOAwHW812xZBLw+MzihGLFxlQ+b/BM5TDq2VIp1FsV1owOkvsL4UG3fmYQ==",
+      "version": "2.0.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-2.0.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-qSSuu2hGtPYLuQMLTdS3wzf3Epel8ijEaa/P4KoB6CcQl94dLYqdt2tZ4HiYKz+EdIs/nrdzvPDogZWwhHbb7w==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7063,9 +7063,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "2.0.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.0.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-o2Wm5Mfkf8uj25oYNCf2rg4YRpkPZdQ9bIoRDYT9bZ00xZh7WVZNdxh6BsWwZ964qLr/6SN83yt+UMFK1nynvQ==",
+      "version": "2.0.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.0.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-F2NCebmIVZIWiBbE/jU9N29X4XeN78adJ5eNVxw7c2iyI0YX5yogeFludS2TX3gChevraA9qT6QmgNEuh/SORw==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7079,30 +7079,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.0.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.0.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-dKliP3b7U49o52S9ka7x9QE3DsGqhdhOJvn2i3aCGeEJTCxdmGJIK62+NtlfzdpIeWjHA0Es1qCp54pahZaQxQ==",
+      "version": "2.0.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.0.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-5WfAmmpXOUwkszqfPPdL0RE+LrNl+i9fKCNX1lJiyp6NrsLu4ACVV/zg8XZ/4xG6l9fgfbiCay7CN944zzlvnw==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.0.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.0.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-60/vQKImFb9uWOX8xwWNR9uUVi2qixB6dNcqnclzBxKvaa9oeTLnMDrRfT83qGKI0kGI2d/TiZHTpoHfpfalFw==",
+      "version": "2.0.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.0.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-cYQM2EVTEeA40AhzawYbEBlY3/vNMydRGnexoNrxPBKsAJgWvNd2ikuNmmYJf6WKVSCtJIU9u/SA77VbZtUEIQ==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "3.0.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.0.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-kWoh/gWrHfVtwEEYgGS5ZVReDc/joYcvLPnoiQS/JU8/Y4KJct5vBSI/6vjkoi4PqQbKGN6tZUIQMCh1Fh/DJg==",
+      "version": "3.0.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.0.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-UdErYibtBv/6puZoYDAf0DYtSWQRhg8jdDhAO/Pj5WV5mzwO9Gt5pfHvY1RS6lZUjgnYOFV/n7gOLFvvuvzUGQ==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-lR4u5Z2efY2URMMTI8BDKjCXhXmeSgLA9PJ5gteduALz0azc8Irr1On1odGwPKYVereu9ggvDFgKUKcLtF15+w==",
+      "version": "1.0.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-zwWKXR9BOC4zK9OR/l7E5b+YMlxlYnjdLtl1TsIAD2uY12aeVjgFDW25CeklMzR+gCPvvAkyWeOmyVcYH3aRVw==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7116,17 +7116,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "2.0.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.0.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-r1eoMj2ZBQSvm3NqA2aYqCjXofck8eAZk9ejb7Gc3KkHCUQ9cO8MOCEwDg/k/saD+sHugH9bwN0naVBkrwp2Qw==",
+      "version": "2.0.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.0.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-88mvs05xiWEY05m5WZEm1VV86qwgOteyDpYgo8N+3WHbguu0qkospoUV91PHte3KPZ9WSmBB0mlflyu1/fo0Qw==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "1.1.0-next-2023-11-29.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.1.0-next-2023-11-29.1.tgz",
-      "integrity": "sha512-1ZG+NUhQ2eDV1vgeKtS41K4RxzfJcKPicx5ZxEoAJ7sbuN3njTvdRVvfN9XK9aC+h+aPmnRZ1qR6RvTGA64soQ==",
+      "version": "1.1.0-next-2023-12-01.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-1.1.0-next-2023-12-01.2.tgz",
+      "integrity": "sha512-/U/JY6NXuDXLzi7n2gfaI+nE8bLbR3yQWGZjOZvnog5Vj1hUa3qb26uHze5DsLz3bLZ47RoQtp3ddNBdxqgBBQ==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
@@ -28,9 +28,11 @@
     : $i18n.ckbtc.bitcoin;
 
   let token: Token;
+  // TODO: Use the ckBTC Token object from the tokens store.
   $: token = {
     symbol: $i18n.ckbtc.btc,
     name: bitcoinLabel,
+    decimals: 8,
   };
 
   let amountE8s = BigInt(0);

--- a/frontend/src/lib/derived/sns/sns-token-symbol-selected.store.ts
+++ b/frontend/src/lib/derived/sns/sns-token-symbol-selected.store.ts
@@ -18,6 +18,7 @@ export const snsTokenSymbolSelectedStore: Readable<Token | undefined> = derived(
       return {
         symbol: selectedTokenMetadata.symbol,
         name: selectedTokenMetadata.name,
+        decimals: selectedTokenMetadata.decimals,
       };
     }
   }

--- a/frontend/src/lib/derived/universes-tokens.derived.ts
+++ b/frontend/src/lib/derived/universes-tokens.derived.ts
@@ -47,6 +47,7 @@ export const ckBTCTokenFeeStore = derived<
               token: {
                 name: value.token.name,
                 symbol: value.token.symbol,
+                decimals: value.token.decimals,
               },
             })
           : undefined,

--- a/frontend/src/lib/types/icrc.ts
+++ b/frontend/src/lib/types/icrc.ts
@@ -6,7 +6,6 @@ import type { Token } from "@dfinity/utils";
  */
 export interface IcrcTokenMetadata extends Token {
   fee: bigint;
-  decimals?: number;
   logo?: string;
   // TODO: integrate "decimals" to replace ICP_DISPLAYED_DECIMALS_DETAILED
 }

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -74,7 +74,7 @@ describe("TokensTable", () => {
       universeId: principal(0),
       balance: TokenAmount.fromE8s({
         amount: 114000000n,
-        token: { name: "Tetris", symbol: "TETRIS" },
+        token: { name: "Tetris", symbol: "TETRIS", decimals: 8 },
       }),
     });
     const po = renderTable({ userTokensData: [token1, token2] });
@@ -98,7 +98,7 @@ describe("TokensTable", () => {
       universeId: principal(0),
       balance: TokenAmount.fromE8s({
         amount: 114000000n,
-        token: { name: "Tetris", symbol: "TETRIS" },
+        token: { name: "Tetris", symbol: "TETRIS", decimals: 8 },
       }),
     });
     const po = renderTable({ userTokensData: [token1, token2] });
@@ -114,7 +114,11 @@ describe("TokensTable", () => {
   it("should render specific text if balance not available", async () => {
     const token1 = createUserToken({
       universeId: OWN_CANISTER_ID,
-      balance: new UnavailableTokenAmount({ name: "ckBTC", symbol: "ckBTC" }),
+      balance: new UnavailableTokenAmount({
+        name: "ckBTC",
+        symbol: "ckBTC",
+        decimals: 8,
+      }),
     });
     const po = renderTable({ userTokensData: [token1] });
 

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
@@ -32,6 +32,7 @@ describe("selected-project-new-transaction-data derived store", () => {
       const token = {
         name: "name",
         symbol: "symbol",
+        decimals: 8,
       };
       snsSwapCommitmentsStore.setSwapCommitment({
         swapCommitment: mockSnsSwapCommitment(rootCanisterId),

--- a/frontend/src/tests/lib/derived/universes-tokens.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-tokens.derived.spec.ts
@@ -57,6 +57,7 @@ describe("universes-tokens", () => {
         token: {
           name: mockCkBTCToken.name,
           symbol: mockCkBTCToken.symbol,
+          decimals: mockCkBTCToken.decimals,
         },
       });
 

--- a/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
@@ -17,7 +17,7 @@ vi.mock("$lib/services/sns-accounts.services", () => {
 
 describe("SnsTransactionModal", () => {
   const rootCanisterId = mockPrincipal;
-  const token = { name: "Test", symbol: "TST" };
+  const token = { name: "Test", symbol: "TST", decimals: 8 };
   const transactionFee = TokenAmount.fromE8s({
     amount: BigInt(10_000),
     token,

--- a/frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts
@@ -62,6 +62,8 @@ describe("DisburseSnsNeuronModal", () => {
   });
 
   it("should display modal", async () => {
+    page.mock({ data: { universe: principalString, neuron: "12344" } });
+
     const { container } = await renderDisburseModal(mockSnsNeuron);
 
     expect(container.querySelector("div.modal")).not.toBeNull();

--- a/frontend/src/tests/lib/modals/sns/SnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsStakeNeuronModal.spec.ts
@@ -32,7 +32,7 @@ vi.mock("$lib/services/sns-neurons.services", () => {
 });
 
 describe("SnsStakeNeuronModal", () => {
-  const token = { name: "SNS", symbol: "SNS" };
+  const token = { name: "SNS", symbol: "SNS", decimals: 8 };
   const renderTransactionModal = () =>
     renderModal({
       component: SnsStakeNeuronModal,

--- a/frontend/src/tests/lib/modals/sns/SplitSnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SplitSnsNeuronModal.spec.ts
@@ -14,7 +14,7 @@ vi.mock("$lib/services/sns-neurons.services", () => {
 });
 
 describe("SplitSnsNeuronModal", () => {
-  const token = { name: "SNS", symbol: "SNS" };
+  const token = { name: "SNS", symbol: "SNS", decimals: 8 };
   const reloadNeuronSpy = vi.fn().mockResolvedValue(undefined);
   const renderSplitNeuronModal = () =>
     renderModal({

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -261,6 +261,7 @@ describe("TransactionModal", () => {
         token: {
           symbol: "TST",
           name: "Test token",
+          decimals: 8,
         },
       });
       const { getByText, getByTestId } = await renderEnter10ICPAndNext({
@@ -292,6 +293,7 @@ describe("TransactionModal", () => {
         token: {
           symbol: "TST",
           name: "Test token",
+          decimals: 8,
         },
       });
       const { getByTestId } = await renderEnter10ICPAndNext({
@@ -311,6 +313,7 @@ describe("TransactionModal", () => {
         token: {
           symbol: "TST",
           name: "Test token",
+          decimals: 8,
         },
       });
       const { getByTestId } = await renderEnter10ICPAndNext({

--- a/frontend/src/tests/mocks/ckbtc-accounts.mock.ts
+++ b/frontend/src/tests/mocks/ckbtc-accounts.mock.ts
@@ -7,12 +7,14 @@ export const mockCkBTCToken: IcrcTokenMetadata = {
   name: "Test account",
   symbol: "ckBTC",
   fee: BigInt(1),
+  decimals: 8,
 };
 
 export const mockCkTESTBTCToken = {
   ...mockCkBTCToken,
   symbol: "ckTESTBTC",
   name: "ckTESTBTC",
+  decimals: 8,
 };
 
 export const mockCkBTCMainAccount: Account = {

--- a/frontend/src/tests/mocks/cketh-accounts.mock.ts
+++ b/frontend/src/tests/mocks/cketh-accounts.mock.ts
@@ -7,14 +7,16 @@ export const mockCkETHToken: IcrcTokenMetadata = {
   name: "ckETH",
   symbol: "ckETH",
   fee: 10_000n,
-  decimals: 18,
+  // TODO: Set to 18 and use TokenAmountV2.
+  decimals: 8,
 };
 
 export const mockCkETHTESTToken: IcrcTokenMetadata = {
   symbol: "ckETHTEST",
   name: "ckETHTEST",
   fee: 10_000n,
-  decimals: 18,
+  // TODO: Set to 18 and use TokenAmountV2.
+  decimals: 8,
 };
 
 export const mockCkETHMainAccount: Account = {

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -203,6 +203,7 @@ export const mockToken: IcrcTokenMetadata = {
   name: "Tetris",
   symbol: "TET",
   fee: BigInt(0),
+  decimals: 8,
 };
 
 export const mockLifecycleResponse: SnsGetLifecycleResponse = {
@@ -242,6 +243,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
       name: "Pacman",
       symbol: "PAC",
       fee: BigInt(0),
+      decimals: 8,
     },
     swap: mockSwap,
     derived: mockDerived,
@@ -266,6 +268,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
       name: "Mario",
       symbol: "SPM",
       fee: BigInt(0),
+      decimals: 8,
     },
     swap: mockSwap,
     derived: mockDerived,
@@ -290,6 +293,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
       name: "Kong",
       symbol: "DKG",
       fee: BigInt(0),
+      decimals: 8,
     },
     swap: mockSwap,
     derived: mockDerived,

--- a/frontend/src/tests/mocks/tokens-page.mock.ts
+++ b/frontend/src/tests/mocks/tokens-page.mock.ts
@@ -90,7 +90,7 @@ export const userTokensPageMock: UserTokenData[] = [
     title: "Test SNS",
     balance: TokenAmount.fromE8s({
       amount: 2160000000n,
-      token: { name: "Test SNS", symbol: "SNS1" },
+      token: { name: "Test SNS", symbol: "SNS1", decimals: 8 },
     }),
     token: snsTetrisToken,
     fee: TokenAmount.fromE8s({
@@ -105,7 +105,7 @@ export const userTokensPageMock: UserTokenData[] = [
     title: "Test SNS 2",
     balance: TokenAmount.fromE8s({
       amount: 1180000000n,
-      token: { name: "Test SNS", symbol: "SNS2" },
+      token: { name: "Test SNS", symbol: "SNS2", decimals: 8 },
     }),
     token: snsPackmanToken,
     fee: TokenAmount.fromE8s({

--- a/frontend/src/tests/mocks/transaction-fee.mock.ts
+++ b/frontend/src/tests/mocks/transaction-fee.mock.ts
@@ -9,7 +9,7 @@ export const mockSnsSelectedTransactionFeeStoreSubscribe =
         ? undefined
         : TokenAmount.fromE8s({
             amount: BigInt(10_000),
-            token: { name: "Test", symbol: "TST" },
+            token: { name: "Test", symbol: "TST", decimals: 8 },
           })
     );
     return () => undefined;


### PR DESCRIPTION
# Motivation

ic-js has a breaking change that requires the `decimals` field in `Token` and `TokenAmount` rejects tokens with `decimals !== 8`.
This PR bumps the next version of ic-js.
We don't yet use `TokenAmountV2` so this PR breaks ckETH.

# Changes

1. Ran `npm run upgrade:next`
2. Remove the `decimals` field from `IcrcTokenMetadata`. It's now inherited from `Token`.
3. Set `token.decimals` in tests and mocks.
4. Set `mockCkETHToken.decimals = 8` to make tests pass while keeping this PR small. It will be set back to 18 when we use `TokenAmountV2`.
5. Set `token.decimals` in `frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte` which creates an ad hoc token instead of getting it from the store.
6. Set `token.decimals` in `frontend/src/lib/derived/sns/sns-token-symbol-selected.store.ts`.
7. Set `token.decimals` in `frontend/src/lib/derived/universes-tokens.derived.ts`.
8. Set the correct universe in `frontend/src/tests/lib/modals/neurons/DisburseSnsNeuronModal.spec.ts` otherwise the selected token store returns undefined.

# Tests

Unit test pass.
Manual UI spot check with ENABLED_CKETH disabled.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary