### PR TITLE
tweak: Finer backtrace for migration test

### DIFF
--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -87,13 +87,13 @@ get_assets() {
   done
 }
 
-test_upgrade_downgrade() {
-  WORKDIR="$(realpath "$(mktemp -d nns-dapp-test-XXXXXX)")"
-  get_assets
-  find "$WORKDIR"
-
+install_wasm1() {
   echo "Installing $(working_wasm 1)..."
   install_nnsdapp "$(working_wasm 1)" "$(working_arguments 1)"
+  verify_healthy
+  test -z "${SCHEMA1:-}" || assert_schema_is "${SCHEMA1}"
+}
+populate() {
   echo "Installing state..."
   while (("$(dfx canister call nns-dapp get_stats | idl2json | jq -r .accounts_count)" < NUM_TOY_ACCOUNTS)); do
     dfx canister call nns-dapp create_toy_accounts "($TOY_ACCOUNT_CHUNK_SIZE: nat)"
@@ -102,15 +102,29 @@ test_upgrade_downgrade() {
   check_state_size
   check_num_transactions
   test -z "${SCHEMA1:-}" || assert_schema_is "${SCHEMA1}"
+}
+upgrade_to_wasm2() {
   echo "Upgrading to $(working_wasm 2)..."
   upgrade_nnsdapp "$(working_wasm 2)" "$(working_arguments 2)"
   check_num_transactions
   test -z "${SCHEMA2:-}" || assert_schema_is "${SCHEMA2}"
+}
+downgrade_to_wasm1() {
   echo "Reverting to $(working_wasm 1)..."
   upgrade_nnsdapp "$(working_wasm 1)" "$(working_arguments 1)"
   verify_healthy
   check_num_transactions
   test -z "${SCHEMA1:-}" || assert_schema_is "${SCHEMA1}"
+}
+
+test_upgrade_downgrade() {
+  WORKDIR="$(realpath "$(mktemp -d nns-dapp-test-XXXXXX)")"
+  get_assets
+  find "$WORKDIR"
+  install_wasm1
+  populate
+  upgrade_to_wasm2
+  downgrade_to_wasm1
   echo SUCCESS
 }
 


### PR DESCRIPTION
# Motivation
The migration test provides backtraces on error.  This is useful, however if we break the long main test function into smaller functions, the backtrace tells us at which stage the test failed.  The backtrace does provide line numbers but typically just knowing the stage is enough, so providing the name avoids having to look in the code for the line number.

# Changes
- Split the migration test into smaller functions.

# Tests
Sample backtrace before:
```
ERROR: Schema is not as expected.
Expected: AccountsInStableMemory
Actual:   Map
=============================================
   at: ./scripts/nns-dapp/migration-test.canister:1: assert_schema_is
   at: ./scripts/nns-dapp/migration-test:104: test_upgrade_downgrade
   at: ./scripts/nns-dapp/migration-test:117: main
```
Sample backtrace after:
```
ERROR: Schema is not as expected.
Expected: AccountsInStableMemory
Actual:   Map
=============================================
   at: ./scripts/nns-dapp/migration-test.canister:1: assert_schema_is
   at: ./scripts/nns-dapp/migration-test:94: install_wasm1
   at: ./scripts/nns-dapp/migration-test:124: test_upgrade_downgrade
   at: ./scripts/nns-dapp/migration-test:131: main
```

# Todos

- [ ] Add entry to changelog (if necessary).
  - Too minor.
