### PR TITLE
fix: Specify which flavour to update

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -38,4 +38,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+- Update the correct flavour of golden file when the NNS Dapp canister API changes.
+
 #### Security

--- a/scripts/nns-dapp/test-exports
+++ b/scripts/nns-dapp/test-exports
@@ -41,6 +41,6 @@ if diff <(sort "$GOLDEN_FILE") <(wasm_exports "$DFX_WASM_PATH" | sort); then
   echo "Exports match"
 else
   echo "Exports do not match"
-  echo "If this looks correct, run '$0 --wasm $DFX_WASM_PATH --update-golden' to update the golden file"
+  echo "If this looks correct, run '$0 --wasm $DFX_WASM_PATH --update-golden --flavour $DFX_FLAVOUR' to update the golden file"
   exit 1
 fi


### PR DESCRIPTION
# Motivation
When the nns-dapp canister API  changes, there are checks to make sure that the change is intentional.  There is a "golden file" that stores the expected API for each flavour of build.  If there is a mismatch in a test build, the check prints:

```
Exports do not match
If this looks correct, run 'scripts/nns-dapp/test-exports --wasm nns-dapp_test.wasm.gz --update-golden' to update the golden file
```

That looks helpful.  But what is not helpful is that the above command updates the production golden file with the test API.

# Changes
- In the suggested command, specify which flavour of golden file to update.

# Tests
The message is now:
```
Exports do not match
If this looks correct, run 'scripts/nns-dapp/test-exports --wasm nns-dapp_test.wasm.gz --update-golden --flavour test' to update the golden file
```
and it does update the intended flavour of golden file.

# Todos

- [x] Add entry to changelog (if necessary).
