### PR TITLE
GIX-2150: New constant ULPS_PER_MATURITY

### DIFF
--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -1,4 +1,3 @@
-import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import type { SnsSwapCommitment } from "$lib/types/sns";
 import type {
   QueryRootCanisterId,
@@ -326,9 +325,7 @@ export const stakeNeuron = async ({
   source: IcrcAccount;
   fee: bigint;
 }): Promise<SnsNeuronId> => {
-  logWithTimestamp(
-    `Staking neuron with ${Number(stakeE8s) / E8S_PER_ICP}: call...`
-  );
+  logWithTimestamp(`Staking neuron with ${Number(stakeE8s)}: call...`);
 
   const { stakeNeuron: stakeNeuronApi } = await wrapper({
     identity,
@@ -345,9 +342,7 @@ export const stakeNeuron = async ({
     fee,
   });
 
-  logWithTimestamp(
-    `Staking neuron with ${Number(stakeE8s) / E8S_PER_ICP}: complete`
-  );
+  logWithTimestamp(`Staking neuron with ${Number(stakeE8s)}: complete`);
   return newNeuronId;
 };
 
@@ -364,9 +359,7 @@ export const increaseStakeNeuron = async ({
   identity: Identity;
   source: IcrcAccount;
 }): Promise<void> => {
-  logWithTimestamp(
-    `Increase stake neuron with ${Number(stakeE8s) / E8S_PER_ICP}: call...`
-  );
+  logWithTimestamp(`Increase stake neuron with ${Number(stakeE8s)}: call...`);
 
   const { increaseStakeNeuron: increaseStakeNeuronApi } = await wrapper({
     identity,
@@ -380,7 +373,5 @@ export const increaseStakeNeuron = async ({
     neuronId,
   });
 
-  logWithTimestamp(
-    `Increase stake neuron with ${Number(stakeE8s) / E8S_PER_ICP}: complete`
-  );
+  logWithTimestamp(`Increase stake neuron with ${Number(stakeE8s)}: complete`);
 };

--- a/frontend/src/lib/api/sns.api.ts
+++ b/frontend/src/lib/api/sns.api.ts
@@ -325,7 +325,7 @@ export const stakeNeuron = async ({
   source: IcrcAccount;
   fee: bigint;
 }): Promise<SnsNeuronId> => {
-  logWithTimestamp(`Staking neuron with ${Number(stakeE8s)}: call...`);
+  logWithTimestamp(`Staking neuron with ${stakeE8s}: call...`);
 
   const { stakeNeuron: stakeNeuronApi } = await wrapper({
     identity,
@@ -342,7 +342,7 @@ export const stakeNeuron = async ({
     fee,
   });
 
-  logWithTimestamp(`Staking neuron with ${Number(stakeE8s)}: complete`);
+  logWithTimestamp(`Staking neuron with ${stakeE8s}: complete`);
   return newNeuronId;
 };
 
@@ -359,7 +359,7 @@ export const increaseStakeNeuron = async ({
   identity: Identity;
   source: IcrcAccount;
 }): Promise<void> => {
-  logWithTimestamp(`Increase stake neuron with ${Number(stakeE8s)}: call...`);
+  logWithTimestamp(`Increase stake neuron with ${stakeE8s}: call...`);
 
   const { increaseStakeNeuron: increaseStakeNeuronApi } = await wrapper({
     identity,
@@ -373,5 +373,5 @@ export const increaseStakeNeuron = async ({
     neuronId,
   });
 
-  logWithTimestamp(`Increase stake neuron with ${Number(stakeE8s)}: complete`);
+  logWithTimestamp(`Increase stake neuron with ${stakeE8s}: complete`);
 };

--- a/frontend/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { NeuronInfo } from "@dfinity/nns";
-  import { ULPS_PER_MATURITY } from "$lib/constants/icp.constants";
+  import { ULPS_PER_MATURITY } from "$lib/constants/neurons.constants";
   import {
     MIN_NEURON_STAKE,
     MATURITY_MODULATION_VARIANCE_PERCENTAGE,

--- a/frontend/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { NeuronInfo } from "@dfinity/nns";
-  import { E8S_PER_ICP } from "$lib/constants/icp.constants";
+  import { ULPS_PER_MATURITY } from "$lib/constants/icp.constants";
   import {
     MIN_NEURON_STAKE,
     MATURITY_MODULATION_VARIANCE_PERCENTAGE,
@@ -50,11 +50,11 @@
         {
           $amount: formatNumber(
             MIN_NEURON_STAKE /
-              E8S_PER_ICP /
+              ULPS_PER_MATURITY /
               MATURITY_MODULATION_VARIANCE_PERCENTAGE,
             { minFraction: 4, maxFraction: 4 }
           ),
-          $min: formatNumber(MIN_NEURON_STAKE / E8S_PER_ICP, {
+          $min: formatNumber(MIN_NEURON_STAKE / ULPS_PER_MATURITY, {
             minFraction: 0,
             maxFraction: 0,
           }),

--- a/frontend/src/lib/constants/icp.constants.ts
+++ b/frontend/src/lib/constants/icp.constants.ts
@@ -1,5 +1,4 @@
 export const E8S_PER_ICP = 100_000_000;
-export const ULPS_PER_MATURITY = 100_000_000;
 export const DEFAULT_TRANSACTION_FEE_E8S = 10_000;
 export const ONE_TRILLION = 1_000_000_000_000;
 

--- a/frontend/src/lib/constants/icp.constants.ts
+++ b/frontend/src/lib/constants/icp.constants.ts
@@ -1,4 +1,5 @@
 export const E8S_PER_ICP = 100_000_000;
+export const ULPS_PER_MATURITY = 100_000_000;
 export const DEFAULT_TRANSACTION_FEE_E8S = 10_000;
 export const ONE_TRILLION = 1_000_000_000_000;
 

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -2,6 +2,7 @@ import { SECONDS_IN_HALF_YEAR } from "$lib/constants/constants";
 import { enumValues } from "$lib/utils/enum.utils";
 import { Topic } from "@dfinity/nns";
 
+export const ULPS_PER_MATURITY = 100_000_000;
 export const MAX_NEURONS_MERGED = 2;
 export const MIN_NEURON_STAKE = 100_000_000;
 export const MAX_CONCURRENCY = 10;

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -1,10 +1,9 @@
 import { SECONDS_IN_HALF_YEAR } from "$lib/constants/constants";
 import { enumValues } from "$lib/utils/enum.utils";
 import { Topic } from "@dfinity/nns";
-import { E8S_PER_ICP } from "./icp.constants";
 
 export const MAX_NEURONS_MERGED = 2;
-export const MIN_NEURON_STAKE = E8S_PER_ICP;
+export const MIN_NEURON_STAKE = 100_000_000;
 export const MAX_CONCURRENCY = 10;
 export const MATURITY_MODULATION_VARIANCE_PERCENTAGE = 0.95;
 // Neuron ids are random u64. Max digits of a u64 is 20.


### PR DESCRIPTION
# Motivation

Clean up after fast development to support different decimals.

In this PR, remove usage of `E8S_PER_ICP` and introduce a new constant `ULPS_PER_MATURITY` instead.

# Changes

* Remove division by `E8S_PER_ICP` in logging info.
* Use `ULPS_PER_MATURITY` instead of `E8S_PER_ICP` in maturity properties. (Not all places yet).
* Hardcode the e8s for `MIN_NEURON_STAKE`, it has nothing to do with `E8S_PER_ICP` anyway.

# Tests

Still passing

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.

