### PR TITLE
Require an iterator over account db entries

### DIFF
--- a/rs/backend/src/accounts_store/schema.rs
+++ b/rs/backend/src/accounts_store/schema.rs
@@ -94,8 +94,14 @@ pub trait AccountsDbTrait {
         }
     }
 
+    /// Iterates over entries in the data store.
+    fn iter(&self) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_>;
+
     /// Iterates over accounts in the data store.
-    fn values(&self) -> Box<dyn Iterator<Item = Account> + '_>;
+    fn values(&self) -> Box<dyn Iterator<Item = Account> + '_> {
+        let iterator = self.iter().map(|(_key, value)| value);
+        Box::new(iterator)
+    }
 
     /// Gets the label of the storage schema.
     fn schema_label(&self) -> SchemaLabel;

--- a/rs/backend/src/accounts_store/schema/accounts_in_stable_memory.rs
+++ b/rs/backend/src/accounts_store/schema/accounts_in_stable_memory.rs
@@ -139,6 +139,14 @@ pub trait AccountsInStableMemoryTrait {
     /// Equivalent of [`super::AccountsDbTrait::db_accounts_len`].
     fn aism_accounts_len(&self) -> u64;
 
+    /// Equivalent of [`super::AccountsDbTrait::iter`].
+    fn aism_iter(&self) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_> {
+        Box::new(
+            self.aism_keys()
+                .filter_map(|key| self.aism_get_account(&key).map(|value| (key, value))),
+        )
+    }
+
     /// Equivalent of [`super::AccountsDbTrait::values`].
     fn aism_values(&self) -> Box<dyn Iterator<Item = Account> + '_> {
         Box::new(self.aism_keys().filter_map(|key| self.aism_get_account(&key)))

--- a/rs/backend/src/accounts_store/schema/accounts_in_stable_memory/mock.rs
+++ b/rs/backend/src/accounts_store/schema/accounts_in_stable_memory/mock.rs
@@ -84,6 +84,9 @@ impl AccountsDbTrait for MockS1DataStorage {
     fn db_accounts_len(&self) -> u64 {
         self.aism_accounts_len()
     }
+    fn iter(&self) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_> {
+        self.aism_iter()
+    }
     fn values(&self) -> Box<dyn Iterator<Item = Account> + '_> {
         self.aism_values()
     }

--- a/rs/backend/src/accounts_store/schema/map.rs
+++ b/rs/backend/src/accounts_store/schema/map.rs
@@ -25,6 +25,10 @@ impl AccountsDbTrait for AccountsDbAsMap {
     fn db_accounts_len(&self) -> u64 {
         self.accounts.len() as u64
     }
+    fn iter(&self) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_> {
+        let iterator = self.accounts.iter().map(|(key, val)| (key.clone(), val.clone()));
+        Box::new(iterator)
+    }
     fn values(&self) -> Box<dyn Iterator<Item = Account> + '_> {
         let iterator = self.accounts.values().cloned();
         Box::new(iterator)

--- a/rs/backend/src/accounts_store/schema/proxy.rs
+++ b/rs/backend/src/accounts_store/schema/proxy.rs
@@ -40,24 +40,35 @@ impl AccountsDbBTreeMapTrait for AccountsDbAsProxy {
 }
 
 impl AccountsDbTrait for AccountsDbAsProxy {
+    // Inserts into all the underlying databases.
     fn db_insert_account(&mut self, account_key: &[u8], account: Account) {
         self.map.db_insert_account(account_key, account);
     }
+    // Checks the authoritative database.
     fn db_contains_account(&self, account_key: &[u8]) -> bool {
         self.map.db_contains_account(account_key)
     }
+    // Gets an account from the authoritative database.
     fn db_get_account(&self, account_key: &[u8]) -> Option<Account> {
         self.map.db_get_account(account_key)
     }
+    // Removes an account from all underlying databases.
     fn db_remove_account(&mut self, account_key: &[u8]) {
         self.map.db_remove_account(account_key);
     }
+    // Gets the length from the authoritative database.
     fn db_accounts_len(&self) -> u64 {
         self.map.db_accounts_len()
     }
+    // Iterates over the entries of the authoritative database.
+    fn iter(&self) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_> {
+        self.map.iter()
+    }
+    // Iterates over the values of the authoritative database.
     fn values(&self) -> Box<dyn Iterator<Item = Account> + '_> {
         self.map.values()
     }
+    // The authoritative schema label.
     fn schema_label(&self) -> SchemaLabel {
         self.map.schema_label()
     }


### PR DESCRIPTION
# Motivation
We need to be able to iterate over all entries in an accounts database.

# Changes
- Add `iter()` to the `AccountsDb` trait.

# Tests
None - I think this is pretty trivial!

# Todos

- [ ] Add entry to changelog (if necessary).
