### PR TITLE
Fix function name

### DIFF
--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -3,7 +3,7 @@ set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 PATH="$SOURCE_DIR:$PATH"
 
-help_text() {
+print_help() {
   cat <<-"EOF"
 	Tests:
 	  - Populating a given schema with large scale data


### PR DESCRIPTION
# Motivation
The name of the help text function is incorrect in the migration test, so the help does not include the intended text.

# Changes
- Rename the help text function to the correct value.

# Tests
- Run locally, `$ scripts/nns-dapp/migration-test --help` now shows the desired text.

# Todos

- [x] Add entry to changelog (if necessary).
  - Too minor to warrant a changelog entry
