### PR TITLE
GIX-2086: Change UserTokenBase type

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import type { UserTokenData, UserTokenLoading } from "$lib/types/tokens-page";
+  import type { UserTokenTableData } from "$lib/types/tokens-page";
   import Row from "./TokensTableRow.svelte";
 
-  export let userTokensData: Array<UserTokenData | UserTokenLoading>;
+  export let userTokensData: UserTokenTableData;
   export let firstColumnHeader: string;
 </script>
 

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import {
     UserTokenAction,
-    type UserTokenBase,
     type UserTokenData,
     type UserTokenLoading,
   } from "$lib/types/tokens-page";
@@ -22,7 +21,7 @@
   import { Spinner } from "@dfinity/gix-components";
   import { isUserTokenData } from "$lib/utils/user-token.utils";
 
-  export let userTokenData: UserTokenData | UserTokenLoading | UserTokenBase;
+  export let userTokenData: UserTokenData | UserTokenLoading;
   export let index: number;
 
   const dispatcher = createEventDispatcher();

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {
     UserTokenAction,
+    type UserTokenBase,
     type UserTokenData,
     type UserTokenLoading,
   } from "$lib/types/tokens-page";
@@ -21,7 +22,7 @@
   import { Spinner } from "@dfinity/gix-components";
   import { isUserTokenData } from "$lib/utils/user-token.utils";
 
-  export let userTokenData: UserTokenData | UserTokenLoading;
+  export let userTokenData: UserTokenData | UserTokenLoading | UserTokenBase;
   export let index: number;
 
   const dispatcher = createEventDispatcher();

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
@@ -77,7 +77,7 @@
       {#if nonNullish(userToken)}
         {#each userToken.actions as action}
           <svelte:component
-            this={actionMapper[action]}
+            this={actionMapper[action.type]}
             {userToken}
             on:nnsAction
           />
@@ -103,7 +103,7 @@
     {#if nonNullish(userToken)}
       {#each userToken.actions as action}
         <svelte:component
-          this={actionMapper[action]}
+          this={actionMapper[action.type]}
           {userToken}
           on:nnsAction
         />

--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -5,7 +5,11 @@ import {
   type IcpAccountsStore,
 } from "$lib/stores/icp-accounts.store";
 import type { Account, AccountType } from "$lib/types/account";
-import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
+import {
+  UserTokenAction,
+  type UserTokenData,
+  type UserTokenTableData,
+} from "$lib/types/tokens-page";
 import type { Universe } from "$lib/types/universe";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { Principal } from "@dfinity/principal";
@@ -52,14 +56,14 @@ const convertAccountToUserTokenData = ({
       token: NNS_TOKEN_DATA,
     }),
     actions: nonNullish(account)
-      ? [UserTokenAction.Receive, UserTokenAction.Send]
+      ? [{ type: UserTokenAction.Receive }, { type: UserTokenAction.Send }]
       : [],
   };
 };
 
 export const icpTokensListUser = derived<
   [Readable<Universe>, IcpAccountsStore, Readable<I18n>],
-  UserTokenData[]
+  UserTokenTableData
 >(
   [nnsUniverseStore, icpAccountsStore, i18n],
   ([nnsUniverse, icpAccounts, i18nObj]) => [

--- a/frontend/src/lib/derived/icp-tokens-list-visitors.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-visitors.derived.ts
@@ -21,6 +21,6 @@ export const icpTokensListVisitors = derived<
       amount: NNS_TOKEN_DATA.fee,
       token: NNS_TOKEN_DATA,
     }),
-    actions: [UserTokenAction.GoToDetail],
+    actions: [{ type: UserTokenAction.GoToDetail }],
   },
 ]);

--- a/frontend/src/lib/derived/tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-user.derived.ts
@@ -42,8 +42,11 @@ const addActions = (userTokenData: UserTokenData): UserTokenData => ({
       ? []
       : [
           ...(userTokenData.universeId.toText() === OWN_CANISTER_ID_TEXT
-            ? [UserTokenAction.GoToDetail]
-            : [UserTokenAction.Receive, UserTokenAction.Send]),
+            ? [{ type: UserTokenAction.GoToDetail }]
+            : [
+                { type: UserTokenAction.Receive },
+                { type: UserTokenAction.Send },
+              ]),
         ],
 });
 

--- a/frontend/src/lib/derived/tokens-list-visitors.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-visitors.derived.ts
@@ -4,7 +4,7 @@ import { tokensListBaseStore } from "./tokens-list-base.derived";
 
 const addVisitorActions = (data: UserTokenData): UserTokenData => ({
   ...data,
-  actions: [UserTokenAction.GoToDetail],
+  actions: [{ type: UserTokenAction.GoToDetail }],
 });
 
 export const tokensListVisitorsStore = derived<

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -11,7 +11,7 @@
     pollAccounts,
   } from "$lib/services/icp-accounts.services";
   import { ICPToken } from "@dfinity/utils";
-  import type { UserTokenData } from "$lib/types/tokens-page";
+  import type { UserTokenTableData } from "$lib/types/tokens-page";
   import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
   import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
@@ -27,7 +27,7 @@
   });
 
   // TODO: Remove default value when we remove the feature flag
-  export let userTokensData: UserTokenData[] = [];
+  export let userTokensData: UserTokenTableData = [];
 </script>
 
 {#if $ENABLE_MY_TOKENS}

--- a/frontend/src/lib/types/tokens-page.ts
+++ b/frontend/src/lib/types/tokens-page.ts
@@ -8,12 +8,17 @@ export enum UserTokenAction {
   Receive = "receive",
 }
 
+export type UserTokenActionData = {
+  type: UserTokenAction;
+  label?: string;
+};
+
 export type UserTokenBase = {
   universeId: Principal;
   title: string;
   subtitle?: string;
   logo: string;
-  actions: UserTokenAction[];
+  actions: UserTokenActionData[];
 };
 
 /**
@@ -34,3 +39,7 @@ export type UserTokenData = UserTokenBase & {
   // Fees are included in the metadata of ICRC tokens, but this is not a list of only ICRC tokens
   fee: TokenAmount;
 };
+
+export type UserTokenTableData = Array<
+  UserTokenData | UserTokenLoading | UserTokenBase
+>;

--- a/frontend/src/lib/types/tokens-page.ts
+++ b/frontend/src/lib/types/tokens-page.ts
@@ -40,6 +40,4 @@ export type UserTokenData = UserTokenBase & {
   fee: TokenAmount;
 };
 
-export type UserTokenTableData = Array<
-  UserTokenData | UserTokenLoading | UserTokenBase
->;
+export type UserTokenTableData = Array<UserTokenData | UserTokenLoading>;

--- a/frontend/src/lib/utils/user-token.utils.ts
+++ b/frontend/src/lib/utils/user-token.utils.ts
@@ -1,11 +1,7 @@
-import type {
-  UserTokenBase,
-  UserTokenData,
-  UserTokenLoading,
-} from "$lib/types/tokens-page";
+import type { UserTokenData, UserTokenLoading } from "$lib/types/tokens-page";
 
 export const isUserTokenData = (
-  userToken: UserTokenData | UserTokenLoading | UserTokenBase
+  userToken: UserTokenData | UserTokenLoading
 ): userToken is UserTokenData => {
   return "balance" in userToken && userToken.balance !== "loading";
 };

--- a/frontend/src/lib/utils/user-token.utils.ts
+++ b/frontend/src/lib/utils/user-token.utils.ts
@@ -1,7 +1,11 @@
-import type { UserTokenData, UserTokenLoading } from "$lib/types/tokens-page";
+import type {
+  UserTokenBase,
+  UserTokenData,
+  UserTokenLoading,
+} from "$lib/types/tokens-page";
 
 export const isUserTokenData = (
-  userToken: UserTokenData | UserTokenLoading
+  userToken: UserTokenData | UserTokenLoading | UserTokenBase
 ): userToken is UserTokenData => {
-  return userToken.balance !== "loading";
+  return "balance" in userToken && userToken.balance !== "loading";
 };

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -143,7 +143,7 @@ describe("TokensTable", () => {
     const po = renderTable({
       userTokensData: [
         createUserToken({
-          actions: [UserTokenAction.Send],
+          actions: [{ type: UserTokenAction.Send }],
         }),
       ],
     });
@@ -160,7 +160,7 @@ describe("TokensTable", () => {
     const po = renderTable({
       userTokensData: [
         createUserToken({
-          actions: [UserTokenAction.Receive],
+          actions: [{ type: UserTokenAction.Receive }],
         }),
       ],
     });
@@ -177,7 +177,7 @@ describe("TokensTable", () => {
     const po = renderTable({
       userTokensData: [
         createUserToken({
-          actions: [UserTokenAction.GoToDetail],
+          actions: [{ type: UserTokenAction.GoToDetail }],
         }),
       ],
     });
@@ -212,7 +212,7 @@ describe("TokensTable", () => {
   it("should trigger event when clicking in Send action", async () => {
     const handleAction = vi.fn();
     const userToken = createUserToken({
-      actions: [UserTokenAction.Send],
+      actions: [{ type: UserTokenAction.Send }],
     });
     const po = renderTable({
       userTokensData: [userToken],
@@ -235,7 +235,7 @@ describe("TokensTable", () => {
   it("should trigger event when clicking in Receive action", async () => {
     const handleAction = vi.fn();
     const userToken = createUserToken({
-      actions: [UserTokenAction.Receive],
+      actions: [{ type: UserTokenAction.Receive }],
     });
     const po = renderTable({
       userTokensData: [userToken],
@@ -258,7 +258,7 @@ describe("TokensTable", () => {
   it("should trigger event when clicking in GoToDetail action", async () => {
     const handleAction = vi.fn();
     const userToken = createUserToken({
-      actions: [UserTokenAction.GoToDetail],
+      actions: [{ type: UserTokenAction.GoToDetail }],
     });
     const po = renderTable({
       userTokensData: [userToken],

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -13,7 +13,10 @@ import { get } from "svelte/store";
 
 describe("icp-tokens-list-user.derived", () => {
   const icpTokenUser: UserTokenData = createIcpUserToken({
-    actions: [UserTokenAction.Receive, UserTokenAction.Send],
+    actions: [
+      { type: UserTokenAction.Receive },
+      { type: UserTokenAction.Send },
+    ],
   });
   const emptyUserTokenData: UserTokenData = {
     ...icpTokenUser,

--- a/frontend/src/tests/lib/derived/icp-tokens-list-visitors.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-visitors.derived.spec.ts
@@ -6,7 +6,7 @@ import { get } from "svelte/store";
 
 describe("icp-tokens-list-visitors.derived", () => {
   const icpTokenVisitor: UserTokenData = createIcpUserToken({
-    actions: [UserTokenAction.GoToDetail],
+    actions: [{ type: UserTokenAction.GoToDetail }],
   });
 
   describe("icpTokensListVisitors", () => {

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -31,7 +31,7 @@ describe("tokens-list-user.derived", () => {
       amount: mockMainAccount.balanceE8s,
       token: NNS_TOKEN_DATA,
     }),
-    actions: [UserTokenAction.GoToDetail],
+    actions: [{ type: UserTokenAction.GoToDetail }],
   });
   const snsTetrisToken = mockSnsToken;
   const snsTetris = {
@@ -68,7 +68,10 @@ describe("tokens-list-user.derived", () => {
       amount: mockSnsMainAccount.balanceE8s,
       token: snsTetrisToken,
     }),
-    actions: [UserTokenAction.Receive, UserTokenAction.Send],
+    actions: [
+      { type: UserTokenAction.Receive },
+      { type: UserTokenAction.Send },
+    ],
   };
   const pacmanTokenBase: UserTokenData = {
     universeId: snsPacman.rootCanisterId,
@@ -88,7 +91,10 @@ describe("tokens-list-user.derived", () => {
       amount: mockSnsMainAccount.balanceE8s,
       token: snsPackmanToken,
     }),
-    actions: [UserTokenAction.Receive, UserTokenAction.Send],
+    actions: [
+      { type: UserTokenAction.Receive },
+      { type: UserTokenAction.Send },
+    ],
   };
   const ckBTCUserToken: UserTokenData = {
     ...ckBTCTokenBase,
@@ -96,7 +102,10 @@ describe("tokens-list-user.derived", () => {
       amount: mockCkBTCMainAccount.balanceE8s,
       token: mockCkBTCToken,
     }),
-    actions: [UserTokenAction.Receive, UserTokenAction.Send],
+    actions: [
+      { type: UserTokenAction.Receive },
+      { type: UserTokenAction.Send },
+    ],
   };
 
   describe("tokensListBaseStore", () => {

--- a/frontend/src/tests/lib/derived/tokens-list-visitors.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-visitors.derived.spec.ts
@@ -65,7 +65,7 @@ describe("tokens-list-base.derived", () => {
       const universeTokens = get(tokensListVisitorsStore);
 
       universeTokens.forEach((token) => {
-        expect(token.actions).toEqual([UserTokenAction.GoToDetail]);
+        expect(token.actions).toEqual([{ type: UserTokenAction.GoToDetail }]);
       });
     });
   });

--- a/frontend/src/tests/mocks/tokens-page.mock.ts
+++ b/frontend/src/tests/mocks/tokens-page.mock.ts
@@ -73,17 +73,20 @@ export const userTokenPageMock: UserTokenData = {
     amount: snsTetrisToken.fee,
     token: mockCkBTCToken,
   }),
-  actions: [UserTokenAction.Send, UserTokenAction.Receive],
+  actions: [{ type: UserTokenAction.Send }, { type: UserTokenAction.Receive }],
 };
 
 export const userTokensPageMock: UserTokenData[] = [
   {
     ...icpTokenBase,
-    actions: [UserTokenAction.GoToDetail],
+    actions: [{ type: UserTokenAction.GoToDetail }],
   },
   {
     ...ckBTCTokenBase,
-    actions: [UserTokenAction.Send, UserTokenAction.Receive],
+    actions: [
+      { type: UserTokenAction.Send },
+      { type: UserTokenAction.Receive },
+    ],
   },
   {
     universeId: principal(0),
@@ -98,7 +101,10 @@ export const userTokensPageMock: UserTokenData[] = [
       token: snsTetrisToken,
     }),
     logo: "sns-logo.svg",
-    actions: [UserTokenAction.Send, UserTokenAction.Receive],
+    actions: [
+      { type: UserTokenAction.Send },
+      { type: UserTokenAction.Receive },
+    ],
   },
   {
     universeId: principal(1),
@@ -113,7 +119,10 @@ export const userTokensPageMock: UserTokenData[] = [
       token: snsPackmanToken,
     }),
     logo: "sns-logo-2.svg",
-    actions: [UserTokenAction.Send, UserTokenAction.Receive],
+    actions: [
+      { type: UserTokenAction.Send },
+      { type: UserTokenAction.Receive },
+    ],
   },
 ];
 


### PR DESCRIPTION
# Motivation

We need to support a new type of Row in the TokensTable.

It's an action that covers the whole row and has a label. The design is [here](https://www.figma.com/file/x8dk5axQUf8Bi43uUsqCHc/NNS-Production-%26-Hand-over?type=design&node-id=408-2886&mode=design&t=wRdtQmzMVgBEbjOF-0).

The idea is to use a UserTokenBase with actions.

Yet, just the action is not enough because we'll need also a label for the action.

In this PR, I change the type of the field `actions` in `UserTokenBase` to `UserTokenActionData[]` with a `type` and a `label`.

# Changes

* Convenient new type UserTokenTableData for the list of data for TokensTable.
* Change type `actions` in `UserTokenBase` to `UserTokenActionData`.
* Change access to the action type in TokensTableRow.

# Tests

* Adapt tests and mocks to new type.
* No new functionality, no new tests.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
