### PR TITLE
GIX-2150: Remove E8S_PER_ICP from tests

### DIFF
--- a/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
@@ -1,5 +1,4 @@
 import ProjectSwapDetails from "$lib/components/project-detail/ProjectSwapDetails.svelte";
-import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { snsTotalTokenSupplyStore } from "$lib/stores/sns-total-token-supply.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
 import { formatToken } from "$lib/utils/token.utils";
@@ -30,7 +29,7 @@ describe("ProjectSwapDetails", () => {
   it("should render total distributed tokens", async () => {
     const po = await renderComponent({
       summary: createSummary({
-        tokensDistributed: 7125n * BigInt(E8S_PER_ICP),
+        tokensDistributed: 712_500_000_000n,
       }),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
     });
@@ -50,7 +49,7 @@ describe("ProjectSwapDetails", () => {
   it("should render min commitment", async () => {
     const po = renderComponent({
       summary: createSummary({
-        minParticipantCommitment: BigInt(2.5 * E8S_PER_ICP),
+        minParticipantCommitment: 250_000_000n,
       }),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
     });
@@ -72,7 +71,7 @@ describe("ProjectSwapDetails", () => {
   it("should render max commitment", async () => {
     const po = renderComponent({
       summary: createSummary({
-        maxParticipantCommitment: BigInt(345 * E8S_PER_ICP),
+        maxParticipantCommitment: 34_500_000_000n,
       }),
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,
     });

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.spec.ts
@@ -1,5 +1,4 @@
 import VotingConfirmationToolbar from "$lib/components/proposal-detail/VotingCard/VotingConfirmationToolbar.svelte";
-import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { votingNeuronSelectStore } from "$lib/stores/vote-registration.store";
 import type { VotingNeuron } from "$lib/types/proposals";
 import { formatVotingPower } from "$lib/utils/neuron.utils";
@@ -9,7 +8,7 @@ import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 
 describe("VotingConfirmationToolbar", () => {
-  const votingPower = BigInt(100 * E8S_PER_ICP);
+  const votingPower = 10_000_000_000n;
   const neuronIdString = `111`;
 
   beforeEach(() => {

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronSelect.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronSelect.spec.ts
@@ -1,5 +1,4 @@
 import VotingNeuronSelect from "$lib/components/proposal-detail/VotingCard/VotingNeuronSelect.svelte";
-import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { votingNeuronSelectStore } from "$lib/stores/vote-registration.store";
 import { formatVotingPower } from "$lib/utils/neuron.utils";
 import { nnsNeuronToVotingNeuron } from "$lib/utils/proposals.utils";
@@ -13,22 +12,23 @@ describe("VotingNeuronSelect", () => {
   const neuron1 = {
     ...mockNeuron,
     neuronId: BigInt(111),
-    votingPower: BigInt(100 * E8S_PER_ICP),
+    votingPower: 10_000_000_000n,
   };
   const neuron2 = {
     ...mockNeuron,
     neuronId: BigInt(222),
-    votingPower: BigInt(300 * E8S_PER_ICP),
+    votingPower: 30_000_000_000n,
   };
   const neuron3 = {
     ...mockNeuron,
     neuronId: BigInt(333),
-    votingPower: BigInt(500 * E8S_PER_ICP),
+    votingPower: 50_000_000_000n,
   };
   const neurons: NeuronInfo[] = [neuron1, neuron2, neuron3];
   const ballots = neurons.map(({ neuronId, votingPower }) => ({
     neuronId,
-    votingPower: votingPower - BigInt(E8S_PER_ICP),
+    // Ballots and neurons have different voting power
+    votingPower: votingPower - 100_000_000n,
     vote: Vote.No,
   }));
   const proposalInfo = {

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.spec.ts
@@ -1,5 +1,4 @@
 import VotingNeuronSelectList from "$lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.svelte";
-import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { votingNeuronSelectStore } from "$lib/stores/vote-registration.store";
 import { formatVotingPower } from "$lib/utils/neuron.utils";
 import { nnsNeuronToVotingNeuron } from "$lib/utils/proposals.utils";
@@ -13,22 +12,23 @@ describe("VotingNeuronSelectList", () => {
   const neuron1 = {
     ...mockNeuron,
     neuronId: BigInt(111),
-    votingPower: BigInt(100 * E8S_PER_ICP),
+    votingPower: 10_000_000_000n,
   };
   const neuron2 = {
     ...mockNeuron,
     neuronId: BigInt(222),
-    votingPower: BigInt(300 * E8S_PER_ICP),
+    votingPower: 30_000_000_000n,
   };
   const neuron3 = {
     ...mockNeuron,
     neuronId: BigInt(333),
-    votingPower: BigInt(500 * E8S_PER_ICP),
+    votingPower: 50_000_000_000n,
   };
   const neurons: NeuronInfo[] = [neuron1, neuron2, neuron3];
   const ballots = neurons.map(({ neuronId, votingPower }) => ({
     neuronId,
-    votingPower: votingPower - BigInt(E8S_PER_ICP),
+    // Ballots and neurons have different voting power
+    votingPower: votingPower - 100_000_000n,
     vote: Vote.No,
   }));
   const proposalInfo = {

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -1,6 +1,5 @@
 import * as minterApi from "$lib/api/ckbtc-minter.api";
 import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
-import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import CkBTCTransactionModal from "$lib/modals/accounts/CkBTCTransactionModal.svelte";
 import { ckBTCTransferTokens } from "$lib/services/ckbtc-accounts.services";
@@ -12,6 +11,7 @@ import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import type { Account } from "$lib/types/account";
 import { TransactionNetwork } from "$lib/types/transaction";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
+import { ulpsToNumber } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import { mockCkBTCAdditionalCanisters } from "$tests/mocks/canisters.mock";
@@ -445,10 +445,10 @@ describe("CkBTCTransactionModal", () => {
       "input[name='amount']"
     );
     expect(input?.value).toEqual(
-      `${
-        Number(mockCkBTCMainAccount.balanceE8s - mockCkBTCToken.fee) /
-        E8S_PER_ICP
-      }`
+      `${ulpsToNumber({
+        ulps: mockCkBTCMainAccount.balanceE8s - mockCkBTCToken.fee,
+        token: mockCkBTCToken,
+      })}`
     );
   };
 
@@ -602,7 +602,10 @@ describe("CkBTCTransactionModal", () => {
         "input[name='amount']"
       );
       expect(input?.value).toEqual(
-        `${Number(mockCkBTCWithdrawalAccount.balanceE8s) / E8S_PER_ICP}`
+        `${ulpsToNumber({
+          ulps: mockCkBTCWithdrawalAccount.balanceE8s,
+          token: mockCkBTCToken,
+        })}`
       );
     });
   });

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -95,13 +95,13 @@ describe("MergeNeuronsModal", () => {
       neuronId: BigInt(10),
       state: NeuronState.Locked,
       controller,
-      stake: 1200000000n,
+      stake: 1_200_000_000n,
     };
     const mergeableNeuron2 = {
       neuronId: BigInt(11),
       state: NeuronState.Locked,
       controller,
-      stake: 3400000000n,
+      stake: 3_400_000_000n,
     };
     const mergeableNeurons = [mergeableNeuron1, mergeableNeuron2];
 
@@ -252,7 +252,9 @@ describe("MergeNeuronsModal", () => {
       expect(await mergedNeuronCard.isPresent()).toBe(true);
       expect(await mergedNeuronCard.getStake()).toBe("46.00 ICP");
       // Just to show where the 46 is coming from:
-      expect(mergeableNeuron1.stake + mergeableNeuron2.stake).toBe(4600000000n);
+      expect(mergeableNeuron1.stake + mergeableNeuron2.stake).toBe(
+        4_600_000_000n
+      );
 
       // Make sure no actual merge happened.
       expect(mergeNeurons).not.toBeCalled();

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -1,7 +1,6 @@
 import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
 import * as governanceApi from "$lib/api/governance.api";
 import { mergeNeurons } from "$lib/api/governance.api";
-import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import MergeNeuronsModal from "$lib/modals/neurons/MergeNeuronsModal.svelte";
 import * as authServices from "$lib/services/auth.services";
 import { listNeurons } from "$lib/services/neurons.services";
@@ -96,13 +95,13 @@ describe("MergeNeuronsModal", () => {
       neuronId: BigInt(10),
       state: NeuronState.Locked,
       controller,
-      stake: BigInt(12 * E8S_PER_ICP),
+      stake: 1200000000n,
     };
     const mergeableNeuron2 = {
       neuronId: BigInt(11),
       state: NeuronState.Locked,
       controller,
-      stake: BigInt(34 * E8S_PER_ICP),
+      stake: 3400000000n,
     };
     const mergeableNeurons = [mergeableNeuron1, mergeableNeuron2];
 
@@ -253,9 +252,7 @@ describe("MergeNeuronsModal", () => {
       expect(await mergedNeuronCard.isPresent()).toBe(true);
       expect(await mergedNeuronCard.getStake()).toBe("46.00 ICP");
       // Just to show where the 46 is coming from:
-      expect(mergeableNeuron1.stake + mergeableNeuron2.stake).toBe(
-        BigInt(46 * E8S_PER_ICP)
-      );
+      expect(mergeableNeuron1.stake + mergeableNeuron2.stake).toBe(4600000000n);
 
       // Make sure no actual merge happened.
       expect(mergeNeurons).not.toBeCalled();

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -39,7 +39,7 @@ import { mock } from "vitest-mock-extended";
 vi.mock("$lib/api/nns-dapp.api");
 vi.mock("$lib/api/icp-ledger.api");
 const neuronStake = 2.2;
-const neuronStakeE8s = 220000000n;
+const neuronStakeE8s = 220_000_000n;
 const newNeuron: NeuronInfo = {
   ...mockNeuron,
   dissolveDelaySeconds: BigInt(0),

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -1,7 +1,6 @@
 import * as ledgerApi from "$lib/api/icp-ledger.api";
 import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import { SYNC_ACCOUNTS_RETRY_SECONDS } from "$lib/constants/accounts.constants";
-import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import NnsStakeNeuronModal from "$lib/modals/neurons/NnsStakeNeuronModal.svelte";
 import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
 import {
@@ -40,7 +39,7 @@ import { mock } from "vitest-mock-extended";
 vi.mock("$lib/api/nns-dapp.api");
 vi.mock("$lib/api/icp-ledger.api");
 const neuronStake = 2.2;
-const neuronStakeE8s = BigInt(Math.round(neuronStake * E8S_PER_ICP));
+const neuronStakeE8s = 220000000n;
 const newNeuron: NeuronInfo = {
   ...mockNeuron,
   dissolveDelaySeconds: BigInt(0),

--- a/frontend/src/tests/lib/modals/sns/SnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsStakeNeuronModal.spec.ts
@@ -86,7 +86,7 @@ describe("SnsStakeNeuronModal", () => {
     const minimumAmount = 1;
     const snsParameters: SnsNervousSystemParameters = {
       ...snsNervousSystemParametersMock,
-      neuron_minimum_stake_e8s: [100000000n],
+      neuron_minimum_stake_e8s: [100_000_000n],
     };
     snsParametersStore.setParameters({
       rootCanisterId: mockPrincipal,

--- a/frontend/src/tests/lib/modals/sns/SnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsStakeNeuronModal.spec.ts
@@ -1,4 +1,3 @@
-import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
 import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
 import SnsStakeNeuronModal from "$lib/modals/sns/neurons/SnsStakeNeuronModal.svelte";
@@ -87,7 +86,7 @@ describe("SnsStakeNeuronModal", () => {
     const minimumAmount = 1;
     const snsParameters: SnsNervousSystemParameters = {
       ...snsNervousSystemParametersMock,
-      neuron_minimum_stake_e8s: [BigInt(minimumAmount * E8S_PER_ICP)],
+      neuron_minimum_stake_e8s: [100000000n],
     };
     snsParametersStore.setParameters({
       rootCanisterId: mockPrincipal,

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -421,7 +421,7 @@ describe("Accounts", () => {
   //   expect(icrcLedgerApi.icrcTransfer).toHaveBeenCalledWith({
   //     identity: mockIdentity,
   //     canisterId: CKETH_LEDGER_CANISTER_ID,
-  //     amount: BigInt(amount * E8S_PER_ICP),
+  //     amount: 200000000n,
   //     to: toAccount,
   //     fee: mockCkETHToken.fee,
   //   });

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -421,7 +421,7 @@ describe("Accounts", () => {
   //   expect(icrcLedgerApi.icrcTransfer).toHaveBeenCalledWith({
   //     identity: mockIdentity,
   //     canisterId: CKETH_LEDGER_CANISTER_ID,
-  //     amount: 200000000n,
+  //     amount: 200_000_000n,
   //     to: toAccount,
   //     fee: mockCkETHToken.fee,
   //   });

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -1,5 +1,4 @@
 import * as ledgerApi from "$lib/api/icrc-ledger.api";
-import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import {
   getIcrcAccountIdentity,
   icrcTransferTokens,
@@ -204,7 +203,7 @@ describe("icrc-accounts-services", () => {
   });
 
   describe("icrcTransferTokens", () => {
-    const amountE8s = BigInt(10 * E8S_PER_ICP);
+    const amountE8s = 1_000_000_000n;
     const fee = 10_000n;
     const destinationAccount = {
       owner: principal(2),

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -1296,7 +1296,7 @@ describe("neurons-services", () => {
     it("should add transaction fee to the amount", async () => {
       neuronsStore.pushNeurons({ neurons, certified: true });
       const amount = 2.2;
-      const amountE8s = 220000000n;
+      const amountE8s = 220_000_000n;
       const transactionFee = DEFAULT_TRANSACTION_FEE_E8S;
       await services.splitNeuron({
         neuron: controlledNeuron,

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -1,9 +1,6 @@
 import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
 import * as api from "$lib/api/governance.api";
-import {
-  DEFAULT_TRANSACTION_FEE_E8S,
-  E8S_PER_ICP,
-} from "$lib/constants/icp.constants";
+import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
 import { MIN_NEURON_STAKE } from "$lib/constants/neurons.constants";
 import * as authServices from "$lib/services/auth.services";
 import {
@@ -217,7 +214,7 @@ describe("neurons-services", () => {
         fromSubAccount: undefined,
         identity: mockIdentity,
         ledgerCanisterIdentity: mockIdentity,
-        stake: BigInt(10 * E8S_PER_ICP),
+        stake: 1_000_000_000n,
       });
       expect(spyStakeNeuron).toBeCalledTimes(1);
       expect(newNeuronId).toEqual(mockNeuron.neuronId);
@@ -236,7 +233,7 @@ describe("neurons-services", () => {
         fromSubAccount: mockSubAccount.subAccount,
         identity: mockIdentity,
         ledgerCanisterIdentity: mockIdentity,
-        stake: BigInt(10 * E8S_PER_ICP),
+        stake: 1_000_000_000n,
       });
       expect(spyStakeNeuron).toBeCalledTimes(1);
       expect(newNeuronId).toEqual(mockNeuron.neuronId);
@@ -261,16 +258,14 @@ describe("neurons-services", () => {
         identity: new AnonymousIdentity(),
         fromSubAccount: undefined,
         ledgerCanisterIdentity: mockHardkwareWalletIdentity,
-        stake: BigInt(10 * E8S_PER_ICP),
+        stake: 1_000_000_000n,
       });
       expect(spyStakeNeuron).toBeCalledTimes(1);
       expect(newNeuronId).toEqual(mockNeuron.neuronId);
       expect(spyStakeNeuronIcrc1).not.toBeCalled();
     });
 
-    it(`stakeNeuron return undefined if amount less than ${
-      E8S_PER_ICP / E8S_PER_ICP
-    } ICP`, async () => {
+    it("stakeNeuron return undefined if amount less than 1 ICP", async () => {
       vi.spyOn(LedgerCanister, "create").mockImplementation(() =>
         mock<LedgerCanister>()
       );
@@ -1301,10 +1296,8 @@ describe("neurons-services", () => {
     it("should add transaction fee to the amount", async () => {
       neuronsStore.pushNeurons({ neurons, certified: true });
       const amount = 2.2;
-      const transactionFee = DEFAULT_TRANSACTION_FEE_E8S / E8S_PER_ICP;
-      // To avoid rounding errors, we round the amount with the fee to the nearest 8 decimals
-      const amountWithFee =
-        Math.round((amount + transactionFee) * E8S_PER_ICP) / E8S_PER_ICP;
+      const amountE8s = 220000000n;
+      const transactionFee = DEFAULT_TRANSACTION_FEE_E8S;
       await services.splitNeuron({
         neuron: controlledNeuron,
         amount,
@@ -1313,7 +1306,7 @@ describe("neurons-services", () => {
       expect(spySplitNeuron).toBeCalledWith({
         identity: mockIdentity,
         neuronId: controlledNeuron.neuronId,
-        amount: numberToE8s(amountWithFee),
+        amount: amountE8s + BigInt(transactionFee),
       });
     });
 

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -1,6 +1,5 @@
 import * as governanceApi from "$lib/api/sns-governance.api";
 import * as api from "$lib/api/sns.api";
-import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
 import { loadSnsAccounts } from "$lib/services/sns-accounts.services";
@@ -1210,7 +1209,7 @@ describe("sns-neurons-services", () => {
         neuronId: mockSnsNeuron.id[0] as SnsNeuronId,
         identity: mockIdentity,
         rootCanisterId: mockPrincipal,
-        amount: BigInt(amount * E8S_PER_ICP) + transactionFee,
+        amount: 1_000_000_000n + transactionFee,
         memo: 0n,
       });
     });

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -22,7 +22,7 @@ import {
   getSnsNeuronIdAsHexString,
   subaccountToHexString,
 } from "$lib/utils/sns-neuron.utils";
-import { numberToE8s } from "$lib/utils/token.utils";
+import { numberToE8s, numberToUlps } from "$lib/utils/token.utils";
 import { bytesToHexString } from "$lib/utils/utils";
 import {
   mockIdentity,
@@ -35,7 +35,7 @@ import {
   mockSnsNeuron,
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
-import { mockTokenStore } from "$tests/mocks/sns-projects.mock";
+import { mockSnsToken, mockTokenStore } from "$tests/mocks/sns-projects.mock";
 import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
 import {
@@ -1209,7 +1209,7 @@ describe("sns-neurons-services", () => {
         neuronId: mockSnsNeuron.id[0] as SnsNeuronId,
         identity: mockIdentity,
         rootCanisterId: mockPrincipal,
-        amount: 1_000_000_000n + transactionFee,
+        amount: numberToUlps({ amount, token: mockSnsToken }) + transactionFee,
         memo: 0n,
       });
     });

--- a/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
@@ -1,9 +1,9 @@
-import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { CkBTCErrorRetrieveBtcMinAmount } from "$lib/types/ckbtc.errors";
 import { NotEnoughAmountError } from "$lib/types/common.errors";
 import { assertCkBTCUserInputAmount } from "$lib/utils/ckbtc.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatToken, ulpsToNumber } from "$lib/utils/token.utils";
+import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
 import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
@@ -83,7 +83,11 @@ describe("ckbtc.utils", () => {
     expect(() =>
       assertCkBTCUserInputAmount({
         ...params,
-        amount: Number(RETRIEVE_BTC_MIN_AMOUNT) / E8S_PER_ICP - 0.00001,
+        amount:
+          ulpsToNumber({
+            ulps: RETRIEVE_BTC_MIN_AMOUNT,
+            token: mockCkBTCToken,
+          }) - 0.00001,
       })
     ).toThrow(
       new CkBTCErrorRetrieveBtcMinAmount(
@@ -101,10 +105,13 @@ describe("ckbtc.utils", () => {
     expect(() =>
       assertCkBTCUserInputAmount({
         ...params,
-        amount:
-          Number(RETRIEVE_BTC_MIN_AMOUNT) / E8S_PER_ICP +
-          Number(params.transactionFee) / E8S_PER_ICP +
-          Number(params.sourceAccount.balanceE8s) / E8S_PER_ICP,
+        amount: ulpsToNumber({
+          ulps:
+            RETRIEVE_BTC_MIN_AMOUNT +
+            params.transactionFee +
+            params.sourceAccount.balanceE8s,
+          token: mockCkBTCToken,
+        }),
       })
     ).toThrow(new NotEnoughAmountError("error.insufficient_funds"));
   });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -6,10 +6,7 @@ import {
   SECONDS_IN_HOUR,
   SECONDS_IN_YEAR,
 } from "$lib/constants/constants";
-import {
-  DEFAULT_TRANSACTION_FEE_E8S,
-  E8S_PER_ICP,
-} from "$lib/constants/icp.constants";
+import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
 import {
   MAX_NEURONS_MERGED,
   MIN_NEURON_STAKE,
@@ -2106,7 +2103,7 @@ describe("neuron-utils", () => {
   describe("minNeuronSplittable", () => {
     it("returns fee plus two ICPs", () => {
       const received = minNeuronSplittable(10_000);
-      expect(received).toBe(10_000 + 2 * E8S_PER_ICP);
+      expect(received).toBe(10_000 + 200000000);
     });
   });
 

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -2103,7 +2103,7 @@ describe("neuron-utils", () => {
   describe("minNeuronSplittable", () => {
     it("returns fee plus two ICPs", () => {
       const received = minNeuronSplittable(10_000);
-      expect(received).toBe(10_000 + 200000000);
+      expect(received).toBe(10_000 + 200_000_000);
     });
   });
 

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -6,6 +6,7 @@ import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
+import { numberToUlps } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
 import TokensRoute from "$routes/(app)/(nns)/tokens/+page.svelte";
 import {
@@ -205,7 +206,7 @@ describe("Tokens route", () => {
             rootCanisterId: rootCanisterIdTetris,
             fee: tetrisToken.fee,
             to: toAccount,
-            amount: 200000000n,
+            amount: numberToUlps({ amount, token: tetrisToken }),
             fromSubAccount: undefined,
             identity: mockIdentity,
           });

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -1,6 +1,5 @@
 import * as snsLedgerApi from "$lib/api/sns-ledger.api";
 import * as ckBTCLedgerApi from "$lib/api/wallet-ledger.api";
-import { E8S_PER_ICP } from "$lib/constants/icp.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
@@ -206,7 +205,7 @@ describe("Tokens route", () => {
             rootCanisterId: rootCanisterIdTetris,
             fee: tetrisToken.fee,
             to: toAccount,
-            amount: BigInt(amount * E8S_PER_ICP),
+            amount: 200000000n,
             fromSubAccount: undefined,
             identity: mockIdentity,
           });


### PR DESCRIPTION
# Motivation

Remove `E8S_PER_ICP` from NNS Dapp.

In this PR, remove the usage of the constant in the test files.

# Changes

* Remove usage of `E8S_PER_ICP` by not multiplying and adding the value directly or using `ulpsToNumber`.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
