### PR TITLE
GIX-2150: Remove E8S_PER_ICP part 3

### DIFF
--- a/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsStakeNeuronModal.svelte
@@ -16,8 +16,8 @@
   import { snsParametersStore } from "$lib/stores/sns-parameters.store";
   import { mapNervousSystemParameters } from "$lib/utils/sns-parameters.utils";
   import type { SnsNervousSystemParameters } from "@dfinity/sns";
-  import { E8S_PER_ICP } from "$lib/constants/icp.constants";
   import { nonNullish } from "@dfinity/utils";
+  import { ulpsToNumber } from "$lib/utils/token.utils";
 
   export let token: Token;
   export let rootCanisterId: Principal;
@@ -44,9 +44,10 @@
   let minimumStake: number | undefined;
   $: minimumStake =
     parameters !== undefined
-      ? Number(
-          mapNervousSystemParameters(parameters).neuron_minimum_stake_e8s
-        ) / E8S_PER_ICP
+      ? ulpsToNumber({
+          ulps: mapNervousSystemParameters(parameters).neuron_minimum_stake_e8s,
+          token,
+        })
       : undefined;
   let checkMinimumStake: ValidateAmountFn;
   $: checkMinimumStake = ({ amount }) => {

--- a/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
@@ -15,9 +15,11 @@
   import AmountInput from "$lib/components/ui/AmountInput.svelte";
   import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
   import { splitNeuron } from "$lib/services/sns-neurons.services";
-  import { E8S_PER_ICP } from "$lib/constants/icp.constants";
   import type { SnsNervousSystemParameters } from "@dfinity/sns";
-  import { formattedTransactionFee } from "$lib/utils/token.utils";
+  import {
+    formattedTransactionFee,
+    ulpsToNumber,
+  } from "$lib/utils/token.utils";
 
   export let rootCanisterId: Principal;
   export let neuron: SnsNeuron;
@@ -44,8 +46,10 @@
   $: max =
     stakeE8s === 0n
       ? 0
-      : Number(stakeE8s - transactionFee - neuronMinimumStake) /
-        Number(E8S_PER_ICP);
+      : ulpsToNumber({
+          ulps: stakeE8s - transactionFee - neuronMinimumStake,
+          token,
+        });
 
   let validForm: boolean;
   $: validForm = isValidInputAmount({ amount, max });

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -1,5 +1,4 @@
 import {
-  E8S_PER_ICP,
   ICP_DISPLAYED_DECIMALS,
   ICP_DISPLAYED_DECIMALS_DETAILED,
   ICP_DISPLAYED_HEIGHT_DECIMALS,
@@ -11,6 +10,9 @@ import {
   isNullish,
   type Token,
 } from "@dfinity/utils";
+
+// Should be used internally in the helpers only.
+const E8S_PER_ICP = 100_000_000;
 
 const countDecimals = (value: number): number => {
   // "1e-7" -> 0.00000001
@@ -169,16 +171,16 @@ export const getMaxTransactionAmount = ({
   maxAmount?: bigint;
   token: Token;
 }): number => {
-  const maxUserAmount = ulpsToE8s({
+  const maxUserAmountE8s = ulpsToE8s({
     ulps: balance - fee,
     decimals: token.decimals,
   });
   if (maxAmount === undefined) {
-    return Math.max(Number(maxUserAmount), 0) / E8S_PER_ICP;
+    return Math.max(Number(maxUserAmountE8s), 0) / E8S_PER_ICP;
   }
   const maxAmountE8s = ulpsToE8s({ ulps: maxAmount, decimals: token.decimals });
   return (
-    Math.min(Number(maxAmountE8s), Math.max(Number(maxUserAmount), 0)) /
+    Math.min(Number(maxAmountE8s), Math.max(Number(maxUserAmountE8s), 0)) /
     E8S_PER_ICP
   );
 };


### PR DESCRIPTION
# Motivation

Remove `E8S_PER_ICP` from NNS Dapp.

In this PR, remove usage in SNS neurons and use it internally in token.utils

# Changes

* Use `ulpsToNumber` instead of dividing by `E8S_PER_ICP` in two components.
* Local variable `E8S_PER_ICP` in token.utils instead of importing the constant.

# Tests

No new functionality, tests still pass.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
