### PR TITLE
ckBTC: Merge Approve and Burn transactions into one

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Iterator over AccountsDbs.
 * Display expiration date for sns proposals.
 * Card with BTC deposit address and QR code in ckBTC wallet.
+* Merge Approve transfer with BTC "Sent" transaction in transaction list.
 
 #### Changed
 

--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -22,6 +22,7 @@
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import IcrcWalletTransactionsList from "$lib/components/accounts/IcrcWalletTransactionsList.svelte";
   import type { PendingUtxo } from "@dfinity/ckbtc";
+  import type { IcrcTransactionWithId } from "@dfinity/ledger-icrc";
   import { nonNullish, isNullish } from "@dfinity/utils";
 
   export let indexCanisterId: CanisterId;
@@ -75,15 +76,23 @@
   const mapTransactions = (
     transactionData: IcrcTransactionData[]
   ): UiTransaction[] => {
+    let prevTransaction: IcrcTransactionWithId | undefined = undefined;
+    let prevUiTransaction: UiTransaction | undefined = undefined;
     const completedTransactions = transactionData
-      .map((transaction: IcrcTransactionData) =>
-        mapCkbtcTransaction({
-          ...transaction,
+      .map(({ transaction, toSelfTransaction }: IcrcTransactionData) => {
+        const uiTransaction = mapCkbtcTransaction({
+          transaction,
+          toSelfTransaction,
+          prevTransaction,
+          prevUiTransaction,
           account,
           token,
           i18n: $i18n,
-        })
-      )
+        });
+        prevTransaction = transaction;
+        prevUiTransaction = uiTransaction;
+        return uiTransaction;
+      })
       .filter(nonNullish);
     return [...pendingTransactions, ...completedTransactions];
   };

--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -235,14 +235,8 @@ export type MapIcrcTransactionType = typeof mapIcrcTransaction;
 // The memo will decode to: [0, [ withdrawalAddress, kytFee, status]]
 type CkbtcBurnMemo = [0, [string, number, number | null | undefined]];
 
-// Note: Transaction are expected to be mapped in reverse chronological order.
-// Some transactions might merge themselves into previous transactions, because
-// they are conceptually part of the same event, so it's important that they
-// appear in the expected order.
 export const mapCkbtcTransaction = (params: {
   transaction: IcrcTransactionWithId;
-  prevTransaction?: IcrcTransactionWithId;
-  prevUiTransaction?: UiTransaction;
   account: Account;
   toSelfTransaction: boolean;
   governanceCanisterId?: Principal;
@@ -268,21 +262,6 @@ export const mapCkbtcTransaction = (params: {
     } catch (err) {
       console.error("Failed to decode ckBTC burn memo", memo, err);
       mappedTransaction.otherParty = i18n.ckbtc.btc_network;
-    }
-  } else if (transaction.approve.length === 1) {
-    const { prevTransaction, prevUiTransaction } = params;
-    if (
-      transaction.approve[0].fee.length === 1 &&
-      prevTransaction?.transaction.burn.length === 1 &&
-      prevUiTransaction?.tokenAmount instanceof TokenAmountV2
-    ) {
-      prevUiTransaction.tokenAmount = TokenAmountV2.fromUlps({
-        amount:
-          prevUiTransaction.tokenAmount.toUlps() +
-          transaction.approve[0].fee[0],
-        token: prevUiTransaction.tokenAmount.token,
-      });
-      return undefined;
     }
   }
   return mappedTransaction;

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -10,6 +10,7 @@ import {
 } from "$tests/mocks/ckbtc-accounts.mock";
 import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import {
+  createApproveTransaction,
   createBurnTransaction,
   mockIcrcTransactionMint,
   mockIcrcTransactionsStoreSubscribe,
@@ -170,6 +171,60 @@ describe("CkBTCTransactionList", () => {
     const cards = await po.getTransactionCardPos();
 
     expect(await cards[0].getIdentifier()).toEqual("From: BTC Network");
+  });
+
+  it("should merge Approve with corresponding Burn", async () => {
+    const btcWithdrawalAddress = "1ASLxsAMbbt4gcrNc6v6qDBW4JkeWAtTeh";
+    const kytFee = 3000;
+    const decodedMemo = [0, [btcWithdrawalAddress, kytFee, undefined]];
+    const burnMemo = new Uint8Array(Cbor.encode(decodedMemo));
+
+    const burnAmount = 300_000_000n;
+    const approveFee = 14n;
+
+    const store = {
+      [CKBTC_UNIVERSE_CANISTER_ID.toText()]: {
+        [mockCkBTCMainAccount.identifier]: {
+          transactions: [
+            {
+              id: 201n,
+              transaction: createBurnTransaction({
+                amount: burnAmount,
+                from: {
+                  owner: mockCkBTCMainAccount.principal,
+                  subaccount: [],
+                },
+                memo: burnMemo,
+              }),
+            },
+            {
+              id: 202n,
+              transaction: createApproveTransaction({
+                fee: approveFee,
+              }),
+            },
+          ],
+          completed: false,
+          oldestTxId: BigInt(0),
+        },
+      },
+    };
+
+    vi.spyOn(icrcTransactionsStore, "subscribe").mockImplementation(
+      mockIcrcTransactionsStoreSubscribe(store)
+    );
+
+    const { po } = renderComponent();
+    const cards = await po.getTransactionCardPos();
+
+    expect(cards).toHaveLength(1);
+    const card = cards[0];
+
+    expect(await card.getHeadline()).toBe("Sent");
+    expect(await card.getIdentifier()).toBe(`To: ${btcWithdrawalAddress}`);
+    // This is the burned amount + approve fee. The KYT fee is deducted after
+    // burning.
+    expect(await card.getAmount()).toBe("-3.00000014");
   });
 
   it("should render pending UTXOs", async () => {

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -220,7 +220,7 @@ describe("CkBTCTransactionList", () => {
     expect(cards).toHaveLength(1);
     const card = cards[0];
 
-    expect(await card.getHeadline()).toBe("Sent");
+    expect(await card.getHeadline()).toBe("BTC Sent");
     expect(await card.getIdentifier()).toBe(`To: ${btcWithdrawalAddress}`);
     // This is the burned amount + approve fee. The KYT fee is deducted after
     // burning.

--- a/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
@@ -565,7 +565,7 @@ describe("icrc-transaction utils", () => {
 
       const burnUiTransaction = uiTransactions[0];
 
-      expect(burnUiTransaction.headline).toBe("Sent");
+      expect(burnUiTransaction.headline).toBe("BTC Sent");
       expect(burnUiTransaction.tokenAmount).toEqual(
         TokenAmountV2.fromUlps({
           amount: burnAmount + approveFee,

--- a/frontend/src/tests/mocks/icrc-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icrc-transactions.mock.ts
@@ -138,6 +138,44 @@ export const createMintTransaction = ({
   };
 };
 
+export const createApproveTransaction = ({
+  timestamp = 12354n,
+  amount = 33_000_000n,
+  fee = 10_000n,
+  from = fakeAccount,
+  memo,
+  createdAt = 123n,
+  spender = fakeAccount,
+}: {
+  timestamp?: bigint;
+  amount?: bigint;
+  fee?: bigint;
+  from?: IcrcCandidAccount;
+  memo?: Uint8Array;
+  createdAt?: bigint;
+  spender?: IcrcCandidAccount;
+}): IcrcTransaction => {
+  return {
+    kind: "approve",
+    timestamp,
+    approve: [
+      {
+        amount,
+        from,
+        memo: toNullable(memo),
+        fee: toNullable(fee),
+        created_at_time: toNullable(createdAt),
+        spender: spender,
+        expected_allowance: [],
+        expires_at: [],
+      },
+    ],
+    burn: [],
+    mint: [],
+    transfer: [],
+  };
+};
+
 export const createBurnTransaction = ({
   timestamp = 12354n,
   amount = 33n,


### PR DESCRIPTION
# Motivation

When withdrawing ckBTC to BTC with ICRC-2 we first make an Approve transaction and then the minter makes a Burn transaction. Since this is part of a single process, we want to render it as a single transaction in the wallet.

# Changes

1. Pass both the previous `IcrcTransactionWithId` and previously returns `UiTransaction` to `mapCkbtcTransaction`. Note that transactions are mapped in reverse chronological order, so the previous transaction happened later in time.
2. In `mapCkbtcTransaction`, if the current transaction is an Approve transaction, check if it was followed by a Burn transaction, and if so, add the fee to the amount burned and remove the Approve transaction from the list.

# Tests

1. Added a test for `mapCkbtcTransaction` with a transaction that should be merged and with one that shouldn't be merged.
2. Added a test for `CkBTCTransactionsList`.
3. Added a convenience method to create Approve transactions.

Before:
<img width="780" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/6f8018b0-fac8-4938-b01c-cab5de904b80">

After:
<img width="776" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/c8fa02af-d302-475d-95fc-118e34daaae5">

# Todos

- [x] Add entry to changelog (if necessary).
