### PR TITLE
GIX-2150: Use TokenAmountV2 new tokens page

### DIFF
--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -9,7 +9,7 @@ import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
 import type { Universe } from "$lib/types/universe";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { Principal } from "@dfinity/principal";
-import { isNullish, nonNullish, TokenAmount } from "@dfinity/utils";
+import { isNullish, nonNullish, TokenAmountV2 } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 import { nnsUniverseStore } from "./nns-universe.derived";
 
@@ -40,14 +40,14 @@ const convertAccountToUserTokenData = ({
     subtitle: account && subtitleMap[account.type],
     // TODO: Add loading balance state
     balance: nonNullish(account)
-      ? TokenAmount.fromE8s({
+      ? TokenAmountV2.fromUlps({
           amount: account.balanceE8s,
           token: NNS_TOKEN_DATA,
         })
       : new UnavailableTokenAmount(NNS_TOKEN_DATA),
     logo: nnsUniverse.logo,
     token: NNS_TOKEN_DATA,
-    fee: TokenAmount.fromE8s({
+    fee: TokenAmountV2.fromUlps({
       amount: NNS_TOKEN_DATA.fee,
       token: NNS_TOKEN_DATA,
     }),

--- a/frontend/src/lib/derived/icp-tokens-list-visitors.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-visitors.derived.ts
@@ -3,7 +3,7 @@ import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
 import type { Universe } from "$lib/types/universe";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { Principal } from "@dfinity/principal";
-import { TokenAmount } from "@dfinity/utils";
+import { TokenAmountV2 } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 import { nnsUniverseStore } from "./nns-universe.derived";
 
@@ -17,7 +17,7 @@ export const icpTokensListVisitors = derived<
     balance: new UnavailableTokenAmount(NNS_TOKEN_DATA),
     logo: nnsUniverse.logo,
     token: NNS_TOKEN_DATA,
-    fee: TokenAmount.fromE8s({
+    fee: TokenAmountV2.fromUlps({
       amount: NNS_TOKEN_DATA.fee,
       token: NNS_TOKEN_DATA,
     }),

--- a/frontend/src/lib/derived/tokens-list-base.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-base.derived.ts
@@ -7,7 +7,7 @@ import type { UserTokenData } from "$lib/types/tokens-page";
 import type { Universe } from "$lib/types/universe";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { Principal } from "@dfinity/principal";
-import { isNullish, nonNullish, TokenAmount } from "@dfinity/utils";
+import { isNullish, nonNullish, TokenAmountV2 } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 import { universesStore } from "./universes.derived";
 
@@ -24,7 +24,7 @@ const convertUniverseToBaseTokenData =
       title: universe.title,
       balance: new UnavailableTokenAmount(token),
       token,
-      fee: TokenAmount.fromE8s({ amount: token.fee, token }),
+      fee: TokenAmountV2.fromUlps({ amount: token.fee, token }),
       logo: universe.logo,
       actions: [],
     };

--- a/frontend/src/lib/derived/tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-user.derived.ts
@@ -6,7 +6,7 @@ import {
 } from "$lib/stores/tokens.store";
 import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
-import { isNullish, TokenAmount } from "@dfinity/utils";
+import { isNullish, TokenAmountV2 } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 import { tokensListBaseStore } from "./tokens-list-base.derived";
 import {
@@ -28,7 +28,7 @@ const addBalance =
     if (isNullish(token) || isNullish(balanceE8s)) {
       return userTokenData;
     }
-    const balance = TokenAmount.fromE8s({ amount: balanceE8s, token });
+    const balance = TokenAmountV2.fromUlps({ amount: balanceE8s, token });
     return {
       ...userTokenData,
       balance,

--- a/frontend/src/lib/types/tokens-page.ts
+++ b/frontend/src/lib/types/tokens-page.ts
@@ -1,6 +1,6 @@
 import type { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import type { Principal } from "@dfinity/principal";
-import type { Token, TokenAmount } from "@dfinity/utils";
+import type { Token, TokenAmountV2 } from "@dfinity/utils";
 
 export enum UserTokenAction {
   Send = "send",
@@ -29,8 +29,8 @@ export type UserTokenLoading = UserTokenBase & {
 };
 
 export type UserTokenData = UserTokenBase & {
-  balance: TokenAmount | UnavailableTokenAmount;
+  balance: TokenAmountV2 | UnavailableTokenAmount;
   token: Token;
   // Fees are included in the metadata of ICRC tokens, but this is not a list of only ICRC tokens
-  fee: TokenAmount;
+  fee: TokenAmountV2;
 };

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -8,7 +8,7 @@ import {
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
 import { createIcpUserToken } from "$tests/mocks/tokens-page.mock";
-import { TokenAmount } from "@dfinity/utils";
+import { TokenAmountV2 } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("icp-tokens-list-user.derived", () => {
@@ -23,7 +23,7 @@ describe("icp-tokens-list-user.derived", () => {
   };
   const mainUserTokenData: UserTokenData = {
     ...icpTokenUser,
-    balance: TokenAmount.fromE8s({
+    balance: TokenAmountV2.fromUlps({
       amount: mockMainAccount.balanceE8s,
       token: NNS_TOKEN_DATA,
     }),
@@ -32,7 +32,7 @@ describe("icp-tokens-list-user.derived", () => {
   };
   const subaccountUserTokenData: UserTokenData = {
     ...icpTokenUser,
-    balance: TokenAmount.fromE8s({
+    balance: TokenAmountV2.fromUlps({
       amount: mockSubAccount.balanceE8s,
       token: NNS_TOKEN_DATA,
     }),
@@ -41,7 +41,7 @@ describe("icp-tokens-list-user.derived", () => {
   };
   const hardwareWalletUserTokenData: UserTokenData = {
     ...icpTokenUser,
-    balance: TokenAmount.fromE8s({
+    balance: TokenAmountV2.fromUlps({
       amount: mockHardwareWalletAccount.balanceE8s,
       token: NNS_TOKEN_DATA,
     }),

--- a/frontend/src/tests/lib/derived/tokens-list-base.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-base.derived.spec.ts
@@ -19,7 +19,7 @@ import {
 } from "$tests/mocks/tokens-page.mock";
 import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
-import { TokenAmount } from "@dfinity/utils";
+import { TokenAmountV2 } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("tokens-list-base.derived", () => {
@@ -46,7 +46,7 @@ describe("tokens-list-base.derived", () => {
     logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/g3pce-2iaae/logo.png",
     balance: new UnavailableTokenAmount(snsTetris.tokenMetadata),
     token: snsTetris.tokenMetadata,
-    fee: TokenAmount.fromE8s({
+    fee: TokenAmountV2.fromUlps({
       amount: snsTetris.tokenMetadata.fee,
       token: snsTetris.tokenMetadata,
     }),
@@ -58,7 +58,7 @@ describe("tokens-list-base.derived", () => {
     logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/f7crg-kabae/logo.png",
     balance: new UnavailableTokenAmount(snsPacman.tokenMetadata),
     token: snsPacman.tokenMetadata,
-    fee: TokenAmount.fromE8s({
+    fee: TokenAmountV2.fromUlps({
       amount: snsPacman.tokenMetadata.fee,
       token: snsPacman.tokenMetadata,
     }),

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -22,12 +22,12 @@ import {
 } from "$tests/mocks/tokens-page.mock";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
-import { TokenAmount } from "@dfinity/utils";
+import { TokenAmountV2 } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("tokens-list-user.derived", () => {
   const icpUserToken: UserTokenData = createIcpUserToken({
-    balance: TokenAmount.fromE8s({
+    balance: TokenAmountV2.fromUlps({
       amount: mockMainAccount.balanceE8s,
       token: NNS_TOKEN_DATA,
     }),
@@ -56,7 +56,7 @@ describe("tokens-list-user.derived", () => {
     logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/g3pce-2iaae/logo.png",
     balance: new UnavailableTokenAmount(snsTetris.tokenMetadata),
     token: snsTetris.tokenMetadata,
-    fee: TokenAmount.fromE8s({
+    fee: TokenAmountV2.fromUlps({
       amount: snsTetris.tokenMetadata.fee,
       token: snsTetris.tokenMetadata,
     }),
@@ -64,7 +64,7 @@ describe("tokens-list-user.derived", () => {
   };
   const tetrisUserToken: UserTokenData = {
     ...tetrisTokenBase,
-    balance: TokenAmount.fromE8s({
+    balance: TokenAmountV2.fromUlps({
       amount: mockSnsMainAccount.balanceE8s,
       token: snsTetrisToken,
     }),
@@ -76,7 +76,7 @@ describe("tokens-list-user.derived", () => {
     logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/f7crg-kabae/logo.png",
     balance: new UnavailableTokenAmount(snsPacman.tokenMetadata),
     token: snsPacman.tokenMetadata,
-    fee: TokenAmount.fromE8s({
+    fee: TokenAmountV2.fromUlps({
       amount: snsPacman.tokenMetadata.fee,
       token: snsPacman.tokenMetadata,
     }),
@@ -84,7 +84,7 @@ describe("tokens-list-user.derived", () => {
   };
   const pacmanUserToken: UserTokenData = {
     ...pacmanTokenBase,
-    balance: TokenAmount.fromE8s({
+    balance: TokenAmountV2.fromUlps({
       amount: mockSnsMainAccount.balanceE8s,
       token: snsPackmanToken,
     }),
@@ -92,7 +92,7 @@ describe("tokens-list-user.derived", () => {
   };
   const ckBTCUserToken: UserTokenData = {
     ...ckBTCTokenBase,
-    balance: TokenAmount.fromE8s({
+    balance: TokenAmountV2.fromUlps({
       amount: mockCkBTCMainAccount.balanceE8s,
       token: mockCkBTCToken,
     }),

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -1,4 +1,5 @@
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { CKETH_UNIVERSE_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import { tokensListUserStore } from "$lib/derived/tokens-list-user.derived";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
@@ -11,15 +12,21 @@ import {
   mockCkBTCMainAccount,
   mockCkBTCToken,
 } from "$tests/mocks/ckbtc-accounts.mock";
+import {
+  mockCkETHMainAccount,
+  mockCkETHToken,
+} from "$tests/mocks/cketh-accounts.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import {
   ckBTCTokenBase,
+  ckETHTokenBase,
   createIcpUserToken,
   icpTokenBase,
 } from "$tests/mocks/tokens-page.mock";
+import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { TokenAmountV2 } from "@dfinity/utils";
@@ -98,6 +105,14 @@ describe("tokens-list-user.derived", () => {
     }),
     actions: [UserTokenAction.Receive, UserTokenAction.Send],
   };
+  const ckETHUserToken: UserTokenData = {
+    ...ckETHTokenBase,
+    balance: TokenAmountV2.fromUlps({
+      amount: mockCkETHMainAccount.balanceE8s,
+      token: mockCkETHToken,
+    }),
+    actions: [UserTokenAction.Receive, UserTokenAction.Send],
+  };
 
   describe("tokensListBaseStore", () => {
     beforeEach(() => {
@@ -107,6 +122,7 @@ describe("tokens-list-user.derived", () => {
       tokensStore.reset();
 
       setSnsProjects([snsTetris, snsPacman]);
+      setCkETHCanisters();
       tokensStore.setTokens({
         [CKBTC_UNIVERSE_CANISTER_ID.toText()]: {
           token: mockCkBTCToken,
@@ -127,6 +143,7 @@ describe("tokens-list-user.derived", () => {
       expect(get(tokensListUserStore)).toEqual([
         icpTokenBase,
         ckBTCTokenBase,
+        ckETHTokenBase,
         tetrisTokenBase,
         pacmanTokenBase,
       ]);
@@ -139,6 +156,7 @@ describe("tokens-list-user.derived", () => {
       expect(get(tokensListUserStore)).toEqual([
         icpUserToken,
         ckBTCTokenBase,
+        ckETHTokenBase,
         tetrisTokenBase,
         pacmanTokenBase,
       ]);
@@ -155,6 +173,24 @@ describe("tokens-list-user.derived", () => {
       expect(get(tokensListUserStore)).toEqual([
         icpTokenBase,
         ckBTCUserToken,
+        ckETHTokenBase,
+        tetrisTokenBase,
+        pacmanTokenBase,
+      ]);
+    });
+
+    it("should return balance and Send and Receive actions if ckETH balance is present", () => {
+      icrcAccountsStore.set({
+        accounts: {
+          accounts: [mockCkETHMainAccount],
+          certified: true,
+        },
+        universeId: CKETH_UNIVERSE_CANISTER_ID,
+      });
+      expect(get(tokensListUserStore)).toEqual([
+        icpTokenBase,
+        ckBTCTokenBase,
+        ckETHUserToken,
         tetrisTokenBase,
         pacmanTokenBase,
       ]);
@@ -169,6 +205,7 @@ describe("tokens-list-user.derived", () => {
       expect(get(tokensListUserStore)).toEqual([
         icpTokenBase,
         ckBTCTokenBase,
+        ckETHTokenBase,
         tetrisUserToken,
         pacmanTokenBase,
       ]);
@@ -185,6 +222,13 @@ describe("tokens-list-user.derived", () => {
         },
         universeId: CKBTC_UNIVERSE_CANISTER_ID,
       });
+      icrcAccountsStore.set({
+        accounts: {
+          accounts: [mockCkETHMainAccount],
+          certified: true,
+        },
+        universeId: CKETH_UNIVERSE_CANISTER_ID,
+      });
       snsAccountsStore.setAccounts({
         accounts: [mockSnsMainAccount],
         certified: true,
@@ -198,6 +242,7 @@ describe("tokens-list-user.derived", () => {
       expect(get(tokensListUserStore)).toEqual([
         icpUserToken,
         ckBTCUserToken,
+        ckETHUserToken,
         tetrisUserToken,
         pacmanUserToken,
       ]);

--- a/frontend/src/tests/mocks/tokens-page.mock.ts
+++ b/frontend/src/tests/mocks/tokens-page.mock.ts
@@ -13,7 +13,7 @@ import {
   type UserTokenLoading,
 } from "$lib/types/tokens-page";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
-import { TokenAmount } from "@dfinity/utils";
+import { TokenAmountV2 } from "@dfinity/utils";
 import { mockCkBTCToken, mockCkTESTBTCToken } from "./ckbtc-accounts.mock";
 import { mockSnsToken, principal } from "./sns-projects.mock";
 
@@ -23,7 +23,7 @@ export const icpTokenBase: UserTokenData = {
   logo: IC_LOGO_ROUNDED,
   balance: new UnavailableTokenAmount(NNS_TOKEN_DATA),
   token: NNS_TOKEN_DATA,
-  fee: TokenAmount.fromE8s({
+  fee: TokenAmountV2.fromUlps({
     amount: NNS_TOKEN_DATA.fee,
     token: NNS_TOKEN_DATA,
   }),
@@ -41,7 +41,7 @@ export const ckBTCTokenBase: UserTokenData = {
   logo: CKBTC_LOGO,
   balance: new UnavailableTokenAmount(mockCkBTCToken),
   token: mockCkBTCToken,
-  fee: TokenAmount.fromE8s({
+  fee: TokenAmountV2.fromUlps({
     amount: mockCkBTCToken.fee,
     token: mockCkBTCToken,
   }),
@@ -53,7 +53,7 @@ export const ckTESTBTCTokenBase: UserTokenData = {
   logo: CKTESTBTC_LOGO,
   balance: new UnavailableTokenAmount(mockCkTESTBTCToken),
   token: mockCkTESTBTCToken,
-  fee: TokenAmount.fromE8s({
+  fee: TokenAmountV2.fromUlps({
     amount: mockCkTESTBTCToken.fee,
     token: mockCkTESTBTCToken,
   }),
@@ -63,13 +63,13 @@ export const ckTESTBTCTokenBase: UserTokenData = {
 export const userTokenPageMock: UserTokenData = {
   universeId: principal(0),
   title: "Test SNS",
-  balance: TokenAmount.fromE8s({
+  balance: TokenAmountV2.fromUlps({
     amount: 2160000000n,
     token: snsTetrisToken,
   }),
   logo: "sns-logo.svg",
   token: snsTetrisToken,
-  fee: TokenAmount.fromE8s({
+  fee: TokenAmountV2.fromUlps({
     amount: snsTetrisToken.fee,
     token: mockCkBTCToken,
   }),
@@ -88,12 +88,12 @@ export const userTokensPageMock: UserTokenData[] = [
   {
     universeId: principal(0),
     title: "Test SNS",
-    balance: TokenAmount.fromE8s({
+    balance: TokenAmountV2.fromUlps({
       amount: 2160000000n,
       token: { name: "Test SNS", symbol: "SNS1", decimals: 8 },
     }),
     token: snsTetrisToken,
-    fee: TokenAmount.fromE8s({
+    fee: TokenAmountV2.fromUlps({
       amount: snsTetrisToken.fee,
       token: snsTetrisToken,
     }),
@@ -103,12 +103,12 @@ export const userTokensPageMock: UserTokenData[] = [
   {
     universeId: principal(1),
     title: "Test SNS 2",
-    balance: TokenAmount.fromE8s({
+    balance: TokenAmountV2.fromUlps({
       amount: 1180000000n,
       token: { name: "Test SNS", symbol: "SNS2", decimals: 8 },
     }),
     token: snsPackmanToken,
-    fee: TokenAmount.fromE8s({
+    fee: TokenAmountV2.fromUlps({
       amount: snsPackmanToken.fee,
       token: snsPackmanToken,
     }),

--- a/frontend/src/tests/mocks/tokens-page.mock.ts
+++ b/frontend/src/tests/mocks/tokens-page.mock.ts
@@ -1,4 +1,5 @@
 import CKBTC_LOGO from "$lib/assets/ckBTC.svg";
+import CKETH_LOGO from "$lib/assets/ckETH.svg";
 import CKTESTBTC_LOGO from "$lib/assets/ckTESTBTC.svg";
 import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
@@ -6,6 +7,7 @@ import {
   CKBTC_UNIVERSE_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
+import { CKETH_UNIVERSE_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import {
   UserTokenAction,
@@ -15,6 +17,7 @@ import {
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { TokenAmountV2 } from "@dfinity/utils";
 import { mockCkBTCToken, mockCkTESTBTCToken } from "./ckbtc-accounts.mock";
+import { mockCkETHToken } from "./cketh-accounts.mock";
 import { mockSnsToken, principal } from "./sns-projects.mock";
 
 export const icpTokenBase: UserTokenData = {
@@ -44,6 +47,18 @@ export const ckBTCTokenBase: UserTokenData = {
   fee: TokenAmountV2.fromUlps({
     amount: mockCkBTCToken.fee,
     token: mockCkBTCToken,
+  }),
+  actions: [],
+};
+export const ckETHTokenBase: UserTokenData = {
+  universeId: CKETH_UNIVERSE_CANISTER_ID,
+  title: "ckETH",
+  logo: CKETH_LOGO,
+  balance: new UnavailableTokenAmount(mockCkETHToken),
+  token: mockCkETHToken,
+  fee: TokenAmountV2.fromUlps({
+    amount: mockCkETHToken.fee,
+    token: mockCkETHToken,
   }),
   actions: [],
 };


### PR DESCRIPTION
# Motivation

Use TokenAmountV2 in the `/tokens` page. Otherwise it won't work becuase ckETH is also there.

In this PR, change the type of `fee` and `balance` in `UserTokenData` to be of type `TokenAmountV2`.

# Changes

* Change the type of the fields of `UserTokenData`.
* Change the tokens list derived stores to create `TokenAmountV2` for balance and fee.

# Tests

* Change mock data of `UserTokenData` to use `UserTokenData`.
* Change test files for tokens list derived stores to expect `TokenAmountV2`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
