### PR TITLE
GIX-1989: Use /tokens in menu items

### DIFF
--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -43,7 +43,7 @@
       href: $accountsPathStore,
       selected: isSelectedPath({
         currentPath: $pageStore.path,
-        paths: [AppPath.Accounts, AppPath.Wallet],
+        paths: [AppPath.Accounts, AppPath.Wallet, AppPath.Tokens],
       }),
       label: "tokens",
       icon: IconWallet,

--- a/frontend/src/lib/derived/paths.derived.ts
+++ b/frontend/src/lib/derived/paths.derived.ts
@@ -1,4 +1,5 @@
 import { pageStore, type Page } from "$lib/derived/page.derived";
+import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
 import {
   buildAccountsUrl,
   buildCanistersUrl,
@@ -7,9 +8,11 @@ import {
 } from "$lib/utils/navigation.utils";
 import { derived, type Readable } from "svelte/store";
 
-export const accountsPathStore = derived<Readable<Page>, string>(
-  pageStore,
-  ({ universe }) => buildAccountsUrl({ universe })
+export const accountsPathStore = derived<
+  [Readable<Page>, Readable<boolean>],
+  string
+>([pageStore, ENABLE_MY_TOKENS], ([{ universe }, tokensEnabled]) =>
+  buildAccountsUrl({ universe, tokensEnabled })
 );
 
 export const neuronsPathStore = derived<Readable<Page>, string>(

--- a/frontend/src/lib/utils/navigation.utils.ts
+++ b/frontend/src/lib/utils/navigation.utils.ts
@@ -47,8 +47,16 @@ const buildUrl = ({
     .map(([key, value]) => `&${key}=${value}`)
     .join("")}`;
 
-export const buildAccountsUrl = ({ universe }: { universe: string }) =>
-  buildUrl({ path: AppPath.Accounts, universe });
+export const buildAccountsUrl = ({
+  universe,
+  tokensEnabled,
+}: {
+  universe: string;
+  tokensEnabled?: boolean;
+}) =>
+  tokensEnabled
+    ? AppPath.Tokens
+    : buildUrl({ path: AppPath.Accounts, universe });
 export const buildNeuronsUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Neurons, universe });
 export const buildProposalsUrl = ({ universe }: { universe: string }) =>

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -4,6 +4,7 @@ import {
   OWN_CANISTER_ID_TEXT,
 } from "$lib/constants/canister-ids.constants";
 import { AppPath, UNIVERSE_PARAM } from "$lib/constants/routes.constants";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { page } from "$mocks/$app/stores";
 import en from "$tests/mocks/i18n.mock";
 import { render } from "@testing-library/svelte";
@@ -36,6 +37,10 @@ describe("MenuItems", () => {
     expect(link.textContent?.trim()).toEqual(en.navigation[labelKey]);
   };
 
+  beforeEach(() => {
+    overrideFeatureFlagsStore.reset();
+  });
+
   it("should render accounts menu item", () =>
     shouldRenderMenuItem({ context: "accounts", labelKey: "tokens" }));
   it("should render neurons menu item", () =>
@@ -66,5 +71,30 @@ describe("MenuItems", () => {
     expect(neuronsLink.getAttribute("href")).toEqual(
       `${AppPath.Neurons}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID.toText()}`
     );
+  });
+
+  describe("when My Tokens page is enabled", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
+    });
+
+    it("should point Tokens to /tokens", () => {
+      page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+      const { getByTestId } = render(MenuItems);
+
+      const accountsLink = getByTestId("menuitem-accounts");
+      expect(accountsLink.getAttribute("href")).toEqual(AppPath.Tokens);
+    });
+
+    it("should have Tokens selected when in /tokens path", () => {
+      page.mock({
+        data: { universe: OWN_CANISTER_ID_TEXT },
+        routeId: AppPath.Tokens,
+      });
+      const { getByTestId } = render(MenuItems);
+
+      const accountsLink = getByTestId("menuitem-accounts");
+      expect(accountsLink.classList.contains("selected")).toBe(true);
+    });
   });
 });

--- a/frontend/src/tests/lib/derived/paths.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/paths.derived.spec.ts
@@ -6,11 +6,16 @@ import {
   neuronsPathStore,
   proposalsPathStore,
 } from "$lib/derived/paths.derived";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { page } from "$mocks/$app/stores";
 import { mockSnsCanisterIdText } from "$tests/mocks/sns.api.mock";
 import { get } from "svelte/store";
 
 describe("paths derived stores", () => {
+  beforeEach(() => {
+    overrideFeatureFlagsStore.reset();
+  });
+
   describe("accountsPathStore", () => {
     it("should return NNS accounts path as default", () => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
@@ -28,6 +33,16 @@ describe("paths derived stores", () => {
       expect($store).toBe(
         `${AppPath.Accounts}/?${UNIVERSE_PARAM}=${mockSnsCanisterIdText}`
       );
+    });
+
+    describe("when My Tokens feature is enabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
+      });
+
+      it("should return the tokens path", () => {
+        expect(get(accountsPathStore)).toBe(AppPath.Tokens);
+      });
     });
   });
 

--- a/frontend/src/tests/lib/utils/navigation.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/navigation.utils.spec.ts
@@ -132,7 +132,7 @@ describe("navigation-utils", () => {
       );
     });
 
-    it("should build accounts url", () => {
+    it("should build accounts url when tokens not enabled", () => {
       expect(
         buildAccountsUrl({
           universe: OWN_CANISTER_ID_TEXT,
@@ -140,6 +140,15 @@ describe("navigation-utils", () => {
       ).toEqual(
         `${AppPath.Accounts}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
       );
+    });
+
+    it("should build accounts url when tokens is enabled", () => {
+      expect(
+        buildAccountsUrl({
+          universe: OWN_CANISTER_ID_TEXT,
+          tokensEnabled: true,
+        })
+      ).toEqual(AppPath.Tokens);
     });
 
     it("should build neurons url", () => {


### PR DESCRIPTION
# Motivation

The menu item "Tokens" in the left sidebar should redirect the user to `/tokens`.

# Changes

* Add the `AppPath.Tokens` to the selected paths for "Tokens" menu item.
* Add optional param `tokensEnabled` to util `buildAccountsUrl`.
* Add `ENABLE_MY_TOKENS` flag store in `accountsPathStore`.

# Tests

* Test the MenuItems with flag enabled.
* Add test for `accountsPathStore` when flag is enabled.
* Add test case for `buildAccountsUrl` with new param `tokensEnabled`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
