### PR TITLE
GIX-2150: Add ckETH to tokens page

### DIFF
--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -39,7 +39,6 @@
 
   let loadSnsAccountsBalancesRequested = false;
   let loadCkBTCAccountsBalancesRequested = false;
-  let loadIcrcAccountsBalancesRequested = false;
 
   const loadSnsAccountsBalances = async (projects: SnsFullProject[]) => {
     // We start when the projects are fetched
@@ -74,20 +73,6 @@
   const loadIcrcTokenAccounts = async (
     icrcCanisters: IcrcCanistersStoreData
   ) => {
-    const universeIds = Object.keys(icrcCanisters);
-
-    // Nothing loaded yet or nothing to load
-    if (universeIds.length === 0) {
-      return;
-    }
-
-    // We trigger the loading of the Icrc Accounts Balances only once
-    if (loadIcrcAccountsBalancesRequested) {
-      return;
-    }
-
-    loadIcrcAccountsBalancesRequested = true;
-
     await loadAccountsBalances(Object.keys(icrcCanisters));
   };
 

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -26,6 +26,7 @@ import {
 import {
   mockCkBTCMainAccount,
   mockCkBTCToken,
+  mockCkTESTBTCToken,
 } from "$tests/mocks/ckbtc-accounts.mock";
 import {
   mockCkETHMainAccount,
@@ -86,9 +87,9 @@ describe("Tokens route", () => {
         async ({ canisterId }) => {
           const tokenMap = {
             [CKBTC_UNIVERSE_CANISTER_ID.toText()]: mockCkBTCToken,
-            [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: mockCkBTCToken,
+            [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: mockCkTESTBTCToken,
             [CKETH_UNIVERSE_CANISTER_ID.toText()]: mockCkETHToken,
-            [CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText()]: mockCkETHToken,
+            [CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText()]: mockCkTESTBTCToken,
           };
           if (isNullish(tokenMap[canisterId.toText()])) {
             throw new Error(


### PR DESCRIPTION
# Motivation

Tokens pages supports ckETH.

In this PR, load the token and balances of the ICRC Canisters. Which ckETH belongs to.

# Changes

* New function called on init in Tokes page route: `loadIcrcTokenAccounts`.
* Refactor `loadCkBTCAccountsBalances` to share code with `loadIcrcTokenAccounts`. This is the same that we have at the moment in the Accounts.svelte.

# Tests

* Test that if there are ICRC Canisters loaded, the tokens are present in the Tokens page.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.

