### PR TITLE
GIX-2110: Use AnchorTag for row if needed

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
@@ -49,7 +49,9 @@
   };
 </script>
 
-<div
+<svelte:element
+  this={nonNullish(userTokenData.rowHref) ? "a" : "div"}
+  href={userTokenData.rowHref}
   role="row"
   tabindex={index + 1}
   on:keypress={handleClick}
@@ -110,14 +112,14 @@
       {/each}
     {/if}
   </div>
-</div>
+</svelte:element>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/interaction";
   @use "@dfinity/gix-components/dist/styles/mixins/media";
   @use "../../../themes/mixins/grid-table";
 
-  div[role="row"] {
+  [role="row"] {
     @include interaction.tappable;
 
     // If we use grid-template-areas, we need to specify all the areas.
@@ -126,6 +128,8 @@
     display: flex;
     flex-direction: column;
     gap: var(--padding-2x);
+
+    text-decoration: none;
 
     @include media.min-width(medium) {
       @include grid-table.row;

--- a/frontend/src/lib/types/tokens-page.ts
+++ b/frontend/src/lib/types/tokens-page.ts
@@ -14,6 +14,7 @@ export type UserTokenBase = {
   subtitle?: string;
   logo: string;
   actions: UserTokenAction[];
+  rowHref?: string;
 };
 
 /**

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -133,12 +133,22 @@ describe("TokensTable", () => {
       balance: TokenAmount.fromE8s({ amount: 314000000n, token: ICPToken }),
       rowHref: href,
     });
-    const po = renderTable({ userTokensData: [token1] });
+    const token2 = createUserToken({
+      universeId: principal(0),
+      balance: TokenAmount.fromE8s({
+        amount: 114000000n,
+        token: { name: "Tetris", symbol: "TETRIS", decimals: 8 },
+      }),
+      rowHref: undefined,
+    });
+    const po = renderTable({ userTokensData: [token1, token2] });
 
     const rows = await po.getRows();
     const row1Po = rows[0];
+    const row2Po = rows[1];
 
     expect(await row1Po.getHref()).toBe(href);
+    expect(await row2Po.getHref()).toBeNull();
   });
 
   it("should render specific text if balance not available", async () => {

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -126,6 +126,21 @@ describe("TokensTable", () => {
     expect(await row2Po.getSubtitle()).toBeNull();
   });
 
+  it("should render href link if rowHref is present", async () => {
+    const href = "/accounts";
+    const token1 = createUserToken({
+      universeId: OWN_CANISTER_ID,
+      balance: TokenAmount.fromE8s({ amount: 314000000n, token: ICPToken }),
+      rowHref: href,
+    });
+    const po = renderTable({ userTokensData: [token1] });
+
+    const rows = await po.getRows();
+    const row1Po = rows[0];
+
+    expect(await row1Po.getHref()).toBe(href);
+  });
+
   it("should render specific text if balance not available", async () => {
     const token1 = createUserToken({
       universeId: OWN_CANISTER_ID,

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -30,6 +30,10 @@ export class TokensTableRowPo extends BasePageObject {
     return balanceElement.byTestId("spinner").isPresent();
   }
 
+  getHref(): Promise<string | null> {
+    return this.root.getAttribute("href");
+  }
+
   getSubtitle(): Promise<string | null> {
     return this.getText("project-subtitle");
   }


### PR DESCRIPTION
# Motivation

The whole row on the Tokens page is really a link to another page.

In this PR, introduce a new optional field in UserTokenData: `"rowHref"`. Optional, because in the icp tokens page the rows are not clickable.

# Changes

* Add optional field `rowHref` in UserTokenData type.
* TokensTableRow uses the new field to render a link with href or not.

# Tests

* Test that Tokens table renders row with href when present.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
