### PR TITLE
GIX-2084: Add Back button to ICP Tokens page

### DIFF
--- a/frontend/src/routes/(app)/(u)/(accounts)/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(accounts)/+layout.svelte
@@ -6,12 +6,16 @@
   import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
   import MainWrapper from "$lib/components/tokens/MainWrapper.svelte";
   import Content from "$lib/components/layout/Content.svelte";
+  import { goto } from "$app/navigation";
+  import { AppPath } from "$lib/constants/routes.constants";
+
+  const back = (): Promise<void> => goto(AppPath.Tokens);
 </script>
 
 <LayoutList title={$i18n.navigation.tokens}>
   <Layout>
     {#if $ENABLE_MY_TOKENS}
-      <Content>
+      <Content {back}>
         <MainWrapper>
           <slot />
         </MainWrapper>

--- a/frontend/src/tests/routes/app/accounts/layout.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/layout.spec.ts
@@ -1,7 +1,10 @@
+import { AppPath } from "$lib/constants/routes.constants";
+import { pageStore } from "$lib/derived/page.derived";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { layoutTitleStore } from "$lib/stores/layout.store";
+import { page } from "$mocks/$app/stores";
 import AccountsLayout from "$routes/(app)/(u)/(accounts)/+layout.svelte";
-import { render } from "@testing-library/svelte";
+import { fireEvent, render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Accounts layout", () => {
@@ -35,6 +38,18 @@ describe("Accounts layout", () => {
       const { queryByTestId } = render(AccountsLayout);
 
       expect(queryByTestId("back")).toBeInTheDocument();
+    });
+
+    it("back button should navigate to tokens page", async () => {
+      page.mock({
+        routeId: AppPath.Accounts,
+      });
+      const { queryByTestId } = render(AccountsLayout);
+
+      expect(get(pageStore).path).toEqual(AppPath.Accounts);
+      await fireEvent.click(queryByTestId("back"));
+
+      expect(get(pageStore).path).toEqual(AppPath.Tokens);
     });
   });
 

--- a/frontend/src/tests/routes/app/accounts/layout.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/layout.spec.ts
@@ -30,9 +30,15 @@ describe("Accounts layout", () => {
         queryByTestId("select-universe-nav-title")
       ).not.toBeInTheDocument();
     });
+
+    it("should render back button", () => {
+      const { queryByTestId } = render(AccountsLayout);
+
+      expect(queryByTestId("back")).toBeInTheDocument();
+    });
   });
 
-  describe("when tokens flag is enabled", () => {
+  describe("when tokens flag is disabled", () => {
     beforeEach(() => {
       overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", false);
     });
@@ -41,6 +47,12 @@ describe("Accounts layout", () => {
       const { queryByTestId } = render(AccountsLayout);
 
       expect(queryByTestId("select-universe-nav-title")).toBeInTheDocument();
+    });
+
+    it("should not render back button", () => {
+      const { queryByTestId } = render(AccountsLayout);
+
+      expect(queryByTestId("back")).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
# Motivation

User can go back to the main tokens pages from the ICP accounts page.

In this PR, add the back button when user is in ICP accounts page with Tokens Table.

# Changes

* Pass the `back` prop to `Content` in accounts layout.

# Tests

* Add two test cases in accounts layout to check when the back button should be present.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
