### PR TITLE
GIX-2171: Use Tokens in "/"

### DIFF
--- a/frontend/src/routes/(app)/(u)/(accounts)/+page.svelte
+++ b/frontend/src/routes/(app)/(u)/(accounts)/+page.svelte
@@ -1,15 +1,12 @@
 <script lang="ts">
-  import SignInAccounts from "$lib/pages/SignInAccounts.svelte";
-  import Accounts from "$lib/routes/Accounts.svelte";
-  import { authSignedInStore } from "$lib/derived/auth.derived";
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
-  import { icpTokensListVisitors } from "$lib/derived/icp-tokens-list-visitors.derived";
+  import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
+  import TokensRoute from "../../(nns)/tokens/+page.svelte";
+  import AccountsRoute from "./accounts/+page.svelte";
 </script>
 
-<TestIdWrapper testId="accounts-plus-page-component">
-  {#if $authSignedInStore}
-    <Accounts />
-  {:else}
-    <SignInAccounts userTokensData={$icpTokensListVisitors} />
-  {/if}
-</TestIdWrapper>
+<!-- TODO: Move this to `routes/(app)/(home) -->
+{#if $ENABLE_MY_TOKENS}
+  <TokensRoute />
+{:else}
+  <AccountsRoute />
+{/if}

--- a/frontend/src/tests/routes/app/home-page.spec.ts
+++ b/frontend/src/tests/routes/app/home-page.spec.ts
@@ -1,0 +1,37 @@
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import HomePage from "$routes/(app)/(u)/(accounts)/+page.svelte";
+import { render } from "@testing-library/svelte";
+
+describe("Home page", () => {
+  beforeEach(() => {
+    overrideFeatureFlagsStore.reset();
+  });
+
+  describe("My Tokens flag enabled", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
+    });
+
+    it("should render the tokens route", () => {
+      const { queryByTestId } = render(HomePage);
+
+      expect(
+        queryByTestId("accounts-plus-page-component")
+      ).not.toBeInTheDocument();
+      expect(queryByTestId("tokens-route-component")).toBeInTheDocument();
+    });
+  });
+
+  describe("My Tokens flag disabled", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", false);
+    });
+
+    it("should render the accounts route", () => {
+      const { queryByTestId } = render(HomePage);
+
+      expect(queryByTestId("accounts-plus-page-component")).toBeInTheDocument();
+      expect(queryByTestId("tokens-route-component")).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

When Tokens is enabled, the home page should be the tokens page.

The current home page is the one in `routes/(app)/(u)/(accounts)/+page.svelte`.

In this PR, I change the logic of this component to render the Tokens route instead of the current Accounts route.

In another PR I'll move the layout and this home page to `routes/(app)/(home)`.

# Changes

* Change logic in `(app)/(u)/(accounts)/+page.svelte` to render either the Accounts route or the Tokens route.

# Tests

* New test for this page to check which component is rendered depending on the flag.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
