### PR TITLE
fix: Cargo install locked

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,7 +47,7 @@ jobs:
           cd /
           sudo apt-get update
           sudo apt-get install -yy hunspell hunspell-en-gb hunspell-en-us clang libclang-dev
-          cargo install --target x86_64-unknown-linux-gnu cargo-spellcheck
+          cargo install --locked --target x86_64-unknown-linux-gnu cargo-spellcheck
       - name: Spellcheck Rust
         run: cargo spellcheck
       - name: Spellcheck changelog

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,7 +47,7 @@ jobs:
           cd /
           sudo apt-get update
           sudo apt-get install -yy hunspell hunspell-en-gb hunspell-en-us clang libclang-dev
-          cargo install --locked --target x86_64-unknown-linux-gnu cargo-spellcheck
+          cargo install --locked --target x86_64-unknown-linux-gnu cargo-spellcheck@0.13.1
       - name: Spellcheck Rust
         run: cargo spellcheck
       - name: Spellcheck changelog


### PR DESCRIPTION
# Motivation
The spellcheck build is broken.

# Changes
- Lock the spellcheck version.
  - Note: There have been no new versions recently but better safe than sorry.
 - Require dependencies to be used as specified in the spellcheck Cargo.lock file.

# Tests
See CI

# Todos

- [ ] Add entry to changelog (if necessary).
