### PR TITLE
Renamed Account.balanceE8s to balanceUlps

### DIFF
--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -46,7 +46,7 @@ export const getIcrcAccount = async ({
   QueryParams): Promise<Account> => {
   const account = { owner, subaccount };
 
-  const balanceE8s = await getBalance({ ...account, certified });
+  const balanceUlps = await getBalance({ ...account, certified });
 
   return {
     identifier: encodeIcrcAccount(account),
@@ -54,7 +54,7 @@ export const getIcrcAccount = async ({
     ...(nonNullish(subaccount) && {
       subAccount: uint8ArrayToArrayOfNumber(new Uint8Array(subaccount)),
     }),
-    balanceE8s,
+    balanceUlps,
     type,
   };
 };

--- a/frontend/src/lib/components/accounts/AccountCard.svelte
+++ b/frontend/src/lib/components/accounts/AccountCard.svelte
@@ -16,7 +16,7 @@
   let identifier: string;
   let balanceUlps: bigint;
 
-  $: ({ identifier, balanceE8s: balanceUlps } = account);
+  $: ({ identifier, balanceUlps } = account);
 
   let href: string | undefined;
   $: href =

--- a/frontend/src/lib/components/accounts/CkBTCWithdrawalAccount.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWithdrawalAccount.svelte
@@ -84,10 +84,10 @@
   $: loading =
     loadingBalance ||
     (nonNullish(account) &&
-      (isNullish(account.balanceE8s) || isNullish(account.identifier)));
+      (isNullish(account.balanceUlps) || isNullish(account.identifier)));
 
   let accountBalance: bigint;
-  $: accountBalance = account?.balanceE8s ?? 0n;
+  $: accountBalance = account?.balanceUlps ?? 0n;
 
   let detailedAccountBalance: string;
   $: detailedAccountBalance = formatToken({

--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -135,7 +135,7 @@
             accountName={$selectedAccountStore.account.name ??
               $i18n.accounts.main}
             balance={TokenAmountV2.fromUlps({
-              amount: $selectedAccountStore.account.balanceE8s,
+              amount: $selectedAccountStore.account.balanceUlps,
               token,
             })}
           >

--- a/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
+++ b/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
@@ -59,7 +59,7 @@
 
   let max = 0;
   $: max = getMaxTransactionAmount({
-    balance: account?.balanceE8s ?? 0n,
+    balance: account?.balanceUlps ?? 0n,
     fee: $transactionsFeesStore.main,
     token: ICPToken,
   });

--- a/frontend/src/lib/components/transaction/TransactionForm.svelte
+++ b/frontend/src/lib/components/transaction/TransactionForm.svelte
@@ -64,7 +64,7 @@
 
   let max = 0;
   $: max = getMaxTransactionAmount({
-    balance: selectedAccount?.balanceE8s,
+    balance: selectedAccount?.balanceUlps,
     fee: toTokenAmountV2(transactionFee).toUlps(),
     maxAmount,
     token,

--- a/frontend/src/lib/components/transaction/TransactionFromAccount.svelte
+++ b/frontend/src/lib/components/transaction/TransactionFromAccount.svelte
@@ -35,7 +35,7 @@
         <AmountDisplay
           singleLine
           amount={TokenAmountV2.fromUlps({
-            amount: selectedAccount.balanceE8s,
+            amount: selectedAccount.balanceUlps,
             token,
           })}
         />

--- a/frontend/src/lib/components/transaction/TransactionSource.svelte
+++ b/frontend/src/lib/components/transaction/TransactionSource.svelte
@@ -10,7 +10,7 @@
 
   let amount: TokenAmountV2;
   $: amount = TokenAmountV2.fromUlps({
-    amount: account.balanceE8s,
+    amount: account.balanceUlps,
     token,
   });
 </script>

--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -41,7 +41,7 @@ const convertAccountToUserTokenData = ({
     // TODO: Add loading balance state
     balance: nonNullish(account)
       ? TokenAmountV2.fromUlps({
-          amount: account.balanceE8s,
+          amount: account.balanceUlps,
           token: NNS_TOKEN_DATA,
         })
       : new UnavailableTokenAmount(NNS_TOKEN_DATA),

--- a/frontend/src/lib/derived/universes-accounts-balance.derived.ts
+++ b/frontend/src/lib/derived/universes-accounts-balance.derived.ts
@@ -14,7 +14,7 @@ import { sumAccounts, sumNnsAccounts } from "$lib/utils/accounts.utils";
 import { derived } from "svelte/store";
 
 export interface UniverseAccountsBalance {
-  // TODO: Rename to balanceUlps
+  // TODO GIX-2154: Rename to balanceUlps
   balanceE8s: bigint | undefined;
   certified: boolean;
 }

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -176,7 +176,7 @@
           />
           <WalletPageHeading
             balance={TokenAmount.fromE8s({
-              amount: $selectedAccountStore.account.balanceE8s,
+              amount: $selectedAccountStore.account.balanceUlps,
               token: ICPToken,
             })}
             accountName={name}

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -137,7 +137,7 @@
           />
           <WalletPageHeading
             balance={TokenAmount.fromE8s({
-              amount: $selectedAccountStore.account.balanceE8s,
+              amount: $selectedAccountStore.account.balanceUlps,
               token,
             })}
             accountName={$selectedAccountStore.account.name ??

--- a/frontend/src/lib/services/icp-accounts.services.ts
+++ b/frontend/src/lib/services/icp-accounts.services.ts
@@ -132,7 +132,7 @@ export const loadAccounts = async ({
           })
         : account.account_identifier,
       icpIdentifier: account.account_identifier,
-      balanceE8s: await getAccountBalance(account.account_identifier),
+      balanceUlps: await getAccountBalance(account.account_identifier),
       type,
       ...("sub_account" in account && { subAccount: account.sub_account }),
       ...("name" in account && { name: account.name }),

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -85,7 +85,7 @@ const getIcrcMainIdentityAccount = async ({
     owner: identity.getPrincipal(),
   };
 
-  const balanceE8s = await queryIcrcBalance({
+  const balanceUlps = await queryIcrcBalance({
     identity,
     canisterId: ledgerCanisterId,
     certified,
@@ -95,7 +95,7 @@ const getIcrcMainIdentityAccount = async ({
   return {
     identifier: encodeIcrcAccount(account),
     principal: account.owner,
-    balanceE8s,
+    balanceUlps,
     type: "main",
   };
 };

--- a/frontend/src/lib/stores/ckbtc-withdrawal-accounts.store.ts
+++ b/frontend/src/lib/stores/ckbtc-withdrawal-accounts.store.ts
@@ -7,9 +7,9 @@ import { writable, type Readable } from "svelte/store";
 
 export type CkBTCBTCWithdrawalAccount = Omit<
   Account,
-  "balanceE8s" | "identifier"
+  "balanceUlps" | "identifier"
 > &
-  Partial<Pick<Account, "balanceE8s" | "identifier">>;
+  Partial<Pick<Account, "balanceUlps" | "identifier">>;
 
 export interface CkBTCBTCWithdrawalAccountData {
   account: CkBTCBTCWithdrawalAccount;

--- a/frontend/src/lib/stores/icp-accounts.store.ts
+++ b/frontend/src/lib/stores/icp-accounts.store.ts
@@ -82,7 +82,7 @@ const initIcpAccountsStore = (): IcpAccountsStore => {
             }
             const mapNewBalance = (account: IcpAccount) => {
               return account.identifier === accountIdentifier
-                ? { ...account, balanceE8s }
+                ? { ...account, balanceUlps: balanceE8s }
                 : account;
             };
             return {

--- a/frontend/src/lib/types/account.ts
+++ b/frontend/src/lib/types/account.ts
@@ -22,8 +22,7 @@ export interface Account {
   identifier: AccountIdentifierText;
   // Main and HardwareWallet accounts have Principal
   principal?: Principal;
-  // TODO: GIX-2154 Rename E8s to Ulps.
-  balanceE8s: bigint;
+  balanceUlps: bigint;
   // Subaccounts and HardwareWallets have name and subAccount
   name?: string;
   subAccount?: SubAccountArray;

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -196,12 +196,13 @@ export const getAccountsByRootCanister = ({
  */
 export const assertEnoughAccountFunds = ({
   account,
+  // TODO: GIX-2154 rename to amountUlps
   amountE8s,
 }: {
   account: Account;
   amountE8s: bigint;
 }): void => {
-  if (account.balanceE8s < amountE8s) {
+  if (account.balanceUlps < amountE8s) {
     throw new NotEnoughAmountError("error.insufficient_funds");
   }
 };
@@ -226,11 +227,13 @@ export const accountName = ({
 export const sumNnsAccounts = (
   accounts: IcpAccountsStoreData | undefined
 ): bigint | undefined =>
-  accounts?.main?.balanceE8s !== undefined
+  accounts?.main?.balanceUlps !== undefined
     ? sumAmountE8s(
-        accounts?.main?.balanceE8s,
-        ...(accounts?.subAccounts || []).map(({ balanceE8s }) => balanceE8s),
-        ...(accounts?.hardwareWallets || []).map(({ balanceE8s }) => balanceE8s)
+        accounts?.main?.balanceUlps,
+        ...(accounts?.subAccounts || []).map(({ balanceUlps }) => balanceUlps),
+        ...(accounts?.hardwareWallets || []).map(
+          ({ balanceUlps }) => balanceUlps
+        )
       )
     : undefined;
 
@@ -239,7 +242,7 @@ export const sumAccounts = (
 ): bigint | undefined =>
   isNullish(accounts) || accounts.length === 0
     ? undefined
-    : sumAmountE8s(...accounts.map(({ balanceE8s }) => balanceE8s));
+    : sumAmountE8s(...accounts.map(({ balanceUlps }) => balanceUlps));
 
 export const hasAccounts = (accounts: Account[]): boolean =>
   accounts.length > 0;

--- a/frontend/src/lib/utils/anonymize.utils.ts
+++ b/frontend/src/lib/utils/anonymize.utils.ts
@@ -104,12 +104,13 @@ export const anonymizeAccount = async (
     return account as undefined | null;
   }
 
-  const { identifier, principal, balanceE8s, name, type, subAccount } = account;
+  const { identifier, principal, balanceUlps, name, type, subAccount } =
+    account;
 
   return {
     identifier: await cutAndAnonymize(identifier),
     principal: anonymiseAvailability(principal),
-    balanceE8s: await anonymizeAmount(balanceE8s),
+    balanceUlps: await anonymizeAmount(balanceUlps),
     name: name,
     type: type,
     subAccount: await cutAndAnonymize(subAccount?.join("")),

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -126,6 +126,7 @@ export const formatTokenV2 = ({
   return formatToken({ value: e8s, detailed, roundingMode });
 };
 
+// TODO GIX-2154: Rename to sumAmounts.
 export const sumAmountE8s = (...amountE8s: bigint[]): bigint =>
   amountE8s.reduce<bigint>((acc, amount) => acc + amount, BigInt(0));
 

--- a/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
@@ -49,7 +49,7 @@ describe("icrc-ledger api", () => {
 
       expect(account).not.toBeUndefined();
 
-      expect(account.balanceE8s).toEqual(BigInt(10_000_000));
+      expect(account.balanceUlps).toEqual(BigInt(10_000_000));
 
       expect(account.principal.toText()).toEqual(
         mockIdentity.getPrincipal().toText()

--- a/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
@@ -65,7 +65,7 @@ describe("sns-ledger api", () => {
       const main = accounts.find(({ type }) => type === "main");
       expect(main).not.toBeUndefined();
 
-      expect(main?.balanceE8s).toEqual(mainBalance);
+      expect(main?.balanceUlps).toEqual(mainBalance);
 
       expect(balanceSpy).toBeCalled();
     });

--- a/frontend/src/tests/lib/api/wallet-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/wallet-ledger.api.spec.ts
@@ -43,7 +43,7 @@ describe("wallet-ledger api", () => {
 
       expect(account).not.toBeUndefined();
 
-      expect(account?.balanceE8s).toEqual(balance);
+      expect(account?.balanceUlps).toEqual(balance);
 
       expect(balanceSpy).toBeCalled();
     });

--- a/frontend/src/tests/lib/components/accounts/AccountCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/AccountCard.spec.ts
@@ -47,7 +47,7 @@ describe("AccountCard", () => {
     );
 
     expect(balance?.textContent).toEqual(
-      `${formatToken({ value: mockMainAccount.balanceE8s })}`
+      `${formatToken({ value: mockMainAccount.balanceUlps })}`
     );
   });
 

--- a/frontend/src/tests/lib/components/accounts/CkBTCWithdrawalAccount.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWithdrawalAccount.spec.ts
@@ -152,7 +152,7 @@ describe("CkBTCWithdrawalAccount", () => {
         const { getByText } = render(CkBTCWithdrawalAccount);
 
         const balance = formatToken({
-          value: mockCkBTCWithdrawalAccount.balanceE8s,
+          value: mockCkBTCWithdrawalAccount.balanceUlps,
           detailed: true,
         });
 
@@ -185,7 +185,7 @@ describe("CkBTCWithdrawalAccount", () => {
           account: {
             account: {
               ...mockCkBTCWithdrawalAccount,
-              balanceE8s: balanceZero,
+              balanceUlps: balanceZero,
             },
             certified: true,
           },
@@ -211,7 +211,7 @@ describe("CkBTCWithdrawalAccount", () => {
 
         vi.spyOn(ledgerApi, "getAccount").mockResolvedValue({
           ...mockCkBTCWithdrawalAccount,
-          balanceE8s: balanceZero,
+          balanceUlps: balanceZero,
         });
       });
 

--- a/frontend/src/tests/lib/components/accounts/CurrentBalance.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CurrentBalance.spec.ts
@@ -8,7 +8,7 @@ import { render } from "@testing-library/svelte";
 describe("CurrentBalance", () => {
   const props = {
     balance: TokenAmount.fromE8s({
-      amount: mockMainAccount.balanceE8s,
+      amount: mockMainAccount.balanceUlps,
       token: ICPToken,
     }),
   };
@@ -27,7 +27,7 @@ describe("CurrentBalance", () => {
     const icp: HTMLSpanElement | null = queryByTestId("token-value");
 
     expect(icp?.innerHTML).toEqual(
-      `${formatToken({ value: mockMainAccount.balanceE8s })}`
+      `${formatToken({ value: mockMainAccount.balanceUlps })}`
     );
     expect(getByText(`ICP`)).toBeTruthy();
   });

--- a/frontend/src/tests/lib/components/ic/AmountDisplay.spec.ts
+++ b/frontend/src/tests/lib/components/ic/AmountDisplay.spec.ts
@@ -6,7 +6,7 @@ import { render } from "@testing-library/svelte";
 
 describe("AmountDisplay", () => {
   const tokenAmount = TokenAmount.fromE8s({
-    amount: mockMainAccount.balanceE8s,
+    amount: mockMainAccount.balanceUlps,
     token: ICPToken,
   });
 
@@ -22,7 +22,7 @@ describe("AmountDisplay", () => {
     const value = container.querySelector("span:first-of-type");
 
     expect(value?.textContent).toEqual(
-      `${formatToken({ value: mockMainAccount.balanceE8s })}`
+      `${formatToken({ value: mockMainAccount.balanceUlps })}`
     );
   });
 
@@ -44,7 +44,7 @@ describe("AmountDisplay", () => {
     const value = container.querySelector("span:first-of-type");
 
     expect(value?.textContent).toEqual(
-      `+${formatToken({ value: mockMainAccount.balanceE8s })}`
+      `+${formatToken({ value: mockMainAccount.balanceUlps })}`
     );
     expect(container.querySelector(".plus-sign")).toBeInTheDocument();
   });
@@ -59,7 +59,7 @@ describe("AmountDisplay", () => {
     const value = container.querySelector("span:first-of-type");
 
     expect(value?.textContent).toEqual(
-      `-${formatToken({ value: mockMainAccount.balanceE8s })}`
+      `-${formatToken({ value: mockMainAccount.balanceUlps })}`
     );
   });
 
@@ -75,7 +75,7 @@ describe("AmountDisplay", () => {
 
     expect(value?.textContent).toEqual(
       `${formatToken({
-        value: mockMainAccount.balanceE8s,
+        value: mockMainAccount.balanceUlps,
         detailed: true,
       })}`
     );

--- a/frontend/src/tests/lib/components/transaction/TransactionSource.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionSource.spec.ts
@@ -24,7 +24,7 @@ describe("TransactionSource", () => {
 
     expect(getByTestId("token-value")?.textContent ?? "").toEqual(
       `${formatToken({
-        value: mockMainAccount.balanceE8s,
+        value: mockMainAccount.balanceUlps,
         detailed: "height_decimals",
       })}`
     );

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -135,18 +135,18 @@ describe("SelectUniverseCard", () => {
       icpAccountsStore.setForTesting({
         main: {
           ...mockMainAccount,
-          balanceE8s: 100_000_000n,
+          balanceUlps: 100_000_000n,
         },
         subAccounts: [
           {
             ...mockSubAccount,
-            balanceE8s: 200_000_000n,
+            balanceUlps: 200_000_000n,
           },
         ],
         hardwareWallets: [
           {
             ...mockHardwareWalletAccount,
-            balanceE8s: 400_000_000n,
+            balanceUlps: 400_000_000n,
           },
         ],
         certified: true,

--- a/frontend/src/tests/lib/components/universe/SelectUniverseDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseDropdown.spec.ts
@@ -95,11 +95,11 @@ describe("SelectUniverseDropdown", () => {
       const accounts = [
         {
           ...mockSnsMainAccount,
-          balanceE8s: 100_000_000n,
+          balanceUlps: 100_000_000n,
         },
         {
           ...mockSnsSubAccount,
-          balanceE8s: 23_000_000n,
+          balanceUlps: 23_000_000n,
         },
       ];
       const rootCanisterId = mockSnsFullProject.rootCanisterId;

--- a/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
+++ b/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
@@ -96,9 +96,9 @@ describe("UniverseAccountsBalance", () => {
       const balance: HTMLElement | null = getByTestId("token-value-label");
 
       const totalBalance =
-        mockMainAccount.balanceE8s +
-        mockSubAccount.balanceE8s +
-        mockHardwareWalletAccount.balanceE8s;
+        mockMainAccount.balanceUlps +
+        mockSubAccount.balanceUlps +
+        mockHardwareWalletAccount.balanceUlps;
 
       expect(balance?.textContent.trim() ?? "").toEqual(
         `${formatToken({
@@ -111,7 +111,7 @@ describe("UniverseAccountsBalance", () => {
     it("should render a total balance for Sns", () => {
       const rootCanisterId = mockSnsFullProject.rootCanisterId;
 
-      const totalBalance = mockSnsMainAccount.balanceE8s;
+      const totalBalance = mockSnsMainAccount.balanceUlps;
 
       snsAccountsStore.setAccounts({
         rootCanisterId,
@@ -136,7 +136,7 @@ describe("UniverseAccountsBalance", () => {
     });
 
     it("should render a total balance for ckBTC", () => {
-      const totalBalance = mockCkBTCMainAccount.balanceE8s;
+      const totalBalance = mockCkBTCMainAccount.balanceUlps;
 
       icrcAccountsStore.set({
         accounts: {
@@ -170,7 +170,7 @@ describe("UniverseAccountsBalance", () => {
           accounts: [
             {
               ...mockCkETHMainAccount,
-              balanceE8s: totalBalanceUlps,
+              balanceUlps: totalBalanceUlps,
             },
           ],
           certified: true,

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -24,7 +24,7 @@ describe("icp-tokens-list-user.derived", () => {
   const mainUserTokenData: UserTokenData = {
     ...icpTokenUser,
     balance: TokenAmountV2.fromUlps({
-      amount: mockMainAccount.balanceE8s,
+      amount: mockMainAccount.balanceUlps,
       token: NNS_TOKEN_DATA,
     }),
     title: "Main",
@@ -33,7 +33,7 @@ describe("icp-tokens-list-user.derived", () => {
   const subaccountUserTokenData: UserTokenData = {
     ...icpTokenUser,
     balance: TokenAmountV2.fromUlps({
-      amount: mockSubAccount.balanceE8s,
+      amount: mockSubAccount.balanceUlps,
       token: NNS_TOKEN_DATA,
     }),
     title: mockSubAccount.name,
@@ -42,7 +42,7 @@ describe("icp-tokens-list-user.derived", () => {
   const hardwareWalletUserTokenData: UserTokenData = {
     ...icpTokenUser,
     balance: TokenAmountV2.fromUlps({
-      amount: mockHardwareWalletAccount.balanceE8s,
+      amount: mockHardwareWalletAccount.balanceUlps,
       token: NNS_TOKEN_DATA,
     }),
     title: mockHardwareWalletAccount.name,

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -35,7 +35,7 @@ import { get } from "svelte/store";
 describe("tokens-list-user.derived", () => {
   const icpUserToken: UserTokenData = createIcpUserToken({
     balance: TokenAmountV2.fromUlps({
-      amount: mockMainAccount.balanceE8s,
+      amount: mockMainAccount.balanceUlps,
       token: NNS_TOKEN_DATA,
     }),
     actions: [UserTokenAction.GoToDetail],
@@ -72,7 +72,7 @@ describe("tokens-list-user.derived", () => {
   const tetrisUserToken: UserTokenData = {
     ...tetrisTokenBase,
     balance: TokenAmountV2.fromUlps({
-      amount: mockSnsMainAccount.balanceE8s,
+      amount: mockSnsMainAccount.balanceUlps,
       token: snsTetrisToken,
     }),
     actions: [UserTokenAction.Receive, UserTokenAction.Send],
@@ -92,7 +92,7 @@ describe("tokens-list-user.derived", () => {
   const pacmanUserToken: UserTokenData = {
     ...pacmanTokenBase,
     balance: TokenAmountV2.fromUlps({
-      amount: mockSnsMainAccount.balanceE8s,
+      amount: mockSnsMainAccount.balanceUlps,
       token: snsPackmanToken,
     }),
     actions: [UserTokenAction.Receive, UserTokenAction.Send],
@@ -100,7 +100,7 @@ describe("tokens-list-user.derived", () => {
   const ckBTCUserToken: UserTokenData = {
     ...ckBTCTokenBase,
     balance: TokenAmountV2.fromUlps({
-      amount: mockCkBTCMainAccount.balanceE8s,
+      amount: mockCkBTCMainAccount.balanceUlps,
       token: mockCkBTCToken,
     }),
     actions: [UserTokenAction.Receive, UserTokenAction.Send],
@@ -108,7 +108,7 @@ describe("tokens-list-user.derived", () => {
   const ckETHUserToken: UserTokenData = {
     ...ckETHTokenBase,
     balance: TokenAmountV2.fromUlps({
-      amount: mockCkETHMainAccount.balanceE8s,
+      amount: mockCkETHMainAccount.balanceUlps,
       token: mockCkETHToken,
     }),
     actions: [UserTokenAction.Receive, UserTokenAction.Send],

--- a/frontend/src/tests/lib/derived/universes-accounts-balance.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-accounts-balance.derived.spec.ts
@@ -32,14 +32,14 @@ describe("universes-accounts-balance.derived", () => {
   it("should derive a balance of Nns accounts", () => {
     const balances = get(universesAccountsBalance);
     expect(balances[OWN_CANISTER_ID_TEXT].balanceE8s).toEqual(
-      mockMainAccount.balanceE8s
+      mockMainAccount.balanceUlps
     );
   });
 
   it("should derive a balance of Sns accounts", () => {
     const balances = get(universesAccountsBalance);
     expect(balances[rootCanisterId.toText()].balanceE8s).toEqual(
-      mockSnsMainAccount.balanceE8s
+      mockSnsMainAccount.balanceUlps
     );
   });
 });

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -446,7 +446,7 @@ describe("CkBTCTransactionModal", () => {
     );
     expect(input?.value).toEqual(
       `${ulpsToNumber({
-        ulps: mockCkBTCMainAccount.balanceE8s - mockCkBTCToken.fee,
+        ulps: mockCkBTCMainAccount.balanceUlps - mockCkBTCToken.fee,
         token: mockCkBTCToken,
       })}`
     );
@@ -603,7 +603,7 @@ describe("CkBTCTransactionModal", () => {
       );
       expect(input?.value).toEqual(
         `${ulpsToNumber({
-          ulps: mockCkBTCWithdrawalAccount.balanceE8s,
+          ulps: mockCkBTCWithdrawalAccount.balanceUlps,
           token: mockCkBTCToken,
         })}`
       );

--- a/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
@@ -45,7 +45,7 @@ describe("IcrcTokenTransactionModal", () => {
         accounts: [
           {
             ...mockIcrcMainAccount,
-            balanceE8s: 1000n * 10n ** 18n,
+            balanceUlps: 1000n * 10n ** 18n,
           },
         ],
         certified: true,

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -306,7 +306,7 @@ describe("NnsStakeNeuronModal", () => {
         icpAccountIdentifier: selectedAccountIdentifier,
       });
       // New balance is set in the store.
-      expect(get(icpAccountsStore).main.balanceE8s).toEqual(newBalanceE8s);
+      expect(get(icpAccountsStore).main.balanceUlps).toEqual(newBalanceE8s);
     });
 
     it("should be able to change dissolve delay in the confirmation screen", async () => {

--- a/frontend/src/tests/lib/pages/CkBTCAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCAccounts.spec.ts
@@ -101,7 +101,7 @@ describe("CkBTCAccounts", () => {
 
       expect(cardTitleRow?.textContent.trim()).toEqual(
         `${formatToken({
-          value: mockCkBTCMainAccount.balanceE8s,
+          value: mockCkBTCMainAccount.balanceUlps,
         })} ${mockCkBTCToken.symbol}`
       );
     });

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -219,7 +219,7 @@ describe("CkBTCWallet", () => {
         return Promise.resolve({
           ...mockCkBTCMainAccount,
           ...(afterTransfer
-            ? { balanceE8s: expectedBalanceAfterTransfer }
+            ? { balanceUlps: expectedBalanceAfterTransfer }
             : {}),
         });
       });

--- a/frontend/src/tests/lib/pages/IcrcTokenAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcTokenAccounts.spec.ts
@@ -94,7 +94,7 @@ describe("IcrcTokenAccounts", () => {
       expect(cardTitleRow?.textContent.trim()).toEqual(
         `${formatTokenV2({
           value: TokenAmountV2.fromUlps({
-            amount: mockCkETHMainAccount.balanceE8s,
+            amount: mockCkETHMainAccount.balanceUlps,
             token: mockCkETHTESTToken,
           }),
         })} ${mockCkETHTESTToken.symbol}`

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -112,7 +112,7 @@ describe("NnsAccounts", () => {
         );
 
         expect(cardTitleRow?.textContent.trim()).toEqual(
-          `${formatToken({ value: mockMainAccount.balanceE8s })} ICP`
+          `${formatToken({ value: mockMainAccount.balanceUlps })} ICP`
         );
       });
 

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -136,7 +136,7 @@ describe("NnsWallet", () => {
 
       expect(getByTestId("token-value-label")?.textContent.trim()).toEqual(
         `${formatToken({
-          value: mockMainAccount.balanceE8s,
+          value: mockMainAccount.balanceUlps,
         })} ${ICPToken.symbol}`
       );
     });

--- a/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
@@ -103,7 +103,7 @@ describe("SnsAccounts", () => {
 
       expect(cardTitleRow?.textContent.trim()).toEqual(
         `${formatToken({
-          value: mockSnsMainAccount.balanceE8s,
+          value: mockSnsMainAccount.balanceUlps,
         })} ${mockSnsToken.symbol}`
       );
     });

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -161,7 +161,7 @@ describe("SnsWallet", () => {
           ?.textContent.trim()
       ).toEqual(
         `${formatToken({
-          value: mockSnsMainAccount.balanceE8s,
+          value: mockSnsMainAccount.balanceUlps,
         })} ${mockSnsToken.symbol}`
       );
     });

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -376,7 +376,7 @@ describe("Accounts", () => {
   //     }),
   //     principal: mockIdentity.getPrincipal(),
   //     type: "main",
-  //     balanceE8s: balanceIcrcToken,
+  //     balanceUlps: balanceIcrcToken,
   //   };
   //
   //   await waitFor(() => {
@@ -561,18 +561,18 @@ describe("Accounts", () => {
         icpAccountsStore.setForTesting({
           main: {
             ...mockMainAccount,
-            balanceE8s: 314000000n,
+            balanceUlps: 314000000n,
           },
           subAccounts: [
             {
               ...mockSubAccount,
-              balanceE8s: 123456789000000n,
+              balanceUlps: 123456789000000n,
             },
           ],
           hardwareWallets: [
             {
               ...mockHardwareWalletAccount,
-              balanceE8s: 222000000n,
+              balanceUlps: 222000000n,
             },
           ],
         });

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -187,7 +187,7 @@ describe("Wallet", () => {
         accounts: [
           {
             ...mockIcrcMainAccount,
-            balanceE8s: balanceBeforeTransfer,
+            balanceUlps: balanceBeforeTransfer,
           },
         ],
         certified: true,

--- a/frontend/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/canisters.services.spec.ts
@@ -427,7 +427,7 @@ describe("canisters-services", () => {
     it("should call api to create a canister", async () => {
       const account = {
         ...mockMainAccount,
-        balanceE8s: 500000000n,
+        balanceUlps: 500000000n,
       };
       const canisterId = await createCanister({
         amount: 3,
@@ -442,7 +442,7 @@ describe("canisters-services", () => {
     it("should not call api if account doesn't have enough funds", async () => {
       const account = {
         ...mockMainAccount,
-        balanceE8s: 200000000n,
+        balanceUlps: 200000000n,
       };
       const canisterId = await createCanister({
         amount: 3,
@@ -457,7 +457,7 @@ describe("canisters-services", () => {
     it("should show toast error if account doesn't have enough funds", async () => {
       const account = {
         ...mockMainAccount,
-        balanceE8s: 200000000n,
+        balanceUlps: 200000000n,
       };
       const canisterId = await createCanister({
         amount: 3,
@@ -492,7 +492,7 @@ describe("canisters-services", () => {
     it("should call api to top up a canister", async () => {
       const account = {
         ...mockMainAccount,
-        balanceE8s: 500000000n,
+        balanceUlps: 500000000n,
       };
       const { success } = await topUpCanister({
         amount: 3,
@@ -507,7 +507,7 @@ describe("canisters-services", () => {
     it("should not call api if account doesn't have enough funds", async () => {
       const account = {
         ...mockMainAccount,
-        balanceE8s: 200000000n,
+        balanceUlps: 200000000n,
       };
       const { success } = await topUpCanister({
         amount: 3,
@@ -522,7 +522,7 @@ describe("canisters-services", () => {
     it("should show toast error if account doesn't have enough funds", async () => {
       const account = {
         ...mockMainAccount,
-        balanceE8s: 200000000n,
+        balanceUlps: 200000000n,
       };
       const { success } = await topUpCanister({
         amount: 3,

--- a/frontend/src/tests/lib/services/ckbtc-accounts-loader.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-accounts-loader.services.spec.ts
@@ -66,7 +66,7 @@ describe("ckbtc-accounts-loader-services", () => {
           .spyOn(ledgerApi, "getAccount")
           .mockResolvedValue({
             ...mockCkBTCWithdrawalAccount,
-            balanceE8s: mockAccountBalance.toE8s(),
+            balanceUlps: mockAccountBalance.toE8s(),
           });
       });
 
@@ -77,7 +77,7 @@ describe("ckbtc-accounts-loader-services", () => {
         });
 
         expect(result.identifier).toBeUndefined();
-        expect(result.balanceE8s).toBeUndefined();
+        expect(result.balanceUlps).toBeUndefined();
 
         expect(spyGetCkBTCAccount).not.toHaveBeenCalled();
       });
@@ -97,7 +97,7 @@ describe("ckbtc-accounts-loader-services", () => {
         });
 
         expect(result.identifier).toEqual(mockCkBTCWithdrawalIdentifier);
-        expect(result.balanceE8s).toEqual(mockAccountBalance.toE8s());
+        expect(result.balanceUlps).toEqual(mockAccountBalance.toE8s());
 
         expect(spyGetCkBTCAccount).toHaveBeenCalledWith({
           identity: params.identity,
@@ -124,7 +124,7 @@ describe("ckbtc-accounts-loader-services", () => {
           const result = await getCkBTCWithdrawalAccount(params);
 
           expect(result.identifier).toEqual(mockCkBTCWithdrawalIdentifier);
-          expect(result.balanceE8s).toEqual(mockAccountBalance.toE8s());
+          expect(result.balanceUlps).toEqual(mockAccountBalance.toE8s());
 
           expect(spyGetCkBTCAccount).toHaveBeenCalledWith({
             identity: params.identity,

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -226,7 +226,7 @@ describe("icp-accounts.services", () => {
         mockAccountDetails
       );
       vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
-        mockMainAccount.balanceE8s
+        mockMainAccount.balanceUlps
       );
       const certified = true;
       const result = await loadAccounts({
@@ -256,7 +256,7 @@ describe("icp-accounts.services", () => {
         account_identifier: mockMainAccount.identifier,
       });
       vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
-        mockHardwareWalletAccount.balanceE8s
+        mockHardwareWalletAccount.balanceUlps
       );
       const certified = true;
 
@@ -307,7 +307,7 @@ describe("icp-accounts.services", () => {
         }).toHex(),
       });
       vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
-        mockHardwareWalletAccount.balanceE8s
+        mockHardwareWalletAccount.balanceUlps
       );
       const certified = true;
 
@@ -354,7 +354,7 @@ describe("icp-accounts.services", () => {
       const mockAccounts = {
         main: {
           ...mockMainAccount,
-          balanceE8s: mainBalanceE8s,
+          balanceUlps: mainBalanceE8s,
         },
         subAccounts: [],
         hardwareWallets: [],
@@ -402,7 +402,7 @@ describe("icp-accounts.services", () => {
       const mockAccounts = {
         main: {
           ...mockMainAccount,
-          balanceE8s: mainBalanceE8s,
+          balanceUlps: mainBalanceE8s,
         },
         subAccounts: [],
         hardwareWallets: [],
@@ -469,7 +469,7 @@ describe("icp-accounts.services", () => {
       }) => ({
         main: {
           ...mockMainAccount,
-          balanceE8s: mainBalanceE8s,
+          balanceUlps: mainBalanceE8s,
         },
         subAccounts: [],
         hardwareWallets: [],
@@ -514,7 +514,7 @@ describe("icp-accounts.services", () => {
       }) => ({
         main: {
           ...mockMainAccount,
-          balanceE8s: mainBalanceE8s,
+          balanceUlps: mainBalanceE8s,
         },
         subAccounts: [],
         hardwareWallets: [],
@@ -555,8 +555,8 @@ describe("icp-accounts.services", () => {
       icpAccountsStore.setForTesting({
         main: mockMainAccount,
       });
-      expect(get(icpAccountsStore).main.balanceE8s).toEqual(
-        mockMainAccount.balanceE8s
+      expect(get(icpAccountsStore).main.balanceUlps).toEqual(
+        mockMainAccount.balanceUlps
       );
       await loadBalance({ accountIdentifier: mockMainAccount.identifier });
 
@@ -572,7 +572,7 @@ describe("icp-accounts.services", () => {
       });
       expect(queryAccountBalanceSpy).toBeCalledTimes(2);
 
-      expect(get(icpAccountsStore).main.balanceE8s).toEqual(newBalanceE8s);
+      expect(get(icpAccountsStore).main.balanceUlps).toEqual(newBalanceE8s);
     });
 
     it("should not show error if only query fails", async () => {
@@ -636,7 +636,7 @@ describe("icp-accounts.services", () => {
       }) => ({
         main: {
           ...mockMainAccount,
-          balanceE8s: mainBalanceE8s,
+          balanceUlps: mainBalanceE8s,
         },
         subAccounts: [],
         hardwareWallets: [],
@@ -710,7 +710,7 @@ describe("icp-accounts.services", () => {
       const mockAccounts = {
         main: {
           ...mockMainAccount,
-          balanceE8s: mainBalanceE8s,
+          balanceUlps: mainBalanceE8s,
         },
         subAccounts: [],
         hardwareWallets: [],
@@ -1161,7 +1161,7 @@ describe("icp-accounts.services", () => {
     const mockAccounts = {
       main: {
         ...mockMainAccount,
-        balanceE8s: mainBalanceE8s,
+        balanceUlps: mainBalanceE8s,
       },
       subAccounts: [],
       hardwareWallets: [],

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -28,7 +28,7 @@ describe("icrc-accounts-services", () => {
     }),
     principal: mockIdentity.getPrincipal(),
     type: "main",
-    balanceE8s,
+    balanceUlps: balanceE8s,
   };
 
   beforeEach(() => {
@@ -255,7 +255,7 @@ describe("icrc-accounts-services", () => {
     it("should load balance after transfer", async () => {
       const initialAccount = {
         ...mockIcrcMainAccount,
-        balanceE8s: balanceE8s + amountE8s,
+        balanceUlps: balanceE8s + amountE8s,
       };
       icrcAccountsStore.set({
         universeId: ledgerCanisterId,
@@ -276,7 +276,7 @@ describe("icrc-accounts-services", () => {
       const finalAccount =
         get(icrcAccountsStore)[ledgerCanisterId.toText()]?.accounts[0];
 
-      expect(finalAccount.balanceE8s).toEqual(balanceE8s);
+      expect(finalAccount.balanceUlps).toEqual(balanceE8s);
     });
   });
 });

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -308,7 +308,7 @@ describe("neurons-services", () => {
         amount,
         account: {
           ...mockMainAccount,
-          balanceE8s: BigInt(amount - 1),
+          balanceUlps: BigInt(amount - 1),
         },
       });
 

--- a/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
@@ -56,7 +56,7 @@ describe("sns-accounts-balance.services", () => {
     // Nns + 1 Sns
     expect(Object.keys(store)).toHaveLength(2);
     expect(store[summary.rootCanisterId.toText()].balanceE8s).toEqual(
-      mockSnsMainAccount.balanceE8s
+      mockSnsMainAccount.balanceUlps
     );
     expect(spyQuery).toBeCalled();
   });

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -1031,7 +1031,7 @@ describe("sns-api", () => {
       const postprocessSpy = vi.fn().mockResolvedValue(undefined);
       const upgradeProgressSpy = vi.fn().mockResolvedValue(undefined);
 
-      expect(get(icpAccountsStore).main.balanceE8s).not.toEqual(newBalanceE8s);
+      expect(get(icpAccountsStore).main.balanceUlps).not.toEqual(newBalanceE8s);
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
@@ -1042,7 +1042,7 @@ describe("sns-api", () => {
         ticket: testTicket,
       });
 
-      expect(get(icpAccountsStore).main.balanceE8s).toEqual(newBalanceE8s);
+      expect(get(icpAccountsStore).main.balanceUlps).toEqual(newBalanceE8s);
     });
 
     it("should update subaccounts's balance in the store", async () => {
@@ -1058,7 +1058,7 @@ describe("sns-api", () => {
       const postprocessSpy = vi.fn().mockResolvedValue(undefined);
       const upgradeProgressSpy = vi.fn().mockResolvedValue(undefined);
 
-      expect(get(icpAccountsStore).main.balanceE8s).not.toEqual(newBalanceE8s);
+      expect(get(icpAccountsStore).main.balanceUlps).not.toEqual(newBalanceE8s);
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
@@ -1069,7 +1069,7 @@ describe("sns-api", () => {
         ticket: snsTicket.ticket,
       });
 
-      expect(get(icpAccountsStore).subAccounts[0].balanceE8s).toEqual(
+      expect(get(icpAccountsStore).subAccounts[0].balanceUlps).toEqual(
         newBalanceE8s
       );
     });

--- a/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
@@ -59,7 +59,7 @@ describe("wallet-uncertified-accounts.services", () => {
     // Nns + ckBTC + ckTESTBTC
     expect(Object.keys(store)).toHaveLength(3);
     expect(store[CKBTC_UNIVERSE_CANISTER_ID.toText()].balanceE8s).toEqual(
-      mockCkBTCMainAccount.balanceE8s
+      mockCkBTCMainAccount.balanceUlps
     );
     expect(spyQuery).toBeCalled();
   });

--- a/frontend/src/tests/lib/stores/ckbtc-withdrawal-accounts.store.spec.ts
+++ b/frontend/src/tests/lib/stores/ckbtc-withdrawal-accounts.store.spec.ts
@@ -33,8 +33,8 @@ describe("ckbtc-withdrawal-accounts-store", () => {
       ]?.account.principal.toText()
     ).toEqual(mockCkBTCWithdrawalIcrcAccount.owner.toText());
     expect(
-      store2[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]?.account.balanceE8s
-    ).toEqual(mockCkBTCWithdrawalAccount.balanceE8s);
+      store2[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]?.account.balanceUlps
+    ).toEqual(mockCkBTCWithdrawalAccount.balanceUlps);
   });
 
   it("should reset", () => {

--- a/frontend/src/tests/lib/stores/icp-accounts.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icp-accounts.store.spec.ts
@@ -108,8 +108,8 @@ describe("icpAccountsStore", () => {
     it("should set balance for main account", () => {
       accountsStoreSet({ main: mockMainAccount, subAccounts: [] });
 
-      expect(get(icpAccountsStore)?.main.balanceE8s).toEqual(
-        mockMainAccount.balanceE8s
+      expect(get(icpAccountsStore)?.main.balanceUlps).toEqual(
+        mockMainAccount.balanceUlps
       );
       const newBalanceE8s = BigInt(100);
       accountsStoreSetBalance({
@@ -117,7 +117,7 @@ describe("icpAccountsStore", () => {
         balanceE8s: newBalanceE8s,
       });
 
-      expect(get(icpAccountsStore)?.main.balanceE8s).toEqual(newBalanceE8s);
+      expect(get(icpAccountsStore)?.main.balanceUlps).toEqual(newBalanceE8s);
     });
 
     it("should set balance for subaccount", () => {
@@ -126,8 +126,8 @@ describe("icpAccountsStore", () => {
         subAccounts: [mockSubAccount],
       });
 
-      expect(get(icpAccountsStore)?.subAccounts[0].balanceE8s).toEqual(
-        mockSubAccount.balanceE8s
+      expect(get(icpAccountsStore)?.subAccounts[0].balanceUlps).toEqual(
+        mockSubAccount.balanceUlps
       );
       const newBalanceE8s = BigInt(100);
       accountsStoreSetBalance({
@@ -136,8 +136,8 @@ describe("icpAccountsStore", () => {
       });
 
       const store = get(icpAccountsStore);
-      expect(store?.subAccounts[0].balanceE8s).toEqual(newBalanceE8s);
-      expect(store.main.balanceE8s).toEqual(mockMainAccount.balanceE8s);
+      expect(store?.subAccounts[0].balanceUlps).toEqual(newBalanceE8s);
+      expect(store.main.balanceUlps).toEqual(mockMainAccount.balanceUlps);
     });
 
     it("should set balance for hw account", () => {
@@ -147,8 +147,8 @@ describe("icpAccountsStore", () => {
         hardwareWallets: [mockHardwareWalletAccount],
       });
 
-      expect(get(icpAccountsStore)?.hardwareWallets[0].balanceE8s).toEqual(
-        mockHardwareWalletAccount.balanceE8s
+      expect(get(icpAccountsStore)?.hardwareWallets[0].balanceUlps).toEqual(
+        mockHardwareWalletAccount.balanceUlps
       );
       const newBalanceE8s = BigInt(100);
       accountsStoreSetBalance({
@@ -156,7 +156,7 @@ describe("icpAccountsStore", () => {
         balanceE8s: newBalanceE8s,
       });
 
-      expect(get(icpAccountsStore)?.hardwareWallets[0].balanceE8s).toEqual(
+      expect(get(icpAccountsStore)?.hardwareWallets[0].balanceUlps).toEqual(
         newBalanceE8s
       );
     });
@@ -175,13 +175,13 @@ describe("icpAccountsStore", () => {
       });
 
       const store = get(icpAccountsStore);
-      expect(store?.hardwareWallets[0].balanceE8s).toEqual(
-        mockHardwareWalletAccount.balanceE8s
+      expect(store?.hardwareWallets[0].balanceUlps).toEqual(
+        mockHardwareWalletAccount.balanceUlps
       );
-      expect(store?.subAccounts[0].balanceE8s).toEqual(
-        mockSubAccount.balanceE8s
+      expect(store?.subAccounts[0].balanceUlps).toEqual(
+        mockSubAccount.balanceUlps
       );
-      expect(store?.main.balanceE8s).toEqual(mockMainAccount.balanceE8s);
+      expect(store?.main.balanceUlps).toEqual(mockMainAccount.balanceUlps);
     });
 
     it("should reapply set balance on new data from an older request", () => {
@@ -193,12 +193,12 @@ describe("icpAccountsStore", () => {
       const dataWithBalances = ({ mainBalance, subBalance, certified }) => ({
         main: {
           ...mockMainAccount,
-          balanceE8s: mainBalance,
+          balanceUlps: mainBalance,
         },
         subAccounts: [
           {
             ...mockSubAccount,
-            balanceE8s: subBalance,
+            balanceUlps: subBalance,
           },
         ],
         certified,
@@ -211,8 +211,8 @@ describe("icpAccountsStore", () => {
         mainBalance: bigint;
         subBalance: bigint;
       }) => {
-        expect(get(icpAccountsStore)?.main.balanceE8s).toEqual(mainBalance);
-        expect(get(icpAccountsStore)?.subAccounts[0].balanceE8s).toEqual(
+        expect(get(icpAccountsStore)?.main.balanceUlps).toEqual(mainBalance);
+        expect(get(icpAccountsStore)?.subAccounts[0].balanceUlps).toEqual(
           subBalance
         );
       };

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -562,7 +562,7 @@ describe("accounts-utils", () => {
         assertEnoughAccountFunds({
           account: {
             ...mockMainAccount,
-            balanceE8s: amountE8s,
+            balanceUlps: amountE8s,
           },
           amountE8s: amountE8s + BigInt(10_000),
         });
@@ -575,7 +575,7 @@ describe("accounts-utils", () => {
         assertEnoughAccountFunds({
           account: {
             ...mockMainAccount,
-            balanceE8s: amountE8s,
+            balanceUlps: amountE8s,
           },
           amountE8s: amountE8s - BigInt(10_000),
         });
@@ -631,9 +631,9 @@ describe("accounts-utils", () => {
   describe("sumNnsAccounts", () => {
     it("should sum accounts balance", () => {
       let totalBalance =
-        mockMainAccount.balanceE8s +
-        mockSubAccount.balanceE8s +
-        mockHardwareWalletAccount.balanceE8s;
+        mockMainAccount.balanceUlps +
+        mockSubAccount.balanceUlps +
+        mockHardwareWalletAccount.balanceUlps;
 
       expect(
         sumNnsAccounts({
@@ -643,7 +643,7 @@ describe("accounts-utils", () => {
         })
       ).toEqual(totalBalance);
 
-      totalBalance = mockMainAccount.balanceE8s + mockSubAccount.balanceE8s;
+      totalBalance = mockMainAccount.balanceUlps + mockSubAccount.balanceUlps;
 
       expect(
         sumNnsAccounts({
@@ -653,7 +653,7 @@ describe("accounts-utils", () => {
         })
       ).toEqual(totalBalance);
 
-      totalBalance = mockMainAccount.balanceE8s;
+      totalBalance = mockMainAccount.balanceUlps;
 
       expect(
         sumNnsAccounts({
@@ -668,13 +668,13 @@ describe("accounts-utils", () => {
   describe("sumAccounts", () => {
     it("should sum accounts balance", () => {
       let totalBalance =
-        mockSnsMainAccount.balanceE8s + mockSnsSubAccount.balanceE8s;
+        mockSnsMainAccount.balanceUlps + mockSnsSubAccount.balanceUlps;
 
       expect(sumAccounts([mockSnsMainAccount, mockSnsSubAccount])).toEqual(
         totalBalance
       );
 
-      totalBalance = mockSnsMainAccount.balanceE8s;
+      totalBalance = mockSnsMainAccount.balanceUlps;
 
       expect(sumAccounts([mockSnsMainAccount])).toEqual(totalBalance);
     });

--- a/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
@@ -109,7 +109,7 @@ describe("ckbtc.utils", () => {
           ulps:
             RETRIEVE_BTC_MIN_AMOUNT +
             params.transactionFee +
-            params.sourceAccount.balanceE8s,
+            params.sourceAccount.balanceUlps,
           token: mockCkBTCToken,
         }),
       })

--- a/frontend/src/tests/mocks/ckbtc-accounts.mock.ts
+++ b/frontend/src/tests/mocks/ckbtc-accounts.mock.ts
@@ -21,7 +21,7 @@ export const mockCkBTCMainAccount: Account = {
   identifier: encodeIcrcAccount({
     owner: mockPrincipal,
   }),
-  balanceE8s: 444556698700000n,
+  balanceUlps: 444556698700000n,
   principal: mockPrincipal,
   type: "main",
 };
@@ -34,7 +34,7 @@ export const mockCkBTCWithdrawalIcrcAccount = decodeIcrcAccount(
 
 export const mockCkBTCWithdrawalAccount: Account = {
   identifier: mockCkBTCWithdrawalIdentifier,
-  balanceE8s: 98711100000n,
+  balanceUlps: 98711100000n,
   principal: mockCkBTCWithdrawalIcrcAccount.owner,
   type: "withdrawalAccount",
 };

--- a/frontend/src/tests/mocks/cketh-accounts.mock.ts
+++ b/frontend/src/tests/mocks/cketh-accounts.mock.ts
@@ -21,7 +21,7 @@ export const mockCkETHMainAccount: Account = {
   identifier: encodeIcrcAccount({
     owner: mockPrincipal,
   }),
-  balanceE8s: 123000000000000000000n,
+  balanceUlps: 123000000000000000000n,
   principal: mockPrincipal,
   type: "main",
 };

--- a/frontend/src/tests/mocks/icp-accounts.store.mock.ts
+++ b/frontend/src/tests/mocks/icp-accounts.store.mock.ts
@@ -13,7 +13,7 @@ export const mockMainAccount: IcpAccount = {
     "d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f",
   icpIdentifier:
     "d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f",
-  balanceE8s: 123456789010000n,
+  balanceUlps: 123456789010000n,
   principal: Principal.fromText("aaaaa-aa"),
   type: "main",
 };
@@ -28,7 +28,7 @@ export const mockSubAccount: IcpAccount = {
     "d0654c53339c85e0e5fff46a2d800101bc3d896caef34e1a0597426792ff9f32",
   icpIdentifier:
     "d0654c53339c85e0e5fff46a2d800101bc3d896caef34e1a0597426792ff9f32",
-  balanceE8s: 123456789010000n,
+  balanceUlps: 123456789010000n,
   subAccount: mockSubAccountArray,
   name: "test subaccount",
   type: "subAccount",
@@ -43,7 +43,7 @@ export const mockHardwareWalletAccount: IcpAccount = {
     "646f4d2d6fcb6fab5ba1547647526b666553467ecb5cb28c8d9ddf451c8f4c21",
   icpIdentifier:
     "646f4d2d6fcb6fab5ba1547647526b666553467ecb5cb28c8d9ddf451c8f4c21",
-  balanceE8s: 123456789010000n,
+  balanceUlps: 123456789010000n,
   principal: hardwareWalletPrincipal,
   name: "hardware wallet account test",
   type: "hardwareWallet",

--- a/frontend/src/tests/mocks/icrc-accounts.mock.ts
+++ b/frontend/src/tests/mocks/icrc-accounts.mock.ts
@@ -6,7 +6,7 @@ export const mockIcrcMainAccount: Account = {
   identifier: encodeIcrcAccount({
     owner: mockPrincipal,
   }),
-  balanceE8s: 890156712340000n,
+  balanceUlps: 890156712340000n,
   principal: mockPrincipal,
   type: "main",
 };

--- a/frontend/src/tests/mocks/sns-accounts.mock.ts
+++ b/frontend/src/tests/mocks/sns-accounts.mock.ts
@@ -16,7 +16,7 @@ export const mockSnsMainAccount: Account = {
   identifier: encodeIcrcAccount({
     owner: mockPrincipal,
   }),
-  balanceE8s: 890156712340000n,
+  balanceUlps: 890156712340000n,
   principal: mockPrincipal,
   type: "main",
 };
@@ -26,7 +26,7 @@ export const mockSnsSubAccount: Account = {
     owner: mockPrincipal,
     subaccount: Uint8Array.from(mockSubAccountArray),
   }),
-  balanceE8s: 567123401890000n,
+  balanceUlps: 567123401890000n,
   subAccount: mockSubAccountArray,
   name: "test subaccount",
   type: "subAccount",

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -107,19 +107,19 @@ describe("Tokens route", () => {
           const accountMap = {
             [CKBTC_UNIVERSE_CANISTER_ID.toText()]: {
               ...mockCkBTCMainAccount,
-              balanceE8s: ckBTCBalanceE8s,
+              balanceUlps: ckBTCBalanceE8s,
             },
             [CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]: {
               ...mockCkBTCMainAccount,
-              balanceE8s: ckBTCBalanceE8s,
+              balanceUlps: ckBTCBalanceE8s,
             },
             [CKETH_UNIVERSE_CANISTER_ID.toText()]: {
               ...mockCkETHMainAccount,
-              balanceE8s: ckETHBalanceUlps,
+              balanceUlps: ckETHBalanceUlps,
             },
             [CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText()]: {
               ...mockCkETHMainAccount,
-              balanceE8s: ckETHBalanceUlps,
+              balanceUlps: ckETHBalanceUlps,
             },
           };
           if (isNullish(accountMap[canisterId.toText()])) {
@@ -137,14 +137,14 @@ describe("Tokens route", () => {
             return [
               {
                 ...mockSnsMainAccount,
-                balanceE8s: tetrisBalanceE8s,
+                balanceUlps: tetrisBalanceE8s,
               },
             ];
           }
           return [
             {
               ...mockSnsMainAccount,
-              balanceE8s: pacmanBalanceE8s,
+              balanceUlps: pacmanBalanceE8s,
             },
           ];
         }
@@ -186,7 +186,7 @@ describe("Tokens route", () => {
         certified: true,
       });
       icpAccountsStore.setForTesting({
-        main: { ...mockMainAccount, balanceE8s: icpBalanceE8s },
+        main: { ...mockMainAccount, balanceUlps: icpBalanceE8s },
       });
     });
 


### PR DESCRIPTION
# Motivation

The nns-dapp `Account` type has a field called `balanceE8s` but this type is also used for ckETH which has 18 decimals.
So the name `balanceE8s` is misleading in that case.

# Changes

1. Renamed `balanceE8s` to `balanceUlps`.
2. Added a few TODOs of related things that should be renamed.

# Tests

pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary