### PR TITLE
GIX-1983: Add TokenAmountV2 ckBTC transaction modal

### DIFF
--- a/frontend/src/lib/derived/universes-tokens.derived.ts
+++ b/frontend/src/lib/derived/universes-tokens.derived.ts
@@ -9,7 +9,7 @@ import type {
 } from "$lib/stores/tokens.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { UniverseCanisterIdText } from "$lib/types/universe";
-import { TokenAmount, nonNullish } from "@dfinity/utils";
+import { TokenAmountV2, nonNullish } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 
 export const nnsTokenStore = derived<
@@ -35,14 +35,14 @@ export const ckBTCTokenFeeStore = derived<
       Record<UniverseCanisterIdText, TokensStoreUniverseData | undefined>
     >,
   ],
-  Record<UniverseCanisterIdText, TokenAmount | undefined>
+  Record<UniverseCanisterIdText, TokenAmountV2 | undefined>
 >([ckBTCTokenStore], ([$ckBTCTokenStore]) =>
   Object.entries($ckBTCTokenStore).reduce(
     (acc, [key, value]) => ({
       ...acc,
       [key]:
         nonNullish(value) && nonNullish(value?.token)
-          ? TokenAmount.fromE8s({
+          ? TokenAmountV2.fromUlps({
               amount: value.token.fee,
               token: {
                 name: value.token.name,

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -12,7 +12,7 @@
   import type { Account } from "$lib/types/account";
   import type { WizardStep } from "@dfinity/gix-components";
   import { ckBTCTransferTokens } from "$lib/services/ckbtc-accounts.services";
-  import { TokenAmount, TokenAmountV2, type Token } from "@dfinity/utils";
+  import { TokenAmountV2, type Token } from "@dfinity/utils";
   import { isUniverseCkTESTBTC } from "$lib/utils/universe.utils";
   import type { UniverseCanisterId } from "$lib/types/universe";
   import type { CkBTCAdditionalCanisters } from "$lib/types/ckbtc-canisters";
@@ -35,14 +35,13 @@
     ckBTCInfoStore,
     type CkBTCInfoStoreUniverseData,
   } from "$lib/stores/ckbtc-info.store";
-  import { toTokenAmountV2 } from "$lib/utils/token.utils";
 
   export let selectedAccount: Account | undefined = undefined;
 
   export let canisters: CkBTCAdditionalCanisters;
   export let universeId: UniverseCanisterId;
   export let token: Token;
-  export let transactionFee: TokenAmount | TokenAmountV2;
+  export let transactionFee: TokenAmountV2;
 
   let withdrawalAccount = selectedAccount?.type === "withdrawalAccount";
 
@@ -58,14 +57,12 @@
 
   // If ckBTC are converted to BTC from the withdrawal account there is no transfer to the ckBTC ledger, therefore no related fee will be applied
   let fee: TokenAmountV2;
-  $: fee = toTokenAmountV2(
-    withdrawalAccount
-      ? TokenAmountV2.fromUlps({
-          amount: 0n,
-          token: transactionFee.token,
-        })
-      : transactionFee
-  );
+  $: fee = withdrawalAccount
+    ? TokenAmountV2.fromUlps({
+        amount: 0n,
+        token: transactionFee.token,
+      })
+    : transactionFee;
 
   let selectedNetwork: TransactionNetwork | undefined = withdrawalAccount
     ? isUniverseCkTESTBTC(universeId)

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionTokenModal.svelte
@@ -10,7 +10,7 @@
   } from "$lib/derived/universes-tokens.derived";
   import type { UniverseCanisterId } from "$lib/types/universe";
   import type { TokensStoreUniverseData } from "$lib/stores/tokens.store";
-  import type { TokenAmount } from "@dfinity/utils";
+  import type { TokenAmountV2 } from "@dfinity/utils";
   import type { CkBTCAdditionalCanisters } from "$lib/types/ckbtc-canisters";
 
   export let data: CkBTCTransactionModalData;
@@ -32,7 +32,7 @@
   let token: TokensStoreUniverseData | undefined = undefined;
   $: token = $ckBTCTokenStore[universeId.toText()];
 
-  let transactionFee: TokenAmount | undefined = undefined;
+  let transactionFee: TokenAmountV2 | undefined = undefined;
   $: transactionFee = $ckBTCTokenFeeStore[universeId.toText()];
 </script>
 

--- a/frontend/src/tests/lib/derived/universes-tokens.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-tokens.derived.spec.ts
@@ -15,7 +15,7 @@ import {
   mockTokensSubscribe,
   mockUniversesTokens,
 } from "$tests/mocks/tokens.mock";
-import { TokenAmount } from "@dfinity/utils";
+import { TokenAmountV2 } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("universes-tokens", () => {
@@ -52,7 +52,7 @@ describe("universes-tokens", () => {
     it("should derive ckBTC token fee", () => {
       const tokenFee = get(ckBTCTokenFeeStore);
 
-      const expectedFee = TokenAmount.fromE8s({
+      const expectedFee = TokenAmountV2.fromUlps({
         amount: mockCkBTCToken.fee,
         token: {
           name: mockCkBTCToken.name,

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -31,7 +31,7 @@ import {
   testTransferTokens,
 } from "$tests/utils/transaction-modal.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
-import { TokenAmount } from "@dfinity/utils";
+import { TokenAmountV2 } from "@dfinity/utils";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import { SvelteComponent, tick } from "svelte";
 import { get } from "svelte/store";
@@ -47,7 +47,7 @@ describe("CkBTCTransactionModal", () => {
       props: {
         selectedAccount,
         token: mockCkBTCToken,
-        transactionFee: TokenAmount.fromE8s({
+        transactionFee: TokenAmountV2.fromUlps({
           amount: mockCkBTCToken.fee,
           token: mockCkBTCToken,
         }),


### PR DESCRIPTION
# Motivation

Use CkBTCTransactionModal in Tokens page. To do that, I need the `CkBTCTransactionModal` to accept `TokenAmountV2` as fee and the token to be type `Token` instead of `IcrcTokenMetadata`.

# Changes

* Change prop type `transactionFee` and `token` in CkBTCTransactionModal.
* Change the type of derived store `ckBTCTokenFeeStore`.
* Change type of local variable in CkBTCTransactionTokenModal

# Tests

* Change expect type in `ckBTCTokenFeeStore`.
* Change the prop type in CkBTCTransactionModal test file.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
