### PR TITLE
GIX-2110: Populate rowHref icp accounts

### DIFF
--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -7,6 +7,7 @@ import {
 import type { Account, AccountType } from "$lib/types/account";
 import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
 import type { Universe } from "$lib/types/universe";
+import { buildWalletUrl } from "$lib/utils/navigation.utils";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { Principal } from "@dfinity/principal";
 import { isNullish, nonNullish, TokenAmountV2 } from "@dfinity/utils";
@@ -51,6 +52,12 @@ const convertAccountToUserTokenData = ({
       amount: NNS_TOKEN_DATA.fee,
       token: NNS_TOKEN_DATA,
     }),
+    rowHref: nonNullish(account)
+      ? buildWalletUrl({
+          universe: nnsUniverse.canisterId.toString(),
+          account: account?.identifier,
+        })
+      : undefined,
     actions: nonNullish(account)
       ? [UserTokenAction.Receive, UserTokenAction.Send]
       : [],

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -1,7 +1,9 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import { icpTokensListUser } from "$lib/derived/icp-tokens-list-user.derived";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
+import { buildWalletUrl } from "$lib/utils/navigation.utils";
 import {
   mockHardwareWalletAccount,
   mockMainAccount,
@@ -29,6 +31,10 @@ describe("icp-tokens-list-user.derived", () => {
     }),
     title: "Main",
     subtitle: undefined,
+    rowHref: buildWalletUrl({
+      universe: OWN_CANISTER_ID_TEXT,
+      account: mockMainAccount.identifier,
+    }),
   };
   const subaccountUserTokenData: UserTokenData = {
     ...icpTokenUser,
@@ -38,6 +44,10 @@ describe("icp-tokens-list-user.derived", () => {
     }),
     title: mockSubAccount.name,
     subtitle: "Linked Account",
+    rowHref: buildWalletUrl({
+      universe: OWN_CANISTER_ID_TEXT,
+      account: mockSubAccount.identifier,
+    }),
   };
   const hardwareWalletUserTokenData: UserTokenData = {
     ...icpTokenUser,
@@ -47,6 +57,10 @@ describe("icp-tokens-list-user.derived", () => {
     }),
     title: mockHardwareWalletAccount.name,
     subtitle: "Hardware Wallet",
+    rowHref: buildWalletUrl({
+      universe: OWN_CANISTER_ID_TEXT,
+      account: mockHardwareWalletAccount.identifier,
+    }),
   };
 
   describe("icpTokensListVisitors", () => {


### PR DESCRIPTION
# Motivation

Users can navigate to the wallet page from the ICP accounts page with the tokens table.

# Changes

* Populate `rowHref` in `icpTokensListUser` derived store.

# Tests

* Add new field to the `icpTokensListUser` test data.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
