### PR TITLE
GIX-2059: Add Account from ICP tokens table

### DIFF
--- a/frontend/src/lib/modals/accounts/AccountsModals.svelte
+++ b/frontend/src/lib/modals/accounts/AccountsModals.svelte
@@ -10,6 +10,7 @@
   import IcrcReceiveModal from "$lib/modals/accounts/IcrcReceiveModal.svelte";
   import BuyIcpModal from "./BuyIcpModal.svelte";
   import type { Account } from "$lib/types/account";
+  import AddAccountModal from "./AddAccountModal.svelte";
 
   let modal:
     | AccountsModal<AccountsReceiveModalData | AccountsModalData>
@@ -46,4 +47,8 @@
 
 {#if type === "icrc-receive" && nonNullish(data)}
   <IcrcReceiveModal on:nnsClose={close} {data} />
+{/if}
+
+{#if type === "add-icp-account"}
+  <AddAccountModal on:nnsClose={close} />
 {/if}

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -34,9 +34,7 @@
   const openAddAccountModal = () => {
     openAccountsModal({
       type: "add-icp-account",
-      data: {
-        account: undefined,
-      },
+      data: undefined,
     });
   };
 </script>
@@ -57,9 +55,7 @@
         aria-label={$i18n.accounts.add_account}
         tabindex={userTokensData.length + 1}
       >
-        <button
-          class="ghost with-icon"
-          on:click|stopPropagation={openAddAccountModal}
+        <button class="ghost with-icon"
           ><IconAdd />{$i18n.accounts.add_account}</button
         >
       </div>

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -16,6 +16,7 @@
   import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { IconAdd } from "@dfinity/gix-components";
+  import { openAccountsModal } from "$lib/utils/modals.utils";
 
   onMount(() => {
     if (!$ENABLE_MY_TOKENS) {
@@ -29,6 +30,15 @@
 
   // TODO: Remove default value when we remove the feature flag
   export let userTokensData: UserTokenData[] = [];
+
+  const openAddAccountModal = () => {
+    openAccountsModal({
+      type: "add-icp-account",
+      data: {
+        account: undefined,
+      },
+    });
+  };
 </script>
 
 {#if $ENABLE_MY_TOKENS}
@@ -37,9 +47,19 @@
       {userTokensData}
       firstColumnHeader={$i18n.tokens.accounts_header}
     >
-      <div slot="last-row" class="add-account-row">
-        <!-- TODO: Add functionality to "Add Account" -->
-        <button class="ghost with-icon"
+      <div
+        slot="last-row"
+        class="add-account-row"
+        data-tid="add-account-row"
+        on:click={openAddAccountModal}
+        on:keypress={openAddAccountModal}
+        role="button"
+        aria-label={$i18n.accounts.add_account}
+        tabindex={userTokensData.length + 1}
+      >
+        <button
+          class="ghost with-icon"
+          on:click|stopPropagation={openAddAccountModal}
           ><IconAdd />{$i18n.accounts.add_account}</button
         >
       </div>

--- a/frontend/src/lib/types/accounts.modal.ts
+++ b/frontend/src/lib/types/accounts.modal.ts
@@ -1,7 +1,11 @@
 import type { Account } from "$lib/types/account";
 import type { UniverseCanisterId } from "$lib/types/universe";
 
-export type AccountsModalType = "nns-receive" | "icrc-receive" | "buy-icp";
+export type AccountsModalType =
+  | "nns-receive"
+  | "icrc-receive"
+  | "buy-icp"
+  | "add-icp-account";
 
 export interface AccountsModalData {
   account: Account | undefined;

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -86,6 +86,26 @@ describe("NnsAccounts", () => {
         },
       ]);
     });
+
+    it("should render add account row with tabindex 1 more than number of accounts", async () => {
+      const mainTokenData = createUserToken({
+        title: "Main",
+        balance: TokenAmount.fromE8s({
+          amount: 314000000n,
+          token: NNS_TOKEN_DATA,
+        }),
+      });
+      const subaccountTokenData = createUserToken({
+        title: "Subaccount test",
+        balance: TokenAmount.fromE8s({
+          amount: 222000000n,
+          token: NNS_TOKEN_DATA,
+        }),
+      });
+      const po = renderComponent([mainTokenData, subaccountTokenData]);
+      // There are two accounts before the add account row
+      expect(await po.getAddAccountRowTabindex()).toBe("3");
+    });
   });
 
   describe("when tokens flag is disabled", () => {

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -1,4 +1,7 @@
+import * as accountsApi from "$lib/api/accounts.api";
+import * as icpLedgerApi from "$lib/api/icp-ledger.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
+import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import CKETH_LOGO from "$lib/assets/ckETH.svg";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
@@ -27,6 +30,7 @@ import { page } from "$mocks/$app/stores";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import {
+  mockAccountDetails,
   mockAccountsStoreData,
   mockHardwareWalletAccount,
   mockMainAccount,
@@ -45,12 +49,16 @@ import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { fireEvent, waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
 import WalletTest from "../pages/AccountsTest.svelte";
 
+vi.mock("$lib/api/accounts.api");
+vi.mock("$lib/api/icp-ledger.api");
 vi.mock("$lib/api/icrc-ledger.api");
+vi.mock("$lib/api/nns-dapp.api");
 
 vi.mock("$lib/services/sns-accounts.services", () => {
   return {
@@ -122,6 +130,9 @@ vi.mock("$lib/services/worker-balances.services", () => ({
 
 describe("Accounts", () => {
   const balanceIcrcToken = 314000000n;
+  const newSubaccountName = "test";
+  const subaccountBalance = 0n;
+  const mainAccountBalance = 314000000n;
 
   const renderComponent = () => {
     const { container } = render(Accounts);
@@ -151,6 +162,29 @@ describe("Accounts", () => {
     vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockResolvedValue(
       balanceIcrcToken
     );
+    vi.spyOn(accountsApi, "createSubAccount").mockResolvedValue(undefined);
+    vi.spyOn(icpLedgerApi, "queryAccountBalance").mockImplementation(
+      async ({ icpAccountIdentifier }) => {
+        if (icpAccountIdentifier === mockMainAccount.identifier) {
+          return mainAccountBalance;
+        } else if (icpAccountIdentifier === mockSubAccount.identifier) {
+          return subaccountBalance;
+        }
+        throw new Error(
+          `Unexpected account identifier ${icpAccountIdentifier}`
+        );
+      }
+    );
+    vi.spyOn(nnsDappApi, "queryAccount").mockResolvedValue({
+      ...mockAccountDetails,
+      sub_accounts: [
+        {
+          name: newSubaccountName,
+          sub_account: mockSubAccount.subAccount,
+          account_identifier: mockSubAccount.identifier,
+        },
+      ],
+    });
 
     vi.spyOn(snsSelectedTransactionFeeStore, "subscribe").mockImplementation(
       mockSnsSelectedTransactionFeeStoreSubscribe()
@@ -561,7 +595,7 @@ describe("Accounts", () => {
         icpAccountsStore.setForTesting({
           main: {
             ...mockMainAccount,
-            balanceUlps: 314000000n,
+            balanceUlps: mainAccountBalance,
           },
           subAccounts: [
             {
@@ -600,6 +634,48 @@ describe("Accounts", () => {
 
         const tablePo = po.getNnsAccountsPo().getTokensTablePo();
         expect(await tablePo.getFirstColumnHeader()).toEqual("Accounts");
+      });
+
+      it("user can add a new account", async () => {
+        icpAccountsStore.setForTesting({
+          main: {
+            ...mockMainAccount,
+            balanceUlps: mainAccountBalance,
+          },
+          subAccounts: [],
+          hardwareWallets: [],
+        });
+        const po = renderComponent();
+
+        const tablePo = po.getNnsAccountsPo().getTokensTablePo();
+        expect(await tablePo.getRowsData()).toEqual([
+          {
+            balance: "3.14 ICP",
+            projectName: "Main",
+          },
+        ]);
+
+        const pagePo = po.getNnsAccountsPo();
+
+        await pagePo.clickAddAccount();
+
+        const modalPo = po.getAddAccountModalPo();
+        expect(await modalPo.isPresent()).toBe(true);
+
+        await modalPo.addAccount(newSubaccountName);
+
+        await runResolvedPromises();
+
+        expect(await tablePo.getRowsData()).toEqual([
+          {
+            balance: "3.14 ICP",
+            projectName: "Main",
+          },
+          {
+            balance: "0 ICP",
+            projectName: newSubaccountName,
+          },
+        ]);
       });
     });
   });

--- a/frontend/src/tests/page-objects/Accounts.page-object.ts
+++ b/frontend/src/tests/page-objects/Accounts.page-object.ts
@@ -4,6 +4,7 @@ import { NnsAccountsFooterPo } from "$tests/page-objects/NnsAccountsFooter.page-
 import { SnsAccountsPo } from "$tests/page-objects/SnsAccounts.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { AddAccountModalPo } from "./AddAccountModal.page-object";
 import { BuyICPModalPo } from "./BuyICPModal.page-object";
 import { IcrcTokenAccountsPo } from "./IcrcTokenAccounts.page-object";
 import { IcrcTokenAccountsFooterPo } from "./IcrcTokenAccountsFooter.page-object";
@@ -46,6 +47,10 @@ export class AccountsPo extends BasePageObject {
 
   getBuyICPModalPo() {
     return BuyICPModalPo.under(this.root);
+  }
+
+  getAddAccountModalPo() {
+    return AddAccountModalPo.under(this.root);
   }
 
   clickSend(): Promise<void> {

--- a/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAccounts.page-object.ts
@@ -18,6 +18,19 @@ export class NnsAccountsPo extends BaseAccountsPo {
     return this.getTokensTablePo().isPresent();
   }
 
+  getAddAccountRow(): PageObjectElement {
+    return this.root.byTestId("add-account-row");
+  }
+
+  getAddAccountRowTabindex(): Promise<string> {
+    return this.getAddAccountRow().getAttribute("tabindex");
+  }
+
+  // Only when MY_TOKENS_ENABLED=true
+  clickAddAccount(): Promise<void> {
+    return this.getAddAccountRow().click();
+  }
+
   getNnsAddAccountPo(): NnsAddAccountPo {
     return NnsAddAccountPo.under(this.root);
   }


### PR DESCRIPTION
# Motivation

Users can add an account from the ICP tokens table.

# Changes

* New AccountsModalType: "add-icp-account"
* Add AddAccountModal to AccountsModals.
* Trigger a `openAccountsModal` when the "Add Account" row is clicked.
* Add click attributes to the "Add Account" row in NnsAccounts.

# Tests

* Add a test in NnsAccounts that the tabindex is properly added to the Add Account row.
* Add a test in the Accounts route that the user can add an account.
* Add methods to POs

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.

