### PR TITLE
chore: Keep dfx server logs

### DIFF
--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -25,6 +25,14 @@ inputs:
     description: "Passed as --mode with the dfx canister install command"
     required: false
     default: "reinstall"
+  logfile:
+    description: "The name of the logfile to write to"
+    required: false
+    default: "dfx.log"
+outputs:
+  logfile:
+    description: The path to the dfx log file
+    value: ${{ inputs.logfile }}
 runs:
   using: "composite"
   steps:
@@ -63,7 +71,7 @@ runs:
       shell: bash
       run: |
         curl -fL --retry 5 ${{ steps.snsdemo_snapshot.outputs.url }} > state.tar.xz
-        dfx-snapshot-restore --snapshot state.tar.xz --verbose
+        dfx-snapshot-restore --snapshot state.tar.xz --verbose &> '${{ inputs.logfile }}'
         dfx identity use snsdemo8
         dfx-sns-demo-healthcheck
     - name: Install nns-dapp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,7 @@ jobs:
         uses: ./.github/actions/start_dfx_snapshot
         with:
           nns_dapp_wasm: 'nns-dapp_test.wasm.gz'
+          logfile: 'dfx-test-downgrade-upgrade.log'
       - name: Downgrade nns-dapp to prod and upgrade back again
         run: ./scripts/nns-dapp/downgrade-upgrade-test -w nns-dapp_test.wasm.gz
       - name: Count upgrade cycles
@@ -134,6 +135,7 @@ jobs:
         uses: ./.github/actions/start_dfx_snapshot
         with:
           nns_dapp_wasm: 'nns-dapp_test.wasm.gz'
+          logfile: 'dfx-test-test-account-api.log'
       - name: Check that test accounts can be created and read
         run: ./scripts/nns-dapp/test-account.test
   test-rest:
@@ -160,6 +162,7 @@ jobs:
         with:
           nns_dapp_wasm: 'nns-dapp.wasm.gz'
           sns_aggregator_wasm: 'sns_aggregator_dev.wasm.gz'
+          logfile: 'dfx-test-rest.log'
       - name: Add go and SNS scripts to the path
         run: |
           echo "$PWD/snsdemo/bin" >> $GITHUB_PATH
@@ -296,6 +299,7 @@ jobs:
         uses: ./.github/actions/start_dfx_snapshot
         with:
           sns_aggregator_wasm: 'sns_aggregator_dev.wasm.gz'
+          logfile: 'dfx-aggregator-test.log'
       - name: Get the earliest data from the sns aggregator
         run: |
           AGGREGATOR_CANISTER_ID="$(dfx canister id sns_aggregator)"


### PR DESCRIPTION
# Motivation
When debugging failures in CI, it is useful to be able to see the logs of the running dfx server.

# Changes
- Save the `dfx start` logs to a file and upload them, so that they can be examined.
- Where a workflow runs dfx start several times, use different names for different runs.
  - Note: It _may_ make sense to make the default name include the job name, however in practice I found some issues with this approach.  I think setting a name manually is fine for now.  For a cleverer default, I would rather wait until there is a solution that really works well.

# Tests
- See CI for sample outputs.
- Usability:  I used this while developing the stable structures migration.

# Todos

- [ ] Add entry to changelog (if necessary).
