### PR TITLE
chore: Useful debug print for accounts store

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -55,6 +55,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Provide missing global config in cache-filling workflow.
 * Update the correct flavour of golden file when the NNS Dapp canister API changes.
 * Specify the node version to use in the version bump test.
+* Summarize the `AccountsStore` contents in its `Debug` representation rather than trying to print its entire contents.
 * Lock the spellcheck version and its dependencies.
 
 #### Security

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -20,6 +20,7 @@ use on_wire::{FromWire, IntoWire};
 use serde::Deserialize;
 use std::cmp::{min, Ordering};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::fmt;
 use std::ops::RangeTo;
 use std::time::{Duration, SystemTime};
 
@@ -34,7 +35,7 @@ type TransactionIndex = u64;
 const PRE_MIGRATION_LIMIT: u64 = 230_000;
 
 /// Accounts, transactions and related data.
-#[derive(Default, Debug, Eq, PartialEq)]
+#[derive(Default, Eq, PartialEq)]
 pub struct AccountsStore {
     // TODO(NNS1-720): Use AccountIdentifier directly as the key for this HashMap
     accounts_db: schema::proxy::AccountsDbAsProxy,
@@ -51,6 +52,26 @@ pub struct AccountsStore {
     hardware_wallet_accounts_count: u64,
     last_ledger_sync_timestamp_nanos: u64,
     neurons_topped_up_count: u64,
+}
+
+impl fmt::Debug for AccountsStore {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "AccountsStore{{accounts_db: {:?}, hardware_wallets_and_sub_accounts: HashMap[{:?}], pending_transactions: HashMap[{:?}], transactions: VecDeque[{:?}], neuron_accounts: HashMap[{:?}], block_height_synced_up_to: {:?}, multi_part_transactions_processor: {:?}, sub_accounts_count: {:?}, hardware_wallet_accounts_count: {:?}, last_ledger_sync_timestamp_nanos: {:?}, neurons_topped_up_count: {:?}}}",
+            self.accounts_db,
+            self.hardware_wallets_and_sub_accounts.len(),
+            self.pending_transactions.len(),
+            self.transactions.len(),
+            self.neuron_accounts.len(),
+            self.block_height_synced_up_to,
+            self.multi_part_transactions_processor,
+            self.sub_accounts_count,
+            self.hardware_wallet_accounts_count,
+            self.last_ledger_sync_timestamp_nanos,
+            self.neurons_topped_up_count,
+        )
+    }
 }
 
 /// An abstraction over sub-accounts and hardware wallets.


### PR DESCRIPTION
# Motivation
The derived debug implementation for the accounts store tries to print e.g. all the accounts in the database.  The printout is huge and not useful.  Much more useful is a summary, such as how many accounts there are in in the authoritative database.

# Changes
- Provide a custom Debug implementation for `AccountsStore` that summarizes the contents instead of trying to print everything.

# Tests
Here is a sample debug printout in compact form, before and after:

## Before
```
AccountsStore { accounts_db: AccountsDbAsProxy { authoritative_db: UnboundedStableBTreeMap(AccountsDbAsUnboundedStableBT
reeMap { accounts: StableBTreeMap{.. 1000 entries} }), migration: None }, hardware_wallets_and_sub_accounts: {AccountIde
ntifier { hash: [228, 151, 180, 173, 185, 89, 137, 231, 11, 131, 115, 103, 149, 207, 216, 1, 84, 172, 45, 116, 82, 99, 8
0, 70, 102, 150, 171, 146] }: SubAccount(AccountIdentifier { hash: [171, 123, 1, 102, 113, 63, 231, 222, 118, 155, 234, 
89, 89, 25, 86, 24, 105, 252, 232, 238, 244, 238, 89, 198, 85, 71, 182, 250] }, 1), AccountIdentifier { hash: [14, 30, 1
7, 54, 241, 206, 4, 248, 40, 124, 242, 21, 177, 40, 37, 57, 47, 143, 243, 180, 135, 132, 162, 255, 35, 210, 8, 164] }: H
ardwareWallet([AccountIdentifier { hash: [80, 155, 149, 27, 36, 72, 240, 207, 132, 249, 121, 69, 149, 94, 206, 237, 193,
 177, 76, 98, 38, 24, 26, 2, 95, 37, 109, 117] }]), AccountIdentifier { hash: [138, 157, 226, 175, 226, 230, 204, 200, 2
09, 9, 4, 19, 60, 155, 119, 65, 113, 96, 15, 164, 191, 130, 40, 69, 123, 110, 27, 131] }: SubAccount(AccountIdentifier {
 hash: [169, 55, 182, 175, 165, 12, 11, 144, 178, 179, 164, 100, 119, 182, 177, 150, 199, 81, 148, 234, 186, 214, 151, 1
19, 201, 28, 96, 80] }, 2), AccountIdentifier { hash: [16, 143, 160, 234, 61, 104, 38, 85, 137, 77, 103, 81, 215, 136, 1
25, 33, 111, 81, 76, 161, 114, 83, 189, 84, 178, 153, 236, 187] }: HardwareWallet([AccountIdentifier { hash: [122, 70, 8
0, 25, 123, 236, 168, 96, 59, 58, 208, 178, 233, 252, 194, 228, 100, 21, 169, 161, 70, 83, 23, 244, 8, 142, 55, 3] }]), 
AccountIdentifier { hash: [112, 29, 31, 10, 252, 219, 144, 186, 44, 44, 252, 156, 175, 122, 2, 44, 228, 122, 90, 211, 64
, 157, 66, 246, 243, 56, 88, 168] }: SubAccount(AccountIdentifier { hash: [78, 157, 79, 254, 220, 50, 212, 247, 11, 204,
 177, 171, 215, 212, 138, 175, 42, 22, 144, 149, 166, 227, 56, 133, 42, 132, 115, 76] }, 2), AccountIdentifier { hash: [
15, 76, 125, 85, 245, 180, 120, 86, 183, 159, 59, 115, 56, 116, 104, 57, 185, 130, 44, 176, 100, 174, 178, 125, 126, 34,
 38, 198] }: HardwareWallet([AccountIdentifier { hash: [115, 43, 30, 227, 208, 51, 189, 15, 118, 93, 70, 155, 26, 93, 18
, 68, 26, 123, 46, 84, 13, 143, 220, 248, 113, 115, 166, 55] }]), AccountIdentifier { hash: [210, 239, 217, 200, 85, 39,
 220, 1, 74, 32, 96, 237, 253, 153, 225, 227, 134, 224, 5, 211, 70, 117, 212, 142, 37, 237, 104, 249] }: SubAccount(Acco
untIdentifier { hash: [251, 220, 89, 15, 176, 25, 6, 75, 202, 222, 95, 76, 250, 203, 65, 107, 68, 206, 56, 51, 149, 181,
 33, 6, 232, 61, 232, 85] }, 2), AccountIdentifier { hash: [59, 66, 249, 226, 241, 155, 154, 78, 22, 172, 187, 203, 89, 
246, 185, 53, 207, 92, 90, 202, 209, 212, 153, 117, 138, 124, 52, 139] }: HardwareWallet([AccountIdentifier { hash: [216
, 97, 92, 178, 131, 199, 33, 185, 33, 247, 178, 3, 118, 9, 137, 183, 137, 107, 254, 91, 81, 30, 6, 48, 99, 140, 8, 228] 
}]), AccountIdentifier { hash: [159, 131, 199, 70, 17, 239, 29, 132, 30, 224, 45, 147, 187, 155, 130, 185, 26, 155, 19, 
154, 81, 160, 128, 230, 105, 221, 96, 116] }: SubAccount(AccountIdentifier { hash: [40, 247, 173, 127, 200, 94, 3, 99, 4
8, 26, 182, 148, 27, 194, 230, 49, 20, 129, 15, 168, 144, 229, 107, 209, 234, 6, 83, 197] }, 1), AccountIdentifier { has
h: [69, 238, 84, 244, 238, 13, 47, 205, 170, 93, 217, 87, 244, 84, 120, 173, 46, 225, 168, 255, 75, 199, 119, 124, 243, 
89, 171, 32] }: SubAccount(AccountIdentifier { hash: [11, 171, 138, 69, 233, 8, 41, 66, 17, 254, 10, 81, 29, 177, 23, 16
, 35, 155, 62, 207, 60, 72, 174, 34, 251, 113, 78, 22] }, 2), AccountIdentifier { hash: [73, 144, 203, 203, 116, 111, 99
, 240, 247, 107, 192, 249, 62, 114, 137, 233, 5, 15, 201, 23, 110, 58, 81, 208, 98, 50, 20, 198] }: SubAccount(AccountId
entifier { hash: [194, 88, 111, 122, 132, 56, 27, 190, 45, 157, 47, 155, 141, 163, 228, 14, 128, 62, 224, 33, 30, 200, 2
[SNIP - this is very long]
```

## After
```
AccountsStore{accounts_db: AccountsDbAsProxy { authoritative_db: UnboundedStableBTreeMap(AccountsDbAsUnboundedStableBTre
eMap { accounts: StableBTreeMap{.. 1000 entries} }), migration: None }, hardware_wallets_and_sub_accounts: HashMap[2000]
, pending_transactions: HashMap[0], transactions: VecDeque[3000], neuron_accounts: HashMap[300], block_height_synced_up_
to: None, multi_part_transactions_processor: MultiPartTransactionsProcessor { queue: [] }, sub_accounts_count: 1500, har
dware_wallet_accounts_count: 500, last_ledger_sync_timestamp_nanos: 0, neurons_topped_up_count: 0}
```

# Todos

- [x] Add entry to changelog (if necessary).
