### PR TITLE
Placeholder for migration state

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -25,6 +25,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Render BTC deposits/withdrawals as "BTC Received"/"BTC Sent".
 * Update Rust version: `1.74.0` -> `1.74.1`
+* Provide space for migration state in the `ProxyDb`.
 
 #### Deprecated
 


### PR DESCRIPTION
# Motivation
When migrating from one database to another, we need to store the migration state.

# Changes
- Replace the secondary db with a container that holds both the second db and the migration state.

# Tests
None - there are no functional changes.

# Todos

- [x] Add entry to changelog (if necessary).
