### PR TITLE
GIX-2057: Add ckBTC logic to Tokens page

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCWithdrawalAccount.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWithdrawalAccount.svelte
@@ -23,8 +23,6 @@
   /**
    * Calling updateBalance has nothing to do with the withdrawal account but, because users are confused about when and how to call it, product required to add this additional call within this process.
    * That way, when user navigate once per session to the ckBTC accounts page, the call is also triggered.
-   *
-   * TODO(GIX-1320): to be removed when ckBTC update_balance is replaced by track_balance
    */
   const updateBalance = async () => {
     const canisters = nonNullish($selectedCkBTCUniverseIdStore)

--- a/frontend/src/lib/services/ckbtc-minter.services.ts
+++ b/frontend/src/lib/services/ckbtc-minter.services.ts
@@ -166,9 +166,9 @@ export const updateBalance = async ({
     ckbtcPendingUtxosStore.setUtxos({ universeId, utxos: pending });
 
     // Workaround. Ultimately we want to poll to update balance and list of transactions
-    await waitForMilliseconds(
-      deferReload ? WALLET_TRANSACTIONS_RELOAD_DELAY : 0
-    );
+    if (deferReload) {
+      await waitForMilliseconds(WALLET_TRANSACTIONS_RELOAD_DELAY);
+    }
 
     if (uiIndicators) {
       if (completed.length > 0) {

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -31,6 +31,9 @@
   } from "$lib/stores/icrc-canisters.store";
   import CkBtcTransactionModal from "$lib/modals/accounts/CkBTCTransactionModal.svelte";
   import { CKBTC_ADDITIONAL_CANISTERS } from "$lib/constants/ckbtc-additional-canister-ids.constants";
+  import { updateBalance } from "$lib/services/ckbtc-minter.services";
+  import { nonNullish } from "@dfinity/utils";
+  import { Principal } from "@dfinity/principal";
 
   onMount(() => {
     if (!$ENABLE_MY_TOKENS) {
@@ -66,6 +69,24 @@
     if (loadCkBTCAccountsBalancesRequested) {
       return;
     }
+
+    /**
+     * Calling updateBalance because users are confused about when and how to call it and product required to add this additional call within this process.
+     * That way, when user navigate once per session to the ckBTC accounts page, the call is also triggered.
+     *
+     * There is also an "Update Balance"
+     */
+    universes.forEach((universe: Universe) => {
+      const ckBTCCanisters = CKBTC_ADDITIONAL_CANISTERS[universe.canisterId];
+      if (nonNullish(ckBTCCanisters.minterCanisterId)) {
+        updateBalance({
+          universeId: Principal.fromText(universe.canisterId),
+          minterCanisterId: ckBTCCanisters.minterCanisterId,
+          reload: undefined,
+          uiIndicators: false,
+        });
+      }
+    });
 
     loadCkBTCAccountsBalancesRequested = true;
 

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -82,7 +82,8 @@
         updateBalance({
           universeId: Principal.fromText(universe.canisterId),
           minterCanisterId: ckBTCCanisters.minterCanisterId,
-          reload: undefined,
+          reload: () => loadAccountsBalances([universe.canisterId]),
+          deferReload: false,
           uiIndicators: false,
         });
       }

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -74,7 +74,7 @@
      * Calling updateBalance because users are confused about when and how to call it and product required to add this additional call within this process.
      * That way, when user navigate once per session to the ckBTC accounts page, the call is also triggered.
      *
-     * There is also an "Update Balance"
+     * There is also a "Check for incoming BTC" button in the Wallet page.
      */
     universes.forEach((universe: Universe) => {
       const ckBTCCanisters = CKBTC_ADDITIONAL_CANISTERS[universe.canisterId];

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -72,7 +72,7 @@
 
     /**
      * Calling updateBalance because users are confused about when and how to call it and product required to add this additional call within this process.
-     * That way, when user navigate once per session to the ckBTC accounts page, the call is also triggered.
+     * That way, when user navigates to the Tokens page, the call is also triggered.
      *
      * There is also a "Check for incoming BTC" button in the Wallet page.
      */


### PR DESCRIPTION
# Motivation

Users might not understand that they need to update the balance after converting BTC to ckBTC. Therefore, the NNS Dapp makes the call to the minter in the background.

In this PR, I add that functionality currently present in the ckBTC Accounts to the Tokens page.

# Changes

* Call service ckBTC Minter `updateBalance` in the Tokens page.

# Tests

* Add a test that simulates the api returning completed UTXOs and checking that the balance is updated.

I also tested manually that after getting some test bitcoins, the balance was never updated even after refreshing. When I introduced the call, the balance was refreshed when the user visited the page.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.

