### PR TITLE
Fix: Allow npm > v10

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -44,6 +44,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Allow npm greater than v10 in frontend project.
+
 #### Deprecated
 
 #### Removed

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -64,7 +64,7 @@
       },
       "engines": {
         "node": ">=18.0.0 <19.0.0",
-        "npm": ">=9.0.0 <10.0.0"
+        "npm": ">=9.0.0 <11.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "start:snapshot": "../scripts/dfx-snapshot-start --snapshot ~/snapshot.tar.xz "
   },
   "engines": {
-    "npm": ">=9.0.0 <10.0.0",
+    "npm": ">=9.0.0 <11.0.0",
     "node": ">=18.0.0 <19.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# Motivation

Latest NodeJS comes with npm v10.2.3. Yet, in package.json we don't allow npm to be greater than 10.

In this PR, allow npm to be greater than 10.

# Changes

## Manual changes
* Change the accepted version range of `npm` in package.json of frontend.

## Automatic changes
* Changes in package-lock.json after runnin `npm i`.

# Tests

Tests should be fixed now.

# Todos

- [x] Add entry to changelog (if necessary).
