### PR TITLE
Fix: TokensTable actions triggering link

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/actions/ReceiveButton.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/actions/ReceiveButton.svelte
@@ -12,7 +12,7 @@
 <button
   class="icon"
   data-tid="receive-button-component"
-  on:click|stopPropagation={() => {
+  on:click|preventDefault|stopPropagation={() => {
     dispatcher("nnsAction", { type: ActionType.Receive, data: userToken });
   }}
 >

--- a/frontend/src/lib/components/tokens/TokensTable/actions/SendButton.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/actions/SendButton.svelte
@@ -12,8 +12,7 @@
 <button
   class="icon"
   data-tid="send-button-component"
-  on:click|preventDefault|stopPropagation={() => {
-    console.log("userToken", userToken);
+  on:click|stopPropagation|preventDefault={() => {
     dispatcher("nnsAction", { type: ActionType.Send, data: userToken });
   }}
 >

--- a/frontend/src/lib/components/tokens/TokensTable/actions/SendButton.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/actions/SendButton.svelte
@@ -12,7 +12,8 @@
 <button
   class="icon"
   data-tid="send-button-component"
-  on:click|stopPropagation={() => {
+  on:click|preventDefault|stopPropagation={() => {
+    console.log("userToken", userToken);
     dispatcher("nnsAction", { type: ActionType.Send, data: userToken });
   }}
 >

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -1,5 +1,6 @@
 import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { AppPath } from "$lib/constants/routes.constants";
 import { ActionType } from "$lib/types/actions";
 import {
   UserTokenAction,
@@ -17,7 +18,7 @@ import { TokensTablePo } from "$tests/page-objects/TokensTable.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { createActionEvent } from "$tests/utils/actions.test-utils";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
-import { render } from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
 import type { Mock } from "vitest";
 import TokensTableTest from "./TokensTableTest.svelte";
 
@@ -270,6 +271,60 @@ describe("TokensTable", () => {
         data: userToken,
       })
     );
+  });
+
+  it("clicking in a Send action should not trigger the row link", async () => {
+    const userToken = createUserToken({
+      actions: [UserTokenAction.Send],
+      rowHref: AppPath.Neurons,
+    });
+
+    const po = renderTable({
+      userTokensData: [userToken],
+      onAction: vi.fn(),
+    });
+
+    const rows = await po.getRows();
+    const rowPo = rows[0];
+
+    const sendButton = rowPo.getSendButton();
+
+    let isClicked = false;
+    sendButton.addEventListener("click", (event) => {
+      expect(event.defaultPrevented).toBe(true);
+      isClicked = true;
+    });
+
+    await sendButton.click();
+
+    await waitFor(() => expect(isClicked).toBe(true));
+  });
+
+  it("clicking in a Receive action should not trigger the row link", async () => {
+    const userToken = createUserToken({
+      actions: [UserTokenAction.Receive],
+      rowHref: AppPath.Neurons,
+    });
+
+    const po = renderTable({
+      userTokensData: [userToken],
+      onAction: vi.fn(),
+    });
+
+    const rows = await po.getRows();
+    const rowPo = rows[0];
+
+    const receiveButton = rowPo.getReceiveButton();
+
+    let isClicked = false;
+    receiveButton.addEventListener("click", (event) => {
+      expect(event.defaultPrevented).toBe(true);
+      isClicked = true;
+    });
+
+    await receiveButton.click();
+
+    await waitFor(() => expect(isClicked).toBe(true));
   });
 
   it("should trigger event when clicking in Receive action", async () => {

--- a/frontend/src/tests/page-objects/jest.page-object.ts
+++ b/frontend/src/tests/page-objects/jest.page-object.ts
@@ -180,4 +180,12 @@ export class JestPageObjectElement implements PageObjectElement {
     await this.waitFor();
     return this.element?.innerHTML ?? "";
   }
+
+  async addEventListener(
+    eventType: string,
+    fn: (e: Event) => void
+  ): Promise<void> {
+    await this.waitFor();
+    this.element?.addEventListener(eventType, fn);
+  }
 }

--- a/frontend/src/tests/page-objects/playwright.page-object.ts
+++ b/frontend/src/tests/page-objects/playwright.page-object.ts
@@ -123,4 +123,8 @@ export class PlaywrightPageObjectElement implements PageObjectElement {
   async innerHtmlForDebugging(): Promise<string> {
     return "not implemeneted";
   }
+
+  async addEventListener(): Promise<void> {
+    throw new Error("Not implement");
+  }
 }

--- a/frontend/src/tests/types/page-object.types.ts
+++ b/frontend/src/tests/types/page-object.types.ts
@@ -36,4 +36,5 @@ export interface PageObjectElement {
   isVisible(): Promise<boolean>;
   blur(): Promise<void>;
   innerHtmlForDebugging(): Promise<string>;
+  addEventListener(eventType: string, fn: (e: Event) => void): Promise<void>;
 }


### PR DESCRIPTION
# Motivation

There was a navigation and full refresh when the user clicked directly in one of the action buttons.

We need to prevent the default behavior of the link as well as stop propagation.

# Changes

* Add `preventDefault` directive to ReceiveButton and SendButton.

The GoToDetailButton will be refactoring into a single span with no clicking functionality because we should rely on the rowHref instead.

# Tests

* Test that when clicking Send or Receive, the default is prevented.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
