### PR TITLE
GIX-1983: Add ICRC Send Transaction

### DIFF
--- a/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
@@ -14,8 +14,6 @@
   import type { Principal } from "@dfinity/principal";
   import { icrcTransferTokens } from "$lib/services/icrc-accounts.services";
 
-  // TODO: Refactor to expect as props the rootCanisterId, transactionFee and token.
-  // This way we can reuse this component in a dashboard page.
   export let selectedAccount: Account | undefined = undefined;
   export let ledgerCanisterId: Principal;
   export let token: Token;

--- a/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
@@ -10,16 +10,15 @@
   import type { Account } from "$lib/types/account";
   import type { WizardStep } from "@dfinity/gix-components";
   import type { TransactionInit } from "$lib/types/transaction";
-  import { TokenAmountV2, nonNullish } from "@dfinity/utils";
+  import { TokenAmountV2, nonNullish, type Token } from "@dfinity/utils";
   import type { Principal } from "@dfinity/principal";
   import { icrcTransferTokens } from "$lib/services/icrc-accounts.services";
-  import type { IcrcTokenMetadata } from "$lib/types/icrc";
 
   // TODO: Refactor to expect as props the rootCanisterId, transactionFee and token.
   // This way we can reuse this component in a dashboard page.
   export let selectedAccount: Account | undefined = undefined;
   export let ledgerCanisterId: Principal;
-  export let token: IcrcTokenMetadata;
+  export let token: Token;
   export let transactionFee: TokenAmountV2;
   export let reloadSourceAccount: (() => void) | undefined = undefined;
 
@@ -49,7 +48,7 @@
       destinationAddress,
       amountUlps: numberToUlps({ amount, token }),
       ledgerCanisterId,
-      fee: token.fee,
+      fee: transactionFee.toUlps(),
     });
 
     stopBusy("accounts");

--- a/frontend/src/lib/utils/universe.utils.ts
+++ b/frontend/src/lib/utils/universe.utils.ts
@@ -6,6 +6,7 @@ import {
 import { AppPath } from "$lib/constants/routes.constants";
 import type { Page } from "$lib/derived/page.derived";
 import { i18n } from "$lib/stores/i18n";
+import type { IcrcCanistersStoreData } from "$lib/stores/icrc-canisters.store";
 import type { SnsSummary } from "$lib/types/sns";
 import type { Universe } from "$lib/types/universe";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -38,6 +39,14 @@ export const isUniverseCkTESTBTC = (
   nonNullish(canisterId) &&
   (typeof canisterId === "string" ? canisterId : canisterId.toText()) ===
     CKTESTBTC_UNIVERSE_CANISTER_ID.toText();
+
+export const isIcrcTokenUniverse = ({
+  universeId,
+  icrcCanisters,
+}: {
+  universeId: Principal;
+  icrcCanisters: IcrcCanistersStoreData;
+}): boolean => nonNullish(icrcCanisters[universeId.toText()]);
 
 export const universeLogoAlt = ({
   summary,

--- a/frontend/src/tests/lib/utils/universes.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/universes.utils.spec.ts
@@ -5,8 +5,10 @@ import {
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { nnsUniverseStore } from "$lib/derived/nns-universe.derived";
+import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
 import {
   createUniverse,
+  isIcrcTokenUniverse,
   isNonGovernanceTokenPath,
   isUniverseCkBTC,
   isUniverseNns,
@@ -17,6 +19,7 @@ import {
   createSummary,
   mockSnsFullProject,
   mockSummary,
+  principal,
 } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { Principal } from "@dfinity/principal";
@@ -148,6 +151,51 @@ describe("universes-utils", () => {
         title: projectName,
         logo,
       });
+    });
+  });
+
+  describe("isIcrcTokenUniverse", () => {
+    beforeEach(() => {
+      icrcCanistersStore.reset();
+    });
+
+    it("should return true if universe is in ICRC Canisters store", () => {
+      const universeId = principal(0);
+      icrcCanistersStore.setCanisters({
+        ledgerCanisterId: universeId,
+        indexCanisterId: principal(1),
+      });
+      expect(
+        isIcrcTokenUniverse({
+          universeId,
+          icrcCanisters: get(icrcCanistersStore),
+        })
+      ).toBe(true);
+    });
+
+    it("should return false if universe is not in ICRC Canisters store", () => {
+      const universeId = principal(0);
+      icrcCanistersStore.setCanisters({
+        ledgerCanisterId: universeId,
+        indexCanisterId: principal(1),
+      });
+      expect(
+        isIcrcTokenUniverse({
+          universeId: principal(2),
+          icrcCanisters: get(icrcCanistersStore),
+        })
+      ).toBe(false);
+    });
+
+    it("should return false when ICRC Canisters store is empty", () => {
+      const universeId = principal(0);
+      icrcCanistersStore.reset();
+      expect(
+        isIcrcTokenUniverse({
+          universeId,
+          icrcCanisters: get(icrcCanistersStore),
+        })
+      ).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/page-objects/TokensRoute.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensRoute.page-object.ts
@@ -1,6 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { CkBTCTransactionModalPo } from "./CkBTCTransactionModal.page-object";
+import { IcrcTokenTransactionModalPo } from "./IcrcTokenTransactionModal.page-object";
 import { SignInTokensPagePo } from "./SignInTokens.page-object";
 import { SnsTransactionModalPo } from "./SnsTransactionModal.page-object";
 import { TokensPagePo } from "./TokensPage.page-object";
@@ -48,5 +49,16 @@ export class TokensRoutePo extends BasePageObject {
     amount: number;
   }): Promise<void> {
     return this.getCkBTCTransactionModalPo().transferToAddress(params);
+  }
+
+  getIcrcTokenTransactionModal(): IcrcTokenTransactionModalPo {
+    return IcrcTokenTransactionModalPo.under(this.root);
+  }
+
+  transferIcrcTokens(params: {
+    destinationAddress: string;
+    amount: number;
+  }): Promise<void> {
+    return this.getIcrcTokenTransactionModal().transferToAddress(params);
   }
 }

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -428,12 +428,12 @@ describe("Tokens route", () => {
             owner: principal(1),
           };
 
+          ckETHBalanceUlps -= amountCkETHTransactionUlps;
           await po.transferIcrcTokens({
             amount: amountCkETHTransaction,
             destinationAddress: encodeIcrcAccount(toAccount),
           });
 
-          ckETHBalanceUlps = ckETHBalanceUlps - amountCkETHTransactionUlps;
           await runResolvedPromises();
 
           expect(icrcLedgerApi.icrcTransfer).toBeCalledTimes(1);

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -77,7 +77,13 @@ describe("Tokens route", () => {
     amount: amountCkBTCTransaction,
     token: mockCkBTCToken,
   });
-  const ckETHBalanceUlps = 4_140_000_000_000_000_000n;
+  const ckETHDefaultBalanceUlps = 4_140_000_000_000_000_000n;
+  let ckETHBalanceUlps = ckETHDefaultBalanceUlps;
+  const amountCkETHTransaction = 2;
+  const amountCkETHTransactionUlps = numberToUlps({
+    amount: amountCkETHTransaction,
+    token: mockCkETHToken,
+  });
   const icpBalanceE8s = 123456789n;
   const noPendingUtxos = new MinterNoNewUtxosError({
     pending_utxos: [],
@@ -98,6 +104,7 @@ describe("Tokens route", () => {
       icrcAccountsStore.reset();
       tokensStore.reset();
       ckBTCBalanceE8s = ckBTCDefaultBalanceE8s;
+      ckETHBalanceUlps = ckETHDefaultBalanceUlps;
       overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
       vi.spyOn(walletLedgerApi, "getToken").mockImplementation(
         async ({ canisterId }) => {
@@ -174,6 +181,20 @@ describe("Tokens route", () => {
         }
       );
       vi.spyOn(icrcLedgerApi, "icrcTransfer").mockResolvedValue(1234n);
+      vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockImplementation(
+        async ({ canisterId }) => {
+          const balanceMap = {
+            [CKETH_UNIVERSE_CANISTER_ID.toText()]: ckETHBalanceUlps,
+            [CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText()]: ckETHBalanceUlps,
+          };
+          if (isNullish(balanceMap[canisterId.toText()])) {
+            throw new Error(
+              `Balance not found for canister ${canisterId.toText()}`
+            );
+          }
+          return balanceMap[canisterId.toText()];
+        }
+      );
       vi.spyOn(ckBTCMinterApi, "updateBalance").mockRejectedValue(
         noPendingUtxos
       );
@@ -381,6 +402,57 @@ describe("Tokens route", () => {
             balance: "2.45 ckBTC",
           });
           expect(await po.getCkBTCTransactionModalPo().isPresent()).toBe(false);
+        });
+
+        it("users can send ckETH tokens", async () => {
+          const po = await renderPage();
+
+          const tokensPagePo = po.getTokensPagePo();
+
+          await tokensPagePo.clickSendOnRow("ckETH");
+
+          expect(await tokensPagePo.getRowData("ckETH")).toEqual({
+            projectName: "ckETH",
+            balance: "4.14 ckETH",
+          });
+
+          await tokensPagePo.clickSendOnRow("ckETH");
+
+          expect(await po.getIcrcTokenTransactionModal().isPresent()).toBe(
+            true
+          );
+
+          expect(icrcLedgerApi.icrcTransfer).not.toBeCalled();
+
+          const toAccount: IcrcAccount = {
+            owner: principal(1),
+          };
+
+          await po.transferIcrcTokens({
+            amount: amountCkETHTransaction,
+            destinationAddress: encodeIcrcAccount(toAccount),
+          });
+
+          ckETHBalanceUlps = ckETHBalanceUlps - amountCkETHTransactionUlps;
+          await runResolvedPromises();
+
+          expect(icrcLedgerApi.icrcTransfer).toBeCalledTimes(1);
+          expect(icrcLedgerApi.icrcTransfer).toBeCalledWith({
+            canisterId: CKETH_UNIVERSE_CANISTER_ID,
+            fee: mockCkETHToken.fee,
+            to: toAccount,
+            amount: amountCkETHTransactionUlps,
+            fromSubAccount: undefined,
+            identity: mockIdentity,
+          });
+
+          expect(await tokensPagePo.getRowData("ckETH")).toEqual({
+            projectName: "ckETH",
+            balance: "2.14 ckETH",
+          });
+          expect(await po.getIcrcTokenTransactionModal().isPresent()).toBe(
+            false
+          );
         });
       });
     });


### PR DESCRIPTION
# Motivation

Users can send ICRC Tokens like ckETH from the Tokens page.

# Changes

* Change the type of `token` in IcrcTokenTransactionModal to be able to pass the token from UserTokenData. There is an issue to combine "Token" and "IcrcTokenMetadata" together.
* New universe utils `isIcrcTokenUniverse`.
* Add new modal type `"icrc-send"` in tokens route page and render IcrcTokenTransactionModal whe this type is triggered.

# Tests

* Test new universe util.
* Test that user can send ckETH from Tokens route.
* Add convenient methods to TokensRoute page object.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
