### PR TITLE
Update aggregator

### DIFF
--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: scripts/did2rs.sh --canister sns_governance --out ic_sns_governance.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-29_23-01/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-12-06_23-01+p2p/rs/sns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -208,6 +208,14 @@ pub struct DeregisterDappCanisters {
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct MintSnsTokens {
+    pub to_principal: Option<Principal>,
+    pub to_subaccount: Option<Subaccount>,
+    pub memo: Option<u64>,
+    pub amount_e8s: Option<u64>,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ManageSnsMetadata {
     pub url: Option<String>,
     pub logo: Option<String>,
@@ -236,6 +244,7 @@ pub enum Action {
     TransferSnsTreasuryFunds(TransferSnsTreasuryFunds),
     UpgradeSnsControlledCanister(UpgradeSnsControlledCanister),
     DeregisterDappCanisters(DeregisterDappCanisters),
+    MintSnsTokens(MintSnsTokens),
     Unspecified(EmptyRecord),
     ManageSnsMetadata(ManageSnsMetadata),
     ExecuteGenericNervousSystemFunction(ExecuteGenericNervousSystemFunction),

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: scripts/did2rs.sh --canister sns_ledger --out ic_sns_ledger.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-29_23-01/rs/rosetta-api/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-12-06_23-01+p2p/rs/rosetta-api/icrc1/ledger/ledger.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: scripts/did2rs.sh --canister sns_root --out ic_sns_root.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-29_23-01/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-12-06_23-01+p2p/rs/sns/root/canister/root.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: scripts/did2rs.sh --canister sns_swap --out ic_sns_swap.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-29_23-01/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-12-06_23-01+p2p/rs/sns/swap/canister/swap.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: scripts/did2rs.sh --canister sns_wasm --out ic_sns_wasm.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-11-29_23-01/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-12-06_23-01+p2p/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(clippy::missing_docs_in_private_items)]


### PR DESCRIPTION
# Motivation
We would like to parse all the latest SNS data.

# Changes
* Updated the Rust code derived from `.did` files in the aggregator.
  * Note: The candid files under `declarations/nns-$CANISTER` are used as inputs.

# Tests
  - [x] Please check the API updates for any breaking changes that affect our code.