### PR TITLE
feat: Add range to AccountsDb trait

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -21,7 +21,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Card with BTC deposit address and QR code in ckBTC wallet.
 * Merge Approve transfer with BTC "Sent" transaction in transaction list.
 * Display Neurons' Fund commitment progress bar.
-* `range()` method to `AccountsDb` trait.
+* `range()` method to `AccountsDbTrait`.
 
 #### Changed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -21,6 +21,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Card with BTC deposit address and QR code in ckBTC wallet.
 * Merge Approve transfer with BTC "Sent" transaction in transaction list.
 * Display Neurons' Fund commitment progress bar.
+* `range()` method to `AccountsDb` trait.
 
 #### Changed
 

--- a/rs/backend/src/accounts_store/schema.rs
+++ b/rs/backend/src/accounts_store/schema.rs
@@ -7,6 +7,7 @@ pub mod proxy;
 // Mechanics
 use crate::accounts_store::Account;
 use candid::{CandidType, Deserialize};
+use core::ops::RangeBounds;
 use serde::Serialize;
 use strum_macros::EnumIter;
 mod label_serialization;
@@ -100,6 +101,9 @@ pub trait AccountsDbTrait {
         let iterator = self.iter().map(|(_key, value)| value);
         Box::new(iterator)
     }
+
+    /// Returns an iterator over the entries in the map where keys belong to the specified range.
+    fn range(&self, key_range: impl RangeBounds<Vec<u8>>) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_>;
 
     /// Gets the label of the storage schema.
     fn schema_label(&self) -> SchemaLabel;

--- a/rs/backend/src/accounts_store/schema/map.rs
+++ b/rs/backend/src/accounts_store/schema/map.rs
@@ -1,9 +1,9 @@
 //! An accounts DB implemented as a hash map.
 
 use super::{Account, AccountsDbBTreeMapTrait, AccountsDbTrait, SchemaLabel};
+use core::fmt;
 use core::ops::RangeBounds;
 use std::collections::BTreeMap;
-use std::fmt;
 
 #[derive(Default, Eq, PartialEq)]
 pub struct AccountsDbAsMap {

--- a/rs/backend/src/accounts_store/schema/map.rs
+++ b/rs/backend/src/accounts_store/schema/map.rs
@@ -1,6 +1,7 @@
 //! An accounts DB implemented as a hash map.
 
 use super::{Account, AccountsDbBTreeMapTrait, AccountsDbTrait, SchemaLabel};
+use core::ops::RangeBounds;
 use std::collections::BTreeMap;
 use std::fmt;
 
@@ -31,6 +32,13 @@ impl AccountsDbTrait for AccountsDbAsMap {
     }
     fn values(&self) -> Box<dyn Iterator<Item = Account> + '_> {
         let iterator = self.accounts.values().cloned();
+        Box::new(iterator)
+    }
+    fn range(&self, key_range: impl RangeBounds<Vec<u8>>) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_> {
+        let iterator = self
+            .accounts
+            .range(key_range)
+            .map(|(key, val)| (key.clone(), val.clone()));
         Box::new(iterator)
     }
     fn schema_label(&self) -> SchemaLabel {

--- a/rs/backend/src/accounts_store/schema/proxy.rs
+++ b/rs/backend/src/accounts_store/schema/proxy.rs
@@ -4,7 +4,8 @@
 use std::collections::BTreeMap;
 mod enum_boilerplate;
 use super::{map::AccountsDbAsMap, Account, AccountsDbBTreeMapTrait, AccountsDbTrait, SchemaLabel};
-use std::fmt;
+use core::fmt;
+use core::ops::RangeBounds;
 
 /// An accounts database delegates API calls to underlying implementations.
 ///
@@ -121,6 +122,10 @@ impl AccountsDbTrait for AccountsDbAsProxy {
             "AccountsDb::Proxy: authoritative schema label: {schema_label:#?}"
         ));
         schema_label
+    }
+    /// Iterates over a range of accounts in the authoritative db.
+    fn range(&self, key_range: impl RangeBounds<Vec<u8>>) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_> {
+        self.authoritative_db.range(key_range)
     }
 }
 

--- a/rs/backend/src/accounts_store/schema/proxy/enum_boilerplate.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/enum_boilerplate.rs
@@ -51,4 +51,9 @@ impl AccountsDbTrait for AccountsDb {
             AccountsDb::Map(map_db) => map_db.iter(),
         }
     }
+    fn range(&self, key_range: impl RangeBounds<Vec<u8>>) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_> {
+        match self {
+            AccountsDb::Map(map_db) => map_db.range(key_range),
+        }
+    }
 }


### PR DESCRIPTION
# Motivation
To migrate data from one database to another, we wish to use ranges to get the next N accounts.

# Changes
- Add `range()` to the `AccountsDb` trait.

# Tests
- None.  These are straight proxies to the `BTreeMap` so tests probably aren't warranted.

# Todos

- [x] Add entry to changelog (if necessary).
