### PR TITLE
Render ckBTC reimbursement transactions

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -21,6 +21,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Card with BTC deposit address and QR code in ckBTC wallet.
 * Merge Approve transfer with BTC "Sent" transaction in transaction list.
 * Display Neurons' Fund commitment progress bar.
+* Render ckBTC Reimbursement transactions.
 
 #### Changed
 

--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -4,7 +4,12 @@
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import Identifier from "$lib/components/ui/Identifier.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { IconUp, IconDown, KeyValuePair } from "@dfinity/gix-components";
+  import {
+    IconReimbursed,
+    IconUp,
+    IconDown,
+    KeyValuePair,
+  } from "@dfinity/gix-components";
   import type { UiTransaction } from "$lib/types/transaction";
   import {
     nonNullish,
@@ -19,10 +24,18 @@
   let tokenAmount: TokenAmount | TokenAmountV2;
   let isIncoming: boolean;
   let isPending: boolean;
+  let isReimbursement: boolean | undefined;
   let otherParty: string | undefined;
   let timestamp: Date | undefined;
-  $: ({ headline, tokenAmount, isIncoming, isPending, otherParty, timestamp } =
-    transaction);
+  $: ({
+    headline,
+    tokenAmount,
+    isIncoming,
+    isPending,
+    isReimbursement,
+    otherParty,
+    timestamp,
+  } = transaction);
 
   let label: string;
   $: label = isIncoming
@@ -39,8 +52,11 @@
     data-tid="icon"
     class:send={!isIncoming}
     class:pending={isPending}
+    class:reimbursed={isReimbursement}
   >
-    {#if isIncoming}
+    {#if isReimbursement}
+      <IconReimbursed size="24px" />
+    {:else if isIncoming}
       <IconDown size="24px" />
     {:else}
       <IconUp size="24px" />
@@ -150,6 +166,11 @@
     &.pending {
       color: var(--pending-color);
       background: var(--pending-background);
+    }
+
+    &.reimbursed {
+      color: var(--alert);
+      background: var(--alert-tint);
     }
   }
 </style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1024,7 +1024,8 @@
     "btc_received": "BTC Received",
     "btc_sent": "BTC Sent",
     "btc_network": "BTC Network",
-    "receiving_btc": "Receiving BTC"
+    "receiving_btc": "Receiving BTC",
+    "reimbursement": "Reimbursement"
   },
   "error__ckbtc": {
     "already_process": "The minter has already been notified and updating the balance is in progress.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1073,6 +1073,7 @@ interface I18nCkbtc {
   btc_sent: string;
   btc_network: string;
   receiving_btc: string;
+  reimbursement: string;
 }
 
 interface I18nError__ckbtc {

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -85,6 +85,7 @@ export interface UiTransaction {
   domKey: string;
   isIncoming: boolean;
   isPending: boolean;
+  isReimbursement?: boolean;
   headline: string;
   // Where the amount is going to or coming from.
   otherParty?: string;

--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -240,6 +240,7 @@ const MINT_TYPE_KYT_FAIL = 2;
 // The memo will decode to either:
 // * Convert: [0, [ tx_id, vout, kyt_fee]]
 // * KytFail: [2, [ kyt_fee, kyt_status, block_index]]
+// Source: https://github.com/dfinity/ic/blob/c22a5aebd4f26ae2e4016de55e3f7aa00d086479/rs/bitcoin/ckbtc/minter/src/memo.rs#L25
 type CkbtcMintMemo =
   | [0, [Uint8Array?, number?, number?]]
   | [2, [number, number?, number?]];

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -114,6 +114,14 @@ describe("TransactionCard", () => {
     expect(await po.hasPendingIcon()).toBe(true);
   });
 
+  it("displays reimbursement transaction", async () => {
+    const po = renderComponent({
+      isReimbursement: true,
+    });
+
+    expect(await po.hasReimbursementIcon()).toBe(true);
+  });
+
   it("displays identifier for received", async () => {
     const po = renderComponent({
       isIncoming: true,

--- a/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
@@ -469,6 +469,73 @@ describe("icrc-transaction utils", () => {
         }),
       });
     });
+
+    it("Renders a reimbursement transaction", () => {
+      const amount = 41_000_000n;
+      const kytFee = 1331;
+      const decodedMemo = [2, [kytFee, 1, 123]];
+      const memo = new Uint8Array(Cbor.encode(decodedMemo));
+
+      const data = mapCkbtcTransaction({
+        transaction: {
+          id: BigInt(1234),
+          transaction: createMintTransaction({
+            amount,
+            to: mainAccount,
+            memo,
+          }),
+        },
+        account: mockCkBTCMainAccount,
+        toSelfTransaction: false,
+        token: mockCkBTCToken,
+        i18n: en,
+      });
+      expect(data).toEqual({
+        domKey: "1234-1",
+        headline: "Reimbursement",
+        isIncoming: true,
+        isPending: false,
+        isReimbursement: true,
+        otherParty: "BTC Network",
+        timestamp: new Date(0),
+        tokenAmount: TokenAmountV2.fromUlps({
+          amount,
+          token: mockCkBTCToken,
+        }),
+      });
+    });
+
+    it("Renders a legacy mint memo as standard incoming BTC", () => {
+      const amount = 41_000_000n;
+      const txIdMemo = new Uint8Array(32).fill(99);
+
+      const data = mapCkbtcTransaction({
+        transaction: {
+          id: BigInt(1234),
+          transaction: createMintTransaction({
+            amount,
+            to: mainAccount,
+            memo: txIdMemo,
+          }),
+        },
+        account: mockCkBTCMainAccount,
+        toSelfTransaction: false,
+        token: mockCkBTCToken,
+        i18n: en,
+      });
+      expect(data).toEqual({
+        domKey: "1234-1",
+        headline: "BTC Received",
+        isIncoming: true,
+        isPending: false,
+        otherParty: "BTC Network",
+        timestamp: new Date(0),
+        tokenAmount: TokenAmountV2.fromUlps({
+          amount,
+          token: mockCkBTCToken,
+        }),
+      });
+    });
   });
 
   describe("mapCkbtcTransactions", () => {

--- a/frontend/src/tests/page-objects/TransactionCard.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionCard.page-object.ts
@@ -41,4 +41,9 @@ export class TransactionCardPo extends BasePageObject {
     const classNames = await this.root.byTestId("icon").getClasses();
     return classNames.includes("pending");
   }
+
+  async hasReimbursementIcon(): Promise<boolean> {
+    const classNames = await this.root.byTestId("icon").getClasses();
+    return classNames.includes("reimbursed");
+  }
 }


### PR DESCRIPTION
# Motivation

When withdrawaing ckBTC to BTC fails, the minter will mint the previously burned amount (minus fees) back into the user's account.
We want to render these transactions as Reimbursement transactions.

# Changes

1. Add `isReimbursement` field to `UiTransaction`.
2. Decode the memo on mint transactions. If we can decode them as failed KYT, mark the transaction as a reimbursed transaction.
3. Render `isReimbursement` transactions with `IconReimbursed` and alert colors.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [x] Add entry to changelog (if necessary).
