### PR TITLE
fix: Truncate error

### DIFF
--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -134,7 +134,7 @@ fn decode_arg(arg: &[u8], arg_types: IDLTypes) -> String {
 pub fn process_proposal_payload(proposal_info: ProposalInfo) -> Json {
     if let Some(Action::ExecuteNnsFunction(f)) = proposal_info.proposal.as_ref().and_then(|p| p.action.as_ref()) {
         transform_payload_to_json(f.nns_function, &f.payload)
-            .unwrap_or_else(|e| serde_json::to_string(&format!("Unable to deserialize payload: {e}")).unwrap())
+            .unwrap_or_else(|e| serde_json::to_string(&format!("Unable to deserialize payload: {e:.400}")).unwrap())
     } else {
         serde_json::to_string("Proposal has no payload").unwrap()
     }


### PR DESCRIPTION
# Motivation
We would like to make proposal payload rendering more robust.

- If schema types do not match, fall back to idl2json.
- If there is still an error, it should not be so large that it fails to return.

This PR addresses the latter.  As an example we have:

```
./scripts/proposals/mk-test-vector --network mainnet --proposal 126392
```
which yields a huge 3Mb error message:
```
$ wc -c /home/max/dfn/nns-dapp/rs/proposals/src/tests/proposals/mainnet/proposals/126392.payload.json
3279306
```

# Changes
Limit the size of the error message to 400 chars.

# Tests
Running the above comamnd on the same proposal now yields a short error:
```
$ cat /home/max/dfn/nns-dapp/rs/proposals/src/tests/proposals/mainnet/proposals/126392.payload.json
"Unable to deserialize payload: Custom(Fail to decode argument 0 from table0 to record {\n  arg : vec nat8;\n  wasm_module : vec nat8;\n  stop_before_installing : bool;\n  mode : variant { reinstall; upgrade; install };\n  canister_id : " <-- Truncated
```

# Todos

- [ ] Add entry to changelog (if necessary).
