### PR TITLE
Proposal rendering fallback

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -36,6 +36,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Limit the size of proposal payload rendering errors, as otherwise the error can become too large to return.
+* Provide a fallback if proposal payloads don't have the expected type.
 
 #### Security
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -34,6 +34,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Limit the size of proposal payload rendering errors, as otherwise the error can become too large to return.
+
 #### Security
 
 * Bump css-tools dev dependency to fix minor vulnerability.

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -142,7 +142,7 @@ const IDL2JSON_OPTIONS: Idl2JsonOptions = Idl2JsonOptions {
     prog: Vec::new(), // These are the type definitions used in proposal payloads.  If we have them, it would be nice to use them.  Do we?
 };
 
-/// Rust types can include things such as functions.  IDL types, sent over a wire, cannot.  Given that we want an IDLType from a more general type we need toconvert th egeneral type to the more specialized type.
+/// Rust types can include things such as functions.  IDL types, sent over a wire, cannot.  Given that we want an IDLType from a more general type we need toconvert the general type to the more specialized type.
 fn type_2_idltype(ty: Type) -> Result<IDLType, String> {
     match ty {
         Type::Null => Ok(IDLType::PrimT(parser_types::PrimType::Null)),

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -134,7 +134,7 @@ fn decode_arg(arg: &[u8], arg_types: IDLTypes) -> String {
 pub fn process_proposal_payload(proposal_info: ProposalInfo) -> Json {
     if let Some(Action::ExecuteNnsFunction(f)) = proposal_info.proposal.as_ref().and_then(|p| p.action.as_ref()) {
         transform_payload_to_json(f.nns_function, &f.payload)
-            .unwrap_or_else(|e| serde_json::to_string(&format!("Unable to deserialize payload: {e}")).unwrap())
+            .unwrap_or_else(|e| serde_json::to_string(&format!("Unable to deserialize payload: {e:.400}")).unwrap())
     } else {
         serde_json::to_string("Proposal has no payload").unwrap()
     }


### PR DESCRIPTION
# Motivation
Proposal schemas change, and not always in a forwards and backwards compatible fashion.  If that happens, the proposal rendering needs to not break.

# Changes
- If proposals fail to parse strictly with the expected types, use `idl2json` for a best-effort conversion.

# Tests
This proposal previously failed to parse:
```
$ ./scripts/proposals/mk-test-vector --network mainnet --proposal 126392
```
It now parses as:
```
[{"arg":"4449444c00017f","canister_id":"rdmx6-jaaaa-aaaaa-aaadq-cai","compute_allocation":[],"memory_allocation":[],"mode":{"upgrade":null},"query_allocation":[],"stop_before_installing":true,"wasm_module":"Bytes with sha256: 1950912f23acea10a63ea1c0a70ac316f2cea6055acde3044e24cb79682c6d40"}]
```

# Todos

- [x] Add entry to changelog (if necessary).
