### PR TITLE
style: fix broken nf commitment title on mobile

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -181,8 +181,6 @@
 </TestIdWrapper>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/dist/styles/mixins/text";
-
   // custom gap between text and the bar
   .commitment-progress-container {
     display: flex;
@@ -195,14 +193,11 @@
     align-items: center;
     gap: var(--padding-0_5x);
 
-    span {
-      @include text.clamp(1);
-    }
-
     // This is the dot with the participation color next to the label
     &::before {
       content: "";
       display: block;
+      flex-shrink: 0;
 
       height: var(--padding);
       width: var(--padding);


### PR DESCRIPTION
# Motivation

Fix broken nf commitment title dots on small mobile screens like galaxy S8  (screenshots)

# Changes

- remove text clamp
- limit dots minimal size

# Tests

| Before | After |
|--------|--------|
| <img width="307" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/08335465-e77c-422d-8eee-eaeea49a5104"> | <img width="310" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/8588d0d3-04d5-4340-b37e-a352bfc4877c"> |

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary since the feature is not on prod yet.