### PR TITLE
GIX-1983: Add ckBTC receive modal

### DIFF
--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -39,6 +39,10 @@
   import { nonNullish } from "@dfinity/utils";
   import { Principal } from "@dfinity/principal";
   import IcrcTokenTransactionModal from "$lib/modals/accounts/IcrcTokenTransactionModal.svelte";
+  import CkBtcReceiveModal from "$lib/modals/accounts/CkBTCReceiveModal.svelte";
+  import type { CkBTCAdditionalCanisters } from "$lib/types/ckbtc-canisters";
+  import { universesAccountsStore } from "$lib/derived/universes-accounts.derived";
+  import type { Account } from "$lib/types/account";
 
   onMount(() => {
     if (!$ENABLE_MY_TOKENS) {
@@ -119,6 +123,12 @@
     });
   };
 
+  const reloadCkBTC = () => {
+    return loadAccountsBalances(
+      $ckBTCUniversesStore.map(({ canisterId }) => canisterId)
+    );
+  };
+
   $: (async () => {
     if ($authSignedInStore) {
       await Promise.allSettled([
@@ -129,15 +139,34 @@
     }
   })();
 
+  type ModalType =
+    | "sns-send"
+    | "nns-send"
+    | "ckbtc-send"
+    | "icrc-send"
+    | "ckbtc-receive";
   let modal:
     | {
-        type: "sns-send" | "nns-send" | "ckbtc-send" | "icrc-send";
+        type: ModalType;
         data: UserTokenData;
       }
     | undefined;
   const closeModal = () => {
     modal = undefined;
   };
+
+  let ckBTCCanisters: CkBTCAdditionalCanisters | undefined;
+  $: ckBTCCanisters =
+    modal && isUniverseCkBTC(modal.data.universeId)
+      ? CKBTC_ADDITIONAL_CANISTERS[modal?.data.universeId.toText()]
+      : undefined;
+
+  let account: Account | undefined;
+  $: account =
+    modal &&
+    $universesAccountsStore[modal.data.universeId.toText()].find(
+      ({ type }) => type === "main"
+    );
 
   const handleAction = ({ detail }: { detail: Action }) => {
     // Any action from non-signed in user should be trigger a login
@@ -159,6 +188,11 @@
       } else {
         // Default to SNS, this might change when we have more universe sources
         modal = { type: "sns-send", data: detail.data };
+      }
+    }
+    if (detail.type === ActionType.Receive) {
+      if (isUniverseCkBTC(detail.data.universeId)) {
+        modal = { type: "ckbtc-receive", data: detail.data };
       }
     }
   };
@@ -200,6 +234,19 @@
       ledgerCanisterId={modal.data.universeId}
       token={modal.data.token}
       transactionFee={modal.data.fee}
+    />
+  {/if}
+
+  {#if modal?.type === "ckbtc-receive" && nonNullish(ckBTCCanisters) && nonNullish(account)}
+    <CkBtcReceiveModal
+      data={{
+        canisters: ckBTCCanisters,
+        account,
+        universeId: modal.data.universeId,
+        canSelectAccount: false,
+        reload: reloadCkBTC,
+      }}
+      on:nnsClose={closeModal}
     />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -123,10 +123,8 @@
     });
   };
 
-  const reloadCkBTC = () => {
-    return loadAccountsBalances(
-      $ckBTCUniversesStore.map(({ canisterId }) => canisterId)
-    );
+  const createReloadAccountBalance = (universeId: Principal) => () => {
+    return loadAccountsBalances([universeId.toText()]);
   };
 
   $: (async () => {
@@ -244,7 +242,7 @@
         account,
         universeId: modal.data.universeId,
         canSelectAccount: false,
-        reload: reloadCkBTC,
+        reload: createReloadAccountBalance(modal.data.universeId),
       }}
       on:nnsClose={closeModal}
     />

--- a/frontend/src/tests/page-objects/TokensPage.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensPage.page-object.ts
@@ -33,4 +33,8 @@ export class TokensPagePo extends BasePageObject {
   clickSendOnRow(projectName: string): Promise<void> {
     return this.getTokensTable().clickSendOnRow(projectName);
   }
+
+  clickReceiveOnRow(projectName: string): Promise<void> {
+    return this.getTokensTable().clickReceiveOnRow(projectName);
+  }
 }

--- a/frontend/src/tests/page-objects/TokensRoute.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensRoute.page-object.ts
@@ -1,5 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { CkBTCReceiveModalPo } from "./CkBTCReceiveModal.page-object";
 import { CkBTCTransactionModalPo } from "./CkBTCTransactionModal.page-object";
 import { IcrcTokenTransactionModalPo } from "./IcrcTokenTransactionModal.page-object";
 import { SignInTokensPagePo } from "./SignInTokens.page-object";
@@ -31,6 +32,10 @@ export class TokensRoutePo extends BasePageObject {
 
   getSnsTransactionModalPo(): SnsTransactionModalPo {
     return SnsTransactionModalPo.under(this.root);
+  }
+
+  getCkBTCReceiveModalPo(): CkBTCReceiveModalPo {
+    return CkBTCReceiveModalPo.under(this.root);
   }
 
   transferSnsTokens(params: {

--- a/frontend/src/tests/page-objects/TokensTable.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTable.page-object.ts
@@ -52,12 +52,32 @@ export class TokensTablePo extends BasePageObject {
     return row.getData();
   }
 
-  async clickSendOnRow(projectName: string): Promise<void> {
+  async clickButtonOnRow({
+    testId,
+    projectName,
+  }: {
+    testId: string;
+    projectName: string;
+  }): Promise<void> {
     const row = await this.findRowByName(projectName);
     if (isNullish(row)) {
       throw new Error(`Row with project name ${projectName} not found`);
     }
-    return row.click("send-button-component");
+    return row.click(testId);
+  }
+
+  async clickSendOnRow(projectName: string): Promise<void> {
+    return this.clickButtonOnRow({
+      testId: "send-button-component",
+      projectName,
+    });
+  }
+
+  async clickReceiveOnRow(projectName: string): Promise<void> {
+    return this.clickButtonOnRow({
+      testId: "receive-button-component",
+      projectName,
+    });
   }
 
   getLastRowText(): Promise<string> {

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -282,6 +282,31 @@ describe("Tokens route", () => {
           ]);
         });
 
+        it("should update balance after using the receive modal", async () => {
+          const po = await renderPage();
+
+          const tokensPagePo = await po.getTokensPagePo();
+
+          expect(await tokensPagePo.getRowData("ckBTC")).toEqual({
+            projectName: "ckBTC",
+            balance: "4.45 ckBTC",
+          });
+
+          await tokensPagePo.clickReceiveOnRow("ckBTC");
+          const modalPo = po.getCkBTCReceiveModalPo();
+          expect(await modalPo.isPresent()).toBe(true);
+
+          ckBTCBalanceE8s += 100_000_000n;
+          await modalPo.clickFinish();
+
+          await runResolvedPromises();
+
+          expect(await tokensPagePo.getRowData("ckBTC")).toEqual({
+            projectName: "ckBTC",
+            balance: "5.45 ckBTC",
+          });
+        });
+
         it("should update the ckBTC balance in the background", async () => {
           const completedUtxos = [
             {


### PR DESCRIPTION
# Motivation

User can open the Receive modal for ckBTC in the Tokens page.

# Changes

* Add the `CkBtcReceiveModal` in the tokens route page.

# Tests

* Add a test that the balance is updated after a click in the receive modal.
* Add convenience methods in POs

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.

