### PR TITLE
GIX-2062: Loading state ICP tokens table

### DIFF
--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -5,12 +5,11 @@ import {
   type IcpAccountsStore,
 } from "$lib/stores/icp-accounts.store";
 import type { Account, AccountType } from "$lib/types/account";
-import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
+import { UserTokenAction, type UserToken } from "$lib/types/tokens-page";
 import type { Universe } from "$lib/types/universe";
 import { buildWalletUrl } from "$lib/utils/navigation.utils";
-import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { Principal } from "@dfinity/principal";
-import { isNullish, nonNullish, TokenAmountV2 } from "@dfinity/utils";
+import { isNullish, TokenAmountV2 } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 import { nnsUniverseStore } from "./nns-universe.derived";
 
@@ -22,7 +21,7 @@ const convertAccountToUserTokenData = ({
   nnsUniverse: Universe;
   i18nObj: I18n;
   account?: Account;
-}): UserTokenData => {
+}): UserToken => {
   const subtitleMap: Record<AccountType, string | undefined> = {
     main: undefined,
     subAccount: i18nObj.accounts.subAccount,
@@ -35,38 +34,42 @@ const convertAccountToUserTokenData = ({
     : account.type === "main"
     ? i18nObj.accounts.main
     : account.name ?? "";
+
+  if (isNullish(account)) {
+    return {
+      universeId: Principal.fromText(nnsUniverse.canisterId),
+      title,
+      balance: "loading",
+      logo: nnsUniverse.logo,
+      actions: [],
+    };
+  }
+
   return {
     universeId: Principal.fromText(nnsUniverse.canisterId),
     title,
-    subtitle: account && subtitleMap[account.type],
-    // TODO: Add loading balance state
-    balance: nonNullish(account)
-      ? TokenAmountV2.fromUlps({
-          amount: account.balanceUlps,
-          token: NNS_TOKEN_DATA,
-        })
-      : new UnavailableTokenAmount(NNS_TOKEN_DATA),
+    subtitle: subtitleMap[account.type],
+    balance: TokenAmountV2.fromUlps({
+      amount: account.balanceUlps,
+      token: NNS_TOKEN_DATA,
+    }),
     logo: nnsUniverse.logo,
     token: NNS_TOKEN_DATA,
     fee: TokenAmountV2.fromUlps({
       amount: NNS_TOKEN_DATA.fee,
       token: NNS_TOKEN_DATA,
     }),
-    rowHref: nonNullish(account)
-      ? buildWalletUrl({
-          universe: nnsUniverse.canisterId.toString(),
-          account: account?.identifier,
-        })
-      : undefined,
-    actions: nonNullish(account)
-      ? [UserTokenAction.Receive, UserTokenAction.Send]
-      : [],
+    rowHref: buildWalletUrl({
+      universe: nnsUniverse.canisterId.toString(),
+      account: account?.identifier,
+    }),
+    actions: [UserTokenAction.Receive, UserTokenAction.Send],
   };
 };
 
 export const icpTokensListUser = derived<
   [Readable<Universe>, IcpAccountsStore, Readable<I18n>],
-  UserTokenData[]
+  UserToken[]
 >(
   [nnsUniverseStore, icpAccountsStore, i18n],
   ([nnsUniverse, icpAccounts, i18nObj]) => [

--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -22,19 +22,6 @@ const convertAccountToUserTokenData = ({
   i18nObj: I18n;
   account?: Account;
 }): UserToken => {
-  const subtitleMap: Record<AccountType, string | undefined> = {
-    main: undefined,
-    subAccount: i18nObj.accounts.subAccount,
-    hardwareWallet: i18nObj.accounts.hardwareWallet,
-    // This is not used in the UI, but it's here for completeness
-    withdrawalAccount: i18nObj.accounts.withdrawalAccount,
-  };
-  const title: string = isNullish(account)
-    ? i18nObj.core.ic
-    : account.type === "main"
-    ? i18nObj.accounts.main
-    : account.name ?? "";
-
   if (isNullish(account)) {
     return {
       universeId: Principal.fromText(nnsUniverse.canisterId),
@@ -44,6 +31,17 @@ const convertAccountToUserTokenData = ({
       actions: [],
     };
   }
+
+  const subtitleMap: Record<AccountType, string | undefined> = {
+    main: undefined,
+    subAccount: i18nObj.accounts.subAccount,
+    hardwareWallet: i18nObj.accounts.hardwareWallet,
+    // This is not used in the UI, but it's here for completeness
+    withdrawalAccount: i18nObj.accounts.withdrawalAccount,
+  };
+
+  const title: string =
+    account.type === "main" ? i18nObj.accounts.main : account.name ?? "";
 
   return {
     universeId: Principal.fromText(nnsUniverse.canisterId),

--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -38,7 +38,7 @@ const convertAccountToUserTokenData = ({
   if (isNullish(account)) {
     return {
       universeId: Principal.fromText(nnsUniverse.canisterId),
-      title,
+      title: i18nObj.accounts.main,
       balance: "loading",
       logo: nnsUniverse.logo,
       actions: [],

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -11,7 +11,7 @@
     pollAccounts,
   } from "$lib/services/icp-accounts.services";
   import { ICPToken } from "@dfinity/utils";
-  import type { UserTokenData } from "$lib/types/tokens-page";
+  import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
   import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
   import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
@@ -29,7 +29,7 @@
   });
 
   // TODO: Remove default value when we remove the feature flag
-  export let userTokensData: UserTokenData[] = [];
+  export let userTokensData: UserToken[] = [];
 
   const openAddAccountModal = () => {
     openAccountsModal({

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -11,7 +11,7 @@
     pollAccounts,
   } from "$lib/services/icp-accounts.services";
   import { ICPToken } from "@dfinity/utils";
-  import type { UserToken, UserTokenData } from "$lib/types/tokens-page";
+  import type { UserToken } from "$lib/types/tokens-page";
   import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
   import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -2,14 +2,21 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import { icpTokensListUser } from "$lib/derived/icp-tokens-list-user.derived";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
-import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
+import {
+  UserTokenAction,
+  type UserTokenData,
+  type UserTokenLoading,
+} from "$lib/types/tokens-page";
 import { buildWalletUrl } from "$lib/utils/navigation.utils";
 import {
   mockHardwareWalletAccount,
   mockMainAccount,
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
-import { createIcpUserToken } from "$tests/mocks/tokens-page.mock";
+import {
+  createIcpUserToken,
+  icpTokenBase,
+} from "$tests/mocks/tokens-page.mock";
 import { TokenAmountV2 } from "@dfinity/utils";
 import { get } from "svelte/store";
 
@@ -17,10 +24,9 @@ describe("icp-tokens-list-user.derived", () => {
   const icpTokenUser: UserTokenData = createIcpUserToken({
     actions: [UserTokenAction.Receive, UserTokenAction.Send],
   });
-  const emptyUserTokenData: UserTokenData = {
-    ...icpTokenUser,
-    title: "Internet Computer",
-    subtitle: undefined,
+  const loadingUserTokenData: UserTokenLoading = {
+    ...icpTokenBase,
+    balance: "loading",
     actions: [],
   };
   const mainUserTokenData: UserTokenData = {
@@ -69,7 +75,7 @@ describe("icp-tokens-list-user.derived", () => {
     });
 
     it("should return empty if no accounts", () => {
-      expect(get(icpTokensListUser)).toEqual([emptyUserTokenData]);
+      expect(get(icpTokensListUser)).toEqual([loadingUserTokenData]);
     });
 
     it("should return only main if no subaccounts and no subaccounts", () => {

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -26,6 +26,7 @@ describe("icp-tokens-list-user.derived", () => {
   });
   const loadingUserTokenData: UserTokenLoading = {
     ...icpTokenBase,
+    title: "Main",
     balance: "loading",
     actions: [],
   };

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -59,6 +59,7 @@ describe("tokens-list-user.derived", () => {
   });
   const icpUserTokenLoading: UserTokenLoading = {
     ...icpTokenBase,
+    title: "Main",
     balance: "loading",
     actions: [],
   };

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -59,7 +59,6 @@ describe("tokens-list-user.derived", () => {
   });
   const icpUserTokenLoading: UserTokenLoading = {
     ...icpTokenBase,
-    title: "Main",
     balance: "loading",
     actions: [],
   };


### PR DESCRIPTION
# Motivation

Add loading state in the ICP tokens table.

# Changes

* Return the `UserToken` instead of `UserTokenData` in `icpTokensListUser`.
* Expect list of `UserToken` in NnsAccounts.
* Return a UserTokenLoading instead of an empty balance when the ICP account is not there.

# Tests

* Change the test expectation when the accounts are not present in `icpTokensListUser`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.

