### PR TITLE
Fix: Wallet back button tokens enabled

### DIFF
--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -14,9 +14,9 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import GetTokens from "$lib/components/ic/GetTokens.svelte";
   import {
-    accountsPathStore,
     canistersPathStore,
     neuronsPathStore,
+    tokensPathStore,
     proposalsPathStore,
   } from "$lib/derived/paths.derived";
   import { keyOf } from "$lib/utils/utils";
@@ -40,7 +40,7 @@
   $: routes = [
     {
       context: "accounts",
-      href: $accountsPathStore,
+      href: $tokensPathStore,
       selected: isSelectedPath({
         currentPath: $pageStore.path,
         paths: [AppPath.Accounts, AppPath.Wallet, AppPath.Tokens],

--- a/frontend/src/lib/derived/paths.derived.ts
+++ b/frontend/src/lib/derived/paths.derived.ts
@@ -13,12 +13,9 @@ import { derived, type Readable } from "svelte/store";
 export const tokensPathStore = derived<
   [Readable<Page>, Readable<boolean>],
   string
->([pageStore, ENABLE_MY_TOKENS], ([{ universe }, isTokensEnabled]) => {
-  if (isTokensEnabled) {
-    return AppPath.Tokens;
-  }
-  return buildAccountsUrl({ universe });
-});
+>([pageStore, ENABLE_MY_TOKENS], ([{ universe }, isTokensEnabled]) =>
+  isTokensEnabled ? AppPath.Tokens : buildAccountsUrl({ universe })
+);
 
 export const accountsPathStore = derived<Readable<Page>, string>(
   pageStore,

--- a/frontend/src/lib/derived/paths.derived.ts
+++ b/frontend/src/lib/derived/paths.derived.ts
@@ -1,3 +1,4 @@
+import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore, type Page } from "$lib/derived/page.derived";
 import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
 import {
@@ -8,11 +9,20 @@ import {
 } from "$lib/utils/navigation.utils";
 import { derived, type Readable } from "svelte/store";
 
-export const accountsPathStore = derived<
+// TODO: Remove and use instead a constant value for AppPath.Tokens when the flag is removed.
+export const tokensPathStore = derived<
   [Readable<Page>, Readable<boolean>],
   string
->([pageStore, ENABLE_MY_TOKENS], ([{ universe }, tokensEnabled]) =>
-  buildAccountsUrl({ universe, tokensEnabled })
+>([pageStore, ENABLE_MY_TOKENS], ([{ universe }, isTokensEnabled]) => {
+  if (isTokensEnabled) {
+    return AppPath.Tokens;
+  }
+  return buildAccountsUrl({ universe });
+});
+
+export const accountsPathStore = derived<Readable<Page>, string>(
+  pageStore,
+  ({ universe }) => buildAccountsUrl({ universe })
 );
 
 export const neuronsPathStore = derived<Readable<Page>, string>(

--- a/frontend/src/lib/utils/navigation.utils.ts
+++ b/frontend/src/lib/utils/navigation.utils.ts
@@ -1,3 +1,4 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import {
   ACCOUNT_PARAM,
   AppPath,
@@ -7,6 +8,8 @@ import {
   UNIVERSE_PARAM,
 } from "$lib/constants/routes.constants";
 import type { NeuronId, ProposalId } from "@dfinity/nns";
+import { Principal } from "@dfinity/principal";
+import { isUniverseNns } from "./universe.utils";
 import { isArrayEmpty } from "./utils";
 
 // If the previous page is a particular detail page and if we have data in store, we don't reset and query the data in store after the route is mounted.
@@ -53,10 +56,19 @@ export const buildAccountsUrl = ({
 }: {
   universe: string;
   tokensEnabled?: boolean;
-}) =>
-  tokensEnabled
-    ? AppPath.Tokens
-    : buildUrl({ path: AppPath.Accounts, universe });
+}) => {
+  try {
+    // `Principal.fromText` throws if the text is not a valid principal
+    const universePrincipal = Principal.fromText(universe);
+    return tokensEnabled && !isUniverseNns(universePrincipal)
+      ? AppPath.Tokens
+      : buildUrl({ path: AppPath.Accounts, universe });
+  } catch (error) {
+    return tokensEnabled
+      ? AppPath.Tokens
+      : buildUrl({ path: AppPath.Accounts, universe: OWN_CANISTER_ID_TEXT });
+  }
+};
 export const buildNeuronsUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Neurons, universe });
 export const buildProposalsUrl = ({ universe }: { universe: string }) =>

--- a/frontend/src/lib/utils/navigation.utils.ts
+++ b/frontend/src/lib/utils/navigation.utils.ts
@@ -1,4 +1,3 @@
-import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import {
   ACCOUNT_PARAM,
   AppPath,
@@ -8,8 +7,6 @@ import {
   UNIVERSE_PARAM,
 } from "$lib/constants/routes.constants";
 import type { NeuronId, ProposalId } from "@dfinity/nns";
-import { Principal } from "@dfinity/principal";
-import { isUniverseNns } from "./universe.utils";
 import { isArrayEmpty } from "./utils";
 
 // If the previous page is a particular detail page and if we have data in store, we don't reset and query the data in store after the route is mounted.
@@ -50,25 +47,8 @@ const buildUrl = ({
     .map(([key, value]) => `&${key}=${value}`)
     .join("")}`;
 
-export const buildAccountsUrl = ({
-  universe,
-  tokensEnabled,
-}: {
-  universe: string;
-  tokensEnabled?: boolean;
-}) => {
-  try {
-    // `Principal.fromText` throws if the text is not a valid principal
-    const universePrincipal = Principal.fromText(universe);
-    return tokensEnabled && !isUniverseNns(universePrincipal)
-      ? AppPath.Tokens
-      : buildUrl({ path: AppPath.Accounts, universe });
-  } catch (error) {
-    return tokensEnabled
-      ? AppPath.Tokens
-      : buildUrl({ path: AppPath.Accounts, universe: OWN_CANISTER_ID_TEXT });
-  }
-};
+export const buildAccountsUrl = ({ universe }: { universe: string }) =>
+  buildUrl({ path: AppPath.Accounts, universe });
 export const buildNeuronsUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Neurons, universe });
 export const buildProposalsUrl = ({ universe }: { universe: string }) =>

--- a/frontend/src/routes/(app)/(u)/(detail)/wallet/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(detail)/wallet/+layout.svelte
@@ -2,10 +2,15 @@
   import Layout from "$lib/components/layout/Layout.svelte";
   import Content from "$lib/components/layout/Content.svelte";
   import { goto } from "$app/navigation";
-  import { accountsPathStore } from "$lib/derived/paths.derived";
+  import {
+    accountsPathStore,
+    tokensPathStore,
+  } from "$lib/derived/paths.derived";
   import LayoutNavGuard from "$lib/components/layout/LayoutNavGuard.svelte";
+  import { isNnsUniverseStore } from "$lib/derived/selected-universe.derived";
 
-  const back = (): Promise<void> => goto($accountsPathStore);
+  const back = (): Promise<void> =>
+    goto($isNnsUniverseStore ? $accountsPathStore : $tokensPathStore);
 </script>
 
 <LayoutNavGuard>

--- a/frontend/src/tests/lib/derived/paths.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/paths.derived.spec.ts
@@ -40,8 +40,18 @@ describe("paths derived stores", () => {
         overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
       });
 
-      it("should return the tokens path", () => {
+      it("should return the tokens path if universe is not NNS", () => {
+        page.mock({ data: { universe: mockSnsCanisterIdText } });
+
         expect(get(accountsPathStore)).toBe(AppPath.Tokens);
+      });
+
+      it("should return the NNS accounts path if universe is NNS", () => {
+        page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+
+        expect(get(accountsPathStore)).toBe(
+          `${AppPath.Accounts}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
+        );
       });
     });
   });

--- a/frontend/src/tests/lib/derived/paths.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/paths.derived.spec.ts
@@ -5,6 +5,7 @@ import {
   canistersPathStore,
   neuronsPathStore,
   proposalsPathStore,
+  tokensPathStore,
 } from "$lib/derived/paths.derived";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { page } from "$mocks/$app/stores";
@@ -14,6 +15,34 @@ import { get } from "svelte/store";
 describe("paths derived stores", () => {
   beforeEach(() => {
     overrideFeatureFlagsStore.reset();
+  });
+
+  describe("tokensPathStore", () => {
+    describe("when My Tokens feature is enabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
+      });
+
+      it("should return the tokens path if universe is not NNS", () => {
+        page.mock({ data: { universe: mockSnsCanisterIdText } });
+
+        expect(get(tokensPathStore)).toBe(AppPath.Tokens);
+      });
+    });
+
+    describe("when My Tokens feature is disabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", false);
+      });
+
+      it("should return the accounts path", () => {
+        page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+
+        expect(get(tokensPathStore)).toBe(
+          `${AppPath.Accounts}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
+        );
+      });
+    });
   });
 
   describe("accountsPathStore", () => {

--- a/frontend/src/tests/lib/derived/paths.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/paths.derived.spec.ts
@@ -63,26 +63,6 @@ describe("paths derived stores", () => {
         `${AppPath.Accounts}/?${UNIVERSE_PARAM}=${mockSnsCanisterIdText}`
       );
     });
-
-    describe("when My Tokens feature is enabled", () => {
-      beforeEach(() => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
-      });
-
-      it("should return the tokens path if universe is not NNS", () => {
-        page.mock({ data: { universe: mockSnsCanisterIdText } });
-
-        expect(get(accountsPathStore)).toBe(AppPath.Tokens);
-      });
-
-      it("should return the NNS accounts path if universe is NNS", () => {
-        page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
-
-        expect(get(accountsPathStore)).toBe(
-          `${AppPath.Accounts}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
-        );
-      });
-    });
   });
 
   describe("neuronsPathStore", () => {

--- a/frontend/src/tests/lib/utils/navigation.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/navigation.utils.spec.ts
@@ -20,7 +20,7 @@ import {
   isSelectedPath,
   reloadRouteData,
 } from "$lib/utils/navigation.utils";
-import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
+import { mockSnsFullProject, principal } from "$tests/mocks/sns-projects.mock";
 
 describe("navigation-utils", () => {
   describe("reload", () => {
@@ -133,19 +133,50 @@ describe("navigation-utils", () => {
     });
 
     it("should build accounts url when tokens not enabled", () => {
+      const universe = principal(0).toText();
+      expect(
+        buildAccountsUrl({
+          universe,
+        })
+      ).toEqual(`${AppPath.Accounts}/?${UNIVERSE_PARAM}=${universe}`);
+    });
+
+    it("should build accounts url when tokens is enabled", () => {
+      const universe = principal(0).toText();
+      expect(
+        buildAccountsUrl({
+          universe,
+          tokensEnabled: true,
+        })
+      ).toEqual(AppPath.Tokens);
+    });
+
+    it("should build accounts url for NNS even with tokens enabled", () => {
       expect(
         buildAccountsUrl({
           universe: OWN_CANISTER_ID_TEXT,
+          tokensEnabled: true,
         })
       ).toEqual(
         `${AppPath.Accounts}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
       );
     });
 
-    it("should build accounts url when tokens is enabled", () => {
+    it("should build accounts url for NNS if universe is not a valid principal string and tokens are not enabled", () => {
       expect(
         buildAccountsUrl({
-          universe: OWN_CANISTER_ID_TEXT,
+          universe: "not-valid",
+          tokensEnabled: false,
+        })
+      ).toEqual(
+        `${AppPath.Accounts}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
+      );
+    });
+
+    it("should build Tokens path if universe is not a valid principal string and tokens are enabled", () => {
+      expect(
+        buildAccountsUrl({
+          universe: "not-valid",
           tokensEnabled: true,
         })
       ).toEqual(AppPath.Tokens);

--- a/frontend/src/tests/lib/utils/navigation.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/navigation.utils.spec.ts
@@ -132,54 +132,13 @@ describe("navigation-utils", () => {
       );
     });
 
-    it("should build accounts url when tokens not enabled", () => {
+    it("should build accounts url", () => {
       const universe = principal(0).toText();
       expect(
         buildAccountsUrl({
           universe,
         })
       ).toEqual(`${AppPath.Accounts}/?${UNIVERSE_PARAM}=${universe}`);
-    });
-
-    it("should build accounts url when tokens is enabled", () => {
-      const universe = principal(0).toText();
-      expect(
-        buildAccountsUrl({
-          universe,
-          tokensEnabled: true,
-        })
-      ).toEqual(AppPath.Tokens);
-    });
-
-    it("should build accounts url for NNS even with tokens enabled", () => {
-      expect(
-        buildAccountsUrl({
-          universe: OWN_CANISTER_ID_TEXT,
-          tokensEnabled: true,
-        })
-      ).toEqual(
-        `${AppPath.Accounts}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
-      );
-    });
-
-    it("should build accounts url for NNS if universe is not a valid principal string and tokens are not enabled", () => {
-      expect(
-        buildAccountsUrl({
-          universe: "not-valid",
-          tokensEnabled: false,
-        })
-      ).toEqual(
-        `${AppPath.Accounts}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
-      );
-    });
-
-    it("should build Tokens path if universe is not a valid principal string and tokens are enabled", () => {
-      expect(
-        buildAccountsUrl({
-          universe: "not-valid",
-          tokensEnabled: true,
-        })
-      ).toEqual(AppPath.Tokens);
     });
 
     it("should build neurons url", () => {

--- a/frontend/src/tests/routes/app/wallet/layout.spec.ts
+++ b/frontend/src/tests/routes/app/wallet/layout.spec.ts
@@ -1,0 +1,98 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { AppPath } from "$lib/constants/routes.constants";
+import { pageStore } from "$lib/derived/page.derived";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import { page } from "$mocks/$app/stores";
+import WalletLayout from "$routes/(app)/(u)/(detail)/wallet/+layout.svelte";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
+import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { fireEvent, render } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+describe("Wallet layout", () => {
+  describe("when tokens flag is enabled", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
+    });
+
+    it("back button should navigate to tokens page if universe is not NNS", async () => {
+      page.mock({
+        routeId: AppPath.Wallet,
+        data: {
+          universe: rootCanisterIdMock.toText(),
+          account: mockSnsMainAccount.identifier,
+        },
+      });
+      const { queryByTestId } = render(WalletLayout);
+
+      expect(get(pageStore).path).toEqual(AppPath.Wallet);
+      await fireEvent.click(queryByTestId("back"));
+
+      expect(get(pageStore).path).toEqual(AppPath.Tokens);
+    });
+
+    it("back button should navigate to Accounts page if universe is NNS", async () => {
+      page.mock({
+        routeId: AppPath.Wallet,
+        data: {
+          universe: OWN_CANISTER_ID_TEXT,
+          account: mockMainAccount.identifier,
+        },
+      });
+      const { queryByTestId } = render(WalletLayout);
+
+      expect(get(pageStore).path).toEqual(AppPath.Wallet);
+      await fireEvent.click(queryByTestId("back"));
+
+      expect(get(pageStore)).toEqual({
+        path: AppPath.Accounts,
+        universe: OWN_CANISTER_ID_TEXT,
+      });
+    });
+  });
+
+  describe("when tokens flag is disabled", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", false);
+    });
+
+    it("back button should navigate to Accounts page if universe is not NNS", async () => {
+      page.mock({
+        routeId: AppPath.Wallet,
+        data: {
+          universe: rootCanisterIdMock.toText(),
+          account: mockSnsMainAccount.identifier,
+        },
+      });
+      const { queryByTestId } = render(WalletLayout);
+
+      expect(get(pageStore).path).toEqual(AppPath.Wallet);
+      await fireEvent.click(queryByTestId("back"));
+
+      expect(get(pageStore)).toEqual({
+        path: AppPath.Accounts,
+        universe: rootCanisterIdMock.toText(),
+      });
+    });
+
+    it("back button should navigate to Accounts page if universe is NNS", async () => {
+      page.mock({
+        routeId: AppPath.Wallet,
+        data: {
+          universe: OWN_CANISTER_ID_TEXT,
+          account: mockMainAccount.identifier,
+        },
+      });
+      const { queryByTestId } = render(WalletLayout);
+
+      expect(get(pageStore).path).toEqual(AppPath.Wallet);
+      await fireEvent.click(queryByTestId("back"));
+
+      expect(get(pageStore)).toEqual({
+        path: AppPath.Accounts,
+        universe: OWN_CANISTER_ID_TEXT,
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

There was a bug that the user was redirected to the Tokens page from an ICP wallet.

Instead, the user should go to the ICP Accounts.

# Changes

* Change implementation of `buildAccountsUrl` to build an accounts page for NNS only.

# Tests

* Add tests for `buildAccountsUrl`.
* Add tests for `accountsPathStore` which uses `buildAccountsUrl`.
* Add a test file for the wallet layout component which is were the bug was.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
