### PR TITLE
GIX-1983: Tokens Page Receive Modal ICRC

### DIFF
--- a/frontend/src/tests/page-objects/TokensRoute.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensRoute.page-object.ts
@@ -3,6 +3,7 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 import { CkBTCReceiveModalPo } from "./CkBTCReceiveModal.page-object";
 import { CkBTCTransactionModalPo } from "./CkBTCTransactionModal.page-object";
 import { IcrcTokenTransactionModalPo } from "./IcrcTokenTransactionModal.page-object";
+import { ReceiveModalPo } from "./ReceiveModal.page-object";
 import { SignInTokensPagePo } from "./SignInTokens.page-object";
 import { SnsTransactionModalPo } from "./SnsTransactionModal.page-object";
 import { TokensPagePo } from "./TokensPage.page-object";
@@ -36,6 +37,10 @@ export class TokensRoutePo extends BasePageObject {
 
   getCkBTCReceiveModalPo(): CkBTCReceiveModalPo {
     return CkBTCReceiveModalPo.under(this.root);
+  }
+
+  getReceiveModalPo(): ReceiveModalPo {
+    return ReceiveModalPo.under(this.root);
   }
 
   transferSnsTokens(params: {


### PR DESCRIPTION
# Motivation

Users can use the receive button of the Tokens Page for SNS and ICRC tokens like ckETH.

# Changes

* In Tokens page: new modal type "icrc-receive" that opens the IcrcReceiveModal.
* Change `createReloadAccountBalance` to call the SNS service instead of `loadAccountsBalances`.

# Tests

* Add convenience method in PO
* Add two tests, one for the receive modal for SNS projects, another for ckETH.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
