### PR TITLE
Rename UniverseAccountsBalance.balanceE8s to balanceUlps

### DIFF
--- a/frontend/src/lib/components/universe/UniverseAccountsBalance.svelte
+++ b/frontend/src/lib/components/universe/UniverseAccountsBalance.svelte
@@ -10,7 +10,7 @@
   export let universe: Universe;
 
   let balanceUlps: bigint | undefined;
-  $: balanceUlps = $universesAccountsBalance[universe.canisterId]?.balanceE8s;
+  $: balanceUlps = $universesAccountsBalance[universe.canisterId]?.balanceUlps;
 
   let token: Token | undefined;
   $: token = $tokensStore[universe.canisterId]?.token;

--- a/frontend/src/lib/derived/tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-user.derived.ts
@@ -36,7 +36,7 @@ const convertToUserTokenData = ({
   baseTokenData: UserTokenBase;
   authData: AuthStoreData;
 }): UserToken => {
-  const balanceUlps = balances[baseTokenData.universeId.toText()]?.balanceE8s;
+  const balanceUlps = balances[baseTokenData.universeId.toText()]?.balanceUlps;
   const token = tokens[baseTokenData.universeId.toText()]?.token;
   const rowHref = isNullish(authData.identity)
     ? undefined

--- a/frontend/src/lib/derived/universes-accounts-balance.derived.ts
+++ b/frontend/src/lib/derived/universes-accounts-balance.derived.ts
@@ -14,8 +14,7 @@ import { sumAccounts, sumNnsAccounts } from "$lib/utils/accounts.utils";
 import { derived } from "svelte/store";
 
 export interface UniverseAccountsBalance {
-  // TODO GIX-2154: Rename to balanceUlps
-  balanceE8s: bigint | undefined;
+  balanceUlps: bigint | undefined;
   certified: boolean;
 }
 
@@ -31,14 +30,14 @@ export const universesAccountsBalance = derived<
   [icpAccountsStore, snsAccountsStore, icrcAccountsStore],
   ([$accountsStore, $snsAccountsStore, $icrcAccountsStore]) => ({
     [OWN_CANISTER_ID_TEXT]: {
-      balanceE8s: sumNnsAccounts($accountsStore),
+      balanceUlps: sumNnsAccounts($accountsStore),
       certified: $accountsStore.certified ?? false,
     },
     ...Object.entries($icrcAccountsStore).reduce(
       (acc, [canisterId, { accounts, certified }]) => ({
         ...acc,
         [canisterId]: {
-          balanceE8s: sumAccounts(accounts),
+          balanceUlps: sumAccounts(accounts),
           certified,
         },
       }),
@@ -48,7 +47,7 @@ export const universesAccountsBalance = derived<
       (acc, [rootCanisterId, { accounts, certified }]) => ({
         ...acc,
         [rootCanisterId]: {
-          balanceE8s: sumAccounts(accounts),
+          balanceUlps: sumAccounts(accounts),
           certified,
         },
       }),

--- a/frontend/src/tests/lib/derived/universes-accounts-balance.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-accounts-balance.derived.spec.ts
@@ -31,14 +31,14 @@ describe("universes-accounts-balance.derived", () => {
 
   it("should derive a balance of Nns accounts", () => {
     const balances = get(universesAccountsBalance);
-    expect(balances[OWN_CANISTER_ID_TEXT].balanceE8s).toEqual(
+    expect(balances[OWN_CANISTER_ID_TEXT].balanceUlps).toEqual(
       mockMainAccount.balanceUlps
     );
   });
 
   it("should derive a balance of Sns accounts", () => {
     const balances = get(universesAccountsBalance);
-    expect(balances[rootCanisterId.toText()].balanceE8s).toEqual(
+    expect(balances[rootCanisterId.toText()].balanceUlps).toEqual(
       mockSnsMainAccount.balanceUlps
     );
   });

--- a/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
@@ -55,7 +55,7 @@ describe("sns-accounts-balance.services", () => {
     const store = get(universesAccountsBalance);
     // Nns + 1 Sns
     expect(Object.keys(store)).toHaveLength(2);
-    expect(store[summary.rootCanisterId.toText()].balanceE8s).toEqual(
+    expect(store[summary.rootCanisterId.toText()].balanceUlps).toEqual(
       mockSnsMainAccount.balanceUlps
     );
     expect(spyQuery).toBeCalled();

--- a/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
@@ -58,7 +58,7 @@ describe("wallet-uncertified-accounts.services", () => {
     const store = get(universesAccountsBalance);
     // Nns + ckBTC + ckTESTBTC
     expect(Object.keys(store)).toHaveLength(3);
-    expect(store[CKBTC_UNIVERSE_CANISTER_ID.toText()].balanceE8s).toEqual(
+    expect(store[CKBTC_UNIVERSE_CANISTER_ID.toText()].balanceUlps).toEqual(
       mockCkBTCMainAccount.balanceUlps
     );
     expect(spyQuery).toBeCalled();


### PR DESCRIPTION
# Motivation

`UniverseAccountsBalance` also holds balances that are not 8 decimals so it's misleading to call them `balanceE8s`.

# Changes

Change `UniverseAccountsBalance.balanceE8s` to `balanceUlps`.

# Tests

Updated

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary