### PR TITLE
Rename parameter of assertEnoughAccountFunds from amountE8s to amountUlps

### DIFF
--- a/frontend/src/lib/components/transaction/TransactionForm.svelte
+++ b/frontend/src/lib/components/transaction/TransactionForm.svelte
@@ -96,7 +96,7 @@
       const tokens = TokenAmountV2.fromNumber({ amount, token });
       assertEnoughAccountFunds({
         account: selectedAccount,
-        amountE8s: tokens.toUlps() + toTokenAmountV2(transactionFee).toUlps(),
+        amountUlps: tokens.toUlps() + toTokenAmountV2(transactionFee).toUlps(),
       });
       errorMessage = validateAmount({ amount, selectedAccount });
     } catch (error: unknown) {

--- a/frontend/src/lib/services/canisters.services.ts
+++ b/frontend/src/lib/services/canisters.services.ts
@@ -79,7 +79,7 @@ export const createCanister = async ({
     if (!(icpAmount instanceof TokenAmount)) {
       throw new LedgerErrorMessage("error.amount_not_valid");
     }
-    assertEnoughAccountFunds({ amountE8s: icpAmount.toE8s(), account });
+    assertEnoughAccountFunds({ amountUlps: icpAmount.toE8s(), account });
 
     const identity = await getAccountIdentity(account.identifier);
     const canisterId = await createCanisterApi({
@@ -139,7 +139,7 @@ export const topUpCanister = async ({
     if (!(icpAmount instanceof TokenAmount)) {
       throw new LedgerErrorMessage("error.amount_not_valid");
     }
-    assertEnoughAccountFunds({ amountE8s: icpAmount.toE8s(), account });
+    assertEnoughAccountFunds({ amountUlps: icpAmount.toE8s(), account });
 
     const identity = await getAccountIdentity(account.identifier);
     await topUpCanisterApi({

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -194,7 +194,7 @@ export const stakeNeuron = async ({
     const stake = numberToE8s(amount);
     assertEnoughAccountFunds({
       account,
-      amountE8s: stake,
+      amountUlps: stake,
     });
 
     if (!isEnoughToStakeNeuron({ stakeE8s: stake })) {

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -445,7 +445,7 @@ export const initiateSnsSaleParticipation = async ({
     const transactionFee = get(transactionsFeesStore).main;
     assertEnoughAccountFunds({
       account,
-      amountE8s: amount.toE8s() + transactionFee,
+      amountUlps: amount.toE8s() + transactionFee,
     });
 
     const project = getProjectFromStore(rootCanisterId);

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -196,13 +196,12 @@ export const getAccountsByRootCanister = ({
  */
 export const assertEnoughAccountFunds = ({
   account,
-  // TODO: GIX-2154 rename to amountUlps
-  amountE8s,
+  amountUlps,
 }: {
   account: Account;
-  amountE8s: bigint;
+  amountUlps: bigint;
 }): void => {
-  if (account.balanceUlps < amountE8s) {
+  if (account.balanceUlps < amountUlps) {
     throw new NotEnoughAmountError("error.insufficient_funds");
   }
 };

--- a/frontend/src/lib/utils/ckbtc.utils.ts
+++ b/frontend/src/lib/utils/ckbtc.utils.ts
@@ -72,7 +72,7 @@ export const assertCkBTCUserInputAmount = ({
 
   assertEnoughAccountFunds({
     account: sourceAccount,
-    amountE8s: amountE8s + transactionFee,
+    amountUlps: amountE8s + transactionFee,
   });
 
   // This assertion is primarily intended to handle edge cases.

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -564,7 +564,7 @@ describe("accounts-utils", () => {
             ...mockMainAccount,
             balanceUlps: amountE8s,
           },
-          amountE8s: amountE8s + BigInt(10_000),
+          amountUlps: amountE8s + BigInt(10_000),
         });
       }).toThrow();
     });
@@ -577,7 +577,7 @@ describe("accounts-utils", () => {
             ...mockMainAccount,
             balanceUlps: amountE8s,
           },
-          amountE8s: amountE8s - BigInt(10_000),
+          amountUlps: amountE8s - BigInt(10_000),
         });
       }).not.toThrow();
     });


### PR DESCRIPTION
# Motivation

`assertEnoughAccountFunds` is also used for accounts with decimals other than 8.
So it's misleading to call the parameter `amountE8s`.

# Changes

Rename the parameter to `amountUlps`.

# Tests

Updated

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary