### PR TITLE
Rename sumAmountE8s to sumAmounts

### DIFF
--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -7,7 +7,7 @@ import type {
 } from "$lib/types/account";
 import { NotEnoughAmountError } from "$lib/types/common.errors";
 import { TransactionNetwork } from "$lib/types/transaction";
-import { sumAmountE8s } from "$lib/utils/token.utils";
+import { sumAmounts } from "$lib/utils/token.utils";
 import { isTransactionNetworkBtc } from "$lib/utils/transactions.utils";
 import { BtcNetwork, parseBtcAddress, type BtcAddress } from "@dfinity/ckbtc";
 import {
@@ -228,7 +228,7 @@ export const sumNnsAccounts = (
   accounts: IcpAccountsStoreData | undefined
 ): bigint | undefined =>
   accounts?.main?.balanceUlps !== undefined
-    ? sumAmountE8s(
+    ? sumAmounts(
         accounts?.main?.balanceUlps,
         ...(accounts?.subAccounts || []).map(({ balanceUlps }) => balanceUlps),
         ...(accounts?.hardwareWallets || []).map(
@@ -242,7 +242,7 @@ export const sumAccounts = (
 ): bigint | undefined =>
   isNullish(accounts) || accounts.length === 0
     ? undefined
-    : sumAmountE8s(...accounts.map(({ balanceUlps }) => balanceUlps));
+    : sumAmounts(...accounts.map(({ balanceUlps }) => balanceUlps));
 
 export const hasAccounts = (accounts: Account[]): boolean =>
   accounts.length > 0;

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -126,9 +126,8 @@ export const formatTokenV2 = ({
   return formatToken({ value: e8s, detailed, roundingMode });
 };
 
-// TODO GIX-2154: Rename to sumAmounts.
-export const sumAmountE8s = (...amountE8s: bigint[]): bigint =>
-  amountE8s.reduce<bigint>((acc, amount) => acc + amount, BigInt(0));
+export const sumAmounts = (...amounts: bigint[]): bigint =>
+  amounts.reduce<bigint>((acc, amount) => acc + amount, BigInt(0));
 
 // To make the fixed transaction fee readable, we do not display it with 8 digits but only till the last digit that is not zero
 // e.g. not 0.00010000 but 0.0001

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -9,7 +9,7 @@ import {
   getMaxTransactionAmount,
   numberToE8s,
   numberToUlps,
-  sumAmountE8s,
+  sumAmounts,
   toTokenAmountV2,
   ulpsToNumber,
 } from "$lib/utils/token.utils";
@@ -311,7 +311,7 @@ describe("token-utils", () => {
     });
   });
 
-  describe("sumAmountE8s", () => {
+  describe("sumAmounts", () => {
     it("should sum amounts of E8s values", () => {
       const icp0 = 0n;
       const icp1 = 100000000n;
@@ -321,10 +321,10 @@ describe("token-utils", () => {
       const icp35 = 350000000n;
       const icp6 = 600000000n;
 
-      expect(sumAmountE8s(icp0, icp1)).toEqual(icp1);
-      expect(sumAmountE8s(icp1, icp2)).toEqual(icp3);
-      expect(sumAmountE8s(icp1, icp2, icp3)).toEqual(icp6);
-      expect(sumAmountE8s(icp15, icp2)).toEqual(icp35);
+      expect(sumAmounts(icp0, icp1)).toEqual(icp1);
+      expect(sumAmounts(icp1, icp2)).toEqual(icp3);
+      expect(sumAmounts(icp1, icp2, icp3)).toEqual(icp6);
+      expect(sumAmounts(icp15, icp2)).toEqual(icp35);
     });
   });
 


### PR DESCRIPTION
# Motivation

`sumAmountE8s` is not specific to 8 decimals (or even to amounts, for that matter).
It just adds up a list of `bigint`s.

# Changes

Rename `sumAmountE8s` to `sumAmounts`.

# Tests

Updated

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary