### PR TITLE
GIX-2150: Migrate to TokenAmountV2

### DIFF
--- a/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-  import { nonNullish } from "@dfinity/utils";
+  import { TokenAmountV2, nonNullish, type Token } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
   import { numberToE8s } from "$lib/utils/token.utils";
   import TransactionReceivedTokenAmount from "$lib/components/transaction/TransactionReceivedTokenAmount.svelte";
   import BitcoinFeeDisplay from "$lib/components/accounts/BitcoinFeeDisplay.svelte";
-  import { TokenAmount, type Token } from "@dfinity/utils";
   import { isUniverseCkTESTBTC } from "$lib/utils/universe.utils";
   import type { UniverseCanisterId } from "$lib/types/universe";
   import {
@@ -50,8 +49,8 @@
       ? amountE8s - estimatedFee
       : BigInt(0);
 
-  let tokenEstimatedAmount: TokenAmount;
-  $: tokenEstimatedAmount = TokenAmount.fromE8s({
+  let tokenEstimatedAmount: TokenAmountV2;
+  $: tokenEstimatedAmount = TokenAmountV2.fromUlps({
     amount: estimatedAmount,
     token,
   });

--- a/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
@@ -9,7 +9,7 @@
     durationTillSwapDeadline,
     durationTillSwapStart,
   } from "$lib/utils/projects.utils";
-  import { TokenAmount, ICPToken } from "@dfinity/utils";
+  import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
   import { secondsToDuration } from "@dfinity/utils";
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
@@ -41,11 +41,11 @@
   let durationTillStart: bigint | undefined;
   $: durationTillStart = durationTillSwapStart(swap);
 
-  let myCommitment: TokenAmount | undefined = undefined;
+  let myCommitment: TokenAmountV2 | undefined = undefined;
   $: {
     const commitmentE8s = getCommitmentE8s(swapCommitment);
     if (nonNullish(commitmentE8s) && commitmentE8s > BigInt(0)) {
-      myCommitment = TokenAmount.fromE8s({
+      myCommitment = TokenAmountV2.fromUlps({
         amount: commitmentE8s,
         token: ICPToken,
       });

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { NeuronInfo } from "@dfinity/nns";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
-  import { TokenAmount, ICPToken } from "@dfinity/utils";
+  import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
   import {
     formatVotingPower,
     getNeuronTags,
@@ -19,8 +19,8 @@
 
   export let neuron: NeuronInfo;
 
-  let amount: TokenAmount;
-  $: amount = TokenAmount.fromE8s({
+  let amount: TokenAmountV2;
+  $: amount = TokenAmountV2.fromUlps({
     amount: neuronStake(neuron),
     token: ICPToken,
   });

--- a/frontend/src/lib/components/neurons/NnsNeuronAmount.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronAmount.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { NeuronInfo } from "@dfinity/nns";
-  import { TokenAmount, ICPToken } from "@dfinity/utils";
+  import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
   import { isSpawning, neuronStake } from "$lib/utils/neuron.utils";
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
@@ -9,8 +9,8 @@
   export let neuron: NeuronInfo;
   export let proposerNeuron = false;
 
-  let neuronICP: TokenAmount;
-  $: neuronICP = TokenAmount.fromE8s({
+  let neuronICP: TokenAmountV2;
+  $: neuronICP = TokenAmountV2.fromUlps({
     amount: neuronStake(neuron),
     token: ICPToken,
   });
@@ -22,7 +22,7 @@
   <AmountDisplay
     title
     label={$i18n.neurons.voting_power}
-    amount={TokenAmount.fromE8s({
+    amount={TokenAmountV2.fromUlps({
       amount: neuron.votingPower,
       token: ICPToken,
     })}

--- a/frontend/src/lib/components/neurons/NnsNeuronDetailCard.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronDetailCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { secondsToDuration } from "@dfinity/utils";
+  import { ICPToken, TokenAmountV2, secondsToDuration } from "@dfinity/utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import {
     formatVotingPower,
@@ -12,13 +12,12 @@
   } from "$lib/utils/neuron.utils";
   import { Card, KeyValuePair } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
-  import { ICPToken, TokenAmount } from "@dfinity/utils";
 
   export let neuron: NeuronInfo;
   export let testId = "nns-neuron-detail-card-component";
 
-  let stake: TokenAmount;
-  $: stake = TokenAmount.fromE8s({
+  let stake: TokenAmountV2;
+  $: stake = TokenAmountV2.fromUlps({
     amount: neuronStake(neuron),
     token: ICPToken,
   });

--- a/frontend/src/lib/components/project-detail/CommitmentProgressBar.svelte
+++ b/frontend/src/lib/components/project-detail/CommitmentProgressBar.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { TokenAmount, ICPToken, nonNullish } from "@dfinity/utils";
+  import {
+    TokenAmount,
+    ICPToken,
+    nonNullish,
+    TokenAmountV2,
+  } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
   import { ProgressBar } from "@dfinity/gix-components";
@@ -53,7 +58,7 @@
           </span>
           <span data-tid="commitment-min-indicator-value">
             <AmountDisplay
-              amount={TokenAmount.fromE8s({
+              amount={TokenAmountV2.fromUlps({
                 amount: minimumIndicator,
                 token: ICPToken,
               })}
@@ -67,7 +72,7 @@
           </span>
           <span data-tid="commitment-max-indicator-value">
             <AmountDisplay
-              amount={TokenAmount.fromE8s({ amount: max, token: ICPToken })}
+              amount={TokenAmountV2.fromUlps({ amount: max, token: ICPToken })}
               singleLine
             />
           </span>

--- a/frontend/src/lib/components/project-detail/CommitmentProgressBar.svelte
+++ b/frontend/src/lib/components/project-detail/CommitmentProgressBar.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
-  import {
-    TokenAmount,
-    ICPToken,
-    nonNullish,
-    TokenAmountV2,
-  } from "@dfinity/utils";
+  import { ICPToken, nonNullish, TokenAmountV2 } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
   import { ProgressBar } from "@dfinity/gix-components";

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TokenAmount, ICPToken } from "@dfinity/utils";
+  import { TokenAmount, ICPToken, TokenAmountV2 } from "@dfinity/utils";
   import type { SnsSummary } from "$lib/types/sns";
   import { i18n } from "$lib/stores/i18n";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
@@ -48,8 +48,8 @@
   let buyersTotalCommitment: bigint;
   $: buyersTotalCommitment = projectCommitments.totalCommitmentE8s;
 
-  let buyersTotalCommitmentIcp: TokenAmount;
-  $: buyersTotalCommitmentIcp = TokenAmount.fromE8s({
+  let buyersTotalCommitmentIcp: TokenAmountV2;
+  $: buyersTotalCommitmentIcp = TokenAmountV2.fromUlps({
     amount: buyersTotalCommitment,
     token: ICPToken,
   });
@@ -103,7 +103,7 @@
 
         <AmountDisplay
           slot="value"
-          amount={TokenAmount.fromE8s({
+          amount={TokenAmountV2.fromUlps({
             amount: projectCommitments.directCommitmentE8s,
             token: ICPToken,
           })}
@@ -142,7 +142,7 @@
         <svelte:fragment slot="value">
           {#if projectCommitments.isNFParticipating && nonNullish(projectCommitments.nfCommitmentE8s)}
             <AmountDisplay
-              amount={TokenAmount.fromE8s({
+              amount={TokenAmountV2.fromUlps({
                 amount: projectCommitments.nfCommitmentE8s,
                 token: ICPToken,
               })}

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TokenAmount, ICPToken, TokenAmountV2 } from "@dfinity/utils";
+  import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
   import type { SnsSummary } from "$lib/types/sns";
   import { i18n } from "$lib/stores/i18n";
   import AmountDisplay from "../ic/AmountDisplay.svelte";

--- a/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TokenAmount, ICPToken } from "@dfinity/utils";
+  import { TokenAmount, ICPToken, TokenAmountV2 } from "@dfinity/utils";
   import {
     getDeniedCountries,
     getMaxNeuronsFundParticipation,
@@ -36,19 +36,19 @@
     token,
   } = summary);
 
-  let minCommitmentIcp: TokenAmount;
-  $: minCommitmentIcp = TokenAmount.fromE8s({
+  let minCommitmentIcp: TokenAmountV2;
+  $: minCommitmentIcp = TokenAmountV2.fromUlps({
     amount: params.min_participant_icp_e8s,
     token: ICPToken,
   });
-  let maxCommitmentIcp: TokenAmount;
-  $: maxCommitmentIcp = TokenAmount.fromE8s({
+  let maxCommitmentIcp: TokenAmountV2;
+  $: maxCommitmentIcp = TokenAmountV2.fromUlps({
     amount: params.max_participant_icp_e8s,
     token: ICPToken,
   });
 
-  let snsTokens: TokenAmount;
-  $: snsTokens = TokenAmount.fromE8s({
+  let snsTokens: TokenAmountV2;
+  $: snsTokens = TokenAmountV2.fromUlps({
     amount: params.sns_token_e8s,
     token,
   });
@@ -106,7 +106,7 @@
       <span slot="key">{$i18n.sns_project_detail.max_nf_commitment} </span>
       <AmountDisplay
         slot="value"
-        amount={TokenAmount.fromE8s({
+        amount={TokenAmountV2.fromUlps({
           amount: maxNFParticipation,
           token: ICPToken,
         })}

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import AmountDisplay from "../ic/AmountDisplay.svelte";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
-  import { TokenAmount, type Token, nonNullish } from "@dfinity/utils";
+  import { type Token, nonNullish, TokenAmountV2 } from "@dfinity/utils";
   import { tokensStore } from "$lib/stores/tokens.store";
   import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
   import {
@@ -23,10 +23,10 @@
   let token: Token | undefined;
   $: token = $tokensStore[$selectedUniverseIdStore.toText()].token;
 
-  let amount: TokenAmount | undefined;
+  let amount: TokenAmountV2 | undefined;
   $: amount =
     nonNullish(token) && nonNullish(neuron)
-      ? TokenAmount.fromE8s({
+      ? TokenAmountV2.fromUlps({
           amount: getSnsNeuronStake(neuron),
           token: token,
         })

--- a/frontend/src/lib/components/sns-neurons/SnsNeuronAmount.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronAmount.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TokenAmount } from "@dfinity/utils";
+  import { TokenAmountV2 } from "@dfinity/utils";
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
   import { getSnsNeuronStake } from "$lib/utils/sns-neuron.utils";
   import type { SnsNeuron } from "@dfinity/sns";
@@ -8,10 +8,10 @@
 
   export let neuron: SnsNeuron;
 
-  let neuronStake: TokenAmount | undefined;
+  let neuronStake: TokenAmountV2 | undefined;
   $: neuronStake =
     $snsTokenSymbolSelectedStore !== undefined
-      ? TokenAmount.fromE8s({
+      ? TokenAmountV2.fromUlps({
           amount: getSnsNeuronStake(neuron),
           // If we got here is because the token symbol is present.
           // The projects without token are discarded filtered out.


### PR DESCRIPTION
# Motivation

Migration to TokenAmountV2

# Changes

Perform simple change from TokenAmount to TokenAmountV2 where it didn't require additional change because TokenAmountV2 is already supported.

# Tests

Still passing.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
