### PR TITLE
Add retrieveBtcStatusV2ByAccount to API

### DIFF
--- a/frontend/src/lib/api/ckbtc-minter.api.ts
+++ b/frontend/src/lib/api/ckbtc-minter.api.ts
@@ -10,6 +10,7 @@ import {
   type MinterParams,
   type RetrieveBtcOk,
   type RetrieveBtcParams,
+  type RetrieveBtcStatusV2WithId,
   type UpdateBalanceOk,
   type WithdrawalAccount,
 } from "@dfinity/ckbtc";
@@ -121,6 +122,28 @@ export const retrieveBtcWithApproval = async ({
   const result = await retrieveBtcWithApprovalApi(params);
 
   logWithTimestamp("Retrieve BTC with approval: done");
+
+  return result;
+};
+
+export const retrieveBtcStatusV2ByAccount = async ({
+  identity,
+  canisterId,
+  certified,
+}: {
+  identity: Identity;
+  canisterId: Principal;
+  certified: boolean;
+}): Promise<RetrieveBtcStatusV2WithId[]> => {
+  logWithTimestamp("Retrieve btc status V2 by account: call...");
+
+  const {
+    canister: { retrieveBtcStatusV2ByAccount: retrieveBtcStatusV2ByAccountApi },
+  } = await ckBTCMinterCanister({ identity, canisterId });
+
+  const result = await retrieveBtcStatusV2ByAccountApi({ certified });
+
+  logWithTimestamp("Retrieve btc status V2 by account: done...");
 
   return result;
 };

--- a/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
+++ b/frontend/src/tests/lib/api/ckbtc-minter.api.spec.ts
@@ -5,6 +5,7 @@ import {
   getWithdrawalAccount,
   minterInfo,
   retrieveBtc,
+  retrieveBtcStatusV2ByAccount,
   retrieveBtcWithApproval,
   updateBalance,
 } from "$lib/api/ckbtc-minter.api";
@@ -16,7 +17,11 @@ import {
   mockUpdateBalanceOk,
 } from "$tests/mocks/ckbtc-minter.mock";
 import type { HttpAgent } from "@dfinity/agent";
-import { CkBTCMinterCanister, type RetrieveBtcOk } from "@dfinity/ckbtc";
+import {
+  CkBTCMinterCanister,
+  type RetrieveBtcOk,
+  type RetrieveBtcStatusV2WithId,
+} from "@dfinity/ckbtc";
 import { mock } from "vitest-mock-extended";
 
 describe("ckbtc-minter api", () => {
@@ -191,6 +196,38 @@ describe("ckbtc-minter api", () => {
         });
 
       expect(call).rejects.toThrowError();
+    });
+  });
+
+  describe("retrieveBtcStatusV2ByAccount", () => {
+    it("returns result", async () => {
+      const statuses: RetrieveBtcStatusV2WithId[] = [
+        {
+          id: 135n,
+          status: {
+            Confirmed: { txid: [1, 2, 3] },
+          },
+        },
+      ];
+
+      const spy =
+        minterCanisterMock.retrieveBtcStatusV2ByAccount.mockResolvedValue(
+          statuses
+        );
+
+      const statusesParams = {
+        certified: true,
+      };
+
+      const result = await retrieveBtcStatusV2ByAccount({
+        ...params,
+        ...statusesParams,
+      });
+
+      expect(result).toEqual(statuses);
+
+      expect(spy).toBeCalledTimes(1);
+      expect(spy).toBeCalledWith(statusesParams);
     });
   });
 


### PR DESCRIPTION
# Motivation

We want to fetch the status of BTC retrievals from the ckBTC minter canister so that we can display which transactions are pending and which have failed.

# Changes

Add `retrieveBtcStatusV2ByAccount` to ckbtc-minter api to call `retrieveBtcStatusV2ByAccount` from ic-js.

# Tests

Unit test was added.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet