### PR TITLE
chore: Show which invalid label

### DIFF
--- a/rs/backend/src/accounts_store/schema.rs
+++ b/rs/backend/src/accounts_store/schema.rs
@@ -138,7 +138,7 @@ pub type SchemaLabelBytes = [u8; SchemaLabel::MAX_BYTES];
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SchemaLabelError {
     InvalidChecksum,
-    InvalidLabel,
+    InvalidLabel(u32),
     InsufficientBytes,
 }
 

--- a/rs/backend/src/accounts_store/schema/label_serialization.rs
+++ b/rs/backend/src/accounts_store/schema/label_serialization.rs
@@ -50,7 +50,7 @@ impl TryFrom<u32> for SchemaLabel {
             0 => Ok(Self::Map),
             #[cfg(test)]
             1 => Ok(Self::AccountsInStableMemory),
-            _ => Err(SchemaLabelError::InvalidLabel),
+            other => Err(SchemaLabelError::InvalidLabel(other)),
         }
     }
 }

--- a/rs/backend/src/accounts_store/schema/label_serialization/tests.rs
+++ b/rs/backend/src/accounts_store/schema/label_serialization/tests.rs
@@ -21,7 +21,10 @@ fn unknown_schema_label_should_fail() {
         "Test error: The bytes actually correspond to a legitimate schema label."
     );
     let label_bytes = SchemaLabel::with_checksum(invalid_label_bytes_without_checksum);
-    assert_eq!(Err(SchemaLabelError::InvalidLabel), SchemaLabel::try_from(&label_bytes));
+    assert_eq!(
+        Err(SchemaLabelError::InvalidLabel(1768515945)),
+        SchemaLabel::try_from(&label_bytes)
+    );
 }
 
 #[test]


### PR DESCRIPTION
# Motivation
Labels are serialized as `u32`.  On parsing, a u32 may not correspond to a valid schema.  There is an error type for tyhis, but it does not indicate what the invalid u32 is, which can be unhelpful.

# Changes
- Include the u32 in the error.

# Tests
- The corresponding test has been updated.

# Todos

- [ ] Add entry to changelog (if necessary).
  - Too minor