### PR TITLE
clean: Implement Eq for tests only

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -35,7 +35,8 @@ type TransactionIndex = u64;
 const PRE_MIGRATION_LIMIT: u64 = 300_000;
 
 /// Accounts, transactions and related data.
-#[derive(Default, Eq, PartialEq)]
+#[derive(Default)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct AccountsStore {
     // TODO(NNS1-720): Use AccountIdentifier directly as the key for this HashMap
     accounts_db: schema::proxy::AccountsDbAsProxy,

--- a/rs/backend/src/accounts_store/schema/map.rs
+++ b/rs/backend/src/accounts_store/schema/map.rs
@@ -5,7 +5,8 @@ use core::fmt;
 use core::ops::RangeBounds;
 use std::collections::BTreeMap;
 
-#[derive(Default, Eq, PartialEq)]
+#[derive(Default)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct AccountsDbAsMap {
     accounts: BTreeMap<Vec<u8>, Account>,
 }

--- a/rs/backend/src/accounts_store/schema/proxy.rs
+++ b/rs/backend/src/accounts_store/schema/proxy.rs
@@ -135,7 +135,7 @@ impl AccountsDbTrait for AccountsDbAsProxy {
 #[cfg(test)]
 impl PartialEq for AccountsDbAsProxy {
     fn eq(&self, other: &Self) -> bool {
-        self.authoritative_db.as_map() == other.authoritative_db.as_map()
+        self.authoritative_db.range(..).eq(other.authoritative_db.range(..))
     }
 }
 #[cfg(test)]

--- a/rs/backend/src/accounts_store/schema/proxy.rs
+++ b/rs/backend/src/accounts_store/schema/proxy.rs
@@ -132,11 +132,13 @@ impl AccountsDbTrait for AccountsDbAsProxy {
 /// Check whether two account databases contain the same data.
 ///
 /// It should be possible to use this to confirm that data has been preserved during a migration.
+#[cfg(test)]
 impl PartialEq for AccountsDbAsProxy {
     fn eq(&self, other: &Self) -> bool {
         self.authoritative_db.as_map() == other.authoritative_db.as_map()
     }
 }
+#[cfg(test)]
 impl Eq for AccountsDbAsProxy {}
 
 #[cfg(test)]

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -13,7 +13,8 @@ pub mod partitions;
 #[cfg(test)]
 pub mod tests;
 
-#[derive(Default, Debug, Eq, PartialEq)]
+#[derive(Default, Debug)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct State {
     // NOTE: When adding new persistent fields here, ensure that these fields
     // are being persisted in the `replace` method below.


### PR DESCRIPTION
# Motivation
Unit tests require `Eq` to verify that state, accounts etc have the expected content.  However the implementations can be prohibitively inefficient with large data so we would prefer to have them present only in test code.

# Changes
- Configure `Eq` and `PartialEq` to be created only in test code.
- For the ProxyDb, the implementation of PartialEq previously depended on converting an arbitrary database format into a `BTreeMap`.  This is unnecessarily expensive as we can iterate of the elements of the two databases regardless of the underlying implementation.

# Tests
- Existing tests should suffice.

# Todos

- [ ] Add entry to changelog (if necessary).
  Too minor.
