### PR TITLE
GIX-2181: Work around frozen sns canister

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -39,6 +39,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Limit the size of proposal payload rendering errors, as otherwise the error can become too large to return.
 * Provide a fallback if proposal payloads don't have the expected type.
+* Temporary work-around for broken SNS.
 
 #### Security
 

--- a/frontend/src/lib/api/sns-wrapper.api.ts
+++ b/frontend/src/lib/api/sns-wrapper.api.ts
@@ -178,10 +178,10 @@ const loadSnsWrappers = async ({
   const error: boolean =
     results.find(({ status }) => status === "rejected") !== undefined;
   if (error) {
-    const rejectedCanisterIds = results
+    const rejectedReasons = results
       .filter(({ status }) => status === "rejected")
-      .map((wrapper) => wrapper.value.root.id.toText());
-    console.error("Rejected SNSes:", rejectedCanisterIds);
+      .map((wrapper) => wrapper.reason);
+    console.error("Rejected SNSes:", rejectedReasons);
     // Ignoring. SNSes will be filtered out below.
   }
 

--- a/frontend/src/lib/api/sns-wrapper.api.ts
+++ b/frontend/src/lib/api/sns-wrapper.api.ts
@@ -178,7 +178,11 @@ const loadSnsWrappers = async ({
   const error: boolean =
     results.find(({ status }) => status === "rejected") !== undefined;
   if (error) {
-    throw new ApiErrorKey("error__sns.init");
+    const rejectedCanisterIds = results
+      .filter(({ status }) => status === "rejected")
+      .map((wrapper) => wrapper.value.root.id.toText());
+    console.error("Rejected SNSes:", rejectedCanisterIds);
+    // Ignoring. SNSes will be filtered out below.
   }
 
   return (

--- a/frontend/src/lib/api/sns-wrapper.api.ts
+++ b/frontend/src/lib/api/sns-wrapper.api.ts
@@ -180,7 +180,9 @@ const loadSnsWrappers = async ({
   if (error) {
     const rejectedReasons = results
       .filter(({ status }) => status === "rejected")
-      .map((wrapper) => wrapper.reason);
+      .map((wrapper) =>
+        "reason" in wrapper ? wrapper.reason : "Reason not present"
+      );
     console.error("Rejected SNSes:", rejectedReasons);
     // Ignoring. SNSes will be filtered out below.
   }


### PR DESCRIPTION
# Motivation

One SNS's root canister was frozen and it broke all SNSes in nns-dapp.

# Changes

Don't throw an error when one of the SNSes is broken but just filter it out of the wrapper.

# Tests

Tested manually by calling `dfx stop` on one of the root canisters.
Without the fix:
https://drive.google.com/file/d/1xF5zRp62HMpQTmlIWTcuWyl9r5JU0ZT7/view

With the fix:
https://drive.google.com/file/d/19VpUbd27HImQDAe0ywrB78tpFc8zQq9D/view

# Todos

- [x] Add entry to changelog (if necessary).
