### PR TITLE
Update didc release to 2023-12-15

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -334,7 +334,7 @@
         "IDL2JSON_VERSION": "0.8.8",
         "OPTIMIZER_VERSION": "0.3.6",
         "BINSTALL_VERSION": "1.3.0",
-        "DIDC_VERSION": "2023-11-16",
+        "DIDC_VERSION": "2023-12-15",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2023-12-06",
         "IC_COMMIT": "release-2023-12-06_23-01+p2p"


### PR DESCRIPTION
# Motivation
A newer version of `didc` is available.

# Changes
## Changes made by a bot triggered by github-merge-queue
- Update the version of `didc` specified in `dfx.json`.

## Changes made by a human (delete if inapplicable)

# Tests
- CI contains tests that detect most breaking changes in `didc`.
- [x] Please check [the didc release notes](https://github.com/dfinity/candid/releases) (if any).
- [x] Please check [the didc git history](https://github.com/dfinity/candid/commits/master/tools/didc) (if reasonably short and understandable).