### PR TITLE
Use ic-cdk println

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,6 +30,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Update Rust version: `1.74.0` -> `1.74.1`
 * Provide space for migration state in the `ProxyDb`.
 * Rename "Launch Pad" to "Launchpad".
+* Use `ic_cdk::println` instead of the `dfn_core` equivalent.
 
 #### Deprecated
 
@@ -54,6 +55,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Allow npm greater than v10 in frontend project.
+* Apply clippy only to target `wasm32-unknown-unknown` but prohibit `std::println` and variants for that target.
 
 #### Deprecated
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,5 +3,7 @@ disallowed-macros = [
     "std::println",
     "std::eprint",
     "std::eprintln",
+]
+disallowed-methods = [
     "dfn_core::api::print",
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-macros = [
+    "std::println",
+]

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,4 +3,5 @@ disallowed-macros = [
     "std::println",
     "std::eprint",
     "std::eprintln",
+    "dfn_core::api::print",
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,6 @@
 disallowed-macros = [
+    "std::print",
     "std::println",
+    "std::eprint",
+    "std::eprintln",
 ]

--- a/rs/backend/src/accounts_store/schema/proxy.rs
+++ b/rs/backend/src/accounts_store/schema/proxy.rs
@@ -1,11 +1,13 @@
 //! Accounts DB that delegates API calls to underlying implementations.
 //!
 //! The proxy manages migrations from one implementation to another.
-use std::collections::BTreeMap;
-mod enum_boilerplate;
 use super::{map::AccountsDbAsMap, Account, AccountsDbBTreeMapTrait, AccountsDbTrait, SchemaLabel};
 use core::fmt;
 use core::ops::RangeBounds;
+use ic_cdk::println;
+use std::collections::BTreeMap;
+
+mod enum_boilerplate;
 
 /// An accounts database delegates API calls to underlying implementations.
 ///
@@ -118,9 +120,7 @@ impl AccountsDbTrait for AccountsDbAsProxy {
     /// The authoritative schema label.
     fn schema_label(&self) -> SchemaLabel {
         let schema_label = self.authoritative_db.schema_label();
-        dfn_core::api::print(format!(
-            "AccountsDb::Proxy: authoritative schema label: {schema_label:#?}"
-        ));
+        println!("AccountsDb::Proxy: authoritative schema label: {schema_label:#?}");
         schema_label
     }
     /// Iterates over a range of accounts in the authoritative db.

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -10,6 +10,7 @@ use dfn_core::api::ic0::time;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
+use ic_cdk::println;
 use ic_certified_map::{labeled, labeled_hash, AsHashTree, Hash, RbTree};
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
@@ -379,7 +380,7 @@ pub fn init_assets() {
 ///       as it would force the data to be copied into a new vector, even when the
 ///       original is no longer needed.
 pub fn insert_tar_xz(compressed: Vec<u8>) {
-    dfn_core::api::print("Inserting assets...");
+    println!("Inserting assets...");
     let mut num_assets = 0;
     let mut decompressed = Vec::new();
     lzma_rs::xz_decompress(&mut compressed.as_ref(), &mut decompressed).unwrap();
@@ -422,7 +423,7 @@ pub fn insert_tar_xz(compressed: Vec<u8>) {
         }
         update_root_hash(&state.asset_hashes.borrow_mut());
     });
-    dfn_core::api::print(format!("Inserted {num_assets} assets."));
+    println!("Inserted {num_assets} assets.");
 }
 
 impl StableState for Assets {

--- a/rs/backend/src/bin/nns-dapp-check-args.rs
+++ b/rs/backend/src/bin/nns-dapp-check-args.rs
@@ -1,5 +1,6 @@
 //! Code for testing arguments
 use candid::Decode;
+use ic_cdk::println;
 use nns_dapp::arguments::CanisterArguments;
 use std::env::args;
 use std::fs;

--- a/rs/backend/src/ledger_sync.rs
+++ b/rs/backend/src/ledger_sync.rs
@@ -2,6 +2,7 @@ use crate::canisters::ledger;
 use crate::state::STATE;
 use candid::Principal;
 use dfn_core::CanisterId;
+use ic_cdk::println;
 use ic_ledger_core::block::BlockType;
 use ic_ledger_core::Tokens;
 use ic_nns_constants::LEDGER_CANISTER_ID;
@@ -98,7 +99,7 @@ async fn get_blocks(from: BlockIndex, tip_of_chain: BlockIndex) -> Result<Vec<(B
                                 },
                             },
                         };
-                        ic_cdk::println!(
+                        println!(
                             "Replacing block {} with dummy block {:?} because of error: {}",
                             range.start() + (index as u64),
                             &dummy,

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -14,6 +14,7 @@ use crate::state::{StableState, State, STATE};
 pub use candid::{CandidType, Deserialize};
 use dfn_candid::{candid, candid_one};
 use dfn_core::{over, over_async};
+use ic_cdk::println;
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade};
 use icp_ledger::AccountIdentifier;
 pub use serde::Serialize;
@@ -39,7 +40,7 @@ type Cycles = u128;
 
 #[init]
 fn init(args: Option<CanisterArguments>) {
-    dfn_core::api::print(format!("init with args: {args:#?}"));
+    println!("init with args: {args:#?}");
     set_canister_arguments(args);
     perf::record_instruction_count("init after set_canister_arguments");
     assets::init_assets();
@@ -51,26 +52,26 @@ fn main() {}
 
 #[pre_upgrade]
 fn pre_upgrade() {
-    dfn_core::api::print(format!(
+    println!(
         "pre_upgrade instruction_counter before saving state: {} stable_memory_size_gib: {} wasm_memory_size_gib: {}",
         ic_cdk::api::instruction_counter(),
         stats::gibibytes(stats::stable_memory_size_bytes()),
         stats::gibibytes(stats::wasm_memory_size_bytes())
-    ));
+    );
     STATE.with(|s| {
         s.pre_upgrade();
     });
-    dfn_core::api::print(format!(
+    println!(
         "pre_upgrade instruction_counter after saving state: {} stable_memory_size_gib: {} wasm_memory_size_gib: {}",
         ic_cdk::api::instruction_counter(),
         stats::gibibytes(stats::stable_memory_size_bytes()),
         stats::gibibytes(stats::wasm_memory_size_bytes())
-    ));
+    );
 }
 
 #[post_upgrade]
 fn post_upgrade(args: Option<CanisterArguments>) {
-    dfn_core::api::print(format!("post_upgrade with args: {args:#?}"));
+    println!("post_upgrade with args: {args:#?}");
     // Saving the instruction counter now will not have the desired effect
     // as the storage is about to be wiped out and replaced with stable memory.
     let counter_before = PerformanceCount::new("post_upgrade start");

--- a/rs/backend/src/state/partitions.rs
+++ b/rs/backend/src/state/partitions.rs
@@ -5,6 +5,7 @@
 //!
 //! This code also stores virtual memory IDs and other memory functions.
 use core::borrow::Borrow;
+use ic_cdk::println;
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
 use ic_stable_structures::{DefaultMemoryImpl, Memory};
 use std::rc::Rc;
@@ -46,11 +47,11 @@ impl Partitions {
         let mut actual_first_bytes = [0u8; MEMORY_MANAGER_MAGIC_BYTES.len()];
         memory.read(0, &mut actual_first_bytes);
         let ans = actual_first_bytes == *MEMORY_MANAGER_MAGIC_BYTES;
-        dfn_core::api::print(format!(
+        println!(
             "END memory is_managed: {}, {:?}",
             ans,
             String::from_utf8(actual_first_bytes.to_vec())
-        ));
+        );
         ans
     }
 

--- a/rs/proposals/src/main.rs
+++ b/rs/proposals/src/main.rs
@@ -1,3 +1,4 @@
+use ic_cdk::println;
 use lib::canisters::nns_governance::api::ProposalInfo;
 use proposals as lib;
 use std::io::{self, Read};

--- a/rs/sns_aggregator/src/state.rs
+++ b/rs/sns_aggregator/src/state.rs
@@ -14,6 +14,7 @@ use crate::{
 use anyhow::anyhow;
 use ic_cdk::api::management_canister::provisional::CanisterId;
 use ic_cdk::api::time;
+use ic_cdk::println;
 use ic_cdk_timers::TimerId;
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -120,7 +121,7 @@ thread_local! {
 
 /// Log to console and store for retrieval by query calls.
 pub fn log(message: String) {
-    ic_cdk::api::print(&message);
+    println!("{}", &message);
     let now = time();
     let message = format!("{now}: {message}");
     STATE.with(|state| {

--- a/scripts/lint-rs
+++ b/scripts/lint-rs
@@ -3,4 +3,4 @@ set -euo pipefail
 # Craete an empty assets file, if there is none.
 test -e assets.tar.xz || touch assets.tar.xz
 # Lint the rust code
-cargo clippy --all-targets --all-features -- -D warnings
+cargo clippy --target wasm32-unknown-unknown --all-features -- -D warnings


### PR DESCRIPTION
# Motivation
Move more code from `dfn_core` to `ic_cdk`.

Note: Apparently `ic_cdk::println` defaults to printing to stdout in e.g. unit tets.  Could be useful.

# Changes
- Change calls to `dfn_core..print` to `ic_cdk::println!`.
- Given that `std::println!` does nothing in production, prevent accidental usage of `std::println` in wasms by:
  - Prohibiting `std::println!` and similar macros in `clippy.toml`
  - Running clippy only against `wasm32-unknown-unknown` as `ic_cdk::println` is `std::println` when run natively, so triggers the lint.
    - Note: It would be nicer if the prohibition in `clippy.toml` could be applied only when the target arch is `wasm32`.  I do not see a way of doing that.  It may perhaps be possible in other ways.

# Tests
- See CI

# Todos

- [x] What happens if `std::println` is used by accident?  Does it
  - Fail to build for wasm32? - Nope, it builds.
  - Build but fail at runtime? - Nope
  - Build and simply do nothing at runtime? <-- Yes
  - Something else?
- [x] Make some kind of static test that prevents `std::println` from being used instead of `ic_cdk::println`.
- [x] Add entry to changelog (if necessary).
