### PR TITLE
Fix automatic update PR description

### DIFF
--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -74,7 +74,6 @@ jobs:
 
             # Changes
             * Updated `snsdemo` version in `dfx.json`.
-            * Ensured that the `dfx` version and IC commit in `dfx.json` match `snsdemo`.
 
             # Tests
             CI should pass.


### PR DESCRIPTION
# Motivation

We have a bot that updates the snsdemo release we use in CI.
The automatic PR description also claims that it updates the IC commit but it does not.

# Changes

Remove the line about the IC commit.

# Tests

none

# Todos

- [ ] Add entry to changelog (if necessary).
no necessary