### PR TITLE
fix: error visibility after clicking on min/max

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -40,6 +40,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Limit the size of proposal payload rendering errors, as otherwise the error can become too large to return.
 * Provide a fallback if proposal payloads don't have the expected type.
 * Temporary work-around for broken SNS.
+* Remaining wrong dissolve delay error message after min/max click.
 
 #### Security
 

--- a/frontend/src/lib/components/ui/DayInput.svelte
+++ b/frontend/src/lib/components/ui/DayInput.svelte
@@ -33,11 +33,13 @@
   const setMin = () => {
     seconds = minInSeconds;
     days = secondsToDays(seconds);
+    showError();
   };
 
   const setMax = () => {
     seconds = maxInSeconds;
     days = secondsToDays(seconds);
+    showError();
   };
 </script>
 

--- a/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
@@ -183,6 +183,43 @@ describe("SetDissolveDelay", () => {
         en.neurons.dissolve_delay_above_maximum
       );
     });
+
+    it("hide error message on min/max click", async () => {
+      const projectMinDays = 183;
+      const minProjectDelayInSeconds = projectMinDays * SECONDS_IN_DAY;
+      const maxProjectDelayInSeconds = SECONDS_IN_EIGHT_YEARS;
+      const { container, component } = render(SetDissolveDelay, {
+        props: {
+          ...defaultComponentProps,
+          neuronDissolveDelaySeconds: 0n,
+          minProjectDelayInSeconds,
+          maxProjectDelayInSeconds,
+          delayInSeconds: 0,
+        },
+      });
+      const po = SetDissolveDelayPo.under(new JestPageObjectElement(container));
+
+      expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
+      expect(await po.getErrorMessage()).toBe(null);
+
+      await po.enterDays(0);
+      expect(await po.getErrorMessage()).toBe(
+        en.neurons.dissolve_delay_below_current
+      );
+
+      await po.clickMin();
+      expect(getDelayInSeconds(component)).toBe(minProjectDelayInSeconds);
+      expect(await po.getErrorMessage()).toBe(null);
+
+      await po.enterDays(Number.MAX_SAFE_INTEGER);
+      expect(await po.getErrorMessage()).toBe(
+        en.neurons.dissolve_delay_below_current
+      );
+
+      await po.clickMax();
+      expect(getDelayInSeconds(component)).toBe(maxProjectDelayInSeconds);
+      expect(await po.getErrorMessage()).toBe(null);
+    });
   });
 
   it("can set same number of days when current number of days is fractional", async () => {

--- a/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
@@ -188,36 +188,27 @@ describe("SetDissolveDelay", () => {
       const projectMinDays = 183;
       const minProjectDelayInSeconds = projectMinDays * SECONDS_IN_DAY;
       const maxProjectDelayInSeconds = SECONDS_IN_EIGHT_YEARS;
-      const { container, component } = render(SetDissolveDelay, {
-        props: {
-          ...defaultComponentProps,
-          neuronDissolveDelaySeconds: 0n,
-          minProjectDelayInSeconds,
-          maxProjectDelayInSeconds,
-          delayInSeconds: 0,
-        },
+      const po = renderComponent({
+        neuronDissolveDelaySeconds: 10n,
+        minProjectDelayInSeconds,
+        maxDelayInSeconds: maxProjectDelayInSeconds,
+        delayInSeconds: 10,
       });
-      const po = SetDissolveDelayPo.under(new JestPageObjectElement(container));
 
-      expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
-      expect(await po.getErrorMessage()).toBe(null);
-
-      await po.enterDays(0);
+      await po.enterDays(projectMinDays - 1);
       expect(await po.getErrorMessage()).toBe(
-        en.neurons.dissolve_delay_below_current
+        en.neurons.dissolve_delay_below_minimum
       );
 
       await po.clickMin();
-      expect(getDelayInSeconds(component)).toBe(minProjectDelayInSeconds);
       expect(await po.getErrorMessage()).toBe(null);
 
-      await po.enterDays(Number.MAX_SAFE_INTEGER);
+      await po.enterDays(maxProjectDelayInSeconds + 1);
       expect(await po.getErrorMessage()).toBe(
-        en.neurons.dissolve_delay_below_current
+        en.neurons.dissolve_delay_above_maximum
       );
 
       await po.clickMax();
-      expect(getDelayInSeconds(component)).toBe(maxProjectDelayInSeconds);
       expect(await po.getErrorMessage()).toBe(null);
     });
   });

--- a/frontend/src/tests/lib/components/ui/DayInput.spec.ts
+++ b/frontend/src/tests/lib/components/ui/DayInput.spec.ts
@@ -143,7 +143,36 @@ describe("DayInput", () => {
     expect(inputElement.value).toBe("30");
   });
 
-  it("should take into accout the max when rounding up", async () => {
+  it("should update error message after Min/Max click", async () => {
+    const initialSeconds = SECONDS_IN_DAY;
+    const minInSeconds = SECONDS_IN_DAY * 30;
+    const maxInSeconds = SECONDS_IN_YEAR;
+    const getInputError = vi.fn(() => null);
+
+    const { queryByTestId } = render(DayInputTest, {
+      props: {
+        seconds: initialSeconds,
+        maxInSeconds,
+        minInSeconds,
+        getInputError,
+      },
+    });
+
+    const minButton = queryByTestId("min-button");
+    const maxButton = queryByTestId("max-button");
+
+    expect(getInputError).toBeCalledTimes(0);
+
+    await fireEvent.click(minButton);
+
+    expect(getInputError).toBeCalledTimes(1);
+
+    await fireEvent.click(maxButton);
+
+    expect(getInputError).toBeCalledTimes(2);
+  });
+
+  it("should take into account the max when rounding up", async () => {
     // This is a fraction that if rounded up would be 366 days.
     const initialSeconds = SECONDS_IN_DAY * 365 + 10;
     // But the max is 365.5 days


### PR DESCRIPTION
# Motivation

Solves the remaining error message after clicking on min/max button.
Steps:
- Add a too big number for the dissolve delay.
- Click on the Min/Max
- Input updated to a valid value, but the error is still displayed.

# Changes

- update error visibility after min/max click

# Tests

- "should update error message after Min/Max click"

# Todos

- [x] Add entry to changelog (if necessary).
