### PR TITLE
GIX-2180: Add accountIdentifier UserTokenData

### DIFF
--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -61,6 +61,7 @@ const convertAccountToUserTokenData = ({
       universe: nnsUniverse.canisterId.toString(),
       account: account?.identifier,
     }),
+    accountIdentifier: account.identifier,
     actions: [UserTokenAction.Receive, UserTokenAction.Send],
   };
 };

--- a/frontend/src/lib/derived/tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-user.derived.ts
@@ -64,7 +64,7 @@ const convertToUserTokenData = ({
       : mainAccount.balanceUlps,
     token,
   });
-  // For ICP, the row represents all the ICP accounts. Therefore, we don't want to set on accountIdentifier.
+  // For ICP, the row represents all the ICP accounts. Therefore, we don't want to set the accountIdentifier.
   const accountIdentifier = isUniverseNns(baseTokenData.universeId)
     ? undefined
     : mainAccount.identifier;
@@ -93,11 +93,11 @@ export const tokensListUserStore = derived<
   UserToken[]
 >(
   [tokensListBaseStore, universesAccountsStore, tokensStore, authStore],
-  ([tokensList, balances, tokens, authData]) =>
+  ([tokensList, accounts, tokens, authData]) =>
     tokensList.map((baseTokenData) =>
       convertToUserTokenData({
         baseTokenData,
-        accounts: balances,
+        accounts,
         tokens,
         authData,
       })

--- a/frontend/src/lib/types/tokens-page.ts
+++ b/frontend/src/lib/types/tokens-page.ts
@@ -40,6 +40,8 @@ export type UserTokenLoading = UserTokenBase & {
 
 export type UserTokenData = UserTokenBase & {
   balance: TokenAmountV2 | UnavailableTokenAmount;
+  // Identifier of the account related to the row (only if the row represents one account, not multiple)
+  accountIdentifier?: string;
   token: Token;
   // Fees are included in the metadata of ICRC tokens, but this is not a list of only ICRC tokens
   fee: TokenAmountV2;

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -236,12 +236,15 @@ export const sumNnsAccounts = (
       )
     : undefined;
 
-export const sumAccounts = (
+export function sumAccounts(acconts: Account[]): bigint;
+export function sumAccounts(acconts: Account[] | undefined): bigint | undefined;
+export function sumAccounts(
   accounts: Account[] | undefined
-): bigint | undefined =>
-  isNullish(accounts) || accounts.length === 0
+): bigint | undefined {
+  return isNullish(accounts)
     ? undefined
     : sumAmounts(...accounts.map(({ balanceUlps }) => balanceUlps));
+}
 
 export const hasAccounts = (accounts: Account[]): boolean =>
   accounts.length > 0;

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -42,6 +42,7 @@ describe("icp-tokens-list-user.derived", () => {
       universe: OWN_CANISTER_ID_TEXT,
       account: mockMainAccount.identifier,
     }),
+    accountIdentifier: mockMainAccount.identifier,
   };
   const subaccountUserTokenData: UserTokenData = {
     ...icpTokenUser,
@@ -55,6 +56,7 @@ describe("icp-tokens-list-user.derived", () => {
       universe: OWN_CANISTER_ID_TEXT,
       account: mockSubAccount.identifier,
     }),
+    accountIdentifier: mockSubAccount.identifier,
   };
   const hardwareWalletUserTokenData: UserTokenData = {
     ...icpTokenUser,
@@ -68,6 +70,7 @@ describe("icp-tokens-list-user.derived", () => {
       universe: OWN_CANISTER_ID_TEXT,
       account: mockHardwareWalletAccount.identifier,
     }),
+    accountIdentifier: mockHardwareWalletAccount.identifier,
   };
 
   describe("icpTokensListVisitors", () => {

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -56,6 +56,7 @@ describe("tokens-list-user.derived", () => {
     }),
     actions: [UserTokenAction.GoToDetail],
     rowHref: buildAccountsUrl({ universe: OWN_CANISTER_ID_TEXT }),
+    accountIdentifier: undefined,
   });
   const icpUserTokenLoading: UserTokenLoading = {
     ...icpTokenBase,
@@ -102,6 +103,7 @@ describe("tokens-list-user.derived", () => {
       universe: snsTetris.rootCanisterId.toText(),
       account: identityMainAccountIdentifier,
     }),
+    accountIdentifier: mockSnsMainAccount.identifier,
   };
   const pacmanTokenLoading: UserTokenLoading = {
     universeId: snsPacman.rootCanisterId,
@@ -126,6 +128,7 @@ describe("tokens-list-user.derived", () => {
       universe: snsPacman.rootCanisterId.toText(),
       account: identityMainAccountIdentifier,
     }),
+    accountIdentifier: mockSnsMainAccount.identifier,
   };
   const ckBTCTokenLoading: UserTokenLoading = {
     ...ckBTCTokenBase,
@@ -153,6 +156,7 @@ describe("tokens-list-user.derived", () => {
       universe: ckBTCTokenBase.universeId.toText(),
       account: identityMainAccountIdentifier,
     }),
+    accountIdentifier: mockCkBTCMainAccount.identifier,
   };
   const ckETHTokenLoading: UserTokenLoading = {
     ...ckETHTokenBase,
@@ -175,6 +179,7 @@ describe("tokens-list-user.derived", () => {
       account: identityMainAccountIdentifier,
     }),
     actions: [UserTokenAction.Receive, UserTokenAction.Send],
+    accountIdentifier: mockCkETHMainAccount.identifier,
   };
 
   describe("tokensListUserStore", () => {

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -678,6 +678,14 @@ describe("accounts-utils", () => {
 
       expect(sumAccounts([mockSnsMainAccount])).toEqual(totalBalance);
     });
+
+    it("should return undefined if no accounts", () => {
+      expect(sumAccounts(undefined)).toBeUndefined();
+    });
+
+    it("should return 0 if accounts list is empty", () => {
+      expect(sumAccounts([])).toBe(0n);
+    });
   });
 
   describe("hasAccounts", () => {


### PR DESCRIPTION
# Motivation

To open the TransactionModal or ReceiveModal in the ICP tokens table, I need to know which account to use based on the row clicked.

I could use the title, but that is fragile because the title might change and not be the name of the account.

Instead, I added an optional field to UserTokenData: accounIdentifier.

# Changes

* New field `accountIdentifier` in `UserTokenData`.
* Populate the new field in `icpTokensListUser`.
* Populate the new field in `tokensListUserStore`. I changed the implementation to read all the universes accounts instead of the balance. I needed it to get the account identifier.
* Use function overloading in helper `sumAccounts`. Convenient to make sure the return is a `bigint` if there are accounts. I also changed the functionality slightly to return 0 when the list is empty. That made more sense to me.

# Tests

* Adapt the tests expectation for `icpTokensListUser`.
* Adapt the tests expectation for `tokensListUserStore`.
* Add tests `sumAccounts` edge cases.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
