### PR TITLE
GIX-2180: Receive in ICP tokens page

### DIFF
--- a/frontend/src/tests/page-objects/Accounts.page-object.ts
+++ b/frontend/src/tests/page-objects/Accounts.page-object.ts
@@ -9,6 +9,7 @@ import { BuyICPModalPo } from "./BuyICPModal.page-object";
 import { IcrcTokenAccountsPo } from "./IcrcTokenAccounts.page-object";
 import { IcrcTokenAccountsFooterPo } from "./IcrcTokenAccountsFooter.page-object";
 import { IcrcTokenTransactionModalPo } from "./IcrcTokenTransactionModal.page-object";
+import { ReceiveModalPo } from "./ReceiveModal.page-object";
 
 export class AccountsPo extends BasePageObject {
   private static readonly TID = "accounts-component";
@@ -51,6 +52,10 @@ export class AccountsPo extends BasePageObject {
 
   getAddAccountModalPo() {
     return AddAccountModalPo.under(this.root);
+  }
+
+  getReceiveModalPo() {
+    return ReceiveModalPo.under(this.root);
   }
 
   clickSend(): Promise<void> {


### PR DESCRIPTION
# Motivation

Users can open the Receive modal from ICP tokens

# Changes

* Listen for nnsAction in NnsAccounts and handle the `ActionType.Receive`.

# Tests

* Add a test for the receive modal when Tokens enabled.
* Add methods to AccontsPo.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
