### PR TITLE
Fix min dissolve delay

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -23,6 +23,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Display Neurons' Fund commitment progress bar.
 * `range()` method to `AccountsDbTrait`.
 * Render ckBTC Reimbursement transactions.
+* Disable dissolve delay editing when the maximum is reached.
 
 #### Changed
 
@@ -40,6 +41,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Limit the size of proposal payload rendering errors, as otherwise the error can become too large to return.
 * Provide a fallback if proposal payloads don't have the expected type.
 * Temporary work-around for broken SNS.
+* Min dissolve delay button updates not only for the first time.
 
 #### Security
 

--- a/frontend/src/lib/components/common/MaxButton.svelte
+++ b/frontend/src/lib/components/common/MaxButton.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { IconSubdirectory } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
+
+  export let disabled = false;
 </script>
 
 <button
@@ -8,6 +10,7 @@
   on:click|preventDefault
   class="ghost"
   type="button"
+  {disabled}
 >
   <span class="icon">
     <IconSubdirectory />

--- a/frontend/src/lib/components/common/MinButton.svelte
+++ b/frontend/src/lib/components/common/MinButton.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { IconSubdirectory } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
+
+  export let disabled = false;
 </script>
 
 <button
@@ -8,6 +10,7 @@
   on:click|preventDefault
   class="ghost"
   type="button"
+  {disabled}
 >
   <span class="icon">
     <IconSubdirectory />

--- a/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -95,11 +95,11 @@
     <div>
       <DayInput
         bind:seconds={delayInSeconds}
+        savedSeconds={Number(neuronDissolveDelaySeconds)}
         maxInSeconds={maxDelayInSeconds}
-        minInSeconds={Math.max(
-          Number(neuronDissolveDelaySeconds),
-          minProjectDelayInSeconds
-        )}
+        minInSeconds={neuronDissolveDelaySeconds >= minProjectDelayInSeconds
+          ? Number(neuronDissolveDelaySeconds) + 1
+          : minProjectDelayInSeconds}
         placeholderLabelKey="neurons.dissolve_delay_placeholder"
         name="dissolve_delay"
         {getInputError}

--- a/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -95,11 +95,12 @@
     <div>
       <DayInput
         bind:seconds={delayInSeconds}
-        savedSeconds={Number(neuronDissolveDelaySeconds)}
+        disabled={Number(neuronDissolveDelaySeconds) === maxDelayInSeconds}
         maxInSeconds={maxDelayInSeconds}
-        minInSeconds={neuronDissolveDelaySeconds >= minProjectDelayInSeconds
-          ? Number(neuronDissolveDelaySeconds) + 1
-          : minProjectDelayInSeconds}
+        minInSeconds={Math.max(
+          Number(neuronDissolveDelaySeconds) + 1,
+          minProjectDelayInSeconds
+        )}
         placeholderLabelKey="neurons.dissolve_delay_placeholder"
         name="dissolve_delay"
         {getInputError}

--- a/frontend/src/lib/components/ui/DayInput.svelte
+++ b/frontend/src/lib/components/ui/DayInput.svelte
@@ -5,6 +5,7 @@
   import { daysToSeconds, secondsToDays } from "$lib/utils/date.utils";
 
   export let seconds: number;
+  export let savedSeconds: number;
   export let maxInSeconds: number;
   export let minInSeconds: number;
   export let placeholderLabelKey = "core.amount";

--- a/frontend/src/lib/components/ui/DayInput.svelte
+++ b/frontend/src/lib/components/ui/DayInput.svelte
@@ -5,7 +5,7 @@
   import { daysToSeconds, secondsToDays } from "$lib/utils/date.utils";
 
   export let seconds: number;
-  export let savedSeconds: number;
+  export let disabled: boolean = false;
   export let maxInSeconds: number;
   export let minInSeconds: number;
   export let placeholderLabelKey = "core.amount";
@@ -40,9 +40,6 @@
     seconds = maxInSeconds;
     days = secondsToDays(seconds);
   };
-
-  let disabled = false;
-  $: disabled = savedSeconds === maxInSeconds;
 </script>
 
 <InputWithError

--- a/frontend/src/lib/components/ui/DayInput.svelte
+++ b/frontend/src/lib/components/ui/DayInput.svelte
@@ -40,6 +40,9 @@
     seconds = maxInSeconds;
     days = secondsToDays(seconds);
   };
+
+  let disabled = false;
+  $: disabled = savedSeconds === maxInSeconds;
 </script>
 
 <InputWithError
@@ -51,7 +54,8 @@
   {errorMessage}
   on:nnsInput={showError}
   on:blur={showError}
+  {disabled}
 >
-  <MinButton on:click={setMin} slot="start" />
-  <MaxButton on:click={setMax} slot="end" />
+  <MinButton on:click={setMin} slot="start" {disabled} />
+  <MaxButton on:click={setMax} slot="end" {disabled} />
 </InputWithError>

--- a/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
@@ -9,6 +9,7 @@ import { SetDissolveDelayPo } from "$tests/page-objects/SetDissolveDelay.page-ob
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NeuronState } from "@dfinity/nns";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
+import { expect } from "@playwright/test";
 import { render } from "@testing-library/svelte";
 
 const defaultComponentProps = {
@@ -238,6 +239,25 @@ describe("SetDissolveDelay", () => {
     expect(await po.getInputWithErrorPo().isDisabled()).toBe(true);
     expect(await po.getMaxButtonPo().isDisabled()).toBe(true);
     expect(await po.getMinButtonPo().isDisabled()).toBe(true);
+  });
+
+  it("should not increase dissolve delay with multiple Min clicks", async () => {
+    const delayInSeconds = 0;
+    const minProjectDelayInDays = 185;
+    const po = renderComponent({
+      ...defaultComponentProps,
+      minProjectDelayInSeconds: minProjectDelayInDays * SECONDS_IN_DAY,
+      neuronDissolveDelaySeconds: BigInt(delayInSeconds),
+      delayInSeconds,
+    });
+
+    expect(await po.getDays()).toBe(0);
+    await po.clickMin();
+    expect(await po.getDays()).toBe(minProjectDelayInDays);
+
+    // after the next min click the value should remain
+    await po.clickMin();
+    expect(await po.getDays()).toBe(minProjectDelayInDays);
   });
 
   const minMaxDaysPairs = [

--- a/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
@@ -227,6 +227,19 @@ describe("SetDissolveDelay", () => {
     expect(getDelayInSeconds(component)).toBe(200 * SECONDS_IN_DAY);
   });
 
+  it("should disable input when maximum is already selected", async () => {
+    const delayInSeconds = defaultComponentProps.maxDelayInSeconds;
+    const po = renderComponent({
+      ...defaultComponentProps,
+      neuronDissolveDelaySeconds: BigInt(delayInSeconds),
+      delayInSeconds,
+    });
+
+    expect(await po.getInputWithErrorPo().isDisabled()).toBe(true);
+    expect(await po.getMaxButtonPo().isDisabled()).toBe(true);
+    expect(await po.getMinButtonPo().isDisabled()).toBe(true);
+  });
+
   const minMaxDaysPairs = [
     { min: 50, max: 500 },
     { min: 50.5, max: 500.5 },

--- a/frontend/src/tests/lib/components/ui/DayInput.spec.ts
+++ b/frontend/src/tests/lib/components/ui/DayInput.spec.ts
@@ -163,4 +163,21 @@ describe("DayInput", () => {
 
     expect(inputElement.value).toBe("365.5");
   });
+
+  it("should apply disabled state", async () => {
+    const { container, queryByTestId } = render(DayInput, {
+      props: {
+        ...defaultProps,
+        disabled: true,
+      },
+    });
+
+    const inputElement = container.querySelector("input");
+    const minButton = queryByTestId("min-button");
+    const maxButton = queryByTestId("max-button");
+
+    expect(inputElement.getAttribute("disabled")).not.toBeNull();
+    expect(minButton.getAttribute("disabled")).not.toBeNull();
+    expect(maxButton.getAttribute("disabled")).not.toBeNull();
+  });
 });


### PR DESCRIPTION
# Motivation

The Min button set available minimum value.

# Changes

- min button logic (+1)
- disable editing when maximum was set

# Tests

- SetDissolveDelay should disable input when maximum is already selected
- DayInput supports disabled prop

# Todos

- [x] Add entry to changelog (if necessary).
