### PR TITLE
Await Playwright page.evaluate

### DIFF
--- a/frontend/src/tests/e2e/design.spec.ts
+++ b/frontend/src/tests/e2e/design.spec.ts
@@ -49,7 +49,7 @@ test.describe("Design", () => {
       await appPo.getAccountsPo().waitFor();
       await appPo.getAccountsPo().getNnsAccountsPo().waitForContentLoaded();
 
-      replaceContent({
+      await replaceContent({
         page,
         selectors: [
           '[data-tid="identifier"]',

--- a/frontend/src/tests/utils/e2e.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.test-utils.ts
@@ -94,7 +94,7 @@ export const setFeatureFlag = ({
     { featureFlag, value }
   );
 
-export const replaceContent = ({
+export const replaceContent = async ({
   page,
   selectors,
   innerHtml,
@@ -102,8 +102,8 @@ export const replaceContent = ({
   page: Page;
   selectors: string[];
   innerHtml: string;
-}) => {
-  page.evaluate(
+}): Promise<void> => {
+  await page.evaluate(
     ({ selectors, innerHtml }) =>
       document.querySelectorAll(selectors.join(", ")).forEach((el) => {
         el.innerHTML = innerHtml;


### PR DESCRIPTION
# Motivation

I noticed a CI run where the token symbols were not masked out in the screenshot.
And I noticed we don't await the `page.evaluate` call that replaces the content.
I don't know if this is the reason but awaiting the call is the right thing to do.

# Changes

Await the Playwright `page.evaluate` call in `replaceContent`.

# Tests

test only

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary