### PR TITLE
GIX-2180: Move IcpTransactionModal

### DIFF
--- a/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
@@ -3,7 +3,6 @@
   import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
   import { i18n } from "$lib/stores/i18n";
   import Footer from "$lib/components/layout/Footer.svelte";
-  import IcpTransactionModal from "$lib/modals/accounts/IcpTransactionModal.svelte";
   import { nonNullish } from "@dfinity/utils";
   import ReceiveButton from "$lib/components/accounts/ReceiveButton.svelte";
   import { syncAccounts } from "$lib/services/icp-accounts.services";
@@ -11,10 +10,6 @@
   import { IconAdd } from "@dfinity/gix-components";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import IC_LOGO from "$lib/assets/icp.svg";
-
-  let modal: "NewTransaction" | undefined = undefined;
-  const openNewTransaction = () => (modal = "NewTransaction");
-  const closeModal = () => (modal = undefined);
 
   // TODO: for performance reason use `loadBalance` to reload specific account
   const reload = async () => await syncAccounts();
@@ -29,18 +24,23 @@
       },
     });
   };
+
+  const openSendNnsModal = () => {
+    openAccountsModal({
+      type: "nns-send",
+      data: {
+        reload: undefined,
+      },
+    });
+  };
 </script>
 
 <TestIdWrapper testId="nns-accounts-footer-component">
-  {#if modal === "NewTransaction"}
-    <IcpTransactionModal on:nnsClose={closeModal} />
-  {/if}
-
   {#if nonNullish($icpAccountsStore)}
     <Footer columns={3}>
       <button
         class="secondary full-width"
-        on:click={openNewTransaction}
+        on:click={openSendNnsModal}
         data-tid="open-new-transaction">{$i18n.accounts.send}</button
       >
 

--- a/frontend/src/lib/modals/accounts/AccountsModals.svelte
+++ b/frontend/src/lib/modals/accounts/AccountsModals.svelte
@@ -11,6 +11,7 @@
   import BuyIcpModal from "./BuyIcpModal.svelte";
   import type { Account } from "$lib/types/account";
   import AddAccountModal from "./AddAccountModal.svelte";
+  import IcpTransactionModal from "./IcpTransactionModal.svelte";
 
   let modal:
     | AccountsModal<AccountsReceiveModalData | AccountsModalData>
@@ -43,6 +44,10 @@
 
 {#if type === "nns-receive" && nonNullish(data)}
   <NnsReceiveModal on:nnsClose={close} {data} />
+{/if}
+
+{#if type === "nns-send"}
+  <IcpTransactionModal on:nnsClose={close} selectedAccount={account} />
 {/if}
 
 {#if type === "icrc-receive" && nonNullish(data)}

--- a/frontend/src/lib/types/accounts.modal.ts
+++ b/frontend/src/lib/types/accounts.modal.ts
@@ -3,6 +3,7 @@ import type { UniverseCanisterId } from "$lib/types/universe";
 
 export type AccountsModalType =
   | "nns-receive"
+  | "nns-send"
   | "icrc-receive"
   | "buy-icp"
   | "add-icp-account";

--- a/frontend/src/tests/page-objects/Accounts.page-object.ts
+++ b/frontend/src/tests/page-objects/Accounts.page-object.ts
@@ -6,6 +6,7 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AddAccountModalPo } from "./AddAccountModal.page-object";
 import { BuyICPModalPo } from "./BuyICPModal.page-object";
+import { IcpTransactionModalPo } from "./IcpTransactionModal.page-object";
 import { IcrcTokenAccountsPo } from "./IcrcTokenAccounts.page-object";
 import { IcrcTokenAccountsFooterPo } from "./IcrcTokenAccountsFooter.page-object";
 import { IcrcTokenTransactionModalPo } from "./IcrcTokenTransactionModal.page-object";
@@ -52,6 +53,10 @@ export class AccountsPo extends BasePageObject {
 
   getAddAccountModalPo() {
     return AddAccountModalPo.under(this.root);
+  }
+
+  getIcpTransactionModalPo() {
+    return IcpTransactionModalPo.under(this.root);
   }
 
   getReceiveModalPo() {


### PR DESCRIPTION
# Motivation

Users can open the Send ICP modal from the tokens table in the ICP tokens page.

In this PR, I move the IcpTransactionModal from the NnsAccountsFooter to the AccountsModals.

This will make it easy to then open it when clicking in the icon of the tokens table.

# Changes

* Add `"nns-send"` to AccountsModalsType.
* Remove IcpTransactionModal from NnsAccountsFooter and dispatch an event instead.
* Add IcpTransactionModal to AccountsModals.

# Tests

* Added a test in the Accounts route that the user can send ICP by clicking in the button of the footer.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.

