### PR TITLE
GIX-2150: Migration to TokenAmountV2

### DIFF
--- a/frontend/src/lib/components/accounts/CurrentBalance.svelte
+++ b/frontend/src/lib/components/accounts/CurrentBalance.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
-  import type { TokenAmount } from "@dfinity/utils";
+  import type { TokenAmountV2 } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
 
-  export let balance: TokenAmount;
+  export let balance: TokenAmountV2;
 </script>
 
 <div>

--- a/frontend/src/lib/components/neuron-detail/ConfirmDisburseNeuron.svelte
+++ b/frontend/src/lib/components/neuron-detail/ConfirmDisburseNeuron.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import type { TokenAmount } from "@dfinity/utils";
+  import type { TokenAmount, TokenAmountV2 } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
   import { i18n } from "$lib/stores/i18n";
   import TransactionInfo from "$lib/components/accounts/TransactionInfo.svelte";
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
 
-  export let amount: TokenAmount;
+  export let amount: TokenAmountV2;
   export let fee: TokenAmount | undefined = undefined;
   export let source: string;
   export let destinationAddress: string;

--- a/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -8,12 +8,12 @@
   import NeuronStateRemainingTime from "$lib/components/neurons/NeuronStateRemainingTime.svelte";
   import DayInput from "$lib/components/ui/DayInput.svelte";
   import type { NeuronState } from "@dfinity/nns";
-  import { type TokenAmount, nonNullish } from "@dfinity/utils";
+  import { nonNullish, type TokenAmountV2 } from "@dfinity/utils";
   import RangeDissolveDelay from "./RangeDissolveDelay.svelte";
 
   export let neuronState: NeuronState;
   export let neuronDissolveDelaySeconds: bigint;
-  export let neuronStake: TokenAmount;
+  export let neuronStake: TokenAmountV2;
   export let delayInSeconds = 0;
   export let minProjectDelayInSeconds: number;
   export let maxDelayInSeconds = 0;
@@ -67,7 +67,7 @@
       <Html
         text={replacePlaceholders($i18n.sns_neurons.token_stake, {
           $amount: valueSpan(
-            formatToken({ value: neuronStake.toE8s(), detailed: true })
+            formatToken({ value: neuronStake.toUlps(), detailed: true })
           ),
           $token: neuronStake.token.symbol,
         })}

--- a/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { formatToken, formatTokenV2 } from "$lib/utils/token.utils";
+  import { formatTokenV2 } from "$lib/utils/token.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { Html } from "@dfinity/gix-components";
   import { valueSpan } from "$lib/utils/utils";

--- a/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { formatToken } from "$lib/utils/token.utils";
+  import { formatToken, formatTokenV2 } from "$lib/utils/token.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { Html } from "@dfinity/gix-components";
   import { valueSpan } from "$lib/utils/utils";
@@ -67,7 +67,7 @@
       <Html
         text={replacePlaceholders($i18n.sns_neurons.token_stake, {
           $amount: valueSpan(
-            formatToken({ value: neuronStake.toUlps(), detailed: true })
+            formatTokenV2({ value: neuronStake, detailed: true })
           ),
           $token: neuronStake.token.symbol,
         })}

--- a/frontend/src/lib/components/neurons/SetNnsDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/SetNnsDissolveDelay.svelte
@@ -11,13 +11,13 @@
   } from "$lib/utils/neuron.utils";
 
   import SetDissolveDelay from "$lib/components/neurons/SetDissolveDelay.svelte";
-  import { TokenAmount, ICPToken } from "@dfinity/utils";
+  import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 
   export let delayInSeconds: number;
   export let neuron: NeuronInfo;
 
-  let neuronStake: TokenAmount;
-  $: neuronStake = TokenAmount.fromE8s({
+  let neuronStake: TokenAmountV2;
+  $: neuronStake = TokenAmountV2.fromUlps({
     amount: getNeuronStake(neuron),
     token: ICPToken,
   });

--- a/frontend/src/lib/components/sns-neurons/SetSnsDissolveDelay.svelte
+++ b/frontend/src/lib/components/sns-neurons/SetSnsDissolveDelay.svelte
@@ -3,7 +3,7 @@
   import type { Token } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { isNullish } from "@dfinity/utils";
+  import { TokenAmountV2, isNullish } from "@dfinity/utils";
   import type { SnsNeuron } from "@dfinity/sns";
   import {
     getSnsLockedTimeInSeconds,
@@ -16,7 +16,6 @@
   import { snsParametersStore } from "$lib/stores/sns-parameters.store";
   import type { Principal } from "@dfinity/principal";
   import { secondsToDissolveDelayDuration } from "$lib/utils/date.utils";
-  import { TokenAmount } from "@dfinity/utils";
   import SetDissolveDelay from "$lib/components/neurons/SetDissolveDelay.svelte";
   import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
   import Hash from "$lib/components/ui/Hash.svelte";
@@ -32,8 +31,8 @@
   let snsParameters: SnsNervousSystemParameters | undefined;
   $: snsParameters = $snsParametersStore[rootCanisterId.toText()]?.parameters;
 
-  let neuronStake: TokenAmount;
-  $: neuronStake = TokenAmount.fromE8s({
+  let neuronStake: TokenAmountV2;
+  $: neuronStake = TokenAmountV2.fromUlps({
     amount: getSnsNeuronStake(neuron),
     token,
   });

--- a/frontend/src/lib/modals/neurons/DisburseNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseNnsNeuronModal.svelte
@@ -4,10 +4,10 @@
   import { i18n } from "$lib/stores/i18n";
   import type { NeuronInfo } from "@dfinity/nns";
   import {
-    TokenAmount,
     ICPToken,
     type Token,
     assertNonNullish,
+    TokenAmountV2,
   } from "@dfinity/utils";
   import type {
     WizardModal,
@@ -55,8 +55,8 @@
   let currentStep: WizardStep | undefined;
   let modal: WizardModal;
   let loading = false;
-  let amount: TokenAmount;
-  $: amount = TokenAmount.fromE8s({
+  let amount: TokenAmountV2;
+  $: amount = TokenAmountV2.fromUlps({
     amount: neuronStake(neuron),
     token: ICPToken,
   });

--- a/frontend/src/lib/modals/neurons/DisburseSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseSnsNeuronModal.svelte
@@ -5,13 +5,17 @@
   import { createEventDispatcher } from "svelte";
   import { disburse } from "$lib/services/sns-neurons.services";
   import type { SnsNeuron } from "@dfinity/sns";
-  import { fromDefinedNullable } from "@dfinity/utils";
+  import {
+    TokenAmountV2,
+    fromDefinedNullable,
+    type Token,
+    type TokenAmount,
+  } from "@dfinity/utils";
   import {
     getSnsNeuronIdAsHexString,
     getSnsNeuronStake,
   } from "$lib/utils/sns-neuron.utils";
   import type { Principal } from "@dfinity/principal";
-  import { TokenAmount, type Token } from "@dfinity/utils";
   import ConfirmDisburseNeuron from "$lib/components/neuron-detail/ConfirmDisburseNeuron.svelte";
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
   import {
@@ -36,8 +40,8 @@
   let source: string;
   $: source = getSnsNeuronIdAsHexString(neuron);
 
-  let amount: TokenAmount;
-  $: amount = TokenAmount.fromE8s({
+  let amount: TokenAmountV2;
+  $: amount = TokenAmountV2.fromUlps({
     amount: getSnsNeuronStake(neuron),
     token: $snsTokenSymbolSelectedStore as Token,
   });

--- a/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
@@ -2,7 +2,7 @@
   import CurrentBalance from "$lib/components/accounts/CurrentBalance.svelte";
   import { Modal, Value, busy } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
-  import { TokenAmount, ICPToken } from "@dfinity/utils";
+  import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
   import { isValidInputAmount, neuronStake } from "$lib/utils/neuron.utils";
   import AmountInput from "$lib/components/ui/AmountInput.svelte";
   import { i18n } from "$lib/stores/i18n";
@@ -23,8 +23,8 @@
   let stakeE8s: bigint;
   $: stakeE8s = neuronStake(neuron);
 
-  let balance: TokenAmount;
-  $: balance = TokenAmount.fromE8s({ amount: stakeE8s, token: ICPToken });
+  let balance: TokenAmountV2;
+  $: balance = TokenAmountV2.fromUlps({ amount: stakeE8s, token: ICPToken });
 
   let max = 0;
   $: max =

--- a/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
@@ -9,7 +9,7 @@
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import type { Principal } from "@dfinity/principal";
   import { isValidInputAmount } from "$lib/utils/neuron.utils";
-  import { TokenAmount } from "@dfinity/utils";
+  import { TokenAmountV2 } from "@dfinity/utils";
   import { fromDefinedNullable } from "@dfinity/utils";
   import CurrentBalance from "$lib/components/accounts/CurrentBalance.svelte";
   import AmountInput from "$lib/components/ui/AmountInput.svelte";
@@ -17,7 +17,7 @@
   import { splitNeuron } from "$lib/services/sns-neurons.services";
   import { E8S_PER_ICP } from "$lib/constants/icp.constants";
   import type { SnsNervousSystemParameters } from "@dfinity/sns";
-  import { formattedTransactionFee } from "$lib/utils/token.utils";
+  import { formatToken } from "$lib/utils/token.utils";
 
   export let rootCanisterId: Principal;
   export let neuron: SnsNeuron;
@@ -31,8 +31,8 @@
   let stakeE8s: E8s;
   $: stakeE8s = getSnsNeuronStake(neuron);
 
-  let balance: TokenAmount;
-  $: balance = TokenAmount.fromE8s({ amount: stakeE8s, token });
+  let balance: TokenAmountV2;
+  $: balance = TokenAmountV2.fromUlps({ amount: stakeE8s, token });
 
   let neuronMinimumStake: bigint;
   $: neuronMinimumStake = fromDefinedNullable(
@@ -100,9 +100,9 @@
       <p class="label">{$i18n.neurons.transaction_fee}</p>
       <p>
         <Value>
-          {formattedTransactionFee(
-            TokenAmount.fromE8s({ amount: transactionFee, token })
-          )}
+          {formatToken({
+            value: transactionFee,
+          })}
         </Value>
         {token.symbol}
       </p>

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -139,16 +139,6 @@ export const formattedTransactionFeeICP = (fee: number | bigint): string =>
     }).toE8s(),
   });
 
-// To make the fixed transaction fee readable, we do not display it with 8 digits but only till the last digit that is not zero
-// e.g. not 0.00010000 but 0.0001
-export const formattedTransactionFee = (fee: TokenAmount): string =>
-  formatToken({
-    value: TokenAmount.fromE8s({
-      amount: fee.toE8s(),
-      token: fee.token,
-    }).toE8s(),
-  });
-
 /**
  * Calculates the maximum amount for a transaction.
  *

--- a/frontend/src/tests/lib/components/neuron-detail/ConfirmDisburseNeuron.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/ConfirmDisburseNeuron.spec.ts
@@ -1,6 +1,6 @@
 import { formattedTransactionFeeICP } from "$lib/utils/token.utils";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
-import { ICPToken, TokenAmount } from "@dfinity/utils";
+import { ICPToken, TokenAmount, TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 import ConfirmDisburseNeuronTest from "./ConfirmDisburseNeuronTest.svelte";
 
@@ -15,7 +15,7 @@ describe("ConfirmDisburseNeuron", () => {
   const amount = 6.66;
   const fee = 1.11;
   const props = {
-    amount: TokenAmount.fromNumber({ amount, token: ICPToken }),
+    amount: TokenAmountV2.fromNumber({ amount, token: ICPToken }),
     source: "test source",
     destinationAddress: "test destination",
     loading: false,

--- a/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
@@ -8,14 +8,14 @@ import en from "$tests/mocks/i18n.mock";
 import { SetDissolveDelayPo } from "$tests/page-objects/SetDissolveDelay.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NeuronState } from "@dfinity/nns";
-import { ICPToken, TokenAmount } from "@dfinity/utils";
+import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 import { expect } from "@playwright/test";
 import { render } from "@testing-library/svelte";
 
 const defaultComponentProps = {
   neuronState: NeuronState.Locked,
   neuronDissolveDelaySeconds: 0,
-  neuronStake: TokenAmount.fromE8s({
+  neuronStake: TokenAmountV2.fromUlps({
     amount: BigInt(200_000_000),
     token: ICPToken,
   }),

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -2,7 +2,6 @@ import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
 import {
   convertIcpToTCycles,
   convertTCyclesToIcpNumber,
-  formattedTransactionFee,
   formattedTransactionFeeICP,
   formatToken,
   formatTokenV2,
@@ -332,16 +331,6 @@ describe("token-utils", () => {
     expect(formattedTransactionFeeICP(DEFAULT_TRANSACTION_FEE_E8S)).toEqual(
       "0.0001"
     ));
-
-  it("should format a specific transaction fee with given token", () =>
-    expect(
-      formattedTransactionFee(
-        TokenAmount.fromE8s({
-          amount: BigInt(DEFAULT_TRANSACTION_FEE_E8S),
-          token: ICPToken,
-        })
-      )
-    ).toEqual("0.0001"));
 
   it("getMaxTransactionAmount should max taking into account fee, maxAmount and converte it to a number", () => {
     const fee = BigInt(DEFAULT_TRANSACTION_FEE_E8S);


### PR DESCRIPTION
# Motivation

Migrate from TokenAmount to TokenAmountV2 that supports different decimals.

In this PR, migrate components related to neurons.

# Changes

* Change TokenAmount to TokenAmountV2 in some places.
* Remove the helper `formattedTransactionFee` which was used by e8s converted to TokenAmount because the helper expected a TokenAmount, to create another TokenAmount, to get the e8s and call `formatToken`. The `token` was not really used anywhere.

# Tests

* Fix broken tests.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
