### PR TITLE
feat: Implement Storable for Account

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -15,6 +15,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 - Disable dissolve delay editing when the maximum is reached.
+- Implement `Storable` for accounts.
 
 #### Changed
 

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -13,11 +13,13 @@ use ic_ledger_core::timestamp::TimeStamp;
 use ic_ledger_core::tokens::SignedTokens;
 use ic_nns_common::types::NeuronId;
 use ic_nns_constants::{CYCLES_MINTING_CANISTER_ID, GOVERNANCE_CANISTER_ID};
+use ic_stable_structures::{storable::Bound, Storable};
 use icp_ledger::Operation::{self, Approve, Burn, Mint, Transfer, TransferFrom};
 use icp_ledger::{AccountIdentifier, BlockIndex, Memo, Subaccount, Tokens};
 use itertools::Itertools;
 use on_wire::{FromWire, IntoWire};
 use serde::Deserialize;
+use std::borrow::Cow;
 use std::cmp::{min, Ordering};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::fmt;
@@ -94,6 +96,20 @@ pub struct Account {
     sub_accounts: HashMap<u8, NamedSubAccount>,
     hardware_wallet_accounts: Vec<NamedHardwareWalletAccount>,
     canisters: Vec<NamedCanister>,
+}
+
+impl Storable for Account {
+    const BOUND: Bound = Bound::Unbounded;
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        let account_serialized = Candid((self,)).into_bytes().expect("Failed to serialize account");
+        account_serialized.to_owned().into()
+    }
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        let (account,) = Candid::from_bytes(bytes.as_ref().to_owned())
+            .map(|c| c.0)
+            .expect("Failed to parse account from store.");
+        account
+    }
 }
 
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -101,14 +101,10 @@ pub struct Account {
 impl Storable for Account {
     const BOUND: Bound = Bound::Unbounded;
     fn to_bytes(&self) -> Cow<'_, [u8]> {
-        let account_serialized = Candid((self,)).into_bytes().expect("Failed to serialize account");
-        account_serialized.to_owned().into()
+        candid::encode_one(self).expect("Failed to serialize account").into()
     }
     fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
-        let (account,) = Candid::from_bytes(bytes.as_ref().to_owned())
-            .map(|c| c.0)
-            .expect("Failed to parse account from store.");
-        account
+        candid::decode_one(&bytes).expect("Failed to parse account from store.")
     }
 }
 

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -1,5 +1,6 @@
 use super::histogram::AccountsStoreHistogram;
 use super::*;
+use crate::accounts_store::toy_data::{toy_account, ToyAccountSize};
 use crate::multi_part_transactions_processor::MultiPartTransactionToBeProcessed;
 use icp_ledger::Tokens;
 use std::str::FromStr;
@@ -1810,4 +1811,24 @@ pub fn test_store_histogram() -> AccountsStoreHistogram {
     *ans.total_hardware_wallet_transactions(0) += 2; // Therefore neither has any hardware wallet transactions.
     *ans.canisters(0) += 2; // Neither test account has canisters.
     ans
+}
+
+/// Stored accounts should be recovered with the same value.
+///
+/// Note: Given that account implement CandidType this is little more than a formality.
+#[test]
+fn accounts_should_implement_storable() {
+    let account = toy_account(
+        1,
+        ToyAccountSize {
+            sub_accounts: 2,
+            canisters: 3,
+            default_account_transactions: 4,
+            sub_account_transactions: 5,
+            hardware_wallets: 6,
+        },
+    );
+    let bytes = account.to_bytes();
+    let parsed = Account::from_bytes(bytes);
+    assert_eq!(account, parsed);
 }


### PR DESCRIPTION
# Motivation
We wish to store accounts in stable memory.

# Changes
- Implement the `Storable` trait for `Account`s

# Tests
- A unit test is included.

# Todos

- [x] Add entry to changelog (if necessary).
