### PR TITLE
GIX-2180: Open IcpTransactionModal from tokens table

### DIFF
--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -21,6 +21,7 @@
   import { ActionType, type Action } from "$lib/types/actions";
   import { findAccount } from "$lib/utils/accounts.utils";
   import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
+  import { toastsError } from "$lib/stores/toasts.store";
 
   onMount(() => {
     if (!$ENABLE_MY_TOKENS) {
@@ -47,7 +48,14 @@
       identifier: detail.data.accountIdentifier,
       accounts: $nnsAccountsListStore,
     });
+    // Edge case: There wouldn't be a row to click on without an account
     if (isNullish(account)) {
+      toastsError({
+        labelKey: "error.account_not_found",
+        substitutions: {
+          $account_identifier: detail.data.accountIdentifier ?? "",
+        },
+      });
       return;
     }
 

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -43,14 +43,15 @@
   };
 
   const handleAction = ({ detail }: { detail: Action }) => {
+    const account = findAccount({
+      identifier: detail.data.accountIdentifier,
+      accounts: $nnsAccountsListStore,
+    });
+    if (isNullish(account)) {
+      return;
+    }
+
     if (detail.type === ActionType.Receive) {
-      const account = findAccount({
-        identifier: detail.data.accountIdentifier,
-        accounts: $nnsAccountsListStore,
-      });
-      if (isNullish(account)) {
-        return;
-      }
       openAccountsModal({
         type: "nns-receive",
         data: {
@@ -60,6 +61,15 @@
           universeId: detail.data.universeId,
           tokenSymbol: detail.data.token.symbol,
           logo: detail.data.logo,
+        },
+      });
+    }
+
+    if (detail.type === ActionType.Send) {
+      openAccountsModal({
+        type: "nns-send",
+        data: {
+          account,
         },
       });
     }

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -776,6 +776,49 @@ describe("Accounts", () => {
           fromSubaccount: undefined,
         });
       });
+
+      it("user can open the send modal from tokens table and make a transaction", async () => {
+        subaccountBalance = 220000000n;
+        icpAccountsStore.setForTesting({
+          main: {
+            ...mockMainAccount,
+            balanceUlps: mainAccountBalance,
+          },
+          subAccounts: [
+            {
+              ...mockSubAccount,
+              balanceUlps: subaccountBalance,
+            },
+          ],
+          hardwareWallets: [],
+        });
+        const po = renderComponent();
+
+        const tablePo = po.getNnsAccountsPo().getTokensTablePo();
+        expect(await tablePo.getRowData(mockSubAccount.name)).toEqual({
+          balance: "2.20 ICP",
+          projectName: "test subaccount",
+        });
+
+        await tablePo.clickSendOnRow(mockSubAccount.name);
+
+        const modalPo = po.getIcpTransactionModalPo();
+        expect(await modalPo.isPresent()).toBe(true);
+
+        subaccountBalance = 120000000n;
+        modalPo.transferToAddress({
+          destinationAddress: mockMainAccount.identifier,
+          amount: 1,
+        });
+
+        await runResolvedPromises();
+
+        expect(await tablePo.getRowData(mockSubAccount.name)).toEqual({
+          balance: "1.20 ICP",
+          projectName: "test subaccount",
+        });
+        expect(await modalPo.isPresent()).toBe(false);
+      });
     });
   });
 

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -806,9 +806,11 @@ describe("Accounts", () => {
         expect(await modalPo.isPresent()).toBe(true);
 
         subaccountBalance = 120000000n;
+        const amount = 1;
+        const destinationAddress = mockMainAccount.identifier;
         modalPo.transferToAddress({
-          destinationAddress: mockMainAccount.identifier,
-          amount: 1,
+          destinationAddress,
+          amount,
         });
 
         await runResolvedPromises();
@@ -818,6 +820,13 @@ describe("Accounts", () => {
           projectName: "test subaccount",
         });
         expect(await modalPo.isPresent()).toBe(false);
+        expect(icpLedgerApi.sendICP).toHaveBeenCalledTimes(1);
+        expect(icpLedgerApi.sendICP).toHaveBeenCalledWith({
+          identity: mockIdentity,
+          to: destinationAddress,
+          amount: TokenAmount.fromNumber({ amount, token: ICPToken }),
+          fromSubAccount: mockSubAccount.subAccount,
+        });
       });
     });
   });


### PR DESCRIPTION
# Motivation

Users can use the Send icon from the ICP Tokens table.

# Changes

* Trigger the "nns-send" event when the tokens table triggers the Send action.

# Tests

* Add a test to send tokens from a subaccounts of the ICP tokens table.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
