### PR TITLE
Rename formatToken to formatTokenE8s

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCWithdrawalAccount.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCWithdrawalAccount.svelte
@@ -10,7 +10,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { Spinner, IconClock, IconCheck } from "@dfinity/gix-components";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { formatToken } from "$lib/utils/token.utils";
+  import { formatTokenE8s } from "$lib/utils/token.utils";
   import { CKBTC_ADDITIONAL_CANISTERS } from "$lib/constants/ckbtc-additional-canister-ids.constants";
   import { toastsError } from "$lib/stores/toasts.store";
   import { emit } from "$lib/utils/events.utils";
@@ -88,7 +88,7 @@
   $: accountBalance = account?.balanceUlps ?? 0n;
 
   let detailedAccountBalance: string;
-  $: detailedAccountBalance = formatToken({
+  $: detailedAccountBalance = formatTokenE8s({
     value: accountBalance,
     detailed: true,
   });

--- a/frontend/src/lib/components/accounts/HardwareWalletNeurons.svelte
+++ b/frontend/src/lib/components/accounts/HardwareWalletNeurons.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import { formatToken } from "$lib/utils/token.utils";
+  import { formatTokenE8s } from "$lib/utils/token.utils";
   import HardwareWalletNeuronAddHotkeyButton from "./HardwareWalletNeuronAddHotkeyButton.svelte";
   import { getContext } from "svelte";
   import type {
@@ -29,7 +29,7 @@
     </p>
 
     <p>
-      {formatToken({ value: fullNeuron?.cachedNeuronStake ?? BigInt(0) })}
+      {formatTokenE8s({ value: fullNeuron?.cachedNeuronStake ?? BigInt(0) })}
     </p>
 
     <p class="hotkey">

--- a/frontend/src/lib/components/neuron-detail/ConfirmSpawnHW.svelte
+++ b/frontend/src/lib/components/neuron-detail/ConfirmSpawnHW.svelte
@@ -3,7 +3,7 @@
   import { createEventDispatcher } from "svelte";
   import { i18n } from "$lib/stores/i18n";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { formatToken } from "$lib/utils/token.utils";
+  import { formatTokenE8s } from "$lib/utils/token.utils";
   import {
     formattedMaturity,
     isEnoughToStakeNeuron,
@@ -40,7 +40,7 @@
         <Html
           text={replacePlaceholders($i18n.neurons.amount_icp_stake, {
             $amount: valueSpan(
-              formatToken({ value: neuronICP, detailed: true })
+              formatTokenE8s({ value: neuronICP, detailed: true })
             ),
           })}
         />

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronVotingPowerSection.svelte
@@ -14,7 +14,7 @@
   import NnsNeuronStateItemAction from "./NnsNeuronStateItemAction.svelte";
   import NnsNeuronDissolveDelayItemAction from "./NnsNeuronDissolveDelayItemAction.svelte";
   import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
-  import { formatToken } from "$lib/utils/token.utils";
+  import { formatTokenE8s } from "$lib/utils/token.utils";
   import { Html, Section } from "@dfinity/gix-components";
 
   export let neuron: NeuronInfo;
@@ -39,7 +39,7 @@
       {replacePlaceholders(
         $i18n.neuron_detail.voting_power_section_description_expanded,
         {
-          $stake: formatToken({
+          $stake: formatTokenE8s({
             value: neuronStake(neuron),
           }),
           $maturityStaked: formattedStakedMaturity(neuron),

--- a/frontend/src/lib/components/neuron-detail/StakeItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/StakeItemAction.svelte
@@ -5,7 +5,7 @@
   import IncreaseStakeButton from "$lib/components/neuron-detail/actions/IncreaseStakeButton.svelte";
   import { i18n } from "$lib/stores/i18n";
   import type { Universe } from "$lib/types/universe";
-  import { formatToken } from "$lib/utils/token.utils";
+  import { formatTokenE8s } from "$lib/utils/token.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
 
   export let universe: Universe;
@@ -24,7 +24,8 @@
   />
   <div class="content">
     <h4 class="token-value">
-      <span data-tid="stake-value">{formatToken({ value: neuronStake })}</span
+      <span data-tid="stake-value"
+        >{formatTokenE8s({ value: neuronStake })}</span
       ><span data-tid="token-symbol">{token.symbol}</span>
     </h4>
     <p class="description" data-tid="staked-description">

--- a/frontend/src/lib/components/neuron-detail/actions/SplitNnsNeuronButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/SplitNnsNeuronButton.svelte
@@ -6,7 +6,7 @@
   } from "$lib/utils/neuron.utils";
   import { i18n } from "$lib/stores/i18n";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { formatToken } from "$lib/utils/token.utils";
+  import { formatTokenE8s } from "$lib/utils/token.utils";
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
   import { mainTransactionFeeStore } from "$lib/stores/transaction-fees.store";
   import { openNnsNeuronModal } from "$lib/utils/modals.utils";
@@ -36,7 +36,7 @@
     text={replacePlaceholders(
       $i18n.neuron_detail.split_neuron_disabled_tooltip,
       {
-        $amount: formatToken({
+        $amount: formatTokenE8s({
           value: BigInt(minNeuronSplittable($mainTransactionFeeStore)),
           detailed: true,
         }),

--- a/frontend/src/lib/components/neurons/ConfirmDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/ConfirmDissolveDelay.svelte
@@ -5,7 +5,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { secondsToDuration } from "@dfinity/utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { formatToken } from "$lib/utils/token.utils";
+  import { formatTokenE8s } from "$lib/utils/token.utils";
   import {
     formatVotingPower,
     neuronStake,
@@ -55,7 +55,9 @@
     <p>
       <Html
         text={replacePlaceholders($i18n.neurons.amount_icp_stake, {
-          $amount: valueSpan(formatToken({ value: neuronICP, detailed: true })),
+          $amount: valueSpan(
+            formatTokenE8s({ value: neuronICP, detailed: true })
+          ),
         })}
       />
     </p>

--- a/frontend/src/lib/components/neurons/NnsNeuronInfo.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronInfo.svelte
@@ -3,7 +3,7 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { neuronStake } from "$lib/utils/neuron.utils";
-  import { formatToken } from "$lib/utils/token.utils";
+  import { formatTokenE8s } from "$lib/utils/token.utils";
   import { valueSpan } from "$lib/utils/utils";
   import { Html } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
@@ -24,7 +24,7 @@
       <Html
         text={replacePlaceholders($i18n.neurons.amount_icp_stake, {
           $amount: valueSpan(
-            formatToken({ value: neuronStake(neuron), detailed: true })
+            formatTokenE8s({ value: neuronStake(neuron), detailed: true })
           ),
         })}
       />

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerExplanation.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerExplanation.svelte
@@ -10,7 +10,7 @@
     getSnsNeuronStake,
   } from "$lib/utils/sns-neuron.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { formatToken } from "$lib/utils/token.utils";
+  import { formatTokenE8s } from "$lib/utils/token.utils";
   import TestIdWrapper from "../common/TestIdWrapper.svelte";
 
   export let neuron: SnsNeuron;
@@ -30,7 +30,7 @@
   <Html
     text={replacePlaceholders(votingPowerMessage, {
       $token: token.symbol,
-      $stake: formatToken({
+      $stake: formatTokenE8s({
         value: getSnsNeuronStake(neuron),
         detailed: true,
       }),

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
@@ -17,7 +17,7 @@
   import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
   import SnsNeuronStateItemAction from "./SnsNeuronStateItemAction.svelte";
   import SnsNeuronDissolveDelayItemAction from "./SnsNeuronDissolveDelayItemAction.svelte";
-  import { formatToken } from "$lib/utils/token.utils";
+  import { formatTokenE8s } from "$lib/utils/token.utils";
   import { secondsToDuration } from "@dfinity/utils";
   import { Html, Section } from "@dfinity/gix-components";
   import { Principal } from "@dfinity/principal";
@@ -50,7 +50,7 @@
       {replacePlaceholders(
         $i18n.neuron_detail.voting_power_section_description_expanded,
         {
-          $stake: formatToken({
+          $stake: formatTokenE8s({
             value: getSnsNeuronStake(neuron),
           }),
           $maturityStaked: formattedStakedMaturity(neuron),

--- a/frontend/src/lib/components/sns-neuron-detail/actions/SnsDisburseMaturityButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/SnsDisburseMaturityButton.svelte
@@ -7,7 +7,7 @@
   import type { SnsNeuron } from "@dfinity/sns";
   import DisburseMaturityButton from "$lib/components/neuron-detail/actions/DisburseMaturityButton.svelte";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { formatToken } from "$lib/utils/token.utils";
+  import { formatTokenE8s } from "$lib/utils/token.utils";
   import { i18n } from "$lib/stores/i18n";
 
   export let neuron: SnsNeuron;
@@ -23,7 +23,7 @@
       : replacePlaceholders(
           $i18n.neuron_detail.disburse_maturity_disabled_tooltip_non_zero,
           {
-            $amount: formatToken({
+            $amount: formatTokenE8s({
               value: minimumAmountToDisburseMaturity(feeE8s),
             }),
           }

--- a/frontend/src/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.svelte
@@ -11,7 +11,7 @@
   import { minNeuronSplittable } from "$lib/utils/sns-neuron.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import type { E8s } from "@dfinity/nns";
-  import { formatToken } from "$lib/utils/token.utils";
+  import { formatTokenE8s } from "$lib/utils/token.utils";
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
   import type { Token } from "@dfinity/utils";
   import VestingTooltipWrapper from "../VestingTooltipWrapper.svelte";
@@ -49,7 +49,7 @@
     text={replacePlaceholders(
       $i18n.neuron_detail.split_neuron_disabled_tooltip,
       {
-        $amount: formatToken({
+        $amount: formatTokenE8s({
           value: minNeuronSplittable({
             fee: transactionFee,
             neuronMinimumStake,

--- a/frontend/src/lib/components/sns-neurons/ConfirmSnsDissolveDelay.svelte
+++ b/frontend/src/lib/components/sns-neurons/ConfirmSnsDissolveDelay.svelte
@@ -3,7 +3,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { secondsToDuration } from "@dfinity/utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { formatToken } from "$lib/utils/token.utils";
+  import { formatTokenE8s } from "$lib/utils/token.utils";
   import { formatVotingPower } from "$lib/utils/neuron.utils";
   import { valueSpan } from "$lib/utils/utils";
   import { Html, busy } from "@dfinity/gix-components";
@@ -61,7 +61,7 @@
       <Html
         text={replacePlaceholders($i18n.sns_neurons.token_stake, {
           $amount: valueSpan(
-            formatToken({ value: neuronStake, detailed: true })
+            formatTokenE8s({ value: neuronStake, detailed: true })
           ),
           $token: token.symbol,
         })}

--- a/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseMaturityModal.svelte
@@ -12,7 +12,7 @@
     type WizardStep,
     KeyValuePair,
   } from "@dfinity/gix-components";
-  import { formatToken } from "$lib/utils/token.utils";
+  import { formatTokenE8s } from "$lib/utils/token.utils";
   import { formatMaturity } from "$lib/utils/neuron.utils";
   import QrWizardModal from "$lib/modals/transaction/QrWizardModal.svelte";
   import SelectDestinationAddress from "$lib/components/accounts/SelectDestinationAddress.svelte";
@@ -69,7 +69,7 @@
     notEnoughMaturitySelected && percentageToDisburse > 0
       ? replacePlaceholders(
           $i18n.neuron_detail.disburse_maturity_disabled_tooltip_non_zero,
-          { $amount: formatToken({ value: minimumAmountE8s }) }
+          { $amount: formatTokenE8s({ value: minimumAmountE8s }) }
         )
       : undefined;
 
@@ -90,12 +90,12 @@
 
   // +/- 5%
   let predictedMinimumTokens: string;
-  $: predictedMinimumTokens = formatToken({
+  $: predictedMinimumTokens = formatTokenE8s({
     value: BigInt(Math.floor(Number(maturityToDisburseE8s) * 0.95)),
     roundingMode: "floor",
   });
   let predictedMaximumTokens: string;
-  $: predictedMaximumTokens = formatToken({
+  $: predictedMaximumTokens = formatTokenE8s({
     value: BigInt(Math.ceil(Number(maturityToDisburseE8s) * 1.05)),
     roundingMode: "ceil",
   });

--- a/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SplitSnsNeuronModal.svelte
@@ -17,7 +17,7 @@
   import { splitNeuron } from "$lib/services/sns-neurons.services";
   import { E8S_PER_ICP } from "$lib/constants/icp.constants";
   import type { SnsNervousSystemParameters } from "@dfinity/sns";
-  import { formatToken } from "$lib/utils/token.utils";
+  import { formatTokenE8s } from "$lib/utils/token.utils";
 
   export let rootCanisterId: Principal;
   export let neuron: SnsNeuron;
@@ -100,7 +100,7 @@
       <p class="label">{$i18n.neurons.transaction_fee}</p>
       <p>
         <Value>
-          {formatToken({
+          {formatTokenE8s({
             value: transactionFee,
           })}
         </Value>

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -44,7 +44,7 @@ import {
   nextMemo,
   subaccountToHexString,
 } from "$lib/utils/sns-neuron.utils";
-import { formatToken, numberToE8s } from "$lib/utils/token.utils";
+import { formatTokenE8s, numberToE8s } from "$lib/utils/token.utils";
 import { hexStringToBytes } from "$lib/utils/utils";
 import type { Identity } from "@dfinity/agent";
 import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
@@ -359,7 +359,7 @@ export const splitNeuron = async ({
       toastsError({
         labelKey: "error__sns.sns_amount_not_enough_stake_neuron",
         substitutions: {
-          $minimum: formatToken({ value: neuronMinimumStake }),
+          $minimum: formatTokenE8s({ value: neuronMinimumStake }),
           $token: token.symbol,
         },
       });

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -75,7 +75,7 @@ import { SALE_PARTICIPATION_RETRY_SECONDS } from "../constants/sns.constants";
 import { snsTicketsStore } from "../stores/sns-tickets.store";
 import { nanoSecondsToDateTime } from "../utils/date.utils";
 import { logWithTimestamp } from "../utils/dev.utils";
-import { formatToken } from "../utils/token.utils";
+import { formatTokenE8s } from "../utils/token.utils";
 
 let toastId: symbol | undefined;
 export const hidePollingToast = (): void => {
@@ -281,8 +281,8 @@ const handleNewSaleTicketError = ({
         toastsError({
           labelKey: "error__sns.sns_sale_invalid_amount",
           substitutions: {
-            $min: formatToken({ value: min_amount_icp_e8s_included }),
-            $max: formatToken({ value: max_amount_icp_e8s_included }),
+            $min: formatTokenE8s({ value: min_amount_icp_e8s_included }),
+            $max: formatTokenE8s({ value: max_amount_icp_e8s_included }),
           },
         });
         return;
@@ -597,7 +597,7 @@ const notifyParticipationAndRemoveTicket = async ({
         level: "warn",
         labelKey: "error__sns.sns_sale_committed_not_equal_to_amount",
         substitutions: {
-          $amount: formatToken({ value: icp_accepted_participation_e8s }),
+          $amount: formatTokenE8s({ value: icp_accepted_participation_e8s }),
         },
         duration: DEFAULT_TOAST_DURATION_MILLIS,
       });

--- a/frontend/src/lib/utils/bitcoin.utils.ts
+++ b/frontend/src/lib/utils/bitcoin.utils.ts
@@ -1,7 +1,7 @@
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 
 export const formatEstimatedFee = (bitcoinEstimatedFee: bigint): string =>
-  formatToken({
+  formatTokenE8s({
     value: bitcoinEstimatedFee,
     detailed: "height_decimals",
   });

--- a/frontend/src/lib/utils/ckbtc.utils.ts
+++ b/frontend/src/lib/utils/ckbtc.utils.ts
@@ -5,7 +5,7 @@ import { CkBTCErrorRetrieveBtcMinAmount } from "$lib/types/ckbtc.errors";
 import { assertEnoughAccountFunds } from "$lib/utils/accounts.utils";
 import { notForceCallStrategy } from "$lib/utils/env.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
-import { formatToken, numberToE8s } from "$lib/utils/token.utils";
+import { formatTokenE8s, numberToE8s } from "$lib/utils/token.utils";
 import { isNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
@@ -62,7 +62,7 @@ export const assertCkBTCUserInputAmount = ({
     } = get(i18n);
     throw new CkBTCErrorRetrieveBtcMinAmount(
       replacePlaceholders(retrieve_btc_min_amount, {
-        $amount: formatToken({
+        $amount: formatTokenE8s({
           value: retrieveBtcMinAmount,
           detailed: true,
         }),

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -54,7 +54,7 @@ import {
 import { nowInSeconds } from "./date.utils";
 import { formatNumber } from "./format.utils";
 import { getVotingBallot, getVotingPower } from "./proposals.utils";
-import { formatToken, numberToUlps } from "./token.utils";
+import { formatTokenE8s, numberToUlps } from "./token.utils";
 import { isDefined } from "./utils";
 
 export type StateInfo = {
@@ -290,7 +290,7 @@ export const formattedStakedMaturity = ({ fullNeuron }: NeuronInfo): string =>
   formatMaturity(fullNeuron?.stakedMaturityE8sEquivalent);
 
 export const formatMaturity = (value?: bigint): string =>
-  formatToken({
+  formatTokenE8s({
     value: isNullish(value) ? BigInt(0) : value,
   });
 

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -24,7 +24,7 @@ import {
 import { nowInSeconds } from "./date.utils";
 import type { I18nSubstitutions } from "./i18n.utils";
 import { getCommitmentE8s } from "./sns.utils";
-import { formatToken } from "./token.utils";
+import { formatTokenE8s } from "./token.utils";
 import { stringifyJson } from "./utils";
 
 export const filterProjectsStatus = ({
@@ -230,7 +230,7 @@ export const validParticipation = ({
       valid: false,
       labelKey: "error__sns.not_enough_amount",
       substitutions: {
-        $amount: formatToken({
+        $amount: formatTokenE8s({
           value: project.summary.swap.params.min_participant_icp_e8s,
           detailed: true,
         }),
@@ -246,11 +246,11 @@ export const validParticipation = ({
       valid: false,
       labelKey: "error__sns.commitment_too_large",
       substitutions: {
-        $newCommitment: formatToken({ value: amount.toE8s() }),
-        $currentCommitment: formatToken({
+        $newCommitment: formatTokenE8s({ value: amount.toE8s() }),
+        $currentCommitment: formatTokenE8s({
           value: getCommitmentE8s(project.swapCommitment) ?? BigInt(0),
         }),
-        $maxCommitment: formatToken({
+        $maxCommitment: formatTokenE8s({
           value: project.summary.swap.params.max_participant_icp_e8s,
         }),
       },
@@ -266,8 +266,8 @@ export const validParticipation = ({
       valid: false,
       labelKey: "error__sns.commitment_exceeds_current_allowed",
       substitutions: {
-        $commitment: formatToken({ value: totalCommitment }),
-        $remainingCommitment: formatToken({
+        $commitment: formatTokenE8s({ value: totalCommitment }),
+        $remainingCommitment: formatTokenE8s({
           value:
             project.summary.swap.params.max_icp_e8s -
             project.summary.derived.buyer_total_icp_e8s,

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -13,7 +13,7 @@ import {
   type NeuronIneligibilityReason,
 } from "$lib/utils/neuron.utils";
 import { mapNervousSystemParameters } from "$lib/utils/sns-parameters.utils";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import type { Identity } from "@dfinity/agent";
 import { NeuronState, Vote, type E8s, type NeuronInfo } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
@@ -482,7 +482,7 @@ export const hasAutoStakeMaturityOn = (
 export const formattedMaturity = (
   neuron: SnsNeuron | null | undefined
 ): string =>
-  formatToken({
+  formatTokenE8s({
     value: neuron?.maturity_e8s_equivalent ?? BigInt(0),
   });
 
@@ -491,7 +491,7 @@ export const formattedMaturity = (
  * @param {SnsNeuron} neuron The neuron that contains the `maturity_e8s_equivalent` and `staked_maturity_e8s_equivalent` which will be summed and formatted
  */
 export const formattedTotalMaturity = (neuron: SnsNeuron): string =>
-  formatToken({
+  formatTokenE8s({
     value:
       neuron.maturity_e8s_equivalent +
       totalDisbursingMaturity(neuron) +
@@ -536,7 +536,7 @@ export const hasStakedMaturity = (
 export const formattedStakedMaturity = (
   neuron: SnsNeuron | null | undefined
 ): string =>
-  formatToken({
+  formatTokenE8s({
     value:
       fromNullable(neuron?.staked_maturity_e8s_equivalent ?? []) ?? BigInt(0),
   });

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -62,7 +62,7 @@ type RoundMode =
  * Jira GIX-1563:
  * - However, if requested, some amount might be displayed with a fix length of 8 decimals, regardless if leading zero or no leading zero
  */
-export const formatToken = ({
+export const formatTokenE8s = ({
   value,
   detailed = false,
   roundingMode,
@@ -123,7 +123,7 @@ export const formatTokenV2 = ({
     const ulps = value.toUlps();
     e8s = ulpsToE8s({ ulps, decimals });
   }
-  return formatToken({ value: e8s, detailed, roundingMode });
+  return formatTokenE8s({ value: e8s, detailed, roundingMode });
 };
 
 export const sumAmounts = (...amounts: bigint[]): bigint =>
@@ -132,7 +132,7 @@ export const sumAmounts = (...amounts: bigint[]): bigint =>
 // To make the fixed transaction fee readable, we do not display it with 8 digits but only till the last digit that is not zero
 // e.g. not 0.00010000 but 0.0001
 export const formattedTransactionFeeICP = (fee: number | bigint): string =>
-  formatToken({
+  formatTokenE8s({
     value: TokenAmount.fromE8s({
       amount: BigInt(fee),
       token: ICPToken,

--- a/frontend/src/tests/lib/components/accounts/AccountCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/AccountCard.spec.ts
@@ -3,7 +3,7 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import type { Account } from "$lib/types/account";
 import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { buildWalletUrl } from "$lib/utils/navigation.utils";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import type { Token } from "@dfinity/utils";
 import { ICPToken } from "@dfinity/utils";
@@ -47,7 +47,7 @@ describe("AccountCard", () => {
     );
 
     expect(balance?.textContent).toEqual(
-      `${formatToken({ value: mockMainAccount.balanceUlps })}`
+      `${formatTokenE8s({ value: mockMainAccount.balanceUlps })}`
     );
   });
 

--- a/frontend/src/tests/lib/components/accounts/BitcoinEstimatedAmountReceived.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BitcoinEstimatedAmountReceived.spec.ts
@@ -2,7 +2,7 @@ import BitcoinEstimatedAmountReceived from "$lib/components/accounts/BitcoinEsti
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { ckBTCInfoStore } from "$lib/stores/ckbtc-info.store";
 import { formatEstimatedFee } from "$lib/utils/bitcoin.utils";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import en from "$tests/mocks/i18n.mock";
 import { render } from "@testing-library/svelte";
@@ -135,7 +135,7 @@ describe("BitcoinEstimatedAmountReceived", () => {
 
     const element = getByTestId("bitcoin-estimated-amount-value");
     expect((element?.textContent ?? "").trim()).toEqual(
-      `${formatToken({
+      `${formatTokenE8s({
         value: 0n,
         detailed: "height_decimals",
       })} ${en.ckbtc.btc}`
@@ -153,7 +153,7 @@ describe("BitcoinEstimatedAmountReceived", () => {
 
     const element = getByTestId("bitcoin-estimated-amount-value");
     expect((element?.textContent ?? "").trim()).toEqual(
-      `${formatToken({
+      `${formatTokenE8s({
         value: 0n,
         detailed: "height_decimals",
       })} ${en.ckbtc.btc}`
@@ -180,7 +180,7 @@ describe("BitcoinEstimatedAmountReceived", () => {
 
     const element = getByTestId("bitcoin-estimated-amount-value");
 
-    const resultBtc = `${formatToken({
+    const resultBtc = `${formatTokenE8s({
       value: 987_000n,
       detailed: "height_decimals",
     })} ${en.ckbtc.btc}`;

--- a/frontend/src/tests/lib/components/accounts/CkBTCWithdrawalAccount.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWithdrawalAccount.spec.ts
@@ -9,7 +9,7 @@ import { ckBTCWithdrawalAccountsStore } from "$lib/stores/ckbtc-withdrawal-accou
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
 import CkBTCAccountsTest from "$tests/lib/components/accounts/CkBTCAccountsTest.svelte";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
@@ -151,7 +151,7 @@ describe("CkBTCWithdrawalAccount", () => {
       it("should render a call to action if balance is bigger than zero", async () => {
         const { getByText } = render(CkBTCWithdrawalAccount);
 
-        const balance = formatToken({
+        const balance = formatTokenE8s({
           value: mockCkBTCWithdrawalAccount.balanceUlps,
           detailed: true,
         });

--- a/frontend/src/tests/lib/components/accounts/CurrentBalance.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CurrentBalance.spec.ts
@@ -1,5 +1,5 @@
 import CurrentBalance from "$lib/components/accounts/CurrentBalance.svelte";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import en from "$tests/mocks/i18n.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
@@ -27,7 +27,7 @@ describe("CurrentBalance", () => {
     const icp: HTMLSpanElement | null = queryByTestId("token-value");
 
     expect(icp?.innerHTML).toEqual(
-      `${formatToken({ value: mockMainAccount.balanceUlps })}`
+      `${formatTokenE8s({ value: mockMainAccount.balanceUlps })}`
     );
     expect(getByText(`ICP`)).toBeTruthy();
   });

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletNeurons.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletNeurons.spec.ts
@@ -1,5 +1,5 @@
 import HardwareWalletNeurons from "$lib/components/accounts/HardwareWalletNeurons.svelte";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import { mockNeuronStake } from "$tests/mocks/hardware-wallet-neurons.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
@@ -39,14 +39,14 @@ describe("HardwareWalletNeurons", () => {
 
     expect(
       getByText(
-        formatToken({
+        formatTokenE8s({
           value: (mockNeuron.fullNeuron as Neuron).cachedNeuronStake,
         })
       )
     ).toBeInTheDocument();
     expect(
       getByText(
-        formatToken({
+        formatTokenE8s({
           value: (mockNeuronStake.fullNeuron as Neuron).cachedNeuronStake,
         })
       )

--- a/frontend/src/tests/lib/components/ic/AmountDisplay.spec.ts
+++ b/frontend/src/tests/lib/components/ic/AmountDisplay.spec.ts
@@ -1,5 +1,5 @@
 import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
@@ -22,7 +22,7 @@ describe("AmountDisplay", () => {
     const value = container.querySelector("span:first-of-type");
 
     expect(value?.textContent).toEqual(
-      `${formatToken({ value: mockMainAccount.balanceUlps })}`
+      `${formatTokenE8s({ value: mockMainAccount.balanceUlps })}`
     );
   });
 
@@ -44,7 +44,7 @@ describe("AmountDisplay", () => {
     const value = container.querySelector("span:first-of-type");
 
     expect(value?.textContent).toEqual(
-      `+${formatToken({ value: mockMainAccount.balanceUlps })}`
+      `+${formatTokenE8s({ value: mockMainAccount.balanceUlps })}`
     );
     expect(container.querySelector(".plus-sign")).toBeInTheDocument();
   });
@@ -59,7 +59,7 @@ describe("AmountDisplay", () => {
     const value = container.querySelector("span:first-of-type");
 
     expect(value?.textContent).toEqual(
-      `-${formatToken({ value: mockMainAccount.balanceUlps })}`
+      `-${formatTokenE8s({ value: mockMainAccount.balanceUlps })}`
     );
   });
 
@@ -74,7 +74,7 @@ describe("AmountDisplay", () => {
     const value = container.querySelector("span:first-of-type");
 
     expect(value?.textContent).toEqual(
-      `${formatToken({
+      `${formatTokenE8s({
         value: mockMainAccount.balanceUlps,
         detailed: true,
       })}`

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -2,7 +2,7 @@ import NnsNeuronCard from "$lib/components/neurons/NnsNeuronCard.svelte";
 import { SECONDS_IN_YEAR } from "$lib/constants/constants";
 import { authStore } from "$lib/stores/auth.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import {
   mockAuthStoreSubscribe,
   mockIdentity,
@@ -78,7 +78,7 @@ describe("NnsNeuronCard", () => {
       },
     });
 
-    const stakeText = formatToken({
+    const stakeText = formatTokenE8s({
       value:
         (mockNeuron.fullNeuron as Neuron).cachedNeuronStake -
         (mockNeuron.fullNeuron as Neuron).neuronFees,
@@ -257,7 +257,7 @@ describe("NnsNeuronCard", () => {
         proposerNeuron: true,
       },
     });
-    const votingValue = formatToken({
+    const votingValue = formatTokenE8s({
       value: mockNeuron.votingPower,
       detailed: true,
     });

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronInfo.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronInfo.spec.ts
@@ -1,6 +1,6 @@
 import NnsNeuronInfo from "$lib/components/neurons/NnsNeuronInfo.svelte";
 import { neuronStake } from "$lib/utils/neuron.utils";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { render } from "@testing-library/svelte";
 
@@ -23,7 +23,9 @@ describe("NnsNeuronInfo", () => {
     });
 
     expect(
-      getByText(formatToken({ value: neuronStake(mockNeuron), detailed: true }))
+      getByText(
+        formatTokenE8s({ value: neuronStake(mockNeuron), detailed: true })
+      )
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
@@ -1,7 +1,7 @@
 import ProjectSwapDetails from "$lib/components/project-detail/ProjectSwapDetails.svelte";
 import { snsTotalTokenSupplyStore } from "$lib/stores/sns-total-token-supply.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import {
   createSummary,
   mockSnsFullProject,
@@ -124,7 +124,7 @@ describe("ProjectSwapDetails", () => {
     });
 
     expect(await po.getTotalSupply()).toMatch(
-      formatToken({ value: totalSupply })
+      formatTokenE8s({ value: totalSupply })
     );
   });
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.spec.ts
@@ -2,7 +2,7 @@ import SplitSnsNeuronButton from "$lib/components/sns-neuron-detail/actions/Spli
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { openSnsNeuronModal } from "$lib/utils/modals.utils";
 import { minNeuronSplittable } from "$lib/utils/sns-neuron.utils";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import en from "$tests/mocks/i18n.mock";
 import {
   createMockSnsNeuron,
@@ -97,7 +97,7 @@ describe("SplitSnsNeuronButton", () => {
     const tooltip = replacePlaceholders(
       en.neuron_detail.split_neuron_disabled_tooltip,
       {
-        $amount: formatToken({
+        $amount: formatTokenE8s({
           value: minNeuronSplittable({
             fee: transactionFee,
             neuronMinimumStake,

--- a/frontend/src/tests/lib/components/sns-neurons/ConfirmSnsDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/ConfirmSnsDissolveDelay.spec.ts
@@ -8,7 +8,7 @@ import {
   getSnsNeuronStake,
   snsNeuronVotingPower,
 } from "$lib/utils/sns-neuron.utils";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import {
@@ -89,7 +89,7 @@ describe("ConfirmSnsDissolveDelay", () => {
 
     expect(
       getByText(
-        formatToken({
+        formatTokenE8s({
           value: getSnsNeuronStake(mockSnsNeuron),
           detailed: true,
         })

--- a/frontend/src/tests/lib/components/sns-neurons/SetSnsDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/SetSnsDissolveDelay.spec.ts
@@ -8,7 +8,7 @@ import {
   getSnsNeuronStake,
   snsNeuronVotingPower,
 } from "$lib/utils/sns-neuron.utils";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import {
@@ -89,7 +89,7 @@ describe("ConfirmSnsDissolveDelay", () => {
 
     expect(
       getByText(
-        formatToken({
+        formatTokenE8s({
           value: getSnsNeuronStake(mockSnsNeuron),
           detailed: true,
         })

--- a/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/SnsNeuronCard.spec.ts
@@ -5,7 +5,7 @@ import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-s
 import { authStore } from "$lib/stores/auth.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import {
   mockAuthStoreSubscribe,
   mockIdentity,
@@ -121,7 +121,7 @@ describe("SnsNeuronCard", () => {
     token !== undefined && expect(getByText(token.symbol)).toBeInTheDocument();
     expect(queryAllByText(en.core.icp).length).toBe(0);
 
-    const stakeText = formatToken({
+    const stakeText = formatTokenE8s({
       value:
         mockSnsNeuron.cached_neuron_stake_e8s - mockSnsNeuron.neuron_fees_e8s,
       detailed: true,

--- a/frontend/src/tests/lib/components/transaction/TransactionReceivedTokenAmount.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionReceivedTokenAmount.spec.ts
@@ -1,5 +1,5 @@
 import TransactionReceivedTokenAmount from "$lib/components/transaction/TransactionReceivedTokenAmount.svelte";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import en from "$tests/mocks/i18n.mock";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
@@ -17,7 +17,7 @@ describe("TransactionReceivedTokenAmount", () => {
 
     expect(
       getByText(
-        formatToken({ value: amount.toE8s(), detailed: "height_decimals" })
+        formatTokenE8s({ value: amount.toE8s(), detailed: "height_decimals" })
       )
     ).toBeInTheDocument();
 
@@ -48,7 +48,7 @@ describe("TransactionReceivedTokenAmount", () => {
     });
 
     expect(getByTestId(testId)?.textContent).toContain(
-      `${formatToken({ value: amount.toE8s(), detailed: true })}`
+      `${formatTokenE8s({ value: amount.toE8s(), detailed: true })}`
     );
   });
 });

--- a/frontend/src/tests/lib/components/transaction/TransactionSource.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionSource.spec.ts
@@ -1,5 +1,5 @@
 import TransactionSource from "$lib/components/transaction/TransactionSource.svelte";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import en from "$tests/mocks/i18n.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { ICPToken } from "@dfinity/utils";
@@ -23,7 +23,7 @@ describe("TransactionSource", () => {
     });
 
     expect(getByTestId("token-value")?.textContent ?? "").toEqual(
-      `${formatToken({
+      `${formatTokenE8s({
         value: mockMainAccount.balanceUlps,
         detailed: "height_decimals",
       })}`

--- a/frontend/src/tests/lib/components/transaction/TransactionSummary.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionSummary.spec.ts
@@ -1,6 +1,6 @@
 import TransactionSummary from "$lib/components/transaction/TransactionSummary.svelte";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
-import { formatToken, numberToE8s } from "$lib/utils/token.utils";
+import { formatTokenE8s, numberToE8s } from "$lib/utils/token.utils";
 import en from "$tests/mocks/i18n.mock";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
@@ -30,7 +30,7 @@ describe("TransactionSummary", () => {
 
     expect(block.textContent).toContain(en.accounts.sending_amount);
     expect(block.textContent).toContain(
-      `${formatToken({ value: e8s, detailed: "height_decimals" })} ${
+      `${formatTokenE8s({ value: e8s, detailed: "height_decimals" })} ${
         token.symbol
       }`
     );
@@ -49,7 +49,7 @@ describe("TransactionSummary", () => {
 
     expect(block.textContent).toContain(label);
     expect(block.textContent).toContain(
-      `${formatToken({
+      `${formatTokenE8s({
         value: transactionFee.toE8s(),
         detailed: "height_decimals",
       })} ${token.symbol}`
@@ -65,7 +65,7 @@ describe("TransactionSummary", () => {
 
     expect(block.textContent).toContain(en.accounts.total_deducted);
     expect(block.textContent).toContain(
-      `${formatToken({
+      `${formatTokenE8s({
         value: e8s + transactionFee.toE8s(),
         detailed: "height_decimals",
       })} ${token.symbol}`

--- a/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
+++ b/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
@@ -6,7 +6,7 @@ import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import { createUniverse } from "$lib/utils/universe.utils";
 import { page } from "$mocks/$app/stores";
 import {
@@ -101,7 +101,7 @@ describe("UniverseAccountsBalance", () => {
         mockHardwareWalletAccount.balanceUlps;
 
       expect(balance?.textContent.trim() ?? "").toEqual(
-        `${formatToken({
+        `${formatTokenE8s({
           value: totalBalance,
           detailed: false,
         })} ${en.core.icp}`
@@ -128,7 +128,7 @@ describe("UniverseAccountsBalance", () => {
       const balance: HTMLElement | null = getByTestId("token-value-label");
 
       expect(balance?.textContent.trim() ?? "").toEqual(
-        `${formatToken({
+        `${formatTokenE8s({
           value: totalBalance,
           detailed: false,
         })} ${mockSnsToken.symbol}`
@@ -155,7 +155,7 @@ describe("UniverseAccountsBalance", () => {
       const balance: HTMLElement | null = getByTestId("token-value-label");
 
       expect(balance?.textContent.trim() ?? "").toEqual(
-        `${formatToken({
+        `${formatTokenE8s({
           value: totalBalance,
           detailed: false,
         })} ${mockCkBTCToken.symbol}`

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -6,7 +6,7 @@ import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import type { Account } from "$lib/types/account";
 import type { ValidateAmountFn } from "$lib/types/transaction";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import {
   mockAuthStoreSubscribe,
   mockPrincipal,
@@ -244,7 +244,7 @@ describe("TransactionModal", () => {
       ).toBeTruthy();
       expect(
         getByText(
-          formatToken({
+          formatTokenE8s({
             value: TokenAmount.fromE8s({
               amount: BigInt(DEFAULT_TRANSACTION_FEE_E8S),
               token: ICPToken,
@@ -276,7 +276,7 @@ describe("TransactionModal", () => {
       ).toBeTruthy();
       expect(
         getByText(
-          formatToken({
+          formatTokenE8s({
             value: TokenAmount.fromE8s({
               amount: fee.toE8s(),
               token: ICPToken,

--- a/frontend/src/tests/lib/pages/CkBTCAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCAccounts.spec.ts
@@ -4,7 +4,7 @@ import CkBTCAccounts from "$lib/pages/CkBTCAccounts.svelte";
 import { syncAccounts } from "$lib/services/wallet-accounts.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
 import {
   mockCkBTCMainAccount,
@@ -100,7 +100,7 @@ describe("CkBTCAccounts", () => {
       );
 
       expect(cardTitleRow?.textContent.trim()).toEqual(
-        `${formatToken({
+        `${formatTokenE8s({
           value: mockCkBTCMainAccount.balanceUlps,
         })} ${mockCkBTCToken.symbol}`
       );

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -7,7 +7,7 @@ import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import type { UserTokenData } from "$lib/types/tokens-page";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountDetails,
@@ -132,7 +132,7 @@ describe("NnsAccounts", () => {
         );
 
         expect(cardTitleRow?.textContent.trim()).toEqual(
-          `${formatToken({ value: mockMainAccount.balanceUlps })} ICP`
+          `${formatTokenE8s({ value: mockMainAccount.balanceUlps })} ICP`
         );
       });
 

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -7,7 +7,7 @@ import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
 import { authStore } from "$lib/stores/auth.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import {
@@ -135,7 +135,7 @@ describe("NnsWallet", () => {
       );
 
       expect(getByTestId("token-value-label")?.textContent.trim()).toEqual(
-        `${formatToken({
+        `${formatTokenE8s({
           value: mockMainAccount.balanceUlps,
         })} ${ICPToken.symbol}`
       );

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -19,7 +19,7 @@ import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
 import { snsSwapCommitmentsStore } from "$lib/stores/sns.store";
 import { userCountryStore } from "$lib/stores/user-country.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
-import { formatToken, numberToE8s } from "$lib/utils/token.utils";
+import { formatTokenE8s, numberToE8s } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
 import * as fakeLocationApi from "$tests/fakes/location-api.fake";
 import {
@@ -406,7 +406,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
           queryByTestId("sns-user-commitment")?.querySelector(
             "[data-tid='token-value']"
           )?.innerHTML
-        ).toMatch(formatToken({ value: userCommitment }));
+        ).toMatch(formatTokenE8s({ value: userCommitment }));
       });
 
       describe("no open ticket and no commitment", () => {
@@ -639,7 +639,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
           queryByTestId("sns-user-commitment")?.querySelector(
             "[data-tid='token-value']"
           )?.innerHTML
-        ).toMatch(formatToken({ value: testTicket.amount_icp_e8s }));
+        ).toMatch(formatTokenE8s({ value: testTicket.amount_icp_e8s }));
         expect(snsApi.querySnsSwapCommitment).toBeCalledTimes(3);
       });
     });
@@ -750,7 +750,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
           queryByTestId("sns-user-commitment")?.querySelector(
             "[data-tid='token-value']"
           )?.innerHTML
-        ).toMatch(formatToken({ value: userCommitment }));
+        ).toMatch(formatTokenE8s({ value: userCommitment }));
       });
     });
   });

--- a/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsAccounts.spec.ts
@@ -3,7 +3,7 @@ import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
 import * as workerBalances from "$lib/services/worker-balances.services";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
 import en from "$tests/mocks/i18n.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
@@ -102,7 +102,7 @@ describe("SnsAccounts", () => {
       );
 
       expect(cardTitleRow?.textContent.trim()).toEqual(
-        `${formatToken({
+        `${formatTokenE8s({
           value: mockSnsMainAccount.balanceUlps,
         })} ${mockSnsToken.symbol}`
       );

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -8,7 +8,7 @@ import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import type { Account } from "$lib/types/account";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
 import AccountsTest from "$tests/lib/pages/AccountsTest.svelte";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
@@ -160,7 +160,7 @@ describe("SnsWallet", () => {
           .querySelector('[data-tid="token-value-label"]')
           ?.textContent.trim()
       ).toEqual(
-        `${formatToken({
+        `${formatTokenE8s({
           value: mockSnsMainAccount.balanceUlps,
         })} ${mockSnsToken.symbol}`
       );

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -20,7 +20,7 @@ import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { nanoSecondsToDateTime } from "$lib/utils/date.utils";
-import { formatToken } from "$lib/utils/token.utils";
+import { formatTokenE8s } from "$lib/utils/token.utils";
 import {
   mockAuthStoreSubscribe,
   mockIdentity,
@@ -662,8 +662,8 @@ describe("sns-api", () => {
         expect.objectContaining({
           labelKey: "error__sns.sns_sale_invalid_amount",
           substitutions: {
-            $min: formatToken({ value: min_amount_icp_e8s_included }),
-            $max: formatToken({ value: max_amount_icp_e8s_included }),
+            $min: formatTokenE8s({ value: min_amount_icp_e8s_included }),
+            $max: formatTokenE8s({ value: max_amount_icp_e8s_included }),
           },
         })
       );

--- a/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/ckbtc.utils.spec.ts
@@ -2,7 +2,7 @@ import { CkBTCErrorRetrieveBtcMinAmount } from "$lib/types/ckbtc.errors";
 import { NotEnoughAmountError } from "$lib/types/common.errors";
 import { assertCkBTCUserInputAmount } from "$lib/utils/ckbtc.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
-import { formatToken, ulpsToNumber } from "$lib/utils/token.utils";
+import { formatTokenE8s, ulpsToNumber } from "$lib/utils/token.utils";
 import { mockCkBTCToken } from "$tests/mocks/ckbtc-accounts.mock";
 import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import en from "$tests/mocks/i18n.mock";
@@ -92,7 +92,7 @@ describe("ckbtc.utils", () => {
     ).toThrow(
       new CkBTCErrorRetrieveBtcMinAmount(
         replacePlaceholders(en.error__ckbtc.retrieve_btc_min_amount, {
-          $amount: formatToken({
+          $amount: formatTokenE8s({
             value: RETRIEVE_BTC_MIN_AMOUNT,
             detailed: true,
           }),

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -3,7 +3,7 @@ import {
   convertIcpToTCycles,
   convertTCyclesToIcpNumber,
   formattedTransactionFeeICP,
-  formatToken,
+  formatTokenE8s,
   formatTokenV2,
   getMaxTransactionAmount,
   numberToE8s,
@@ -18,89 +18,98 @@ import { ICPToken, TokenAmount, TokenAmountV2 } from "@dfinity/utils";
 
 describe("token-utils", () => {
   it("should format token", () => {
-    expect(formatToken({ value: BigInt(0) })).toEqual("0");
+    expect(formatTokenE8s({ value: BigInt(0) })).toEqual("0");
     // TODO: this following test used to equals 0.0000001 but because of the new ICP conversion it now renders 0.00
-    // expect(formatToken({value: BigInt(10)})).toEqual("0.0000001");
-    expect(formatToken({ value: BigInt(100) })).toEqual("0.000001");
-    expect(formatToken({ value: BigInt(100000000) })).toEqual("1.00");
-    expect(formatToken({ value: BigInt(1000000000) })).toEqual("10.00");
-    expect(formatToken({ value: BigInt(1010000000) })).toEqual("10.10");
-    expect(formatToken({ value: BigInt(1012300000) })).toEqual("10.12");
-    expect(formatToken({ value: BigInt(20000000000) })).toEqual("200.00");
-    expect(formatToken({ value: BigInt(20000000001) })).toEqual("200.00");
-    expect(formatToken({ value: BigInt(200000000000) })).toEqual(`2'000.00`);
-    expect(formatToken({ value: BigInt(200000000000000) })).toEqual(
+    // expect(formatTokenE8s({value: BigInt(10)})).toEqual("0.0000001");
+    expect(formatTokenE8s({ value: BigInt(100) })).toEqual("0.000001");
+    expect(formatTokenE8s({ value: BigInt(100000000) })).toEqual("1.00");
+    expect(formatTokenE8s({ value: BigInt(1000000000) })).toEqual("10.00");
+    expect(formatTokenE8s({ value: BigInt(1010000000) })).toEqual("10.10");
+    expect(formatTokenE8s({ value: BigInt(1012300000) })).toEqual("10.12");
+    expect(formatTokenE8s({ value: BigInt(20000000000) })).toEqual("200.00");
+    expect(formatTokenE8s({ value: BigInt(20000000001) })).toEqual("200.00");
+    expect(formatTokenE8s({ value: BigInt(200000000000) })).toEqual(`2'000.00`);
+    expect(formatTokenE8s({ value: BigInt(200000000000000) })).toEqual(
       `2'000'000.00`
     );
   });
 
   it("should format token detailed", () => {
-    expect(formatToken({ value: BigInt(0), detailed: true })).toEqual("0");
-    expect(formatToken({ value: BigInt(100), detailed: true })).toEqual(
+    expect(formatTokenE8s({ value: BigInt(0), detailed: true })).toEqual("0");
+    expect(formatTokenE8s({ value: BigInt(100), detailed: true })).toEqual(
       "0.000001"
     );
-    expect(formatToken({ value: BigInt(100000000), detailed: true })).toEqual(
-      "1.00"
-    );
-    expect(formatToken({ value: BigInt(1000000000), detailed: true })).toEqual(
-      "10.00"
-    );
-    expect(formatToken({ value: BigInt(1010000000), detailed: true })).toEqual(
-      "10.10"
-    );
-    expect(formatToken({ value: BigInt(1012300000), detailed: true })).toEqual(
-      "10.123"
-    );
-    expect(formatToken({ value: BigInt(20000000000), detailed: true })).toEqual(
-      "200.00"
-    );
-    expect(formatToken({ value: BigInt(20000000001), detailed: true })).toEqual(
-      "200.00000001"
-    );
     expect(
-      formatToken({ value: BigInt(200000000000), detailed: true })
+      formatTokenE8s({ value: BigInt(100000000), detailed: true })
+    ).toEqual("1.00");
+    expect(
+      formatTokenE8s({ value: BigInt(1000000000), detailed: true })
+    ).toEqual("10.00");
+    expect(
+      formatTokenE8s({ value: BigInt(1010000000), detailed: true })
+    ).toEqual("10.10");
+    expect(
+      formatTokenE8s({ value: BigInt(1012300000), detailed: true })
+    ).toEqual("10.123");
+    expect(
+      formatTokenE8s({ value: BigInt(20000000000), detailed: true })
+    ).toEqual("200.00");
+    expect(
+      formatTokenE8s({ value: BigInt(20000000001), detailed: true })
+    ).toEqual("200.00000001");
+    expect(
+      formatTokenE8s({ value: BigInt(200000000000), detailed: true })
     ).toEqual(`2'000.00`);
     expect(
-      formatToken({ value: BigInt(200000000000000), detailed: true })
+      formatTokenE8s({ value: BigInt(200000000000000), detailed: true })
     ).toEqual(`2'000'000.00`);
   });
 
   it("should format token detailed with height decimals", () => {
     expect(
-      formatToken({ value: BigInt(0), detailed: "height_decimals" })
+      formatTokenE8s({ value: BigInt(0), detailed: "height_decimals" })
     ).toEqual("0");
     expect(
-      formatToken({ value: BigInt(1), detailed: "height_decimals" })
+      formatTokenE8s({ value: BigInt(1), detailed: "height_decimals" })
     ).toEqual("0.00000001");
     expect(
-      formatToken({ value: BigInt(10), detailed: "height_decimals" })
+      formatTokenE8s({ value: BigInt(10), detailed: "height_decimals" })
     ).toEqual("0.00000010");
     expect(
-      formatToken({ value: BigInt(100), detailed: "height_decimals" })
+      formatTokenE8s({ value: BigInt(100), detailed: "height_decimals" })
     ).toEqual("0.00000100");
     expect(
-      formatToken({ value: BigInt(100000000), detailed: "height_decimals" })
+      formatTokenE8s({ value: BigInt(100000000), detailed: "height_decimals" })
     ).toEqual("1.00000000");
     expect(
-      formatToken({ value: BigInt(1000000000), detailed: "height_decimals" })
+      formatTokenE8s({ value: BigInt(1000000000), detailed: "height_decimals" })
     ).toEqual("10.00000000");
     expect(
-      formatToken({ value: BigInt(1010000000), detailed: "height_decimals" })
+      formatTokenE8s({ value: BigInt(1010000000), detailed: "height_decimals" })
     ).toEqual("10.10000000");
     expect(
-      formatToken({ value: BigInt(1012300000), detailed: "height_decimals" })
+      formatTokenE8s({ value: BigInt(1012300000), detailed: "height_decimals" })
     ).toEqual("10.12300000");
     expect(
-      formatToken({ value: BigInt(20000000000), detailed: "height_decimals" })
+      formatTokenE8s({
+        value: BigInt(20000000000),
+        detailed: "height_decimals",
+      })
     ).toEqual("200.00000000");
     expect(
-      formatToken({ value: BigInt(20000000001), detailed: "height_decimals" })
+      formatTokenE8s({
+        value: BigInt(20000000001),
+        detailed: "height_decimals",
+      })
     ).toEqual("200.00000001");
     expect(
-      formatToken({ value: BigInt(200000000000), detailed: "height_decimals" })
+      formatTokenE8s({
+        value: BigInt(200000000000),
+        detailed: "height_decimals",
+      })
     ).toEqual(`2'000.00000000`);
     expect(
-      formatToken({
+      formatTokenE8s({
         value: BigInt(200000000000000),
         detailed: "height_decimals",
       })
@@ -110,12 +119,12 @@ describe("token-utils", () => {
   it("should use roundingMode", () => {
     // NodeJS supports roundingMode since v19
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#browser_compatibility
-    // expect(formatToken({ value: 111_100_000n, roundingMode: "ceil" })).toEqual(
+    // expect(formatTokenE8s({ value: 111_100_000n, roundingMode: "ceil" })).toEqual(
     //   "1.12"
     // );
-    expect(formatToken({ value: 111_100_000n, roundingMode: "ceil" })).toEqual(
-      "1.11"
-    );
+    expect(
+      formatTokenE8s({ value: 111_100_000n, roundingMode: "ceil" })
+    ).toEqual("1.11");
   });
 
   describe("formatTokenV2", () => {
@@ -135,7 +144,7 @@ describe("token-utils", () => {
         detailed?: boolean | "height_decimals";
         roundingMode?: "ceil";
       }) => {
-        const format1 = formatToken({
+        const format1 = formatTokenE8s({
           value,
           detailed,
           roundingMode,


### PR DESCRIPTION
# Motivation

Now that we have ckETH which has 18 decimals, it's important to be clear when a function only supports 8 decimals.
`formatToken` only supports 8 decimals. For a different number of decimals, we should use `formatTokenV2` and `TokenAmountV2`.

# Changes

Rename `formatToken` to `formatTokenE8s`.

# Tests

existing tests pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary