### PR TITLE
update:gix components

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,6 +30,7 @@ proposal is successful, the changes it released will be moved from this file to
 - Remaining wrong dissolve delay error message after min/max click.
 - Avoid unnecessary calls to SNS root canister ids to get the canister ids.
 - Min dissolve delay button updates not only for the first time.
+- Fix scrollbar in multiline toast message. 
 
 #### Security
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -277,9 +277,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "3.1.0-next-2023-12-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-3.1.0-next-2023-12-12.1.tgz",
-      "integrity": "sha512-wXXTfDYc86vwVcKTy2PXMv2G4+vcffKiUGaqwQdgk28S8/meG9QJlFEkZ0S+UoFf/rXOYDWtxGzIElXErVT0wQ==",
+      "version": "3.1.0-next-2023-12-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-3.1.0-next-2023-12-19.1.tgz",
+      "integrity": "sha512-As+6K+vp3Gj5Z+jdm3EqMXLZPdV+L4UxyBneFbBgfN2LNQcCr4XbnbdQW1A8wwAWXvGgs+2xFDJEjAj7ETRCLQ==",
       "dependencies": {
         "dompurify": "^3.0.6",
         "html5-qrcode": "^2.3.8",
@@ -7347,9 +7347,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "3.1.0-next-2023-12-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-3.1.0-next-2023-12-12.1.tgz",
-      "integrity": "sha512-wXXTfDYc86vwVcKTy2PXMv2G4+vcffKiUGaqwQdgk28S8/meG9QJlFEkZ0S+UoFf/rXOYDWtxGzIElXErVT0wQ==",
+      "version": "3.1.0-next-2023-12-19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-3.1.0-next-2023-12-19.1.tgz",
+      "integrity": "sha512-As+6K+vp3Gj5Z+jdm3EqMXLZPdV+L4UxyBneFbBgfN2LNQcCr4XbnbdQW1A8wwAWXvGgs+2xFDJEjAj7ETRCLQ==",
       "requires": {
         "dompurify": "^3.0.6",
         "html5-qrcode": "^2.3.8",


### PR DESCRIPTION
# Motivation

Update `gix-component` to get multiline toast fix.
The fix: https://github.com/dfinity/gix-components/pull/342

By @dskloetd: use the icon test IDs added in https://github.com/dfinity/gix-components/pull/343

# Changes

- npm run update:gix

# Tests

None

# Todos

- [x] Add entry to changelog (if necessary).
