### PR TITLE
Check icons in TransactionCard test

### DIFF
--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -258,7 +258,7 @@ describe("CkBTCTransactionList", () => {
 
     expect(cards).toHaveLength(1);
     const card = cards[0];
-    expect(await card.hasPendingIcon()).toBe(true);
+    expect(await card.hasPendingReceiveIcon()).toBe(true);
     expect(await card.getHeadline()).toBe("Receiving BTC");
     expect(await card.getIdentifier()).toBe("From: BTC Network");
     // 0.01 deposited minus 0.00004 KYT fee.

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -30,13 +30,15 @@ describe("TransactionCard", () => {
     return TransactionCardPo.under(new JestPageObjectElement(container));
   };
 
-  it("renders received headline", async () => {
+  it("renders received transaction", async () => {
     const headline = "Received";
     const po = renderComponent({
       headline,
+      isIncoming: true,
     });
 
     expect(await po.getHeadline()).toBe(headline);
+    expect(await po.hasReceivedIcon()).toBe(true);
   });
 
   it("renders burn description", async () => {
@@ -60,13 +62,15 @@ describe("TransactionCard", () => {
     expect(await po.getIdentifier()).toBe("To: withdrwala-address");
   });
 
-  it("renders sent headline", async () => {
+  it("renders sent transaction", async () => {
     const headline = "Sent";
     const po = renderComponent({
       headline,
+      isIncoming: false,
     });
 
     expect(await po.getHeadline()).toBe(headline);
+    expect(await po.hasSentIcon()).toBe(true);
   });
 
   it("renders transaction ICPs with - sign", async () => {
@@ -101,17 +105,18 @@ describe("TransactionCard", () => {
     expect(normalizeWhitespace(await po.getDate())).toBe(
       "Mar 14, 2021 12:00 AM"
     );
-    expect(await po.hasPendingIcon()).toBe(false);
+    expect(await po.hasPendingReceiveIcon()).toBe(false);
   });
 
-  it("displays pending transaction", async () => {
+  it("displays pending recevie transaction", async () => {
     const po = renderComponent({
       isPending: true,
+      isIncoming: true,
       timestamp: null,
     });
 
     expect(normalizeWhitespace(await po.getDate())).toBe("Pending...");
-    expect(await po.hasPendingIcon()).toBe(true);
+    expect(await po.hasPendingReceiveIcon()).toBe(true);
   });
 
   it("displays reimbursement transaction", async () => {

--- a/frontend/src/tests/page-objects/TransactionCard.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionCard.page-object.ts
@@ -37,13 +37,32 @@ export class TransactionCardPo extends BasePageObject {
     return this.getAmountDisplayPo().getAmount();
   }
 
-  async hasPendingIcon(): Promise<boolean> {
+  async hasIconClass(className: string): Promise<boolean> {
     const classNames = await this.root.byTestId("icon").getClasses();
-    return classNames.includes("pending");
+    return classNames.includes(className);
+  }
+
+  async hasSentIcon(): Promise<boolean> {
+    const hasIcon = await this.isPresent("icon-up");
+    const hasClass = await this.hasIconClass("send");
+    return hasIcon && hasClass;
+  }
+
+  async hasReceivedIcon(): Promise<boolean> {
+    const hasIcon = await this.isPresent("icon-down");
+    const hasClass = await this.hasIconClass("send");
+    return hasIcon && !hasClass;
+  }
+
+  async hasPendingReceiveIcon(): Promise<boolean> {
+    const hasIcon = await this.isPresent("icon-down");
+    const hasClass = await this.hasIconClass("pending");
+    return hasIcon && hasClass;
   }
 
   async hasReimbursementIcon(): Promise<boolean> {
-    const classNames = await this.root.byTestId("icon").getClasses();
-    return classNames.includes("reimbursed");
+    const hasIcon = await this.isPresent("icon-reimbursed");
+    const hasClass = await this.hasIconClass("reimbursed");
+    return hasIcon && hasClass;
   }
 }


### PR DESCRIPTION
# Motivation

`TransactionCard` renders both an icon image and class.
So far we only tested the class.

# Changes

Also test that we have the right icon image in `TransactionCard.page-object.ts`.

# Tests

only tests

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary