### PR TITLE
Take retrieval status into account in mapCkbtcTransaction

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1025,7 +1025,9 @@
     "btc_sent": "BTC Sent",
     "btc_network": "BTC Network",
     "receiving_btc": "Receiving BTC",
-    "reimbursement": "Reimbursement"
+    "reimbursement": "Reimbursement",
+    "sending_btc": "Sending BTC",
+    "sending_btc_failed": "Sending BTC failed"
   },
   "error__ckbtc": {
     "already_process": "The minter has already been notified and updating the balance is in progress.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1074,6 +1074,8 @@ interface I18nCkbtc {
   btc_network: string;
   receiving_btc: string;
   reimbursement: string;
+  sending_btc: string;
+  sending_btc_failed: string;
 }
 
 interface I18nError__ckbtc {

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -85,6 +85,7 @@ export interface UiTransaction {
   domKey: string;
   isIncoming: boolean;
   isPending: boolean;
+  isFailed?: boolean;
   isReimbursement?: boolean;
   headline: string;
   // Where the amount is going to or coming from.

--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -11,7 +11,7 @@ import { AccountTransactionType } from "$lib/types/transaction";
 import type { UniverseCanisterId } from "$lib/types/universe";
 import { transactionName } from "$lib/utils/transactions.utils";
 import { Cbor } from "@dfinity/agent";
-import type { PendingUtxo } from "@dfinity/ckbtc";
+import type { PendingUtxo, RetrieveBtcStatusV2 } from "@dfinity/ckbtc";
 import type {
   IcrcTransaction,
   IcrcTransactionWithId,
@@ -270,6 +270,7 @@ export const mapCkbtcTransaction = (params: {
   governanceCanisterId?: Principal;
   token: Token | undefined;
   i18n: I18n;
+  retrieveBtcStatus?: RetrieveBtcStatusV2;
 }): UiTransaction | undefined => {
   const mappedTransaction = mapIcrcTransaction(params);
   if (isNullish(mappedTransaction)) {
@@ -290,6 +291,25 @@ export const mapCkbtcTransaction = (params: {
     }
   } else if (transaction.burn.length === 1) {
     mappedTransaction.headline = i18n.ckbtc.btc_sent;
+    const status = params.retrieveBtcStatus;
+    if (status) {
+      if ("Reimbursed" in status || "AmmountTooLow" in status) {
+        mappedTransaction.headline = i18n.ckbtc.sending_btc_failed;
+        mappedTransaction.isFailed = true;
+      } else if (
+        "Pending" in status ||
+        "Signing" in status ||
+        "Sending" in status ||
+        "Submitted" in status ||
+        "WillReimburse" in status
+      ) {
+        mappedTransaction.headline = i18n.ckbtc.sending_btc;
+        mappedTransaction.isPending = true;
+      } else if (!("Confiremd" in status)) {
+        console.error("Unknown retrieveBtcStatusV2:", status);
+        // Leave the transaction as "Sent".
+      }
+    }
     const memo = transaction.burn[0].memo[0] as Uint8Array;
     try {
       const decodedMemo = Cbor.decode(memo) as CkbtcBurnMemo;

--- a/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
@@ -31,6 +31,7 @@ import {
 } from "$tests/mocks/sns-accounts.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { Cbor } from "@dfinity/agent";
+import type { RetrieveBtcStatusV2 } from "@dfinity/ckbtc";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
 import {
   ICPToken,
@@ -497,6 +498,139 @@ describe("icrc-transaction utils", () => {
         isPending: false,
         isReimbursement: true,
         otherParty: "BTC Network",
+        timestamp: new Date(0),
+        tokenAmount: TokenAmountV2.fromUlps({
+          amount,
+          token: mockCkBTCToken,
+        }),
+      });
+    });
+
+    it("Renders a pending burn transaction as pending", () => {
+      const amount = 76_000_000n;
+      const btcWithdrawalAddress = "1ASLxsAMbbt4gcrNc6v6qDBW4JkeWAtTeh";
+      const kytFee = 1333;
+      const decodedMemo = [0, [btcWithdrawalAddress, kytFee, undefined]];
+      const memo = new Uint8Array(Cbor.encode(decodedMemo));
+
+      const retrieveBtcStatus: RetrieveBtcStatusV2 = {
+        Pending: null,
+      };
+
+      const data = mapCkbtcTransaction({
+        transaction: {
+          id: BigInt(1234),
+          transaction: createBurnTransaction({
+            amount,
+            from: mainAccount,
+            memo,
+          }),
+        },
+        account: mockCkBTCMainAccount,
+        toSelfTransaction: false,
+        token: mockCkBTCToken,
+        i18n: en,
+        retrieveBtcStatus,
+      });
+      expect(data).toEqual({
+        domKey: "1234-1",
+        headline: "Sending BTC",
+        isIncoming: false,
+        isPending: true,
+        otherParty: btcWithdrawalAddress,
+        timestamp: new Date(0),
+        tokenAmount: TokenAmountV2.fromUlps({
+          amount,
+          token: mockCkBTCToken,
+        }),
+      });
+    });
+
+    it("Renders a confirmed burn transaction as sent", () => {
+      const amount = 76_000_000n;
+      const btcWithdrawalAddress = "1ASLxsAMbbt4gcrNc6v6qDBW4JkeWAtTeh";
+      const kytFee = 1333;
+      const decodedMemo = [0, [btcWithdrawalAddress, kytFee, undefined]];
+      const memo = new Uint8Array(Cbor.encode(decodedMemo));
+
+      const retrieveBtcStatus: RetrieveBtcStatusV2 = {
+        Confirmed: {
+          txid: new Uint8Array([1, 2, 1, 1]),
+        },
+      };
+
+      const data = mapCkbtcTransaction({
+        transaction: {
+          id: BigInt(1234),
+          transaction: createBurnTransaction({
+            amount,
+            from: mainAccount,
+            memo,
+          }),
+        },
+        account: mockCkBTCMainAccount,
+        toSelfTransaction: false,
+        token: mockCkBTCToken,
+        i18n: en,
+        retrieveBtcStatus,
+      });
+      expect(data).toEqual({
+        domKey: "1234-1",
+        headline: "BTC Sent",
+        isIncoming: false,
+        isPending: false,
+        otherParty: btcWithdrawalAddress,
+        timestamp: new Date(0),
+        tokenAmount: TokenAmountV2.fromUlps({
+          amount,
+          token: mockCkBTCToken,
+        }),
+      });
+    });
+
+    it("Renders a reimbursed burn transaction as failed", () => {
+      const amount = 75_000_000n;
+      const btcWithdrawalAddress = "1ASLxsAMbbt4gcrNc6v6qDBW4JkeWAtTeh";
+      const kytFee = 1333;
+      const decodedMemo = [0, [btcWithdrawalAddress, kytFee, undefined]];
+      const memo = new Uint8Array(Cbor.encode(decodedMemo));
+
+      const retrieveBtcStatus: RetrieveBtcStatusV2 = {
+        Reimbursed: {
+          account: {
+            owner: mockPrincipal,
+            subaccount: [],
+          },
+          mint_block_index: 1256n,
+          amount,
+          reason: {
+            CallFailed: null,
+          },
+        },
+      };
+
+      const data = mapCkbtcTransaction({
+        transaction: {
+          id: BigInt(1234),
+          transaction: createBurnTransaction({
+            amount,
+            from: mainAccount,
+            memo,
+          }),
+        },
+        account: mockCkBTCMainAccount,
+        toSelfTransaction: false,
+        token: mockCkBTCToken,
+        i18n: en,
+        retrieveBtcStatus,
+      });
+      expect(data).toEqual({
+        domKey: "1234-1",
+        headline: "Sending BTC failed",
+        isIncoming: false,
+        isPending: false,
+        isFailed: true,
+        otherParty: btcWithdrawalAddress,
         timestamp: new Date(0),
         tokenAmount: TokenAmountV2.fromUlps({
           amount,


### PR DESCRIPTION
# Motivation

We want to render failed and pending "Sending BTC" transactions as such.
These statuses are not part of the transactions themselves but come from the ckBTC minter and then put in a store.

In this PR we change the mapping function to take the status into account when creation the `UiTransaction`.

# Changes

1. Add a new `isFailed` field to `UiTransaction` to indicate a failed transaction.
2. Add an optional parameter to `mapCkbtcTransaction` to pass the retrieval status if there is one.
3. If there is a status, output a pending or failed transaction if appropriate.
4. Add i18n strings for the transaction headlines.

# Tests

Unit tests added.
Tested manually in another branch with more changes.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet