### PR TITLE
GIX-2183: Unnecessary error toast

### DIFF
--- a/frontend/src/lib/services/ckbtc-minter.services.ts
+++ b/frontend/src/lib/services/ckbtc-minter.services.ts
@@ -189,11 +189,12 @@ export const updateBalance = async ({
     return { success: true };
   } catch (error: unknown) {
     const err = mapUpdateBalanceError(error);
-
-    toastsError({
-      labelKey: "error__ckbtc.update_balance",
-      err,
-    });
+    if (uiIndicators) {
+      toastsError({
+        labelKey: "error__ckbtc.update_balance",
+        err,
+      });
+    }
 
     return { success: false, err };
   } finally {

--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -359,6 +359,30 @@ describe("ckbtc-minter-services", () => {
         expect(spyOnToastsShow).not.toHaveBeenCalled();
       });
 
+      it("should not toast error on error if no ui indicators", async () => {
+        const spyUpdateBalance = vi
+          .spyOn(minterApi, "updateBalance")
+          .mockImplementation(async () => {
+            throw new MinterAlreadyProcessingError();
+          });
+
+        const spyOnToastsError = vi.spyOn(toastsStore, "toastsError");
+
+        await services.updateBalance({
+          ...params,
+          uiIndicators: false,
+        });
+
+        await waitFor(() =>
+          expect(spyUpdateBalance).toBeCalledWith({
+            identity: mockIdentity,
+            canisterId: CKBTC_MINTER_CANISTER_ID,
+          })
+        );
+
+        expect(spyOnToastsError).not.toHaveBeenCalled();
+      });
+
       it("should not handle no new UTXOs success if no ui indicators", async () => {
         vi.spyOn(minterApi, "updateBalance").mockImplementation(async () => {
           throw new MinterNoNewUtxosError({


### PR DESCRIPTION
# Motivation

In mainnet, when the user visits twice the Tokens page a toast error might appear because of the background task to call update_balance on the ckBTC minter.

In this PR, do not show the toast error if `uiIndicators` is set to `false`.

# Changes

* In `updateBalance` ckbtc minter service, show error toast only when `uiIndicators` is `true`.

# Tests

* Add a test for the new functionality.
* Tested manually that when the api endpoint raises this error the toast is not shown.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
