### PR TITLE
GIX-2184: Bold token title

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
@@ -67,7 +67,7 @@
         framed
       />
       <div class="title-wrapper">
-        <span data-tid="project-name">{userTokenData.title}</span>
+        <h5 data-tid="project-name">{userTokenData.title}</h5>
         {#if nonNullish(userTokenData.subtitle)}
           <span data-tid="project-subtitle" class="description"
             >{userTokenData.subtitle}</span
@@ -118,6 +118,10 @@
   @use "@dfinity/gix-components/dist/styles/mixins/interaction";
   @use "@dfinity/gix-components/dist/styles/mixins/media";
   @use "../../../themes/mixins/grid-table";
+
+  h5 {
+    margin: 0;
+  }
 
   [role="row"] {
     @include interaction.tappable;


### PR DESCRIPTION
# Motivation

The token's title should be bold per design.

I used h5 because it matches the style and it makes sense from semantics perspective also.

# Changes

* Wrap the row title with h5 instead of span. Remove default margin on h5.

# Tests

* No test, only UI changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
