### PR TITLE
GIX-2184: Fix padding icp tokens page

### DIFF
--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -34,6 +34,7 @@
   import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
   import IcrcTokenAccountsFooter from "$lib/components/accounts/IcrcTokenAccountsFooter.svelte";
   import IcrcTokenAccountsModals from "$lib/modals/accounts/IcrcTokenAccountsModals.svelte";
+  import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
 
   // TODO: This component is mounted twice. Understand why and fix it.
 
@@ -117,7 +118,8 @@
 </script>
 
 <TestIdWrapper testId="accounts-component">
-  <main>
+  <!-- TODO: Remove the `main` element and the rest of unused elements when removing flag ENABLE_MY_TOKENS -->
+  <main class:noPadding={$ENABLE_MY_TOKENS}>
     <SummaryUniverse />
 
     {#if $isNnsUniverseStore}
@@ -154,5 +156,9 @@
 <style lang="scss">
   main {
     padding-bottom: var(--footer-height);
+
+    &.noPadding {
+      padding: 0;
+    }
   }
 </style>


### PR DESCRIPTION
# Motivation

There was a visual bug in the ICP Tokens page because the outer paddings weren't the same as in the Tokens page. This bug was visible in mobile devices.

The problem came from an extra padding added by a `main`'s default padding inside the Accounts route. This `main` will be removed when the flag is removed, but for now, I fixed it by passing a class and setting the padding to 0 when the flag is enabled.

# Changes

* Add a new class `noPadding` to the `main` in Accounts route and set it when ENABLE_MY_TOKENS is enabled.

# Tests

Only UI changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
