### PR TITLE
GIX-2184: Add accountsTitleStore

### DIFF
--- a/frontend/src/lib/derived/accounts-title.derived.ts
+++ b/frontend/src/lib/derived/accounts-title.derived.ts
@@ -1,0 +1,19 @@
+import { i18n } from "$lib/stores/i18n";
+import { tokensStore, type TokensStore } from "$lib/stores/tokens.store";
+import { replacePlaceholders } from "$lib/utils/i18n.utils";
+import { isNullish } from "@dfinity/utils";
+import { derived, type Readable } from "svelte/store";
+import { pageStore, type Page } from "./page.derived";
+
+export const accountsTitleStore = derived<
+  [Readable<Page>, TokensStore, Readable<I18n>],
+  string
+>([pageStore, tokensStore, i18n], ([{ universe }, tokensData, i18nObj]) => {
+  const token = tokensData[universe]?.token;
+  if (isNullish(token)) {
+    return i18nObj.navigation.tokens;
+  }
+  return replacePlaceholders(i18nObj.navigation.universe_tokens, {
+    $tokenSymbol: token.symbol,
+  });
+});

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -141,6 +141,7 @@
   },
   "navigation": {
     "tokens": "My Tokens",
+    "universe_tokens": "My $tokenSymbol Tokens",
     "canisters": "My Canisters",
     "neurons": "My Neuron Staking",
     "voting": "Vote on Proposals",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -147,6 +147,7 @@ interface I18nWarning {
 
 interface I18nNavigation {
   tokens: string;
+  universe_tokens: string;
   canisters: string;
   neurons: string;
   voting: string;

--- a/frontend/src/tests/lib/derived/accounts-title.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/accounts-title.derived.spec.ts
@@ -1,0 +1,50 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { AppPath } from "$lib/constants/routes.constants";
+import { accountsTitleStore } from "$lib/derived/accounts-title.derived";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { page } from "$mocks/$app/stores";
+import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
+import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { get } from "svelte/store";
+
+describe("accountsTitleStore", () => {
+  beforeEach(() => {
+    page.mock({
+      routeId: AppPath.Accounts,
+      data: { universe: OWN_CANISTER_ID_TEXT },
+    });
+    tokensStore.reset();
+  });
+
+  it("returns 'My Tokens' if no token is found", () => {
+    // the ICP token is hardcoded in the `tokensStore`, so it will always be found
+    page.mock({
+      routeId: AppPath.Accounts,
+      data: { universe: rootCanisterIdMock.toText() },
+    });
+
+    expect(get(accountsTitleStore)).toEqual("My Tokens");
+  });
+
+  it("returns the ICP in the title", () => {
+    expect(get(accountsTitleStore)).toEqual("My ICP Tokens");
+  });
+
+  it("returns the token of the universe in the title", () => {
+    // the ICP token is hardcoded in the `tokensStore`, so it will always be found
+    page.mock({
+      routeId: AppPath.Accounts,
+      data: { universe: rootCanisterIdMock.toText() },
+    });
+
+    tokensStore.setToken({
+      canisterId: rootCanisterIdMock,
+      token: {
+        ...mockSnsToken,
+        symbol: "TTRS",
+      },
+    });
+
+    expect(get(accountsTitleStore)).toEqual("My TTRS Tokens");
+  });
+});

--- a/frontend/src/tests/lib/derived/accounts-title.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/accounts-title.derived.spec.ts
@@ -31,7 +31,6 @@ describe("accountsTitleStore", () => {
   });
 
   it("returns the token of the universe in the title", () => {
-    // the ICP token is hardcoded in the `tokensStore`, so it will always be found
     page.mock({
       routeId: AppPath.Accounts,
       data: { universe: rootCanisterIdMock.toText() },


### PR DESCRIPTION
# Motivation

Change the title of the accounts page to have the name of the token on it.

This is a change requested regarding the new tokens page, but I believe that it's a good change even for the current accounts page. Therefore, I didn't put it behind the feature flag.

In this PR, I introduce the store that I want to use in the layout to set the title. But I don't use it yet.

# Changes

* New store `accountsTitleStore`.
* New i18n key

# Tests

* Test new store `accountsTitleStore`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.

