### PR TITLE
Fix mapCkbtcTransaction issue

### DIFF
--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -305,7 +305,7 @@ export const mapCkbtcTransaction = (params: {
       ) {
         mappedTransaction.headline = i18n.ckbtc.sending_btc;
         mappedTransaction.isPending = true;
-      } else if (!("Confiremd" in status)) {
+      } else if (!("Confirmed" in status)) {
         console.error("Unknown retrieveBtcStatusV2:", status);
         // Leave the transaction as "Sent".
       }

--- a/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
@@ -79,6 +79,10 @@ describe("icrc-transaction utils", () => {
     to: subAccount,
   });
 
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe("getSortedTransactionsFromStore", () => {
     it("should return transactions sorted by date", () => {
       const transactions = [secondTx, oldestTx, recentTx];
@@ -731,6 +735,11 @@ describe("icrc-transaction utils", () => {
     });
 
     it("Merges Approve transaction with corresponding Burn transaction", () => {
+      const btcWithdrawalAddress = "1ASLxsAMbbt4gcrNc6v6qDBW4JkeWAtTeh";
+      const kytFee = 1333;
+      const decodedMemo = [0, [btcWithdrawalAddress, kytFee, undefined]];
+      const memo = new Uint8Array(Cbor.encode(decodedMemo));
+
       const burnAmount = 200_000_000n;
       const approveFee = 13n;
 
@@ -748,6 +757,7 @@ describe("icrc-transaction utils", () => {
           id: 102n,
           transaction: createBurnTransaction({
             amount: burnAmount,
+            memo,
           }),
         },
         toSelfTransaction: false,


### PR DESCRIPTION
# Motivation

There was a typo in the "Confirmed" retrieval status in `mapCkbtcTransaction`.
The test would have failed before of the error logging, but another test mocked out the error logging and it wasn't reset.

# Changes

1. `vi.restoreAllMocks` in `beforeEach`.
2. Fix the typo.
3. Fix another test which started logging an error about the memo not being decodable.

# Tests

updated

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary