### PR TITLE
Rename: isNonGovernanceTokenPath to isAllTokensPath

### DIFF
--- a/frontend/src/lib/derived/selectable-universes.derived.ts
+++ b/frontend/src/lib/derived/selectable-universes.derived.ts
@@ -5,10 +5,7 @@ import {
   type IcrcCanistersStoreData,
 } from "$lib/stores/icrc-canisters.store";
 import type { Universe } from "$lib/types/universe";
-import {
-  isNonGovernanceTokenPath,
-  isUniverseCkBTC,
-} from "$lib/utils/universe.utils";
+import { isAllTokensPath, isUniverseCkBTC } from "$lib/utils/universe.utils";
 import { isNullish } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 import { universesStore } from "./universes.derived";
@@ -27,7 +24,7 @@ export const selectableUniversesStore = derived<
     // The rest show all universes except for ckBTC, and ICRC Tokens
     universes.filter(
       ({ canisterId }) =>
-        isNonGovernanceTokenPath(page) ||
+        isAllTokensPath(page) ||
         (!isUniverseCkBTC(canisterId) && isNullish(icrcCanisters[canisterId]))
     )
 );

--- a/frontend/src/lib/derived/selected-universe.derived.ts
+++ b/frontend/src/lib/derived/selected-universe.derived.ts
@@ -16,7 +16,7 @@ import {
 } from "$lib/stores/icrc-canisters.store";
 import type { Universe, UniverseCanisterId } from "$lib/types/universe";
 import {
-  isNonGovernanceTokenPath,
+  isAllTokensPath,
   isUniverseCkBTC,
   isUniverseCkTESTBTC,
   isUniverseNns,
@@ -68,7 +68,7 @@ export const selectedUniverseIdStore: Readable<Principal> = derived<
     const isCkBTC = isUniverseCkBTC(canisterId);
     const isIcrcToken = nonNullish(icrcCanisters[canisterId.toText()]);
     // ckBTC and ICRC Tokens are only available on Accounts therefore we fallback to Nns if selected and user switch to another view
-    if ((isCkBTC || isIcrcToken) && !isNonGovernanceTokenPath(page)) {
+    if ((isCkBTC || isIcrcToken) && !isAllTokensPath(page)) {
       return OWN_CANISTER_ID;
     }
     if (
@@ -107,7 +107,7 @@ export const selectedIcrcTokenUniverseIdStore = derived(
     Page,
     IcrcCanistersStoreData,
   ]) =>
-    isNonGovernanceTokenPath($page)
+    isAllTokensPath($page)
       ? $icrcCanistersStore[$pageUniverseIdStore.toText()]?.ledgerCanisterId
       : undefined
 );

--- a/frontend/src/lib/utils/universe.utils.ts
+++ b/frontend/src/lib/utils/universe.utils.ts
@@ -15,6 +15,11 @@ import type { Principal } from "@dfinity/principal";
 import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
+/**
+ * Returns whether the path is either Wallet or Accounts.
+ *
+ * Those are the only paths that support all tokens.
+ */
 export const isAllTokensPath = ({ path }: Page): boolean =>
   isSelectedPath({
     currentPath: path,

--- a/frontend/src/lib/utils/universe.utils.ts
+++ b/frontend/src/lib/utils/universe.utils.ts
@@ -15,7 +15,7 @@ import type { Principal } from "@dfinity/principal";
 import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
-export const isNonGovernanceTokenPath = ({ path }: Page): boolean =>
+export const isAllTokensPath = ({ path }: Page): boolean =>
   isSelectedPath({
     currentPath: path,
     paths: [AppPath.Accounts, AppPath.Wallet],

--- a/frontend/src/tests/lib/utils/universes.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/universes.utils.spec.ts
@@ -8,8 +8,8 @@ import { nnsUniverseStore } from "$lib/derived/nns-universe.derived";
 import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
 import {
   createUniverse,
+  isAllTokensPath,
   isIcrcTokenUniverse,
-  isNonGovernanceTokenPath,
   isUniverseCkBTC,
   isUniverseNns,
   universeLogoAlt,
@@ -26,17 +26,17 @@ import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 
 describe("universes-utils", () => {
-  describe("isNonGovernanceTokenPath", () => {
+  describe("isAllTokensPath", () => {
     it("should support ICRC token", () => {
       expect(
-        isNonGovernanceTokenPath({
+        isAllTokensPath({
           universe: "not used here",
           path: AppPath.Accounts,
         })
       ).toBeTruthy();
 
       expect(
-        isNonGovernanceTokenPath({
+        isAllTokensPath({
           universe: "not used here",
           path: AppPath.Wallet,
         })
@@ -45,14 +45,14 @@ describe("universes-utils", () => {
 
     it("should not support ICRC Token", () => {
       expect(
-        isNonGovernanceTokenPath({
+        isAllTokensPath({
           universe: "not used here",
           path: AppPath.Neurons,
         })
       ).toBe(false);
 
       expect(
-        isNonGovernanceTokenPath({
+        isAllTokensPath({
           universe: "not used here",
           path: AppPath.Proposal,
         })


### PR DESCRIPTION
# Motivation

Improve readability of utils.

In this PR, rename util isNonGovernanceTokenPath to isAllTokensPath

Change triggered by [this discussion](https://github.com/dfinity/nns-dapp/pull/3872#discussion_r1406695028).

# Changes

* Rename isNonGovernanceTokenPath to isAllTokensPath

# Tests

* Fix rename

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
