### PR TITLE
GIX-2079: Take retrieval status into account in mapCkbtcTransactions

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -80,6 +80,8 @@
       account,
       token,
       i18n: $i18n,
+      // TODO GIX-2079: Pass actual statuses.
+      retrieveBtcStatuses: [],
     });
     return [...pendingTransactions, ...completedTransactions];
   };

--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -11,7 +11,11 @@ import { AccountTransactionType } from "$lib/types/transaction";
 import type { UniverseCanisterId } from "$lib/types/universe";
 import { transactionName } from "$lib/utils/transactions.utils";
 import { Cbor } from "@dfinity/agent";
-import type { PendingUtxo, RetrieveBtcStatusV2 } from "@dfinity/ckbtc";
+import type {
+  PendingUtxo,
+  RetrieveBtcStatusV2,
+  RetrieveBtcStatusV2WithId,
+} from "@dfinity/ckbtc";
 import type {
   IcrcTransaction,
   IcrcTransactionWithId,
@@ -332,14 +336,22 @@ export const mapCkbtcTransactions = ({
   account,
   token,
   i18n,
+  retrieveBtcStatuses,
 }: {
   transactionData: IcrcTransactionData[];
   account: Account;
   token: Token | undefined;
   i18n: I18n;
+  retrieveBtcStatuses: RetrieveBtcStatusV2WithId[];
 }): UiTransaction[] => {
   let prevTransaction: IcrcTransactionWithId | undefined = undefined;
   let prevUiTransaction: UiTransaction | undefined = undefined;
+  const statusById = new Map<bigint, RetrieveBtcStatusV2>();
+  for (const { id, status } of retrieveBtcStatuses) {
+    if (status) {
+      statusById.set(id, status);
+    }
+  }
   return transactionData
     .map(({ transaction, toSelfTransaction }: IcrcTransactionData) => {
       if (
@@ -363,6 +375,7 @@ export const mapCkbtcTransactions = ({
         account,
         token,
         i18n,
+        retrieveBtcStatus: statusById.get(transaction.id),
       });
       prevTransaction = transaction;
       prevUiTransaction = uiTransaction;


### PR DESCRIPTION
# Motivation

We want to render failed and pending "Sending BTC" transactions as such.
These statuses are not part of the transactions themselves but come from the ckBTC minter and then put in a store.

In this PR we pass the status from `mapCkbtcTransactions` (plural) to `mapCkbtcTransaction` singular.
We don't yet pass the statuses to `mapCkbtcTransactions` (plural).

# Changes

1. Add a `retrieveBtcStatuses` parameter to `mapCkbtcTransactions`.
2. Convert the array to a map and use the map to pass the correct status to each invocation of `mapCkbtcTransaction`.

# Tests

1. Extract some test values from test and put them in a larger scope so they can be used.
2. Add a unit test with multiple statuses for different transactions and test that they are applied correctly.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet