### PR TITLE
feat: Don't save a map on the heap except when it makes sense

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 - Disable dissolve delay editing when the maximum is reached.
 - Implement `Storable` for accounts.
 - `UnboundedStableBTreeMap` as an account storage medium.
+- Save accounts in the `pre_upgrade` hook only when accounts are stored in the heap.
 - Migration functions.
 
 #### Changed

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -28,7 +28,7 @@ use std::time::{Duration, SystemTime};
 
 pub mod histogram;
 pub mod schema;
-use schema::{proxy::AccountsDbAsProxy, AccountsDbBTreeMapTrait, AccountsDbTrait};
+use schema::{proxy::AccountsDbAsProxy, AccountsDbTrait};
 
 type TransactionIndex = u64;
 
@@ -1568,8 +1568,9 @@ impl AccountsStore {
 
 impl StableState for AccountsStore {
     fn encode(&self) -> Vec<u8> {
+        let empty_accounts = BTreeMap::<Vec<u8>, Account>::new();
         Candid((
-            &self.accounts_db.as_map(),
+            &self.accounts_db.as_map_maybe().unwrap_or(&empty_accounts),
             &self.hardware_wallets_and_sub_accounts,
             // TODO: Remove pending_transactions
             HashMap::<(AccountIdentifier, AccountIdentifier), (TransactionType, u64)>::new(),

--- a/rs/backend/src/accounts_store/schema/proxy.rs
+++ b/rs/backend/src/accounts_store/schema/proxy.rs
@@ -65,18 +65,16 @@ impl AccountsDbAsProxy {
             migration: None,
         }
     }
-}
-
-impl AccountsDbBTreeMapTrait for AccountsDbAsProxy {
-    fn from_map(map: BTreeMap<Vec<u8>, Account>) -> Self {
+    pub fn from_map(map: BTreeMap<Vec<u8>, Account>) -> Self {
         Self {
             authoritative_db: AccountsDb::Map(AccountsDbAsMap::from_map(map)),
             migration: None,
         }
     }
-    fn as_map(&self) -> &BTreeMap<Vec<u8>, Account> {
+    /// Provides a reference to the underlying map, if that is how accounts are stored.
+    pub fn as_map_maybe(&self) -> Option<&BTreeMap<Vec<u8>, Account>> {
         match &self.authoritative_db {
-            AccountsDb::Map(map_db) => map_db.as_map(),
+            AccountsDb::Map(map_db) => Some(map_db.as_map()),
         }
     }
 }

--- a/rs/backend/src/accounts_store/schema/proxy/tests.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/tests.rs
@@ -5,18 +5,12 @@ use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
 use crate::accounts_store::schema::tests::toy_account;
-use crate::accounts_store::schema::AccountsDbBTreeMapTrait;
 use crate::accounts_store::{CanisterId, NamedCanister};
 
-use super::super::tests::{assert_map_conversions_work, test_accounts_db};
+use super::super::tests::test_accounts_db;
 use super::*;
 
 test_accounts_db!(AccountsDbAsProxy::default());
-
-#[test]
-fn map_conversions_should_work() {
-    assert_map_conversions_work::<AccountsDbAsProxy>();
-}
 
 fn migration_steps_should_work(accounts_db: &mut AccountsDbAsProxy, new_accounts_db: AccountsDb) {
     // During the migration, the accounts db should behave as if no migration were in progress,


### PR DESCRIPTION
# Motivation
When accounts are stored in stable memory, it no longer makes sense to save the accounts with all the other data on the heap.

# Changes
- Serialize accounts in the `pre_upgrade` hook only when accounts are stored as a `BTreeMap` on the heap.

# Tests
- Existing tests for `Map` to `Map` upgrades still suffice.

# Todos

- [x] Add entry to changelog (if necessary).
