### PR TITLE
Save stats

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,7 @@ proposal is successful, the changes it released will be moved from this file to
 - Implement `Storable` for accounts.
 - `UnboundedStableBTreeMap` as an account storage medium.
 - Save accounts in the `pre_upgrade` hook only when accounts are stored in the heap.
+- Save account stats in the `pre_upgrade` hook rather than recomputing them in the `post_upgrade` hook.
 - Migration functions.
 
 #### Changed

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -50,9 +50,7 @@ pub struct AccountsStore {
     neuron_accounts: HashMap<AccountIdentifier, NeuronDetails>,
     block_height_synced_up_to: Option<BlockIndex>,
     multi_part_transactions_processor: MultiPartTransactionsProcessor,
-
-    sub_accounts_count: u64,
-    hardware_wallet_accounts_count: u64,
+    accounts_db_stats: AccountsDbStats,
     last_ledger_sync_timestamp_nanos: u64,
     neurons_topped_up_count: u64,
 }
@@ -61,7 +59,7 @@ impl fmt::Debug for AccountsStore {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "AccountsStore{{accounts_db: {:?}, hardware_wallets_and_sub_accounts: HashMap[{:?}], pending_transactions: HashMap[{:?}], transactions: VecDeque[{:?}], neuron_accounts: HashMap[{:?}], block_height_synced_up_to: {:?}, multi_part_transactions_processor: {:?}, sub_accounts_count: {:?}, hardware_wallet_accounts_count: {:?}, last_ledger_sync_timestamp_nanos: {:?}, neurons_topped_up_count: {:?}}}",
+            "AccountsStore{{accounts_db: {:?}, hardware_wallets_and_sub_accounts: HashMap[{:?}], pending_transactions: HashMap[{:?}], transactions: VecDeque[{:?}], neuron_accounts: HashMap[{:?}], block_height_synced_up_to: {:?}, multi_part_transactions_processor: {:?}, accounts_db_stats: {:?}, last_ledger_sync_timestamp_nanos: {:?}, neurons_topped_up_count: {:?}}}",
             self.accounts_db,
             self.hardware_wallets_and_sub_accounts.len(),
             self.pending_transactions.len(),
@@ -69,12 +67,17 @@ impl fmt::Debug for AccountsStore {
             self.neuron_accounts.len(),
             self.block_height_synced_up_to,
             self.multi_part_transactions_processor,
-            self.sub_accounts_count,
-            self.hardware_wallet_accounts_count,
+            self.accounts_db_stats,
             self.last_ledger_sync_timestamp_nanos,
             self.neurons_topped_up_count,
         )
     }
+}
+
+#[derive(Default, CandidType, Deserialize, Debug)]
+pub struct AccountsDbStats {
+    pub sub_accounts_count: u64,
+    pub hardware_wallet_accounts_count: u64,
 }
 
 /// An abstraction over sub-accounts and hardware wallets.
@@ -504,7 +507,7 @@ impl AccountsStore {
                     sub_account_identifier,
                     AccountWrapper::SubAccount(account_identifier, sub_account_id),
                 );
-                self.sub_accounts_count += 1;
+                self.accounts_db_stats.sub_accounts_count += 1;
             }
 
             response
@@ -577,7 +580,7 @@ impl AccountsStore {
                 self.accounts_db
                     .db_insert_account(&account_identifier.to_vec(), account);
 
-                self.hardware_wallet_accounts_count += 1;
+                self.accounts_db_stats.hardware_wallet_accounts_count += 1;
                 self.link_hardware_wallet_to_account(account_identifier, hardware_wallet_account_identifier);
                 RegisterHardwareWalletResponse::Ok
             }
@@ -1098,8 +1101,8 @@ impl AccountsStore {
             Duration::from_nanos(timestamp_now_nanos - self.last_ledger_sync_timestamp_nanos);
 
         stats.accounts_count = self.accounts_db.db_accounts_len();
-        stats.sub_accounts_count = self.sub_accounts_count;
-        stats.hardware_wallet_accounts_count = self.hardware_wallet_accounts_count;
+        stats.sub_accounts_count = self.accounts_db_stats.sub_accounts_count;
+        stats.hardware_wallet_accounts_count = self.accounts_db_stats.hardware_wallet_accounts_count;
         stats.transactions_count = self.transactions.len() as u64;
         stats.block_height_synced_up_to = self.block_height_synced_up_to;
         stats.earliest_transaction_timestamp_nanos =
@@ -1597,6 +1600,7 @@ impl StableState for AccountsStore {
             multi_part_transactions_processor,
             last_ledger_sync_timestamp_nanos,
             neurons_topped_up_count,
+            accounts_db_stats_maybe,
         ): (
             BTreeMap<Vec<u8>, Account>,
             HashMap<AccountIdentifier, AccountWrapper>,
@@ -1607,6 +1611,7 @@ impl StableState for AccountsStore {
             MultiPartTransactionsProcessor,
             u64,
             u64,
+            Option<AccountsDbStats>,
         ) = Candid::from_bytes(bytes).map(|c| c.0)?;
 
         // Remove duplicate transactions from hardware wallet accounts
@@ -1623,12 +1628,21 @@ impl StableState for AccountsStore {
             }
         }
 
-        let mut sub_accounts_count: u64 = 0;
-        let mut hardware_wallet_accounts_count: u64 = 0;
-        for account in accounts.values() {
-            sub_accounts_count += account.sub_accounts.len() as u64;
-            hardware_wallet_accounts_count += account.hardware_wallet_accounts.len() as u64;
-        }
+        let accounts_db_stats = match accounts_db_stats_maybe {
+            Some(counts) => counts,
+            None => {
+                let mut sub_accounts_count: u64 = 0;
+                let mut hardware_wallet_accounts_count: u64 = 0;
+                for account in accounts.values() {
+                    sub_accounts_count += account.sub_accounts.len() as u64;
+                    hardware_wallet_accounts_count += account.hardware_wallet_accounts.len() as u64;
+                }
+                AccountsDbStats {
+                    sub_accounts_count,
+                    hardware_wallet_accounts_count,
+                }
+            }
+        };
 
         Ok(AccountsStore {
             accounts_db: AccountsDbAsProxy::from_map(accounts),
@@ -1638,8 +1652,7 @@ impl StableState for AccountsStore {
             neuron_accounts,
             block_height_synced_up_to,
             multi_part_transactions_processor,
-            sub_accounts_count,
-            hardware_wallet_accounts_count,
+            accounts_db_stats,
             last_ledger_sync_timestamp_nanos,
             neurons_topped_up_count,
         })

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -74,7 +74,7 @@ impl fmt::Debug for AccountsStore {
     }
 }
 
-#[derive(Default, CandidType, Deserialize, Debug)]
+#[derive(Default, CandidType, Deserialize, Debug, Eq, PartialEq)]
 pub struct AccountsDbStats {
     pub sub_accounts_count: u64,
     pub hardware_wallet_accounts_count: u64,


### PR DESCRIPTION
# Motivation
Currently, in the post_upgrade hook stats are computed over all accounts.  This will become too expensive once accounts are stored in stable memory.

Instead we would like to preserve these stats on upgrade.

# Changes
- Save the `accounts_db` stats in the `pre_upgrade()` hook.
- In the `post_upgrade()` hook, compute stats only if they are not already available.

# Tests
- The downgrade-upgrade test verifies that this is forwards and backwards compatible.

# Todos

- [x] Add entry to changelog (if necessary).
