### PR TITLE
Render failed BTC withdrawal transactions

### DIFF
--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -6,6 +6,7 @@
   import { i18n } from "$lib/stores/i18n";
   import {
     IconReimbursed,
+    IconErrorOutline,
     IconUp,
     IconDown,
     KeyValuePair,
@@ -24,6 +25,7 @@
   let tokenAmount: TokenAmount | TokenAmountV2;
   let isIncoming: boolean;
   let isPending: boolean;
+  let isFailed: boolean | undefined;
   let isReimbursement: boolean | undefined;
   let otherParty: string | undefined;
   let timestamp: Date | undefined;
@@ -32,6 +34,7 @@
     tokenAmount,
     isIncoming,
     isPending,
+    isFailed,
     isReimbursement,
     otherParty,
     timestamp,
@@ -52,9 +55,11 @@
     data-tid="icon"
     class:send={!isIncoming}
     class:pending={isPending}
-    class:reimbursed={isReimbursement}
+    class:failed={isFailed || isReimbursement}
   >
-    {#if isReimbursement}
+    {#if isFailed}
+      <IconErrorOutline size="24px" />
+    {:else if isReimbursement}
       <IconReimbursed size="24px" />
     {:else if isIncoming}
       <IconDown size="24px" />
@@ -168,7 +173,7 @@
       background: var(--pending-background);
     }
 
-    &.reimbursed {
+    &.failed {
       color: var(--alert);
       background: var(--alert-tint);
     }

--- a/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionCard.spec.ts
@@ -127,6 +127,14 @@ describe("TransactionCard", () => {
     expect(await po.hasReimbursementIcon()).toBe(true);
   });
 
+  it("displays failed transaction", async () => {
+    const po = renderComponent({
+      isFailed: true,
+    });
+
+    expect(await po.hasFailedIcon()).toBe(true);
+  });
+
   it("displays identifier for received", async () => {
     const po = renderComponent({
       isIncoming: true,

--- a/frontend/src/tests/page-objects/TransactionCard.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionCard.page-object.ts
@@ -62,7 +62,13 @@ export class TransactionCardPo extends BasePageObject {
 
   async hasReimbursementIcon(): Promise<boolean> {
     const hasIcon = await this.isPresent("icon-reimbursed");
-    const hasClass = await this.hasIconClass("reimbursed");
+    const hasClass = await this.hasIconClass("failed");
+    return hasIcon && hasClass;
+  }
+
+  async hasFailedIcon(): Promise<boolean> {
+    const hasIcon = await this.isPresent("icon-error-outline");
+    const hasClass = await this.hasIconClass("failed");
     return hasIcon && hasClass;
   }
 }


### PR DESCRIPTION
# Motivation

We want to render failed "Sending BTC" transactions as such.
This PR has just the UI changes to render failed transaction.
Detecting failed transactions is done in other PRs.

# Changes


1. If `UiTransaction.isFailed` is true render a different icon.
2. Use a CSS class that renders the icon in a red color. This is the same color that reimbursed transactions also use.
3. Add a method to the page object to check for the failed icon and class.
4. Test that `isFailed` results in using the failed icon.

# Tests

Unit test is included.
Tested manually in another branch.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet.