### PR TITLE
Use page objects in SnsWallet.spec.ts

### DIFF
--- a/frontend/src/lib/components/accounts/ReceiveAddressQRCode.svelte
+++ b/frontend/src/lib/components/accounts/ReceiveAddressQRCode.svelte
@@ -43,7 +43,9 @@
 
   {#if addressSelected && qrCodeRendered}
     <div data-tid="qr-address-label" class="address-block">
-      <p class="label no-margin"><slot name="address-label" /></p>
+      <p class="label no-margin" data-tid="token-address-label">
+        <slot name="address-label" />
+      </p>
       <div class="address">
         <span class="value" data-tid="qrcode-display-address">{address}</span>
         <Copy value={address ?? ""} />

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -11,6 +11,7 @@
     type WalletContext,
     type WalletStore,
   } from "$lib/types/wallet.context";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import Footer from "$lib/components/layout/Footer.svelte";
   import { i18n } from "$lib/stores/i18n";
   import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";
@@ -122,72 +123,74 @@
     : undefined;
 </script>
 
-<Island>
-  <main class="legacy" data-tid="sns-wallet">
-    <section>
-      {#if nonNullish($selectedAccountStore.account) && nonNullish($snsOnlyProjectStore) && nonNullish($snsProjectSelectedStore) && nonNullish(token)}
-        <SnsBalancesObserver
-          rootCanisterId={$snsOnlyProjectStore}
-          accounts={[$selectedAccountStore.account]}
-          ledgerCanisterId={$snsProjectSelectedStore.summary.ledgerCanisterId}
-        >
-          <WalletPageHeader
-            universe={$selectedUniverseStore}
-            walletAddress={$selectedAccountStore.account.identifier}
-          />
-          <WalletPageHeading
-            balance={TokenAmount.fromE8s({
-              amount: $selectedAccountStore.account.balanceUlps,
-              token,
-            })}
-            accountName={$selectedAccountStore.account.name ??
-              $i18n.accounts.main}
-          />
-
-          <Separator spacing="none" />
-
-          <SnsTransactionsList
+<TestIdWrapper testId="sns-wallet-component">
+  <Island>
+    <main class="legacy" data-tid="sns-wallet">
+      <section>
+        {#if nonNullish($selectedAccountStore.account) && nonNullish($snsOnlyProjectStore) && nonNullish($snsProjectSelectedStore) && nonNullish(token)}
+          <SnsBalancesObserver
             rootCanisterId={$snsOnlyProjectStore}
-            account={$selectedAccountStore.account}
-            {token}
-          />
-        </SnsBalancesObserver>
-      {:else}
-        <Spinner />
-      {/if}
-    </section>
-  </main>
+            accounts={[$selectedAccountStore.account]}
+            ledgerCanisterId={$snsProjectSelectedStore.summary.ledgerCanisterId}
+          >
+            <WalletPageHeader
+              universe={$selectedUniverseStore}
+              walletAddress={$selectedAccountStore.account.identifier}
+            />
+            <WalletPageHeading
+              balance={TokenAmount.fromE8s({
+                amount: $selectedAccountStore.account.balanceUlps,
+                token,
+              })}
+              accountName={$selectedAccountStore.account.name ??
+                $i18n.accounts.main}
+            />
 
-  <Footer>
-    <button
-      class="primary"
-      on:click={() => (showModal = "send")}
-      {disabled}
-      data-tid="open-new-sns-transaction">{$i18n.accounts.send}</button
-    >
+            <Separator spacing="none" />
 
-    <ReceiveButton
-      type="icrc-receive"
-      account={$selectedAccountStore.account}
-      reload={reloadAccount}
-      testId="receive-sns"
-      universeId={$snsOnlyProjectStore}
-      logo={$selectedUniverseStore?.summary?.metadata.logo ?? IC_LOGO}
-      tokenSymbol={$selectedUniverseStore?.summary?.token.symbol}
+            <SnsTransactionsList
+              rootCanisterId={$snsOnlyProjectStore}
+              account={$selectedAccountStore.account}
+              {token}
+            />
+          </SnsBalancesObserver>
+        {:else}
+          <Spinner />
+        {/if}
+      </section>
+    </main>
+
+    <Footer>
+      <button
+        class="primary"
+        on:click={() => (showModal = "send")}
+        {disabled}
+        data-tid="open-new-sns-transaction">{$i18n.accounts.send}</button
+      >
+
+      <ReceiveButton
+        type="icrc-receive"
+        account={$selectedAccountStore.account}
+        reload={reloadAccount}
+        testId="receive-sns"
+        universeId={$snsOnlyProjectStore}
+        logo={$selectedUniverseStore?.summary?.metadata.logo ?? IC_LOGO}
+        tokenSymbol={$selectedUniverseStore?.summary?.token.symbol}
+      />
+    </Footer>
+  </Island>
+
+  {#if showModal && nonNullish($snsOnlyProjectStore)}
+    <SnsTransactionModal
+      on:nnsClose={() => (showModal = undefined)}
+      selectedAccount={$selectedAccountStore.account}
+      rootCanisterId={$snsOnlyProjectStore}
+      loadTransactions
+      {token}
+      transactionFee={toTokenAmountV2($snsSelectedTransactionFeeStore)}
     />
-  </Footer>
-</Island>
-
-{#if showModal && nonNullish($snsOnlyProjectStore)}
-  <SnsTransactionModal
-    on:nnsClose={() => (showModal = undefined)}
-    selectedAccount={$selectedAccountStore.account}
-    rootCanisterId={$snsOnlyProjectStore}
-    loadTransactions
-    {token}
-    transactionFee={toTokenAmountV2($snsSelectedTransactionFeeStore)}
-  />
-{/if}
+  {/if}
+</TestIdWrapper>
 
 <style lang="scss">
   section {

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -1,31 +1,26 @@
 import * as snsIndexApi from "$lib/api/sns-index.api";
 import * as snsLedgerApi from "$lib/api/sns-ledger.api";
-import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
 import SnsWallet from "$lib/pages/SnsWallet.svelte";
 import * as workerBalances from "$lib/services/worker-balances.services";
 import * as workerTransactions from "$lib/services/worker-transactions.services";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import type { Account } from "$lib/types/account";
-import { replacePlaceholders } from "$lib/utils/i18n.utils";
-import { formatTokenE8s } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
 import AccountsTest from "$tests/lib/pages/AccountsTest.svelte";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
-import en from "$tests/mocks/i18n.mock";
 import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
-import { waitModalIntroEnd } from "$tests/mocks/modal.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
-import { testAccountsModal } from "$tests/utils/accounts.test-utils";
+import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
+import { SnsWalletPo } from "$tests/page-objects/SnsWallet.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import { testTransferTokens } from "$tests/utils/transaction-modal.test-utils";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { SnsSwapLifecycle } from "@dfinity/sns";
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
-import { get } from "svelte/store";
+import { render } from "@testing-library/svelte";
 
 vi.mock("$lib/api/sns-ledger.api");
 vi.mock("$lib/api/sns-index.api");
@@ -75,6 +70,12 @@ describe("SnsWallet", () => {
   const fee = 10_000n;
   const projectName = "Tetris";
 
+  const renderComponent = async () => {
+    const { container } = render(SnsWallet, props);
+    await runResolvedPromises();
+    return SnsWalletPo.under(new JestPageObjectElement(container));
+  };
+
   beforeEach(() => {
     resetIdentity();
     vi.clearAllMocks();
@@ -112,16 +113,16 @@ describe("SnsWallet", () => {
     });
 
     it("should hide spinner when account is loaded", async () => {
-      const { queryByTestId } = render(SnsWallet, props);
+      const po = await renderComponent();
 
-      expect(queryByTestId("spinner")).toBeInTheDocument();
-
-      await waitFor(() => expect(resolve).toBeDefined());
-
-      resolve([mockSnsMainAccount]);
       await runResolvedPromises();
+      expect(await po.hasSpinner()).toBe(true);
 
-      expect(queryByTestId("spinner")).toBeNull();
+      expect(resolve).toBeDefined();
+      resolve([mockSnsMainAccount]);
+
+      await runResolvedPromises();
+      expect(await po.hasSpinner()).toBe(false);
     });
   });
 
@@ -133,92 +134,63 @@ describe("SnsWallet", () => {
     });
 
     it("should render sns project name", async () => {
-      const { getByTestId } = render(SnsWallet, props);
+      const po = await renderComponent();
 
-      await runResolvedPromises();
-
-      const titleRow = getByTestId("universe-page-summary-component");
-
-      expect(titleRow.textContent.trim()).toBe(projectName);
+      expect(await po.getWalletPageHeaderPo().getUniverse()).toBe(projectName);
     });
 
     it("should render transactions", async () => {
-      const { queryByTestId } = render(SnsWallet, props);
+      const po = await renderComponent();
 
-      await runResolvedPromises();
-
-      expect(queryByTestId("transactions-list")).toBeInTheDocument();
+      expect(await po.getIcrcTransactionsListPo().isPresent()).toBe(true);
     });
 
     it("should render 'Main' as subtitle", async () => {
-      const { queryByTestId } = render(SnsWallet, props);
+      const po = await renderComponent();
 
-      await runResolvedPromises();
-
-      expect(queryByTestId("wallet-page-heading-subtitle").textContent).toBe(
-        "Main"
-      );
+      expect(await po.getWalletPageHeadingPo().getSubtitle()).toBe("Main");
     });
 
     it("should render a balance with token", async () => {
-      const { getByTestId } = render(SnsWallet, props);
+      vi.spyOn(snsLedgerApi, "getSnsAccounts").mockResolvedValue([
+        {
+          ...mockSnsMainAccount,
+          balanceUlps: 2_233_000_000n,
+        },
+      ]);
 
-      await runResolvedPromises();
+      const po = await renderComponent();
 
-      expect(
-        getByTestId("wallet-page-heading-component")
-          .querySelector('[data-tid="token-value-label"]')
-          ?.textContent.trim()
-      ).toEqual(
-        `${formatTokenE8s({
-          value: mockSnsMainAccount.balanceUlps,
-        })} ${testToken.symbol}`
-      );
+      expect(await po.getWalletPageHeadingPo().getTitle()).toBe("22.33 OOO");
     });
 
     it("should open new transaction modal", async () => {
-      const result = render(SnsWallet, props);
+      const po = await renderComponent();
 
       await runResolvedPromises();
+      expect(await po.getSnsTransactionModalPo().isPresent()).toBe(false);
 
-      const { queryByTestId, getByTestId } = result;
+      await po.clickSendButton();
 
-      await waitFor(() =>
-        expect(queryByTestId("open-new-sns-transaction")).toBeInTheDocument()
-      );
-
-      await testAccountsModal({ result, testId: "open-new-sns-transaction" });
-
-      expect(getByTestId("transaction-step-1")).toBeInTheDocument();
+      await runResolvedPromises();
+      expect(await po.getSnsTransactionModalPo().isPresent()).toBe(true);
     });
 
     it("should make a new transaction", async () => {
-      const result = render(SnsWallet, props);
+      const po = await renderComponent();
 
-      await runResolvedPromises();
-
-      const { queryByTestId, getByTestId } = result;
-
-      await waitFor(() =>
-        expect(queryByTestId("open-new-sns-transaction")).toBeInTheDocument()
-      );
-
-      await testAccountsModal({ result, testId: "open-new-sns-transaction" });
-
-      expect(getByTestId("transaction-step-1")).toBeInTheDocument();
-
-      expect(snsLedgerApi.snsTransfer).toHaveBeenCalledTimes(0);
+      await po.clickSendButton();
 
       const destinationAccount = {
         owner: principal(1),
       };
-      await testTransferTokens({
-        result,
-        amount: "2",
-        destinationAddress: encodeIcrcAccount(destinationAccount),
-      });
 
-      await runResolvedPromises();
+      expect(snsLedgerApi.snsTransfer).toHaveBeenCalledTimes(0);
+
+      await po.getSnsTransactionModalPo().transferToAddress({
+        destinationAddress: encodeIcrcAccount(destinationAccount),
+        amount: 2,
+      });
 
       expect(snsLedgerApi.snsTransfer).toHaveBeenCalledTimes(1);
       expect(snsLedgerApi.snsTransfer).toHaveBeenCalledWith({
@@ -236,81 +208,68 @@ describe("SnsWallet", () => {
       testComponent: SnsWallet,
     };
 
-    it("should open receive modal with sns logo", async () => {
-      const result = render(AccountsTest, { props: modalProps });
-
+    const renderWalletAndModal = async (): Promise<{
+      walletPo: SnsWalletPo;
+      receiveModalPo: ReceiveModalPo;
+    }> => {
+      const { container } = render(AccountsTest, modalProps);
       await runResolvedPromises();
+      return {
+        walletPo: SnsWalletPo.under(new JestPageObjectElement(container)),
+        receiveModalPo: ReceiveModalPo.under(
+          new JestPageObjectElement(container)
+        ),
+      };
+    };
 
-      await testAccountsModal({ result, testId: "receive-sns" });
+    it("should open receive modal with sns logo", async () => {
+      const { walletPo, receiveModalPo } = await renderWalletAndModal();
 
-      const { container, getByTestId } = result;
+      runResolvedPromises();
+      expect(await receiveModalPo.isPresent()).toBe(false);
 
-      expect(getByTestId("receive-modal")).not.toBeNull();
+      await walletPo.clickReceiveButton();
 
-      await waitFor(() => {
-        expect(getByTestId("qr-code")).not.toBeNull();
-      });
-
-      expect(
-        container
-          .querySelector("[data-tid=receive-modal] [data-tid=logo]")
-          .getAttribute("alt")
-      ).toEqual(testTokenSymbol);
+      runResolvedPromises();
+      expect(await receiveModalPo.isPresent()).toBe(true);
+      await receiveModalPo.waitForQrCode();
+      expect(await receiveModalPo.getLogoAltText()).toBe(testTokenSymbol);
     });
 
     it("should reload account after finish receiving tokens", async () => {
-      const result = render(AccountsTest, { props: modalProps });
+      const { walletPo, receiveModalPo } = await renderWalletAndModal();
 
-      await runResolvedPromises();
-
-      await testAccountsModal({ result, testId: "receive-sns" });
-
-      const { getByTestId, container } = result;
-
-      await waitModalIntroEnd({
-        container,
-        selector: "[data-tid='reload-receive-account']",
-      });
+      await walletPo.clickReceiveButton();
 
       // Query + update
       expect(snsLedgerApi.getSnsAccounts).toHaveBeenCalledTimes(2);
       // Transactions can only be fetched from the Index canister with `updated` calls for now.
       expect(snsIndexApi.getSnsTransactions).toHaveBeenCalledTimes(1);
 
-      fireEvent.click(
-        getByTestId("reload-receive-account") as HTMLButtonElement
-      );
+      await receiveModalPo.clickFinish();
 
       await runResolvedPromises();
-
       expect(snsLedgerApi.getSnsAccounts).toHaveBeenCalledTimes(4);
       expect(snsIndexApi.getSnsTransactions).toHaveBeenCalledTimes(2);
     });
 
     it("should display receive modal information", async () => {
-      const result = render(AccountsTest, { props: modalProps });
+      const { walletPo, receiveModalPo } = await renderWalletAndModal();
 
-      await runResolvedPromises();
+      await walletPo.clickReceiveButton();
 
-      await testAccountsModal({ result, testId: "receive-sns" });
+      runResolvedPromises();
+      expect(await receiveModalPo.isPresent()).toBe(true);
 
-      const { getByText } = result;
+      await receiveModalPo.waitForQrCode();
 
-      const store = get(selectedUniverseStore);
-
-      const title = replacePlaceholders(en.wallet.token_address, {
-        $tokenSymbol: store.summary?.token.symbol ?? "error-title-is-undefined",
-      });
-
-      expect(getByText(title)).toBeInTheDocument();
+      expect(await receiveModalPo.getTokenAddressLabel()).toBe("OOO Address");
     });
 
     it("should init worker that sync the balance", async () => {
       const spy = vi.spyOn(workerBalances, "initBalancesWorker");
 
-      render(SnsWallet, props);
-
-      await runResolvedPromises();
+      await renderComponent();
 
       expect(spy).toHaveBeenCalledTimes(1);
     });
@@ -318,11 +277,9 @@ describe("SnsWallet", () => {
     it("should init worker that sync the transactions", async () => {
       const spy = vi.spyOn(workerTransactions, "initTransactionsWorker");
 
-      const { queryByTestId } = render(SnsWallet, props);
+      const po = await renderComponent();
 
-      await runResolvedPromises();
-
-      expect(queryByTestId("transactions-list")).toBeInTheDocument();
+      expect(await po.getIcrcTransactionsListPo().isPresent()).toBe(true);
 
       expect(spy).toHaveBeenCalledTimes(1);
     });

--- a/frontend/src/tests/page-objects/ReceiveModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ReceiveModal.page-object.ts
@@ -11,4 +11,16 @@ export class ReceiveModalPo extends BasePageObject {
   clickFinish(): Promise<void> {
     return this.click("reload-receive-account");
   }
+
+  waitForQrCode(): Promise<void> {
+    return this.waitFor("qr-code");
+  }
+
+  async getLogoAltText(): Promise<string> {
+    return this.root.byTestId("logo").getAttribute("alt");
+  }
+
+  async getTokenAddressLabel(): Promise<string> {
+    return this.getText("token-address-label");
+  }
 }

--- a/frontend/src/tests/page-objects/SnsWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsWallet.page-object.ts
@@ -1,0 +1,42 @@
+import { IcrcTransactionsListPo } from "$tests/page-objects/IcrcTransactionsList.page-object";
+import { SnsTransactionModalPo } from "$tests/page-objects/SnsTransactionModal.page-object";
+import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-object";
+import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SnsWalletPo extends BasePageObject {
+  private static readonly TID = "sns-wallet-component";
+
+  static under(element: PageObjectElement): SnsWalletPo {
+    return new SnsWalletPo(element.byTestId(SnsWalletPo.TID));
+  }
+
+  getWalletPageHeaderPo(): WalletPageHeaderPo {
+    return WalletPageHeaderPo.under(this.root);
+  }
+
+  getWalletPageHeadingPo(): WalletPageHeadingPo {
+    return WalletPageHeadingPo.under(this.root);
+  }
+
+  getIcrcTransactionsListPo(): IcrcTransactionsListPo {
+    return IcrcTransactionsListPo.under(this.root);
+  }
+
+  getSnsTransactionModalPo(): SnsTransactionModalPo {
+    return SnsTransactionModalPo.under(this.root);
+  }
+
+  hasSpinner(): Promise<boolean> {
+    return this.isPresent("spinner");
+  }
+
+  clickSendButton(): Promise<void> {
+    return this.click("open-new-sns-transaction");
+  }
+
+  clickReceiveButton(): Promise<void> {
+    return this.click("receive-sns");
+  }
+}


### PR DESCRIPTION
# Motivation

Make the test easier to maintain and less fragile.

# Changes

1. Add test IDs to existing components.
2. Add necessary page object functionality.
3. Use page objects in `frontend/src/tests/lib/pages/SnsWallet.spec.ts`.

# Tests

only

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary