### PR TITLE
chore:  Add stable storage to AccountsDb enum

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -28,7 +28,11 @@ use std::time::{Duration, SystemTime};
 
 pub mod histogram;
 pub mod schema;
-use schema::{proxy::AccountsDbAsProxy, AccountsDbTrait};
+use schema::{
+    map::AccountsDbAsMap,
+    proxy::{AccountsDb, AccountsDbAsProxy},
+    AccountsDbBTreeMapTrait, AccountsDbTrait,
+};
 
 type TransactionIndex = u64;
 
@@ -1630,8 +1634,10 @@ impl StableState for AccountsStore {
             hardware_wallet_accounts_count += account.hardware_wallet_accounts.len() as u64;
         }
 
+        let accounts_db = AccountsDb::Map(AccountsDbAsMap::from_map(accounts));
+
         Ok(AccountsStore {
-            accounts_db: AccountsDbAsProxy::from_map(accounts),
+            accounts_db: AccountsDbAsProxy::from(accounts_db),
             hardware_wallets_and_sub_accounts,
             pending_transactions,
             transactions,

--- a/rs/backend/src/accounts_store/schema/accounts_in_unbounded_stable_btree_map.rs
+++ b/rs/backend/src/accounts_store/schema/accounts_in_unbounded_stable_btree_map.rs
@@ -8,12 +8,12 @@
 use super::{Account, AccountsDbTrait, SchemaLabel};
 use core::ops::RangeBounds;
 #[cfg(test)]
+use ic_stable_structures::memory_manager::VirtualMemory;
+#[cfg(test)]
 use ic_stable_structures::DefaultMemoryImpl;
 use ic_stable_structures::{btreemap::BTreeMap as StableBTreeMap, Memory};
 #[cfg(test)]
 use std::collections::BTreeMap as StdBTreeMap;
-#[cfg(test)]
-use ic_stable_structures::memory_manager::VirtualMemory;
 use std::fmt;
 
 #[cfg(test)]

--- a/rs/backend/src/accounts_store/schema/accounts_in_unbounded_stable_btree_map.rs
+++ b/rs/backend/src/accounts_store/schema/accounts_in_unbounded_stable_btree_map.rs
@@ -12,10 +12,12 @@ use ic_stable_structures::DefaultMemoryImpl;
 use ic_stable_structures::{btreemap::BTreeMap as StableBTreeMap, Memory};
 #[cfg(test)]
 use std::collections::BTreeMap as StdBTreeMap;
+#[cfg(test)]
+use ic_stable_structures::memory_manager::VirtualMemory;
 use std::fmt;
 
-// TODO: Uncomment when used.
-// type ProductionMemoryType = VirtualMemory<DefaultMemoryImpl>;
+#[cfg(test)]
+pub type ProductionMemoryType = VirtualMemory<DefaultMemoryImpl>;
 
 pub struct AccountsDbAsUnboundedStableBTreeMap<M>
 where

--- a/rs/backend/src/accounts_store/schema/proxy/enum_boilerplate.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/enum_boilerplate.rs
@@ -17,7 +17,7 @@ impl AccountsDbTrait for AccountsDb {
     fn db_insert_account(&mut self, account_key: &[u8], account: Account) {
         match self {
             AccountsDb::Map(map_db) => map_db.db_insert_account(account_key, account),
-#[cfg(test)]
+            #[cfg(test)]
             AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => {
                 unbounded_stable_btree_map_db.db_insert_account(account_key, account)
             }
@@ -26,7 +26,7 @@ impl AccountsDbTrait for AccountsDb {
     fn db_contains_account(&self, account_key: &[u8]) -> bool {
         match self {
             AccountsDb::Map(map_db) => map_db.db_contains_account(account_key),
-#[cfg(test)]
+            #[cfg(test)]
             AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => {
                 unbounded_stable_btree_map_db.db_contains_account(account_key)
             }
@@ -35,7 +35,7 @@ impl AccountsDbTrait for AccountsDb {
     fn db_get_account(&self, account_key: &[u8]) -> Option<Account> {
         match self {
             AccountsDb::Map(map_db) => map_db.db_get_account(account_key),
-#[cfg(test)]
+            #[cfg(test)]
             AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => {
                 unbounded_stable_btree_map_db.db_get_account(account_key)
             }
@@ -44,7 +44,7 @@ impl AccountsDbTrait for AccountsDb {
     fn db_remove_account(&mut self, account_key: &[u8]) {
         match self {
             AccountsDb::Map(map_db) => map_db.db_remove_account(account_key),
-#[cfg(test)]
+            #[cfg(test)]
             AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => {
                 unbounded_stable_btree_map_db.db_remove_account(account_key)
             }
@@ -53,7 +53,7 @@ impl AccountsDbTrait for AccountsDb {
     fn db_accounts_len(&self) -> u64 {
         match self {
             AccountsDb::Map(map_db) => map_db.db_accounts_len(),
-#[cfg(test)]
+            #[cfg(test)]
             AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => {
                 unbounded_stable_btree_map_db.db_accounts_len()
             }
@@ -62,14 +62,14 @@ impl AccountsDbTrait for AccountsDb {
     fn iter(&self) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_> {
         match self {
             AccountsDb::Map(map_db) => map_db.iter(),
-#[cfg(test)]
+            #[cfg(test)]
             AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => unbounded_stable_btree_map_db.iter(),
         }
     }
     fn range(&self, key_range: impl RangeBounds<Vec<u8>>) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_> {
         match self {
             AccountsDb::Map(map_db) => map_db.range(key_range),
-#[cfg(test)]
+            #[cfg(test)]
             AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => {
                 unbounded_stable_btree_map_db.range(key_range)
             }

--- a/rs/backend/src/accounts_store/schema/proxy/enum_boilerplate.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/enum_boilerplate.rs
@@ -3,57 +3,76 @@
 //! Each function is implemented by calling the same function on the applicable variant.  There is probably a macro for this.
 use super::*;
 
-impl AccountsDbBTreeMapTrait for AccountsDb {
-    fn as_map(&self) -> &BTreeMap<Vec<u8>, Account> {
-        match self {
-            AccountsDb::Map(map_db) => map_db.as_map(),
-        }
-    }
-    fn from_map(map: BTreeMap<Vec<u8>, Account>) -> Self {
-        AccountsDb::Map(AccountsDbAsMap::from_map(map))
-    }
-}
-
 // TODO: This is boilerplate.  can it be eliminated with a macro?
 impl AccountsDbTrait for AccountsDb {
     fn schema_label(&self) -> SchemaLabel {
         match &self {
             AccountsDb::Map(map_db) => map_db.schema_label(),
+            #[cfg(test)]
+            AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => {
+                unbounded_stable_btree_map_db.schema_label()
+            }
         }
     }
     fn db_insert_account(&mut self, account_key: &[u8], account: Account) {
         match self {
             AccountsDb::Map(map_db) => map_db.db_insert_account(account_key, account),
+#[cfg(test)]
+            AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => {
+                unbounded_stable_btree_map_db.db_insert_account(account_key, account)
+            }
         }
     }
     fn db_contains_account(&self, account_key: &[u8]) -> bool {
         match self {
             AccountsDb::Map(map_db) => map_db.db_contains_account(account_key),
+#[cfg(test)]
+            AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => {
+                unbounded_stable_btree_map_db.db_contains_account(account_key)
+            }
         }
     }
     fn db_get_account(&self, account_key: &[u8]) -> Option<Account> {
         match self {
             AccountsDb::Map(map_db) => map_db.db_get_account(account_key),
+#[cfg(test)]
+            AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => {
+                unbounded_stable_btree_map_db.db_get_account(account_key)
+            }
         }
     }
     fn db_remove_account(&mut self, account_key: &[u8]) {
         match self {
             AccountsDb::Map(map_db) => map_db.db_remove_account(account_key),
+#[cfg(test)]
+            AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => {
+                unbounded_stable_btree_map_db.db_remove_account(account_key)
+            }
         }
     }
     fn db_accounts_len(&self) -> u64 {
         match self {
             AccountsDb::Map(map_db) => map_db.db_accounts_len(),
+#[cfg(test)]
+            AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => {
+                unbounded_stable_btree_map_db.db_accounts_len()
+            }
         }
     }
     fn iter(&self) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_> {
         match self {
             AccountsDb::Map(map_db) => map_db.iter(),
+#[cfg(test)]
+            AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => unbounded_stable_btree_map_db.iter(),
         }
     }
     fn range(&self, key_range: impl RangeBounds<Vec<u8>>) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_> {
         match self {
             AccountsDb::Map(map_db) => map_db.range(key_range),
+#[cfg(test)]
+            AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => {
+                unbounded_stable_btree_map_db.range(key_range)
+            }
         }
     }
 }

--- a/rs/backend/src/accounts_store/schema/proxy/tests.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/tests.rs
@@ -1,3 +1,4 @@
+use ic_stable_structures::{memory_manager, Memory};
 use proptest::proptest;
 use rand::seq::IteratorRandom;
 use rand::{Rng, SeedableRng};
@@ -6,6 +7,7 @@ use strum_macros::EnumIter;
 
 use crate::accounts_store::schema::tests::toy_account;
 use crate::accounts_store::{CanisterId, NamedCanister};
+use crate::state::partitions::Partitions;
 
 use super::super::tests::test_accounts_db;
 use super::*;
@@ -16,7 +18,9 @@ fn migration_steps_should_work(accounts_db: &mut AccountsDbAsProxy, new_accounts
     // During the migration, the accounts db should behave as if no migration were in progress,
     // regardless of what CRUD operations are performed.  We check this by running another database
     // with the same contents but no migration.
-    let reference_db = AccountsDbAsProxy::from_map(accounts_db.range(..).collect());
+    let reference_db = AccountsDbAsProxy::from(AccountsDb::Map(AccountsDbAsMap::from_map(
+        accounts_db.range(..).collect(),
+    )));
     assert_eq!(*accounts_db, reference_db);
     // Start the migration.
     accounts_db.start_migrating_accounts_to(new_accounts_db);
@@ -157,6 +161,8 @@ fn assert_migration_works_with_other_operations<R>(
         0,
         "Test setup failure: The new database should be empty."
     );
+    // Check which schema we are moving to.
+    let expected_final_schema_label = new_accounts_db.schema_label();
     // Start migration.
     accounts_db.start_migrating_accounts_to(new_accounts_db);
     // Perform operations.
@@ -168,6 +174,10 @@ fn assert_migration_works_with_other_operations<R>(
     }
     // Migration should now be complete.
     assert!(accounts_db.migration.is_none());
+    assert!(
+        accounts_db.schema_label() == expected_final_schema_label,
+        "The final schema should be {expected_final_schema_label:#?}"
+    );
 }
 
 fn assert_map_to_map_migration_works_with_other_operations<R>(rng: &mut R)
@@ -188,10 +198,62 @@ where
     assert_migration_works_with_other_operations(&mut accounts_db, &mut reference_db, new_accounts_db, rng);
 }
 
+fn assert_map_to_stable_migration_works_with_other_operations<R>(rng: &mut R)
+where
+    R: Rng,
+{
+    let mut accounts_db = AccountsDbAsProxy::default();
+    let mut reference_db = AccountsDbAsProxy::default();
+    let raw_memory = DefaultMemoryImpl::default();
+    raw_memory.grow(5);
+    let memory_manager = memory_manager::MemoryManager::init(raw_memory);
+    let new_accounts_db = AccountsDb::UnboundedStableBTreeMap(AccountsDbAsUnboundedStableBTreeMap::new(
+        memory_manager.get(Partitions::ACCOUNTS_MEMORY_ID),
+    ));
+    // Insert some accounts
+    let number_of_accounts_to_migrate: u32 = rng.gen_range(0..40);
+    for _ in 0..number_of_accounts_to_migrate {
+        Operation::Insert.perform(&mut accounts_db, &mut reference_db, rng);
+    }
+    // Test migration
+    assert_migration_works_with_other_operations(&mut accounts_db, &mut reference_db, new_accounts_db, rng);
+}
+
+fn assert_stable_to_map_migration_works_with_other_operations<R>(rng: &mut R)
+where
+    R: Rng,
+{
+    let raw_memory = DefaultMemoryImpl::default();
+    raw_memory.grow(5);
+    let memory_manager = memory_manager::MemoryManager::init(raw_memory);
+    let accounts_db = AccountsDbAsUnboundedStableBTreeMap::new(memory_manager.get(Partitions::ACCOUNTS_MEMORY_ID));
+    let mut accounts_db = AccountsDbAsProxy::from(AccountsDb::UnboundedStableBTreeMap(accounts_db));
+    let mut reference_db = AccountsDbAsProxy::default();
+    let new_accounts_db = AccountsDb::Map(AccountsDbAsMap::default());
+    // Insert some accounts
+    let number_of_accounts_to_migrate: u32 = rng.gen_range(0..40);
+    for _ in 0..number_of_accounts_to_migrate {
+        Operation::Insert.perform(&mut accounts_db, &mut reference_db, rng);
+    }
+    // Test migration
+    assert_migration_works_with_other_operations(&mut accounts_db, &mut reference_db, new_accounts_db, rng);
+}
+
 proptest! {
     #[test]
     fn map_to_map_migration_should_work_with_other_operations(seed: u64) {
         let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
         assert_map_to_map_migration_works_with_other_operations(&mut rng);
     }
+    #[test]
+    fn map_to_stable_migration_should_work_with_other_operations(seed: u64) {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        assert_map_to_stable_migration_works_with_other_operations(&mut rng);
+    }
+    #[test]
+    fn stable_to_map_migration_should_work_with_other_operations(seed: u64) {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        assert_stable_to_map_migration_works_with_other_operations(&mut rng);
+    }
+
 }

--- a/rs/backend/src/accounts_store/schema/proxy/tests.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/tests.rs
@@ -205,7 +205,6 @@ where
     let mut accounts_db = AccountsDbAsProxy::default();
     let mut reference_db = AccountsDbAsProxy::default();
     let raw_memory = DefaultMemoryImpl::default();
-    raw_memory.grow(5);
     let memory_manager = memory_manager::MemoryManager::init(raw_memory);
     let new_accounts_db = AccountsDb::UnboundedStableBTreeMap(AccountsDbAsUnboundedStableBTreeMap::new(
         memory_manager.get(Partitions::ACCOUNTS_MEMORY_ID),
@@ -224,7 +223,6 @@ where
     R: Rng,
 {
     let raw_memory = DefaultMemoryImpl::default();
-    raw_memory.grow(5);
     let memory_manager = memory_manager::MemoryManager::init(raw_memory);
     let accounts_db = AccountsDbAsUnboundedStableBTreeMap::new(memory_manager.get(Partitions::ACCOUNTS_MEMORY_ID));
     let mut accounts_db = AccountsDbAsProxy::from(AccountsDb::UnboundedStableBTreeMap(accounts_db));


### PR DESCRIPTION
# Motivation
Stable storage has been defined but needs to be added to the enum of possible databases before the proxy can use it.

# Changes
- Add stable storage to the `AccountsDb` enum.
- Apply the `ProxyDb` migration test to migrations between stable and maps.
- Simplify the constructors - we have a choice between adding constructors and deleting constructors but having slightly more verbose code.  On balance I would rather have fewer methods that are exercised more often.

# Tests
- Unit tests for migrations are included.  The `ProxyDb` exists purely to support migrations.

# Todos

- [x] Add entry to changelog (if necessary).
  - Covered by an existing changelog entry.
