### PR TITLE
Consistently use selector in JestPageObjectElement

### DIFF
--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -258,9 +258,6 @@ describe("SnsWallet", () => {
 
       await walletPo.clickReceiveButton();
 
-      runResolvedPromises();
-      expect(await receiveModalPo.isPresent()).toBe(true);
-
       await receiveModalPo.waitForQrCode();
 
       expect(await receiveModalPo.getTokenAddressLabel()).toBe("OOO Address");

--- a/frontend/src/tests/page-objects/jest.page-object.ts
+++ b/frontend/src/tests/page-objects/jest.page-object.ts
@@ -9,7 +9,7 @@ import userEvent from "@testing-library/user-event";
 export class JestPageObjectElement implements PageObjectElement {
   // The element represented by JestPageObjectElement is found by applying the
   // selector to the base element.
-  private baseElement: Element;
+  private readonly baseElement: Element;
   private readonly selector: string | undefined;
 
   constructor(element: Element, params?: { selector: string }) {


### PR DESCRIPTION
# Motivation

`JestPageObjectElement` is used to reference an element in the DOM in unit tests that use page objects.
The object can reference elements before they actually exist by referencing a parent element and a selector pointing from the parent element to the desired element.
We can then call `isPresent` to check if the element is already there and if so, `this.element` is populated.
However this can lead to confusing situations because if you don't call `isPresent` the element might actually be there but `this.element` is not populated until we check if the element is there.

To avoid this kind of situation we should just always look for the element based on the ancestor and selector rather than mixing sometimes already having the element and sometimes looking for it from the selector.

# Changes

1. Remove the `this.element` field.
2. Instead have a `this.baseElement` field which has to be combined with the selector to find the actual element references by the `PageObjectElement`.
3. Remove the `this.parent` field because `this.baseElement` is always the furthest parent.
4. Add `getElement()` to find the relevant element by applying the selector.
5. Use `this.getElement()` instead of `this.element`.
6. Remove `getRootAndFullSelector` since we now always work with a root (baseElement) and full selector.

# Tests

Removed one call to `isPresent()` that was only there for the reason explained in the Motivation above.

All tests still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary