### PR TITLE
Add bitcoin entry to dfx.json

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -44,6 +44,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+Entry for bitcoin canister in `dfx.json`.
+
 #### Changed
 
 - Apply clippy only to target `wasm32-unknown-unknown` but prohibit `std::println` and variants for that target.

--- a/dfx.json
+++ b/dfx.json
@@ -144,6 +144,13 @@
         }
       }
     },
+    "bitcoin": {
+      "remote" : {
+        "id": {
+          "mainnet": "ghsi2-tqaaa-aaaan-aaaca-cai"
+        }
+      }
+    },
     "ckbtc_ledger": {
       "build": [
         "true"

--- a/dfx.json
+++ b/dfx.json
@@ -145,7 +145,7 @@
       }
     },
     "bitcoin": {
-      "remote" : {
+      "remote": {
         "id": {
           "mainnet": "ghsi2-tqaaa-aaaan-aaaca-cai"
         }


### PR DESCRIPTION
# Motivation

Currently I have to manually add this entry every time I want to make calls to the bitcoin canister or to the mock bitcoin canister installed by snsdemo.

# Changes

Add an entry to `dfx.json` for the bitcoin canister.

# Tests

Tested manually:
```
$ dfx canister info bitcoin
Controllers: xoner-xjuk3-73eim-3t4hg-wbe5m-s76az-sii6q-7f34l-qclzc-tce2s-eae
Module hash: 0xf0f29e3c5638b368b7c37516c3e0da7975730ce4964e75ea1f159de4b6f7cfbc

$ dfx canister info bitcoin  --network mainnet
Controllers: r7inp-6aaaa-aaaaa-aaabq-cai
Module hash: 0x09f5647a45ff6d5d05b2b0ed48613fb2365b5fe6573ba0e901509c39fb9564ac
```

# Todos

- [x] Add entry to changelog (if necessary).