### PR TITLE
Ns function helpers

### DIFF
--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -178,12 +178,9 @@ export const swapEndedMoreThanOneWeekAgo = ({
  */
 export const isNativeNervousSystemFunction = (
   nsFunction: SnsNervousSystemFunction
-): boolean => {
-  return (
-    Object.keys(fromNullable(nsFunction.function_type) ?? {})?.[0] ===
-    "NativeNervousSystemFunction"
-  );
-};
+): boolean =>
+  "NativeNervousSystemFunction" in
+  (fromNullable(nsFunction.function_type) ?? {});
 
 /**
  * Returns true if the FunctionType is GenericNervousSystemFunction (custom per sns).
@@ -191,5 +188,5 @@ export const isNativeNervousSystemFunction = (
 export const isGenericNervousSystemFunction = (
   nsFunction: SnsNervousSystemFunction
 ): boolean =>
-  Object.keys(fromNullable(nsFunction.function_type) ?? {})?.[0] ===
-  "GenericNervousSystemFunction";
+  "GenericNervousSystemFunction" in
+  (fromNullable(nsFunction.function_type) ?? {});

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -7,6 +7,7 @@ import type { Principal } from "@dfinity/principal";
 import type {
   SnsGetAutoFinalizationStatusResponse,
   SnsGetDerivedStateResponse,
+  SnsNervousSystemFunction,
 } from "@dfinity/sns";
 import type { DerivedState } from "@dfinity/sns/dist/candid/sns_swap";
 import { fromNullable, isNullish, nonNullish } from "@dfinity/utils";
@@ -171,3 +172,24 @@ export const swapEndedMoreThanOneWeekAgo = ({
   const oneWeekAgoInSeconds = BigInt(nowInSeconds - SECONDS_IN_DAY * 7);
   return oneWeekAgoInSeconds > summary.swap.params.swap_due_timestamp_seconds;
 };
+
+/**
+ * Returns true if the FunctionType is NativeNervousSystemFunction (same for all same-version snses).
+ */
+export const isNativeNervousSystemFunction = (
+  nsFunction: SnsNervousSystemFunction
+): boolean => {
+  return (
+    Object.keys(fromNullable(nsFunction.function_type) ?? {})?.[0] ===
+    "NativeNervousSystemFunction"
+  );
+};
+
+/**
+ * Returns true if the FunctionType is GenericNervousSystemFunction (custom per sns).
+ */
+export const isGenericNervousSystemFunction = (
+  nsFunction: SnsNervousSystemFunction
+): boolean =>
+  Object.keys(fromNullable(nsFunction.function_type) ?? {})?.[0] ===
+  "GenericNervousSystemFunction";

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -6,13 +6,19 @@ import {
   getCommitmentE8s,
   getSwapCanisterAccount,
   hasOpenTicketInProcess,
+  isGenericNervousSystemFunction,
   isInternalRefreshBuyerTokensError,
+  isNativeNervousSystemFunction,
   isSnsFinalizing,
   parseSnsSwapSaleBuyerCount,
   swapEndedMoreThanOneWeekAgo,
 } from "$lib/utils/sns.utils";
 import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { createFinalizationStatusMock } from "$tests/mocks/sns-finalization-status.mock";
+import {
+  genericNervousSystemFunctionMock,
+  nativeNervousSystemFunctionMock,
+} from "$tests/mocks/sns-functions.mock";
 import {
   createBuyersState,
   createSummary,
@@ -332,6 +338,32 @@ sale_participants_count ${saleBuyerCount} 1677707139456
       expect(
         swapEndedMoreThanOneWeekAgo({ summary: summary1, nowInSeconds })
       ).toBe(true);
+    });
+  });
+
+  describe("isNativeNervousSystemFunction", () => {
+    it("should return true for NativeNervousSystemFunction", () => {
+      expect(
+        isNativeNervousSystemFunction(nativeNervousSystemFunctionMock)
+      ).toBe(true);
+    });
+    it("should return false for not NativeNervousSystemFunction", () => {
+      expect(
+        isNativeNervousSystemFunction(genericNervousSystemFunctionMock)
+      ).toBe(false);
+    });
+  });
+
+  describe("isGenericNervousSystemFunction", () => {
+    it("should return true for GenericNervousSystemFunction", () => {
+      expect(
+        isGenericNervousSystemFunction(genericNervousSystemFunctionMock)
+      ).toBe(true);
+    });
+    it("should return false for not GenericNervousSystemFunction", () => {
+      expect(
+        isGenericNervousSystemFunction(nativeNervousSystemFunctionMock)
+      ).toBe(false);
     });
   });
 });

--- a/frontend/src/tests/mocks/sns-functions.mock.ts
+++ b/frontend/src/tests/mocks/sns-functions.mock.ts
@@ -6,3 +6,43 @@ export const nervousSystemFunctionMock: SnsNervousSystemFunction = {
   description: ["This is a description"],
   function_type: [{ NativeNervousSystemFunction: {} }],
 };
+
+export const allTopicsNervousSystemFunctionMock: SnsNervousSystemFunction = {
+  id: 0n,
+  name: "All Topics",
+  description: ["Catch-all w.r.t to following for all types of proposals."],
+  function_type: [
+    {
+      NativeNervousSystemFunction: {},
+    },
+  ],
+};
+
+export const nativeNervousSystemFunctionMock: SnsNervousSystemFunction = {
+  id: 1n,
+  name: "Motion",
+  description: [
+    "Side-effect-less proposals to set general governance direction.",
+  ],
+  function_type: [
+    {
+      NativeNervousSystemFunction: {},
+    },
+  ],
+};
+
+export const genericNervousSystemFunctionMock: SnsNervousSystemFunction = {
+  id: 1001n,
+  name: "Generic Motion",
+  description: ["Proposal to upgrade the WASM of a core SNS canister."],
+  function_type: [
+    {
+      GenericNervousSystemFunction: {
+        validator_canister_id: [],
+        target_canister_id: [],
+        validator_method_name: [],
+        target_method_name: [],
+      },
+    },
+  ],
+};


### PR DESCRIPTION
# Motivation

Helpers to get the nsFunction type.
Part of https://github.com/dfinity/nns-dapp/pull/3801

# Changes

- extend nsFunction mock
- `isNativeNervousSystemFunction`
- `isGenericNervousSystemFunction`

# Tests

- tests for new utils

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary
