### PR TITLE
Load BTC retrieval statuses in ckBTC wallet

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -20,6 +20,7 @@ proposal is successful, the changes it released will be moved from this file to
 - Save accounts in the `pre_upgrade` hook only when accounts are stored in the heap.
 - Save account stats in the `pre_upgrade` hook rather than recomputing them in the `post_upgrade` hook.
 - Migration functions.
+- Render pending and failed BTC withdrawal transaction as such.
 
 #### Changed
 

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -13,6 +13,7 @@
   import { CKBTC_ADDITIONAL_CANISTERS } from "$lib/constants/ckbtc-additional-canister-ids.constants";
   import CkBTCInfoCard from "$lib/components/accounts/CkBTCInfoCard.svelte";
   import type { TokensStoreUniverseData } from "$lib/stores/tokens.store";
+  import { loadRetrieveBtcStatuses } from "$lib/services/ckbtc-minter.services";
   import { loadCkBTCInfo } from "$lib/services/ckbtc-info.services";
   import IcrcWalletPage from "$lib/components/accounts/IcrcWalletPage.svelte";
   import { writable } from "svelte/store";
@@ -47,7 +48,15 @@
   // transactions?.reloadTransactions?.() returns a promise.
   // However, the UI displays skeletons while loading and the user can proceed with other operations during this time.
   // That is why we do not need to wait for the promise to resolve here.
-  const reloadTransactions = () => transactions?.reloadTransactions?.();
+  const reloadTransactions = () => {
+    $selectedCkBTCUniverseIdStore &&
+      canisters &&
+      loadRetrieveBtcStatuses({
+        universeId: $selectedCkBTCUniverseIdStore,
+        minterCanisterId: canisters?.minterCanisterId,
+      });
+    return transactions?.reloadTransactions?.();
+  };
 
   let canisters: CkBTCAdditionalCanisters | undefined = undefined;
   $: canisters = nonNullish($selectedCkBTCUniverseIdStore)
@@ -73,6 +82,13 @@
       universeId: $selectedCkBTCUniverseIdStore,
       minterCanisterId: canisters?.minterCanisterId,
     }))();
+
+  $: $selectedCkBTCUniverseIdStore &&
+    canisters &&
+    loadRetrieveBtcStatuses({
+      universeId: $selectedCkBTCUniverseIdStore,
+      minterCanisterId: canisters?.minterCanisterId,
+    });
 </script>
 
 <IcrcWalletPage

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -53,7 +53,7 @@
       canisters &&
       loadRetrieveBtcStatuses({
         universeId: $selectedCkBTCUniverseIdStore,
-        minterCanisterId: canisters?.minterCanisterId,
+        minterCanisterId: canisters.minterCanisterId,
       });
     return transactions?.reloadTransactions?.();
   };
@@ -87,7 +87,7 @@
     canisters &&
     loadRetrieveBtcStatuses({
       universeId: $selectedCkBTCUniverseIdStore,
-      minterCanisterId: canisters?.minterCanisterId,
+      minterCanisterId: canisters.minterCanisterId,
     });
 </script>
 

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -1,3 +1,4 @@
+import * as ckbtcMinterApi from "$lib/api/ckbtc-minter.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
@@ -31,6 +32,7 @@ import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
 vi.mock("$lib/api/icrc-ledger.api");
+vi.mock("$lib/api/ckbtc-minter.api");
 
 vi.mock("$lib/services/sns-accounts.services", () => {
   return {
@@ -96,6 +98,9 @@ describe("Wallet", () => {
     icpAccountsStore.setForTesting(mockAccountsStoreData);
     overrideFeatureFlagsStore.reset();
     vi.spyOn(icrcLedgerApi, "icrcTransfer").mockResolvedValue(1234n);
+    vi.mocked(ckbtcMinterApi.retrieveBtcStatusV2ByAccount).mockResolvedValue(
+      []
+    );
   });
 
   beforeAll(() => {


### PR DESCRIPTION
# Motivation

We want to render failed and pending "Sending BTC" transactions as such.
These statuses are not part of the transactions themselves but come from the ckBTC minter.
In this PR we call the service method that loads the statuses and puts them in the store.
This is the final PR that ties it all together.

# Changes

1. Call `loadRetrieveBtcStatuses` when opening the `CkBTCWallet` component.
2. Also call `loadRetrieveBtcStatuses` after making a transaction.

# Tests

2 unit tests added.

# Todos

- [x] Add entry to changelog (if necessary).
