### PR TITLE
GIX-2187: Redirect from SNS wallet to accounts for wrong account identifier

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -36,6 +36,7 @@ proposal is successful, the changes it released will be moved from this file to
 - Avoid unnecessary calls to SNS root canister ids to get the canister ids.
 - Min dissolve delay button updates not only for the first time.
 - Fix scrollbar in multiline toast message. 
+- Go back to accounts page for incorrect account identifier in SNS wallet page.
 
 #### Security
 

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { buildAccountsUrl } from "$lib/utils/navigation.utils";
+  import { goto } from "$app/navigation";
+  import { hasAccounts } from "$lib/utils/accounts.utils";
   import type { Principal } from "@dfinity/principal";
   import { Spinner, busy } from "@dfinity/gix-components";
   import { setContext } from "svelte";
@@ -62,6 +65,13 @@
     store: selectedAccountStore,
   });
 
+  const goBack = (): Promise<void> =>
+    goto(
+      buildAccountsUrl({
+        universe: $selectedUniverseStore.canisterId,
+      })
+    );
+
   export let accountIdentifier: string | undefined | null = undefined;
 
   const load = () => {
@@ -74,6 +84,19 @@
         account: selectedAccount,
         neurons: [],
       });
+    }
+    // Accounts are loaded in store but no account identifier is matching
+    if (
+      hasAccounts($snsProjectAccountsStore ?? []) &&
+      isNullish($selectedAccountStore.account)
+    ) {
+      toastsError({
+        labelKey: replacePlaceholders($i18n.error.account_not_found, {
+          $account_identifier: accountIdentifier ?? "",
+        }),
+      });
+
+      goBack();
     }
   };
 

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -20,6 +20,7 @@ import { SnsWalletPo } from "$tests/page-objects/SnsWallet.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { toastsStore } from "@dfinity/gix-components";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
@@ -84,6 +85,7 @@ describe("SnsWallet", () => {
     vi.clearAllMocks();
     snsAccountsStore.reset();
     transactionsFeesStore.reset();
+    toastsStore.reset();
     vi.spyOn(snsIndexApi, "getSnsTransactions").mockResolvedValue({
       oldestTxId: BigInt(1234),
       transactions: [mockIcrcTransactionWithId],
@@ -299,6 +301,12 @@ describe("SnsWallet", () => {
         path: AppPath.Accounts,
         universe: rootCanisterIdText,
       });
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: 'Sorry, the account "" was not found',
+        },
+      ]);
     });
 
     it("should nagigate to accounts when account identifier is invalid", async () => {
@@ -313,6 +321,12 @@ describe("SnsWallet", () => {
         path: AppPath.Accounts,
         universe: rootCanisterIdText,
       });
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: 'Sorry, the account "invalid-account-identifier" was not found',
+        },
+      ]);
     });
 
     it("should stay on the wallet page when account identifier is valid", async () => {
@@ -327,6 +341,7 @@ describe("SnsWallet", () => {
         path: AppPath.Wallet,
         universe: rootCanisterIdText,
       });
+      expect(get(toastsStore)).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
# Motivation

When you go to a wallet page without an account identifier in the URL, this is invalid and you are redirected to the accounts page.
But not for SNS wallets. There you just get an infinite loading spinner.
For consistency, SNS wallets should also redirect to the accounts page.

# Changes

In `SnsWallet.svelte`, when the account identifier does not match any of the accounts, go back to the accounts page of the same universe.
This is similar to what [IcrcWalletPage.svelte](https://github.com/dfinity/nns-dapp/blob/fd4ce83c1fc11801b43041359bdebfb58b5d3b6d/frontend/src/lib/components/accounts/IcrcWalletPage.svelte#L74) does (although there it doesn't keep the universe which is a bug that should be fixed in another PR).

# Tests

Added unit tests for missing, invalid and valid account identifier.
Tested manually.

# Todos

- [x] Add entry to changelog (if necessary).
