### PR TITLE
Use concise bigint notation

### DIFF
--- a/frontend/src/lib/api/proposals.api.ts
+++ b/frontend/src/lib/api/proposals.api.ts
@@ -87,7 +87,7 @@ export const queryProposal = async ({
   const response = await governance.listProposals({
     request: {
       limit: 1,
-      beforeProposal: proposalId + BigInt(1),
+      beforeProposal: proposalId + 1n,
       includeRewardStatus: [],
       excludeTopic: [],
       includeStatus: [],

--- a/frontend/src/lib/api/sns-dummy.api.ts
+++ b/frontend/src/lib/api/sns-dummy.api.ts
@@ -46,7 +46,7 @@ const nsFunctionProposal1 = {
   action: [
     {
       AddGenericNervousSystemFunction: {
-        id: BigInt(1002),
+        id: 1_002n,
         name: "Dummy System Function",
         description: ["This is a dummy system function."],
         function_type: [
@@ -75,7 +75,7 @@ const nsFunctionProposal2 = {
   action: [
     {
       AddGenericNervousSystemFunction: {
-        id: BigInt(1003),
+        id: 1_003n,
         name: "Dummy System Function 2",
         description: ["This is the second dummy system function."],
         function_type: [
@@ -106,7 +106,7 @@ const executeNSFunctionProposal = {
   action: [
     {
       ExecuteGenericNervousSystemFunction: {
-        function_id: BigInt(1002),
+        function_id: 1_002n,
         payload: new Uint8Array(),
       },
     },
@@ -121,7 +121,7 @@ const executeNSFunctionProposal = {
 //     "# Summary\nThis is a dummy proposal to remove a *nervous system function*.",
 //   action: [
 //     {
-//       RemoveGenericNervousSystemFunction: BigInt(1002),
+//       RemoveGenericNervousSystemFunction: 1_002n,
 //     },
 //   ] as [SnsAction],
 // };
@@ -163,8 +163,8 @@ const transferFundsProposal = {
         from_treasury: 1,
         to_principal: [Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai")],
         to_subaccount: [],
-        memo: [BigInt(33333)],
-        amount_e8s: BigInt(100_000_000_000),
+        memo: [33_333n],
+        amount_e8s: 100_000_000_000n,
       },
     },
   ] as [SnsAction],

--- a/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
+++ b/frontend/src/lib/components/accounts/BitcoinEstimatedAmountReceived.svelte
@@ -34,20 +34,19 @@
     decimals: 8,
   };
 
-  let amountE8s = BigInt(0);
-  $: amountE8s = nonNullish(amount) ? numberToE8s(amount) : BigInt(0);
+  let amountE8s = 0n;
+  $: amountE8s = nonNullish(amount) ? numberToE8s(amount) : 0n;
 
-  let estimatedFee = BigInt(0);
-  $: estimatedFee =
-    (bitcoinEstimatedFee ?? BigInt(0)) + (kytEstimatedFee ?? BigInt(0));
+  let estimatedFee = 0n;
+  $: estimatedFee = (bitcoinEstimatedFee ?? 0n) + (kytEstimatedFee ?? 0n);
 
-  let estimatedAmount = BigInt(0);
+  let estimatedAmount = 0n;
   $: estimatedAmount =
     nonNullish(bitcoinEstimatedFee) &&
     nonNullish(kytEstimatedFee) &&
     amountE8s > estimatedFee
       ? amountE8s - estimatedFee
-      : BigInt(0);
+      : 0n;
 
   let tokenEstimatedAmount: TokenAmountV2;
   $: tokenEstimatedAmount = TokenAmountV2.fromUlps({

--- a/frontend/src/lib/components/accounts/HardwareWalletNeurons.svelte
+++ b/frontend/src/lib/components/accounts/HardwareWalletNeurons.svelte
@@ -29,7 +29,7 @@
     </p>
 
     <p>
-      {formatTokenE8s({ value: fullNeuron?.cachedNeuronStake ?? BigInt(0) })}
+      {formatTokenE8s({ value: fullNeuron?.cachedNeuronStake ?? 0n })}
     </p>
 
     <p class="hotkey">

--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -38,8 +38,7 @@
   $: commitmentE8s = getCommitmentE8s(swapCommitment);
 
   let userHasParticipated: boolean;
-  $: userHasParticipated =
-    nonNullish(commitmentE8s) && commitmentE8s > BigInt(0);
+  $: userHasParticipated = nonNullish(commitmentE8s) && commitmentE8s > 0n;
 
   let href: string;
   $: href = `${AppPath.Project}/?project=${project.rootCanisterId.toText()}`;

--- a/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
@@ -44,7 +44,7 @@
   let myCommitment: TokenAmountV2 | undefined = undefined;
   $: {
     const commitmentE8s = getCommitmentE8s(swapCommitment);
-    if (nonNullish(commitmentE8s) && commitmentE8s > BigInt(0)) {
+    if (nonNullish(commitmentE8s) && commitmentE8s > 0n) {
       myCommitment = TokenAmountV2.fromUlps({
         amount: commitmentE8s,
         token: ICPToken,

--- a/frontend/src/lib/components/neuron-detail/ConfirmSpawnHW.svelte
+++ b/frontend/src/lib/components/neuron-detail/ConfirmSpawnHW.svelte
@@ -19,7 +19,7 @@
 
   let disabled: boolean;
   $: disabled = !isEnoughToStakeNeuron({
-    stakeE8s: neuron.fullNeuron?.maturityE8sEquivalent ?? BigInt(0),
+    stakeE8s: neuron.fullNeuron?.maturityE8sEquivalent ?? 0n,
   });
 
   const dispatcher = createEventDispatcher();

--- a/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
@@ -118,7 +118,7 @@
     <span slot="key">{$i18n.sns_project_detail.sale_end} </span>
     <DateSeconds
       slot="value"
-      seconds={Number(params.swap_due_timestamp_seconds ?? BigInt(0))}
+      seconds={Number(params.swap_due_timestamp_seconds ?? 0n)}
       tagName="span"
     />
   </KeyValuePair>

--- a/frontend/src/lib/components/project-detail/ProjectTimelineUserCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectTimelineUserCommitment.svelte
@@ -38,8 +38,7 @@
   $: isAdopted = swap.lifecycle === SnsSwapLifecycle.Adopted;
 
   let hasParticipated: boolean;
-  $: hasParticipated =
-    nonNullish(myCommitment) && myCommitment.toE8s() > BigInt(0);
+  $: hasParticipated = nonNullish(myCommitment) && myCommitment.toE8s() > 0n;
 
   let dataIsRendered: boolean;
   $: dataIsRendered = isOpen || isAdopted || hasParticipated;

--- a/frontend/src/lib/components/proposals/Countdown.svelte
+++ b/frontend/src/lib/components/proposals/Countdown.svelte
@@ -7,7 +7,7 @@
 
   export let deadlineTimestampSeconds: bigint | undefined;
 
-  const ZERO = BigInt(0);
+  const ZERO = 0n;
 
   let clear: NodeJS.Timeout | undefined;
   let countdown: bigint | undefined = undefined;
@@ -36,10 +36,7 @@
 
     // No need to schedule an update if the countdown is longer than an hour plus the auth session duration because even if we refresh,
     // the display value would remain the same until the end of the session
-    if (
-      countdown >
-      AUTH_SESSION_DURATION / BigInt(1_000_000_000) + BigInt(3600)
-    ) {
+    if (countdown > AUTH_SESSION_DURATION / 1_000_000_000n + 3_600n) {
       clearCountdown();
       return;
     }
@@ -57,7 +54,7 @@
    */
   const nextTimeout = () => {
     const frequency: "minutes" | "seconds" =
-      (countdown ?? ZERO) > BigInt(3600) ? "minutes" : "seconds";
+      (countdown ?? ZERO) > 3_600n ? "minutes" : "seconds";
     clear = setTimeout(
       next,
       frequency === "minutes" ? 60000 : 1000

--- a/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
@@ -73,7 +73,7 @@
       description={$i18n.proposal_detail.created_description}
     />
 
-    {#if decided_timestamp_seconds > BigInt(0)}
+    {#if decided_timestamp_seconds > 0n}
       <ProposalSystemInfoEntry
         labelKey="decided_prefix"
         testId="proposal-system-info-decided"
@@ -82,7 +82,7 @@
       />
     {/if}
 
-    {#if executed_timestamp_seconds > BigInt(0)}
+    {#if executed_timestamp_seconds > 0n}
       <ProposalSystemInfoEntry
         labelKey="executed_prefix"
         testId="proposal-system-info-executed"
@@ -91,7 +91,7 @@
       />
     {/if}
 
-    {#if failed_timestamp_seconds > BigInt(0)}
+    {#if failed_timestamp_seconds > 0n}
       <ProposalSystemInfoEntry
         labelKey="failed_prefix"
         testId="proposal-system-info-failed"

--- a/frontend/src/lib/constants/api.constants.ts
+++ b/frontend/src/lib/constants/api.constants.ts
@@ -1,11 +1,11 @@
 export const DFINITY_NEURON = {
-  id: BigInt(27),
+  id: 27n,
   name: "DFINITY Foundation",
   description: undefined,
 };
 
 export const IC_NEURON = {
-  id: BigInt(28),
+  id: 28n,
   name: "Internet Computer Association",
   description: undefined,
 };

--- a/frontend/src/lib/constants/sns-neurons.constants.ts
+++ b/frontend/src/lib/constants/sns-neurons.constants.ts
@@ -13,6 +13,6 @@ export const MANAGE_HOTKEY_PERMISSIONS = [
   SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_MANAGE_PRINCIPALS,
 ];
 
-export const UNSPECIFIED_FUNCTION_ID = BigInt(0);
+export const UNSPECIFIED_FUNCTION_ID = 0n;
 
 export const SNS_NEURON_ID_DISPLAY_LENGTH = 14;

--- a/frontend/src/lib/derived/proposals.derived.ts
+++ b/frontend/src/lib/derived/proposals.derived.ts
@@ -31,7 +31,7 @@ export const sortedProposals: Readable<ProposalsStore> = derived(
   [proposalsStore],
   ([{ proposals, certified }]) => ({
     proposals: proposals.sort(({ id: proposalIdA }, { id: proposalIdB }) =>
-      Number((proposalIdB ?? BigInt(0)) - (proposalIdA ?? BigInt(0)))
+      Number((proposalIdB ?? 0n) - (proposalIdA ?? 0n))
     ),
     certified,
   })

--- a/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
@@ -28,7 +28,7 @@
 
   let max = 0;
   $: max =
-    stakeE8s === BigInt(0)
+    stakeE8s === 0n
       ? 0
       : ulpsToNumber({
           ulps: stakeE8s - BigInt($mainTransactionFeeStore),

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -123,7 +123,7 @@
 
       const updateProgress = (step: SaleStep) => (progressStep = step);
       const userCommitment =
-        getCommitmentE8s($projectDetailStore.swapCommitment) ?? BigInt(0);
+        getCommitmentE8s($projectDetailStore.swapCommitment) ?? 0n;
 
       const { success } = await initiateSnsSaleParticipation({
         account: sourceAccount,

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -187,7 +187,7 @@ export const loadSnsNervousSystemFunctions = async (
       // TODO: Ideally, the name from the backend is user-friendly.
       // https://dfinity.atlassian.net/browse/GIX-1169
       const snsNervousSystemFunctions = nsFunctions.map((nsFunction) => {
-        if (nsFunction.id === BigInt(0)) {
+        if (nsFunction.id === 0n) {
           const translationKeys = get(i18n);
           return {
             ...nsFunction,

--- a/frontend/src/lib/services/sns-neurons-check-balances.services.ts
+++ b/frontend/src/lib/services/sns-neurons-check-balances.services.ts
@@ -169,7 +169,7 @@ const checkNeuronsSubaccounts = async ({
   for (let index = 0; index < MAX_NEURONS_SUBACCOUNTS; index++) {
     try {
       // In case there is an error getting the balance, the loop stops.
-      currentBalance = BigInt(0);
+      currentBalance = 0n;
       const subaccount = neuronSubaccount({
         controller,
         index,
@@ -216,7 +216,7 @@ const checkNeuronsSubaccounts = async ({
         }
       }
       // If the balance is 0 and there is no neuron in that subaccount, stop checking.
-      if (currentBalance === BigInt(0) && neuronNotFound) {
+      if (currentBalance === 0n && neuronNotFound) {
         break;
       }
     } catch (error) {

--- a/frontend/src/lib/utils/anonymize.utils.ts
+++ b/frontend/src/lib/utils/anonymize.utils.ts
@@ -453,8 +453,7 @@ const anonymizeBuyer = async ([buyer, state]: [
     icp: [
       {
         ...state.icp[0],
-        amount_e8s:
-          (await anonymizeAmount(state.icp[0]?.amount_e8s)) ?? BigInt(0),
+        amount_e8s: (await anonymizeAmount(state.icp[0]?.amount_e8s)) ?? 0n,
       } as SnsTransferableAmount,
     ],
     has_created_neuron_recipes: state.has_created_neuron_recipes,

--- a/frontend/src/lib/utils/ckbtc.utils.ts
+++ b/frontend/src/lib/utils/ckbtc.utils.ts
@@ -39,7 +39,7 @@ export const assertCkBTCUserInputAmount = ({
   const amountE8s = numberToE8s(amount);
 
   // No additional check if amount is zero because user might be entering a value such as 0.00000...
-  if (amountE8s === BigInt(0)) {
+  if (amountE8s === 0n) {
     return;
   }
 

--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -200,8 +200,7 @@ export const mapIcrcTransaction = ({
     const isReceive =
       toSelfTransaction === true || txInfo.from !== account.identifier;
     const useFee = !isReceive;
-    const feeApplied =
-      useFee && txInfo.fee !== undefined ? txInfo.fee : BigInt(0);
+    const feeApplied = useFee && txInfo.fee !== undefined ? txInfo.fee : 0n;
 
     const headline = transactionName({
       type,

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -123,8 +123,8 @@ export const neuronVotingPower = ({
   const dissolveDelay =
     newDissolveDelayInSeconds ?? neuron.dissolveDelaySeconds;
   const stakeE8s =
-    (neuron.fullNeuron?.cachedNeuronStake ?? BigInt(0)) +
-    (neuron.fullNeuron?.stakedMaturityE8sEquivalent ?? BigInt(0));
+    (neuron.fullNeuron?.cachedNeuronStake ?? 0n) +
+    (neuron.fullNeuron?.stakedMaturityE8sEquivalent ?? 0n);
   return votingPower({
     stakeE8s,
     dissolveDelay,
@@ -163,7 +163,7 @@ export const votingPower = ({
   minDissolveDelaySeconds = SECONDS_IN_HALF_YEAR,
 }: VotingPowerParams): bigint => {
   if (dissolveDelay < minDissolveDelaySeconds) {
-    return BigInt(0);
+    return 0n;
   }
   const dissolveDelayMultiplier = bonusMultiplier({
     amount: dissolveDelay,
@@ -278,8 +278,8 @@ export const formattedMaturity = ({ fullNeuron }: NeuronInfo): string =>
  */
 export const formattedTotalMaturity = ({ fullNeuron }: NeuronInfo): string =>
   formatMaturity(
-    (fullNeuron?.maturityE8sEquivalent ?? BigInt(0)) +
-      (fullNeuron?.stakedMaturityE8sEquivalent ?? BigInt(0))
+    (fullNeuron?.maturityE8sEquivalent ?? 0n) +
+      (fullNeuron?.stakedMaturityE8sEquivalent ?? 0n)
   );
 
 /**
@@ -291,7 +291,7 @@ export const formattedStakedMaturity = ({ fullNeuron }: NeuronInfo): string =>
 
 export const formatMaturity = (value?: bigint): string =>
   formatTokenE8s({
-    value: isNullish(value) ? BigInt(0) : value,
+    value: isNullish(value) ? 0n : value,
   });
 
 export const sortNeuronsByCreatedTimestamp = (
@@ -444,7 +444,7 @@ export const canUserManageNeuronFundParticipation = ({
 export const neuronStake = (neuron: NeuronInfo): bigint =>
   neuron.fullNeuron?.cachedNeuronStake !== undefined
     ? neuron.fullNeuron?.cachedNeuronStake - neuron.fullNeuron?.neuronFees
-    : BigInt(0);
+    : 0n;
 
 export interface FolloweesNeuron {
   neuronId: NeuronId;
@@ -498,7 +498,7 @@ export const isValidInputAmount = ({
 
 export const isEnoughToStakeNeuron = ({
   stakeE8s,
-  feeE8s = BigInt(0),
+  feeE8s = 0n,
 }: {
   stakeE8s: bigint;
   feeE8s?: bigint;
@@ -847,7 +847,7 @@ export const votedNeuronDetails = ({
     ) as CompactNeuronInfo[];
 
 export const hasEnoughMaturityToStake = ({ fullNeuron }: NeuronInfo): boolean =>
-  (fullNeuron?.maturityE8sEquivalent ?? BigInt(0)) > BigInt(0);
+  (fullNeuron?.maturityE8sEquivalent ?? 0n) > 0n;
 
 export const minNeuronSplittable = (fee: number): number =>
   2 * MIN_NEURON_STAKE + fee;
@@ -893,7 +893,7 @@ export const validTopUpAmount = ({
   amount: number;
 }): boolean => {
   const amountUlps = numberToUlps({ amount, token: ICPToken });
-  const neuronStakeUlps = neuron.fullNeuron?.cachedNeuronStake ?? BigInt(0);
+  const neuronStakeUlps = neuron.fullNeuron?.cachedNeuronStake ?? 0n;
   return amountUlps + neuronStakeUlps > MIN_NEURON_STAKE;
 };
 

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -109,7 +109,7 @@ export const currentUserMaxCommitment = ({
     swap.params.max_icp_e8s - derived.buyer_total_icp_e8s;
   const remainingUserCommitment =
     swap.params.max_participant_icp_e8s -
-    (getCommitmentE8s(swapCommitment) ?? BigInt(0));
+    (getCommitmentE8s(swapCommitment) ?? 0n);
   return remainingProjectCommitment < remainingUserCommitment
     ? remainingProjectCommitment
     : remainingUserCommitment;
@@ -130,7 +130,7 @@ const commitmentTooSmall = ({
   amount: TokenAmount;
 }): boolean =>
   summary.swap.params.min_participant_icp_e8s >
-  amount.toE8s() + (getCommitmentE8s(swapCommitment) ?? BigInt(0));
+  amount.toE8s() + (getCommitmentE8s(swapCommitment) ?? 0n);
 const commitmentTooLarge = ({
   summary,
   amountE8s,
@@ -163,14 +163,14 @@ export const canUserParticipateToSwap = ({
   summary: SnsSummary | undefined | null;
   swapCommitment: SnsSwapCommitment | undefined | null;
 }): boolean => {
-  const myCommitment = getCommitmentE8s(swapCommitment) ?? BigInt(0);
+  const myCommitment = getCommitmentE8s(swapCommitment) ?? 0n;
 
   return (
     summary !== undefined &&
     summary !== null &&
     isProjectOpen(summary) &&
     // Whether user can still participate with 1 e8
-    !commitmentTooLarge({ summary, amountE8s: myCommitment + BigInt(1) })
+    !commitmentTooLarge({ summary, amountE8s: myCommitment + 1n })
   );
 };
 
@@ -203,7 +203,7 @@ export const hasUserParticipatedToSwap = ({
   swapCommitment,
 }: {
   swapCommitment: SnsSwapCommitment | undefined | null;
-}): boolean => (getCommitmentE8s(swapCommitment) ?? BigInt(0)) > BigInt(0);
+}): boolean => (getCommitmentE8s(swapCommitment) ?? 0n) > 0n;
 
 export const validParticipation = ({
   project,
@@ -238,7 +238,7 @@ export const validParticipation = ({
     };
   }
   const totalCommitment =
-    (getCommitmentE8s(project.swapCommitment) ?? BigInt(0)) + amount.toE8s();
+    (getCommitmentE8s(project.swapCommitment) ?? 0n) + amount.toE8s();
   if (
     commitmentTooLarge({ summary: project.summary, amountE8s: totalCommitment })
   ) {
@@ -248,7 +248,7 @@ export const validParticipation = ({
       substitutions: {
         $newCommitment: formatTokenE8s({ value: amount.toE8s() }),
         $currentCommitment: formatTokenE8s({
-          value: getCommitmentE8s(project.swapCommitment) ?? BigInt(0),
+          value: getCommitmentE8s(project.swapCommitment) ?? 0n,
         }),
         $maxCommitment: formatTokenE8s({
           value: project.summary.swap.params.max_participant_icp_e8s,
@@ -359,7 +359,7 @@ export const participateButtonStatus = ({
   // Whether user can still participate with 1 e8
   const userReachedMaxCommitment = commitmentTooLarge({
     summary,
-    amountE8s: currentCommitment + BigInt(1),
+    amountE8s: currentCommitment + 1n,
   });
   if (userReachedMaxCommitment) {
     return "disabled-max-participation";

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -212,7 +212,7 @@ export const selectedNeuronsVotingPower = ({
   neurons
     .filter(({ neuronIdString }) => selectedIds.includes(neuronIdString))
     .map(({ votingPower }) => votingPower)
-    .reduce((sum, votingPower) => sum + votingPower, BigInt(0));
+    .reduce((sum, votingPower) => sum + votingPower, 0n);
 
 /**
  * Generate new selected neuron id list after new neurons response w/o spoiling the previously done user selection
@@ -534,12 +534,12 @@ export const updateProposalVote = ({
       ...(proposalInfo.latestTally as Tally),
       yes:
         vote === Vote.Yes
-          ? (proposalInfo.latestTally?.yes ?? BigInt(0)) + votingPower
-          : proposalInfo.latestTally?.yes ?? BigInt(0),
+          ? (proposalInfo.latestTally?.yes ?? 0n) + votingPower
+          : proposalInfo.latestTally?.yes ?? 0n,
       no:
         vote === Vote.No
-          ? (proposalInfo.latestTally?.no ?? BigInt(0)) + votingPower
-          : proposalInfo.latestTally?.no ?? BigInt(0),
+          ? (proposalInfo.latestTally?.no ?? 0n) + votingPower
+          : proposalInfo.latestTally?.no ?? 0n,
     },
   };
 };

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -56,7 +56,7 @@ export const getSnsNeuronState = ({
     return NeuronState.Dissolved;
   }
   if ("DissolveDelaySeconds" in dissolveState) {
-    return dissolveState.DissolveDelaySeconds === BigInt(0)
+    return dissolveState.DissolveDelaySeconds === 0n
       ? // 0 = already dissolved (more info: https://gitlab.com/dfinity-lab/public/ic/-/blob/master/rs/nns/governance/src/governance.rs#L827)
         NeuronState.Dissolved
       : NeuronState.Locked;
@@ -431,7 +431,7 @@ export const isSnsNeuron = (
  * @returns {boolean}
  */
 export const hasValidStake = (neuron: SnsNeuron): boolean =>
-  neuron.cached_neuron_stake_e8s + neuron.maturity_e8s_equivalent > BigInt(0);
+  neuron.cached_neuron_stake_e8s + neuron.maturity_e8s_equivalent > 0n;
 
 /*
 - The amount to split minus the transfer fee is more than the minimum stake (thus the child neuron will have at least the minimum stake)
@@ -483,7 +483,7 @@ export const formattedMaturity = (
   neuron: SnsNeuron | null | undefined
 ): string =>
   formatTokenE8s({
-    value: neuron?.maturity_e8s_equivalent ?? BigInt(0),
+    value: neuron?.maturity_e8s_equivalent ?? 0n,
   });
 
 /**
@@ -495,7 +495,7 @@ export const formattedTotalMaturity = (neuron: SnsNeuron): string =>
     value:
       neuron.maturity_e8s_equivalent +
       totalDisbursingMaturity(neuron) +
-      (fromNullable(neuron?.staked_maturity_e8s_equivalent ?? []) ?? BigInt(0)),
+      (fromNullable(neuron?.staked_maturity_e8s_equivalent ?? []) ?? 0n),
   });
 
 /**
@@ -504,7 +504,7 @@ export const formattedTotalMaturity = (neuron: SnsNeuron): string =>
  */
 export const hasEnoughMaturityToStake = (
   neuron: SnsNeuron | null | undefined
-): boolean => (neuron?.maturity_e8s_equivalent ?? BigInt(0)) > BigInt(0);
+): boolean => (neuron?.maturity_e8s_equivalent ?? 0n) > 0n;
 
 /**
  * Is the maturity of the neuron bigger than the minimum amount to disburse?
@@ -537,8 +537,7 @@ export const formattedStakedMaturity = (
   neuron: SnsNeuron | null | undefined
 ): string =>
   formatTokenE8s({
-    value:
-      fromNullable(neuron?.staked_maturity_e8s_equivalent ?? []) ?? BigInt(0),
+    value: fromNullable(neuron?.staked_maturity_e8s_equivalent ?? []) ?? 0n,
   });
 
 /**
@@ -718,7 +717,7 @@ export const snsNeuronVotingPower = ({
     Math.max(
       Number(
         getSnsNeuronStake(neuron) +
-          (fromNullable(staked_maturity_e8s_equivalent) ?? BigInt(0))
+          (fromNullable(staked_maturity_e8s_equivalent) ?? 0n)
       ),
       0
     )
@@ -982,7 +981,7 @@ export const totalDisbursingMaturity = ({
 }: SnsNeuron): bigint =>
   disburse_maturity_in_progress.reduce(
     (acc, disbursement) => acc + disbursement.amount_e8s,
-    BigInt(0)
+    0n
   );
 
 /**

--- a/frontend/src/lib/utils/sns-proposals.utils.ts
+++ b/frontend/src/lib/utils/sns-proposals.utils.ts
@@ -254,15 +254,15 @@ export const snsDecisionStatus = (
     executed_timestamp_seconds,
     failed_timestamp_seconds,
   } = proposal;
-  if (decided_timestamp_seconds === BigInt(0)) {
+  if (decided_timestamp_seconds === 0n) {
     return SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN;
   }
 
   if (isAccepted(proposal)) {
-    if (executed_timestamp_seconds > BigInt(0)) {
+    if (executed_timestamp_seconds > 0n) {
       return SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_EXECUTED;
     }
-    if (failed_timestamp_seconds > BigInt(0)) {
+    if (failed_timestamp_seconds > 0n) {
       return SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_FAILED;
     }
     return SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED;
@@ -284,7 +284,7 @@ export const snsRewardStatus = ({
   wait_for_quiet_state,
   is_eligible_for_rewards,
 }: SnsProposalData): SnsProposalRewardStatus => {
-  if (reward_event_round > BigInt(0)) {
+  if (reward_event_round > 0n) {
     return SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_SETTLED;
   }
 
@@ -326,10 +326,7 @@ export const sortSnsProposalsById = (
   proposals === undefined
     ? undefined
     : [...proposals].sort(({ id: idA }, { id: idB }) =>
-        (fromNullable(idA)?.id ?? BigInt(0)) >
-        (fromNullable(idB)?.id ?? BigInt(0))
-          ? -1
-          : 1
+        (fromNullable(idA)?.id ?? 0n) > (fromNullable(idB)?.id ?? 0n) ? -1 : 1
       );
 
 const getAction = (proposal: SnsProposalData): SnsAction | undefined =>

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -30,7 +30,7 @@ export const getSwapCanisterAccount = ({
 
 /**
  * Returns `undefined` if swapCommitment is not present yet.
- * Returns `BigInt(0)` if myCommitment is present but user has no commitment or amount is not present either.
+ * Returns `0n` if myCommitment is present but user has no commitment or amount is not present either.
  * Returns commitment e8s if commitment is defined.
  */
 export const getCommitmentE8s = (
@@ -40,8 +40,7 @@ export const getCommitmentE8s = (
     return undefined;
   }
   return (
-    fromNullable(swapCommitment?.myCommitment?.icp ?? [])?.amount_e8s ??
-    BigInt(0)
+    fromNullable(swapCommitment?.myCommitment?.icp ?? [])?.amount_e8s ?? 0n
   );
 };
 

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -71,7 +71,7 @@ export const formatTokenE8s = ({
   detailed?: boolean | "height_decimals";
   roundingMode?: RoundMode;
 }): string => {
-  if (value === BigInt(0)) {
+  if (value === 0n) {
     return "0";
   }
 
@@ -127,7 +127,7 @@ export const formatTokenV2 = ({
 };
 
 export const sumAmounts = (...amounts: bigint[]): bigint =>
-  amounts.reduce<bigint>((acc, amount) => acc + amount, BigInt(0));
+  amounts.reduce<bigint>((acc, amount) => acc + amount, 0n);
 
 // To make the fixed transaction fee readable, we do not display it with 8 digits but only till the last digit that is not zero
 // e.g. not 0.00010000 but 0.0001
@@ -149,8 +149,8 @@ export const formattedTransactionFeeICP = (fee: number | bigint): string =>
  * @returns {number} The maximum amount for the transaction.
  */
 export const getMaxTransactionAmount = ({
-  balance = BigInt(0),
-  fee = BigInt(0),
+  balance = 0n,
+  fee = 0n,
   maxAmount,
   token,
 }: {

--- a/frontend/src/lib/workers/auth.worker.ts
+++ b/frontend/src/lib/workers/auth.worker.ts
@@ -111,7 +111,7 @@ const emitExpirationTime = (delegation: DelegationChain) => {
 
   // 1_000_000 as NANO_SECONDS_IN_MILLISECOND. Constant not imported to not break prod build.
   const authRemainingTime =
-    new Date(Number(expirationTime / BigInt(1_000_000))).getTime() - Date.now();
+    new Date(Number(expirationTime / 1_000_000n)).getTime() - Date.now();
 
   postMessage({
     msg: "nnsDelegationRemainingTime",

--- a/frontend/static/assets/libs/dummy-proposals.utils.js
+++ b/frontend/static/assets/libs/dummy-proposals.utils.js
@@ -265,14 +265,14 @@ const makeNetworkEconomicsDummyProposalRequest = ({
   summary,
   action: {
     ManageNetworkEconomics: {
-      neuronMinimumStake: BigInt(100_000_000),
+      neuronMinimumStake: 100_000_000n,
       maxProposalsToKeepPerTopic: 1000,
-      neuronManagementFeePerProposal: BigInt(10_000),
-      rejectCost: BigInt(10_000_000),
-      transactionFee: BigInt(1000),
+      neuronManagementFeePerProposal: 10_000n,
+      rejectCost: 10_000_000n,
+      transactionFee: 1_000n,
       neuronSpawnDissolveDelaySeconds: BigInt(3600 * 24 * 7),
-      minimumIcpXdrRate: BigInt(1),
-      maximumNodeProviderRewards: BigInt(10_000_000_000),
+      minimumIcpXdrRate: 1n,
+      maximumNodeProviderRewards: 10_000_000_000n,
     },
   },
 });
@@ -294,9 +294,9 @@ const makeRewardNodeProviderDummyProposal = ({
         rewardAccount: undefined,
       },
       rewardMode: {
-        RewardToNeuron: { dissolveDelaySeconds: BigInt(1000) },
+        RewardToNeuron: { dissolveDelaySeconds: 1_000n },
       },
-      amountE8s: BigInt(10_000_000),
+      amountE8s: 10_000_000n,
     },
   },
 });


### PR DESCRIPTION
# Motivation

`bigint`s can be written as `123n` but in many places we write `BigInt(123)`.
The former is more concise and also more accurate if the number actually requires a `bigint` for full accuracy.

# Changes

1. Replace `BigInt(???)` with `???n`.
2. Add underscore separators for numbers with more than 3 digits if they weren't there already.

This PR only does non-test files. There are a lot more cases in tests and it would make this PR too big.

# Tests

Still pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary