### PR TITLE
Replace markdown container styles

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "3.1.0-next-2023-12-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-3.1.0-next-2023-12-19.1.tgz",
-      "integrity": "sha512-As+6K+vp3Gj5Z+jdm3EqMXLZPdV+L4UxyBneFbBgfN2LNQcCr4XbnbdQW1A8wwAWXvGgs+2xFDJEjAj7ETRCLQ==",
+      "version": "3.1.0-next-2023-12-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-3.1.0-next-2023-12-28.1.tgz",
+      "integrity": "sha512-ZBjCUFdZdpiYDVhyuwp0SlvQ0zD2mPUNYgquRhH4mkcBVSAGd1GMaDNlldNvYTeUt61P6evQ6Qv2306otBz8wA==",
       "dependencies": {
         "dompurify": "^3.0.6",
         "html5-qrcode": "^2.3.8",
@@ -7357,9 +7357,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "3.1.0-next-2023-12-19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-3.1.0-next-2023-12-19.1.tgz",
-      "integrity": "sha512-As+6K+vp3Gj5Z+jdm3EqMXLZPdV+L4UxyBneFbBgfN2LNQcCr4XbnbdQW1A8wwAWXvGgs+2xFDJEjAj7ETRCLQ==",
+      "version": "3.1.0-next-2023-12-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-3.1.0-next-2023-12-28.1.tgz",
+      "integrity": "sha512-ZBjCUFdZdpiYDVhyuwp0SlvQ0zD2mPUNYgquRhH4mkcBVSAGd1GMaDNlldNvYTeUt61P6evQ6Qv2306otBz8wA==",
       "requires": {
         "dompurify": "^3.0.6",
         "html5-qrcode": "^2.3.8",

--- a/frontend/src/lib/components/common/JsonPreview.svelte
+++ b/frontend/src/lib/components/common/JsonPreview.svelte
@@ -29,7 +29,7 @@
 </script>
 
 <div
-  class="content-cell-island markdown-container"
+  class="content-cell-island content-cell-island--highlighted container"
   data-tid="json-preview-component"
 >
   {#if $jsonRepresentationModeStore === "tree" && isExpandedAllVisible}
@@ -51,7 +51,7 @@
       {/if}
     </button>
   {/if}
-  <div class="json-container">
+  <div class="json-wrapper">
     <TestIdWrapper testId="json-wrapper">
       {#if $jsonRepresentationModeStore === "tree"}
         <div in:fade>
@@ -72,6 +72,13 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";
+
+  .container {
+    // reset "content-cell-island" padding
+    padding: 0;
+    // to place expand-all button
+    position: relative;
+  }
 
   .expand-all {
     padding: 0;
@@ -94,22 +101,10 @@
     }
   }
 
-  .json-container {
+  .json-wrapper {
     // json content scrolling
     overflow-x: auto;
     // same as "content-cell-island"
     padding: var(--padding-2x);
-  }
-
-  // TODO(max): rename and move to gix-components
-  .markdown-container {
-    // custom island styles
-    background: var(--card-background-disabled);
-    color: var(--description-color);
-
-    // reset "content-cell-island" padding
-    padding: 0;
-    // to place expand-all button
-    position: relative;
   }
 </style>

--- a/frontend/src/lib/components/common/JsonPreview.svelte
+++ b/frontend/src/lib/components/common/JsonPreview.svelte
@@ -29,7 +29,7 @@
 </script>
 
 <div
-  class="content-cell-island content-cell-island--highlighted container"
+  class="content-cell-island__card container"
   data-tid="json-preview-component"
 >
   {#if $jsonRepresentationModeStore === "tree" && isExpandedAllVisible}

--- a/frontend/src/lib/components/common/JsonPreview.svelte
+++ b/frontend/src/lib/components/common/JsonPreview.svelte
@@ -7,7 +7,6 @@
   import RawJson from "$lib/components/common/RawJson.svelte";
   import { fade } from "svelte/transition";
   import { jsonRepresentationModeStore } from "$lib/derived/json-representation.derived";
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   const DEFAULT_EXPANDED_LEVEL = 1;
 

--- a/frontend/src/lib/components/common/JsonPreview.svelte
+++ b/frontend/src/lib/components/common/JsonPreview.svelte
@@ -51,22 +51,20 @@
       {/if}
     </button>
   {/if}
-  <div class="json-wrapper">
-    <TestIdWrapper testId="json-wrapper">
-      {#if $jsonRepresentationModeStore === "tree"}
-        <div in:fade>
-          <TreeJson
-            testId="tree-json"
-            json={expandedData}
-            defaultExpandedLevel={isAllExpanded ? Number.MAX_SAFE_INTEGER : 1}
-          />
-        </div>
-      {:else}
-        <div in:fade>
-          <RawJson testId="raw-json" {json} />
-        </div>
-      {/if}
-    </TestIdWrapper>
+  <div data-tid="json-wrapper" class="json-wrapper">
+    {#if $jsonRepresentationModeStore === "tree"}
+      <div in:fade>
+        <TreeJson
+          testId="tree-json"
+          json={expandedData}
+          defaultExpandedLevel={isAllExpanded ? Number.MAX_SAFE_INTEGER : 1}
+        />
+      </div>
+    {:else}
+      <div in:fade>
+        <RawJson testId="raw-json" {json} />
+      </div>
+    {/if}
   </div>
 </div>
 

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -87,7 +87,7 @@
   {#if isMinParticipationReached}
     <p
       data-tid="min-participation-reached"
-      class="content-cell-island content-cell-island--highlighted min-participation-reached"
+      class="content-cell-island__card min-participation-reached"
     >
       {$i18n.sns_project_detail.min_participation_reached}
     </p>

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -87,7 +87,7 @@
   {#if isMinParticipationReached}
     <p
       data-tid="min-participation-reached"
-      class="content-cell-island markdown-container"
+      class="content-cell-island content-cell-island--highlighted min-participation-reached"
     >
       {$i18n.sns_project_detail.min_participation_reached}
     </p>
@@ -213,11 +213,7 @@
     }
   }
 
-  // TODO(max): rename and move to gix-components
-  .markdown-container {
+  .min-participation-reached {
     margin: 0;
-    // custom island styles
-    background: var(--card-background-disabled);
-    color: var(--description-color);
   }
 </style>

--- a/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
@@ -14,7 +14,9 @@
   {/if}
 
   {#if nonNullish(summary) && summary !== ""}
-    <div class="content-cell-island markdown-container">
+    <div
+      class="content-cell-island content-cell-island--highlighted markdown-container"
+    >
       <Markdown text={summary} />
     </div>
   {/if}
@@ -27,12 +29,8 @@
   .markdown {
     overflow-wrap: break-word;
 
-    // TODO(max): rename and move to gix-components
     .markdown-container {
       margin-top: var(--padding-2x);
-      // custom island styles
-      background: var(--card-background-disabled);
-      color: var(--description-color);
     }
 
     :global(.markdown-container > :last-child) {

--- a/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSummary.svelte
@@ -14,9 +14,7 @@
   {/if}
 
   {#if nonNullish(summary) && summary !== ""}
-    <div
-      class="content-cell-island content-cell-island--highlighted markdown-container"
-    >
+    <div class="content-cell-island__card markdown-container">
       <Markdown text={summary} />
     </div>
   {/if}


### PR DESCRIPTION
# Motivation

Replace custom classes for island card w/ `content-cell-island__card` class.

# Changes

- `npm update:gix`
- replace card styles with `content-cell-island__card`

# Tests

<img width="716" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/573c4cca-8f36-4aac-bbc6-a471bb256af0">

<img width="720" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/18e232f0-83ec-4102-a623-734f527c5b30">

<img width="720" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/5f52aa42-836b-439d-918a-04565e0316fa">

# Todos

- [ ] Add entry to changelog (if necessary).
Not needed