### PR TITLE
Update snsdemo to release-2023-12-27

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -344,7 +344,7 @@
         "BINSTALL_VERSION": "1.3.0",
         "DIDC_VERSION": "2023-12-15",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2023-12-18",
+        "SNSDEMO_RELEASE": "release-2023-12-27",
         "IC_COMMIT": "release-2023-12-13_23-01"
       },
       "packtool": ""


### PR DESCRIPTION
# Motivation
We would like to keep the testing environment, provided by snsdemo, up to date.

# Changes
* Updated `snsdemo` version in `dfx.json`.

# Tests
CI should pass.