### PR TITLE
Keep universe in goBack in IcrcWalletPage

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -38,6 +38,7 @@ proposal is successful, the changes it released will be moved from this file to
 - Min dissolve delay button updates not only for the first time.
 - Fix scrollbar in multiline toast message. 
 - Go back to accounts page for incorrect account identifier in SNS wallet page.
+- Stay on the same universe when navigating back from wallet to the accounts page.
 
 #### Security
 

--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -12,7 +12,7 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { i18n } from "$lib/stores/i18n";
   import { goto } from "$app/navigation";
-  import { AppPath } from "$lib/constants/routes.constants";
+  import { buildAccountsUrl } from "$lib/utils/navigation.utils";
   import type { UniverseCanisterId } from "$lib/types/universe";
   import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
   import IcrcBalancesObserver from "$lib/components/accounts/IcrcBalancesObserver.svelte";
@@ -31,7 +31,12 @@
 
   const reloadOnlyAccountFromStore = () => setSelectedAccount();
 
-  const goBack = (): Promise<void> => goto(AppPath.Accounts);
+  const goBack = async (): Promise<void> =>
+    goto(
+      buildAccountsUrl({
+        universe: $selectedUniverseStore.canisterId,
+      })
+    );
 
   // e.g. is called from "Receive" modal after user click "Done"
   export const reloadAccount = async () => {

--- a/frontend/src/tests/lib/pages/WalletTest.svelte
+++ b/frontend/src/tests/lib/pages/WalletTest.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { AppPath } from "$lib/constants/routes.constants";
+  import { pathForRouteId } from "$lib/utils/page.utils";
+  import { page } from "$app/stores";
+  import type { SvelteComponent } from "svelte";
+
+  export let testComponent: typeof SvelteComponent;
+  export let accountIdentifier: string | undefined = undefined;
+  let currentAppPath: string | undefined = undefined;
+  $: currentAppPath = pathForRouteId($page.route.id);
+</script>
+
+{#if currentAppPath === AppPath.Wallet}
+  <svelte:component this={testComponent} {accountIdentifier} />
+{/if}


### PR DESCRIPTION
# Motivation

In `IcrcWalletPage` (and other wallets) when there is no or an incorrect account identifier, we navigate back to the accounts page.
In `SnsWallet` it navigates to the accounts page of the same universe but in `IcrcWalletPage` it reverts to the ICP universe.
Instead it should stay with the universe of the wallet we were on.

In an earlier version of this PR, the test would end up in an infinite loop because navigating to a different URL would trigger the `selectedIcrcTokenUniverseIdStore` which would result in `IcrcWalletPage` trying again to load the data and again trying to go back to the accounts page etc.
In reality this would not happen, because as soon as the app navigates away from the wallet page, the component would be unmounted and it wouldn't try to load data anymore. To make the test more realistic, I added a wrapper component that only renders the wallet if the page store shows that we are on the wallet route.

# Changes

1. Include the universe in the URL when navigating from the `IcrcWalletPage` to the accounts page.
2. Render `IcrcWallet` inside a wrapper component `WalletTest.svelte` which only renders the component if we're on the wallet route, to make the test more realistic and avoid an infinite loop.
3. Change the test to use the new test wrapper.
4. Change the test to expect the universe in the URL.
5. Drive-by improvement: Expect error toast messages.

# Tests

Unit tests updated.
Tested manually.

# Todos

- [x] Add entry to changelog (if necessary).
