### PR TITLE
Use concise bigint notation in tests

### DIFF
--- a/frontend/src/tests/fakes/governance-api.fake.ts
+++ b/frontend/src/tests/fakes/governance-api.fake.ts
@@ -107,7 +107,7 @@ async function mergeNeurons({
   // merge happened.
   targetNeuron.fullNeuron.cachedNeuronStake +=
     sourceNeuron.fullNeuron.cachedNeuronStake;
-  sourceNeuron.fullNeuron.cachedNeuronStake = BigInt(0);
+  sourceNeuron.fullNeuron.cachedNeuronStake = 0n;
 }
 
 async function simulateMergeNeurons({

--- a/frontend/src/tests/fakes/sns-governance-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-governance-api.fake.ts
@@ -227,7 +227,7 @@ async function getNeuronBalance({
     // the fake.
     return neuron.cached_neuron_stake_e8s;
   }
-  return BigInt(0);
+  return 0n;
 }
 
 async function refreshNeuron(params: {

--- a/frontend/src/tests/fakes/sns-ledger-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-ledger-api.fake.ts
@@ -53,7 +53,7 @@ async function transactionFee({
   rootCanisterId: Principal;
   certified: boolean;
 }): Promise<bigint> {
-  return BigInt(10_000);
+  return 10_000n;
 }
 
 async function getSnsToken({

--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -153,7 +153,7 @@ const shouldInvalidateCacheOnFailure = async <P, R>({
 };
 
 describe("neurons api-service", () => {
-  const neuronId = BigInt(12);
+  const neuronId = 12n;
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -184,13 +184,13 @@ describe("neurons api-service", () => {
     it("should call queryNeuron api", async () => {
       expect(
         await governanceApiService.queryNeuron({
-          neuronId: BigInt(1),
+          neuronId: 1n,
           ...params,
         })
       ).toEqual(neuron1);
       expect(
         await governanceApiService.queryNeuron({
-          neuronId: BigInt(2),
+          neuronId: 2n,
           ...params,
         })
       ).toEqual(neuron2);
@@ -199,7 +199,7 @@ describe("neurons api-service", () => {
 
     it("should fail if queryNeuron api fails", async () => {
       expect(() =>
-        governanceApiService.queryNeuron({ neuronId: BigInt(999), ...params })
+        governanceApiService.queryNeuron({ neuronId: 999n, ...params })
       ).rejects.toThrow("No neuron with id 999");
       expect(api.queryNeuron).toHaveBeenCalledTimes(1);
     });
@@ -208,7 +208,7 @@ describe("neurons api-service", () => {
       await shouldNotInvalidateCache({
         apiFunc: api.queryNeuron,
         apiServiceFunc: governanceApiService.queryNeuron,
-        params: { neuronId: BigInt(1), ...params },
+        params: { neuronId: 1n, ...params },
       });
     });
   });
@@ -455,7 +455,7 @@ describe("neurons api-service", () => {
     const rewardEvent1: RewardEvent = mockRewardEvent;
     const rewardEvent2: RewardEvent = {
       ...rewardEvent1,
-      rounds_since_last_distribution: [BigInt(2_000)],
+      rounds_since_last_distribution: [2_000n],
     };
     beforeEach(() => {
       vi.spyOn(api, "queryLastestRewardEvent").mockImplementation(
@@ -603,7 +603,7 @@ describe("neurons api-service", () => {
       neuronId,
       identity: mockIdentity,
       toAccount: mockMainAccount.identifier,
-      amount: BigInt(10_000_000),
+      amount: 10_000_000n,
     };
 
     it("should call disburse api", () => {
@@ -750,8 +750,8 @@ describe("neurons api-service", () => {
   describe("mergeNeurons", () => {
     const params = {
       identity: mockIdentity,
-      sourceNeuronId: BigInt(2),
-      targetNeuronId: BigInt(20),
+      sourceNeuronId: 2n,
+      targetNeuronId: 20n,
     };
 
     it("should call mergeNeurons api", () => {
@@ -812,7 +812,7 @@ describe("neurons api-service", () => {
       neuronId,
       identity: mockIdentity,
       topic: Topic.ExchangeRate,
-      followees: [BigInt(2), BigInt(20)],
+      followees: [2n, 20n],
     };
 
     it("should call setFollowees api", () => {
@@ -841,8 +841,8 @@ describe("neurons api-service", () => {
   describe("simulateMergeNeurons", () => {
     const params = {
       identity: mockIdentity,
-      sourceNeuronId: BigInt(3),
-      targetNeuronId: BigInt(21),
+      sourceNeuronId: 3n,
+      targetNeuronId: 21n,
     };
 
     it("should call simulateMergeNeurons api", () => {
@@ -902,7 +902,7 @@ describe("neurons api-service", () => {
     const params = {
       neuronId,
       identity: mockIdentity,
-      amount: BigInt(10_000_000),
+      amount: 10_000_000n,
     };
 
     it("should call splitNeuron api", async () => {
@@ -962,7 +962,7 @@ describe("neurons api-service", () => {
   describe("stakeNeuron", () => {
     const params = {
       identity: mockIdentity,
-      stake: BigInt(10_000_000),
+      stake: 10_000_000n,
       controller: mockPrincipal,
       ledgerCanisterIdentity: mockIdentity,
       fromSubaccount: new Uint8Array(),
@@ -995,7 +995,7 @@ describe("neurons api-service", () => {
   describe("stakeNeuronIcrc1", () => {
     const params = {
       identity: mockIdentity,
-      stake: BigInt(10_000_000),
+      stake: 10_000_000n,
       controller: mockPrincipal,
       ledgerCanisterIdentity: mockIdentity,
       fromSubaccount: new Uint8Array(),

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -204,13 +204,11 @@ describe("canisters-api", () => {
 
   describe("getIcpToCyclesExchangeRate", () => {
     it("should call CMC to get conversion rate", async () => {
-      mockCMCCanister.getIcpToCyclesConversionRate.mockResolvedValue(
-        BigInt(10_000)
-      );
+      mockCMCCanister.getIcpToCyclesConversionRate.mockResolvedValue(10_000n);
 
       const response = await getIcpToCyclesExchangeRate(mockIdentity);
       expect(mockCMCCanister.getIcpToCyclesConversionRate).toBeCalled();
-      expect(response).toEqual(BigInt(10_000));
+      expect(response).toEqual(10_000n);
     });
   });
 
@@ -223,7 +221,7 @@ describe("canisters-api", () => {
     });
 
     it("should make a transfer, notify and attach the canister", async () => {
-      mockLedgerCanister.transfer.mockResolvedValue(BigInt(10));
+      mockLedgerCanister.transfer.mockResolvedValue(10n);
       mockCMCCanister.notifyCreateCanister.mockResolvedValue(
         mockCanisterDetails.id
       );
@@ -245,7 +243,7 @@ describe("canisters-api", () => {
     });
 
     it("should attach the canister if name max length", async () => {
-      mockLedgerCanister.transfer.mockResolvedValue(BigInt(10));
+      mockLedgerCanister.transfer.mockResolvedValue(10n);
       mockCMCCanister.notifyCreateCanister.mockResolvedValue(
         mockCanisterDetails.id
       );
@@ -267,7 +265,7 @@ describe("canisters-api", () => {
     });
 
     it("should notify twice if the first call returns Processing", async () => {
-      mockLedgerCanister.transfer.mockResolvedValue(BigInt(10));
+      mockLedgerCanister.transfer.mockResolvedValue(10n);
       mockCMCCanister.notifyCreateCanister
         .mockRejectedValueOnce(new ProcessingError())
         .mockResolvedValue(mockCanisterDetails.id);
@@ -284,7 +282,7 @@ describe("canisters-api", () => {
     });
 
     it("handles creating from subaccounts", async () => {
-      mockLedgerCanister.transfer.mockResolvedValue(BigInt(10));
+      mockLedgerCanister.transfer.mockResolvedValue(10n);
       mockCMCCanister.notifyCreateCanister.mockResolvedValue(
         mockCanisterDetails.id
       );
@@ -368,8 +366,8 @@ describe("canisters-api", () => {
     });
 
     it("should make a transfer and notify", async () => {
-      mockLedgerCanister.transfer.mockResolvedValue(BigInt(10));
-      mockCMCCanister.notifyTopUp.mockResolvedValue(BigInt(10));
+      mockLedgerCanister.transfer.mockResolvedValue(10n);
+      mockCMCCanister.notifyTopUp.mockResolvedValue(10n);
 
       await topUpCanister({
         identity: mockIdentity,
@@ -384,10 +382,10 @@ describe("canisters-api", () => {
     });
 
     it("should notify twice if the first returns ProcessingError", async () => {
-      mockLedgerCanister.transfer.mockResolvedValue(BigInt(10));
+      mockLedgerCanister.transfer.mockResolvedValue(10n);
       mockCMCCanister.notifyTopUp
         .mockRejectedValueOnce(new ProcessingError())
-        .mockResolvedValue(BigInt(10));
+        .mockResolvedValue(10n);
 
       await topUpCanister({
         identity: mockIdentity,
@@ -401,8 +399,8 @@ describe("canisters-api", () => {
     });
 
     it("should make a transfer from subaccounts", async () => {
-      mockLedgerCanister.transfer.mockResolvedValue(BigInt(10));
-      mockCMCCanister.notifyTopUp.mockResolvedValue(BigInt(10));
+      mockLedgerCanister.transfer.mockResolvedValue(10n);
+      mockCMCCanister.notifyTopUp.mockResolvedValue(10n);
 
       const toSubAccount = principalToSubAccount(mockCanisterDetails.id);
       // To create a canister you need to send ICP to an account owned by the CMC, so that the CMC can burn those funds.

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -66,7 +66,7 @@ describe("neurons-api", () => {
 
     expect(mockGovernanceCanister.stakeNeuron).not.toBeCalled();
 
-    const stake = BigInt(20_000_000);
+    const stake = 20_000_000n;
     const controller = mockIdentity.getPrincipal();
     const fromSubAccount = [2, 3, 4];
 
@@ -95,7 +95,7 @@ describe("neurons-api", () => {
 
     expect(mockGovernanceCanister.stakeNeuronIcrc1).not.toBeCalled();
 
-    const stake = BigInt(20_000_000);
+    const stake = 20_000_000n;
     const controller = mockIdentity.getPrincipal();
     const fromSubAccount = new Uint8Array([5, 6, 7]);
 
@@ -156,7 +156,7 @@ describe("neurons-api", () => {
       );
 
       await increaseDissolveDelay({
-        neuronId: BigInt(10),
+        neuronId: 10n,
         dissolveDelayInSeconds: 12000,
         identity: mockIdentity,
       });
@@ -174,7 +174,7 @@ describe("neurons-api", () => {
 
       const call = () =>
         increaseDissolveDelay({
-          neuronId: BigInt(10),
+          neuronId: 10n,
           dissolveDelayInSeconds: 12000,
           identity: mockIdentity,
         });
@@ -191,9 +191,9 @@ describe("neurons-api", () => {
 
       await setFollowees({
         identity: mockIdentity,
-        neuronId: BigInt(10),
+        neuronId: 10n,
         topic: Topic.ExchangeRate,
-        followees: [BigInt(4), BigInt(7)],
+        followees: [4n, 7n],
       });
 
       expect(mockGovernanceCanister.setFollowees).toBeCalled();
@@ -210,9 +210,9 @@ describe("neurons-api", () => {
       const call = () =>
         setFollowees({
           identity: mockIdentity,
-          neuronId: BigInt(10),
+          neuronId: 10n,
           topic: Topic.ExchangeRate,
-          followees: [BigInt(4), BigInt(7)],
+          followees: [4n, 7n],
         });
       await expect(call).rejects.toThrow(error);
     });
@@ -226,7 +226,7 @@ describe("neurons-api", () => {
 
       await joinCommunityFund({
         identity: mockIdentity,
-        neuronId: BigInt(10),
+        neuronId: 10n,
       });
 
       expect(mockGovernanceCanister.joinCommunityFund).toBeCalled();
@@ -243,7 +243,7 @@ describe("neurons-api", () => {
       const call = () =>
         joinCommunityFund({
           identity: mockIdentity,
-          neuronId: BigInt(10),
+          neuronId: 10n,
         });
       await expect(call).rejects.toThrow(error);
     });
@@ -257,7 +257,7 @@ describe("neurons-api", () => {
 
       await leaveCommunityFund({
         identity: mockIdentity,
-        neuronId: BigInt(10),
+        neuronId: 10n,
       });
 
       expect(mockGovernanceCanister.leaveCommunityFund).toBeCalled();
@@ -274,7 +274,7 @@ describe("neurons-api", () => {
       const call = () =>
         leaveCommunityFund({
           identity: mockIdentity,
-          neuronId: BigInt(10),
+          neuronId: 10n,
         });
       await expect(call).rejects.toThrow(error);
     });
@@ -289,7 +289,7 @@ describe("neurons-api", () => {
       await disburse({
         identity: mockIdentity,
         toAccountId: mockMainAccount.identifier,
-        neuronId: BigInt(10),
+        neuronId: 10n,
       });
 
       expect(mockGovernanceCanister.disburse).toBeCalled();
@@ -307,7 +307,7 @@ describe("neurons-api", () => {
         disburse({
           identity: mockIdentity,
           toAccountId: mockMainAccount.identifier,
-          neuronId: BigInt(10),
+          neuronId: 10n,
         });
       await expect(call).rejects.toThrow(error);
     });
@@ -322,7 +322,7 @@ describe("neurons-api", () => {
       await mergeMaturity({
         identity: mockIdentity,
         percentageToMerge: 50,
-        neuronId: BigInt(10),
+        neuronId: 10n,
       });
 
       expect(mockGovernanceCanister.mergeMaturity).toBeCalled();
@@ -340,7 +340,7 @@ describe("neurons-api", () => {
         mergeMaturity({
           identity: mockIdentity,
           percentageToMerge: 50,
-          neuronId: BigInt(10),
+          neuronId: 10n,
         });
       await expect(call).rejects.toThrow(error);
     });
@@ -355,7 +355,7 @@ describe("neurons-api", () => {
       await stakeMaturity({
         identity: mockIdentity,
         percentageToStake: 50,
-        neuronId: BigInt(10),
+        neuronId: 10n,
       });
 
       expect(mockGovernanceCanister.stakeMaturity).toBeCalled();
@@ -373,7 +373,7 @@ describe("neurons-api", () => {
         stakeMaturity({
           identity: mockIdentity,
           percentageToStake: 50,
-          neuronId: BigInt(10),
+          neuronId: 10n,
         });
 
       await expect(call).rejects.toThrow(error);
@@ -389,7 +389,7 @@ describe("neurons-api", () => {
       await autoStakeMaturity({
         identity: mockIdentity,
         autoStake: true,
-        neuronId: BigInt(10),
+        neuronId: 10n,
       });
 
       expect(mockGovernanceCanister.autoStakeMaturity).toBeCalled();
@@ -407,7 +407,7 @@ describe("neurons-api", () => {
         autoStakeMaturity({
           identity: mockIdentity,
           autoStake: true,
-          neuronId: BigInt(10),
+          neuronId: 10n,
         });
 
       await expect(call).rejects.toThrow(error);
@@ -420,7 +420,7 @@ describe("neurons-api", () => {
 
       const expected = {
         autoStake: true,
-        neuronId: BigInt(10),
+        neuronId: 10n,
       };
 
       await autoStakeMaturity({
@@ -438,7 +438,7 @@ describe("neurons-api", () => {
 
       const expected = {
         autoStake: false,
-        neuronId: BigInt(10),
+        neuronId: 10n,
       };
 
       await autoStakeMaturity({
@@ -452,7 +452,7 @@ describe("neurons-api", () => {
 
   describe("spawnNeuron", () => {
     it("spawn a neuron from a percentage of the maturity successfully", async () => {
-      const newNeuronId = BigInt(12333);
+      const newNeuronId = 12_333n;
       mockGovernanceCanister.spawnNeuron.mockImplementation(
         vi.fn().mockResolvedValue(newNeuronId)
       );
@@ -460,7 +460,7 @@ describe("neurons-api", () => {
       const actualNeuronId = await spawnNeuron({
         identity: mockIdentity,
         percentageToSpawn: 50,
-        neuronId: BigInt(10),
+        neuronId: 10n,
       });
 
       expect(mockGovernanceCanister.spawnNeuron).toBeCalled();
@@ -479,7 +479,7 @@ describe("neurons-api", () => {
         spawnNeuron({
           identity: mockIdentity,
           percentageToSpawn: 50,
-          neuronId: BigInt(10),
+          neuronId: 10n,
         });
       await expect(call).rejects.toThrow(error);
     });
@@ -493,8 +493,8 @@ describe("neurons-api", () => {
 
       await mergeNeurons({
         identity: mockIdentity,
-        sourceNeuronId: BigInt(10),
-        targetNeuronId: BigInt(11),
+        sourceNeuronId: 10n,
+        targetNeuronId: 11n,
       });
 
       expect(mockGovernanceCanister.mergeNeurons).toBeCalled();
@@ -511,8 +511,8 @@ describe("neurons-api", () => {
       const call = () =>
         mergeNeurons({
           identity: mockIdentity,
-          sourceNeuronId: BigInt(10),
-          targetNeuronId: BigInt(11),
+          sourceNeuronId: 10n,
+          targetNeuronId: 11n,
         });
       await expect(call).rejects.toThrow(error);
     });
@@ -526,8 +526,8 @@ describe("neurons-api", () => {
 
       await simulateMergeNeurons({
         identity: mockIdentity,
-        sourceNeuronId: BigInt(10),
-        targetNeuronId: BigInt(11),
+        sourceNeuronId: 10n,
+        targetNeuronId: 11n,
       });
 
       expect(mockGovernanceCanister.simulateMergeNeurons).toBeCalled();
@@ -544,8 +544,8 @@ describe("neurons-api", () => {
       const call = () =>
         simulateMergeNeurons({
           identity: mockIdentity,
-          sourceNeuronId: BigInt(10),
-          targetNeuronId: BigInt(11),
+          sourceNeuronId: 10n,
+          targetNeuronId: 11n,
         });
       await expect(call).rejects.toThrow(error);
     });
@@ -559,7 +559,7 @@ describe("neurons-api", () => {
 
       await addHotkey({
         identity: mockIdentity,
-        neuronId: BigInt(10),
+        neuronId: 10n,
         principal: Principal.fromText("aaaaa-aa"),
       });
 
@@ -577,7 +577,7 @@ describe("neurons-api", () => {
       const call = () =>
         addHotkey({
           identity: mockIdentity,
-          neuronId: BigInt(10),
+          neuronId: 10n,
           principal: Principal.fromText("aaaaa-aa"),
         });
       await expect(call).rejects.toThrow(error);
@@ -592,7 +592,7 @@ describe("neurons-api", () => {
 
       await removeHotkey({
         identity: mockIdentity,
-        neuronId: BigInt(10),
+        neuronId: 10n,
         principal: Principal.fromText("aaaaa-aa"),
       });
 
@@ -610,7 +610,7 @@ describe("neurons-api", () => {
       const call = () =>
         removeHotkey({
           identity: mockIdentity,
-          neuronId: BigInt(10),
+          neuronId: 10n,
           principal: Principal.fromText("aaaaa-aa"),
         });
       await expect(call).rejects.toThrow(error);
@@ -625,7 +625,7 @@ describe("neurons-api", () => {
 
       await startDissolving({
         identity: mockIdentity,
-        neuronId: BigInt(10),
+        neuronId: 10n,
       });
 
       expect(mockGovernanceCanister.startDissolving).toBeCalled();
@@ -642,7 +642,7 @@ describe("neurons-api", () => {
       const call = () =>
         startDissolving({
           identity: mockIdentity,
-          neuronId: BigInt(10),
+          neuronId: 10n,
         });
       await expect(call).rejects.toThrow(error);
     });
@@ -656,7 +656,7 @@ describe("neurons-api", () => {
 
       await stopDissolving({
         identity: mockIdentity,
-        neuronId: BigInt(10),
+        neuronId: 10n,
       });
 
       expect(mockGovernanceCanister.stopDissolving).toBeCalled();
@@ -673,22 +673,22 @@ describe("neurons-api", () => {
       const call = () =>
         stopDissolving({
           identity: mockIdentity,
-          neuronId: BigInt(10),
+          neuronId: 10n,
         });
       await expect(call).rejects.toThrow(error);
     });
   });
 
   describe("splitNeuron", () => {
-    const amount = BigInt(220_000_000);
+    const amount = 220_000_000n;
     it("updates neuron successfully", async () => {
       mockGovernanceCanister.splitNeuron.mockImplementation(
-        vi.fn().mockResolvedValue(BigInt(11))
+        vi.fn().mockResolvedValue(11n)
       );
 
       await splitNeuron({
         identity: mockIdentity,
-        neuronId: BigInt(10),
+        neuronId: 10n,
         amount,
       });
 
@@ -706,7 +706,7 @@ describe("neurons-api", () => {
       const call = () =>
         splitNeuron({
           identity: mockIdentity,
-          neuronId: BigInt(10),
+          neuronId: 10n,
           amount,
         });
       expect(mockGovernanceCanister.splitNeuron).not.toBeCalled();
@@ -715,9 +715,9 @@ describe("neurons-api", () => {
   });
 
   describe("registerVote", () => {
-    const neuronId = BigInt(110);
+    const neuronId = 110n;
     const identity = mockIdentity;
-    const proposalId = BigInt(110);
+    const proposalId = 110n;
 
     it("should call the canister to cast vote neuronIds count", async () => {
       await registerVote({

--- a/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
@@ -25,16 +25,16 @@ describe("icp-ledger.api", () => {
 
     const { identifier: accountIdentifier } = mockMainAccount;
     const amount = TokenAmount.fromE8s({
-      amount: BigInt(11_000),
+      amount: 11_000n,
       token: ICPToken,
     });
 
     const now = Date.now();
-    const nowInBigIntNanoSeconds = BigInt(now) * BigInt(1_000_000);
+    const nowInBigIntNanoSeconds = BigInt(now) * 1_000_000n;
 
     beforeEach(() => {
       const ledgerMock = mock<LedgerCanister>();
-      ledgerMock.transfer.mockResolvedValue(BigInt(0));
+      ledgerMock.transfer.mockResolvedValue(0n);
       vi.useFakeTimers().setSystemTime(now);
 
       vi.spyOn(LedgerCanister, "create").mockImplementation(
@@ -79,7 +79,7 @@ describe("icp-ledger.api", () => {
     });
 
     it("should call ledger to send ICP with memo", async () => {
-      const memo = BigInt(444555);
+      const memo = 444_555n;
       await sendICP({
         identity: mockIdentity,
         to: accountIdentifier,
@@ -96,8 +96,8 @@ describe("icp-ledger.api", () => {
     });
 
     it("should call ledger to send ICP with createdAt", async () => {
-      const memo = BigInt(444555);
-      const createdAt = BigInt(123456);
+      const memo = 444_555n;
+      const createdAt = 123_456n;
       await sendICP({
         identity: mockIdentity,
         to: accountIdentifier,
@@ -120,16 +120,16 @@ describe("icp-ledger.api", () => {
 
     const owner = mockIdentity.getPrincipal();
     const amount = TokenAmount.fromE8s({
-      amount: BigInt(11_000),
+      amount: 11_000n,
       token: ICPToken,
     });
 
     const now = Date.now();
-    const nowInBigIntNanoSeconds = BigInt(now) * BigInt(1_000_000);
+    const nowInBigIntNanoSeconds = BigInt(now) * 1_000_000n;
 
     beforeEach(() => {
       const ledgerMock = mock<LedgerCanister>();
-      ledgerMock.icrc1Transfer.mockResolvedValue(BigInt(0));
+      ledgerMock.icrc1Transfer.mockResolvedValue(0n);
       vi.useFakeTimers().setSystemTime(now);
 
       vi.spyOn(LedgerCanister, "create").mockImplementation(
@@ -156,7 +156,7 @@ describe("icp-ledger.api", () => {
     });
 
     it("should call ledger to send ICP with fee", async () => {
-      const fee = 15000n;
+      const fee = 15_000n;
       await sendIcpIcrc1({
         identity: mockIdentity,
         to: { owner },
@@ -215,7 +215,7 @@ describe("icp-ledger.api", () => {
 
     it("should call ledger to send ICP with createdAt", async () => {
       const icrc1Memo = Uint8Array.from([4, 4, 5, 5]);
-      const createdAt = BigInt(123456);
+      const createdAt = 123_456n;
       await sendIcpIcrc1({
         identity: mockIdentity,
         to: { owner },
@@ -252,7 +252,7 @@ describe("icp-ledger.api", () => {
   });
 
   describe("transactionFee", () => {
-    const fee = BigInt(10_000);
+    const fee = 10_000n;
     const ledgerMock = mock<LedgerCanister>();
     ledgerMock.transactionFee.mockResolvedValue(fee);
 
@@ -270,7 +270,7 @@ describe("icp-ledger.api", () => {
   });
 
   describe("queryAccountBalance", () => {
-    const balance = BigInt(10_000_000);
+    const balance = 10_000_000n;
     const ledgerMock = mock<LedgerCanister>();
     ledgerMock.accountBalance.mockResolvedValue(balance);
 

--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -8,7 +8,7 @@ describe("icrc-index api", () => {
     account: {
       owner: mockPrincipal,
     },
-    maxResults: BigInt(10),
+    maxResults: 10n,
   };
 
   const transaction = {
@@ -17,7 +17,7 @@ describe("icrc-index api", () => {
 
   describe("getTransactions", () => {
     it("returns list of transaction", async () => {
-      const transactions = [{ transaction, id: BigInt(1) }];
+      const transactions = [{ transaction, id: 1n }];
 
       const getTransactionsSpy = vi.fn().mockResolvedValue({
         transactions,

--- a/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
@@ -38,7 +38,7 @@ describe("icrc-ledger api", () => {
 
   describe("getIcrcMainAccount", () => {
     it("returns main account with balance and project token metadata", async () => {
-      const balanceSpy = vi.fn().mockResolvedValue(BigInt(10_000_000));
+      const balanceSpy = vi.fn().mockResolvedValue(10_000_000n);
 
       const account = await getIcrcAccount({
         certified: true,
@@ -49,7 +49,7 @@ describe("icrc-ledger api", () => {
 
       expect(account).not.toBeUndefined();
 
-      expect(account.balanceUlps).toEqual(BigInt(10_000_000));
+      expect(account.balanceUlps).toEqual(10_000_000n);
 
       expect(account.principal.toText()).toEqual(
         mockIdentity.getPrincipal().toText()
@@ -111,9 +111,9 @@ describe("icrc-ledger api", () => {
 
       await executeIcrcTransfer({
         to: { owner: mockIdentity.getPrincipal() },
-        amount: BigInt(10_000_000),
-        createdAt: BigInt(123456),
-        fee: BigInt(10_000),
+        amount: 10_000_000n,
+        createdAt: 123_456n,
+        fee: 10_000n,
         transfer: transferSpy,
       });
 
@@ -129,9 +129,9 @@ describe("icrc-ledger api", () => {
       await icrcTransfer({
         identity: mockIdentity,
         to: { owner: mockIdentity.getPrincipal() },
-        amount: BigInt(10_000_000),
-        createdAt: BigInt(123456),
-        fee: BigInt(10_000),
+        amount: 10_000_000n,
+        createdAt: 123_456n,
+        fee: 10_000n,
         canisterId: CKBTC_LEDGER_CANISTER_ID,
       });
 
@@ -141,11 +141,11 @@ describe("icrc-ledger api", () => {
 
   describe("approveTransfer", () => {
     it("successfully calls approve api", async () => {
-      const expectedBlockIndex = BigInt(123456);
+      const expectedBlockIndex = 123_456n;
       const approveSpy =
         ledgerCanisterMock.approve.mockResolvedValue(expectedBlockIndex);
       const spenderPrincipal = Principal.fromHex("123abc");
-      const amount = BigInt(13_000_000);
+      const amount = 13_000_000n;
       const nowMillis = 123456789;
       vi.setSystemTime(nowMillis);
 
@@ -173,15 +173,15 @@ describe("icrc-ledger api", () => {
     });
 
     it("successfully passes optional params", async () => {
-      const expectedBlockIndex = BigInt(123456);
+      const expectedBlockIndex = 123_456n;
       const approveSpy =
         ledgerCanisterMock.approve.mockResolvedValue(expectedBlockIndex);
       const spenderPrincipal = Principal.fromHex("123abc");
-      const amount = BigInt(13_000_000);
-      const expectedAllowance = BigInt(135_000_000);
-      const expiresAt = BigInt(123999000000);
-      const createdAt = BigInt(123456000000);
-      const fee = BigInt(17_000);
+      const amount = 13_000_000n;
+      const expectedAllowance = 135_000_000n;
+      const expiresAt = 123_999_000_000n;
+      const createdAt = 123_456_000_000n;
+      const fee = 17_000n;
       const fromSubaccount = new Uint8Array([1, 9, 3]);
 
       const actualBlockIndex = await approveTransfer({
@@ -233,7 +233,7 @@ describe("icrc-ledger api", () => {
 
   describe("queryIcrcBalance", () => {
     it("successfully calls balance endpoint", async () => {
-      const balanceE8s = 314000000n;
+      const balanceE8s = 314_000_000n;
       ledgerCanisterMock.balance.mockResolvedValue(balanceE8s);
 
       const account: IcrcAccount = {

--- a/frontend/src/tests/lib/api/proposals.api.spec.ts
+++ b/frontend/src/tests/lib/api/proposals.api.spec.ts
@@ -80,7 +80,7 @@ describe("proposals-api", () => {
 
   describe("load", () => {
     it("should call the canister to get proposalInfo", async () => {
-      const proposalId = BigInt(404);
+      const proposalId = 404n;
       const certified = false;
 
       const proposal = await queryProposal({
@@ -119,7 +119,7 @@ describe("proposals-api", () => {
       const spyGetProposalPayload = vi.spyOn(nnsDappMock, "getProposalPayload");
 
       await queryProposalPayload({
-        proposalId: BigInt(0),
+        proposalId: 0n,
         identity: mockIdentity,
       });
 

--- a/frontend/src/tests/lib/api/sns-governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-governance.api.spec.ts
@@ -327,7 +327,7 @@ describe("sns-api", () => {
     await claimNeuron({
       identity: mockIdentity,
       rootCanisterId: rootCanisterIdMock,
-      memo: BigInt(2),
+      memo: 2n,
       controller: Principal.fromText("aaaaa-aa"),
       subaccount: arrayOfNumberToUint8Array([1, 2, 3]),
     });
@@ -342,7 +342,7 @@ describe("sns-api", () => {
       identity: mockIdentity,
       rootCanisterId: rootCanisterIdMock,
       neuronId: mockSnsNeuron.id[0],
-      functionId: BigInt(3),
+      functionId: 3n,
       followees: [followee1, followee2],
     });
 
@@ -385,7 +385,7 @@ describe("sns-api", () => {
 
   it("should get proposals", async () => {
     const proposalId: SnsProposalId = {
-      id: BigInt(2),
+      id: 2n,
     };
     const res = await queryProposal({
       identity: mockIdentity,

--- a/frontend/src/tests/lib/api/sns-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-index.api.spec.ts
@@ -5,7 +5,7 @@ import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 vi.mock("$lib/proxy/api.import.proxy");
 const getTransactionsSpy = vi.fn().mockResolvedValue({
   transactions: [],
-  oldest_tx_id: BigInt(2),
+  oldest_tx_id: 2n,
 });
 vi.mock("$lib/api/sns-wrapper.api", () => {
   return {
@@ -24,7 +24,7 @@ describe("sns-index api", () => {
         account: {
           owner: mockPrincipal,
         },
-        maxResults: BigInt(10),
+        maxResults: 10n,
       });
 
       expect(result.transactions).toBeDefined();

--- a/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-ledger.api.spec.ts
@@ -12,10 +12,10 @@ import {
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 
 vi.mock("$lib/proxy/api.import.proxy");
-const mainBalance = BigInt(10_000_000);
-const fee = BigInt(10_000);
+const mainBalance = 10_000_000n;
+const fee = 10_000n;
 const transactionFeeSpy = vi.fn().mockResolvedValue(fee);
-const transferSpy = vi.fn().mockResolvedValue(BigInt(10));
+const transferSpy = vi.fn().mockResolvedValue(10n);
 
 let metadataReturn = mockQueryTokenResponse;
 const setMetadataError = () => (metadataReturn = []);
@@ -103,9 +103,9 @@ describe("sns-ledger api", () => {
         identity: mockIdentity,
         rootCanisterId: rootCanisterIdMock,
         to: { owner: mockIdentity.getPrincipal() },
-        amount: BigInt(10_000_000),
-        createdAt: BigInt(123456),
-        fee: BigInt(10_000),
+        amount: 10_000_000n,
+        createdAt: 123_456n,
+        fee: 10_000n,
       });
 
       expect(transferSpy).toBeCalled();

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -53,21 +53,21 @@ describe("sns-api", () => {
     derived: [
       {
         sns_tokens_per_icp: 1,
-        buyer_total_icp_e8s: BigInt(1_000_000_000),
+        buyer_total_icp_e8s: 1_000_000_000n,
       },
     ],
   };
 
   const derivedState = {
     sns_tokens_per_icp: [1],
-    buyer_total_icp_e8s: [BigInt(1_000_000_000)],
+    buyer_total_icp_e8s: [1_000_000_000n],
   };
   const lifecycleResponse: SnsGetLifecycleResponse = {
     lifecycle: [SnsSwapLifecycle.Open],
-    decentralization_sale_open_timestamp_seconds: [BigInt(1)],
+    decentralization_sale_open_timestamp_seconds: [1n],
   };
   const notifyParticipationSpy = vi.fn().mockResolvedValue(undefined);
-  const mockUserCommitment = createBuyersState(BigInt(100_000_000));
+  const mockUserCommitment = createBuyersState(100_000_000n);
   const getUserCommitmentSpy = vi.fn().mockResolvedValue(mockUserCommitment);
   const getDerivedStateSpy = vi.fn().mockResolvedValue(derivedState);
   const getLifecycleSpy = vi.fn().mockResolvedValue(lifecycleResponse);
@@ -193,12 +193,12 @@ describe("sns-api", () => {
     const neuronId = await stakeNeuron({
       identity: mockIdentity,
       rootCanisterId: rootCanisterIdMock,
-      stakeE8s: BigInt(200_000_000),
+      stakeE8s: 200_000_000n,
       source: {
         owner: mockPrincipal,
       },
       controller: mockPrincipal,
-      fee: BigInt(10000),
+      fee: 10_000n,
     });
 
     expect(neuronId).toEqual(mockSnsNeuron.id);
@@ -209,7 +209,7 @@ describe("sns-api", () => {
     await increaseStakeNeuron({
       identity: mockIdentity,
       rootCanisterId: rootCanisterIdMock,
-      stakeE8s: BigInt(200_000_000),
+      stakeE8s: 200_000_000n,
       source: {
         owner: mockPrincipal,
       },

--- a/frontend/src/tests/lib/api/wallet-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/wallet-index.api.spec.ts
@@ -28,7 +28,7 @@ describe("wallet-index api", () => {
     account: {
       owner: mockPrincipal,
     },
-    maxResults: BigInt(10),
+    maxResults: 10n,
     indexCanisterId: CKBTC_INDEX_CANISTER_ID,
   };
 
@@ -38,7 +38,7 @@ describe("wallet-index api", () => {
 
   describe("getTransactions", () => {
     it("should returns transactions", async () => {
-      const id = BigInt(1);
+      const id = 1n;
 
       const getTransactionsSpy =
         indexCanisterMock.getTransactions.mockResolvedValue({

--- a/frontend/src/tests/lib/api/wallet-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/wallet-ledger.api.spec.ts
@@ -29,7 +29,7 @@ describe("wallet-ledger api", () => {
 
   describe("getAccount", () => {
     it("returns main account with balance", async () => {
-      const balance = BigInt(10_000_000);
+      const balance = 10_000_000n;
 
       const balanceSpy = ledgerCanisterMock.balance.mockResolvedValue(balance);
 

--- a/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
@@ -23,22 +23,22 @@ describe("ICManagementCanister", () => {
   describe("ICManagementCanister.getCanisterDetails", () => {
     it("returns account identifier when success", async () => {
       const settings = {
-        freezing_threshold: BigInt(2),
+        freezing_threshold: 2n,
         controllers: [
           Principal.fromText(
             "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe"
           ),
         ],
-        memory_allocation: BigInt(4),
-        compute_allocation: BigInt(10),
+        memory_allocation: 4n,
+        compute_allocation: 10n,
       };
       const response: CanisterStatusResponse = {
         status: { running: null },
-        memory_size: BigInt(1000),
-        cycles: BigInt(10_000),
+        memory_size: 1_000n,
+        cycles: 10_000n,
         settings,
         module_hash: [],
-        idle_cycles_burned_per_day: BigInt(30_000),
+        idle_cycles_burned_per_day: 30_000n,
       };
       const service = mock<IcManagementService>();
       service.canister_status.mockResolvedValue(response);

--- a/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/nns-dapp.canister.spec.ts
@@ -464,7 +464,7 @@ describe("NNSDapp", () => {
       const nnsDapp = await createNnsDapp(service);
 
       await nnsDapp.getProposalPayload({
-        proposalId: BigInt(0),
+        proposalId: 0n,
       });
 
       expect(service.get_proposal_payload).toBeCalled();
@@ -479,7 +479,7 @@ describe("NNSDapp", () => {
     const nnsDapp = await createNnsDapp(service);
 
     const result = await nnsDapp.getProposalPayload({
-      proposalId: BigInt(0),
+      proposalId: 0n,
     });
 
     expect(result).toEqual({ test: "data" });
@@ -494,7 +494,7 @@ describe("NNSDapp", () => {
 
     const call = () =>
       nnsDapp.getProposalPayload({
-        proposalId: BigInt(0),
+        proposalId: 0n,
       });
 
     expect(call).rejects.toThrowError(ProposalPayloadNotFoundError);
@@ -509,7 +509,7 @@ describe("NNSDapp", () => {
 
     const call = () =>
       nnsDapp.getProposalPayload({
-        proposalId: BigInt(0),
+        proposalId: 0n,
       });
 
     expect(call).rejects.toThrowError(ProposalPayloadTooLargeError);
@@ -524,7 +524,7 @@ describe("NNSDapp", () => {
 
     const call = () =>
       nnsDapp.getProposalPayload({
-        proposalId: BigInt(0),
+        proposalId: 0n,
       });
 
     expect(call).rejects.toThrowError(UnknownProposalPayloadError);

--- a/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCTransactionsList.spec.ts
@@ -80,7 +80,7 @@ describe("CkBTCTransactionList", () => {
         [mockCkBTCMainAccount.identifier]: {
           transactions: [
             {
-              id: BigInt(123),
+              id: 123n,
               transaction: createBurnTransaction({
                 // Missing memo should result in fallback description.
                 from: {
@@ -91,7 +91,7 @@ describe("CkBTCTransactionList", () => {
             },
           ],
           completed: false,
-          oldestTxId: BigInt(0),
+          oldestTxId: 0n,
         },
       },
     };
@@ -120,7 +120,7 @@ describe("CkBTCTransactionList", () => {
         [mockCkBTCMainAccount.identifier]: {
           transactions: [
             {
-              id: BigInt(123),
+              id: 123n,
               transaction: createBurnTransaction({
                 memo,
                 from: {
@@ -131,7 +131,7 @@ describe("CkBTCTransactionList", () => {
             },
           ],
           completed: false,
-          oldestTxId: BigInt(0),
+          oldestTxId: 0n,
         },
       },
     };
@@ -224,12 +224,12 @@ describe("CkBTCTransactionList", () => {
         [mockCkBTCMainAccount.identifier]: {
           transactions: [
             {
-              id: BigInt(123),
+              id: 123n,
               transaction: mockIcrcTransactionMint,
             },
           ],
           completed: false,
-          oldestTxId: BigInt(0),
+          oldestTxId: 0n,
         },
       },
     };
@@ -276,7 +276,7 @@ describe("CkBTCTransactionList", () => {
             },
           ],
           completed: false,
-          oldestTxId: BigInt(0),
+          oldestTxId: 0n,
         },
       },
     };

--- a/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsList.spec.ts
@@ -134,7 +134,7 @@ describe("IcrcWalletTransactionList", () => {
         [mockCkBTCMainAccount.identifier]: {
           transactions: [mockIcrcTransactionWithId],
           completed: false,
-          oldestTxId: BigInt(0),
+          oldestTxId: 0n,
         },
       },
     };
@@ -154,7 +154,7 @@ describe("IcrcWalletTransactionList", () => {
         [mockCkBTCMainAccount.identifier]: {
           transactions: [mockIcrcTransactionWithIdToSelf],
           completed: false,
-          oldestTxId: BigInt(0),
+          oldestTxId: 0n,
         },
       },
     };
@@ -174,7 +174,7 @@ describe("IcrcWalletTransactionList", () => {
         [mockCkBTCMainAccount.identifier]: {
           transactions: [mockIcrcTransactionWithId],
           completed: false,
-          oldestTxId: BigInt(0),
+          oldestTxId: 0n,
         },
       },
     };
@@ -222,7 +222,7 @@ describe("IcrcWalletTransactionList", () => {
         [mockCkBTCMainAccount.identifier]: {
           transactions: [],
           completed: false,
-          oldestTxId: BigInt(0),
+          oldestTxId: 0n,
         },
       },
     };

--- a/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsObserver.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsObserver.spec.ts
@@ -33,7 +33,7 @@ describe("IcrcWalletTransactionsObserver", () => {
     canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
     transactions: [mockIcrcTransactionWithId],
     accountIdentifier: mockCkBTCMainAccount.identifier,
-    oldestTxId: BigInt(10),
+    oldestTxId: 10n,
     completed: false,
   };
 

--- a/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsTransactionCard.spec.ts
@@ -60,8 +60,8 @@ describe("NnsTransactionCard", () => {
       ...mockReceivedFromMainAccountTransaction,
       transfer: {
         Send: {
-          fee: { e8s: BigInt(10000) },
-          amount: { e8s: BigInt(110000000) },
+          fee: { e8s: 10_000n },
+          amount: { e8s: 110_000_000n },
           to: swapCanisterAccount.toHex(),
         },
       },

--- a/frontend/src/tests/lib/components/accounts/SnsTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsTransactionsList.spec.ts
@@ -73,7 +73,7 @@ describe("SnsTransactionList", () => {
         [mockSnsMainAccount.identifier]: {
           transactions: [mockIcrcTransactionWithId],
           completed: false,
-          oldestTxId: BigInt(0),
+          oldestTxId: 0n,
         },
       },
     };

--- a/frontend/src/tests/lib/components/accounts/SnsWalletTransactionsObserver.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsWalletTransactionsObserver.spec.ts
@@ -35,7 +35,7 @@ describe("SnsWalletTransactionsObserver", () => {
     canisterId: rootCanisterIdMock,
     transactions: [mockIcrcTransactionWithId],
     accountIdentifier: mockSnsMainAccount.identifier,
-    oldestTxId: BigInt(10),
+    oldestTxId: 10n,
     completed: false,
   };
 

--- a/frontend/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
+++ b/frontend/src/tests/lib/components/canisters/SelectCyclesCanister.spec.ts
@@ -7,12 +7,12 @@ import SelectCyclesCanisterTest from "./SelectCyclesCanisterTest.svelte";
 
 vitest.mock("$lib/services/canisters.services", () => {
   return {
-    getIcpToCyclesExchangeRate: vitest.fn().mockResolvedValue(BigInt(10_000)),
+    getIcpToCyclesExchangeRate: vitest.fn().mockResolvedValue(10_000n),
   };
 });
 
 describe("SelectCyclesCanister", () => {
-  const props = { icpToCyclesExchangeRate: BigInt(10_000) };
+  const props = { icpToCyclesExchangeRate: 10_000n };
   it("renders button", () => {
     const { queryByText } = render(SelectCyclesCanisterTest, { props });
 

--- a/frontend/src/tests/lib/components/common/Json.spec.ts
+++ b/frontend/src/tests/lib/components/common/Json.spec.ts
@@ -67,7 +67,8 @@ describe("Json", () => {
 
   it("should render bigint", () =>
     testJsonRender({
-      bigint: BigInt("12345678901234567890123456789012345678901234567890"),
+      bigint:
+        12_345_678_901_234_567_890_123_456_789_012_345_678_901_234_567_890n,
     }));
 
   it("should render function", () =>

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
@@ -7,7 +7,7 @@ import FolloweeTest from "./FolloweeTest.svelte";
 
 describe("Followee", () => {
   const followee = {
-    neuronId: BigInt(111),
+    neuronId: 111n,
     topics: [Topic.ExchangeRate, Topic.Governance, Topic.Kyc],
   };
 

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
@@ -93,7 +93,7 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
     const neuron: NeuronInfo = {
       ...controlledNeuron,
       state: NeuronState.Dissolved,
-      dissolveDelaySeconds: BigInt(0),
+      dissolveDelaySeconds: 0n,
     };
     const po = renderComponent(neuron);
 
@@ -106,7 +106,7 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
     const neuron: NeuronInfo = {
       ...mockNeuron,
       state: NeuronState.Dissolved,
-      dissolveDelaySeconds: BigInt(0),
+      dissolveDelaySeconds: 0n,
       fullNeuron: {
         ...mockNeuron.fullNeuron,
         controller: "not-controller",
@@ -126,7 +126,7 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
     const neuron: NeuronInfo = {
       ...mockNeuron,
       state: NeuronState.Dissolved,
-      dissolveDelaySeconds: BigInt(0),
+      dissolveDelaySeconds: 0n,
       fullNeuron: {
         ...mockNeuron.fullNeuron,
         controller: mockHardwareWalletAccount.principal.toText(),

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronHotkeysCard.spec.ts
@@ -15,7 +15,7 @@ import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
 
 vi.mock("$lib/services/neurons.services", () => {
   return {
-    removeHotkey: vi.fn().mockResolvedValue(BigInt(10)),
+    removeHotkey: vi.fn().mockResolvedValue(10n),
     getNeuronFromStore: vi.fn(),
   };
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
@@ -68,7 +68,7 @@ describe("NnsNeuronPageHeading", () => {
   it("should render neuron's fund tag if belongs part of neurons fund", async () => {
     const po = renderComponent({
       ...mockNeuron,
-      joinedCommunityFundTimestampSeconds: BigInt(12333444),
+      joinedCommunityFundTimestampSeconds: 12_333_444n,
     });
 
     expect(await po.getNeuronTags()).toEqual(["Neurons' fund"]);
@@ -100,7 +100,7 @@ describe("NnsNeuronPageHeading", () => {
     });
     const po = renderComponent({
       ...mockNeuron,
-      joinedCommunityFundTimestampSeconds: BigInt(12333444),
+      joinedCommunityFundTimestampSeconds: 12_333_444n,
       fullNeuron: {
         ...mockNeuron.fullNeuron,
         controller: "not-current-principal",

--- a/frontend/src/tests/lib/components/neuron-detail/actions/DissolveActionButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/DissolveActionButton.spec.ts
@@ -26,7 +26,7 @@ describe("DissolveActionButton", () => {
       props: {
         neuron: {
           ...mockNeuron,
-          neuronId: BigInt(10),
+          neuronId: 10n,
           state: NeuronState.Locked,
         },
       },
@@ -40,7 +40,7 @@ describe("DissolveActionButton", () => {
       props: {
         neuron: {
           ...mockNeuron,
-          neuronId: BigInt(10),
+          neuronId: 10n,
           state: NeuronState.Dissolving,
         },
       },
@@ -54,7 +54,7 @@ describe("DissolveActionButton", () => {
       props: {
         neuron: {
           ...mockNeuron,
-          neuronId: BigInt(10),
+          neuronId: 10n,
           state: NeuronState.Locked,
         },
       },
@@ -82,7 +82,7 @@ describe("DissolveActionButton", () => {
       props: {
         neuron: {
           ...mockNeuron,
-          neuronId: BigInt(10),
+          neuronId: 10n,
           state: NeuronState.Dissolving,
         },
       },

--- a/frontend/src/tests/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.spec.ts
@@ -54,7 +54,7 @@ describe("JoinCommunityFundCheckbox", () => {
   it("renders checked if neuron is part of the fund", () => {
     const neuron = {
       ...mockNeuron,
-      joinedCommunityFundTimestampSeconds: BigInt(1200),
+      joinedCommunityFundTimestampSeconds: 1_200n,
     };
 
     const { queryByTestId } = render(NeuronContextActionsTest, {
@@ -117,7 +117,7 @@ describe("JoinCommunityFundCheckbox", () => {
   it("allows neuron to leave community fund", async () => {
     const neuron = {
       ...mockNeuron,
-      joinedCommunityFundTimestampSeconds: BigInt(10),
+      joinedCommunityFundTimestampSeconds: 10n,
     };
 
     const { container, queryByTestId } = render(NeuronContextActionsTest, {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsStakeMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsStakeMaturityButton.spec.ts
@@ -33,7 +33,7 @@ describe("NnsStakeMaturityButton", () => {
           ...mockNeuron,
           fullNeuron: {
             ...mockNeuron.fullNeuron,
-            maturityE8sEquivalent: BigInt(0),
+            maturityE8sEquivalent: 0n,
           },
         },
         testComponent: NnsStakeMaturityButton,

--- a/frontend/src/tests/lib/components/neuron-detail/actions/SplitNnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/SplitNnsNeuronButton.spec.ts
@@ -27,7 +27,7 @@ describe("SplitNeuronButton", () => {
           ...mockNeuron,
           fullNeuron: {
             ...mockFullNeuron,
-            cachedNeuronStake: BigInt(10),
+            cachedNeuronStake: 10n,
           },
         },
         testComponent: SplitNeuronButton,
@@ -47,7 +47,7 @@ describe("SplitNeuronButton", () => {
           ...mockNeuron,
           fullNeuron: {
             ...mockFullNeuron,
-            cachedNeuronStake: BigInt(1_000_000_000),
+            cachedNeuronStake: 1_000_000_000n,
           },
         },
         testComponent: SplitNeuronButton,

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -111,7 +111,7 @@ describe("NnsNeuronCard", () => {
       props: {
         neuron: {
           ...mockNeuron,
-          joinedCommunityFundTimestampSeconds: BigInt(1000),
+          joinedCommunityFundTimestampSeconds: 1_000n,
         },
       },
     });

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronDetailCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronDetailCard.spec.ts
@@ -15,7 +15,7 @@ describe("NnsNeuronDetailCard", () => {
   it("should render neuron id", async () => {
     const po = renderComponent({
       ...mockNeuron,
-      neuronId: BigInt(123789),
+      neuronId: 123_789n,
     });
 
     expect(await po.getNeuronId()).toBe("123789");
@@ -26,8 +26,8 @@ describe("NnsNeuronDetailCard", () => {
       ...mockNeuron,
       fullNeuron: {
         ...mockFullNeuron,
-        cachedNeuronStake: BigInt(3_000_000_000),
-        neuronFees: BigInt(1_000_000_000),
+        cachedNeuronStake: 3_000_000_000n,
+        neuronFees: 1_000_000_000n,
       },
     });
 
@@ -56,7 +56,7 @@ describe("NnsNeuronDetailCard", () => {
   it("should render neuron voting power", async () => {
     const po = renderComponent({
       ...mockNeuron,
-      votingPower: BigInt(3_000_000_000),
+      votingPower: 3_000_000_000n,
     });
 
     expect(await po.getVotingPower()).toBe("30.00");
@@ -67,8 +67,8 @@ describe("NnsNeuronDetailCard", () => {
       ...mockNeuron,
       fullNeuron: {
         ...mockFullNeuron,
-        maturityE8sEquivalent: BigInt(300_000_000),
-        stakedMaturityE8sEquivalent: BigInt(500_000_000),
+        maturityE8sEquivalent: 300_000_000n,
+        stakedMaturityE8sEquivalent: 500_000_000n,
       },
     });
 
@@ -80,8 +80,8 @@ describe("NnsNeuronDetailCard", () => {
       ...mockNeuron,
       fullNeuron: {
         ...mockFullNeuron,
-        maturityE8sEquivalent: BigInt(300_000_000),
-        stakedMaturityE8sEquivalent: BigInt(500_000_000),
+        maturityE8sEquivalent: 300_000_000n,
+        stakedMaturityE8sEquivalent: 500_000_000n,
       },
     });
 

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronsFooter.spec.ts
@@ -25,15 +25,15 @@ describe("NnsNeurons", () => {
     beforeEach(() => {
       const mockNeuron2 = {
         ...mockNeuron,
-        neuronId: BigInt(223),
+        neuronId: 223n,
       };
       const spawningNeuron = {
         ...mockNeuron,
         state: NeuronState.Spawning,
-        neuronId: BigInt(456),
+        neuronId: 456n,
         fullNeuron: {
           ...mockFullNeuron,
-          spawnAtTimesSeconds: BigInt(12312313),
+          spawnAtTimesSeconds: 12_312_313n,
         },
       };
       vi.spyOn(neuronsStore, "subscribe").mockImplementation(

--- a/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
@@ -16,7 +16,7 @@ const defaultComponentProps = {
   neuronState: NeuronState.Locked,
   neuronDissolveDelaySeconds: 0,
   neuronStake: TokenAmountV2.fromUlps({
-    amount: BigInt(200_000_000),
+    amount: 200_000_000n,
     token: ICPToken,
   }),
   delayInSeconds: 0,

--- a/frontend/src/tests/lib/components/project-detail/CommitmentProgressBar.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/CommitmentProgressBar.spec.ts
@@ -6,9 +6,9 @@ import { render } from "@testing-library/svelte";
 describe("CommitmentProgressBar", () => {
   const color: "primary" | "warning" = "primary";
   const props = {
-    participationE8s: 1500n,
-    max: BigInt(3000),
-    minimumIndicator: BigInt(1500),
+    participationE8s: 1_500n,
+    max: 3_000n,
+    minimumIndicator: 1_500n,
     color,
   };
 
@@ -27,7 +27,7 @@ describe("CommitmentProgressBar", () => {
       ...props,
       participationE8s: 150_000_000n,
     });
-    expect(await po.getCommitmentE8s()).toBe(150000000n);
+    expect(await po.getCommitmentE8s()).toBe(150000_000n);
   });
 
   it("should display minimum indicators", async () => {

--- a/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
@@ -59,7 +59,7 @@ describe("ProjectStatusSection", () => {
       summary: mockSnsFullProject.summary,
       swapCommitment: {
         rootCanisterId: mockSnsFullProject.rootCanisterId,
-        myCommitment: createBuyersState(BigInt(2_500_000_000)),
+        myCommitment: createBuyersState(2_500_000_000n),
       },
     });
     expect(await po.getCommitmentAmount()).toBe("25.00");

--- a/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectSwapDetails.spec.ts
@@ -112,7 +112,7 @@ describe("ProjectSwapDetails", () => {
   });
 
   it("should render total token supply if present", async () => {
-    const totalSupply = BigInt(2_000_000_000);
+    const totalSupply = 2_000_000_000n;
     const totalTokensSupply = TokenAmount.fromE8s({
       amount: totalSupply,
       token: mockSummary.token,

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalVotingSection.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalVotingSection.spec.ts
@@ -25,15 +25,15 @@ describe("ProposalVotingSection", () => {
 
   const neuronIds = [111, 222].map(BigInt);
 
-  const proposalTimestampSeconds = BigInt(100);
+  const proposalTimestampSeconds = 100n;
   const ineligibleNeuron = {
     ...mockNeuron,
-    createdTimestampSeconds: proposalTimestampSeconds + BigInt(1),
+    createdTimestampSeconds: proposalTimestampSeconds + 1n,
   } as NeuronInfo;
 
   const neurons: NeuronInfo[] = neuronIds.map((neuronId) => ({
     ...mockNeuron,
-    createdTimestampSeconds: BigInt(BigInt(1000)),
+    createdTimestampSeconds: BigInt(1_000n),
     dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR),
     neuronId,
   }));
@@ -53,7 +53,7 @@ describe("ProposalVotingSection", () => {
   const proposalInfo = {
     ...mockProposalInfo,
     ballots: neuronIds.map((neuronId) => ({ neuronId }) as Ballot),
-    proposalTimestampSeconds: BigInt(2000),
+    proposalTimestampSeconds: 2_000n,
     status: ProposalStatus.Open,
   };
 

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/NnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/NnsVotingCard.spec.ts
@@ -32,12 +32,12 @@ describe("VotingCard", () => {
   const proposalInfo: ProposalInfo = {
     ...mockProposalInfo,
     ballots: neuronIds.map((neuronId) => ({ neuronId }) as Ballot),
-    proposalTimestampSeconds: BigInt(2000),
+    proposalTimestampSeconds: 2_000n,
     status: ProposalStatus.Open,
   };
   const neurons: NeuronInfo[] = neuronIds.map((neuronId) => ({
     ...mockNeuron,
-    createdTimestampSeconds: BigInt(BigInt(1000)),
+    createdTimestampSeconds: BigInt(1_000n),
     dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR),
     neuronId,
     permission_type: Int32Array.from([

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronSelect.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronSelect.spec.ts
@@ -11,17 +11,17 @@ import { render, waitFor } from "@testing-library/svelte";
 describe("VotingNeuronSelect", () => {
   const neuron1 = {
     ...mockNeuron,
-    neuronId: BigInt(111),
+    neuronId: 111n,
     votingPower: 10_000_000_000n,
   };
   const neuron2 = {
     ...mockNeuron,
-    neuronId: BigInt(222),
+    neuronId: 222n,
     votingPower: 30_000_000_000n,
   };
   const neuron3 = {
     ...mockNeuron,
-    neuronId: BigInt(333),
+    neuronId: 333n,
     votingPower: 50_000_000_000n,
   };
   const neurons: NeuronInfo[] = [neuron1, neuron2, neuron3];

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.spec.ts
@@ -11,17 +11,17 @@ import { get } from "svelte/store";
 describe("VotingNeuronSelectList", () => {
   const neuron1 = {
     ...mockNeuron,
-    neuronId: BigInt(111),
+    neuronId: 111n,
     votingPower: 10_000_000_000n,
   };
   const neuron2 = {
     ...mockNeuron,
-    neuronId: BigInt(222),
+    neuronId: 222n,
     votingPower: 30_000_000_000n,
   };
   const neuron3 = {
     ...mockNeuron,
-    neuronId: BigInt(333),
+    neuronId: 333n,
     votingPower: 50_000_000_000n,
   };
   const neurons: NeuronInfo[] = [neuron1, neuron2, neuron3];

--- a/frontend/src/tests/lib/components/proposals/ProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/ProposalCard.spec.ts
@@ -9,7 +9,7 @@ describe("ProposalCard", () => {
   const props = {
     hidden: false,
     status: "open",
-    id: BigInt(112),
+    id: 112n,
     heading: "Treasury Proposal",
     title: "Give me my tokens",
     proposer: "2",

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
@@ -46,17 +46,17 @@ describe("SnsNeuronFollowingCard", () => {
     };
     const function0: SnsNervousSystemFunction = {
       ...nervousSystemFunctionMock,
-      id: BigInt(0),
+      id: 0n,
       name: "function0",
     };
     const function1: SnsNervousSystemFunction = {
       ...nervousSystemFunctionMock,
-      id: BigInt(1),
+      id: 1n,
       name: "function1",
     };
     const function2: SnsNervousSystemFunction = {
       ...nervousSystemFunctionMock,
-      id: BigInt(2),
+      id: 2n,
       name: "function2",
     };
     const followee1 = createMockSnsNeuron({

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.spec.ts
@@ -96,7 +96,7 @@ describe("DissolveSnsNeuronButton", () => {
     const { container, queryByTestId } = render(DissolveSnsNeuronButtonTest, {
       props: {
         neuron: createMockSnsNeuron({
-          stake: BigInt(10_000_000_000),
+          stake: 10_000_000_000n,
           id: [1, 2, 2, 9, 9, 3, 2],
           state: NeuronState.Dissolving,
         }),

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.spec.ts
@@ -38,7 +38,7 @@ describe("SnsStakeMaturityButton", () => {
       props: {
         neuron: {
           ...mockSnsNeuron,
-          maturity_e8s_equivalent: BigInt(0),
+          maturity_e8s_equivalent: 0n,
           staked_maturity_e8s_equivalent: [],
         },
       },

--- a/frontend/src/tests/lib/components/sns-neurons/SnsNeuronsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/SnsNeuronsFooter.spec.ts
@@ -17,15 +17,15 @@ describe("SnsNeuron footer", () => {
   beforeEach(() => {
     const mockNeuron2 = {
       ...mockNeuron,
-      neuronId: BigInt(223),
+      neuronId: 223n,
     };
     const spawningNeuron = {
       ...mockNeuron,
       state: NeuronState.Spawning,
-      neuronId: BigInt(223),
+      neuronId: 223n,
       fullNeuron: {
         ...mockFullNeuron,
-        spawnAtTimesSeconds: BigInt(12312313),
+        spawnAtTimesSeconds: 12_312_313n,
       },
     };
     vi.spyOn(neuronsStore, "subscribe").mockImplementation(
@@ -39,7 +39,7 @@ describe("SnsNeuron footer", () => {
         token: mockSnsFullProject.summary.token,
         rootCanisterId: mockSnsFullProject.rootCanisterId,
         transactionFee: TokenAmount.fromE8s({
-          amount: BigInt(10_000),
+          amount: 10_000n,
           token: mockSnsFullProject.summary.token,
         }),
       })

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalCard.spec.ts
@@ -114,13 +114,13 @@ describe("SnsProposalCard", () => {
   it("should render a specific color for the status", () => {
     const proposalData: SnsProposalData = {
       ...mockSnsProposal,
-      decided_timestamp_seconds: BigInt(2222),
+      decided_timestamp_seconds: 2_222n,
       latest_tally: [
         {
-          yes: BigInt(10),
-          no: BigInt(3),
-          total: BigInt(30),
-          timestamp_seconds: BigInt(2222),
+          yes: 10n,
+          no: 3n,
+          total: 30n,
+          timestamp_seconds: 2_222n,
         },
       ],
       executed_timestamp_seconds: BigInt(nowInSeconds),

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalSystemInfoSection.spec.ts
@@ -22,7 +22,7 @@ describe("ProposalSystemInfoSection", () => {
   fakeSnsGovernanceApi.install();
 
   const rootCanisterId = mockCanisterId;
-  const testNervousFunctionId = BigInt(1);
+  const testNervousFunctionId = 1n;
   const testNervousFunctionName = "test function";
   const nervousFunction = {
     ...nervousSystemFunctionMock,
@@ -53,7 +53,7 @@ describe("ProposalSystemInfoSection", () => {
     const openProposal = {
       ...createSnsProposal({
         status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
-        proposalId: BigInt(2),
+        proposalId: 2n,
       }),
       action: testNervousFunctionId,
     };
@@ -142,7 +142,7 @@ describe("ProposalSystemInfoSection", () => {
     const adoptedProposal = {
       ...createSnsProposal({
         status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_ADOPTED,
-        proposalId: BigInt(2),
+        proposalId: 2n,
       }),
     };
     const props = {
@@ -174,7 +174,7 @@ describe("ProposalSystemInfoSection", () => {
     const executedProposal = {
       ...createSnsProposal({
         status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_EXECUTED,
-        proposalId: BigInt(2),
+        proposalId: 2n,
       }),
     };
     const props = {
@@ -207,7 +207,7 @@ describe("ProposalSystemInfoSection", () => {
     const failedProposal = {
       ...createSnsProposal({
         status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_FAILED,
-        proposalId: BigInt(2),
+        proposalId: 2n,
       }),
     };
     const props = {

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalsList.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalsList.spec.ts
@@ -6,15 +6,15 @@ import { render } from "@testing-library/svelte";
 describe("SnsProposalsList", () => {
   const proposal1: SnsProposalData = {
     ...mockSnsProposal,
-    id: [{ id: BigInt(1) }],
+    id: [{ id: 1n }],
   };
   const proposal2: SnsProposalData = {
     ...mockSnsProposal,
-    id: [{ id: BigInt(2) }],
+    id: [{ id: 2n }],
   };
   const proposal3: SnsProposalData = {
     ...mockSnsProposal,
-    id: [{ id: BigInt(3) }],
+    id: [{ id: 3n }],
   };
   const proposals = [proposal1, proposal2, proposal3];
 

--- a/frontend/src/tests/lib/components/transaction/TransactionReceivedTokenAmount.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionReceivedTokenAmount.spec.ts
@@ -6,7 +6,7 @@ import { render } from "@testing-library/svelte";
 
 describe("TransactionReceivedTokenAmount", () => {
   const amount = TokenAmount.fromE8s({
-    amount: BigInt(11_000),
+    amount: 11_000n,
     token: ICPToken,
   });
 

--- a/frontend/src/tests/lib/components/transaction/TransactionSummary.spec.ts
+++ b/frontend/src/tests/lib/components/transaction/TransactionSummary.spec.ts
@@ -9,7 +9,7 @@ describe("TransactionSummary", () => {
   const amount = 123456.789;
   const token = ICPToken;
   const transactionFee = TokenAmount.fromE8s({
-    amount: BigInt(10_000),
+    amount: 10_000n,
     token,
   });
 

--- a/frontend/src/tests/lib/components/ui/DateSeconds.spec.ts
+++ b/frontend/src/tests/lib/components/ui/DateSeconds.spec.ts
@@ -3,7 +3,7 @@ import { normalizeWhitespace } from "$tests/utils/utils.test-utils";
 import { render } from "@testing-library/svelte";
 
 describe("DateSeconds", () => {
-  const seconds = Number(BigInt("0"));
+  const seconds = 0;
 
   const test = ({
     container,

--- a/frontend/src/tests/lib/derived/neurons-voted-last-reward-event.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/neurons-voted-last-reward-event.derived.spec.ts
@@ -7,8 +7,8 @@ import { Vote, type NeuronInfo, type RewardEvent } from "@dfinity/nns";
 import { get } from "svelte/store";
 
 describe("neuronsVotedInLastRewardEventStore", () => {
-  const settledProposal1 = { id: BigInt(123) };
-  const settledProposal2 = { id: BigInt(456) };
+  const settledProposal1 = { id: 123n };
+  const settledProposal2 = { id: 456n };
   const settledProposals = [settledProposal1, settledProposal2];
   const rewardEvent: RewardEvent = {
     ...mockRewardEvent,
@@ -41,11 +41,11 @@ describe("neuronsVotedInLastRewardEventStore", () => {
   it("returns empty array if neurons have not voted in the reward proposals", () => {
     const neuron1: NeuronInfo = {
       ...neuronNoVotes,
-      neuronId: BigInt(1),
+      neuronId: 1n,
     };
     const neuron2: NeuronInfo = {
       ...neuronNoVotes,
-      neuronId: BigInt(2),
+      neuronId: 2n,
     };
     nnsLatestRewardEventStore.setLatestRewardEvent({
       certified: true,
@@ -63,11 +63,11 @@ describe("neuronsVotedInLastRewardEventStore", () => {
   it("returns neuron ids of the neurons that voted in at least one settled proposals", () => {
     const neuronNotVoted: NeuronInfo = {
       ...neuronNoVotes,
-      neuronId: BigInt(1),
+      neuronId: 1n,
     };
     const neuronVotedAll: NeuronInfo = {
       ...mockNeuron,
-      neuronId: BigInt(2),
+      neuronId: 2n,
       recentBallots: settledProposals.map(({ id }) => ({
         proposalId: id,
         vote: Vote.Yes,
@@ -75,7 +75,7 @@ describe("neuronsVotedInLastRewardEventStore", () => {
     };
     const neuronVotedOne: NeuronInfo = {
       ...mockNeuron,
-      neuronId: BigInt(3),
+      neuronId: 3n,
       recentBallots: [
         {
           proposalId: settledProposal1.id,
@@ -104,7 +104,7 @@ describe("neuronsVotedInLastRewardEventStore", () => {
   it("does not return neurons that voted in proposals but are not settled in the latest reward event", () => {
     const neuronVotedSettled: NeuronInfo = {
       ...mockNeuron,
-      neuronId: BigInt(2),
+      neuronId: 2n,
       recentBallots: [
         {
           proposalId: settledProposal1.id,
@@ -118,10 +118,10 @@ describe("neuronsVotedInLastRewardEventStore", () => {
     };
     const neuronVotedNotSettled: NeuronInfo = {
       ...mockNeuron,
-      neuronId: BigInt(3),
+      neuronId: 3n,
       recentBallots: [
         {
-          proposalId: BigInt(133333),
+          proposalId: 133_333n,
           vote: Vote.Yes,
         },
         {

--- a/frontend/src/tests/lib/derived/proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/proposals.derived.spec.ts
@@ -7,31 +7,31 @@ describe("proposals-derived", () => {
   it("should derives and sort proposals store", () => {
     const storeProposals = [
       {
-        id: BigInt(3),
+        id: 3n,
       },
       {
-        id: BigInt(10),
+        id: 10n,
       },
       {
-        id: BigInt(5),
+        id: 5n,
       },
       {
-        id: BigInt(1),
+        id: 1n,
       },
     ];
 
     const expectedProposals = [
       {
-        id: BigInt(10),
+        id: 10n,
       },
       {
-        id: BigInt(5),
+        id: 5n,
       },
       {
-        id: BigInt(3),
+        id: 3n,
       },
       {
-        id: BigInt(1),
+        id: 1n,
       },
     ];
 

--- a/frontend/src/tests/lib/derived/sns/sns-filtered-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-filtered-proposals.derived.spec.ts
@@ -16,15 +16,15 @@ import { get } from "svelte/store";
 describe("snsFilteredProposalsStore", () => {
   const snsProposal1: SnsProposalData = {
     ...mockSnsProposal,
-    id: [{ id: BigInt(2) }],
+    id: [{ id: 2n }],
   };
   const snsProposal2: SnsProposalData = {
     ...mockSnsProposal,
-    id: [{ id: BigInt(2) }],
+    id: [{ id: 2n }],
   };
   const snsProposal3: SnsProposalData = {
     ...mockSnsProposal,
-    id: [{ id: BigInt(3) }],
+    id: [{ id: 3n }],
   };
 
   beforeEach(() => {
@@ -90,15 +90,15 @@ describe("snsFilteredProposalsStore", () => {
   it("should return open proposals if Open status is checked", () => {
     const rootCanisterId = mockPrincipal;
     const openProposal = createSnsProposal({
-      proposalId: BigInt(2),
+      proposalId: 2n,
       status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
     });
     const failedProposal1 = createSnsProposal({
-      proposalId: BigInt(3),
+      proposalId: 3n,
       status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_FAILED,
     });
     const failedProposal2 = createSnsProposal({
-      proposalId: BigInt(4),
+      proposalId: 4n,
       status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_FAILED,
     });
     const proposals: SnsProposalData[] = [
@@ -139,17 +139,17 @@ describe("snsFilteredProposalsStore", () => {
   it("should return accept votes proposals if Accepting Votes status is checked", () => {
     const rootCanisterId = mockPrincipal;
     const acceptVotesProposal = createSnsProposal({
-      proposalId: BigInt(2),
+      proposalId: 2n,
       status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
       rewardStatus: SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
     });
     const settledProposal = createSnsProposal({
-      proposalId: BigInt(3),
+      proposalId: 3n,
       status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_FAILED,
       rewardStatus: SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_SETTLED,
     });
     const readyToSettleProposal = createSnsProposal({
-      proposalId: BigInt(4),
+      proposalId: 4n,
       status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_EXECUTED,
       rewardStatus:
         SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_READY_TO_SETTLE,

--- a/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
@@ -26,7 +26,7 @@ describe("snsSelectedTransactionFeeStore", () => {
     setSnsProjects([projectParams]);
     page.mock({ data: { universe } });
 
-    const fee = BigInt(10_000);
+    const fee = 10_000n;
     transactionsFeesStore.setFee({
       rootCanisterId,
       fee,

--- a/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
@@ -39,24 +39,24 @@ describe("sortedSnsNeuronStore", () => {
     const neurons: SnsNeuron[] = [
       {
         ...createMockSnsNeuron({
-          stake: BigInt(1_000_000_000),
+          stake: 1_000_000_000n,
           id: [1, 5, 3, 9, 1, 1, 1],
         }),
-        created_timestamp_seconds: BigInt(1),
+        created_timestamp_seconds: 1n,
       },
       {
         ...createMockSnsNeuron({
-          stake: BigInt(2_000_000_000),
+          stake: 2_000_000_000n,
           id: [1, 5, 3, 9, 9, 3, 2],
         }),
-        created_timestamp_seconds: BigInt(3),
+        created_timestamp_seconds: 3n,
       },
       {
         ...createMockSnsNeuron({
-          stake: BigInt(10_000_000_000),
+          stake: 10_000_000_000n,
           id: [1, 2, 2, 9, 9, 3, 2],
         }),
-        created_timestamp_seconds: BigInt(2),
+        created_timestamp_seconds: 2n,
       },
     ];
     snsNeuronsStore.setNeurons({
@@ -80,25 +80,25 @@ describe("sortedSnsNeuronStore", () => {
     const neurons: SnsNeuron[] = [
       {
         ...createMockSnsNeuron({
-          stake: BigInt(0),
+          stake: 0n,
           id: [1, 5, 3, 9, 1, 1, 1],
         }),
-        created_timestamp_seconds: BigInt(1),
-        maturity_e8s_equivalent: BigInt(0),
+        created_timestamp_seconds: 1n,
+        maturity_e8s_equivalent: 0n,
       },
       {
         ...createMockSnsNeuron({
-          stake: BigInt(2_000_000_000),
+          stake: 2_000_000_000n,
           id: [1, 5, 3, 9, 9, 3, 2],
         }),
-        created_timestamp_seconds: BigInt(3),
+        created_timestamp_seconds: 3n,
       },
       {
         ...createMockSnsNeuron({
-          stake: BigInt(10_000_000_000),
+          stake: 10_000_000_000n,
           id: [1, 2, 2, 9, 9, 3, 2],
         }),
-        created_timestamp_seconds: BigInt(2),
+        created_timestamp_seconds: 2n,
       },
     ];
     snsNeuronsStore.setNeurons({
@@ -118,24 +118,24 @@ describe("sortedSnsNeuronStore", () => {
     const neurons1: SnsNeuron[] = [
       {
         ...createMockSnsNeuron({
-          stake: BigInt(1_000_000_000),
+          stake: 1_000_000_000n,
           id: [1, 5, 3, 9, 1, 1, 1],
         }),
-        created_timestamp_seconds: BigInt(1),
+        created_timestamp_seconds: 1n,
       },
       {
         ...createMockSnsNeuron({
-          stake: BigInt(2_000_000_000),
+          stake: 2_000_000_000n,
           id: [1, 5, 3, 9, 9, 3, 2],
         }),
-        created_timestamp_seconds: BigInt(3),
+        created_timestamp_seconds: 3n,
       },
       {
         ...createMockSnsNeuron({
-          stake: BigInt(10_000_000_000),
+          stake: 10_000_000_000n,
           id: [1, 2, 2, 9, 9, 3, 2],
         }),
-        created_timestamp_seconds: BigInt(2),
+        created_timestamp_seconds: 2n,
       },
     ];
     snsNeuronsStore.setNeurons({
@@ -146,24 +146,24 @@ describe("sortedSnsNeuronStore", () => {
     const neurons2: SnsNeuron[] = [
       {
         ...createMockSnsNeuron({
-          stake: BigInt(1_000_000_000),
+          stake: 1_000_000_000n,
           id: [1, 5, 3, 9, 1, 1, 1],
         }),
-        created_timestamp_seconds: BigInt(2),
+        created_timestamp_seconds: 2n,
       },
       {
         ...createMockSnsNeuron({
-          stake: BigInt(2_000_000_000),
+          stake: 2_000_000_000n,
           id: [1, 5, 3, 9, 9, 3, 2],
         }),
-        created_timestamp_seconds: BigInt(1),
+        created_timestamp_seconds: 1n,
       },
       {
         ...createMockSnsNeuron({
-          stake: BigInt(10_000_000_000),
+          stake: 10_000_000_000n,
           id: [1, 2, 2, 9, 9, 3, 2],
         }),
-        created_timestamp_seconds: BigInt(3),
+        created_timestamp_seconds: 3n,
       },
     ];
     snsNeuronsStore.setNeurons({
@@ -199,26 +199,26 @@ describe("sortedSnsUserNeuronsStore", () => {
   it("should not return CF neurons", async () => {
     const cfNeuron: SnsNeuron = {
       ...createMockSnsNeuron({
-        stake: BigInt(10_000_000_000),
+        stake: 10_000_000_000n,
         id: [1, 2, 2, 9, 9, 3, 2],
       }),
-      created_timestamp_seconds: BigInt(2),
-      source_nns_neuron_id: [BigInt(2)],
+      created_timestamp_seconds: 2n,
+      source_nns_neuron_id: [2n],
     };
     const neurons: SnsNeuron[] = [
       {
         ...createMockSnsNeuron({
-          stake: BigInt(1_000_000_000),
+          stake: 1_000_000_000n,
           id: [1, 5, 3, 9, 1, 1, 1],
         }),
-        created_timestamp_seconds: BigInt(1),
+        created_timestamp_seconds: 1n,
       },
       {
         ...createMockSnsNeuron({
-          stake: BigInt(2_000_000_000),
+          stake: 2_000_000_000n,
           id: [1, 5, 3, 9, 9, 3, 2],
         }),
-        created_timestamp_seconds: BigInt(3),
+        created_timestamp_seconds: 3n,
       },
       cfNeuron,
     ];
@@ -241,27 +241,27 @@ describe("sortedSnsCFNeuronsStore", () => {
   it("should not return CF neurons", async () => {
     const cfNeuron1: SnsNeuron = {
       ...createMockSnsNeuron({
-        stake: BigInt(10_000_000_000),
+        stake: 10_000_000_000n,
         id: [1, 2, 2, 9, 9, 3, 2],
       }),
-      source_nns_neuron_id: [BigInt(2)],
-      created_timestamp_seconds: BigInt(3),
+      source_nns_neuron_id: [2n],
+      created_timestamp_seconds: 3n,
     };
     const cfNeuron2: SnsNeuron = {
       ...createMockSnsNeuron({
-        stake: BigInt(2_000_000_000),
+        stake: 2_000_000_000n,
         id: [1, 5, 3, 9, 9, 3, 2],
       }),
-      source_nns_neuron_id: [BigInt(3)],
-      created_timestamp_seconds: BigInt(2),
+      source_nns_neuron_id: [3n],
+      created_timestamp_seconds: 2n,
     };
     const neurons: SnsNeuron[] = [
       {
         ...createMockSnsNeuron({
-          stake: BigInt(1_000_000_000),
+          stake: 1_000_000_000n,
           id: [1, 5, 3, 9, 1, 1, 1],
         }),
-        created_timestamp_seconds: BigInt(1),
+        created_timestamp_seconds: 1n,
       },
       cfNeuron2,
       cfNeuron1,

--- a/frontend/src/tests/lib/derived/sns/sns-total-supply-token-amount.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-total-supply-token-amount.derived.spec.ts
@@ -20,7 +20,7 @@ describe("snsTotalSupplyTokenAmountStore", () => {
       ({ rootCanisterId }) => rootCanisterId
     );
     setSnsProjects(projectsParams);
-    const totalSupplyBase = BigInt(10_000_000_000);
+    const totalSupplyBase = 10_000_000_000n;
     const totalSupplies = rootCanisterIds.map((rootCanisterId, index) => ({
       rootCanisterId,
       totalSupply: totalSupplyBase * BigInt(index + 1),

--- a/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
@@ -19,7 +19,7 @@ describe("SnsTransactionModal", () => {
   const rootCanisterId = mockPrincipal;
   const token = { name: "Test", symbol: "TST", decimals: 8 };
   const transactionFee = TokenAmountV2.fromUlps({
-    amount: BigInt(10_000),
+    amount: 10_000n,
     token,
   });
   const renderTransactionModal = (selectedAccount?: Account) =>

--- a/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
@@ -20,7 +20,7 @@ import AddCyclesModalTest from "./AddCyclesModalTest.svelte";
 
 vi.mock("$lib/services/canisters.services", () => {
   return {
-    getIcpToCyclesExchangeRate: vi.fn().mockResolvedValue(BigInt(100_000)),
+    getIcpToCyclesExchangeRate: vi.fn().mockResolvedValue(100_000n),
     topUpCanister: vi.fn().mockResolvedValue({ success: true }),
   };
 });

--- a/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
@@ -25,7 +25,7 @@ import { tick } from "svelte";
 
 vi.mock("$lib/services/canisters.services", () => {
   return {
-    getIcpToCyclesExchangeRate: vi.fn().mockResolvedValue(BigInt(10_000)),
+    getIcpToCyclesExchangeRate: vi.fn().mockResolvedValue(10_000n),
     createCanister: vi
       .fn()
       .mockImplementation(() => Promise.resolve(mockCanister.canister_id)),

--- a/frontend/src/tests/lib/modals/neurons/AddHotkeyModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/AddHotkeyModal.spec.ts
@@ -8,7 +8,7 @@ import type { SvelteComponent } from "svelte";
 
 vi.mock("$lib/services/neurons.services", () => {
   return {
-    addHotkey: vi.fn().mockResolvedValue(BigInt(10)),
+    addHotkey: vi.fn().mockResolvedValue(10n),
     getNeuronFromStore: vi.fn(),
   };
 });

--- a/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
@@ -131,7 +131,7 @@ describe("DisburseNnsNeuronModal", () => {
     });
 
     it("should fetch accounts and render account selector", async () => {
-      const mainBalanceE8s = BigInt(10_000_000);
+      const mainBalanceE8s = 10_000_000n;
       let resolveQueryAccount;
       const queryAccountPromise = new Promise<AccountDetails>((resolve) => {
         resolveQueryAccount = () => resolve(mockAccountDetails);
@@ -173,7 +173,7 @@ describe("DisburseNnsNeuronModal", () => {
       vi.clearAllMocks();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);
-      const mainBalanceE8s = BigInt(10_000_000);
+      const mainBalanceE8s = 10_000_000n;
       vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
         mainBalanceE8s
       );

--- a/frontend/src/tests/lib/modals/neurons/FollowNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/FollowNeuronsModal.spec.ts
@@ -26,7 +26,7 @@ describe("FollowNeuronsModal", () => {
       followees: [
         {
           topic: Topic.ExchangeRate,
-          followees: [BigInt(27), BigInt(28)],
+          followees: [27n, 28n],
         },
       ],
     },

--- a/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
@@ -41,7 +41,7 @@ describe("IncreaseNeuronStakeModal", () => {
     });
 
     it("should fetch accounts and render account selector", async () => {
-      const mainBalanceE8s = BigInt(10_000_000);
+      const mainBalanceE8s = 10_000_000n;
       vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
         mainBalanceE8s
       );

--- a/frontend/src/tests/lib/modals/neurons/JoinCommunityFundModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/JoinCommunityFundModal.spec.ts
@@ -31,7 +31,7 @@ describe("ConfirmationModal", () => {
   it("should render leave text if neuron is part of the Neurons' Fund", async () => {
     const neuron: NeuronInfo = {
       ...controlledNeuron,
-      joinedCommunityFundTimestampSeconds: BigInt(123444),
+      joinedCommunityFundTimestampSeconds: 123_444n,
     };
     const po = renderComponent(neuron);
     expect(await po.getContentText()).toBe(

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -92,13 +92,13 @@ describe("MergeNeuronsModal", () => {
   describe("when mergeable neurons by user", () => {
     const controller = testIdentity.getPrincipal().toText();
     const mergeableNeuron1 = {
-      neuronId: BigInt(10),
+      neuronId: 10n,
       state: NeuronState.Locked,
       controller,
       stake: 1_200_000_000n,
     };
     const mergeableNeuron2 = {
-      neuronId: BigInt(11),
+      neuronId: 11n,
       state: NeuronState.Locked,
       controller,
       stake: 3_400_000_000n,
@@ -203,7 +203,7 @@ describe("MergeNeuronsModal", () => {
         neuronId: mergeableNeuron2.neuronId,
       });
       await runResolvedPromises();
-      expect(getStake(sourceNeuron)).toBe(BigInt(0));
+      expect(getStake(sourceNeuron)).toBe(0n);
       expect(getStake(targetNeuron)).toBe(
         mergeableNeuron1.stake + mergeableNeuron2.stake
       );
@@ -329,12 +329,12 @@ describe("MergeNeuronsModal", () => {
   describe("when mergeable neurons by hardware wallet", () => {
     const controller = mockHardwareWalletAccount.principal?.toText() as string;
     const mergeableNeuron1 = {
-      neuronId: BigInt(10),
+      neuronId: 10n,
       state: NeuronState.Locked,
       controller,
     };
     const mergeableNeuron2 = {
-      neuronId: BigInt(11),
+      neuronId: 11n,
       state: NeuronState.Locked,
       controller,
     };
@@ -363,12 +363,12 @@ describe("MergeNeuronsModal", () => {
 
   describe("when neurons from main user and hardware wallet", () => {
     const neuronHW = {
-      neuronId: BigInt(10),
+      neuronId: 10n,
       state: NeuronState.Locked,
       controller: mockHardwareWalletAccount.principal?.toText() as string,
     };
     const neuronMain = {
-      neuronId: BigInt(11),
+      neuronId: 11n,
       state: NeuronState.Locked,
       controller: testIdentity.getPrincipal().toText(),
     };

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeMaturityModal.spec.ts
@@ -25,7 +25,7 @@ describe("NnsStakeMaturityModal", () => {
     ...mockNeuron,
     fullNeuron: {
       ...mockFullNeuron,
-      maturityE8sEquivalent: BigInt(1_000_000),
+      maturityE8sEquivalent: 1_000_000n,
     },
   };
   const neuronHW = {

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -42,8 +42,8 @@ const neuronStake = 2.2;
 const neuronStakeE8s = 220_000_000n;
 const newNeuron: NeuronInfo = {
   ...mockNeuron,
-  dissolveDelaySeconds: BigInt(0),
-  ageSeconds: BigInt(0),
+  dissolveDelaySeconds: 0n,
+  ageSeconds: 0n,
   fullNeuron: {
     ...mockFullNeuron,
     cachedNeuronStake: neuronStakeE8s,
@@ -86,7 +86,7 @@ describe("NnsStakeNeuronModal", () => {
 
   describe("main account selection", () => {
     let queryBalanceSpy: SpyInstance;
-    const newBalanceE8s = BigInt(10_000_000);
+    const newBalanceE8s = 10_000_000n;
     beforeEach(() => {
       neuronsStore.setNeurons({ neurons: [newNeuron], certified: true });
       icpAccountsStore.setForTesting({
@@ -532,7 +532,7 @@ describe("NnsStakeNeuronModal", () => {
     beforeEach(() => {
       neuronsStore.setNeurons({ neurons: [newNeuron], certified: true });
       icpAccountsStore.resetForTesting();
-      const mainBalanceE8s = BigInt(10_000_000);
+      const mainBalanceE8s = 10_000_000n;
       vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
         mainBalanceE8s
       );
@@ -560,7 +560,7 @@ describe("NnsStakeNeuronModal", () => {
       vi.clearAllTimers();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);
-      const mainBalanceE8s = BigInt(10_000_000);
+      const mainBalanceE8s = 10_000_000n;
       vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
         mainBalanceE8s
       );

--- a/frontend/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
@@ -12,7 +12,7 @@ import { fireEvent } from "@testing-library/svelte";
 
 vi.mock("$lib/services/neurons.services", () => {
   return {
-    spawnNeuron: vi.fn().mockResolvedValue(BigInt(10)),
+    spawnNeuron: vi.fn().mockResolvedValue(10n),
     getNeuronFromStore: vi.fn(),
   };
 });
@@ -22,7 +22,7 @@ describe("SpawnNeuronModal", () => {
     ...mockNeuron,
     fullNeuron: {
       ...mockFullNeuron,
-      maturityE8sEquivalent: BigInt(10_000_000),
+      maturityE8sEquivalent: 10_000_000n,
     },
   };
 
@@ -67,7 +67,7 @@ describe("SpawnNeuronModal", () => {
           ...neuron,
           fullNeuron: {
             ...neuron.fullNeuron,
-            maturityE8sEquivalent: BigInt(1_000_000),
+            maturityE8sEquivalent: 1_000_000n,
           },
         },
       },

--- a/frontend/src/tests/lib/modals/proposals/VoteConfirmationModal.spec.ts
+++ b/frontend/src/tests/lib/modals/proposals/VoteConfirmationModal.spec.ts
@@ -8,7 +8,7 @@ describe("VoteConfirmationModal", () => {
     const { container, getByText } = render(VoteConfirmationModal, {
       props: {
         voteType: Vote.Yes,
-        votingPower: BigInt(4000000000),
+        votingPower: 4_000_000_000n,
       },
     });
     expect(
@@ -23,7 +23,7 @@ describe("VoteConfirmationModal", () => {
     const { container, getByText } = render(VoteConfirmationModal, {
       props: {
         voteType: Vote.No,
-        votingPower: BigInt(4000000000),
+        votingPower: 4_000_000_000n,
       },
     });
     expect(
@@ -38,7 +38,7 @@ describe("VoteConfirmationModal", () => {
     const { getByText } = render(VoteConfirmationModal, {
       props: {
         voteType: Vote.No,
-        votingPower: BigInt(4000000000),
+        votingPower: 4_000_000_000n,
       },
     });
     expect(getByText("40.00", { exact: false })).toBeInTheDocument();
@@ -48,7 +48,7 @@ describe("VoteConfirmationModal", () => {
     const { container } = render(VoteConfirmationModal, {
       props: {
         voteType: Vote.No,
-        votingPower: BigInt(4000000000),
+        votingPower: 4_000_000_000n,
       },
     });
     expect(

--- a/frontend/src/tests/lib/modals/sns/FollowSnsNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/FollowSnsNeuronsModal.spec.ts
@@ -49,15 +49,15 @@ describe("FollowSnsNeuronsModal", () => {
   it("displays the functions to follow", () => {
     const function0: SnsNervousSystemFunction = {
       ...nervousSystemFunctionMock,
-      id: BigInt(0),
+      id: 0n,
     };
     const function1: SnsNervousSystemFunction = {
       ...nervousSystemFunctionMock,
-      id: BigInt(1),
+      id: 1n,
     };
     const function2: SnsNervousSystemFunction = {
       ...nervousSystemFunctionMock,
-      id: BigInt(2),
+      id: 2n,
     };
     snsFunctionsStore.setProjectFunctions({
       rootCanisterId,

--- a/frontend/src/tests/lib/modals/sns/NewSnsFolloweeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/NewSnsFolloweeModal.spec.ts
@@ -16,7 +16,7 @@ vi.mock("$lib/services/sns-neurons.services", () => {
 
 describe("NewSnsFolloweeModal", () => {
   const reload = vi.fn();
-  const functionId = BigInt(4);
+  const functionId = 4n;
 
   const renderNewSnsFolloweeModal = (): RenderResult<SvelteComponent> =>
     renderSelectedSnsNeuronContext({

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -219,9 +219,9 @@ describe("ParticipateSwapModal", () => {
       const po = await renderSwapModalPo({
         swapCommitment: {
           ...mockSwapCommitment,
-          myCommitment: createBuyersState(BigInt(0)),
+          myCommitment: createBuyersState(0n),
         },
-        minParticipantCommitment: BigInt(100000000),
+        minParticipantCommitment: 100_000_000n,
       });
       const form = po.getTransactionFormPo();
       await form.enterAmount(1);
@@ -232,9 +232,9 @@ describe("ParticipateSwapModal", () => {
       const po = await renderSwapModalPo({
         swapCommitment: {
           ...mockSwapCommitment,
-          myCommitment: createBuyersState(BigInt(0)),
+          myCommitment: createBuyersState(0n),
         },
-        minParticipantCommitment: BigInt(100000000),
+        minParticipantCommitment: 100_000_000n,
       });
       const form = po.getTransactionFormPo();
       await form.enterAmount(0.01);
@@ -248,9 +248,9 @@ describe("ParticipateSwapModal", () => {
       const po = await renderSwapModalPo({
         swapCommitment: {
           ...mockSwapCommitment,
-          myCommitment: createBuyersState(BigInt(0)),
+          myCommitment: createBuyersState(0n),
         },
-        minParticipantCommitment: BigInt(100000278),
+        minParticipantCommitment: 100_000_278n,
       });
       const form = po.getTransactionFormPo();
       await form.enterAmount(0.01);
@@ -279,7 +279,7 @@ describe("ParticipateSwapModal", () => {
   });
 
   describe("when accounts are not available", () => {
-    const mainBalanceE8s = BigInt(10_000_000);
+    const mainBalanceE8s = 10_000_000n;
     let queryAccountSpy: SpyInstance;
     let queryAccountBalanceSpy: SpyInstance;
     let resolveQueryAccounts;
@@ -355,7 +355,7 @@ describe("ParticipateSwapModal", () => {
       vi.clearAllTimers();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);
-      const mainBalanceE8s = BigInt(10_000_000);
+      const mainBalanceE8s = 10_000_000n;
       vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
         mainBalanceE8s
       );

--- a/frontend/src/tests/lib/modals/sns/SnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsStakeNeuronModal.spec.ts
@@ -38,7 +38,7 @@ describe("SnsStakeNeuronModal", () => {
       props: {
         token,
         transactionFee: TokenAmount.fromE8s({
-          amount: BigInt(10_000),
+          amount: 10_000n,
           token,
         }),
         rootCanisterId: mockPrincipal,

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -257,7 +257,7 @@ describe("TransactionModal", () => {
 
     it("should move to the last step and render passed transaction fee", async () => {
       const fee = TokenAmount.fromE8s({
-        amount: BigInt(20_000),
+        amount: 20_000n,
         token: {
           symbol: "TST",
           name: "Test token",
@@ -289,7 +289,7 @@ describe("TransactionModal", () => {
 
     it("should move to the last step and show ledger fees", async () => {
       const fee = TokenAmount.fromE8s({
-        amount: BigInt(20_000),
+        amount: 20_000n,
         token: {
           symbol: "TST",
           name: "Test token",
@@ -309,7 +309,7 @@ describe("TransactionModal", () => {
 
     it("should move to the last step and hide ledger fees", async () => {
       const fee = TokenAmount.fromE8s({
-        amount: BigInt(20_000),
+        amount: 20_000n,
         token: {
           symbol: "TST",
           name: "Test token",

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -193,7 +193,7 @@ describe("NnsAccounts", () => {
     describe("when no accounts", () => {
       beforeEach(() => {
         icpAccountsStore.resetForTesting();
-        const mainBalanceE8s = BigInt(10_000_000);
+        const mainBalanceE8s = 10_000_000n;
         vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
           mainBalanceE8s
         );
@@ -230,7 +230,7 @@ describe("NnsAccounts", () => {
         cancelPollAccounts();
         const now = Date.now();
         vi.useFakeTimers().setSystemTime(now);
-        const mainBalanceE8s = BigInt(10_000_000);
+        const mainBalanceE8s = 10_000_000n;
         vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
           mainBalanceE8s
         );

--- a/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeuronDetail.spec.ts
@@ -22,7 +22,7 @@ vi.mock("$lib/api/governance.api");
 describe("NeuronDetail", () => {
   fakeGovernanceApi.install();
 
-  const neuronId = BigInt(314);
+  const neuronId = 314n;
   const latestRewardEventTimestamp = Math.floor(
     new Date("1992-05-22T21:00:00").getTime() / 1000
   );

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -22,15 +22,15 @@ describe("NnsNeurons", () => {
   describe("with enough neurons", () => {
     const mockNeuron2 = {
       ...mockNeuron,
-      neuronId: BigInt(223),
+      neuronId: 223n,
     };
     const spawningNeuron = {
       ...mockNeuron,
       state: NeuronState.Spawning,
-      neuronId: BigInt(224),
+      neuronId: 224n,
       fullNeuron: {
         ...mockFullNeuron,
-        spawnAtTimesSeconds: BigInt(12312313),
+        spawnAtTimesSeconds: 12_312_313n,
       },
     };
     const neurons = [mockNeuron, spawningNeuron, mockNeuron2];

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -40,7 +40,7 @@ describe("NnsWallet", () => {
   const props = {
     accountIdentifier: mockMainAccount.identifier,
   };
-  const mainBalanceE8s = BigInt(10_000_000);
+  const mainBalanceE8s = 10_000_000n;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -289,7 +289,7 @@ describe("NnsWallet", () => {
     beforeEach(() => {
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);
-      const mainBalanceE8s = BigInt(10_000_000);
+      const mainBalanceE8s = 10_000_000n;
       vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
         mainBalanceE8s
       );

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -75,7 +75,7 @@ describe("ProjectDetail", () => {
   const rootCanisterId = mockCanisterId;
   const userCountryCode = "CH";
   const notUserCountryCode = "US";
-  const newBalance = BigInt(10_000_000_000);
+  const newBalance = 10_000_000_000n;
   const saleBuyerCount = 1_000_000;
   const rawMetricsText = `
 # TYPE sale_buyer_count gauge
@@ -106,7 +106,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
 
     vi.spyOn(snsApi, "querySnsDerivedState").mockResolvedValue({
       sns_tokens_per_icp: [1],
-      buyer_total_icp_e8s: [BigInt(200_000_000)],
+      buyer_total_icp_e8s: [200_000_000n],
       cf_participant_count: [],
       direct_participant_count: [],
       cf_neuron_count: [],
@@ -345,7 +345,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
 
       vi.spyOn(snsSaleApi, "getOpenTicket").mockResolvedValue(undefined);
       vi.spyOn(snsApi, "querySnsLifecycle").mockResolvedValue({
-        decentralization_sale_open_timestamp_seconds: [BigInt(11231312)],
+        decentralization_sale_open_timestamp_seconds: [11_231_312n],
         lifecycle: [SnsSwapLifecycle.Open],
       });
 
@@ -373,22 +373,22 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
           icp_accepted_participation_e8s: testTicket.amount_icp_e8s,
           icp_ledger_account_balance_e8s: testTicket.amount_icp_e8s,
         });
-        vi.spyOn(ledgerApi, "sendICP").mockResolvedValue(BigInt(10));
+        vi.spyOn(ledgerApi, "sendICP").mockResolvedValue(10n);
         vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
-          BigInt(1_000_000_000)
+          1_000_000_000n
         );
       });
 
       it("should show user's commitment", async () => {
-        const userCommitment = BigInt(100_000_000);
+        const userCommitment = 100_000_000n;
         vi.spyOn(snsApi, "querySnsSwapCommitment").mockResolvedValue({
           rootCanisterId,
           myCommitment: {
             icp: [
               {
-                transfer_start_timestamp_seconds: BigInt(123444),
+                transfer_start_timestamp_seconds: 123_444n,
                 amount_e8s: userCommitment,
-                transfer_success_timestamp_seconds: BigInt(123445),
+                transfer_success_timestamp_seconds: 123_445n,
                 transfer_fee_paid_e8s: [],
                 amount_transferred_e8s: [],
               },
@@ -475,9 +475,9 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
         const finalCommitment = {
           icp: [
             {
-              transfer_start_timestamp_seconds: BigInt(123444),
+              transfer_start_timestamp_seconds: 123_444n,
               amount_e8s: amountE8s,
-              transfer_success_timestamp_seconds: BigInt(123445),
+              transfer_success_timestamp_seconds: 123_445n,
             },
           ],
           has_created_neuron_recipes: [],
@@ -595,9 +595,9 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
         const finalCommitment = {
           icp: [
             {
-              transfer_start_timestamp_seconds: BigInt(123444),
+              transfer_start_timestamp_seconds: 123_444n,
               amount_e8s: testTicket.amount_icp_e8s,
-              transfer_success_timestamp_seconds: BigInt(123445),
+              transfer_success_timestamp_seconds: 123_445n,
             },
           ],
           has_created_neuron_recipes: [],
@@ -685,7 +685,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
       const props = {
         rootCanisterId: rootCanisterId.toText(),
       };
-      const userCommitment = BigInt(100_000_000);
+      const userCommitment = 100_000_000n;
       beforeEach(() => {
         setSnsProjects([
           {
@@ -700,9 +700,9 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
           myCommitment: {
             icp: [
               {
-                transfer_start_timestamp_seconds: BigInt(123444),
+                transfer_start_timestamp_seconds: 123_444n,
                 amount_e8s: userCommitment,
-                transfer_success_timestamp_seconds: BigInt(123445),
+                transfer_success_timestamp_seconds: 123_445n,
                 transfer_fee_paid_e8s: [],
                 amount_transferred_e8s: [],
               },

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -39,7 +39,7 @@ describe("SnsNeurons", () => {
       id: [1, 2, 6],
       stake: neuronNFStake,
     }),
-    source_nns_neuron_id: [BigInt(123)],
+    source_nns_neuron_id: [123n],
   };
   const projectName = "Tetris";
   const getNeuronBalanceMock = async ({ neuronId }) => {

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -35,7 +35,7 @@ vi.mock("$lib/api/sns-governance.api");
 
 describe("SnsProposalDetail", () => {
   fakeSnsGovernanceApi.install();
-  const proposalId = { id: BigInt(3) };
+  const proposalId = { id: 3n };
   const rootCanisterId = mockCanisterId;
 
   const renderComponent = async () => {
@@ -66,7 +66,7 @@ describe("SnsProposalDetail", () => {
     });
 
     it("should show skeleton while loading proposal", async () => {
-      const proposalId = { id: BigInt(3) };
+      const proposalId = { id: 3n };
       fakeSnsGovernanceApi.addProposalWith({
         identity: new AnonymousIdentity(),
         rootCanisterId,
@@ -135,7 +135,7 @@ describe("SnsProposalDetail", () => {
     });
 
     it("should render the name of the nervous function as title", async () => {
-      const functionId = BigInt(12);
+      const functionId = 12n;
       const functionName = "test function";
       fakeSnsGovernanceApi.addNervousSystemFunctionWith({
         rootCanisterId,

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -37,7 +37,7 @@ describe("SnsProposals", () => {
 
   const rootCanisterId = mockPrincipal;
   const functionName = "test_function";
-  const functionId = BigInt(3);
+  const functionId = 3n;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -171,13 +171,13 @@ describe("SnsProposals", () => {
     const proposals: SnsProposalData[] = [
       createSnsProposal({
         status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
-        proposalId: BigInt(1),
+        proposalId: 1n,
         rewardStatus:
           SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
       }),
       createSnsProposal({
         status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_EXECUTED,
-        proposalId: BigInt(2),
+        proposalId: 2n,
         rewardStatus: SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_SETTLED,
       }),
     ];
@@ -185,7 +185,7 @@ describe("SnsProposals", () => {
       vi.spyOn(authStore, "subscribe").mockImplementation(
         mockAuthStoreNoIdentitySubscribe
       );
-      const functionId = BigInt(3);
+      const functionId = 3n;
       fakeSnsGovernanceApi.addProposalWith({
         identity: new AnonymousIdentity(),
         rootCanisterId,

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -87,7 +87,7 @@ describe("SnsWallet", () => {
     transactionsFeesStore.reset();
     toastsStore.reset();
     vi.spyOn(snsIndexApi, "getSnsTransactions").mockResolvedValue({
-      oldestTxId: BigInt(1234),
+      oldestTxId: 1_234n,
       transactions: [mockIcrcTransactionWithId],
     });
     vi.spyOn(snsLedgerApi, "transactionFee").mockResolvedValue(fee);
@@ -204,7 +204,7 @@ describe("SnsWallet", () => {
       expect(snsLedgerApi.snsTransfer).toHaveBeenCalledWith({
         identity: mockIdentity,
         rootCanisterId,
-        amount: 200000000n,
+        amount: 200000_000n,
         fromSubaccount: undefined,
         fee,
         to: destinationAccount,

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -313,7 +313,7 @@ describe("Accounts", () => {
 
     transactionsFeesStore.setFee({
       rootCanisterId: mockSnsFullProject.rootCanisterId,
-      fee: BigInt(10_000),
+      fee: 10_000n,
       certified: true,
     });
     const { queryByTestId, getByTestId } = render(Accounts);

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -27,7 +27,7 @@ vi.mock("$lib/api/sns.api");
 
 const testCommittedSnsCanisterId = Principal.fromHex("897654");
 const testOpenSnsCanisterId = Principal.fromHex("567812");
-const testNnsNeuronId = BigInt(543);
+const testNnsNeuronId = 543n;
 
 describe("Neurons", () => {
   fakeGovernanceApi.install();

--- a/frontend/src/tests/lib/services/_public/proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/proposals.services.spec.ts
@@ -162,7 +162,7 @@ describe("proposals-services", () => {
 
       beforeEach(() => {
         spyQueryProposal.mockImplementation(() =>
-          Promise.resolve({ ...mockProposals[0], id: BigInt(666) })
+          Promise.resolve({ ...mockProposals[0], id: 666n })
         );
         proposalsStore.setProposals({
           proposals: mockProposals,
@@ -174,10 +174,10 @@ describe("proposals-services", () => {
         expect(spyQueryProposal).not.toBeCalled();
         let result;
         await loadProposal({
-          proposalId: BigInt(666),
+          proposalId: 666n,
           setProposal: (proposal: ProposalInfo) => (result = proposal),
         });
-        expect(result?.id).toBe(BigInt(666));
+        expect(result?.id).toBe(666n);
         expect(spyQueryProposal).toBeCalledTimes(2);
       });
     });
@@ -195,7 +195,7 @@ describe("proposals-services", () => {
         expect(toastsShow).not.toBeCalled();
 
         await loadProposal({
-          proposalId: BigInt(0),
+          proposalId: 0n,
           setProposal: vi.fn,
         });
         expect(toastsShow).toBeCalledTimes(1);
@@ -282,16 +282,16 @@ describe("proposals-services", () => {
       const spyQueryProposal = vi
         .spyOn(api, "queryProposal")
         .mockImplementation(() =>
-          Promise.resolve({ ...mockProposals[0], id: BigInt(666) })
+          Promise.resolve({ ...mockProposals[0], id: 666n })
         );
       expect(spyQueryProposal).not.toBeCalled();
 
       let result;
       await loadProposal({
-        proposalId: BigInt(666),
+        proposalId: 666n,
         setProposal: (proposal: ProposalInfo) => (result = proposal),
       });
-      expect(result?.id).toBe(BigInt(666));
+      expect(result?.id).toBe(666n);
       expect(spyQueryProposal).toBeCalledTimes(1);
     });
   });
@@ -341,19 +341,19 @@ describe("proposals-services", () => {
 
     it("should call queryProposalPayload", async () => {
       expect(spyQueryProposalPayload).not.toBeCalled();
-      await loadProposalPayload({ proposalId: BigInt(0) });
+      await loadProposalPayload({ proposalId: 0n });
       expect(spyQueryProposalPayload).toBeCalledTimes(1);
     });
 
     it("should update proposalPayloadsStore", async () => {
       const spyOnSetPayload = vi.spyOn(proposalPayloadsStore, "setPayload");
       expect(spyOnSetPayload).not.toBeCalled();
-      await loadProposalPayload({ proposalId: BigInt(0) });
+      await loadProposalPayload({ proposalId: 0n });
 
       expect(spyOnSetPayload).toBeCalledTimes(2);
       expect(spyOnSetPayload).toHaveBeenLastCalledWith({
         payload: { data: "test" },
-        proposalId: BigInt(0),
+        proposalId: 0n,
       });
     });
 
@@ -364,9 +364,9 @@ describe("proposals-services", () => {
         throw new ProposalPayloadNotFoundError();
       });
 
-      await loadProposalPayload({ proposalId: BigInt(0) });
+      await loadProposalPayload({ proposalId: 0n });
 
-      expect(get(proposalPayloadsStore).get(BigInt(0))).toBeNull();
+      expect(get(proposalPayloadsStore).get(0n)).toBeNull();
     });
 
     it("should update proposalPayloadsStore with null if the payload was not found", async () => {
@@ -376,9 +376,9 @@ describe("proposals-services", () => {
         throw new ProposalPayloadTooLargeError();
       });
 
-      await loadProposalPayload({ proposalId: BigInt(0) });
+      await loadProposalPayload({ proposalId: 0n });
 
-      expect(get(proposalPayloadsStore).get(BigInt(0))).toEqual({
+      expect(get(proposalPayloadsStore).get(0n)).toEqual({
         error: "Payload too large",
       });
     });

--- a/frontend/src/tests/lib/services/_public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns-proposals.services.spec.ts
@@ -39,15 +39,15 @@ describe("sns-proposals services", () => {
   });
   const proposal1: SnsProposalData = {
     ...mockSnsProposal,
-    id: [{ id: BigInt(1) }],
+    id: [{ id: 1n }],
   };
   const proposal2: SnsProposalData = {
     ...mockSnsProposal,
-    id: [{ id: BigInt(2) }],
+    id: [{ id: 2n }],
   };
   const proposal3: SnsProposalData = {
     ...mockSnsProposal,
-    id: [{ id: BigInt(3) }],
+    id: [{ id: 3n }],
   };
   const proposals = [proposal1, proposal2, proposal3];
   describe("loadSnsProposals", () => {
@@ -81,7 +81,7 @@ describe("sns-proposals services", () => {
       });
 
       it("should call queryProposals with the last proposal id params", async () => {
-        const proposalId = { id: BigInt(1) };
+        const proposalId = { id: 1n };
         await loadSnsProposals({
           rootCanisterId: mockPrincipal,
           beforeProposalId: proposalId,
@@ -99,7 +99,7 @@ describe("sns-proposals services", () => {
       });
 
       it("should call queryProposals with selected decision status filters", async () => {
-        const proposalId = { id: BigInt(1) };
+        const proposalId = { id: 1n };
         const rootCanisterId = mockPrincipal;
         const decisionStatus = [
           {

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -37,7 +37,7 @@ describe("app-services", () => {
     ]);
 
     mockNNSDappCanister.getAccount.mockResolvedValue(mockAccountDetails);
-    mockLedgerCanister.accountBalance.mockResolvedValue(BigInt(100_000_000));
+    mockLedgerCanister.accountBalance.mockResolvedValue(100_000_000n);
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 

--- a/frontend/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/canisters.services.spec.ts
@@ -44,8 +44,8 @@ const blockedApiPaths = ["$lib/api/canisters.api", "$lib/api/icp-ledger.api"];
 describe("canisters-services", () => {
   blockAllCallsTo(blockedApiPaths);
 
-  const newBalanceE8s = BigInt(100_000_000);
-  const exchangeRate = BigInt(10_000);
+  const newBalanceE8s = 100_000_000n;
+  const exchangeRate = 10_000n;
   let spyQueryCanisters: SpyInstance;
   let spyQueryAccountBalance: SpyInstance;
   let spyAttachCanister: SpyInstance;

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -147,7 +147,7 @@ describe("icp-accounts.services", () => {
         .mockResolvedValue(mockAccountDetails);
       const queryAccountBalanceSpy = vi
         .spyOn(ledgerApi, "queryAccountBalance")
-        .mockResolvedValue(BigInt(0));
+        .mockResolvedValue(0n);
       const certified = true;
       await loadAccounts({
         identity: mockIdentity,
@@ -170,7 +170,7 @@ describe("icp-accounts.services", () => {
       vi.spyOn(nnsdappApi, "queryAccount").mockResolvedValue(accountDetails);
       const queryAccountBalanceSpy = vi
         .spyOn(ledgerApi, "queryAccountBalance")
-        .mockResolvedValue(BigInt(0));
+        .mockResolvedValue(0n);
 
       const certified = true;
       await loadAccounts({
@@ -199,7 +199,7 @@ describe("icp-accounts.services", () => {
       vi.spyOn(nnsdappApi, "queryAccount").mockResolvedValue(accountDetails);
       const queryAccountBalanceSpy = vi
         .spyOn(ledgerApi, "queryAccountBalance")
-        .mockResolvedValue(BigInt(0));
+        .mockResolvedValue(0n);
 
       const certified = true;
       await loadAccounts({
@@ -344,7 +344,7 @@ describe("icp-accounts.services", () => {
 
   describe("initAccounts", () => {
     it("should sync accounts", async () => {
-      const mainBalanceE8s = BigInt(10_000_000);
+      const mainBalanceE8s = 10_000_000n;
       const queryAccountBalanceSpy = vi
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockResolvedValue(mainBalanceE8s);
@@ -392,7 +392,7 @@ describe("icp-accounts.services", () => {
 
   describe("syncAccounts", () => {
     it("should sync accounts", async () => {
-      const mainBalanceE8s = BigInt(10_000_000);
+      const mainBalanceE8s = 10_000_000n;
       const queryAccountBalanceSpy = vi
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockResolvedValue(mainBalanceE8s);
@@ -445,8 +445,8 @@ describe("icp-accounts.services", () => {
     });
 
     it("update response replaces query response", async () => {
-      const queryMainBalanceE8s = BigInt(10_000_000);
-      const updateMainBalanceE8s = BigInt(20_000_000);
+      const queryMainBalanceE8s = 10_000_000n;
+      const updateMainBalanceE8s = 20_000_000n;
       const queryBalanceResponse = Promise.resolve(queryMainBalanceE8s);
       let resolveUpdateResponse;
       const updateBalanceResponse = new Promise<bigint>((resolve) => {
@@ -490,8 +490,8 @@ describe("icp-accounts.services", () => {
     });
 
     it("old update response does not replace newer response", async () => {
-      const queryMainBalanceE8s = BigInt(10_000_000);
-      const updateMainBalanceE8s = BigInt(20_000_000);
+      const queryMainBalanceE8s = 10_000_000n;
+      const updateMainBalanceE8s = 20_000_000n;
       const queryBalanceResponse = Promise.resolve(queryMainBalanceE8s);
       let resolveUpdateResponse;
       const updateBalanceResponse = new Promise<bigint>((resolve) => {
@@ -526,7 +526,7 @@ describe("icp-accounts.services", () => {
         accountsWith({ mainBalanceE8s: queryMainBalanceE8s, certified: false })
       );
 
-      const newerMainBalanceE8s = BigInt(30_000_000);
+      const newerMainBalanceE8s = 30_000_000n;
       vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
         newerMainBalanceE8s
       );
@@ -548,7 +548,7 @@ describe("icp-accounts.services", () => {
 
   describe("loadBalance", () => {
     it("should query account balance and load it in store", async () => {
-      const newBalanceE8s = BigInt(10_000_000);
+      const newBalanceE8s = 10_000_000n;
       const queryAccountBalanceSpy = vi
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockResolvedValue(newBalanceE8s);
@@ -576,7 +576,7 @@ describe("icp-accounts.services", () => {
     });
 
     it("should not show error if only query fails", async () => {
-      const newBalanceE8s = BigInt(10_000_000);
+      const newBalanceE8s = 10_000_000n;
       const queryAccountBalanceSpy = vi
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockImplementation(async (args) => {
@@ -612,8 +612,8 @@ describe("icp-accounts.services", () => {
     });
 
     it("old update response does not replace newer response", async () => {
-      const queryMainBalanceE8s = BigInt(10_000_000);
-      const updateMainBalanceE8s = BigInt(20_000_000);
+      const queryMainBalanceE8s = 10_000_000n;
+      const updateMainBalanceE8s = 20_000_000n;
       const queryBalanceResponse = Promise.resolve(queryMainBalanceE8s);
       let resolveUpdateResponse;
       const updateBalanceResponse = new Promise<bigint>((resolve) => {
@@ -648,7 +648,7 @@ describe("icp-accounts.services", () => {
         accountsWith({ mainBalanceE8s: queryMainBalanceE8s, certified: false })
       );
 
-      const newerMainBalanceE8s = BigInt(30_000_000);
+      const newerMainBalanceE8s = 30_000_000n;
       vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
         newerMainBalanceE8s
       );
@@ -668,7 +668,7 @@ describe("icp-accounts.services", () => {
     });
 
     it("should query account balance for Icrc address", async () => {
-      const newBalanceE8s = BigInt(10_000_000);
+      const newBalanceE8s = 10_000_000n;
       const queryAccountBalanceSpy = vi
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockResolvedValue(newBalanceE8s);
@@ -689,7 +689,7 @@ describe("icp-accounts.services", () => {
   });
 
   describe("services", () => {
-    const mainBalanceE8s = BigInt(10_000_000);
+    const mainBalanceE8s = 10_000_000n;
 
     let queryAccountBalanceSpy: SpyInstance;
     let queryAccountSpy: SpyInstance;
@@ -773,7 +773,7 @@ describe("icp-accounts.services", () => {
   });
 
   describe("transferICP", () => {
-    const mainBalanceE8s = BigInt(10_000_000);
+    const mainBalanceE8s = 10_000_000n;
     const sourceAccount = mockMainAccount;
     const transferICPParams: NewTransaction = {
       sourceAccount,
@@ -786,7 +786,7 @@ describe("icp-accounts.services", () => {
       queryAccountBalanceSpy = vi
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockResolvedValue(mainBalanceE8s);
-      spySendICP = vi.spyOn(ledgerApi, "sendICP").mockResolvedValue(BigInt(20));
+      spySendICP = vi.spyOn(ledgerApi, "sendICP").mockResolvedValue(20n);
     });
 
     it("should transfer ICP", async () => {
@@ -796,9 +796,7 @@ describe("icp-accounts.services", () => {
     });
 
     it("should not transfer ICP for invalid address", async () => {
-      const spy = vi
-        .spyOn(icrcLedgerApi, "icrcTransfer")
-        .mockResolvedValue(BigInt(1));
+      const spy = vi.spyOn(icrcLedgerApi, "icrcTransfer").mockResolvedValue(1n);
 
       const result = await transferICP({
         ...transferICPParams,
@@ -812,9 +810,7 @@ describe("icp-accounts.services", () => {
     });
 
     it("should transfer ICP using an Icrc destination address", async () => {
-      const spy = vi
-        .spyOn(ledgerApi, "sendIcpIcrc1")
-        .mockResolvedValue(BigInt(1));
+      const spy = vi.spyOn(ledgerApi, "sendIcpIcrc1").mockResolvedValue(1n);
 
       await transferICP({
         ...transferICPParams,
@@ -894,7 +890,7 @@ describe("icp-accounts.services", () => {
     beforeEach(() => {
       queryAccountBalanceSpy = vi
         .spyOn(ledgerApi, "queryAccountBalance")
-        .mockResolvedValue(BigInt(0));
+        .mockResolvedValue(0n);
       queryAccountSpy = vi
         .spyOn(nnsDappApi, "queryAccount")
         .mockResolvedValue(mockAccountDetails);
@@ -1157,7 +1153,7 @@ describe("icp-accounts.services", () => {
   });
 
   describe("pollAccounts", () => {
-    const mainBalanceE8s = BigInt(10_000_000);
+    const mainBalanceE8s = 10_000_000n;
     const mockAccounts = {
       main: {
         ...mockMainAccount,

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -110,7 +110,7 @@ vi.mock("$lib/proxy/icp-ledger.services.proxy", () => {
 describe("neurons-services", () => {
   const notControlledNeuron = {
     ...mockNeuron,
-    neuronId: BigInt(123),
+    neuronId: 123n,
     fullNeuron: {
       ...mockFullNeuron,
       controller: "not-controller",
@@ -118,7 +118,7 @@ describe("neurons-services", () => {
   };
   const controlledNeuron = {
     ...mockNeuron,
-    neuronId: BigInt(1234),
+    neuronId: 1_234n,
     fullNeuron: {
       ...mockFullNeuron,
       controller: mockIdentity.getPrincipal().toText(),
@@ -126,13 +126,13 @@ describe("neurons-services", () => {
   };
   const sameControlledNeuron = {
     ...mockNeuron,
-    neuronId: BigInt(1234555),
+    neuronId: 1_234_555n,
     fullNeuron: {
       ...mockFullNeuron,
       controller: mockIdentity.getPrincipal().toText(),
     },
   };
-  const newSpawnedNeuronId = BigInt(1234);
+  const newSpawnedNeuronId = 1_234n;
 
   const neurons = [sameControlledNeuron, controlledNeuron];
 
@@ -190,7 +190,7 @@ describe("neurons-services", () => {
     );
     spyAddHotkey.mockResolvedValue();
     spyRemoveHotkey.mockResolvedValue();
-    spySplitNeuron.mockResolvedValue(BigInt(11));
+    spySplitNeuron.mockResolvedValue(11n);
     spyStartDissolving.mockResolvedValue();
     spyStopDissolving.mockResolvedValue();
     spySetFollowees.mockResolvedValue();
@@ -411,7 +411,7 @@ describe("neurons-services", () => {
       setNoIdentity();
 
       await updateDelay({
-        neuronId: BigInt(10),
+        neuronId: 10n,
         dissolveDelayInSeconds: 12000,
       });
 
@@ -476,7 +476,7 @@ describe("neurons-services", () => {
     it("should call leaveCommunity find if neuron is in the fund already", async () => {
       const neuron = {
         ...controlledNeuron,
-        joinedCommunityFundTimestampSeconds: BigInt(2000),
+        joinedCommunityFundTimestampSeconds: 2_000n,
       };
       neuronsStore.pushNeurons({ neurons: [neuron], certified: true });
       expect(spyLeaveCommunityFund).not.toBeCalled();
@@ -872,7 +872,7 @@ describe("neurons-services", () => {
     it("should not merge neurons if different controllers", async () => {
       const neuron = {
         ...mockNeuron,
-        neuronId: BigInt(5555),
+        neuronId: 5_555n,
         fullNeuron: {
           ...mockFullNeuron,
           controller: "another",
@@ -914,7 +914,7 @@ describe("neurons-services", () => {
       });
       const neuron1 = {
         ...mockNeuron,
-        neuronId: BigInt(5555),
+        neuronId: 5_555n,
         fullNeuron: {
           ...mockFullNeuron,
           controller: smallerVersionIdentity.getPrincipal().toText(),
@@ -922,7 +922,7 @@ describe("neurons-services", () => {
       };
       const neuron2 = {
         ...mockNeuron,
-        neuronId: BigInt(5556),
+        neuronId: 5_556n,
         fullNeuron: {
           ...mockFullNeuron,
           controller: smallerVersionIdentity.getPrincipal().toText(),
@@ -983,7 +983,7 @@ describe("neurons-services", () => {
     it("should not simulate merging neurons if different controllers", async () => {
       const neuron = {
         ...mockNeuron,
-        neuronId: BigInt(5555),
+        neuronId: 5_555n,
         fullNeuron: {
           ...mockFullNeuron,
           controller: "another",
@@ -1012,7 +1012,7 @@ describe("neurons-services", () => {
       const hwPrincipal = mockHardwareWalletAccount.principal.toText();
       const neuron1 = {
         ...mockNeuron,
-        neuronId: BigInt(5555),
+        neuronId: 5_555n,
         fullNeuron: {
           ...mockFullNeuron,
           controller: hwPrincipal,
@@ -1020,7 +1020,7 @@ describe("neurons-services", () => {
       };
       const neuron2 = {
         ...mockNeuron,
-        neuronId: BigInt(5556),
+        neuronId: 5_556n,
         fullNeuron: {
           ...mockFullNeuron,
           controller: hwPrincipal,
@@ -1227,7 +1227,7 @@ describe("neurons-services", () => {
     it("should not update neuron if no identity", async () => {
       setNoIdentity();
 
-      await startDissolving(BigInt(10));
+      await startDissolving(10n);
 
       expectToastError(en.error.missing_identity);
       expect(spyStartDissolving).not.toBeCalled();
@@ -1257,7 +1257,7 @@ describe("neurons-services", () => {
     it("should not update neuron if no identity", async () => {
       setNoIdentity();
 
-      await stopDissolving(BigInt(10));
+      await stopDissolving(10n);
 
       expectToastError(en.error.missing_identity);
       expect(spyStopDissolving).not.toBeCalled();
@@ -1345,7 +1345,7 @@ describe("neurons-services", () => {
       });
       const neuron = {
         ...mockNeuron,
-        neuronId: BigInt(5555),
+        neuronId: 5_555n,
         fullNeuron: {
           ...mockFullNeuron,
           controller: smallerVersionIdentity.getPrincipal().toText(),
@@ -1370,7 +1370,7 @@ describe("neurons-services", () => {
 
   describe("add followee", () => {
     it("should add the followee to next call", async () => {
-      const followee = BigInt(8);
+      const followee = 8n;
       neuronsStore.setNeurons({ neurons, certified: true });
       const topic = Topic.ExchangeRate;
 
@@ -1413,7 +1413,7 @@ describe("neurons-services", () => {
 
     it("should not call api if trying follow a neuron already added", async () => {
       const topic = Topic.ExchangeRate;
-      const followee = BigInt(10);
+      const followee = 10n;
       const neuron = {
         ...controlledNeuron,
         fullNeuron: {
@@ -1434,7 +1434,7 @@ describe("neurons-services", () => {
     });
 
     it("should not call api if no identity", async () => {
-      const followee = BigInt(8);
+      const followee = 8n;
       neuronsStore.setNeurons({ neurons, certified: true });
       const topic = Topic.ExchangeRate;
 
@@ -1455,7 +1455,7 @@ describe("neurons-services", () => {
         neurons: [notControlledNeuron],
         certified: true,
       });
-      const followee = BigInt(8);
+      const followee = 8n;
       const topic = Topic.ExchangeRate;
 
       await addFollowee({
@@ -1469,7 +1469,7 @@ describe("neurons-services", () => {
     });
 
     it("should call api if not controlled by user but controlled by hotkey", async () => {
-      const followee = BigInt(8);
+      const followee = 8n;
       const topic = Topic.ExchangeRate;
       const hotkeyNeuron = {
         ...notControlledNeuron,
@@ -1500,7 +1500,7 @@ describe("neurons-services", () => {
     });
 
     it("should not call api if not controlled by user but controlled by hotkey for topic Manage Neuron", async () => {
-      const followee = BigInt(8);
+      const followee = 8n;
       const topic = Topic.ManageNeuron;
       const hotkeyNeuron = {
         ...notControlledNeuron,
@@ -1525,7 +1525,7 @@ describe("neurons-services", () => {
   });
 
   describe("remove followee", () => {
-    const followee = BigInt(8);
+    const followee = 8n;
     const topic = Topic.ExchangeRate;
     const neuronFollowing = {
       ...controlledNeuron,
@@ -1535,7 +1535,7 @@ describe("neurons-services", () => {
       },
     };
     it("should remove the followee to next call", async () => {
-      const followee = BigInt(8);
+      const followee = 8n;
       const topic = Topic.ExchangeRate;
       const neuronFollowing = {
         ...controlledNeuron,
@@ -1578,7 +1578,7 @@ describe("neurons-services", () => {
     });
 
     it("should not call api if user not controller nor hotkey", async () => {
-      const followee = BigInt(8);
+      const followee = 8n;
       const topic = Topic.ExchangeRate;
       const notControlled = {
         ...notControlledNeuron,
@@ -1602,7 +1602,7 @@ describe("neurons-services", () => {
     });
 
     it("should call api if user not controller but controlled by hotkey", async () => {
-      const followee = BigInt(8);
+      const followee = 8n;
       const topic = Topic.ExchangeRate;
       const hotkeyNeuron = {
         ...notControlledNeuron,
@@ -1633,7 +1633,7 @@ describe("neurons-services", () => {
     });
 
     it("should not call api if user not controller but controlled by hotkey and topic is manage neuron", async () => {
-      const followee = BigInt(8);
+      const followee = 8n;
       const topic = Topic.ManageNeuron;
       const hotkeyNeuron = {
         ...notControlledNeuron,
@@ -1692,7 +1692,7 @@ describe("neurons-services", () => {
     });
 
     it("should call setNeuron even if the neuron doesn't have fullNeuron", async () => {
-      const neuronId = BigInt(333333);
+      const neuronId = 333_333n;
       const publicInfoNeuron = {
         ...mockNeuron,
         neuronId,

--- a/frontend/src/tests/lib/services/oberserver.services.spec.ts
+++ b/frontend/src/tests/lib/services/oberserver.services.spec.ts
@@ -14,7 +14,7 @@ describe("observer.services", () => {
     canisterId: rootCanisterIdMock,
     transactions: [mockIcrcTransactionWithId],
     accountIdentifier: mockSnsMainAccount.identifier,
-    oldestTxId: BigInt(10),
+    oldestTxId: 10n,
     completed: false,
   };
 

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -104,7 +104,7 @@ describe("sns-accounts-services", () => {
       const spyAccountsQuery = vi
         .spyOn(ledgerApi, "getSnsAccounts")
         .mockImplementation(() => Promise.resolve([mockSnsMainAccount]));
-      const fee = BigInt(10_000);
+      const fee = 10_000n;
       const spyFeeQuery = vi
         .spyOn(ledgerApi, "transactionFee")
         .mockImplementation(() => Promise.resolve(fee));
@@ -143,7 +143,7 @@ describe("sns-accounts-services", () => {
     it("should call sns transfer tokens", async () => {
       transactionsFeesStore.setFee({
         rootCanisterId: mockPrincipal,
-        fee: BigInt(100),
+        fee: 100n,
         certified: true,
       });
       const spyTransfer = vi
@@ -166,7 +166,7 @@ describe("sns-accounts-services", () => {
     it("should load transactions if flag is passed", async () => {
       transactionsFeesStore.setFee({
         rootCanisterId: mockPrincipal,
-        fee: BigInt(100),
+        fee: 100n,
         certified: true,
       });
       const spyTransfer = vi
@@ -190,7 +190,7 @@ describe("sns-accounts-services", () => {
     it("should show toast and return success false if transfer fails", async () => {
       transactionsFeesStore.setFee({
         rootCanisterId: mockPrincipal,
-        fee: BigInt(100),
+        fee: 100n,
         certified: true,
       });
       const spyTransfer = vi

--- a/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
@@ -43,11 +43,11 @@ describe("sns-neurons-check-balances-services", () => {
         .mockImplementationOnce(() =>
           Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s)
         )
-        .mockImplementation(() => Promise.resolve(BigInt(0)));
+        .mockImplementation(() => Promise.resolve(0n));
       await checkSnsNeuronBalances({
         rootCanisterId: mockPrincipal,
         neurons: [neuron],
-        neuronMinimumStake: 100000000n,
+        neuronMinimumStake: 100_000_000n,
       });
 
       await waitFor(() => expect(spyNeuronBalance).toBeCalled());
@@ -64,7 +64,7 @@ describe("sns-neurons-check-balances-services", () => {
         ...mockSnsNeuron,
         id: [neuronId] as [SnsNeuronId],
       };
-      const stake = neuron.cached_neuron_stake_e8s + BigInt(10_000);
+      const stake = neuron.cached_neuron_stake_e8s + 10_000n;
       const updatedNeuron = {
         ...neuron,
         cached_neuron_stake_e8s: stake,
@@ -75,18 +75,16 @@ describe("sns-neurons-check-balances-services", () => {
       const spyNeuronBalance = vi
         .spyOn(governanceApi, "getNeuronBalance")
         .mockImplementationOnce(() =>
-          Promise.resolve(
-            mockSnsNeuron.cached_neuron_stake_e8s + BigInt(10_000)
-          )
+          Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s + 10_000n)
         )
-        .mockImplementation(() => Promise.resolve(BigInt(0)));
+        .mockImplementation(() => Promise.resolve(0n));
       const spyRefreshNeuron = vi
         .spyOn(governanceApi, "refreshNeuron")
         .mockImplementation(() => Promise.resolve(undefined));
       await checkSnsNeuronBalances({
         rootCanisterId: mockPrincipal,
         neurons: [neuron],
-        neuronMinimumStake: 100000000n,
+        neuronMinimumStake: 100_000_000n,
       });
 
       await waitFor(() => expect(spyRefreshNeuron).toBeCalled());
@@ -109,21 +107,21 @@ describe("sns-neurons-check-balances-services", () => {
       };
       const updatedNeuron = {
         ...neuron,
-        cached_neuron_stake_e8s: BigInt(0),
+        cached_neuron_stake_e8s: 0n,
       };
       const spyNeuronQuery = vi
         .spyOn(governanceApi, "getSnsNeuron")
         .mockImplementation(() => Promise.resolve(updatedNeuron));
       const spyNeuronBalance = vi
         .spyOn(governanceApi, "getNeuronBalance")
-        .mockImplementation(() => Promise.resolve(BigInt(0)));
+        .mockImplementation(() => Promise.resolve(0n));
       const spyRefreshNeuron = vi
         .spyOn(governanceApi, "refreshNeuron")
         .mockImplementation(() => Promise.resolve(undefined));
       await checkSnsNeuronBalances({
         rootCanisterId: mockPrincipal,
         neurons: [neuron],
-        neuronMinimumStake: 100000000n,
+        neuronMinimumStake: 100_000_000n,
       });
 
       await waitFor(() => expect(spyRefreshNeuron).toBeCalled());
@@ -140,9 +138,7 @@ describe("sns-neurons-check-balances-services", () => {
       const spyNeuronBalance = vi
         .spyOn(governanceApi, "getNeuronBalance")
         .mockImplementation(() =>
-          Promise.resolve(
-            mockSnsNeuron.cached_neuron_stake_e8s + BigInt(10_000)
-          )
+          Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s + 10_000n)
         );
       const res = await neuronNeedsRefresh({
         rootCanisterId: mockPrincipal,

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -117,7 +117,7 @@ describe("sns-neurons-services", () => {
           .mockImplementationOnce(() =>
             Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s)
           )
-          .mockImplementation(() => Promise.resolve(BigInt(0)));
+          .mockImplementation(() => Promise.resolve(0n));
         const spyOnNervousSystemParameters = vi
           .spyOn(governanceApi, "nervousSystemParameters")
           .mockResolvedValue(snsNervousSystemParametersMock);
@@ -165,7 +165,7 @@ describe("sns-neurons-services", () => {
           .mockImplementationOnce(() =>
             Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s)
           )
-          .mockImplementation(() => Promise.resolve(BigInt(0)));
+          .mockImplementation(() => Promise.resolve(0n));
 
         // expect parameters to be in store
         expect(
@@ -202,11 +202,9 @@ describe("sns-neurons-services", () => {
       const spyNeuronBalance = vi
         .spyOn(governanceApi, "getNeuronBalance")
         .mockImplementationOnce(() =>
-          Promise.resolve(
-            mockSnsNeuron.cached_neuron_stake_e8s + BigInt(10_000)
-          )
+          Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s + 10_000n)
         )
-        .mockImplementation(() => Promise.resolve(BigInt(0)));
+        .mockImplementation(() => Promise.resolve(0n));
       const spyRefreshNeuron = vi
         .spyOn(governanceApi, "refreshNeuron")
         .mockImplementation(() => Promise.resolve(undefined));
@@ -242,8 +240,8 @@ describe("sns-neurons-services", () => {
         .mockImplementationOnce(() =>
           Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s)
         )
-        .mockImplementationOnce(() => Promise.resolve(BigInt(200_000_000)))
-        .mockImplementation(() => Promise.resolve(BigInt(0)));
+        .mockImplementationOnce(() => Promise.resolve(200_000_000n))
+        .mockImplementation(() => Promise.resolve(0n));
       const spyClaimNeuron = vi
         .spyOn(governanceApi, "claimNeuron")
         .mockImplementation(() => Promise.resolve(undefined));
@@ -329,7 +327,7 @@ describe("sns-neurons-services", () => {
           .mockImplementationOnce(() =>
             Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s)
           )
-          .mockImplementation(() => Promise.resolve(BigInt(0)));
+          .mockImplementation(() => Promise.resolve(0n));
         const spyQuery = vi
           .spyOn(governanceApi, "getSnsNeuron")
           .mockImplementation(() => Promise.resolve(neuron));
@@ -367,7 +365,7 @@ describe("sns-neurons-services", () => {
           ...mockSnsNeuron,
           id: [neuronId] as [SnsNeuronId],
         };
-        const stake = neuron.cached_neuron_stake_e8s + BigInt(10_000);
+        const stake = neuron.cached_neuron_stake_e8s + 10_000n;
         const updatedNeuron = {
           ...neuron,
           cached_neuron_stake_e8s: stake,
@@ -375,7 +373,7 @@ describe("sns-neurons-services", () => {
         const spyNeuronBalance = vi
           .spyOn(governanceApi, "getNeuronBalance")
           .mockImplementationOnce(() => Promise.resolve(stake))
-          .mockImplementation(() => Promise.resolve(BigInt(0)));
+          .mockImplementation(() => Promise.resolve(0n));
         const spyQuery = vi
           .spyOn(governanceApi, "getSnsNeuron")
           // First is the query call and returns old neuron
@@ -662,7 +660,7 @@ describe("sns-neurons-services", () => {
     it("should call sns api stakeNeuron, query neurons again and load sns accounts", async () => {
       transactionsFeesStore.setFee({
         rootCanisterId: mockPrincipal,
-        fee: BigInt(100),
+        fee: 100n,
         certified: true,
       });
       const spyStake = vi
@@ -852,7 +850,7 @@ describe("sns-neurons-services", () => {
     };
     const followeeHex2 = subaccountToHexString(followee2.id);
     const rootCanisterId = mockPrincipal;
-    const functionId = BigInt(3);
+    const functionId = 3n;
 
     beforeEach(() => {
       setFolloweesSpy = vi
@@ -891,7 +889,7 @@ describe("sns-neurons-services", () => {
       );
       const neuron: SnsNeuron = {
         ...mockSnsNeuron,
-        followees: [[BigInt(4), { followees: [followee1] }]],
+        followees: [[4n, { followees: [followee1] }]],
       };
       await addFollowee({
         rootCanisterId,
@@ -975,7 +973,7 @@ describe("sns-neurons-services", () => {
       id: arrayOfNumberToUint8Array([1, 2, 4]),
     };
     const rootCanisterId = mockPrincipal;
-    const functionId = BigInt(3);
+    const functionId = 3n;
 
     beforeEach(() => {
       setFolloweesSpy = vi
@@ -1196,7 +1194,7 @@ describe("sns-neurons-services", () => {
 
       const amount = 10;
 
-      const neuronMinimumStake = 1000n;
+      const neuronMinimumStake = 1_000n;
       const { success } = await splitNeuron({
         neuronId: mockSnsNeuron.id[0] as SnsNeuronId,
         rootCanisterId: mockPrincipal,
@@ -1220,7 +1218,7 @@ describe("sns-neurons-services", () => {
         .mockImplementation(() => Promise.resolve())
         .mockReset();
       const amount = 0.00001;
-      const neuronMinimumStake = 2000n;
+      const neuronMinimumStake = 2_000n;
       const { success } = await splitNeuron({
         neuronId: mockSnsNeuron.id[0] as SnsNeuronId,
         rootCanisterId: mockPrincipal,

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -119,7 +119,7 @@ describe("sns-api", () => {
     derived: [
       {
         sns_tokens_per_icp: 1,
-        buyer_total_icp_e8s: BigInt(1_000_000_000),
+        buyer_total_icp_e8s: 1_000_000_000n,
       },
     ],
   };
@@ -917,7 +917,7 @@ describe("sns-api", () => {
       const account = {
         ...mockMainAccount,
         balance: TokenAmount.fromE8s({
-          amount: BigInt(1_000_000_000_000),
+          amount: 1_000_000_000_000n,
           token: ICPToken,
         }),
       };
@@ -939,7 +939,7 @@ describe("sns-api", () => {
       expect(spyOnNewSaleTicketApi).toBeCalledTimes(1);
       expect(spyOnNewSaleTicketApi).toBeCalledWith(
         expect.objectContaining({
-          amount_icp_e8s: 100000000n,
+          amount_icp_e8s: 100_000_000n,
         })
       );
       expect(spyOnSendICP).toBeCalledTimes(1);
@@ -967,7 +967,7 @@ describe("sns-api", () => {
       const account = {
         ...mockMainAccount,
         balance: TokenAmount.fromE8s({
-          amount: BigInt(1_000_000_000_000),
+          amount: 1_000_000_000_000n,
           token: ICPToken,
         }),
       };

--- a/frontend/src/tests/lib/services/sns-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-transactions.services.spec.ts
@@ -24,10 +24,10 @@ describe("sns-transactions-services", () => {
       const spyGetTransactions = vi
         .spyOn(indexApi, "getSnsTransactions")
         .mockResolvedValue({
-          oldestTxId: BigInt(1234),
+          oldestTxId: 1_234n,
           transactions: [mockIcrcTransactionWithId],
         });
-      const start = BigInt(1234);
+      const start = 1_234n;
       const canisterId = Principal.fromText("tmxop-wyaaa-aaaaa-aaapa-cai");
       await services.loadSnsAccountTransactions({
         canisterId,
@@ -68,7 +68,7 @@ describe("sns-transactions-services", () => {
       const spyGetTransactions = vi
         .spyOn(indexApi, "getSnsTransactions")
         .mockResolvedValue({
-          oldestTxId: BigInt(1234),
+          oldestTxId: 1_234n,
           transactions: [mockIcrcTransactionWithId],
         });
       const canisterId = Principal.fromText("tmxop-wyaaa-aaaaa-aaapa-cai");
@@ -101,11 +101,11 @@ describe("sns-transactions-services", () => {
       const spyGetTransactions = vi
         .spyOn(indexApi, "getSnsTransactions")
         .mockResolvedValue({
-          oldestTxId: BigInt(1234),
+          oldestTxId: 1_234n,
           transactions: [mockIcrcTransactionWithId],
         });
       const canisterId = Principal.fromText("tmxop-wyaaa-aaaaa-aaapa-cai");
-      const oldestTxId = BigInt(1234);
+      const oldestTxId = 1_234n;
       icrcTransactionsStore.addTransactions({
         canisterId,
         accountIdentifier: mockSnsMainAccount.identifier,

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -108,7 +108,7 @@ describe("sns-services", () => {
     it("should call api to get total commitments and load them in stores", async () => {
       const derivedState: SnsGetDerivedStateResponse = {
         sns_tokens_per_icp: [2],
-        buyer_total_icp_e8s: [BigInt(1_000_000_000)],
+        buyer_total_icp_e8s: [1_000_000_000n],
         cf_participant_count: [],
         direct_participant_count: [],
         cf_neuron_count: [],
@@ -133,7 +133,7 @@ describe("sns-services", () => {
     it("should call api with the strategy passed", async () => {
       const derivedState: SnsGetDerivedStateResponse = {
         sns_tokens_per_icp: [1],
-        buyer_total_icp_e8s: [BigInt(1_000_000_000)],
+        buyer_total_icp_e8s: [1_000_000_000n],
         cf_participant_count: [],
         direct_participant_count: [],
         cf_neuron_count: [],
@@ -162,7 +162,7 @@ describe("sns-services", () => {
     it("should call api to get total commitments and load them in store and keep polling", async () => {
       const derivedState: SnsGetDerivedStateResponse = {
         sns_tokens_per_icp: [2],
-        buyer_total_icp_e8s: [BigInt(2_000_000_000)],
+        buyer_total_icp_e8s: [2_000_000_000n],
         cf_participant_count: [],
         direct_participant_count: [],
         cf_neuron_count: [],
@@ -276,7 +276,7 @@ describe("sns-services", () => {
       const newLifeCycle = SnsSwapLifecycle.Committed;
       const lifeCycleResponse: SnsGetLifecycleResponse = {
         lifecycle: [newLifeCycle],
-        decentralization_sale_open_timestamp_seconds: [BigInt(1)],
+        decentralization_sale_open_timestamp_seconds: [1n],
       };
 
       const spy = vi

--- a/frontend/src/tests/lib/services/transaction-fee.services.spec.ts
+++ b/frontend/src/tests/lib/services/transaction-fee.services.spec.ts
@@ -5,7 +5,7 @@ import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { get } from "svelte/store";
 
 describe("transactionFee-services", () => {
-  const fee = BigInt(30_000);
+  const fee = 30_000n;
 
   beforeEach(() => {
     resetIdentity();
@@ -40,7 +40,7 @@ describe("transactionFee-services", () => {
       it("it should not call api if the fee is in the store is certified", async () => {
         transactionsFeesStore.setFee({
           rootCanisterId: mockPrincipal,
-          fee: BigInt(10_000),
+          fee: 10_000n,
           certified: true,
         });
         await loadSnsTransactionFee({ rootCanisterId: mockPrincipal });
@@ -51,7 +51,7 @@ describe("transactionFee-services", () => {
       it("it should call api if the fee is in the store is not certified", async () => {
         transactionsFeesStore.setFee({
           rootCanisterId: mockPrincipal,
-          fee: BigInt(10_000),
+          fee: 10_000n,
           certified: false,
         });
         await loadSnsTransactionFee({ rootCanisterId: mockPrincipal });

--- a/frontend/src/tests/lib/services/vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/vote-registration.services.spec.ts
@@ -37,7 +37,7 @@ vi.mock("$lib/services/$public/proposals.services", () => {
 });
 
 describe("vote-registration-services", () => {
-  const neuronIds = [BigInt(0), BigInt(1), BigInt(2)];
+  const neuronIds = [0n, 1n, 2n];
   const neurons = neuronIds.map((neuronId) => ({
     ...mockNeuron,
     neuronId,
@@ -434,7 +434,7 @@ describe("vote-registration-services", () => {
 
     it("should display error if no identity", async () => {
       await registerNnsVotes({
-        neuronIds: [BigInt(0)],
+        neuronIds: [0n],
         proposalInfo: proposal,
         vote: Vote.Yes,
         reloadProposalCallback: () => {

--- a/frontend/src/tests/lib/services/wallet-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-transactions.services.spec.ts
@@ -27,10 +27,10 @@ describe("wallet-transactions-services", () => {
       const spyGetTransactions = vi
         .spyOn(indexApi, "getTransactions")
         .mockResolvedValue({
-          oldestTxId: BigInt(1234),
+          oldestTxId: 1_234n,
           transactions: [mockIcrcTransactionWithId],
         });
-      const start = BigInt(1234);
+      const start = 1_234n;
 
       await services.loadWalletTransactions({
         account: mockCkBTCMainAccount,
@@ -68,7 +68,7 @@ describe("wallet-transactions-services", () => {
       const spyGetTransactions = vi
         .spyOn(indexApi, "getTransactions")
         .mockResolvedValue({
-          oldestTxId: BigInt(1234),
+          oldestTxId: 1_234n,
           transactions: [mockIcrcTransactionWithId],
         });
 
@@ -104,11 +104,11 @@ describe("wallet-transactions-services", () => {
       const spyGetTransactions = vi
         .spyOn(indexApi, "getTransactions")
         .mockResolvedValue({
-          oldestTxId: BigInt(1234),
+          oldestTxId: 1_234n,
           transactions: [mockIcrcTransactionWithId],
         });
 
-      const oldestTxId = BigInt(1234);
+      const oldestTxId = 1_234n;
 
       icrcTransactionsStore.addTransactions({
         canisterId: CKBTC_UNIVERSE_CANISTER_ID,

--- a/frontend/src/tests/lib/stores/icp-accounts.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icp-accounts.store.spec.ts
@@ -111,7 +111,7 @@ describe("icpAccountsStore", () => {
       expect(get(icpAccountsStore)?.main.balanceUlps).toEqual(
         mockMainAccount.balanceUlps
       );
-      const newBalanceE8s = BigInt(100);
+      const newBalanceE8s = 100n;
       accountsStoreSetBalance({
         accountIdentifier: mockMainAccount.identifier,
         balanceE8s: newBalanceE8s,
@@ -129,7 +129,7 @@ describe("icpAccountsStore", () => {
       expect(get(icpAccountsStore)?.subAccounts[0].balanceUlps).toEqual(
         mockSubAccount.balanceUlps
       );
-      const newBalanceE8s = BigInt(100);
+      const newBalanceE8s = 100n;
       accountsStoreSetBalance({
         accountIdentifier: mockSubAccount.identifier,
         balanceE8s: newBalanceE8s,
@@ -150,7 +150,7 @@ describe("icpAccountsStore", () => {
       expect(get(icpAccountsStore)?.hardwareWallets[0].balanceUlps).toEqual(
         mockHardwareWalletAccount.balanceUlps
       );
-      const newBalanceE8s = BigInt(100);
+      const newBalanceE8s = 100n;
       accountsStoreSetBalance({
         accountIdentifier: mockHardwareWalletAccount.identifier,
         balanceE8s: newBalanceE8s,
@@ -168,7 +168,7 @@ describe("icpAccountsStore", () => {
         hardwareWallets: [mockHardwareWalletAccount],
       });
 
-      const newBalanceE8s = BigInt(100);
+      const newBalanceE8s = 100n;
       accountsStoreSetBalance({
         accountIdentifier: "not-matching-identifier",
         balanceE8s: newBalanceE8s,
@@ -185,10 +185,10 @@ describe("icpAccountsStore", () => {
     });
 
     it("should reapply set balance on new data from an older request", () => {
-      const mainBalance1 = BigInt(100);
-      const mainBalance2 = BigInt(200);
-      const subBalance1 = BigInt(300);
-      const subBalance2 = BigInt(400);
+      const mainBalance1 = 100n;
+      const mainBalance2 = 200n;
+      const subBalance1 = 300n;
+      const subBalance2 = 400n;
 
       const dataWithBalances = ({ mainBalance, subBalance, certified }) => ({
         main: {

--- a/frontend/src/tests/lib/stores/icrc-transactions.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icrc-transactions.store.spec.ts
@@ -13,7 +13,7 @@ describe("icrc-transactions", () => {
       canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
       transactions: [mockIcrcTransactionWithId],
       accountIdentifier: mockCkBTCMainAccount.identifier,
-      oldestTxId: BigInt(10),
+      oldestTxId: 10n,
       completed: false,
     });
 
@@ -31,7 +31,7 @@ describe("icrc-transactions", () => {
       canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
       transactions: [mockIcrcTransactionWithId],
       accountIdentifier: mockCkBTCWithdrawalAccount.identifier,
-      oldestTxId: BigInt(10),
+      oldestTxId: 10n,
       completed: false,
     });
 
@@ -66,7 +66,7 @@ describe("icrc-transactions", () => {
       canisterId,
       transactions: [mockIcrcTransactionWithId],
       accountIdentifier: identifier,
-      oldestTxId: BigInt(10),
+      oldestTxId: 10n,
       completed: false,
     });
 
@@ -79,7 +79,7 @@ describe("icrc-transactions", () => {
       canisterId,
       transactions: [mockIcrcTransactionWithId, mockIcrcTransactionWithId],
       accountIdentifier: identifier,
-      oldestTxId: BigInt(10),
+      oldestTxId: 10n,
       completed: false,
     });
 

--- a/frontend/src/tests/lib/stores/neurons.store.spec.ts
+++ b/frontend/src/tests/lib/stores/neurons.store.spec.ts
@@ -13,8 +13,8 @@ describe("neurons-store", () => {
   describe("neuronsStore", () => {
     it("should set neurons", () => {
       const neurons: NeuronInfo[] = [
-        { ...mockNeuron, neuronId: BigInt(1) },
-        { ...mockNeuron, neuronId: BigInt(2) },
+        { ...mockNeuron, neuronId: 1n },
+        { ...mockNeuron, neuronId: 2n },
       ];
       neuronsStore.setNeurons({ neurons, certified: true });
 
@@ -24,8 +24,8 @@ describe("neurons-store", () => {
 
     it("should reset neurons", () => {
       const neurons: NeuronInfo[] = [
-        { ...mockNeuron, neuronId: BigInt(1) },
-        { ...mockNeuron, neuronId: BigInt(2) },
+        { ...mockNeuron, neuronId: 1n },
+        { ...mockNeuron, neuronId: 2n },
       ];
       neuronsStore.setNeurons({ neurons, certified: true });
 
@@ -40,14 +40,14 @@ describe("neurons-store", () => {
 
     it("should push neurons", () => {
       const neurons: NeuronInfo[] = [
-        { ...mockNeuron, neuronId: BigInt(1) },
-        { ...mockNeuron, neuronId: BigInt(2) },
+        { ...mockNeuron, neuronId: 1n },
+        { ...mockNeuron, neuronId: 2n },
       ];
       neuronsStore.setNeurons({ neurons, certified: true });
 
       const moreNeurons: NeuronInfo[] = [
-        { ...mockNeuron, neuronId: BigInt(3) },
-        { ...mockNeuron, neuronId: BigInt(4) },
+        { ...mockNeuron, neuronId: 3n },
+        { ...mockNeuron, neuronId: 4n },
       ];
       neuronsStore.pushNeurons({ neurons: moreNeurons, certified: true });
 
@@ -59,15 +59,15 @@ describe("neurons-store", () => {
     });
 
     it("should substitute duplicated neurons", () => {
-      const duplicatedNeuron = { ...mockNeuron, neuronId: BigInt(2) };
+      const duplicatedNeuron = { ...mockNeuron, neuronId: 2n };
       const neurons: NeuronInfo[] = [
-        { ...mockNeuron, neuronId: BigInt(1) },
+        { ...mockNeuron, neuronId: 1n },
         duplicatedNeuron,
       ];
       neuronsStore.setNeurons({ neurons, certified: true });
 
       const moreNeurons: NeuronInfo[] = [
-        { ...mockNeuron, neuronId: BigInt(3) },
+        { ...mockNeuron, neuronId: 3n },
         duplicatedNeuron,
       ];
       neuronsStore.pushNeurons({ neurons: moreNeurons, certified: true });
@@ -90,14 +90,14 @@ describe("neurons-store", () => {
       const neurons: NeuronInfo[] = [
         {
           ...mockNeuron,
-          neuronId: BigInt(1),
+          neuronId: 1n,
           fullNeuron: {
             ...mockNeuron.fullNeuron,
-            cachedNeuronStake: BigInt(0),
-            maturityE8sEquivalent: BigInt(0),
+            cachedNeuronStake: 0n,
+            maturityE8sEquivalent: 0n,
           },
         },
-        { ...mockNeuron, neuronId: BigInt(2) },
+        { ...mockNeuron, neuronId: 2n },
       ];
       neuronsStore.setNeurons({ neurons, certified: true });
 
@@ -111,9 +111,9 @@ describe("neurons-store", () => {
   describe("sortedNeuronStore", () => {
     it("should sort neurons by createdTimestampSeconds", () => {
       const neurons = [
-        { ...mockNeuron, createdTimestampSeconds: BigInt(2) },
-        { ...mockNeuron, createdTimestampSeconds: BigInt(1) },
-        { ...mockNeuron, createdTimestampSeconds: BigInt(3) },
+        { ...mockNeuron, createdTimestampSeconds: 2n },
+        { ...mockNeuron, createdTimestampSeconds: 1n },
+        { ...mockNeuron, createdTimestampSeconds: 3n },
       ];
       neuronsStore.setNeurons({ neurons: [...neurons], certified: true });
       expect(get(sortedNeuronStore)).toEqual([

--- a/frontend/src/tests/lib/stores/nns-reward-event.store.spec.ts
+++ b/frontend/src/tests/lib/stores/nns-reward-event.store.spec.ts
@@ -31,11 +31,11 @@ describe("nnsLatestRewardEventStore", () => {
   it("should not change the reward event that has an older timestamp if the event in the store is certified and the new event is not certified", () => {
     const newReward = {
       ...mockRewardEvent,
-      actual_timestamp_seconds: BigInt(4),
+      actual_timestamp_seconds: 4n,
     };
     const oldReward = {
       ...mockRewardEvent,
-      actual_timestamp_seconds: BigInt(3),
+      actual_timestamp_seconds: 3n,
     };
     nnsLatestRewardEventStore.setLatestRewardEvent({
       rewardEvent: newReward,
@@ -52,11 +52,11 @@ describe("nnsLatestRewardEventStore", () => {
   it("should change the reward event that has an older timestamp if the event in the store is not certified and the new event is certified", () => {
     const newReward = {
       ...mockRewardEvent,
-      actual_timestamp_seconds: BigInt(4),
+      actual_timestamp_seconds: 4n,
     };
     const oldReward = {
       ...mockRewardEvent,
-      actual_timestamp_seconds: BigInt(3),
+      actual_timestamp_seconds: 3n,
     };
     nnsLatestRewardEventStore.setLatestRewardEvent({
       rewardEvent: newReward,
@@ -73,11 +73,11 @@ describe("nnsLatestRewardEventStore", () => {
   it("should not change the reward event that has an older timestamp if the event in the store is not certified and the new event is also not certified", () => {
     const newReward = {
       ...mockRewardEvent,
-      actual_timestamp_seconds: BigInt(4),
+      actual_timestamp_seconds: 4n,
     };
     const oldReward = {
       ...mockRewardEvent,
-      actual_timestamp_seconds: BigInt(3),
+      actual_timestamp_seconds: 3n,
     };
     nnsLatestRewardEventStore.setLatestRewardEvent({
       rewardEvent: newReward,

--- a/frontend/src/tests/lib/stores/proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/proposals.store.spec.ts
@@ -38,10 +38,10 @@ describe("proposals-store", () => {
 
     it("should push proposals with certified-version replacement", () => {
       const queryProposals = generateMockProposals(10, {
-        proposalTimestampSeconds: BigInt(0),
+        proposalTimestampSeconds: 0n,
       });
       const updateProposals = generateMockProposals(10, {
-        proposalTimestampSeconds: BigInt(1),
+        proposalTimestampSeconds: 1n,
       });
       proposalsStore.setProposals({
         proposals: queryProposals,
@@ -79,7 +79,7 @@ describe("proposals-store", () => {
     it("should replace proposals", () => {
       const allProposals = generateMockProposals(10);
       const replacedProposals = generateMockProposals(10, {
-        proposalTimestampSeconds: BigInt(666),
+        proposalTimestampSeconds: 666n,
       });
       proposalsStore.setProposals({ proposals: allProposals, certified: true });
       proposalsStore.replaceProposals(replacedProposals);
@@ -190,26 +190,26 @@ describe("proposals-store", () => {
   describe("proposalPayloadStore", () => {
     it("should store a payload", () => {
       proposalPayloadsStore.setPayload({
-        proposalId: BigInt(0),
+        proposalId: 0n,
         payload: null,
       });
 
-      expect(get(proposalPayloadsStore).get(BigInt(0))).toBeNull();
+      expect(get(proposalPayloadsStore).get(0n)).toBeNull();
     });
 
     it("should throw on initial map set", () => {
-      const call = () => get(proposalPayloadsStore).set(BigInt(0), null);
+      const call = () => get(proposalPayloadsStore).set(0n, null);
 
       expect(call).toThrow();
     });
 
     it("should throw on map set after update", () => {
       proposalPayloadsStore.setPayload({
-        proposalId: BigInt(0),
+        proposalId: 0n,
         payload: null,
       });
 
-      const call = () => get(proposalPayloadsStore).set(BigInt(0), null);
+      const call = () => get(proposalPayloadsStore).set(0n, null);
 
       expect(call).toThrow();
     });

--- a/frontend/src/tests/lib/stores/sns-neurons.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-neurons.store.spec.ts
@@ -11,11 +11,11 @@ describe("SNS Neurons stores", () => {
     it("should set neurons for a project", () => {
       const neurons: SnsNeuron[] = [
         createMockSnsNeuron({
-          stake: BigInt(1_000_000_000),
+          stake: 1_000_000_000n,
           id: [1, 5, 3, 9, 1, 1, 1],
         }),
         createMockSnsNeuron({
-          stake: BigInt(2_000_000_000),
+          stake: 2_000_000_000n,
           id: [1, 5, 3, 9, 9, 3, 2],
         }),
       ];
@@ -32,11 +32,11 @@ describe("SNS Neurons stores", () => {
     it("should reset neurons for a project", () => {
       const neurons: SnsNeuron[] = [
         createMockSnsNeuron({
-          stake: BigInt(1_000_000_000),
+          stake: 1_000_000_000n,
           id: [1, 5, 3, 9, 1, 1, 1],
         }),
         createMockSnsNeuron({
-          stake: BigInt(2_000_000_000),
+          stake: 2_000_000_000n,
           id: [1, 5, 3, 9, 9, 3, 2],
         }),
       ];
@@ -54,11 +54,11 @@ describe("SNS Neurons stores", () => {
     it("should add neurons for another project", () => {
       const neurons1: SnsNeuron[] = [
         createMockSnsNeuron({
-          stake: BigInt(1_000_000_000),
+          stake: 1_000_000_000n,
           id: [1, 5, 3, 9, 1, 1, 1],
         }),
         createMockSnsNeuron({
-          stake: BigInt(2_000_000_000),
+          stake: 2_000_000_000n,
           id: [1, 5, 3, 9, 9, 3, 2],
         }),
       ];
@@ -69,11 +69,11 @@ describe("SNS Neurons stores", () => {
       });
       const neurons2: SnsNeuron[] = [
         createMockSnsNeuron({
-          stake: BigInt(1_000_000_000),
+          stake: 1_000_000_000n,
           id: [1, 5, 3, 4, 1, 1, 1],
         }),
         createMockSnsNeuron({
-          stake: BigInt(2_000_000_000),
+          stake: 2_000_000_000n,
           id: [1, 5, 2, 9, 9, 3, 2],
         }),
       ];
@@ -90,15 +90,15 @@ describe("SNS Neurons stores", () => {
 
     it("should add neurons to a project with neurons", () => {
       const neuron1 = createMockSnsNeuron({
-        stake: BigInt(1_000_000_000),
+        stake: 1_000_000_000n,
         id: [1, 5, 3, 9, 1, 1, 1],
       });
       const neuron2 = createMockSnsNeuron({
-        stake: BigInt(2_000_000_000),
+        stake: 2_000_000_000n,
         id: [1, 5, 3, 9, 9, 3, 2],
       });
       const neuron3 = createMockSnsNeuron({
-        stake: BigInt(2_000_000_000),
+        stake: 2_000_000_000n,
         id: [1, 5, 2, 9, 9, 3, 2],
       });
       const neurons1: SnsNeuron[] = [neuron1, neuron2];

--- a/frontend/src/tests/lib/stores/sns-proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-proposals.store.spec.ts
@@ -8,15 +8,15 @@ import { get } from "svelte/store";
 describe("SNS Proposals stores", () => {
   const snsProposal1: SnsProposalData = {
     ...mockSnsProposal,
-    id: [{ id: BigInt(2) }],
+    id: [{ id: 2n }],
   };
   const snsProposal2: SnsProposalData = {
     ...mockSnsProposal,
-    id: [{ id: BigInt(2) }],
+    id: [{ id: 2n }],
   };
   const snsProposal3: SnsProposalData = {
     ...mockSnsProposal,
-    id: [{ id: BigInt(3) }],
+    id: [{ id: 3n }],
   };
   describe("snsProposalsStore", () => {
     afterEach(() => snsProposalsStore.reset());

--- a/frontend/src/tests/lib/stores/sns-total-token-supply.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-total-token-supply.store.spec.ts
@@ -7,7 +7,7 @@ describe("SNS Total Tokens Supply store", () => {
   beforeEach(() => snsTotalTokenSupplyStore.reset());
 
   const totalSupplyData = {
-    totalSupply: BigInt(1000_000_000),
+    totalSupply: 1_000_000_000n,
     certified: true,
   };
 
@@ -64,7 +64,7 @@ describe("SNS Total Tokens Supply store", () => {
       totalSupplyData.totalSupply
     );
 
-    const newSupply = BigInt(2000_000_000);
+    const newSupply = 2_000_000_000n;
     snsTotalTokenSupplyStore.setTotalTokenSupplies([
       {
         rootCanisterId,

--- a/frontend/src/tests/lib/stores/sns-transactions.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-transactions.store.spec.ts
@@ -16,7 +16,7 @@ describe("SNS Transactions store", () => {
         canisterId: mockPrincipal,
         transactions: [mockIcrcTransactionWithId],
         accountIdentifier: mockSnsMainAccount.identifier,
-        oldestTxId: BigInt(10),
+        oldestTxId: 10n,
         completed: false,
       });
 
@@ -32,7 +32,7 @@ describe("SNS Transactions store", () => {
         canisterId: mockPrincipal,
         transactions: [mockIcrcTransactionWithId],
         accountIdentifier: mockSnsMainAccount.identifier,
-        oldestTxId: BigInt(10),
+        oldestTxId: 10n,
         completed: false,
       });
 
@@ -40,7 +40,7 @@ describe("SNS Transactions store", () => {
         canisterId: mockPrincipal,
         transactions: [mockIcrcTransactionWithId],
         accountIdentifier: mockSnsSubAccount.identifier,
-        oldestTxId: BigInt(10),
+        oldestTxId: 10n,
         completed: false,
       });
 
@@ -58,28 +58,28 @@ describe("SNS Transactions store", () => {
     it("should not add duplicated transactions", () => {
       const tx1 = {
         ...mockIcrcTransactionWithId,
-        id: BigInt(1),
+        id: 1n,
       };
       const tx2 = {
         ...mockIcrcTransactionWithId,
-        id: BigInt(2),
+        id: 2n,
       };
       const tx3 = {
         ...mockIcrcTransactionWithId,
-        id: BigInt(3),
+        id: 3n,
       };
       icrcTransactionsStore.addTransactions({
         canisterId: mockPrincipal,
         transactions: [tx1, tx2],
         accountIdentifier: mockSnsMainAccount.identifier,
-        oldestTxId: BigInt(10),
+        oldestTxId: 10n,
         completed: false,
       });
       icrcTransactionsStore.addTransactions({
         canisterId: mockPrincipal,
         transactions: [tx1, tx3],
         accountIdentifier: mockSnsMainAccount.identifier,
-        oldestTxId: BigInt(10),
+        oldestTxId: 10n,
         completed: false,
       });
 
@@ -93,17 +93,17 @@ describe("SNS Transactions store", () => {
     it("should not change txOldestId if not oldest", () => {
       const tx1 = {
         ...mockIcrcTransactionWithId,
-        id: BigInt(1),
+        id: 1n,
       };
       const tx2 = {
         ...mockIcrcTransactionWithId,
-        id: BigInt(2),
+        id: 2n,
       };
       const tx3 = {
         ...mockIcrcTransactionWithId,
-        id: BigInt(3),
+        id: 3n,
       };
-      const oldestTxId = BigInt(1);
+      const oldestTxId = 1n;
       icrcTransactionsStore.addTransactions({
         canisterId: mockPrincipal,
         transactions: [tx1, tx2],
@@ -115,7 +115,7 @@ describe("SNS Transactions store", () => {
         canisterId: mockPrincipal,
         transactions: [tx1, tx3],
         accountIdentifier: mockSnsMainAccount.identifier,
-        oldestTxId: BigInt(3),
+        oldestTxId: 3n,
         completed: false,
       });
 
@@ -131,7 +131,7 @@ describe("SNS Transactions store", () => {
         canisterId: mockPrincipal,
         transactions: [mockIcrcTransactionWithId],
         accountIdentifier: mockSnsMainAccount.identifier,
-        oldestTxId: BigInt(10),
+        oldestTxId: 10n,
         completed: false,
       });
 
@@ -153,7 +153,7 @@ describe("SNS Transactions store", () => {
         canisterId: mockPrincipal,
         transactions: [mockIcrcTransactionWithId],
         accountIdentifier: mockSnsMainAccount.identifier,
-        oldestTxId: BigInt(10),
+        oldestTxId: 10n,
         completed: false,
       });
       const accountsInStore = get(icrcTransactionsStore);
@@ -166,7 +166,7 @@ describe("SNS Transactions store", () => {
         canisterId: principal2,
         transactions: [mockIcrcTransactionWithId],
         accountIdentifier: mockSnsMainAccount.identifier,
-        oldestTxId: BigInt(10),
+        oldestTxId: 10n,
         completed: false,
       });
       const accountsInStore2 = get(icrcTransactionsStore);

--- a/frontend/src/tests/lib/stores/sns.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns.store.spec.ts
@@ -74,19 +74,19 @@ describe("sns.store", () => {
       const proposals = [
         {
           ...mockProposalInfo,
-          id: BigInt(111),
+          id: 111n,
           deadlineTimestampSeconds: BigInt(Math.round(nowSeconds + 10000)),
           status: ProposalStatus.Rejected,
         },
         {
           ...mockProposalInfo,
-          id: BigInt(222),
+          id: 222n,
           deadlineTimestampSeconds: BigInt(Math.round(nowSeconds - 10000)),
           status: ProposalStatus.Open,
         },
         {
           ...mockProposalInfo,
-          id: BigInt(222),
+          id: 222n,
           deadlineTimestampSeconds: BigInt(Math.round(nowSeconds + 10000)),
           status: ProposalStatus.Accepted,
         },

--- a/frontend/src/tests/lib/stores/transaction-fees.store.spec.ts
+++ b/frontend/src/tests/lib/stores/transaction-fees.store.spec.ts
@@ -24,7 +24,7 @@ describe("transactionsFeesStore", () => {
   });
 
   it("should reset to default", () => {
-    transactionsFeesStore.setMain(BigInt(40_000));
+    transactionsFeesStore.setMain(40_000n);
     const fee1 = get(transactionsFeesStore);
     transactionsFeesStore.setMain(BigInt(DEFAULT_TRANSACTION_FEE_E8S));
     const fee2 = get(transactionsFeesStore);
@@ -34,13 +34,13 @@ describe("transactionsFeesStore", () => {
   it("should set fee of an sns project", () => {
     transactionsFeesStore.setFee({
       rootCanisterId: mockPrincipal,
-      fee: BigInt(40_000),
+      fee: 40_000n,
       certified: true,
     });
     const store1 = get(transactionsFeesStore);
     const { fee: fee1 } = store1.projects[mockPrincipal.toText()];
 
-    const expectedFee = BigInt(50_000);
+    const expectedFee = 50_000n;
     transactionsFeesStore.setFee({
       rootCanisterId: mockPrincipal,
       fee: expectedFee,
@@ -55,8 +55,8 @@ describe("transactionsFeesStore", () => {
 
   it("should set fee of multiple sns projects", () => {
     const rootCanister2 = Principal.fromText("aaaaa-aa");
-    const expectedFee1 = BigInt(40_000);
-    const expectedFee2 = BigInt(50_000);
+    const expectedFee1 = 40_000n;
+    const expectedFee2 = 50_000n;
     transactionsFeesStore.setFees([
       {
         rootCanisterId: mockPrincipal,

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -557,27 +557,27 @@ describe("accounts-utils", () => {
 
   describe("assertEnoughAccountFunds", () => {
     it("should throw if not enough balance", () => {
-      const amountE8s = BigInt(1_000_000_000);
+      const amountE8s = 1_000_000_000n;
       expect(() => {
         assertEnoughAccountFunds({
           account: {
             ...mockMainAccount,
             balanceUlps: amountE8s,
           },
-          amountUlps: amountE8s + BigInt(10_000),
+          amountUlps: amountE8s + 10_000n,
         });
       }).toThrow();
     });
 
     it("should not throw if not enough balance", () => {
-      const amountE8s = BigInt(1_000_000_000);
+      const amountE8s = 1_000_000_000n;
       expect(() => {
         assertEnoughAccountFunds({
           account: {
             ...mockMainAccount,
             balanceUlps: amountE8s,
           },
-          amountUlps: amountE8s - BigInt(10_000),
+          amountUlps: amountE8s - 10_000n,
         });
       }).not.toThrow();
     });

--- a/frontend/src/tests/lib/utils/canisters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/canisters.utils.spec.ts
@@ -70,10 +70,10 @@ describe("canister-utils", () => {
 
   describe("formatCyclesToTCycles", () => {
     it("formats cycles into T Cycles with three decimals of accuracy", () => {
-      expect(formatCyclesToTCycles(BigInt(1_000_000_000_000))).toBe("1.000");
-      expect(formatCyclesToTCycles(BigInt(876_500_000_000))).toBe("0.877");
-      expect(formatCyclesToTCycles(BigInt(876_400_000_000))).toBe("0.876");
-      expect(formatCyclesToTCycles(BigInt(10_120_000_000_000))).toBe("10.120");
+      expect(formatCyclesToTCycles(1_000_000_000_000n)).toBe("1.000");
+      expect(formatCyclesToTCycles(876_500_000_000n)).toBe("0.877");
+      expect(formatCyclesToTCycles(876_400_000_000n)).toBe("0.876");
+      expect(formatCyclesToTCycles(10_120_000_000_000n)).toBe("10.120");
     });
   });
 

--- a/frontend/src/tests/lib/utils/date.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/date.utils.spec.ts
@@ -115,9 +115,9 @@ describe("secondsToDissolveDelayDuration", () => {
   });
 
   it("should display 2 years, 9 months, 11 days", () => {
-    expect(secondsToDissolveDelayDuration(BigInt(87654321))).toContain("2");
-    expect(secondsToDissolveDelayDuration(BigInt(87654321))).toContain("9");
-    expect(secondsToDissolveDelayDuration(BigInt(87654321))).toContain("11");
+    expect(secondsToDissolveDelayDuration(87_654_321n)).toContain("2");
+    expect(secondsToDissolveDelayDuration(87_654_321n)).toContain("9");
+    expect(secondsToDissolveDelayDuration(87_654_321n)).toContain("11");
   });
 });
 
@@ -138,7 +138,7 @@ describe("secondsToDate", () => {
 
 describe("secondsToDateTime", () => {
   it("should return formatted start date and time in 1970", () => {
-    expect(normalizeWhitespace(secondsToDateTime(BigInt(0)))).toEqual(
+    expect(normalizeWhitespace(secondsToDateTime(0n))).toEqual(
       "Jan 1, 1970 12:00 AM"
     );
   });
@@ -155,7 +155,7 @@ describe("secondsToDateTime", () => {
 
 describe("nanoSecondsToDateTime", () => {
   it("should return formatted start date and time in 1970", () => {
-    expect(normalizeWhitespace(nanoSecondsToDateTime(BigInt(0)))).toEqual(
+    expect(normalizeWhitespace(nanoSecondsToDateTime(0n))).toEqual(
       "Jan 1, 1970 12:00 AM"
     );
   });

--- a/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
@@ -57,24 +57,24 @@ describe("icrc-transaction utils", () => {
     from: mainAccount,
   });
   const recentTx = {
-    id: BigInt(1234),
+    id: 1_234n,
     transaction: {
       ...transactionFromMainToSubaccount.transaction,
-      timestamp: BigInt(3000),
+      timestamp: 3_000n,
     },
   };
   const secondTx = {
-    id: BigInt(1235),
+    id: 1_235n,
     transaction: {
       ...transactionFromMainToSubaccount.transaction,
-      timestamp: BigInt(2000),
+      timestamp: 2_000n,
     },
   };
   const oldestTx = {
-    id: BigInt(1236),
+    id: 1_236n,
     transaction: {
       ...transactionFromMainToSubaccount.transaction,
-      timestamp: BigInt(1000),
+      timestamp: 1_000n,
     },
   };
   const selfTransaction = createIcrcTransactionWithId({
@@ -87,7 +87,7 @@ describe("icrc-transaction utils", () => {
         owner: mockPrincipal,
         subaccount: [],
       },
-      mint_block_index: 1256n,
+      mint_block_index: 1_256n,
       amount,
       reason: {
         CallFailed: null,
@@ -119,7 +119,7 @@ describe("icrc-transaction utils", () => {
           [mockSnsMainAccount.identifier]: {
             transactions,
             completed: false,
-            oldestTxId: BigInt(1234),
+            oldestTxId: 1_234n,
           },
         },
       };
@@ -148,7 +148,7 @@ describe("icrc-transaction utils", () => {
           [mockSnsMainAccount.identifier]: {
             transactions: [selfTransaction],
             completed: false,
-            oldestTxId: BigInt(1234),
+            oldestTxId: 1_234n,
           },
         },
       };
@@ -305,7 +305,7 @@ describe("icrc-transaction utils", () => {
       const data = mapTransaction({
         ...defaultParams,
         transaction: {
-          id: BigInt(1234),
+          id: 1_234n,
           transaction: createApproveTransaction({
             timestamp:
               BigInt(defaultTimestamp.getTime()) *
@@ -368,7 +368,7 @@ describe("icrc-transaction utils", () => {
       const amount = 35_000_000n;
       const data = mapIcrcTransaction({
         transaction: {
-          id: BigInt(1234),
+          id: 1_234n,
           transaction: createBurnTransaction({
             from: mainAccount,
             amount,
@@ -406,7 +406,7 @@ describe("icrc-transaction utils", () => {
 
       const data = mapCkbtcTransaction({
         transaction: {
-          id: BigInt(1234),
+          id: 1_234n,
           transaction: createBurnTransaction({
             amount,
             from: mainAccount,
@@ -444,7 +444,7 @@ describe("icrc-transaction utils", () => {
 
       const data = mapCkbtcTransaction({
         transaction: {
-          id: BigInt(1234),
+          id: 1_234n,
           transaction: createBurnTransaction({
             amount,
             from: mainAccount,
@@ -478,7 +478,7 @@ describe("icrc-transaction utils", () => {
 
       const data = mapCkbtcTransaction({
         transaction: {
-          id: BigInt(1234),
+          id: 1_234n,
           transaction: createMintTransaction({
             amount,
             to: mainAccount,
@@ -511,7 +511,7 @@ describe("icrc-transaction utils", () => {
 
       const data = mapCkbtcTransaction({
         transaction: {
-          id: BigInt(1234),
+          id: 1_234n,
           transaction: createMintTransaction({
             amount,
             to: mainAccount,
@@ -547,7 +547,7 @@ describe("icrc-transaction utils", () => {
 
       const data = mapCkbtcTransaction({
         transaction: {
-          id: BigInt(1234),
+          id: 1_234n,
           transaction: createBurnTransaction({
             amount,
             from: mainAccount,
@@ -583,7 +583,7 @@ describe("icrc-transaction utils", () => {
 
       const data = mapCkbtcTransaction({
         transaction: {
-          id: BigInt(1234),
+          id: 1_234n,
           transaction: createBurnTransaction({
             amount,
             from: mainAccount,
@@ -621,7 +621,7 @@ describe("icrc-transaction utils", () => {
 
       const data = mapCkbtcTransaction({
         transaction: {
-          id: BigInt(1234),
+          id: 1_234n,
           transaction: createBurnTransaction({
             amount,
             from: mainAccount,
@@ -655,7 +655,7 @@ describe("icrc-transaction utils", () => {
 
       const data = mapCkbtcTransaction({
         transaction: {
-          id: BigInt(1234),
+          id: 1_234n,
           transaction: createMintTransaction({
             amount,
             to: mainAccount,
@@ -722,7 +722,7 @@ describe("icrc-transaction utils", () => {
           otherParty: mockSnsSubAccount.identifier,
           timestamp: new Date(0),
           tokenAmount: TokenAmountV2.fromUlps({
-            amount: 200010000n,
+            amount: 200_010_000n,
             token: mockCkBTCToken,
           }),
         },
@@ -734,7 +734,7 @@ describe("icrc-transaction utils", () => {
           otherParty: mockSnsSubAccount.identifier,
           timestamp: new Date(0),
           tokenAmount: TokenAmountV2.fromUlps({
-            amount: 300000000n,
+            amount: 300_000_000n,
             token: mockCkBTCToken,
           }),
         },
@@ -975,24 +975,24 @@ describe("icrc-transaction utils", () => {
 
   describe("getOldestTransactionId", () => {
     const recentTx = {
-      id: BigInt(1234),
+      id: 1_234n,
       transaction: {
         ...transactionFromMainToSubaccount.transaction,
-        timestamp: BigInt(3000),
+        timestamp: 3_000n,
       },
     };
     const secondTx = {
-      id: BigInt(1235),
+      id: 1_235n,
       transaction: {
         ...transactionFromMainToSubaccount.transaction,
-        timestamp: BigInt(2000),
+        timestamp: 2_000n,
       },
     };
     const oldestTx = {
-      id: BigInt(1236),
+      id: 1_236n,
       transaction: {
         ...transactionFromMainToSubaccount.transaction,
-        timestamp: BigInt(1000),
+        timestamp: 1_000n,
       },
     };
 
@@ -1004,7 +1004,7 @@ describe("icrc-transaction utils", () => {
           [mockSnsMainAccount.identifier]: {
             transactions,
             completed: false,
-            oldestTxId: BigInt(1234),
+            oldestTxId: 1_234n,
           },
         },
       };
@@ -1035,7 +1035,7 @@ describe("icrc-transaction utils", () => {
           [mockSnsMainAccount.identifier]: {
             transactions,
             completed: false,
-            oldestTxId: BigInt(1234),
+            oldestTxId: 1_234n,
           },
         },
       };
@@ -1057,12 +1057,12 @@ describe("icrc-transaction utils", () => {
           [mockSnsMainAccount.identifier]: {
             transactions: [transactionFromMainToSubaccount],
             completed: false,
-            oldestTxId: BigInt(1234),
+            oldestTxId: 1_234n,
           },
           [mockSnsSubAccount.identifier]: {
             transactions: [transactionFromMainToSubaccount],
             completed: true,
-            oldestTxId: BigInt(1234),
+            oldestTxId: 1_234n,
           },
         },
       };

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -110,8 +110,8 @@ describe("neuron-utils", () => {
     }) as TokenAmount;
     const neuron = {
       ...mockNeuron,
-      ageSeconds: BigInt(0),
-      dissolveDelaySeconds: BigInt(0),
+      ageSeconds: 0n,
+      dissolveDelaySeconds: 0n,
       fullNeuron: {
         ...mockFullNeuron,
         cachedNeuronStake: tokenStake.toE8s(),
@@ -121,9 +121,9 @@ describe("neuron-utils", () => {
       expect(
         neuronVotingPower({
           neuron: mockNeuron,
-          newDissolveDelayInSeconds: BigInt(100),
+          newDissolveDelayInSeconds: 100n,
         })
-      ).toBe(BigInt(0));
+      ).toBe(0n);
     });
 
     it("should return more than stake when delay more than six months", () => {
@@ -146,7 +146,7 @@ describe("neuron-utils", () => {
         neuronVotingPower({
           neuron: agedNeuron,
         })
-      ).toBe(tokenStake.toE8s() * BigInt(2));
+      ).toBe(tokenStake.toE8s() * 2n);
     });
 
     it("should take into account age bonus", () => {
@@ -158,7 +158,7 @@ describe("neuron-utils", () => {
 
       const notSoAgedNeuron = {
         ...neuron,
-        ageSeconds: BigInt(2),
+        ageSeconds: 2n,
         dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR),
       };
       const powerWithAge = neuronVotingPower({
@@ -193,7 +193,7 @@ describe("neuron-utils", () => {
         dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR * 1.5),
         fullNeuron: {
           ...mockFullNeuron,
-          cachedNeuronStake: BigInt(200_000_000),
+          cachedNeuronStake: 200_000_000n,
         },
       };
       const power = neuronVotingPower({
@@ -205,15 +205,15 @@ describe("neuron-utils", () => {
 
   describe("formatVotingPower", () => {
     it("should format", () => {
-      expect(formatVotingPower(BigInt(0))).toBe("0.00");
-      expect(formatVotingPower(BigInt(100000000))).toBe("1.00");
-      expect(formatVotingPower(BigInt(9999900000))).toBe("100.00");
+      expect(formatVotingPower(0n)).toBe("0.00");
+      expect(formatVotingPower(100_000_000n)).toBe("1.00");
+      expect(formatVotingPower(9_999_900_000n)).toBe("100.00");
     });
   });
 
   describe("dissolveDelayMultiplier", () => {
     it("be 1 when dissolve is 0", () => {
-      expect(dissolveDelayMultiplier(BigInt(0))).toBe(1);
+      expect(dissolveDelayMultiplier(0n)).toBe(1);
     });
 
     it("be 2 when dissolve is eight years", () => {
@@ -233,7 +233,7 @@ describe("neuron-utils", () => {
       expect(
         dissolveDelayMultiplier(BigInt(SECONDS_IN_HALF_YEAR))
       ).toBeGreaterThan(1);
-      expect(dissolveDelayMultiplier(BigInt(1000))).toBeGreaterThan(1);
+      expect(dissolveDelayMultiplier(1_000n)).toBeGreaterThan(1);
     });
 
     it("returns expected multiplier for one year", () => {
@@ -243,7 +243,7 @@ describe("neuron-utils", () => {
 
   describe("ageMultiplier", () => {
     it("be 1 when age is 0", () => {
-      expect(ageMultiplier(BigInt(0))).toBe(1);
+      expect(ageMultiplier(0n)).toBe(1);
     });
 
     it("be 1.25 when age is four years", () => {
@@ -257,7 +257,7 @@ describe("neuron-utils", () => {
 
     it("returns more than 1 with positive age", () => {
       expect(ageMultiplier(BigInt(SECONDS_IN_HALF_YEAR))).toBeGreaterThan(1);
-      expect(ageMultiplier(BigInt(1000))).toBeGreaterThan(1);
+      expect(ageMultiplier(1_000n)).toBeGreaterThan(1);
     });
 
     it("returns expected multiplier for one year", () => {
@@ -305,7 +305,7 @@ describe("neuron-utils", () => {
     it("returns whether the stake is valid or not", () => {
       const fullNeuronWithEnoughStake = {
         ...mockFullNeuron,
-        cachedNeuronStake: BigInt(3_000_000_000),
+        cachedNeuronStake: 3_000_000_000n,
       };
       const neuronWithEnoughStake = {
         ...mockNeuron,
@@ -315,8 +315,8 @@ describe("neuron-utils", () => {
 
       const fullNeuronWithEnoughStakeInMaturity = {
         ...mockFullNeuron,
-        cachedNeuronStake: BigInt(100_000_000),
-        maturityE8sEquivalent: BigInt(3_000_000_000),
+        cachedNeuronStake: 100_000_000n,
+        maturityE8sEquivalent: 3_000_000_000n,
       };
       const neuronWithEnoughStakeInMaturity = {
         ...mockNeuron,
@@ -347,7 +347,7 @@ describe("neuron-utils", () => {
     it("returns true when neuron has joined community", () => {
       const joinedNeuron = {
         ...mockNeuron,
-        joinedCommunityFundTimestampSeconds: BigInt(100),
+        joinedCommunityFundTimestampSeconds: 100n,
       };
       expect(hasJoinedCommunityFund(joinedNeuron)).toBe(true);
     });
@@ -496,7 +496,7 @@ describe("neuron-utils", () => {
         fullNeuron: {
           ...mockFullNeuron,
           cachedNeuronStake: stake.toE8s(),
-          maturityE8sEquivalent: stake.toE8s() / BigInt(2),
+          maturityE8sEquivalent: stake.toE8s() / 2n,
         },
       };
       expect(formattedMaturity(neuron)).toBe("1.00");
@@ -512,7 +512,7 @@ describe("neuron-utils", () => {
         fullNeuron: {
           ...mockFullNeuron,
           cachedNeuronStake: stake.toE8s(),
-          maturityE8sEquivalent: BigInt(0),
+          maturityE8sEquivalent: 0n,
         },
       };
       expect(formattedMaturity(neuron)).toBe("0");
@@ -538,7 +538,7 @@ describe("neuron-utils", () => {
         fullNeuron: {
           ...mockFullNeuron,
           maturityE8sEquivalent: stake.toE8s(),
-          stakedMaturityE8sEquivalent: stake.toE8s() / BigInt(2),
+          stakedMaturityE8sEquivalent: stake.toE8s() / 2n,
         },
       };
       expect(formattedTotalMaturity(neuron)).toBe("3.00");
@@ -554,7 +554,7 @@ describe("neuron-utils", () => {
         fullNeuron: {
           ...mockFullNeuron,
           maturityE8sEquivalent: stake.toE8s(),
-          stakedMaturityE8sEquivalent: BigInt(0),
+          stakedMaturityE8sEquivalent: 0n,
         },
       };
 
@@ -570,7 +570,7 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: {
           ...mockFullNeuron,
-          maturityE8sEquivalent: BigInt(0),
+          maturityE8sEquivalent: 0n,
           stakedMaturityE8sEquivalent: stake.toE8s(),
         },
       };
@@ -597,7 +597,7 @@ describe("neuron-utils", () => {
         fullNeuron: {
           ...mockFullNeuron,
           cachedNeuronStake: stake.toE8s(),
-          stakedMaturityE8sEquivalent: stake.toE8s() / BigInt(2),
+          stakedMaturityE8sEquivalent: stake.toE8s() / 2n,
         },
       };
       expect(formattedStakedMaturity(neuron)).toBe("1.00");
@@ -613,7 +613,7 @@ describe("neuron-utils", () => {
         fullNeuron: {
           ...mockFullNeuron,
           cachedNeuronStake: stake.toE8s(),
-          stakedMaturityE8sEquivalent: BigInt(0),
+          stakedMaturityE8sEquivalent: 0n,
         },
       };
       expect(formattedStakedMaturity(neuron)).toBe("0");
@@ -622,9 +622,9 @@ describe("neuron-utils", () => {
 
   describe("sortNeuronsByCreatedTimestamp", () => {
     it("should sort neurons by createdTimestampSeconds", () => {
-      const neuron1 = { ...mockNeuron, createdTimestampSeconds: BigInt(1) };
-      const neuron2 = { ...mockNeuron, createdTimestampSeconds: BigInt(2) };
-      const neuron3 = { ...mockNeuron, createdTimestampSeconds: BigInt(3) };
+      const neuron1 = { ...mockNeuron, createdTimestampSeconds: 1n };
+      const neuron2 = { ...mockNeuron, createdTimestampSeconds: 2n };
+      const neuron3 = { ...mockNeuron, createdTimestampSeconds: 3n };
       expect(sortNeuronsByCreatedTimestamp([])).toEqual([]);
       expect(sortNeuronsByCreatedTimestamp([neuron1])).toEqual([neuron1]);
       expect(
@@ -828,11 +828,11 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: {
           ...mockFullNeuron,
-          cachedNeuronStake: BigInt(100),
-          neuronFees: BigInt(10),
+          cachedNeuronStake: 100n,
+          neuronFees: 10n,
         },
       };
-      expect(neuronStake(neuron)).toBe(BigInt(90));
+      expect(neuronStake(neuron)).toBe(90n);
     });
 
     it("should return 0n when stake is not available", () => {
@@ -840,7 +840,7 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: undefined,
       };
-      expect(neuronStake(neuron)).toBe(BigInt(0));
+      expect(neuronStake(neuron)).toBe(0n);
     });
   });
 
@@ -851,7 +851,7 @@ describe("neuron-utils", () => {
     };
     const ballotWithProposalId: BallotInfo = {
       vote: Vote.Yes,
-      proposalId: BigInt(0),
+      proposalId: 0n,
     };
 
     it("should filter out ballots w/o proposalIds", () => {
@@ -899,15 +899,15 @@ describe("neuron-utils", () => {
           followees: [
             {
               topic: Topic.ExchangeRate,
-              followees: [BigInt(0), BigInt(1)],
+              followees: [0n, 1n],
             },
             {
               topic: Topic.Kyc,
-              followees: [BigInt(1)],
+              followees: [1n],
             },
             {
               topic: Topic.Governance,
-              followees: [BigInt(0), BigInt(1), BigInt(2)],
+              followees: [0n, 1n, 2n],
             },
           ],
         },
@@ -915,15 +915,15 @@ describe("neuron-utils", () => {
 
       expect(followeesNeurons(neuron)).toStrictEqual([
         {
-          neuronId: BigInt(0),
+          neuronId: 0n,
           topics: [Topic.ExchangeRate, Topic.Governance],
         },
         {
-          neuronId: BigInt(1),
+          neuronId: 1n,
           topics: [Topic.ExchangeRate, Topic.Kyc, Topic.Governance],
         },
         {
-          neuronId: BigInt(2),
+          neuronId: 2n,
           topics: [Topic.Governance],
         },
       ]);
@@ -1017,24 +1017,22 @@ describe("neuron-utils", () => {
 
   describe("isEnoughToStakeNeuron", () => {
     it("return true if enough ICP to create a neuron", () => {
-      expect(isEnoughToStakeNeuron({ stakeE8s: BigInt(300_000_000) })).toBe(
-        true
-      );
+      expect(isEnoughToStakeNeuron({ stakeE8s: 300_000_000n })).toBe(true);
     });
     it("returns false if not enough ICP to create a neuron", () => {
-      expect(isEnoughToStakeNeuron({ stakeE8s: BigInt(10_000) })).toBe(false);
+      expect(isEnoughToStakeNeuron({ stakeE8s: 10_000n })).toBe(false);
     });
 
     it("takes into account fee", () => {
       expect(
         isEnoughToStakeNeuron({
-          stakeE8s: BigInt(100_000_000),
-          feeE8s: BigInt(10_000),
+          stakeE8s: 100_000_000n,
+          feeE8s: 10_000n,
         })
       ).toBe(false);
       expect(
         isEnoughToStakeNeuron({
-          stakeE8s: BigInt(100_000_000),
+          stakeE8s: 100_000_000n,
         })
       ).toBe(true);
     });
@@ -1242,7 +1240,7 @@ describe("neuron-utils", () => {
     it("returns 'Neurons' Fund' if neuron is part of Neurons' Fund", () => {
       const neuron: NeuronInfo = {
         ...mockNeuron,
-        joinedCommunityFundTimestampSeconds: 123445n,
+        joinedCommunityFundTimestampSeconds: 123_445n,
         fullNeuron: {
           ...mockNeuron.fullNeuron,
         },
@@ -1260,7 +1258,7 @@ describe("neuron-utils", () => {
     it("returns 'Neurons' Fund' and 'Hotkey Control'", () => {
       const neuron: NeuronInfo = {
         ...mockNeuron,
-        joinedCommunityFundTimestampSeconds: 123445n,
+        joinedCommunityFundTimestampSeconds: 123_445n,
         fullNeuron: {
           ...mockNeuron.fullNeuron,
           hotKeys: [mockIdentity.getPrincipal().toText()],
@@ -1280,7 +1278,7 @@ describe("neuron-utils", () => {
     it("returns 'Neurons' Fund' and 'Hardware Wallet'", () => {
       const neuron: NeuronInfo = {
         ...mockNeuron,
-        joinedCommunityFundTimestampSeconds: 123445n,
+        joinedCommunityFundTimestampSeconds: 123_445n,
         fullNeuron: {
           ...mockNeuron.fullNeuron,
           hotKeys: [mockIdentity.getPrincipal().toText()],
@@ -1339,7 +1337,7 @@ describe("neuron-utils", () => {
       const neuron: NeuronInfo = {
         ...mockNeuron,
         neuronType: NeuronType.Seed,
-        joinedCommunityFundTimestampSeconds: 123445n,
+        joinedCommunityFundTimestampSeconds: 123_445n,
         fullNeuron: {
           ...mockNeuron.fullNeuron,
           neuronType: NeuronType.Seed,
@@ -1398,7 +1396,7 @@ describe("neuron-utils", () => {
 
   describe("allHaveSameFollowees", () => {
     it("returns true if same followees", () => {
-      const followees = [BigInt(4), BigInt(6), BigInt(9)];
+      const followees = [4n, 6n, 9n];
       expect(allHaveSameFollowees([followees, [...followees]])).toBe(true);
     });
 
@@ -1407,13 +1405,13 @@ describe("neuron-utils", () => {
     });
 
     it("returns false if not same followees", () => {
-      const followees1 = [BigInt(4), BigInt(6), BigInt(9)];
-      const followees2 = [BigInt(1), BigInt(6), BigInt(9)];
+      const followees1 = [4n, 6n, 9n];
+      const followees2 = [1n, 6n, 9n];
       expect(allHaveSameFollowees([followees1, followees2])).toBe(false);
     });
 
     it("returns false if not the same amount", () => {
-      const followees = [BigInt(4), BigInt(6), BigInt(9)];
+      const followees = [4n, 6n, 9n];
       expect(allHaveSameFollowees([followees, followees.slice(1)])).toBe(false);
     });
   });
@@ -1425,7 +1423,7 @@ describe("neuron-utils", () => {
         state: NeuronState.Spawning,
         fullNeuron: {
           ...mockFullNeuron,
-          spawnAtTimesSeconds: BigInt(123123113),
+          spawnAtTimesSeconds: 123_123_113n,
         },
       };
       expect(isSpawning(neuron)).toBe(true);
@@ -1459,11 +1457,11 @@ describe("neuron-utils", () => {
       };
       const neuron2 = {
         ...neuron,
-        neuronId: BigInt(444),
+        neuronId: 444n,
       };
       const neuron3 = {
         ...neuron,
-        neuronId: BigInt(445),
+        neuronId: 445n,
       };
       const wrappedNeurons = mapMergeableNeurons({
         neurons: [neuron, neuron2, neuron3],
@@ -1490,8 +1488,8 @@ describe("neuron-utils", () => {
       };
       const neuron2 = {
         ...mockNeuron,
-        neuronId: BigInt(444),
-        joinedCommunityFundTimestampSeconds: BigInt(1234),
+        neuronId: 444n,
+        joinedCommunityFundTimestampSeconds: 1_234n,
         fullNeuron: {
           ...mockFullNeuron,
           controller: "not-user",
@@ -1581,15 +1579,15 @@ describe("neuron-utils", () => {
       };
       const neuronFollowingManageNeuron = {
         ...neuron,
-        neuronId: BigInt(444),
+        neuronId: 444n,
         fullNeuron: {
           ...neuron.fullNeuron,
-          followees: [{ topic: Topic.ManageNeuron, followees: [BigInt(444)] }],
+          followees: [{ topic: Topic.ManageNeuron, followees: [444n] }],
         },
       };
       const neuron3 = {
         ...neuron,
-        neuronId: BigInt(445),
+        neuronId: 445n,
       };
       const wrappedNeurons = mapMergeableNeurons({
         neurons: [neuron, neuronFollowingManageNeuron, neuron3],
@@ -1615,7 +1613,7 @@ describe("neuron-utils", () => {
       };
       const notSameControllerNeuron = {
         ...neuron,
-        neuronId: BigInt(444),
+        neuronId: 444n,
         fullNeuron: {
           ...neuron.fullNeuron,
           controller: mainAccountController,
@@ -1623,7 +1621,7 @@ describe("neuron-utils", () => {
       };
       const neuron3 = {
         ...neuron,
-        neuronId: BigInt(445),
+        neuronId: 445n,
       };
       const wrappedNeurons = mapMergeableNeurons({
         neurons: [neuron, notSameControllerNeuron, neuron3],
@@ -1651,15 +1649,15 @@ describe("neuron-utils", () => {
       };
       const neuronFollowingManageNeuron = {
         ...neuron,
-        neuronId: BigInt(444),
+        neuronId: 444n,
         fullNeuron: {
           ...neuron.fullNeuron,
-          followees: [{ topic: Topic.ManageNeuron, followees: [BigInt(444)] }],
+          followees: [{ topic: Topic.ManageNeuron, followees: [444n] }],
         },
       };
       const neuron3 = {
         ...neuron,
-        neuronId: BigInt(445),
+        neuronId: 445n,
       };
       const wrappedNeurons = mapMergeableNeurons({
         neurons: [neuron, neuronFollowingManageNeuron, neuron3],
@@ -1686,23 +1684,23 @@ describe("neuron-utils", () => {
       };
       const neuronFollowingManageNeuron = {
         ...neuron,
-        neuronId: BigInt(444),
+        neuronId: 444n,
         fullNeuron: {
           ...neuron.fullNeuron,
-          followees: [{ topic: Topic.ManageNeuron, followees: [BigInt(444)] }],
+          followees: [{ topic: Topic.ManageNeuron, followees: [444n] }],
         },
       };
       const neuron3 = {
         ...neuron,
-        neuronId: BigInt(445),
+        neuronId: 445n,
       };
       const neuron4 = {
         ...neuron,
-        neuronId: BigInt(455),
+        neuronId: 455n,
       };
       const neuron5 = {
         ...neuron,
-        neuronId: BigInt(465),
+        neuronId: 465n,
       };
       const wrappedNeurons = mapMergeableNeurons({
         neurons: [
@@ -1736,7 +1734,7 @@ describe("neuron-utils", () => {
       };
       const neuron2 = {
         ...mockNeuron,
-        neuronId: BigInt(444),
+        neuronId: 444n,
         fullNeuron: {
           ...mockFullNeuron,
           controller: "same",
@@ -1765,7 +1763,7 @@ describe("neuron-utils", () => {
       };
       const neuron2 = {
         ...mockNeuron,
-        neuronId: BigInt(444),
+        neuronId: 444n,
         fullNeuron: {
           ...mockFullNeuron,
           controller: "controller-2",
@@ -1783,21 +1781,21 @@ describe("neuron-utils", () => {
           followees: [
             {
               topic: Topic.ManageNeuron,
-              followees: [BigInt(10), BigInt(40)],
+              followees: [10n, 40n],
             },
           ],
         },
       };
       const neuron2 = {
         ...mockNeuron,
-        neuronId: BigInt(444),
+        neuronId: 444n,
         fullNeuron: {
           ...mockFullNeuron,
           controller: "controller",
           followees: [
             {
               topic: Topic.ManageNeuron,
-              followees: [BigInt(10)],
+              followees: [10n],
             },
           ],
         },
@@ -1814,21 +1812,21 @@ describe("neuron-utils", () => {
           followees: [
             {
               topic: Topic.ManageNeuron,
-              followees: [BigInt(40), BigInt(10)],
+              followees: [40n, 10n],
             },
           ],
         },
       };
       const neuron2 = {
         ...mockNeuron,
-        neuronId: BigInt(444),
+        neuronId: 444n,
         fullNeuron: {
           ...mockFullNeuron,
           controller: "controller",
           followees: [
             {
               topic: Topic.ManageNeuron,
-              followees: [BigInt(10), BigInt(40)],
+              followees: [10n, 40n],
             },
           ],
         },
@@ -1845,14 +1843,14 @@ describe("neuron-utils", () => {
           followees: [
             {
               topic: Topic.ManageNeuron,
-              followees: [BigInt(40), BigInt(10)],
+              followees: [40n, 10n],
             },
           ],
         },
       };
       const neuron2 = {
         ...mockNeuron,
-        neuronId: BigInt(444),
+        neuronId: 444n,
         fullNeuron: {
           ...mockFullNeuron,
           controller: "controller",
@@ -1871,21 +1869,21 @@ describe("neuron-utils", () => {
           followees: [
             {
               topic: Topic.ManageNeuron,
-              followees: [BigInt(40), BigInt(10)],
+              followees: [40n, 10n],
             },
           ],
         },
       };
       const neuron2 = {
         ...mockNeuron,
-        neuronId: BigInt(444),
+        neuronId: 444n,
         fullNeuron: {
           ...mockFullNeuron,
           controller: "controller",
           followees: [
             {
               topic: Topic.ManageNeuron,
-              followees: [BigInt(40), BigInt(200)],
+              followees: [40n, 200n],
             },
           ],
         },
@@ -1900,7 +1898,7 @@ describe("neuron-utils", () => {
       };
       const neuron2 = {
         ...mockNeuron,
-        neuronId: BigInt(444),
+        neuronId: 444n,
         neuronType: undefined,
       };
       expect(canBeMerged([neuron, neuron2]).isValid).toBe(false);
@@ -1913,7 +1911,7 @@ describe("neuron-utils", () => {
       };
       const neuron2 = {
         ...mockNeuron,
-        neuronId: BigInt(444),
+        neuronId: 444n,
         neuronType: NeuronType.Ect,
       };
       expect(canBeMerged([neuron, neuron2]).isValid).toBe(true);
@@ -1926,7 +1924,7 @@ describe("neuron-utils", () => {
       };
       const neuron2 = {
         ...mockNeuron,
-        neuronId: BigInt(444),
+        neuronId: 444n,
         neuronType: undefined,
       };
       expect(canBeMerged([neuron, neuron2]).isValid).toBe(true);
@@ -1937,15 +1935,15 @@ describe("neuron-utils", () => {
     const followees = [
       {
         topic: Topic.ExchangeRate,
-        followees: [BigInt(0), BigInt(1)],
+        followees: [0n, 1n],
       },
       {
         topic: Topic.Kyc,
-        followees: [BigInt(1)],
+        followees: [1n],
       },
       {
         topic: Topic.Governance,
-        followees: [BigInt(0), BigInt(1), BigInt(2)],
+        followees: [0n, 1n, 2n],
       },
     ];
     const neuron = {
@@ -1998,7 +1996,7 @@ describe("neuron-utils", () => {
         followees: [
           {
             topic: Topic.ExchangeRate,
-            followees: [BigInt(0), BigInt(1)],
+            followees: [0n, 1n],
           },
         ],
       },
@@ -2017,7 +2015,7 @@ describe("neuron-utils", () => {
         followees: [
           {
             topic: Topic.ManageNeuron,
-            followees: [BigInt(0), BigInt(1)],
+            followees: [0n, 1n],
           },
         ],
       },
@@ -2067,17 +2065,17 @@ describe("neuron-utils", () => {
 
   describe("votedNeuronDetails", () => {
     it("should return array of CompactNeuronInfo", () => {
-      const neuronId1 = BigInt(10_000);
-      const neuronId2 = BigInt(20_000);
-      const proposalId = BigInt(1111);
+      const neuronId1 = 10_000n;
+      const neuronId2 = 20_000n;
+      const proposalId = 1_111n;
       const ballot1 = {
         neuronId: neuronId1,
-        votingPower: BigInt(40),
+        votingPower: 40n,
         vote: Vote.No,
       };
       const ballot2 = {
         neuronId: neuronId2,
-        votingPower: BigInt(50),
+        votingPower: 50n,
         vote: Vote.Yes,
       };
       const neuron1 = {
@@ -2109,9 +2107,9 @@ describe("neuron-utils", () => {
     });
 
     it("should filters out neurons without vote", () => {
-      const neuronId1 = BigInt(10_000);
-      const neuronId2 = BigInt(20_000);
-      const proposalId = BigInt(1111);
+      const neuronId1 = 10_000n;
+      const neuronId2 = 20_000n;
+      const proposalId = 1_111n;
       const neuron1 = {
         ...mockNeuron,
         neuronId: neuronId1,
@@ -2124,7 +2122,7 @@ describe("neuron-utils", () => {
       };
       const ballot1 = {
         neuronId: neuronId1,
-        votingPower: BigInt(40),
+        votingPower: 40n,
         vote: Vote.No,
       };
       const proposal = {
@@ -2146,8 +2144,8 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: {
           ...mockFullNeuron,
-          cachedNeuronStake: BigInt(1_000_000_000),
-          neuronFees: BigInt(10),
+          cachedNeuronStake: 1_000_000_000n,
+          neuronFees: 10n,
         },
       };
       expect(neuronCanBeSplit({ neuron, fee: 10_000 })).toBe(true);
@@ -2158,8 +2156,8 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: {
           ...mockFullNeuron,
-          cachedNeuronStake: BigInt(100),
-          neuronFees: BigInt(10),
+          cachedNeuronStake: 100n,
+          neuronFees: 10n,
         },
       };
       expect(neuronCanBeSplit({ neuron, fee: 10_000 })).toBe(false);
@@ -2180,7 +2178,7 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: {
           ...mockFullNeuron,
-          maturityE8sEquivalent: BigInt(0),
+          maturityE8sEquivalent: 0n,
         },
       };
       expect(hasEnoughMaturityToStake(neuron)).toBe(false);
@@ -2191,7 +2189,7 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: {
           ...mockFullNeuron,
-          maturityE8sEquivalent: BigInt(1000),
+          maturityE8sEquivalent: 1_000n,
         },
       };
       expect(hasEnoughMaturityToStake(neuron)).toBe(true);
@@ -2219,7 +2217,7 @@ describe("neuron-utils", () => {
   describe("getNeuronById", () => {
     afterEach(() => neuronsStore.setNeurons({ neurons: [], certified: true }));
     it("returns neuron when present in store", () => {
-      const neuronId = BigInt(1234);
+      const neuronId = 1_234n;
       const neuron = {
         ...mockNeuron,
         neuronId,
@@ -2231,10 +2229,10 @@ describe("neuron-utils", () => {
     });
 
     it("returns undefined when not present in store", () => {
-      const neuronId = BigInt(1234);
+      const neuronId = 1_234n;
       const neuron = {
         ...mockNeuron,
-        neuronId: BigInt(1235),
+        neuronId: 1_235n,
       };
       neuronsStore.setNeurons({ neurons: [neuron], certified: true });
       const store = get(neuronsStore);
@@ -2243,7 +2241,7 @@ describe("neuron-utils", () => {
     });
 
     it("returns undefined if no neurons in store", () => {
-      const neuronId = BigInt(1234);
+      const neuronId = 1_234n;
       const store = get(neuronsStore);
       const received = getNeuronById({ neuronsStore: store, neuronId });
       expect(received).toBeUndefined();
@@ -2267,7 +2265,7 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: {
           ...mockFullNeuron,
-          cachedNeuronStake: BigInt(10),
+          cachedNeuronStake: 10n,
         },
       };
       expect(
@@ -2310,7 +2308,7 @@ describe("neuron-utils", () => {
   });
 
   describe("filterIneligibleNnsNeurons", () => {
-    const proposalTimestampSeconds = BigInt(100);
+    const proposalTimestampSeconds = 100n;
     const testProposalInfo = {
       ...mockProposalInfo,
       proposalTimestampSeconds,
@@ -2318,19 +2316,19 @@ describe("neuron-utils", () => {
         {
           neuronId: 3n,
           vote: Vote.Yes,
-          votingPower: 12345n,
+          votingPower: 12_345n,
         },
       ],
     } as ProposalInfo;
     const testSinceNeuron = {
       ...mockNeuron,
       neuronId: 1n,
-      createdTimestampSeconds: proposalTimestampSeconds + BigInt(1),
+      createdTimestampSeconds: proposalTimestampSeconds + 1n,
     } as NeuronInfo;
     const testShortNeuron = {
       ...mockNeuron,
       neuronId: 2n,
-      createdTimestampSeconds: proposalTimestampSeconds - BigInt(1),
+      createdTimestampSeconds: proposalTimestampSeconds - 1n,
     } as NeuronInfo;
     const testVotedNeuron = {
       ...mockNeuron,
@@ -2379,26 +2377,28 @@ describe("neuron-utils", () => {
     it("should return last distribution timestamp w/o rollovers", () => {
       const testRewardEvent = {
         ...mockRewardEvent,
-        actual_timestamp_seconds: 12234455555n,
+        actual_timestamp_seconds: 12_234_455_555n,
         settled_proposals: [
           {
             id: 0n,
           },
         ],
       } as RewardEvent;
-      expect(maturityLastDistribution(testRewardEvent)).toEqual(12234455555n);
+      expect(maturityLastDistribution(testRewardEvent)).toEqual(
+        12_234_455_555n
+      );
     });
 
     it("should return last distribution timestamp after 3 rollovers", () => {
       const testRewardEvent = {
         ...mockRewardEvent,
-        actual_timestamp_seconds: 12234455555n,
+        actual_timestamp_seconds: 12_234_455_555n,
         rounds_since_last_distribution: [3n],
         settled_proposals: [],
       } as RewardEvent;
       const threeDays = BigInt(3 * SECONDS_IN_DAY);
       expect(maturityLastDistribution(testRewardEvent)).toEqual(
-        12234455555n - threeDays
+        12_234_455_555n - threeDays
       );
     });
   });

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -469,14 +469,14 @@ describe("project-utils", () => {
 
   describe("currentUserMaxCommitment", () => {
     it("returns the user maximum when no participation yet", () => {
-      const projectMax = BigInt(10_000_000_000);
-      const userMax = BigInt(1_000_000_000);
+      const projectMax = 10_000_000_000n;
+      const userMax = 1_000_000_000n;
       const validProject: SnsFullProject = {
         ...mockSnsFullProject,
         summary: {
           ...mockSnsFullProject.summary,
           derived: {
-            buyer_total_icp_e8s: BigInt(0),
+            buyer_total_icp_e8s: 0n,
             sns_tokens_per_icp: 1,
             cf_participant_count: [],
             direct_participant_count: [],
@@ -488,7 +488,7 @@ describe("project-utils", () => {
             ...mockSnsFullProject.summary.swap,
             params: {
               ...mockSnsFullProject.summary.swap.params,
-              min_participant_icp_e8s: BigInt(100_000_000),
+              min_participant_icp_e8s: 100_000_000n,
               max_participant_icp_e8s: userMax,
               max_icp_e8s: projectMax,
             },
@@ -500,9 +500,9 @@ describe("project-utils", () => {
     });
 
     it("returns the remainder to the user maximum if already participated", () => {
-      const projectMax = BigInt(10_000_000_000);
-      const userMax = BigInt(1_000_000_000);
-      const userCommitment = BigInt(400_000_000);
+      const projectMax = 10_000_000_000n;
+      const userMax = 1_000_000_000n;
+      const userCommitment = 400_000_000n;
       const validProject: SnsFullProject = {
         ...mockSnsFullProject,
         summary: {
@@ -520,7 +520,7 @@ describe("project-utils", () => {
             ...mockSnsFullProject.summary.swap,
             params: {
               ...mockSnsFullProject.summary.swap.params,
-              min_participant_icp_e8s: BigInt(100_000_000),
+              min_participant_icp_e8s: 100_000_000n,
               max_participant_icp_e8s: userMax,
               max_icp_e8s: projectMax,
             },
@@ -540,9 +540,9 @@ describe("project-utils", () => {
     });
 
     it("returns the remainder to the project maximum if remainder lower than user max", () => {
-      const projectMax = BigInt(10_000_000_000);
-      const userMax = BigInt(1_000_000_000);
-      const projectCommitment = BigInt(9_500_000_000);
+      const projectMax = 10_000_000_000n;
+      const userMax = 1_000_000_000n;
+      const projectCommitment = 9_500_000_000n;
       const validProject: SnsFullProject = {
         ...mockSnsFullProject,
         summary: {
@@ -560,7 +560,7 @@ describe("project-utils", () => {
             ...mockSnsFullProject.summary.swap,
             params: {
               ...mockSnsFullProject.summary.swap.params,
-              min_participant_icp_e8s: BigInt(100_000_000),
+              min_participant_icp_e8s: 100_000_000n,
               max_participant_icp_e8s: userMax,
               max_icp_e8s: projectMax,
             },
@@ -574,10 +574,10 @@ describe("project-utils", () => {
     });
 
     it("returns the remainder to the user maximum even when current commitment minus max is lower than maximum per user", () => {
-      const projectMax = BigInt(10_000_000_000);
-      const userMax = BigInt(1_000_000_000);
-      const projectCommitment = BigInt(9_200_000_000);
-      const userCommitment = BigInt(400_000_000);
+      const projectMax = 10_000_000_000n;
+      const userMax = 1_000_000_000n;
+      const projectCommitment = 9_200_000_000n;
+      const userCommitment = 400_000_000n;
       const validProject: SnsFullProject = {
         ...mockSnsFullProject,
         summary: {
@@ -595,7 +595,7 @@ describe("project-utils", () => {
             ...mockSnsFullProject.summary.swap,
             params: {
               ...mockSnsFullProject.summary.swap.params,
-              min_participant_icp_e8s: BigInt(100_000_000),
+              min_participant_icp_e8s: 100_000_000n,
               max_participant_icp_e8s: userMax,
               max_icp_e8s: projectMax,
             },
@@ -617,8 +617,8 @@ describe("project-utils", () => {
 
   describe("projectRemainingAmount", () => {
     it("returns remaining amount taking into account current commitment", () => {
-      const projectMax = BigInt(10_000_000_000);
-      const projectCommitment = BigInt(9_200_000_000);
+      const projectMax = 10_000_000_000n;
+      const projectCommitment = 9_200_000_000n;
       const summary: SnsSummary = {
         ...mockSnsFullProject.summary,
         derived: {
@@ -634,8 +634,8 @@ describe("project-utils", () => {
           ...mockSnsFullProject.summary.swap,
           params: {
             ...mockSnsFullProject.summary.swap.params,
-            min_participant_icp_e8s: BigInt(100_000_000),
-            max_participant_icp_e8s: BigInt(1_000_000_000),
+            min_participant_icp_e8s: 100_000_000n,
+            max_participant_icp_e8s: 1_000_000_000n,
             max_icp_e8s: projectMax,
           },
         },
@@ -647,13 +647,13 @@ describe("project-utils", () => {
   });
 
   describe("validParticipation", () => {
-    const validAmountE8s = BigInt(1_000_000_000);
+    const validAmountE8s = 1_000_000_000n;
     const validProject: SnsFullProject = {
       ...mockSnsFullProject,
       summary: {
         ...mockSnsFullProject.summary,
         derived: {
-          buyer_total_icp_e8s: BigInt(0),
+          buyer_total_icp_e8s: 0n,
           sns_tokens_per_icp: 1,
           cf_participant_count: [],
           direct_participant_count: [],
@@ -666,16 +666,16 @@ describe("project-utils", () => {
           lifecycle: SnsSwapLifecycle.Open,
           params: {
             ...mockSnsFullProject.summary.swap.params,
-            min_participant_icp_e8s: validAmountE8s - BigInt(10_000),
-            max_participant_icp_e8s: validAmountE8s + BigInt(10_000),
-            max_icp_e8s: validAmountE8s + BigInt(10_000),
+            min_participant_icp_e8s: validAmountE8s - 10_000n,
+            max_participant_icp_e8s: validAmountE8s + 10_000n,
+            max_icp_e8s: validAmountE8s + 10_000n,
           },
         },
       },
       swapCommitment: {
         ...(mockSnsFullProject.swapCommitment as SnsSwapCommitment),
         myCommitment: {
-          icp: [createTransferableAmount(BigInt(0))],
+          icp: [createTransferableAmount(0n)],
           has_created_neuron_recipes: [],
         },
       },
@@ -750,7 +750,7 @@ describe("project-utils", () => {
       const { valid } = validParticipation({
         project,
         amount: TokenAmount.fromE8s({
-          amount: validAmountE8s + BigInt(10_000),
+          amount: validAmountE8s + 10_000n,
           token: ICPToken,
         }),
       });
@@ -766,7 +766,7 @@ describe("project-utils", () => {
             ...validProject.summary.swap,
             params: {
               ...validProject.summary.swap.params,
-              max_participant_icp_e8s: validAmountE8s * BigInt(2),
+              max_participant_icp_e8s: validAmountE8s * 2n,
             },
           },
         },
@@ -781,7 +781,7 @@ describe("project-utils", () => {
       const { valid } = validParticipation({
         project,
         amount: TokenAmount.fromE8s({
-          amount: validAmountE8s + BigInt(10_000),
+          amount: validAmountE8s + 10_000n,
           token: ICPToken,
         }),
       });
@@ -789,9 +789,9 @@ describe("project-utils", () => {
     });
 
     it("returns false if amount is larger than project remainder to get to maximum", () => {
-      const maxE8s = BigInt(1_000_000_000);
-      const participationE8s = BigInt(100_000_000);
-      const currentE8s = BigInt(950_000_000);
+      const maxE8s = 1_000_000_000n;
+      const participationE8s = 100_000_000n;
+      const currentE8s = 950_000_000n;
       const project: SnsFullProject = {
         ...validProject,
         summary: {
@@ -825,12 +825,12 @@ describe("project-utils", () => {
     });
 
     it("returns false if amount is smaller than project remainder to get to maximum, but larger than user remainder until max", () => {
-      const maxProject = BigInt(100_000_000_000);
-      const minPerUser = BigInt(100_000_000);
-      const maxPerUser = BigInt(2_000_000_000);
-      const currentProjectParticipation = BigInt(99_500_000_000);
-      const currentUserParticipation = BigInt(800_000_000);
-      const newParticipation = BigInt(600_000_000);
+      const maxProject = 100_000_000_000n;
+      const minPerUser = 100_000_000n;
+      const maxPerUser = 2_000_000_000n;
+      const currentProjectParticipation = 99_500_000_000n;
+      const currentUserParticipation = 800_000_000n;
+      const newParticipation = 600_000_000n;
       const project: SnsFullProject = {
         ...validProject,
         summary: {
@@ -874,15 +874,15 @@ describe("project-utils", () => {
   });
 
   describe("validParticipation", () => {
-    const maxProject = BigInt(100_000_000_000);
-    const minPerUser = BigInt(100_000_000);
-    const maxPerUser = BigInt(2_000_000_000);
+    const maxProject = 100_000_000_000n;
+    const minPerUser = 100_000_000n;
+    const maxPerUser = 2_000_000_000n;
     const project: SnsFullProject = {
       ...mockSnsFullProject,
       summary: {
         ...mockSnsFullProject.summary,
         derived: {
-          buyer_total_icp_e8s: BigInt(0),
+          buyer_total_icp_e8s: 0n,
           sns_tokens_per_icp: 1,
           cf_participant_count: [],
           direct_participant_count: [],
@@ -925,7 +925,7 @@ describe("project-utils", () => {
       };
 
       // User can participate with amount less than min
-      const secondAmountUser = BigInt(10);
+      const secondAmountUser = 10n;
       const { valid: v2 } = validParticipation({
         project,
         amount: TokenAmount.fromE8s({
@@ -982,7 +982,7 @@ describe("project-utils", () => {
       const { valid: v7 } = validParticipation({
         project,
         amount: TokenAmount.fromE8s({
-          amount: maxPerUser - initialAmountUser + BigInt(10_000),
+          amount: maxPerUser - initialAmountUser + 10_000n,
           token: ICPToken,
         }),
       });
@@ -992,9 +992,9 @@ describe("project-utils", () => {
 
   describe("commitmentExceedsAmountLeft", () => {
     it("returns true if amount is larger than maximum left", () => {
-      const maxE8s = BigInt(1_000_000_000);
-      const participationE8s = BigInt(100_000_000);
-      const currentE8s = BigInt(950_000_000);
+      const maxE8s = 1_000_000_000n;
+      const participationE8s = 100_000_000n;
+      const currentE8s = 950_000_000n;
       const summary: SnsSummary = {
         ...mockSnsFullProject.summary,
         derived: {
@@ -1022,9 +1022,9 @@ describe("project-utils", () => {
     });
 
     it("returns false if amount is smaller than maximum left", () => {
-      const maxE8s = BigInt(1_000_000_000);
-      const participationE8s = BigInt(100_000_000);
-      const currentE8s = BigInt(850_000_000);
+      const maxE8s = 1_000_000_000n;
+      const participationE8s = 100_000_000n;
+      const currentE8s = 850_000_000n;
       const summary: SnsSummary = {
         ...mockSnsFullProject.summary,
         derived: {
@@ -1079,7 +1079,7 @@ describe("project-utils", () => {
           subaccount: [],
         },
       ],
-      amount_icp_e8s: BigInt(1000_000_000),
+      amount_icp_e8s: 1_000_000_000n,
     };
 
     it("returns 'logged-out' if user is not logged in", () => {
@@ -1171,7 +1171,7 @@ describe("project-utils", () => {
         myCommitment: {
           icp: [
             createTransferableAmount(
-              summary.swap.params.max_participant_icp_e8s + BigInt(1)
+              summary.swap.params.max_participant_icp_e8s + 1n
             ),
           ],
           has_created_neuron_recipes: [],
@@ -1285,13 +1285,13 @@ describe("project-utils", () => {
   });
 
   describe("getProjectCommitmentSplit", () => {
-    const nfCommitment = 10000000000n;
-    const directCommitment = 20000000000n;
+    const nfCommitment = 10_000_000_000n;
+    const directCommitment = 20_000_000_000n;
 
     describe("when NF participation is present", () => {
       it("returns the commitments split if min-max direct participations are present", () => {
-        const minDirectParticipation = 10000000000n;
-        const maxDirectParticipation = 100000000000n;
+        const minDirectParticipation = 10_000_000_000n;
+        const maxDirectParticipation = 100_000_000_000n;
         const summary = createSummary({
           currentTotalCommitment: directCommitment + nfCommitment,
           directCommitment,
@@ -1316,10 +1316,10 @@ describe("project-utils", () => {
           directCommitment,
           neuronsFundCommitment: nfCommitment,
           minDirectParticipation: undefined,
-          maxDirectParticipation: 100000000000n,
+          maxDirectParticipation: 100_000_000_000n,
         });
         expect(getProjectCommitmentSplit(summary)).toEqual({
-          totalCommitmentE8s: 30000000000n,
+          totalCommitmentE8s: 30_000_000_000n,
         });
       });
 
@@ -1328,20 +1328,20 @@ describe("project-utils", () => {
           currentTotalCommitment: directCommitment + nfCommitment,
           directCommitment,
           neuronsFundCommitment: nfCommitment,
-          minDirectParticipation: 100000000000n,
+          minDirectParticipation: 100_000_000_000n,
           maxDirectParticipation: undefined,
         });
         expect(getProjectCommitmentSplit(summary)).toEqual({
-          totalCommitmentE8s: 30000000000n,
+          totalCommitmentE8s: 30_000_000_000n,
         });
       });
     });
 
     describe("when NF participation is 0", () => {
       it("returns the commitments split if NF participation is present even when 0", () => {
-        const directCommitment = 20000000000n;
-        const minDirectParticipation = 10000000000n;
-        const maxDirectParticipation = 100000000000n;
+        const directCommitment = 20_000_000_000n;
+        const minDirectParticipation = 10_000_000_000n;
+        const maxDirectParticipation = 100_000_000_000n;
         const summary = createSummary({
           currentTotalCommitment: directCommitment,
           directCommitment,
@@ -1350,8 +1350,8 @@ describe("project-utils", () => {
           maxDirectParticipation,
         });
         expect(getProjectCommitmentSplit(summary)).toEqual({
-          totalCommitmentE8s: 20000000000n,
-          directCommitmentE8s: 20000000000n,
+          totalCommitmentE8s: 20_000_000_000n,
+          directCommitmentE8s: 20_000_000_000n,
           nfCommitmentE8s: 0n,
           minDirectCommitmentE8s: minDirectParticipation,
           maxDirectCommitmentE8s: maxDirectParticipation,
@@ -1362,10 +1362,10 @@ describe("project-utils", () => {
 
     describe("when direct participation is not present", () => {
       it("returns the overall commitments even if nf commitment and min-max direct participations are present", () => {
-        const minDirectParticipation = 10000000000n;
-        const maxDirectParticipation = 100000000000n;
+        const minDirectParticipation = 10_000_000_000n;
+        const maxDirectParticipation = 100_000_000_000n;
 
-        const currentTotalCommitment = 30000000000n;
+        const currentTotalCommitment = 30_000_000_000n;
         const summary = createSummary({
           currentTotalCommitment,
           directCommitment: undefined,
@@ -1382,8 +1382,8 @@ describe("project-utils", () => {
 
     describe("when neurons fund participation is not present", () => {
       it("returns the overall commitments even if nf commitment and min-max direct participations are present", () => {
-        const minDirectParticipation = 10000000000n;
-        const maxDirectParticipation = 100000000000n;
+        const minDirectParticipation = 10_000_000_000n;
+        const maxDirectParticipation = 100_000_000_000n;
 
         const summary = createSummary({
           currentTotalCommitment: nfCommitment + directCommitment,
@@ -1402,8 +1402,8 @@ describe("project-utils", () => {
 
     describe("when NF enhancement fields are present, but NF is not participating", () => {
       it("returns the commitments split with NF as `null`", () => {
-        const minDirectParticipation = 10000000000n;
-        const maxDirectParticipation = 100000000000n;
+        const minDirectParticipation = 10_000_000_000n;
+        const maxDirectParticipation = 100_000_000_000n;
         const summary = createSummary({
           currentTotalCommitment: directCommitment,
           directCommitment,

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -67,7 +67,7 @@ const actionWithEmpty = {
     amountE8s: undefined,
     rewardMode: {
       RewardToNeuron: {
-        dissolveDelaySeconds: BigInt(1000),
+        dissolveDelaySeconds: 1_000n,
       },
     },
   },
@@ -103,14 +103,14 @@ describe("proposals-utils", () => {
       ...proposal,
       ballots: [
         {
-          neuronId: BigInt(0),
+          neuronId: 0n,
           vote: vote ?? Vote.Unspecified,
         } as Ballot,
       ],
     });
     const neurons = [
       {
-        neuronId: BigInt(0),
+        neuronId: 0n,
       } as NeuronInfo,
     ];
 
@@ -169,7 +169,7 @@ describe("proposals-utils", () => {
             ...mockProposals[0],
             ballots: [
               {
-                neuronId: BigInt(0),
+                neuronId: 0n,
                 vote: Vote.Unspecified,
               } as Ballot,
             ],
@@ -189,7 +189,7 @@ describe("proposals-utils", () => {
             ...mockProposals[1],
             ballots: [
               {
-                neuronId: BigInt(0),
+                neuronId: 0n,
                 vote: Vote.Unspecified,
               } as Ballot,
             ],
@@ -391,7 +391,7 @@ describe("proposals-utils", () => {
             ...mockProposals[0],
             ballots: [
               {
-                neuronId: BigInt(0),
+                neuronId: 0n,
                 vote: Vote.Unspecified,
               } as Ballot,
             ],
@@ -413,7 +413,7 @@ describe("proposals-utils", () => {
             ...mockProposals[0],
             ballots: [
               {
-                neuronId: BigInt(0),
+                neuronId: 0n,
                 vote: Vote.Unspecified,
               } as Ballot,
             ],
@@ -424,7 +424,7 @@ describe("proposals-utils", () => {
           },
           neurons: [
             {
-              neuronId: BigInt(666),
+              neuronId: 666n,
             } as NeuronInfo,
           ],
           identity: mockIdentity,
@@ -436,7 +436,7 @@ describe("proposals-utils", () => {
   describe("hasMatchingProposals", () => {
     const neurons = [
       {
-        neuronId: BigInt(0),
+        neuronId: 0n,
       } as NeuronInfo,
     ];
 
@@ -459,7 +459,7 @@ describe("proposals-utils", () => {
             ...proposal,
             ballots: [
               {
-                neuronId: BigInt(0),
+                neuronId: 0n,
                 vote: Vote.Unspecified,
               } as Ballot,
             ],
@@ -481,7 +481,7 @@ describe("proposals-utils", () => {
               ...mockProposals[0],
               ballots: [
                 {
-                  neuronId: BigInt(0),
+                  neuronId: 0n,
                   vote: Vote.Unspecified,
                 } as Ballot,
               ],
@@ -504,7 +504,7 @@ describe("proposals-utils", () => {
               ...mockProposals[1],
               ballots: [
                 {
-                  neuronId: BigInt(0),
+                  neuronId: 0n,
                   vote: Vote.Unspecified,
                 } as Ballot,
               ],
@@ -527,7 +527,7 @@ describe("proposals-utils", () => {
               ...mockProposals[0],
               ballots: [
                 {
-                  neuronId: BigInt(0),
+                  neuronId: 0n,
                   vote: Vote.Unspecified,
                 } as Ballot,
               ],
@@ -550,7 +550,7 @@ describe("proposals-utils", () => {
               ...mockProposals[1],
               ballots: [
                 {
-                  neuronId: BigInt(0),
+                  neuronId: 0n,
                   vote: Vote.Unspecified,
                 } as Ballot,
               ],
@@ -572,7 +572,7 @@ describe("proposals-utils", () => {
               ...mockProposals[0],
               ballots: [
                 {
-                  neuronId: BigInt(0),
+                  neuronId: 0n,
                   vote: Vote.Yes,
                 } as Ballot,
               ],
@@ -608,7 +608,7 @@ describe("proposals-utils", () => {
               ...mockProposals[0],
               ballots: [
                 {
-                  neuronId: BigInt(0),
+                  neuronId: 0n,
                   vote: Vote.Yes,
                 } as Ballot,
               ],
@@ -630,7 +630,7 @@ describe("proposals-utils", () => {
               ...mockProposals[0],
               ballots: [
                 {
-                  neuronId: BigInt(0),
+                  neuronId: 0n,
                   vote: Vote.No,
                 } as Ballot,
               ],
@@ -687,7 +687,7 @@ describe("proposals-utils", () => {
       ...mockProposalInfo,
       ballots: neurons.map(({ neuronId, votingPower }) => ({
         neuronId,
-        votingPower: votingPower - BigInt(1),
+        votingPower: votingPower - 1n,
         vote: Vote.No,
       })),
     });
@@ -700,7 +700,7 @@ describe("proposals-utils", () => {
           neurons: neurons.map(toTestNnsVotingNode(proposal)),
           selectedIds: [1, 2, 3].map(String),
         })
-      ).toBe(BigInt(6));
+      ).toBe(6n);
     });
 
     it("should take into account only selected neurons", () => {
@@ -722,7 +722,7 @@ describe("proposals-utils", () => {
           neurons: neurons.map(toTestNnsVotingNode(proposal)),
           selectedIds: [],
         })
-      ).toBe(BigInt(0));
+      ).toBe(0n);
     });
   });
 
@@ -823,7 +823,7 @@ describe("proposals-utils", () => {
       proposals[0].id = undefined;
       const idSet = proposalIdSet(proposals);
       expect(idSet.size).toBe(1);
-      expect(Array.from(idSet)).toStrictEqual([BigInt(1)]);
+      expect(Array.from(idSet)).toStrictEqual([1n]);
     });
   });
 
@@ -865,7 +865,7 @@ describe("proposals-utils", () => {
       status: ProposalStatus.Open,
       rewardStatus: ProposalRewardStatus.AcceptVotes,
       deadlineTimestampSeconds,
-      proposer: BigInt(1234),
+      proposer: 1_234n,
     });
 
     const proposal = {
@@ -897,7 +897,7 @@ describe("proposals-utils", () => {
       expect(deadline).toEqual(
         deadlineTimestampSeconds - BigInt(nowInSeconds())
       );
-      expect(proposer).toEqual(BigInt(1234));
+      expect(proposer).toEqual(1_234n);
       expect(title).toEqual(proposal.title);
       expect(url).toEqual(proposal.url);
 
@@ -983,10 +983,10 @@ describe("proposals-utils", () => {
 
   describe("replaceAndConcatenateProposals", () => {
     const proposalsA = generateMockProposals(10, {
-      proposalTimestampSeconds: BigInt(0),
+      proposalTimestampSeconds: 0n,
     });
     const proposalsB = generateMockProposals(10, {
-      proposalTimestampSeconds: BigInt(0),
+      proposalTimestampSeconds: 0n,
     });
 
     it("should replace proposals by id", () => {
@@ -1046,10 +1046,10 @@ describe("proposals-utils", () => {
 
   describe("replaceProposals", () => {
     const oldProposals = generateMockProposals(10, {
-      proposalTimestampSeconds: BigInt(1),
+      proposalTimestampSeconds: 1n,
     });
     const newProposals = generateMockProposals(10, {
-      proposalTimestampSeconds: BigInt(2),
+      proposalTimestampSeconds: 2n,
     });
 
     it("should replace proposals", () => {
@@ -1082,10 +1082,10 @@ describe("proposals-utils", () => {
 
   describe("getVotingBallot", () => {
     it("should return ballot of neuron if present", () => {
-      const neuronId = BigInt(100);
+      const neuronId = 100n;
       const ballot: Ballot = {
         neuronId,
-        votingPower: BigInt(30),
+        votingPower: 30n,
         vote: Vote.Yes,
       };
       const proposal = {
@@ -1101,10 +1101,10 @@ describe("proposals-utils", () => {
     });
 
     it("should return undefined if ballot not present", () => {
-      const neuronId = BigInt(100);
+      const neuronId = 100n;
       const ballot: Ballot = {
-        neuronId: BigInt(400),
-        votingPower: BigInt(30),
+        neuronId: 400n,
+        votingPower: 30n,
         vote: Vote.Yes,
       };
       const proposal = {
@@ -1122,14 +1122,14 @@ describe("proposals-utils", () => {
 
   describe("getVotingPower", () => {
     it("should return ballot voting power if present", () => {
-      const neuronId = BigInt(100);
+      const neuronId = 100n;
       const neuron = {
         ...mockNeuron,
         neuronId,
       };
       const ballot: Ballot = {
         neuronId,
-        votingPower: BigInt(30),
+        votingPower: 30n,
         vote: Vote.Yes,
       };
       const proposal = {
@@ -1280,13 +1280,13 @@ describe("proposals-utils", () => {
 
   describe("nnsNeuronToVotingNeuron", () => {
     it("should generate VotingNeuron from NeuronInfo", () => {
-      const neuronId = BigInt(100);
+      const neuronId = 100n;
       const neuron = {
         ...mockNeuron,
         neuronId,
         votingPower: 0n,
       };
-      const votingPower = 123456789n;
+      const votingPower = 123_456_789n;
       const ballot: Ballot = {
         neuronId,
         votingPower,

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -183,15 +183,15 @@ describe("sns-neuron utils", () => {
     it("should sort neurons by created_timestamp_seconds", () => {
       const neuron1 = {
         ...mockSnsNeuron,
-        created_timestamp_seconds: BigInt(1),
+        created_timestamp_seconds: 1n,
       };
       const neuron2 = {
         ...mockSnsNeuron,
-        created_timestamp_seconds: BigInt(2),
+        created_timestamp_seconds: 2n,
       };
       const neuron3 = {
         ...mockSnsNeuron,
-        created_timestamp_seconds: BigInt(3),
+        created_timestamp_seconds: 3n,
       };
       expect(sortSnsNeuronsByCreatedTimestamp([])).toEqual([]);
       expect(sortSnsNeuronsByCreatedTimestamp([neuron1])).toEqual([neuron1]);
@@ -250,7 +250,7 @@ describe("sns-neuron utils", () => {
       });
       neuron.dissolve_state = [
         {
-          DissolveDelaySeconds: BigInt(0),
+          DissolveDelaySeconds: 0n,
         },
       ];
       expect(getSnsNeuronState(neuron)).toEqual(NeuronState.Dissolved);
@@ -324,10 +324,10 @@ describe("sns-neuron utils", () => {
 
   describe("getSnsNeuronStake", () => {
     it("returns stake minus neuron fees", () => {
-      const stake1 = BigInt(100);
-      const stake2 = BigInt(200);
-      const fees1 = BigInt(10);
-      const fees2 = BigInt(0);
+      const stake1 = 100n;
+      const stake2 = 200n;
+      const fees1 = 10n;
+      const fees2 = 0n;
       const neuron1: SnsNeuron = {
         ...mockSnsNeuron,
         cached_neuron_stake_e8s: stake1,
@@ -1191,8 +1191,8 @@ describe("sns-neuron utils", () => {
     it("returns true if neuron has stake greater than 0", () => {
       const neuron: SnsNeuron = {
         ...mockSnsNeuron,
-        cached_neuron_stake_e8s: BigInt(10_000_000),
-        maturity_e8s_equivalent: BigInt(0),
+        cached_neuron_stake_e8s: 10_000_000n,
+        maturity_e8s_equivalent: 0n,
       };
       expect(hasValidStake(neuron)).toBeTruthy();
     });
@@ -1200,8 +1200,8 @@ describe("sns-neuron utils", () => {
     it("returns true if neuron has maturity greater than 0", () => {
       const neuron: SnsNeuron = {
         ...mockSnsNeuron,
-        cached_neuron_stake_e8s: BigInt(0),
-        maturity_e8s_equivalent: BigInt(10_000_000),
+        cached_neuron_stake_e8s: 0n,
+        maturity_e8s_equivalent: 10_000_000n,
       };
       expect(hasValidStake(neuron)).toBeTruthy();
     });
@@ -1209,8 +1209,8 @@ describe("sns-neuron utils", () => {
     it("returns true if neuron has maturity and stake greater than 0", () => {
       const neuron: SnsNeuron = {
         ...mockSnsNeuron,
-        cached_neuron_stake_e8s: BigInt(10_000_000),
-        maturity_e8s_equivalent: BigInt(10_000_000),
+        cached_neuron_stake_e8s: 10_000_000n,
+        maturity_e8s_equivalent: 10_000_000n,
       };
       expect(hasValidStake(neuron)).toBeTruthy();
     });
@@ -1218,8 +1218,8 @@ describe("sns-neuron utils", () => {
     it("returns false if neuron has no maturity and no stake", () => {
       const neuron: SnsNeuron = {
         ...mockSnsNeuron,
-        cached_neuron_stake_e8s: BigInt(0),
-        maturity_e8s_equivalent: BigInt(0),
+        cached_neuron_stake_e8s: 0n,
+        maturity_e8s_equivalent: 0n,
       };
       expect(hasValidStake(neuron)).toBe(false);
     });
@@ -1230,9 +1230,9 @@ describe("sns-neuron utils", () => {
       expect(
         minNeuronSplittable({
           fee: 100n,
-          neuronMinimumStake: 1000n,
+          neuronMinimumStake: 1_000n,
         })
-      ).toBe(2100n);
+      ).toBe(2_100n);
     });
   });
 
@@ -1240,9 +1240,9 @@ describe("sns-neuron utils", () => {
     it("returns true if enough", () => {
       expect(
         isEnoughAmountToSplit({
-          amount: 1100n,
+          amount: 1_100n,
           fee: 100n,
-          neuronMinimumStake: 1000n,
+          neuronMinimumStake: 1_000n,
         })
       ).toBeTruthy();
     });
@@ -1250,9 +1250,9 @@ describe("sns-neuron utils", () => {
     it("returns false if not enough", () => {
       expect(
         isEnoughAmountToSplit({
-          amount: 1099n,
+          amount: 1_099n,
           fee: 100n,
-          neuronMinimumStake: 1000n,
+          neuronMinimumStake: 1_000n,
         })
       ).toBe(false);
     });
@@ -1264,11 +1264,11 @@ describe("sns-neuron utils", () => {
         hasEnoughStakeToSplit({
           neuron: {
             ...mockSnsNeuron,
-            cached_neuron_stake_e8s: 2100n,
+            cached_neuron_stake_e8s: 2_100n,
             neuron_fees_e8s: 0n,
           },
           fee: 100n,
-          neuronMinimumStake: 1000n,
+          neuronMinimumStake: 1_000n,
         })
       ).toBeTruthy();
     });
@@ -1278,11 +1278,11 @@ describe("sns-neuron utils", () => {
         hasEnoughStakeToSplit({
           neuron: {
             ...mockSnsNeuron,
-            cached_neuron_stake_e8s: 2099n,
+            cached_neuron_stake_e8s: 2_099n,
             neuron_fees_e8s: 0n,
           },
           fee: 100n,
-          neuronMinimumStake: 1000n,
+          neuronMinimumStake: 1_000n,
         })
       ).toBe(false);
     });
@@ -1292,7 +1292,7 @@ describe("sns-neuron utils", () => {
     it("returns maturity with two decimals", () => {
       const neuron = {
         ...mockSnsNeuron,
-        maturity_e8s_equivalent: BigInt(200000000),
+        maturity_e8s_equivalent: 200_000_000n,
       };
       expect(formattedMaturity(neuron)).toBe("2.00");
     });
@@ -1300,7 +1300,7 @@ describe("sns-neuron utils", () => {
     it("returns 0 when maturity is 0", () => {
       const neuron = {
         ...mockSnsNeuron,
-        maturity_e8s_equivalent: BigInt(0),
+        maturity_e8s_equivalent: 0n,
         staked_maturity_e8s_equivalent: [] as [] | [bigint],
       };
       expect(formattedMaturity(neuron)).toBe("0");
@@ -1316,7 +1316,7 @@ describe("sns-neuron utils", () => {
     it("returns maturity with two decimals", () => {
       const neuron = {
         ...mockSnsNeuron,
-        maturity_e8s_equivalent: BigInt(200000000),
+        maturity_e8s_equivalent: 200_000_000n,
         staked_maturity_e8s_equivalent: [] as [] | [bigint],
       };
       expect(formattedTotalMaturity(neuron)).toBe("2.00");
@@ -1325,7 +1325,7 @@ describe("sns-neuron utils", () => {
     it("returns total if maturity only is provided", () => {
       const neuron = {
         ...mockSnsNeuron,
-        maturity_e8s_equivalent: BigInt(200000000),
+        maturity_e8s_equivalent: 200_000_000n,
         staked_maturity_e8s_equivalent: [] as [] | [bigint],
       };
       expect(formattedTotalMaturity(neuron)).toBe("2.00");
@@ -1334,8 +1334,8 @@ describe("sns-neuron utils", () => {
     it("returns sum if staked maturity is provided", () => {
       const neuron = {
         ...mockSnsNeuron,
-        maturity_e8s_equivalent: BigInt(200000000),
-        staked_maturity_e8s_equivalent: [BigInt(200000000)] as [] | [bigint],
+        maturity_e8s_equivalent: 200_000_000n,
+        staked_maturity_e8s_equivalent: [200_000_000n] as [] | [bigint],
       };
       expect(formattedTotalMaturity(neuron)).toBe("4.00");
     });
@@ -1347,8 +1347,8 @@ describe("sns-neuron utils", () => {
       };
       const neuron: SnsNeuron = {
         ...mockSnsNeuron,
-        maturity_e8s_equivalent: BigInt(200000000),
-        staked_maturity_e8s_equivalent: [BigInt(200000000)] as [] | [bigint],
+        maturity_e8s_equivalent: 200_000_000n,
+        staked_maturity_e8s_equivalent: [200_000_000n] as [] | [bigint],
         disburse_maturity_in_progress: [activeDisbursement],
       };
       expect(formattedTotalMaturity(neuron)).toBe("6.00");
@@ -1357,7 +1357,7 @@ describe("sns-neuron utils", () => {
     it("returns 0 when maturity is 0", () => {
       const neuron = {
         ...mockSnsNeuron,
-        maturity_e8s_equivalent: BigInt(0),
+        maturity_e8s_equivalent: 0n,
         staked_maturity_e8s_equivalent: [] as [] | [bigint],
       };
       expect(formattedTotalMaturity(neuron)).toBe("0");
@@ -1368,7 +1368,7 @@ describe("sns-neuron utils", () => {
     it("should return true if staked maturity", () => {
       const neuron1 = {
         ...mockSnsNeuron,
-        maturity_e8s_equivalent: BigInt(200000000),
+        maturity_e8s_equivalent: 200_000_000n,
       };
       expect(hasEnoughMaturityToStake(neuron1)).toBe(true);
       const neuron2 = {
@@ -1381,7 +1381,7 @@ describe("sns-neuron utils", () => {
     it("should return false if no staked maturity", () => {
       const neuron = {
         ...mockSnsNeuron,
-        maturity_e8s_equivalent: BigInt(0),
+        maturity_e8s_equivalent: 0n,
       };
 
       expect(hasEnoughMaturityToStake(neuron)).toBe(false);
@@ -1398,7 +1398,7 @@ describe("sns-neuron utils", () => {
     it("should return true if maturity is more than fee in worst modulation scenario", () => {
       const neuron = {
         ...mockSnsNeuron,
-        maturity_e8s_equivalent: 10526n + 1n,
+        maturity_e8s_equivalent: 10_526n + 1n,
       };
       expect(hasEnoughMaturityToDisburse({ neuron, feeE8s })).toBe(true);
     });
@@ -1424,7 +1424,7 @@ describe("sns-neuron utils", () => {
     it("should return true if has staked maturity", () => {
       const neuron = {
         ...mockSnsNeuron,
-        staked_maturity_e8s_equivalent: [BigInt(200000000)] as [] | [bigint],
+        staked_maturity_e8s_equivalent: [200_000_000n] as [] | [bigint],
       };
       expect(hasStakedMaturity(neuron)).toBeTruthy();
     });
@@ -1432,7 +1432,7 @@ describe("sns-neuron utils", () => {
     it("should return also true if staked maturity is zero", () => {
       const neuron = {
         ...mockSnsNeuron,
-        staked_maturity_e8s_equivalent: [BigInt(0)] as [] | [bigint],
+        staked_maturity_e8s_equivalent: [0n] as [] | [bigint],
       };
       expect(hasStakedMaturity(neuron)).toBeTruthy();
     });
@@ -1455,7 +1455,7 @@ describe("sns-neuron utils", () => {
     it("returns staked maturity with two decimals", () => {
       const neuron = {
         ...mockSnsNeuron,
-        staked_maturity_e8s_equivalent: [BigInt(2)] as [] | [bigint],
+        staked_maturity_e8s_equivalent: [2n] as [] | [bigint],
       };
       expect(formattedStakedMaturity(neuron)).toBe("0.00000002");
     });
@@ -1463,7 +1463,7 @@ describe("sns-neuron utils", () => {
     it("returns 0 when staked maturity is 0", () => {
       const neuron = {
         ...mockSnsNeuron,
-        staked_maturity_e8s_equivalent: [BigInt(0)] as [] | [bigint],
+        staked_maturity_e8s_equivalent: [0n] as [] | [bigint],
       };
       expect(formattedStakedMaturity(neuron)).toBe("0");
     });
@@ -1478,7 +1478,7 @@ describe("sns-neuron utils", () => {
     it("returns true if the neurons is from the community fund", () => {
       const neuron: SnsNeuron = {
         ...mockSnsNeuron,
-        source_nns_neuron_id: [BigInt(2)],
+        source_nns_neuron_id: [2n],
         staked_maturity_e8s_equivalent: [] as [] | [bigint],
       };
       expect(isCommunityFund(neuron)).toBeTruthy();
@@ -1496,24 +1496,24 @@ describe("sns-neuron utils", () => {
     it("returns true when neuron stake does not match the balance", () => {
       const neuron: SnsNeuron = {
         ...mockSnsNeuron,
-        cached_neuron_stake_e8s: BigInt(2),
+        cached_neuron_stake_e8s: 2n,
       };
       expect(
         needsRefresh({
           neuron,
-          balanceE8s: BigInt(1),
+          balanceE8s: 1n,
         })
       ).toBeTruthy();
     });
     it("returns false when the neuron stake matches the balance", () => {
       const neuron: SnsNeuron = {
         ...mockSnsNeuron,
-        cached_neuron_stake_e8s: BigInt(2),
+        cached_neuron_stake_e8s: 2n,
       };
       expect(
         needsRefresh({
           neuron,
-          balanceE8s: BigInt(2),
+          balanceE8s: 2n,
         })
       ).toBe(false);
     });
@@ -1522,15 +1522,15 @@ describe("sns-neuron utils", () => {
   describe("followeesByNeuronId", () => {
     const function0: SnsNervousSystemFunction = {
       ...nervousSystemFunctionMock,
-      id: BigInt(0),
+      id: 0n,
     };
     const function1: SnsNervousSystemFunction = {
       ...nervousSystemFunctionMock,
-      id: BigInt(1),
+      id: 1n,
     };
     const function2: SnsNervousSystemFunction = {
       ...nervousSystemFunctionMock,
-      id: BigInt(2),
+      id: 2n,
     };
     const nsFunctions = [function0, function1, function2];
     const neuron1 = createMockSnsNeuron({
@@ -1582,15 +1582,15 @@ describe("sns-neuron utils", () => {
   describe("followeesByFunction", () => {
     const function0: SnsNervousSystemFunction = {
       ...nervousSystemFunctionMock,
-      id: BigInt(0),
+      id: 0n,
     };
     const function1: SnsNervousSystemFunction = {
       ...nervousSystemFunctionMock,
-      id: BigInt(1),
+      id: 1n,
     };
     const function2: SnsNervousSystemFunction = {
       ...nervousSystemFunctionMock,
-      id: BigInt(2),
+      id: 2n,
     };
     const neuron1 = createMockSnsNeuron({
       id: [1, 2, 3, 4],
@@ -1603,9 +1603,7 @@ describe("sns-neuron utils", () => {
         ...mockSnsNeuron,
         followees: [],
       };
-      expect(followeesByFunction({ neuron, functionId: BigInt(2) })).toEqual(
-        []
-      );
+      expect(followeesByFunction({ neuron, functionId: 2n })).toEqual([]);
     });
 
     it("returns empty if no followees for that function", () => {
@@ -1637,7 +1635,7 @@ describe("sns-neuron utils", () => {
     const votingPowerNeuron: SnsNeuron = {
       ...mockSnsNeuron,
       staked_maturity_e8s_equivalent: [],
-      maturity_e8s_equivalent: BigInt(0),
+      maturity_e8s_equivalent: 0n,
       neuron_fees_e8s: 0n,
       dissolve_state: [{ DissolveDelaySeconds: 100n }],
       aging_since_timestamp_seconds: 0n,
@@ -2455,7 +2453,7 @@ describe("sns-neuron utils", () => {
           created_timestamp_seconds: yesterday,
           vesting_period_seconds: [BigInt(SECONDS_IN_MONTH)],
         })
-      ).toEqual(2543400n);
+      ).toEqual(2_543_400n);
     });
 
     it("returns 0n if no vesting", () => {
@@ -2485,7 +2483,7 @@ describe("sns-neuron utils", () => {
         id: [1],
         activeDisbursementsE8s: [300_000_000n, 120_000_000n, 100_000_000n],
       });
-      expect(totalDisbursingMaturity(neuron)).toBe(520000000n);
+      expect(totalDisbursingMaturity(neuron)).toBe(520_000_000n);
     });
 
     it("returns 0 if not active disbursements", () => {
@@ -2499,7 +2497,7 @@ describe("sns-neuron utils", () => {
 
   describe("minimumAmountToDisburseMaturity", () => {
     it("returns worst case of maturity modulation", () => {
-      expect(minimumAmountToDisburseMaturity(10_000n)).toBe(10527n);
+      expect(minimumAmountToDisburseMaturity(10_000n)).toBe(10_527n);
     });
 
     it("returns 0 if fee is 0", () => {

--- a/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
@@ -37,16 +37,16 @@ import { arrayOfNumberToUint8Array } from "@dfinity/utils";
 
 describe("sns-proposals utils", () => {
   const acceptedTally = {
-    yes: BigInt(10),
-    no: BigInt(2),
-    total: BigInt(20),
-    timestamp_seconds: BigInt(1),
+    yes: 10n,
+    no: 2n,
+    total: 20n,
+    timestamp_seconds: 1n,
   };
   const rejectedTally = {
-    yes: BigInt(10),
-    no: BigInt(20),
-    total: BigInt(30),
-    timestamp_seconds: BigInt(1),
+    yes: 10n,
+    no: 20n,
+    total: 30n,
+    timestamp_seconds: 1n,
   };
   describe("isAccepted", () => {
     it("should return true if the proposal is accepted", () => {
@@ -70,7 +70,7 @@ describe("sns-proposals utils", () => {
     it("should return OPEN status", () => {
       const proposal: SnsProposalData = {
         ...mockSnsProposal,
-        decided_timestamp_seconds: BigInt(0),
+        decided_timestamp_seconds: 0n,
       };
       expect(snsDecisionStatus(proposal)).toBe(
         SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN
@@ -80,8 +80,8 @@ describe("sns-proposals utils", () => {
     it("should return EXECUTED status", () => {
       const proposal: SnsProposalData = {
         ...mockSnsProposal,
-        decided_timestamp_seconds: BigInt(10),
-        executed_timestamp_seconds: BigInt(10),
+        decided_timestamp_seconds: 10n,
+        executed_timestamp_seconds: 10n,
         latest_tally: [acceptedTally],
       };
       expect(snsDecisionStatus(proposal)).toBe(
@@ -92,9 +92,9 @@ describe("sns-proposals utils", () => {
     it("should return FAILED status", () => {
       const proposal: SnsProposalData = {
         ...mockSnsProposal,
-        decided_timestamp_seconds: BigInt(10),
-        executed_timestamp_seconds: BigInt(0),
-        failed_timestamp_seconds: BigInt(10),
+        decided_timestamp_seconds: 10n,
+        executed_timestamp_seconds: 0n,
+        failed_timestamp_seconds: 10n,
         latest_tally: [acceptedTally],
       };
       expect(snsDecisionStatus(proposal)).toBe(
@@ -105,9 +105,9 @@ describe("sns-proposals utils", () => {
     it("should return ADOPTED status", () => {
       const proposal: SnsProposalData = {
         ...mockSnsProposal,
-        decided_timestamp_seconds: BigInt(10),
-        executed_timestamp_seconds: BigInt(0),
-        failed_timestamp_seconds: BigInt(0),
+        decided_timestamp_seconds: 10n,
+        executed_timestamp_seconds: 0n,
+        failed_timestamp_seconds: 0n,
         latest_tally: [acceptedTally],
       };
       expect(snsDecisionStatus(proposal)).toBe(
@@ -118,9 +118,9 @@ describe("sns-proposals utils", () => {
     it("should return REJECTED status", () => {
       const proposal: SnsProposalData = {
         ...mockSnsProposal,
-        decided_timestamp_seconds: BigInt(10),
-        executed_timestamp_seconds: BigInt(0),
-        failed_timestamp_seconds: BigInt(0),
+        decided_timestamp_seconds: 10n,
+        executed_timestamp_seconds: 0n,
+        failed_timestamp_seconds: 0n,
         latest_tally: [rejectedTally],
       };
       expect(snsDecisionStatus(proposal)).toBe(
@@ -137,7 +137,7 @@ describe("sns-proposals utils", () => {
     it("should return SETTLED", () => {
       const proposal: SnsProposalData = {
         ...mockSnsProposal,
-        reward_event_round: BigInt(2),
+        reward_event_round: 2n,
       };
       expect(snsRewardStatus(proposal)).toBe(
         SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_SETTLED
@@ -148,10 +148,10 @@ describe("sns-proposals utils", () => {
       const now = BigInt(nowInSeconds());
       const proposal: SnsProposalData = {
         ...mockSnsProposal,
-        reward_event_round: BigInt(0),
+        reward_event_round: 0n,
         wait_for_quiet_state: [
           {
-            current_deadline_timestamp_seconds: now + BigInt(100),
+            current_deadline_timestamp_seconds: now + 100n,
           },
         ],
       };
@@ -164,10 +164,10 @@ describe("sns-proposals utils", () => {
       const now = BigInt(nowInSeconds());
       const proposal: SnsProposalData = {
         ...mockSnsProposal,
-        reward_event_round: BigInt(0),
+        reward_event_round: 0n,
         wait_for_quiet_state: [
           {
-            current_deadline_timestamp_seconds: now - BigInt(100),
+            current_deadline_timestamp_seconds: now - 100n,
           },
         ],
         is_eligible_for_rewards: true,
@@ -181,10 +181,10 @@ describe("sns-proposals utils", () => {
       const now = BigInt(nowInSeconds());
       const proposal: SnsProposalData = {
         ...mockSnsProposal,
-        reward_event_round: BigInt(0),
+        reward_event_round: 0n,
         wait_for_quiet_state: [
           {
-            current_deadline_timestamp_seconds: now - BigInt(100),
+            current_deadline_timestamp_seconds: now - 100n,
           },
         ],
         is_eligible_for_rewards: false,
@@ -204,11 +204,11 @@ describe("sns-proposals utils", () => {
       const now = BigInt(nowInSeconds());
       const proposalData: SnsProposalData = {
         ...mockSnsProposal,
-        decided_timestamp_seconds: BigInt(0),
-        reward_event_round: BigInt(0),
+        decided_timestamp_seconds: 0n,
+        reward_event_round: 0n,
         wait_for_quiet_state: [
           {
-            current_deadline_timestamp_seconds: now + BigInt(100),
+            current_deadline_timestamp_seconds: now + 100n,
           },
         ],
       };
@@ -229,11 +229,11 @@ describe("sns-proposals utils", () => {
       const now = BigInt(nowInSeconds());
       const proposalData: SnsProposalData = {
         ...mockSnsProposal,
-        decided_timestamp_seconds: BigInt(0),
-        reward_event_round: BigInt(0),
+        decided_timestamp_seconds: 0n,
+        reward_event_round: 0n,
         wait_for_quiet_state: [
           {
-            current_deadline_timestamp_seconds: now - BigInt(100),
+            current_deadline_timestamp_seconds: now - 100n,
           },
         ],
       };
@@ -251,7 +251,7 @@ describe("sns-proposals utils", () => {
         summary: "Description test",
         action: [{ UpgradeSnsToNextVersion: {} }],
       };
-      const current_deadline_timestamp_seconds = BigInt(1123);
+      const current_deadline_timestamp_seconds = 1_123n;
       const proposalData = {
         ...mockSnsProposal,
         proposal: [proposal],
@@ -289,18 +289,18 @@ describe("sns-proposals utils", () => {
     it("should return the last proposal id", async () => {
       const proposal1: SnsProposalData = {
         ...mockSnsProposal,
-        id: [{ id: BigInt(1) }],
+        id: [{ id: 1n }],
       };
       const proposal2: SnsProposalData = {
         ...mockSnsProposal,
-        id: [{ id: BigInt(2) }],
+        id: [{ id: 2n }],
       };
       const proposal3: SnsProposalData = {
         ...mockSnsProposal,
-        id: [{ id: BigInt(3) }],
+        id: [{ id: 3n }],
       };
       const proposalId = lastProposalId([proposal3, proposal1, proposal2]);
-      expect(proposalId.id).toEqual(BigInt(1));
+      expect(proposalId.id).toEqual(1n);
     });
 
     it("should return undefined when empty array", () => {
@@ -313,15 +313,15 @@ describe("sns-proposals utils", () => {
     it("sorts proposals by id in descending", () => {
       const proposal1: SnsProposalData = {
         ...mockSnsProposal,
-        id: [{ id: BigInt(1) }],
+        id: [{ id: 1n }],
       };
       const proposal2: SnsProposalData = {
         ...mockSnsProposal,
-        id: [{ id: BigInt(2) }],
+        id: [{ id: 2n }],
       };
       const proposal3: SnsProposalData = {
         ...mockSnsProposal,
-        id: [{ id: BigInt(3) }],
+        id: [{ id: 3n }],
       };
       const sortedProposals = sortSnsProposalsById([
         proposal3,
@@ -448,7 +448,7 @@ describe("sns-proposals utils", () => {
 
   describe("snsProposalId", () => {
     it("should return proposal id", () => {
-      const testId = 123987n;
+      const testId = 123_987n;
       const testProposal: SnsProposalData = {
         ...mockSnsProposal,
         id: [
@@ -463,7 +463,7 @@ describe("sns-proposals utils", () => {
 
   describe("snsProposalIdString", () => {
     it("should stringify proposal id", () => {
-      const testId = 123987n;
+      const testId = 123_987n;
       const testProposal: SnsProposalData = {
         ...mockSnsProposal,
         id: [
@@ -561,7 +561,7 @@ describe("sns-proposals utils", () => {
         ...mockSnsNeuron,
         id: [{ id: arrayOfNumberToUint8Array([1, 2, 3]) }],
         staked_maturity_e8s_equivalent: [],
-        maturity_e8s_equivalent: BigInt(0),
+        maturity_e8s_equivalent: 0n,
         neuron_fees_e8s: 0n,
         dissolve_state: [{ DissolveDelaySeconds: 100n }],
         aging_since_timestamp_seconds: 0n,

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -67,7 +67,7 @@ describe("sns-utils", () => {
           has_created_neuron_recipes: [],
         },
       };
-      expect(getCommitmentE8s(commitment)).toEqual(BigInt(0));
+      expect(getCommitmentE8s(commitment)).toEqual(0n);
     });
 
     it("returns 0 if no user commitment", () => {
@@ -75,7 +75,7 @@ describe("sns-utils", () => {
         rootCanisterId: mockPrincipal,
         myCommitment: undefined,
       };
-      expect(getCommitmentE8s(commitment)).toEqual(BigInt(0));
+      expect(getCommitmentE8s(commitment)).toEqual(0n);
     });
 
     it("returns undefined if commitment not loaded", () => {
@@ -277,9 +277,9 @@ sale_participants_count ${saleBuyerCount} 1677707139456
       ).toEqual({
         buyer_total_icp_e8s: BigInt(100 * 100000000),
         sns_tokens_per_icp: 1,
-        cf_participant_count: [BigInt(100)],
-        direct_participant_count: [BigInt(300)],
-        cf_neuron_count: [BigInt(200)],
+        cf_participant_count: [100n],
+        direct_participant_count: [300n],
+        cf_neuron_count: [200n],
         direct_participation_icp_e8s: [],
         neurons_fund_participation_icp_e8s: [],
       });

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -18,99 +18,97 @@ import { ICPToken, TokenAmount, TokenAmountV2 } from "@dfinity/utils";
 
 describe("token-utils", () => {
   it("should format token", () => {
-    expect(formatTokenE8s({ value: BigInt(0) })).toEqual("0");
+    expect(formatTokenE8s({ value: 0n })).toEqual("0");
     // TODO: this following test used to equals 0.0000001 but because of the new ICP conversion it now renders 0.00
-    // expect(formatTokenE8s({value: BigInt(10)})).toEqual("0.0000001");
-    expect(formatTokenE8s({ value: BigInt(100) })).toEqual("0.000001");
-    expect(formatTokenE8s({ value: BigInt(100000000) })).toEqual("1.00");
-    expect(formatTokenE8s({ value: BigInt(1000000000) })).toEqual("10.00");
-    expect(formatTokenE8s({ value: BigInt(1010000000) })).toEqual("10.10");
-    expect(formatTokenE8s({ value: BigInt(1012300000) })).toEqual("10.12");
-    expect(formatTokenE8s({ value: BigInt(20000000000) })).toEqual("200.00");
-    expect(formatTokenE8s({ value: BigInt(20000000001) })).toEqual("200.00");
-    expect(formatTokenE8s({ value: BigInt(200000000000) })).toEqual(`2'000.00`);
-    expect(formatTokenE8s({ value: BigInt(200000000000000) })).toEqual(
+    // expect(formatTokenE8s({value: 10n})).toEqual("0.0000001");
+    expect(formatTokenE8s({ value: 100n })).toEqual("0.000001");
+    expect(formatTokenE8s({ value: 100_000_000n })).toEqual("1.00");
+    expect(formatTokenE8s({ value: 1_000_000_000n })).toEqual("10.00");
+    expect(formatTokenE8s({ value: 1_010_000_000n })).toEqual("10.10");
+    expect(formatTokenE8s({ value: 1_012_300_000n })).toEqual("10.12");
+    expect(formatTokenE8s({ value: 20_000_000_000n })).toEqual("200.00");
+    expect(formatTokenE8s({ value: 20_000_000_001n })).toEqual("200.00");
+    expect(formatTokenE8s({ value: 200_000_000_000n })).toEqual(`2'000.00`);
+    expect(formatTokenE8s({ value: 200_000_000_000_000n })).toEqual(
       `2'000'000.00`
     );
   });
 
   it("should format token detailed", () => {
-    expect(formatTokenE8s({ value: BigInt(0), detailed: true })).toEqual("0");
-    expect(formatTokenE8s({ value: BigInt(100), detailed: true })).toEqual(
-      "0.000001"
+    expect(formatTokenE8s({ value: 0n, detailed: true })).toEqual("0");
+    expect(formatTokenE8s({ value: 100n, detailed: true })).toEqual("0.000001");
+    expect(formatTokenE8s({ value: 100_000_000n, detailed: true })).toEqual(
+      "1.00"
+    );
+    expect(formatTokenE8s({ value: 1_000_000_000n, detailed: true })).toEqual(
+      "10.00"
+    );
+    expect(formatTokenE8s({ value: 1_010_000_000n, detailed: true })).toEqual(
+      "10.10"
+    );
+    expect(formatTokenE8s({ value: 1_012_300_000n, detailed: true })).toEqual(
+      "10.123"
+    );
+    expect(formatTokenE8s({ value: 20_000_000_000n, detailed: true })).toEqual(
+      "200.00"
+    );
+    expect(formatTokenE8s({ value: 20_000_000_001n, detailed: true })).toEqual(
+      "200.00000001"
+    );
+    expect(formatTokenE8s({ value: 200_000_000_000n, detailed: true })).toEqual(
+      `2'000.00`
     );
     expect(
-      formatTokenE8s({ value: BigInt(100000000), detailed: true })
-    ).toEqual("1.00");
-    expect(
-      formatTokenE8s({ value: BigInt(1000000000), detailed: true })
-    ).toEqual("10.00");
-    expect(
-      formatTokenE8s({ value: BigInt(1010000000), detailed: true })
-    ).toEqual("10.10");
-    expect(
-      formatTokenE8s({ value: BigInt(1012300000), detailed: true })
-    ).toEqual("10.123");
-    expect(
-      formatTokenE8s({ value: BigInt(20000000000), detailed: true })
-    ).toEqual("200.00");
-    expect(
-      formatTokenE8s({ value: BigInt(20000000001), detailed: true })
-    ).toEqual("200.00000001");
-    expect(
-      formatTokenE8s({ value: BigInt(200000000000), detailed: true })
-    ).toEqual(`2'000.00`);
-    expect(
-      formatTokenE8s({ value: BigInt(200000000000000), detailed: true })
+      formatTokenE8s({ value: 200_000_000_000_000n, detailed: true })
     ).toEqual(`2'000'000.00`);
   });
 
   it("should format token detailed with height decimals", () => {
+    expect(formatTokenE8s({ value: 0n, detailed: "height_decimals" })).toEqual(
+      "0"
+    );
+    expect(formatTokenE8s({ value: 1n, detailed: "height_decimals" })).toEqual(
+      "0.00000001"
+    );
+    expect(formatTokenE8s({ value: 10n, detailed: "height_decimals" })).toEqual(
+      "0.00000010"
+    );
     expect(
-      formatTokenE8s({ value: BigInt(0), detailed: "height_decimals" })
-    ).toEqual("0");
-    expect(
-      formatTokenE8s({ value: BigInt(1), detailed: "height_decimals" })
-    ).toEqual("0.00000001");
-    expect(
-      formatTokenE8s({ value: BigInt(10), detailed: "height_decimals" })
-    ).toEqual("0.00000010");
-    expect(
-      formatTokenE8s({ value: BigInt(100), detailed: "height_decimals" })
+      formatTokenE8s({ value: 100n, detailed: "height_decimals" })
     ).toEqual("0.00000100");
     expect(
-      formatTokenE8s({ value: BigInt(100000000), detailed: "height_decimals" })
+      formatTokenE8s({ value: 100_000_000n, detailed: "height_decimals" })
     ).toEqual("1.00000000");
     expect(
-      formatTokenE8s({ value: BigInt(1000000000), detailed: "height_decimals" })
+      formatTokenE8s({ value: 1_000_000_000n, detailed: "height_decimals" })
     ).toEqual("10.00000000");
     expect(
-      formatTokenE8s({ value: BigInt(1010000000), detailed: "height_decimals" })
+      formatTokenE8s({ value: 1_010_000_000n, detailed: "height_decimals" })
     ).toEqual("10.10000000");
     expect(
-      formatTokenE8s({ value: BigInt(1012300000), detailed: "height_decimals" })
+      formatTokenE8s({ value: 1_012_300_000n, detailed: "height_decimals" })
     ).toEqual("10.12300000");
     expect(
       formatTokenE8s({
-        value: BigInt(20000000000),
+        value: 20_000_000_000n,
         detailed: "height_decimals",
       })
     ).toEqual("200.00000000");
     expect(
       formatTokenE8s({
-        value: BigInt(20000000001),
+        value: 20_000_000_001n,
         detailed: "height_decimals",
       })
     ).toEqual("200.00000001");
     expect(
       formatTokenE8s({
-        value: BigInt(200000000000),
+        value: 200_000_000_000n,
         detailed: "height_decimals",
       })
     ).toEqual(`2'000.00000000`);
     expect(
       formatTokenE8s({
-        value: BigInt(200000000000000),
+        value: 200_000_000_000_000n,
         detailed: "height_decimals",
       })
     ).toEqual(`2'000'000.00000000`);
@@ -161,45 +159,47 @@ describe("token-utils", () => {
       it("should format token", () => {
         expect(testFormat({ value: 0n })).toEqual("0");
         // TODO: this following test used to equals 0.0000001 but because of the new ICP conversion it now renders 0.00
-        // expect(testFormat({value: BigInt(10)})).toEqual("0.0000001");
+        // expect(testFormat({value: 10n})).toEqual("0.0000001");
         expect(testFormat({ value: 100n })).toEqual("0.000001");
-        expect(testFormat({ value: 100000000n })).toEqual("1.00");
-        expect(testFormat({ value: 1000000000n })).toEqual("10.00");
-        expect(testFormat({ value: 1010000000n })).toEqual("10.10");
-        expect(testFormat({ value: 1012300000n })).toEqual("10.12");
-        expect(testFormat({ value: 20000000000n })).toEqual("200.00");
-        expect(testFormat({ value: 20000000001n })).toEqual("200.00");
-        expect(testFormat({ value: 200000000000n })).toEqual(`2'000.00`);
-        expect(testFormat({ value: 200000000000000n })).toEqual(`2'000'000.00`);
+        expect(testFormat({ value: 100_000_000n })).toEqual("1.00");
+        expect(testFormat({ value: 1_000_000_000n })).toEqual("10.00");
+        expect(testFormat({ value: 1_010_000_000n })).toEqual("10.10");
+        expect(testFormat({ value: 1_012_300_000n })).toEqual("10.12");
+        expect(testFormat({ value: 20_000_000_000n })).toEqual("200.00");
+        expect(testFormat({ value: 20_000_000_001n })).toEqual("200.00");
+        expect(testFormat({ value: 200_000_000_000n })).toEqual(`2'000.00`);
+        expect(testFormat({ value: 200_000_000_000_000n })).toEqual(
+          `2'000'000.00`
+        );
       });
 
       it("should format token detailed", () => {
         expect(testFormat({ value: 0n, detailed: true })).toEqual("0");
         expect(testFormat({ value: 100n, detailed: true })).toEqual("0.000001");
-        expect(testFormat({ value: 100000000n, detailed: true })).toEqual(
+        expect(testFormat({ value: 100_000_000n, detailed: true })).toEqual(
           "1.00"
         );
-        expect(testFormat({ value: 1000000000n, detailed: true })).toEqual(
+        expect(testFormat({ value: 1_000_000_000n, detailed: true })).toEqual(
           "10.00"
         );
-        expect(testFormat({ value: 1010000000n, detailed: true })).toEqual(
+        expect(testFormat({ value: 1_010_000_000n, detailed: true })).toEqual(
           "10.10"
         );
-        expect(testFormat({ value: 1012300000n, detailed: true })).toEqual(
+        expect(testFormat({ value: 1_012_300_000n, detailed: true })).toEqual(
           "10.123"
         );
-        expect(testFormat({ value: 20000000000n, detailed: true })).toEqual(
+        expect(testFormat({ value: 20_000_000_000n, detailed: true })).toEqual(
           "200.00"
         );
-        expect(testFormat({ value: 20000000001n, detailed: true })).toEqual(
+        expect(testFormat({ value: 20_000_000_001n, detailed: true })).toEqual(
           "200.00000001"
         );
-        expect(testFormat({ value: 200000000000n, detailed: true })).toEqual(
+        expect(testFormat({ value: 200_000_000_000n, detailed: true })).toEqual(
           `2'000.00`
         );
-        expect(testFormat({ value: 200000000000000n, detailed: true })).toEqual(
-          `2'000'000.00`
-        );
+        expect(
+          testFormat({ value: 200_000_000_000_000n, detailed: true })
+        ).toEqual(`2'000'000.00`);
       });
 
       it("should format token detailed with height decimals", () => {
@@ -216,29 +216,29 @@ describe("token-utils", () => {
           testFormat({ value: 100n, detailed: "height_decimals" })
         ).toEqual("0.00000100");
         expect(
-          testFormat({ value: 100000000n, detailed: "height_decimals" })
+          testFormat({ value: 100_000_000n, detailed: "height_decimals" })
         ).toEqual("1.00000000");
         expect(
-          testFormat({ value: 1000000000n, detailed: "height_decimals" })
+          testFormat({ value: 1_000_000_000n, detailed: "height_decimals" })
         ).toEqual("10.00000000");
         expect(
-          testFormat({ value: 1010000000n, detailed: "height_decimals" })
+          testFormat({ value: 1_010_000_000n, detailed: "height_decimals" })
         ).toEqual("10.10000000");
         expect(
-          testFormat({ value: 1012300000n, detailed: "height_decimals" })
+          testFormat({ value: 1_012_300_000n, detailed: "height_decimals" })
         ).toEqual("10.12300000");
         expect(
-          testFormat({ value: 20000000000n, detailed: "height_decimals" })
+          testFormat({ value: 20_000_000_000n, detailed: "height_decimals" })
         ).toEqual("200.00000000");
         expect(
-          testFormat({ value: 20000000001n, detailed: "height_decimals" })
+          testFormat({ value: 20_000_000_001n, detailed: "height_decimals" })
         ).toEqual("200.00000001");
         expect(
-          testFormat({ value: 200000000000n, detailed: "height_decimals" })
+          testFormat({ value: 200_000_000_000n, detailed: "height_decimals" })
         ).toEqual(`2'000.00000000`);
         expect(
           testFormat({
-            value: 200000000000000n,
+            value: 200_000_000_000_000n,
             detailed: "height_decimals",
           })
         ).toEqual(`2'000'000.00000000`);
@@ -293,7 +293,7 @@ describe("token-utils", () => {
     };
 
     it("should convert TokenAmount to TokenAmountV2", () => {
-      const amount = 123456n;
+      const amount = 123_456n;
       expect(
         toTokenAmountV2(
           TokenAmount.fromE8s({
@@ -310,7 +310,7 @@ describe("token-utils", () => {
     });
 
     it("should return TokenAmountV2 as is", () => {
-      const amount = 123457n;
+      const amount = 123_457n;
       const tokenAmountV2 = TokenAmountV2.fromUlps({
         amount,
         token,
@@ -322,12 +322,12 @@ describe("token-utils", () => {
   describe("sumAmounts", () => {
     it("should sum amounts of E8s values", () => {
       const icp0 = 0n;
-      const icp1 = 100000000n;
-      const icp15 = 150000000n;
-      const icp2 = 200000000n;
-      const icp3 = 300000000n;
-      const icp35 = 350000000n;
-      const icp6 = 600000000n;
+      const icp1 = 100_000_000n;
+      const icp15 = 150_000_000n;
+      const icp2 = 200_000_000n;
+      const icp3 = 300_000_000n;
+      const icp35 = 350_000_000n;
+      const icp6 = 600_000_000n;
 
       expect(sumAmounts(icp0, icp1)).toEqual(icp1);
       expect(sumAmounts(icp1, icp2)).toEqual(icp3);
@@ -346,66 +346,66 @@ describe("token-utils", () => {
     expect(getMaxTransactionAmount({ fee, token: ICPToken })).toEqual(0);
     expect(
       getMaxTransactionAmount({
-        balance: BigInt(0),
+        balance: 0n,
         fee,
         token: ICPToken,
       })
     ).toEqual(0);
     expect(
       getMaxTransactionAmount({
-        balance: BigInt(10_000),
+        balance: 10_000n,
         fee,
         token: ICPToken,
       })
     ).toEqual(0);
     expect(
       getMaxTransactionAmount({
-        balance: BigInt(11_000),
+        balance: 11_000n,
         fee,
         token: ICPToken,
       })
     ).toEqual(0.00001);
     expect(
       getMaxTransactionAmount({
-        balance: BigInt(100_000_000),
+        balance: 100_000_000n,
         fee,
         token: ICPToken,
       })
     ).toEqual(0.9999);
     expect(
       getMaxTransactionAmount({
-        balance: BigInt(1_000_000_000),
-        maxAmount: BigInt(500_000_000),
+        balance: 1_000_000_000n,
+        maxAmount: 500_000_000n,
         token: ICPToken,
       })
     ).toEqual(5);
     expect(
       getMaxTransactionAmount({
-        balance: BigInt(1_000_000_000),
+        balance: 1_000_000_000n,
         fee,
         token: ICPToken,
-        maxAmount: BigInt(500_000_000),
+        maxAmount: 500_000_000n,
       })
     ).toEqual(5);
     expect(
       getMaxTransactionAmount({
-        balance: BigInt(100_000_000),
+        balance: 100_000_000n,
         fee,
         token: ICPToken,
-        maxAmount: BigInt(500_000_000),
+        maxAmount: 500_000_000n,
       })
     ).toEqual(0.9999);
     expect(
       getMaxTransactionAmount({
-        balance: BigInt(0),
+        balance: 0n,
         fee,
         token: ICPToken,
-        maxAmount: BigInt(500_000_000),
+        maxAmount: 500_000_000n,
       })
     ).toEqual(0);
     expect(
       getMaxTransactionAmount({
-        balance: BigInt(0),
+        balance: 0n,
         fee,
         token: ICPToken,
       })
@@ -433,45 +433,45 @@ describe("token-utils", () => {
 
   describe("convertIcpToTCycles", () => {
     it("converts ICP to TCycles", () => {
+      expect(convertIcpToTCycles({ icpNumber: 1, exchangeRate: 10_000n })).toBe(
+        1
+      );
       expect(
-        convertIcpToTCycles({ icpNumber: 1, exchangeRate: BigInt(10_000) })
-      ).toBe(1);
-      expect(
-        convertIcpToTCycles({ icpNumber: 2.5, exchangeRate: BigInt(10_000) })
+        convertIcpToTCycles({ icpNumber: 2.5, exchangeRate: 10_000n })
       ).toBe(2.5);
       expect(
-        convertIcpToTCycles({ icpNumber: 2.5, exchangeRate: BigInt(20_000) })
+        convertIcpToTCycles({ icpNumber: 2.5, exchangeRate: 20_000n })
       ).toBe(5);
-      expect(
-        convertIcpToTCycles({ icpNumber: 1, exchangeRate: BigInt(15_000) })
-      ).toBe(1.5);
+      expect(convertIcpToTCycles({ icpNumber: 1, exchangeRate: 15_000n })).toBe(
+        1.5
+      );
     });
   });
 
   describe("convertTCyclesToIcpNumber", () => {
     it("converts TCycles to number", () => {
       expect(
-        convertTCyclesToIcpNumber({ tCycles: 1, exchangeRate: BigInt(10_000) })
+        convertTCyclesToIcpNumber({ tCycles: 1, exchangeRate: 10_000n })
       ).toBe(1);
       expect(
         convertTCyclesToIcpNumber({
           tCycles: 2.5,
-          exchangeRate: BigInt(10_000),
+          exchangeRate: 10_000n,
         })
       ).toBe(2.5);
       expect(
         convertTCyclesToIcpNumber({
           tCycles: 2.5,
-          exchangeRate: BigInt(20_000),
+          exchangeRate: 20_000n,
         })
       ).toBe(1.25);
       expect(
-        convertTCyclesToIcpNumber({ tCycles: 1, exchangeRate: BigInt(15_000) })
+        convertTCyclesToIcpNumber({ tCycles: 1, exchangeRate: 15_000n })
       ).toBe(2 / 3);
       expect(
         convertTCyclesToIcpNumber({
           tCycles: 4.32,
-          exchangeRate: BigInt(10_000),
+          exchangeRate: 10_000n,
         })
       ).toBe(4.32);
     });
@@ -479,10 +479,10 @@ describe("token-utils", () => {
 
   describe("numberToE8s", () => {
     it("converts number to e8s", () => {
-      expect(numberToE8s(1.14)).toBe(BigInt(114_000_000));
-      expect(numberToE8s(1)).toBe(BigInt(100_000_000));
-      expect(numberToE8s(3.14)).toBe(BigInt(314_000_000));
-      expect(numberToE8s(0.14)).toBe(BigInt(14_000_000));
+      expect(numberToE8s(1.14)).toBe(114_000_000n);
+      expect(numberToE8s(1)).toBe(100_000_000n);
+      expect(numberToE8s(3.14)).toBe(314_000_000n);
+      expect(numberToE8s(0.14)).toBe(14_000_000n);
     });
   });
 
@@ -647,7 +647,7 @@ describe("token-utils", () => {
       };
       expect(
         ulpsToNumber({
-          ulps: 1142n,
+          ulps: 1_142n,
           token,
         })
       ).toBe(1142);

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -108,8 +108,8 @@ describe("transactions-utils", () => {
         ...mockReceivedFromMainAccountTransaction,
         transfer: {
           Send: {
-            fee: { e8s: BigInt(10000) },
-            amount: { e8s: BigInt(110000000) },
+            fee: { e8s: 10_000n },
+            amount: { e8s: 110_000_000n },
             to: swapCanisterAccount.toHex(),
           },
         },
@@ -132,8 +132,8 @@ describe("transactions-utils", () => {
         ...mockReceivedFromMainAccountTransaction,
         transfer: {
           Receive: {
-            fee: { e8s: BigInt(10000) },
-            amount: { e8s: BigInt(110000000) },
+            fee: { e8s: 10_000n },
+            amount: { e8s: 110_000_000n },
             from: swapCanisterAccount.toHex(),
           },
         },
@@ -194,17 +194,17 @@ describe("transactions-utils", () => {
       const transactions = mapToSelfTransaction([
         {
           ...mockSentToSubAccountTransaction,
-          timestamp: { timestamp_nanos: BigInt("111") },
+          timestamp: { timestamp_nanos: 111n },
         },
         mockReceivedFromMainAccountTransaction,
         mockReceivedFromMainAccountTransaction,
         {
           ...mockSentToSubAccountTransaction,
-          timestamp: { timestamp_nanos: BigInt("222") },
+          timestamp: { timestamp_nanos: 222n },
         },
         {
           ...mockSentToSubAccountTransaction,
-          timestamp: { timestamp_nanos: BigInt("333") },
+          timestamp: { timestamp_nanos: 333n },
         },
         mockSentToSubAccountTransaction,
         mockSentToSubAccountTransaction,
@@ -335,8 +335,8 @@ describe("transactions-utils", () => {
         ...mockReceivedFromMainAccountTransaction,
         transfer: {
           Send: {
-            fee: { e8s: BigInt(10000) },
-            amount: { e8s: BigInt(110000000) },
+            fee: { e8s: 10_000n },
+            amount: { e8s: 110_000_000n },
             to: swapCanisterAccount.toHex(),
           },
         },
@@ -360,8 +360,8 @@ describe("transactions-utils", () => {
         ...mockReceivedFromMainAccountTransaction,
         transfer: {
           Receive: {
-            fee: { e8s: BigInt(10000) },
-            amount: { e8s: BigInt(110000000) },
+            fee: { e8s: 10_000n },
+            amount: { e8s: 110_000_000n },
             from: swapCanisterAccount.toHex(),
           },
         },
@@ -547,7 +547,7 @@ describe("transactions-utils", () => {
           amount: 222n,
           fee: 333n,
         })
-      ).toBe(BigInt(222 + 333));
+      ).toBe(222n + 333n);
     });
 
     it("should calculate without fee", () => {
@@ -557,14 +557,14 @@ describe("transactions-utils", () => {
           amount: 222n,
           fee: 333n,
         })
-      ).toBe(BigInt(222));
+      ).toBe(222n);
     });
 
     it("should throw when no fee", () => {
       expect(() =>
         transactionDisplayAmount({
           useFee: true,
-          amount: BigInt(222),
+          amount: 222n,
           fee: undefined,
         })
       ).toThrow();

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -44,9 +44,7 @@ describe("utils", () => {
     });
 
     it("should stringify JSON with bigint", () => {
-      expect(stringifyJson({ a: BigInt(123) })).toBe(
-        JSON.stringify({ a: "123" })
-      );
+      expect(stringifyJson({ a: 123n })).toBe(JSON.stringify({ a: "123" }));
     });
 
     it("should preserve undefined values", () => {
@@ -62,7 +60,7 @@ describe("utils", () => {
     it("should convert bigints to function call in devMode", () => {
       expect(
         stringifyJson(
-          { value: BigInt("123456789012345678901234567890") },
+          { value: 123_456_789_012_345_678_901_234_567_890n },
           { devMode: true }
         )
       ).toBe(`{"value":"BigInt('123456789012345678901234567890')"}`);
@@ -930,7 +928,9 @@ describe("utils", () => {
 
     it("returns true for bigint", () => {
       expect(
-        typeOfLikeANumber(99999999999999999999999999999999999999999999n)
+        typeOfLikeANumber(
+          99_999_999_999_999_999_999_999_999_999_999_999_999_999_999n
+        )
       ).toBe(true);
     });
 
@@ -979,10 +979,13 @@ describe("utils", () => {
     });
 
     it("should split bigints", () => {
-      expect(splitE8sIntoChunks(12345678n)).toStrictEqual(["12345678"]);
-      expect(splitE8sIntoChunks(1234567890n)).toStrictEqual(["12", "34567890"]);
-      expect(splitE8sIntoChunks(123456789n)).toStrictEqual(["1", "23456789"]);
-      expect(splitE8sIntoChunks(12345678901234567890n)).toStrictEqual([
+      expect(splitE8sIntoChunks(12_345_678n)).toStrictEqual(["12345678"]);
+      expect(splitE8sIntoChunks(1_234_567_890n)).toStrictEqual([
+        "12",
+        "34567890",
+      ]);
+      expect(splitE8sIntoChunks(123_456_789n)).toStrictEqual(["1", "23456789"]);
+      expect(splitE8sIntoChunks(12_345_678_901_234_567_890n)).toStrictEqual([
         "1234",
         "56789012",
         "34567890",

--- a/frontend/src/tests/lib/worker-api/canisters.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/canisters.worker-api.spec.ts
@@ -11,8 +11,8 @@ vi.mock("@dfinity/agent");
 describe("canisters-worker-api", () => {
   const response: CanisterStatusResponse = {
     status: { running: null },
-    memory_size: BigInt(1000),
-    cycles: BigInt(10_000),
+    memory_size: 1_000n,
+    cycles: 10_000n,
     settings: {
       controllers: [],
       freezing_threshold: 0n,
@@ -47,8 +47,8 @@ describe("canisters-worker-api", () => {
       expect(result).toEqual({
         id: mockCanisterDetails.id,
         status: CanisterStatus.Running,
-        memorySize: 1000n,
-        cycles: 10000n,
+        memorySize: 1_000n,
+        cycles: 10_000n,
         settings: {
           controllers: [],
           freezingThreshold: 0n,

--- a/frontend/src/tests/lib/worker-api/icrc-index.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/icrc-index.worker-api.spec.ts
@@ -21,7 +21,7 @@ describe("icrc-index.worker-api", () => {
     account: {
       owner: mockPrincipal,
     },
-    maxResults: BigInt(10),
+    maxResults: 10n,
     indexCanisterId: CKBTC_INDEX_CANISTER_ID.toText(),
     host: HOST,
     fetchRootKey: FETCH_ROOT_KEY,
@@ -32,7 +32,7 @@ describe("icrc-index.worker-api", () => {
   } as unknown as IcrcTransaction;
 
   it("should returns transactions", async () => {
-    const id = BigInt(1);
+    const id = 1n;
 
     const getTransactionsSpy =
       indexCanisterMock.getTransactions.mockResolvedValue({

--- a/frontend/src/tests/lib/worker-api/icrc-ledger.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/icrc-ledger.worker-api.spec.ts
@@ -28,7 +28,7 @@ describe("icrc-ledger.worker-api", () => {
   };
 
   it("should return balance", async () => {
-    const balance = BigInt(10_000_000);
+    const balance = 10_000_000n;
 
     const balanceSpy = ledgerCanisterMock.balance.mockResolvedValue(balance);
 

--- a/frontend/src/tests/lib/worker-services/icrc-balances.worker-services.spec.ts
+++ b/frontend/src/tests/lib/worker-services/icrc-balances.worker-services.spec.ts
@@ -37,7 +37,7 @@ describe("balances.worker-services", () => {
   };
 
   it("should return balances for accounts", async () => {
-    const balance = BigInt(10_000_000);
+    const balance = 10_000_000n;
 
     const balanceSpy = ledgerCanisterMock.balance.mockResolvedValue(balance);
 

--- a/frontend/src/tests/lib/worker-services/icrc-transactions.worker-services.spec.ts
+++ b/frontend/src/tests/lib/worker-services/icrc-transactions.worker-services.spec.ts
@@ -37,7 +37,7 @@ describe("transactions.worker-services", () => {
   };
 
   it("should returns new transactions", async () => {
-    const id = BigInt(1);
+    const id = 1n;
     const transactions = [{ transaction, id }];
 
     const getTransactionsSpy =
@@ -70,7 +70,7 @@ describe("transactions.worker-services", () => {
   });
 
   it("should returns new transactions for multiple accounts", async () => {
-    const id = BigInt(1);
+    const id = 1n;
     const transactions = [{ transaction, id }];
 
     const getTransactionsSpy =

--- a/frontend/src/tests/mocks/canisters.mock.ts
+++ b/frontend/src/tests/mocks/canisters.mock.ts
@@ -27,26 +27,26 @@ export const mockCanisters: CanisterInfo[] = [
 ];
 
 export const mockCanisterSettings = {
-  freezing_threshold: BigInt(2),
+  freezing_threshold: 2n,
   controllers: [
     "xlmdg-vkosz-ceopx-7wtgu-g3xmd-koiyc-awqaq-7modz-zf6r6-364rh-oqe",
   ],
-  memory_allocation: BigInt(4),
-  compute_allocation: BigInt(10),
+  memory_allocation: 4n,
+  compute_allocation: 10n,
 };
 
 export const mockCanisterDetails: CanisterDetails = {
   id: mockCanisterId,
   status: CanisterStatus.Running,
-  memorySize: BigInt(10),
-  cycles: BigInt(30),
+  memorySize: 10n,
+  cycles: 30n,
   settings: {
     controllers: [mockIdentity.getPrincipal().toText()],
-    freezingThreshold: BigInt(30),
-    memoryAllocation: BigInt(1000),
-    computeAllocation: BigInt(2000),
+    freezingThreshold: 30n,
+    memoryAllocation: 1_000n,
+    computeAllocation: 2_000n,
   },
-  idleCyclesBurnedPerDay: BigInt(3000),
+  idleCyclesBurnedPerDay: 3_000n,
 };
 
 export const mockCanistersStoreSubscribe = (

--- a/frontend/src/tests/mocks/ckbtc-accounts.mock.ts
+++ b/frontend/src/tests/mocks/ckbtc-accounts.mock.ts
@@ -6,7 +6,7 @@ import { mockPrincipal } from "./auth.store.mock";
 export const mockCkBTCToken: IcrcTokenMetadata = {
   name: "Test account",
   symbol: "ckBTC",
-  fee: BigInt(1),
+  fee: 1n,
   decimals: 8,
 };
 
@@ -21,7 +21,7 @@ export const mockCkBTCMainAccount: Account = {
   identifier: encodeIcrcAccount({
     owner: mockPrincipal,
   }),
-  balanceUlps: 444556698700000n,
+  balanceUlps: 444_556_698_700_000n,
   principal: mockPrincipal,
   type: "main",
 };
@@ -34,7 +34,7 @@ export const mockCkBTCWithdrawalIcrcAccount = decodeIcrcAccount(
 
 export const mockCkBTCWithdrawalAccount: Account = {
   identifier: mockCkBTCWithdrawalIdentifier,
-  balanceUlps: 98711100000n,
+  balanceUlps: 98_711_100_000n,
   principal: mockCkBTCWithdrawalIcrcAccount.owner,
   type: "withdrawalAccount",
 };

--- a/frontend/src/tests/mocks/governance.canister.mock.ts
+++ b/frontend/src/tests/mocks/governance.canister.mock.ts
@@ -33,7 +33,7 @@ export class MockGovernanceCanister extends GovernanceCanister {
       // mock getProposal call
       return {
         proposals: this.proposals.filter(
-          ({ id }) => id === (request.beforeProposal as bigint) - BigInt(1)
+          ({ id }) => id === (request.beforeProposal as bigint) - 1n
         ),
       };
     }

--- a/frontend/src/tests/mocks/hardware-wallet-neurons.store.mock.ts
+++ b/frontend/src/tests/mocks/hardware-wallet-neurons.store.mock.ts
@@ -5,10 +5,10 @@ import { mockFullNeuron, mockNeuron } from "./neurons.mock";
 
 export const mockNeuronStake = {
   ...mockNeuron,
-  neuronId: BigInt("123"),
+  neuronId: 123n,
   fullNeuron: {
     ...mockFullNeuron,
-    cachedNeuronStake: BigInt(2_000_000_000),
+    cachedNeuronStake: 2_000_000_000n,
   },
 };
 

--- a/frontend/src/tests/mocks/icrc-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icrc-transactions.mock.ts
@@ -50,9 +50,9 @@ export const createIcrcTransactionWithId = ({
           subaccount: [] as [],
         },
         memo: toNullable(memo),
-        created_at_time: [BigInt(123)],
-        amount: amount ?? BigInt(33),
-        fee: [fee ?? BigInt(1)],
+        created_at_time: [123n],
+        amount: amount ?? 33n,
+        fee: [fee ?? 1n],
         spender: [],
       },
     ],
@@ -72,7 +72,7 @@ const fakeSubAccount = {
 
 const mockIcrcTransactionTransfer: IcrcTransaction = {
   kind: "transfer",
-  timestamp: BigInt(12354),
+  timestamp: 12_354n,
   burn: [],
   mint: [],
   transfer: [
@@ -80,9 +80,9 @@ const mockIcrcTransactionTransfer: IcrcTransaction = {
       to: fakeSubAccount,
       from: fakeAccount,
       memo: [],
-      created_at_time: [BigInt(123)],
-      amount: BigInt(33),
-      fee: [BigInt(1)],
+      created_at_time: [123n],
+      amount: 33n,
+      fee: [1n],
       spender: [],
     },
   ],
@@ -91,7 +91,7 @@ const mockIcrcTransactionTransfer: IcrcTransaction = {
 
 const mockIcrcTransactionTransferToSelf: IcrcTransaction = {
   kind: "transfer",
-  timestamp: BigInt(12354),
+  timestamp: 12_354n,
   burn: [],
   mint: [],
   transfer: [
@@ -99,9 +99,9 @@ const mockIcrcTransactionTransferToSelf: IcrcTransaction = {
       to: fakeAccount,
       from: fakeAccount,
       memo: [],
-      created_at_time: [BigInt(123)],
-      amount: BigInt(33),
-      fee: [BigInt(1)],
+      created_at_time: [123n],
+      amount: 33n,
+      fee: [1n],
       spender: [],
     },
   ],
@@ -109,7 +109,7 @@ const mockIcrcTransactionTransferToSelf: IcrcTransaction = {
 };
 
 export const createMintTransaction = ({
-  timestamp = 12354n,
+  timestamp = 12_354n,
   amount = 33n,
   to = fakeAccount,
   memo,
@@ -139,7 +139,7 @@ export const createMintTransaction = ({
 };
 
 export const createApproveTransaction = ({
-  timestamp = 12354n,
+  timestamp = 12_354n,
   amount = 33_000_000n,
   fee = 10_000n,
   from = fakeAccount,
@@ -177,7 +177,7 @@ export const createApproveTransaction = ({
 };
 
 export const createBurnTransaction = ({
-  timestamp = 12354n,
+  timestamp = 12_354n,
   amount = 33n,
   from = fakeAccount,
   memo,
@@ -215,13 +215,13 @@ export const mockIcrcTransactionBurn: IcrcTransaction = createBurnTransaction(
 
 export const mockIcrcTransactionMint: IcrcTransaction = {
   kind: "mint",
-  timestamp: BigInt(12354),
+  timestamp: 12_354n,
   burn: [],
   mint: [
     {
-      amount: BigInt(33),
+      amount: 33n,
       memo: [],
-      created_at_time: [BigInt(123)],
+      created_at_time: [123n],
       to: fakeAccount,
     },
   ],
@@ -230,12 +230,12 @@ export const mockIcrcTransactionMint: IcrcTransaction = {
 };
 
 export const mockIcrcTransactionWithId: IcrcTransactionWithId = {
-  id: BigInt(123),
+  id: 123n,
   transaction: mockIcrcTransactionTransfer,
 };
 
 export const mockIcrcTransactionWithIdToSelf: IcrcTransactionWithId = {
-  id: BigInt(124),
+  id: 124n,
   transaction: mockIcrcTransactionTransferToSelf,
 };
 

--- a/frontend/src/tests/mocks/ledger.canister.mock.ts
+++ b/frontend/src/tests/mocks/ledger.canister.mock.ts
@@ -20,7 +20,7 @@ export class MockLedgerCanister extends LedgerCanister {
     accountIdentifier: AccountIdentifier;
     certified?: boolean | undefined;
   }): Promise<bigint> => {
-    return BigInt(1);
+    return 1n;
   };
 
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
@@ -31,6 +31,6 @@ export class MockLedgerCanister extends LedgerCanister {
     fee?: bigint | undefined;
     fromSubAccount?: number[] | undefined;
   }): Promise<BlockHeight> => {
-    return BigInt(0);
+    return 0n;
   };
 }

--- a/frontend/src/tests/mocks/neurons.mock.ts
+++ b/frontend/src/tests/mocks/neurons.mock.ts
@@ -5,20 +5,20 @@ import type { Subscriber } from "svelte/store";
 import { mockIdentity } from "./auth.store.mock";
 
 export const mockFullNeuron: Neuron = {
-  id: BigInt(1),
+  id: 1n,
   stakedMaturityE8sEquivalent: undefined,
   controller: undefined,
   recentBallots: [],
   neuronType: undefined,
   kycVerified: true,
   notForProfit: false,
-  cachedNeuronStake: BigInt(3_000_000_000),
-  createdTimestampSeconds: BigInt(10),
+  cachedNeuronStake: 3_000_000_000n,
+  createdTimestampSeconds: 10n,
   autoStakeMaturity: undefined,
-  maturityE8sEquivalent: BigInt(10),
-  agingSinceTimestampSeconds: BigInt(10),
+  maturityE8sEquivalent: 10n,
+  agingSinceTimestampSeconds: 10n,
   spawnAtTimesSeconds: undefined,
-  neuronFees: BigInt(0),
+  neuronFees: 0n,
   hotKeys: [],
   accountIdentifier:
     "d0654c53339c85e0e5fff46a2d800101bc3d896caef34e1a0597426792ff9f32",
@@ -38,16 +38,16 @@ export const createMockFullNeuron = (id: number | bigint) => {
 };
 
 export const mockNeuron: NeuronInfo = {
-  neuronId: BigInt(1),
-  dissolveDelaySeconds: BigInt(11111),
+  neuronId: 1n,
+  dissolveDelaySeconds: 11_111n,
   recentBallots: [],
   neuronType: undefined,
-  createdTimestampSeconds: BigInt(10),
+  createdTimestampSeconds: 10n,
   state: NeuronState.Locked,
   joinedCommunityFundTimestampSeconds: undefined,
-  retrievedAtTimestampSeconds: BigInt(10),
-  votingPower: BigInt(300_000_000),
-  ageSeconds: BigInt(100),
+  retrievedAtTimestampSeconds: 10n,
+  votingPower: 300_000_000n,
+  ageSeconds: 100n,
   fullNeuron: mockFullNeuron,
 };
 
@@ -63,7 +63,7 @@ export const createMockNeuron = (id: number | bigint) => {
 };
 
 export const mockKnownNeuron: KnownNeuron = {
-  id: BigInt(1000),
+  id: 1_000n,
   name: "Famous Neuron",
   description: undefined,
 };

--- a/frontend/src/tests/mocks/nns-reward-event.mock.ts
+++ b/frontend/src/tests/mocks/nns-reward-event.mock.ts
@@ -1,11 +1,11 @@
 import type { RewardEvent } from "@dfinity/nns";
 
 export const mockRewardEvent: RewardEvent = {
-  rounds_since_last_distribution: [BigInt(1_000)],
-  day_after_genesis: BigInt(365),
-  actual_timestamp_seconds: BigInt(12234455555),
-  total_available_e8s_equivalent: BigInt(20_000_000_000),
-  distributed_e8s_equivalent: BigInt(2_000_000_000),
+  rounds_since_last_distribution: [1_000n],
+  day_after_genesis: 365n,
+  actual_timestamp_seconds: 12_234_455_555n,
+  total_available_e8s_equivalent: 20_000_000_000n,
+  distributed_e8s_equivalent: 2_000_000_000n,
   settled_proposals: [],
-  latest_round_available_e8s_equivalent: [BigInt(1_000_000_000)],
+  latest_round_available_e8s_equivalent: [1_000_000_000n],
 };

--- a/frontend/src/tests/mocks/proposal.mock.ts
+++ b/frontend/src/tests/mocks/proposal.mock.ts
@@ -5,7 +5,7 @@ import { deadlineTimestampSeconds } from "./proposals.store.mock";
 /**
  * Generate mock proposals with autoincremented "id".
  * @param count How many proposals to create
- * @param fields Static fields to set to mock entries e.g. {proposalTimestampSeconds: BigInt(0)}
+ * @param fields Static fields to set to mock entries e.g. {proposalTimestampSeconds: 0n}
  * @returns List of mock proposals (not fully set)
  */
 export const generateMockProposals = (
@@ -31,10 +31,10 @@ export const proposalActionRewardNodeProvider = {
     nodeProvider: {
       id: "aaaaa-aa",
     },
-    amountE8s: BigInt(10000000),
+    amountE8s: 10_000_000n,
     rewardMode: {
       RewardToNeuron: {
-        dissolveDelaySeconds: BigInt(1000),
+        dissolveDelaySeconds: 1_000n,
       },
     },
   },
@@ -48,24 +48,24 @@ export const proposalActionNnsFunction21 = {
 
 // Not a valid `ProposalInfo` object. Only related to the test fields are included
 export const mockProposalInfo: ProposalInfo = {
-  id: BigInt(10000),
+  id: 10_000n,
   proposal: {
     title: "title",
     url: "https://url.com",
     action: proposalActionMotion,
     summary: "summary-content",
   },
-  proposer: BigInt(123),
+  proposer: 123n,
   latestTally: {
-    no: BigInt(400000000),
-    yes: BigInt(600000000),
+    no: 400_000_000n,
+    yes: 600_000_000n,
   },
   topic: 8,
   status: 2,
   rewardStatus: 3,
   ballots: [
     {
-      neuronId: BigInt(0),
+      neuronId: 0n,
     },
   ],
   deadlineTimestampSeconds,

--- a/frontend/src/tests/mocks/proposals.store.mock.ts
+++ b/frontend/src/tests/mocks/proposals.store.mock.ts
@@ -16,14 +16,14 @@ export const deadlineTimestampSeconds = BigInt(
 
 export const mockProposals: ProposalInfo[] = [
   {
-    id: BigInt(404),
+    id: 404n,
     proposal: {
       title: "Proposal1",
       summary:
         "Initialize datacenter records. For more info about this proposal, read the forum announcement: https://forum.dfinity.org/t/improvements-to-node-provider-remuneration/10553",
       action: {
         RegisterKnownNeuron: {
-          id: [{ id: BigInt(1) }],
+          id: [{ id: 1n }],
           known_neuron_data: [
             {
               name: "test",
@@ -42,11 +42,11 @@ export const mockProposals: ProposalInfo[] = [
         neuronId: mockNeuron.neuronId,
       } as Ballot,
     ],
-    proposer: BigInt(123456789),
+    proposer: 123_456_789n,
     deadlineTimestampSeconds,
   },
   {
-    id: BigInt(303),
+    id: 303n,
     proposal: {
       title: "Proposal2",
       summary:
@@ -61,7 +61,7 @@ export const mockProposals: ProposalInfo[] = [
         neuronId: mockNeuron.neuronId,
       } as Ballot,
     ],
-    proposer: BigInt(987654321),
+    proposer: 987_654_321n,
     deadlineTimestampSeconds,
   },
 ] as unknown as ProposalInfo[];

--- a/frontend/src/tests/mocks/sns-functions.mock.ts
+++ b/frontend/src/tests/mocks/sns-functions.mock.ts
@@ -1,7 +1,7 @@
 import type { SnsNervousSystemFunction } from "@dfinity/sns";
 
 export const nervousSystemFunctionMock: SnsNervousSystemFunction = {
-  id: BigInt(30),
+  id: 30n,
   name: "Governance",
   description: ["This is a description"],
   function_type: [{ NativeNervousSystemFunction: {} }],

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -26,8 +26,8 @@ import { rootCanisterIdMock } from "./sns.api.mock";
 export const mockSnsNeuronTimestampSeconds = 3600 * 24 * 6;
 
 export const mockActiveDisbursement: DisburseMaturityInProgress = {
-  timestamp_of_disbursement_seconds: 10000n,
-  amount_e8s: 1000000n,
+  timestamp_of_disbursement_seconds: 10_000n,
+  amount_e8s: 1_000_000n,
   account_to_disburse_to: [
     {
       owner: [mockPrincipal],
@@ -37,19 +37,19 @@ export const mockActiveDisbursement: DisburseMaturityInProgress = {
 };
 
 export const createMockSnsNeuron = ({
-  stake = BigInt(1_000_000_000),
+  stake = 1_000_000_000n,
   id,
   state,
   permissions = [],
   vesting,
-  votingPowerMultiplier = BigInt(100),
+  votingPowerMultiplier = 100n,
   dissolveDelaySeconds = BigInt(Math.floor(3600 * 24 * 365 * 2)),
   whenDissolvedTimestampSeconds = BigInt(
     Math.floor(Date.now() / 1000 + 3600 * 24 * 365 * 2)
   ),
-  ageSinceTimestampSeconds = BigInt(1000),
-  stakedMaturity = BigInt(100_000_000),
-  maturity = BigInt(100_000_000),
+  ageSinceTimestampSeconds = 1_000n,
+  stakedMaturity = 100_000_000n,
+  maturity = 100_000_000n,
   createdTimestampSeconds = BigInt(nowInSeconds() - SECONDS_IN_DAY),
   sourceNnsNeuronId,
   activeDisbursementsE8s = [],
@@ -99,7 +99,7 @@ export const createMockSnsNeuron = ({
                 },
           ],
     followees: [],
-    neuron_fees_e8s: BigInt(0),
+    neuron_fees_e8s: 0n,
     vesting_period_seconds:
       vesting === undefined
         ? []
@@ -118,7 +118,7 @@ export const mockSnsNeuronId = {
 };
 
 export const mockSnsNeuron = createMockSnsNeuron({
-  stake: BigInt(1_000_000_000),
+  stake: 1_000_000_000n,
   id: [1, 5, 3, 9, 9, 3, 2],
 });
 
@@ -126,7 +126,7 @@ export const mockSnsNeuronWithPermissions = (
   permissions: SnsNeuronPermissionType[]
 ): SnsNeuron => ({
   ...createMockSnsNeuron({
-    stake: BigInt(1_000_000_000),
+    stake: 1_000_000_000n,
     id: [1, 5, 3, 9, 9, 3, 2],
   }),
   permissions: [
@@ -170,7 +170,7 @@ export const snsNervousSystemParametersMock: SnsNervousSystemParameters = {
       followees: [[0n, { followees: [mockSnsNeuronId] }]],
     },
   ],
-  max_dissolve_delay_seconds: [3155760000n],
+  max_dissolve_delay_seconds: [3_155_760_000n],
   max_dissolve_delay_bonus_percentage: [100n],
   max_followees_per_function: [15n],
   neuron_claimer_permissions: [
@@ -178,15 +178,15 @@ export const snsNervousSystemParametersMock: SnsNervousSystemParameters = {
       permissions: Int32Array.from(enumValues(SnsNeuronPermissionType)),
     },
   ],
-  neuron_minimum_stake_e8s: [100000000n],
-  max_neuron_age_for_age_bonus: [15778800n],
-  initial_voting_period_seconds: [345600n],
-  neuron_minimum_dissolve_delay_to_vote_seconds: [2629800n],
-  reject_cost_e8s: [100000000n],
+  neuron_minimum_stake_e8s: [100_000_000n],
+  max_neuron_age_for_age_bonus: [15_778_800n],
+  initial_voting_period_seconds: [345_600n],
+  neuron_minimum_dissolve_delay_to_vote_seconds: [2_629_800n],
+  reject_cost_e8s: [100_000_000n],
   max_proposals_to_keep_per_action: [100],
-  wait_for_quiet_deadline_increase_seconds: [86400n],
-  max_number_of_neurons: [200000n],
-  transaction_fee_e8s: [10000n],
+  wait_for_quiet_deadline_increase_seconds: [86_400n],
+  max_number_of_neurons: [200_000n],
+  transaction_fee_e8s: [10_000n],
   max_number_of_proposals_with_ballots: [700n],
   max_age_bonus_percentage: [25n],
   neuron_grantable_permissions: [
@@ -198,8 +198,8 @@ export const snsNervousSystemParametersMock: SnsNervousSystemParameters = {
     {
       final_reward_rate_basis_points: [0n],
       initial_reward_rate_basis_points: [0n],
-      reward_rate_transition_duration_seconds: [31557600n],
-      round_duration_seconds: [86400n],
+      reward_rate_transition_duration_seconds: [31_557_600n],
+      round_duration_seconds: [86_400n],
     },
   ],
   max_number_of_principals_per_neuron: [5n],

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -49,9 +49,9 @@ export const principal = (index: number): Principal => {
 export const createTransferableAmount = (
   amount: bigint
 ): SnsTransferableAmount => ({
-  transfer_start_timestamp_seconds: BigInt(0),
+  transfer_start_timestamp_seconds: 0n,
   amount_e8s: amount,
-  transfer_success_timestamp_seconds: BigInt(0),
+  transfer_success_timestamp_seconds: 0n,
   transfer_fee_paid_e8s: [],
   amount_transferred_e8s: [],
 });
@@ -86,13 +86,13 @@ const SECONDS_IN_DAY = 60 * 60 * 24;
 const SECONDS_TODAY = +new Date(new Date().toJSON().split("T")[0]) / 1000;
 
 export const mockSnsParams: SnsParams = {
-  min_participant_icp_e8s: BigInt(150000000),
+  min_participant_icp_e8s: 150_000_000n,
   max_icp_e8s: BigInt(3000 * 100000000),
   neuron_basket_construction_parameters: [],
   swap_due_timestamp_seconds: BigInt(SECONDS_TODAY + SECONDS_IN_DAY * 5),
   min_participants: 1,
-  sns_token_e8s: BigInt(150000000),
-  max_participant_icp_e8s: BigInt(5000000000),
+  sns_token_e8s: 150_000_000n,
+  max_participant_icp_e8s: 5_000_000_000n,
   min_icp_e8s: BigInt(1500 * 100000000),
   sale_delay_seconds: [],
   min_direct_participation_icp_e8s: [],
@@ -145,7 +145,7 @@ export const mockSwap: SnsSummarySwap = {
   decentralization_sale_open_timestamp_seconds: undefined,
   finalize_swap_in_progress: [],
   lifecycle: SnsSwapLifecycle.Open,
-  open_sns_token_swap_proposal_id: [BigInt(1000)],
+  open_sns_token_swap_proposal_id: [1_000n],
   buyers: [],
   params: mockSnsParams,
   direct_participation_icp_e8s: [],
@@ -161,7 +161,7 @@ export const mockQuerySwap: SnsSwap = {
   init: [],
   already_tried_to_auto_finalize: [],
   lifecycle: SnsSwapLifecycle.Open,
-  open_sns_token_swap_proposal_id: [BigInt(1000)],
+  open_sns_token_swap_proposal_id: [1_000n],
   buyers: [],
   params: [mockSnsParams],
   next_ticket_id: [],
@@ -174,9 +174,9 @@ export const mockQuerySwap: SnsSwap = {
 export const mockDerived: SnsSwapDerivedState = {
   buyer_total_icp_e8s: BigInt(100 * 100000000),
   sns_tokens_per_icp: 1,
-  cf_participant_count: [BigInt(100)],
-  direct_participant_count: [BigInt(300)],
-  cf_neuron_count: [BigInt(200)],
+  cf_participant_count: [100n],
+  direct_participant_count: [300n],
+  cf_neuron_count: [200n],
   direct_participation_icp_e8s: [],
   neurons_fund_participation_icp_e8s: [],
 };
@@ -184,9 +184,9 @@ export const mockDerived: SnsSwapDerivedState = {
 export const mockDerivedResponse: SnsGetDerivedStateResponse = {
   buyer_total_icp_e8s: [BigInt(100 * 100000000)],
   sns_tokens_per_icp: [1],
-  cf_participant_count: [BigInt(100)],
-  direct_participant_count: [BigInt(300)],
-  cf_neuron_count: [BigInt(200)],
+  cf_participant_count: [100n],
+  direct_participant_count: [300n],
+  cf_neuron_count: [200n],
   direct_participation_icp_e8s: [],
   neurons_fund_participation_icp_e8s: [],
 };
@@ -202,7 +202,7 @@ export const mockMetadata: SnsSummaryMetadata = {
 export const mockToken: IcrcTokenMetadata = {
   name: "Tetris",
   symbol: "TET",
-  fee: BigInt(0),
+  fee: 0n,
   decimals: 8,
 };
 
@@ -242,7 +242,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     token: {
       name: "Pacman",
       symbol: "PAC",
-      fee: BigInt(0),
+      fee: 0n,
       decimals: 8,
     },
     swap: mockSwap,
@@ -267,7 +267,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     token: {
       name: "Mario",
       symbol: "SPM",
-      fee: BigInt(0),
+      fee: 0n,
       decimals: 8,
     },
     swap: mockSwap,
@@ -292,7 +292,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     token: {
       name: "Kong",
       symbol: "DKG",
-      fee: BigInt(0),
+      fee: 0n,
       decimals: 8,
     },
     swap: mockSwap,
@@ -360,7 +360,7 @@ export const createSummary = ({
   tokensDistributed = 2_000_000_000_000n,
   minParticipantCommitment = 100_000_000n,
   maxParticipantCommitment = 5_000_000_000n,
-  swapDueTimestampSeconds = 1630444800n,
+  swapDueTimestampSeconds = 1_630_444_800n,
   minTotalCommitment,
   maxTotalCommitment,
   currentTotalCommitment,
@@ -469,12 +469,12 @@ export const mockQueryMetadataResponse: SnsGetMetadataResponse = {
 export const mockSnsToken: IcrcTokenMetadata = {
   symbol: "TST",
   name: "Tetris",
-  fee: BigInt(40_000),
+  fee: 40_000n,
   decimals: 8,
 };
 
 export const mockQueryTokenResponse: IcrcTokenMetadataResponse = [
-  [IcrcMetadataResponseEntries.DECIMALS, { Nat: BigInt(8) }],
+  [IcrcMetadataResponseEntries.DECIMALS, { Nat: 8n }],
   [IcrcMetadataResponseEntries.NAME, { Text: mockSnsToken.name }],
   [IcrcMetadataResponseEntries.SYMBOL, { Text: mockSnsToken.symbol }],
   [IcrcMetadataResponseEntries.FEE, { Nat: mockSnsToken.fee }],

--- a/frontend/src/tests/mocks/sns-proposals.mock.ts
+++ b/frontend/src/tests/mocks/sns-proposals.mock.ts
@@ -14,28 +14,28 @@ import type { Subscriber } from "svelte/store";
 export const mockSnsProposal: SnsProposalData = {
   id: [
     {
-      id: BigInt(2),
+      id: 2n,
     },
   ],
   payload_text_rendering: ["Payload text rendering"],
-  action: BigInt(2),
+  action: 2n,
   failure_reason: [],
   ballots: [],
-  reward_event_round: BigInt(1),
-  failed_timestamp_seconds: BigInt(0),
-  proposal_creation_timestamp_seconds: BigInt(12313123),
-  initial_voting_period_seconds: BigInt(0),
-  reject_cost_e8s: BigInt(10_000_000),
+  reward_event_round: 1n,
+  failed_timestamp_seconds: 0n,
+  proposal_creation_timestamp_seconds: 12_313_123n,
+  initial_voting_period_seconds: 0n,
+  reject_cost_e8s: 10_000_000n,
   latest_tally: [
     {
-      no: BigInt(10),
-      yes: BigInt(10),
-      total: BigInt(100_000),
-      timestamp_seconds: BigInt(22),
+      no: 10n,
+      yes: 10n,
+      total: 100_000n,
+      timestamp_seconds: 22n,
     },
   ],
-  wait_for_quiet_deadline_increase_seconds: BigInt(0),
-  decided_timestamp_seconds: BigInt(0),
+  wait_for_quiet_deadline_increase_seconds: 0n,
+  decided_timestamp_seconds: 0n,
   proposal: [
     {
       title: "Proposal title",
@@ -47,28 +47,28 @@ export const mockSnsProposal: SnsProposalData = {
   proposer: [{ id: arrayOfNumberToUint8Array([1, 2, 3, 0, 0, 1]) }],
   wait_for_quiet_state: [
     {
-      current_deadline_timestamp_seconds: BigInt(10),
+      current_deadline_timestamp_seconds: 10n,
     },
   ],
   is_eligible_for_rewards: true,
-  executed_timestamp_seconds: BigInt(0),
+  executed_timestamp_seconds: 0n,
   reward_event_end_timestamp_seconds: [],
   minimum_yes_proportion_of_exercised: [],
   minimum_yes_proportion_of_total: [],
 };
 
 const acceptedTally: SnsTally = {
-  no: BigInt(1),
-  yes: BigInt(10),
-  total: BigInt(11),
-  timestamp_seconds: BigInt(123455),
+  no: 1n,
+  yes: 10n,
+  total: 11n,
+  timestamp_seconds: 123_455n,
 };
 
 const rejectedTally: SnsTally = {
-  no: BigInt(10),
-  yes: BigInt(1),
-  total: BigInt(11),
-  timestamp_seconds: BigInt(123455),
+  no: 10n,
+  yes: 1n,
+  total: 11n,
+  timestamp_seconds: 123_455n,
 };
 
 const addRewardStatusData = ({
@@ -85,31 +85,31 @@ const addRewardStatusData = ({
     case SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES:
       return {
         ...proposal,
-        reward_event_round: BigInt(0),
+        reward_event_round: 0n,
         wait_for_quiet_state: [
           {
-            current_deadline_timestamp_seconds: BigInt(10_000) + now,
+            current_deadline_timestamp_seconds: 10_000n + now,
           },
         ],
       };
     case SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_SETTLED:
       return {
         ...proposal,
-        reward_event_round: BigInt(0),
+        reward_event_round: 0n,
         wait_for_quiet_state: [
           {
-            current_deadline_timestamp_seconds: BigInt(10_000) - now,
+            current_deadline_timestamp_seconds: 10_000n - now,
           },
         ],
       };
     case SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_READY_TO_SETTLE:
       return {
         ...proposal,
-        reward_event_round: BigInt(0),
+        reward_event_round: 0n,
         is_eligible_for_rewards: true,
         wait_for_quiet_state: [
           {
-            current_deadline_timestamp_seconds: BigInt(10_000) - now,
+            current_deadline_timestamp_seconds: 10_000n - now,
           },
         ],
       };
@@ -129,7 +129,7 @@ export const createSnsProposal = ({
   rewardStatus,
   proposalId,
   ballots = [],
-  createdAt = BigInt(12313123),
+  createdAt = 12_313_123n,
 }: {
   status: SnsProposalDecisionStatus;
   rewardStatus?: SnsProposalRewardStatus;
@@ -145,7 +145,7 @@ export const createSnsProposal = ({
           ...mockSnsProposal,
           id,
           latest_tally: [acceptedTally],
-          decided_timestamp_seconds: BigInt(0),
+          decided_timestamp_seconds: 0n,
           ballots,
           proposal_creation_timestamp_seconds: createdAt,
         },
@@ -157,9 +157,9 @@ export const createSnsProposal = ({
           ...mockSnsProposal,
           id,
           latest_tally: [acceptedTally],
-          decided_timestamp_seconds: BigInt(11223),
-          executed_timestamp_seconds: BigInt(0),
-          failed_timestamp_seconds: BigInt(0),
+          decided_timestamp_seconds: 11_223n,
+          executed_timestamp_seconds: 0n,
+          failed_timestamp_seconds: 0n,
           ballots,
           proposal_creation_timestamp_seconds: createdAt,
         },
@@ -171,9 +171,9 @@ export const createSnsProposal = ({
           ...mockSnsProposal,
           id,
           latest_tally: [acceptedTally],
-          decided_timestamp_seconds: BigInt(11223),
-          executed_timestamp_seconds: BigInt(0),
-          failed_timestamp_seconds: BigInt(112231320),
+          decided_timestamp_seconds: 11_223n,
+          executed_timestamp_seconds: 0n,
+          failed_timestamp_seconds: 112_231_320n,
           ballots,
           proposal_creation_timestamp_seconds: createdAt,
         },
@@ -185,9 +185,9 @@ export const createSnsProposal = ({
           ...mockSnsProposal,
           id,
           latest_tally: [acceptedTally],
-          decided_timestamp_seconds: BigInt(11223),
-          executed_timestamp_seconds: BigInt(112231320),
-          failed_timestamp_seconds: BigInt(0),
+          decided_timestamp_seconds: 11_223n,
+          executed_timestamp_seconds: 112_231_320n,
+          failed_timestamp_seconds: 0n,
           ballots,
           proposal_creation_timestamp_seconds: createdAt,
         },
@@ -199,9 +199,9 @@ export const createSnsProposal = ({
           ...mockSnsProposal,
           id,
           latest_tally: [rejectedTally],
-          decided_timestamp_seconds: BigInt(11223),
-          executed_timestamp_seconds: BigInt(0),
-          failed_timestamp_seconds: BigInt(0),
+          decided_timestamp_seconds: 11_223n,
+          executed_timestamp_seconds: 0n,
+          failed_timestamp_seconds: 0n,
           ballots,
           proposal_creation_timestamp_seconds: createdAt,
         },

--- a/frontend/src/tests/mocks/transaction-fee.mock.ts
+++ b/frontend/src/tests/mocks/transaction-fee.mock.ts
@@ -8,7 +8,7 @@ export const mockSnsSelectedTransactionFeeStoreSubscribe =
       notDefined
         ? undefined
         : TokenAmount.fromE8s({
-            amount: BigInt(10_000),
+            amount: 10_000n,
             token: { name: "Test", symbol: "TST", decimals: 8 },
           })
     );

--- a/frontend/src/tests/mocks/transaction.mock.ts
+++ b/frontend/src/tests/mocks/transaction.mock.ts
@@ -6,8 +6,8 @@ import { mockMainAccount, mockSubAccount } from "./icp-accounts.store.mock";
 import { mockSnsToken } from "./sns-projects.mock";
 
 export const createMockSendTransaction = ({
-  amount = 110000023n,
-  fee = 10000n,
+  amount = 110_000_023n,
+  fee = 10_000n,
   to = mockSubAccount.identifier,
 }: {
   amount?: bigint;
@@ -15,9 +15,9 @@ export const createMockSendTransaction = ({
   to?: string;
 }): NnsTransaction => ({
   transaction_type: [{ Transfer: null }],
-  memo: BigInt(0),
-  timestamp: { timestamp_nanos: BigInt("0") },
-  block_height: BigInt(208),
+  memo: 0n,
+  timestamp: { timestamp_nanos: 0n },
+  block_height: 208n,
   transfer: {
     Send: {
       to,
@@ -32,8 +32,8 @@ export const mockSentToSubAccountTransaction = createMockSendTransaction({
 });
 
 export const createMockReceiveTransaction = ({
-  amount = 110000000n,
-  fee = 10000n,
+  amount = 110_000_000n,
+  fee = 10_000n,
   from = mockMainAccount.identifier,
 }: {
   amount?: bigint;
@@ -41,9 +41,9 @@ export const createMockReceiveTransaction = ({
   from?: string;
 }): NnsTransaction => ({
   transaction_type: [{ Transfer: null }],
-  memo: BigInt(0),
-  timestamp: { timestamp_nanos: BigInt("1652121288218078256") },
-  block_height: BigInt(208),
+  memo: 0n,
+  timestamp: { timestamp_nanos: 1_652_121_288_218_078_256n },
+  block_height: 208n,
   transfer: {
     Receive: {
       fee: { e8s: fee },
@@ -56,7 +56,7 @@ export const createMockReceiveTransaction = ({
 export const mockReceivedFromMainAccountTransaction =
   createMockReceiveTransaction({ from: mockMainAccount.identifier });
 
-const displayAmount = 11000000000000000n;
+const displayAmount = 11_000_000_000_000_000n;
 
 export const mockTransactionReceiveDataFromMain: Transaction = {
   type: AccountTransactionType.Send,

--- a/frontend/src/tests/workflows/CreateSubaccount.spec.ts
+++ b/frontend/src/tests/workflows/CreateSubaccount.spec.ts
@@ -37,7 +37,7 @@ describe("Accounts", () => {
     vi.spyOn(console, "error").mockImplementation(vi.fn);
     queryAccountBalanceSpy = vi
       .spyOn(ledgerApi, "queryAccountBalance")
-      .mockResolvedValue(BigInt(0));
+      .mockResolvedValue(0n);
     queryAccountSpy = vi
       .spyOn(nnsDappApi, "queryAccount")
       .mockResolvedValue(mockAccountDetails);

--- a/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
@@ -31,7 +31,7 @@ const proposal = {
     {
       neuronId: mockNeuron.neuronId,
       vote: Vote.Yes,
-      votingPower: BigInt(10_000_000),
+      votingPower: 10_000_000n,
     },
   ],
 };


### PR DESCRIPTION
# Motivation

Similar to https://github.com/dfinity/nns-dapp/pull/4114 but for test files.

`bigint`s can be written as `123n` but in many places we write `BigInt(123)` or `BigInt("123").
The former is more concise and also more accurate if the number actually requires a bigint for full accuracy.

# Changes

1. Replace `BigInt(???)` with `???n`.
2. Add underscore separators for numbers with more than 3 digits if they weren't there already.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary