### PR TITLE
GIX-2187: Test incorrect account identifier for NNS wallet

### DIFF
--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -236,7 +236,7 @@ describe("IcrcWallet", () => {
       // await waitFor(() => expect(spy).toHaveBeenCalled());
     });
 
-    it("should nagigate to accounts when account identifier is missing", async () => {
+    it("should navigate to accounts when account identifier is missing", async () => {
       expect(get(pageStore)).toEqual({
         path: AppPath.Wallet,
         universe: CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText(),
@@ -256,7 +256,7 @@ describe("IcrcWallet", () => {
       ]);
     });
 
-    it("should nagigate to accounts when account identifier is invalid", async () => {
+    it("should navigate to accounts when account identifier is invalid", async () => {
       expect(get(pageStore)).toEqual({
         path: AppPath.Wallet,
         universe: CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText(),

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -77,21 +77,6 @@ describe("NnsWallet", () => {
     };
   };
 
-  const testToolbarButton = ({
-    container,
-    disabled,
-  }: {
-    container: HTMLElement;
-    disabled: boolean;
-  }) => {
-    const button = container.querySelector("footer div.toolbar button");
-
-    expect(button).not.toBeNull();
-    expect((button as HTMLButtonElement).hasAttribute("disabled")).toEqual(
-      disabled
-    );
-  };
-
   describe("no accounts", () => {
     beforeEach(() => {
       vi.spyOn(nnsDappApi, "queryAccount").mockResolvedValue(

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -6,10 +6,7 @@ import NnsWallet from "$lib/pages/NnsWallet.svelte";
 import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
 import { authStore } from "$lib/stores/auth.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
-import { replacePlaceholders } from "$lib/utils/i18n.utils";
-import { formatTokenE8s } from "$lib/utils/token.utils";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
-import en from "$tests/mocks/i18n.mock";
 import {
   mockAccountDetails,
   mockAccountsStoreData,
@@ -17,17 +14,16 @@ import {
   mockMainAccount,
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
-import {
-  modalToolbarSelector,
-  waitModalIntroEnd,
-} from "$tests/mocks/modal.mock";
-import { testAccountsModal } from "$tests/utils/accounts.test-utils";
+import { IcpTransactionModalPo } from "$tests/page-objects/IcpTransactionModal.page-object";
+import { NnsWalletPo } from "$tests/page-objects/NnsWallet.page-object";
+import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import {
   advanceTime,
   runResolvedPromises,
 } from "$tests/utils/timers.test-utils";
-import { ICPToken } from "@dfinity/utils";
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { Principal } from "@dfinity/principal";
+import { render } from "@testing-library/svelte";
 import { tick } from "svelte";
 import type { SpyInstance } from "vitest";
 import AccountsTest from "./AccountsTest.svelte";
@@ -55,6 +51,32 @@ describe("NnsWallet", () => {
     vi.spyOn(accountsApi, "getTransactions").mockResolvedValue([]);
   });
 
+  const renderWallet = (props) => {
+    const { container } = render(NnsWallet, props);
+    const po = NnsWalletPo.under(new JestPageObjectElement(container));
+    return po;
+  };
+
+  const renderWalletAndModals = async (
+    props
+  ): Promise<{
+    walletPo: NnsWalletPo;
+    transactionModalPo: IcpTransactionModalPo;
+    receiveModalPo: ReceiveModalPo;
+  }> => {
+    const { container } = render(AccountsTest, props);
+    await runResolvedPromises();
+    return {
+      walletPo: NnsWalletPo.under(new JestPageObjectElement(container)),
+      transactionModalPo: IcpTransactionModalPo.under(
+        new JestPageObjectElement(container)
+      ),
+      receiveModalPo: ReceiveModalPo.under(
+        new JestPageObjectElement(container)
+      ),
+    };
+  };
+
   const testToolbarButton = ({
     container,
     disabled,
@@ -77,40 +99,48 @@ describe("NnsWallet", () => {
       );
     });
 
-    it("should render a spinner while loading", () => {
-      const { getByTestId } = render(NnsWallet);
+    it("should render a spinner while loading", async () => {
+      const po = renderWallet({});
 
-      expect(getByTestId("spinner")).not.toBeNull();
+      expect(await po.hasSpinner()).toBe(true);
     });
 
-    it("new transaction action should be disabled while loading", () => {
-      const { container } = render(NnsWallet);
+    it("new transaction action should be disabled while loading", async () => {
+      const po = renderWallet({});
 
-      testToolbarButton({ container, disabled: true });
+      expect(await po.getSendButtonPo().isDisabled()).toBe(true);
     });
 
     it("new transaction should remain disabled if route is valid but store is not loaded", async () => {
-      const { container } = render(NnsWallet, props);
+      const po = renderWallet(props);
 
       // init
-      testToolbarButton({ container, disabled: true });
+      expect(await po.getSendButtonPo().isDisabled()).toBe(true);
 
       await tick();
 
       // route set triggers get account
-      testToolbarButton({ container, disabled: true });
+      expect(await po.getSendButtonPo().isDisabled()).toBe(true);
     });
 
     it("should show new accounts after being loaded", async () => {
-      const { queryByTestId } = render(NnsWallet, props);
-
-      expect(queryByTestId("wallet-page-heading-component")).toBeNull();
-
-      await waitFor(() =>
-        expect(
-          queryByTestId("wallet-page-heading-component")
-        ).toBeInTheDocument()
+      let resolveQueryBalance;
+      vi.spyOn(ledgerApi, "queryAccountBalance").mockImplementation(
+        () =>
+          new Promise<bigint>((resolve) => {
+            resolveQueryBalance = () => resolve(mainBalanceE8s);
+          })
       );
+
+      const po = renderWallet(props);
+
+      await runResolvedPromises();
+      expect(await po.getWalletPageHeadingPo().isPresent()).toBe(false);
+
+      resolveQueryBalance();
+
+      await runResolvedPromises();
+      expect(await po.getWalletPageHeadingPo().isPresent()).toBe(true);
     });
   });
 
@@ -120,31 +150,30 @@ describe("NnsWallet", () => {
     });
 
     it("should render nns project name", async () => {
-      const { getByTestId } = render(NnsWallet, props);
+      const po = renderWallet(props);
 
-      const titleRow = getByTestId("universe-page-summary-component");
-
-      expect(titleRow.textContent.trim()).toBe("Internet Computer");
+      expect(await po.getWalletPageHeaderPo().getUniverse()).toBe(
+        "Internet Computer"
+      );
     });
 
     it("should render a balance with token in summary", async () => {
-      const { getByTestId } = render(NnsWallet, props);
+      icpAccountsStore.setForTesting({
+        ...mockAccountsStoreData,
+        main: {
+          ...mockMainAccount,
+          balanceUlps: 432_100_000n,
+        },
+      });
+      const po = renderWallet(props);
 
-      await waitFor(() =>
-        expect(getByTestId("token-value-label")).not.toBeNull()
-      );
-
-      expect(getByTestId("token-value-label")?.textContent.trim()).toEqual(
-        `${formatTokenE8s({
-          value: mockMainAccount.balanceUlps,
-        })} ${ICPToken.symbol}`
-      );
+      expect(await po.getWalletPageHeadingPo().getTitle()).toBe("4.32 ICP");
     });
 
     it("should enable new transaction action for route and store", async () => {
-      const { container } = render(NnsWallet, props);
+      const po = renderWallet(props);
 
-      await waitFor(() => testToolbarButton({ container, disabled: false }));
+      expect(await po.getSendButtonPo().isDisabled()).toBe(false);
     });
 
     const modalProps = {
@@ -153,78 +182,59 @@ describe("NnsWallet", () => {
     };
 
     it("should open transaction modal", async () => {
-      const result = render(AccountsTest, { props: modalProps });
-
-      await testAccountsModal({ result, testId: "new-transaction" });
+      const { walletPo, transactionModalPo } =
+        await renderWalletAndModals(modalProps);
+      expect(await transactionModalPo.isPresent()).toBe(false);
+      await walletPo.clickSend();
+      expect(await transactionModalPo.isPresent()).toBe(true);
     });
 
     it("should open transaction modal on step select destination because selected account is current account", async () => {
-      const result = render(AccountsTest, { props: modalProps });
-
-      await testAccountsModal({ result, testId: "new-transaction" });
-
-      const { getByTestId } = result;
-
-      await waitFor(() =>
-        expect(getByTestId("transaction-step-1")).toBeInTheDocument()
+      const { walletPo, transactionModalPo } =
+        await renderWalletAndModals(modalProps);
+      await walletPo.clickSend();
+      expect(await transactionModalPo.getTransactionFormPo().isPresent()).toBe(
+        true
       );
     });
 
     it("should display SkeletonCard while loading transactions", async () => {
-      const { getByTestId } = render(NnsWallet, props);
+      const po = renderWallet(props);
 
-      expect(getByTestId("skeleton-card")).toBeInTheDocument();
+      expect(
+        await po.getTransactionListPo().getSkeletonCardPo().isPresent()
+      ).toBe(true);
     });
 
     it("should open receive modal", async () => {
-      const result = render(AccountsTest, { props: modalProps });
+      const { walletPo, receiveModalPo } =
+        await renderWalletAndModals(modalProps);
 
-      await testAccountsModal({ result, testId: "receive-icp" });
-
-      const { getByTestId } = result;
-
-      expect(getByTestId("receive-modal")).not.toBeNull();
+      expect(await receiveModalPo.isPresent()).toBe(false);
+      await walletPo.clickReceive();
+      expect(await receiveModalPo.isPresent()).toBe(true);
     });
 
     it("should display receive modal information", async () => {
-      const result = render(AccountsTest, { props: modalProps });
+      const { walletPo, receiveModalPo } =
+        await renderWalletAndModals(modalProps);
 
-      await testAccountsModal({ result, testId: "receive-icp" });
-
-      const { getByText } = result;
-
-      expect(
-        getByText(
-          replacePlaceholders(en.wallet.token_address, {
-            $tokenSymbol: en.core.icp,
-          })
-        )
-      ).toBeInTheDocument();
+      await walletPo.clickReceive();
+      expect(await receiveModalPo.getTokenAddressLabel()).toBe("ICP Address");
     });
 
     it("should reload account after finish receiving tokens", async () => {
-      const result = render(AccountsTest, { props: modalProps });
+      const { walletPo, receiveModalPo } =
+        await renderWalletAndModals(modalProps);
 
-      await testAccountsModal({ result, testId: "receive-icp" });
+      await walletPo.clickReceive();
 
-      const { getByTestId, container } = result;
-
-      await waitModalIntroEnd({ container, selector: modalToolbarSelector });
-
-      await waitFor(() =>
-        expect(accountsApi.getTransactions).toBeCalledTimes(2)
-      );
+      expect(accountsApi.getTransactions).toBeCalledTimes(2);
       expect(ledgerApi.queryAccountBalance).not.toBeCalled();
 
-      await waitFor(() => expect(getByTestId("receive-modal")).not.toBeNull());
+      await receiveModalPo.clickFinish();
 
-      fireEvent.click(
-        getByTestId("reload-receive-account") as HTMLButtonElement
-      );
-
-      await waitFor(() =>
-        expect(accountsApi.getTransactions).toBeCalledTimes(4)
-      );
+      expect(accountsApi.getTransactions).toBeCalledTimes(4);
       expect(ledgerApi.queryAccountBalance).toBeCalledTimes(2);
     });
   });
@@ -242,18 +252,25 @@ describe("NnsWallet", () => {
     };
 
     it("should Rename button", async () => {
-      const { queryByTestId } = render(NnsWallet, props);
-      expect(
-        queryByTestId("open-rename-subaccount-button")
-      ).toBeInTheDocument();
+      const po = renderWallet(props);
+
+      expect(await po.getRenameButtonPo().isPresent()).toBe(true);
     });
   });
 
   describe("accounts loaded (Hardware Wallet)", () => {
+    const testHwPrincipalText = "5dstn-f5lvo-v2xk5-lvmja-g";
+    const testHwPrincipal = Principal.fromText(testHwPrincipalText);
+
     beforeEach(() => {
       icpAccountsStore.setForTesting({
         ...mockAccountsStoreData,
-        hardwareWallets: [mockHardwareWalletAccount],
+        hardwareWallets: [
+          {
+            ...mockHardwareWalletAccount,
+            principal: testHwPrincipal,
+          },
+        ],
       });
     });
 
@@ -266,21 +283,17 @@ describe("NnsWallet", () => {
     });
 
     it("should display principal", async () => {
-      const { queryByText } = render(NnsWallet, props);
-      const principal = mockHardwareWalletAccount?.principal?.toString();
+      const po = renderWallet(props);
 
-      expect(principal?.length).toBeGreaterThan(0);
-      expect(
-        queryByText(`${principal}`, {
-          exact: false,
-        })
-      ).toBeInTheDocument();
+      expect(await po.getWalletPageHeadingPo().getPrincipal()).toBe(
+        testHwPrincipalText
+      );
     });
 
     it("should display hardware wallet buttons", async () => {
-      const { queryByTestId } = render(NnsWallet, props);
-      expect(queryByTestId("ledger-list-button")).toBeInTheDocument();
-      expect(queryByTestId("ledger-show-button")).toBeInTheDocument();
+      const po = renderWallet(props);
+      expect(await po.getListNeuronsButtonPo().isPresent()).toBe(true);
+      expect(await po.getShowHardwareWalletButtonPo().isPresent()).toBe(true);
     });
   });
 

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -289,7 +289,7 @@ describe("SnsWallet", () => {
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
-    it("should nagigate to accounts when account identifier is missing", async () => {
+    it("should navigate to accounts when account identifier is missing", async () => {
       expect(get(pageStore)).toEqual({
         path: AppPath.Wallet,
         universe: rootCanisterIdText,
@@ -309,7 +309,7 @@ describe("SnsWallet", () => {
       ]);
     });
 
-    it("should nagigate to accounts when account identifier is invalid", async () => {
+    it("should navigate to accounts when account identifier is invalid", async () => {
       expect(get(pageStore)).toEqual({
         path: AppPath.Wallet,
         universe: rootCanisterIdText,

--- a/frontend/src/tests/page-objects/NnsWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsWallet.page-object.ts
@@ -1,6 +1,9 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { IcpTransactionModalPo } from "$tests/page-objects/IcpTransactionModal.page-object";
 import { TransactionListPo } from "$tests/page-objects/TransactionList.page-object";
+import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-object";
+import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsWalletPo extends BasePageObject {
@@ -8,6 +11,14 @@ export class NnsWalletPo extends BasePageObject {
 
   static under(element: PageObjectElement): NnsWalletPo {
     return new NnsWalletPo(element.byTestId(NnsWalletPo.TID));
+  }
+
+  getWalletPageHeaderPo(): WalletPageHeaderPo {
+    return WalletPageHeaderPo.under(this.root);
+  }
+
+  getWalletPageHeadingPo(): WalletPageHeadingPo {
+    return WalletPageHeadingPo.under(this.root);
   }
 
   getIcpTransactionModalPo(): IcpTransactionModalPo {
@@ -18,8 +29,36 @@ export class NnsWalletPo extends BasePageObject {
     return TransactionListPo.under(this.root);
   }
 
+  getSendButtonPo(): ButtonPo {
+    return this.getButton("new-transaction");
+  }
+
+  getRenameButtonPo(): ButtonPo {
+    return this.getButton("open-rename-subaccount-button");
+  }
+
+  getListNeuronsButtonPo(): ButtonPo {
+    return this.getButton("ledger-list-button");
+  }
+
+  getShowHardwareWalletButtonPo(): ButtonPo {
+    return this.getButton("ledger-show-button");
+  }
+
+  hasSpinner(): Promise<boolean> {
+    return this.isPresent("spinner");
+  }
+
   clickSend(): Promise<void> {
-    return this.getButton("new-transaction").click();
+    return this.getSendButtonPo().click();
+  }
+
+  clickReceive(): Promise<void> {
+    return this.getButton("receive-icp").click();
+  }
+
+  clickRename(): Promise<void> {
+    return this.getRenameButtonPo().click();
   }
 
   async transferToAccount({


### PR DESCRIPTION
# Motivation

When you go to a wallet page without an account identifier in the URL, this is invalid and you are redirected to the accounts page.
We want to instead show the main account for that universe.
Currently there are no tests covering this behavior for the NNS wallet.
So before changing the behavior in all wallets I'm adding missing test coverage.

This PR adds the missing test coverage for NNS wallet.

# Changes

1. Add tests for navigation on missing, invalid and correct account identifiers.
2. Fix a typo in a related test description that has been copied around.

# Tests

pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary