### PR TITLE
GIX-2187: Default to main account when accountIdentifier is missing

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,6 +26,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 - Use `ic_cdk::println` instead of the `dfn_core` equivalent.
+- Default to main account on wallet page when `account` parameter is missing from the URL.
 
 #### Deprecated
 

--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -5,8 +5,7 @@
   import type { WalletStore } from "$lib/types/wallet.context";
   import { debugSelectedAccountStore } from "$lib/derived/debug.derived";
   import {
-    mainAccount,
-    findAccount,
+    findAccountOrDefaultToMain,
     hasAccounts,
   } from "$lib/utils/accounts.utils";
   import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
@@ -60,13 +59,10 @@
     const accounts = nonNullish(selectedUniverseId)
       ? $icrcAccountsStore[selectedUniverseId.toText()]?.accounts ?? []
       : [];
-    // If there is no accountIdentifier specified, default to the main account.
-    const account = isNullish(accountIdentifier)
-      ? mainAccount(accounts)
-      : findAccount({
-          identifier: accountIdentifier,
-          accounts,
-        });
+    const account = findAccountOrDefaultToMain({
+      identifier: accountIdentifier,
+      accounts,
+    });
     selectedAccountStore.set({
       account,
       neurons: [],

--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -4,7 +4,11 @@
   import type { Writable } from "svelte/store";
   import type { WalletStore } from "$lib/types/wallet.context";
   import { debugSelectedAccountStore } from "$lib/derived/debug.derived";
-  import { findAccount, hasAccounts } from "$lib/utils/accounts.utils";
+  import {
+    mainAccount,
+    findAccount,
+    hasAccounts,
+  } from "$lib/utils/accounts.utils";
   import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
   import { TokenAmountV2, isNullish, nonNullish } from "@dfinity/utils";
   import { syncAccounts as syncWalletAccounts } from "$lib/services/wallet-accounts.services";
@@ -53,13 +57,18 @@
   };
 
   export const setSelectedAccount = () => {
+    const accounts = nonNullish(selectedUniverseId)
+      ? $icrcAccountsStore[selectedUniverseId.toText()]?.accounts ?? []
+      : [];
+    // If there is no accountIdentifier specified, default to the main account.
+    const account = isNullish(accountIdentifier)
+      ? mainAccount(accounts)
+      : findAccount({
+          identifier: accountIdentifier,
+          accounts,
+        });
     selectedAccountStore.set({
-      account: findAccount({
-        identifier: accountIdentifier,
-        accounts: nonNullish(selectedUniverseId)
-          ? $icrcAccountsStore[selectedUniverseId.toText()]?.accounts ?? []
-          : [],
-      }),
+      account,
       neurons: [],
     });
   };

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Account } from "$lib/types/account";
   import { onDestroy, onMount, setContext } from "svelte";
   import { i18n } from "$lib/stores/i18n";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
@@ -23,6 +24,7 @@
   import {
     accountName,
     findAccount,
+    mainAccount,
     isAccountHardwareWallet,
   } from "$lib/utils/accounts.utils";
   import {
@@ -112,15 +114,32 @@
     }
   };
 
+  const setSelectedAccount = ({
+    identifier,
+    accounts,
+  }: {
+    identifier: string | undefined | null;
+    accounts: Account[];
+  }) => {
+    // If there is no accountIdentifier specified, default to the main account.
+    const account = isNullish(identifier)
+      ? mainAccount(accounts)
+      : findAccount({
+          identifier,
+          accounts,
+        });
+    selectedAccountStore.set({
+      account,
+      neurons: [],
+    });
+  };
+
   // We need an object to handle case where the identifier does not exist and the wallet page is loaded directly
   // First call: identifier is set, accounts store is empty, selectedAccount is undefined
   // Second call: identifier is set, accounts store is set, selectedAccount is still undefined
-  $: selectedAccountStore.set({
-    account: findAccount({
-      identifier: accountIdentifier,
-      accounts: $nnsAccountsListStore,
-    }),
-    neurons: [],
+  $: setSelectedAccount({
+    identifier: accountIdentifier,
+    accounts: $nnsAccountsListStore,
   });
 
   $: (async () => await accountDidUpdate($selectedAccountStore))();

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -23,8 +23,7 @@
   } from "$lib/types/wallet.context";
   import {
     accountName,
-    findAccount,
-    mainAccount,
+    findAccountOrDefaultToMain,
     isAccountHardwareWallet,
   } from "$lib/utils/accounts.utils";
   import {
@@ -121,13 +120,10 @@
     identifier: string | undefined | null;
     accounts: Account[];
   }) => {
-    // If there is no accountIdentifier specified, default to the main account.
-    const account = isNullish(identifier)
-      ? mainAccount(accounts)
-      : findAccount({
-          identifier,
-          accounts,
-        });
+    const account = findAccountOrDefaultToMain({
+      identifier,
+      accounts,
+    });
     selectedAccountStore.set({
       account,
       neurons: [],

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -2,6 +2,7 @@
   import { buildAccountsUrl } from "$lib/utils/navigation.utils";
   import { goto } from "$app/navigation";
   import { hasAccounts } from "$lib/utils/accounts.utils";
+  import { mainAccount, findAccount } from "$lib/utils/accounts.utils";
   import type { Principal } from "@dfinity/principal";
   import { Spinner, busy } from "@dfinity/gix-components";
   import { setContext } from "svelte";
@@ -75,16 +76,18 @@
   export let accountIdentifier: string | undefined | null = undefined;
 
   const load = () => {
-    if (nonNullish(accountIdentifier)) {
-      const selectedAccount = $snsProjectAccountsStore?.find(
-        ({ identifier }) => identifier === accountIdentifier
-      );
-
-      selectedAccountStore.set({
-        account: selectedAccount,
-        neurons: [],
-      });
-    }
+    const accounts = $snsProjectAccountsStore ?? [];
+    // If there is no accountIdentifier specified, default to the main account.
+    const selectedAccount = isNullish(accountIdentifier)
+      ? mainAccount(accounts)
+      : findAccount({
+          identifier: accountIdentifier,
+          accounts,
+        });
+    selectedAccountStore.set({
+      account: selectedAccount,
+      neurons: [],
+    });
     // Accounts are loaded in store but no account identifier is matching
     if (
       hasAccounts($snsProjectAccountsStore ?? []) &&

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -2,7 +2,7 @@
   import { buildAccountsUrl } from "$lib/utils/navigation.utils";
   import { goto } from "$app/navigation";
   import { hasAccounts } from "$lib/utils/accounts.utils";
-  import { mainAccount, findAccount } from "$lib/utils/accounts.utils";
+  import { findAccountOrDefaultToMain } from "$lib/utils/accounts.utils";
   import type { Principal } from "@dfinity/principal";
   import { Spinner, busy } from "@dfinity/gix-components";
   import { setContext } from "svelte";
@@ -77,13 +77,10 @@
 
   const load = () => {
     const accounts = $snsProjectAccountsStore ?? [];
-    // If there is no accountIdentifier specified, default to the main account.
-    const selectedAccount = isNullish(accountIdentifier)
-      ? mainAccount(accounts)
-      : findAccount({
-          identifier: accountIdentifier,
-          accounts,
-        });
+    const selectedAccount = findAccountOrDefaultToMain({
+      identifier: accountIdentifier,
+      accounts,
+    });
     selectedAccountStore.set({
       account: selectedAccount,
       neurons: [],

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -214,6 +214,24 @@ export const mainAccount = (accounts: Account[]): Account | undefined => {
   return accounts.find((account) => account.type === "main");
 };
 
+/**
+ * Returns the main account if identifier is nullish but returns undefined if the
+ * identfiier is present but not found.
+ */
+export const findAccountOrDefaultToMain = ({
+  identifier,
+  accounts,
+}: {
+  identifier: AccountIdentifierText | undefined | null;
+  accounts: Account[];
+}): Account | undefined =>
+  isNullish(identifier)
+    ? mainAccount(accounts)
+    : findAccount({
+        identifier,
+        accounts,
+      });
+
 export const accountName = ({
   account,
   mainName,

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -236,24 +236,23 @@ describe("IcrcWallet", () => {
       // await waitFor(() => expect(spy).toHaveBeenCalled());
     });
 
-    it("should navigate to accounts when account identifier is missing", async () => {
+    it("should default to main account when account identifier is missing", async () => {
       expect(get(pageStore)).toEqual({
         path: AppPath.Wallet,
         universe: CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText(),
       });
-      await renderWallet({
+      const po = await renderWallet({
         accountIdentifier: undefined,
       });
       expect(get(pageStore)).toEqual({
-        path: AppPath.Accounts,
+        path: AppPath.Wallet,
         universe: CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText(),
       });
-      expect(get(toastsStore)).toMatchObject([
-        {
-          level: "error",
-          text: 'Sorry, the account "" was not found',
-        },
-      ]);
+      expect(get(toastsStore)).toEqual([]);
+
+      expect(await po.getWalletPageHeaderPo().getWalletAddress()).toBe(
+        mockCkETHMainAccount.identifier
+      );
     });
 
     it("should navigate to accounts when account identifier is invalid", async () => {

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -119,15 +119,16 @@ describe("NnsWallet", () => {
     });
 
     it("should render a spinner while loading", async () => {
+      const resolveQueryAccount = pauseQueryAccountBalance();
       const po = await renderWallet({});
 
+      await runResolvedPromises();
       expect(await po.hasSpinner()).toBe(true);
-    });
 
-    it("new transaction action should be disabled while loading", async () => {
-      const po = await renderWallet({});
+      resolveQueryAccount();
 
-      expect(await po.getSendButtonPo().isDisabled()).toBe(true);
+      await runResolvedPromises();
+      expect(await po.hasSpinner()).toBe(false);
     });
 
     it("new transaction should remain disabled if route is valid but store is not loaded", async () => {
@@ -265,19 +266,18 @@ describe("NnsWallet", () => {
         path: AppPath.Wallet,
         universe: OWN_CANISTER_ID_TEXT,
       });
-      await renderWallet({
+      const po = await renderWallet({
         accountIdentifier: undefined,
       });
       expect(get(pageStore)).toEqual({
-        path: AppPath.Accounts,
+        path: AppPath.Wallet,
         universe: OWN_CANISTER_ID_TEXT,
       });
-      expect(get(toastsStore)).toMatchObject([
-        {
-          level: "error",
-          text: 'Sorry, the account "" was not found',
-        },
-      ]);
+      expect(get(toastsStore)).toEqual([]);
+
+      expect(await po.getWalletPageHeaderPo().getWalletAddress()).toBe(
+        mockMainAccount.identifier
+      );
     });
 
     it("should navigate to accounts when account identifier is invalid", async () => {

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -289,24 +289,23 @@ describe("SnsWallet", () => {
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
-    it("should navigate to accounts when account identifier is missing", async () => {
+    it("should default to main account when account identifier is missing", async () => {
       expect(get(pageStore)).toEqual({
         path: AppPath.Wallet,
         universe: rootCanisterIdText,
       });
-      await renderComponent({
+      const po = await renderComponent({
         accountIdentifier: undefined,
       });
       expect(get(pageStore)).toEqual({
-        path: AppPath.Accounts,
+        path: AppPath.Wallet,
         universe: rootCanisterIdText,
       });
-      expect(get(toastsStore)).toMatchObject([
-        {
-          level: "error",
-          text: 'Sorry, the account "" was not found',
-        },
-      ]);
+      expect(get(toastsStore)).toEqual([]);
+
+      expect(await po.getWalletPageHeaderPo().getWalletAddress()).toBe(
+        mockSnsMainAccount.identifier
+      );
     });
 
     it("should navigate to accounts when account identifier is invalid", async () => {

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -6,6 +6,7 @@ import {
   emptyAddress,
   filterHardwareWalletAccounts,
   findAccount,
+  findAccountOrDefaultToMain,
   getAccountByPrincipal,
   getAccountByRootCanister,
   getAccountsByRootCanister,
@@ -596,6 +597,37 @@ describe("accounts-utils", () => {
         mockSnsSubAccount,
       ];
       expect(mainAccount(accounts)).toEqual(mockSnsMainAccount);
+    });
+  });
+
+  describe("findAccountOrDefaultToMain", () => {
+    const accounts = [mockMainAccount, mockSubAccount];
+
+    it("should return main account if no identifier is provided", () => {
+      expect(
+        findAccountOrDefaultToMain({ identifier: undefined, accounts })
+      ).toBe(mockMainAccount);
+    });
+
+    it("should find no account if not matches", () => {
+      expect(
+        findAccountOrDefaultToMain({ identifier: "aaa", accounts })
+      ).toBeUndefined();
+    });
+
+    it("should return corresponding account", () => {
+      expect(
+        findAccountOrDefaultToMain({
+          identifier: mockMainAccount.identifier,
+          accounts,
+        })
+      ).toEqual(mockMainAccount);
+      expect(
+        findAccountOrDefaultToMain({
+          identifier: mockSubAccount.identifier,
+          accounts,
+        })
+      ).toEqual(mockSubAccount);
     });
   });
 


### PR DESCRIPTION
# Motivation

People want to be able to link from external websites to the ckBTC wallet page, which has information about converting BTC to ckBTC.
This should work whether the user is signed-in or not.
When linking from an external website, the account identifier of the user is not known so it can't be included in the URL.
To make this work we want the wallet deep-link URL work even when know account identifier is specified.
In that case we default to the main account for the given wallet.
For consistency we do the same SNS and NSS wallets.

# Changes

1. Default to the main account when no account identifier is specified in the `IcrcWallet` component.
2. Default to the main account when no account identifier is specified in the `SnsWallet` component. 
3. Default to the main account when no account identifier is specified in the `NnsWallet` component. 

# Tests

Adjust unit tests for each wallet where no account identifier is specified to default to the main account instead of navigating to the accounts page.

Fix `"should render a spinner while loading"` in `NnsWallet.spec.ts`. It previously faked the loading state by not specifying an account identifier. Now we put it in loading state by pausing the API.

Remove `"new transaction action should be disabled while loading"` in `NnsWallet.spec.ts`. It did not simulate the loading state correctly and the test below it covers the same functionality.

# Todos

- [x] Add entry to changelog (if necessary).
