### PR TITLE
GIX-2187: Allow CkBTCInfoCard without account

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1029,7 +1029,8 @@
     "receiving_btc": "Receiving BTC",
     "reimbursement": "Reimbursement",
     "sending_btc": "Sending BTC",
-    "sending_btc_failed": "Sending BTC failed"
+    "sending_btc_failed": "Sending BTC failed",
+    "sign_in_for_address": "Sign in to see your BTC deposit address."
   },
   "error__ckbtc": {
     "already_process": "The minter has already been notified and updating the balance is in progress.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1078,6 +1078,7 @@ interface I18nCkbtc {
   reimbursement: string;
   sending_btc: string;
   sending_btc_failed: string;
+  sign_in_for_address: string;
 }
 
 interface I18nError__ckbtc {

--- a/frontend/src/tests/page-objects/CkBTCInfoCard.page-object.ts
+++ b/frontend/src/tests/page-objects/CkBTCInfoCard.page-object.ts
@@ -29,12 +29,20 @@ export class CkBTCInfoCardPo extends BasePageObject {
     return this.root.byTestId("block-explorer-link");
   }
 
+  hasBlockExplorerLink(): Promise<boolean> {
+    return this.isPresent("block-explorer-link");
+  }
+
   getUpdateBalanceButton(): ButtonPo {
     return this.getButton("manual-refresh-balance");
   }
 
   hasUpdateBalanceButton(): Promise<boolean> {
     return this.getUpdateBalanceButton().isPresent();
+  }
+
+  hasSignInForAddressMessage(): Promise<boolean> {
+    return this.isPresent("sign-in-for-address");
   }
 
   hasQrCode(): Promise<boolean> {


### PR DESCRIPTION
# Motivation

We want to allow deep linking into the ckBTC wallet page so people can learn about BTC -> ckBTC conversion.
This should work even when users are not signed in.
The components on the wallet page currently assume that the user is always signed in or the wallet page wouldn't be shown. So this needs to change.

In this PR we support not being signed in for the `CkBTCInfoCard` component by allowing to not pass the `account` prop.

When signed in:

<img width="736" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/23e13d50-92db-4027-bcb4-f8289f6783ed">

When not signed in:

<img width="755" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/f28771ca-43e7-4b1a-9b63-0b428b22adad">

A placeholder for the address QR code will be added later.

This change is not yet user visible because it's still not possible to see the wallet page without being signed in.

# Changes

1. Change the types of `account` and `identifier` to include `undefined.
2. Load the BTC address whenever the identifier is defined, instead of only on mount. This is for the case where the user signs in while on the wallet page.
3. Exclude the sentence with the block explorer link if there is no account.
4. Exclude the QR code of the BTC address if there is no account.
5. Instead of showing the BTC address, show a message to tell the user to sign in.
6. Exclude the "Check for incoming BTC" button if there is no account.

# Tests

1. Unit tests that various elements are not rendered.
2. Unit test that the sign in message is rendered.
3. Additional unit test to make sure that setting the account after rendering works, for the case where the user signs in on the wallet page.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet