### PR TITLE
Voted neurons update

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -23,6 +23,7 @@ proposal is successful, the changes it released will be moved from this file to
 - Render pending and failed BTC withdrawal transaction as such.
 - Add `ENABLE_SNS_TYPES_FILTER` feature flag.
 - Redesign proposal detail neurons block (collapsible).
+- Display status in "voted neurons" headline.
 
 #### Changed
 

--- a/frontend/src/lib/components/proposal-detail/MyVotes.svelte
+++ b/frontend/src/lib/components/proposal-detail/MyVotes.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
   import { Vote } from "@dfinity/nns";
   import { i18n } from "$lib/stores/i18n";
-  import {
-    IconThumbDown,
-    IconThumbUp,
-    KeyValuePair,
-  } from "@dfinity/gix-components";
+  import { KeyValuePair } from "@dfinity/gix-components";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import {
     formatVotingPower,
@@ -15,14 +11,9 @@
   import { SNS_NEURON_ID_DISPLAY_LENGTH } from "$lib/constants/sns-neurons.constants";
   import VotingCardNeuronList from "$lib/components/proposal-detail/VotingCard/VotingCardNeuronList.svelte";
   import { fade } from "svelte/transition";
+  import VoteResultIcon from "$lib/components/proposal-detail/VotingCard/VoteResultIcon.svelte";
 
   export let neuronsVotedForProposal: CompactNeuronInfo[] = [];
-
-  const voteIconMapper = {
-    [Vote.No]: IconThumbDown,
-    [Vote.Yes]: IconThumbUp,
-    [Vote.Unspecified]: undefined,
-  };
 
   const voteMapper = ({ neuron, vote }: { neuron: string; vote: Vote }) => {
     const stringMapper = {
@@ -64,9 +55,7 @@
             data-tid="my-votes-voting-power"
           >
             <span>{formatVotingPower(neuron.votingPower)}</span>
-            {#if voteIconMapper[neuron.vote]}
-              <svelte:component this={voteIconMapper[neuron.vote]} />
-            {/if}
+            <VoteResultIcon vote={neuron.vote} />
           </span>
         </KeyValuePair>
       </li>

--- a/frontend/src/lib/components/proposal-detail/VotingCard/ExpandableProposalNeurons.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/ExpandableProposalNeurons.svelte
@@ -46,6 +46,10 @@
   .container {
     padding-bottom: var(--padding-2x);
     border-bottom: 1px solid var(--tertiary);
+
+    &:last-of-type {
+      border-bottom: none;
+    }
   }
 
   .header {

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VoteResultIcon.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VoteResultIcon.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { Vote } from "@dfinity/nns";
+  import { IconThumbDown, IconThumbUp } from "@dfinity/gix-components";
+  import { nonNullish } from "@dfinity/utils";
+
+  export let vote: Vote;
+
+  const voteIconMapper = {
+    [Vote.No]: IconThumbDown,
+    [Vote.Yes]: IconThumbUp,
+    [Vote.Unspecified]: undefined,
+  };
+</script>
+
+{#if nonNullish(voteIconMapper[vote])}
+  <svelte:component this={voteIconMapper[vote]} />
+{/if}

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotedNeuronList.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotedNeuronList.svelte
@@ -9,6 +9,8 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import ExpandableProposalNeurons from "$lib/components/proposal-detail/VotingCard/ExpandableProposalNeurons.svelte";
   import MyVotes from "$lib/components/proposal-detail/MyVotes.svelte";
+  import { Vote } from "@dfinity/nns";
+  import VoteResultIcon from "$lib/components/proposal-detail/VotingCard/VoteResultIcon.svelte";
 
   export let neuronsVotedForProposal: CompactNeuronInfo[];
 
@@ -17,14 +19,33 @@
 
   let votedNeuronCount: number;
   $: votedNeuronCount = neuronsVotedForProposal.length;
+
+  // Equals `Vote.Unspecified` when not all neurons voted the same way
+  let allVotedVote: Vote;
+  $: allVotedVote = neuronsVotedForProposal.some(
+    ({ vote }) => neuronsVotedForProposal[0]?.vote !== vote
+  )
+    ? Vote.Unspecified
+    : neuronsVotedForProposal?.[0].vote ?? Vote.Unspecified;
+
+  $: console.log("allVotedVote", allVotedVote, neuronsVotedForProposal);
 </script>
 
 {#if votedNeuronCount > 0}
   <ExpandableProposalNeurons testId="voted-neurons">
     <svelte:fragment slot="start">
-      {replacePlaceholders($i18n.proposal_detail.neurons_voted, {
-        $count: `${votedNeuronCount}`,
-      })}
+      <span
+        class="headline"
+        class:yes={allVotedVote === Vote.Yes}
+        class:no={allVotedVote === Vote.No}
+      >
+        {replacePlaceholders($i18n.proposal_detail.neurons_voted, {
+          $count: `${votedNeuronCount}`,
+        })}
+        {#if allVotedVote !== Vote.Unspecified}
+          <VoteResultIcon vote={allVotedVote} />
+        {/if}
+      </span>
     </svelte:fragment>
     <svelte:fragment slot="end">
       <span class="label">{$i18n.proposal_detail__vote.voting_power}</span>
@@ -35,3 +56,18 @@
     <MyVotes {neuronsVotedForProposal} />
   </ExpandableProposalNeurons>
 {/if}
+
+<style lang="scss">
+  .headline {
+    display: flex;
+    align-items: center;
+    gap: var(--padding);
+
+    &.yes {
+      color: var(--positive-emphasis);
+    }
+    &.no {
+      color: var(--negative-emphasis);
+    }
+  }
+</style>

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotedNeuronList.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotedNeuronList.svelte
@@ -41,9 +41,7 @@
         {replacePlaceholders($i18n.proposal_detail.neurons_voted, {
           $count: `${votedNeuronCount}`,
         })}
-        {#if allVotedVote !== Vote.Unspecified}
-          <VoteResultIcon vote={allVotedVote} />
-        {/if}
+        <VoteResultIcon vote={allVotedVote} />
       </span>
     </svelte:fragment>
     <svelte:fragment slot="end">

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotedNeuronList.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotedNeuronList.svelte
@@ -26,15 +26,14 @@
     ({ vote }) => neuronsVotedForProposal[0]?.vote !== vote
   )
     ? Vote.Unspecified
-    : neuronsVotedForProposal?.[0].vote ?? Vote.Unspecified;
-
-  $: console.log("allVotedVote", allVotedVote, neuronsVotedForProposal);
+    : neuronsVotedForProposal[0]?.vote ?? Vote.Unspecified;
 </script>
 
 {#if votedNeuronCount > 0}
   <ExpandableProposalNeurons testId="voted-neurons">
     <svelte:fragment slot="start">
       <span
+        data-tid="voted-neurons-headline"
         class="headline"
         class:yes={allVotedVote === Vote.Yes}
         class:no={allVotedVote === Vote.No}

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingCard.spec.ts
@@ -45,6 +45,11 @@ describe("VotingCard", () => {
     votingPower: 200n,
     vote: Vote.Yes,
   };
+  const noVoted: CompactNeuronInfo = {
+    idString: "200",
+    votingPower: 200n,
+    vote: Vote.No,
+  };
 
   const renderComponent = async (props = {}) => {
     const { container } = render(VotingCard, {
@@ -140,6 +145,39 @@ describe("VotingCard", () => {
       expect(await po.getVotableNeurons().isPresent()).toBe(true);
       expect(await po.getVotedNeurons().isPresent()).toBe(true);
       expect(await po.getIneligibleNeurons().isPresent()).toBe(false);
+    });
+
+    describe("Voted neurons headline state", () => {
+      it("should display Yes state when all voted yes", async () => {
+        const po = await renderComponent({
+          neuronsVotedForProposal: [yesVoted],
+        });
+
+        expect(await po.getVotedNeuronHeadlineYesIcon().isPresent()).toBe(true);
+        expect(await po.getVotedNeuronHeadlineNoIcon().isPresent()).toBe(false);
+      });
+
+      it("should display No state when all voted yes", async () => {
+        const po = await renderComponent({
+          neuronsVotedForProposal: [noVoted],
+        });
+
+        expect(await po.getVotedNeuronHeadlineNoIcon().isPresent()).toBe(true);
+        expect(await po.getVotedNeuronHeadlineYesIcon().isPresent()).toBe(
+          false
+        );
+      });
+
+      it("should not display a voting state when all not voted the same", async () => {
+        const po = await renderComponent({
+          neuronsVotedForProposal: [yesVoted, noVoted],
+        });
+
+        expect(await po.getVotedNeuronHeadlineYesIcon().isPresent()).toBe(
+          false
+        );
+        expect(await po.getVotedNeuronHeadlineNoIcon().isPresent()).toBe(false);
+      });
     });
   });
 });

--- a/frontend/src/tests/page-objects/VotingCard.page-object.ts
+++ b/frontend/src/tests/page-objects/VotingCard.page-object.ts
@@ -21,6 +21,18 @@ export class VotingCardPo extends BasePageObject {
     return this.root.byTestId("voted-neurons");
   }
 
+  getVotedNeuronHeadline(): PageObjectElement {
+    return this.getVotedNeurons().byTestId("voted-neurons-headline");
+  }
+
+  getVotedNeuronHeadlineYesIcon(): PageObjectElement {
+    return this.getVotedNeuronHeadline().byTestId("thumb-up");
+  }
+
+  getVotedNeuronHeadlineNoIcon(): PageObjectElement {
+    return this.getVotedNeuronHeadline().byTestId("thumb-down");
+  }
+
   getIneligibleNeurons(): PageObjectElement {
     return this.root.byTestId("ineligible-neurons");
   }


### PR DESCRIPTION
# Motivation

In order to improve voted state readability, the voting state is displayed in the "voted neurons" header. When not all neurons voted the same way, no state is displayd.

# Changes

- Display `thumb-up` icon in gree when all voted neuron voted `Yes`
- Display `thumb-down` icon in red when all voted neuron voted `No`
- Removed bottom line from the last element (designer's request)

# Tests

- "Voted neurons headline state"

# Todos

- [x] Add entry to changelog (if necessary).

# Screenshots

## State in the headline

| Yes only | No only | Mixed |
|--------|--------|--------|
| <img width="373" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/2e94536b-d5c2-406b-9cb7-c124c90b6431"> | <img width="373" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/75ea12d6-93b2-4e8e-a030-3f07f8c13350"> | <img width="373" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/49f515d9-b588-4ea6-bbb6-2a9196cf8a11"> | 

## Collapsed

<img width="897" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/a2d91618-b4ef-4368-a300-171cbd00f7d7">

## Removed bottom border from the last block

| Before | After |
|--------|--------|
| <img width="376" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/a7eb2697-fd34-43de-9194-d4bacd548047"> | <img width="377" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/017cdbcc-6543-434b-8032-85cb3affdb28"> | 
