### PR TITLE
Allow absent wallet address in WalletPageHeader

### DIFF
--- a/frontend/src/lib/components/accounts/WalletPageHeader.svelte
+++ b/frontend/src/lib/components/accounts/WalletPageHeader.svelte
@@ -3,9 +3,10 @@
   import PageHeader from "../common/PageHeader.svelte";
   import IdentifierHash from "../ui/IdentifierHash.svelte";
   import UniversePageSummary from "../universe/UniversePageSummary.svelte";
+  import { nonNullish } from "@dfinity/utils";
 
   export let universe: Universe;
-  export let walletAddress: string;
+  export let walletAddress: string | undefined;
 </script>
 
 <PageHeader testId="wallet-page-header-component">
@@ -15,7 +16,9 @@
     class="description header-end"
     data-tid="wallet-header-account-identifier"
   >
-    <IdentifierHash identifier={walletAddress} />
+    {#if nonNullish(walletAddress)}
+      <IdentifierHash identifier={walletAddress} />
+    {/if}
   </span>
 </PageHeader>
 

--- a/frontend/src/tests/lib/components/accounts/WalletPageHeader.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/WalletPageHeader.spec.ts
@@ -1,18 +1,25 @@
 import WalletPageHeader from "$lib/components/accounts/WalletPageHeader.svelte";
 import type { Universe } from "$lib/types/universe";
-import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockUniverse } from "$tests/mocks/sns-projects.mock";
 import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 
 describe("WalletPageHeading", () => {
+  const universeName = "Test universe";
+  const universe: Universe = {
+    ...mockUniverse,
+    title: universeName,
+  };
+  const walletAddress =
+    "d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f";
+
   const renderComponent = ({
-    walletAddress = mockMainAccount.identifier,
-    universe = mockUniverse,
+    walletAddress,
+    universe,
   }: {
-    walletAddress?: string;
-    universe?: Universe;
+    walletAddress: string;
+    universe: Universe;
   }) => {
     const { container } = render(WalletPageHeader, {
       props: {
@@ -23,25 +30,23 @@ describe("WalletPageHeading", () => {
     return WalletPageHeaderPo.under(new JestPageObjectElement(container));
   };
 
-  it("should render account identifier", async () => {
+  it("should render universe name and account identifier", async () => {
     const po = renderComponent({
-      walletAddress:
-        "d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f",
+      universe,
+      walletAddress,
     });
 
-    expect(await po.getWalletAddress()).toBe(
-      "d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f"
-    );
+    expect(await po.getUniverse()).toBe(universeName);
+    expect(await po.getWalletAddress()).toBe(walletAddress);
   });
 
-  it("should render universe name", async () => {
-    const universeName = "Test universe";
-    const universe: Universe = {
-      ...mockUniverse,
-      title: universeName,
-    };
-    const po = renderComponent({ universe });
+  it("should render universe name and no account identifier", async () => {
+    const po = renderComponent({
+      universe,
+      walletAddress: undefined,
+    });
 
     expect(await po.getUniverse()).toBe(universeName);
+    expect(await po.getHashPo().isPresent()).toBe(false);
   });
 });

--- a/frontend/src/tests/page-objects/WalletPageHeader.page-object.ts
+++ b/frontend/src/tests/page-objects/WalletPageHeader.page-object.ts
@@ -14,7 +14,11 @@ export class WalletPageHeaderPo extends BasePageObject {
     return UniversePageSummaryPo.under(this.root).getTitle();
   }
 
+  getHashPo(): HashPo {
+    return HashPo.under(this.root);
+  }
+
   getWalletAddress(): Promise<string> {
-    return HashPo.under(this.root).getText();
+    return this.getHashPo().getText();
   }
 }


### PR DESCRIPTION
# Motivation

We want to make deep links to wallet pages, render a logged-out version of the wallet page.
When the user is not logged in, there is no wallet address known.
So we need to be able to render the `WalletPageHeader` component without wallet address.

This PR does not change anything user visible because it's not yet possible to see the wallet page while not logged in.

# Changes

Allow not passing a wallet address to the `WalletPageHeader` component. Then don't render the `IdentifierHash` component.

# Tests

1. Merge the existing tests for the wallet address and universe name.
2. Add an extra test where the wallet address is absent.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet