### PR TITLE
Fix parsing the proposal ID in scripts/nns-dapp/release

### DIFF
--- a/scripts/nns-dapp/release
+++ b/scripts/nns-dapp/release
@@ -150,13 +150,15 @@ echo
 read -rp "Execute? (y/N) " COMMAND_OK
 if [[ "$COMMAND_OK" = [yY] ]]; then
   if [[ "${PROPOSAL_ID_FILE:-}" ]]; then
-    # The ic-admin command writes 1 line to stderr with the following format:
+    # The ic-admin command writes 1 line (among others) to stderr with the following format:
     # submit_proposal for Upgrade NNS Canister: qoctq-giaaa-aaaaa-aaaea-cai to wasm with hash: 35315f0a44a16b1221a295ba253d018ed824e18cb1d2458c7933fe588efb45f4 response: Ok(proposal 213)
     # We want to parse the proposal ID out of that. First we redirect stderr to
     # stdout, then we use sed to extract the proposal ID, then we tee it to a
     # file, then we direct it back to stderr.
     (
       "${@}" 2>&1 1>&3 |
+        grep -E 'proposal [0-9]+' |
+        head -1 |
         sed -E 's/.*\(proposal (.*)\)/\1/' |
         tee "$PROPOSAL_ID_FILE"
     ) 3>&1 >&2


### PR DESCRIPTION
# Motivation

`scripts/nns-dapp/release` has a flag to write the created proposal ID to a file.
This functionality depended on `ic-admin` writing only a single line to stdout.
But newer versions of `ic-admin` write more to stdout, breaking the proposal ID parsing.

# Changes

`grep` for the specific line containing the proposal ID and ignore everything else.

# Tests

Tested manually on local with
```
$ PATH=$PATH:../../snsdemo/tree2/bin scripts/nns-dapp/release --save-proposal-id-to-file tmp-id --network local --neuron "$(cat ~/.config/dfx/identity/snsdemo8/neurons/local)"

$ cat tmp-id
```

# Todos

- [x] Add entry to changelog (if necessary).
