### PR TITLE
Fix balances observers

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -28,6 +28,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Reverted the upgrade to SvelteKit 2 as it breaks iOS 15.
+* Auto updating wallet balances
 
 #### Security
 

--- a/frontend/src/lib/components/accounts/IcrcBalancesObserver.svelte
+++ b/frontend/src/lib/components/accounts/IcrcBalancesObserver.svelte
@@ -21,7 +21,7 @@
         return nonNullish(selectedAccount)
           ? ({
               ...selectedAccount,
-              balanceE8s: balance,
+              balanceUlps: balance,
             } as Account)
           : undefined;
       })

--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -136,35 +136,34 @@
           universeId={selectedUniverseId}
           accounts={[$selectedAccountStore.account]}
           reload={reloadOnlyAccountFromStore}
+        />
+        <WalletPageHeader
+          universe={$selectedUniverseStore}
+          walletAddress={$selectedAccountStore.account.identifier}
+        />
+        <WalletPageHeading
+          accountName={$selectedAccountStore.account.name ??
+            $i18n.accounts.main}
+          balance={TokenAmountV2.fromUlps({
+            amount: $selectedAccountStore.account.balanceUlps,
+            token,
+          })}
         >
-          <WalletPageHeader
-            universe={$selectedUniverseStore}
-            walletAddress={$selectedAccountStore.account.identifier}
-          />
-          <WalletPageHeading
-            accountName={$selectedAccountStore.account.name ??
-              $i18n.accounts.main}
-            balance={TokenAmountV2.fromUlps({
-              amount: $selectedAccountStore.account.balanceUlps,
-              token,
-            })}
-          >
-            <slot name="header-actions" />
-          </WalletPageHeading>
+          <slot name="header-actions" />
+        </WalletPageHeading>
 
-          {#if $$slots["info-card"]}
-            <div class="content-cell-island info-card">
-              <slot name="info-card" />
-            </div>
-          {/if}
-
-          <Separator spacing="none" />
-
-          <!-- Transactions and the explanation go together. -->
-          <div>
-            <slot name="page-content" />
+        {#if $$slots["info-card"]}
+          <div class="content-cell-island info-card">
+            <slot name="info-card" />
           </div>
-        </IcrcBalancesObserver>
+        {/if}
+
+        <Separator spacing="none" />
+
+        <!-- Transactions and the explanation go together. -->
+        <div>
+          <slot name="page-content" />
+        </div>
       {:else}
         <Spinner />
       {/if}

--- a/frontend/src/lib/components/accounts/SnsBalancesObserver.svelte
+++ b/frontend/src/lib/components/accounts/SnsBalancesObserver.svelte
@@ -22,7 +22,7 @@
         return nonNullish(selectedAccount)
           ? {
               ...selectedAccount,
-              balanceE8s: balance,
+              balanceUlps: balance,
             }
           : undefined;
       })

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -155,28 +155,27 @@
             rootCanisterId={$snsOnlyProjectStore}
             accounts={[$selectedAccountStore.account]}
             ledgerCanisterId={$snsProjectSelectedStore.summary.ledgerCanisterId}
-          >
-            <WalletPageHeader
-              universe={$selectedUniverseStore}
-              walletAddress={$selectedAccountStore.account.identifier}
-            />
-            <WalletPageHeading
-              balance={TokenAmount.fromE8s({
-                amount: $selectedAccountStore.account.balanceUlps,
-                token,
-              })}
-              accountName={$selectedAccountStore.account.name ??
-                $i18n.accounts.main}
-            />
+          />
+          <WalletPageHeader
+            universe={$selectedUniverseStore}
+            walletAddress={$selectedAccountStore.account.identifier}
+          />
+          <WalletPageHeading
+            balance={TokenAmount.fromE8s({
+              amount: $selectedAccountStore.account.balanceUlps,
+              token,
+            })}
+            accountName={$selectedAccountStore.account.name ??
+              $i18n.accounts.main}
+          />
 
-            <Separator spacing="none" />
+          <Separator spacing="none" />
 
-            <SnsTransactionsList
-              rootCanisterId={$snsOnlyProjectStore}
-              account={$selectedAccountStore.account}
-              {token}
-            />
-          </SnsBalancesObserver>
+          <SnsTransactionsList
+            rootCanisterId={$snsOnlyProjectStore}
+            account={$selectedAccountStore.account}
+            {token}
+          />
         {:else}
           <Spinner />
         {/if}

--- a/frontend/src/tests/lib/components/accounts/IcrcBalancesObserver.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcBalancesObserver.spec.ts
@@ -93,7 +93,7 @@ describe("IcrcBalancesObserver", () => {
       const updatedStore = get(icrcAccountsStore);
       expect(
         updatedStore[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()].accounts
-      ).toEqual([{ ...mockCkBTCMainAccount, balanceE8s: 123456n }]);
+      ).toEqual([{ ...mockCkBTCMainAccount, balanceUlps: 123456n }]);
     });
   });
 

--- a/frontend/src/tests/lib/components/accounts/SnsBalancesObserver.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsBalancesObserver.spec.ts
@@ -107,7 +107,7 @@ describe("SnsBalancesObserver", () => {
     await waitFor(() => {
       const updatedStore = get(snsAccountsStore);
       expect(updatedStore[rootCanisterIdMock.toText()].accounts).toEqual([
-        { ...mockSnsMainAccount, balanceE8s: 123456n },
+        { ...mockSnsMainAccount, balanceUlps: 123456n },
       ]);
     });
   });


### PR DESCRIPTION
# Motivation

We want to be able to render wallet pages to signed-out users.
When the user is not signed in, there is no balance to observer so the observer should be separated from the content that can be displayed to signed-out users. So the content should not be passed as a slot of the observer, but should be a sibling of the observer.
After I made this change, I tested if the observer (still) worked, and I realized that the observer was actually already broken before.
It was broken by https://github.com/dfinity/nns-dapp/pull/3995 which changed `Account.balanceE8s` to `Account.balanceUlps` while the observers kept setting the `balanceE8s` field. This was not caught by the test because the test also checked that the `balanceE8s` field was set.
So in addition to fixing the usage of the field, I wanted to add a test that would have caught the issue.
And while adding the test I ran into what seems like a bug in Svelte where it would not update values render inside a slot.
Since my plan was to move the content outside the slot of the observer, I decided not to investigate further and just do the fix and the move in the same PR.

# Changes

1. In `IcrcBalancesObserver.svelte` and `SnsBalancesObserver.svelte` set `balanceUlps` instead of `balanceE8s`.
2. In `IcrcWalletPage.svelte` and `SnsWallet.svelte` move the content outside the respective Observer slot.

# Tests

1. Update the Observer tests to check the `balanceUlps` field instead of the `balanceE8s` field.
2. Add wallet tests to check that the balances passed from the observer callback are actually rendered.

# Todos

- [x] Add entry to changelog (if necessary).
