### PR TITLE
Bump next for iOS 15

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.1.0-next-2023-12-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.1.0-next-2023-12-20.tgz",
-      "integrity": "sha512-yZST+/yI8+dOWUO29o4PmAiBL9F+wjDSzifu3K3xv35cN4msa8J4Gt6OmNPLVZDTxGE1TVsGnplBCAK/J9v7xw==",
+      "version": "2.1.0-next-2024-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.1.0-next-2024-01-09.1.tgz",
+      "integrity": "sha512-T1htcu9amAj6a8cNAl2ZefOgfV5+Y8nd7dJu2wLbZY0fm/BGWTOI2mkE7E2dZS7ZCWw945bWT6UDct7iXJ+NfA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "2.1.0-next-2023-12-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-2.1.0-next-2023-12-20.tgz",
-      "integrity": "sha512-pXtSVaSZLK/rz5hC9HzWeDVSEDxYgifLGdq3NpYGX2aOTFiBwrcbF2MWRME1NZ/u1Mekq4Ye4vvn9+Vn/sztvA==",
+      "version": "2.1.0-next-2024-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-2.1.0-next-2024-01-09.1.tgz",
+      "integrity": "sha512-nqlD5YcCGr7vE9jD0qFc+f2VOgSk4S/A7x93BwUzvR8M05IFOeBvZ+ZROs53swR3Sec9a9ZFSVa+IhkHqwGDpw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "2.1.0-next-2023-12-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.1.0-next-2023-12-20.tgz",
-      "integrity": "sha512-pfnsvZjyJRZ1FM7oPsV2nGxXa1KfgN4VBywfPDYMBxxptegkacryz2WmS8Mzn7soo504soZ8Ud6I918BW0/Lng==",
+      "version": "2.1.0-next-2024-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.1.0-next-2024-01-09.1.tgz",
+      "integrity": "sha512-aiC3cg0I9v/Zqp8nrEajb10UI+xBHm5GKsXMUtD69tgWbjPCRbes23VDVqwRk8sjzdOkkTupC7Tr7M1XqGpMDA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.1.0-next-2023-12-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.1.0-next-2023-12-20.tgz",
-      "integrity": "sha512-RJJlSWV8z4Kcrzm7Gar/EMnPMMn5w/50N2w2lhIza6squlSdfGI/eKniHVb9bUDk5MnxPDjMNPkqOXM4l/UkBA==",
+      "version": "2.1.1-next-2024-01-09",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.1.1-next-2024-01-09.tgz",
+      "integrity": "sha512-/Bsvrjx1oExn2+EtsifWixFxWdAY606AOkX64XzgyWLymuV3XgJN2lLnyNyhPLQ/hWXMAKL3DjYpbcpaR+KgFw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.1.0-next-2023-12-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.0-next-2023-12-20.tgz",
-      "integrity": "sha512-PDiLD6UoMnOSNlSbEAT9os4HNN3l1/quXOcWp24aWDsYT8Bc9nr6KdyhtwFYT5oPvfYLOTFTL6cWcfPHWSKS6w==",
+      "version": "2.1.0-next-2024-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.0-next-2024-01-09.1.tgz",
+      "integrity": "sha512-Y5I+4PJdJuN+KIBQaE1HW5oGUeF1a4xfomQI1We3MShIkzBbDkMqHYbP0xiQl7tnFLwHvCnt+gz9sBtJ/i0wfA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "3.1.0-next-2023-12-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.1.0-next-2023-12-20.tgz",
-      "integrity": "sha512-e/GZTTxyXCy7n8URuRBq1UjFEPTNHrbofqQFkfd0zGXHkP4zPm2wuKoTShrrFlBFmAum2x7FyGfqYAq8lcHrMw==",
+      "version": "3.1.0-next-2024-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.1.0-next-2024-01-09.1.tgz",
+      "integrity": "sha512-B2rDBaj10rN0baMt2c252Se+uAtRQd+Jd96ZtySoa5CGRweYs7EsfDk2I9cUSip/wSkFbxk3plxcrb4OKac+BA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -358,9 +358,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.0-next-2023-12-20.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-12-20.1.tgz",
-      "integrity": "sha512-gs/A2jUOcxax+EbbfIrNLPDFpYgh8iK/BSlRoTpxdtsAFGWNNOaqugDUG3kyeomxtfxiKaFlfwJtlRCCc8Ks6A==",
+      "version": "1.0.0-next-2024-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2024-01-09.1.tgz",
+      "integrity": "sha512-SkgaVjRmDH3qghsP4tHYFQvXw+7lVPv9ipM0axFGqgYQuGv83YpDdkL8MhvozGUWFXycQXzlkOf1ZeKmVpY7OQ==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "2.1.0-next-2023-12-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.0-next-2023-12-20.tgz",
-      "integrity": "sha512-FEIBD2jsZHOljmCRiPav21Up1G9xc/+bMCugQEVyVWFrJmh7mMlkGfwxpCdAk9nsU8rIFWKsxhjuFQDK8jGZRg==",
+      "version": "2.1.0-next-2024-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.0-next-2024-01-09.1.tgz",
+      "integrity": "sha512-lbzwBr5nPJVkfBYJ4V9i5a5i6LXfxMrwZjL3KbLM4IdlT2XmxYgEDso94MGdQg0r8wBYKSSuggzpqh5XlIpJCg==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.0.0-next-2023-12-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.0.0-next-2023-12-20.tgz",
-      "integrity": "sha512-3ccyeJcA9zm5BxOYduYQNmd2E5p5A+2B1GIJvjOJOy+A5bvhFBT1BtM+uHGeXRA6nUGGEza7iGyn8shLtmp4cQ==",
+      "version": "2.0.0-next-2024-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.0.0-next-2024-01-09.1.tgz",
+      "integrity": "sha512-3JiSNsxX4WRfJCYbCvHBT/aQjXz9S/DH1Trzfy4YZLTvdMUfAKSxvquX+LBXQb33RPXCQxTcUxzm2sFLjGEUZg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7047,9 +7047,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.1.0-next-2023-12-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.1.0-next-2023-12-20.tgz",
-      "integrity": "sha512-yZST+/yI8+dOWUO29o4PmAiBL9F+wjDSzifu3K3xv35cN4msa8J4Gt6OmNPLVZDTxGE1TVsGnplBCAK/J9v7xw==",
+      "version": "2.1.0-next-2024-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.1.0-next-2024-01-09.1.tgz",
+      "integrity": "sha512-T1htcu9amAj6a8cNAl2ZefOgfV5+Y8nd7dJu2wLbZY0fm/BGWTOI2mkE7E2dZS7ZCWw945bWT6UDct7iXJ+NfA==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7057,9 +7057,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "2.1.0-next-2023-12-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-2.1.0-next-2023-12-20.tgz",
-      "integrity": "sha512-pXtSVaSZLK/rz5hC9HzWeDVSEDxYgifLGdq3NpYGX2aOTFiBwrcbF2MWRME1NZ/u1Mekq4Ye4vvn9+Vn/sztvA==",
+      "version": "2.1.0-next-2024-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-2.1.0-next-2024-01-09.1.tgz",
+      "integrity": "sha512-nqlD5YcCGr7vE9jD0qFc+f2VOgSk4S/A7x93BwUzvR8M05IFOeBvZ+ZROs53swR3Sec9a9ZFSVa+IhkHqwGDpw==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7073,9 +7073,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "2.1.0-next-2023-12-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.1.0-next-2023-12-20.tgz",
-      "integrity": "sha512-pfnsvZjyJRZ1FM7oPsV2nGxXa1KfgN4VBywfPDYMBxxptegkacryz2WmS8Mzn7soo504soZ8Ud6I918BW0/Lng==",
+      "version": "2.1.0-next-2024-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.1.0-next-2024-01-09.1.tgz",
+      "integrity": "sha512-aiC3cg0I9v/Zqp8nrEajb10UI+xBHm5GKsXMUtD69tgWbjPCRbes23VDVqwRk8sjzdOkkTupC7Tr7M1XqGpMDA==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7089,30 +7089,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.1.0-next-2023-12-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.1.0-next-2023-12-20.tgz",
-      "integrity": "sha512-RJJlSWV8z4Kcrzm7Gar/EMnPMMn5w/50N2w2lhIza6squlSdfGI/eKniHVb9bUDk5MnxPDjMNPkqOXM4l/UkBA==",
+      "version": "2.1.1-next-2024-01-09",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.1.1-next-2024-01-09.tgz",
+      "integrity": "sha512-/Bsvrjx1oExn2+EtsifWixFxWdAY606AOkX64XzgyWLymuV3XgJN2lLnyNyhPLQ/hWXMAKL3DjYpbcpaR+KgFw==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.1.0-next-2023-12-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.0-next-2023-12-20.tgz",
-      "integrity": "sha512-PDiLD6UoMnOSNlSbEAT9os4HNN3l1/quXOcWp24aWDsYT8Bc9nr6KdyhtwFYT5oPvfYLOTFTL6cWcfPHWSKS6w==",
+      "version": "2.1.0-next-2024-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.0-next-2024-01-09.1.tgz",
+      "integrity": "sha512-Y5I+4PJdJuN+KIBQaE1HW5oGUeF1a4xfomQI1We3MShIkzBbDkMqHYbP0xiQl7tnFLwHvCnt+gz9sBtJ/i0wfA==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "3.1.0-next-2023-12-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.1.0-next-2023-12-20.tgz",
-      "integrity": "sha512-e/GZTTxyXCy7n8URuRBq1UjFEPTNHrbofqQFkfd0zGXHkP4zPm2wuKoTShrrFlBFmAum2x7FyGfqYAq8lcHrMw==",
+      "version": "3.1.0-next-2024-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.1.0-next-2024-01-09.1.tgz",
+      "integrity": "sha512-B2rDBaj10rN0baMt2c252Se+uAtRQd+Jd96ZtySoa5CGRweYs7EsfDk2I9cUSip/wSkFbxk3plxcrb4OKac+BA==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.0-next-2023-12-20.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2023-12-20.1.tgz",
-      "integrity": "sha512-gs/A2jUOcxax+EbbfIrNLPDFpYgh8iK/BSlRoTpxdtsAFGWNNOaqugDUG3kyeomxtfxiKaFlfwJtlRCCc8Ks6A==",
+      "version": "1.0.0-next-2024-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2024-01-09.1.tgz",
+      "integrity": "sha512-SkgaVjRmDH3qghsP4tHYFQvXw+7lVPv9ipM0axFGqgYQuGv83YpDdkL8MhvozGUWFXycQXzlkOf1ZeKmVpY7OQ==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7126,17 +7126,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "2.1.0-next-2023-12-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.0-next-2023-12-20.tgz",
-      "integrity": "sha512-FEIBD2jsZHOljmCRiPav21Up1G9xc/+bMCugQEVyVWFrJmh7mMlkGfwxpCdAk9nsU8rIFWKsxhjuFQDK8jGZRg==",
+      "version": "2.1.0-next-2024-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.0-next-2024-01-09.1.tgz",
+      "integrity": "sha512-lbzwBr5nPJVkfBYJ4V9i5a5i6LXfxMrwZjL3KbLM4IdlT2XmxYgEDso94MGdQg0r8wBYKSSuggzpqh5XlIpJCg==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.0.0-next-2023-12-20",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.0.0-next-2023-12-20.tgz",
-      "integrity": "sha512-3ccyeJcA9zm5BxOYduYQNmd2E5p5A+2B1GIJvjOJOy+A5bvhFBT1BtM+uHGeXRA6nUGGEza7iGyn8shLtmp4cQ==",
+      "version": "2.0.0-next-2024-01-09.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.0.0-next-2024-01-09.1.tgz",
+      "integrity": "sha512-3JiSNsxX4WRfJCYbCvHBT/aQjXz9S/DH1Trzfy4YZLTvdMUfAKSxvquX+LBXQb33RPXCQxTcUxzm2sFLjGEUZg==",
       "requires": {}
     },
     "@esbuild/android-arm": {


### PR DESCRIPTION
# Motivation

Bump ic-js next that introduces the patch for iOS 15 ([PR](https://github.com/dfinity/ic-js/pull/513)) which we temporarely solved by rolling back Sveltekit from v2 to v1 ([PR](#4149)).

# Changes

- `npm run upgrade:next`