### PR TITLE
test: Use the new migration test in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,39 @@ jobs:
         run: ./scripts/nns-dapp/downgrade-upgrade-test -w nns-dapp_test.wasm.gz
       - name: Count upgrade cycles
         run: scripts/nns-dapp/estimate-upgrade-cycles | tee -a $GITHUB_STEP_SUMMARY
+  test-upgrade-map:
+    needs: build
+    runs-on: ubuntu-20.04
+    timeout-minutes: 40
+    steps:
+      - name: Checkout nns-dapp
+        uses: actions/checkout@v3
+      - name: Get nns-dapp_test
+        uses: actions/download-artifact@v3
+        with:
+          name: out
+          path: out
+      - name: Install ic-wasm
+        uses: ./.github/actions/install_ic_wasm
+      - name: Install tools
+        run: |
+          sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
+          DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+          cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)" && idl2json --version
+      - name: Start dfx
+        run: dfx start --clean --background &>test-upgrade-map-dfx.log
+      - name: Put assets in the default location
+        run: |
+          ls
+          ls out
+      - name: Upgrade to self, keeping the storage schema as map
+        run: ./scripts/nns-dapp/migration-test --schema1 Map --schema2 Map --accounts 10000
+      - name: Upload dfx logs
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-upgrade-map-dfx.log
+          path: test-upgrade-map-dfx.log
   test-test-account-api:
     needs: build
     runs-on: ubuntu-20.04

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -38,6 +38,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+- Exercise new migration test.
+
 #### Changed
 
 #### Deprecated

--- a/scripts/nns-dapp/migration-test.canister
+++ b/scripts/nns-dapp/migration-test.canister
@@ -16,7 +16,7 @@ migration_test_canisters_help() {
 
 	A list of functions:
 	EOF
-  declare -F | awk '{print "        " $3}' | grep -vw "$FUNCNAME"
+  declare -F | awk '{print "        " $3}' | grep -vw "${FUNCNAME[0]}"
 }
 
 # Verifies that the nns-dapp canister is healthy

--- a/scripts/nns-dapp/migration-test.canister
+++ b/scripts/nns-dapp/migration-test.canister
@@ -75,7 +75,7 @@ check_num_transactions() {
 # Wait for the migration countdown to complete.
 wait_for_migration() {
   local migration_countdown
-  for ((i = 0; i < 120; i++)); do
+  for ((i = 0; i < 1200; i++)); do
     migration_countdown="$(dfx canister call nns-dapp get_stats --query | idl2json | jq '.migration_countdown[0] // 0')" # TODO: Remove the default when prod has migration countdown stats
     echo "Migration countdown: $migration_countdown"
     if ((migration_countdown == 0)); then
@@ -96,14 +96,15 @@ wait_for_migration() {
 # - Creates the canister if it doesn't exist
 # - Installs the canister even if the wasm is the same
 install_nnsdapp() {
-  local wasm argfile
+  local wasm argfile argument
   wasm="$1"
   argfile="$2"
+  argument="$(cat "$argfile")"
   if dfx canister id nns-dapp >/dev/null 2>/dev/null; then
     upgrade_nnsdapp "$wasm" "$argfile"
   else
     dfx canister create nns-dapp
-    dfx canister install nns-dapp --wasm "$wasm" --argument "$(cat "$argfile")" --yes
+    dfx canister install nns-dapp --wasm "$wasm" --argument "$argument" --yes --upgrade-unchanged
     scripts/dfx-canister-check-wasm-hash --wasm "$wasm" --canister nns-dapp
     verify_healthy
   fi
@@ -114,15 +115,15 @@ install_nnsdapp() {
 # TODO: Record upgrade cycles
 # TODO: Record state size
 upgrade_nnsdapp() {
-  local wasm argfile
+  local prestate poststate wasm argfile argument
   wasm="$1"
   argfile="$2"
-  local prestate poststate
+  argument="$(cat "$argfile")"
   prestate="$(get_upgrade_invariants | tee /dev/stderr)"
   # Check that the data is plausible
   # TODO: Check that the prestate is not empty; first we need to populate the state.
   # TODO: Consider storing all accounts data in a merkle tree so that we can check just the root hash.
-  dfx canister install --upgrade-unchanged nns-dapp --wasm "$wasm" --mode upgrade --argument "$(cat "$argfile")" --yes
+  dfx canister install --upgrade-unchanged nns-dapp --wasm "$wasm" --mode upgrade --argument "$argument" --yes
   scripts/dfx-canister-check-wasm-hash --wasm "$wasm" --canister nns-dapp
   verify_healthy
   wait_for_migration

--- a/scripts/nns-dapp/migration-test.canister
+++ b/scripts/nns-dapp/migration-test.canister
@@ -1,6 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Prints help message
+migration_test_canisters_help() {
+  cat <<-EOF
+	A library of methods for getting and manipulating the nns-canister state.
+
+	Usage:
+	- Source this file from your code.
+	- You can also call this file directly.  This may be useful for
+	  ad-hoc runs but is not intended for production use.
+
+	Usage: scripts/nns-dapp/migration-test.canister <function> [arguments..]
+	e.g.:  scripts/nns-dapp/migration-test.canister verify_healthy
+
+	A list of functions:
+	EOF
+  declare -F | awk '{print "        " $3}' | grep -vw "$FUNCNAME"
+}
+
 # Verifies that the nns-dapp canister is healthy
 verify_healthy() {
   dfx canister call nns-dapp get_stats
@@ -205,20 +223,7 @@ assert_schema_is() {
 # This file is intended to be sourced, but if called directly, offer some help
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   if (($# == 0)) || [[ "${1:-}" == "--help" ]]; then
-    cat <<-EOF
-		A library of methods for getting and manipulating the nns-canister state.
-
-		Usage:
-		- Source this file from your code.
-		- You can also call this file directly.  This may be useful for
-		  ad-hoc runs but is not intended for production use.
-
-      Usage: scripts/nns-dapp/migration-test.canister <function> [arguments..]
-      e.g.:  scripts/nns-dapp/migration-test.canister verify_healthy
-
-      A list of functions:
-		EOF
-    declare -F | awk '{print "        " $3}'
+    migration_test_canisters_help
     exit 0
   fi
   "${@}"

--- a/scripts/nns-dapp/migration-test.getters
+++ b/scripts/nns-dapp/migration-test.getters
@@ -16,7 +16,7 @@ migration_test_getters_help() {
 
       A list of functions:
 		EOF
-  declare -F | awk '{print "        " $3}' | grep -vw "$FUNCNAME"
+  declare -F | awk '{print "        " $3}' | grep -vw "${FUNCNAME[0]}"
 }
 
 # Downloads a released asset

--- a/scripts/nns-dapp/migration-test.getters
+++ b/scripts/nns-dapp/migration-test.getters
@@ -1,6 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Prints help
+migration_test_getters_help() {
+  cat <<-EOF
+		A library of methods for getting assets.
+
+		Usage:
+		- Source this file from your code.
+		- You can also call this file directly.  This may be useful for
+		  ad-hoc runs but is not intended for production use.
+
+      Usage: scripts/nns-dapp/migration-test.getters <function> [arguments..]
+      e.g.:  scripts/nns-dapp/migration-test.getters get_wasm prod ./prod.wasm.gz
+
+      A list of functions:
+		EOF
+  declare -F | awk '{print "        " $3}' | grep -vw "$FUNCNAME"
+}
+
 # Downloads a released asset
 # TODO: Unit Test
 download_asset() {
@@ -88,23 +106,10 @@ set_arguments_schema() {
 
 # This file is intended to be sourced, but if called directly, offer some help
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  . "${0%.getters}.linters"
   if (($# == 0)) || [[ "${1:-}" == "--help" ]]; then
-    cat <<-EOF
-		A library of methods for getting assets.
-
-		Usage:
-		- Source this file from your code.
-		- You can also call this file directly.  This may be useful for
-		  ad-hoc runs but is not intended for production use.
-
-      Usage: scripts/nns-dapp/migration-test.getters <function> [arguments..]
-      e.g.:  scripts/nns-dapp/migration-test.getters get_wasm prod ./prod.wasm.gz
-
-      A list of functions:
-		EOF
-    declare -F | awk '{print "        " $3}'
+    migration_test_getters_help
     exit 0
   fi
+  . "${0%.getters}.linters"
   "${@}"
 fi

--- a/scripts/nns-dapp/migration-test.linters
+++ b/scripts/nns-dapp/migration-test.linters
@@ -1,6 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+migration_test_linters_help() {
+  cat <<-EOF
+		A library of methods for linting wasms and argument files.
+
+		Usage:
+		- Source this file from your code.
+		- You can also call this file directly.  This may be useful for
+		  ad-hoc runs but is not intended for production use.
+
+      Usage: scripts/nns-dapp/migration-test.linters <function> [arguments..]
+      e.g.:  scripts/nns-dapp/migration-test.linters lint_release_name 'fox trot'
+             ERROR: Invalid release name
+             Expected: A valid git tag name
+             Actual:   'fox trot'
+
+      A list of functions:
+		EOF
+  declare -F | awk '{print "        " $3}' | grep -vw "$FUNCNAME"
+}
+
 # Checks that the configuration number is valid.
 # TODO: Unit Test
 lint_configuration_num() {
@@ -123,23 +143,7 @@ lint_argfile() {
 # TODO: Unit Test
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   if (($# == 0)) || [[ "${1:-}" == "--help" ]]; then
-    cat <<-EOF
-		A library of methods for linting wasms and argument files.
-
-		Usage:
-		- Source this file from your code.
-		- You can also call this file directly.  This may be useful for
-		  ad-hoc runs but is not intended for production use.
-
-      Usage: scripts/nns-dapp/migration-test.linters <function> [arguments..]
-      e.g.:  scripts/nns-dapp/migration-test.linters lint_release_name 'fox trot'
-             ERROR: Invalid release name
-             Expected: A valid git tag name
-             Actual:   'fox trot'
-
-      A list of functions:
-		EOF
-    declare -F | awk '{print "        " $3}'
+    migration_test_linters_help
     exit 0
   fi
   "${@}"

--- a/scripts/nns-dapp/migration-test.linters
+++ b/scripts/nns-dapp/migration-test.linters
@@ -18,7 +18,7 @@ migration_test_linters_help() {
 
       A list of functions:
 		EOF
-  declare -F | awk '{print "        " $3}' | grep -vw "$FUNCNAME"
+  declare -F | awk '{print "        " $3}' | grep -vw "${FUNCNAME[0]}"
 }
 
 # Checks that the configuration number is valid.


### PR DESCRIPTION
# Motivation
The migration to stable memory needs a more tests than our downgrade-upgrade tests provide.  In previous PR,  a copy of the downgrade-upgrade test was made and refactored to allow it to test any migration rather than just to prod and back.  This test was used locally during stable memory development but not (yet) exercised in CI.  Let's test the simplest case first - just upgrade to self - to gain confidence that the test works as expected.

Note: This does NOT yet replace the downgrade-upgrade test.  Given  that there have been many changes to the test it would be nice to know that it works reliably in the simplest setting possible before using it for more complicated cases.

# Changes
- Exercise the new migration test, just for a simple upgrade-to-self with classic stable-memory-on-heap storage.

# Tests
- See CI

# Todos

- [x] Add entry to changelog (if necessary).
