### PR TITLE
GIX-2150: Migrate to TokenAmountV2

### DIFF
--- a/frontend/src/lib/components/accounts/WalletPageHeading.svelte
+++ b/frontend/src/lib/components/accounts/WalletPageHeading.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
-  import {
-    isNullish,
-    nonNullish,
-    type TokenAmount,
-    TokenAmountV2,
-  } from "@dfinity/utils";
+  import { isNullish, nonNullish, type TokenAmountV2 } from "@dfinity/utils";
   import PageHeading from "../common/PageHeading.svelte";
   import { SkeletonText } from "@dfinity/gix-components";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
@@ -19,7 +14,7 @@
   import Tooltip from "../ui/Tooltip.svelte";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
 
-  export let balance: TokenAmount | TokenAmountV2 | undefined = undefined;
+  export let balance: TokenAmountV2 | undefined = undefined;
   export let accountName: string;
   export let principal: Principal | undefined = undefined;
 

--- a/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TokenAmount, ICPToken, TokenAmountV2 } from "@dfinity/utils";
+  import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
   import {
     getDeniedCountries,
     getMaxNeuronsFundParticipation,
@@ -53,7 +53,7 @@
     token,
   });
 
-  let snsTotalTokenSupply: TokenAmount | undefined | null;
+  let snsTotalTokenSupply: TokenAmountV2 | undefined | null;
   $: snsTotalTokenSupply = $projectDetailStore.totalTokensSupply;
 
   let deniedCountryCodes: CountryCode[];

--- a/frontend/src/lib/derived/sns/sns-total-supply-token-amount.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-total-supply-token-amount.derived.ts
@@ -4,12 +4,12 @@ import {
 } from "$lib/stores/sns-total-token-supply.store";
 import { snsSummariesStore } from "$lib/stores/sns.store";
 import type { RootCanisterIdText, SnsSummary } from "$lib/types/sns";
-import { nonNullish, TokenAmount } from "@dfinity/utils";
+import { nonNullish, TokenAmountV2 } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 
 export const snsTotalSupplyTokenAmountStore = derived<
   [Readable<SnsTotalTokenSupplyStoreData>, Readable<SnsSummary[]>],
-  Record<RootCanisterIdText, TokenAmount>
+  Record<RootCanisterIdText, TokenAmountV2>
 >(
   [snsTotalTokenSupplyStore, snsSummariesStore],
   ([$snsTotalTokenSupplyStore, $snsSummariesStore]) => {
@@ -20,7 +20,7 @@ export const snsTotalSupplyTokenAmountStore = derived<
 
         return nonNullish(totalTokenSupplyStoreEntry?.totalSupply)
           ? {
-              totalSupply: TokenAmount.fromE8s({
+              totalSupply: TokenAmountV2.fromUlps({
                 amount: totalTokenSupplyStoreEntry?.totalSupply,
                 token,
               }),
@@ -28,7 +28,7 @@ export const snsTotalSupplyTokenAmountStore = derived<
             }
           : undefined;
       })
-      .reduce<Record<string, TokenAmount>>((acc, data) => {
+      .reduce<Record<string, TokenAmountV2>>((acc, data) => {
         if (nonNullish(data)) {
           const { totalSupply, rootCanisterId } = data;
           acc[rootCanisterId.toText()] = totalSupply;

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -38,7 +38,12 @@
   import { pageStore } from "$lib/derived/page.derived";
   import Separator from "$lib/components/ui/Separator.svelte";
   import WalletModals from "$lib/modals/accounts/WalletModals.svelte";
-  import { ICPToken, TokenAmount, isNullish, nonNullish } from "@dfinity/utils";
+  import {
+    ICPToken,
+    TokenAmountV2,
+    isNullish,
+    nonNullish,
+  } from "@dfinity/utils";
   import ReceiveButton from "$lib/components/accounts/ReceiveButton.svelte";
   import type { AccountIdentifierText } from "$lib/types/account";
   import WalletPageHeader from "$lib/components/accounts/WalletPageHeader.svelte";
@@ -190,7 +195,7 @@
             walletAddress={$selectedAccountStore.account.identifier}
           />
           <WalletPageHeading
-            balance={TokenAmount.fromE8s({
+            balance={TokenAmountV2.fromUlps({
               amount: $selectedAccountStore.account.balanceUlps,
               token: ICPToken,
             })}

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -26,7 +26,7 @@
     snsOnlyProjectStore,
     snsProjectSelectedStore,
   } from "$lib/derived/sns/sns-selected-project.derived";
-  import { TokenAmount, isNullish, nonNullish } from "@dfinity/utils";
+  import { TokenAmountV2, isNullish, nonNullish } from "@dfinity/utils";
   import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
   import { loadSnsAccountTransactions } from "$lib/services/sns-transactions.services";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -161,7 +161,7 @@
             walletAddress={$selectedAccountStore.account.identifier}
           />
           <WalletPageHeading
-            balance={TokenAmount.fromE8s({
+            balance={TokenAmountV2.fromUlps({
               amount: $selectedAccountStore.account.balanceUlps,
               token,
             })}

--- a/frontend/src/lib/types/project-detail.context.ts
+++ b/frontend/src/lib/types/project-detail.context.ts
@@ -1,4 +1,4 @@
-import type { TokenAmount } from "@dfinity/utils";
+import type { TokenAmountV2 } from "@dfinity/utils";
 import type { Writable } from "svelte/store";
 import type { SnsSummary, SnsSwapCommitment } from "./sns";
 
@@ -11,7 +11,7 @@ import type { SnsSummary, SnsSwapCommitment } from "./sns";
 export type ProjectDetailStore = {
   summary: SnsSummary | undefined | null;
   swapCommitment: SnsSwapCommitment | undefined | null;
-  totalTokensSupply?: TokenAmount | undefined | null;
+  totalTokensSupply?: TokenAmountV2 | undefined | null;
 };
 
 export interface ProjectDetailContext {

--- a/frontend/src/tests/lib/components/accounts/WalletPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/WalletPageHeading.spec.ts
@@ -5,22 +5,22 @@ import en from "$tests/mocks/i18n.mock";
 import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { Principal } from "@dfinity/principal";
-import { ICPToken, TokenAmount } from "@dfinity/utils";
+import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("WalletPageHeading", () => {
-  const balance = TokenAmount.fromString({
+  const balance = TokenAmountV2.fromString({
     amount: "1",
     token: ICPToken,
-  }) as TokenAmount;
+  }) as TokenAmountV2;
   const accountName = "Account Name";
   const renderComponent = ({
     balance,
     accountName,
     principal,
   }: {
-    balance?: TokenAmount;
+    balance?: TokenAmountV2;
     accountName: string;
     principal?: Principal;
   }) => {
@@ -35,10 +35,10 @@ describe("WalletPageHeading", () => {
   };
 
   it("should render balance as title and no skeleton", async () => {
-    const balance = TokenAmount.fromString({
+    const balance = TokenAmountV2.fromString({
       amount: "3.14159265",
       token: ICPToken,
-    }) as TokenAmount;
+    }) as TokenAmountV2;
     const po = renderComponent({ balance, accountName });
 
     expect(await po.getTitle()).toBe("3.14 ICP");
@@ -46,10 +46,10 @@ describe("WalletPageHeading", () => {
   });
 
   it("should render tooltip with detailed balance", async () => {
-    const balance = TokenAmount.fromString({
+    const balance = TokenAmountV2.fromString({
       amount: "3.14159265",
       token: ICPToken,
-    }) as TokenAmount;
+    }) as TokenAmountV2;
     const po = renderComponent({ balance, accountName });
 
     expect(await po.getTooltipText()).toBe("Current balance: 3.14159265 ICP");
@@ -90,7 +90,7 @@ describe("WalletPageHeading", () => {
     accountName,
   }: {
     intersecting: boolean;
-    balance: TokenAmount;
+    balance: TokenAmountV2;
     accountName: string;
     expectedHeader: string;
   }) => {

--- a/frontend/src/tests/lib/derived/sns/sns-total-supply-token-amount.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-total-supply-token-amount.derived.spec.ts
@@ -3,7 +3,7 @@ import { snsTotalTokenSupplyStore } from "$lib/stores/sns-total-token-supply.sto
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
-import { TokenAmount } from "@dfinity/utils";
+import { TokenAmountV2 } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("snsTotalSupplyTokenAmountStore", () => {
@@ -32,8 +32,8 @@ describe("snsTotalSupplyTokenAmountStore", () => {
 
     for (let i = 0; i < rootCanisterIds.length; i++) {
       const oneTotalSupply = store[rootCanisterIds[i].toText()];
-      expect(oneTotalSupply).toBeInstanceOf(TokenAmount);
-      expect(oneTotalSupply.toE8s()).toEqual(totalSupplies[i].totalSupply);
+      expect(oneTotalSupply).toBeInstanceOf(TokenAmountV2);
+      expect(oneTotalSupply.toUlps()).toEqual(totalSupplies[i].totalSupply);
     }
   });
 });

--- a/frontend/src/tests/mocks/sns.mock.ts
+++ b/frontend/src/tests/mocks/sns.mock.ts
@@ -8,7 +8,7 @@ import { nowInSeconds } from "$lib/utils/date.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
 import ContextWrapperTest from "$tests/lib/components/ContextWrapperTest.svelte";
 import type { Principal } from "@dfinity/principal";
-import type { TokenAmount } from "@dfinity/utils";
+import type { TokenAmountV2 } from "@dfinity/utils";
 import { toNullable } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
@@ -46,7 +46,7 @@ export const renderContextCmp = ({
 }: {
   summary?: SnsSummary;
   swapCommitment?: SnsSwapCommitment;
-  totalTokensSupply?: TokenAmount;
+  totalTokensSupply?: TokenAmountV2;
   Component: typeof SvelteComponent;
   reload?: () => void;
 }) =>


### PR DESCRIPTION
# Motivation

Migrate from TokenAmount to TokenAmountV2 which supports different decimals.

In this PR, change the Wallet and Swap components.

# Changes

* WalletPageHeading only supports TokenAmountV2.
* Migrate `snsTotalTokenSupply` to TokenAmountV2.
* Migrate `snsTotalSupplyTokenAmountStore` to TokenAmountV2.
* NnsWallet uses TokenAmountV2 for WalletPageHeading.
* SnsWallet uses TokenAmountV2 for WalletPageHeading.

# Tests

* Change spec file of WalletPageHeading to use TokenAmountV2.
* Fix test for snsTotalSupplyTokenAmountStore after migration.
* Change type of `totalTokensSupply` in `renderContextCmp`.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
