### PR TITLE
GIX-1984: Redirect from /accounts to /tokens accordingly

### DIFF
--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -35,8 +35,17 @@
   import IcrcTokenAccountsFooter from "$lib/components/accounts/IcrcTokenAccountsFooter.svelte";
   import IcrcTokenAccountsModals from "$lib/modals/accounts/IcrcTokenAccountsModals.svelte";
   import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
+  import { goto } from "$app/navigation";
+  import { AppPath } from "$lib/constants/routes.constants";
 
   // TODO: This component is mounted twice. Understand why and fix it.
+
+  $: {
+    // When using the new Tokens table, the Accounts page is enabled only for NNS.
+    if ($ENABLE_MY_TOKENS && !$isNnsUniverseStore) {
+      goto(AppPath.Tokens, { replaceState: true });
+    }
+  }
 
   // Selected project ID on mount is excluded from load accounts balances. See documentation.
   let selectedUniverseId = $selectedUniverseIdStore;

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -868,9 +868,11 @@ describe("Accounts", () => {
       },
     });
 
+    expect(get(pageStore)?.path).toEqual(AppPath.Accounts);
+
     render(Accounts);
 
-    await waitFor(() => expect(get(pageStore)?.path).toEqual(AppPath.Tokens));
+    expect(get(pageStore)?.path).toEqual(AppPath.Tokens);
   });
 
   it("should not redirect to Tokens page when tokens page is not enabled and universe is not NNS", async () => {
@@ -883,18 +885,11 @@ describe("Accounts", () => {
       },
     });
 
+    expect(get(pageStore)?.path).toEqual(AppPath.Accounts);
+
     render(Accounts);
 
-    // We wait for the `waitFor` to throw an error when waiting for the page to change.
-    // This is to keep the test similar to the previous one when we waited for the page to change.
-    await waitFor(() => {
-      const call = async () => {
-        await waitFor(() =>
-          expect(get(pageStore)?.path).toEqual(AppPath.Tokens)
-        );
-      };
-      expect(call).rejects.toThrowError();
-    });
+    expect(get(pageStore)?.path).toEqual(AppPath.Accounts);
   });
 
   it("should not redirect to Tokens page when tokens page is enabled and universe is NNS", async () => {
@@ -907,17 +902,10 @@ describe("Accounts", () => {
       },
     });
 
+    expect(get(pageStore)?.path).toEqual(AppPath.Accounts);
+
     render(Accounts);
 
-    // We wait for the `waitFor` to throw an error when waiting for the page to change.
-    // This is to keep the test similar to the previous one when we waited for the page to change.
-    await waitFor(() => {
-      const call = async () => {
-        await waitFor(() =>
-          expect(get(pageStore)?.path).toEqual(AppPath.Tokens)
-        );
-      };
-      expect(call).rejects.toThrowError();
-    });
+    expect(get(pageStore)?.path).toEqual(AppPath.Accounts);
   });
 });

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -896,4 +896,28 @@ describe("Accounts", () => {
       expect(call).rejects.toThrowError();
     });
   });
+
+  it("should not redirect to Tokens page when tokens page is enabled and universe is NNS", async () => {
+    overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
+
+    page.mock({
+      data: {
+        universe: OWN_CANISTER_ID_TEXT,
+        routeId: AppPath.Accounts,
+      },
+    });
+
+    render(Accounts);
+
+    // We wait for the `waitFor` to throw an error when waiting for the page to change.
+    // This is to keep the test similar to the previous one when we waited for the page to change.
+    await waitFor(() => {
+      const call = async () => {
+        await waitFor(() =>
+          expect(get(pageStore)?.path).toEqual(AppPath.Tokens)
+        );
+      };
+      expect(call).rejects.toThrowError();
+    });
+  });
 });


### PR DESCRIPTION
# Motivation

When the new tokens page is enabled, the `/accounts` page is only accessible for NNS universe.

# Changes

* Redirect to `/tokens` from `/accounts` if the universe is not NNS.

# Tests

* Add tests for the redirection logic.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necesary.
