### PR TITLE
GIX-2176: Fix tabindex Tokens footer buttons

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -2,7 +2,7 @@
   import { i18n } from "$lib/stores/i18n";
   import type { UserToken } from "$lib/types/tokens-page";
   import { nonNullish } from "@dfinity/utils";
-  import Row from "./TokensTableRow.svelte";
+  import TokensTableRow from "./TokensTableRow.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let userTokensData: Array<UserToken>;
@@ -22,9 +22,9 @@
     </div>
   </div>
   <div role="rowgroup">
-    {#each userTokensData as userTokenData, index}
+    {#each userTokensData as userTokenData}
       <div class="row-wrapper">
-        <Row on:nnsAction {userTokenData} {index} />
+        <TokensTableRow on:nnsAction {userTokenData} />
       </div>
     {/each}
   </div>

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
@@ -22,7 +22,6 @@
   import { isUserTokenData } from "$lib/utils/user-token.utils";
 
   export let userTokenData: UserTokenData | UserTokenLoading;
-  export let index: number;
 
   const dispatcher = createEventDispatcher();
 
@@ -53,7 +52,7 @@
   this={nonNullish(userTokenData.rowHref) ? "a" : "div"}
   href={userTokenData.rowHref}
   role="row"
-  tabindex={index + 1}
+  tabindex="0"
   on:keypress={handleClick}
   on:click={handleClick}
   data-tid="tokens-table-row-component"

--- a/frontend/src/lib/components/tokens/TokensTable/actions/ReceiveButton.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/actions/ReceiveButton.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <button
-  class="icon"
+  class="icon-only"
   data-tid="receive-button-component"
   on:click|preventDefault|stopPropagation={() => {
     dispatcher("nnsAction", { type: ActionType.Receive, data: userToken });

--- a/frontend/src/lib/components/tokens/TokensTable/actions/SendButton.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/actions/SendButton.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <button
-  class="icon"
+  class="icon-only"
   data-tid="send-button-component"
   on:click|stopPropagation|preventDefault={() => {
     dispatcher("nnsAction", { type: ActionType.Send, data: userToken });

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -99,9 +99,10 @@
         on:keypress={openAddAccountModal}
         role="button"
         aria-label={$i18n.accounts.add_account}
-        tabindex={userTokensData.length + 1}
+        tabindex="0"
       >
-        <button class="ghost with-icon"
+        <!-- Skip tabindex the button because it's already in the row -->
+        <button tabindex="-1" class="ghost with-icon"
           ><IconAdd />{$i18n.accounts.add_account}</button
         >
       </div>

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -87,7 +87,7 @@ describe("NnsAccounts", () => {
       ]);
     });
 
-    it("should render add account row with tabindex 1 more than number of accounts", async () => {
+    it("should render add account row with tabindex 0", async () => {
       const mainTokenData = createUserToken({
         title: "Main",
         balance: TokenAmount.fromE8s({
@@ -103,8 +103,7 @@ describe("NnsAccounts", () => {
         }),
       });
       const po = renderComponent([mainTokenData, subaccountTokenData]);
-      // There are two accounts before the add account row
-      expect(await po.getAddAccountRowTabindex()).toBe("3");
+      expect(await po.getAddAccountRowTabindex()).toBe("0");
     });
   });
 


### PR DESCRIPTION
# Motivation

User couldn't access the buttons in the footer with the keyboard.

Fix, use tabindex="0" instead of incrementing them.

There is an issue that the buttons are not highlighted nicely when focused. I raised the issue with @meodai who is now working on colors.

# Changes

* Set tabindex of the TokensTableRow to `"0"`.
* Remove the prop index from the TokensTableRow.
* Typo in the class `"icon"` of the button. It should have been `"icon-only"`. This way they come with the proper focus (and buggy) style.
* Set the last row's tabindex of the NNS Tokens Table to `"0"` as well and to `"-1"` for the button to avoid going there and moving directly to the footer.

# Tests

* This logic was not tested and now it's a fixed attribute. Therefore, no extra tests are needed.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.

