### PR TITLE
Balance placeholder instead of skeleton in wallet page

### DIFF
--- a/frontend/src/lib/components/accounts/WalletPageHeading.svelte
+++ b/frontend/src/lib/components/accounts/WalletPageHeading.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { isNullish, nonNullish, type TokenAmountV2 } from "@dfinity/utils";
   import PageHeading from "../common/PageHeading.svelte";
-  import { SkeletonText } from "@dfinity/gix-components";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
   import HeadingSubtitle from "../common/HeadingSubtitle.svelte";
   import type { Principal } from "@dfinity/principal";
@@ -57,9 +56,7 @@
         <AmountDisplay amount={balance} size="huge" singleLine />
       </Tooltip>
     {:else}
-      <div data-tid="skeleton" class="skeleton">
-        <SkeletonText tagName="h1" />
-      </div>
+      <h1 data-tid="balance-placeholder">-/-</h1>
     {/if}
   </svelte:fragment>
   <div
@@ -94,12 +91,5 @@
     & p {
       margin: 0;
     }
-  }
-
-  .skeleton {
-    // This is a width for the skeleton that looks good on desktop and mobile.
-    // Based on $breakpoint-xsmall: 320px;
-    width: 320px;
-    max-width: calc(100% - var(--padding-2x));
   }
 </style>

--- a/frontend/src/tests/lib/components/accounts/WalletPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/WalletPageHeading.spec.ts
@@ -42,7 +42,7 @@ describe("WalletPageHeading", () => {
     const po = renderComponent({ balance, accountName });
 
     expect(await po.getTitle()).toBe("3.14 ICP");
-    expect(await po.hasSkeleton()).toBe(false);
+    expect(await po.hasBalancePlaceholder()).toBe(false);
   });
 
   it("should render tooltip with detailed balance", async () => {
@@ -53,16 +53,16 @@ describe("WalletPageHeading", () => {
     const po = renderComponent({ balance, accountName });
 
     expect(await po.getTooltipText()).toBe("Current balance: 3.14159265 ICP");
-    expect(await po.hasSkeleton()).toBe(false);
+    expect(await po.hasBalancePlaceholder()).toBe(false);
   });
 
-  it("should render skeleton if no balance", async () => {
+  it("should render balance placeholder if no balance", async () => {
     const po = renderComponent({
       balance: undefined,
       accountName: accountName,
     });
 
-    expect(await po.hasSkeleton()).toBe(true);
+    expect(await po.hasBalancePlaceholder()).toBe(true);
   });
 
   it("should render name as subtitle", async () => {

--- a/frontend/src/tests/page-objects/WalletPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/WalletPageHeading.page-object.ts
@@ -12,7 +12,7 @@ export class WalletPageHeadingPo extends BasePageObject {
   }
 
   async getTitle(): Promise<string | null> {
-    if (await this.hasSkeleton()) {
+    if (await this.hasBalancePlaceholder()) {
       return null;
     }
     return AmountDisplayPo.under(this.root).getText();
@@ -22,8 +22,8 @@ export class WalletPageHeadingPo extends BasePageObject {
     return TooltipPo.under(this.root).getText();
   }
 
-  hasSkeleton(): Promise<boolean> {
-    return this.isPresent("skeleton");
+  hasBalancePlaceholder(): Promise<boolean> {
+    return this.isPresent("balance-placeholder");
   }
 
   getSubtitle(): Promise<string> {


### PR DESCRIPTION
# Motivation

We want to be able to render a wallet page (with placeholders) to a user who's not signed in.
Currently if you don't pass a balance to `WalletPageHeading` it renders a skeleton.
But the code currently never renders a `WalletPageHeading` when no balance is available.
When we show a wallet page while the user is not signed in, we want to render `-/-` as a wallet place holder.

# Changes

Remove the code to render a skeleton balance and replace it with rendering `-/-` when no balance is passed to `WalletPageHeading`.

This is not yet user visible because it's not yet possible to visit a wallet page without being signed in.

# Tests

Unit test is updated.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet