### PR TITLE
chore: remove redundant imports

### DIFF
--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerActionsEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerActionsEntry.spec.ts
@@ -11,7 +11,6 @@ import { ProposalProposerActionsEntryPo } from "$tests/page-objects/ProposalProp
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import type { Action, Proposal } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
-import { beforeEach } from "vitest";
 
 const proposalWithMotionAction = {
   ...mockProposalInfo.proposal,

--- a/frontend/src/tests/lib/components/proposal-detail/VotesResults.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotesResults.spec.ts
@@ -9,7 +9,6 @@ import en from "$tests/mocks/i18n.mock";
 import { VotesResultPo } from "$tests/page-objects/VotesResults.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
-import { describe } from "vitest";
 
 const now = nowInSeconds();
 

--- a/frontend/src/tests/lib/stores/writable-stored.spec.ts
+++ b/frontend/src/tests/lib/stores/writable-stored.spec.ts
@@ -1,7 +1,6 @@
 import { StoreLocalStorageKey } from "$lib/constants/stores.constants";
 import { writableStored } from "$lib/stores/writable-stored";
 import { get } from "svelte/store";
-import { describe } from "vitest";
 
 describe("writableStored", () => {
   afterEach(() => {


### PR DESCRIPTION
# Motivation

Remove redundant imports in tests.

# Changes

- remove `beforeEach`
- remove `describe`

# Tests

pass

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary