### PR TITLE
style: replace missing purple with orchid colour

### DIFF
--- a/frontend/src/lib/components/proposal-detail/VotesResults.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotesResults.svelte
@@ -321,7 +321,7 @@
     border-radius: 50%;
 
     &.immediate-majority {
-      background: var(--purple-600);
+      background: var(--orchid);
     }
     &.standard-majority {
       background: var(--orange);
@@ -412,7 +412,7 @@
     border-radius: 50%;
   }
   :global(.votes-results-legends .inline-maturity-icon.immediate-majority) {
-    background: var(--purple-600);
+    background: var(--orchid);
   }
   :global(.votes-results-legends .inline-maturity-icon.standard-majority) {
     background: var(--orange);


### PR DESCRIPTION
# Motivation

Replace the missing after the redesign `--purple-600` colour w/ the closest `--orchid`. No additional missing CSS variables were found.

# Changes

- css

# Tests

No code changes

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

# Screenshots

| Before | After |
|--------|--------|
| <img width="387" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/0671fd03-5819-4e6e-bbe8-6791f0acdb37"> | <img width="388" alt="Screenshot 2024-01-11 at 10 50 55" src="https://github.com/dfinity/nns-dapp/assets/98811342/3ec97c60-a1fa-4899-a9d4-d3282ac5bff3"> | 
| | <img width="390" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/8754a495-f061-44d8-ac2a-76bfd100e2bc"> |



