### PR TITLE
GIX-2063: Redirect after login tokens page

### DIFF
--- a/frontend/src/lib/components/common/SignIn.svelte
+++ b/frontend/src/lib/components/common/SignIn.svelte
@@ -9,7 +9,12 @@
   $: disabled = $authSignedInStore || !$layoutAuthReady;
 </script>
 
-<button on:click={login} data-tid="login-button" class="primary" {disabled}>
+<button
+  on:click={() => login()}
+  data-tid="login-button"
+  class="primary"
+  {disabled}
+>
   <slot>{$i18n.auth.login}</slot>
   {#if disabled}
     <div class="spinner">

--- a/frontend/src/lib/components/common/SignIn.svelte
+++ b/frontend/src/lib/components/common/SignIn.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <button
-  on:click={() => login()}
+  on:click={(_) => login()}
   data-tid="login-button"
   class="primary"
   {disabled}

--- a/frontend/src/lib/components/header/LoginIconOnly.svelte
+++ b/frontend/src/lib/components/header/LoginIconOnly.svelte
@@ -8,7 +8,7 @@
 <button
   data-tid="toolbar-login"
   class="icon-only toggle"
-  on:click={login}
+  on:click={() => login()}
   aria-label={$i18n.auth.login}
   disabled={!$layoutAuthReady}
 >

--- a/frontend/src/lib/components/header/LoginIconOnly.svelte
+++ b/frontend/src/lib/components/header/LoginIconOnly.svelte
@@ -8,7 +8,7 @@
 <button
   data-tid="toolbar-login"
   class="icon-only toggle"
-  on:click={() => login()}
+  on:click={(_) => login()}
   aria-label={$i18n.auth.login}
   disabled={!$layoutAuthReady}
 >

--- a/frontend/src/lib/services/auth.services.ts
+++ b/frontend/src/lib/services/auth.services.ts
@@ -11,7 +11,9 @@ import { get } from "svelte/store";
 const msgParam = "msg";
 const levelParam = "level";
 
-export const login = async () => {
+export const login = async (
+  redirectionBuilder?: (identity: Identity) => string
+) => {
   const onError = (err: unknown) => {
     if (err === "UserInterrupt") {
       // We do not display an error if user explicitly cancelled the process of sign-in. User is most certainly aware of it.
@@ -24,7 +26,7 @@ export const login = async () => {
     });
   };
 
-  await authStore.signIn(onError);
+  await authStore.signIn({ onError, redirectionBuilder });
 };
 
 export const logout = async ({

--- a/frontend/src/lib/stores/auth.store.ts
+++ b/frontend/src/lib/stores/auth.store.ts
@@ -99,7 +99,6 @@ const initAuthStore = (): AuthStore => {
         }),
         maxTimeToLive: AUTH_SESSION_DURATION,
         onSuccess: () => {
-          // Ideally II would redirect to the desired path but, it does not support it yet.
           if (nonNullish(redirectionBuilder) && nonNullish(authClient)) {
             goto(redirectionBuilder(authClient?.getIdentity()));
           }

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -44,6 +44,12 @@
   import { universesAccountsStore } from "$lib/derived/universes-accounts.derived";
   import type { Account } from "$lib/types/account";
   import IcrcReceiveModal from "$lib/modals/accounts/IcrcReceiveModal.svelte";
+  import {
+    buildAccountsUrl,
+    buildWalletUrl,
+  } from "$lib/utils/navigation.utils";
+  import type { Identity } from "@dfinity/agent";
+  import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
 
   onMount(() => {
     if (!$ENABLE_MY_TOKENS) {
@@ -180,7 +186,18 @@
   const handleAction = ({ detail }: { detail: Action }) => {
     // Any action from non-signed in user should be trigger a login
     if (!$authSignedInStore) {
-      login();
+      if (isUniverseNns(detail.data.universeId)) {
+        login(() =>
+          buildAccountsUrl({ universe: detail.data.universeId.toText() })
+        );
+      } else {
+        login((identity: Identity) =>
+          buildWalletUrl({
+            universe: detail.data.universeId.toText(),
+            account: encodeIcrcAccount({ owner: identity.getPrincipal() }),
+          })
+        );
+      }
     }
     if (detail.type === ActionType.Send) {
       if (isUniverseNns(detail.data.universeId)) {

--- a/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -74,6 +74,20 @@ describe("auth-services", () => {
       expect(spy).toHaveBeenCalled();
     });
 
+    it("login should call redirectionBuilder with identity on success", async () => {
+      vi.spyOn(mockAuthClient, "login").mockImplementation(
+        async ({ onSuccess }: { onSuccess: () => Promise<void> }) => {
+          onSuccess();
+        }
+      );
+      mockAuthClient.getIdentity.mockReturnValue(mockIdentity);
+
+      const redirectionBuilder = vi.fn();
+      await login(redirectionBuilder);
+
+      expect(redirectionBuilder).toHaveBeenCalledWith(mockIdentity);
+    });
+
     it("should not toast error on auth-client error UserInterrupt", async () => {
       vi.spyOn(mockAuthClient, "login").mockImplementation(
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/frontend/src/tests/lib/stores/auth.store.spec.ts
+++ b/frontend/src/tests/lib/stores/auth.store.spec.ts
@@ -4,6 +4,7 @@ import {
   OLD_MAINNET_IDENTITY_SERVICE_URL,
 } from "$lib/constants/identity.constants";
 import { authStore } from "$lib/stores/auth.store";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { AuthClient } from "@dfinity/auth-client";
 import { mock } from "vitest-mock-extended";
 
@@ -34,9 +35,31 @@ describe("auth-store", () => {
       onSuccess();
     };
 
-    await authStore.signIn(() => {
-      // do nothing on error here
+    await authStore.signIn({
+      onError: () => {
+        // do nothing on error here
+      },
     });
+  });
+
+  it("should call auth-client login's redirectionBuilder if present on sign-in", async () => {
+    const redirectionBuilder = vi.fn();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore: test file
+    mockAuthClient.login = async ({ onSuccess }: { onSuccess: () => void }) => {
+      onSuccess();
+    };
+    mockAuthClient.getIdentity.mockReturnValue(mockIdentity);
+
+    await authStore.signIn({
+      onError: () => {
+        // do nothing on error here
+      },
+      redirectionBuilder,
+    });
+
+    expect(redirectionBuilder).toHaveBeenCalledTimes(1);
+    expect(redirectionBuilder).toHaveBeenCalledWith(mockIdentity);
   });
 
   it("should call auth-client with identity provider", async () => {
@@ -59,8 +82,10 @@ describe("auth-store", () => {
       onSuccess();
     };
 
-    await authStore.signIn(() => {
-      // do nothing on error here
+    await authStore.signIn({
+      onError: () => {
+        // do nothing on error here
+      },
     });
     window.location.host = host;
   });
@@ -85,8 +110,10 @@ describe("auth-store", () => {
       onSuccess();
     };
 
-    await authStore.signIn(() => {
-      // do nothing on error here
+    await authStore.signIn({
+      onError: () => {
+        // do nothing on error here
+      },
     });
     window.location.host = host;
   });
@@ -111,8 +138,10 @@ describe("auth-store", () => {
       onSuccess();
     };
 
-    await authStore.signIn(() => {
-      // do nothing on error here
+    await authStore.signIn({
+      onError: () => {
+        // do nothing on error here
+      },
     });
     window.location.host = host;
   });


### PR DESCRIPTION
# Motivation

User is redirected after logging in using the rows of the tokens table according to the row they clicked.

# Changes

* Add optional parameter `redirectionBuilder` to `signIn` method on auth store and use it on success if present.
* Add optional parameter `redirectionBuilder` to `login` auth service.
* Pass a `redirectionBuilder` from Tokens route when user clicks row and is not authenticated.

# Tests

* Add tests for the new parameter in authStore.
* Add tests for the new parameter in auth service.
* Add tests for the new functionality in tokens route.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
