### PR TITLE
Forward --domain flag from dfx-snapshot-start to dfx

### DIFF
--- a/scripts/dfx-snapshot-start
+++ b/scripts/dfx-snapshot-start
@@ -23,6 +23,7 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=s long=snapshot desc="The snapshot .zip or .tar.xz file" variable=SNAPSHOT_ARCHIVE default="snapshot.tar.xz"
 clap.define short=c long=clean desc="Extract a clean state from the .zip file, even if a directory with extracted state exists" variable=CLEAN nargs=0 default="false"
 clap.define long=host desc="Passed to dfx start as --host" variable=DFX_HOST
+clap.define long=domain desc="Passed to dfx start as --domain" variable=DFX_DOMAIN
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -64,8 +65,13 @@ echo "*  starting the replica may just hang after a panic.                *"
 echo "*                                                                   *"
 echo "*********************************************************************"
 
+DFX_ARGS=()
+
 if [ "${DFX_HOST:-}" ]; then
-  DFX_ARGS=("--host" "$DFX_HOST")
+  DFX_ARGS+=("--host" "$DFX_HOST")
+fi
+if [ "${DFX_DOMAIN:-}" ]; then
+  DFX_ARGS+=("--domain" "$DFX_DOMAIN")
 fi
 dfx start "${DFX_ARGS[@]}"
 


### PR DESCRIPTION
# Motivation

We want to serve dfx snapshots from DevEnv for manual testing.
Since dfx 0.15.3 this requires passing a `--domain` flag.

# Changes

Forward the `--domain` flag from `dfx-snapshot-start` to `dfx`.

# Tests

Tested manually on my DevEnv.

# Todos

- [x] Add entry to changelog (if necessary).
