### PR TITLE
GIX-2150: Remove usage of TokenAmount in api layer

### DIFF
--- a/frontend/src/lib/api/canisters.api.ts
+++ b/frontend/src/lib/api/canisters.api.ts
@@ -28,7 +28,6 @@ import type { Identity } from "@dfinity/agent";
 import { CMCCanister, ProcessingError, type Cycles } from "@dfinity/cmc";
 import { AccountIdentifier, SubAccount } from "@dfinity/ledger-icp";
 import type { Principal } from "@dfinity/principal";
-import type { TokenAmount } from "@dfinity/utils";
 import { nonNullish, principalToSubAccount } from "@dfinity/utils";
 import { sendICP } from "./icp-ledger.api";
 import { nnsDappCanister } from "./nns-dapp.api";
@@ -212,7 +211,7 @@ export const createCanister = async ({
   fromSubAccount,
 }: {
   identity: Identity;
-  amount: TokenAmount;
+  amount: bigint;
   name?: string;
   fromSubAccount?: SubAccountArray;
 }): Promise<Principal> => {
@@ -315,7 +314,7 @@ export const topUpCanister = async ({
 }: {
   identity: Identity;
   canisterId: Principal;
-  amount: TokenAmount;
+  amount: bigint;
   fromSubAccount?: SubAccountArray;
 }): Promise<void> => {
   logWithTimestamp(`Topping up canister ${canisterId.toText()} call...`);

--- a/frontend/src/lib/api/icp-ledger.api.ts
+++ b/frontend/src/lib/api/icp-ledger.api.ts
@@ -33,7 +33,7 @@ export const sendICP = async ({
 }: {
   identity: Identity;
   to: string;
-  amount: TokenAmount;
+  amount: bigint;
   fromSubAccount?: SubAccountArray | undefined;
   memo?: bigint;
   createdAt?: bigint;
@@ -43,7 +43,7 @@ export const sendICP = async ({
 
   const response = await canister.transfer({
     to: AccountIdentifier.fromHex(to),
-    amount: amount.toE8s(),
+    amount,
     fromSubAccount,
     memo,
     createdAt: createdAt ?? nowInBigIntNanoSeconds(),

--- a/frontend/src/lib/services/canisters.services.ts
+++ b/frontend/src/lib/services/canisters.services.ts
@@ -27,7 +27,7 @@ import {
   toToastError,
 } from "$lib/utils/error.utils";
 import type { Principal } from "@dfinity/principal";
-import { ICPToken, TokenAmount } from "@dfinity/utils";
+import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 import { getAuthenticatedIdentity } from "./auth.services";
 import { getAccountIdentity, loadBalance } from "./icp-accounts.services";
 import { queryAndUpdate } from "./utils.services";
@@ -75,16 +75,16 @@ export const createCanister = async ({
   name?: string;
 }): Promise<Principal | undefined> => {
   try {
-    const icpAmount = TokenAmount.fromNumber({ amount, token: ICPToken });
-    if (!(icpAmount instanceof TokenAmount)) {
+    const icpAmount = TokenAmountV2.fromNumber({ amount, token: ICPToken });
+    if (!(icpAmount instanceof TokenAmountV2)) {
       throw new LedgerErrorMessage("error.amount_not_valid");
     }
-    assertEnoughAccountFunds({ amountUlps: icpAmount.toE8s(), account });
+    assertEnoughAccountFunds({ amountUlps: icpAmount.toUlps(), account });
 
     const identity = await getAccountIdentity(account.identifier);
     const canisterId = await createCanisterApi({
       identity,
-      amount: icpAmount,
+      amount: icpAmount.toUlps(),
       fromSubAccount: account.subAccount,
       name,
     });
@@ -135,17 +135,17 @@ export const topUpCanister = async ({
   account: Account;
 }): Promise<{ success: boolean }> => {
   try {
-    const icpAmount = TokenAmount.fromNumber({ amount, token: ICPToken });
-    if (!(icpAmount instanceof TokenAmount)) {
+    const icpAmount = TokenAmountV2.fromNumber({ amount, token: ICPToken });
+    if (!(icpAmount instanceof TokenAmountV2)) {
       throw new LedgerErrorMessage("error.amount_not_valid");
     }
-    assertEnoughAccountFunds({ amountUlps: icpAmount.toE8s(), account });
+    assertEnoughAccountFunds({ amountUlps: icpAmount.toUlps(), account });
 
     const identity = await getAccountIdentity(account.identifier);
     await topUpCanisterApi({
       identity,
       canisterId,
-      amount: icpAmount,
+      amount: icpAmount.toUlps(),
       fromSubAccount: account.subAccount,
     });
     // We don't wait for `loadBalance` to finish to give a better UX to the user.

--- a/frontend/src/lib/services/icp-accounts.services.ts
+++ b/frontend/src/lib/services/icp-accounts.services.ts
@@ -328,7 +328,7 @@ export const transferICP = async ({
           identity,
           to,
           fromSubAccount: subAccount,
-          amount: tokenAmount,
+          amount: tokenAmount.toE8s(),
         }));
 
     // Transfer can be to one of the user's account.

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -653,7 +653,7 @@ const pollTransfer = ({
       sendICP({
         identity,
         to,
-        amount,
+        amount: amount.toE8s(),
         fromSubAccount,
         createdAt,
         memo,

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -31,7 +31,7 @@ import {
   LedgerCanister,
   SubAccount,
 } from "@dfinity/ledger-icp";
-import { ICPToken, TokenAmount, principalToSubAccount } from "@dfinity/utils";
+import { principalToSubAccount } from "@dfinity/utils";
 import { mock } from "vitest-mock-extended";
 
 describe("canisters-api", () => {
@@ -228,10 +228,7 @@ describe("canisters-api", () => {
 
       const response = await createCanister({
         identity: mockIdentity,
-        amount: TokenAmount.fromString({
-          amount: "3",
-          token: ICPToken,
-        }) as TokenAmount,
+        amount: 300000000n,
       });
       expect(mockLedgerCanister.transfer).toBeCalled();
       expect(mockCMCCanister.notifyCreateCanister).toBeCalled();
@@ -251,10 +248,7 @@ describe("canisters-api", () => {
       const longName = "a".repeat(MAX_CANISTER_NAME_LENGTH);
       const response = await createCanister({
         identity: mockIdentity,
-        amount: TokenAmount.fromString({
-          amount: "3",
-          token: ICPToken,
-        }) as TokenAmount,
+        amount: 300000000n,
         name: longName,
       });
       expect(mockNNSDappCanister.attachCanister).toBeCalledWith({
@@ -272,10 +266,7 @@ describe("canisters-api", () => {
 
       const response = await createCanister({
         identity: mockIdentity,
-        amount: TokenAmount.fromString({
-          amount: "3",
-          token: ICPToken,
-        }) as TokenAmount,
+        amount: 300000000n,
       });
       expect(mockCMCCanister.notifyCreateCanister).toHaveBeenCalledTimes(2);
       expect(response).toEqual(mockCanisterDetails.id);
@@ -286,10 +277,7 @@ describe("canisters-api", () => {
       mockCMCCanister.notifyCreateCanister.mockResolvedValue(
         mockCanisterDetails.id
       );
-      const amount = TokenAmount.fromString({
-        amount: "3",
-        token: ICPToken,
-      }) as TokenAmount;
+      const amount = 300000000n;
 
       const response = await createCanister({
         identity: mockIdentity,
@@ -307,7 +295,7 @@ describe("canisters-api", () => {
       expect(mockLedgerCanister.transfer).toBeCalledWith({
         memo: CREATE_CANISTER_MEMO,
         to: AccountIdentifier.fromHex(recipient.toHex()),
-        amount: amount.toE8s(),
+        amount,
         fromSubAccount: mockSubAccount.subAccount,
         createdAt: nowInBigIntNanoSeconds(),
       });
@@ -325,10 +313,7 @@ describe("canisters-api", () => {
       const call = () =>
         createCanister({
           identity: mockIdentity,
-          amount: TokenAmount.fromString({
-            amount: "3",
-            token: ICPToken,
-          }) as TokenAmount,
+          amount: 300000000n,
         });
       expect(call).rejects.toThrow();
       expect(mockCMCCanister.notifyCreateCanister).not.toBeCalled();
@@ -340,10 +325,7 @@ describe("canisters-api", () => {
       const call = () =>
         createCanister({
           identity: mockIdentity,
-          amount: TokenAmount.fromString({
-            amount: "3",
-            token: ICPToken,
-          }) as TokenAmount,
+          amount: 300000000n,
           name: longName,
         });
 
@@ -371,10 +353,7 @@ describe("canisters-api", () => {
 
       await topUpCanister({
         identity: mockIdentity,
-        amount: TokenAmount.fromString({
-          amount: "3",
-          token: ICPToken,
-        }) as TokenAmount,
+        amount: 300000000n,
         canisterId: mockCanisterDetails.id,
       });
       expect(mockLedgerCanister.transfer).toBeCalled();
@@ -389,10 +368,7 @@ describe("canisters-api", () => {
 
       await topUpCanister({
         identity: mockIdentity,
-        amount: TokenAmount.fromString({
-          amount: "3",
-          token: ICPToken,
-        }) as TokenAmount,
+        amount: 300000000n,
         canisterId: mockCanisterDetails.id,
       });
       expect(mockCMCCanister.notifyTopUp).toHaveBeenCalledTimes(2);
@@ -410,10 +386,7 @@ describe("canisters-api", () => {
         subAccount: SubAccount.fromBytes(toSubAccount) as SubAccount,
       });
 
-      const amount = TokenAmount.fromString({
-        amount: "3",
-        token: ICPToken,
-      }) as TokenAmount;
+      const amount = 300000000n;
       await topUpCanister({
         identity: mockIdentity,
         amount,
@@ -424,7 +397,7 @@ describe("canisters-api", () => {
       expect(mockLedgerCanister.transfer).toBeCalledWith({
         memo: TOP_UP_CANISTER_MEMO,
         to: AccountIdentifier.fromHex(recipient.toHex()),
-        amount: amount.toE8s(),
+        amount,
         fromSubAccount: mockSubAccount.subAccount,
         createdAt: nowInBigIntNanoSeconds(),
       });
@@ -438,10 +411,7 @@ describe("canisters-api", () => {
       const call = () =>
         topUpCanister({
           identity: mockIdentity,
-          amount: TokenAmount.fromString({
-            amount: "3",
-            token: ICPToken,
-          }) as TokenAmount,
+          amount: 300000000n,
           canisterId: mockCanisterDetails.id,
         });
       expect(call).rejects.toThrow();

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -228,7 +228,7 @@ describe("canisters-api", () => {
 
       const response = await createCanister({
         identity: mockIdentity,
-        amount: 300000000n,
+        amount: 300_000_000n,
       });
       expect(mockLedgerCanister.transfer).toBeCalled();
       expect(mockCMCCanister.notifyCreateCanister).toBeCalled();
@@ -248,7 +248,7 @@ describe("canisters-api", () => {
       const longName = "a".repeat(MAX_CANISTER_NAME_LENGTH);
       const response = await createCanister({
         identity: mockIdentity,
-        amount: 300000000n,
+        amount: 300_000_000n,
         name: longName,
       });
       expect(mockNNSDappCanister.attachCanister).toBeCalledWith({
@@ -266,7 +266,7 @@ describe("canisters-api", () => {
 
       const response = await createCanister({
         identity: mockIdentity,
-        amount: 300000000n,
+        amount: 300_000_000n,
       });
       expect(mockCMCCanister.notifyCreateCanister).toHaveBeenCalledTimes(2);
       expect(response).toEqual(mockCanisterDetails.id);
@@ -277,7 +277,7 @@ describe("canisters-api", () => {
       mockCMCCanister.notifyCreateCanister.mockResolvedValue(
         mockCanisterDetails.id
       );
-      const amount = 300000000n;
+      const amount = 300_000_000n;
 
       const response = await createCanister({
         identity: mockIdentity,
@@ -313,7 +313,7 @@ describe("canisters-api", () => {
       const call = () =>
         createCanister({
           identity: mockIdentity,
-          amount: 300000000n,
+          amount: 300_000_000n,
         });
       expect(call).rejects.toThrow();
       expect(mockCMCCanister.notifyCreateCanister).not.toBeCalled();
@@ -325,7 +325,7 @@ describe("canisters-api", () => {
       const call = () =>
         createCanister({
           identity: mockIdentity,
-          amount: 300000000n,
+          amount: 300_000_000n,
           name: longName,
         });
 
@@ -353,7 +353,7 @@ describe("canisters-api", () => {
 
       await topUpCanister({
         identity: mockIdentity,
-        amount: 300000000n,
+        amount: 300_000_000n,
         canisterId: mockCanisterDetails.id,
       });
       expect(mockLedgerCanister.transfer).toBeCalled();
@@ -368,7 +368,7 @@ describe("canisters-api", () => {
 
       await topUpCanister({
         identity: mockIdentity,
-        amount: 300000000n,
+        amount: 300_000_000n,
         canisterId: mockCanisterDetails.id,
       });
       expect(mockCMCCanister.notifyTopUp).toHaveBeenCalledTimes(2);
@@ -386,7 +386,7 @@ describe("canisters-api", () => {
         subAccount: SubAccount.fromBytes(toSubAccount) as SubAccount,
       });
 
-      const amount = 300000000n;
+      const amount = 300_000_000n;
       await topUpCanister({
         identity: mockIdentity,
         amount,
@@ -411,7 +411,7 @@ describe("canisters-api", () => {
       const call = () =>
         topUpCanister({
           identity: mockIdentity,
-          amount: 300000000n,
+          amount: 300_000_000n,
           canisterId: mockCanisterDetails.id,
         });
       expect(call).rejects.toThrow();

--- a/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
@@ -24,10 +24,7 @@ describe("icp-ledger.api", () => {
     let spyTransfer;
 
     const { identifier: accountIdentifier } = mockMainAccount;
-    const amount = TokenAmount.fromE8s({
-      amount: 11_000n,
-      token: ICPToken,
-    });
+    const amount = 11_000n;
 
     const now = Date.now();
     const nowInBigIntNanoSeconds = BigInt(now) * 1_000_000n;
@@ -53,7 +50,7 @@ describe("icp-ledger.api", () => {
 
       expect(spyTransfer).toHaveBeenCalledWith({
         to: AccountIdentifier.fromHex(accountIdentifier),
-        amount: amount.toE8s(),
+        amount,
         createdAt: nowInBigIntNanoSeconds,
       });
     });
@@ -72,7 +69,7 @@ describe("icp-ledger.api", () => {
 
       expect(spyTransfer).toHaveBeenCalledWith({
         to: AccountIdentifier.fromHex(accountIdentifier),
-        amount: amount.toE8s(),
+        amount,
         fromSubAccount,
         createdAt: nowInBigIntNanoSeconds,
       });
@@ -89,7 +86,7 @@ describe("icp-ledger.api", () => {
 
       expect(spyTransfer).toHaveBeenCalledWith({
         to: AccountIdentifier.fromHex(accountIdentifier),
-        amount: amount.toE8s(),
+        amount,
         memo,
         createdAt: nowInBigIntNanoSeconds,
       });
@@ -108,7 +105,7 @@ describe("icp-ledger.api", () => {
 
       expect(spyTransfer).toHaveBeenCalledWith({
         to: AccountIdentifier.fromHex(accountIdentifier),
-        amount: amount.toE8s(),
+        amount,
         memo,
         createdAt,
       });

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -774,7 +774,7 @@ describe("Accounts", () => {
         expect(icpLedgerApi.sendICP).toHaveBeenCalledWith({
           identity: mockIdentity,
           to: destinationAddress,
-          amount: TokenAmount.fromNumber({ amount, token: ICPToken }),
+          amount: TokenAmount.fromNumber({ amount, token: ICPToken }).toE8s(),
           fromSubaccount: undefined,
         });
       });
@@ -826,7 +826,7 @@ describe("Accounts", () => {
         expect(icpLedgerApi.sendICP).toHaveBeenCalledWith({
           identity: mockIdentity,
           to: destinationAddress,
-          amount: TokenAmount.fromNumber({ amount, token: ICPToken }),
+          amount: TokenAmount.fromNumber({ amount, token: ICPToken }).toE8s(),
           fromSubAccount: mockSubAccount.subAccount,
         });
       });


### PR DESCRIPTION
# Motivation

Stop using TokenAmount.

In this PR, remove TokenAmount from ledger api `sendICP` and use `bigint` instead.

# Changes

* Change parameter's type `amount` in `sendICP` to `bigint`.
* Change usage of `sendICP` to pass a `bigint`.
* Change patameter's type `amount` in canister api functions.
* Change canister services to stop using `TokenAmount`.


# Tests

* Fix tests after changes in ledger and canister api spec files.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
