### PR TITLE
Extract TransactionIcon from TransactionCard component

### DIFF
--- a/frontend/src/lib/components/accounts/TransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/TransactionCard.svelte
@@ -1,17 +1,15 @@
 <script lang="ts">
+  import TransactionIcon from "./TransactionIcon.svelte";
   import ColumnRow from "$lib/components/ui/ColumnRow.svelte";
   import DateSeconds from "$lib/components/ui/DateSeconds.svelte";
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import Identifier from "$lib/components/ui/Identifier.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import {
-    IconReimbursed,
-    IconErrorOutline,
-    IconUp,
-    IconDown,
-    KeyValuePair,
-  } from "@dfinity/gix-components";
-  import type { UiTransaction } from "$lib/types/transaction";
+  import { KeyValuePair } from "@dfinity/gix-components";
+  import type {
+    UiTransaction,
+    TransactionIconType,
+  } from "$lib/types/transaction";
   import {
     nonNullish,
     type TokenAmount,
@@ -40,6 +38,15 @@
     timestamp,
   } = transaction);
 
+  let iconType: TransactionIconType;
+  $: iconType = isReimbursement
+    ? "reimbursed"
+    : isFailed
+    ? "failed"
+    : isIncoming
+    ? "received"
+    : "sent";
+
   let label: string;
   $: label = isIncoming
     ? $i18n.wallet.direction_from
@@ -50,22 +57,8 @@
 </script>
 
 <article data-tid="transaction-card" transition:fade|global>
-  <div
-    class="icon"
-    data-tid="icon"
-    class:send={!isIncoming}
-    class:pending={isPending}
-    class:failed={isFailed || isReimbursement}
-  >
-    {#if isFailed}
-      <IconErrorOutline size="24px" />
-    {:else if isReimbursement}
-      <IconReimbursed size="24px" />
-    {:else if isIncoming}
-      <IconDown size="24px" />
-    {:else}
-      <IconUp size="24px" />
-    {/if}
+  <div class="icon">
+    <TransactionIcon type={iconType} {isPending} />
   </div>
 
   <div class="transaction">
@@ -149,33 +142,6 @@
   }
 
   .icon {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    background: var(--check-tint);
-    color: var(--check);
-
-    border-radius: var(--border-radius);
-
-    width: var(--padding-6x);
-    aspect-ratio: 1 / 1;
-
     margin: var(--padding-0_5x) 0;
-
-    &.send {
-      background: var(--background);
-      color: var(--disable-contrast);
-    }
-
-    &.pending {
-      color: var(--pending-color);
-      background: var(--pending-background);
-    }
-
-    &.failed {
-      color: var(--alert);
-      background: var(--alert-tint);
-    }
   }
 </style>

--- a/frontend/src/lib/components/accounts/TransactionIcon.svelte
+++ b/frontend/src/lib/components/accounts/TransactionIcon.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import {
+    IconReimbursed,
+    IconErrorOutline,
+    IconUp,
+    IconDown,
+  } from "@dfinity/gix-components";
+  import type { TransactionIconType } from "$lib/types/transaction";
+
+  export let type: TransactionIconType;
+  export let isPending: boolean = false;
+</script>
+
+<div
+  class="icon {type}"
+  class:pending={isPending}
+  data-tid="transaction-icon-component"
+>
+  {#if type === "sent"}
+    <IconUp size="24px" />
+  {:else if type === "received"}
+    <IconDown size="24px" />
+  {:else if type === "failed"}
+    <IconErrorOutline size="24px" />
+  {:else if type === "reimbursed"}
+    <IconReimbursed size="24px" />
+  {/if}
+</div>
+
+<style lang="scss">
+  .icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    border-radius: var(--border-radius);
+
+    width: var(--padding-6x);
+    aspect-ratio: 1 / 1;
+
+    &.received {
+      background: var(--check-tint);
+      color: var(--check);
+    }
+
+    &.sent {
+      background: var(--background);
+      color: var(--disable-contrast);
+    }
+
+    &.reimbursed,
+    &.failed {
+      color: var(--alert);
+      background: var(--alert-tint);
+    }
+
+    &.pending {
+      color: var(--pending-color);
+      background: var(--pending-background);
+    }
+  }
+</style>

--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -80,6 +80,8 @@ export interface Transaction {
   date: Date;
 }
 
+export type TransactionIconType = "sent" | "received" | "failed" | "reimbursed";
+
 export interface UiTransaction {
   // Used in forEach for consistent rendering.
   domKey: string;

--- a/frontend/src/tests/lib/components/accounts/TransactionIcon.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionIcon.spec.ts
@@ -1,0 +1,97 @@
+import TransactionIcon from "$lib/components/accounts/TransactionIcon.svelte";
+import type { TransactionIconType } from "$lib/types/transaction";
+import { TransactionIconPo } from "$tests/page-objects/TransactionIcon.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("TransactionIcon", () => {
+  const renderComponent = (props: {
+    type: TransactionIconType;
+    isPending?: boolean;
+  }) => {
+    const { container } = render(TransactionIcon, { props });
+    return TransactionIconPo.under(new JestPageObjectElement(container));
+  };
+
+  it("renders sent icon", async () => {
+    const po = renderComponent({
+      type: "sent",
+      isPending: false,
+    });
+
+    expect(await po.isSentIcon()).toBe(true);
+    expect(await po.isPendingSendIcon()).toBe(false);
+    expect(await po.isReceivedIcon()).toBe(false);
+    expect(await po.isPendingReceiveIcon()).toBe(false);
+    expect(await po.isReimbursementIcon()).toBe(false);
+    expect(await po.isFailedIcon()).toBe(false);
+  });
+
+  it("renders pending sent icon", async () => {
+    const po = renderComponent({
+      type: "sent",
+      isPending: true,
+    });
+
+    expect(await po.isPendingSendIcon()).toBe(true);
+    expect(await po.isSentIcon()).toBe(false);
+    expect(await po.isReceivedIcon()).toBe(false);
+    expect(await po.isPendingReceiveIcon()).toBe(false);
+    expect(await po.isReimbursementIcon()).toBe(false);
+    expect(await po.isFailedIcon()).toBe(false);
+  });
+
+  it("renders received icon", async () => {
+    const po = renderComponent({
+      type: "received",
+      isPending: false,
+    });
+
+    expect(await po.isReceivedIcon()).toBe(true);
+    expect(await po.isPendingReceiveIcon()).toBe(false);
+    expect(await po.isSentIcon()).toBe(false);
+    expect(await po.isPendingSendIcon()).toBe(false);
+    expect(await po.isReimbursementIcon()).toBe(false);
+    expect(await po.isFailedIcon()).toBe(false);
+  });
+
+  it("renders pending received icon", async () => {
+    const po = renderComponent({
+      type: "received",
+      isPending: true,
+    });
+
+    expect(await po.isPendingReceiveIcon()).toBe(true);
+    expect(await po.isReceivedIcon()).toBe(false);
+    expect(await po.isSentIcon()).toBe(false);
+    expect(await po.isPendingSendIcon()).toBe(false);
+    expect(await po.isReimbursementIcon()).toBe(false);
+    expect(await po.isFailedIcon()).toBe(false);
+  });
+
+  it("renders failed icon", async () => {
+    const po = renderComponent({
+      type: "failed",
+    });
+
+    expect(await po.isFailedIcon()).toBe(true);
+    expect(await po.isSentIcon()).toBe(false);
+    expect(await po.isPendingSendIcon()).toBe(false);
+    expect(await po.isReceivedIcon()).toBe(false);
+    expect(await po.isPendingReceiveIcon()).toBe(false);
+    expect(await po.isReimbursementIcon()).toBe(false);
+  });
+
+  it("renders reimbursed icon", async () => {
+    const po = renderComponent({
+      type: "reimbursed",
+    });
+
+    expect(await po.isReimbursementIcon()).toBe(true);
+    expect(await po.isSentIcon()).toBe(false);
+    expect(await po.isPendingSendIcon()).toBe(false);
+    expect(await po.isReceivedIcon()).toBe(false);
+    expect(await po.isPendingReceiveIcon()).toBe(false);
+    expect(await po.isFailedIcon()).toBe(false);
+  });
+});

--- a/frontend/src/tests/page-objects/TransactionCard.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionCard.page-object.ts
@@ -1,4 +1,5 @@
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
+import { TransactionIconPo } from "$tests/page-objects/TransactionIcon.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -15,6 +16,10 @@ export class TransactionCardPo extends BasePageObject {
     return Array.from(await element.allByTestId(TransactionCardPo.TID)).map(
       (el) => new TransactionCardPo(el)
     );
+  }
+
+  getTransactionIconPo(): TransactionIconPo {
+    return TransactionIconPo.under(this.root);
   }
 
   getHeadline(): Promise<string> {
@@ -37,38 +42,23 @@ export class TransactionCardPo extends BasePageObject {
     return this.getAmountDisplayPo().getAmount();
   }
 
-  async hasIconClass(className: string): Promise<boolean> {
-    const classNames = await this.root.byTestId("icon").getClasses();
-    return classNames.includes(className);
-  }
-
   async hasSentIcon(): Promise<boolean> {
-    const hasIcon = await this.isPresent("icon-up");
-    const hasClass = await this.hasIconClass("send");
-    return hasIcon && hasClass;
+    return this.getTransactionIconPo().isSentIcon();
   }
 
   async hasReceivedIcon(): Promise<boolean> {
-    const hasIcon = await this.isPresent("icon-down");
-    const hasClass = await this.hasIconClass("send");
-    return hasIcon && !hasClass;
+    return this.getTransactionIconPo().isReceivedIcon();
   }
 
   async hasPendingReceiveIcon(): Promise<boolean> {
-    const hasIcon = await this.isPresent("icon-down");
-    const hasClass = await this.hasIconClass("pending");
-    return hasIcon && hasClass;
+    return this.getTransactionIconPo().isPendingReceiveIcon();
   }
 
   async hasReimbursementIcon(): Promise<boolean> {
-    const hasIcon = await this.isPresent("icon-reimbursed");
-    const hasClass = await this.hasIconClass("failed");
-    return hasIcon && hasClass;
+    return this.getTransactionIconPo().isReimbursementIcon();
   }
 
   async hasFailedIcon(): Promise<boolean> {
-    const hasIcon = await this.isPresent("icon-error-outline");
-    const hasClass = await this.hasIconClass("failed");
-    return hasIcon && hasClass;
+    return this.getTransactionIconPo().isFailedIcon();
   }
 }

--- a/frontend/src/tests/page-objects/TransactionIcon.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionIcon.page-object.ts
@@ -1,0 +1,51 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class TransactionIconPo extends BasePageObject {
+  private static readonly TID = "transaction-icon-component";
+
+  static under(element: PageObjectElement): TransactionIconPo {
+    return new TransactionIconPo(element.byTestId(TransactionIconPo.TID));
+  }
+
+  async hasIconClass(className: string): Promise<boolean> {
+    const classNames = await this.root.getClasses();
+    return classNames.includes(className);
+  }
+
+  async isSentIcon(): Promise<boolean> {
+    const hasIcon = await this.isPresent("icon-up");
+    const hasClass = await this.hasIconClass("sent");
+    return hasIcon && hasClass && !(await this.isPendingSendIcon());
+  }
+
+  async isPendingSendIcon(): Promise<boolean> {
+    const hasIcon = await this.isPresent("icon-up");
+    const hasClass = await this.hasIconClass("pending");
+    return hasIcon && hasClass;
+  }
+
+  async isReceivedIcon(): Promise<boolean> {
+    const hasIcon = await this.isPresent("icon-down");
+    const hasClass = await this.hasIconClass("received");
+    return hasIcon && hasClass && !(await this.isPendingReceiveIcon());
+  }
+
+  async isPendingReceiveIcon(): Promise<boolean> {
+    const hasIcon = await this.isPresent("icon-down");
+    const hasClass = await this.hasIconClass("pending");
+    return hasIcon && hasClass;
+  }
+
+  async isReimbursementIcon(): Promise<boolean> {
+    const hasIcon = await this.isPresent("icon-reimbursed");
+    const hasClass = await this.hasIconClass("reimbursed");
+    return hasIcon && hasClass;
+  }
+
+  async isFailedIcon(): Promise<boolean> {
+    const hasIcon = await this.isPresent("icon-error-outline");
+    const hasClass = await this.hasIconClass("failed");
+    return hasIcon && hasClass;
+  }
+}


### PR DESCRIPTION
# Motivation

Design asked to put a transaction icon as a placeholder when there are no transactions, [here](https://www.figma.com/file/x8dk5axQUf8Bi43uUsqCHc/NNS-Production-%26-Hand-over?type=design&node-id=1319-1085&mode=design&t=c9WzuZezrkC9IYMo-4).
Also, in the future we might use them in transaction detail modals.

This PR just extracts the icon component to make it available in future PRs.

# Changes

1. Create `TransactionIcon.svelte` to render a transaction icon.
2. Use it in `TransactionCard.svelte` instead of rendering inline.
3. Add a unit test.
4. Add a page object.
5. Update existing page object.

# Tests

Unit test added.
Looks good on manual inspection:

<img width="485" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/2a9b4869-1bdf-4e83-b77e-ed1b72f64d49">

<img width="480" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/835adf49-101b-47ca-81c9-528bce01792a">

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary