### PR TITLE
Remove double scroll container from My Tokens table

### DIFF
--- a/frontend/src/lib/components/tokens/MainWrapper.svelte
+++ b/frontend/src/lib/components/tokens/MainWrapper.svelte
@@ -17,13 +17,6 @@
     justify-content: center;
     width: 100%;
 
-    padding: var(--padding-2x) var(--padding-2x) var(--padding)
-      var(--padding-2x);
-
-    @include media.min-width(large) {
-      padding: var(--padding-4x) 0 var(--padding);
-    }
-
     & .content {
       width: 100%;
 

--- a/frontend/src/lib/components/tokens/MainWrapper.svelte
+++ b/frontend/src/lib/components/tokens/MainWrapper.svelte
@@ -21,7 +21,7 @@
       var(--padding-2x);
 
     @include media.min-width(large) {
-      padding: var(--padding-4x) 0 0 0;
+      padding: var(--padding-4x) 0 var(--padding);
     }
 
     & .content {

--- a/frontend/src/lib/components/tokens/MainWrapper.svelte
+++ b/frontend/src/lib/components/tokens/MainWrapper.svelte
@@ -15,7 +15,6 @@
     display: flex;
     align-items: stretch;
     justify-content: center;
-    height: 100%;
     width: 100%;
 
     padding: var(--padding-2x) var(--padding-2x) var(--padding)
@@ -27,11 +26,8 @@
 
     & .content {
       width: 100%;
-      height: 100%;
 
       overflow-x: hidden;
-      overflow-y: auto;
-
       @include media.min-width(large) {
         width: var(--island-width);
         max-width: var(--island-max-width);


### PR DESCRIPTION
# Motivation

The `main` element of the My Tokens table is a scrolling container, but it exists in another scroll container.
This results in a strange cut-off at the top and bottom and strange placement of the scroll bar.
See https://github.com/dfinity/nns-dapp/pull/4182 for details.

# Changes

1. Remove `height` and `overflow-y` from the `main` element.
2. Remove custom padding that was necessary because of the double scroll container.

# Tests

Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary