### PR TITLE
GIX-2187: Make ICRC wallet renderable when not signed in.

### DIFF
--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -167,7 +167,7 @@
           walletAddress={$selectedAccountStore.account?.identifier}
         />
         <WalletPageHeading
-          accountName={$selectedAccountStore?.account?.name ??
+          accountName={$selectedAccountStore.account?.name ??
             $i18n.accounts.main}
           balance={nonNullish($selectedAccountStore.account) &&
           nonNullish(token)

--- a/frontend/src/lib/pages/IcrcWallet.svelte
+++ b/frontend/src/lib/pages/IcrcWallet.svelte
@@ -2,6 +2,7 @@
   import { selectedIcrcTokenUniverseIdStore } from "$lib/derived/selected-universe.derived";
   import { nonNullish } from "@dfinity/utils";
   import IcrcWalletPage from "$lib/components/accounts/IcrcWalletPage.svelte";
+  import NoTransactions from "$lib/components/accounts/NoTransactions.svelte";
   import { writable } from "svelte/store";
   import type { WalletStore } from "$lib/types/wallet.context";
   import IcrcWalletTransactionsList from "$lib/components/accounts/IcrcWalletTransactionsList.svelte";
@@ -54,6 +55,8 @@
         {token}
         bind:this={transactions}
       />
+    {:else}
+      <NoTransactions />
     {/if}
   </svelte:fragment>
 

--- a/frontend/src/tests/page-objects/IcrcWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/IcrcWallet.page-object.ts
@@ -1,5 +1,6 @@
 import { IcrcTransactionsListPo } from "$tests/page-objects/IcrcTransactionsList.page-object";
 import { IcrcWalletFooterPo } from "$tests/page-objects/IcrcWalletFooter.page-object";
+import { SignInPo } from "$tests/page-objects/SignIn.page-object";
 import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-object";
 import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
@@ -24,11 +25,23 @@ export class IcrcWalletPo extends BasePageObject {
     return WalletPageHeadingPo.under(this.root);
   }
 
+  getSignInPo(): SignInPo {
+    return SignInPo.under(this.root);
+  }
+
   getWalletFooterPo(): IcrcWalletFooterPo {
     return IcrcWalletFooterPo.under(this.root);
   }
 
+  hasSignInButton(): Promise<boolean> {
+    return this.getSignInPo().isPresent();
+  }
+
   hasSpinner(): Promise<boolean> {
     return this.isPresent("spinner");
+  }
+
+  hasNoTransactions(): Promise<boolean> {
+    return this.isPresent("no-transactions-component");
   }
 }


### PR DESCRIPTION
# Motivation

We want to be able to show wallet pages when the user is not logged in.
This PR makes it possible to render the `IcrcWallet.svelte` page when the user is not logged in.
This is not a user visible change because `wallet/+page.svelte` still doesn't render any wallet when the user is not logged in.

# Changes

1. Don't load data until the user is logged in.
2. Don't render `IcrcBalancesObserver` if the user is not logged in.
3. Treat `selectedAccountStore.account` as nullable because we want to render most of the page when there is no account.
4. Use `SignInGuard` to render a sign in button if the user is not logged in.
5. Render the no-transactions placeholder instead of the `IcrcWalletTransactionsList` component if there is no account.

# Tests

Unit tests are added.
Tested manually in another branch.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet