### PR TITLE
Fix BTC address QR code spinner in dark theme

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,6 +26,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* BTC deposit address QR code spinner in dark theme.
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/components/accounts/CkBTCInfoCard.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCInfoCard.svelte
@@ -206,6 +206,7 @@
 
     grid-area: qr;
     background: white;
+    color: black;
     width: var(--qr-code-size);
     height: var(--qr-code-size);
     border: var(--padding) solid white;


### PR DESCRIPTION
# Motivation

When using the `Spinner` component, it renders in the current color.
By default, this is dark in the light theme and light in the dark theme.
But the QR code for the BTC deposit address is always rendered on a white background, so it should always have a dark spinner.

# Changes

Set `color` to `black` in the `qr-code` element.

# Tests

Tested manually:

<img width="788" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/f6d1b2f3-aae7-457e-9b40-735902ea3827">

# Todos

- [x] Add entry to changelog (if necessary).
