### PR TITLE
GIX-2187: Make ckBTC wallet renderable when not signed in.

### DIFF
--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import { authSignedInStore } from "$lib/derived/auth.derived";
   import { hasAccounts } from "$lib/utils/accounts.utils";
   import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
   import { isNullish, nonNullish } from "@dfinity/utils";
   import CkBTCTransactionsList from "$lib/components/accounts/CkBTCTransactionsList.svelte";
+  import NoTransactions from "$lib/components/accounts/NoTransactions.svelte";
   import {
     ckBTCTokenFeeStore,
     ckBTCTokenStore,
@@ -70,6 +72,7 @@
 
   let canMakeTransactions = false;
   $: canMakeTransactions =
+    $authSignedInStore &&
     nonNullish($selectedCkBTCUniverseIdStore) &&
     hasAccounts(
       $icrcAccountsStore[$selectedCkBTCUniverseIdStore.toText()]?.accounts ?? []
@@ -77,14 +80,16 @@
     nonNullish($ckBTCTokenFeeStore[$selectedCkBTCUniverseIdStore.toText()]) &&
     nonNullish($ckBTCTokenStore[$selectedCkBTCUniverseIdStore.toText()]);
 
-  $: (async () =>
-    await loadCkBTCInfo({
-      universeId: $selectedCkBTCUniverseIdStore,
-      minterCanisterId: canisters?.minterCanisterId,
-    }))();
+  $: $authSignedInStore &&
+    (async () =>
+      await loadCkBTCInfo({
+        universeId: $selectedCkBTCUniverseIdStore,
+        minterCanisterId: canisters?.minterCanisterId,
+      }))();
 
   $: $selectedCkBTCUniverseIdStore &&
     canisters &&
+    $authSignedInStore &&
     loadRetrieveBtcStatuses({
       universeId: $selectedCkBTCUniverseIdStore,
       minterCanisterId: canisters.minterCanisterId,
@@ -101,7 +106,7 @@
   {reloadTransactions}
 >
   <svelte:fragment slot="info-card">
-    {#if nonNullish($selectedAccountStore.account) && nonNullish($selectedCkBTCUniverseIdStore) && nonNullish(canisters)}
+    {#if nonNullish($selectedCkBTCUniverseIdStore) && nonNullish(canisters)}
       <CkBTCInfoCard
         account={$selectedAccountStore.account}
         universeId={$selectedCkBTCUniverseIdStore}
@@ -120,6 +125,8 @@
         indexCanisterId={canisters.indexCanisterId}
         token={token?.token}
       />
+    {:else}
+      <NoTransactions />
     {/if}
   </svelte:fragment>
 

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -176,6 +176,16 @@ describe("IcrcWallet", () => {
       const po = await renderWallet({});
       expect(await po.hasNoTransactions()).toBe(true);
     });
+
+    it("should not render send/receive buttons", async () => {
+      const po = await renderWallet({});
+      expect(await po.getWalletFooterPo().getSendButtonPo().isPresent()).toBe(
+        false
+      );
+      expect(
+        await po.getWalletFooterPo().getReceiveButtonPo().isPresent()
+      ).toBe(false);
+    });
   });
 
   describe("accounts not loaded", () => {

--- a/frontend/src/tests/page-objects/CkBTCWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/CkBTCWallet.page-object.ts
@@ -1,6 +1,7 @@
 import { CkBTCInfoCardPo } from "$tests/page-objects/CkBTCInfoCard.page-object";
 import { CkBTCWalletFooterPo } from "$tests/page-objects/CkBTCWalletFooter.page-object";
 import { IcrcTransactionsListPo } from "$tests/page-objects/IcrcTransactionsList.page-object";
+import { SignInPo } from "$tests/page-objects/SignIn.page-object";
 import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-object";
 import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
@@ -25,6 +26,10 @@ export class CkBTCWalletPo extends BasePageObject {
     return WalletPageHeadingPo.under(this.root);
   }
 
+  getSignInPo(): SignInPo {
+    return SignInPo.under(this.root);
+  }
+
   getCkBTCWalletFooterPo(): CkBTCWalletFooterPo {
     return CkBTCWalletFooterPo.under(this.root);
   }
@@ -33,11 +38,19 @@ export class CkBTCWalletPo extends BasePageObject {
     return CkBTCInfoCardPo.under(this.root);
   }
 
+  hasSignInButton(): Promise<boolean> {
+    return this.getSignInPo().isPresent();
+  }
+
   clickRefreshBalance(): Promise<void> {
     return this.getCkBTCInfoCardPo().getUpdateBalanceButton().click();
   }
 
   hasSpinner(): Promise<boolean> {
     return this.isPresent("spinner");
+  }
+
+  hasNoTransactions(): Promise<boolean> {
+    return this.isPresent("no-transactions-component");
   }
 }

--- a/frontend/src/tests/page-objects/CkBTCWalletFooter.page-object.ts
+++ b/frontend/src/tests/page-objects/CkBTCWalletFooter.page-object.ts
@@ -1,3 +1,4 @@
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -8,11 +9,19 @@ export class CkBTCWalletFooterPo extends BasePageObject {
     return new CkBTCWalletFooterPo(element.byTestId(CkBTCWalletFooterPo.TID));
   }
 
+  getSendButtonPo(): ButtonPo {
+    return this.getButton("open-ckbtc-transaction");
+  }
+
+  getReceiveButtonPo(): ButtonPo {
+    return this.getButton("receive-ckbtc");
+  }
+
   clickSendButton(): Promise<void> {
-    return this.click("open-ckbtc-transaction");
+    return this.getSendButtonPo().click();
   }
 
   clickReceiveButton(): Promise<void> {
-    return this.click("receive-ckbtc");
+    return this.getReceiveButtonPo().click();
   }
 }

--- a/frontend/src/tests/page-objects/IcrcWalletFooter.page-object.ts
+++ b/frontend/src/tests/page-objects/IcrcWalletFooter.page-object.ts
@@ -1,3 +1,4 @@
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -8,11 +9,19 @@ export class IcrcWalletFooterPo extends BasePageObject {
     return new IcrcWalletFooterPo(element.byTestId(IcrcWalletFooterPo.TID));
   }
 
+  getSendButtonPo(): ButtonPo {
+    return this.getButton("open-new-icrc-token-transaction");
+  }
+
+  getReceiveButtonPo(): ButtonPo {
+    return this.getButton("receive-icrc");
+  }
+
   clickSendButton(): Promise<void> {
-    return this.click("open-new-icrc-token-transactionn");
+    return this.getSendButtonPo().click();
   }
 
   clickReceiveButton(): Promise<void> {
-    return this.click("receive-icrc");
+    return this.getReceiveButtonPo().click();
   }
 }


### PR DESCRIPTION
# Motivation

We want to be able to show wallet pages when the user is not logged in.
This PR makes it possible to render the `CkBTCWallet.svelte` page when the user is not logged in.
This is not a user visible change because `wallet/+page.svelte` still doesn't render any wallet when the user is not logged in.

# Changes

1. Hide Send/Receive buttons.
2. Don't load data.
3. Don't require `nonNullish($selectedAccountStore.account)` to show the info card.
4. Show transaction list placeholder.

The rest of the functionality comes from reusing `IcrcWalletPage.svelte`.

# Tests

Unit tests added.
Also added missing tests for Send/Receive button for `IcrcWalletPage` that should have been in the [previous PR](https://github.com/dfinity/nns-dapp/pull/4196).
Test manually in a separate branch.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet