### PR TITLE
refactor: rename sns filter

### DIFF
--- a/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
@@ -11,14 +11,14 @@
   import FiltersButton from "../ui/FiltersButton.svelte";
   import SnsFilterRewardsModal from "$lib/modals/sns/proposals/SnsFilterRewardsModal.svelte";
 
-  let modal: "topics" | "rewards" | "status" | undefined = undefined;
+  let modal: "types" | "rewards" | "status" | undefined = undefined;
 
   let rootCanisterId: Principal;
   $: rootCanisterId = $selectedUniverseIdStore;
   let filtersStore: ProjectFiltersStoreData | undefined;
   $: filtersStore = $snsFiltersStore[rootCanisterId.toText()];
 
-  const openFilters = (filtersModal: "topics" | "rewards" | "status") => {
+  const openFilters = (filtersModal: "types" | "rewards" | "status") => {
     modal = filtersModal;
   };
 


### PR DESCRIPTION
# Motivation

There is no Topics in snses. And to better reflect the logic the filter "topics" has been renamed to "types".

# Changes

- renmaing

# Tests

works

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary