### PR TITLE
GIX-2187: Make SNS wallet renderable when not signed in.

### DIFF
--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -5,7 +5,7 @@
   import { hasAccounts } from "$lib/utils/accounts.utils";
   import { findAccountOrDefaultToMain } from "$lib/utils/accounts.utils";
   import type { Principal } from "@dfinity/principal";
-  import { Spinner, busy } from "@dfinity/gix-components";
+  import { Spinner } from "@dfinity/gix-components";
   import { setContext } from "svelte";
   import { writable } from "svelte/store";
   import { snsProjectAccountsStore } from "$lib/derived/sns/sns-project-accounts.derived";
@@ -123,9 +123,6 @@
 
   $: accountIdentifier, $snsProjectAccountsStore, load();
 
-  let disabled = false;
-  $: disabled = isNullish($selectedAccountStore.account) || $busy;
-
   const reloadAccount = async () => {
     try {
       await Promise.all([
@@ -206,7 +203,6 @@
         <button
           class="primary"
           on:click={() => (showModal = "send")}
-          {disabled}
           data-tid="open-new-sns-transaction">{$i18n.accounts.send}</button
         >
 

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { authSignedInStore } from "$lib/derived/auth.derived";
   import { buildAccountsUrl } from "$lib/utils/navigation.utils";
   import { goto } from "$app/navigation";
   import { hasAccounts } from "$lib/utils/accounts.utils";
@@ -20,6 +21,8 @@
   import { i18n } from "$lib/stores/i18n";
   import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";
   import SnsTransactionsList from "$lib/components/accounts/SnsTransactionsList.svelte";
+  import NoTransactions from "$lib/components/accounts/NoTransactions.svelte";
+  import SignInGuard from "$lib/components/common/SignInGuard.svelte";
   import Separator from "$lib/components/ui/Separator.svelte";
   import { Island } from "@dfinity/gix-components";
   import {
@@ -55,7 +58,7 @@
     }
   };
 
-  $: onSnsProjectChanged($snsOnlyProjectStore);
+  $: $authSignedInStore && onSnsProjectChanged($snsOnlyProjectStore);
 
   const selectedAccountStore = writable<WalletStore>({
     account: undefined,
@@ -154,56 +157,70 @@
   <Island>
     <main class="legacy" data-tid="sns-wallet">
       <section>
-        {#if nonNullish($selectedAccountStore.account) && nonNullish($snsOnlyProjectStore) && nonNullish($snsProjectSelectedStore) && nonNullish(token)}
-          <SnsBalancesObserver
-            rootCanisterId={$snsOnlyProjectStore}
-            accounts={[$selectedAccountStore.account]}
-            ledgerCanisterId={$snsProjectSelectedStore.summary.ledgerCanisterId}
-          />
+        {#if nonNullish($snsOnlyProjectStore) && nonNullish($snsProjectSelectedStore) && (!$authSignedInStore || nonNullish($selectedAccountStore.account))}
+          {#if nonNullish($selectedAccountStore.account) && nonNullish(token)}
+            <SnsBalancesObserver
+              rootCanisterId={$snsOnlyProjectStore}
+              accounts={[$selectedAccountStore.account]}
+              ledgerCanisterId={$snsProjectSelectedStore.summary
+                .ledgerCanisterId}
+            />
+          {/if}
           <WalletPageHeader
             universe={$selectedUniverseStore}
-            walletAddress={$selectedAccountStore.account.identifier}
+            walletAddress={$selectedAccountStore.account?.identifier}
           />
           <WalletPageHeading
-            balance={TokenAmountV2.fromUlps({
-              amount: $selectedAccountStore.account.balanceUlps,
-              token,
-            })}
-            accountName={$selectedAccountStore.account.name ??
+            balance={nonNullish($selectedAccountStore.account) &&
+            nonNullish(token)
+              ? TokenAmountV2.fromUlps({
+                  amount: $selectedAccountStore.account.balanceUlps,
+                  token,
+                })
+              : undefined}
+            accountName={$selectedAccountStore.account?.name ??
               $i18n.accounts.main}
-          />
+          >
+            <SignInGuard />
+          </WalletPageHeading>
 
           <Separator spacing="none" />
 
-          <SnsTransactionsList
-            rootCanisterId={$snsOnlyProjectStore}
-            account={$selectedAccountStore.account}
-            {token}
-          />
+          {#if nonNullish($selectedAccountStore.account)}
+            <SnsTransactionsList
+              rootCanisterId={$snsOnlyProjectStore}
+              account={$selectedAccountStore.account}
+              {token}
+            />
+          {:else}
+            <NoTransactions />
+          {/if}
         {:else}
           <Spinner />
         {/if}
       </section>
     </main>
 
-    <Footer>
-      <button
-        class="primary"
-        on:click={() => (showModal = "send")}
-        {disabled}
-        data-tid="open-new-sns-transaction">{$i18n.accounts.send}</button
-      >
+    {#if nonNullish($selectedAccountStore.account)}
+      <Footer>
+        <button
+          class="primary"
+          on:click={() => (showModal = "send")}
+          {disabled}
+          data-tid="open-new-sns-transaction">{$i18n.accounts.send}</button
+        >
 
-      <ReceiveButton
-        type="icrc-receive"
-        account={$selectedAccountStore.account}
-        reload={reloadAccount}
-        testId="receive-sns"
-        universeId={$snsOnlyProjectStore}
-        logo={$selectedUniverseStore?.summary?.metadata.logo ?? IC_LOGO}
-        tokenSymbol={$selectedUniverseStore?.summary?.token.symbol}
-      />
-    </Footer>
+        <ReceiveButton
+          type="icrc-receive"
+          account={$selectedAccountStore.account}
+          reload={reloadAccount}
+          testId="receive-sns"
+          universeId={$snsOnlyProjectStore}
+          logo={$selectedUniverseStore?.summary?.metadata.logo ?? IC_LOGO}
+          tokenSymbol={$selectedUniverseStore?.summary?.token.symbol}
+        />
+      </Footer>
+    {/if}
   </Island>
 
   {#if showModal && nonNullish($snsOnlyProjectStore)}

--- a/frontend/src/tests/page-objects/SnsWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsWallet.page-object.ts
@@ -1,4 +1,6 @@
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { IcrcTransactionsListPo } from "$tests/page-objects/IcrcTransactionsList.page-object";
+import { SignInPo } from "$tests/page-objects/SignIn.page-object";
 import { SnsTransactionModalPo } from "$tests/page-objects/SnsTransactionModal.page-object";
 import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-object";
 import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
@@ -28,15 +30,35 @@ export class SnsWalletPo extends BasePageObject {
     return SnsTransactionModalPo.under(this.root);
   }
 
+  getSignInPo(): SignInPo {
+    return SignInPo.under(this.root);
+  }
+
+  getSendButtonPo(): ButtonPo {
+    return this.getButton("open-new-sns-transaction");
+  }
+
+  getReceiveButtonPo(): ButtonPo {
+    return this.getButton("receive-sns");
+  }
+
+  hasSignInButton(): Promise<boolean> {
+    return this.getSignInPo().isPresent();
+  }
+
   hasSpinner(): Promise<boolean> {
     return this.isPresent("spinner");
   }
 
+  hasNoTransactions(): Promise<boolean> {
+    return this.isPresent("no-transactions-component");
+  }
+
   clickSendButton(): Promise<void> {
-    return this.click("open-new-sns-transaction");
+    return this.getSendButtonPo().click();
   }
 
   clickReceiveButton(): Promise<void> {
-    return this.click("receive-sns");
+    return this.getReceiveButtonPo().click();
   }
 }


### PR DESCRIPTION
# Motivation

We want to be able to show wallet pages when the user is not logged in.
This PR makes it possible to render the `SnsWallet.svelte` page when the user is not logged in.
This is not a user visible change because `wallet/+page.svelte` still doesn't render any wallet when the user is not logged in.

# Changes

1. Don't load data until the user is logged in.
2. Don't render `SnsBalancesObserver` if the user is not logged in.
3. Treat `selectedAccountStore.account` as nullable because we want to render most of the page when there is no account.
4. Use SignInGuard to render a sign in button if the user is not logged in.
5. Render the no-transactions placeholder instead of the SnsWalletTransactionsList component if there is no account.
6. Hide Send/Receive buttons if there is no account.

# Tests

Unit tests are added.
Tested manually in another branch.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet