### PR TITLE
GIX-2187: Make NNS wallet renderable when not signed in.

### DIFF
--- a/frontend/src/tests/page-objects/NnsWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsWallet.page-object.ts
@@ -1,5 +1,6 @@
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { IcpTransactionModalPo } from "$tests/page-objects/IcpTransactionModal.page-object";
+import { SignInPo } from "$tests/page-objects/SignIn.page-object";
 import { TransactionListPo } from "$tests/page-objects/TransactionList.page-object";
 import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-object";
 import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
@@ -29,8 +30,16 @@ export class NnsWalletPo extends BasePageObject {
     return TransactionListPo.under(this.root);
   }
 
+  getSignInPo(): SignInPo {
+    return SignInPo.under(this.root);
+  }
+
   getSendButtonPo(): ButtonPo {
     return this.getButton("new-transaction");
+  }
+
+  getReceiveButtonPo(): ButtonPo {
+    return this.getButton("receive-icp");
   }
 
   getRenameButtonPo(): ButtonPo {
@@ -45,8 +54,16 @@ export class NnsWalletPo extends BasePageObject {
     return this.getButton("ledger-show-button");
   }
 
+  hasSignInButton(): Promise<boolean> {
+    return this.getSignInPo().isPresent();
+  }
+
   hasSpinner(): Promise<boolean> {
     return this.isPresent("spinner");
+  }
+
+  hasNoTransactions(): Promise<boolean> {
+    return this.isPresent("no-transactions-component");
   }
 
   clickSend(): Promise<void> {
@@ -54,7 +71,7 @@ export class NnsWalletPo extends BasePageObject {
   }
 
   clickReceive(): Promise<void> {
-    return this.getButton("receive-icp").click();
+    return this.getReceiveButtonPo().click();
   }
 
   clickRename(): Promise<void> {


### PR DESCRIPTION
# Motivation

We want to be able to show wallet pages when the user is not logged in.
This PR makes it possible to render the `NnsWallet.svelte` page when the user is not logged in.
This is not a user visible change because `wallet/+page.svelte` still doesn't render any wallet when the user is not logged in.

# Changes

1. Don't `pollAccounts` until the user is logged in.
2. Treat `selectedAccountStore.account` as nullable because we want to render most of the page when there is no account.
3. Use SignInGuard to render a sign in button if the user is not logged in.
4. Render the no-transactions placeholder instead of the SnsWalletTransactionsList component if there is no account.
5. Hide Send/Receive buttons if there is no account.

# Tests

Unit tests are added.
Tested manually in another branch.

Drive-by: Use the real auth store instead of `mockAuthStoreSubscribe`.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet