### PR TITLE
feat: TypesFilterModal

### DIFF
--- a/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
@@ -10,6 +10,8 @@
   import FiltersWrapper from "../proposals/FiltersWrapper.svelte";
   import FiltersButton from "../ui/FiltersButton.svelte";
   import SnsFilterRewardsModal from "$lib/modals/sns/proposals/SnsFilterRewardsModal.svelte";
+  import SnsFilterTypesModal from "$lib/modals/sns/proposals/SnsFilterTypesModal.svelte";
+  import { ENABLE_SNS_TYPES_FILTER } from "$lib/stores/feature-flags.store";
 
   let modal: "types" | "rewards" | "status" | undefined = undefined;
 
@@ -28,6 +30,17 @@
 </script>
 
 <FiltersWrapper>
+  {#if $ENABLE_SNS_TYPES_FILTER}
+    <FiltersButton
+      testId="filters-by-types"
+      totalFilters={filtersStore?.types.length ?? 0}
+      activeFilters={filtersStore?.types.filter(({ checked }) => checked)
+        .length ?? 0}
+      on:nnsFilter={() => openFilters("types")}
+    >
+      {$i18n.voting.types}
+    </FiltersButton>
+  {/if}
   <FiltersButton
     testId="filters-by-rewards"
     totalFilters={filtersStore?.rewardStatus.length ?? 0}
@@ -45,6 +58,14 @@
     >{$i18n.voting.status}</FiltersButton
   >
 </FiltersWrapper>
+
+{#if modal === "types"}
+  <SnsFilterTypesModal
+    filters={filtersStore?.types}
+    {rootCanisterId}
+    on:nnsClose={close}
+  />
+{/if}
 
 {#if modal === "status"}
   <SnsFilterStatusModal

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -406,6 +406,7 @@
     "title": "Voting",
     "text": "The Internet Computer network runs under the control of the Network Nervous System, which adopts proposals and automatically executes corresponding actions. Anyone can submit a proposal, which are decided as the result of voting activity by neurons.",
     "topics": "Topics",
+    "types": "Types",
     "rewards": "Reward Status",
     "status": "Proposal Status",
     "hide_unavailable_proposals": "Show only proposals you can still vote for",

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -3,7 +3,7 @@
   import { createEventDispatcher } from "svelte";
   import { Checkbox } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
-  import type { Filter } from "$lib/types/filters";
+  import type { Filter, SnsProposalTypeFilterId } from "$lib/types/filters";
   import { onMount } from "svelte";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { isNullish } from "@dfinity/utils";
@@ -18,6 +18,7 @@
   } from "@dfinity/nns";
 
   type FiltersData =
+    | SnsProposalTypeFilterId
     | SnsProposalRewardStatus
     | Topic
     | ProposalRewardStatus

--- a/frontend/src/lib/modals/sns/proposals/SnsFilterTypesModal.svelte
+++ b/frontend/src/lib/modals/sns/proposals/SnsFilterTypesModal.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import FilterModal from "$lib/modals/common/FilterModal.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { snsFiltersStore } from "$lib/stores/sns-filters.store";
+  import type { Filter, SnsProposalTypeFilterId } from "$lib/types/filters";
+  import type { Principal } from "@dfinity/principal";
+  import { createEventDispatcher } from "svelte";
+
+  export let rootCanisterId: Principal;
+  export let filters: Filter<SnsProposalTypeFilterId>[] = [];
+
+  // This is a temporary value to be used inside the modal. It's initialized based on the prop filters;
+  let selectedFilters: Array<SnsProposalTypeFilterId> =
+    filters.filter((item) => item.checked).map(({ value }) => value) ?? [];
+  // This is a temporary value to be used inside the modal
+  let filtersValues: Filter<SnsProposalTypeFilterId>[];
+  $: filtersValues = filters.map((filter) => ({
+    ...filter,
+    checked: selectedFilters.includes(filter.value),
+  }));
+
+  const dispatch = createEventDispatcher();
+  let filter: () => void;
+  $: filter = () => {
+    snsFiltersStore.setCheckTypes({
+      checkedTypes: selectedFilters,
+      rootCanisterId,
+    });
+    dispatch("nnsClose");
+  };
+
+  const onChange = ({
+    detail: { filter },
+  }: CustomEvent<{
+    filter: Filter<SnsProposalTypeFilterId> | undefined;
+  }>) => {
+    if (filter === undefined) {
+      return;
+    }
+    selectedFilters = [
+      ...selectedFilters.filter((status) => status !== filter?.value),
+      // Toggle the checked value
+      ...(filter.checked ? [] : [filter.value]),
+    ];
+  };
+
+  const clear = () => {
+    selectedFilters = [];
+  };
+
+  const selectAll = () => {
+    selectedFilters = filters.map(({ value }) => value);
+  };
+</script>
+
+<FilterModal
+  on:nnsClose
+  on:nnsConfirm={filter}
+  on:nnsChange={onChange}
+  on:nnsSelectAll={selectAll}
+  on:nnsClearSelection={clear}
+  filters={filtersValues}
+>
+  <span slot="title">{$i18n.voting.types}</span>
+</FilterModal>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -420,6 +420,7 @@ interface I18nVoting {
   title: string;
   text: string;
   topics: string;
+  types: string;
   rewards: string;
   status: string;
   hide_unavailable_proposals: string;

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalsFilters.spec.ts
@@ -3,21 +3,13 @@ import { fireEvent, render, waitFor } from "@testing-library/svelte";
 
 describe("SnsProposalsFilters", () => {
   it("should render types filter button", () => {
-    const { queryByTestId } = render(SnsProposalsFilters, {
-      props: {
-        nsFunctions: [],
-      },
-    });
+    const { queryByTestId } = render(SnsProposalsFilters);
 
     expect(queryByTestId("filters-by-types")).toBeInTheDocument();
   });
 
   it("should show filter modal when types filter is clicked", async () => {
-    const { queryByTestId } = render(SnsProposalsFilters, {
-      props: {
-        nsFunctions: [],
-      },
-    });
+    const { queryByTestId } = render(SnsProposalsFilters);
 
     const statusFilterButton = queryByTestId("filters-by-types");
     statusFilterButton && fireEvent.click(statusFilterButton);

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalsFilters.spec.ts
@@ -2,6 +2,31 @@ import SnsProposalsFilters from "$lib/components/sns-proposals/SnsProposalsFilte
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 
 describe("SnsProposalsFilters", () => {
+  it("should render types filter button", () => {
+    const { queryByTestId } = render(SnsProposalsFilters, {
+      props: {
+        nsFunctions: [],
+      },
+    });
+
+    expect(queryByTestId("filters-by-types")).toBeInTheDocument();
+  });
+
+  it("should show filter modal when types filter is clicked", async () => {
+    const { queryByTestId } = render(SnsProposalsFilters, {
+      props: {
+        nsFunctions: [],
+      },
+    });
+
+    const statusFilterButton = queryByTestId("filters-by-types");
+    statusFilterButton && fireEvent.click(statusFilterButton);
+
+    await waitFor(() =>
+      expect(queryByTestId("filter-modal")).toBeInTheDocument()
+    );
+  });
+
   it("should render status filter button", () => {
     const { queryByTestId } = render(SnsProposalsFilters);
 

--- a/frontend/src/tests/lib/modals/sns/SnsFilterTypesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsFilterTypesModal.spec.ts
@@ -1,0 +1,173 @@
+import SnsFilterTypesModal from "$lib/modals/sns/proposals/SnsFilterTypesModal.svelte";
+import { snsFiltersStore } from "$lib/stores/sns-filters.store";
+import type { Filter, SnsProposalTypeFilterId } from "$lib/types/filters";
+import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
+import { clickByTestId } from "$tests/utils/utils.test-utils";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+describe("SnsFilterTypesModal", () => {
+  afterEach(() => {
+    snsFiltersStore.reset();
+  });
+  const filters: Filter<SnsProposalTypeFilterId>[] = [
+    {
+      id: "1",
+      name: "Motion",
+      value: "1",
+      checked: true,
+    },
+    {
+      id: "2",
+      name: "Motion",
+      value: "2",
+      checked: false,
+    },
+  ];
+  const props = {
+    rootCanisterId: mockPrincipal,
+    filters,
+  };
+
+  it("should display modal", () => {
+    const { container } = render(SnsFilterTypesModal, {
+      props,
+    });
+
+    expect(container.querySelector("div.modal")).not.toBeNull();
+  });
+
+  it("should render title", () => {
+    const { getByText } = render(SnsFilterTypesModal, {
+      props,
+    });
+
+    expect(getByText(en.voting.types)).toBeInTheDocument();
+  });
+
+  it("should render checkboxes", () => {
+    const { container } = render(SnsFilterTypesModal, {
+      props,
+    });
+
+    expect(container.querySelectorAll("input[type=checkbox]")).toHaveLength(
+      filters.length
+    );
+  });
+
+  it("should forward close modal event", () =>
+    new Promise<void>((done) => {
+      const { container, component } = render(SnsFilterTypesModal, {
+        props,
+      });
+
+      component.$on("nnsClose", () => {
+        done();
+      });
+
+      const button: HTMLButtonElement | null = container.querySelector(
+        "button:first-of-type"
+      );
+
+      button && fireEvent.click(button);
+    }));
+
+  it("should update selection", async () => {
+    const uncheckedFilters = filters.map((filter) => ({
+      ...filter,
+      checked: false,
+    }));
+    snsFiltersStore.setTypes({
+      rootCanisterId: mockPrincipal,
+      types: uncheckedFilters,
+    });
+    const { queryAllByTestId, queryByTestId } = render(SnsFilterTypesModal, {
+      props: {
+        ...props,
+        filters: uncheckedFilters,
+      },
+    });
+
+    const inputs = queryAllByTestId("checkbox") as HTMLInputElement[];
+    const firstInput = inputs[0];
+    fireEvent.click(firstInput);
+    await waitFor(() => expect(firstInput.checked).toBeTruthy());
+
+    const secondInput = inputs[1];
+    fireEvent.click(secondInput);
+    await waitFor(() => expect(secondInput.checked).toBeTruthy());
+
+    await clickByTestId(queryByTestId, "apply-filters");
+
+    const types = get(snsFiltersStore)[mockPrincipal.toText()]?.types;
+
+    expect(types.filter(({ checked }) => checked).length).toEqual(2);
+  });
+
+  it("should select all filters", async () => {
+    const uncheckedFilters = filters.map((filter) => ({
+      ...filter,
+      checked: false,
+    }));
+    snsFiltersStore.setTypes({
+      rootCanisterId: mockPrincipal,
+      types: uncheckedFilters,
+    });
+    const { queryAllByTestId, queryByTestId } = render(SnsFilterTypesModal, {
+      props: {
+        ...props,
+        filters: uncheckedFilters,
+      },
+    });
+
+    const inputs = queryAllByTestId("checkbox") as HTMLInputElement[];
+    await waitFor(() =>
+      expect(inputs.reduce((acc, input) => acc && input.checked, true)).toBe(
+        false
+      )
+    );
+
+    await clickByTestId(queryByTestId, "filter-modal-select-all");
+
+    const inputs2 = queryAllByTestId("checkbox") as HTMLInputElement[];
+    await waitFor(() =>
+      expect(inputs2.reduce((acc, input) => acc && input.checked, true)).toBe(
+        true
+      )
+    );
+  });
+
+  it("should clear filters", async () => {
+    const uncheckedFilters = filters.map((filter) => ({
+      ...filter,
+      checked: true,
+    }));
+    snsFiltersStore.setTypes({
+      rootCanisterId: mockPrincipal,
+      types: uncheckedFilters,
+    });
+    const { queryAllByTestId, queryByTestId } = render(SnsFilterTypesModal, {
+      props: {
+        ...props,
+        filters: uncheckedFilters,
+      },
+    });
+
+    const inputs = queryAllByTestId("checkbox") as HTMLInputElement[];
+    await waitFor(() =>
+      expect(inputs.reduce((acc, input) => acc && input.checked, true)).toBe(
+        true
+      )
+    );
+
+    await clickByTestId(queryByTestId, "filter-modal-clear");
+
+    const inputs2 = queryAllByTestId("checkbox") as HTMLInputElement[];
+    await waitFor(() =>
+      expect(inputs2.reduce((acc, input) => acc || input.checked, false)).toBe(
+        false
+      )
+    );
+  });
+});


### PR DESCRIPTION
# Motivation

Display the `Types` filter modal behind the `ENABLE_SNS_TYPES_FILTER` flag till it's ready. The final pull request will incorporate the selected options into the getProposal request.

# Changes

- `Types` filter button (behind the feature flag)
- `SnsFilterTypesModal`

# Tests

- button should be visible and clickable
- modal should work

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.

# Screenshots

| Button | Modal |
|--------|--------|
| <img width="560" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/a94dddbe-c979-44ad-a7b6-253ecdef9064"> | <img width="519" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/a1f80bbd-e5ea-4112-95d0-fb14b4a20d80"> | 



