### PR TITLE
fix: use all neurons in voting card

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,7 +30,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * BTC deposit address QR code spinner in dark theme.
-* Missing NF-neurons on sns proposal detail page.
+* Missing NF-neurons on SNS proposal detail page.
 
 #### Security
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,6 +30,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * BTC deposit address QR code spinner in dark theme.
+* Missing NF-neurons on sns proposal detail page.
 
 #### Security
 

--- a/frontend/src/lib/components/sns-proposals/SnsVotingCard.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsVotingCard.svelte
@@ -6,7 +6,7 @@
     SnsVote,
   } from "@dfinity/sns";
   import { fromDefinedNullable, nonNullish } from "@dfinity/utils";
-  import { sortedSnsUserNeuronsStore } from "$lib/derived/sns/sns-sorted-neurons.derived";
+  import { snsSortedNeuronStore } from "$lib/derived/sns/sns-sorted-neurons.derived";
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import type { UniverseCanisterIdText } from "$lib/types/universe";
   import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
@@ -62,7 +62,7 @@
   $: votableNeurons = nonNullish($authStore.identity)
     ? votableSnsNeurons({
         proposal,
-        neurons: $sortedSnsUserNeuronsStore,
+        neurons: $snsSortedNeuronStore,
         identity: $authStore.identity,
       })
     : [];
@@ -123,9 +123,9 @@
   };
 
   let neuronsVotedForProposal: CompactNeuronInfo[] = [];
-  $: if ($sortedSnsUserNeuronsStore.length > 0) {
+  $: if ($snsSortedNeuronStore.length > 0) {
     neuronsVotedForProposal = votedSnsNeuronDetails({
-      neurons: $sortedSnsUserNeuronsStore,
+      neurons: $snsSortedNeuronStore,
       proposal,
     });
   }
@@ -135,7 +135,7 @@
   $: ineligibleNeurons = nonNullish($authStore.identity)
     ? snsNeuronsToIneligibleNeuronData({
         neurons: ineligibleSnsNeurons({
-          neurons: $sortedSnsUserNeuronsStore,
+          neurons: $snsSortedNeuronStore,
           proposal,
           identity: $authStore.identity,
         }),
@@ -152,7 +152,7 @@
         );
 
   let hasNeurons = false;
-  $: hasNeurons = $sortedSnsUserNeuronsStore.length > 0;
+  $: hasNeurons = $snsSortedNeuronStore.length > 0;
 </script>
 
 <VotingCard

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
@@ -96,6 +96,8 @@ describe("SnsVotingCard", () => {
         id: [2],
         state: NeuronState.Locked,
         createdTimestampSeconds: neuronCreatedAt,
+        // Should also work with NF neurons the same way as with own neurons
+        sourceNnsNeuronId: 12345n,
       }),
       permissions: permissionsWithTypeVote,
     },


### PR DESCRIPTION
# Motivation

Fix missing NF-neurons in the SNS proposal details voting block.

# Changes

- switch to use all user neurons `snsSortedNeuronStore`.

# Tests

- `SnsVotingCard` should display NF neurons as well

# Todos

- [x] Add entry to changelog (if necessary).

