### PR TITLE
Keep local replica accessible locally

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -51,4 +51,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Keep local replica accessible locally when specifying --domain to dfx-snapshot-start.
+
 #### Security

--- a/scripts/dfx-snapshot-start
+++ b/scripts/dfx-snapshot-start
@@ -71,7 +71,7 @@ if [ "${DFX_HOST:-}" ]; then
   DFX_ARGS+=("--host" "$DFX_HOST")
 fi
 if [ "${DFX_DOMAIN:-}" ]; then
-  DFX_ARGS+=("--domain" "$DFX_DOMAIN")
+  DFX_ARGS+=("--domain" "localhost" "--domain" "$DFX_DOMAIN")
 fi
 dfx start "${DFX_ARGS[@]}"
 


### PR DESCRIPTION
# Motivation

`dfx` has a flag `--domain` which you need to specify to make the replica accessible remotely at that domain.
But when you do, this overrides the default value, which is `localhost` so then the replica is no longer accessible from the machine itself at `localhost`.
To make the replica accessible on both domains, we need to pass the `--domain` flag twice.

# Changes

Pass `--domain localhost` to replica when specifying an additional domain to `dfx-snapshot-start`.

# Tests

Tested manually on my DevEnv.

# Todos

- [x] Add entry to changelog (if necessary).
