### PR TITLE
Refactor: Migrate to TokenAmountV2

### DIFF
--- a/frontend/src/lib/components/accounts/SnsAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/SnsAccountsFooter.svelte
@@ -15,7 +15,6 @@
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
   import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
   import IC_LOGO from "$lib/assets/icp.svg";
-  import { toTokenAmountV2 } from "$lib/utils/token.utils";
 
   // TODO: Support adding subaccounts
   let modal: "NewTransaction" | undefined = undefined;
@@ -38,7 +37,7 @@
   <SnsTransactionModal
     rootCanisterId={$selectedUniverseIdStore}
     token={$snsTokenSymbolSelectedStore}
-    transactionFee={toTokenAmountV2($snsSelectedTransactionFeeStore)}
+    transactionFee={$snsSelectedTransactionFeeStore}
     on:nnsClose={closeModal}
   />
 {/if}

--- a/frontend/src/lib/components/accounts/TransactionInfo.svelte
+++ b/frontend/src/lib/components/accounts/TransactionInfo.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import { mainTransactionFeeStore } from "$lib/stores/transaction-fees.store";
-  import { formattedTransactionFeeICP } from "$lib/utils/token.utils";
+  import { formatTokenV2 } from "$lib/utils/token.utils";
   import { Value } from "@dfinity/gix-components";
-  import type { TokenAmount } from "@dfinity/utils";
+  import type { TokenAmountV2 } from "@dfinity/utils";
 
   export let feeOnly = false;
   export let source: string;
   export let destination: string;
   export let hardwareWallet = false;
-  export let fee: TokenAmount | undefined = undefined;
+  export let fee: TokenAmountV2;
 </script>
 
 {#if !feeOnly}
@@ -32,11 +31,7 @@
   <p class="label">{$i18n.accounts.transaction_fee}</p>
 
   <p class="fee">
-    <Value
-      >{formattedTransactionFeeICP(
-        fee?.toE8s() ?? $mainTransactionFeeStore
-      )}</Value
-    >
+    <Value>{formatTokenV2({ value: fee })}</Value>
     {fee?.token.symbol ?? $i18n.core.icp}
   </p>
 </div>

--- a/frontend/src/lib/components/neuron-detail/ConfirmDisburseNeuron.svelte
+++ b/frontend/src/lib/components/neuron-detail/ConfirmDisburseNeuron.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import type { TokenAmount, TokenAmountV2 } from "@dfinity/utils";
+  import type { TokenAmountV2 } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
   import { i18n } from "$lib/stores/i18n";
   import TransactionInfo from "$lib/components/accounts/TransactionInfo.svelte";
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
 
   export let amount: TokenAmountV2;
-  export let fee: TokenAmount | undefined = undefined;
+  export let fee: TokenAmountV2;
   export let source: string;
   export let destinationAddress: string;
   export let loading = false;

--- a/frontend/src/lib/components/sns-neurons/SnsNeuronsFooter.svelte
+++ b/frontend/src/lib/components/sns-neurons/SnsNeuronsFooter.svelte
@@ -6,7 +6,6 @@
   import SnsStakeNeuronModal from "$lib/modals/sns/neurons/SnsStakeNeuronModal.svelte";
   import { snsSelectedProjectNewTxData } from "$lib/derived/sns/sns-selected-project-new-tx-data.derived";
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
-  import { toTokenAmountV2 } from "$lib/utils/token.utils";
 
   type ModalKey = "stake-neuron";
   let showModal: ModalKey | undefined = undefined;
@@ -30,9 +29,7 @@
         token={$snsSelectedProjectNewTxData.token}
         on:nnsClose={closeModal}
         rootCanisterId={$snsSelectedProjectNewTxData.rootCanisterId}
-        transactionFee={toTokenAmountV2(
-          $snsSelectedProjectNewTxData.transactionFee
-        )}
+        transactionFee={$snsSelectedProjectNewTxData.transactionFee}
         governanceCanisterId={$snsProjectSelectedStore.summary
           .governanceCanisterId}
       />

--- a/frontend/src/lib/derived/sns/sns-selected-project-new-tx-data.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-selected-project-new-tx-data.derived.ts
@@ -1,5 +1,5 @@
 import type { Principal } from "@dfinity/principal";
-import type { Token, TokenAmount } from "@dfinity/utils";
+import type { Token, TokenAmountV2 } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 import { selectedUniverseIdStore } from "../selected-universe.derived";
 import { snsSelectedTransactionFeeStore } from "./sns-selected-transaction-fee.store";
@@ -8,7 +8,7 @@ import { snsTokenSymbolSelectedStore } from "./sns-token-symbol-selected.store";
 interface SnsNewTxData {
   token: Token;
   rootCanisterId: Principal;
-  transactionFee: TokenAmount;
+  transactionFee: TokenAmountV2;
 }
 
 export const snsSelectedProjectNewTxData: Readable<SnsNewTxData | undefined> =

--- a/frontend/src/lib/derived/sns/sns-selected-transaction-fee.store.ts
+++ b/frontend/src/lib/derived/sns/sns-selected-transaction-fee.store.ts
@@ -1,20 +1,21 @@
 import { tokensStore } from "$lib/stores/tokens.store";
-import { TokenAmount, nonNullish } from "@dfinity/utils";
+import { TokenAmountV2, nonNullish } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 import { snsOnlyProjectStore } from "./sns-selected-project.derived";
 
-export const snsSelectedTransactionFeeStore: Readable<TokenAmount | undefined> =
-  derived(
-    [snsOnlyProjectStore, tokensStore],
-    ([selectedRootCanisterId, tokensStore]) => {
-      const selectedToken = nonNullish(selectedRootCanisterId)
-        ? tokensStore[selectedRootCanisterId.toText()]?.token
-        : undefined;
-      if (nonNullish(selectedToken)) {
-        return TokenAmount.fromE8s({
-          amount: selectedToken.fee,
-          token: selectedToken,
-        });
-      }
+export const snsSelectedTransactionFeeStore: Readable<
+  TokenAmountV2 | undefined
+> = derived(
+  [snsOnlyProjectStore, tokensStore],
+  ([selectedRootCanisterId, tokensStore]) => {
+    const selectedToken = nonNullish(selectedRootCanisterId)
+      ? tokensStore[selectedRootCanisterId.toText()]?.token
+      : undefined;
+    if (nonNullish(selectedToken)) {
+      return TokenAmountV2.fromUlps({
+        amount: selectedToken.fee,
+        token: selectedToken,
+      });
     }
-  );
+  }
+);

--- a/frontend/src/lib/modals/neurons/DisburseNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseNnsNeuronModal.svelte
@@ -29,6 +29,7 @@
     cancelPollAccounts,
     pollAccounts,
   } from "$lib/services/icp-accounts.services";
+  import { mainTransactionFeeE8sStore } from "$lib/stores/transaction-fees.store";
 
   export let neuron: NeuronInfo;
 
@@ -153,6 +154,10 @@
       {loading}
       {destinationAddress}
       on:nnsBack={modal.back}
+      fee={TokenAmountV2.fromUlps({
+        amount: $mainTransactionFeeE8sStore,
+        token: ICPToken,
+      })}
     />
   {/if}
 </QrWizardModal>

--- a/frontend/src/lib/modals/neurons/DisburseSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/DisburseSnsNeuronModal.svelte
@@ -9,7 +9,7 @@
     TokenAmountV2,
     fromDefinedNullable,
     type Token,
-    type TokenAmount,
+    nonNullish,
   } from "@dfinity/utils";
   import {
     getSnsNeuronIdAsHexString,
@@ -46,7 +46,7 @@
     token: $snsTokenSymbolSelectedStore as Token,
   });
 
-  let fee: TokenAmount | undefined;
+  let fee: TokenAmountV2 | undefined;
   $: fee = $snsSelectedTransactionFeeStore;
 
   const dispatcher = createEventDispatcher();
@@ -117,7 +117,7 @@
     ><span data-tid="disburse-sns-neuron-modal">{currentStep?.title}</span
     ></svelte:fragment
   >
-  {#if currentStep?.name === "ConfirmDisburse" && destinationAddress !== undefined}
+  {#if currentStep?.name === "ConfirmDisburse" && destinationAddress !== undefined && nonNullish(fee)}
     <ConfirmDisburseNeuron
       on:nnsClose
       on:nnsBack={() => {

--- a/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
@@ -17,7 +17,6 @@
   import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
-  import { toTokenAmountV2 } from "$lib/utils/token.utils";
 
   export let neuronId: SnsNeuronId;
   export let token: Token;
@@ -83,7 +82,7 @@
     $snsProjectSelectedStore?.summary.governanceCanisterId;
 
   let transactionFee: TokenAmountV2 | undefined = undefined;
-  $: transactionFee = toTokenAmountV2($snsSelectedTransactionFeeStore);
+  $: transactionFee = $snsSelectedTransactionFeeStore;
 
   let loading = true;
   $: loading =

--- a/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsNeuronModals.svelte
@@ -71,7 +71,7 @@
     : undefined;
 
   let transactionFee: E8s | undefined;
-  $: transactionFee = $snsSelectedTransactionFeeStore?.toE8s();
+  $: transactionFee = $snsSelectedTransactionFeeStore?.toUlps();
 
   const onSnsNeuronDetailModal = ({ detail }: CustomEvent<SnsNeuronModal>) =>
     (modal = detail);

--- a/frontend/src/lib/pages/SnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/SnsNeuronDetail.svelte
@@ -71,7 +71,7 @@
     $snsParametersStore?.[rootCanisterId?.toText() ?? ""]?.parameters;
 
   let transactionFee: E8s | undefined;
-  $: transactionFee = $snsSelectedTransactionFeeStore?.toE8s();
+  $: transactionFee = $snsSelectedTransactionFeeStore?.toUlps();
 
   let token: Token;
   $: token = $snsTokenSymbolSelectedStore as Token;

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -42,7 +42,6 @@
   import WalletPageHeading from "$lib/components/accounts/WalletPageHeading.svelte";
   import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
   import IC_LOGO from "$lib/assets/icp.svg";
-  import { toTokenAmountV2 } from "$lib/utils/token.utils";
   import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
   import { AppPath } from "$lib/constants/routes.constants";
 
@@ -226,7 +225,7 @@
       rootCanisterId={$snsOnlyProjectStore}
       loadTransactions
       {token}
-      transactionFee={toTokenAmountV2($snsSelectedTransactionFeeStore)}
+      transactionFee={$snsSelectedTransactionFeeStore}
     />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/tests/lib/components/neuron-detail/ConfirmDisburseNeuron.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/ConfirmDisburseNeuron.spec.ts
@@ -1,6 +1,6 @@
 import { formattedTransactionFeeICP } from "$lib/utils/token.utils";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
-import { ICPToken, TokenAmount, TokenAmountV2 } from "@dfinity/utils";
+import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 import ConfirmDisburseNeuronTest from "./ConfirmDisburseNeuronTest.svelte";
 
@@ -19,7 +19,7 @@ describe("ConfirmDisburseNeuron", () => {
     source: "test source",
     destinationAddress: "test destination",
     loading: false,
-    fee: TokenAmount.fromNumber({ amount: fee, token: ICPToken }),
+    fee: TokenAmountV2.fromNumber({ amount: fee, token: ICPToken }),
   };
 
   it("should display amount", async () => {

--- a/frontend/src/tests/lib/components/sns-neurons/SnsNeuronsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/SnsNeuronsFooter.spec.ts
@@ -10,7 +10,7 @@ import {
 } from "$tests/mocks/neurons.mock";
 import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
 import { NeuronState } from "@dfinity/nns";
-import { TokenAmount } from "@dfinity/utils";
+import { TokenAmountV2 } from "@dfinity/utils";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 
 describe("SnsNeuron footer", () => {
@@ -38,7 +38,7 @@ describe("SnsNeuron footer", () => {
       mockStoreSubscribe({
         token: mockSnsFullProject.summary.token,
         rootCanisterId: mockSnsFullProject.rootCanisterId,
-        transactionFee: TokenAmount.fromE8s({
+        transactionFee: TokenAmountV2.fromUlps({
           amount: 10_000n,
           token: mockSnsFullProject.summary.token,
         }),

--- a/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-project-new-tx-data.derived.spec.ts
@@ -59,7 +59,7 @@ describe("selected-project-new-transaction-data derived store", () => {
         rootCanisterId.toText()
       );
       expect(storeData.token).toEqual(token);
-      expect(storeData.transactionFee.toE8s()).toEqual(fee);
+      expect(storeData.transactionFee.toUlps()).toEqual(fee);
     });
 
     it("returns undefined if no transaction fee", () => {

--- a/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-selected-transaction-fee.store.spec.ts
@@ -38,7 +38,7 @@ describe("snsSelectedTransactionFeeStore", () => {
 
     const actualFeeTokens = get(snsSelectedTransactionFeeStore);
 
-    expect(actualFeeTokens?.toE8s()).toBe(fee);
+    expect(actualFeeTokens?.toUlps()).toBe(fee);
     expect(actualFeeTokens?.token.symbol).toBe(mockToken.symbol);
   });
 

--- a/frontend/src/tests/mocks/transaction-fee.mock.ts
+++ b/frontend/src/tests/mocks/transaction-fee.mock.ts
@@ -1,13 +1,13 @@
-import { TokenAmount } from "@dfinity/utils";
+import { TokenAmountV2 } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
 
 export const mockSnsSelectedTransactionFeeStoreSubscribe =
   (notDefined = false) =>
-  (run: Subscriber<TokenAmount>): (() => void) => {
+  (run: Subscriber<TokenAmountV2>): (() => void) => {
     run(
       notDefined
         ? undefined
-        : TokenAmount.fromE8s({
+        : TokenAmountV2.fromUlps({
             amount: 10_000n,
             token: { name: "Test", symbol: "TST", decimals: 8 },
           })


### PR DESCRIPTION
# Motivation

Migrate to TokenAmountV2 which supports decimals different than 8.

In this PR, I change `snsSelectedTransactionFeeStore` to return a `TokenAmountV2`.

# Changes

* Set `snsSelectedTransactionFeeStore` to return `TokenAmountV2`.
* Change dependencies accordingly.
* Remove unnecessary `toTokenAmountV2`.

# Tests

* Change mock accordingly.
* Fix test data.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
