### PR TITLE
GIX-2172: Remove old BTC withdrawal flow

### DIFF
--- a/frontend/src/lib/components/accounts/ConvertBtcInProgress.svelte
+++ b/frontend/src/lib/components/accounts/ConvertBtcInProgress.svelte
@@ -5,7 +5,6 @@
   import { ConvertBtcStep } from "$lib/types/ckbtc-convert";
 
   export let progressStep: ConvertBtcStep;
-  export let transferToLedgerStep = true;
   export let useIcrc2 = false;
 
   let steps: [ProgressStep, ...ProgressStep[]] = [
@@ -20,15 +19,6 @@
           text: $i18n.ckbtc.step_initialization,
           state: "next",
         }) as ProgressStep,
-    ...(transferToLedgerStep && !useIcrc2
-      ? [
-          {
-            step: ConvertBtcStep.LOCKING_CKBTC,
-            text: $i18n.ckbtc.step_locking_ckbtc,
-            state: "next",
-          } as ProgressStep,
-        ]
-      : []),
     {
       step: ConvertBtcStep.SEND_BTC,
       text: $i18n.ckbtc.step_send_btc,

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -3,7 +3,6 @@
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
   import { toastsSuccess } from "$lib/stores/toasts.store";
-  import { ENABLE_CKBTC_ICRC2 } from "$lib/stores/feature-flags.store";
   import type { NewTransaction, TransactionInit } from "$lib/types/transaction";
   import { TransactionNetwork } from "$lib/types/transaction";
   import type { ValidateAmountFn } from "$lib/types/transaction";
@@ -17,7 +16,6 @@
   import type { UniverseCanisterId } from "$lib/types/universe";
   import type { CkBTCAdditionalCanisters } from "$lib/types/ckbtc-canisters";
   import {
-    convertCkBTCToBtc,
     convertCkBTCToBtcIcrc2,
     type ConvertCkBTCToBtcParams,
     retrieveBtc,
@@ -132,15 +130,9 @@
     if (withdrawalAccount) {
       useIcrc2ForProgress = false;
       ({ success } = await retrieveBtc(params));
-    } else if ($ENABLE_CKBTC_ICRC2) {
+    } else {
       useIcrc2ForProgress = true;
       ({ success } = await convertCkBTCToBtcIcrc2({
-        source: sourceAccount,
-        ...params,
-      }));
-    } else {
-      useIcrc2ForProgress = false;
-      ({ success } = await convertCkBTCToBtc({
         source: sourceAccount,
         ...params,
       }));
@@ -238,7 +230,6 @@
   <ConvertBtcInProgress
     slot="in_progress"
     {progressStep}
-    transferToLedgerStep={!withdrawalAccount}
     useIcrc2={useIcrc2ForProgress}
   />
 </TransactionModal>

--- a/frontend/src/lib/types/ckbtc-convert.ts
+++ b/frontend/src/lib/types/ckbtc-convert.ts
@@ -1,6 +1,5 @@
 export enum ConvertBtcStep {
   INITIALIZATION = "initialization",
-  LOCKING_CKBTC = "locking_ckbtc",
   APPROVE_TRANSFER = "approve_transfer",
   SEND_BTC = "send_btc",
   RELOAD = "reload",

--- a/frontend/src/tests/lib/components/accounts/ConvertBtcInProgress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ConvertBtcInProgress.spec.ts
@@ -19,130 +19,11 @@ describe("ConvertBtcInProgress", () => {
     expect(element.textContent).toContain(en.core.do_not_close);
   });
 
-  describe("with transfer to ledger", () => {
-    it("should render steps", () => {
-      const { container } = render(ConvertBtcInProgress, {
-        props: {
-          progressStep: ConvertBtcStep.INITIALIZATION,
-        },
-      });
-
-      // ConvertBtcStep minus ConvertBtcStep.DONE
-      expect(container.querySelectorAll(".step").length).toEqual(4);
-    });
-
-    it("should render step initialization completed", () => {
-      const result = render(ConvertBtcInProgress, {
-        props: {
-          progressStep: ConvertBtcStep.LOCKING_CKBTC,
-        },
-      });
-
-      testProgress({
-        result,
-        position: 1,
-        label: en.ckbtc.step_initialization,
-        status: "Completed",
-      });
-    });
-
-    it("should render step locking ckbtc in progress", () => {
-      const result = render(ConvertBtcInProgress, {
-        props: {
-          progressStep: ConvertBtcStep.LOCKING_CKBTC,
-        },
-      });
-
-      testProgress({
-        result,
-        position: 2,
-        label: en.ckbtc.step_locking_ckbtc,
-        status: "In progress",
-      });
-    });
-
-    it("should render step locking ckbtc completed", () => {
-      const result = render(ConvertBtcInProgress, {
-        props: {
-          progressStep: ConvertBtcStep.SEND_BTC,
-        },
-      });
-
-      testProgress({
-        result,
-        position: 2,
-        label: en.ckbtc.step_locking_ckbtc,
-        status: "Completed",
-      });
-    });
-
-    it("should render step send btc in progress", () => {
-      const result = render(ConvertBtcInProgress, {
-        props: {
-          progressStep: ConvertBtcStep.SEND_BTC,
-        },
-      });
-
-      testProgress({
-        result,
-        position: 3,
-        label: en.ckbtc.step_send_btc,
-        status: "In progress",
-      });
-    });
-
-    it("should render step send btc completed", () => {
-      const result = render(ConvertBtcInProgress, {
-        props: {
-          progressStep: ConvertBtcStep.RELOAD,
-        },
-      });
-
-      testProgress({
-        result,
-        position: 3,
-        label: en.ckbtc.step_send_btc,
-        status: "Completed",
-      });
-    });
-
-    it("should render step reload in progress", () => {
-      const result = render(ConvertBtcInProgress, {
-        props: {
-          progressStep: ConvertBtcStep.RELOAD,
-        },
-      });
-
-      testProgress({
-        result,
-        position: 4,
-        label: en.ckbtc.step_reload,
-        status: "In progress",
-      });
-    });
-
-    it("should render step reload completed", () => {
-      const result = render(ConvertBtcInProgress, {
-        props: {
-          progressStep: ConvertBtcStep.DONE,
-        },
-      });
-
-      testProgress({
-        result,
-        position: 4,
-        label: en.sns_sale.step_reload,
-        status: "Completed",
-      });
-    });
-  });
-
   describe("without transfer to ledger", () => {
     it("should render steps", () => {
       const { container } = render(ConvertBtcInProgress, {
         props: {
           progressStep: ConvertBtcStep.INITIALIZATION,
-          transferToLedgerStep: false,
         },
       });
 
@@ -154,7 +35,6 @@ describe("ConvertBtcInProgress", () => {
       const result = render(ConvertBtcInProgress, {
         props: {
           progressStep: ConvertBtcStep.SEND_BTC,
-          transferToLedgerStep: false,
         },
       });
 
@@ -170,7 +50,6 @@ describe("ConvertBtcInProgress", () => {
       const result = render(ConvertBtcInProgress, {
         props: {
           progressStep: ConvertBtcStep.SEND_BTC,
-          transferToLedgerStep: false,
         },
       });
 
@@ -186,7 +65,6 @@ describe("ConvertBtcInProgress", () => {
       const result = render(ConvertBtcInProgress, {
         props: {
           progressStep: ConvertBtcStep.RELOAD,
-          transferToLedgerStep: false,
         },
       });
 
@@ -202,7 +80,6 @@ describe("ConvertBtcInProgress", () => {
       const result = render(ConvertBtcInProgress, {
         props: {
           progressStep: ConvertBtcStep.RELOAD,
-          transferToLedgerStep: false,
         },
       });
 
@@ -218,7 +95,6 @@ describe("ConvertBtcInProgress", () => {
       const result = render(ConvertBtcInProgress, {
         props: {
           progressStep: ConvertBtcStep.DONE,
-          transferToLedgerStep: false,
         },
       });
 

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -6,7 +6,6 @@ import { ckBTCTransferTokens } from "$lib/services/ckbtc-accounts.services";
 import * as services from "$lib/services/ckbtc-convert.services";
 import { authStore } from "$lib/stores/auth.store";
 import { ckBTCInfoStore } from "$lib/stores/ckbtc-info.store";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import type { Account } from "$lib/types/account";
 import { TransactionNetwork } from "$lib/types/transaction";
@@ -58,7 +57,6 @@ describe("CkBTCTransactionModal", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    overrideFeatureFlagsStore.reset();
 
     vi.mocked(ckBTCTransferTokens).mockResolvedValue({ blockIndex: undefined });
     vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
@@ -102,25 +100,6 @@ describe("CkBTCTransactionModal", () => {
 
     await waitFor(() => expect(ckBTCTransferTokens).toBeCalled());
   });
-
-  const testConvertCkBTCToBTC = async ({
-    success,
-    eventName,
-  }: {
-    success: boolean;
-    eventName: "nnsClose" | "nnsTransfer";
-  }) => {
-    const spy = vi
-      .spyOn(services, "convertCkBTCToBtc")
-      .mockResolvedValue({ success });
-
-    await testTransfer({
-      eventName,
-      selectedNetwork: TransactionNetwork.BTC_TESTNET,
-    });
-
-    await waitFor(() => expect(spy).toBeCalled());
-  };
 
   const testConvertCkBTCToBTCWithIcrc2 = async ({
     success,
@@ -183,57 +162,7 @@ describe("CkBTCTransactionModal", () => {
     await waitFor(() => expect(onEnd).toBeCalled());
   };
 
-  describe("without ICRC-2", () => {
-    beforeEach(() => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_CKBTC_ICRC2", false);
-    });
-
-    it("should convert ckBTC to Bitcoin", async () => {
-      await testConvertCkBTCToBTC({ success: true, eventName: "nnsTransfer" });
-    });
-
-    it("should close modal on ckBTC to Bitcoin error", async () => {
-      await testConvertCkBTCToBTC({ success: false, eventName: "nnsClose" });
-    });
-
-    it("should render progress when converting ckBTC to Bitcoin without ICRC-2", async () => {
-      vi.spyOn(services, "convertCkBTCToBtc").mockResolvedValue({
-        success: true,
-      });
-
-      const result = await renderTransactionModal();
-
-      await testTransferTokens({
-        result,
-        selectedNetwork: TransactionNetwork.BTC_TESTNET,
-        destinationAddress: mockBTCAddressTestnet,
-      });
-
-      await waitFor(() =>
-        expect(result.getByTestId("in-progress-warning")).not.toBeNull()
-      );
-
-      // In progress + transfer to ledger + sending BTC + reload
-      expect(result.container.querySelectorAll("div.step").length).toEqual(4);
-    });
-
-    it("should display estimated time in modal", async () => {
-      toastsStore.reset();
-
-      await testConvertCkBTCToBTC({ success: true, eventName: "nnsTransfer" });
-
-      const toastData = get(toastsStore);
-      expect(toastData[0].text).toEqual(
-        en.ckbtc.transaction_success_about_thirty_minutes
-      );
-    });
-  });
-
-  describe("with ICRC-2", () => {
-    beforeEach(() => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_CKBTC_ICRC2", true);
-    });
-
+  describe("convert BTC to ckBTC with ICRC-2", () => {
     it("should convert ckBTC to Bitcoin", async () => {
       await testConvertCkBTCToBTCWithIcrc2({
         success: true,
@@ -564,9 +493,6 @@ describe("CkBTCTransactionModal", () => {
     });
 
     it("should render progress without step transfer", async () => {
-      vi.spyOn(services, "convertCkBTCToBtc").mockResolvedValue({
-        success: true,
-      });
       vi.spyOn(services, "retrieveBtc").mockResolvedValue({ success: true });
 
       const result = await renderTransactionModal(mockCkBTCWithdrawalAccount);

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -13,7 +13,6 @@ import * as services from "$lib/services/wallet-accounts.services";
 import { bitcoinAddressStore } from "$lib/stores/bitcoin.store";
 import { ckBTCInfoStore } from "$lib/stores/ckbtc-info.store";
 import { ckbtcRetrieveBtcStatusesStore } from "$lib/stores/ckbtc-retrieve-btc-statuses.store";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { Account } from "$lib/types/account";
@@ -123,7 +122,6 @@ describe("CkBTCWallet", () => {
     ckBTCInfoStore.reset();
     bitcoinAddressStore.reset();
     ckbtcRetrieveBtcStatusesStore.reset();
-    overrideFeatureFlagsStore.reset();
     resetIdentity();
 
     vi.mocked(icrcIndexApi.getTransactions).mockResolvedValue({
@@ -381,75 +379,7 @@ describe("CkBTCWallet", () => {
       expect(icrcIndexApi.getTransactions).toBeCalledTimes(2);
     });
 
-    describe("without ICRC-2", () => {
-      beforeEach(() => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_CKBTC_ICRC2", false);
-      });
-
-      it("should update account after withdrawing BTC", async () => {
-        const { walletPo, sendModalPo } = await renderWalletAndModal();
-
-        // Check original sum
-        expect(await walletPo.getWalletPageHeadingPo().getTitle()).toBe(
-          "4'445'566.99 ckBTC"
-        );
-
-        // Make transfer
-        await walletPo.getCkBTCWalletFooterPo().clickSendButton();
-        await sendModalPo.transferToAddress({
-          destinationAddress: testnetBtcAddress,
-          amount: 10,
-        });
-
-        await runResolvedPromises();
-        expect(icrcLedgerApi.icrcTransfer).toBeCalledTimes(1);
-        expect(icrcLedgerApi.approveTransfer).toBeCalledTimes(0);
-        expect(ckbtcMinterApi.retrieveBtcWithApproval).toBeCalledTimes(0);
-
-        // Account should have been updated and sum should be reflected
-        expect(await walletPo.getWalletPageHeadingPo().getTitle()).toBe(
-          "0.00011111 ckBTC"
-        );
-      });
-
-      it("should reload transactions after withdrawing BTC", async () => {
-        const { walletPo, sendModalPo } = await renderWalletAndModal();
-
-        expect(icrcIndexApi.getTransactions).toBeCalledTimes(1);
-
-        // Check original sum
-        expect(await walletPo.getWalletPageHeadingPo().getTitle()).toBe(
-          "4'445'566.99 ckBTC"
-        );
-
-        // Make transfer
-        await walletPo.getCkBTCWalletFooterPo().clickSendButton();
-        await sendModalPo.transferToAddress({
-          destinationAddress: testnetBtcAddress,
-          amount: 10,
-        });
-
-        await runResolvedPromises();
-        expect(icrcLedgerApi.icrcTransfer).toBeCalledTimes(1);
-        expect(icrcLedgerApi.approveTransfer).toBeCalledTimes(0);
-        expect(ckbtcMinterApi.retrieveBtcWithApproval).toBeCalledTimes(0);
-
-        expect(icrcIndexApi.getTransactions).toBeCalledTimes(2);
-
-        await advanceTime(WALLET_TRANSACTIONS_RELOAD_DELAY + 1000);
-
-        // This additional loading of transactions is not necessary.
-        // TODO: Remove the double reloading and change the expected number of
-        // calls from 2 to 3.
-        expect(icrcIndexApi.getTransactions).toBeCalledTimes(3);
-      });
-    });
-
-    describe("with ICRC-2", () => {
-      beforeEach(() => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_CKBTC_ICRC2", true);
-      });
-
+    describe("convert ckBTC to BTC with ICRC-2", () => {
       it("should update account after withdrawing BTC", async () => {
         const { walletPo, sendModalPo } = await renderWalletAndModal();
 

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -1,37 +1,24 @@
 import * as agent from "$lib/api/agent.api";
 import * as minterApi from "$lib/api/ckbtc-minter.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
-import * as ledgerApi from "$lib/api/wallet-ledger.api";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import * as ckbtcAccountsServices from "$lib/services/ckbtc-accounts.services";
 import {
-  convertCkBTCToBtc,
   convertCkBTCToBtcIcrc2,
   retrieveBtc,
 } from "$lib/services/ckbtc-convert.services";
 import { loadCkBTCWithdrawalAccount } from "$lib/services/ckbtc-withdrawal-accounts.services";
 import { loadWalletTransactions } from "$lib/services/wallet-transactions.services";
-import { bitcoinConvertBlockIndexes } from "$lib/stores/bitcoin.store";
 import { ckBTCWithdrawalAccountsStore } from "$lib/stores/ckbtc-withdrawal-accounts.store";
 import * as toastsStore from "$lib/stores/toasts.store";
-import { tokensStore } from "$lib/stores/tokens.store";
 import { ConvertBtcStep } from "$lib/types/ckbtc-convert";
-import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
-import {
-  mockIdentity,
-  mockPrincipal,
-  resetIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCkBTCAdditionalCanisters } from "$tests/mocks/canisters.mock";
 import {
   mockBTCAddressTestnet,
   mockCkBTCMainAccount,
-  mockCkBTCToken,
-  mockCkBTCWithdrawalAccount,
 } from "$tests/mocks/ckbtc-accounts.mock";
-import { mockSubAccountArray } from "$tests/mocks/icp-accounts.store.mock";
-import { mockTokens } from "$tests/mocks/tokens.mock";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { HttpAgent } from "@dfinity/agent";
 import {
@@ -39,11 +26,6 @@ import {
   MinterInsufficientFundsError,
   type RetrieveBtcOk,
 } from "@dfinity/ckbtc";
-import {
-  IcrcLedgerCanister,
-  decodeIcrcAccount,
-  encodeIcrcAccount,
-} from "@dfinity/ledger-icrc";
 import type { Mock } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -63,12 +45,6 @@ describe("ckbtc-convert-services", () => {
     canisters: mockCkBTCAdditionalCanisters,
   };
 
-  const convert = async (updateProgressSpy: () => void) =>
-    await convertCkBTCToBtc({
-      ...params,
-      updateProgress: updateProgressSpy,
-    });
-
   const expectStepsPerformed = ({
     updateProgressSpy,
     steps,
@@ -80,19 +56,6 @@ describe("ckbtc-convert-services", () => {
       expect(updateProgressSpy).toHaveBeenNthCalledWith(index + 1, step);
     });
     expect(updateProgressSpy).toBeCalledTimes(steps.length);
-  };
-
-  const expectAllStepsPerformed = (updateProgressSpy: Mock) => {
-    expectStepsPerformed({
-      updateProgressSpy,
-      steps: [
-        ConvertBtcStep.INITIALIZATION,
-        ConvertBtcStep.LOCKING_CKBTC,
-        ConvertBtcStep.SEND_BTC,
-        ConvertBtcStep.RELOAD,
-        ConvertBtcStep.DONE,
-      ],
-    });
   };
 
   beforeEach(() => {
@@ -113,287 +76,6 @@ describe("ckbtc-convert-services", () => {
       .mockResolvedValue(undefined);
 
     vi.useFakeTimers().setSystemTime(now);
-  });
-
-  describe("convert flow", () => {
-    const mockWithdrawalAccount = {
-      owner: mockPrincipal,
-      subaccount: [Uint8Array.from(mockSubAccountArray)] as [Uint8Array],
-    };
-
-    describe("withdrawal account succeed", () => {
-      const getWithdrawalAccountSpy = minterCanisterMock.getWithdrawalAccount;
-      const ledgerCanisterMock = mock<IcrcLedgerCanister>();
-
-      beforeEach(() => {
-        vi.spyOn(IcrcLedgerCanister, "create").mockImplementation(
-          () => ledgerCanisterMock
-        );
-        getWithdrawalAccountSpy.mockResolvedValue(mockWithdrawalAccount);
-      });
-
-      it("should get a withdrawal account", async () => {
-        const updateProgressSpy = vi.fn();
-
-        await convert(updateProgressSpy);
-
-        expect(getWithdrawalAccountSpy).toBeCalledWith();
-
-        expectStepsPerformed({
-          updateProgressSpy,
-          steps: [ConvertBtcStep.INITIALIZATION, ConvertBtcStep.LOCKING_CKBTC],
-        });
-      });
-
-      describe("transfer tokens succeed", () => {
-        const transferSpy = ledgerCanisterMock.transfer;
-        const amountE8s = numberToE8s(params.amount);
-
-        beforeEach(() => {
-          minterCanisterMock.retrieveBtc.mockReset();
-          tokensStore.setTokens(mockTokens);
-          transferSpy.mockResolvedValue(123n);
-          vi.spyOn(ledgerApi, "getAccount").mockImplementation(() =>
-            Promise.resolve(mockCkBTCMainAccount)
-          );
-        });
-
-        it("should transfer tokens to ledger", async () => {
-          const blockIndexAddSpy = vi.spyOn(
-            bitcoinConvertBlockIndexes,
-            "addBlockIndex"
-          );
-
-          const updateProgressSpy = vi.fn();
-
-          await convert(updateProgressSpy);
-
-          const to = decodeIcrcAccount(
-            encodeIcrcAccount({
-              owner: mockWithdrawalAccount.owner,
-              subaccount: mockWithdrawalAccount.subaccount[0],
-            })
-          );
-
-          expect(transferSpy).toBeCalledWith({
-            amount: amountE8s,
-            created_at_time: nowInBigIntNanoSeconds(),
-            fee: mockCkBTCToken.fee,
-            from_subaccount: undefined,
-            to: {
-              owner: to.owner,
-              subaccount: [to.subaccount],
-            },
-          });
-
-          // We test ledger here but the all test go through therefore all steps performed
-          expectAllStepsPerformed(updateProgressSpy);
-
-          // Should have added the block index to local storage
-          expect(blockIndexAddSpy).toHaveBeenCalledWith(123n);
-        });
-
-        describe("retrieve btc succeed", () => {
-          const ok: RetrieveBtcOk = {
-            block_index: 1n,
-          };
-
-          const retrieveBtcSpy = minterCanisterMock.retrieveBtc;
-
-          beforeEach(() => {
-            retrieveBtcSpy.mockResolvedValue(ok);
-          });
-
-          it("should retrieve btc", async () => {
-            const updateProgressSpy = vi.fn();
-
-            await convert(updateProgressSpy);
-
-            expect(retrieveBtcSpy).toBeCalledWith({
-              address: mockBTCAddressTestnet,
-              amount: amountE8s,
-            });
-
-            // We test ledger here but the all test go through therefore all steps performed
-            expectAllStepsPerformed(updateProgressSpy);
-          });
-
-          it("should load transactions and withdrawal account", async () => {
-            const updateProgressSpy = vi.fn();
-            expect(loadCkBTCAccountsSpy).toBeCalledTimes(0);
-            expect(loadWalletTransactions).toBeCalledTimes(0);
-            expect(loadCkBTCWithdrawalAccount).toBeCalledTimes(0);
-
-            await convert(updateProgressSpy);
-
-            // We only test that the call is made here. Test should be covered by its respective service.
-            expect(loadCkBTCAccountsSpy).not.toBeCalled();
-            expect(loadWalletTransactions).toBeCalledTimes(1);
-            expect(loadCkBTCWithdrawalAccount).toBeCalledTimes(1);
-
-            expectAllStepsPerformed(updateProgressSpy);
-          });
-
-          it("should remove block index from local storage", async () => {
-            const blockIndexRemoveSpy = vi.spyOn(
-              bitcoinConvertBlockIndexes,
-              "removeBlockIndex"
-            );
-
-            const updateProgressSpy = vi.fn();
-
-            await convert(updateProgressSpy);
-
-            expect(blockIndexRemoveSpy).toHaveBeenCalledWith(123n);
-          });
-        });
-
-        describe("retrieve btc fails", () => {
-          it("should display an error if retrieve btc fails", async () => {
-            minterCanisterMock.retrieveBtc.mockImplementation(async () => {
-              throw new Error();
-            });
-
-            const spyOnToastsError = vi.spyOn(toastsStore, "toastsError");
-
-            const updateProgressSpy = vi.fn();
-
-            await convert(updateProgressSpy);
-
-            expect(spyOnToastsError).toBeCalled();
-
-            expectStepsPerformed({
-              updateProgressSpy,
-              steps: [
-                ConvertBtcStep.INITIALIZATION,
-                ConvertBtcStep.LOCKING_CKBTC,
-                ConvertBtcStep.SEND_BTC,
-                ConvertBtcStep.RELOAD,
-              ],
-            });
-          });
-
-          it("should remove the block index from local storage because ui is still active", async () => {
-            const blockIndexRemoveSpy = vi.spyOn(
-              bitcoinConvertBlockIndexes,
-              "removeBlockIndex"
-            );
-
-            minterCanisterMock.retrieveBtc.mockImplementation(async () => {
-              throw new Error();
-            });
-
-            const updateProgressSpy = vi.fn();
-
-            await convert(updateProgressSpy);
-
-            expect(blockIndexRemoveSpy).toHaveBeenCalledWith(123n);
-          });
-        });
-      });
-
-      describe("transfer tokens fails", () => {
-        it("should display an error transfer to ledger fails", async () => {
-          ledgerCanisterMock.transfer.mockImplementation(async () => {
-            throw new Error();
-          });
-
-          const spyOnToastsError = vi.spyOn(toastsStore, "toastsError");
-
-          const updateProgressSpy = vi.fn();
-
-          await convert(updateProgressSpy);
-
-          expect(spyOnToastsError).toBeCalled();
-
-          expectStepsPerformed({
-            updateProgressSpy,
-            steps: [
-              ConvertBtcStep.INITIALIZATION,
-              ConvertBtcStep.LOCKING_CKBTC,
-            ],
-          });
-        });
-
-        it("should not add block index to local storage", async () => {
-          const blockIndexAddSpy = vi.spyOn(
-            bitcoinConvertBlockIndexes,
-            "addBlockIndex"
-          );
-
-          ledgerCanisterMock.transfer.mockImplementation(async () => {
-            throw new Error();
-          });
-
-          const updateProgressSpy = vi.fn();
-
-          await convert(updateProgressSpy);
-
-          expect(blockIndexAddSpy).not.toBeCalled();
-        });
-      });
-    });
-
-    describe("withdrawal account already loaded in store", () => {
-      const getWithdrawalAccountSpy = minterCanisterMock.getWithdrawalAccount;
-
-      beforeEach(() => {
-        getWithdrawalAccountSpy.mockResolvedValue(mockWithdrawalAccount);
-      });
-
-      it("should not call to get a withdrawal account", async () => {
-        const updateProgressSpy = vi.fn();
-
-        ckBTCWithdrawalAccountsStore.set({
-          account: {
-            account: mockCkBTCWithdrawalAccount,
-            certified: true,
-          },
-          universeId: CKBTC_UNIVERSE_CANISTER_ID,
-        });
-
-        await convert(updateProgressSpy);
-
-        expect(getWithdrawalAccountSpy).not.toBeCalledWith();
-      });
-
-      it("should get a withdrawal account if store value is not certified", async () => {
-        const updateProgressSpy = vi.fn();
-
-        ckBTCWithdrawalAccountsStore.set({
-          account: {
-            account: mockCkBTCWithdrawalAccount,
-            certified: false,
-          },
-          universeId: CKBTC_UNIVERSE_CANISTER_ID,
-        });
-
-        await convert(updateProgressSpy);
-
-        expect(getWithdrawalAccountSpy).toBeCalledWith();
-      });
-    });
-
-    describe("withdrawal account fails", () => {
-      it("should display an error if no withdrawal account can be fetched", async () => {
-        minterCanisterMock.getWithdrawalAccount.mockImplementation(async () => {
-          throw new Error();
-        });
-
-        const spyOnToastsError = vi.spyOn(toastsStore, "toastsError");
-
-        const updateProgressSpy = vi.fn();
-
-        await convert(updateProgressSpy);
-
-        expect(spyOnToastsError).toBeCalled();
-
-        expectStepsPerformed({
-          updateProgressSpy,
-          steps: [ConvertBtcStep.INITIALIZATION],
-        });
-      });
-    });
   });
 
   describe("retrieve BTC", () => {


### PR DESCRIPTION
# Motivation

There are currently 3 BTC withdrawal flows:
1. Transfer ckBTC to minter withdrawal account, then ask minter to convert (only with ENABLED_CKBTC_ICRC2 disabled)
2. Have existing ckBTC in withdrawal account and ask the minter to convert (regardless of ENABLED_CKBTC_ICRC2)
3. Approve a transfer, then ask the minter to convert directly from your account (only with ENABLED_CKBTC_ICRC2 enabled)

This PR removes the first and keeps the other 2.
The second flow will be remove soon in another PR.

# Changes

1. Remove the possibility of rendering the "transfer to withdrawal account" step from `ConvertBtcInProgress.svelte
`.
2. Remove the check on `ENABLE_CKBTC_ICRC2` in `CkBTCTransactionModal.svelte` and determine the flow based only on whether we are trying to use an already funded withdrawal address or not.
3. Remove the service method for transferring to a withdrawal account and then withdrawing.
4. Remove tests for the removed flow.

# Tests

Unit tests removed.
Tested manually that ICRC2 flow still works.

# Todos

- [x] Add entry to changelog (if necessary).
