### PR TITLE
Refactor: Migration from transactionsFeesStore to tokensStore

### DIFF
--- a/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
+++ b/frontend/src/lib/components/neurons/NnsStakeNeuron.svelte
@@ -8,7 +8,7 @@
   import { getMaxTransactionAmount } from "$lib/utils/token.utils";
   import AmountInput from "$lib/components/ui/AmountInput.svelte";
   import { isAccountHardwareWallet } from "$lib/utils/accounts.utils";
-  import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
+  import { mainTransactionFeeE8sStore } from "$lib/stores/transaction-fees.store";
   import { busy } from "@dfinity/gix-components";
   import TransactionFromAccount from "$lib/components/transaction/TransactionFromAccount.svelte";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
@@ -60,7 +60,7 @@
   let max = 0;
   $: max = getMaxTransactionAmount({
     balance: account?.balanceUlps ?? 0n,
-    fee: $transactionsFeesStore.main,
+    fee: $mainTransactionFeeE8sStore,
     token: ICPToken,
   });
 

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -6,7 +6,7 @@ import { loadSnsToken } from "$lib/services/sns-tokens.services";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { toastsError } from "$lib/stores/toasts.store";
-import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
+import { tokensStore } from "$lib/stores/tokens.store";
 import type { Account } from "$lib/types/account";
 import { toToastError } from "$lib/utils/error.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
@@ -83,7 +83,7 @@ export const snsTransferTokens = async ({
   amount: number;
   loadTransactions: boolean;
 }): Promise<{ blockIndex: IcrcBlockIndex | undefined }> => {
-  const fee = get(transactionsFeesStore).projects[rootCanisterId.toText()]?.fee;
+  const fee = get(tokensStore)[rootCanisterId.toText()]?.token.fee;
 
   return transferTokens({
     source,

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -30,7 +30,7 @@ import {
 } from "$lib/stores/sns-neurons.store";
 import { snsParametersStore } from "$lib/stores/sns-parameters.store";
 import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
-import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
+import { tokensStore } from "$lib/stores/tokens.store";
 import type { Account } from "$lib/types/account";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import { notForceCallStrategy } from "$lib/utils/env.utils";
@@ -340,9 +340,7 @@ export const splitNeuron = async ({
     const token = get(snsTokenSymbolSelectedStore);
     assertNonNullish(token, "token not defined");
 
-    const transactionFee = get(transactionsFeesStore).projects[
-      rootCanisterId.toText()
-    ]?.fee;
+    const transactionFee = get(tokensStore)[rootCanisterId.toText()]?.token.fee;
     assertNonNullish(transactionFee, "fee not defined");
 
     const amountE8s = numberToE8s(amount);
@@ -562,8 +560,7 @@ export const stakeNeuron = async ({
     const identity = await getAuthenticatedIdentity();
     const stakeE8s = numberToE8s(amount);
 
-    const fee = get(transactionsFeesStore).projects[rootCanisterId.toText()]
-      ?.fee;
+    const fee = get(tokensStore)[rootCanisterId.toText()]?.token.fee;
 
     if (!fee) {
       throw new Error("error.transaction_fee_not_found");

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -20,7 +20,7 @@ import {
   toastsShow,
   toastsSuccess,
 } from "$lib/stores/toasts.store";
-import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
+import { mainTransactionFeeE8sStore } from "$lib/stores/transaction-fees.store";
 import type { Account } from "$lib/types/account";
 import { ApiErrorKey } from "$lib/types/api.errors";
 import { LedgerErrorKey } from "$lib/types/ledger.errors";
@@ -442,7 +442,7 @@ export const initiateSnsSaleParticipation = async ({
     updateProgress(SaleStep.INITIALIZATION);
 
     // amount validation
-    const transactionFee = get(transactionsFeesStore).main;
+    const transactionFee = get(mainTransactionFeeE8sStore);
     assertEnoughAccountFunds({
       account,
       amountUlps: amount.toE8s() + transactionFee,

--- a/frontend/src/tests/lib/components/accounts/SnsAccountsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SnsAccountsFooter.spec.ts
@@ -1,7 +1,7 @@
 import * as snsLedgerApi from "$lib/api/sns-ledger.api";
 import SnsAccountsFooter from "$lib/components/accounts/SnsAccountsFooter.svelte";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
-import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
+import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
 import AccountsTest from "$tests/lib/pages/AccountsTest.svelte";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
@@ -38,16 +38,19 @@ describe("SnsAccountsFooter", () => {
     ]);
 
     snsAccountsStore.reset();
-    transactionsFeesStore.reset();
+    tokensStore.reset();
     setSnsProjects([
       {
         rootCanisterId,
         lifecycle: SnsSwapLifecycle.Committed,
       },
     ]);
-    transactionsFeesStore.setFee({
-      rootCanisterId,
-      fee,
+    tokensStore.setToken({
+      canisterId: rootCanisterId,
+      token: {
+        ...mockSnsToken,
+        fee,
+      },
       certified: true,
     });
 

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -8,7 +8,7 @@ import * as workerBalances from "$lib/services/worker-balances.services";
 import * as workerTransactions from "$lib/services/worker-transactions.services";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
-import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
+import { tokensStore } from "$lib/stores/tokens.store";
 import type { Account } from "$lib/types/account";
 import { page } from "$mocks/$app/stores";
 import AccountsTest from "$tests/lib/pages/AccountsTest.svelte";
@@ -92,7 +92,7 @@ describe("SnsWallet", () => {
     resetIdentity();
     vi.clearAllMocks();
     snsAccountsStore.reset();
-    transactionsFeesStore.reset();
+    tokensStore.reset();
     toastsStore.reset();
     overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", false);
     vi.spyOn(snsIndexApi, "getSnsTransactions").mockResolvedValue({
@@ -111,6 +111,14 @@ describe("SnsWallet", () => {
         tokenMetadata: testToken,
       },
     ]);
+    tokensStore.setToken({
+      canisterId: rootCanisterId,
+      token: {
+        ...testToken,
+        fee,
+      },
+      certified: true,
+    });
     page.mock({
       data: { universe: rootCanisterIdText },
       routeId: AppPath.Wallet,

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -5,10 +5,12 @@ import { loadSnsAccountTransactions } from "$lib/services/sns-transactions.servi
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import * as toastsStore from "$lib/stores/toasts.store";
+import { tokensStore } from "$lib/stores/tokens.store";
 import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
 import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
+import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import type { HttpAgent } from "@dfinity/agent";
 import { waitFor } from "@testing-library/svelte";
 import { tick } from "svelte";
@@ -129,6 +131,7 @@ describe("sns-accounts-services", () => {
     beforeEach(() => {
       vi.clearAllMocks();
       snsAccountsStore.reset();
+      tokensStore.reset();
       vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       spyAccounts = vi
@@ -136,14 +139,13 @@ describe("sns-accounts-services", () => {
         .mockImplementation(() => Promise.resolve([mockSnsMainAccount]));
     });
 
-    afterEach(() => {
-      transactionsFeesStore.reset();
-    });
-
     it("should call sns transfer tokens", async () => {
-      transactionsFeesStore.setFee({
-        rootCanisterId: mockPrincipal,
-        fee: 100n,
+      tokensStore.setToken({
+        canisterId: mockPrincipal,
+        token: {
+          ...mockSnsToken,
+          fee: 100n,
+        },
         certified: true,
       });
       const spyTransfer = vi
@@ -164,9 +166,12 @@ describe("sns-accounts-services", () => {
     });
 
     it("should load transactions if flag is passed", async () => {
-      transactionsFeesStore.setFee({
-        rootCanisterId: mockPrincipal,
-        fee: 100n,
+      tokensStore.setToken({
+        canisterId: mockPrincipal,
+        token: {
+          ...mockSnsToken,
+          fee: 100n,
+        },
         certified: true,
       });
       const spyTransfer = vi
@@ -188,9 +193,12 @@ describe("sns-accounts-services", () => {
     });
 
     it("should show toast and return success false if transfer fails", async () => {
-      transactionsFeesStore.setFee({
-        rootCanisterId: mockPrincipal,
-        fee: 100n,
+      tokensStore.setToken({
+        canisterId: mockPrincipal,
+        token: {
+          ...mockSnsToken,
+          fee: 100n,
+        },
         certified: true,
       });
       const spyTransfer = vi
@@ -213,7 +221,7 @@ describe("sns-accounts-services", () => {
     });
 
     it("should show toast and return success false if there is no transaction fee", async () => {
-      transactionsFeesStore.reset();
+      tokensStore.reset();
       const spyTransfer = vi
         .spyOn(ledgerApi, "snsTransfer")
         .mockRejectedValue(new Error("test error"));

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -17,7 +17,7 @@ import {
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { snsParametersStore } from "$lib/stores/sns-parameters.store";
 import { toastsError } from "$lib/stores/toasts.store";
-import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
+import { tokensStore } from "$lib/stores/tokens.store";
 import {
   getSnsNeuronIdAsHexString,
   subaccountToHexString,
@@ -653,14 +653,14 @@ describe("sns-neurons-services", () => {
   });
 
   describe("stakeNeuron", () => {
-    afterEach(() => {
-      transactionsFeesStore.reset();
+    beforeEach(() => {
+      tokensStore.reset();
     });
 
     it("should call sns api stakeNeuron, query neurons again and load sns accounts", async () => {
-      transactionsFeesStore.setFee({
-        rootCanisterId: mockPrincipal,
-        fee: 100n,
+      tokensStore.setToken({
+        canisterId: mockPrincipal,
+        token: { ...mockSnsToken, fee: 100n },
         certified: true,
       });
       const spyStake = vi
@@ -683,7 +683,7 @@ describe("sns-neurons-services", () => {
     });
 
     it("should not call sns api stakeNeuron if fee is not present", async () => {
-      transactionsFeesStore.reset();
+      tokensStore.reset();
       const spyStake = vi
         .spyOn(api, "stakeNeuron")
         .mockImplementation(() => Promise.resolve(mockSnsNeuron.id[0]));
@@ -1171,9 +1171,10 @@ describe("sns-neurons-services", () => {
         .spyOn(snsTokenSymbolSelectedStore, "subscribe")
         .mockImplementation(mockTokenStore);
 
-      transactionsFeesStore.setFee({
-        rootCanisterId: mockPrincipal,
-        fee: BigInt(transactionFee),
+      tokensStore.reset();
+      tokensStore.setToken({
+        canisterId: mockPrincipal,
+        token: { ...mockSnsToken, fee: transactionFee },
         certified: true,
       });
     });
@@ -1181,7 +1182,6 @@ describe("sns-neurons-services", () => {
     afterEach(() => {
       snsNeuronsStoreSpy.mockClear();
       snsTokenSymbolSelectedStoreSpy.mockClear();
-      transactionsFeesStore.reset();
     });
 
     it("should call api.addNeuronPermissions", async () => {

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -18,7 +18,7 @@ import * as busyStore from "$lib/stores/busy.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
 import * as toastsStore from "$lib/stores/toasts.store";
-import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
+import { tokensStore } from "$lib/stores/tokens.store";
 import { nanoSecondsToDateTime } from "$lib/utils/date.utils";
 import { formatTokenE8s } from "$lib/utils/token.utils";
 import {
@@ -167,6 +167,7 @@ describe("sns-api", () => {
 
     snsTicketsStore.reset();
     icpAccountsStore.resetForTesting();
+    tokensStore.reset();
 
     spyOnNewSaleTicketApi.mockResolvedValue(testSnsTicket.ticket);
     spyOnNotifyPaymentFailureApi.mockResolvedValue(undefined);
@@ -177,10 +178,9 @@ describe("sns-api", () => {
 
     spyOnSendICP.mockResolvedValue(13n);
 
-    const fee = mockSnsToken.fee;
-    transactionsFeesStore.setFee({
-      rootCanisterId: rootCanisterIdMock,
-      fee,
+    tokensStore.setToken({
+      canisterId: rootCanisterIdMock,
+      token: mockSnsToken,
       certified: true,
     });
 


### PR DESCRIPTION
# Motivation

Remove the transactionFeeStore.

In this PR, migrate some components and services.

# Changes

* Use derived `mainTransactionFeeE8sStore` instead of `transactionsFeesStore` in NnsStakeNeuron and sns-sale services.
* Get the SNS fee from `tokensStore` instead of `transactionsFeesStore` in sns services.

# Tests

* Change the test setup of related tests to use tokensStore.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
