### PR TITLE
Console feature to temporarily add ICRC-1 token

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -15,6 +15,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Add "API Boundary Node Management" topic support.
+* A work-around to recover unsupported ICRC-1 tokens.
 
 #### Changed
 

--- a/frontend/src/lib/assets/question-mark.svg
+++ b/frontend/src/lib/assets/question-mark.svg
@@ -1,0 +1,4 @@
+<svg width="146" height="146" viewBox="0 0 146 146" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="73" cy="73" r="73" fill="black" />
+  <text x="50%" y="55%" text-anchor="middle" dy=".3em" fill="white" font-size="100" font-family="Arial" >?</text>
+</svg>

--- a/frontend/src/lib/derived/icrc-universes.derived.ts
+++ b/frontend/src/lib/derived/icrc-universes.derived.ts
@@ -1,5 +1,6 @@
 import CKETH_LOGO from "$lib/assets/ckETH.svg";
 import CKSEPOLIAETH_LOGO from "$lib/assets/ckSepoliaETH.svg";
+import UNKNOWN_LOGO from "$lib/assets/question-mark.svg";
 import {
   CKETHSEPOLIA_UNIVERSE_CANISTER_ID,
   CKETH_UNIVERSE_CANISTER_ID,
@@ -22,16 +23,16 @@ const convertIcrcCanistersToUniverse = ({
 }): Universe | undefined => {
   const universeId = canisters.ledgerCanisterId.toText();
   const token = tokensData[universeId];
+  if (isNullish(token)) {
+    return;
+  }
   // TODO: Read logo from token https://dfinity.atlassian.net/browse/GIX-2140
   const logo =
     universeId === CKETH_UNIVERSE_CANISTER_ID.toText()
       ? CKETH_LOGO
       : universeId === CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText()
       ? CKSEPOLIAETH_LOGO
-      : undefined;
-  if (isNullish(token) || isNullish(logo)) {
-    return;
-  }
+      : UNKNOWN_LOGO;
   return {
     canisterId: universeId,
     title: token.token.name,

--- a/frontend/src/lib/stores/icrc-canisters.store.ts
+++ b/frontend/src/lib/stores/icrc-canisters.store.ts
@@ -1,5 +1,7 @@
+import { browser } from "$app/environment";
 import type { UniverseCanisterIdText } from "$lib/types/universe";
-import type { Principal } from "@dfinity/principal";
+import { Principal } from "@dfinity/principal";
+import { nonNullish } from "@dfinity/utils";
 import type { Readable } from "svelte/store";
 import { writable } from "svelte/store";
 
@@ -54,3 +56,30 @@ const initIcrcCanistersStore = (): IcrcCanistersStore => {
 };
 
 export const icrcCanistersStore = initIcrcCanistersStore();
+
+// Useful to help people record coins they accidentally sent to NNS dapp, but
+// which are not officially supported by the NNS dapp.
+//
+// In the devtools console, run:
+// __experimentalAddIcrc1Token(ledgerCanisterId, indexCanisterId)
+if (browser) {
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  (
+    window as unknown as {
+      __experimentalAddIcrc1Token: (
+        ledgerCanisterId: string,
+        indexCanisterId: string
+      ) => void;
+    }
+  ).__experimentalAddIcrc1Token = (
+    ledgerCanisterId: string,
+    indexCanisterId?: string
+  ) => {
+    icrcCanistersStore.setCanisters({
+      ledgerCanisterId: Principal.fromText(ledgerCanisterId),
+      indexCanisterId: nonNullish(indexCanisterId)
+        ? Principal.fromText(indexCanisterId)
+        : (undefined as unknown as Principal) /* use at your own risk */,
+    });
+  };
+}

--- a/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
@@ -87,7 +87,7 @@ describe("icrcTokensUniversesStore", () => {
   });
 
   // TODO: https://dfinity.atlassian.net/browse/GIX-2140
-  it("doesn't return non-cketh universes", () => {
+  it("returns question mark logo for  non-cketh universes", () => {
     // For not it's because the logo is not yet parsed in the token.
     const ledgerCanisterId = principal(1);
     tokensStore.setTokens({
@@ -100,6 +100,10 @@ describe("icrcTokensUniversesStore", () => {
       ledgerCanisterId: ledgerCanisterId,
       indexCanisterId: principal(2),
     });
-    expect(get(icrcTokensUniversesStore)).toEqual([]);
+    expect(get(icrcTokensUniversesStore)).toMatchObject([
+      {
+        logo: "/src/lib/assets/question-mark.svg",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
# Motivation

Sometimes people accidentally send tokens to their NNS dapp address while those tokens are not supported by NNS dapp.
It would be nice if there was a way to recover those tokens.

The experience could definitely be improved but I don't want to spend more time on this now, so please review based on whether this is an improvement or not.

# Changes

1. Provide a hard coded logo for unknown tokens.
2. Add a method to the `window` object to add a ledger and index canister to the store.

# Tests

1. Adjusted an existing unit test for an unknown token.
2. Tested manually adding an unknown ledger.

Currently it happens to work with and without index canister but there are no guarantees:
```
__experimentalAddIcrc1Token('m7h5t-euaaa-aaaaa-qabia-cai');
__experimentalAddIcrc1Token('m7h5t-euaaa-aaaaa-qabia-cai', 'myg3h-jmaaa-aaaaa-qabiq-cai');
```
<img width="991" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/7c4a2981-e8a6-4093-87ce-ecaa682eeb2c">


# Todos

- [x] Add entry to changelog (if necessary).
