### PR TITLE
GIX-2080: CreateSubaccount workflow test with tokens page

### DIFF
--- a/frontend/src/tests/workflows/CreateSubaccount.spec.ts
+++ b/frontend/src/tests/workflows/CreateSubaccount.spec.ts
@@ -5,13 +5,20 @@ import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import Accounts from "$lib/routes/Accounts.svelte";
 import { authStore } from "$lib/stores/auth.store";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { page } from "$mocks/$app/stores";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import {
+  mockAuthStoreSubscribe,
+  mockIdentity,
+} from "$tests/mocks/auth.store.mock";
 import {
   mockAccountDetails,
   mockMainAccount,
+  mockSubAccountDetails,
 } from "$tests/mocks/icp-accounts.store.mock";
+import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import type { HttpAgent } from "@dfinity/agent";
 import { fireEvent, waitFor } from "@testing-library/dom";
@@ -32,16 +39,26 @@ vi.mock("$lib/api/nns-dapp.api");
 describe("Accounts", () => {
   let queryAccountBalanceSpy: SpyInstance;
   let queryAccountSpy: SpyInstance;
+  const newSubaccountName = "test name";
+
+  const mockSubaccount = {
+    ...mockSubAccountDetails,
+    name: newSubaccountName,
+  };
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
     vi.spyOn(console, "error").mockImplementation(vi.fn);
+
     queryAccountBalanceSpy = vi
       .spyOn(ledgerApi, "queryAccountBalance")
       .mockResolvedValue(0n);
-    queryAccountSpy = vi
-      .spyOn(nnsDappApi, "queryAccount")
-      .mockResolvedValue(mockAccountDetails);
+    queryAccountSpy = vi.spyOn(nnsDappApi, "queryAccount").mockResolvedValue({
+      ...mockAccountDetails,
+      sub_accounts: [mockSubaccount],
+    });
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
+    overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", false);
   });
 
   it("should create a subaccount in NNS", async () => {
@@ -80,5 +97,51 @@ describe("Accounts", () => {
     await waitFor(() => expect(createSubAccount).toHaveBeenCalled());
     await waitFor(() => expect(queryAccountSpy).toBeCalled());
     await waitFor(() => expect(queryAccountBalanceSpy).toBeCalled());
+  });
+
+  describe("when tokens page flag is enabled", async () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
+    });
+
+    it("should create a subaccount in NNS", async () => {
+      page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+      icpAccountsStore.setForTesting({
+        main: mockMainAccount,
+        subAccounts: [],
+        hardwareWallets: [],
+      });
+      const { container } = render(Accounts);
+
+      const accountsPo = AccountsPo.under(new JestPageObjectElement(container));
+
+      await accountsPo.getNnsAccountsPo().clickAddAccount();
+
+      const initialRows = await accountsPo
+        .getNnsAccountsPo()
+        .getTokensTablePo()
+        .getRows();
+      expect(initialRows.length).toBe(1);
+      expect(await initialRows[0].getProjectName()).toBe("Main");
+      expect(createSubAccount).not.toHaveBeenCalled();
+
+      const modalPo = accountsPo.getAddAccountModalPo();
+      await modalPo.waitFor();
+      await modalPo.addAccount(newSubaccountName);
+      await modalPo.waitForClosed();
+
+      const subAccountRow = await accountsPo
+        .getNnsAccountsPo()
+        .getTokensTablePo()
+        .getRowByName(newSubaccountName);
+      await subAccountRow.waitFor();
+      expect(await subAccountRow.getProjectName()).toBe(newSubaccountName);
+
+      expect(createSubAccount).toHaveBeenCalledTimes(1);
+      expect(createSubAccount).toHaveBeenCalledWith({
+        name: newSubaccountName,
+        identity: mockIdentity,
+      });
+    });
   });
 });


### PR DESCRIPTION
# Motivation

Set `ENABLE_MY_TOKENS` true in vitest.setup.

In this PR, add the CreateSubaccount.spec test for the tokens page and set the ENABLE_MY_TOKENS before testing.

# Changes

* New test in CreateSubaccount.spec to test the same but with the new UI and set the flag before the tests.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
