### PR TITLE
GIX-2080: Fix failing tests with default `ENABLE_MY_TOKENS` true

### DIFF
--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -58,19 +58,25 @@ describe("MenuItems", () => {
     expect(() => getByTestId("get-icp-button")).toThrow();
   });
 
-  it("should point Tokens and Neurons to NNS from the project page", () => {
-    page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
-    const { getByTestId } = render(MenuItems);
+  describe("when My Tokens page is disabled", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", false);
+    });
 
-    const accountsLink = getByTestId("menuitem-accounts");
-    expect(accountsLink.getAttribute("href")).toEqual(
-      `${AppPath.Accounts}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID.toText()}`
-    );
+    it("should point Tokens and Neurons to NNS from the project page", () => {
+      page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+      const { getByTestId } = render(MenuItems);
 
-    const neuronsLink = getByTestId("menuitem-neurons");
-    expect(neuronsLink.getAttribute("href")).toEqual(
-      `${AppPath.Neurons}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID.toText()}`
-    );
+      const accountsLink = getByTestId("menuitem-accounts");
+      expect(accountsLink.getAttribute("href")).toEqual(
+        `${AppPath.Accounts}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID.toText()}`
+      );
+
+      const neuronsLink = getByTestId("menuitem-neurons");
+      expect(neuronsLink.getAttribute("href")).toEqual(
+        `${AppPath.Neurons}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID.toText()}`
+      );
+    });
   });
 
   describe("when My Tokens page is enabled", () => {

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -165,6 +165,9 @@ describe("Accounts", () => {
     icrcAccountsStore.reset();
     setCkETHCanisters();
     overrideFeatureFlagsStore.reset();
+    // TODO: GIX-1985 Remove all the tests outside the describe once the feature flag is enabled by default.
+    overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", false);
+
     subaccountBalance = subaccountBalanceDefault;
     mainAccountBalance = mainAccountBalanceDefault;
 


### PR DESCRIPTION
# Motivation

Set `ENABLE_MY_TOKENS` in vitest.setup.

The following were failing because the test expected `ENABLE_MY_TOKENS` to be `false`.

# Changes

* Move test `"should point Tokens and Neurons to NNS from the project page"` from MenuItems.spec within a describe with `ENABLE_MY_TOKENS` as `false`.
* Set `ENABLE_MY_TOKENS` to `false` in the main `beforeEach` of the Acconts.spec.ts file.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
