### PR TITLE
GIX-2063: Allow buildWalletUrl without account

### DIFF
--- a/frontend/src/lib/utils/navigation.utils.ts
+++ b/frontend/src/lib/utils/navigation.utils.ts
@@ -7,6 +7,7 @@ import {
   UNIVERSE_PARAM,
 } from "$lib/constants/routes.constants";
 import type { NeuronId, ProposalId } from "@dfinity/nns";
+import { nonNullish } from "@dfinity/utils";
 import { isArrayEmpty } from "./utils";
 
 // If the previous page is a particular detail page and if we have data in store, we don't reset and query the data in store after the route is mounted.
@@ -61,12 +62,12 @@ export const buildWalletUrl = ({
   account,
 }: {
   universe: string;
-  account: string;
+  account?: string;
 }): string =>
   buildUrl({
     path: AppPath.Wallet,
     universe,
-    params: { [ACCOUNT_PARAM]: account },
+    params: nonNullish(account) ? { [ACCOUNT_PARAM]: account } : undefined,
   });
 
 export const buildNeuronUrl = ({

--- a/frontend/src/tests/lib/utils/navigation.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/navigation.utils.spec.ts
@@ -99,6 +99,14 @@ describe("navigation-utils", () => {
       );
     });
 
+    it("should build wallet url without account", () => {
+      expect(
+        buildWalletUrl({
+          universe: OWN_CANISTER_ID_TEXT,
+        })
+      ).toEqual(`${AppPath.Wallet}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`);
+    });
+
     it("should build neuron url", () => {
       expect(
         buildNeuronUrl({


### PR DESCRIPTION
# Motivation

When user clicks in a row in the Tokens table and is not logged it it should be redirected to the according page. Either wallet page or ICP accounts.

In this PR, allow `buildWalletUrl` without an `account` parameter.

# Changes

* `buildWalletUrl` can be called without `account`.

# Tests

* Add a test when `buildWalletUrl` is called without `account`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
