### PR TITLE
Add exclude type param

### DIFF
--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -64,9 +64,13 @@
     // Once we have the initial filters, we load the proposals.
     if (
       nonNullish(currentProjectCanisterId) &&
-      nonNullish(filters[currentProjectCanisterId.toText()])
+      nonNullish(filters[currentProjectCanisterId.toText()]) &&
+      nonNullish($nsFunctionsStore)
     ) {
-      await loadSnsProposals({ rootCanisterId: currentProjectCanisterId });
+      await loadSnsProposals({
+        rootCanisterId: currentProjectCanisterId,
+        snsFunctions: $nsFunctionsStore,
+      });
     }
   };
 
@@ -74,13 +78,17 @@
   // TODO(e2e): cover this with e2e tests.
   $: $snsOnlyProjectStore,
     $snsFiltersStore,
+    $nsFunctionsStore,
     (() => fetchProposals($snsFiltersStore))();
 
   let loadingNextPage = false;
   let loadNextPage: () => void;
   $: loadNextPage = async () => {
     const selectedProjectCanisterId = $snsOnlyProjectStore;
-    if (selectedProjectCanisterId !== undefined) {
+    if (
+      selectedProjectCanisterId !== undefined &&
+      nonNullish($nsFunctionsStore)
+    ) {
       const beforeProposalId = nonNullish(currentProjectCanisterId)
         ? lastProposalId(
             $snsProposalsStore[currentProjectCanisterId.toText()]?.proposals ??
@@ -91,6 +99,7 @@
       loadingNextPage = true;
       await loadSnsProposals({
         rootCanisterId: selectedProjectCanisterId,
+        snsFunctions: $nsFunctionsStore,
         beforeProposalId,
       });
       loadingNextPage = false;

--- a/frontend/src/lib/services/$public/sns-proposals.services.ts
+++ b/frontend/src/lib/services/$public/sns-proposals.services.ts
@@ -22,9 +22,11 @@ import {
   hasPermissionToVote,
   subaccountToHexString,
 } from "$lib/utils/sns-neuron.utils";
+import { toExcludeTypeParameter } from "$lib/utils/sns-proposals.utils";
 import { NeuronState } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import type {
+  SnsNervousSystemFunction,
   SnsNeuron,
   SnsNeuronId,
   SnsProposalData,
@@ -79,9 +81,11 @@ export const registerVote = async ({
 export const registerVoteDemo = async ({
   vote,
   proposal,
+  snsFunctions,
 }: {
   vote: SnsVote;
   proposal: SnsProposalData;
+  snsFunctions: SnsNervousSystemFunction[];
 }) => {
   let registrations = 0;
 
@@ -122,6 +126,7 @@ export const registerVoteDemo = async ({
 
     await loadSnsProposals({
       rootCanisterId,
+      snsFunctions,
     });
 
     toastsSuccess({
@@ -137,12 +142,18 @@ export const registerVoteDemo = async ({
 
 export const loadSnsProposals = async ({
   rootCanisterId,
+  snsFunctions,
   beforeProposalId,
 }: {
   rootCanisterId: Principal;
+  snsFunctions: SnsNervousSystemFunction[];
   beforeProposalId?: SnsProposalId;
 }): Promise<void> => {
   const filters = get(snsSelectedFiltersStore)[rootCanisterId.toText()];
+  const excludeType = toExcludeTypeParameter({
+    filter: filters?.types ?? [],
+    snsFunctions,
+  });
   return queryAndUpdate<SnsProposalData[], unknown>({
     identityType: "current",
     request: ({ certified, identity }) =>
@@ -152,7 +163,7 @@ export const loadSnsProposals = async ({
           beforeProposal: beforeProposalId,
           includeStatus:
             filters?.decisionStatus.map(({ value }) => value) ?? [],
-          // TODO: add filter by nervous function
+          excludeType,
           // TODO: add filter by reward status
         },
         identity,

--- a/frontend/src/lib/utils/sns-proposals.utils.ts
+++ b/frontend/src/lib/utils/sns-proposals.utils.ts
@@ -14,8 +14,8 @@ import type {
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import {
-  isGenericNervousSystemFunction,
-  isNativeNervousSystemFunction,
+  isSnsGenericNervousSystemFunction,
+  isSnsesNativeNervousSystemFunction,
 } from "$lib/utils/sns.utils";
 import { basisPointsToPercent } from "$lib/utils/utils";
 import { Vote } from "@dfinity/nns";
@@ -496,7 +496,7 @@ export const toExcludeTypeParameter = ({
     return [];
   }
   const nativeNsFunctionIds = snsFunctions
-    .filter(isNativeNervousSystemFunction)
+    .filter(isSnsesNativeNervousSystemFunction)
     .map(({ id }) => id);
   const isNativeNsFunctionSelected = (nsFunctionId: bigint) =>
     filter.some(({ id, checked }) => id === nsFunctionId.toString() && checked);
@@ -504,12 +504,12 @@ export const toExcludeTypeParameter = ({
     (id) => !isNativeNsFunctionSelected(id)
   );
   const genericNsFunctionIds = snsFunctions
-    .filter(isGenericNervousSystemFunction)
+    .filter(isSnsGenericNervousSystemFunction)
     .map(({ id }) => id);
-  const isGenericNsFunctionChecked = filter.some(
+  const isSnsGenericNsFunctionChecked = filter.some(
     ({ id, checked }) => id === ALL_SNS_GENERIC_PROPOSAL_TYPES_ID && checked
   );
-  const excludedGenericNsFunctionIds = isGenericNsFunctionChecked
+  const excludedGenericNsFunctionIds = isSnsGenericNsFunctionChecked
     ? []
     : genericNsFunctionIds;
 
@@ -536,7 +536,7 @@ export const generateSnsProposalTypesFilterData = ({
     typesFilterState.find(({ id: stateId }) => id === stateId)?.checked !==
     false;
   const nativeNsFunctionEntries: Filter<SnsProposalTypeFilterId>[] = nsFunctions
-    .filter(isNativeNervousSystemFunction)
+    .filter(isSnsesNativeNervousSystemFunction)
     // ignore { 0n: "All Topics"}
     .filter(({ id }) => id !== ALL_SNS_PROPOSAL_TYPES_NS_FUNCTION_ID)
     .map((entry) => ({
@@ -557,7 +557,7 @@ export const generateSnsProposalTypesFilterData = ({
     }
   );
   const genericNsFunctionEntries: Filter<SnsProposalTypeFilterId>[] =
-    nsFunctions.some(isGenericNervousSystemFunction)
+    nsFunctions.some(isSnsGenericNervousSystemFunction)
       ? // Replace all generic entries w/ a single "All Generic"
         [
           {

--- a/frontend/src/lib/utils/sns-proposals.utils.ts
+++ b/frontend/src/lib/utils/sns-proposals.utils.ts
@@ -480,6 +480,46 @@ export const getUniversalProposalStatus = (
   return statusType;
 };
 
+/**
+ * Returns the proposal type ids that should be excluded from the response.
+ * snsFunctions are needed to process "All Generic" entry (when not selected, include all generic ids).
+ */
+export const toExcludeTypeParameter = ({
+  filter,
+  snsFunctions,
+}: {
+  filter: Filter<SnsProposalTypeFilterId>[];
+  snsFunctions: SnsNervousSystemFunction[];
+}): bigint[] => {
+  // If no filter is selected, return all functions
+  if (filter.length === 0) {
+    return [];
+  }
+  const nativeNsFunctionIds = snsFunctions
+    .filter(isNativeNervousSystemFunction)
+    .map(({ id }) => id);
+  const isNativeNsFunctionSelected = (nsFunctionId: bigint) =>
+    filter.some(({ id, checked }) => id === nsFunctionId.toString() && checked);
+  const excludedNativeNsFunctionIds = nativeNsFunctionIds.filter(
+    (id) => !isNativeNsFunctionSelected(id)
+  );
+  const genericNsFunctionIds = snsFunctions
+    .filter(isGenericNervousSystemFunction)
+    .map(({ id }) => id);
+  const isGenericNsFunctionChecked = filter.some(
+    ({ id, checked }) => id === ALL_SNS_GENERIC_PROPOSAL_TYPES_ID && checked
+  );
+  const excludedGenericNsFunctionIds = isGenericNsFunctionChecked
+    ? []
+    : genericNsFunctionIds;
+
+  return (
+    [...excludedNativeNsFunctionIds, ...excludedGenericNsFunctionIds]
+      // never exclude { 0n: "All Topics"}
+      .filter((id) => id !== ALL_SNS_PROPOSAL_TYPES_NS_FUNCTION_ID)
+  );
+};
+
 // Generate new "types" filter data, but preserve the checked state of the current filter state
 // `nsFunctions` can be changed on the backend, and to display recently created proposal types, new entries should be preselected.
 export const generateSnsProposalTypesFilterData = ({

--- a/frontend/src/lib/utils/sns-proposals.utils.ts
+++ b/frontend/src/lib/utils/sns-proposals.utils.ts
@@ -15,7 +15,7 @@ import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import {
   isSnsGenericNervousSystemFunction,
-  isSnsesNativeNervousSystemFunction,
+  isSnsNativeNervousSystemFunction,
 } from "$lib/utils/sns.utils";
 import { basisPointsToPercent } from "$lib/utils/utils";
 import { Vote } from "@dfinity/nns";
@@ -496,7 +496,7 @@ export const toExcludeTypeParameter = ({
     return [];
   }
   const nativeNsFunctionIds = snsFunctions
-    .filter(isSnsesNativeNervousSystemFunction)
+    .filter(isSnsNativeNervousSystemFunction)
     .map(({ id }) => id);
   const isNativeNsFunctionSelected = (nsFunctionId: bigint) =>
     filter.some(({ id, checked }) => id === nsFunctionId.toString() && checked);
@@ -536,7 +536,7 @@ export const generateSnsProposalTypesFilterData = ({
     typesFilterState.find(({ id: stateId }) => id === stateId)?.checked !==
     false;
   const nativeNsFunctionEntries: Filter<SnsProposalTypeFilterId>[] = nsFunctions
-    .filter(isSnsesNativeNervousSystemFunction)
+    .filter(isSnsNativeNervousSystemFunction)
     // ignore { 0n: "All Topics"}
     .filter(({ id }) => id !== ALL_SNS_PROPOSAL_TYPES_NS_FUNCTION_ID)
     .map((entry) => ({

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -175,7 +175,7 @@ export const swapEndedMoreThanOneWeekAgo = ({
 /**
  * Returns true if the FunctionType is NativeNervousSystemFunction (same for all same-version snses).
  */
-export const isNativeNervousSystemFunction = (
+export const isSnsesNativeNervousSystemFunction = (
   nsFunction: SnsNervousSystemFunction
 ): boolean =>
   "NativeNervousSystemFunction" in
@@ -184,7 +184,7 @@ export const isNativeNervousSystemFunction = (
 /**
  * Returns true if the FunctionType is GenericNervousSystemFunction (custom per sns).
  */
-export const isGenericNervousSystemFunction = (
+export const isSnsGenericNervousSystemFunction = (
   nsFunction: SnsNervousSystemFunction
 ): boolean =>
   "GenericNervousSystemFunction" in

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -173,7 +173,9 @@ export const swapEndedMoreThanOneWeekAgo = ({
 };
 
 /**
- * Returns true if the FunctionType is NativeNervousSystemFunction (same for all same-version snses).
+ * Returns true if the FunctionType is NativeNervousSystemFunction.
+ * Native means that the function can be executed only on its SNS canisters.
+ * (same for all same-version snses)
  */
 export const isSnsNativeNervousSystemFunction = (
   nsFunction: SnsNervousSystemFunction
@@ -182,7 +184,9 @@ export const isSnsNativeNervousSystemFunction = (
   (fromNullable(nsFunction.function_type) ?? {});
 
 /**
- * Returns true if the FunctionType is GenericNervousSystemFunction (custom per sns).
+ * Returns true if the FunctionType is GenericNervousSystemFunction
+ * Generic means that the function can be executed outside the SNS canisters (on any canister).
+ * (custom per sns).
  */
 export const isSnsGenericNervousSystemFunction = (
   nsFunction: SnsNervousSystemFunction

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -175,7 +175,7 @@ export const swapEndedMoreThanOneWeekAgo = ({
 /**
  * Returns true if the FunctionType is NativeNervousSystemFunction (same for all same-version snses).
  */
-export const isSnsesNativeNervousSystemFunction = (
+export const isSnsNativeNervousSystemFunction = (
   nsFunction: SnsNervousSystemFunction
 ): boolean =>
   "NativeNervousSystemFunction" in

--- a/frontend/src/tests/lib/services/_public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns-proposals.services.spec.ts
@@ -67,12 +67,14 @@ describe("sns-proposals services", () => {
       it("should call queryProposals with the default params", async () => {
         await loadSnsProposals({
           rootCanisterId: mockPrincipal,
+          snsFunctions: [],
         });
         expect(queryProposalsSpy).toHaveBeenCalledWith({
           params: {
             limit: DEFAULT_SNS_PROPOSALS_PAGE_SIZE,
             beforeProposal: undefined,
             includeStatus: [],
+            excludeType: [],
           },
           identity: new AnonymousIdentity(),
           certified: false,
@@ -85,12 +87,14 @@ describe("sns-proposals services", () => {
         await loadSnsProposals({
           rootCanisterId: mockPrincipal,
           beforeProposalId: proposalId,
+          snsFunctions: [],
         });
         expect(queryProposalsSpy).toHaveBeenCalledWith({
           params: {
             limit: DEFAULT_SNS_PROPOSALS_PAGE_SIZE,
             beforeProposal: proposalId,
             includeStatus: [],
+            excludeType: [],
           },
           identity: new AnonymousIdentity(),
           certified: false,
@@ -125,12 +129,14 @@ describe("sns-proposals services", () => {
         await loadSnsProposals({
           rootCanisterId,
           beforeProposalId: proposalId,
+          snsFunctions: [],
         });
         expect(queryProposalsSpy).toHaveBeenCalledWith({
           params: {
             limit: DEFAULT_SNS_PROPOSALS_PAGE_SIZE,
             beforeProposal: proposalId,
             includeStatus: selectedDecisionStatus,
+            excludeType: [],
           },
           identity: new AnonymousIdentity(),
           certified: false,
@@ -141,6 +147,7 @@ describe("sns-proposals services", () => {
       it("should load the proposals in the store", async () => {
         await loadSnsProposals({
           rootCanisterId: mockPrincipal,
+          snsFunctions: [],
         });
         await waitFor(() => {
           const storeData = get(snsProposalsStore);
@@ -153,6 +160,7 @@ describe("sns-proposals services", () => {
       it("set completed to true if response has less than page size", async () => {
         await loadSnsProposals({
           rootCanisterId: mockPrincipal,
+          snsFunctions: [],
         });
         await waitFor(() => {
           const storeData = get(snsProposalsStore);
@@ -175,12 +183,14 @@ describe("sns-proposals services", () => {
       it("should call queryProposals with user's identity", async () => {
         await loadSnsProposals({
           rootCanisterId: mockPrincipal,
+          snsFunctions: [],
         });
         expect(queryProposalsSpy).toHaveBeenCalledWith({
           params: {
             limit: DEFAULT_SNS_PROPOSALS_PAGE_SIZE,
             beforeProposal: undefined,
             includeStatus: [],
+            excludeType: [],
           },
           identity: mockIdentity,
           certified: false,

--- a/frontend/src/tests/lib/services/_public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns-proposals.services.spec.ts
@@ -9,6 +9,7 @@ import { authStore } from "$lib/stores/auth.store";
 import { snsFiltersStore } from "$lib/stores/sns-filters.store";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
 import * as toastsFunctions from "$lib/stores/toasts.store";
+import type { Filter, SnsProposalTypeFilterId } from "$lib/types/filters";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import {
   mockAuthStoreNoIdentitySubscribe,
@@ -17,6 +18,10 @@ import {
   mockPrincipal,
 } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import {
+  genericNervousSystemFunctionMock,
+  nativeNervousSystemFunctionMock,
+} from "$tests/mocks/sns-functions.mock";
 import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { AnonymousIdentity } from "@dfinity/agent";
 import { toastsStore } from "@dfinity/gix-components";
@@ -196,6 +201,36 @@ describe("sns-proposals services", () => {
           certified: false,
           rootCanisterId: mockPrincipal,
         });
+      });
+
+      it("should call queryProposals with excludeType parameter", async () => {
+        const nativeFunctionId = nativeNervousSystemFunctionMock.id;
+        const genericFunctionId = genericNervousSystemFunctionMock.id;
+        const nativeFilterEntry: Filter<SnsProposalTypeFilterId> = {
+          id: `${nativeFunctionId}`,
+          name: "string",
+          value: `${nativeFunctionId}`,
+          checked: true,
+        };
+        snsFiltersStore.setTypes({
+          rootCanisterId: mockPrincipal,
+          types: [nativeFilterEntry],
+        });
+        await loadSnsProposals({
+          rootCanisterId: mockPrincipal,
+          snsFunctions: [
+            nativeNervousSystemFunctionMock,
+            genericNervousSystemFunctionMock,
+          ],
+        });
+        expect(queryProposalsSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            params: expect.objectContaining({
+              // exclude generic type, because only native was selected
+              excludeType: [genericFunctionId],
+            }),
+          })
+        );
       });
     });
   });

--- a/frontend/src/tests/lib/services/_public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns-proposals.services.spec.ts
@@ -206,7 +206,7 @@ describe("sns-proposals services", () => {
       it("should call queryProposals with excludeType parameter", async () => {
         const nativeFunctionId = nativeNervousSystemFunctionMock.id;
         const genericFunctionId = genericNervousSystemFunctionMock.id;
-        const nativeFilterEntry: Filter<SnsProposalTypeFilterId> = {
+        const nativeFilterEntryChecked: Filter<SnsProposalTypeFilterId> = {
           id: `${nativeFunctionId}`,
           name: "string",
           value: `${nativeFunctionId}`,
@@ -214,7 +214,7 @@ describe("sns-proposals services", () => {
         };
         snsFiltersStore.setTypes({
           rootCanisterId: mockPrincipal,
-          types: [nativeFilterEntry],
+          types: [nativeFilterEntryChecked],
         });
         await loadSnsProposals({
           rootCanisterId: mockPrincipal,

--- a/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
@@ -1,3 +1,4 @@
+import { ALL_SNS_PROPOSAL_TYPES_NS_FUNCTION_ID } from "$lib/constants/sns-proposals.constants";
 import type { Filter, SnsProposalTypeFilterId } from "$lib/types/filters";
 import { ALL_SNS_GENERIC_PROPOSAL_TYPES_ID } from "$lib/types/filters";
 import { nowInSeconds } from "$lib/utils/date.utils";
@@ -832,20 +833,23 @@ describe("sns-proposals utils", () => {
   });
 
   describe("toExcludeTypeParameter", () => {
+    const allTypesNsFunctionId = ALL_SNS_PROPOSAL_TYPES_NS_FUNCTION_ID;
+    const nativeNsFunctionId = 1n;
+    const genericNsFunctionId = 1001n;
     // Prepare sns functions
     const allTopicsNativeNsFunction: SnsNervousSystemFunction = {
       ...nativeNervousSystemFunctionMock,
-      id: 0n,
+      id: allTypesNsFunctionId,
       name: "All Topics",
     };
     const nativeNsFunction: SnsNervousSystemFunction = {
       ...nativeNervousSystemFunctionMock,
-      id: 1n,
+      id: nativeNsFunctionId,
       name: "name",
     };
     const genericNsFunction: SnsNervousSystemFunction = {
       ...genericNervousSystemFunctionMock,
-      id: 1001n,
+      id: genericNsFunctionId,
       name: "name",
     };
     const snsFunctions: SnsNervousSystemFunction[] = [
@@ -860,12 +864,13 @@ describe("sns-proposals utils", () => {
       value: "1",
       checked: true,
     };
-    const snsSpecificFilterEntry: Filter<SnsProposalTypeFilterId> = {
-      id: ALL_SNS_GENERIC_PROPOSAL_TYPES_ID,
-      name: "string",
-      value: ALL_SNS_GENERIC_PROPOSAL_TYPES_ID,
-      checked: true,
-    };
+    const allGenericProposalTypesFilterEntry: Filter<SnsProposalTypeFilterId> =
+      {
+        id: ALL_SNS_GENERIC_PROPOSAL_TYPES_ID,
+        name: "string",
+        value: ALL_SNS_GENERIC_PROPOSAL_TYPES_ID,
+        checked: true,
+      };
 
     it("should return empty list if nothing checked", () => {
       expect(
@@ -881,19 +886,19 @@ describe("sns-proposals utils", () => {
         toExcludeTypeParameter({
           filter: [],
           snsFunctions,
-        }).find((id) => id === 0n)
+        }).find((id) => id === allTypesNsFunctionId)
       ).toBe(undefined);
       expect(
         toExcludeTypeParameter({
           filter: [nativeFilterEntry],
           snsFunctions,
-        }).find((id) => id === 0n)
+        }).find((id) => id === allTypesNsFunctionId)
       ).toBe(undefined);
       expect(
         toExcludeTypeParameter({
-          filter: [snsSpecificFilterEntry],
+          filter: [allGenericProposalTypesFilterEntry],
           snsFunctions,
-        }).find((id) => id === 0n)
+        }).find((id) => id === allTypesNsFunctionId)
       ).toBe(undefined);
     });
 
@@ -903,16 +908,16 @@ describe("sns-proposals utils", () => {
           filter: [nativeFilterEntry],
           snsFunctions,
         })
-      ).toStrictEqual([1001n]);
+      ).toStrictEqual([genericNsFunctionId]);
     });
 
-    it('should exclude generic when "SNS_SPECIFIC" is selected', () => {
+    it('should exclude generic when "All $snsName specific proposals" is selected', () => {
       expect(
         toExcludeTypeParameter({
-          filter: [snsSpecificFilterEntry],
+          filter: [allGenericProposalTypesFilterEntry],
           snsFunctions,
         })
-      ).toStrictEqual([1n]);
+      ).toStrictEqual([nativeNsFunctionId]);
     });
   });
 

--- a/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-proposals.utils.spec.ts
@@ -834,7 +834,8 @@ describe("sns-proposals utils", () => {
 
   describe("toExcludeTypeParameter", () => {
     const allTypesNsFunctionId = ALL_SNS_PROPOSAL_TYPES_NS_FUNCTION_ID;
-    const nativeNsFunctionId = 1n;
+    const nativeNsFunctionId1 = 1n;
+    const nativeNsFunctionId2 = 2n;
     const genericNsFunctionId = 1001n;
     // Prepare sns functions
     const allTopicsNativeNsFunction: SnsNervousSystemFunction = {
@@ -842,9 +843,14 @@ describe("sns-proposals utils", () => {
       id: allTypesNsFunctionId,
       name: "All Topics",
     };
-    const nativeNsFunction: SnsNervousSystemFunction = {
+    const nativeNsFunction1: SnsNervousSystemFunction = {
       ...nativeNervousSystemFunctionMock,
-      id: nativeNsFunctionId,
+      id: nativeNsFunctionId1,
+      name: "name",
+    };
+    const nativeNsFunction2: SnsNervousSystemFunction = {
+      ...nativeNervousSystemFunctionMock,
+      id: nativeNsFunctionId2,
       name: "name",
     };
     const genericNsFunction: SnsNervousSystemFunction = {
@@ -854,17 +860,24 @@ describe("sns-proposals utils", () => {
     };
     const snsFunctions: SnsNervousSystemFunction[] = [
       allTopicsNativeNsFunction,
-      nativeNsFunction,
+      nativeNsFunction1,
+      nativeNsFunction2,
       genericNsFunction,
     ];
     // Prepare type filters
-    const nativeFilterEntry: Filter<SnsProposalTypeFilterId> = {
-      id: "1",
-      name: "string",
-      value: "1",
+    const nativeFilterEntry1Checked: Filter<SnsProposalTypeFilterId> = {
+      id: String(nativeNsFunctionId1),
+      name: "string 1",
+      value: String(nativeNsFunctionId1),
       checked: true,
     };
-    const allGenericProposalTypesFilterEntry: Filter<SnsProposalTypeFilterId> =
+    const nativeFilterEntry2Checked: Filter<SnsProposalTypeFilterId> = {
+      id: String(nativeNsFunctionId2),
+      name: "string 2",
+      value: String(nativeNsFunctionId2),
+      checked: true,
+    };
+    const allGenericProposalTypesFilterEntryChecked: Filter<SnsProposalTypeFilterId> =
       {
         id: ALL_SNS_GENERIC_PROPOSAL_TYPES_ID,
         name: "string",
@@ -890,13 +903,13 @@ describe("sns-proposals utils", () => {
       ).toBe(undefined);
       expect(
         toExcludeTypeParameter({
-          filter: [nativeFilterEntry],
+          filter: [nativeFilterEntry1Checked],
           snsFunctions,
         }).find((id) => id === allTypesNsFunctionId)
       ).toBe(undefined);
       expect(
         toExcludeTypeParameter({
-          filter: [allGenericProposalTypesFilterEntry],
+          filter: [allGenericProposalTypesFilterEntryChecked],
           snsFunctions,
         }).find((id) => id === allTypesNsFunctionId)
       ).toBe(undefined);
@@ -905,19 +918,38 @@ describe("sns-proposals utils", () => {
     it("should exclude all except selected native ns function", () => {
       expect(
         toExcludeTypeParameter({
-          filter: [nativeFilterEntry],
+          filter: [nativeFilterEntry1Checked, nativeFilterEntry2Checked],
           snsFunctions,
         })
       ).toStrictEqual([genericNsFunctionId]);
     });
 
+    it("should exclude non selected entries", () => {
+      expect(
+        toExcludeTypeParameter({
+          filter: [
+            nativeFilterEntry1Checked,
+            {
+              ...nativeFilterEntry2Checked,
+              checked: false,
+            },
+            {
+              ...allGenericProposalTypesFilterEntryChecked,
+              checked: false,
+            },
+          ],
+          snsFunctions,
+        })
+      ).toStrictEqual([nativeNsFunctionId2, genericNsFunctionId]);
+    });
+
     it('should exclude generic when "All $snsName specific proposals" is selected', () => {
       expect(
         toExcludeTypeParameter({
-          filter: [allGenericProposalTypesFilterEntry],
+          filter: [allGenericProposalTypesFilterEntryChecked],
           snsFunctions,
         })
-      ).toStrictEqual([nativeNsFunctionId]);
+      ).toStrictEqual([nativeNsFunctionId1, nativeNsFunctionId2]);
     });
   });
 

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -9,7 +9,7 @@ import {
   isInternalRefreshBuyerTokensError,
   isSnsFinalizing,
   isSnsGenericNervousSystemFunction,
-  isSnsesNativeNervousSystemFunction,
+  isSnsNativeNervousSystemFunction,
   parseSnsSwapSaleBuyerCount,
   swapEndedMoreThanOneWeekAgo,
 } from "$lib/utils/sns.utils";
@@ -344,12 +344,12 @@ sale_participants_count ${saleBuyerCount} 1677707139456
   describe("isNativeNervousSystemFunction", () => {
     it("should return true for NativeNervousSystemFunction", () => {
       expect(
-        isSnsesNativeNervousSystemFunction(nativeNervousSystemFunctionMock)
+        isSnsNativeNervousSystemFunction(nativeNervousSystemFunctionMock)
       ).toBe(true);
     });
     it("should return false for not NativeNervousSystemFunction", () => {
       expect(
-        isSnsesNativeNervousSystemFunction(genericNervousSystemFunctionMock)
+        isSnsNativeNervousSystemFunction(genericNervousSystemFunctionMock)
       ).toBe(false);
     });
   });

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -6,10 +6,10 @@ import {
   getCommitmentE8s,
   getSwapCanisterAccount,
   hasOpenTicketInProcess,
-  isGenericNervousSystemFunction,
   isInternalRefreshBuyerTokensError,
-  isNativeNervousSystemFunction,
   isSnsFinalizing,
+  isSnsGenericNervousSystemFunction,
+  isSnsesNativeNervousSystemFunction,
   parseSnsSwapSaleBuyerCount,
   swapEndedMoreThanOneWeekAgo,
 } from "$lib/utils/sns.utils";
@@ -344,25 +344,25 @@ sale_participants_count ${saleBuyerCount} 1677707139456
   describe("isNativeNervousSystemFunction", () => {
     it("should return true for NativeNervousSystemFunction", () => {
       expect(
-        isNativeNervousSystemFunction(nativeNervousSystemFunctionMock)
+        isSnsesNativeNervousSystemFunction(nativeNervousSystemFunctionMock)
       ).toBe(true);
     });
     it("should return false for not NativeNervousSystemFunction", () => {
       expect(
-        isNativeNervousSystemFunction(genericNervousSystemFunctionMock)
+        isSnsesNativeNervousSystemFunction(genericNervousSystemFunctionMock)
       ).toBe(false);
     });
   });
 
-  describe("isGenericNervousSystemFunction", () => {
+  describe("isSnsGenericNervousSystemFunction", () => {
     it("should return true for GenericNervousSystemFunction", () => {
       expect(
-        isGenericNervousSystemFunction(genericNervousSystemFunctionMock)
+        isSnsGenericNervousSystemFunction(genericNervousSystemFunctionMock)
       ).toBe(true);
     });
     it("should return false for not GenericNervousSystemFunction", () => {
       expect(
-        isGenericNervousSystemFunction(nativeNervousSystemFunctionMock)
+        isSnsGenericNervousSystemFunction(nativeNervousSystemFunctionMock)
       ).toBe(false);
     });
   });


### PR DESCRIPTION
# Motivation

Add `excludeType` parameter support. It will be used to filter sns proposals by types.

# Changes

- pass down `nsFunctions` to the `loadSnsProposals` service (needs to calculate `excludeType` param).
- added `toExcludeTypeParameter` function.
- calculate `excludeType` and add it to the request

# Tests

- `toExcludeTypeParameter`
- add nsFunctions argument to sns proposal service specs

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet