### PR TITLE
GIX-2063: Add link in ICP tokens table not logged in

### DIFF
--- a/frontend/src/lib/derived/icp-tokens-list-visitors.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-visitors.derived.ts
@@ -1,6 +1,8 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
 import type { Universe } from "$lib/types/universe";
+import { buildWalletUrl } from "$lib/utils/navigation.utils";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { Principal } from "@dfinity/principal";
 import { TokenAmountV2 } from "@dfinity/utils";
@@ -22,5 +24,8 @@ export const icpTokensListVisitors = derived<
       token: NNS_TOKEN_DATA,
     }),
     actions: [UserTokenAction.GoToDetail],
+    rowHref: buildWalletUrl({
+      universe: OWN_CANISTER_ID_TEXT,
+    }),
   },
 ]);

--- a/frontend/src/tests/lib/derived/icp-tokens-list-visitors.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-visitors.derived.spec.ts
@@ -1,3 +1,4 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { icpTokensListVisitors } from "$lib/derived/icp-tokens-list-visitors.derived";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { UserTokenAction, type UserTokenData } from "$lib/types/tokens-page";
@@ -5,8 +6,9 @@ import { createIcpUserToken } from "$tests/mocks/tokens-page.mock";
 import { get } from "svelte/store";
 
 describe("icp-tokens-list-visitors.derived", () => {
-  const icpTokenVisitor: UserTokenData = createIcpUserToken({
+  const expectedIcpTokenVisitor: UserTokenData = createIcpUserToken({
     actions: [UserTokenAction.GoToDetail],
+    rowHref: `/wallet/?u=${OWN_CANISTER_ID_TEXT}`,
   });
 
   describe("icpTokensListVisitors", () => {
@@ -15,7 +17,7 @@ describe("icp-tokens-list-visitors.derived", () => {
     });
 
     it("should return ICP with unavailable balance", () => {
-      expect(get(icpTokensListVisitors)).toEqual([icpTokenVisitor]);
+      expect(get(icpTokensListVisitors)).toEqual([expectedIcpTokenVisitor]);
     });
   });
 });

--- a/frontend/src/tests/routes/app/accounts/page.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/page.spec.ts
@@ -55,7 +55,7 @@ describe("Accounts page", () => {
         expect(await pagePo.hasEmptyCards()).toBe(false);
       });
 
-      it("should rende Internet Computer row with href to wallet page", async () => {
+      it("should render Internet Computer row with href to wallet page", async () => {
         const po = renderComponent();
 
         const icpRow = await po

--- a/frontend/src/tests/routes/app/accounts/page.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/page.spec.ts
@@ -55,6 +55,18 @@ describe("Accounts page", () => {
         expect(await pagePo.hasEmptyCards()).toBe(false);
       });
 
+      it("should rende Internet Computer row with href to wallet page", async () => {
+        const po = renderComponent();
+
+        const icpRow = await po
+          .getSignInAccountsPo()
+          .getTokensTablePo()
+          .getRowByName("Internet Computer");
+        expect(await icpRow.getHref()).toEqual(
+          `/wallet/?u=${OWN_CANISTER_ID_TEXT}`
+        );
+      });
+
       it("renders 'Accounts' as tokens first column", async () => {
         const po = renderComponent();
 


### PR DESCRIPTION
# Motivation

Non-logged in user can navigate across tokens, accounts and wallet.

In this PR, add a link to the ICP wallet from the ICP to the IC row accounts page when the user is not logged in.

# Changes

* Add `rowHref` to `icpTokensListVisitorsStore`.

# Tests

* Add the new `rowHref` to the expected result in the `icpTokensListVisitorsStore` test file.
* Add a test to the accounts page spec file that the href is rendered when the user is not logged in.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
