### PR TITLE
Clean up SnsNeuronsFooter.spec.ts

### DIFF
--- a/frontend/src/tests/lib/components/sns-neurons/SnsNeuronsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/SnsNeuronsFooter.spec.ts
@@ -1,61 +1,50 @@
 import SnsNeuronsFooter from "$lib/components/sns-neurons/SnsNeuronsFooter.svelte";
-import { snsSelectedProjectNewTxData } from "$lib/derived/sns/sns-selected-project-new-tx-data.derived";
-import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
-import { neuronsStore } from "$lib/stores/neurons.store";
-import { mockStoreSubscribe } from "$tests/mocks/commont.mock";
-import {
-  buildMockNeuronsStoreSubscribe,
-  mockFullNeuron,
-  mockNeuron,
-} from "$tests/mocks/neurons.mock";
-import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
-import { NeuronState } from "@dfinity/nns";
-import { TokenAmount } from "@dfinity/utils";
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { page } from "$mocks/$app/stores";
+import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
+import { SnsNeuronsFooterPo } from "$tests/page-objects/SnsNeuronsFooter.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { SnsSwapLifecycle } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
 
 describe("SnsNeuron footer", () => {
+  const rootCanisterId = principal(23);
+  const snsDogToken = {
+    ...mockSnsToken,
+    symbol: "DOG",
+  };
+  const snsDog = {
+    rootCanisterId,
+    projectName: "Dog",
+    tokenMetadata: snsDogToken,
+    lifecycle: SnsSwapLifecycle.Committed,
+  };
+
   beforeEach(() => {
-    const mockNeuron2 = {
-      ...mockNeuron,
-      neuronId: 223n,
-    };
-    const spawningNeuron = {
-      ...mockNeuron,
-      state: NeuronState.Spawning,
-      neuronId: 223n,
-      fullNeuron: {
-        ...mockFullNeuron,
-        spawnAtTimesSeconds: 12_312_313n,
-      },
-    };
-    vi.spyOn(neuronsStore, "subscribe").mockImplementation(
-      buildMockNeuronsStoreSubscribe([mockNeuron, mockNeuron2, spawningNeuron])
-    );
+    setSnsProjects([snsDog]);
+    tokensStore.setToken({
+      certified: true,
+      canisterId: rootCanisterId,
+      token: snsDogToken,
+    });
+    page.mock({
+      data: { universe: rootCanisterId.toText() },
+    });
   });
 
+  const renderComponent = () => {
+    const { container } = render(SnsNeuronsFooter);
+    return SnsNeuronsFooterPo.under(new JestPageObjectElement(container));
+  };
+
   it("should open the StakeSnsNeuronModal on click to stake SNS Neurons", async () => {
-    vi.spyOn(snsSelectedProjectNewTxData, "subscribe").mockImplementation(
-      mockStoreSubscribe({
-        token: mockSnsFullProject.summary.token,
-        rootCanisterId: mockSnsFullProject.rootCanisterId,
-        transactionFee: TokenAmount.fromE8s({
-          amount: 10_000n,
-          token: mockSnsFullProject.summary.token,
-        }),
-      })
-    );
-    vi.spyOn(snsProjectSelectedStore, "subscribe").mockImplementation(
-      mockStoreSubscribe(mockSnsFullProject)
-    );
-    const { queryByTestId } = render(SnsNeuronsFooter);
+    const po = renderComponent();
+    expect(await po.getStakeNeuronsButtonPo().isPresent()).toBe(true);
+    expect(await po.getSnsStakeNeuronModalPo().isPresent()).toBe(false);
 
-    const toolbarButton = queryByTestId("stake-sns-neuron-button");
-    expect(toolbarButton).not.toBeNull();
+    await po.clickStakeNeuronsButton();
 
-    toolbarButton !== null && (await fireEvent.click(toolbarButton));
-
-    await waitFor(() =>
-      expect(queryByTestId("transaction-step-1")).toBeInTheDocument()
-    );
+    expect(await po.getSnsStakeNeuronModalPo().isPresent()).toBe(true);
   });
 });


### PR DESCRIPTION
# Motivation

Make the test easier to read and maintain.

# Changes

1. Remove existing setup from `beforeEach` because it wasn't used.
2. Replace setup inside the test by instead of mocking the store, filling the real stores, and put this setup in `beforeEach`.
3. Use page object.

# Tests

only tests

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary