### PR TITLE
GIX-2080: Enable tokens flag for sns-governance e2e test

### DIFF
--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -31,9 +31,10 @@ test("Test SNS governance", async ({ page, context }) => {
   expect(snsProjectName).toMatch(/[A-Z]{5}/);
 
   step("Acquire tokens");
-  await appPo.getSnsTokens({ amount: 20, name: snsProjectName });
+  const askedAmount = 20;
+  await appPo.getSnsTokens({ amount: askedAmount, name: snsProjectName });
 
-  expect(await snsUniverseRow.getBalanceNumber()).toEqual("20.00");
+  expect(await snsUniverseRow.getBalanceNumber()).toEqual(askedAmount);
 
   step("Stake a neuron");
   await appPo.goToNeurons();

--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -1,45 +1,46 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  setFeatureFlag,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test SNS governance", async ({ page, context }) => {
-  await page.goto("/accounts");
+  await page.goto("/");
   await expect(page).toHaveTitle("My ICP Tokens / NNS Dapp");
+  // TODO: GIX-1985 Remove this once the feature flag is enabled by default
+  await setFeatureFlag({ page, featureFlag: "ENABLE_MY_TOKENS", value: true });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
   const appPo = new AppPo(pageElement);
 
-  // Open universes selector
-  await appPo.openUniverses();
-
   step("Navigate to SNS universe");
-  const snsUniverseCards = await appPo
-    .getSelectUniverseListPo()
-    .getSnsUniverseCards();
-  expect(snsUniverseCards.length).toBeGreaterThanOrEqual(1);
-  const snsUniverseCard = snsUniverseCards[0];
-  const snsProjectName = await snsUniverseCard.getName();
+  const snsUniverseRows = await appPo
+    .getTokensPo()
+    .getTokensPagePo()
+    .getTokensTable()
+    .getSnsRows();
+  expect(snsUniverseRows.length).toBeGreaterThanOrEqual(1);
+  const snsUniverseRow = snsUniverseRows[0];
+  const snsProjectName = await snsUniverseRow.getProjectName();
 
   // Our test SNS project names are always 5 uppercase letters.
   expect(snsProjectName).toMatch(/[A-Z]{5}/);
 
-  await snsUniverseCard.click();
-
   step("Acquire tokens");
   await appPo.getSnsTokens({ amount: 20, name: snsProjectName });
 
-  expect(
-    await appPo
-      .getAccountsPo()
-      .getSnsAccountsPo()
-      .getMainAccountCardPo()
-      .getBalance()
-  ).toEqual("20.00");
+  expect(await snsUniverseRow.getBalanceNumber()).toEqual("20.00");
 
   step("Stake a neuron");
   await appPo.goToNeurons();
+
+  await appPo.openUniverses();
+  await appPo.getSelectUniverseListPo().clickOnSnsUniverse(snsProjectName);
+
   await appPo.getNeuronsPo().getSnsNeuronsPo().waitForContentLoaded();
   expect(
     await appPo.getNeuronsPo().getSnsNeuronsPo().getEmptyMessage()

--- a/frontend/src/tests/page-objects/GetTokens.page-object.ts
+++ b/frontend/src/tests/page-objects/GetTokens.page-object.ts
@@ -48,6 +48,7 @@ export class GetTokensPo extends BasePageObject {
   }): Promise<void> {
     await this.clickGetTokens();
     await this.waitForOption(name);
+    await this.getDropdown().select(name);
     await this.getTokens(amount);
   }
 

--- a/frontend/src/tests/page-objects/SelectUniverseList.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectUniverseList.page-object.ts
@@ -64,4 +64,16 @@ export class SelectUniverseListPo extends BasePageObject {
     }
     throw new Error("ckBTC card not found");
   }
+
+  async clickOnSnsUniverse(name: string): Promise<void> {
+    const cards = await this.getSelectUniverseCardPos();
+    const names = await Promise.all(cards.map((card) => card.getName()));
+    for (let i = 0; i < names.length; i++) {
+      if (names[i] === name) {
+        await cards[i].click();
+        return;
+      }
+    }
+    throw new Error(`${name} card not found`);
+  }
 }

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -30,6 +30,21 @@ export class TokensTableRowPo extends BasePageObject {
     );
   }
 
+  static countUnder({
+    element,
+    count,
+  }: {
+    element: PageObjectElement;
+    count?: number | undefined;
+  }): TokensTableRowPo[] {
+    return element
+      .countByTestId({
+        tid: TokensTableRowPo.TID,
+        count,
+      })
+      .map((el) => new TokensTableRowPo(el));
+  }
+
   getProjectName(): Promise<string> {
     return this.getText("project-name");
   }

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -53,8 +53,8 @@ export class TokensTableRowPo extends BasePageObject {
     return this.getText("token-value-label");
   }
 
-  getBalanceNumber(): Promise<string> {
-    return AmountDisplayPo.under(this.root).getAmount();
+  async getBalanceNumber(): Promise<number> {
+    return Number(await AmountDisplayPo.under(this.root).getAmount());
   }
 
   waitForBalance(): Promise<void> {

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -1,4 +1,5 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { AmountDisplayPo } from "./AmountDisplay.page-object";
 import { BasePageObject } from "./base.page-object";
 
 export type TokensTableRowData = {
@@ -35,6 +36,10 @@ export class TokensTableRowPo extends BasePageObject {
 
   getBalance(): Promise<string> {
     return this.getText("token-value-label");
+  }
+
+  getBalanceNumber(): Promise<string> {
+    return AmountDisplayPo.under(this.root).getAmount();
   }
 
   waitForBalance(): Promise<void> {


### PR DESCRIPTION
# Motivation

Enable tokens feature flat for mainnet.

In this PR, set flag to true for sns-governance test.

# Changes

* Set tokens flag to true in sns-governance.spec and change the flow to adapt to the tokens page.
* Add choosing the dropdown option in `getSnsTokens`. This worked before because it was in the same universe as the SNS and was initially selected.
* Add helper method `clickOnSnsUniverse` to SelectUniverseList.
* Add method to get SNS rows in TokensTable PO and helper constructor in TokensTableRow PO.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
