### PR TITLE
GIX-2080: Enable tokens page flag for merge-neurons e2e test

### DIFF
--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -17,11 +17,11 @@ test("Test merge neurons", async ({ page, context }) => {
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
   const appPo = new AppPo(pageElement);
 
-  step("Go to the neurons tab");
-  await appPo.goToNeurons();
-
   step("Get some ICP");
   await appPo.getIcpTokens(10);
+
+  step("Go to the neurons tab");
+  await appPo.goToNeurons();
 
   step("Stake a neuron");
   const footerPo = appPo.getNeuronsPo().getNnsNeuronsFooterPo();

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -1,21 +1,27 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  setFeatureFlag,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test merge neurons", async ({ page, context }) => {
-  await page.goto("/accounts");
+  await page.goto("/");
   await expect(page).toHaveTitle("My ICP Tokens / NNS Dapp");
+  // TODO: GIX-1985 Remove this once the feature flag is enabled by default
+  await setFeatureFlag({ page, featureFlag: "ENABLE_MY_TOKENS", value: true });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
   const appPo = new AppPo(pageElement);
 
-  step("Get some ICP");
-  await appPo.getIcpTokens(10);
-
   step("Go to the neurons tab");
   await appPo.goToNeurons();
+
+  step("Get some ICP");
+  await appPo.getIcpTokens(10);
 
   step("Stake a neuron");
   const footerPo = appPo.getNeuronsPo().getNnsNeuronsFooterPo();


### PR DESCRIPTION
# Motivation

Enable tokens flag in mainnet.

In this PR, set the flag to true for merge-neurons e2e test.

# Changes

* Set flag to true in merge-neurons test and use the home instead of `/accounts`.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
