### PR TITLE
Update proposal rendering

### DIFF
--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-12-13_23-01/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-09_23-01+new-p2p/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
@@ -477,20 +477,6 @@ pub struct MakingSnsProposal {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
-pub struct SeedAccount {
-    pub error_count: u64,
-    pub account_id: String,
-    pub neuron_type: i32,
-    pub tag_end_timestamp_seconds: Option<u64>,
-    pub tag_start_timestamp_seconds: Option<u64>,
-}
-
-#[derive(Serialize, CandidType, Deserialize)]
-pub struct SeedAccounts {
-    pub accounts: Vec<SeedAccount>,
-}
-
-#[derive(Serialize, CandidType, Deserialize)]
 pub struct MostRecentMonthlyNodeProviderRewards {
     pub timestamp: u64,
     pub rewards: Vec<RewardNodeProvider>,
@@ -785,7 +771,6 @@ pub struct Neuron {
 pub struct Governance {
     pub default_followees: Vec<(i32, Followees)>,
     pub making_sns_proposal: Option<MakingSnsProposal>,
-    pub seed_accounts: Option<SeedAccounts>,
     pub most_recent_monthly_node_provider_rewards: Option<MostRecentMonthlyNodeProviderRewards>,
     pub maturity_modulation_last_updated_at_timestamp_seconds: Option<u64>,
     pub wait_for_quiet_threshold_seconds: u64,

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-12-13_23-01/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-09_23-01+new-p2p/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
@@ -19,7 +19,6 @@ pub struct EmptyRecord {}
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct AddApiBoundaryNodePayload {
     pub node_id: Principal,
-    pub domain: String,
     pub version: String,
 }
 
@@ -336,12 +335,6 @@ pub struct SetFirewallConfigPayload {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
-pub struct UpdateApiBoundaryNodeDomainPayload {
-    pub node_id: Principal,
-    pub domain: String,
-}
-
-#[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateApiBoundaryNodesVersionPayload {
     pub version: String,
     pub node_ids: Vec<Principal>,
@@ -367,6 +360,12 @@ pub struct UpdateElectedReplicaVersionsPayload {
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateNodeDirectlyPayload {
     pub idkg_dealing_encryption_pk: Option<serde_bytes::ByteBuf>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct UpdateNodeDomainDirectlyPayload {
+    pub node_id: Principal,
+    pub domain: Option<String>,
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
@@ -555,9 +554,6 @@ impl Service {
     pub async fn set_firewall_config(&self, arg0: SetFirewallConfigPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "set_firewall_config", (arg0,)).await
     }
-    pub async fn update_api_boundary_node_domain(&self, arg0: UpdateApiBoundaryNodeDomainPayload) -> CallResult<()> {
-        ic_cdk::call(self.0, "update_api_boundary_node_domain", (arg0,)).await
-    }
     pub async fn update_api_boundary_nodes_version(
         &self,
         arg0: UpdateApiBoundaryNodesVersionPayload,
@@ -575,6 +571,9 @@ impl Service {
     }
     pub async fn update_node_directly(&self, arg0: UpdateNodeDirectlyPayload) -> CallResult<(Result1,)> {
         ic_cdk::call(self.0, "update_node_directly", (arg0,)).await
+    }
+    pub async fn update_node_domain_directly(&self, arg0: UpdateNodeDomainDirectlyPayload) -> CallResult<(Result1,)> {
+        ic_cdk::call(self.0, "update_node_domain_directly", (arg0,)).await
     }
     pub async fn update_node_ipv_4_config_directly(
         &self,

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2023-12-13_23-01/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-09_23-01+new-p2p/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.

# Changes
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.
  * Note: The candid files under `declarations/nns-$CANISTER` are used as inputs.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.