### PR TITLE
GIX-2080: Enable tokens page for disburse e2e test

### DIFF
--- a/frontend/src/tests/e2e/disburse.spec.ts
+++ b/frontend/src/tests/e2e/disburse.spec.ts
@@ -31,7 +31,7 @@ test("Test disburse neuron", async ({ page, context }) => {
     .stakeNeuron({ amount: stake, dissolveDelayDays: 0 });
 
   step("Check account balance before disburse");
-  await appPo.goToTokens();
+  await appPo.goToAccounts();
   const icpRowBeforeDisburse = appPo
     .getTokensPo()
     .getTokensPagePo()
@@ -54,7 +54,7 @@ test("Test disburse neuron", async ({ page, context }) => {
   await appPo.getNeuronDetailPo().getNnsNeuronDetailPo().disburseNeuron();
 
   step("Check account balance after disburse");
-  await appPo.goToTokens();
+  await appPo.goToAccounts();
   const icpRowAfterDisburse = appPo
     .getTokensPo()
     .getTokensPagePo()

--- a/frontend/src/tests/e2e/disburse.spec.ts
+++ b/frontend/src/tests/e2e/disburse.spec.ts
@@ -1,11 +1,17 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  setFeatureFlag,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test disburse neuron", async ({ page, context }) => {
-  await page.goto("/accounts");
+  await page.goto("/");
   await expect(page).toHaveTitle("My ICP Tokens / NNS Dapp");
+  // TODO: GIX-1985 Remove this once the feature flag is enabled by default
+  await setFeatureFlag({ page, featureFlag: "ENABLE_MY_TOKENS", value: true });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
@@ -25,14 +31,15 @@ test("Test disburse neuron", async ({ page, context }) => {
     .stakeNeuron({ amount: stake, dissolveDelayDays: 0 });
 
   step("Check account balance before disburse");
-  await appPo.goToAccounts();
-  const mainAccountBalanceBeforeDisburse = Number(
-    await appPo
-      .getAccountsPo()
-      .getNnsAccountsPo()
-      .getMainAccountCardPo()
-      .getBalance()
-  );
+  await appPo.goToTokens();
+  const icpRowBeforeDisburse = appPo
+    .getTokensPo()
+    .getTokensPagePo()
+    .getTokensTable()
+    .getRowByName("Internet Computer");
+  await icpRowBeforeDisburse.waitForBalance();
+  const mainAccountBalanceBeforeDisburse =
+    await icpRowBeforeDisburse.getBalanceNumber();
 
   step("Open the neuron details");
   await appPo.goToNeurons();
@@ -47,14 +54,15 @@ test("Test disburse neuron", async ({ page, context }) => {
   await appPo.getNeuronDetailPo().getNnsNeuronDetailPo().disburseNeuron();
 
   step("Check account balance after disburse");
-  await appPo.goToAccounts();
-  const mainAccountBalanceAfterDisburse = Number(
-    await appPo
-      .getAccountsPo()
-      .getNnsAccountsPo()
-      .getMainAccountCardPo()
-      .getBalance()
-  );
+  await appPo.goToTokens();
+  const icpRowAfterDisburse = appPo
+    .getTokensPo()
+    .getTokensPagePo()
+    .getTokensTable()
+    .getRowByName("Internet Computer");
+  await icpRowAfterDisburse.waitForBalance();
+  const mainAccountBalanceAfterDisburse =
+    await icpRowAfterDisburse.getBalanceNumber();
 
   // Actually there is a difference equal to the transaction fee, but it's
   // rounded away in the UI.

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -99,7 +99,15 @@ export class AppPo extends BasePageObject {
     await this.getBackdropPo().waitForAbsent();
   }
 
+  // GIX-2080: Remove this once the feature flag is enabled by default
   async goToAccounts(): Promise<void> {
+    await this.openMenu();
+    await this.getMenuItemsPo().clickAccounts();
+    // Menu closes automatically.
+    await this.getBackdropPo().waitForAbsent();
+  }
+
+  async goToTokens(): Promise<void> {
     await this.openMenu();
     await this.getMenuItemsPo().clickAccounts();
     // Menu closes automatically.

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -99,15 +99,8 @@ export class AppPo extends BasePageObject {
     await this.getBackdropPo().waitForAbsent();
   }
 
-  // GIX-2080: Remove this once the feature flag is enabled by default
+  // GIX-2080: Rename to "goToTokens"
   async goToAccounts(): Promise<void> {
-    await this.openMenu();
-    await this.getMenuItemsPo().clickAccounts();
-    // Menu closes automatically.
-    await this.getBackdropPo().waitForAbsent();
-  }
-
-  async goToTokens(): Promise<void> {
     await this.openMenu();
     await this.getMenuItemsPo().clickAccounts();
     // Menu closes automatically.


### PR DESCRIPTION
# Motivation

Enable tokens page flag for mainnet.

In this PR, enable the flag for disburse e2e test.

# Changes

* Change disburse e2e test to tokens page.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
