### PR TITLE
GIX-2080: Enable tokes flag proposals e2e test

### DIFF
--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -2,21 +2,25 @@ import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  setFeatureFlag,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { ProposalStatus, Topic } from "@dfinity/nns";
 import { expect, test } from "@playwright/test";
 
 test("Test neuron voting", async ({ page, context }) => {
-  await page.goto("/accounts");
+  await page.goto("/");
   await expect(page).toHaveTitle("My ICP Tokens / NNS Dapp");
-
+  // TODO: GIX-1985 Remove this once the feature flag is enabled by default
+  await setFeatureFlag({ page, featureFlag: "ENABLE_MY_TOKENS", value: true });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
   const appPo = new AppPo(pageElement);
 
   step("Get some ICP");
-  await appPo.goToAccounts();
   await appPo.getIcpTokens(21);
 
   // should be created before dummy proposals


### PR DESCRIPTION
# Motivation

Enable tokens page in mainnet.

In this PR, enable tokens flag in proposals e2e test.

# Changes

* Enable tokens flag in proposals e2e test.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
