### PR TITLE
Chore: Add default feature flags

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Changed wording about staking neurons to staking tokens.
+* Add missing feature flags to default feature flags value.
 
 #### Deprecated
 

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -58,7 +58,7 @@ export type FeatureKey = keyof FeatureFlags<boolean>;
  */
 export const FEATURE_FLAG_ENVIRONMENT: FeatureFlags<boolean> = JSON.parse(
   envVars?.featureFlags ??
-    '{"ENABLE_CKBTC": true, "ENABLE_CKTESTBTC": false, "ENABLE_ICP_ICRC": false}'
+    '{"ENABLE_CKBTC": true, "ENABLE_CKTESTBTC": false, "ENABLE_ICP_ICRC": false, "ENABLE_MY_TOKENS": true, "ENABLE_CKETH": true, "ENABLE_SNS_TYPES_FILTER": false}'
 );
 
 export const IS_TESTNET: boolean =


### PR DESCRIPTION
# Motivation

Improve installing NNS Dapp on different environments.

In this PR, add some missing feature flags to the default value of the feature flags.

# Changes

* Change default value of `FEATURE_FLAG_ENVIRONMENT`.

# Tests

Not test for this default value.

# Todos

- [x] Add entry to changelog (if necessary).