### PR TITLE
Add copy button for followee neuron ID

### DIFF
--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -19,6 +19,7 @@ here after a successful release.
 
 * Add "API Boundary Node Management" topic support.
 * A work-around to recover unsupported ICRC-1 tokens.
+* Copy button to followed neuron IDs.
 
 #### Changed
 

--- a/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
@@ -3,7 +3,7 @@
   import type { FolloweesNeuron } from "$lib/utils/neuron.utils";
   import { i18n } from "$lib/stores/i18n";
   import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
-  import { Tag } from "@dfinity/gix-components";
+  import { Copy, Tag } from "@dfinity/gix-components";
   import {
     NNS_NEURON_CONTEXT_KEY,
     type NnsNeuronContext,
@@ -43,18 +43,31 @@
 
 <TestIdWrapper testId="followee-component">
   <TagsList {id}>
-    <button
-      slot="title"
-      name="title"
-      {id}
-      class="text"
-      on:click={openVotingHistory}
-    >
-      {name}
-    </button>
+    <div class="neuron" slot="title">
+      <button name="title" {id} class="text" on:click={openVotingHistory}>
+        {name}
+      </button>
+      <div class="copy">
+        <Copy value={followee.neuronId.toString()} />
+      </div>
+    </div>
 
     {#each followee.topics as topic}
       <Tag tagName="li">{topicTitle(topic)}</Tag>
     {/each}
   </TagsList>
 </TestIdWrapper>
+
+<style lang="scss">
+  .neuron {
+    align-items: center;
+    display: inline-flex;
+
+    .copy {
+      align-items: center;
+      display: inline-flex;
+      // Make sure the icon doesn't increase the line height.
+      max-height: 0;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsFollowee.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsFollowee.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Tag } from "@dfinity/gix-components";
   import type { SnsFolloweesByNeuron } from "$lib/utils/sns-neuron.utils";
+  import TestIdWrapper from "../common/TestIdWrapper.svelte";
   import Hash from "../ui/Hash.svelte";
   import TagsList from "../ui/TagsList.svelte";
 
@@ -8,16 +9,18 @@
 </script>
 
 <!-- TODO: Open Voting history modal https://dfinity.atlassian.net/browse/GIX-1156 -->
-<TagsList id={followee.neuronIdHex}>
-  <Hash
-    text={followee.neuronIdHex}
-    id={followee.neuronIdHex}
-    tagName="h5"
-    slot="title"
-    showCopy
-  />
+<TestIdWrapper testId="sns-followee-component">
+  <TagsList id={followee.neuronIdHex}>
+    <Hash
+      text={followee.neuronIdHex}
+      id={followee.neuronIdHex}
+      tagName="h5"
+      slot="title"
+      showCopy
+    />
 
-  {#each followee.nsFunctions as nsFunction (nsFunction.id)}
-    <Tag tagName="li">{nsFunction.name}</Tag>
-  {/each}
-</TagsList>
+    {#each followee.nsFunctions as nsFunction (nsFunction.id)}
+      <Tag tagName="li">{nsFunction.name}</Tag>
+    {/each}
+  </TagsList>
+</TestIdWrapper>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsFollowee.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsFollowee.svelte
@@ -14,6 +14,7 @@
     id={followee.neuronIdHex}
     tagName="h5"
     slot="title"
+    showCopy
   />
 
   {#each followee.nsFunctions as nsFunction (nsFunction.id)}

--- a/frontend/src/lib/components/ui/Hash.svelte
+++ b/frontend/src/lib/components/ui/Hash.svelte
@@ -33,7 +33,7 @@
     >
   </Tooltip>
   {#if showCopy}
-    <div class="copy" data-tid="copy-icon">
+    <div class="copy">
       <Copy value={text} />
     </div>
   {/if}

--- a/frontend/src/lib/components/ui/Hash.svelte
+++ b/frontend/src/lib/components/ui/Hash.svelte
@@ -33,7 +33,7 @@
     >
   </Tooltip>
   {#if showCopy}
-    <div class="copy">
+    <div class="copy" data-tid="copy-icon">
       <Copy value={text} />
     </div>
   {/if}

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
@@ -7,14 +7,23 @@ import { render } from "@testing-library/svelte";
 import FolloweeTest from "./FolloweeTest.svelte";
 
 describe("Followee", () => {
+  let copySpy;
+
   const followee = {
     neuronId: 111n,
     topics: [Topic.ExchangeRate, Topic.Governance, Topic.Kyc],
   };
 
   beforeEach(() => {
-    vi.spyOn(console, "error").mockReturnValue();
     knownNeuronsStore.reset();
+
+    vi.spyOn(console, "error").mockReturnValue();
+    copySpy = vi.fn();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: copySpy,
+      },
+    });
   });
 
   const renderComponent = () => {
@@ -75,5 +84,13 @@ describe("Followee", () => {
 
     const po = renderComponent();
     expect(await po.getName()).toBe(neuronName);
+  });
+
+  it("should have a copy button", async () => {
+    const po = renderComponent();
+
+    expect(copySpy).not.toBeCalled();
+    await po.copy();
+    expect(copySpy).toBeCalledWith(`${followee.neuronId}`);
   });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/Followee.spec.ts
@@ -86,7 +86,7 @@ describe("Followee", () => {
     expect(await po.getName()).toBe(neuronName);
   });
 
-  it("should have a copy button", async () => {
+  it("should copy neuron ID to clipboard when copy button is clicked", async () => {
     const po = renderComponent();
 
     expect(copySpy).not.toBeCalled();

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsFollowee.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsFollowee.spec.ts
@@ -1,0 +1,42 @@
+import SnsFollowee from "$lib/components/sns-neuron-detail/SnsFollowee.svelte";
+import { SnsFolloweePo } from "$tests/page-objects/SnsFollowee.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("SnsFollowee", () => {
+  let copySpy;
+
+  beforeEach(() => {
+    copySpy = vi.fn();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: copySpy,
+      },
+    });
+  });
+
+  const renderComponent = (neuronId) => {
+    const { container } = render(SnsFollowee, {
+      followee: {
+        neuronIdHex: neuronId,
+        nsFunctions: [
+          {
+            id: 1n,
+            name: "Motion",
+          },
+        ],
+      },
+    });
+    return SnsFolloweePo.under(new JestPageObjectElement(container));
+  };
+
+  it("should have a copy button", async () => {
+    const neuronId = "12ab";
+    const po = renderComponent(neuronId);
+    expect(await po.getHashPo().hasCopyButton()).toBe(true);
+
+    expect(copySpy).not.toBeCalled();
+    await po.getHashPo().copy();
+    expect(copySpy).toBeCalledWith(neuronId);
+  });
+});

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsFollowee.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsFollowee.spec.ts
@@ -30,7 +30,7 @@ describe("SnsFollowee", () => {
     return SnsFolloweePo.under(new JestPageObjectElement(container));
   };
 
-  it("should have a copy button", async () => {
+  it("should copy neuron ID to clipboard when copy button is clicked", async () => {
     const neuronId = "12ab";
     const po = renderComponent(neuronId);
     expect(await po.getHashPo().hasCopyButton()).toBe(true);

--- a/frontend/src/tests/page-objects/Followee.page-object.ts
+++ b/frontend/src/tests/page-objects/Followee.page-object.ts
@@ -33,4 +33,8 @@ export class FolloweePo extends BasePageObject {
   openModal(): Promise<void> {
     return this.getButton().click();
   }
+
+  copy(): Promise<void> {
+    return this.getButton("copy-component").click();
+  }
 }

--- a/frontend/src/tests/page-objects/Hash.page-object.ts
+++ b/frontend/src/tests/page-objects/Hash.page-object.ts
@@ -1,5 +1,6 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class HashPo extends BasePageObject {
@@ -13,7 +14,19 @@ export class HashPo extends BasePageObject {
     return TooltipPo.under(this.root);
   }
 
+  getCopyButtonPo(): ButtonPo {
+    return this.getButton("copy-component");
+  }
+
   getText(): Promise<string> {
     return this.getTooltipPo().getText();
+  }
+
+  hasCopyButton(): Promise<boolean> {
+    return this.getCopyButtonPo().isPresent();
+  }
+
+  copy(): Promise<void> {
+    return this.getCopyButtonPo().click();
   }
 }

--- a/frontend/src/tests/page-objects/SnsFollowee.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsFollowee.page-object.ts
@@ -1,0 +1,15 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { HashPo } from "$tests/page-objects/Hash.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SnsFolloweePo extends BasePageObject {
+  private static readonly TID = "sns-followee-component";
+
+  static under(element: PageObjectElement): SnsFolloweePo {
+    return new SnsFolloweePo(element.byTestId(SnsFolloweePo.TID));
+  }
+
+  getHashPo(): HashPo {
+    return HashPo.under(this.root);
+  }
+}


### PR DESCRIPTION
# Motivation

Currently the only way to copy the SNS neuron ID of a followee is to look in the DOM inspector.

# Changes

1. Add copy button to SNS neuron ID for followed SNS neurons.
2. Add a copy button to the ID for followed NNS neurons for completeness.

# Tests

Unit tests added.
Tested manually.

<img width="327" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/1a04cf17-9c18-4119-bda1-edea796d351b">

# Todos

- [x] Add entry to changelog (if necessary).
