### PR TITLE
GIX-2060: Remove deprecated transactionsFeeStore

### DIFF
--- a/frontend/src/lib/derived/main-transaction-fee.derived.ts
+++ b/frontend/src/lib/derived/main-transaction-fee.derived.ts
@@ -1,8 +1,16 @@
-import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
-import { ICPToken, TokenAmount } from "@dfinity/utils";
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { TokenAmount, isNullish } from "@dfinity/utils";
 import { derived } from "svelte/store";
 
-export const mainTransactionFeeStoreAsToken = derived(
-  transactionsFeesStore,
-  ($store) => TokenAmount.fromE8s({ amount: $store.main, token: ICPToken })
-);
+export const mainTransactionFeeStoreAsToken = derived(tokensStore, ($store) => {
+  const icpToken = $store[OWN_CANISTER_ID_TEXT].token;
+  if (isNullish(icpToken)) {
+    return TokenAmount.fromE8s({
+      amount: NNS_TOKEN_DATA.fee,
+      token: NNS_TOKEN_DATA,
+    });
+  }
+  return TokenAmount.fromE8s({ amount: icpToken.fee, token: icpToken });
+});

--- a/frontend/src/lib/derived/main-transaction-fee.derived.ts
+++ b/frontend/src/lib/derived/main-transaction-fee.derived.ts
@@ -1,5 +1,4 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
-import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { TokenAmount, isNullish } from "@dfinity/utils";
 import { derived } from "svelte/store";
@@ -7,10 +6,8 @@ import { derived } from "svelte/store";
 export const mainTransactionFeeStoreAsToken = derived(tokensStore, ($store) => {
   const icpToken = $store[OWN_CANISTER_ID_TEXT].token;
   if (isNullish(icpToken)) {
-    return TokenAmount.fromE8s({
-      amount: NNS_TOKEN_DATA.fee,
-      token: NNS_TOKEN_DATA,
-    });
+    // This can't happen because the tokensStore always contains the NNS token.
+    throw new Error("ICP token not found");
   }
   return TokenAmount.fromE8s({ amount: icpToken.fee, token: icpToken });
 });

--- a/frontend/src/lib/stores/tokens.store.ts
+++ b/frontend/src/lib/stores/tokens.store.ts
@@ -40,6 +40,7 @@ export interface TokensStore extends Readable<TokensStoreData> {
  *
  */
 const initTokensStore = (): TokensStore => {
+  // Always keep the NNS token as initial data. Other derived stores will raise an error if the token is not found.
   const initialTokensStoreData: TokensStoreData = {
     [OWN_CANISTER_ID_TEXT]: NNS_TOKEN,
   };

--- a/frontend/src/lib/stores/transaction-fees.store.ts
+++ b/frontend/src/lib/stores/transaction-fees.store.ts
@@ -107,8 +107,7 @@ export const transactionsFeesStore = initTransactionFeesStore();
 export const mainTransactionFeeStore: Readable<number> = derived(
   tokensStore,
   ($store) =>
-    Number($store[OWN_CANISTER_ID_TEXT]?.token.fee) ??
-    Number(NNS_TOKEN_DATA.fee)
+    Number($store[OWN_CANISTER_ID_TEXT]?.token.fee ?? NNS_TOKEN_DATA.fee)
 );
 
 export const mainTransactionFeeE8sStore: Readable<bigint> = derived(

--- a/frontend/src/lib/stores/transaction-fees.store.ts
+++ b/frontend/src/lib/stores/transaction-fees.store.ts
@@ -1,6 +1,9 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
+import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import type { Principal } from "@dfinity/principal";
 import { derived, writable, type Readable } from "svelte/store";
+import { tokensStore } from "./tokens.store";
 
 interface ProjectFeeData {
   fee: bigint;
@@ -102,11 +105,13 @@ export const transactionsFeesStore = initTransactionFeesStore();
  * @deprecated prefer mainTransactionFeeE8sStore to use e8s for amount of tokens instead of Number.
  */
 export const mainTransactionFeeStore = derived(
-  transactionsFeesStore,
-  ($store) => Number($store.main)
+  tokensStore,
+  ($store) =>
+    $store[OWN_CANISTER_ID_TEXT]?.token.fee ?? Number(NNS_TOKEN_DATA.fee)
 );
 
 export const mainTransactionFeeE8sStore = derived(
-  transactionsFeesStore,
-  ($store) => $store.main
+  tokensStore,
+  ($store) =>
+    $store[OWN_CANISTER_ID_TEXT]?.token.fee ?? Number(NNS_TOKEN_DATA.fee)
 );

--- a/frontend/src/lib/stores/transaction-fees.store.ts
+++ b/frontend/src/lib/stores/transaction-fees.store.ts
@@ -104,14 +104,14 @@ export const transactionsFeesStore = initTransactionFeesStore();
 /**
  * @deprecated prefer mainTransactionFeeE8sStore to use e8s for amount of tokens instead of Number.
  */
-export const mainTransactionFeeStore = derived(
+export const mainTransactionFeeStore: Readable<number> = derived(
   tokensStore,
   ($store) =>
-    $store[OWN_CANISTER_ID_TEXT]?.token.fee ?? Number(NNS_TOKEN_DATA.fee)
+    Number($store[OWN_CANISTER_ID_TEXT]?.token.fee) ??
+    Number(NNS_TOKEN_DATA.fee)
 );
 
-export const mainTransactionFeeE8sStore = derived(
+export const mainTransactionFeeE8sStore: Readable<bigint> = derived(
   tokensStore,
-  ($store) =>
-    $store[OWN_CANISTER_ID_TEXT]?.token.fee ?? Number(NNS_TOKEN_DATA.fee)
+  ($store) => $store[OWN_CANISTER_ID_TEXT]?.token.fee ?? NNS_TOKEN_DATA.fee
 );

--- a/frontend/src/lib/stores/transaction-fees.store.ts
+++ b/frontend/src/lib/stores/transaction-fees.store.ts
@@ -1,7 +1,7 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
-import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import type { Principal } from "@dfinity/principal";
+import { isNullish } from "@dfinity/utils";
 import { derived, writable, type Readable } from "svelte/store";
 import { tokensStore } from "./tokens.store";
 
@@ -106,11 +106,24 @@ export const transactionsFeesStore = initTransactionFeesStore();
  */
 export const mainTransactionFeeStore: Readable<number> = derived(
   tokensStore,
-  ($store) =>
-    Number($store[OWN_CANISTER_ID_TEXT]?.token.fee ?? NNS_TOKEN_DATA.fee)
+  ($store) => {
+    const icpToken = $store[OWN_CANISTER_ID_TEXT]?.token;
+    if (isNullish(icpToken)) {
+      // This can't happen because the tokensStore always contains the NNS token.
+      throw new Error("ICP token not found");
+    }
+    return Number(icpToken.fee);
+  }
 );
 
 export const mainTransactionFeeE8sStore: Readable<bigint> = derived(
   tokensStore,
-  ($store) => $store[OWN_CANISTER_ID_TEXT]?.token.fee ?? NNS_TOKEN_DATA.fee
+  ($store) => {
+    const icpToken = $store[OWN_CANISTER_ID_TEXT]?.token;
+    if (isNullish(icpToken)) {
+      // This can't happen because the tokensStore always contains the NNS token.
+      throw new Error("ICP token not found");
+    }
+    return icpToken.fee;
+  }
 );

--- a/frontend/src/tests/lib/derived/transaction-fee.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/transaction-fee.derived.spec.ts
@@ -1,13 +1,12 @@
-import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
 import { mainTransactionFeeStoreAsToken } from "$lib/derived/main-transaction-fee.derived";
-import { transactionsFeesStore } from "$lib/stores/transaction-fees.store";
+import { tokensStore } from "$lib/stores/tokens.store";
 import { TokenAmount } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("mainTransactionFeeStoreAsToken", () => {
-  beforeEach(() =>
-    transactionsFeesStore.setMain(BigInt(DEFAULT_TRANSACTION_FEE_E8S))
-  );
+  beforeEach(() => {
+    tokensStore.reset();
+  });
   it("should return transaction fee as token", () => {
     const value = get(mainTransactionFeeStoreAsToken);
     expect(value instanceof TokenAmount).toBeTruthy();

--- a/frontend/src/tests/lib/stores/transaction-fees.store.spec.ts
+++ b/frontend/src/tests/lib/stores/transaction-fees.store.spec.ts
@@ -1,4 +1,6 @@
+import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
+import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import { tokensStore } from "$lib/stores/tokens.store";
 import {
   mainTransactionFeeStore,
@@ -18,10 +20,19 @@ describe("transactionsFeesStore", () => {
     expect(main).toEqual(BigInt(DEFAULT_TRANSACTION_FEE_E8S));
   });
 
-  it("should set main value", () => {
-    const newFee = 40_000;
-    const fee = get(mainTransactionFeeStore);
-    expect(fee).toBe(newFee);
+  it("should set ICP fee value", () => {
+    expect(get(mainTransactionFeeStore)).toBe(Number(NNS_TOKEN_DATA.fee));
+
+    const newFee = 40_000n;
+    tokensStore.setToken({
+      canisterId: OWN_CANISTER_ID,
+      token: {
+        ...NNS_TOKEN_DATA,
+        fee: newFee,
+      },
+      certified: true,
+    });
+    expect(get(mainTransactionFeeStore)).toBe(Number(newFee));
   });
 
   it("should reset to default", () => {

--- a/frontend/src/tests/lib/stores/transaction-fees.store.spec.ts
+++ b/frontend/src/tests/lib/stores/transaction-fees.store.spec.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
+import { tokensStore } from "$lib/stores/tokens.store";
 import {
   mainTransactionFeeStore,
   transactionsFeesStore,
@@ -8,9 +9,10 @@ import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 
 describe("transactionsFeesStore", () => {
-  beforeEach(() =>
-    transactionsFeesStore.setMain(BigInt(DEFAULT_TRANSACTION_FEE_E8S))
-  );
+  beforeEach(() => {
+    transactionsFeesStore.setMain(BigInt(DEFAULT_TRANSACTION_FEE_E8S));
+    tokensStore.reset();
+  });
   it("should set it to default transaction fee", () => {
     const { main } = get(transactionsFeesStore);
     expect(main).toEqual(BigInt(DEFAULT_TRANSACTION_FEE_E8S));
@@ -18,7 +20,6 @@ describe("transactionsFeesStore", () => {
 
   it("should set main value", () => {
     const newFee = 40_000;
-    transactionsFeesStore.setMain(BigInt(newFee));
     const fee = get(mainTransactionFeeStore);
     expect(fee).toBe(newFee);
   });


### PR DESCRIPTION
# Motivation

Remove deprecated `transactionsFeesStore`.

In this PR, remove the usage in the derived stores that returns the fee of the ICP.

# Changes

* `mainTransactionFeeStore` uses `tokensStore`.
* `mainTransactionFeeE8sStore` uses `tokensStore`.
* `mainTransactionFeeStoreAsToken` uses `tokensStore`.

# Tests

* Adapt `mainTransactionFeeStoreAsToken` spec file to use tokensStore.
* Adapt `mainTransactionFeeStore` test case to use tokensStore.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.

