### PR TITLE
Remove 'Linked Account' badge

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Changed wording about staking neurons to staking tokens.
 * Add missing feature flags to default feature flags value.
+* Various wording changes.
 
 #### Deprecated
 

--- a/frontend/src/lib/components/accounts/AccountBadge.svelte
+++ b/frontend/src/lib/components/accounts/AccountBadge.svelte
@@ -6,6 +6,6 @@
 </script>
 
 <!-- No badge for main account -->
-{#if account.type !== "main"}
+{#if !["main", "subAccount"].includes(account.type)}
   <small class="label">{$i18n.accounts[account.type]}</small>
 {/if}

--- a/frontend/src/lib/components/accounts/AccountBadge.svelte
+++ b/frontend/src/lib/components/accounts/AccountBadge.svelte
@@ -6,6 +6,6 @@
 </script>
 
 <!-- No badge for main account -->
-{#if !["main", "subAccount"].includes(account.type)}
+{#if account.type !== "main" && account.type !== "subAccount"}
   <small class="label">{$i18n.accounts[account.type]}</small>
 {/if}

--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -34,7 +34,7 @@ const convertAccountToUserTokenData = ({
 
   const subtitleMap: Record<AccountType, string | undefined> = {
     main: undefined,
-    subAccount: i18nObj.accounts.subAccount,
+    subAccount: undefined,
     hardwareWallet: i18nObj.accounts.hardwareWallet,
   };
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -202,7 +202,6 @@
     "edit_name": "Edit Name",
     "new_linked_account_enter_name": "Enter Account Name",
     "new_linked_account_placeholder": "Account Name",
-    "subAccount": "Linked Account",
     "hardwareWallet": "Hardware Wallet",
     "select_source": "Select Source Account",
     "select_destination": "Select Destination",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -211,7 +211,6 @@ interface I18nAccounts {
   edit_name: string;
   new_linked_account_enter_name: string;
   new_linked_account_placeholder: string;
-  subAccount: string;
   hardwareWallet: string;
   select_source: string;
   select_destination: string;

--- a/frontend/src/tests/lib/components/accounts/AccountBadge.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/AccountBadge.spec.ts
@@ -13,15 +13,15 @@ describe("AccountBadge", () => {
       props: { account: mockMainAccount },
     });
 
-    expect(() => getByText(en.accounts.subAccount, { exact: false })).toThrow();
+    expect(() => getByText("Linked Account", { exact: false })).toThrow();
   });
 
-  it("should render linked account badge", () => {
+  it("should not render linked account badge", () => {
     const { getByText } = render(AccountBadge, {
       props: { account: mockSubAccount },
     });
 
-    expect(getByText(en.accounts.subAccount)).toBeInTheDocument();
+    expect(() => getByText("Linked Account", { exact: false })).toThrow();
   });
 
   it("should render hardware wallet badge", () => {

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -51,7 +51,7 @@ describe("icp-tokens-list-user.derived", () => {
       token: NNS_TOKEN_DATA,
     }),
     title: mockSubAccount.name,
-    subtitle: "Linked Account",
+    subtitle: undefined,
     rowHref: buildWalletUrl({
       universe: OWN_CANISTER_ID_TEXT,
       account: mockSubAccount.identifier,


### PR DESCRIPTION
# Motivation

Requested in point 3 of https://www.notion.so/dfinityorg/Wording-Changes-4411020138ce4d09b6605ad1fdbb9555

# Changes

Remove the "Linked Account" badge on subaccounts both in the old accounts page and the new tokens table.

# Tests

Unit tests modified.

# Todos

- [x] Add entry to changelog (if necessary).
Added an entry which will also cover some future changes.