### PR TITLE
preparation: Implement state traits manually

### DIFF
--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -13,8 +13,6 @@ pub mod partitions;
 #[cfg(test)]
 pub mod tests;
 
-#[derive(Default, Debug)]
-#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct State {
     // NOTE: When adding new persistent fields here, ensure that these fields
     // are being persisted in the `replace` method below.
@@ -22,6 +20,42 @@ pub struct State {
     pub assets: RefCell<Assets>,
     pub asset_hashes: RefCell<AssetHashes>,
     pub performance: RefCell<PerformanceCounts>,
+    // TODO: Take ownership of stable memory.
+}
+
+#[cfg(test)]
+impl PartialEq for State {
+    /// Compares essential content of two states for equality.
+    ///
+    /// Excluded from the comparison:
+    /// - Raw stable memory owned by the state.
+    fn eq(&self, other: &Self) -> bool {
+        (self.accounts_store == other.accounts_store)
+            && (self.assets == other.assets)
+            && (self.asset_hashes == other.asset_hashes)
+            && (self.performance == other.performance)
+    }
+}
+#[cfg(test)]
+impl Eq for State {}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            accounts_store: RefCell::new(AccountsStore::default()),
+            assets: RefCell::new(Assets::default()),
+            asset_hashes: RefCell::new(AssetHashes::default()),
+            performance: RefCell::new(PerformanceCounts::default()),
+        }
+    }
+}
+
+impl core::fmt::Debug for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "State {{")?;
+        writeln!(f, "  accounts: {:?}", &self.accounts_store.borrow())?;
+        writeln!(f, "}}")
+    }
 }
 
 impl State {


### PR DESCRIPTION
# Motivation
We would like to restrict changes to stable memory, so that such changes are made only as part of updates to the state structure.  We will do this by adding a reference to memory in state and making changes only via that pointer.   However we will need to implement traits such as Debug and Eq manually.

# Changes
- Implement Debug manually.
  - Alternative considered: Implement the Debug trait for stable memory.  Rejected as the Debug printout is already much too verbose.  It seems better to limit the debug printout to what is actually useful.
- Implement `Default` manually, so that the default can later include the stable memory.
- Implement `Eq` manually, as I would like to ignore changes to the stable memory pointer when comparing state e.g. pre and post upgrade.  I would like to restrict access to memory but carry on not caring how the state is represented, as long as the meaningful content of the state is the same.

# Tests
- Tests are unchanged.

# Todos

- [ ] Add entry to changelog (if necessary).
