### PR TITLE
style: replace `grid-areas` with `order` to avoid extra gaps

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,7 +30,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
-* Fix extra gaps on launchpad page.
+* Fix gaps between sections on the mobile launchpad page.
 
 #### Security
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,6 +30,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Fix extra gaps on launchpad page.
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/pages/Launchpad.svelte
+++ b/frontend/src/lib/pages/Launchpad.svelte
@@ -61,31 +61,19 @@
   main {
     display: grid;
     gap: var(--padding-4x);
-    grid-template-areas:
-      "open-projects"
-      "upcoming-projects"
-      "proposals"
-      "committed-projects";
 
-    @include media.min-width(medium) {
-      grid-template-areas:
-        "open-projects"
-        "upcoming-projects"
-        "committed-projects"
-        "proposals";
-    }
-
-    .open-projects {
-      grid-area: open-projects;
-    }
-    .upcoming-projects {
-      grid-area: upcoming-projects;
-    }
+    // display "proposals" before "committed-projects" on mobile
     .committed-projects {
-      grid-area: committed-projects;
+      order: 2;
+      @include media.min-width(medium) {
+        order: 1;
+      }
     }
     .proposals {
-      grid-area: proposals;
+      order: 1;
+      @include media.min-width(medium) {
+        order: 2;
+      }
     }
   }
 


### PR DESCRIPTION
# Motivation

Fix double gaps on launchpad page (screen 1)

# Changes

- Replace `grid-areas` with `order` to avoid extra gaps.

# Tests

Only style changes

# Todos

- [x] Add entry to changelog (if necessary).

# Screenshots

| Before | After |
|--------|--------|
| <img width="416" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/8d72c2d0-0e6e-4cba-b7bd-1b16d7ba8ed6"> | <img width="416" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/e4d5c79f-1cc4-4532-a4aa-df466476245b"> |



