### PR TITLE
Chore: Upgrade next dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.1.0-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.1.0-next-2024-01-18.1.tgz",
-      "integrity": "sha512-10UbPyaYfJ/9SqeNkEv4r5Q84ev+HEL+JeB+dLs55dZGI98Wpeo2I3PiHiLNiDhr+UpeiUVv+wxCuUFi4L/KoQ==",
+      "version": "2.1.0-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.1.0-next-2024-01-23.tgz",
+      "integrity": "sha512-21QEHV8y1xFXNpgdHq8EqX+EwAh4XrjvycBJzhHUnbPYEOHlXPKyMZe3hhhFAPSk3RL/RSVqilhfBMv49rfu8Q==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "2.1.0-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-2.1.0-next-2024-01-18.1.tgz",
-      "integrity": "sha512-z4pAUL2a9Y6h789sjY1qRl1XuuEOHT2tq1EqJyAgA/xMgf3okETUpFLBoJ/6Kj+aDnpn98F3yuKVFBk75HgMUg==",
+      "version": "2.1.0-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-2.1.0-next-2024-01-23.tgz",
+      "integrity": "sha512-hqvTvwigwg5PTcOXazfeBwMLubC7rLyILd6q30NQ9rJaub3YWwDMQgQUQitveHtj2XnchWQgSBymd66KxBRxFg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "2.1.0-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.1.0-next-2024-01-18.1.tgz",
-      "integrity": "sha512-JHlA5iLXfB+JReBzSOc0yu8BVYhKdUOlYoxAGZHPa3bs6j3FbHpJ57BuYDe/QALzZGMz2LB1YgjUT2aVrCrglw==",
+      "version": "2.1.0-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.1.0-next-2024-01-23.tgz",
+      "integrity": "sha512-HLc+NIiug2lLxjEn0HrazLLYq8kSpWq/djfpGOhHPHUq1ictDlwSD3/jTCtPiUa4CorfLksf8/e8q9+Fd1DOqg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.1.1-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.1.1-next-2024-01-18.1.tgz",
-      "integrity": "sha512-AkmNtNvDbCbCTd7OUocD7qCI4G/U4XoIcgh4T156rEkV++2z52atuyLOzH0KvYPlbsrtwvh2KytAi78X4/syoA==",
+      "version": "2.1.1-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.1.1-next-2024-01-23.tgz",
+      "integrity": "sha512-C5JG12acD5ohTxem4OLNTBdNw0LUjLrb0Q9Gz3xt587Av7Owb7udlicgJMjeaSJLlxDaaGLMETA89oTQZLu1/A==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.1.0-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.0-next-2024-01-18.1.tgz",
-      "integrity": "sha512-Tr4ippF4ZzWlWGmZT193JI3XZT7CxfNi1UeJET6IZa+VIvSTMmdqfIa8FKqQL69oJD4IuXI3GFzERsstqVn3xA==",
+      "version": "2.1.0-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.0-next-2024-01-23.tgz",
+      "integrity": "sha512-nNOGqdKhnYxWnXtGeb+gkFfESZgEqGp4mypwhYrcLNesMKk/vuMcp8EPXgxwjKH+zEKRY5WJfJM7ratQMqdxPA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "3.1.0-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.1.0-next-2024-01-18.1.tgz",
-      "integrity": "sha512-BxGyNOk2FDyuxbX14zsZVBQ5NTaMkHni7woSHZT1fHIaF+46yTAlSgLUJAXBlNfwlxreY8E1W+KConAHjyVlsw==",
+      "version": "3.1.0-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.1.0-next-2024-01-23.tgz",
+      "integrity": "sha512-PUZ6NGpQRY0oapfeRwnlbQFKq9uYP0VUMyipihtix7ZdA4M93MJDlued0DkmAbRg+w6V8ARpX5ajoFVOtxtBuQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -358,9 +358,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.0-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2024-01-18.1.tgz",
-      "integrity": "sha512-WX6hHHDnv+2SrKmQOHHEXzarUXMqRN0oGo34JDY6FvGsJo1XOEfXXExiRByzSMlw41Li4LN4agOWZllPimUm1g==",
+      "version": "1.0.0-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2024-01-23.tgz",
+      "integrity": "sha512-83yIYTd0qCN+5SQnFU14QpEqT1kUUtTj+Ks9YyAvDNZjdrzpjWzyMtUjXR+lWj8E/otvReaOXvhW+Wkc4bh85g==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "2.1.0-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.0-next-2024-01-18.1.tgz",
-      "integrity": "sha512-hpJGGSCTYe+PG8VGJ4g4xnjp1qxDZSqCb0yf0yVHO2trVve1pxNMA1zrNHxlRWoMQNCuJWuF+nBXF/tLZtlQlg==",
+      "version": "2.1.0-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.0-next-2024-01-23.tgz",
+      "integrity": "sha512-UOBdyGeq1A8zJMabxzNEQxxwxiFhmEV6DFevdxdBSdcd/1HBfq5oartLAODTzmPmZ10jXga4ZX7+eEvj2Tb1SA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.0.0-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.0.0-next-2024-01-18.1.tgz",
-      "integrity": "sha512-n9+Osx4RbfJvZ6d6dbp5+iB9MhocLgJsWemGVJNUzIyzqp7E/zk+aoLLvd+q2Yj4NIM91jIEuRwhtVVGYBSOIQ==",
+      "version": "2.0.0-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.0.0-next-2024-01-23.tgz",
+      "integrity": "sha512-G6nNXklhy1wthULSeSapQEXo+5nuWH10aMjUWgKJlulAsMcx6F6i12au1kj4iTi5k16cK+dDaaez27HGbUgrBw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7047,9 +7047,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.1.0-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.1.0-next-2024-01-18.1.tgz",
-      "integrity": "sha512-10UbPyaYfJ/9SqeNkEv4r5Q84ev+HEL+JeB+dLs55dZGI98Wpeo2I3PiHiLNiDhr+UpeiUVv+wxCuUFi4L/KoQ==",
+      "version": "2.1.0-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.1.0-next-2024-01-23.tgz",
+      "integrity": "sha512-21QEHV8y1xFXNpgdHq8EqX+EwAh4XrjvycBJzhHUnbPYEOHlXPKyMZe3hhhFAPSk3RL/RSVqilhfBMv49rfu8Q==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7057,9 +7057,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "2.1.0-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-2.1.0-next-2024-01-18.1.tgz",
-      "integrity": "sha512-z4pAUL2a9Y6h789sjY1qRl1XuuEOHT2tq1EqJyAgA/xMgf3okETUpFLBoJ/6Kj+aDnpn98F3yuKVFBk75HgMUg==",
+      "version": "2.1.0-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-2.1.0-next-2024-01-23.tgz",
+      "integrity": "sha512-hqvTvwigwg5PTcOXazfeBwMLubC7rLyILd6q30NQ9rJaub3YWwDMQgQUQitveHtj2XnchWQgSBymd66KxBRxFg==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7073,9 +7073,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "2.1.0-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.1.0-next-2024-01-18.1.tgz",
-      "integrity": "sha512-JHlA5iLXfB+JReBzSOc0yu8BVYhKdUOlYoxAGZHPa3bs6j3FbHpJ57BuYDe/QALzZGMz2LB1YgjUT2aVrCrglw==",
+      "version": "2.1.0-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.1.0-next-2024-01-23.tgz",
+      "integrity": "sha512-HLc+NIiug2lLxjEn0HrazLLYq8kSpWq/djfpGOhHPHUq1ictDlwSD3/jTCtPiUa4CorfLksf8/e8q9+Fd1DOqg==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7089,30 +7089,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.1.1-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.1.1-next-2024-01-18.1.tgz",
-      "integrity": "sha512-AkmNtNvDbCbCTd7OUocD7qCI4G/U4XoIcgh4T156rEkV++2z52atuyLOzH0KvYPlbsrtwvh2KytAi78X4/syoA==",
+      "version": "2.1.1-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.1.1-next-2024-01-23.tgz",
+      "integrity": "sha512-C5JG12acD5ohTxem4OLNTBdNw0LUjLrb0Q9Gz3xt587Av7Owb7udlicgJMjeaSJLlxDaaGLMETA89oTQZLu1/A==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.1.0-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.0-next-2024-01-18.1.tgz",
-      "integrity": "sha512-Tr4ippF4ZzWlWGmZT193JI3XZT7CxfNi1UeJET6IZa+VIvSTMmdqfIa8FKqQL69oJD4IuXI3GFzERsstqVn3xA==",
+      "version": "2.1.0-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.0-next-2024-01-23.tgz",
+      "integrity": "sha512-nNOGqdKhnYxWnXtGeb+gkFfESZgEqGp4mypwhYrcLNesMKk/vuMcp8EPXgxwjKH+zEKRY5WJfJM7ratQMqdxPA==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "3.1.0-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.1.0-next-2024-01-18.1.tgz",
-      "integrity": "sha512-BxGyNOk2FDyuxbX14zsZVBQ5NTaMkHni7woSHZT1fHIaF+46yTAlSgLUJAXBlNfwlxreY8E1W+KConAHjyVlsw==",
+      "version": "3.1.0-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.1.0-next-2024-01-23.tgz",
+      "integrity": "sha512-PUZ6NGpQRY0oapfeRwnlbQFKq9uYP0VUMyipihtix7ZdA4M93MJDlued0DkmAbRg+w6V8ARpX5ajoFVOtxtBuQ==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.0-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2024-01-18.1.tgz",
-      "integrity": "sha512-WX6hHHDnv+2SrKmQOHHEXzarUXMqRN0oGo34JDY6FvGsJo1XOEfXXExiRByzSMlw41Li4LN4agOWZllPimUm1g==",
+      "version": "1.0.0-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2024-01-23.tgz",
+      "integrity": "sha512-83yIYTd0qCN+5SQnFU14QpEqT1kUUtTj+Ks9YyAvDNZjdrzpjWzyMtUjXR+lWj8E/otvReaOXvhW+Wkc4bh85g==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7126,17 +7126,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "2.1.0-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.0-next-2024-01-18.1.tgz",
-      "integrity": "sha512-hpJGGSCTYe+PG8VGJ4g4xnjp1qxDZSqCb0yf0yVHO2trVve1pxNMA1zrNHxlRWoMQNCuJWuF+nBXF/tLZtlQlg==",
+      "version": "2.1.0-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.0-next-2024-01-23.tgz",
+      "integrity": "sha512-UOBdyGeq1A8zJMabxzNEQxxwxiFhmEV6DFevdxdBSdcd/1HBfq5oartLAODTzmPmZ10jXga4ZX7+eEvj2Tb1SA==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.0.0-next-2024-01-18.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.0.0-next-2024-01-18.1.tgz",
-      "integrity": "sha512-n9+Osx4RbfJvZ6d6dbp5+iB9MhocLgJsWemGVJNUzIyzqp7E/zk+aoLLvd+q2Yj4NIM91jIEuRwhtVVGYBSOIQ==",
+      "version": "2.0.0-next-2024-01-23",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.0.0-next-2024-01-23.tgz",
+      "integrity": "sha512-G6nNXklhy1wthULSeSapQEXo+5nuWH10aMjUWgKJlulAsMcx6F6i12au1kj4iTi5k16cK+dDaaez27HGbUgrBw==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/lib/types/sns-aggregator.ts
+++ b/frontend/src/lib/types/sns-aggregator.ts
@@ -71,10 +71,15 @@ interface CachedLinearScalingCoefficient {
   to_direct_participation_icp_e8s?: number | null;
 }
 
+interface CachedIdealMatchedParticipationFunction {
+  serialized_representation?: string | null;
+}
+
 export type CachedNeuronsFundParticipationConstraints = {
   coefficient_intervals: Array<CachedLinearScalingCoefficient>;
   max_neurons_fund_participation_icp_e8s?: number | null;
   min_direct_participation_threshold_icp_e8s?: number | null;
+  ideal_matched_participation_function?: CachedIdealMatchedParticipationFunction;
 };
 
 // TODO: update when the candid is updated with the new init params

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -126,6 +126,7 @@ const convertNeuronsFundParticipationConstraints = (
       constraints.min_direct_participation_threshold_icp_e8s
     )
   ),
+  ideal_matched_participation_function: [],
 });
 
 const convertSwapInitParams = (
@@ -373,6 +374,8 @@ const convertDtoToLifecycle = (
     )
   ),
   lifecycle: toNullable(data.lifecycle),
+  // TODO: Add support in SNS Aggregaro for these fields
+  decentralization_swap_termination_timestamp_seconds: [],
 });
 
 type PartialSummary = Omit<

--- a/frontend/src/tests/lib/api/sns.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns.api.spec.ts
@@ -65,6 +65,7 @@ describe("sns-api", () => {
   const lifecycleResponse: SnsGetLifecycleResponse = {
     lifecycle: [SnsSwapLifecycle.Open],
     decentralization_sale_open_timestamp_seconds: [1n],
+    decentralization_swap_termination_timestamp_seconds: [],
   };
   const notifyParticipationSpy = vi.fn().mockResolvedValue(undefined);
   const mockUserCommitment = createBuyersState(100_000_000n);

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsActiveDisbursementEntry.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsActiveDisbursementEntry.spec.ts
@@ -18,6 +18,7 @@ describe("SnsActiveDisbursementEntry", () => {
         subaccount: [],
       },
     ],
+    finalize_disbursement_timestamp_seconds: [],
   };
   const renderComponent = (disbursement: DisburseMaturityInProgress) => {
     const { container } = render(SnsActiveDisbursementEntry, {

--- a/frontend/src/tests/lib/modals/sns/SnsActiveDisbursementsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsActiveDisbursementsModal.spec.ts
@@ -17,6 +17,7 @@ describe("SnsActiveDisbursementsModal", () => {
         subaccount: [],
       },
     ],
+    finalize_disbursement_timestamp_seconds: [],
   };
 
   const renderComponent = async (neuron: SnsNeuron) => {

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -347,6 +347,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
       vi.spyOn(snsApi, "querySnsLifecycle").mockResolvedValue({
         decentralization_sale_open_timestamp_seconds: [11_231_312n],
         lifecycle: [SnsSwapLifecycle.Open],
+        decentralization_swap_termination_timestamp_seconds: [],
       });
 
       cancelPollGetOpenTicket();

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -277,6 +277,7 @@ describe("sns-services", () => {
       const lifeCycleResponse: SnsGetLifecycleResponse = {
         lifecycle: [newLifeCycle],
         decentralization_sale_open_timestamp_seconds: [1n],
+        decentralization_swap_termination_timestamp_seconds: [],
       };
 
       const spy = vi

--- a/frontend/src/tests/lib/stores/sns-finalization-status.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-finalization-status.store.spec.ts
@@ -130,6 +130,8 @@ describe("sns finalization status stores", () => {
             sweep_icp_result: [],
             claim_neuron_result: [],
             sweep_sns_result: [],
+            create_sns_neuron_recipes_result: [],
+            settle_neurons_fund_participation_result: [],
           },
         ],
         has_auto_finalize_been_attempted: [true],

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -439,6 +439,7 @@ describe("sns aggregator converters utils", () => {
           lifecycle: {
             decentralization_sale_open_timestamp_seconds: [1690786778n],
             lifecycle: [2],
+            decentralization_swap_termination_timestamp_seconds: [],
           },
         })
       );
@@ -573,6 +574,7 @@ describe("sns aggregator converters utils", () => {
                     ],
                     max_neurons_fund_participation_icp_e8s: [300000000000n],
                     min_direct_participation_threshold_icp_e8s: [10000000000n],
+                    ideal_matched_participation_function: [],
                   },
                 ],
                 min_direct_participation_icp_e8s: [300000000000n],

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -263,6 +263,8 @@ sale_participants_count ${saleBuyerCount} 1677707139456
             sweep_icp_result: [],
             claim_neuron_result: [],
             sweep_sns_result: [],
+            create_sns_neuron_recipes_result: [],
+            settle_neurons_fund_participation_result: [],
           },
         ],
         has_auto_finalize_been_attempted: [true],

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -34,6 +34,7 @@ export const mockActiveDisbursement: DisburseMaturityInProgress = {
       subaccount: [],
     },
   ],
+  finalize_disbursement_timestamp_seconds: [],
 };
 
 export const createMockSnsNeuron = ({

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -169,6 +169,7 @@ export const mockQuerySwap: SnsSwap = {
   purge_old_tickets_next_principal: [],
   direct_participation_icp_e8s: [],
   neurons_fund_participation_icp_e8s: [],
+  decentralization_swap_termination_timestamp_seconds: [],
 };
 
 export const mockDerived: SnsSwapDerivedState = {
@@ -209,6 +210,7 @@ export const mockToken: IcrcTokenMetadata = {
 export const mockLifecycleResponse: SnsGetLifecycleResponse = {
   lifecycle: [SnsSwapLifecycle.Open],
   decentralization_sale_open_timestamp_seconds: [],
+  decentralization_swap_termination_timestamp_seconds: [],
 };
 
 export const mockSnsSummaryList: SnsSummary[] = [
@@ -396,6 +398,7 @@ export const createSummary = ({
               toNullable(maxNFParticipation),
             coefficient_intervals: [],
             min_direct_participation_threshold_icp_e8s: [],
+            ideal_matched_participation_function: [],
           },
         ]
       : [],

--- a/frontend/src/tests/mocks/sns-response.mock.ts
+++ b/frontend/src/tests/mocks/sns-response.mock.ts
@@ -36,6 +36,7 @@ const swapToQuerySwap = (swap: SnsSummarySwap): [SnsSwap] => [
     purge_old_tickets_next_principal: [],
     direct_participation_icp_e8s: [],
     neurons_fund_participation_icp_e8s: [],
+    decentralization_swap_termination_timestamp_seconds: [],
   },
 ];
 


### PR DESCRIPTION
# Motivation

Upgrade next dependencies after updating Candid files for sns-js.

# Changes

## Automatic Changes

* Script `npm run upgrade:next` updated the file package.lock.json

## Manual Changes

* Add `ideal_matched_participation_function` to the Aggregator type because it's already supported in the aggregator.
* Add `ideal_matched_participation_function` and `decentralization_swap_termination_timestamp_seconds` to the aggregator converters.

# Tests

* Add new optional fields to quite a few mocks in our tests. I will use this to create another PR to put all those mocks in a separate file to have the changes centralized next time.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary. No new functionality is added.

