### PR TITLE
Chore: Add reviewers to update PRs by CI

### DIFF
--- a/.github/workflows/update-aggregator.yml
+++ b/.github/workflows/update-aggregator.yml
@@ -35,6 +35,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>
           base: main
+          reviewers: mstrasinskis, dskloetd, lmuntaner
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: rs/sns_aggregator/src/types/*
           branch: bot-aggregator-update

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main
+          reviewers: mstrasinskis, dskloetd, lmuntaner
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: dfx.json
           commit-message: Update didc release

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main
+          reviewers: mstrasinskis, dskloetd, lmuntaner
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
             dfx.json

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -42,6 +42,7 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-proposals-update
           branch-suffix: timestamp
+          reviewers: mstrasinskis, dskloetd, lmuntaner
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: rs/proposals/src/canisters/*/api.rs
           delete-branch: true

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main
+          reviewers: mstrasinskis, dskloetd, lmuntaner
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: ./rust-toolchain.toml
           commit-message: Update rust version

--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -64,6 +64,7 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-snsdemo-update
           branch-suffix: timestamp
+          reviewers: mstrasinskis, dskloetd, lmuntaner
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: dfx.json
           delete-branch: true

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -38,6 +38,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+* Add `reviewers` to the `update-*.yml` workflows that create PRs.
+
 #### Changed
 
 #### Deprecated


### PR DESCRIPTION
# Motivation

We have some nice workflows that create PRs to update dependencies. They are accumulating because there are no reviewers.

In this PR, add reviewers for the udpate workflows.

Example PR: https://github.com/dfinity/nns-dapp/pull/4284

# Changes

* Add `reviewers: mstrasinskis, dskloetd, lmuntaner` to the `update-*.yml` CI workflows.

# Tests

Not necessary.

# Todos

- [x] Add entry to changelog (if necessary).
