### PR TITLE
Remove input error outline for dissolve delay below project minimum

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -27,6 +27,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Removed
 
 * ckBTC withdrawal account.
+* Don't show the red error outline on dissolve delay input when the dissolve delay is not enough to have voting power.
 
 #### Fixed
 

--- a/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
+++ b/frontend/src/lib/components/neurons/SetDissolveDelay.svelte
@@ -29,6 +29,12 @@
   let disableUpdate: boolean;
   $: disableUpdate = shouldUpdateBeDisabled(delayInSeconds);
 
+  let warningMessage: string | undefined;
+  $: warningMessage =
+    delayInSeconds > 0 && delayInSeconds < minProjectDelayInSeconds
+      ? $i18n.neurons.dissolve_delay_below_minimum
+      : undefined;
+
   const getInputError = (delayInSeconds: number) => {
     if (delayInSeconds > maxDelayInSeconds) {
       return $i18n.neurons.dissolve_delay_above_maximum;
@@ -36,19 +42,11 @@
     if (delayInSeconds <= neuronDissolveDelaySeconds) {
       return $i18n.neurons.dissolve_delay_below_current;
     }
-    if (delayInSeconds < minProjectDelayInSeconds) {
-      return $i18n.neurons.dissolve_delay_below_minimum;
-    }
     return undefined;
   };
 
   const shouldUpdateBeDisabled = (delayInSeconds: number): boolean => {
-    const error = getInputError(delayInSeconds);
-    // It's allowed to set the dissolve delay below the project minimum but we
-    // still show a warning message to the user.
-    return (
-      nonNullish(error) && error !== $i18n.neurons.dissolve_delay_below_minimum
-    );
+    return nonNullish(getInputError(delayInSeconds));
   };
 
   const cancel = () => dispatch("nnsCancel");
@@ -111,6 +109,7 @@
         placeholderLabelKey="neurons.dissolve_delay_placeholder"
         name="dissolve_delay"
         {getInputError}
+        {warningMessage}
       />
     </div>
     <div class="range">

--- a/frontend/src/lib/components/ui/DayInput.svelte
+++ b/frontend/src/lib/components/ui/DayInput.svelte
@@ -16,6 +16,7 @@
   // And we don't want to expose days outside.
   // That's why we expect the error function, instead of relying on the parent to calculate it based on `seconds`.
   export let getInputError: (value: number) => string | undefined;
+  export let warningMessage: string | undefined = undefined;
 
   // Round up the first time to not show a lot of decimal places.
   let days: number = Math.min(
@@ -51,6 +52,7 @@
   max={secondsToDays(maxInSeconds)}
   inputType="number"
   {errorMessage}
+  {warningMessage}
   on:nnsInput={showError}
   on:blur={showError}
   {disabled}

--- a/frontend/src/lib/components/ui/InputWithError.svelte
+++ b/frontend/src/lib/components/ui/InputWithError.svelte
@@ -12,8 +12,9 @@
   export let minLength: number | undefined = undefined;
   export let max: number | undefined = undefined;
   export let errorMessage: string | undefined = undefined;
-  let error: boolean;
-  $: error = errorMessage !== undefined;
+  let hasError: boolean;
+  $: hasError = errorMessage !== undefined;
+  export let warningMessage: string | undefined = undefined;
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
   export let autocomplete: "off" | "on" | undefined = undefined;
   export let value: string | number | undefined = undefined;
@@ -22,7 +23,7 @@
   export let testId = "input-with-error-compoment";
 </script>
 
-<div class="wrapper" data-tid={testId} class:error>
+<div class="wrapper" data-tid={testId} class:error={hasError}>
   <Input
     {inputType}
     {required}
@@ -45,11 +46,11 @@
     <slot name="inner-end" slot="inner-end" />
   </Input>
 
-  {#if error}
+  {#if errorMessage || warningMessage}
     <p class="error-message" data-tid="input-error-message">
       <IconInfo />
       <span>
-        {errorMessage}
+        {errorMessage ?? warningMessage}
       </span>
     </p>
   {/if}

--- a/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
@@ -124,22 +124,25 @@ describe("SetDissolveDelay", () => {
 
       expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
       expect(await po.getErrorMessage()).toBe(null);
+      expect(await po.hasErrorOutline()).toBe(false);
 
       await po.enterDays(neuronDays);
       expect(await po.getErrorMessage()).toBe(
         en.neurons.dissolve_delay_below_current
       );
+      expect(await po.hasErrorOutline()).toBe(true);
       expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
 
       await po.enterDays(neuronDays - 1.5);
       expect(await po.getErrorMessage()).toBe(
         en.neurons.dissolve_delay_below_current
       );
+      expect(await po.hasErrorOutline()).toBe(true);
       expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
 
       await po.enterDays(neuronDays + 1);
       expect(await po.getErrorMessage()).toBe(null);
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(await po.hasErrorOutline()).toBe(false);
       expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
     });
 
@@ -157,16 +160,21 @@ describe("SetDissolveDelay", () => {
 
       expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
       expect(await po.getErrorMessage()).toBe(null);
+      expect(await po.hasErrorOutline()).toBe(false);
 
       await po.enterDays(projectMinDays - 1);
       expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
       expect(await po.getErrorMessage()).toBe(
         en.neurons.dissolve_delay_below_minimum
       );
+      // We don't show the error outline because the submit button is enabled.
+      // The message is only treated as a warning.
+      expect(await po.hasErrorOutline()).toBe(false);
 
       await po.enterDays(projectMinDays);
       expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
       expect(await po.getErrorMessage()).toBe(null);
+      expect(await po.hasErrorOutline()).toBe(false);
     });
 
     it("when text input above max project delay", async () => {
@@ -179,11 +187,13 @@ describe("SetDissolveDelay", () => {
       await po.enterDays(projectMaxDays);
       expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
       expect(await po.getErrorMessage()).toBe(null);
+      expect(await po.hasErrorOutline()).toBe(false);
       await po.enterDays(projectMaxDays + 1);
       expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
       expect(await po.getErrorMessage()).toBe(
         en.neurons.dissolve_delay_above_maximum
       );
+      expect(await po.hasErrorOutline()).toBe(true);
     });
 
     it("hide error message on min/max click", async () => {
@@ -201,17 +211,21 @@ describe("SetDissolveDelay", () => {
       expect(await po.getErrorMessage()).toBe(
         en.neurons.dissolve_delay_below_minimum
       );
+      expect(await po.hasErrorOutline()).toBe(true);
 
       await po.clickMin();
       expect(await po.getErrorMessage()).toBe(null);
+      expect(await po.hasErrorOutline()).toBe(false);
 
       await po.enterDays(maxProjectDelayInSeconds + 1);
       expect(await po.getErrorMessage()).toBe(
         en.neurons.dissolve_delay_above_maximum
       );
+      expect(await po.hasErrorOutline()).toBe(true);
 
       await po.clickMax();
       expect(await po.getErrorMessage()).toBe(null);
+      expect(await po.hasErrorOutline()).toBe(false);
     });
   });
 
@@ -227,20 +241,24 @@ describe("SetDissolveDelay", () => {
     expect(await po.getProgressBarSeconds()).toBe(1001 * SECONDS_IN_DAY);
 
     expect(await po.getErrorMessage()).toBe(null);
+    expect(await po.hasErrorOutline()).toBe(false);
     expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
 
     await po.enterDays(1002);
     expect(await po.getErrorMessage()).toBe(null);
+    expect(await po.hasErrorOutline()).toBe(false);
     expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
 
     await po.enterDays(1000);
     expect(await po.getErrorMessage()).toBe(
       en.neurons.dissolve_delay_below_current
     );
+    expect(await po.hasErrorOutline()).toBe(true);
     expect(await po.getUpdateButtonPo().isDisabled()).toBe(true);
 
     await po.enterDays(1001);
     expect(await po.getErrorMessage()).toBe(null);
+    expect(await po.hasErrorOutline()).toBe(false);
     expect(await po.getUpdateButtonPo().isDisabled()).toBe(false);
   });
 

--- a/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/SetDissolveDelay.spec.ts
@@ -211,7 +211,7 @@ describe("SetDissolveDelay", () => {
       expect(await po.getErrorMessage()).toBe(
         en.neurons.dissolve_delay_below_minimum
       );
-      expect(await po.hasErrorOutline()).toBe(true);
+      expect(await po.hasErrorOutline()).toBe(false);
 
       await po.clickMin();
       expect(await po.getErrorMessage()).toBe(null);

--- a/frontend/src/tests/lib/components/ui/InputWithError.spec.ts
+++ b/frontend/src/tests/lib/components/ui/InputWithError.spec.ts
@@ -1,23 +1,73 @@
 import InputWithError from "$lib/components/ui/InputWithError.svelte";
+import { InputWithErrorPo } from "$tests/page-objects/InputWithError.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 
 describe("Input", () => {
   const props = { name: "name", placeholderLabelKey: "test.placeholder" };
 
-  it("should render an input", () => {
-    const { getByTestId } = render(InputWithError, {
-      props,
+  const renderComponent = (props) => {
+    const { container } = render(InputWithError, { props });
+    return InputWithErrorPo.under({
+      element: new JestPageObjectElement(container),
     });
+  };
 
-    expect(getByTestId("input-ui-element")).toBeInTheDocument();
+  it("should render an input", async () => {
+    const po = renderComponent(props);
+    expect(await po.getTextInputPo().isPresent()).toBe(true);
   });
 
-  it("should render an error message", () => {
+  it("should render an error message", async () => {
     const errorMessage = "test error";
-    const { getByText } = render(InputWithError, {
-      props: { ...props, errorMessage },
+    const po = renderComponent({
+      ...props,
+      errorMessage,
     });
 
-    expect(getByText(errorMessage)).toBeInTheDocument();
+    expect(await po.getErrorMessage()).toBe(errorMessage);
+  });
+
+  it("should render an error outline for an error message", async () => {
+    const errorMessage = "test error";
+    const po = renderComponent({
+      ...props,
+      errorMessage,
+    });
+
+    expect(await po.hasErrorOutline()).toBe(true);
+  });
+
+  it("should render a warning message", async () => {
+    const warningMessage = "test warning";
+    const po = renderComponent({
+      ...props,
+      warningMessage,
+    });
+
+    expect(await po.getErrorMessage()).toBe(warningMessage);
+  });
+
+  it("should not render an error outline for a warning message", async () => {
+    const warningMessage = "test warning";
+    const po = renderComponent({
+      ...props,
+      warningMessage,
+    });
+
+    expect(await po.hasErrorOutline()).toBe(false);
+  });
+
+  it("should not render a warning message with an error message", async () => {
+    const errorMessage = "test error";
+    const warningMessage = "test warning";
+    const po = renderComponent({
+      ...props,
+      errorMessage,
+      warningMessage,
+    });
+
+    expect(await po.getErrorMessage()).toBe(errorMessage);
+    expect(await po.hasErrorOutline()).toBe(true);
   });
 });

--- a/frontend/src/tests/page-objects/InputWithError.page-object.ts
+++ b/frontend/src/tests/page-objects/InputWithError.page-object.ts
@@ -44,4 +44,8 @@ export class InputWithErrorPo extends SimpleBasePageObject {
       ? (await this.getText("input-error-message")).trim()
       : null;
   }
+
+  async hasErrorOutline(): Promise<boolean> {
+    return (await this.root.getClasses()).includes("error");
+  }
 }

--- a/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/SetDissolveDelay.page-object.ts
@@ -82,6 +82,10 @@ export class SetDissolveDelayPo extends BasePageObject {
     return this.getInputWithErrorPo().getErrorMessage();
   }
 
+  hasErrorOutline(): Promise<boolean> {
+    return this.getInputWithErrorPo().hasErrorOutline();
+  }
+
   async getProgressBarSeconds(): Promise<number> {
     return this.getRangeDissolveDelayPo().getProgressBarSeconds();
   }


### PR DESCRIPTION
# Motivation

Requested in point 14 of https://www.notion.so/dfinityorg/Wording-Changes-4411020138ce4d09b6605ad1fdbb9555

When the dissolve delay is not enough to have voting power, we should an error message but we don't disable the "Set Delay" button.
Additionally to not disabling the button we should also not put a red outline on the input field.

# Changes

1. Add an extra prop `warningMessage` on `InputWithError`. Setting the warning message show the message similar to an error message but it does not cause the red outline.
2. Use the `warningMessage` prop for the warning about not having voting power.

# Tests

1. Use page objects for existing tests in `InputWithError.spec.ts`.
2. Add unit tests for `warningMessage`.
3. Add expects for the error outline in `SetDissolveDelay.spec.ts`.

# Todos

- [x] Add entry to changelog (if necessary).
