### PR TITLE
Fix: Flaky ckbtc e2e test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Skip build for testing
         # Set to true and set a recent `run_id` below to reuse an existing build
         # instead of building.
-        if: false
-        id: skip_build
+        if: true
+        id: 7637823560
         run: |
           echo "skip_build=true" >> "$GITHUB_OUTPUT"
           mkdir out

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,14 +30,14 @@ jobs:
       - name: Skip build for testing
         # Set to true and set a recent `run_id` below to reuse an existing build
         # instead of building.
-        if: true
+        if: false
         id: skip_build
         run: |
           echo "skip_build=true" >> "$GITHUB_OUTPUT"
           mkdir out
           # The run ID is the number at the end of a URL like this:
           # https://github.com/dfinity/nns-dapp/actions/runs/5801187848
-          run_id=7637823560
+          run_id=5801187848
           gh run download "$run_id" --dir ./out -n out
       - name: Build nns-dapp repo
         if: steps.skip_build.outputs.skip_build != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,13 +31,13 @@ jobs:
         # Set to true and set a recent `run_id` below to reuse an existing build
         # instead of building.
         if: true
-        id: 7637823560
+        id: skip_build
         run: |
           echo "skip_build=true" >> "$GITHUB_OUTPUT"
           mkdir out
           # The run ID is the number at the end of a URL like this:
           # https://github.com/dfinity/nns-dapp/actions/runs/5801187848
-          run_id=5801187848
+          run_id=7637823560
           gh run download "$run_id" --dir ./out -n out
       - name: Build nns-dapp repo
         if: steps.skip_build.outputs.skip_build != 'true'

--- a/frontend/src/tests/e2e/ckbtc.spec.ts
+++ b/frontend/src/tests/e2e/ckbtc.spec.ts
@@ -22,6 +22,7 @@ test("Test accounts requirements", async ({ page, context }) => {
     .getTokensPo()
     .getTokensPagePo()
     .getTokensTable();
+  await tokensTablePo.waitFor();
   const ckBTCRow = await tokensTablePo.getRowByName("ckBTC");
   await ckBTCRow.waitForBalance();
   expect(await ckBTCRow.getBalance()).toBe("0 ckBTC");

--- a/frontend/src/tests/page-objects/playwright.page-object.ts
+++ b/frontend/src/tests/page-objects/playwright.page-object.ts
@@ -1,5 +1,5 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { expect, type Locator, type Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 
 export class PlaywrightPageObjectElement implements PageObjectElement {
   readonly locator: Locator;
@@ -104,7 +104,7 @@ export class PlaywrightPageObjectElement implements PageObjectElement {
   }
 
   waitForAbsent(): Promise<void> {
-    return expect(this.locator).toHaveCount(0);
+    return this.locator.waitFor({ state: "detached" });
   }
 
   click(): Promise<void> {


### PR DESCRIPTION
# Motivation

The ckbtc.spec e2e test is flaky and sometimes fails.

The issue seems to be that the `waitForAbsent` on the Spinner within the balance is not waiting until it's removed.

It's weird because I would have expected it to fail if the spinner is still there. I wasn't able to replicate it locally, so it's hard to find the cause and the solution.

In this PR, I change the implementation of `waitForAbsent` to use `location.waitFor`.

I will keep monitoring the CI failures.

# Changes

* Change the implementation of `waitForAbsent` in playwright element.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
