### PR TITLE
Do not hide vote in progress proposals

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -31,6 +31,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Fix gaps between sections on the mobile launchpad page.
+* Fix proposal back navigation during voting.
 
 #### Security
 

--- a/frontend/src/lib/derived/proposals.derived.ts
+++ b/frontend/src/lib/derived/proposals.derived.ts
@@ -8,10 +8,6 @@ import {
   proposalsFiltersStore,
   proposalsStore,
 } from "$lib/stores/proposals.store";
-import {
-  voteRegistrationStore,
-  type VoteRegistrationStoreMap,
-} from "$lib/stores/vote-registration.store";
 import { hideProposal } from "$lib/utils/proposals.utils";
 import type { Identity } from "@dfinity/agent";
 import type { NeuronInfo, ProposalInfo } from "@dfinity/nns";
@@ -49,13 +45,11 @@ const hide = ({
   proposalInfo,
   filters,
   neurons,
-  registrations,
   identity,
 }: {
   proposalInfo: ProposalInfo;
   filters: ProposalsFiltersStore;
   neurons: NeuronInfo[];
-  registrations: VoteRegistrationStoreMap;
   identity: Identity | undefined | null;
 }): boolean =>
   hideProposal({
@@ -63,14 +57,7 @@ const hide = ({
     proposalInfo,
     neurons,
     identity,
-  }) ||
-  // hide proposals that are currently in the "complete" voting state
-  Object.values(registrations).find((votings) => {
-    return votings.find(
-      ({ proposalIdString, status }) =>
-        `${proposalInfo.id}` === proposalIdString && status === "complete"
-    );
-  }) !== undefined;
+  });
 
 export interface UIProposalsStore {
   proposals: (ProposalInfo & { hidden: boolean })[];
@@ -78,27 +65,14 @@ export interface UIProposalsStore {
 }
 
 export const uiProposals: Readable<UIProposalsStore> = derived(
-  [
-    sortedProposals,
-    proposalsFiltersStore,
-    definedNeuronsStore,
-    voteRegistrationStore,
-    authStore,
-  ],
-  ([
-    { proposals, certified },
-    filters,
-    neurons,
-    { registrations },
-    { identity },
-  ]) => ({
+  [sortedProposals, proposalsFiltersStore, definedNeuronsStore, authStore],
+  ([{ proposals, certified }, filters, neurons, { identity }]) => ({
     proposals: proposals.map((proposalInfo) => ({
       ...proposalInfo,
       hidden: hide({
         proposalInfo,
         filters,
         neurons,
-        registrations,
         identity,
       }),
     })),

--- a/frontend/src/lib/derived/proposals.derived.ts
+++ b/frontend/src/lib/derived/proposals.derived.ts
@@ -64,12 +64,13 @@ const hide = ({
     neurons,
     identity,
   }) ||
-  // hide proposals that are currently in the voting state
-  Object.values(registrations).find((votings) =>
-    votings.find(
-      ({ proposalIdString }) => `${proposalInfo.id}` === proposalIdString
-    )
-  ) !== undefined;
+  // hide proposals that are currently in the "complete" voting state
+  Object.values(registrations).find((votings) => {
+    return votings.find(
+      ({ proposalIdString, status }) =>
+        `${proposalInfo.id}` === proposalIdString && status === "complete"
+    );
+  }) !== undefined;
 
 export interface UIProposalsStore {
   proposals: (ProposalInfo & { hidden: boolean })[];

--- a/frontend/src/lib/stores/vote-registration.store.ts
+++ b/frontend/src/lib/stores/vote-registration.store.ts
@@ -8,10 +8,7 @@ import type { Vote } from "@dfinity/nns";
 import type { SnsVote } from "@dfinity/sns";
 import { writable, type Readable } from "svelte/store";
 
-export type VoteRegistrationStatus =
-  | "vote-registration"
-  | "post-update"
-  | "complete";
+export type VoteRegistrationStatus = "vote-registration" | "post-update";
 
 export interface VoteRegistrationStoreEntry {
   status: VoteRegistrationStatus;

--- a/frontend/src/tests/lib/stores/vote-registration.store.spec.ts
+++ b/frontend/src/tests/lib/stores/vote-registration.store.spec.ts
@@ -44,25 +44,19 @@ describe("voting-store", () => {
 
       voteRegistrationStore.updateStatus({
         proposalIdString: voteA.proposalIdString,
-        status: "complete",
+        status: "post-update",
         canisterId: OWN_CANISTER_ID,
       });
 
       expect(
         get(voteRegistrationStore).registrations[OWN_CANISTER_ID.toText()][0]
           .status
-      ).toEqual("complete");
+      ).toEqual("post-update");
     });
 
     it("should remove completed voting items", () => {
       voteRegistrationStore.add({ ...voteA, canisterId: OWN_CANISTER_ID });
       voteRegistrationStore.add({ ...voteB, canisterId: OWN_CANISTER_ID });
-
-      voteRegistrationStore.updateStatus({
-        status: "complete",
-        proposalIdString: voteA.proposalIdString,
-        canisterId: OWN_CANISTER_ID,
-      });
 
       voteRegistrationStore.remove({
         proposalIdString: voteA.proposalIdString,


### PR DESCRIPTION
# Motivation

Because "Show only proposals you can still vote for" can be unchecked or voting actions may take a few seconds, it is expected that the proposal will be accessible through navigation until it is complete. 

1. Start from nns proposal list page
2. Uncheck “`Show only proposals you can still vote for`" if checked
3. Start voting process on proposal with id N
4. Quickly click “Older” to navigate to N-1
5. Right after navigation click “Newer”

Expected navigation to proposal N, not N+1.

# Changes

- ignore the temporal voting status (from `vote registrations store`) in `is proposal hidden` logic. The proposal entry remains in the `voteRegistrationStore` only till the voting is done.
- drop `VoteRegistrationStatus.complete` since it's not used anymore (It's a relic that we still rely on it).

# Tests

- update relevant tests

# Todos

- [x] Add entry to changelog (if necessary).

# Screenshots

Issue w/ selected checkbox
https://github.com/dfinity/nns-dapp/assets/98811342/8fc2bf51-3b71-4380-83b0-aa466743a7ee

Issue w/o selected checkbox
https://github.com/dfinity/nns-dapp/assets/98811342/f6b166a3-c6af-4d5c-9a27-55c12629cbc2

After the fix
https://github.com/dfinity/nns-dapp/assets/98811342/3c5a1183-6964-4882-875c-1524c5abf41f



