### PR TITLE
Add ModalPo base page object

### DIFF
--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -107,7 +107,9 @@ describe("MergeNeuronsModal", () => {
 
     it("renders title", async () => {
       const po = await renderMergeModal([mergeableNeuron1]);
-      expect(await po.getTitle()).toBe(en.neurons.merge_neurons_modal_title);
+      expect(await po.getModalTitle()).toBe(
+        en.neurons.merge_neurons_modal_title
+      );
     });
 
     it("renders disabled button", async () => {

--- a/frontend/src/tests/page-objects/Accounts.page-object.ts
+++ b/frontend/src/tests/page-objects/Accounts.page-object.ts
@@ -83,7 +83,7 @@ export class AccountsPo extends BasePageObject {
     const receiveModalPo = this.getReceiveModalPo();
     await receiveModalPo.waitFor();
     const address = await receiveModalPo.getAddress();
-    await receiveModalPo.close();
+    await receiveModalPo.closeModal();
     return address;
   }
 }

--- a/frontend/src/tests/page-objects/AddAccountModal.page-object.ts
+++ b/frontend/src/tests/page-objects/AddAccountModal.page-object.ts
@@ -1,9 +1,9 @@
 import { AddAccountTypePo } from "$tests/page-objects/AddAccountType.page-object";
 import { AddSubAccountPo } from "$tests/page-objects/AddSubAccount.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class AddAccountModalPo extends BasePageObject {
+export class AddAccountModalPo extends ModalPo {
   private static readonly TID = "add-account-modal-component";
 
   static under(element: PageObjectElement): AddAccountModalPo {
@@ -34,9 +34,5 @@ export class AddAccountModalPo extends BasePageObject {
     await this.chooseLinkedAccount();
     await this.enterAccountName(name);
     await this.clickCreate();
-  }
-
-  waitForClosed(): Promise<void> {
-    return this.root.waitForAbsent();
   }
 }

--- a/frontend/src/tests/page-objects/AddSnsHotkeyModal.page-object.ts
+++ b/frontend/src/tests/page-objects/AddSnsHotkeyModal.page-object.ts
@@ -1,7 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class AddSnsHotkeyModalPo extends BasePageObject {
+export class AddSnsHotkeyModalPo extends ModalPo {
   private static readonly TID = "add-hotkey-neuron-modal";
 
   static under(element: PageObjectElement): AddSnsHotkeyModalPo {

--- a/frontend/src/tests/page-objects/BuyICPModal.page-object.ts
+++ b/frontend/src/tests/page-objects/BuyICPModal.page-object.ts
@@ -1,8 +1,8 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { HashPo } from "./Hash.page-object";
 
-export class BuyICPModalPo extends BasePageObject {
+export class BuyICPModalPo extends ModalPo {
   private static readonly TID = "buy-icp-modal-component";
 
   static under(element: PageObjectElement): BuyICPModalPo {

--- a/frontend/src/tests/page-objects/CkBTCReceiveModal.page-object.ts
+++ b/frontend/src/tests/page-objects/CkBTCReceiveModal.page-object.ts
@@ -1,7 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class CkBTCReceiveModalPo extends BasePageObject {
+export class CkBTCReceiveModalPo extends ModalPo {
   private static readonly TID = "ckbtc-receive-modal";
 
   static under(element: PageObjectElement): CkBTCReceiveModalPo {

--- a/frontend/src/tests/page-objects/ConfirmationModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ConfirmationModal.page-object.ts
@@ -1,7 +1,7 @@
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { BasePageObject } from "./base.page-object";
 
-export class ConfirmationModalPo extends BasePageObject {
+export class ConfirmationModalPo extends ModalPo {
   private static TID = "confirmation-modal-component";
 
   static under(element: PageObjectElement): ConfirmationModalPo {

--- a/frontend/src/tests/page-objects/DisburseMaturityModal.page-object.ts
+++ b/frontend/src/tests/page-objects/DisburseMaturityModal.page-object.ts
@@ -1,10 +1,10 @@
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import { NeuronConfirmActionScreenPo } from "$tests/page-objects/NeuronConfirmActionScreen.page-object";
 import { NeuronSelectPercentagePo } from "$tests/page-objects/NeuronSelectPercentage.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { SelectDestinationAddressPo } from "./SelectDestinationAddress.page-object";
 
-export class DisburseMaturityModalPo extends BasePageObject {
+export class DisburseMaturityModalPo extends ModalPo {
   private static readonly TID = "disburse-maturity-modal-component";
 
   static under(element: PageObjectElement): DisburseMaturityModalPo {

--- a/frontend/src/tests/page-objects/DisburseNnsNeuronModal.page-object.ts
+++ b/frontend/src/tests/page-objects/DisburseNnsNeuronModal.page-object.ts
@@ -1,9 +1,9 @@
 import { ConfirmDisburseNeuronPo } from "$tests/page-objects/ConfirmDisburseNeuron.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import { NnsDestinationAddressPo } from "$tests/page-objects/NnsDestinationAddress.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class DisburseNnsNeuronModalPo extends BasePageObject {
+export class DisburseNnsNeuronModalPo extends ModalPo {
   private static readonly TID = "disburse-nns-neuron-modal-component";
 
   static under(element: PageObjectElement): DisburseNnsNeuronModalPo {

--- a/frontend/src/tests/page-objects/FilterModal.page-object.ts
+++ b/frontend/src/tests/page-objects/FilterModal.page-object.ts
@@ -1,8 +1,8 @@
 import { CheckboxPo } from "$tests/page-objects/Checkbox.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class FilterModalPo extends BasePageObject {
+export class FilterModalPo extends ModalPo {
   private static readonly TID = "filter-modal";
 
   static under(element: PageObjectElement): FilterModalPo {

--- a/frontend/src/tests/page-objects/MergeNeuronsModal.page-object.ts
+++ b/frontend/src/tests/page-objects/MergeNeuronsModal.page-object.ts
@@ -1,9 +1,9 @@
 import { ConfirmNeuronsMergePo } from "$tests/page-objects/ConfirmNeuronsMerge.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import { SelectNeuronsToMergePo } from "$tests/page-objects/SelectNeuronsToMerge.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class MergeNeuronsModalPo extends BasePageObject {
+export class MergeNeuronsModalPo extends ModalPo {
   static readonly TID = "merge-neurons-modal-component";
 
   static under(element: PageObjectElement): MergeNeuronsModalPo {
@@ -16,10 +16,6 @@ export class MergeNeuronsModalPo extends BasePageObject {
 
   getConfirmNeuronsMergePo(): ConfirmNeuronsMergePo {
     return ConfirmNeuronsMergePo.under(this.root);
-  }
-
-  getTitle(): Promise<string> {
-    return this.getText("modal-title");
   }
 
   async mergeNeurons({

--- a/frontend/src/tests/page-objects/Modal.page-object.ts
+++ b/frontend/src/tests/page-objects/Modal.page-object.ts
@@ -15,4 +15,3 @@ export class ModalPo extends BasePageObject {
     return this.root.waitForAbsent();
   }
 }
-

--- a/frontend/src/tests/page-objects/Modal.page-object.ts
+++ b/frontend/src/tests/page-objects/Modal.page-object.ts
@@ -1,0 +1,18 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+
+// ModalPo should not be used directly but rather as a base class for specific
+// modal components.
+export class ModalPo extends BasePageObject {
+  getModalTitle(): Promise<string> {
+    return this.getText("modal-title");
+  }
+
+  closeModal(): Promise<void> {
+    return this.click("close-modal");
+  }
+
+  waitForClosed(): Promise<void> {
+    return this.root.waitForAbsent();
+  }
+}
+

--- a/frontend/src/tests/page-objects/NnsStakeNeuronModal.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsStakeNeuronModal.page-object.ts
@@ -1,12 +1,12 @@
 import { AddUserToHotkeysPo } from "$tests/page-objects/AddUserToHotkeys.page-object";
 import { ConfirmDissolveDelayPo } from "$tests/page-objects/ConfirmDissolveDelay.page-object";
 import { EditFollowNeuronsPo } from "$tests/page-objects/EditFollowNeurons.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import { NnsStakeNeuronPo } from "$tests/page-objects/NnsStakeNeuron.page-object";
 import { SetDissolveDelayPo } from "$tests/page-objects/SetDissolveDelay.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class NnsStakeNeuronModalPo extends BasePageObject {
+export class NnsStakeNeuronModalPo extends ModalPo {
   private static readonly TID = "nns-stake-neuron-modal-component";
 
   static under(element: PageObjectElement): NnsStakeNeuronModalPo | null {
@@ -33,10 +33,6 @@ export class NnsStakeNeuronModalPo extends BasePageObject {
 
   getEditFollowNeuronsPo(): EditFollowNeuronsPo {
     return EditFollowNeuronsPo.under(this.root);
-  }
-
-  closeModal(): Promise<void> {
-    return this.click("close-modal");
   }
 
   async stake({

--- a/frontend/src/tests/page-objects/ReceiveModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ReceiveModal.page-object.ts
@@ -1,7 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class ReceiveModalPo extends BasePageObject {
+export class ReceiveModalPo extends ModalPo {
   private static readonly TID = "receive-modal";
 
   static under(element: PageObjectElement): ReceiveModalPo {
@@ -10,10 +10,6 @@ export class ReceiveModalPo extends BasePageObject {
 
   clickFinish(): Promise<void> {
     return this.click("reload-receive-account");
-  }
-
-  close(): Promise<void> {
-    return this.click("close-modal");
   }
 
   waitForQrCode(): Promise<void> {

--- a/frontend/src/tests/page-objects/RenameCanisterModal.page-object.ts
+++ b/frontend/src/tests/page-objects/RenameCanisterModal.page-object.ts
@@ -1,9 +1,9 @@
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import { TextInputFormPo } from "$tests/page-objects/TextInputForm.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class RenameCanisterModalPo extends BasePageObject {
+export class RenameCanisterModalPo extends ModalPo {
   private static readonly TID = "rename-canister-modal-component";
 
   static under(element: PageObjectElement): RenameCanisterModalPo {

--- a/frontend/src/tests/page-objects/SnsActiveDisbursementsModal.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsActiveDisbursementsModal.page-object.ts
@@ -1,8 +1,8 @@
 import { ActiveDisbursementEntryPo } from "$tests/page-objects/ActiveDisbursementEntry.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class SnsActiveDisbursementsModalPo extends BasePageObject {
+export class SnsActiveDisbursementsModalPo extends ModalPo {
   private static readonly TID = "sns-active-disbursements-modal";
 
   static under(element: PageObjectElement): SnsActiveDisbursementsModalPo {

--- a/frontend/src/tests/page-objects/TransactionModal.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionModal.page-object.ts
@@ -1,15 +1,11 @@
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import { TransactionFormPo } from "$tests/page-objects/TransactionForm.page-object";
 import { TransactionReviewPo } from "$tests/page-objects/TransactionReview.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 // This should not be used directly but rather as a base class for specific
 // transaction modals.
-export class TransactionModalBasePo extends BasePageObject {
-  getModalTitle(): Promise<string> {
-    return this.getText("modal-title");
-  }
-
+export class TransactionModalBasePo extends ModalPo {
   getTransactionFormPo(): TransactionFormPo {
     return TransactionFormPo.under(this.root);
   }
@@ -61,10 +57,6 @@ export class TransactionModalBasePo extends BasePageObject {
       );
     }
     await review.clickSend();
-  }
-
-  waitForClosed(): Promise<void> {
-    return this.root.waitForAbsent();
   }
 }
 

--- a/frontend/src/tests/page-objects/VotingHistoryModal.page-object.ts
+++ b/frontend/src/tests/page-objects/VotingHistoryModal.page-object.ts
@@ -1,7 +1,7 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class VotingHistoryModalPo extends BasePageObject {
+export class VotingHistoryModalPo extends ModalPo {
   private static readonly TID = "voting-history-modal";
 
   static under(element: PageObjectElement): VotingHistoryModalPo {


### PR DESCRIPTION
# Motivation

To avoid duplicate implementations of modal functionality in page objects and provide convenience methods to all modal page objects.

# Changes

1. Add a base class for modal page objects.
2. Extend `ModalPo` in modal page objects.
3. Remove duplicate modal functionality from modal page object subclasses.
4. Update tests that need to use a new common method name.

# Tests

only tests

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary