### PR TITLE
Use page objects in FollowNeuronsModal.spec.ts

### DIFF
--- a/frontend/src/lib/components/neurons/FollowTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowTopicSection.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <article data-tid={`follow-topic-${id}-section`}>
-  <Collapsible {id} iconSize="medium">
+  <Collapsible {id} iconSize="medium" testId="collapsible">
     <div class="wrapper" slot="header">
       <span class="value"><slot name="title" /></span>
       <span class="badge" data-tid={`topic-${id}-followees-badge`}>

--- a/frontend/src/lib/modals/neurons/FollowNeuronsModal.svelte
+++ b/frontend/src/lib/modals/neurons/FollowNeuronsModal.svelte
@@ -7,7 +7,11 @@
   export let neuronId: NeuronId;
 </script>
 
-<Modal on:nnsClose --modal-content-overflow-y="scroll">
+<Modal
+  testId="follow-neurons-modal-component"
+  on:nnsClose
+  --modal-content-overflow-y="scroll"
+>
   <svelte:fragment slot="title"
     >{$i18n.neurons.follow_neurons_screen}</svelte:fragment
   >

--- a/frontend/src/tests/lib/components/neurons/EditFollowNeurons.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/EditFollowNeurons.spec.ts
@@ -1,19 +1,57 @@
 import EditFollowNeurons from "$lib/components/neurons/EditFollowNeurons.svelte";
-import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { neuronsStore } from "$lib/stores/neurons.store";
+import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
+import { EditFollowNeuronsPo } from "$tests/page-objects/EditFollowNeurons.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { Topic } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 
-vi.mock("$lib/services/known-neurons.services", () => {
-  return {
-    listKnownNeurons: vi.fn(),
-  };
-});
-
 describe("EditFollowNeurons", () => {
-  // Tested in FollowNeuronsModal.spec.ts
-  it("is not tested in isolation", () => {
-    render(EditFollowNeurons, {
-      props: { neuronId: mockNeuron.neuronId },
+  const neuronFollowing = {
+    ...mockNeuron,
+    fullNeuron: {
+      ...mockFullNeuron,
+      followees: [
+        {
+          topic: Topic.ExchangeRate,
+          followees: [27n, 28n],
+        },
+      ],
+    },
+  };
+
+  const fillNeuronStore = () =>
+    neuronsStore.setNeurons({
+      neurons: [neuronFollowing],
+      certified: true,
     });
-    expect(true).toBeTruthy();
+
+  beforeEach(() => {
+    neuronsStore.reset();
+    fillNeuronStore();
+  });
+
+  const renderComponent = () => {
+    const { container } = render(EditFollowNeurons, {
+      props: {
+        neuronId: neuronFollowing.neuronId,
+      },
+    });
+
+    return EditFollowNeuronsPo.under(new JestPageObjectElement(container));
+  };
+
+  it("renders badge with numbers of followees on the topic", async () => {
+    const po = renderComponent();
+    expect(await po.getBadgeNumber(Topic.ExchangeRate)).toBe(2);
+    expect(await po.getBadgeNumber(Topic.Governance)).toBe(0);
+  });
+
+  it("displays the followees of the user in specific topic", async () => {
+    const po = renderComponent();
+    const topicSectionPo = await po.getFollowTopicSectionPo(Topic.ExchangeRate);
+    expect(await topicSectionPo.getCollapsiblePo().isExpanded()).toBe(false);
+    await topicSectionPo.getCollapsiblePo().expand();
+    expect(await topicSectionPo.getCollapsiblePo().isExpanded()).toBe(true);
   });
 });

--- a/frontend/src/tests/lib/modals/neurons/FollowNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/FollowNeuronsModal.spec.ts
@@ -1,22 +1,10 @@
 import FollowNeuronsModal from "$lib/modals/neurons/FollowNeuronsModal.svelte";
 import { neuronsStore } from "$lib/stores/neurons.store";
-import en from "$tests/mocks/i18n.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
-import { isNotVisible } from "$tests/utils/utils.test-utils";
+import { FollowNeuronsModalPo } from "$tests/page-objects/FollowNeuronsModal.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { Topic } from "@dfinity/nns";
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
-
-vi.mock("$lib/services/neurons.services", () => {
-  return {
-    removeFollowee: vi.fn().mockResolvedValue(undefined),
-  };
-});
-
-vi.mock("$lib/services/known-neurons.services", () => {
-  return {
-    listKnownNeurons: vi.fn(),
-  };
-});
+import { render } from "@testing-library/svelte";
 
 describe("FollowNeuronsModal", () => {
   const neuronFollowing = {
@@ -38,66 +26,33 @@ describe("FollowNeuronsModal", () => {
       certified: true,
     });
 
-  beforeAll(() => fillNeuronStore());
-
-  it("renders title", () => {
-    const { queryByText } = render(FollowNeuronsModal, {
-      props: {
-        neuronId: neuronFollowing.neuronId,
-      },
-    });
-
-    expect(queryByText(en.neurons.follow_neurons_screen)).toBeInTheDocument();
+  beforeEach(() => {
+    neuronsStore.reset();
+    fillNeuronStore();
   });
 
-  it("renders badge with numbers of followees on the topic", () => {
-    const { queryByTestId } = render(FollowNeuronsModal, {
+  const renderComponent = () => {
+    const { container } = render(FollowNeuronsModal, {
       props: {
         neuronId: neuronFollowing.neuronId,
       },
     });
 
-    const badgeExchange = queryByTestId(
-      `topic-${Topic.ExchangeRate}-followees-badge`
-    );
+    return FollowNeuronsModalPo.under(new JestPageObjectElement(container));
+  };
 
-    expect(badgeExchange).not.toBeNull();
-    expect(badgeExchange?.innerHTML).toBe("2");
-
-    const badgeGovernance = queryByTestId(
-      `topic-${Topic.Governance}-followees-badge`
-    );
-
-    expect(badgeGovernance).not.toBeNull();
-    expect(badgeGovernance?.innerHTML).toBe("0");
+  it("renders title", async () => {
+    const po = renderComponent();
+    expect(await po.getModalTitle()).toBe("Follow neurons");
   });
 
-  it("displays the followees of the user in specific topic", async () => {
-    const { queryByTestId } = render(FollowNeuronsModal, {
-      props: {
-        neuronId: neuronFollowing.neuronId,
-      },
-    });
-
-    const topicSection = queryByTestId(
-      `follow-topic-${Topic.ExchangeRate}-section`
-    );
-    expect(topicSection).not.toBeNull();
-
-    if (topicSection !== null) {
-      const collapsibleContent = topicSection.querySelector(
-        "[data-tid='collapsible-content']"
-      );
-      expect(isNotVisible(collapsibleContent)).toBe(true);
-
-      const collapsibleButton = topicSection.querySelector(
-        '[data-tid="collapsible-expand-button"]'
-      );
-      expect(collapsibleButton).not.toBeNull();
-
-      collapsibleButton && (await fireEvent.click(collapsibleButton));
-
-      await waitFor(() => expect(isNotVisible(collapsibleContent)).toBe(false));
-    }
+  it("renders badge with numbers of followees on the topic", async () => {
+    const po = renderComponent();
+    expect(
+      await po.getEditFollowNeuronsPo().getBadgeNumber(Topic.ExchangeRate)
+    ).toBe(2);
+    expect(
+      await po.getEditFollowNeuronsPo().getBadgeNumber(Topic.Governance)
+    ).toBe(0);
   });
 });

--- a/frontend/src/tests/page-objects/Collapsible.page-object.ts
+++ b/frontend/src/tests/page-objects/Collapsible.page-object.ts
@@ -1,0 +1,24 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class CollapsiblePo extends BasePageObject {
+  static under({
+    element,
+    testId,
+  }:{
+    element: PageObjectElement,
+    testId: string,
+  }): CollapsiblePo {
+    return new CollapsiblePo(element.byTestId(testId));
+  }
+
+  expand(): Promise<void> {
+    return this.click("collapsible-expand-button");
+  }
+
+  async isExpanded(): Promise<boolean> {
+    const classes = await this.root.byTestId("collapsible-content").getClasses();
+    return classes.includes("expanded");
+  }
+}
+

--- a/frontend/src/tests/page-objects/EditFollowNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/EditFollowNeurons.page-object.ts
@@ -1,10 +1,23 @@
+import { FollowTopicSectionPo } from "$tests/page-objects/FollowTopicSection.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import type { Topic } from "@dfinity/nns";
 
 export class EditFollowNeuronsPo extends BasePageObject {
   private static readonly TID = "edit-followers-screen";
 
   static under(element: PageObjectElement): EditFollowNeuronsPo {
     return new EditFollowNeuronsPo(element.byTestId(EditFollowNeuronsPo.TID));
+  }
+
+  getFollowTopicSectionPo(topic: Topic): FollowTopicSectionPo {
+    return FollowTopicSectionPo.under({
+      element: this.root,
+      topic,
+    });
+  }
+
+  getBadgeNumber(topic: Topic): Promise<number> {
+    return this.getFollowTopicSectionPo(topic).getBadgeNumber();
   }
 }

--- a/frontend/src/tests/page-objects/FollowNeuronsModal.page-object.ts
+++ b/frontend/src/tests/page-objects/FollowNeuronsModal.page-object.ts
@@ -1,0 +1,22 @@
+import { AddUserToHotkeysPo } from "$tests/page-objects/AddUserToHotkeys.page-object";
+import { ConfirmDissolveDelayPo } from "$tests/page-objects/ConfirmDissolveDelay.page-object";
+import { EditFollowNeuronsPo } from "$tests/page-objects/EditFollowNeurons.page-object";
+import { NnsStakeNeuronPo } from "$tests/page-objects/NnsStakeNeuron.page-object";
+import { SetDissolveDelayPo } from "$tests/page-objects/SetDissolveDelay.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class FollowNeuronsModalPo extends ModalPo {
+  private static readonly TID = "follow-neurons-modal-component";
+
+  static under(element: PageObjectElement): FollowNeuronsModalPo | null {
+    return new FollowNeuronsModalPo(
+      element.byTestId(FollowNeuronsModalPo.TID)
+    );
+  }
+
+  getEditFollowNeuronsPo(): EditFollowNeuronsPo {
+    return EditFollowNeuronsPo.under(this.root);
+  }
+}

--- a/frontend/src/tests/page-objects/FollowTopicSection.page-object.ts
+++ b/frontend/src/tests/page-objects/FollowTopicSection.page-object.ts
@@ -1,0 +1,43 @@
+import type { Topic } from "@dfinity/nns";
+import { CollapsiblePo } from "$tests/page-objects/Collapsible.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class FollowTopicSectionPo extends BasePageObject {
+  private readonly topic: Topic;
+
+  constructor({
+    element,
+    topic,
+  }:{
+    element: PageObjectElement,
+    topic: Topic,
+  }) {
+    super(element);
+    this.topic = topic;
+  }
+
+  static under({
+    element
+    , topic,
+  }:{
+    element: PageObjectElement,
+    topic: Topic,
+  }): FollowTopicSectionPo {
+    return new FollowTopicSectionPo({
+      element: element.byTestId(`follow-topic-${topic}-section`),
+      topic,
+      });
+  }
+
+  getCollapsiblePo(): CollapsiblePo {
+    return CollapsiblePo.under({
+      element: this.root,
+      testId: "collapsible",
+    });
+  }
+
+  async getBadgeNumber(): Promise<number> {
+    return Number(await this.getText(`topic-${this.topic}-followees-badge`));
+  }
+}


### PR DESCRIPTION
# Motivation

Make the test easier to read and maintain.

# Changes

1. Add test IDS.
2. Add page objects `FollowNeuronsModalPo`, `EditFollowNeuronsPo`, `FollowTopicSectionPo` and `CollapsiblePo`.
3. Move `EditFollowNeurons` specific tests from `FollowNeuronsModal.spec.ts` to `EditFollowNeurons.spec.ts`.
4. Change tests to use page objects.
5. Remove unnecessary service mocking.

# Tests

yes

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary