### PR TITLE
Update proposal rendering

### DIFF
--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-09_23-01+new-p2p/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-18_23-01+dts-off/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-09_23-01+new-p2p/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-18_23-01+dts-off/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-09_23-01+new-p2p/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-18_23-01+dts-off/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.

# Changes
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.
  * Note: The candid files under `declarations/nns-$CANISTER` are used as inputs.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.