### PR TITLE
Neuron tag tests

### DIFF
--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -157,7 +157,11 @@ describe("NnsNeuronCard", () => {
 
     const po = NnsNeuronCardPo.under(new JestPageObjectElement(container));
 
-    expect(await po.getNeuronTags()).toEqual(["Hardware Wallet Controlled"]);
+    expect(await po.getNeuronTags()).toHaveLength(1);
+
+    const tag = (await po.getNeuronTags())[0];
+    expect(await tag.getTagText()).toBe("Hardware Wallet Controlled");
+    expect(await tag.getTooltip().isPresent()).toBe(false);
   });
 
   it("renders neuron type tag when not default", async () => {
@@ -180,7 +184,12 @@ describe("NnsNeuronCard", () => {
 
     const po = NnsNeuronCardPo.under(new JestPageObjectElement(container));
 
-    expect(await po.getNeuronTags()).toEqual(["Seed Seed Neuron"]);
+    expect(await po.getNeuronTags()).toHaveLength(1);
+
+    const tag = (await po.getNeuronTags())[0];
+    expect(await tag.getTagText()).toBe("Seed");
+    expect(await tag.getTooltip().isPresent()).toBe(true);
+    expect(await tag.getTooltipText()).toBe("Seed Neuron");
   });
 
   it("renders proper text when status is LOCKED", async () => {

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -151,7 +151,7 @@ describe("NnsNeuronCard", () => {
 
     const po = NnsNeuronCardPo.under(new JestPageObjectElement(container));
 
-    expect(await po.getNeuronTags()).toHaveLength(0);
+    expect(await po.getNeuronTagPos()).toHaveLength(0);
   });
 
   it("renders the hardware wallet label and not hotkey when neuron is controlled by hardware wallet", async () => {
@@ -175,14 +175,14 @@ describe("NnsNeuronCard", () => {
 
     const po = NnsNeuronCardPo.under(new JestPageObjectElement(container));
 
-    expect(await po.getNeuronTags()).toHaveLength(1);
+    expect(await po.getNeuronTagPos()).toHaveLength(1);
 
-    expect(await (await po.getNeuronTags())[0].getTagText()).toBe(
+    expect(await (await po.getNeuronTagPos())[0].getTagText()).toBe(
       "Hardware Wallet Controlled"
     );
-    expect(await (await po.getNeuronTags())[0].getTooltip().isPresent()).toBe(
-      false
-    );
+    expect(
+      await (await po.getNeuronTagPos())[0].getTooltipPo().isPresent()
+    ).toBe(false);
   });
 
   it("renders neuron type tag when not default", async () => {
@@ -205,13 +205,13 @@ describe("NnsNeuronCard", () => {
 
     const po = NnsNeuronCardPo.under(new JestPageObjectElement(container));
 
-    expect(await po.getNeuronTags()).toHaveLength(1);
+    expect(await po.getNeuronTagPos()).toHaveLength(1);
 
-    expect(await (await po.getNeuronTags())[0].getTagText()).toBe("Seed");
-    expect(await (await po.getNeuronTags())[0].getTooltip().isPresent()).toBe(
-      true
-    );
-    expect(await (await po.getNeuronTags())[0].getTooltipText()).toBe(
+    expect(await (await po.getNeuronTagPos())[0].getTagText()).toBe("Seed");
+    expect(
+      await (await po.getNeuronTagPos())[0].getTooltipPo().isPresent()
+    ).toBe(true);
+    expect(await (await po.getNeuronTagPos())[0].getTooltipText()).toBe(
       "Seed Neuron"
     );
   });
@@ -238,10 +238,10 @@ describe("NnsNeuronCard", () => {
     });
     const po = NnsNeuronCardPo.under(new JestPageObjectElement(container));
 
-    expect(await po.getNeuronTags()).toHaveLength(2);
+    expect(await po.getNeuronTagPos()).toHaveLength(2);
 
-    expect(await (await po.getNeuronTags())[0].getTagText()).toBe("Seed");
-    expect(await (await po.getNeuronTags())[1].getTagText()).toBe(
+    expect(await (await po.getNeuronTagPos())[0].getTagText()).toBe("Seed");
+    expect(await (await po.getNeuronTagPos())[1].getTagText()).toBe(
       "Hardware Wallet Controlled"
     );
   });

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -238,12 +238,10 @@ describe("NnsNeuronCard", () => {
     });
     const po = NnsNeuronCardPo.under(new JestPageObjectElement(container));
 
-    expect(await po.getNeuronTagPos()).toHaveLength(2);
-
-    expect(await (await po.getNeuronTagPos())[0].getTagText()).toBe("Seed");
-    expect(await (await po.getNeuronTagPos())[1].getTagText()).toBe(
-      "Hardware Wallet Controlled"
-    );
+    expect(await po.getNeuronTags()).toEqual([
+      "Seed",
+      "Hardware Wallet Controlled",
+    ]);
   });
 
   it("renders proper text when status is LOCKED", async () => {

--- a/frontend/src/tests/page-objects/NeuronTag.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronTag.page-object.ts
@@ -14,19 +14,19 @@ export class NeuronTagPo extends BasePageObject {
     );
   }
 
-  getTag(): TagPo {
+  getTagPo(): TagPo {
     return TagPo.under(this.root);
   }
 
   getTagText(): Promise<string> {
-    return this.getTag().getText();
+    return this.getTagPo().getText();
   }
 
-  getTooltip(): TooltipPo {
+  getTooltipPo(): TooltipPo {
     return TooltipPo.under(this.root);
   }
 
   getTooltipText(): Promise<string> {
-    return TooltipPo.under(this.root).getText();
+    return this.getTooltipPo().getText();
   }
 }

--- a/frontend/src/tests/page-objects/NeuronTag.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronTag.page-object.ts
@@ -1,0 +1,36 @@
+import { TagPo } from "$tests/page-objects/Tag.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { TooltipPo } from "./Tooltip.page-object";
+
+export class NeuronTagPo extends BasePageObject {
+  private static readonly TID = "neuron-tag";
+
+  static under(element: PageObjectElement): NeuronTagPo {
+    return new NeuronTagPo(element.byTestId(NeuronTagPo.TID));
+  }
+
+  static async allUnder(element: PageObjectElement): Promise<NeuronTagPo[]> {
+    return Promise.all(
+      Array.from(await element.allByTestId(NeuronTagPo.TID)).map(async (el) => {
+        return new NeuronTagPo(el);
+      })
+    );
+  }
+
+  getTag(): TagPo {
+    return TagPo.under(this.root);
+  }
+
+  getTagText(): Promise<string> {
+    return this.getTag().getText();
+  }
+
+  getTooltip(): TooltipPo {
+    return TooltipPo.under(this.root);
+  }
+
+  getTooltipText(): Promise<string> {
+    return TooltipPo.under(this.root).getText();
+  }
+}

--- a/frontend/src/tests/page-objects/NeuronTag.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronTag.page-object.ts
@@ -6,10 +6,6 @@ import { TooltipPo } from "./Tooltip.page-object";
 export class NeuronTagPo extends BasePageObject {
   private static readonly TID = "neuron-tag";
 
-  static under(element: PageObjectElement): NeuronTagPo {
-    return new NeuronTagPo(element.byTestId(NeuronTagPo.TID));
-  }
-
   static async allUnder(element: PageObjectElement): Promise<NeuronTagPo[]> {
     return Promise.all(
       Array.from(await element.allByTestId(NeuronTagPo.TID)).map(async (el) => {

--- a/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
@@ -47,7 +47,7 @@ export class NnsNeuronCardPo extends BasePageObject {
     return Number(await this.getText("token-value"));
   }
 
-  getNeuronTags(): Promise<NeuronTagPo[]> {
-    return this.getCardTitlePo().getNeuronTags();
+  getNeuronTagPos(): Promise<NeuronTagPo[]> {
+    return this.getCardTitlePo().getNeuronTagPos();
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
@@ -50,4 +50,8 @@ export class NnsNeuronCardPo extends BasePageObject {
   getNeuronTagPos(): Promise<NeuronTagPo[]> {
     return this.getCardTitlePo().getNeuronTagPos();
   }
+
+  getNeuronTags(): Promise<string[]> {
+    return this.getCardTitlePo().getNeuronTags();
+  }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCard.page-object.ts
@@ -1,4 +1,5 @@
 import { NeuronCardContainerPo } from "$tests/page-objects/NeuronCardContainer.page-object";
+import type { NeuronTagPo } from "$tests/page-objects/NeuronTag.page-object";
 import { NnsNeuronCardTitlePo } from "$tests/page-objects/NnsNeuronCardTitle.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -46,7 +47,7 @@ export class NnsNeuronCardPo extends BasePageObject {
     return Number(await this.getText("token-value"));
   }
 
-  getNeuronTags(): Promise<string[]> {
+  getNeuronTags(): Promise<NeuronTagPo[]> {
     return this.getCardTitlePo().getNeuronTags();
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
@@ -13,7 +13,7 @@ export class NnsNeuronCardTitlePo extends BasePageObject {
     return this.root.querySelector("[data-tid=neuron-id]").getText();
   }
 
-  getNeuronTags(): Promise<NeuronTagPo[]> {
+  getNeuronTagPos(): Promise<NeuronTagPo[]> {
     return NeuronTagPo.allUnder(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
@@ -1,3 +1,4 @@
+import { NeuronTagPo } from "$tests/page-objects/NeuronTag.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -12,8 +13,7 @@ export class NnsNeuronCardTitlePo extends BasePageObject {
     return this.root.querySelector("[data-tid=neuron-id]").getText();
   }
 
-  async getNeuronTags(): Promise<string[]> {
-    const elements = await this.root.allByTestId("neuron-tag");
-    return Promise.all(elements.map((tag) => tag.getText()));
+  getNeuronTags(): Promise<NeuronTagPo[]> {
+    return NeuronTagPo.allUnder(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronCardTitle.page-object.ts
@@ -13,6 +13,11 @@ export class NnsNeuronCardTitlePo extends BasePageObject {
     return this.root.querySelector("[data-tid=neuron-id]").getText();
   }
 
+  async getNeuronTags(): Promise<string[]> {
+    const pos = await this.getNeuronTagPos();
+    return Promise.all(pos.map((po) => po.getTagText()));
+  }
+
   getNeuronTagPos(): Promise<NeuronTagPo[]> {
     return NeuronTagPo.allUnder(this.root);
   }

--- a/frontend/src/tests/page-objects/Tag.page-object.ts
+++ b/frontend/src/tests/page-objects/Tag.page-object.ts
@@ -4,6 +4,10 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class TagPo extends BasePageObject {
   private static readonly TID = "tag";
 
+  static under(element: PageObjectElement): TagPo {
+    return new TagPo(element.byTestId(TagPo.TID));
+  }
+
   static async allUnder(element: PageObjectElement): Promise<TagPo[]> {
     return Array.from(await element.allByTestId(TagPo.TID)).map(
       (el) => new TagPo(el)


### PR DESCRIPTION
# Motivation

Add tests for `NeuronTag` tooltip.

# Changes

- add `NeuronTagPo` to return separately tag text and tooltip text
- `getNeuronTags` to return `NeuronTagPos` instead of raw text
- update current tests to use  `NeuronTagPo`
- check for correct tooltip text
- additionally added "check for no tags" and "check for multiple tags" rendering in `NnsNeuronCard` 

# Tests

Yes

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary