### PR TITLE
Remove neuron tag tooltip

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -25,6 +25,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Add missing feature flags to default feature flags value.
 * Various wording changes.
 * Various wording changes.
+* Display the full neuron type text within the tag.
 
 #### Deprecated
 

--- a/frontend/src/lib/components/ui/NeuronTag.svelte
+++ b/frontend/src/lib/components/ui/NeuronTag.svelte
@@ -1,25 +1,11 @@
 <script lang="ts">
-  import Tooltip from "$lib/components/ui/Tooltip.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { Tag } from "@dfinity/gix-components";
   import type { NeuronTagData } from "$lib/utils/neuron.utils";
-  import { nonNullish } from "@dfinity/utils";
 
   export let tag: NeuronTagData;
-
-  let text: string;
-  $: text = tag.text;
-
-  let description: string | undefined;
-  $: description = tag.description;
 </script>
 
 <TestIdWrapper testId="neuron-tag">
-  {#if nonNullish(tag.description)}
-    <Tooltip id="neuron-type-tag-tooltip" text={description}>
-      <Tag>{text}</Tag>
-    </Tooltip>
-  {:else}
-    <Tag>{text}</Tag>
-  {/if}
+  <Tag>{tag.text}</Tag>
 </TestIdWrapper>

--- a/frontend/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/src/lib/components/ui/Tooltip.svelte
@@ -7,6 +7,7 @@
   export let text = "";
   export let noWrap = false;
   export let top = false;
+  export let center = false;
   export let containerSelector = "main";
 
   let tooltipComponent: HTMLDivElement | undefined = undefined;
@@ -65,14 +66,15 @@
 
     // If tooltip overflow both on left and right, we only set the left anchor.
     // It would need the width to be maximized to window screen too but it seems to be an acceptable edge case.
-    tooltipStyle =
-      overflowLeft > 0
-        ? `--tooltip-transform-x: calc(-50% + ${overflowLeft}px)`
-        : overflowRight > 0
-        ? `--tooltip-transform-x: calc(-50% - ${overflowRight}px)`
-        : leftToMainCenter
-        ? `--tooltip-transform-x: 0`
-        : undefined;
+    tooltipStyle = center
+      ? `--tooltip-transform-x: calc(-50%)`
+      : overflowLeft > 0
+      ? `--tooltip-transform-x: calc(-50% + ${overflowLeft}px)`
+      : overflowRight > 0
+      ? `--tooltip-transform-x: calc(-50% - ${overflowRight}px)`
+      : leftToMainCenter
+      ? `--tooltip-transform-x: 0`
+      : undefined;
   });
 
   $: innerWidth, tooltipComponent, target, setPosition();

--- a/frontend/src/lib/components/ui/Tooltip.svelte
+++ b/frontend/src/lib/components/ui/Tooltip.svelte
@@ -7,7 +7,6 @@
   export let text = "";
   export let noWrap = false;
   export let top = false;
-  export let center = false;
   export let containerSelector = "main";
 
   let tooltipComponent: HTMLDivElement | undefined = undefined;
@@ -66,15 +65,14 @@
 
     // If tooltip overflow both on left and right, we only set the left anchor.
     // It would need the width to be maximized to window screen too but it seems to be an acceptable edge case.
-    tooltipStyle = center
-      ? `--tooltip-transform-x: calc(-50%)`
-      : overflowLeft > 0
-      ? `--tooltip-transform-x: calc(-50% + ${overflowLeft}px)`
-      : overflowRight > 0
-      ? `--tooltip-transform-x: calc(-50% - ${overflowRight}px)`
-      : leftToMainCenter
-      ? `--tooltip-transform-x: 0`
-      : undefined;
+    tooltipStyle =
+      overflowLeft > 0
+        ? `--tooltip-transform-x: calc(-50% + ${overflowLeft}px)`
+        : overflowRight > 0
+        ? `--tooltip-transform-x: calc(-50% - ${overflowRight}px)`
+        : leftToMainCenter
+        ? `--tooltip-transform-x: 0`
+        : undefined;
   });
 
   $: innerWidth, tooltipComponent, target, setPosition();

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -263,9 +263,7 @@
   },
   "neuron_types": {
     "seed": "Seed",
-    "seedDescription": "Seed Neuron",
-    "ect": "ECT",
-    "ectDescription": "Early Contributor Token Neuron"
+    "ect": "Early Contributor Token"
   },
   "neurons": {
     "title": "Neurons",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -273,9 +273,7 @@ interface I18nAccounts {
 
 interface I18nNeuron_types {
   seed: string;
-  seedDescription: string;
   ect: string;
-  ectDescription: string;
 }
 
 interface I18nNeurons {

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -370,7 +370,6 @@ export const isHotKeyControllable = ({
 
 export type NeuronTagData = {
   text: string;
-  description?: string;
 };
 
 export const getNeuronTags = ({
@@ -387,15 +386,9 @@ export const getNeuronTags = ({
   const tags: NeuronTagData[] = [];
 
   if (isSeedNeuron(neuron)) {
-    tags.push({
-      text: i18n.neuron_types.seed,
-      description: i18n.neuron_types.seedDescription,
-    });
+    tags.push({ text: i18n.neuron_types.seed });
   } else if (isEctNeuron(neuron)) {
-    tags.push({
-      text: i18n.neuron_types.ect,
-      description: i18n.neuron_types.ectDescription,
-    });
+    tags.push({ text: i18n.neuron_types.ect });
   }
 
   if (hasJoinedCommunityFund(neuron)) {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
@@ -146,6 +146,6 @@ describe("NnsNeuronPageHeading", () => {
       },
     });
 
-    expect(await po.getNeuronTags()).toEqual(["ECT"]);
+    expect(await po.getNeuronTags()).toEqual(["Early Contributor Token"]);
   });
 });

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -180,7 +180,7 @@ describe("NnsNeuronCard", () => {
 
     const po = NnsNeuronCardPo.under(new JestPageObjectElement(container));
 
-    expect(await po.getNeuronTags()).toEqual(["Seed Seed Neuron"]);
+    expect(await po.getNeuronTags()).toEqual(["Seed"]);
   });
 
   it("renders proper text when status is LOCKED", async () => {

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1140,7 +1140,7 @@ describe("neuron-utils", () => {
       text: "Seed",
     } as NeuronTagData;
     const ectTag = {
-      text: "ECT",
+      text: "Early Contributor Token",
     } as NeuronTagData;
     it("returns 'hotkey' if neuron is controllable by hotkey and hardware wallet is not the controller", () => {
       const neuron = {

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1138,11 +1138,9 @@ describe("neuron-utils", () => {
     const nfTag = { text: "Neurons' fund" } as NeuronTagData;
     const seedTag = {
       text: "Seed",
-      description: "Seed Neuron",
     } as NeuronTagData;
     const ectTag = {
       text: "ECT",
-      description: "Early Contributor Token Neuron",
     } as NeuronTagData;
     it("returns 'hotkey' if neuron is controllable by hotkey and hardware wallet is not the controller", () => {
       const neuron = {


### PR DESCRIPTION
# Motivation

Display the full neuron type text within the tag (no acronyms). Remove tag tooltip since it's not necessary anymore.

# Changes

- remove neuron type description support.
- update tag texts to have no acronyms.

# Tests

- adjust tests to have no descriptions.

# Todos

- [x] Add entry to changelog (if necessary).


# Screenshots
<img width="1000" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/9d909e87-a21a-42eb-a11c-1a865341587f">

