### PR TITLE
GIX-2060: Remove mainTransactionFeeStore

### DIFF
--- a/frontend/src/lib/components/accounts/TransactionInfo.svelte
+++ b/frontend/src/lib/components/accounts/TransactionInfo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { mainTransactionFeeStore } from "$lib/derived/main-transaction-fee.derived";
+  import { mainTransactionFeeE8sStore } from "$lib/derived/main-transaction-fee.derived";
   import { i18n } from "$lib/stores/i18n";
   import { formattedTransactionFeeICP } from "$lib/utils/token.utils";
   import { Value } from "@dfinity/gix-components";
@@ -34,7 +34,7 @@
   <p class="fee">
     <Value
       >{formattedTransactionFeeICP(
-        fee?.toE8s() ?? $mainTransactionFeeStore
+        fee?.toE8s() ?? $mainTransactionFeeE8sStore
       )}</Value
     >
     {fee?.token.symbol ?? $i18n.core.icp}

--- a/frontend/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/SpawnNeuronButton.svelte
@@ -49,12 +49,12 @@
         $i18n.neuron_detail.spawn_neuron_disabled_tooltip,
         {
           $amount: formatNumber(
-            MIN_NEURON_STAKE /
+            Number(MIN_NEURON_STAKE) /
               ULPS_PER_MATURITY /
               MATURITY_MODULATION_VARIANCE_PERCENTAGE,
             { minFraction: 4, maxFraction: 4 }
           ),
-          $min: formatNumber(MIN_NEURON_STAKE / ULPS_PER_MATURITY, {
+          $min: formatNumber(Number(MIN_NEURON_STAKE) / ULPS_PER_MATURITY, {
             minFraction: 0,
             maxFraction: 0,
           }),

--- a/frontend/src/lib/components/neuron-detail/actions/SplitNnsNeuronButton.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/SplitNnsNeuronButton.svelte
@@ -10,14 +10,14 @@
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
   import { openNnsNeuronModal } from "$lib/utils/modals.utils";
   import { ICPToken } from "@dfinity/utils";
-  import { mainTransactionFeeStore } from "$lib/derived/main-transaction-fee.derived";
+  import { mainTransactionFeeE8sStore } from "$lib/derived/main-transaction-fee.derived";
 
   export let neuron: NeuronInfo;
 
   let splittable: boolean;
   $: splittable = neuronCanBeSplit({
     neuron,
-    fee: $mainTransactionFeeStore,
+    fee: $mainTransactionFeeE8sStore,
   });
 
   const openModal = () =>
@@ -37,7 +37,7 @@
       $i18n.neuron_detail.split_neuron_disabled_tooltip,
       {
         $amount: formatTokenE8s({
-          value: BigInt(minNeuronSplittable($mainTransactionFeeStore)),
+          value: BigInt(minNeuronSplittable($mainTransactionFeeE8sStore)),
           detailed: true,
         }),
         $token: ICPToken.symbol,

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -4,7 +4,7 @@ import { Topic } from "@dfinity/nns";
 
 export const ULPS_PER_MATURITY = 100_000_000;
 export const MAX_NEURONS_MERGED = 2;
-export const MIN_NEURON_STAKE = 100_000_000;
+export const MIN_NEURON_STAKE = 100_000_000n;
 export const MAX_CONCURRENCY = 10;
 export const MATURITY_MODULATION_VARIANCE_PERCENTAGE = 0.95;
 // Neuron ids are random u64. Max digits of a u64 is 20.

--- a/frontend/src/lib/derived/main-transaction-fee.derived.ts
+++ b/frontend/src/lib/derived/main-transaction-fee.derived.ts
@@ -15,21 +15,6 @@ export const mainTransactionFeeStoreAsToken: Readable<TokenAmount> = derived(
   }
 );
 
-/**
- * @deprecated prefer mainTransactionFeeE8sStore to use e8s for amount of tokens instead of Number.
- */
-export const mainTransactionFeeStore: Readable<number> = derived(
-  tokensStore,
-  ($store) => {
-    const icpToken = $store[OWN_CANISTER_ID_TEXT]?.token;
-    if (isNullish(icpToken)) {
-      // This can't happen because the tokensStore always contains the NNS token.
-      throw new Error("ICP token not found");
-    }
-    return Number(icpToken.fee);
-  }
-);
-
 export const mainTransactionFeeE8sStore: Readable<bigint> = derived(
   tokensStore,
   ($store) => {

--- a/frontend/src/lib/modals/canisters/AddCyclesModal.svelte
+++ b/frontend/src/lib/modals/canisters/AddCyclesModal.svelte
@@ -29,7 +29,7 @@
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import TransactionFromAccount from "$lib/components/transaction/TransactionFromAccount.svelte";
   import { filterHardwareWalletAccounts } from "$lib/utils/accounts.utils";
-  import { mainTransactionFeeStore } from "$lib/derived/main-transaction-fee.derived";
+  import { mainTransactionFeeE8sStore } from "$lib/derived/main-transaction-fee.derived";
 
   let icpToCyclesExchangeRate: bigint | undefined;
   onMount(async () => {
@@ -129,7 +129,7 @@
           <Html
             text={replacePlaceholders($i18n.canisters.transaction_fee, {
               $amount: valueSpan(
-                formattedTransactionFeeICP($mainTransactionFeeStore)
+                formattedTransactionFeeICP($mainTransactionFeeE8sStore)
               ),
             })}
           />

--- a/frontend/src/lib/modals/canisters/CreateCanisterModal.svelte
+++ b/frontend/src/lib/modals/canisters/CreateCanisterModal.svelte
@@ -13,7 +13,7 @@
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
   import { toastsError, toastsShow } from "$lib/stores/toasts.store";
-  import { mainTransactionFeeStore } from "$lib/derived/main-transaction-fee.derived";
+  import { mainTransactionFeeE8sStore } from "$lib/derived/main-transaction-fee.derived";
   import type { Account } from "$lib/types/account";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { formattedTransactionFeeICP } from "$lib/utils/token.utils";
@@ -156,7 +156,7 @@
             <Html
               text={replacePlaceholders($i18n.canisters.minimum_cycles_text_2, {
                 $amount: valueSpan(
-                  formattedTransactionFeeICP($mainTransactionFeeStore)
+                  formattedTransactionFeeICP($mainTransactionFeeE8sStore)
                 ),
               })}
             />

--- a/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
@@ -14,7 +14,7 @@
   import { createEventDispatcher } from "svelte";
   import { splitNeuron } from "$lib/services/neurons.services";
   import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
-  import { mainTransactionFeeStore } from "$lib/derived/main-transaction-fee.derived";
+  import { mainTransactionFeeE8sStore } from "$lib/derived/main-transaction-fee.derived";
 
   export let neuron: NeuronInfo;
 
@@ -31,7 +31,7 @@
     stakeE8s === 0n
       ? 0
       : ulpsToNumber({
-          ulps: stakeE8s - BigInt($mainTransactionFeeStore),
+          ulps: stakeE8s - $mainTransactionFeeE8sStore,
           token: ICPToken,
         });
 
@@ -78,7 +78,8 @@
     <div>
       <p class="label">{$i18n.neurons.transaction_fee}</p>
       <p>
-        <Value>{formattedTransactionFeeICP($mainTransactionFeeStore)}</Value> ICP
+        <Value>{formattedTransactionFeeICP($mainTransactionFeeE8sStore)}</Value>
+        ICP
       </p>
     </div>
 

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -512,7 +512,7 @@ export const isEnoughMaturityToSpawn = ({
   );
   return (
     maturitySelected >=
-    MIN_NEURON_STAKE / MATURITY_MODULATION_VARIANCE_PERCENTAGE
+    Number(MIN_NEURON_STAKE) / MATURITY_MODULATION_VARIANCE_PERCENTAGE
   );
 };
 
@@ -845,16 +845,16 @@ export const neuronsVotingPower = (neurons?: CompactNeuronInfo[]): bigint =>
 export const hasEnoughMaturityToStake = ({ fullNeuron }: NeuronInfo): boolean =>
   (fullNeuron?.maturityE8sEquivalent ?? 0n) > 0n;
 
-export const minNeuronSplittable = (fee: number): number =>
-  2 * MIN_NEURON_STAKE + fee;
+export const minNeuronSplittable = (fee: bigint): bigint =>
+  2n * MIN_NEURON_STAKE + fee;
 
 export const neuronCanBeSplit = ({
   neuron,
   fee,
 }: {
   neuron: NeuronInfo;
-  fee: number;
-}): boolean => neuronStake(neuron) >= BigInt(minNeuronSplittable(fee));
+  fee: bigint;
+}): boolean => neuronStake(neuron) >= minNeuronSplittable(fee);
 
 export const getNeuronById = ({
   neuronsStore,

--- a/frontend/src/tests/lib/derived/main-transaction-fee.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/main-transaction-fee.derived.spec.ts
@@ -2,7 +2,6 @@ import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import {
   mainTransactionFeeE8sStore,
-  mainTransactionFeeStore,
   mainTransactionFeeStoreAsToken,
 } from "$lib/derived/main-transaction-fee.derived";
 import { tokensStore } from "$lib/stores/tokens.store";
@@ -16,21 +15,6 @@ describe("mainTransactionFeeStoreAsToken", () => {
   it("should return transaction fee as token", () => {
     const value = get(mainTransactionFeeStoreAsToken);
     expect(value instanceof TokenAmount).toBeTruthy();
-  });
-
-  it("should set ICP fee value as number", () => {
-    expect(get(mainTransactionFeeStore)).toBe(Number(NNS_TOKEN_DATA.fee));
-
-    const newFee = 40_000n;
-    tokensStore.setToken({
-      canisterId: OWN_CANISTER_ID,
-      token: {
-        ...NNS_TOKEN_DATA,
-        fee: newFee,
-      },
-      certified: true,
-    });
-    expect(get(mainTransactionFeeStore)).toBe(Number(newFee));
   });
 
   it("should set ICP fee value as bigint", () => {

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -1883,7 +1883,7 @@ describe("neurons-services", () => {
           ...mockNeuron,
           fullNeuron: {
             ...mockFullNeuron,
-            cachedNeuronStake: BigInt(MIN_NEURON_STAKE / 2 - 10),
+            cachedNeuronStake: MIN_NEURON_STAKE / 2n - 10n,
           },
         },
         amount: 0.01,

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -957,7 +957,7 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: {
           ...mockFullNeuron,
-          maturityE8sEquivalent: BigInt(MIN_NEURON_STAKE + 1_000),
+          maturityE8sEquivalent: MIN_NEURON_STAKE + 1_000n,
         },
       };
       expect(isEnoughMaturityToSpawn({ neuron, percentage: 100 })).toBe(false);
@@ -966,7 +966,7 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: {
           ...mockFullNeuron,
-          maturityE8sEquivalent: BigInt(MIN_NEURON_STAKE * 2 + 1_000),
+          maturityE8sEquivalent: MIN_NEURON_STAKE * 2n + 1_000n,
         },
       };
       expect(isEnoughMaturityToSpawn({ neuron: neuron2, percentage: 50 })).toBe(
@@ -978,7 +978,7 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: {
           ...mockFullNeuron,
-          maturityE8sEquivalent: BigInt(MIN_NEURON_STAKE * 3 + 1_000),
+          maturityE8sEquivalent: MIN_NEURON_STAKE * 3n + 1_000n,
         },
       };
       expect(isEnoughMaturityToSpawn({ neuron, percentage: 100 })).toBe(true);
@@ -987,7 +987,7 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: {
           ...mockFullNeuron,
-          maturityE8sEquivalent: BigInt(MIN_NEURON_STAKE * 5 + 1_000),
+          maturityE8sEquivalent: MIN_NEURON_STAKE * 5n + 1_000n,
         },
       };
       expect(isEnoughMaturityToSpawn({ neuron: neuron2, percentage: 50 })).toBe(
@@ -999,7 +999,7 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: {
           ...mockFullNeuron,
-          maturityE8sEquivalent: BigInt(MIN_NEURON_STAKE - 1_000),
+          maturityE8sEquivalent: MIN_NEURON_STAKE - 1_000n,
         },
       };
       expect(isEnoughMaturityToSpawn({ neuron, percentage: 100 })).toBe(false);
@@ -1008,7 +1008,7 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: {
           ...mockFullNeuron,
-          maturityE8sEquivalent: BigInt(MIN_NEURON_STAKE * 2 + 1_000),
+          maturityE8sEquivalent: MIN_NEURON_STAKE * 2n + 1_000n,
         },
       };
       expect(isEnoughMaturityToSpawn({ neuron: neuron2, percentage: 10 })).toBe(
@@ -2166,7 +2166,7 @@ describe("neuron-utils", () => {
           neuronFees: 10n,
         },
       };
-      expect(neuronCanBeSplit({ neuron, fee: 10_000 })).toBe(true);
+      expect(neuronCanBeSplit({ neuron, fee: 10_000n })).toBe(true);
     });
 
     it("should return false if neuron has not enough stake to be splitted", () => {
@@ -2178,7 +2178,7 @@ describe("neuron-utils", () => {
           neuronFees: 10n,
         },
       };
-      expect(neuronCanBeSplit({ neuron, fee: 10_000 })).toBe(false);
+      expect(neuronCanBeSplit({ neuron, fee: 10_000n })).toBe(false);
     });
   });
 
@@ -2227,8 +2227,8 @@ describe("neuron-utils", () => {
 
   describe("minNeuronSplittable", () => {
     it("returns fee plus two ICPs", () => {
-      const received = minNeuronSplittable(10_000);
-      expect(received).toBe(10_000 + 200_000_000);
+      const received = minNeuronSplittable(10_000n);
+      expect(received).toBe(10_000n + 200_000_000n);
     });
   });
 
@@ -2272,7 +2272,7 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: {
           ...mockFullNeuron,
-          cachedNeuronStake: BigInt(MIN_NEURON_STAKE * 2),
+          cachedNeuronStake: MIN_NEURON_STAKE * 2n,
         },
       };
       expect(validTopUpAmount({ neuron, amount: 0.001 })).toBe(true);
@@ -2299,7 +2299,7 @@ describe("neuron-utils", () => {
         ...mockNeuron,
         fullNeuron: {
           ...mockFullNeuron,
-          cachedNeuronStake: BigInt(MIN_NEURON_STAKE / 2 - 10),
+          cachedNeuronStake: MIN_NEURON_STAKE / 2n - 10n,
         },
       };
       expect(


### PR DESCRIPTION
# Motivation

Use `bigint` for e8s and ulps.

In this PR, Remove deprecated store `mainTransactionFeeStore`.

The reason to stop using it is because it returned e8s in the `number` type instead of `bigint`.

# Changes

* Remove `mainTransactionFeeStore` and use instead `mainTransactionFeeE8sStore`.
* Convert `MIN_NEURON_STAKE` to `bigint`.
* Change parameter and return type in `minNeuronSplittable` to `bigint`.
* Change parameter type in `neuronCanBeSplit` to `bigint`.

# Tests

* Remove test for `mainTransactionFeeStore`.
* Convert parameter inputs from number to bigint.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
