### PR TITLE
Update aggregator

### DIFF
--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_governance --out ic_sns_governance.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-09_23-01+new-p2p/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-18_23-01+dts-off/rs/sns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -134,7 +134,6 @@ pub struct RewardEvent {
     pub rounds_since_last_distribution: Option<u64>,
     pub actual_timestamp_seconds: u64,
     pub end_timestamp_seconds: Option<u64>,
-    pub total_available_e8s_equivalent: Option<u64>,
     pub distributed_e8s_equivalent: u64,
     pub round: u64,
     pub settled_proposals: Vec<ProposalId>,

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs.orig
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs.orig
@@ -120,15 +120,17 @@ pub struct BlockRange {
     pub blocks: Vec<Block>,
 }
 
-pub type QueryBlockArchiveFn = candid::Func;
-#[derive(CandidType, Deserialize)]
+candid::define_function!(pub QueryBlockArchiveFn : (GetBlocksArgs) -> (
+    BlockRange,
+  ) query);
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetBlocksResponseArchivedBlocksItem {
     pub callback: QueryBlockArchiveFn,
     pub start: BlockIndex,
     pub length: candid::Nat,
 }
 
-#[derive(CandidType, Deserialize)]
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetBlocksResponse {
     pub certificate: Option<serde_bytes::ByteBuf>,
     pub first_index: BlockIndex,
@@ -206,15 +208,17 @@ pub struct TransactionRange {
     pub transactions: Vec<Transaction>,
 }
 
-pub type QueryArchiveFn = candid::Func;
-#[derive(CandidType, Deserialize)]
+candid::define_function!(pub QueryArchiveFn : (GetTransactionsRequest) -> (
+    TransactionRange,
+  ) query);
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetTransactionsResponseArchivedTransactionsItem {
     pub callback: QueryArchiveFn,
     pub start: TxIndex,
     pub length: candid::Nat,
 }
 
-#[derive(CandidType, Deserialize)]
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetTransactionsResponse {
     pub first_index: TxIndex,
     pub log_length: candid::Nat,

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_root --out ic_sns_root.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-09_23-01+new-p2p/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-18_23-01+dts-off/rs/sns/root/canister/root.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_swap --out ic_sns_swap.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-09_23-01+new-p2p/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-18_23-01+dts-off/rs/sns/swap/canister/swap.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -334,6 +334,7 @@ pub struct GetLifecycleArg {}
 pub struct GetLifecycleResponse {
     pub decentralization_sale_open_timestamp_seconds: Option<u64>,
     pub lifecycle: Option<i32>,
+    pub decentralization_swap_termination_timestamp_seconds: Option<u64>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -452,6 +453,7 @@ pub struct Swap {
     pub direct_participation_icp_e8s: Option<u64>,
     pub lifecycle: i32,
     pub purge_old_tickets_next_principal: Option<serde_bytes::ByteBuf>,
+    pub decentralization_swap_termination_timestamp_seconds: Option<u64>,
     pub buyers: Vec<(String, BuyerState)>,
     pub params: Option<Params>,
     pub open_sns_token_swap_proposal_id: Option<u64>,

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out ic_sns_wasm.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-09_23-01+new-p2p/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-18_23-01+dts-off/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(clippy::missing_docs_in_private_items)]


### PR DESCRIPTION
# Motivation
We would like to parse all the latest SNS data.

# Changes
* Updated the Rust code derived from `.did` files in the aggregator.
  * Note: The candid files under `declarations/nns-$CANISTER` are used as inputs.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.