### PR TITLE
Chore: Add pattern to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ node_modules/
 web-assets/
 playwright-report/
 playwright-results/
+*.orig
 
 **/*.rs.bk
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -50,7 +50,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Add `reviewers` to the `update-*.yml` workflows that create PRs.
-* Add `.orig` file extension to gitignore.
+* Add `.orig` file extension to "gitignore" file.
 
 #### Changed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -50,7 +50,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Add `reviewers` to the `update-*.yml` workflows that create PRs.
-* Add `.orig` file extension to `.gitignore`` file.
+* Add `.orig` file extension to `.gitignore` file.
 
 #### Changed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -50,6 +50,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Add `reviewers` to the `update-*.yml` workflows that create PRs.
+* Add `.orig` file extension to gitignore.
 
 #### Changed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -50,7 +50,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Add `reviewers` to the `update-*.yml` workflows that create PRs.
-* Add `.orig` file extension to "gitignore" file.
+* Add `.orig` file extension to `.gitignore`` file.
 
 #### Changed
 


### PR DESCRIPTION
# Motivation

The `*.orig` extension is used for some scripts to update candid types but it's only a temporary file. Some PRs from the bots add all the files to git and it might include this temporary files.

In this PR, I add the extension to gitignore.

# Changes

* Add `.orig` file extension to gitignore

# Tests

I created `test.orig` file and confirmed that it was ignored by git.

# Todos

- [x] Add entry to changelog (if necessary).
