### PR TITLE
Add TooltipIcon component

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -41,6 +41,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Fix gaps between sections on the mobile launchpad page.
 * Fix proposal back navigation during voting.
 * Fix tooltip positioning.
+* Tooltip icon style.
 
 #### Security
 

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -3,12 +3,7 @@
   import { fromDefinedNullable } from "@dfinity/utils";
   import { getContext } from "svelte";
   import { ICON_SIZE_LARGE } from "$lib/constants/layout.constants";
-  import {
-    IconClose,
-    IconInfo,
-    IconWarning,
-    Value,
-  } from "@dfinity/gix-components";
+  import { IconClose, IconWarning, Value } from "@dfinity/gix-components";
   import { removeHotkey } from "$lib/services/sns-neurons.services";
   import { authStore } from "$lib/stores/auth.store";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
@@ -23,7 +18,7 @@
     canIdentityManageHotkeys,
   } from "$lib/utils/sns-neuron.utils";
   import CardInfo from "$lib/components/ui/CardInfo.svelte";
-  import { Tooltip } from "@dfinity/gix-components";
+  import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
   import AddSnsHotkeyButton from "./actions/AddSnsHotkeyButton.svelte";
   import { toastsShow } from "$lib/stores/toasts.store";
   import { goto } from "$app/navigation";
@@ -111,14 +106,10 @@
       <div class="title" slot="start">
         <h3>{$i18n.neuron_detail.hotkeys_title}</h3>
         {#if showTooltip}
-          <Tooltip
-            id="sns-hotkeys-info"
+          <TooltipIcon
+            tooltipId="sns-hotkeys-info"
             text={$i18n.sns_neuron_detail.add_hotkey_tooltip}
-          >
-            <span>
-              <IconInfo />
-            </span>
-          </Tooltip>
+          />
         {/if}
       </div>
       {#if hotkeys.length === 0}
@@ -171,8 +162,6 @@
 
   .title {
     display: flex;
-    align-items: center;
-    gap: var(--padding-0_5x);
   }
 
   h3 {

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte
@@ -162,6 +162,7 @@
 
   .title {
     display: flex;
+    gap: var(--padding);
   }
 
   h3 {

--- a/frontend/src/lib/components/ui/TooltipIcon.svelte
+++ b/frontend/src/lib/components/ui/TooltipIcon.svelte
@@ -16,6 +16,5 @@
     display: inline-flex;
     align-items: center;
     color: var(--tertiary);
-    margin-left: var(--padding);
   }
 </style>

--- a/frontend/src/lib/components/ui/TooltipIcon.svelte
+++ b/frontend/src/lib/components/ui/TooltipIcon.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { IconInfo, Tooltip } from "@dfinity/gix-components";
+
+  export let tooltipId: string;
+  export let text: string;
+</script>
+
+<div class="wrapper" data-tid="tooltip-icon-component">
+  <Tooltip id={tooltipId} {text}>
+    <IconInfo />
+  </Tooltip>
+</div>
+
+<style lang="scss">
+  .wrapper {
+    display: inline-flex;
+    align-items: center;
+    color: var(--tertiary);
+    margin-left: var(--padding);
+  }
+</style>

--- a/frontend/src/tests/lib/components/ui/TooltipIcon.spec.ts
+++ b/frontend/src/tests/lib/components/ui/TooltipIcon.spec.ts
@@ -1,0 +1,30 @@
+import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("TooltipIcon", () => {
+  const text = "This is the text displayed in the tooltip";
+  const tooltipId = "example-tooltip-id";
+
+  const renderComponent = () => {
+    const { container } = render(TooltipIcon, { text, tooltipId });
+    return TooltipIconPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should have an info icon", async () => {
+    const po = renderComponent();
+    expect(await po.isPresent("icon-info")).toBe(true);
+  });
+
+  it("should have the tooltip text", async () => {
+    const po = renderComponent();
+    expect(await po.getText()).toBe(text);
+  });
+
+  it("should have the tooltip ID", async () => {
+    const po = renderComponent().getTooltipPo();
+    expect(await po.getAriaDescribedBy()).toBe(tooltipId);
+    expect(await po.getTooltipId()).toBe(tooltipId);
+  });
+});

--- a/frontend/src/tests/page-objects/Tooltip.page-object.ts
+++ b/frontend/src/tests/page-objects/Tooltip.page-object.ts
@@ -12,4 +12,14 @@ export class TooltipPo extends BasePageObject {
   getText(): Promise<string> {
     return assertNonNullish(this.root.querySelector(".tooltip")).getText();
   }
+
+  getAriaDescribedBy(): Promise<string> {
+    return this.root
+      .querySelector(".tooltip-target")
+      .getAttribute("aria-describedby");
+  }
+
+  getTooltipId(): Promise<string> {
+    return this.root.querySelector(".tooltip").getAttribute("id");
+  }
 }

--- a/frontend/src/tests/page-objects/TooltipIcon.page-object.ts
+++ b/frontend/src/tests/page-objects/TooltipIcon.page-object.ts
@@ -1,0 +1,19 @@
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class TooltipIconPo extends BasePageObject {
+  private static readonly TID = "tooltip-icon-component";
+
+  static under(element: PageObjectElement): TooltipIconPo {
+    return new TooltipIconPo(element.byTestId(TooltipIconPo.TID));
+  }
+
+  getTooltipPo(): TooltipPo {
+    return TooltipPo.under(this.root);
+  }
+
+  getText(): Promise<string> {
+    return this.getTooltipPo().getText();
+  }
+}


### PR DESCRIPTION
# Motivation

We have one place where we have an info icon with a tooltip and we want to add more.
For convenience and consistency I'm factoring out the existing one into a separate component.
I'm also giving it the standard icon color and padding.
This makes the existing usage consistent with other info icons.

# Changes

1. Create `TooltipIcon` component which has an `IconInfo` with a `Tooltip`.
2. Give it a left margin of `--padding` so the parent component doesn't have to style the gap.
3. Give it a color and make it center aligned.
4. Use the `TooltipIcon` in `SnsNeuronHotkeysCard.svelte` to replace the current ad-hoc implementation.

# Tests

Unit tests added.

The affected icon is the one next to "Hotkeys".
"Following" is included for comparison.

Before:
<img width="189" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/8539687d-0da6-43e1-9214-4ff5ace4b36d">

After:
<img width="211" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/48a621d1-e3a1-437a-a5e0-400e716a92b3">


# Todos

- [x] Add entry to changelog (if necessary).
