### PR TITLE
Add tooltip icon to dissolve delay item action

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Close button at the bottom of follow neurons modal.
+* Info tooltips in neuron details.
 
 #### Changed
 

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte
@@ -6,12 +6,13 @@
     getSpawningTimeInSeconds,
     isNeuronControllable,
   } from "$lib/utils/neuron.utils";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { IconClockNoFill } from "@dfinity/gix-components";
   import { NeuronState, type NeuronInfo } from "@dfinity/nns";
   import CommonItemAction from "../ui/CommonItemAction.svelte";
   import IncreaseDissolveDelayButton from "./actions/IncreaseDissolveDelayButton.svelte";
   import { keyOf } from "$lib/utils/utils";
-  import { secondsToDuration } from "@dfinity/utils";
+  import { secondsToDuration, ICPToken } from "@dfinity/utils";
   import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
   import { authStore } from "$lib/stores/auth.store";
   import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
@@ -48,7 +49,13 @@
   });
 </script>
 
-<CommonItemAction testId="nns-neuron-dissolve-delay-item-action-component">
+<CommonItemAction
+  testId="nns-neuron-dissolve-delay-item-action-component"
+  tooltipText={replacePlaceholders($i18n.neuron_detail.dissolve_delay_tooltip, {
+    $token: ICPToken.symbol,
+  })}
+  tooltipId="dissolve-delay-info-icon"
+>
   <IconClockNoFill slot="icon" />
   <span slot="title" data-tid="dissolve-delay-text"
     >{`${keyOf({

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.svelte
@@ -4,7 +4,8 @@
   import { NeuronState } from "@dfinity/nns";
   import CommonItemAction from "../ui/CommonItemAction.svelte";
   import { keyOf } from "$lib/utils/utils";
-  import { secondsToDuration } from "@dfinity/utils";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { secondsToDuration, type Token } from "@dfinity/utils";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
   import {
     dissolveDelayMultiplier,
@@ -19,6 +20,7 @@
 
   export let neuron: SnsNeuron;
   export let parameters: SnsNervousSystemParameters;
+  export let token: Token;
 
   let state: NeuronState;
   $: state = getSnsNeuronState(neuron);
@@ -52,7 +54,13 @@
   });
 </script>
 
-<CommonItemAction testId="sns-neuron-dissolve-delay-item-action-component">
+<CommonItemAction
+  testId="sns-neuron-dissolve-delay-item-action-component"
+  tooltipText={replacePlaceholders($i18n.neuron_detail.dissolve_delay_tooltip, {
+    $token: token.symbol,
+  })}
+  tooltipId="sns-dissolve-delay-info-icon"
+>
   <IconClockNoFill slot="icon" />
   <span slot="title" data-tid="dissolve-delay-text"
     >{`${keyOf({

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
@@ -88,7 +88,7 @@
   <ul class="content">
     <SnsStakeItemAction {neuron} {token} {universe} />
     <SnsNeuronStateItemAction {neuron} snsParameters={parameters} />
-    <SnsNeuronDissolveDelayItemAction {neuron} {parameters} />
+    <SnsNeuronDissolveDelayItemAction {neuron} {parameters} {token} />
   </ul>
 </Section>
 

--- a/frontend/src/lib/components/ui/CommonItemAction.svelte
+++ b/frontend/src/lib/components/ui/CommonItemAction.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
+  import TooltipIcon from "./TooltipIcon.svelte";
   import { ItemAction } from "@dfinity/gix-components";
+  import { nonNullish } from "@dfinity/utils";
 
   export let testId: string;
+  export let tooltipText: string | undefined = undefined;
+  export let tooltipId: string | undefined = undefined;
 </script>
 
 <ItemAction {testId}>
@@ -9,7 +13,12 @@
     <slot name="icon" />
   </div>
   <div class="content">
-    <h4 data-tid="staked-maturity"><slot name="title" /></h4>
+    <h4>
+      <slot name="title" />
+      {#if nonNullish(tooltipText) && nonNullish(tooltipId)}
+        <TooltipIcon {tooltipId} text={tooltipText} />
+      {/if}
+    </h4>
     <p class="description"><slot name="subtitle" /></p>
   </div>
   <div slot="actions" class="actions">
@@ -24,6 +33,8 @@
     gap: var(--padding);
     p,
     h4 {
+      display: flex;
+      gap: var(--padding);
       margin: 0;
     }
   }

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -720,7 +720,8 @@
     "neuron_account": "Neuron Account",
     "dissolve_date": "Dissolve Date",
     "amount_maturity": "$amount maturity",
-    "created": "Date created"
+    "created": "Date created",
+    "dissolve_delay_tooltip": "Your neuron can be locked, unlocked or dissolving. In a locked state, it is accruing age bonus, while its dissolve delay stays constant. If the neuron is in a dissolving state, its age bonus is set to 0, while dissolve delay decreases with time. After dissolve delay reaches 0, the neuron is unlocked, and $token held in it can be sent to any $token account."
   },
   "sns_launchpad": {
     "header": "Launchpad",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -744,6 +744,7 @@ interface I18nNeuron_detail {
   dissolve_date: string;
   amount_maturity: string;
   created: string;
+  dissolve_delay_tooltip: string;
 }
 
 interface I18nSns_launchpad {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.spec.ts
@@ -15,6 +15,7 @@ import {
   createMockSnsNeuron,
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
+import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import { SnsNeuronDissolveDelayItemActionPo } from "$tests/page-objects/SnsNeuronDissolveDelayItemAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NeuronState } from "@dfinity/nns";
@@ -36,6 +37,11 @@ describe("SnsNeuronDissolveDelayItemAction", () => {
     max_dissolve_delay_seconds: [maxDissolveDelay],
     max_dissolve_delay_bonus_percentage: [25n],
   };
+  const token = {
+    ...mockSnsToken,
+    symbol: "ZXCV",
+  };
+
   const renderComponent = (
     neuron: SnsNeuron,
     parameters: SnsNervousSystemParameters = snsParameters
@@ -44,6 +50,7 @@ describe("SnsNeuronDissolveDelayItemAction", () => {
       props: {
         neuron,
         parameters,
+        token,
       },
     });
 
@@ -139,5 +146,16 @@ describe("SnsNeuronDissolveDelayItemAction", () => {
     const po = renderComponent(neuron);
 
     expect(await po.hasIncreaseDissolveDelayButton()).toBe(false);
+  });
+
+  it("should render the token symbol in the tooltip text", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolved,
+      permissions: [noDissolvePermissions],
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getTooltipIconPo().getText()).toContain(token.symbol);
   });
 });

--- a/frontend/src/tests/lib/components/ui/CommonItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/ui/CommonItemAction.spec.ts
@@ -1,0 +1,39 @@
+import CommonItemAction from "$lib/components/ui/CommonItemAction.svelte";
+import { SnsNeuronDissolveDelayItemActionPo } from "$tests/page-objects/SnsNeuronDissolveDelayItemAction.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("CommonItemAction", () => {
+  const tooltipText = "Example tooltip text";
+  const tooltipId = "example-tooltip-id";
+
+  const renderComponent = () => {
+    const { container } = render(CommonItemAction, {
+      props: {
+        testId: SnsNeuronDissolveDelayItemActionPo.TID,
+        tooltipText,
+        tooltipId,
+      },
+    });
+
+    // We don't use CommonItemAction separately so we use the page object of a
+    // parent component.
+    return SnsNeuronDissolveDelayItemActionPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should render the tooltip text", async () => {
+    const po = renderComponent();
+
+    expect(await po.getTooltipIconPo().getText()).toBe(tooltipText);
+  });
+
+  it("should render the tooltip id", async () => {
+    const po = renderComponent();
+
+    expect(await po.getTooltipIconPo().getTooltipPo().getTooltipId()).toBe(
+      tooltipId
+    );
+  });
+});

--- a/frontend/src/tests/page-objects/SnsNeuronDissolveDelayItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDissolveDelayItemAction.page-object.ts
@@ -1,6 +1,7 @@
+import { DissolveDelayBonusTextPo } from "$tests/page-objects/DissolveDelayBonusText.page-object";
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { DissolveDelayBonusTextPo } from "./DissolveDelayBonusText.page-object";
 
 export class SnsNeuronDissolveDelayItemActionPo extends BasePageObject {
   private static readonly TID =
@@ -10,6 +11,10 @@ export class SnsNeuronDissolveDelayItemActionPo extends BasePageObject {
     return new SnsNeuronDissolveDelayItemActionPo(
       element.byTestId(SnsNeuronDissolveDelayItemActionPo.TID)
     );
+  }
+
+  getTooltipIconPo(): TooltipIconPo {
+    return TooltipIconPo.under(this.root);
   }
 
   getDissolveState(): Promise<string> {

--- a/frontend/src/tests/page-objects/SnsNeuronDissolveDelayItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronDissolveDelayItemAction.page-object.ts
@@ -4,8 +4,7 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SnsNeuronDissolveDelayItemActionPo extends BasePageObject {
-  private static readonly TID =
-    "sns-neuron-dissolve-delay-item-action-component";
+  static readonly TID = "sns-neuron-dissolve-delay-item-action-component";
 
   static under(element: PageObjectElement): SnsNeuronDissolveDelayItemActionPo {
     return new SnsNeuronDissolveDelayItemActionPo(


### PR DESCRIPTION
# Motivation

Requested in point 22 of https://www.notion.so/dfinityorg/Wording-Changes-4411020138ce4d09b6605ad1fdbb9555

# Changes

1. Add fields to `CommonItemAction` to add an optional tooltip next to the title.
2. Use the fields in `NnsNeuronDissolveDelayItemAction.svelte` and `SnsNeuronDissolveDelayItemAction.svelte` to explain the dissolve delay.
3. Pass the token to `SnsNeuronDissolveDelayItemAction` to use in the tooltip message.

# Tests

Added a unit test that the tooltip text includes the token symbol.

<img width="428" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/33e39c01-e4d4-42b0-9c58-f015e0a6651d">


# Todos

- [x] Add entry to changelog (if necessary).
Added an entry which will also cover the next PR.