### PR TITLE
Add tooltip icon to neuron state item action

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { NeuronState, type NeuronInfo } from "@dfinity/nns";
+  import { ICPToken } from "@dfinity/utils";
   import {
     ageMultiplier,
     getStateInfo,
@@ -7,6 +8,7 @@
     type StateInfo,
   } from "$lib/utils/neuron.utils";
   import { i18n } from "$lib/stores/i18n";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { keyOf } from "$lib/utils/utils";
   import DisburseButton from "./actions/DisburseButton.svelte";
   import DissolveActionButton from "./actions/DissolveActionButton.svelte";
@@ -28,7 +30,13 @@
   });
 </script>
 
-<CommonItemAction testId="nns-neuron-state-item-action-component">
+<CommonItemAction
+  testId="nns-neuron-state-item-action-component"
+  tooltipText={replacePlaceholders($i18n.neuron_detail.neuron_state_tooltip, {
+    $token: ICPToken.symbol,
+  })}
+  tooltipId="neuron-state-info-icon"
+>
   <svelte:fragment slot="icon">
     {#if stateInfo?.Icon !== undefined}
       <svelte:component this={stateInfo.Icon} />

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { NeuronState } from "@dfinity/nns";
+  import type { Token } from "@dfinity/utils";
   import { getStateInfo, type StateInfo } from "$lib/utils/neuron.utils";
   import { i18n } from "$lib/stores/i18n";
   import { keyOf } from "$lib/utils/utils";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import CommonItemAction from "$lib/components/ui/CommonItemAction.svelte";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
   import {
@@ -18,6 +20,7 @@
 
   export let neuron: SnsNeuron;
   export let snsParameters: SnsNervousSystemParameters;
+  export let token: Token;
 
   let state: NeuronState;
   $: state = getSnsNeuronState(neuron);
@@ -45,7 +48,13 @@
     });
 </script>
 
-<CommonItemAction testId="sns-neuron-state-item-action-component">
+<CommonItemAction
+  testId="sns-neuron-state-item-action-component"
+  tooltipText={replacePlaceholders($i18n.neuron_detail.neuron_state_tooltip, {
+    $token: token.symbol,
+  })}
+  tooltipId="sns-neuron-state-info-icon"
+>
   <svelte:fragment slot="icon">
     {#if stateInfo?.Icon !== undefined}
       <svelte:component this={stateInfo.Icon} />

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte
@@ -87,7 +87,7 @@
   </p>
   <ul class="content">
     <SnsStakeItemAction {neuron} {token} {universe} />
-    <SnsNeuronStateItemAction {neuron} snsParameters={parameters} />
+    <SnsNeuronStateItemAction {neuron} snsParameters={parameters} {token} />
     <SnsNeuronDissolveDelayItemAction {neuron} {parameters} {token} />
   </ul>
 </Section>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -721,6 +721,7 @@
     "dissolve_date": "Dissolve Date",
     "amount_maturity": "$amount maturity",
     "created": "Date created",
+    "neuron_state_tooltip": "Your neuron can be locked, unlocked or dissolving. In a locked state, it is accruing age bonus, while its dissolve delay stays constant. If the neuron is in a dissolving state, its age bonus is set to 0, while dissolve delay decreases with time. After dissolve delay reaches 0, the neuron is unlocked, and $token held in it can be sent to any $token account.",
     "dissolve_delay_tooltip": "Your neuron can be locked, unlocked or dissolving. In a locked state, it is accruing age bonus, while its dissolve delay stays constant. If the neuron is in a dissolving state, its age bonus is set to 0, while dissolve delay decreases with time. After dissolve delay reaches 0, the neuron is unlocked, and $token held in it can be sent to any $token account."
   },
   "sns_launchpad": {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -744,6 +744,7 @@ interface I18nNeuron_detail {
   dissolve_date: string;
   amount_maturity: string;
   created: string;
+  neuron_state_tooltip: string;
   dissolve_delay_tooltip: string;
 }
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.spec.ts
@@ -10,6 +10,7 @@ import {
   createMockSnsNeuron,
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
+import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import { SnsNeuronStateItemActionPo } from "$tests/page-objects/SnsNeuronStateItemAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NeuronState } from "@dfinity/nns";
@@ -19,11 +20,17 @@ import { render } from "@testing-library/svelte";
 
 describe("SnsNeuronStateItemAction", () => {
   const nowInSeconds = 1689843195;
+  const token = {
+    ...mockSnsToken,
+    symbol: "ASDF",
+  };
+
   const renderComponent = (neuron: SnsNeuron) => {
     const { container } = render(SnsNeuronStateItemAction, {
       props: {
         neuron,
         snsParameters: snsNervousSystemParametersMock,
+        token,
       },
     });
 
@@ -161,5 +168,16 @@ describe("SnsNeuronStateItemAction", () => {
     const po = renderComponent(neuron);
 
     expect(await po.getAgeBonus()).toBe("No age bonus");
+  });
+
+  it("should render token symbol in tooltip text", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolved,
+      permissions: [controllerPermissions],
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getTooltipIconPo().getText()).toContain(token.symbol);
   });
 });

--- a/frontend/src/tests/page-objects/SnsNeuronStateItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeuronStateItemAction.page-object.ts
@@ -1,3 +1,4 @@
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AgeBonusTextPo } from "./AgeBonusText.page-object";
@@ -10,6 +11,10 @@ export class SnsNeuronStateItemActionPo extends BasePageObject {
     return new SnsNeuronStateItemActionPo(
       element.byTestId(SnsNeuronStateItemActionPo.TID)
     );
+  }
+
+  getTooltipIconPo(): TooltipIconPo {
+    return TooltipIconPo.under(this.root);
   }
 
   getState(): Promise<string> {


### PR DESCRIPTION
# Motivation

In https://github.com/dfinity/nns-dapp/pull/4326, I accidentally mixed up points 22 and 23 of https://www.notion.so/dfinityorg/Wording-Changes-4411020138ce4d09b6605ad1fdbb9555 and put the tooltip text for the neuron state on the item action for the dissolve delay.
In this PR I put that same text on the item action for the neuron state, where it should be.
In the next PR I will fix the text for the dissolve delay item action.

# Changes

1. Add a tooltip icon to `NnsNeuronStateItemAction` and `SnsNeuronStateItemAction`.
2. Pass the `token` to  `SnsNeuronStateItemAction` to render in the tooltip text.

# Tests

Unit test added.

<img width="791" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/82217201-9391-47e3-918e-0663dc569532">

# Todos

- [ ] Add entry to changelog (if necessary).
covered