### PR TITLE
Fix dissolve delay item action tooltip

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte
@@ -47,13 +47,26 @@
     identity: $authStore.identity,
     accounts: $icpAccountsStore,
   });
+
+  let duration: string;
+  $: duration =
+    remainingTimeSeconds > 0n
+      ? secondsToDuration({ seconds: remainingTimeSeconds, i18n: $i18n.time })
+      : "0";
+
+  let tooltipText: string | undefined;
+  $: tooltipText =
+    remainingTimeSeconds > 0n
+      ? replacePlaceholders($i18n.neuron_detail.dissolve_delay_tooltip, {
+          $token: ICPToken.symbol,
+          $duration: duration,
+        })
+      : undefined;
 </script>
 
 <CommonItemAction
   testId="nns-neuron-dissolve-delay-item-action-component"
-  tooltipText={replacePlaceholders($i18n.neuron_detail.dissolve_delay_tooltip, {
-    $token: ICPToken.symbol,
-  })}
+  {tooltipText}
   tooltipId="dissolve-delay-info-icon"
 >
   <IconClockNoFill slot="icon" />
@@ -61,11 +74,7 @@
     >{`${keyOf({
       obj: $i18n.neuron_detail,
       key: stateTextMapper[neuron.state],
-    })} ${
-      remainingTimeSeconds > 0n
-        ? secondsToDuration({ seconds: remainingTimeSeconds, i18n: $i18n.time })
-        : "0"
-    }`}</span
+    })} ${duration}`}</span
   >
   <svelte:fragment slot="subtitle">
     {#if Number(remainingTimeSeconds) >= NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE}

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.svelte
@@ -52,13 +52,26 @@
     neuron,
     identity: $authStore.identity,
   });
+
+  let duration: string;
+  $: duration =
+    dissolvingTime > 0n
+      ? secondsToDuration({ seconds: dissolvingTime, i18n: $i18n.time })
+      : "0";
+
+  let tooltipText: string | undefined;
+  $: tooltipText =
+    dissolvingTime > 0n
+      ? replacePlaceholders($i18n.neuron_detail.dissolve_delay_tooltip, {
+          $token: token.symbol,
+          $duration: duration,
+        })
+      : undefined;
 </script>
 
 <CommonItemAction
   testId="sns-neuron-dissolve-delay-item-action-component"
-  tooltipText={replacePlaceholders($i18n.neuron_detail.dissolve_delay_tooltip, {
-    $token: token.symbol,
-  })}
+  {tooltipText}
   tooltipId="sns-dissolve-delay-info-icon"
 >
   <IconClockNoFill slot="icon" />
@@ -66,11 +79,7 @@
     >{`${keyOf({
       obj: $i18n.neuron_detail,
       key: stateTextMapper[state],
-    })} ${
-      dissolvingTime > 0n
-        ? secondsToDuration({ seconds: dissolvingTime, i18n: $i18n.time })
-        : "0"
-    }`}</span
+    })} ${duration}`}</span
   >
   <svelte:fragment slot="subtitle">
     {#if dissolvingTime >= minimumDelayToVoteInSeconds}

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -722,7 +722,7 @@
     "amount_maturity": "$amount maturity",
     "created": "Date created",
     "neuron_state_tooltip": "Your neuron can be locked, unlocked or dissolving. In a locked state, it is accruing age bonus, while its dissolve delay stays constant. If the neuron is in a dissolving state, its age bonus is set to 0, while dissolve delay decreases with time. After dissolve delay reaches 0, the neuron is unlocked, and $token held in it can be sent to any $token account.",
-    "dissolve_delay_tooltip": "Your neuron can be locked, unlocked or dissolving. In a locked state, it is accruing age bonus, while its dissolve delay stays constant. If the neuron is in a dissolving state, its age bonus is set to 0, while dissolve delay decreases with time. After dissolve delay reaches 0, the neuron is unlocked, and $token held in it can be sent to any $token account."
+    "dissolve_delay_tooltip": "Dissolve delay is the minimum amount of time you have to wait for the neuron to unlock, and $token to be available again. If your neuron is dissolving, your $token will be available in $duration."
   },
   "sns_launchpad": {
     "header": "Launchpad",

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
@@ -136,4 +136,28 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
 
     expect(await po.hasIncreaseDissolveDelayButton()).toBe(true);
   });
+
+  it("should not render a tooltip without dissolve delay", async () => {
+    const neuron: NeuronInfo = {
+      ...controlledNeuron,
+      state: NeuronState.Dissolved,
+      dissolveDelaySeconds: 0n,
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getTooltipIconPo().isPresent()).toBe(false);
+  });
+
+  it("should render the dissolve duration in the tooltip text", async () => {
+    const neuron: NeuronInfo = {
+      ...controlledNeuron,
+      state: NeuronState.Locked,
+      dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR * 2),
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getTooltipIconPo().getText()).toContain(
+      "available in 2 years, 12 hours"
+    );
+  });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
@@ -148,7 +148,7 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
     expect(await po.getTooltipIconPo().isPresent()).toBe(false);
   });
 
-  it("should render the dissolve duration in the tooltip text", async () => {
+  it("should render tooltip when locked", async () => {
     const neuron: NeuronInfo = {
       ...controlledNeuron,
       state: NeuronState.Locked,
@@ -156,12 +156,12 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
     };
     const po = renderComponent(neuron);
 
-    expect(await po.getTooltipIconPo().getText()).toContain(
-      "available in 2 years, 12 hours"
+    expect(await po.getTooltipIconPo().getText()).toBe(
+      "Dissolve delay is the minimum amount of time you have to wait for the neuron to unlock, and ICP to be available again. If your neuron is dissolving, your ICP will be available in 2 years, 12 hours."
     );
   });
 
-  it("should render the dissolve duration in the tooltip text when dissolving", async () => {
+  it("should render tooltip when dissolving", async () => {
     const neuron: NeuronInfo = {
       ...controlledNeuron,
       state: NeuronState.Dissolving,
@@ -169,8 +169,8 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
     };
     const po = renderComponent(neuron);
 
-    expect(await po.getTooltipIconPo().getText()).toContain(
-      "available in 2 years, 12 hours."
+    expect(await po.getTooltipIconPo().getText()).toBe(
+      "Dissolve delay is the minimum amount of time you have to wait for the neuron to unlock, and ICP to be available again. If your neuron is dissolving, your ICP will be available in 2 years, 12 hours."
     );
   });
 });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
@@ -160,4 +160,17 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
       "available in 2 years, 12 hours"
     );
   });
+
+  it("should render the dissolve duration in the tooltip text when dissolving", async () => {
+    const neuron: NeuronInfo = {
+      ...controlledNeuron,
+      state: NeuronState.Dissolving,
+      dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR * 2),
+    };
+    const po = renderComponent(neuron);
+
+    expect(await po.getTooltipIconPo().getText()).toContain(
+      "available in 2 years, 12 hours."
+    );
+  });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.spec.ts
@@ -160,7 +160,7 @@ describe("SnsNeuronDissolveDelayItemAction", () => {
     expect(await po.getTooltipIconPo().isPresent()).toBe(false);
   });
 
-  it("should render the token symbol in the tooltip text", async () => {
+  it("should render tooltip when locked", async () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       state: NeuronState.Locked,
@@ -169,24 +169,12 @@ describe("SnsNeuronDissolveDelayItemAction", () => {
     });
     const po = renderComponent(neuron);
 
-    expect(await po.getTooltipIconPo().getText()).toContain(token.symbol);
-  });
-
-  it("should render the dissolve duration in the tooltip text", async () => {
-    const neuron = createMockSnsNeuron({
-      id: [1],
-      state: NeuronState.Locked,
-      permissions: [noDissolvePermissions],
-      dissolveDelaySeconds: BigInt(SECONDS_IN_FOUR_YEARS),
-    });
-    const po = renderComponent(neuron);
-
-    expect(await po.getTooltipIconPo().getText()).toContain(
-      "available in 4 years."
+    expect(await po.getTooltipIconPo().getText()).toBe(
+      "Dissolve delay is the minimum amount of time you have to wait for the neuron to unlock, and ZXCV to be available again. If your neuron is dissolving, your ZXCV will be available in 4 years."
     );
   });
 
-  it("should render the dissolve duration in the tooltip text when dissolving", async () => {
+  it("should render tooltip when dissolving", async () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       state: NeuronState.Dissolving,
@@ -198,8 +186,8 @@ describe("SnsNeuronDissolveDelayItemAction", () => {
     });
     const po = renderComponent(neuron);
 
-    expect(await po.getTooltipIconPo().getText()).toContain(
-      "available in 4 years."
+    expect(await po.getTooltipIconPo().getText()).toBe(
+      "Dissolve delay is the minimum amount of time you have to wait for the neuron to unlock, and ZXCV to be available again. If your neuron is dissolving, your ZXCV will be available in 4 years."
     );
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.spec.ts
@@ -148,14 +148,41 @@ describe("SnsNeuronDissolveDelayItemAction", () => {
     expect(await po.hasIncreaseDissolveDelayButton()).toBe(false);
   });
 
-  it("should render the token symbol in the tooltip text", async () => {
+  it("should not render a tooltip without dissolve delay", async () => {
     const neuron = createMockSnsNeuron({
       id: [1],
       state: NeuronState.Dissolved,
       permissions: [noDissolvePermissions],
+      dissolveDelaySeconds: 0n,
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getTooltipIconPo().isPresent()).toBe(false);
+  });
+
+  it("should render the token symbol in the tooltip text", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Locked,
+      permissions: [noDissolvePermissions],
+      dissolveDelaySeconds: BigInt(SECONDS_IN_FOUR_YEARS),
     });
     const po = renderComponent(neuron);
 
     expect(await po.getTooltipIconPo().getText()).toContain(token.symbol);
+  });
+
+  it("should render the dissolve duration in the tooltip text", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Locked,
+      permissions: [noDissolvePermissions],
+      dissolveDelaySeconds: BigInt(SECONDS_IN_FOUR_YEARS),
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getTooltipIconPo().getText()).toContain(
+      "available in 4 years"
+    );
   });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.spec.ts
@@ -182,7 +182,24 @@ describe("SnsNeuronDissolveDelayItemAction", () => {
     const po = renderComponent(neuron);
 
     expect(await po.getTooltipIconPo().getText()).toContain(
-      "available in 4 years"
+      "available in 4 years."
+    );
+  });
+
+  it("should render the dissolve duration in the tooltip text when dissolving", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+      state: NeuronState.Dissolving,
+      permissions: [noDissolvePermissions],
+      dissolveDelaySeconds: BigInt(SECONDS_IN_FOUR_YEARS),
+      whenDissolvedTimestampSeconds: BigInt(
+        nowInSeconds + SECONDS_IN_FOUR_YEARS
+      ),
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getTooltipIconPo().getText()).toContain(
+      "available in 4 years."
     );
   });
 });

--- a/frontend/src/tests/page-objects/NnsNeuronDissolveDelayItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDissolveDelayItemAction.page-object.ts
@@ -1,3 +1,4 @@
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { DissolveDelayBonusTextPo } from "./DissolveDelayBonusText.page-object";
@@ -10,6 +11,10 @@ export class NnsNeuronDissolveDelayItemActionPo extends BasePageObject {
     return new NnsNeuronDissolveDelayItemActionPo(
       element.byTestId(NnsNeuronDissolveDelayItemActionPo.TID)
     );
+  }
+
+  getTooltipIconPo(): TooltipIconPo {
+    return TooltipIconPo.under(this.root);
   }
 
   getDissolveState(): Promise<string> {


### PR DESCRIPTION
# Motivation

In https://github.com/dfinity/nns-dapp/pull/4326, I accidentally mixed up points 22 and 23 of https://www.notion.so/dfinityorg/Wording-Changes-4411020138ce4d09b6605ad1fdbb9555 and put the tooltip text for the neuron state on the item action for the dissolve delay.
In this PR we put the correct tooltip in the dissolve delay item action.
The intended behavior also requires additional logic because the intended tooltip text includes the dissolve delay duration and the tooltip should be hidden if the neuron is unlocked.

# Changes

1. Include the duration in the dissolve delay item action tooltip.
2. Hide the tooltip if there is no dissolve delay.

# Tests

Unit tests added.

<img width="433" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/619ba218-6b0b-4492-8445-cd9a796f7b39">

# Todos

- [ ] Add entry to changelog (if necessary).
covered