### PR TITLE
Add tooltip on staked maturity

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsStakedMaturityItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsStakedMaturityItemAction.svelte
@@ -4,6 +4,7 @@
   import { IconStakedMaturity } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
   import CommonItemAction from "../ui/CommonItemAction.svelte";
+  import TooltipIcon from "../ui/TooltipIcon.svelte";
 
   export let neuron: NeuronInfo;
 </script>
@@ -14,6 +15,10 @@
     >{formattedStakedMaturity(neuron)}</span
   >
   <svelte:fragment slot="subtitle"
-    >{$i18n.neuron_detail.staked_description}</svelte:fragment
+    >{$i18n.neuron_detail.staked_description}
+    <TooltipIcon
+      text={$i18n.neuron_detail.nns_staked_maturity_tooltip}
+      tooltipId="staked-maturity-tooltip"
+    /></svelte:fragment
   >
 </CommonItemAction>

--- a/frontend/src/lib/components/sns-neuron-detail/SnsStakedMaturityItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsStakedMaturityItemAction.svelte
@@ -4,6 +4,7 @@
   import CommonItemAction from "$lib/components/ui/CommonItemAction.svelte";
   import type { SnsNeuron } from "@dfinity/sns";
   import { formattedStakedMaturity } from "$lib/utils/sns-neuron.utils";
+  import TooltipIcon from "../ui/TooltipIcon.svelte";
 
   export let neuron: SnsNeuron;
 </script>
@@ -14,6 +15,10 @@
     >{formattedStakedMaturity(neuron)}</span
   >
   <svelte:fragment slot="subtitle"
-    >{$i18n.neuron_detail.staked_description}</svelte:fragment
+    >{$i18n.neuron_detail.staked_description}
+    <TooltipIcon
+      text={$i18n.neuron_detail.sns_staked_maturity_tooltip}
+      tooltipId="sns-staked-maturity-tooltip"
+    /></svelte:fragment
   >
 </CommonItemAction>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -617,6 +617,8 @@
     "voting_power_section_description_expanded_zero_nns": "The dissolve delay must be greater than 6 months for the neuron to have voting power. Learn more about voting power on the <a href=\"$dashboardLink\" rel=\"noopener noreferrer\" aria-label=\"more info about voting power\" target=\"_blank\">dashboard</a>.",
     "maturity_section_description": "Earn rewards by voting on proposals and/or following active neurons.",
     "staked_description": "Staked",
+    "nns_staked_maturity_tooltip": "Staked maturity contributes to the neuron’s voting power, but cannot be spawned into a new neuron.",
+    "sns_staked_maturity_tooltip": "Staked maturity contributes to the neuron’s voting power, but cannot be disbursed.",
     "age_bonus_label": "Age bonus: +$ageBonus",
     "dissolve_bonus_label": "Dissolve delay bonus: +$dissolveBonus",
     "no_age_bonus": "No age bonus",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -640,6 +640,8 @@ interface I18nNeuron_detail {
   voting_power_section_description_expanded_zero_nns: string;
   maturity_section_description: string;
   staked_description: string;
+  nns_staked_maturity_tooltip: string;
+  sns_staked_maturity_tooltip: string;
   age_bonus_label: string;
   dissolve_bonus_label: string;
   no_age_bonus: string;


### PR DESCRIPTION
# Motivation

Requested in point 24 of https://www.notion.so/dfinityorg/Wording-Changes-4411020138ce4d09b6605ad1fdbb9555

# Changes

1. Add tooltip for NNS staked maturity
2. Add tooltip for SNS staked maturity

# Tests

No logic so no tests.

<img width="339" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/cb43e533-3560-4a34-9b05-1466cfeaff9a">


# Todos

- [ ] Add entry to changelog (if necessary).
covered