### PR TITLE
Chore: Move to weekly workflows

### DIFF
--- a/.github/workflows/update-aggregator.yml
+++ b/.github/workflows/update-aggregator.yml
@@ -53,12 +53,11 @@ jobs:
 
             # Tests
               - [ ] Please check the API updates for any breaking changes that affect our code.
-              
               Breaking changes are:
-              * New mandatory fields
-              * Removing or renaming fields
-              * Changing the type of a field
-              * Adding new variants
+                * New mandatory fields
+                * Removing or renaming fields
+                * Changing the type of a field
+                * Adding new variants
       - name: Report on the action
         # Since the this is a scheduled job, a failure won't be shown on any
         # PR status. To notify the team, we send a message to our Slack channel on failure.

--- a/.github/workflows/update-aggregator.yml
+++ b/.github/workflows/update-aggregator.yml
@@ -3,7 +3,8 @@
 name: Update aggregator candid bindings
 on:
   schedule:
-    - cron: '30 3 * * *'
+    # Check for updates on candid interface for the aggregator every monday at 3:30am.
+    - cron: '30 3 * * MON'
   workflow_dispatch:
   push:
     branches:
@@ -41,10 +42,10 @@ jobs:
           branch: bot-aggregator-update
           branch-suffix: timestamp
           delete-branch: true
-          title: 'Update aggregator'
+          title: 'Update aggregator candid bindings'
           body: |
             # Motivation
-            We would like to parse all the latest SNS data.
+            We would like to parse all the latest SNS data. To do so, we update the candid interfaces for the SNS aggregator.
 
             # Changes
             * Updated the Rust code derived from `.did` files in the aggregator.
@@ -52,6 +53,12 @@ jobs:
 
             # Tests
               - [ ] Please check the API updates for any breaking changes that affect our code.
+              
+              Breaking changes are:
+              * New mandatory fields
+              * Removing or renaming fields
+              * Changing the type of a field
+              * Adding new variants
       - name: Report on the action
         # Since the this is a scheduled job, a failure won't be shown on any
         # PR status. To notify the team, we send a message to our Slack channel on failure.

--- a/.github/workflows/update-aggregator.yml
+++ b/.github/workflows/update-aggregator.yml
@@ -46,6 +46,7 @@ jobs:
           body: |
             # Motivation
             We would like to parse all the latest SNS data. To do so, we update the candid interfaces for the SNS aggregator.
+            Even with no changes, just updating the reference is good practice.
 
             # Changes
             * Updated the Rust code derived from `.did` files in the aggregator.

--- a/.github/workflows/update-aggregator.yml
+++ b/.github/workflows/update-aggregator.yml
@@ -56,7 +56,8 @@ jobs:
               - [ ] Please check the API updates for any breaking changes that affect our code.
               Breaking changes are:
                 * New mandatory fields
-                * Removing or renaming fields
+                * Removing mandatory fields
+                * Renaming fields
                 * Changing the type of a field
                 * Adding new variants
       - name: Report on the action

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -3,8 +3,8 @@
 name: didc Update
 on:
   schedule:
-    # check for new `didc` releases daily at 7:30
-    - cron: '30 7 * * *'
+    # check for new `didc` releases every tuesday at 7:30.
+    - cron: '30 7 * * TUE'
   workflow_dispatch:
 jobs:
   didc-update:

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -59,6 +59,7 @@ jobs:
           body: |
             # Motivation
             A newer version of `didc` is available.
+            Even with no changes, just updating the reference is good practice.
 
             # Changes
             ## Changes made by a bot triggered by ${{ github.actor }}

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -3,8 +3,8 @@
 name: Update IC
 on:
   schedule:
-    # Check for new IC releases daily at 7:30.  Upstream releases about once weekly.
-    - cron: '30 7 * * *'
+    # Check for new IC releases every wednesday at 7:30.
+    - cron: '30 7 * * WED'
   push:
     branches:
       - update-ic-workflow
@@ -103,11 +103,15 @@ jobs:
             - Update the version of `ic` specified in `dfx.json`.
             - Update the NNS candid files to the versions in that commit.
 
-            ## Changes made by a human (delete if inapplicable)
-
             # Tests
             - See CI
             - [ ] Check for breaking changes in the APIs and schedule any required follow-on work.
+
+            Breaking changes are:
+              * New mandatory fields
+              * Removing or renaming fields
+              * Changing the type of a field
+              * Adding new variants
           # Since this is a scheduled job, a failure won't be shown on any
           # PR status. To notify the team, we send a message to our Slack channel on failure.
       - name: Notify Slack on failure

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -97,6 +97,7 @@ jobs:
           body: |
             # Motivation
             A newer release of the internet computer is available.
+            Even with no changes, just updating the reference is good practice.
 
             # Changes
             ## Changes made by a bot triggered by ${{ github.actor }}

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -110,9 +110,10 @@ jobs:
 
             Breaking changes are:
               * New mandatory fields
-              * Removing or renaming fields
-              * Changing the type of a field
-              * Adding new variants
+                * Removing mandatory fields
+                * Renaming fields
+                * Changing the type of a field
+                * Adding new variants
           # Since this is a scheduled job, a failure won't be shown on any
           # PR status. To notify the team, we send a message to our Slack channel on failure.
       - name: Notify Slack on failure

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -53,6 +53,7 @@ jobs:
           body: |
             # Motivation
             We would like to render all the latest proposal types.
+            Even with no changes, just updating the reference is good practice.
 
             # Changes
             * Updated the Rust code derived from `.did` files in the proposals payload rendering crate.

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -3,7 +3,8 @@
 name: Update proposals
 on:
   schedule:
-    - cron: '30 3 * * *'
+    # Check for updates on candid interface for the proposals every thursday at 3:30am.
+    - cron: '30 3 * * THU'
   workflow_dispatch:
   push:
     branches:
@@ -46,7 +47,7 @@ jobs:
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: rs/proposals/src/canisters/*/api.rs
           delete-branch: true
-          title: 'Update proposal rendering'
+          title: 'Update proposal rendering dependencies'
           # Note: It is _likely_ but not guaranteed that the .did files match the `IC_COMMIT` in `dfx.json`.  The files in the PR have a header that give this information reliably.
           #       We do _not_ put a commit in the PR title as it could be misleading.
           body: |
@@ -60,6 +61,12 @@ jobs:
             # Tests
               - [ ] Please check the API updates for any breaking changes that affect our code.
               - [ ] Please check for new proposal types and add tests for them.
+
+            Breaking changes are:
+              * New mandatory fields
+              * Removing or renaming fields
+              * Changing the type of a field
+              * Adding new variants
           # Since the this is a scheduled job, a failure won't be shown on any
           # PR status. To notify the team, we send a message to our Slack channel on failure.
       - name: Report on the action

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -65,9 +65,10 @@ jobs:
 
             Breaking changes are:
               * New mandatory fields
-              * Removing or renaming fields
-              * Changing the type of a field
-              * Adding new variants
+                * Removing mandatory fields
+                * Renaming fields
+                * Changing the type of a field
+                * Adding new variants
           # Since the this is a scheduled job, a failure won't be shown on any
           # PR status. To notify the team, we send a message to our Slack channel on failure.
       - name: Report on the action

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -48,6 +48,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Frequencey of updaet workflows moved to weekly instead of daily.
+
 #### Deprecated
 
 #### Removed

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -48,7 +48,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
-* Frequencey of updaet workflows moved to weekly instead of daily.
+* Frequency of update workflows moved to weekly instead of daily.
 
 #### Deprecated
 


### PR DESCRIPTION
# Motivation

Managing dependencies should not overwhelm the team with PRs.

In this PR, I moved the workflows to a weekly frequency.

# Changes

* Move update-aggregator workflow to every monday and improve PR title and description.
* Move update-didc workflow to every tuesday.
* Move update-ic workflow to every wednesday and improve PR description.
* Move update-proposals workflow to every thursday and improve PR title and description.

# Tests

I pushed one branch to trigger one of the changed workflows to test that it still run successfully: https://github.com/dfinity/nns-dapp/actions/runs/7709246969

# Todos

- [x] Add entry to changelog (if necessary).