### PR TITLE
GIX-2140: Read logo from metadata

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,7 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Close button at the bottom of follow neurons modal.
 * Info tooltips in neuron details.
-* Use logo for token (if present) for ICRC (but non-SNS) tokens.
+* Use logo for token (if present) for `ICRC` (but non-`SNS`) tokens.
 
 #### Changed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Close button at the bottom of follow neurons modal.
 * Info tooltips in neuron details.
+* Use logo for token (if present) for ICRC (but non-SNS) tokens.
 
 #### Changed
 

--- a/frontend/src/lib/derived/icrc-universes.derived.ts
+++ b/frontend/src/lib/derived/icrc-universes.derived.ts
@@ -22,12 +22,12 @@ const convertIcrcCanistersToUniverse = ({
   tokensData: TokensStoreData;
 }): Universe | undefined => {
   const universeId = canisters.ledgerCanisterId.toText();
-  const token = tokensData[universeId];
-  if (isNullish(token)) {
+  const tokenData = tokensData[universeId];
+  if (isNullish(tokenData)) {
     return;
   }
   const logo =
-    token.token.logo ??
+    tokenData.token.logo ??
     (universeId === CKETH_UNIVERSE_CANISTER_ID.toText()
       ? CKETH_LOGO
       : universeId === CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText()
@@ -35,7 +35,7 @@ const convertIcrcCanistersToUniverse = ({
       : UNKNOWN_LOGO);
   return {
     canisterId: universeId,
-    title: token.token.name,
+    title: tokenData.token.name,
     logo,
   };
 };

--- a/frontend/src/lib/derived/icrc-universes.derived.ts
+++ b/frontend/src/lib/derived/icrc-universes.derived.ts
@@ -26,13 +26,13 @@ const convertIcrcCanistersToUniverse = ({
   if (isNullish(token)) {
     return;
   }
-  // TODO: Read logo from token https://dfinity.atlassian.net/browse/GIX-2140
   const logo =
-    universeId === CKETH_UNIVERSE_CANISTER_ID.toText()
+    token.token.logo ??
+    (universeId === CKETH_UNIVERSE_CANISTER_ID.toText()
       ? CKETH_LOGO
       : universeId === CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText()
       ? CKSEPOLIAETH_LOGO
-      : UNKNOWN_LOGO;
+      : UNKNOWN_LOGO);
   return {
     canisterId: universeId,
     title: token.token.name,

--- a/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
@@ -86,9 +86,7 @@ describe("icrcTokensUniversesStore", () => {
     ]);
   });
 
-  // TODO: https://dfinity.atlassian.net/browse/GIX-2140
-  it("returns question mark logo for  non-cketh universes", () => {
-    // For not it's because the logo is not yet parsed in the token.
+  it("returns question mark logo if logo not present in token and it's not a ckBTC nor ckETH canister", () => {
     const ledgerCanisterId = principal(1);
     tokensStore.setTokens({
       [ledgerCanisterId.toText()]: {
@@ -103,6 +101,29 @@ describe("icrcTokensUniversesStore", () => {
     expect(get(icrcTokensUniversesStore)).toMatchObject([
       {
         logo: "/src/lib/assets/question-mark.svg",
+      },
+    ]);
+  });
+
+  it("returns question mark logo if logo not present in token", () => {
+    const ledgerCanisterId = principal(1);
+    const logo = "data:image/svg+xml;base64,PHN2ZyB3...";
+    tokensStore.setTokens({
+      [ledgerCanisterId.toText()]: {
+        certified: true,
+        token: {
+          ...mockToken,
+          logo,
+        },
+      },
+    });
+    icrcCanistersStore.setCanisters({
+      ledgerCanisterId: ledgerCanisterId,
+      indexCanisterId: principal(2),
+    });
+    expect(get(icrcTokensUniversesStore)).toMatchObject([
+      {
+        logo,
       },
     ]);
   });

--- a/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icrc-universes.derived.spec.ts
@@ -105,7 +105,7 @@ describe("icrcTokensUniversesStore", () => {
     ]);
   });
 
-  it("returns question mark logo if logo not present in token", () => {
+  it("returns logo from the token", () => {
     const ledgerCanisterId = principal(1);
     const logo = "data:image/svg+xml;base64,PHN2ZyB3...";
     tokensStore.setTokens({


### PR DESCRIPTION
# Motivation

Logo of the universe is read from the ledger metadata for added ICRC canisters.

# Changes

* Use the `logo` field in the token if present in `icrcTokensUniversesStore`.

# Tests

* Change one test description for unknown logo and add a new test when logo is present in the token.
* I tested by adding a new ICRC canister (which was an SNS) in the console.

# Todos

- [x] Add entry to changelog (if necessary).

