### PR TITLE
Rename state save/restore

### DIFF
--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -59,7 +59,7 @@ fn pre_upgrade() {
         stats::gibibytes(stats::wasm_memory_size_bytes())
     );
     STATE.with(|s| {
-        s.pre_upgrade();
+        s.save();
     });
     println!(
         "pre_upgrade instruction_counter after saving state: {} stable_memory_size_gib: {} wasm_memory_size_gib: {}",
@@ -76,7 +76,7 @@ fn post_upgrade(args: Option<CanisterArguments>) {
     // as the storage is about to be wiped out and replaced with stable memory.
     let counter_before = PerformanceCount::new("post_upgrade start");
     STATE.with(|s| {
-        s.replace(State::post_upgrade());
+        s.replace(State::restore());
     });
     perf::save_instruction_count(counter_before);
     perf::record_instruction_count("post_upgrade after state_recovery");

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -83,7 +83,7 @@ impl State {
         SchemaLabel::try_from(&schema_label_bytes[..]).ok()
     }
 
-    /// Create the state from stable memory in the `post_upgrade()` hook.
+    /// Creates the state from stable memory in the `post_upgrade()` hook.
     ///
     /// Note: The stable memory may have been created by any of these schemas:
     /// - The previous schema, when first migrating from the previous schema to the current schema.
@@ -94,30 +94,30 @@ impl State {
     /// - Deploy a release with a parser for the new schema.
     /// - Then, deploy a release that writes the new schema.
     /// This way it is possible to roll back after deploying the new schema.
-    pub fn post_upgrade() -> Self {
+    pub fn restore() -> Self {
         match Self::schema_version_from_stable_memory() {
-            None => Self::post_upgrade_unversioned(),
+            None => Self::restore_unversioned(),
             Some(version) => {
                 trap_with(&format!("Unknown schema version: {version:?}"));
                 unreachable!();
             }
         }
     }
-    /// Save any unsaved state to stable memory.
-    pub fn pre_upgrade(&self) {
-        self.pre_upgrade_unversioned()
+    /// Saves any unsaved state to stable memory.
+    pub fn save(&self) {
+        self.save_unversioned()
     }
 }
 
 // The unversioned schema.
 impl State {
-    /// Save any unsaved state to stable memory.
-    fn pre_upgrade_unversioned(&self) {
+    /// Saves any unsaved state to stable memory.
+    fn save_unversioned(&self) {
         let bytes = self.encode();
         stable::set(&bytes);
     }
-    /// Create the state from stable memory in the `post_upgrade()` hook.
-    fn post_upgrade_unversioned() -> Self {
+    /// Creates the state from stable memory in the `post_upgrade()` hook.
+    fn restore_unversioned() -> Self {
         let bytes = stable::get();
         State::decode(bytes).unwrap_or_else(|e| {
             trap_with(&format!("Decoding stable memory failed. Error: {e:?}"));


### PR DESCRIPTION
# Motivation
State currently has pre_upgrade and post_upgrade methods.  These currently just save and restore state, but the names invite other code.  Renaming the methods to save and restore is more accurate and discourage adding other hook code here.

# Changes
- Rename the methods used to save and restore state from stable memory.

# Tests
- Existing tests should suffice; there is no change in functionality.

# Todos

- [ ] Add entry to changelog (if necessary).
