### PR TITLE
GIX-2189: Use ReceiveModalPo in ReceiveModal.spec

### DIFF
--- a/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
+++ b/frontend/src/lib/components/accounts/SelectAccountDropdown.svelte
@@ -9,6 +9,7 @@
   import type { Principal } from "@dfinity/principal";
   import { universesAccountsStore } from "$lib/derived/universes-accounts.derived";
   import { isNullish } from "@dfinity/utils";
+  import TestIdWrapper from "../common/TestIdWrapper.svelte";
 
   export let selectedAccount: Account | undefined = undefined;
   export let rootCanisterId: Principal;
@@ -50,23 +51,25 @@
     })();
 </script>
 
-{#if selectableAccounts.length === 0}
-  <div class="select">
-    <Spinner size="small" inline />
-  </div>
-{:else}
-  <Dropdown
-    name="account"
-    bind:selectedValue={selectedAccountIdentifier}
-    testId="select-account-dropdown"
-  >
-    {#each selectableAccounts as { identifier, name } (identifier)}
-      <DropdownItem value={identifier}
-        >{name ?? $i18n.accounts.main}</DropdownItem
-      >
-    {/each}
-  </Dropdown>
-{/if}
+<TestIdWrapper testId="select-account-dropdown-component">
+  {#if selectableAccounts.length === 0}
+    <div class="select">
+      <Spinner size="small" inline />
+    </div>
+  {:else}
+    <Dropdown
+      name="account"
+      bind:selectedValue={selectedAccountIdentifier}
+      testId="select-account-dropdown"
+    >
+      {#each selectableAccounts as { identifier, name } (identifier)}
+        <DropdownItem value={identifier}
+          >{name ?? $i18n.accounts.main}</DropdownItem
+        >
+      {/each}
+    </Dropdown>
+  {/if}
+</TestIdWrapper>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/form";

--- a/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
@@ -41,22 +41,17 @@ describe("ReceiveModal", () => {
         canSelectAccount,
       },
     });
-    return {
-      po: ReceiveModalPo.under(new JestPageObjectElement(container)),
-      getByTestId,
-      getByText,
-      container,
-    };
+    return ReceiveModalPo.under(new JestPageObjectElement(container));
   };
 
   it("should render a QR code", async () => {
-    const { po } = await renderReceiveModal({});
+    const po = await renderReceiveModal({});
 
     expect(await po.hasQrCode()).toBe(true);
   });
 
   it("should render account identifier (without being shortened)", async () => {
-    const { po } = await renderReceiveModal({
+    const po = await renderReceiveModal({
       account: mockMainAccount,
     });
 
@@ -64,13 +59,13 @@ describe("ReceiveModal", () => {
   });
 
   it("should render a logo", async () => {
-    const { po } = await renderReceiveModal({});
+    const po = await renderReceiveModal({});
 
     expect(await po.getLogoAltText()).toBe(logoArialLabel);
   });
 
   it("should reload account", async () => {
-    const { po } = await renderReceiveModal({});
+    const po = await renderReceiveModal({});
 
     await po.clickFinish();
 
@@ -84,7 +79,7 @@ describe("ReceiveModal", () => {
       hardwareWallets: undefined,
     });
 
-    const { po } = await renderReceiveModal({
+    const po = await renderReceiveModal({
       canSelectAccount: true,
     });
 
@@ -98,7 +93,7 @@ describe("ReceiveModal", () => {
       hardwareWallets: undefined,
     });
 
-    const { po } = await renderReceiveModal({
+    const po = await renderReceiveModal({
       canSelectAccount: true,
       account: undefined,
     });

--- a/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
@@ -7,27 +7,29 @@ import {
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
-import { fireEvent, waitFor } from "@testing-library/svelte";
+import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 
 describe("ReceiveModal", () => {
   const reloadSpy = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
+    icpAccountsStore.resetForTesting();
   });
 
   const qrCodeLabel = "test QR code";
   const logo = "logo";
   const logoArialLabel = "logo aria-label";
 
-  const renderReceiveModal = ({
+  const renderReceiveModal = async ({
     canSelectAccount = false,
     account = mockMainAccount,
   }: {
     canSelectAccount?: boolean;
     account?: Account;
-  }) =>
-    renderModal({
+  }) => {
+    const { container, getByTestId, getByText } = await renderModal({
       component: ReceiveModal,
       props: {
         account,
@@ -39,35 +41,40 @@ describe("ReceiveModal", () => {
         canSelectAccount,
       },
     });
+    return {
+      po: ReceiveModalPo.under(new JestPageObjectElement(container)),
+      getByTestId,
+      getByText,
+      container,
+    };
+  };
 
   it("should render a QR code", async () => {
-    const { getByTestId } = await renderReceiveModal({});
+    const { po } = await renderReceiveModal({});
 
-    expect(getByTestId("qr-code")).toBeInTheDocument();
+    expect(await po.hasQrCode()).toBe(true);
   });
 
   it("should render account identifier (without being shortened)", async () => {
-    const { getByText } = await renderReceiveModal({});
+    const { po } = await renderReceiveModal({
+      account: mockMainAccount,
+    });
 
-    await waitFor(() =>
-      expect(getByText(mockMainAccount.identifier)).toBeInTheDocument()
-    );
+    expect(await po.getAddress()).toBe(mockMainAccount.identifier);
   });
 
   it("should render a logo", async () => {
-    const { getByTestId } = await renderReceiveModal({});
+    const { po } = await renderReceiveModal({});
 
-    await waitFor(() =>
-      expect(getByTestId("logo").getAttribute("alt")).toEqual(logoArialLabel)
-    );
+    expect(await po.getLogoAltText()).toBe(logoArialLabel);
   });
 
   it("should reload account", async () => {
-    const { getByTestId } = await renderReceiveModal({});
+    const { po } = await renderReceiveModal({});
 
-    fireEvent.click(getByTestId("reload-receive-account") as HTMLButtonElement);
+    await po.clickFinish();
 
-    await waitFor(() => expect(reloadSpy).toHaveBeenCalled());
+    expect(reloadSpy).toHaveBeenCalled();
   });
 
   it("should render a dropdown to select account", async () => {
@@ -77,13 +84,11 @@ describe("ReceiveModal", () => {
       hardwareWallets: undefined,
     });
 
-    const { getByTestId } = await renderReceiveModal({
+    const { po } = await renderReceiveModal({
       canSelectAccount: true,
     });
 
-    await waitFor(() =>
-      expect(getByTestId("select-account-dropdown")).toBeInTheDocument()
-    );
+    expect(await po.getDropdownAccounts().isPresent()).toBe(true);
   });
 
   it("should select account", async () => {
@@ -93,32 +98,16 @@ describe("ReceiveModal", () => {
       hardwareWallets: undefined,
     });
 
-    const { getByTestId, container } = await renderReceiveModal({
+    const { po } = await renderReceiveModal({
       canSelectAccount: true,
       account: undefined,
     });
 
-    await waitFor(() =>
-      expect(getByTestId("select-account-dropdown")).toBeInTheDocument()
-    );
+    // Main account is selected by default
+    expect(await po.getAddress()).toBe(mockMainAccount.identifier);
 
-    const selectElement = container.querySelector("select");
-    selectElement &&
-      expect(selectElement.value).toBe(mockMainAccount.identifier);
+    await po.select(mockSubAccount.identifier);
 
-    expect(getByTestId("qrcode-display-address")?.textContent).toEqual(
-      mockMainAccount.identifier
-    );
-
-    selectElement &&
-      fireEvent.change(selectElement, {
-        target: { value: mockSubAccount.identifier },
-      });
-
-    await waitFor(() =>
-      expect(getByTestId("qrcode-display-address")?.textContent).toEqual(
-        mockSubAccount.identifier
-      )
-    );
+    expect(await po.getAddress()).toBe(mockSubAccount.identifier);
   });
 });

--- a/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
@@ -29,7 +29,7 @@ describe("ReceiveModal", () => {
     canSelectAccount?: boolean;
     account?: Account;
   }) => {
-    const { container, getByTestId, getByText } = await renderModal({
+    const { container } = await renderModal({
       component: ReceiveModal,
       props: {
         account,

--- a/frontend/src/tests/page-objects/ReceiveModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ReceiveModal.page-object.ts
@@ -1,5 +1,6 @@
 import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { SelectAccountDropdownPo } from "./SelectAccountDropdown.page-object";
 
 export class ReceiveModalPo extends ModalPo {
   private static readonly TID = "receive-modal";
@@ -16,6 +17,10 @@ export class ReceiveModalPo extends ModalPo {
     return this.waitFor("qr-code");
   }
 
+  hasQrCode(): Promise<boolean> {
+    return this.isPresent("qr-code");
+  }
+
   async getLogoAltText(): Promise<string> {
     return this.root.byTestId("logo").getAttribute("alt");
   }
@@ -26,5 +31,13 @@ export class ReceiveModalPo extends ModalPo {
 
   getAddress(): Promise<string> {
     return this.getText("qrcode-display-address");
+  }
+
+  getDropdownAccounts() {
+    return SelectAccountDropdownPo.under(this.root);
+  }
+
+  select(accountIdentifier: string) {
+    return this.getDropdownAccounts().select(accountIdentifier);
   }
 }

--- a/frontend/src/tests/page-objects/SelectAccountDropdown.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectAccountDropdown.page-object.ts
@@ -1,0 +1,21 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { DropdownPo } from "./Dropdown.page-object";
+
+export class SelectAccountDropdownPo extends BasePageObject {
+  private static readonly TID = "select-account-dropdown-component";
+
+  static under(element: PageObjectElement): SelectAccountDropdownPo {
+    return new SelectAccountDropdownPo(
+      element.byTestId(SelectAccountDropdownPo.TID)
+    );
+  }
+
+  getDropdown() {
+    return DropdownPo.under(this.root);
+  }
+
+  select(option: string): Promise<void> {
+    return this.getDropdown().select(option);
+  }
+}


### PR DESCRIPTION
# Motivation

Add the token symbol at the title of the ReceiveModal.

In this PR, I move the ReceiveModal.spec to use page objects.

# Changes

* Add TestIdWrapper to SelectAccountDropdown.svelte

# Tests

* New PO SelectAccountDropdownPo
* Add method to ReceiveModalPo
* Move ReceiveModal.spec to use the ReceiveModalPo.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
