### PR TITLE
Bump ic-js after release

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.1.0-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.1.0-next-2024-01-29.tgz",
-      "integrity": "sha512-pCcHS5zsql2F+6z7J4M3SVMh7eW0CavHOFT+l+E6YIkREZrYOHks0qVhQuaWR6Lf+dgPgUm/v3Txk8CXJTJr8A==",
+      "version": "2.1.1-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.1.1-next-2024-01-30.tgz",
+      "integrity": "sha512-HYPHwDjHdzgCSQriFkPXhW0HnfotUDNAdywar9ULG5g2Ztv65mxLM4aoZzu7TdjSMUieAZgqenWn3W83qtiZhA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "2.1.0-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-2.1.0-next-2024-01-29.tgz",
-      "integrity": "sha512-UhVADboJVLUNNICf5nVLHKdQUz2JpWeyUHoGKoW39U6nZtAhKW5WmxCqaDgMmUYT0K1hbQeS7EQIdhwqgc8wuQ==",
+      "version": "3.0.0-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.0-next-2024-01-30.tgz",
+      "integrity": "sha512-ZXmtboEEvf9qOM0Vb2KlQoRQ9PkZVsxZS/dBuXnprvOSfzsPePGp9CmN7wTy4DtsRXIarrXCaCiYfsMogv1vbA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "2.1.0-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.1.0-next-2024-01-29.tgz",
-      "integrity": "sha512-lFgqcpy9aCYtL3/BaThjaL3p9qWY2UjGFqgy/5o32OiPTw3Ln2MpCzMmkY/B82h/Nmnz9Ts0zMwenN/op8cI4A==",
+      "version": "2.2.0-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.2.0-next-2024-01-30.tgz",
+      "integrity": "sha512-TbaRTMk68YLZE5w3z6QcTFtAWMTpKp7zvTWC4eB4YUAXmc8SNL6oQEOs0MG9wWt6M5KbK/JEFzU1BDpQYHdBvg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.1.1-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.1.1-next-2024-01-29.tgz",
-      "integrity": "sha512-VaNthzVjr2jGkuUyWeXWra8yk1Mj4sL4q2OinK/kVMz7I30PgN2liaPLU9P5cQnCdpV36tqeeG5sHVDTqn1i3w==",
+      "version": "2.1.2-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.1.2-next-2024-01-30.tgz",
+      "integrity": "sha512-oWqKDmHSJYqtQazoRPcf74ULJ5eAacInN/iEC94swOdO7lGmkvmRHeOacFEqnF+STIm7fHxRKyHFEBUknNZF/A==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.1.0-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.0-next-2024-01-29.tgz",
-      "integrity": "sha512-fT41S4iZeK2eSlDnDgX3Jw1uJLTEblTSgyzWqp2WNvFzFqEqXsFm/jabjWoQoKorVO+snqR0GiovDA7arBDLdQ==",
+      "version": "2.1.1-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.1-next-2024-01-30.tgz",
+      "integrity": "sha512-/XLzITm0rC8tXwHikO3lqVSnwJCW5itC4smzkUxy6Ta1xw3wTETIbfScViA+qkCZdWKW0VCn608FQAPMJKIqyQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "3.1.0-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.1.0-next-2024-01-29.tgz",
-      "integrity": "sha512-Aj74NV4J0Dbnv+JXrK4b/MoyuoEW2XPY6rvuHEPx7leORaZdqlXbnHVWRnO6dYpfmVgIyFZrQ1ZGe767wARJ1A==",
+      "version": "3.1.1-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.1.1-next-2024-01-30.tgz",
+      "integrity": "sha512-BDKSfpvrhpd32a+4nmPHAEVvUDVLA74O0tRADn3RtzUiFCn7J2kdkBDxvDMwfYwNGRRjuTsT5HbQbswA0qnvvw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -358,9 +358,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.0-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2024-01-29.tgz",
-      "integrity": "sha512-AmwgyjgBm0C9ulQyh34Us2bCLkaBm9zq4IYpJVmGCxwP94jk7II/z6EWE1wdyj2D2y57hHhsh0FevQ0P6vVt2A==",
+      "version": "1.0.1-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-01-30.tgz",
+      "integrity": "sha512-F4JiAM5m7gm0pLZXy4WE3ZWUpbFNqrTj23wxiJ5L5imyfIqZgjtyLn4kiJSCLKRWk8xCf1aVH62JcmKC/8VCpg==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "2.1.0-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.0-next-2024-01-29.tgz",
-      "integrity": "sha512-uv8gcRQb19VBozpn2xGdisQiqKw9WZgIj3vR+Xn0nCFLkAHjRT0zg7FyyusHl590qDcF8ZgKVOHEURxbZMlx2Q==",
+      "version": "2.1.1-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.1-next-2024-01-30.tgz",
+      "integrity": "sha512-HzwaxQxWzLPO0lFKME5akT5fJ96XTav1VCRao9G6cO1zqQ5UU6mWOfV/o4rpmw74/z7/Oc8wUyMQSnXG7y2k8w==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.0.0-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.0.0-next-2024-01-29.tgz",
-      "integrity": "sha512-AzSbx7pWs0+3gRX6DJvVsTk3B2wWpKa8Mily6X7v28X1mP4kGm3HmnOgbMAWPhV26CFLHprTnR25qlXUcbaTmQ==",
+      "version": "2.1.0-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.0-next-2024-01-30.tgz",
+      "integrity": "sha512-VUxOw2h7AZrWQh5peacohdH5Wk9DqZuA8P/JIPB2ALMMEwI3CWCy6FldbOF3R3L8K5Cc38Cwk2FfF0wVEsa1Gg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7047,9 +7047,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.1.0-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.1.0-next-2024-01-29.tgz",
-      "integrity": "sha512-pCcHS5zsql2F+6z7J4M3SVMh7eW0CavHOFT+l+E6YIkREZrYOHks0qVhQuaWR6Lf+dgPgUm/v3Txk8CXJTJr8A==",
+      "version": "2.1.1-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.1.1-next-2024-01-30.tgz",
+      "integrity": "sha512-HYPHwDjHdzgCSQriFkPXhW0HnfotUDNAdywar9ULG5g2Ztv65mxLM4aoZzu7TdjSMUieAZgqenWn3W83qtiZhA==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7057,9 +7057,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "2.1.0-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-2.1.0-next-2024-01-29.tgz",
-      "integrity": "sha512-UhVADboJVLUNNICf5nVLHKdQUz2JpWeyUHoGKoW39U6nZtAhKW5WmxCqaDgMmUYT0K1hbQeS7EQIdhwqgc8wuQ==",
+      "version": "3.0.0-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.0-next-2024-01-30.tgz",
+      "integrity": "sha512-ZXmtboEEvf9qOM0Vb2KlQoRQ9PkZVsxZS/dBuXnprvOSfzsPePGp9CmN7wTy4DtsRXIarrXCaCiYfsMogv1vbA==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7073,9 +7073,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "2.1.0-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.1.0-next-2024-01-29.tgz",
-      "integrity": "sha512-lFgqcpy9aCYtL3/BaThjaL3p9qWY2UjGFqgy/5o32OiPTw3Ln2MpCzMmkY/B82h/Nmnz9Ts0zMwenN/op8cI4A==",
+      "version": "2.2.0-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.2.0-next-2024-01-30.tgz",
+      "integrity": "sha512-TbaRTMk68YLZE5w3z6QcTFtAWMTpKp7zvTWC4eB4YUAXmc8SNL6oQEOs0MG9wWt6M5KbK/JEFzU1BDpQYHdBvg==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7089,30 +7089,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.1.1-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.1.1-next-2024-01-29.tgz",
-      "integrity": "sha512-VaNthzVjr2jGkuUyWeXWra8yk1Mj4sL4q2OinK/kVMz7I30PgN2liaPLU9P5cQnCdpV36tqeeG5sHVDTqn1i3w==",
+      "version": "2.1.2-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.1.2-next-2024-01-30.tgz",
+      "integrity": "sha512-oWqKDmHSJYqtQazoRPcf74ULJ5eAacInN/iEC94swOdO7lGmkvmRHeOacFEqnF+STIm7fHxRKyHFEBUknNZF/A==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.1.0-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.0-next-2024-01-29.tgz",
-      "integrity": "sha512-fT41S4iZeK2eSlDnDgX3Jw1uJLTEblTSgyzWqp2WNvFzFqEqXsFm/jabjWoQoKorVO+snqR0GiovDA7arBDLdQ==",
+      "version": "2.1.1-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.1-next-2024-01-30.tgz",
+      "integrity": "sha512-/XLzITm0rC8tXwHikO3lqVSnwJCW5itC4smzkUxy6Ta1xw3wTETIbfScViA+qkCZdWKW0VCn608FQAPMJKIqyQ==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "3.1.0-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.1.0-next-2024-01-29.tgz",
-      "integrity": "sha512-Aj74NV4J0Dbnv+JXrK4b/MoyuoEW2XPY6rvuHEPx7leORaZdqlXbnHVWRnO6dYpfmVgIyFZrQ1ZGe767wARJ1A==",
+      "version": "3.1.1-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.1.1-next-2024-01-30.tgz",
+      "integrity": "sha512-BDKSfpvrhpd32a+4nmPHAEVvUDVLA74O0tRADn3RtzUiFCn7J2kdkBDxvDMwfYwNGRRjuTsT5HbQbswA0qnvvw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.0-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.0-next-2024-01-29.tgz",
-      "integrity": "sha512-AmwgyjgBm0C9ulQyh34Us2bCLkaBm9zq4IYpJVmGCxwP94jk7II/z6EWE1wdyj2D2y57hHhsh0FevQ0P6vVt2A==",
+      "version": "1.0.1-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-01-30.tgz",
+      "integrity": "sha512-F4JiAM5m7gm0pLZXy4WE3ZWUpbFNqrTj23wxiJ5L5imyfIqZgjtyLn4kiJSCLKRWk8xCf1aVH62JcmKC/8VCpg==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7126,17 +7126,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "2.1.0-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.0-next-2024-01-29.tgz",
-      "integrity": "sha512-uv8gcRQb19VBozpn2xGdisQiqKw9WZgIj3vR+Xn0nCFLkAHjRT0zg7FyyusHl590qDcF8ZgKVOHEURxbZMlx2Q==",
+      "version": "2.1.1-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.1-next-2024-01-30.tgz",
+      "integrity": "sha512-HzwaxQxWzLPO0lFKME5akT5fJ96XTav1VCRao9G6cO1zqQ5UU6mWOfV/o4rpmw74/z7/Oc8wUyMQSnXG7y2k8w==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.0.0-next-2024-01-29",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.0.0-next-2024-01-29.tgz",
-      "integrity": "sha512-AzSbx7pWs0+3gRX6DJvVsTk3B2wWpKa8Mily6X7v28X1mP4kGm3HmnOgbMAWPhV26CFLHprTnR25qlXUcbaTmQ==",
+      "version": "2.1.0-next-2024-01-30",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.0-next-2024-01-30.tgz",
+      "integrity": "sha512-VUxOw2h7AZrWQh5peacohdH5Wk9DqZuA8P/JIPB2ALMMEwI3CWCy6FldbOF3R3L8K5Cc38Cwk2FfF0wVEsa1Gg==",
       "requires": {}
     },
     "@esbuild/android-arm": {


### PR DESCRIPTION
# Motivation

Ic-js has been released (see [2024.01.30-1600Z](https://github.com/dfinity/ic-js/releases/tag/2024.01.30-1600Z)). This PR propagates the new version number and last changes ("candid query keyword certified fix") to NNS dapp using a next version (that has also been published).
