### PR TITLE
chore: Bump setup-node

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,7 @@ jobs:
         run: jq -r '"CARGO_SORT_VERSION=\(.defaults.build.config.CARGO_SORT_VERSION)"' dfx.json >> $GITHUB_ENV
       - name: Get node version
         run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install shfmt
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Get node version
         run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install dependencies
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Get node version
         run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install dependencies
@@ -261,7 +261,7 @@ jobs:
         run: sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
       - name: Get node version
         run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Bumping the package versions works

--- a/.github/workflows/reproducible-assets.yaml
+++ b/.github/workflows/reproducible-assets.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Get node version
         run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Get dfx version

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -51,6 +51,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Frequency of update workflows moved to weekly instead of daily.
+* Update GitHub actions to newer versions.
 
 #### Deprecated
 


### PR DESCRIPTION
# Motivation
GitHub CI is issuing warnings for actions that use Node v16:
![Screenshot from 2024-01-30 17-46-41](https://github.com/dfinity/nns-dapp/assets/5982633/aba348be-4cc5-4afb-bc70-d771c32967f8)

Note: When these were all updated, CI failed, so these are updated individually.

# Changes
* Bump the `setup-node` GitHub action to more recent versions.

# Tests
See CI.  There should be no more warnings about old node from this action.  There are expected to be warnings from other actions.

# Todos

- [x] Add entry to changelog (if necessary).
