### PR TITLE
chore: Bump checkout

### DIFF
--- a/.github/actions/checkout_snsdemo/action.yaml
+++ b/.github/actions/checkout_snsdemo/action.yaml
@@ -63,7 +63,7 @@ runs:
         fi
     - name: Get snsdemo
       if: ${{ steps.have_snsdemo.outputs.have_snsdemo == 'false' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: 'dfinity/snsdemo'
         path: '${{ inputs.path }}'

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -51,7 +51,7 @@ runs:
         test -n "$URL" || URL="https://github.com/dfinity/snsdemo/releases/download/${{ steps.snsdemo_ref.outputs.ref }}/snsdemo_snapshot_ubuntu-22.04.tar.xz"
         echo "url=$URL" >> "$GITHUB_OUTPUT"
     - name: Get SNS scripts
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: 'dfinity/snsdemo'
         path: 'snsdemo'

--- a/.github/actions/test-e2e/action.yml
+++ b/.github/actions/test-e2e/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout nns-dapp
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Get nns-dapp
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout nns-dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Skip build for testing
         # Set to true and set a recent `run_id` below to reuse an existing build
         # instead of building.
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout nns-dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Playwright e2e test shard 1/2
         uses: ./.github/actions/test-e2e
         with:
@@ -92,7 +92,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout nns-dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Playwright e2e test shard 2/2
         uses: ./.github/actions/test-e2e
         with:
@@ -104,7 +104,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout nns-dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get nns-dapp_test
         uses: actions/download-artifact@v3
         with:
@@ -124,7 +124,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout nns-dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get nns-dapp_test
         uses: actions/download-artifact@v3
         with:
@@ -157,7 +157,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout nns-dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get nns-dapp_test
         uses: actions/download-artifact@v3
         with:
@@ -177,7 +177,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout nns-dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get nns-dapp
         uses: actions/download-artifact@v3
         with:
@@ -258,7 +258,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout nns-dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Check dockerfile for changes
@@ -323,7 +323,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout nns-dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get sns_aggregator_dev
         uses: actions/download-artifact@v3
         with:
@@ -427,7 +427,7 @@ jobs:
     needs: build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get docker build outputs
         uses: actions/download-artifact@v3
         with:
@@ -498,7 +498,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success
         with:
           needs: '${{ toJson(needs) }}'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,7 @@ jobs:
       DFX_NETWORK: mainnet
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get cargo sort version
         run: jq -r '"CARGO_SORT_VERSION=\(.defaults.build.config.CARGO_SORT_VERSION)"' dfx.json >> $GITHUB_ENV
       - name: Get node version
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install spellcheck
         run: |
           cd /
@@ -58,7 +58,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: |
@@ -85,7 +85,7 @@ jobs:
       DFX_NETWORK: mainnet
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get node version
         run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
       - uses: actions/setup-node@v3
@@ -106,7 +106,7 @@ jobs:
       DFX_NETWORK: mainnet
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get node version
         run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
       - uses: actions/setup-node@v3
@@ -122,7 +122,7 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run ShellCheck
         run: |
           sudo apt-get update
@@ -132,7 +132,7 @@ jobs:
     name: IC Commit
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install didc
         run: |
           USER_BIN="$HOME/.local/bin"
@@ -156,7 +156,7 @@ jobs:
     name: Release template
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install didc
@@ -188,7 +188,7 @@ jobs:
     name: Config is as expected
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install dfx
         run: DFX_VERSION="$(jq -r .dfx dfx.json)" sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
       - name: Install cargo binstall
@@ -202,14 +202,14 @@ jobs:
     name: Asset chunking works
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test chunking
         run: scripts/nns-dapp/split-assets.test
   migration-test-utils-work:
     name: Migration test utilities work
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install cargo binstall
         uses: ./.github/actions/install_binstall
       - name: Install idl2json
@@ -226,7 +226,7 @@ jobs:
     name: Can get NNS proposal args
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install didc
         run: |
           USER_BIN="$HOME/.local/bin"
@@ -248,13 +248,13 @@ jobs:
   docker-build-cli-flags:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: docker-build prints help
         run: ./scripts/docker-build --help | grep -i usage
   minor-version-bump-works:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install yq
         run: sudo snap install yq
       - name: Install sponge
@@ -289,7 +289,7 @@ jobs:
         os: [ubuntu-20.04, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install bash and sha256sum if on Mac
         run: |
           if command -v brew ; then
@@ -310,7 +310,7 @@ jobs:
         os: [ubuntu-20.04, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install bash if on Mac
         run: |
           if command -v brew ; then
@@ -325,7 +325,7 @@ jobs:
         os: [ubuntu-20.04, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install bash if on Mac
         run: |
           if command -v brew ; then
@@ -340,7 +340,7 @@ jobs:
         os: [ubuntu-20.04, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install bash if on Mac
         run: |
           if command -v brew ; then
@@ -351,7 +351,7 @@ jobs:
     name: The nns-dapp npm and cargo versions should match
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Backend and frontend have the same version
         run: |
           backend_version="$(cargo metadata | jq -r '.packages[] | select(.name == "nns-dapp").version')"
@@ -365,7 +365,7 @@ jobs:
   network-config:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install sponge
         run: sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
       - name: Getting network config works
@@ -394,7 +394,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success
         with:
           needs: '${{ toJson(needs) }}'

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -39,7 +39,7 @@ jobs:
       DFX_NETWORK: app
     steps:
       - name: Checkout nns-dapp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         # TODO: This builds, it doesn't use a release.  We probably want at least the option of using releases.
       - name: Get versions
         id: tool_versions

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -23,7 +23,7 @@ jobs:
   builder:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # We use `buildx` and its GitHub Actions caching support `type=gha`. For
       # more information, see
       # https://github.com/docker/build-push-action/issues/539

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Preflight checks
         id: preflight
         run: |
@@ -53,7 +53,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success
         with:
           needs: '${{ toJson(needs) }}'

--- a/.github/workflows/reproducible-assets.yaml
+++ b/.github/workflows/reproducible-assets.yaml
@@ -36,7 +36,7 @@ jobs:
                   ;;
           esac
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get node version
         run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
       - uses: actions/setup-node@v3

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: docker-practice/actions-setup-docker@master
         timeout-minutes: 12
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Helps with debugging
       - name: Show versions
         run: |

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.pull_request.merged
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Tag main as tip
         run: |
           git tag -f tip

--- a/.github/workflows/update-aggregator.yml
+++ b/.github/workflows/update-aggregator.yml
@@ -14,7 +14,7 @@ jobs:
   update-aggregator:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install didc
         run: |
           USER_BIN="$HOME/.local/bin"

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -10,7 +10,7 @@ jobs:
   didc-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # First, check `didc` releases (on the candid repo) for a new version.
       - name: Check new didc version
         id: update

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -17,7 +17,7 @@ jobs:
   update-ic:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Find newer ic release, if any
         id: update
         run: |
@@ -53,7 +53,7 @@ jobs:
           echo "ref=$SNSDEMO_RELEASE" >> "$GITHUB_OUTPUT"
       - name: Get SNS scripts
         if: ${{ steps.have_snsdemo.outputs.have_snsdemo }} == 'false'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'dfinity/snsdemo'
           path: 'snsdemo'

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -14,7 +14,7 @@ jobs:
   update-proposals:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install didc
         run: |
           USER_BIN="$HOME/.local/bin"

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -14,7 +14,7 @@ jobs:
   rust-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # First, check rust GitHub releases for a new version. We assume that the
         # latest version's tag name is the version.
       - name: Install yq

--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -14,7 +14,7 @@ jobs:
   update-snsdemo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Update to match the snsdemo repo
         id: update
         run: |
@@ -32,7 +32,7 @@ jobs:
             fi
           } >> "$GITHUB_OUTPUT"
       - name: Get snsdemo repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: ${{ steps.update.outputs.updated == '1' }}
         with:
           repository: 'dfinity/snsdemo'


### PR DESCRIPTION
# Motivation
GitHub is emitting warnings for actions based on node16.  `checkout` is one of the affected actions.

# Changes
* Update the version of the checkout action used in CI.

# Tests
See CI.  There should be no warnings caused by the checkout action.

# Todos

- [ ] Add entry to changelog (if necessary).
  - Covered by a generic entry about updating GitHub actions.
