### PR TITLE
chore: Update setup-buildx-action

### DIFF
--- a/.github/actions/build_nns_dapp/action.yaml
+++ b/.github/actions/build_nns_dapp/action.yaml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up docker buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     - name: Create global config
       shell: bash
       run: echo "{}" > global-config.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,7 +270,7 @@ jobs:
           fi
       - name: Set up docker buildx
         if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Create a blank global config
         run: echo "{}" > global-config.json
       - name: Build wasms

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -28,7 +28,7 @@ jobs:
       # more information, see
       # https://github.com/docker/build-push-action/issues/539
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Provide empty global config
         run: echo '{}' > global-config.json
       - name: Build docker artifacts


### PR DESCRIPTION
# Motivation
GitHub is emitting warnings for actions based on node16.

# Changes
* Update `setup-buildx-action` to the latest version.

# Tests
CI should have no errors about nodejs from this action.

# Todos

- [ ] Add entry to changelog (if necessary).
