### PR TITLE
GIX-2189: Add token to ReceiveModal title

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Close button at the bottom of follow neurons modal.
 * Info tooltips in neuron details.
 * Use logo for token (if present) for `ICRC` (but non-`SNS`) tokens.
+* Add the token symbol in the receive modal.
 
 #### Changed
 

--- a/frontend/src/lib/components/accounts/CkBTCReceiveButton.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCReceiveButton.svelte
@@ -43,5 +43,5 @@
   class="secondary"
   disabled={disableButton}
   on:click={openReceive}
-  data-tid="receive-ckbtc">{$i18n.ckbtc.receive}</button
+  data-tid="receive-ckbtc">{$i18n.core.receive}</button
 >

--- a/frontend/src/lib/components/accounts/ReceiveButton.svelte
+++ b/frontend/src/lib/components/accounts/ReceiveButton.svelte
@@ -33,5 +33,5 @@
   class="secondary"
   on:click={openModal}
   disabled={$busy}
-  data-tid={testId}>{$i18n.ckbtc.receive}</button
+  data-tid={testId}>{$i18n.core.receive}</button
 >

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -32,6 +32,8 @@
     "finish": "Finish",
     "unknown": "Unknown",
     "expand_all": "Expand All",
+    "receive_with_token": "Receive $token",
+    "receive": "Receive",
     "collapse_all": "Collapse All"
   },
   "error": {
@@ -1005,7 +1007,6 @@
     "test_title": "ckTESTBTC",
     "logo": "Chain-key Bitcoin (ckBTC) logo",
     "test_logo": "Chain-key Bitcoin (ckTESTBTC) logo",
-    "receive": "Receive",
     "qrcode_aria_label_bitcoin": "A QR code that renders the address to receive Bitcoin",
     "qrcode_aria_label_ckBTC": "A QR code that renders the address to receive ckBTC",
     "bitcoin": "Bitcoin",

--- a/frontend/src/lib/modals/accounts/CkBTCReceiveModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCReceiveModal.svelte
@@ -120,7 +120,7 @@
 </script>
 
 <Modal testId="ckbtc-receive-modal" on:nnsClose on:introend={onIntroEnd}>
-  <span slot="title">{$i18n.ckbtc.receive}</span>
+  <span slot="title">{$i18n.core.receive}</span>
 
   <div class="receive">
     <Segment bind:selectedSegmentId bind:this={segment}>

--- a/frontend/src/lib/modals/accounts/IcrcReceiveModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcReceiveModal.svelte
@@ -32,6 +32,7 @@
     {reload}
     {universeId}
     {canSelectAccount}
+    {tokenSymbol}
   >
     <svelte:fragment slot="address-label"
       >{replacePlaceholders($i18n.wallet.token_address, {

--- a/frontend/src/lib/modals/accounts/NnsReceiveModal.svelte
+++ b/frontend/src/lib/modals/accounts/NnsReceiveModal.svelte
@@ -6,6 +6,7 @@
   import IC_LOGO from "$lib/assets/icp.svg";
   import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { ICPToken } from "@dfinity/utils";
 
   export let data: AccountsReceiveModalData;
 
@@ -25,6 +26,7 @@
   {reload}
   universeId={OWN_CANISTER_ID}
   {canSelectAccount}
+  tokenSymbol={ICPToken.symbol}
 >
   <svelte:fragment slot="address-label"
     >{replacePlaceholders($i18n.wallet.token_address, {

--- a/frontend/src/lib/modals/accounts/ReceiveModal.svelte
+++ b/frontend/src/lib/modals/accounts/ReceiveModal.svelte
@@ -8,6 +8,7 @@
   import { QR_CODE_RENDERED_DEFAULT_STATE } from "$lib/constants/mockable.constants";
   import type { UniverseCanisterId } from "$lib/types/universe";
   import ReceiveSelectAccountDropdown from "$lib/components/accounts/ReceiveSelectAccountDropdown.svelte";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
 
   export let universeId: UniverseCanisterId;
   export let account: Account | undefined;
@@ -16,6 +17,7 @@
   export let logoArialLabel: string;
   export let reload: (() => Promise<void>) | undefined;
   export let canSelectAccount: boolean;
+  export let tokenSymbol: string;
 
   let qrCodeRendered = QR_CODE_RENDERED_DEFAULT_STATE;
 
@@ -38,7 +40,11 @@
 </script>
 
 <Modal testId="receive-modal" on:nnsClose on:introend={onIntroEnd}>
-  <span slot="title">{$i18n.ckbtc.receive}</span>
+  <span slot="title"
+    >{replacePlaceholders($i18n.core.receive_with_token, {
+      $token: tokenSymbol,
+    })}</span
+  >
 
   <ReceiveSelectAccountDropdown
     {account}

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -35,6 +35,8 @@ interface I18nCore {
   finish: string;
   unknown: string;
   expand_all: string;
+  receive_with_token: string;
+  receive: string;
   collapse_all: string;
 }
 
@@ -1054,7 +1056,6 @@ interface I18nCkbtc {
   test_title: string;
   logo: string;
   test_logo: string;
-  receive: string;
   qrcode_aria_label_bitcoin: string;
   qrcode_aria_label_ckBTC: string;
   bitcoin: string;

--- a/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
@@ -21,6 +21,7 @@ describe("ReceiveModal", () => {
   const qrCodeLabel = "test QR code";
   const logo = "logo";
   const logoArialLabel = "logo aria-label";
+  const tokenSymbol = "TST";
 
   const renderReceiveModal = async ({
     canSelectAccount = false,
@@ -39,6 +40,7 @@ describe("ReceiveModal", () => {
         reload: reloadSpy,
         universeId: OWN_CANISTER_ID,
         canSelectAccount,
+        tokenSymbol,
       },
     });
     return ReceiveModalPo.under(new JestPageObjectElement(container));
@@ -48,6 +50,12 @@ describe("ReceiveModal", () => {
     const po = await renderReceiveModal({});
 
     expect(await po.hasQrCode()).toBe(true);
+  });
+
+  it("should render token symbol in title", async () => {
+    const po = await renderReceiveModal({});
+
+    expect(await po.getModalTitle()).toBe(`Receive ${tokenSymbol}`);
   });
 
   it("should render account identifier (without being shortened)", async () => {


### PR DESCRIPTION
# Motivation

Help the user understand the context of the transaction.

In this PR, we add the token symbol in the ReceiveModal.

It's missing adding it in the CkBTReveiveModal which will come in ahoter PR.

# Changes

* Change the i18n key "receive" from "ckBTC" to `"core"`and add `receive_with_token` for the modal title.
* Change `ckBTC.receive` to `core.receive_with_token` in the ReceiveModal and to `core.receive` everywhere else.
* Add `tokenSymbol` as prop in ReceiveModal.
* Pass the new prop to ReceiveModal in IcrcReceiveModal and NnsReceiveModal

# Tests

* Add a test in ReceiveModal.spec.

# Todos

- [x] Add entry to changelog (if necessary).
