### PR TITLE
Chore: Remove duplicated button styles

### DIFF
--- a/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
@@ -62,10 +62,3 @@
     </Footer>
   {/if}
 </TestIdWrapper>
-
-<style lang="scss">
-  @use "../../themes/mixins/button";
-  button {
-    @include button.with-icon;
-  }
-</style>

--- a/frontend/src/lib/modals/accounts/BuyIcpModal.svelte
+++ b/frontend/src/lib/modals/accounts/BuyIcpModal.svelte
@@ -66,7 +66,6 @@
 </Modal>
 
 <style lang="scss">
-  @use "../../themes/mixins/button";
   .content {
     display: flex;
     flex-direction: column;
@@ -79,38 +78,5 @@
 
     padding: var(--padding-2x);
     border-radius: var(--border-radius);
-  }
-
-  a.button {
-    box-sizing: border-box;
-
-    padding: var(--padding) var(--padding-2x);
-
-    border-radius: var(--border-radius);
-    border-top: 1px solid transparent;
-    border-bottom: 1px solid transparent;
-
-    position: relative;
-    min-height: var(--button-min-height);
-
-    font-weight: var(--font-weight-bold);
-    text-decoration: none;
-
-    &.primary {
-      background: var(--primary);
-      color: var(--primary-contrast);
-
-      &:hover,
-      &:focus {
-        background: var(--primary-shade);
-      }
-    }
-    &.full-width {
-      width: 100%;
-    }
-
-    &.with-icon {
-      @include button.with-icon;
-    }
   }
 </style>

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -137,7 +137,6 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/interaction";
-  @use "../themes/mixins/button";
 
   .add-account-row {
     @include interaction.tappable;

--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -157,9 +157,5 @@
     &:hover {
       background-color: var(--table-row-background-hover);
     }
-
-    & button.with-icon {
-      @include button.with-icon;
-    }
   }
 </style>

--- a/frontend/src/lib/themes/mixins/_button.scss
+++ b/frontend/src/lib/themes/mixins/_button.scss
@@ -1,7 +1,0 @@
-// TODO: Move to gix-components https://dfinity.atlassian.net/browse/GIX-2108
-@mixin with-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--padding-0_5x);
-}


### PR DESCRIPTION
# Motivation

Remove unnecessary CSS. CSS to style a link like a button was added in the gix-components.

In this PR, remove the duplicated styles in NNS Dapp.

# Changes

* Remove mixin button.scss
* Remove CSS to use the button mixin
* Remove CSS to style an anchor tag like a button in BuyICPModal

The classes used are the same that were implemented in gix-components. Therefore, there is no need to change them.

# Tests

I checked that all looked the same as before.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
