### PR TITLE
chore: Bump GitHub cache action from v3 to v4

### DIFF
--- a/.github/actions/install_ic_wasm/action.yaml
+++ b/.github/actions/install_ic_wasm/action.yaml
@@ -12,7 +12,7 @@ runs:
         echo "IC_WASM_PATH=/home/runner/.cargo/bin/ic-wasm" >> "$GITHUB_OUTPUT"
     - name: Cache ic-wasm
       id: cache-ic-wasm
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.ic-wasm-version.outputs.IC_WASM_PATH }}
         key: ${{ runner.os }}-${{ steps.ic-wasm-version.outputs.IC_WASM_VERSION }}-ic-wasm

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -59,7 +59,7 @@ jobs:
         os: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
# Motivation
GitHub actions using node v 16 are deprecated:
![Screenshot from 2024-01-31 11-30-32](https://github.com/dfinity/nns-dapp/assets/5982633/71f63fa7-aeff-4ed6-943e-2b8b231166f9)

# Changes
* Update GitHub cache version from v3 to v4

# Tests
- See CI

# Todos

- [ ] Add entry to changelog (if necessary).
  - Covered by an existing changelog entry for updating GitHub actions.
