### PR TITLE
chore: Bump up/download-artifact

### DIFF
--- a/.github/actions/test-e2e/action.yml
+++ b/.github/actions/test-e2e/action.yml
@@ -20,11 +20,11 @@ runs:
     - name: Checkout nns-dapp
       uses: actions/checkout@v4
     - name: Get nns-dapp
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: nns-dapp
     - name: Get sns_aggregator_dev
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: sns_aggregator_dev
     - name: Start snapshot environment

--- a/.github/actions/test-e2e/action.yml
+++ b/.github/actions/test-e2e/action.yml
@@ -60,7 +60,7 @@ runs:
       run: |
         find frontend/playwright-*
     - name: Upload Playwright results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
         name: playwright-failure-results
@@ -79,7 +79,7 @@ runs:
         fi
     - name: Upload screenshots
       if: ${{ steps.check-screenshots.outputs.screenshots }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: updated-screenshots
         path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,31 +45,31 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Upload nns-dapp wasm module'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nns-dapp
           path: out/nns-dapp.wasm.gz
           retention-days: 3
       - name: 'Upload nns-dapp test wasm module'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nns-dapp_test
           path: out/nns-dapp_test.wasm.gz
           retention-days: 3
       - name: 'Upload sns_aggregator wasm module'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sns_aggregator
           path: out/sns_aggregator.wasm.gz
           retention-days: 3
       - name: 'Upload sns_aggregator_dev wasm module'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sns_aggregator_dev
           path: out/sns_aggregator_dev.wasm.gz
           retention-days: 3
       - name: 'Upload whole out directory'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: out
           path: out
@@ -147,7 +147,7 @@ jobs:
         run: ./scripts/nns-dapp/migration-test --schema1 Map --schema2 Map --accounts 10000
       - name: Upload dfx logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-upgrade-map-dfx.log
           path: test-upgrade-map-dfx.log
@@ -438,7 +438,7 @@ jobs:
       - name: 'Record the git commit and any tags'
         run: git log | head -n1 > out/commit.txt
       - name: 'Upload ${{ matrix.BUILD_NAME }} nns-dapp wasm module'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nns-dapp for ${{ matrix.BUILD_NAME }}
           path: |
@@ -449,7 +449,7 @@ jobs:
             out/frontend-config.sh
             out/deployment-config.json
       - name: 'Upload sns_aggregator wasm module'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sns_aggregator for ${{ matrix.BUILD_NAME }}
           path: |
@@ -461,7 +461,7 @@ jobs:
           assets_dir: 'out'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Upload frontend assets'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: NNS frontend assets
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Checkout nns-dapp
         uses: actions/checkout@v4
       - name: Get nns-dapp_test
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nns-dapp_test
       - name: Start snapshot environment
@@ -126,7 +126,7 @@ jobs:
       - name: Checkout nns-dapp
         uses: actions/checkout@v4
       - name: Get nns-dapp_test
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: out
           path: out
@@ -159,7 +159,7 @@ jobs:
       - name: Checkout nns-dapp
         uses: actions/checkout@v4
       - name: Get nns-dapp_test
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nns-dapp_test
       - name: Start empty nns-dapp
@@ -179,15 +179,15 @@ jobs:
       - name: Checkout nns-dapp
         uses: actions/checkout@v4
       - name: Get nns-dapp
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nns-dapp
       - name: Get sns_aggregator
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sns_aggregator
       - name: Get sns_aggregator_dev
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sns_aggregator_dev
       - name: Start snapshot environment
@@ -287,19 +287,19 @@ jobs:
           outputs: ./out-mainnet
       - name: Get nns-dapp
         if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nns-dapp
           path: out-local
       - name: Get sns_aggregator
         if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sns_aggregator
           path: out-local
       - name: Get sns_aggregator_dev
         if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sns_aggregator_dev
           path: out-local
@@ -325,7 +325,7 @@ jobs:
       - name: Checkout nns-dapp
         uses: actions/checkout@v4
       - name: Get sns_aggregator_dev
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sns_aggregator_dev
       - name: Start snapshot environment
@@ -429,7 +429,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Get docker build outputs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: out
           path: out

--- a/.github/workflows/reproducible-assets.yaml
+++ b/.github/workflows/reproducible-assets.yaml
@@ -86,8 +86,8 @@ jobs:
       - name: 'Upload hashes'
         uses: actions/upload-artifact@v4
         with:
-          name: hashes
-          path: hashes/*.txt
+          name: "hashes_${{ matrix.os }}_${{ matrix.time }}"
+          path: "hashes/assets_sha256_${{ matrix.os }}_${{ matrix.time }}.txt"
   compare_hashes:
     runs-on: ubuntu-latest
     needs: [native_asset_build]
@@ -96,7 +96,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: hashes
-          path: hashes
+          pattern: hashes_*
       - name: Print hashes
         run: |
           echo Hashes:

--- a/.github/workflows/reproducible-assets.yaml
+++ b/.github/workflows/reproducible-assets.yaml
@@ -92,11 +92,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: [native_asset_build]
     steps:
+      - name: Merge Hashes
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: hashes
+          pattern: hashes_*
+      - name: Merge Builds
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: builds
+          pattern: build_*
       - name: Get hashes
         uses: actions/download-artifact@v4
         with:
           name: hashes
-          pattern: hashes_*
+          path: hashes
       - name: Print hashes
         run: |
           echo Hashes:

--- a/.github/workflows/reproducible-assets.yaml
+++ b/.github/workflows/reproducible-assets.yaml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: builds
+          name: "build_${{ matrix.os }}_${{ matrix.time }}"
           path: builds/*.tar.xz
           retention-days: 1
       - name: 'Output the hash'

--- a/.github/workflows/reproducible-assets.yaml
+++ b/.github/workflows/reproducible-assets.yaml
@@ -93,7 +93,7 @@ jobs:
     needs: [native_asset_build]
     steps:
       - name: Get hashes
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: hashes
           path: hashes

--- a/.github/workflows/reproducible-assets.yaml
+++ b/.github/workflows/reproducible-assets.yaml
@@ -73,7 +73,7 @@ jobs:
           cp assets.tar.xz "builds/assets_${{ matrix.os }}_${{ matrix.time }}.tar.xz"
           cp sourcemaps.tar.xz "builds/sourcemaps_${{ matrix.os }}_${{ matrix.time }}.tar.xz"
       - name: 'Upload assets'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: builds
@@ -84,7 +84,7 @@ jobs:
           mkdir -p hashes
           sha256sum assets.tar.xz > "hashes/assets_sha256_${{ matrix.os }}_${{ matrix.time }}.txt"
       - name: 'Upload hashes'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: hashes
           path: hashes/*.txt

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -42,13 +42,13 @@ jobs:
       - name: Build
         run: ./scripts/docker-build
       - name: 'Upload nns-dapp wasm module'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nns-dapp-mainnet-wasm-${{ matrix.os }}
           path: nns-dapp.wasm.gz
           retention-days: 3
       - name: 'Upload assets'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nns-dapp-assets-${{ matrix.os }}
           path: assets.tar.xz
@@ -61,7 +61,7 @@ jobs:
         run: |
           sha256sum assets.tar.xz > "hashes/assets_sha256_${{ matrix.os }}_${{ matrix.time }}.txt"
       - name: 'Upload hashes'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: hashes
           path: hashes/*.txt

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -70,7 +70,7 @@ jobs:
     needs: [docker_build]
     steps:
       - name: Get hashes
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: hashes
           path: hashes


### PR DESCRIPTION
# Motivation
GitHub actions using node v16 are deprecated.  `download-artifact` is a case in point:
![Screenshot from 2024-01-31 11-41-26](https://github.com/dfinity/nns-dapp/assets/5982633/0115b935-c060-429c-af38-45aa0205ed2a)

# Changes
* Update `upload-artifact` and `download-artifact` to version 4.
  Note: This is breaking change and requires a couple of small adjustments.  Please see the release notes here: https://github.com/actions/download-artifact/releases/tag/v4.0.0

# Tests
* CI should contain no Nodejs warnings about this particular action.

# Todos

- [x] Add entry to changelog (if necessary).
  - Covered by an existing changelog entry