### PR TITLE
Chore: Use SelectAccountDropdownPo

### DIFF
--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -128,7 +128,7 @@ describe("NnsStakeNeuronModal", () => {
           .getNnsStakeNeuronPo()
           .getTransactionFromAccountPo()
           .getSelectAccountDropdownPo()
-          .isPresent()
+          .hasDropdown()
       ).toBe(true);
     });
 

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -127,7 +127,7 @@ describe("NnsStakeNeuronModal", () => {
         await po
           .getNnsStakeNeuronPo()
           .getTransactionFromAccountPo()
-          .getDropdownPo()
+          .getSelectAccountDropdownPo()
           .isPresent()
       ).toBe(true);
     });
@@ -423,8 +423,8 @@ describe("NnsStakeNeuronModal", () => {
         await po
           .getNnsStakeNeuronPo()
           .getTransactionFromAccountPo()
-          .getDropdownPo()
-          .isPresent()
+          .getSelectAccountDropdownPo()
+          .hasDropdown()
       ).toBe(false);
 
       resolveQueryAccount();
@@ -434,8 +434,8 @@ describe("NnsStakeNeuronModal", () => {
         await po
           .getNnsStakeNeuronPo()
           .getTransactionFromAccountPo()
-          .getDropdownPo()
-          .isPresent()
+          .getSelectAccountDropdownPo()
+          .hasDropdown()
       ).toBe(true);
     });
   });

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -304,12 +304,16 @@ describe("ParticipateSwapModal", () => {
         .getTransactionFromAccountPo();
 
       await runResolvedPromises();
-      expect(await fromAccount.getDropdownPo().isPresent()).toBe(false);
+      expect(await fromAccount.getSelectAccountDropdownPo().hasDropdown()).toBe(
+        false
+      );
 
       resolveQueryAccounts(mockAccountDetails);
 
       await runResolvedPromises();
-      expect(await fromAccount.getDropdownPo().isPresent()).toBe(true);
+      expect(await fromAccount.getSelectAccountDropdownPo().hasDropdown()).toBe(
+        true
+      );
     });
 
     const expectSpyCalledWithQueryOnly = ({

--- a/frontend/src/tests/page-objects/SelectAccountDropdown.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectAccountDropdown.page-object.ts
@@ -22,4 +22,8 @@ export class SelectAccountDropdownPo extends BasePageObject {
   getOptions(): Promise<string[]> {
     return this.getDropdown().getOptions();
   }
+
+  hasDropdown(): Promise<boolean> {
+    return this.getDropdown().isPresent();
+  }
 }

--- a/frontend/src/tests/page-objects/SelectAccountDropdown.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectAccountDropdown.page-object.ts
@@ -18,4 +18,8 @@ export class SelectAccountDropdownPo extends BasePageObject {
   select(option: string): Promise<void> {
     return this.getDropdown().select(option);
   }
+
+  getOptions(): Promise<string[]> {
+    return this.getDropdown().getOptions();
+  }
 }

--- a/frontend/src/tests/page-objects/TransactionFromAccount.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionFromAccount.page-object.ts
@@ -1,6 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
-import { DropdownPo } from "$tests/page-objects/Dropdown.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { SelectAccountDropdownPo } from "./SelectAccountDropdown.page-object";
 
 export class TransactionFromAccountPo extends BasePageObject {
   private static readonly TID = "transaction-from-account";
@@ -11,8 +11,8 @@ export class TransactionFromAccountPo extends BasePageObject {
     );
   }
 
-  getDropdownPo(): DropdownPo {
-    return DropdownPo.under(this.root);
+  getDropdownPo(): SelectAccountDropdownPo {
+    return SelectAccountDropdownPo.under(this.root);
   }
 
   async selectAccount(accountName: string): Promise<void> {

--- a/frontend/src/tests/page-objects/TransactionFromAccount.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionFromAccount.page-object.ts
@@ -11,15 +11,15 @@ export class TransactionFromAccountPo extends BasePageObject {
     );
   }
 
-  getDropdownPo(): SelectAccountDropdownPo {
+  getSelectAccountDropdownPo(): SelectAccountDropdownPo {
     return SelectAccountDropdownPo.under(this.root);
   }
 
   async selectAccount(accountName: string): Promise<void> {
-    await this.getDropdownPo().select(accountName);
+    await this.getSelectAccountDropdownPo().select(accountName);
   }
 
   getAccounts(): Promise<string[]> {
-    return this.getDropdownPo().getOptions();
+    return this.getSelectAccountDropdownPo().getOptions();
   }
 }


### PR DESCRIPTION
# Motivation

Be consistent. Use the SelectAccountDropdownPo instead of the DropdownPo directly.

# Changes

* Add methods to SelectAccountDropdownPo.
* TransactionFromAccountPo uses SelectAccountDropdownPo instead of DropdownPo directly. Change method names.
* Change the tests using TransactionFromAccountPo's dropdown.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
