### PR TITLE
GIX-2189: Add token to CkBTCReceiveModal

### DIFF
--- a/frontend/src/lib/modals/accounts/CkBTCReceiveModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCReceiveModal.svelte
@@ -120,7 +120,11 @@
 </script>
 
 <Modal testId="ckbtc-receive-modal" on:nnsClose on:introend={onIntroEnd}>
-  <span slot="title">{$i18n.core.receive}</span>
+  <span slot="title"
+    >{replacePlaceholders($i18n.core.receive_with_token, {
+      $token: tokenLabel,
+    })}</span
+  >
 
   <div class="receive">
     <Segment bind:selectedSegmentId bind:this={segment}>

--- a/frontend/src/tests/lib/modals/accounts/CkBTCReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCReceiveModal.spec.ts
@@ -133,6 +133,16 @@ describe("BtcCkBTCReceiveModal", () => {
         expect(getByText(mockBTCAddressTestnet)).toBeInTheDocument();
       });
 
+      it("should render Bitcoin label in title", async () => {
+        const { container, getByTestId } = await renderReceiveModal({
+          universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        });
+
+        await selectSegmentBTC(container);
+
+        expect(getByTestId("modal-title").textContent).toBe("Receive Bitcoin");
+      });
+
       it("should render a KYT fee", async () => {
         const { getByTestId, container } = await renderReceiveModal({});
 
@@ -292,6 +302,14 @@ describe("BtcCkBTCReceiveModal", () => {
       });
 
       await waitFor(() => expect(getByText(title)).toBeInTheDocument());
+    });
+
+    it("should render ckBTC label in title", async () => {
+      const { getByTestId } = await renderReceiveModal({
+        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+      });
+
+      expect(getByTestId("modal-title").textContent).toBe("Receive ckBTC");
     });
 
     it("should reload account", async () => {


### PR DESCRIPTION
# Motivation

Help the user understand the context of the transaction.

In this PR, we add the token symbol in the CkBTCReceiveModal.

# Changes

* Use `i18n.core.receive_with_token` as title for CkBTCReceiveModal with the token label.

# Tests

* Add two tests to check that the selected token label is added in the modal's title.

# Todos

- [ ] Add entry to changelog (if necessary).

Already added in another PR.