### PR TITLE
Feat: Add fee to sendICP and stakeNeuron

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -20,6 +20,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Use logo for token (if present) for `ICRC` (but non-`SNS`) tokens.
 * Filtering SNS Proposals by type.
 * Add the token symbol in the receive modal.
+* Add fee as mandatory when making ICP transactions.
 
 #### Changed
 

--- a/frontend/src/lib/api/canisters.api.ts
+++ b/frontend/src/lib/api/canisters.api.ts
@@ -211,11 +211,13 @@ export const createCanister = async ({
   amount,
   name,
   fromSubAccount,
+  fee,
 }: {
   identity: Identity;
   amount: bigint;
   name?: string;
   fromSubAccount?: SubAccountArray;
+  fee: bigint;
 }): Promise<Principal> => {
   logWithTimestamp("Create canister call...");
 
@@ -247,6 +249,7 @@ export const createCanister = async ({
     amount,
     fromSubAccount,
     createdAt,
+    fee,
   });
 
   // If this fails or the client loses connection, nns dapp backend polls the transactions
@@ -313,11 +316,13 @@ export const topUpCanister = async ({
   canisterId,
   amount,
   fromSubAccount,
+  fee,
 }: {
   identity: Identity;
   canisterId: Principal;
   amount: bigint;
   fromSubAccount?: SubAccountArray;
+  fee: bigint;
 }): Promise<void> => {
   logWithTimestamp(`Topping up canister ${canisterId.toText()} call...`);
 
@@ -335,6 +340,7 @@ export const topUpCanister = async ({
     to: recipient.toHex(),
     fromSubAccount,
     createdAt,
+    fee,
   });
 
   // If this fails or the client loses connection

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -389,6 +389,7 @@ export type ApiStakeNeuronParams = ApiCallParams & {
   controller: Principal;
   ledgerCanisterIdentity: Identity;
   fromSubAccount?: SubAccountArray;
+  fee: bigint;
 };
 
 /**
@@ -400,6 +401,7 @@ export const stakeNeuron = async ({
   ledgerCanisterIdentity,
   identity,
   fromSubAccount,
+  fee,
 }: ApiStakeNeuronParams): Promise<NeuronId> => {
   logWithTimestamp(`Staking Neuron call...`);
   const { canister } = await governanceCanister({ identity });
@@ -416,6 +418,7 @@ export const stakeNeuron = async ({
     fromSubAccount,
     ledgerCanister,
     createdAt,
+    fee,
   });
   logWithTimestamp(`Staking Neuron complete.`);
   return response;

--- a/frontend/src/lib/api/icp-ledger.api.ts
+++ b/frontend/src/lib/api/icp-ledger.api.ts
@@ -30,6 +30,7 @@ export const sendICP = async ({
   fromSubAccount,
   memo,
   createdAt,
+  fee,
 }: {
   identity: Identity;
   to: string;
@@ -37,6 +38,7 @@ export const sendICP = async ({
   fromSubAccount?: SubAccountArray | undefined;
   memo?: bigint;
   createdAt?: bigint;
+  fee: bigint;
 }): Promise<BlockHeight> => {
   logWithTimestamp(`Sending icp call...`);
   const { canister } = await ledgerCanister({ identity });
@@ -47,6 +49,7 @@ export const sendICP = async ({
     fromSubAccount,
     memo,
     createdAt: createdAt ?? nowInBigIntNanoSeconds(),
+    fee,
   });
   logWithTimestamp(`Sending icp complete.`);
   return response;

--- a/frontend/src/lib/services/canisters.services.ts
+++ b/frontend/src/lib/services/canisters.services.ts
@@ -15,6 +15,7 @@ import type {
 } from "$lib/canisters/ic-management/ic-management.canister.types";
 import type { CanisterDetails as CanisterInfo } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
+import { mainTransactionFeeE8sStore } from "$lib/derived/main-transaction-fee.derived";
 import { canistersStore } from "$lib/stores/canisters.store";
 import { toastsError, toastsShow } from "$lib/stores/toasts.store";
 import type { Account } from "$lib/types/account";
@@ -28,6 +29,7 @@ import {
 } from "$lib/utils/error.utils";
 import type { Principal } from "@dfinity/principal";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
+import { get } from "svelte/store";
 import { getAuthenticatedIdentity } from "./auth.services";
 import { getAccountIdentity, loadBalance } from "./icp-accounts.services";
 import { queryAndUpdate } from "./utils.services";
@@ -82,11 +84,13 @@ export const createCanister = async ({
     assertEnoughAccountFunds({ amountUlps: icpAmount.toUlps(), account });
 
     const identity = await getAccountIdentity(account.identifier);
+    const fee = get(mainTransactionFeeE8sStore);
     const canisterId = await createCanisterApi({
       identity,
       amount: icpAmount.toUlps(),
       fromSubAccount: account.subAccount,
       name,
+      fee,
     });
     await listCanisters({ clearBeforeQuery: false });
     // We don't wait for `loadBalance` to finish to give a better UX to the user.
@@ -142,11 +146,13 @@ export const topUpCanister = async ({
     assertEnoughAccountFunds({ amountUlps: icpAmount.toUlps(), account });
 
     const identity = await getAccountIdentity(account.identifier);
+    const fee = get(mainTransactionFeeE8sStore);
     await topUpCanisterApi({
       identity,
       canisterId,
       amount: icpAmount.toUlps(),
       fromSubAccount: account.subAccount,
+      fee,
     });
     // We don't wait for `loadBalance` to finish to give a better UX to the user.
     // update calls might be slow.

--- a/frontend/src/lib/services/icp-accounts.services.ts
+++ b/frontend/src/lib/services/icp-accounts.services.ts
@@ -329,6 +329,7 @@ export const transferICP = async ({
           to,
           fromSubAccount: subAccount,
           amount: tokenAmount.toE8s(),
+          fee: feeE8s,
         }));
 
     // Transfer can be to one of the user's account.

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -212,6 +212,7 @@ export const stakeNeuron = async ({
     }
     const { ledgerCanisterIdentity, controller, fromSubAccount, identity } =
       getStakeNeuronPropsByAccount({ account, accountIdentity });
+    const fee = get(mainTransactionFeeE8sStore);
 
     const newNeuronId = await governanceApiService.stakeNeuron({
       stake,
@@ -219,6 +220,7 @@ export const stakeNeuron = async ({
       ledgerCanisterIdentity,
       controller,
       fromSubAccount,
+      fee,
     });
 
     if (loadNeuron) {

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -640,6 +640,7 @@ const pollTransfer = ({
   fromSubAccount,
   memo,
   createdAt,
+  fee,
 }: {
   identity: Identity;
   to: string;
@@ -647,6 +648,7 @@ const pollTransfer = ({
   fromSubAccount?: SubAccountArray | undefined;
   memo?: bigint;
   createdAt?: bigint;
+  fee: bigint;
 }) =>
   poll({
     fn: (): Promise<BlockHeight> =>
@@ -657,6 +659,7 @@ const pollTransfer = ({
         fromSubAccount,
         createdAt,
         memo,
+        fee,
       }),
     // Should still just retry in case of TxCreatedInFutureError
     // (this error should be gone in a couple of seconds)
@@ -730,6 +733,7 @@ export const participateInSnsSale = async ({
       swapCanisterId,
       controller,
     });
+    const fee = get(mainTransactionFeeE8sStore);
 
     logWithTimestamp("[sale] 1. transfer (time,id):", creationTime, ticketId);
 
@@ -744,6 +748,7 @@ export const participateInSnsSale = async ({
       createdAt: creationTime,
       memo: ticketId,
       identity,
+      fee,
     });
   } catch (err) {
     console.error("[sale] on transfer", err);

--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -966,6 +966,7 @@ describe("neurons api-service", () => {
       controller: mockPrincipal,
       ledgerCanisterIdentity: mockIdentity,
       fromSubaccount: new Uint8Array(),
+      fee: 10_000n,
     };
 
     it("should call stakeNeuron api", async () => {

--- a/frontend/src/tests/lib/api/canisters.api.spec.ts
+++ b/frontend/src/tests/lib/api/canisters.api.spec.ts
@@ -39,6 +39,7 @@ describe("canisters-api", () => {
   const mockCMCCanister = mock<CMCCanister>();
   const mockICManagementCanister = mock<ICManagementCanister>();
   const mockLedgerCanister = mock<LedgerCanister>();
+  const fee = 10_000n;
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -229,6 +230,7 @@ describe("canisters-api", () => {
       const response = await createCanister({
         identity: mockIdentity,
         amount: 300_000_000n,
+        fee,
       });
       expect(mockLedgerCanister.transfer).toBeCalled();
       expect(mockCMCCanister.notifyCreateCanister).toBeCalled();
@@ -250,6 +252,7 @@ describe("canisters-api", () => {
         identity: mockIdentity,
         amount: 300_000_000n,
         name: longName,
+        fee,
       });
       expect(mockNNSDappCanister.attachCanister).toBeCalledWith({
         name: longName,
@@ -267,6 +270,7 @@ describe("canisters-api", () => {
       const response = await createCanister({
         identity: mockIdentity,
         amount: 300_000_000n,
+        fee,
       });
       expect(mockCMCCanister.notifyCreateCanister).toHaveBeenCalledTimes(2);
       expect(response).toEqual(mockCanisterDetails.id);
@@ -283,6 +287,7 @@ describe("canisters-api", () => {
         identity: mockIdentity,
         amount,
         fromSubAccount: mockSubAccount.subAccount,
+        fee,
       });
       const principal = mockIdentity.getPrincipal();
       const toSubAccount = principalToSubAccount(principal);
@@ -298,6 +303,7 @@ describe("canisters-api", () => {
         amount,
         fromSubAccount: mockSubAccount.subAccount,
         createdAt: nowInBigIntNanoSeconds(),
+        fee,
       });
       expect(mockCMCCanister.notifyCreateCanister).toBeCalled();
       expect(mockNNSDappCanister.attachCanister).toBeCalledWith({
@@ -314,6 +320,7 @@ describe("canisters-api", () => {
         createCanister({
           identity: mockIdentity,
           amount: 300_000_000n,
+          fee,
         });
       expect(call).rejects.toThrow();
       expect(mockCMCCanister.notifyCreateCanister).not.toBeCalled();
@@ -327,6 +334,7 @@ describe("canisters-api", () => {
           identity: mockIdentity,
           amount: 300_000_000n,
           name: longName,
+          fee,
         });
 
       expect(call).rejects.toThrowError(
@@ -355,6 +363,7 @@ describe("canisters-api", () => {
         identity: mockIdentity,
         amount: 300_000_000n,
         canisterId: mockCanisterDetails.id,
+        fee,
       });
       expect(mockLedgerCanister.transfer).toBeCalled();
       expect(mockCMCCanister.notifyTopUp).toBeCalled();
@@ -370,6 +379,7 @@ describe("canisters-api", () => {
         identity: mockIdentity,
         amount: 300_000_000n,
         canisterId: mockCanisterDetails.id,
+        fee,
       });
       expect(mockCMCCanister.notifyTopUp).toHaveBeenCalledTimes(2);
     });
@@ -392,6 +402,7 @@ describe("canisters-api", () => {
         amount,
         canisterId: mockCanisterDetails.id,
         fromSubAccount: mockSubAccount.subAccount,
+        fee,
       });
 
       expect(mockLedgerCanister.transfer).toBeCalledWith({
@@ -400,6 +411,7 @@ describe("canisters-api", () => {
         amount,
         fromSubAccount: mockSubAccount.subAccount,
         createdAt: nowInBigIntNanoSeconds(),
+        fee,
       });
       expect(mockLedgerCanister.transfer).toBeCalled();
       expect(mockCMCCanister.notifyTopUp).toBeCalled();
@@ -413,6 +425,7 @@ describe("canisters-api", () => {
           identity: mockIdentity,
           amount: 300_000_000n,
           canisterId: mockCanisterDetails.id,
+          fee,
         });
       expect(call).rejects.toThrow();
       expect(mockCMCCanister.notifyTopUp).not.toBeCalled();

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -69,6 +69,7 @@ describe("neurons-api", () => {
     const stake = 20_000_000n;
     const controller = mockIdentity.getPrincipal();
     const fromSubAccount = [2, 3, 4];
+    const fee = 10_000n;
 
     await stakeNeuron({
       stake,
@@ -76,6 +77,7 @@ describe("neurons-api", () => {
       ledgerCanisterIdentity: mockIdentity,
       identity: mockIdentity,
       fromSubAccount,
+      fee,
     });
 
     expect(mockGovernanceCanister.stakeNeuron).toBeCalledTimes(1);
@@ -84,6 +86,7 @@ describe("neurons-api", () => {
         stake,
         principal: controller,
         fromSubAccount,
+        fee,
       })
     );
   });

--- a/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-ledger.api.spec.ts
@@ -25,6 +25,7 @@ describe("icp-ledger.api", () => {
 
     const { identifier: accountIdentifier } = mockMainAccount;
     const amount = 11_000n;
+    const fee = 10_000n;
 
     const now = Date.now();
     const nowInBigIntNanoSeconds = BigInt(now) * 1_000_000n;
@@ -46,12 +47,14 @@ describe("icp-ledger.api", () => {
         identity: mockIdentity,
         to: accountIdentifier,
         amount,
+        fee,
       });
 
       expect(spyTransfer).toHaveBeenCalledWith({
         to: AccountIdentifier.fromHex(accountIdentifier),
         amount,
         createdAt: nowInBigIntNanoSeconds,
+        fee,
       });
     });
 
@@ -65,6 +68,7 @@ describe("icp-ledger.api", () => {
         to: accountIdentifier,
         amount,
         fromSubAccount,
+        fee,
       });
 
       expect(spyTransfer).toHaveBeenCalledWith({
@@ -72,6 +76,7 @@ describe("icp-ledger.api", () => {
         amount,
         fromSubAccount,
         createdAt: nowInBigIntNanoSeconds,
+        fee,
       });
     });
 
@@ -82,6 +87,7 @@ describe("icp-ledger.api", () => {
         to: accountIdentifier,
         amount,
         memo,
+        fee,
       });
 
       expect(spyTransfer).toHaveBeenCalledWith({
@@ -89,6 +95,7 @@ describe("icp-ledger.api", () => {
         amount,
         memo,
         createdAt: nowInBigIntNanoSeconds,
+        fee,
       });
     });
 
@@ -101,6 +108,7 @@ describe("icp-ledger.api", () => {
         amount,
         memo,
         createdAt,
+        fee,
       });
 
       expect(spyTransfer).toHaveBeenCalledWith({
@@ -108,6 +116,7 @@ describe("icp-ledger.api", () => {
         amount,
         memo,
         createdAt,
+        fee,
       });
     });
   });

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -10,6 +10,7 @@ import {
   CKETH_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/cketh-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
+import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import {
   snsProjectsCommittedStore,
@@ -758,6 +759,7 @@ describe("Accounts", () => {
           to: destinationAddress,
           amount: TokenAmount.fromNumber({ amount, token: ICPToken }).toE8s(),
           fromSubaccount: undefined,
+          fee: NNS_TOKEN_DATA.fee,
         });
       });
 
@@ -810,6 +812,7 @@ describe("Accounts", () => {
           to: destinationAddress,
           amount: TokenAmount.fromNumber({ amount, token: ICPToken }).toE8s(),
           fromSubAccount: mockSubAccount.subAccount,
+          fee: NNS_TOKEN_DATA.fee,
         });
       });
     });

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -2,6 +2,7 @@ import { resetNeuronsApiService } from "$lib/api-services/governance.api-service
 import * as api from "$lib/api/governance.api";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
 import { MIN_NEURON_STAKE } from "$lib/constants/neurons.constants";
+import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import * as authServices from "$lib/services/auth.services";
 import {
   getAccountIdentityByPrincipal,
@@ -215,6 +216,7 @@ describe("neurons-services", () => {
         identity: mockIdentity,
         ledgerCanisterIdentity: mockIdentity,
         stake: 1_000_000_000n,
+        fee: NNS_TOKEN_DATA.fee,
       });
       expect(spyStakeNeuron).toBeCalledTimes(1);
       expect(newNeuronId).toEqual(mockNeuron.neuronId);
@@ -234,6 +236,7 @@ describe("neurons-services", () => {
         identity: mockIdentity,
         ledgerCanisterIdentity: mockIdentity,
         stake: 1_000_000_000n,
+        fee: NNS_TOKEN_DATA.fee,
       });
       expect(spyStakeNeuron).toBeCalledTimes(1);
       expect(newNeuronId).toEqual(mockNeuron.neuronId);
@@ -259,6 +262,7 @@ describe("neurons-services", () => {
         fromSubAccount: undefined,
         ledgerCanisterIdentity: mockHardkwareWalletIdentity,
         stake: 1_000_000_000n,
+        fee: NNS_TOKEN_DATA.fee,
       });
       expect(spyStakeNeuron).toBeCalledTimes(1);
       expect(newNeuronId).toEqual(mockNeuron.neuronId);


### PR DESCRIPTION
# Motivation

Remove proto dependency.

When the fee of a transaction is not passed, the LedgerCanister will get the fee with a request because the fee is mandatory. The hardware wallet doesn't support the action of getting the ledger fee; therefore, that call fails and also the whole transaction call.

In this PR, I added the `fee` as mandatory in both `sendIcp` and `stakeNeuron` api functions.

# Changes

* Add `fee` in canister api functions that call `sendICP`.
* Add `fee` to `stakeNeuron` governance api function.
* Add `fee` to `sendICP` icp-ledger api function.
* Add `fee` in canister services.
* Add `fee` in icp-account service `transferICP`.
* Add `fee` in call to `sendICP` inside the governance service `stakeNeuron`.
* Add `fee` in call to `sendICP` inside the sns-sale service `participateInSnsSale `.

# Tests

* Add `fee` to the api functions that needed it and the expects.
* Add `fee` to the expect data in Accounts.spec
* Add `fee` to the expect in the services specs.

# Todos

- [x] Add entry to changelog (if necessary).
