### PR TITLE
GIX-2189: Add token in Send transactions

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 The NNS Dapp is released through proposals in the Network Nervous System. Once a
 proposal is successful, the changes it released will be moved from this file to
-`CHANGELOG_Nns*Dapp.md`.
+`CHANGELOG_Nns-Dapp.md`.
 
 ## Unreleased
 
@@ -16,7 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 - Close button at the bottom of follow neurons modal.
 - Info tooltips in neuron details.
-- Use logo for token (if present) for `ICRC` (but non\*`SNS`) tokens.
+- Use logo for token (if present) for `ICRC` (but non-`SNS`) tokens.
 - Filtering SNS Proposals by type.
 - Add the token symbol in the receive modal.
 - Add fee as mandatory when making ICP transactions.

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -1,4 +1,3 @@
-
 # Unreleased changelog NNS Dapp
 
 All notable changes to the NNS Dapp will be documented in this file.
@@ -15,35 +14,36 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
-* Close button at the bottom of follow neurons modal.
-* Info tooltips in neuron details.
-* Use logo for token (if present) for `ICRC` (but non-`SNS`) tokens.
-* Filtering SNS Proposals by type.
-* Add the token symbol in the receive modal.
-* Add fee as mandatory when making ICP transactions.
+- Close button at the bottom of follow neurons modal.
+- Info tooltips in neuron details.
+- Use logo for token (if present) for `ICRC` (but non-`SNS`) tokens.
+- Filtering SNS Proposals by type.
+- Add the token symbol in the receive modal.
+- Add fee as mandatory when making ICP transactions.
+- Add the token symbol in the send modals.
 
 #### Changed
 
-* Various wording changes.
-* Display the full neuron type text within the tag.
-* Wording in "no neurons to vote" section.
-* Implement `State` traits manually rather than automatically.
-* Voting power calculation formatting.
-* Voting rewards description.
+- Various wording changes.
+- Display the full neuron type text within the tag.
+- Wording in "no neurons to vote" section.
+- Implement `State` traits manually rather than automatically.
+- Voting power calculation formatting.
+- Voting rewards description.
 
 #### Deprecated
 
 #### Removed
 
-* Remove `ENABLE_CKETH` feature flag.
-* Remove unused `transactionsFeesStore` and related.
-* Unused `i18n` messages.
+- Remove `ENABLE_CKETH` feature flag.
+- Remove unused `transactionsFeesStore` and related.
+- Unused `i18n` messages.
 
 #### Fixed
 
-* Fix proposal back navigation during voting.
-* Fix tooltip positioning.
-* Tooltip icon style.
+- Fix proposal back navigation during voting.
+- Fix tooltip positioning.
+- Tooltip icon style.
 
 #### Security
 
@@ -53,12 +53,12 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
-* Add `.orig` file extension to `.gitignore` file.
+- Add `.orig` file extension to `.gitignore` file.
 
 #### Changed
 
-* Frequency of update workflows moved to weekly instead of daily.
-* Update GitHub actions to newer versions.
+- Frequency of update workflows moved to weekly instead of daily.
+- Update GitHub actions to newer versions.
 
 #### Deprecated
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 The NNS Dapp is released through proposals in the Network Nervous System. Once a
 proposal is successful, the changes it released will be moved from this file to
-`CHANGELOG_Nns-Dapp.md`.
+`CHANGELOG_Nns*Dapp.md`.
 
 ## Unreleased
 
@@ -16,7 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 - Close button at the bottom of follow neurons modal.
 - Info tooltips in neuron details.
-- Use logo for token (if present) for `ICRC` (but non-`SNS`) tokens.
+- Use logo for token (if present) for `ICRC` (but non\*`SNS`) tokens.
 - Filtering SNS Proposals by type.
 - Add the token symbol in the receive modal.
 - Add fee as mandatory when making ICP transactions.

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -1,3 +1,4 @@
+
 # Unreleased changelog NNS Dapp
 
 All notable changes to the NNS Dapp will be documented in this file.

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -32,6 +32,7 @@
     "expand_all": "Expand All",
     "receive_with_token": "Receive $token",
     "receive": "Receive",
+    "send_with_token": "Send $token",
     "collapse_all": "Collapse All"
   },
   "error": {

--- a/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcpTransactionModal.svelte
@@ -12,6 +12,8 @@
   import type { WizardStep } from "@dfinity/gix-components";
   import { mainTransactionFeeStoreAsToken } from "$lib/derived/main-transaction-fee.derived";
   import type { TransactionInit } from "$lib/types/transaction";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { ICPToken } from "@dfinity/utils";
 
   export let selectedAccount: Account | undefined = undefined;
 
@@ -23,7 +25,9 @@
 
   $: title =
     currentStep?.name === "Form"
-      ? $i18n.accounts.send
+      ? replacePlaceholders($i18n.core.send_with_token, {
+          $token: ICPToken.symbol,
+        })
       : currentStep?.name === "QRCode"
       ? $i18n.accounts.scan_qr_code
       : $i18n.accounts.you_are_sending;

--- a/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenTransactionModal.svelte
@@ -28,7 +28,9 @@
 
   $: title =
     currentStep?.name === "Form"
-      ? $i18n.accounts.send
+      ? replacePlaceholders($i18n.core.send_with_token, {
+          $token: token.symbol,
+        })
       : currentStep?.name === "QRCode"
       ? $i18n.accounts.scan_qr_code
       : $i18n.accounts.you_are_sending;

--- a/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/SnsTransactionModal.svelte
@@ -29,7 +29,11 @@
 
   $: title =
     currentStep?.name === "Form"
-      ? $i18n.accounts.send
+      ? nonNullish(token)
+        ? replacePlaceholders($i18n.core.send_with_token, {
+            $token: token.symbol,
+          })
+        : $i18n.accounts.send
       : currentStep?.name === "QRCode"
       ? $i18n.accounts.scan_qr_code
       : $i18n.accounts.you_are_sending;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -35,6 +35,7 @@ interface I18nCore {
   expand_all: string;
   receive_with_token: string;
   receive: string;
+  send_with_token: string;
   collapse_all: string;
 }
 

--- a/frontend/src/tests/lib/modals/accounts/IcpTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcpTransactionModal.spec.ts
@@ -8,6 +8,8 @@ import {
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
+import { IcpTransactionModalPo } from "$tests/page-objects/IcpTransactionModal.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { queryToggleById } from "$tests/utils/toggle.test-utils";
 import { fireEvent, waitFor } from "@testing-library/svelte";
 
@@ -28,10 +30,22 @@ describe("IcpTransactionModal", () => {
       props: {},
     });
 
+  const renderModalToPo = async () => {
+    const { container } = await renderTransactionModal();
+
+    return IcpTransactionModalPo.under(new JestPageObjectElement(container));
+  };
+
   beforeEach(() => {
     vi.spyOn(icpAccountsStore, "subscribe").mockImplementation(
       mockAccountsStoreSubscribe([mockSubAccount])
     );
+  });
+
+  it("should render token in the modal title", async () => {
+    const po = await renderModalToPo();
+
+    expect(await po.getModalTitle()).toBe("Send ICP");
   });
 
   it("should transfer icps", async () => {

--- a/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
@@ -37,6 +37,27 @@ describe("IcrcTokenTransactionModal", () => {
     vi.spyOn(ledgerApi, "icrcTransfer").mockResolvedValue(1234n);
   });
 
+  const renderModalComponent = async () => {
+    const { container } = await renderModal({
+      component: IcrcTokenTransactionModal,
+      props: {
+        ledgerCanisterId,
+        token,
+        transactionFee,
+      },
+    });
+
+    return IcrcTokenTransactionModalPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should render token in the modal title", async () => {
+    const po = await renderModalComponent();
+
+    expect(await po.getModalTitle()).toBe(`Send ${token.symbol}`);
+  });
+
   it("should transfer tokens", async () => {
     // Used to choose the source account
     icrcAccountsStore.set({
@@ -52,18 +73,7 @@ describe("IcrcTokenTransactionModal", () => {
       },
     });
 
-    const { container } = await renderModal({
-      component: IcrcTokenTransactionModal,
-      props: {
-        ledgerCanisterId,
-        token,
-        transactionFee,
-      },
-    });
-
-    const po = IcrcTokenTransactionModalPo.under(
-      new JestPageObjectElement(container)
-    );
+    const po = await renderModalComponent();
 
     const toAccount = {
       owner: principal(2),

--- a/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/SnsTransactionModal.spec.ts
@@ -5,6 +5,8 @@ import type { Account } from "$lib/types/account";
 import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
+import { SnsTransactionModalPo } from "$tests/page-objects/SnsTransactionModal.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { testTransferTokens } from "$tests/utils/transaction-modal.test-utils";
 import { TokenAmountV2 } from "@dfinity/utils";
 import { waitFor } from "@testing-library/svelte";
@@ -33,9 +35,21 @@ describe("SnsTransactionModal", () => {
       },
     });
 
+  const renderModalToPo = async () => {
+    const { container } = await renderTransactionModal();
+
+    return SnsTransactionModalPo.under(new JestPageObjectElement(container));
+  };
+
   beforeEach(() => {
     resetIdentity();
     snsAccountsStore.reset();
+  });
+
+  it("should render token in the modal title", async () => {
+    const po = await renderModalToPo();
+
+    expect(await po.getModalTitle()).toBe(`Send ${token.symbol}`);
   });
 
   it("should transfer tokens", async () => {


### PR DESCRIPTION
# Motivation

With the new tokens page the modals are not so clearly defined within a universe. To help the user be aware of the transactions, design proposed to add the token symbol in the Send and Receive modals' title.

In this PR, add the token symbol i the title of Send transactions, except ckBTC.

# Changes

* New i18n key "core.send_with_token".
* Use new i18n for the title of the first step in IcpTransactionModal.
* Use new i18n for the title of the first step in IcrcTokenTransactionModal.
* Use new i18n for the title of the first step in SnsTransactionModal.

# Tests

* Add a test to check the modals's title in IcpTransactionModal.spec.
* Add a test to check the modals's title in IcrcTokenTransactionModal.spec.
* Add a test to check the modals's title in SnsTransactionModal.spec.

# Todos

- [x] Add entry to changelog (if necessary).
