### PR TITLE
Clean up BallotSummary and test

### DIFF
--- a/frontend/src/lib/components/neuron-detail/Ballots/BallotSummary.svelte
+++ b/frontend/src/lib/components/neuron-detail/Ballots/BallotSummary.svelte
@@ -2,11 +2,9 @@
   import type { BallotInfo, ProposalId, ProposalInfo } from "@dfinity/nns";
   import { onMount } from "svelte";
   import { loadProposal } from "$lib/services/$public/proposals.services";
-  import { Vote } from "@dfinity/nns";
-  import { i18n } from "$lib/stores/i18n";
   import ProposalSummary from "$lib/components/proposal-detail/ProposalSummary.svelte";
   import { KeyValuePairInfo, SkeletonText } from "@dfinity/gix-components";
-  import { keyOf } from "$lib/utils/utils";
+  import { getVoteDisplay } from "$lib/utils/proposals.utils";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let ballot: Required<BallotInfo>;
@@ -27,9 +25,9 @@
 <TestIdWrapper testId="ballot-summary-component">
   {#if proposal?.proposal !== undefined}
     <KeyValuePairInfo testId="ballot-summary">
-      <p slot="key" class="value">{proposal.id}</p>
-      <p slot="value" class="vote value">
-        {keyOf({ obj: $i18n.core, key: Vote[ballot.vote].toLowerCase() })}
+      <p slot="key" class="value" data-tid="proposal-id">{proposal.id}</p>
+      <p slot="value" class="vote value" data-tid="vote">
+        {getVoteDisplay(ballot.vote)}
       </p>
       <div slot="info" class="summary">
         <ProposalSummary summary={proposal.proposal.summary} />

--- a/frontend/src/lib/components/proposal-detail/MyVotes.svelte
+++ b/frontend/src/lib/components/proposal-detail/MyVotes.svelte
@@ -7,6 +7,7 @@
     formatVotingPower,
     type CompactNeuronInfo,
   } from "$lib/utils/neuron.utils";
+  import { getVoteDisplay } from "$lib/utils/proposals.utils";
   import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
   import { SNS_NEURON_ID_DISPLAY_LENGTH } from "$lib/constants/sns-neurons.constants";
   import VotingCardNeuronList from "$lib/components/proposal-detail/VotingCard/VotingCardNeuronList.svelte";
@@ -16,15 +17,9 @@
   export let neuronsVotedForProposal: CompactNeuronInfo[] = [];
 
   const voteMapper = ({ neuron, vote }: { neuron: string; vote: Vote }) => {
-    const stringMapper = {
-      [Vote.No]: $i18n.core.no,
-      [Vote.Yes]: $i18n.core.yes,
-      [Vote.Unspecified]: "",
-    };
-
     return replacePlaceholders($i18n.proposal_detail__vote.vote_status, {
       $neuronId: neuron.toString(),
-      $vote: stringMapper[vote],
+      $vote: getVoteDisplay(vote),
     });
   };
 </script>

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -628,3 +628,15 @@ export const getUniversalProposalStatus = (
 
   return statusType;
 };
+
+export const getVoteDisplay = (vote: Vote): string => {
+  const i18nObj = get(i18n);
+  switch (vote) {
+    case Vote.Yes:
+      return i18nObj.core.yes;
+    case Vote.No:
+      return i18nObj.core.no;
+    case Vote.Unspecified:
+      return i18nObj.core.unspecified;
+  }
+};

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -5,6 +5,7 @@ import {
   excludeProposals,
   getNnsFunctionKey,
   getUniversalProposalStatus,
+  getVoteDisplay,
   getVotingBallot,
   getVotingPower,
   hasMatchingProposals,
@@ -1331,6 +1332,14 @@ describe("proposals-utils", () => {
       expect(
         getUniversalProposalStatus(proposalWithStatus(ProposalStatus.Failed))
       ).toBe("failed");
+    });
+  });
+
+  describe("getVoteDisplay", () => {
+    it("should render vote", () => {
+      expect(getVoteDisplay(Vote.Yes)).toBe("Yes");
+      expect(getVoteDisplay(Vote.No)).toBe("No");
+      expect(getVoteDisplay(Vote.Unspecified)).toBe("Unspecified");
     });
   });
 });

--- a/frontend/src/tests/page-objects/BallotSummary.page-object.ts
+++ b/frontend/src/tests/page-objects/BallotSummary.page-object.ts
@@ -16,6 +16,26 @@ export class BallotSummaryPo extends BasePageObject {
     });
   }
 
+  getProposalSummaryPo(): KeyValuePairInfoPo {
+    return KeyValuePairInfoPo.under({
+      element: this.root,
+      testId: "proposal-summary",
+    });
+  }
+
+  async waitForLoaded(): Promise<void> {
+    await this.root.byTestId("skeleton-text").waitForAbsent();
+    await this.root.byTestId("spinner").waitForAbsent();
+  }
+
+  getProposalId(): Promise<string> {
+    return this.getText("proposal-id");
+  }
+
+  getVote(): Promise<string> {
+    return this.getText("vote");
+  }
+
   clickInfoIcon(): Promise<void> {
     return this.getKeyValuePairPo().clickInfoIcon();
   }


### PR DESCRIPTION
# Motivation

Make code easier to read and maintain.

# Changes

1. Extract code to render a string for a `Vote` to a `util`.
2. Use page objects in `BallotSummary.spec.ts`

# Tests

Updated and added

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary