### PR TITLE
Remove unused i18n.auth messages

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -152,18 +152,7 @@
   },
   "auth": {
     "login": "Sign in with Internet Identity",
-    "title": "Open and autonomous governance running",
-    "on_chain": "100% on-chain",
-    "wallet": "Wallet",
-    "earn": "Vote & earn rewards",
-    "launchpad": "SNS Launchpad",
-    "ic_logo": "Internet Computer logo",
-    "dashboard": "Dashboard",
-    "voting_rewards": "Voting rewards",
-    "logo": "Network Nervous System logo",
-    "github_link": "Link to NNS-dapp repo on GitHub",
-    "background": "An abstract image for design and presentation purpose only",
-    "internetcomputer_dot_org_link": "Link to internetcomputer.org"
+    "ic_logo": "Internet Computer logo"
   },
   "accounts": {
     "main": "Main",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -160,18 +160,7 @@ interface I18nHeader {
 
 interface I18nAuth {
   login: string;
-  title: string;
-  on_chain: string;
-  wallet: string;
-  earn: string;
-  launchpad: string;
   ic_logo: string;
-  dashboard: string;
-  voting_rewards: string;
-  logo: string;
-  github_link: string;
-  background: string;
-  internetcomputer_dot_org_link: string;
 }
 
 interface I18nAccounts {


### PR DESCRIPTION
# Motivation

Having unused code can be confusing.

I search for all usages of `auth.` messages and found only these:
```
$ for x in $(jq -r '.auth | paths | join(".")' frontend/src/lib/i18n/en.json); do git grep -w -o "auth.$x"; done
frontend/src/lib/components/common/SignIn.svelte:auth.login
frontend/src/lib/components/common/SignInGuard.svelte:auth.login
frontend/src/lib/components/header/LoginIconOnly.svelte:auth.login
frontend/src/tests/lib/components/summary/SummaryLogo.spec.ts:auth.ic_logo
frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts:auth.ic_logo
frontend/src/tests/lib/routes/Accounts.spec.ts:auth.ic_logo
frontend/src/tests/lib/utils/universes.utils.spec.ts:auth.ic_logo
```

So only `login` and `ic_logo` are used and the rest can be removed.

# Changes

Remove all entries from `i18n.auth` except `login` and `ic_logo`.

# Tests

pass

# Todos

- [ ] Add entry to changelog (if necessary).
covered