### PR TITLE
GIX-2189: Add token label in ckBTC send modal

### DIFF
--- a/frontend/src/lib/components/transaction/TransactionFormItemNetwork.svelte
+++ b/frontend/src/lib/components/transaction/TransactionFormItemNetwork.svelte
@@ -14,6 +14,7 @@
 <div
   class:placeholder={!notEmptyString(selectedNetwork)}
   class:readonly={networkReadonly}
+  data-tid="transaction-form-item-network-component"
 >
   <p class="label">{$i18n.accounts.network}</p>
 

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -31,6 +31,7 @@
     ckBTCInfoStore,
     type CkBTCInfoStoreUniverseData,
   } from "$lib/stores/ckbtc-info.store";
+  import { isUniverseCkTESTBTC } from "$lib/utils/universe.utils";
 
   export let selectedAccount: Account | undefined = undefined;
 
@@ -49,10 +50,19 @@
 
   let currentStep: WizardStep | undefined;
 
+  const getTitleForm = (isBtc: boolean) =>
+    replacePlaceholders($i18n.core.send_with_token, {
+      $token: isBtc
+        ? isUniverseCkTESTBTC(universeId)
+          ? $i18n.ckbtc.test_bitcoin
+          : $i18n.ckbtc.bitcoin
+        : token.symbol,
+    });
+
   let title: string;
   $: title =
     currentStep?.name === "Form"
-      ? $i18n.accounts.send
+      ? getTitleForm(networkBtc)
       : currentStep?.name === "Progress"
       ? $i18n.ckbtc.sending_ckbtc_to_btc
       : currentStep?.name === "QRCode"

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -31,7 +31,6 @@
     ckBTCInfoStore,
     type CkBTCInfoStoreUniverseData,
   } from "$lib/stores/ckbtc-info.store";
-  import { isUniverseCkTESTBTC } from "$lib/utils/universe.utils";
 
   export let selectedAccount: Account | undefined = undefined;
 
@@ -50,19 +49,12 @@
 
   let currentStep: WizardStep | undefined;
 
-  const getTitleForm = (isBtc: boolean) =>
-    replacePlaceholders($i18n.core.send_with_token, {
-      $token: isBtc
-        ? isUniverseCkTESTBTC(universeId)
-          ? $i18n.ckbtc.test_bitcoin
-          : $i18n.ckbtc.bitcoin
-        : token.symbol,
-    });
-
   let title: string;
   $: title =
     currentStep?.name === "Form"
-      ? getTitleForm(networkBtc)
+      ? replacePlaceholders($i18n.core.send_with_token, {
+          $token: networkBtc ? $i18n.ckbtc.btc : token.symbol,
+        })
       : currentStep?.name === "Progress"
       ? $i18n.ckbtc.sending_ckbtc_to_btc
       : currentStep?.name === "QRCode"

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -22,6 +22,8 @@ import {
 import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import en from "$tests/mocks/i18n.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
+import { CkBTCTransactionModalPo } from "$tests/page-objects/CkBTCTransactionModal.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import {
   testTransferFormTokens,
   testTransferReviewTokens,
@@ -52,6 +54,12 @@ describe("CkBTCTransactionModal", () => {
         universeId: CKTESTBTC_UNIVERSE_CANISTER_ID,
       },
     });
+
+  const renderModalToPo = async () => {
+    const { container } = await renderTransactionModal();
+
+    return CkBTCTransactionModalPo.under(new JestPageObjectElement(container));
+  };
 
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -86,6 +94,12 @@ describe("CkBTCTransactionModal", () => {
       minter_fee: 123n,
       bitcoin_fee: 456n,
     });
+  });
+
+  it("should show ckBTC label in modal title", async () => {
+    const po = await renderModalToPo();
+
+    expect(await po.getModalTitle()).toBe("Send ckBTC");
   });
 
   it("should transfer tokens", async () => {
@@ -142,6 +156,14 @@ describe("CkBTCTransactionModal", () => {
   };
 
   describe("convert BTC to ckBTC with ICRC-2", () => {
+    it("should show Bitcoin label in modal title", async () => {
+      const po = await renderModalToPo();
+
+      await po.selectNetwork(TransactionNetwork.BTC_TESTNET);
+
+      expect(await po.getModalTitle()).toBe("Send Bitcoin Testnet");
+    });
+
     it("should convert ckBTC to Bitcoin", async () => {
       await testConvertCkBTCToBTCWithIcrc2({
         success: true,

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -161,7 +161,7 @@ describe("CkBTCTransactionModal", () => {
 
       await po.selectNetwork(TransactionNetwork.BTC_TESTNET);
 
-      expect(await po.getModalTitle()).toBe("Send Bitcoin Testnet");
+      expect(await po.getModalTitle()).toBe("Send BTC");
     });
 
     it("should convert ckBTC to Bitcoin", async () => {

--- a/frontend/src/tests/page-objects/CkBTCTransactionModal.page-object.ts
+++ b/frontend/src/tests/page-objects/CkBTCTransactionModal.page-object.ts
@@ -11,11 +11,11 @@ export class CkBTCTransactionModalPo extends TransactionModalBasePo {
     );
   }
 
-  getTransactionFormItemNetwork() {
+  getTransactionFormItemNetworkPo() {
     return TransactionFormItemNetworkPo.under(this.root);
   }
 
   async selectNetwork(network: string) {
-    return this.getTransactionFormItemNetwork().selectNetwork(network);
+    return this.getTransactionFormItemNetworkPo().selectNetwork(network);
   }
 }

--- a/frontend/src/tests/page-objects/CkBTCTransactionModal.page-object.ts
+++ b/frontend/src/tests/page-objects/CkBTCTransactionModal.page-object.ts
@@ -1,5 +1,6 @@
 import { TransactionModalBasePo } from "$tests/page-objects/TransactionModal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { TransactionFormItemNetworkPo } from "./TransactionFormItemNetwor.page-object";
 
 export class CkBTCTransactionModalPo extends TransactionModalBasePo {
   private static readonly TID = "ckbtc-transaction-modal-component";
@@ -8,5 +9,13 @@ export class CkBTCTransactionModalPo extends TransactionModalBasePo {
     return new CkBTCTransactionModalPo(
       element.byTestId(CkBTCTransactionModalPo.TID)
     );
+  }
+
+  getTransactionFormItemNetwork() {
+    return TransactionFormItemNetworkPo.under(this.root);
+  }
+
+  async selectNetwork(network: string) {
+    return this.getTransactionFormItemNetwork().selectNetwork(network);
   }
 }

--- a/frontend/src/tests/page-objects/TransactionFormItemNetwor.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionFormItemNetwor.page-object.ts
@@ -11,11 +11,11 @@ export class TransactionFormItemNetworkPo extends BasePageObject {
     );
   }
 
-  getDropdown() {
+  getDropdownPo() {
     return DropdownPo.under(this.root);
   }
 
   async selectNetwork(network: string) {
-    return this.getDropdown().select(network);
+    return this.getDropdownPo().select(network);
   }
 }

--- a/frontend/src/tests/page-objects/TransactionFormItemNetwor.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionFormItemNetwor.page-object.ts
@@ -1,0 +1,21 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { DropdownPo } from "./Dropdown.page-object";
+import { BasePageObject } from "./base.page-object";
+
+export class TransactionFormItemNetworkPo extends BasePageObject {
+  private static readonly TID = "transaction-form-item-network-component";
+
+  static under(element: PageObjectElement): TransactionFormItemNetworkPo {
+    return new TransactionFormItemNetworkPo(
+      element.byTestId(TransactionFormItemNetworkPo.TID)
+    );
+  }
+
+  getDropdown() {
+    return DropdownPo.under(this.root);
+  }
+
+  async selectNetwork(network: string) {
+    return this.getDropdown().select(network);
+  }
+}


### PR DESCRIPTION
# Motivation

Help users understand the context better by adding the token symbol in the title of the send modals.

In this PR, add the token label in the ckBTC transaction modal.

# Changes

* New helper `getTitleForm` inside CkBTCTransactionModal to select the title in the first step depending on the network and the universe id.

# Tests

* Add test id to TransactionFormItemNetwork and create its page object.
* Add two tests to CkBTCTransactionModal.spec. One to check the ckBTC label and the other one when the network is BTC.


# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary. There is already a changelog entry for this.
