### PR TITLE
Make usage of i18n message clearer

### DIFF
--- a/frontend/src/lib/modals/neurons/DissolveActionButtonModal.svelte
+++ b/frontend/src/lib/modals/neurons/DissolveActionButtonModal.svelte
@@ -8,7 +8,6 @@
   import { type NeuronId, type NeuronInfo, NeuronState } from "@dfinity/nns";
   import ConfirmationModal from "$lib/modals/common/ConfirmationModal.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import { keyOf } from "$lib/utils/utils";
   import { createEventDispatcher } from "svelte";
 
   export let neuron: NeuronInfo;
@@ -17,13 +16,12 @@
   $: ({ neuronId } = neuron);
 
   let isDissolving: boolean;
-  let descriptionKey: string;
-  $: {
-    isDissolving = neuron.state === NeuronState.Dissolving;
-    descriptionKey = isDissolving
-      ? "stop_dissolve_description"
-      : "start_dissolve_description";
-  }
+  $: isDissolving = neuron.state === NeuronState.Dissolving;
+
+  let description: string;
+  $: description = isDissolving
+    ? $i18n.neuron_detail.stop_dissolve_description
+    : $i18n.neuron_detail.start_dissolve_description;
 
   const dispatch = createEventDispatcher();
 
@@ -39,6 +37,6 @@
 <ConfirmationModal on:nnsClose on:nnsConfirm={dissolveAction}>
   <div data-tid="dissolve-action-modal">
     <h4>{$i18n.core.confirm}</h4>
-    <p>{keyOf({ obj: $i18n.neuron_detail, key: descriptionKey })}</p>
+    <p>{description}</p>
   </div>
 </ConfirmationModal>

--- a/frontend/src/lib/modals/sns/neurons/DissolveSnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/DissolveSnsNeuronModal.svelte
@@ -9,7 +9,6 @@
     stopDissolving,
   } from "$lib/services/sns-neurons.services";
   import type { Principal } from "@dfinity/principal";
-  import { keyOf } from "$lib/utils/utils";
   import { createEventDispatcher } from "svelte";
   import { snsOnlyProjectStore } from "$lib/derived/sns/sns-selected-project.derived";
 
@@ -18,13 +17,12 @@
   export let reloadNeuron: () => Promise<void>;
 
   let isDissolving: boolean;
-  let descriptionKey: string;
-  $: {
-    isDissolving = neuronState === NeuronState.Dissolving;
-    descriptionKey = isDissolving
-      ? "stop_dissolve_description"
-      : "start_dissolve_description";
-  }
+  $: isDissolving = neuronState === NeuronState.Dissolving;
+
+  let description: string;
+  $: description = isDissolving
+    ? $i18n.neuron_detail.stop_dissolve_description
+    : $i18n.neuron_detail.start_dissolve_description;
 
   const dissolveAction = async () => {
     const action = isDissolving ? stopDissolving : startDissolving;
@@ -48,7 +46,7 @@
 <ConfirmationModal on:nnsClose on:nnsConfirm={dissolveAction}>
   <div data-tid="dissolve-sns-neuron-modal">
     <h4>{$i18n.core.confirm}</h4>
-    <p>{keyOf({ obj: $i18n.neuron_detail, key: descriptionKey })}</p>
+    <p>{description}</p>
   </div>
 </ConfirmationModal>
 


### PR DESCRIPTION
# Motivation

Make the code more readable and make it easier to find unused i18n messages.

# Changes

1. Use `$i18n.neuron_detail.stop_dissolve_description` and `$i18n.neuron_detail.start_dissolve_description` directly instead of through `keyOf`.
2. Don't combine multiple assignments in a single Svelte `$:` block when it's not necessary.

# Tests

Still pass.

Also tested manually.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary