### PR TITLE
Use i18n messages directly in Projects.svelte

### DIFF
--- a/frontend/src/lib/components/launchpad/Projects.svelte
+++ b/frontend/src/lib/components/launchpad/Projects.svelte
@@ -3,7 +3,6 @@
   import ProjectCard from "./ProjectCard.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import SkeletonProjectCard from "$lib/components/ui/SkeletonProjectCard.svelte";
-  import { keyOf } from "$lib/utils/utils";
   import { isLoadingSnsProjectsStore } from "$lib/stores/sns.store";
   import {
     snsProjectsActivePadStore,
@@ -26,18 +25,15 @@
   $: loading = $isLoadingSnsProjectsStore;
 
   const mapper: Record<SnsSwapLifecycle, string> = {
-    [SnsSwapLifecycle.Open]: "no_open_projects",
-    [SnsSwapLifecycle.Adopted]: "no_opening_soon_projects",
-    [SnsSwapLifecycle.Committed]: "no_committed_projects",
-    [SnsSwapLifecycle.Unspecified]: "no_projects",
-    [SnsSwapLifecycle.Aborted]: "no_projects",
-    [SnsSwapLifecycle.Pending]: "no_projects",
+    [SnsSwapLifecycle.Open]: $i18n.sns_launchpad.no_open_projects,
+    [SnsSwapLifecycle.Adopted]: $i18n.sns_launchpad.no_opening_soon_projects,
+    [SnsSwapLifecycle.Committed]: $i18n.sns_launchpad.no_committed_projects,
+    [SnsSwapLifecycle.Unspecified]: $i18n.sns_launchpad.no_projects,
+    [SnsSwapLifecycle.Aborted]: $i18n.sns_launchpad.no_projects,
+    [SnsSwapLifecycle.Pending]: $i18n.sns_launchpad.no_projects,
   };
   let noProjectsMessageLabel: string;
-  $: noProjectsMessageLabel = keyOf({
-    obj: $i18n.sns_launchpad,
-    key: mapper[status],
-  });
+  $: noProjectsMessageLabel = mapper[status];
 </script>
 
 <TestIdWrapper {testId}>


### PR DESCRIPTION
# Motivation

Make the code easier to understand and make it easier to find unused i18n messages.

# Changes

In `Projects.svelte` use `$i18n` messages directly instead of through `keyOf`.

# Tests

Still pass.
And tested manually.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary