### PR TITLE
Fix typo in labelKey error.neuron_account_not_found

### DIFF
--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -978,7 +978,7 @@ export const topUpNeuron = async ({
 }): Promise<{ success: boolean }> => {
   if (neuron.fullNeuron?.accountIdentifier === undefined) {
     toastsError({
-      labelKey: "errors.neuron_account_not_found",
+      labelKey: "error.neuron_account_not_found",
     });
     return { success: false };
   }

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -1879,6 +1879,7 @@ describe("neurons-services", () => {
       expect(transferICP).not.toBeCalled();
       expect(spyClaimOrRefresh).not.toBeCalled();
       expect(spyGetNeuron).not.toBeCalled();
+      expectToastError(en.error.neuron_account_not_found);
     });
 
     it("should fail if amount and neuron stake are not enough", async () => {


### PR DESCRIPTION
# Motivation

There is no `"errors"` (plural) in `i18n` but `error.neuron_account_not_found` does exist.

# Changes

Change `errors` (plural) to `error` (singular).

# Tests

Unit test updated.

I'm not sure how to reproduce this to test it manually.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary