### PR TITLE
Use i18n messages directly in MenuItems.svelte

### DIFF
--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -19,7 +19,6 @@
     tokensPathStore,
     proposalsPathStore,
   } from "$lib/derived/paths.derived";
-  import { keyOf } from "$lib/utils/utils";
   import { pageStore } from "$lib/derived/page.derived";
   import { isSelectedPath } from "$lib/utils/navigation.utils";
   import MenuMetrics from "$lib/components/common/MenuMetrics.svelte";
@@ -28,7 +27,7 @@
     context: string;
     href: string;
     selected: boolean;
-    label: string;
+    title: string;
     icon:
       | typeof IconWallet
       | typeof IconPassword
@@ -45,7 +44,7 @@
         currentPath: $pageStore.path,
         paths: [AppPath.Accounts, AppPath.Wallet, AppPath.Tokens],
       }),
-      label: "tokens",
+      title: $i18n.navigation.tokens,
       icon: IconWallet,
     },
     {
@@ -55,7 +54,7 @@
         currentPath: $pageStore.path,
         paths: [AppPath.Neurons, AppPath.Neuron],
       }),
-      label: "neurons",
+      title: $i18n.navigation.neurons,
       icon: IconPassword,
     },
     {
@@ -65,7 +64,7 @@
         currentPath: $pageStore.path,
         paths: [AppPath.Proposals, AppPath.Proposal],
       }),
-      label: "voting",
+      title: $i18n.navigation.voting,
       icon: IconUsers,
     },
     {
@@ -75,7 +74,7 @@
         currentPath: $pageStore.path,
         paths: [AppPath.Launchpad, AppPath.Project],
       }),
-      label: "launchpad",
+      title: $i18n.navigation.launchpad,
       icon: IconRocketLaunch,
     },
     {
@@ -85,16 +84,14 @@
         currentPath: $pageStore.path,
         paths: [AppPath.Canisters, AppPath.Canister],
       }),
-      label: "canisters",
+      title: $i18n.navigation.canisters,
       icon: IconExplore,
     },
   ];
 </script>
 
 <TestIdWrapper testId="menu-items-component">
-  {#each routes as { context, label, href, icon, statusIcon, selected } (context)}
-    {@const title = keyOf({ obj: $i18n.navigation, key: label })}
-
+  {#each routes as { context, title, href, icon, statusIcon, selected } (context)}
     <MenuItem {href} testId={`menuitem-${context}`} {selected} {title}>
       <svelte:component this={icon} slot="icon" />
       <svelte:fragment>{title}</svelte:fragment>


### PR DESCRIPTION
# Motivation

There is no benefit in using `keyOf` instead of accessing `$i18n` directly and referencing the entries directly makes it easier to find unused messages.

# Changes

Instead of using `keyOf` refer to `$i18n.navigation.*` directly.

# Tests

Existing tests still pass (and fail if I use a different message).
Also tested manually.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary