### PR TITLE
Use topic (sub)title i18n messages directly

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/Followee.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Topic } from "@dfinity/nns";
-  import type { FolloweesNeuron } from "$lib/utils/neuron.utils";
+  import { type FolloweesNeuron, getTopicTitle } from "$lib/utils/neuron.utils";
   import { i18n } from "$lib/stores/i18n";
   import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
   import { Copy, Tag } from "@dfinity/gix-components";
@@ -17,9 +17,7 @@
   export let followee: FolloweesNeuron;
 
   // TODO: Align with `en.governance.json` "topics.[topic]"
-  const topicTitle = (topic: Topic) =>
-    $i18n.follow_neurons[`topic_${topic}_title`];
-
+  const topicTitle = (topic: Topic) => getTopicTitle({ topic, i18n: $i18n });
   let id: string;
   $: id = `followee-${followee.neuronId}`;
   let name: string;

--- a/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
+++ b/frontend/src/lib/components/neurons/FollowNnsTopicSection.svelte
@@ -6,7 +6,11 @@
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";
   import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
-  import { followeesByTopic } from "$lib/utils/neuron.utils";
+  import {
+    followeesByTopic,
+    getTopicTitle,
+    getTopicSubtitle,
+  } from "$lib/utils/neuron.utils";
   import FollowTopicSection from "./FollowTopicSection.svelte";
   import { IconClose, Value } from "@dfinity/gix-components";
 
@@ -15,9 +19,9 @@
 
   // TODO: Align with `en.governance.json` "topics.[topic]"
   let title: string;
-  $: title = $i18n.follow_neurons[`topic_${topic}_title`];
+  $: title = getTopicTitle({ topic, i18n: $i18n });
   let subtitle: string;
-  $: subtitle = $i18n.follow_neurons[`topic_${topic}_subtitle`];
+  $: subtitle = getTopicSubtitle({ topic, i18n: $i18n });
 
   let showNewFolloweeModal = false;
   type FolloweeData = {

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -955,7 +955,7 @@ export const getTopicTitle = ({
   topic: Topic;
   i18n: I18n;
 }): string => {
-  const mapper = {
+  const mapper: Record<Topic, string> = {
     [Topic.Unspecified]: i18n.follow_neurons.topic_0_title,
     [Topic.ManageNeuron]: i18n.follow_neurons.topic_1_title,
     [Topic.ExchangeRate]: i18n.follow_neurons.topic_2_title,
@@ -983,7 +983,7 @@ export const getTopicSubtitle = ({
   topic: Topic;
   i18n: I18n;
 }): string => {
-  const mapper = {
+  const mapper: Record<Topic, string> = {
     [Topic.Unspecified]: i18n.follow_neurons.topic_0_subtitle,
     [Topic.ManageNeuron]: i18n.follow_neurons.topic_1_subtitle,
     [Topic.ExchangeRate]: i18n.follow_neurons.topic_2_subtitle,

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -947,3 +947,60 @@ export const maturityLastDistribution = ({
 
 export const neuronDashboardUrl = ({ neuronId }: NeuronInfo): string =>
   `https://dashboard.internetcomputer.org/neuron/${neuronId.toString()}`;
+
+export const getTopicTitle = ({
+  topic,
+  i18n,
+}: {
+  topic: Topic;
+  i18n: I18n;
+}): string => {
+  const mapper = {
+    [Topic.Unspecified]: i18n.follow_neurons.topic_0_title,
+    [Topic.ManageNeuron]: i18n.follow_neurons.topic_1_title,
+    [Topic.ExchangeRate]: i18n.follow_neurons.topic_2_title,
+    [Topic.NetworkEconomics]: i18n.follow_neurons.topic_3_title,
+    [Topic.Governance]: i18n.follow_neurons.topic_4_title,
+    [Topic.NodeAdmin]: i18n.follow_neurons.topic_5_title,
+    [Topic.ParticipantManagement]: i18n.follow_neurons.topic_6_title,
+    [Topic.SubnetManagement]: i18n.follow_neurons.topic_7_title,
+    [Topic.NetworkCanisterManagement]: i18n.follow_neurons.topic_8_title,
+    [Topic.Kyc]: i18n.follow_neurons.topic_9_title,
+    [Topic.NodeProviderRewards]: i18n.follow_neurons.topic_10_title,
+    [Topic.SnsDecentralizationSale]: i18n.follow_neurons.topic_11_title,
+    [Topic.SubnetReplicaVersionManagement]: i18n.follow_neurons.topic_12_title,
+    [Topic.ReplicaVersionManagement]: i18n.follow_neurons.topic_13_title,
+    [Topic.SnsAndCommunityFund]: i18n.follow_neurons.topic_14_title,
+    [Topic.ApiBoundaryNodeManagement]: i18n.follow_neurons.topic_15_title,
+  };
+  return mapper[topic];
+};
+
+export const getTopicSubtitle = ({
+  topic,
+  i18n,
+}: {
+  topic: Topic;
+  i18n: I18n;
+}): string => {
+  const mapper = {
+    [Topic.Unspecified]: i18n.follow_neurons.topic_0_subtitle,
+    [Topic.ManageNeuron]: i18n.follow_neurons.topic_1_subtitle,
+    [Topic.ExchangeRate]: i18n.follow_neurons.topic_2_subtitle,
+    [Topic.NetworkEconomics]: i18n.follow_neurons.topic_3_subtitle,
+    [Topic.Governance]: i18n.follow_neurons.topic_4_subtitle,
+    [Topic.NodeAdmin]: i18n.follow_neurons.topic_5_subtitle,
+    [Topic.ParticipantManagement]: i18n.follow_neurons.topic_6_subtitle,
+    [Topic.SubnetManagement]: i18n.follow_neurons.topic_7_subtitle,
+    [Topic.NetworkCanisterManagement]: i18n.follow_neurons.topic_8_subtitle,
+    [Topic.Kyc]: i18n.follow_neurons.topic_9_subtitle,
+    [Topic.NodeProviderRewards]: i18n.follow_neurons.topic_10_subtitle,
+    [Topic.SnsDecentralizationSale]: i18n.follow_neurons.topic_11_subtitle,
+    [Topic.SubnetReplicaVersionManagement]:
+      i18n.follow_neurons.topic_12_subtitle,
+    [Topic.ReplicaVersionManagement]: i18n.follow_neurons.topic_13_subtitle,
+    [Topic.SnsAndCommunityFund]: i18n.follow_neurons.topic_14_subtitle,
+    [Topic.ApiBoundaryNodeManagement]: i18n.follow_neurons.topic_15_subtitle,
+  };
+  return mapper[topic];
+};

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -37,6 +37,8 @@ import {
   getNeuronById,
   getNeuronTags,
   getSpawningTimeInSeconds,
+  getTopicSubtitle,
+  getTopicTitle,
   hasEnoughMaturityToStake,
   hasJoinedCommunityFund,
   hasValidStake,
@@ -2547,6 +2549,143 @@ describe("neuron-utils", () => {
           identity: mockIdentity,
         })
       ).toBe(false);
+    });
+  });
+
+  describe("getTopicTitle", () => {
+    it("should return a title for every topic", () => {
+      for (const topic of Object.values(Topic)) {
+        if (typeof topic !== "string") {
+          expect(getTopicTitle({ topic, i18n: en })).toBe(
+            en.follow_neurons[`topic_${topic}_title`]
+          );
+        }
+      }
+    });
+
+    it("should return the correct title", () => {
+      expect(getTopicTitle({ topic: Topic.Unspecified, i18n: en })).toBe(
+        "All Except Governance, and SNS & Neurons' Fund"
+      );
+      expect(getTopicTitle({ topic: Topic.ManageNeuron, i18n: en })).toBe(
+        "Manage Neuron"
+      );
+      expect(getTopicTitle({ topic: Topic.ExchangeRate, i18n: en })).toBe(
+        "Exchange Rate"
+      );
+      expect(getTopicTitle({ topic: Topic.NetworkEconomics, i18n: en })).toBe(
+        "Network Economics"
+      );
+      expect(getTopicTitle({ topic: Topic.Governance, i18n: en })).toBe(
+        "Governance"
+      );
+      expect(getTopicTitle({ topic: Topic.NodeAdmin, i18n: en })).toBe(
+        "Node Admin"
+      );
+      expect(
+        getTopicTitle({ topic: Topic.ParticipantManagement, i18n: en })
+      ).toBe("Participant Management");
+      expect(getTopicTitle({ topic: Topic.SubnetManagement, i18n: en })).toBe(
+        "Subnet Management"
+      );
+      expect(
+        getTopicTitle({ topic: Topic.NetworkCanisterManagement, i18n: en })
+      ).toBe("System Canister Management");
+      expect(getTopicTitle({ topic: Topic.Kyc, i18n: en })).toBe("KYC");
+      expect(
+        getTopicTitle({ topic: Topic.NodeProviderRewards, i18n: en })
+      ).toBe("Node Provider Rewards");
+      expect(
+        getTopicTitle({ topic: Topic.SnsDecentralizationSale, i18n: en })
+      ).toBe("SNS Decentralization Swap");
+      expect(
+        getTopicTitle({ topic: Topic.SubnetReplicaVersionManagement, i18n: en })
+      ).toBe("Subnet Replica Version Management");
+      expect(
+        getTopicTitle({ topic: Topic.ReplicaVersionManagement, i18n: en })
+      ).toBe("Replica Version Management");
+      expect(
+        getTopicTitle({ topic: Topic.SnsAndCommunityFund, i18n: en })
+      ).toBe("SNS & Neurons' Fund");
+      expect(
+        getTopicTitle({ topic: Topic.ApiBoundaryNodeManagement, i18n: en })
+      ).toBe("API Boundary Node Management");
+    });
+  });
+
+  describe("getTopicSubtitle", () => {
+    it("should return a title for every topic", () => {
+      for (const topic of Object.values(Topic)) {
+        if (typeof topic !== "string") {
+          expect(getTopicSubtitle({ topic, i18n: en })).toBe(
+            en.follow_neurons[`topic_${topic}_subtitle`]
+          );
+        }
+      }
+    });
+
+    it("should return the correct subtitle", () => {
+      expect(getTopicSubtitle({ topic: Topic.Unspecified, i18n: en })).toBe(
+        "Follow neurons on all proposal topics except the governance topic, and SNS & Neurons' Fund."
+      );
+      expect(getTopicSubtitle({ topic: Topic.ManageNeuron, i18n: en })).toBe(
+        "Proposals that manage specific neurons, for example making them perform actions."
+      );
+      expect(getTopicSubtitle({ topic: Topic.ExchangeRate, i18n: en })).toBe(
+        "All proposals that provide “real time” information about the value of ICP, as measured by an IMF SDR, which allows the NNS to convert ICP to cycles (which power computation) at a rate which keeps their real world cost constant."
+      );
+      expect(
+        getTopicSubtitle({ topic: Topic.NetworkEconomics, i18n: en })
+      ).toBe(
+        "Proposals that administer network economics, for example, determining what rewards should be paid to node operators."
+      );
+      expect(getTopicSubtitle({ topic: Topic.Governance, i18n: en })).toBe(
+        "All proposals that administer governance, for example to freeze malicious canisters that are harming the network."
+      );
+      expect(getTopicSubtitle({ topic: Topic.NodeAdmin, i18n: en })).toBe(
+        "All proposals that administer node machines somehow, including, but not limited to, upgrading or configuring the OS, upgrading or configuring the virtual machine framework and upgrading or configuring the node replica software."
+      );
+      expect(
+        getTopicSubtitle({ topic: Topic.ParticipantManagement, i18n: en })
+      ).toBe(
+        "All proposals that administer network participants, for example, granting and revoking DCIDs (data center identities) or NOIDs (node operator identities)."
+      );
+      expect(
+        getTopicSubtitle({ topic: Topic.SubnetManagement, i18n: en })
+      ).toBe(
+        "All proposals that administer network subnets, for example creating new subnets, adding and removing subnet nodes, and splitting subnets."
+      );
+      expect(
+        getTopicSubtitle({ topic: Topic.NetworkCanisterManagement, i18n: en })
+      ).toBe(
+        "Installing and upgrading “system” canisters that belong to the network. For example, upgrading the NNS."
+      );
+      expect(getTopicSubtitle({ topic: Topic.Kyc, i18n: en })).toBe(
+        "Proposals that update KYC information for regulatory purposes, for example during the initial Genesis distribution of ICP in the form of neurons."
+      );
+      expect(
+        getTopicSubtitle({ topic: Topic.NodeProviderRewards, i18n: en })
+      ).toBe("Proposals that reward node providers");
+      expect(
+        getTopicSubtitle({ topic: Topic.SnsDecentralizationSale, i18n: en })
+      ).toBe("Proposals for SNS");
+      expect(
+        getTopicSubtitle({
+          topic: Topic.SubnetReplicaVersionManagement,
+          i18n: en,
+        })
+      ).toBe("Proposals handling updates of a subnet's replica version");
+      expect(
+        getTopicSubtitle({ topic: Topic.ReplicaVersionManagement, i18n: en })
+      ).toBe(
+        "Proposals dealing with blessing and retirement of replica versions"
+      );
+      expect(
+        getTopicSubtitle({ topic: Topic.SnsAndCommunityFund, i18n: en })
+      ).toBe("Proposals related to SNS and Neurons' Fund");
+      expect(
+        getTopicSubtitle({ topic: Topic.ApiBoundaryNodeManagement, i18n: en })
+      ).toBe("Proposals related to the management of API boundary nodes");
     });
   });
 });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -16,6 +16,7 @@ import { DEPRECATED_TOPICS } from "$lib/constants/proposals.constants";
 import type { IcpAccountsStoreData } from "$lib/stores/icp-accounts.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
+import { enumValues } from "$lib/utils/enum.utils";
 import {
   ageMultiplier,
   allHaveSameFollowees,
@@ -2554,12 +2555,10 @@ describe("neuron-utils", () => {
 
   describe("getTopicTitle", () => {
     it("should return a title for every topic", () => {
-      for (const topic of Object.values(Topic)) {
-        if (typeof topic !== "string") {
-          expect(getTopicTitle({ topic, i18n: en })).toBe(
-            en.follow_neurons[`topic_${topic}_title`]
-          );
-        }
+      for (const topic of enumValues(Topic)) {
+        expect(getTopicTitle({ topic, i18n: en })).toBe(
+          en.follow_neurons[`topic_${topic}_title`]
+        );
       }
     });
 
@@ -2615,12 +2614,10 @@ describe("neuron-utils", () => {
 
   describe("getTopicSubtitle", () => {
     it("should return a title for every topic", () => {
-      for (const topic of Object.values(Topic)) {
-        if (typeof topic !== "string") {
-          expect(getTopicSubtitle({ topic, i18n: en })).toBe(
-            en.follow_neurons[`topic_${topic}_subtitle`]
-          );
-        }
+      for (const topic of enumValues(Topic)) {
+        expect(getTopicSubtitle({ topic, i18n: en })).toBe(
+          en.follow_neurons[`topic_${topic}_subtitle`]
+        );
       }
     });
 


### PR DESCRIPTION
# Motivation

I want to set up a test that makes sure there are no unused i18n message.
For this I'm trying to make it easy to find if i18n messages are used.
For this I'm trying to reduce the dynamic usages of i18n messages.

In this PR, I change the dynamic usage of `i18n.follow_neurons["topic_${topic}_title"]` to direct usage of specific messages.

# Changes

1. Add `getTopicTitle` and `getTopicSubtitle` which each have a map from `Topic` to specific messages.
2. Use these functions in `Followee.svelte` and `FollowNnsTopicSection.svelte`

# Tests

Unit tests added

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary