### PR TITLE
Use i18n directly in transactionNames

### DIFF
--- a/frontend/src/lib/components/accounts/NnsTransactionCard.svelte
+++ b/frontend/src/lib/components/accounts/NnsTransactionCard.svelte
@@ -46,7 +46,7 @@
           transactionId: transaction.block_height,
           toSelfTransaction,
           token: ICPToken,
-          transactionNames: $i18n.transaction_names,
+          i18n: $i18n,
         });
       } catch (err: unknown) {
         uiTransaction = undefined;

--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -205,7 +205,7 @@ export const mapIcrcTransaction = ({
     const headline = transactionName({
       type,
       isReceive,
-      labels: i18n.transaction_names,
+      i18n,
     });
     const otherParty = isReceive ? txInfo.from : txInfo.to;
 

--- a/frontend/src/lib/utils/transactions.utils.ts
+++ b/frontend/src/lib/utils/transactions.utils.ts
@@ -149,19 +149,19 @@ export const toUiTransaction = ({
   transactionId,
   toSelfTransaction,
   token,
-  transactionNames,
+  i18n,
 }: {
   transaction: Transaction;
   transactionId: bigint;
   toSelfTransaction: boolean;
   token: Token;
-  transactionNames: I18nTransaction_names;
+  i18n: I18n;
 }): UiTransaction => {
   const isIncoming = transaction.isReceive || toSelfTransaction;
   const headline = transactionName({
     type: transaction.type,
     isReceive: isIncoming,
-    labels: transactionNames,
+    i18n,
   });
   const otherParty = isIncoming ? transaction.from : transaction.to;
 
@@ -186,17 +186,40 @@ export const toUiTransaction = ({
 export const transactionName = ({
   type,
   isReceive,
-  labels,
+  i18n,
 }: {
   type: AccountTransactionType;
   isReceive: boolean;
-  labels: I18nTransaction_names;
-}): string =>
-  type === AccountTransactionType.Send
-    ? isReceive
-      ? labels.receive
-      : labels.send
-    : labels[type] ?? type;
+  i18n: I18n;
+}): string => {
+  switch (type) {
+    case AccountTransactionType.Send:
+      return isReceive
+        ? i18n.transaction_names.receive
+        : i18n.transaction_names.send;
+    case AccountTransactionType.Approve:
+      return i18n.transaction_names.approve;
+    case AccountTransactionType.Burn:
+      return i18n.transaction_names.burn;
+    case AccountTransactionType.Mint:
+      return i18n.transaction_names.mint;
+    case AccountTransactionType.StakeNeuron:
+      return i18n.transaction_names.stakeNeuron;
+    case AccountTransactionType.StakeNeuronNotification:
+      return i18n.transaction_names.stakeNeuronNotification;
+    case AccountTransactionType.TopUpNeuron:
+      return i18n.transaction_names.topUpNeuron;
+    case AccountTransactionType.CreateCanister:
+      return i18n.transaction_names.createCanister;
+    case AccountTransactionType.TopUpCanister:
+      return i18n.transaction_names.topUpCanister;
+    case AccountTransactionType.ParticipateSwap:
+      return i18n.transaction_names.participateSwap;
+    case AccountTransactionType.RefundSwap:
+      return i18n.transaction_names.refundSwap;
+  }
+  return type;
+};
 
 /** (from==to workaround) Set `mapToSelfNnsTransaction: true` when sender and receiver are the same account (e.g. transmitting from `main` to `main` account) */
 export const mapToSelfTransaction = (

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -397,7 +397,7 @@ describe("transactions-utils", () => {
       transactionId: 123n,
       toSelfTransaction: false,
       token: ICPToken,
-      transactionNames: en.transaction_names,
+      i18n: en,
     };
 
     const defaultExpectedUiTransaction: UiTransaction = {
@@ -578,7 +578,7 @@ describe("transactions-utils", () => {
           transactionName({
             type: key as AccountTransactionType,
             isReceive: false,
-            labels: en.transaction_names,
+            i18n: en,
           })
         ).toBe(en.transaction_names[key as AccountTransactionType]);
       }
@@ -589,7 +589,7 @@ describe("transactions-utils", () => {
         transactionName({
           type: AccountTransactionType.Send,
           isReceive: true,
-          labels: en.transaction_names,
+          i18n: en,
         })
       ).toBe(en.transaction_names.receive);
     });
@@ -599,7 +599,7 @@ describe("transactions-utils", () => {
         transactionName({
           type: "test" as AccountTransactionType,
           isReceive: true,
-          labels: en.transaction_names,
+          i18n: en,
         })
       ).toBe("test");
     });


### PR DESCRIPTION
# Motivation

I'm trying to make it easier to find unused i18n message and I also think this makes the code easier to understand.

# Changes

1. Instead of passing `i18n.transaction_name` to `transactionName`, pass `i18n`.
2. Instead of using the transaction type as a key, handle each transaction type explicitly.

# Tests

Updated

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary