### PR TITLE
Remove more unused i18n entries

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -140,7 +140,6 @@
   },
   "header": {
     "menu": "Open menu to access navigation options",
-    "title": "NETWORK NERVOUS SYSTEM",
     "logout": "Logout",
     "account_menu": "Open menu to access logout button"
   },
@@ -362,8 +361,6 @@
     "add": "Add Followee"
   },
   "voting": {
-    "title": "Voting",
-    "text": "The Internet Computer network runs under the control of the Network Nervous System, which adopts proposals and automatically executes corresponding actions. Anyone can submit a proposal, which are decided as the result of voting activity by neurons.",
     "topics": "Topics",
     "types": "Types",
     "rewards": "Reward Status",
@@ -400,8 +397,6 @@
   },
   "canister_detail": {
     "title": "Canister",
-    "id": "ID: $canisterId",
-    "cycles": "Cycles",
     "controllers": "Controllers",
     "t_cycles": "T Cycles",
     "add_cycles": "Add Cycles",
@@ -448,8 +443,6 @@
   },
   "wallet": {
     "title": "Account",
-    "address": "Address",
-    "principal": "Principal",
     "direction_from": "From:",
     "direction_to": "To:",
     "no_transactions": "Transactions will appear here.",
@@ -477,7 +470,6 @@
     "neurons_voted_plural": "$count neurons voted",
     "loading_neurons": "Loading your neurons...",
     "payload": "Payload",
-    "vote": "Vote",
     "created_prefix": "Created",
     "created_description": "The date when this proposal was created.",
     "decided_prefix": "Decided",
@@ -503,12 +495,10 @@
     "id": "ID"
   },
   "proposal_detail__vote": {
-    "headline": "Cast Vote",
     "vote_with_neurons": "Vote with $votable_count/$all_count Neuron",
     "vote_with_neurons_plural": "Vote with $votable_count/$all_count Neurons",
     "voting_power_label": "Voting Power:",
     "vote_progress": "Vote Progress",
-    "total": "Total",
     "adopt": "Adopt",
     "reject": "Reject",
     "confirm_adopt_headline": "Adopt Proposal",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -147,7 +147,6 @@ interface I18nNavigation {
 
 interface I18nHeader {
   menu: string;
-  title: string;
   logout: string;
   account_menu: string;
 }
@@ -376,8 +375,6 @@ interface I18nFollow_neurons {
 }
 
 interface I18nVoting {
-  title: string;
-  text: string;
   topics: string;
   types: string;
   rewards: string;
@@ -416,8 +413,6 @@ interface I18nCanisters {
 
 interface I18nCanister_detail {
   title: string;
-  id: string;
-  cycles: string;
   controllers: string;
   t_cycles: string;
   add_cycles: string;
@@ -466,8 +461,6 @@ interface I18nTransaction_names {
 
 interface I18nWallet {
   title: string;
-  address: string;
-  principal: string;
   direction_from: string;
   direction_to: string;
   no_transactions: string;
@@ -497,7 +490,6 @@ interface I18nProposal_detail {
   neurons_voted_plural: string;
   loading_neurons: string;
   payload: string;
-  vote: string;
   created_prefix: string;
   created_description: string;
   decided_prefix: string;
@@ -524,12 +516,10 @@ interface I18nProposal_detail {
 }
 
 interface I18nProposal_detail__vote {
-  headline: string;
   vote_with_neurons: string;
   vote_with_neurons_plural: string;
   voting_power_label: string;
   vote_progress: string;
-  total: string;
   adopt: string;
   reject: string;
   confirm_adopt_headline: string;


### PR DESCRIPTION
# Motivation

None of these are used directly
```
for x in header.title voting.title voting.text canister_detail.id canister_detail.cycles wallet.address wallet.principal proposal_detail.vote proposal_detail__vote.headline proposal_detail__vote.total ; do git grep -F $x; done
```

And I don't think they are used dynamically.

# Changes

1. `header.title`
2. `voting.title`
3. `voting.text`
4. `canister_detail.id`
5. `canister_detail.cycles`
6. `wallet.address`
7. `wallet.principal`
8. `proposal_detail.vote`
9. `proposal_detail__vote.headline`
10. `proposal_detail__vote.total`

# Tests

Still pass

# Todos

- [ ] Add entry to changelog (if necessary).
covered