### PR TITLE
Use i18n directly in dissolve delay item action

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte
@@ -11,7 +11,6 @@
   import { NeuronState, type NeuronInfo } from "@dfinity/nns";
   import CommonItemAction from "../ui/CommonItemAction.svelte";
   import IncreaseDissolveDelayButton from "./actions/IncreaseDissolveDelayButton.svelte";
-  import { keyOf } from "$lib/utils/utils";
   import { secondsToDuration, ICPToken } from "@dfinity/utils";
   import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
   import { authStore } from "$lib/stores/auth.store";
@@ -29,12 +28,13 @@
   let spawningTime: bigint | undefined;
   $: spawningTime = getSpawningTimeInSeconds(neuron);
 
-  const stateTextMapper = {
-    [NeuronState.Dissolved]: "dissolve_delay_row_title",
-    [NeuronState.Dissolving]: "remaining_title",
-    [NeuronState.Spawning]: "remaining_title",
-    [NeuronState.Locked]: "dissolve_delay_row_title",
-    [NeuronState.Unspecified]: "unspecified",
+  let stateTextMapper: Record<NeuronState, string>;
+  $: stateTextMapper = {
+    [NeuronState.Dissolved]: $i18n.neuron_detail.dissolve_delay_row_title,
+    [NeuronState.Dissolving]: $i18n.neuron_detail.remaining_title,
+    [NeuronState.Spawning]: $i18n.neuron_detail.remaining_title,
+    [NeuronState.Locked]: $i18n.neuron_detail.dissolve_delay_row_title,
+    [NeuronState.Unspecified]: $i18n.neuron_detail.unspecified,
   };
 
   let remainingTimeSeconds: bigint;
@@ -71,10 +71,7 @@
 >
   <IconClockNoFill slot="icon" />
   <span slot="title" data-tid="dissolve-delay-text"
-    >{`${keyOf({
-      obj: $i18n.neuron_detail,
-      key: stateTextMapper[neuron.state],
-    })} ${duration}`}</span
+    >{`${stateTextMapper[neuron.state]} ${duration}`}</span
   >
   <svelte:fragment slot="subtitle">
     {#if Number(remainingTimeSeconds) >= NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE}

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.svelte
@@ -3,7 +3,6 @@
   import { IconClockNoFill } from "@dfinity/gix-components";
   import { NeuronState } from "@dfinity/nns";
   import CommonItemAction from "../ui/CommonItemAction.svelte";
-  import { keyOf } from "$lib/utils/utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { secondsToDuration, type Token } from "@dfinity/utils";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
@@ -34,12 +33,13 @@
   let dissolvingTime: bigint;
   $: dissolvingTime = getSnsDissolveDelaySeconds(neuron) ?? 0n;
 
-  const stateTextMapper = {
-    [NeuronState.Dissolved]: "dissolve_delay_row_title",
-    [NeuronState.Dissolving]: "remaining_title",
-    [NeuronState.Spawning]: "remaining_title",
-    [NeuronState.Locked]: "dissolve_delay_row_title",
-    [NeuronState.Unspecified]: "unspecified",
+  let stateTextMapper: Record<NeuronState, string>;
+  $: stateTextMapper = {
+    [NeuronState.Dissolved]: $i18n.neuron_detail.dissolve_delay_row_title,
+    [NeuronState.Dissolving]: $i18n.neuron_detail.remaining_title,
+    [NeuronState.Spawning]: $i18n.neuron_detail.remaining_title,
+    [NeuronState.Locked]: $i18n.neuron_detail.dissolve_delay_row_title,
+    [NeuronState.Unspecified]: $i18n.neuron_detail.unspecified,
   };
 
   let minimumDelayToVoteInSeconds: bigint;
@@ -76,10 +76,7 @@
 >
   <IconClockNoFill slot="icon" />
   <span slot="title" data-tid="dissolve-delay-text"
-    >{`${keyOf({
-      obj: $i18n.neuron_detail,
-      key: stateTextMapper[state],
-    })} ${duration}`}</span
+    >{`${stateTextMapper[state]} ${duration}`}</span
   >
   <svelte:fragment slot="subtitle">
     {#if dissolvingTime >= minimumDelayToVoteInSeconds}


### PR DESCRIPTION
# Motivation

Make it easier to find unused i18n messages and make the code easier to understand.

# Changes

Instead of using `keyOf` access `i18n` directly in `NnsNeuronDissolveDelayItemAction.svelte` and `SnsNeuronDissolveDelayItemAction.svelte`.

# Tests

Existing tests pass.
Tested manually.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary