### PR TITLE
Use i18n directly in ProposalSystemInfoSection

### DIFF
--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoEntry.svelte
@@ -1,18 +1,15 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import { keyOf } from "$lib/utils/utils";
   import { Html, KeyValuePairInfo } from "@dfinity/gix-components";
 
-  export let labelKey: string;
+  export let label: string;
   export let testId: string;
   export let value: string;
   export let description: string | undefined;
 </script>
 
 <KeyValuePairInfo {testId} alignIconRight>
-  <span slot="key" class="description"
-    >{keyOf({ obj: $i18n.proposal_detail, key: labelKey })}</span
-  >
+  <span slot="key" class="description">{label}</span>
   <span class="value" slot="value" data-tid={`${testId}-value`}>{value}</span>
 
   <svelte:fragment slot="info">

--- a/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalSystemInfoSection.svelte
@@ -54,7 +54,7 @@
 >
   {#if type !== undefined}
     <ProposalSystemInfoEntry
-      labelKey="type_prefix"
+      label={$i18n.proposal_detail.type_prefix}
       testId="proposal-system-info-type"
       value={type}
       description={typeDescription}
@@ -63,7 +63,7 @@
 
   {#if topic !== undefined}
     <ProposalSystemInfoEntry
-      labelKey="topic_prefix"
+      label={$i18n.proposal_detail.topic_prefix}
       testId="proposal-system-info-topic"
       value={topic}
       description={topicDescription}
@@ -71,14 +71,14 @@
   {/if}
 
   <ProposalSystemInfoEntry
-    labelKey="status_prefix"
+    label={$i18n.proposal_detail.status_prefix}
     testId="proposal-system-info-status"
     value={statusString}
     description={statusDescription}
   />
 
   <ProposalSystemInfoEntry
-    labelKey="reward_prefix"
+    label={$i18n.proposal_detail.reward_prefix}
     testId="proposal-system-info-reward"
     value={rewardStatusString}
     description={rewardStatusDescription}
@@ -86,7 +86,7 @@
 
   {#if created !== undefined}
     <ProposalSystemInfoEntry
-      labelKey="created_prefix"
+      label={$i18n.proposal_detail.created_prefix}
       testId="proposal-system-info-created"
       value={secondsToDateTime(created)}
       description={$i18n.proposal_detail.created_description}
@@ -95,7 +95,7 @@
 
   {#if decided !== undefined}
     <ProposalSystemInfoEntry
-      labelKey="decided_prefix"
+      label={$i18n.proposal_detail.decided_prefix}
       testId="proposal-system-info-decided"
       value={secondsToDateTime(decided)}
       description={$i18n.proposal_detail.decided_description}
@@ -104,7 +104,7 @@
 
   {#if executed !== undefined}
     <ProposalSystemInfoEntry
-      labelKey="executed_prefix"
+      label={$i18n.proposal_detail.executed_prefix}
       testId="proposal-system-info-executed"
       value={secondsToDateTime(executed)}
       description={$i18n.proposal_detail.executed_description}
@@ -113,7 +113,7 @@
 
   {#if failed !== undefined}
     <ProposalSystemInfoEntry
-      labelKey="failed_prefix"
+      label={$i18n.proposal_detail.failed_prefix}
       testId="proposal-system-info-failed"
       value={secondsToDateTime(failed)}
       description={$i18n.proposal_detail.failed_description}

--- a/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalSystemInfoSection.svelte
@@ -45,7 +45,7 @@
   <div class="content-cell-details">
     {#if nonNullish(type)}
       <ProposalSystemInfoEntry
-        labelKey="type_prefix"
+        label={$i18n.proposal_detail.type_prefix}
         testId="proposal-system-info-type"
         value={type}
         description={typeDescription}
@@ -53,21 +53,21 @@
     {/if}
 
     <ProposalSystemInfoEntry
-      labelKey="status_prefix"
+      label={$i18n.proposal_detail.status_prefix}
       testId="proposal-system-info-status"
       value={statusString}
       description={statusDescription}
     />
 
     <ProposalSystemInfoEntry
-      labelKey="reward_prefix"
+      label={$i18n.proposal_detail.reward_prefix}
       testId="proposal-system-info-reward"
       value={rewardStatusString}
       description={rewardStatusDescription}
     />
 
     <ProposalSystemInfoEntry
-      labelKey="created_prefix"
+      label={$i18n.proposal_detail.created_prefix}
       testId="proposal-system-info-created"
       value={secondsToDateTime(proposal_creation_timestamp_seconds)}
       description={$i18n.proposal_detail.created_description}
@@ -75,7 +75,7 @@
 
     {#if decided_timestamp_seconds > 0n}
       <ProposalSystemInfoEntry
-        labelKey="decided_prefix"
+        label={$i18n.proposal_detail.decided_prefix}
         testId="proposal-system-info-decided"
         value={secondsToDateTime(decided_timestamp_seconds)}
         description={$i18n.proposal_detail.decided_description}
@@ -84,7 +84,7 @@
 
     {#if executed_timestamp_seconds > 0n}
       <ProposalSystemInfoEntry
-        labelKey="executed_prefix"
+        label={$i18n.proposal_detail.executed_prefix}
         testId="proposal-system-info-executed"
         value={secondsToDateTime(executed_timestamp_seconds)}
         description={$i18n.proposal_detail.executed_description}
@@ -93,7 +93,7 @@
 
     {#if failed_timestamp_seconds > 0n}
       <ProposalSystemInfoEntry
-        labelKey="failed_prefix"
+        label={$i18n.proposal_detail.failed_prefix}
         testId="proposal-system-info-failed"
         value={secondsToDateTime(failed_timestamp_seconds)}
         description={$i18n.proposal_detail.failed_description}


### PR DESCRIPTION
# Motivation

Make it easier to find unused i18n messages and make the code easier to understand.

# Changes

Instead of passing `labelKey` to `ProposalSystemInfoEntry` and using `keyOf` there, pass the i18n message directly.

# Tests

Existing tests pass.
Tested manually.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary