### PR TITLE
refactor: replace "button" with "a" tag

### DIFF
--- a/frontend/src/lib/components/proposal-detail/VotingCard/StakeNeuronToVote.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/StakeNeuronToVote.svelte
@@ -2,7 +2,6 @@
   import { IconExpandCircleDown, Collapsible } from "@dfinity/gix-components";
   import { fade } from "svelte/transition";
   import { i18n } from "$lib/stores/i18n";
-  import { goto } from "$app/navigation";
   import { neuronsPathStore } from "$lib/derived/paths.derived";
   import { isNnsUniverseStore } from "$lib/derived/selected-universe.derived";
   import { nnsTokenStore } from "$lib/derived/universes-tokens.derived";
@@ -47,8 +46,6 @@
           $tokenSymbol: token,
           $project: snsName,
         }));
-
-  const gotoNeurons = () => goto($neuronsPathStore);
 </script>
 
 <TestIdWrapper testId="stake-neuron-to-vote-component">
@@ -75,15 +72,15 @@
         <p class="description" data-tid="stake-neuron-description">
           {description}
         </p>
-        <button
+        <a
+          href={$neuronsPathStore}
           data-tid="stake-neuron-button"
-          class="secondary stake-neuron-button"
-          type="button"
-          on:click|stopPropagation={gotoNeurons}
-          >{replacePlaceholders($i18n.proposal_detail__vote.stake_neuron, {
-            $token: token,
-          })}</button
+          class="button secondary stake-neuron-button"
         >
+          {replacePlaceholders($i18n.proposal_detail__vote.stake_neuron, {
+            $token: token,
+          })}
+        </a>
         <slot />
       </Collapsible>
     </div>

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/StakeNeuronToVote.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/StakeNeuronToVote.spec.ts
@@ -1,7 +1,4 @@
 import StakeNeuronToVote from "$lib/components/proposal-detail/VotingCard/StakeNeuronToVote.svelte";
-import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
-import { AppPath } from "$lib/constants/routes.constants";
-import { pageStore } from "$lib/derived/page.derived";
 import { page } from "$mocks/$app/stores";
 import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
 import { StakeNeuronToVotePo } from "$tests/page-objects/StakeNeuronToVote.page-object";
@@ -9,7 +6,6 @@ import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
-import { get } from "svelte/store";
 
 describe("StakeNeuronToVote", () => {
   const renderComponent = async () => {
@@ -57,12 +53,9 @@ describe("StakeNeuronToVote", () => {
     it("should navigate to nns neurons page", async () => {
       const po = await renderAndExpand();
 
-      await po.clickGotoNeurons();
-
-      expect(get(pageStore)).toEqual({
-        path: AppPath.Neurons,
-        universe: OWN_CANISTER_ID_TEXT,
-      });
+      expect(await po.clickGotoNeuronsLink()).toEqual(
+        "/neurons/?u=qhbym-qaaaa-aaaaa-aaafq-cai"
+      );
     });
   });
 
@@ -111,12 +104,9 @@ describe("StakeNeuronToVote", () => {
     it("should navigate to sns neurons page", async () => {
       const po = await renderAndExpand();
 
-      await po.clickGotoNeurons();
-
-      expect(get(pageStore)).toEqual({
-        path: AppPath.Neurons,
-        universe: rootCanisterId.toText(),
-      });
+      expect(await po.clickGotoNeuronsLink()).toEqual(
+        "/neurons/?u=g3pce-2iaae"
+      );
     });
   });
 });

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/StakeNeuronToVote.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/StakeNeuronToVote.spec.ts
@@ -53,7 +53,7 @@ describe("StakeNeuronToVote", () => {
     it("should navigate to nns neurons page", async () => {
       const po = await renderAndExpand();
 
-      expect(await po.clickGotoNeuronsLink()).toEqual(
+      expect(await po.getGotoNeuronsLinkHref()).toEqual(
         "/neurons/?u=qhbym-qaaaa-aaaaa-aaafq-cai"
       );
     });
@@ -104,7 +104,7 @@ describe("StakeNeuronToVote", () => {
     it("should navigate to sns neurons page", async () => {
       const po = await renderAndExpand();
 
-      expect(await po.clickGotoNeuronsLink()).toEqual(
+      expect(await po.getGotoNeuronsLinkHref()).toEqual(
         "/neurons/?u=g3pce-2iaae"
       );
     });

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/StakeNeuronToVote.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/StakeNeuronToVote.spec.ts
@@ -47,7 +47,7 @@ describe("StakeNeuronToVote", () => {
     it("should display NNS version of the button", async () => {
       const po = await renderAndExpand();
 
-      await expect(await po.getGotoNeuronsButtonText()).toBe("Stake ICP");
+      await expect(await po.getGotoNeuronsLinkText()).toBe("Stake ICP");
     });
 
     it("should navigate to nns neurons page", async () => {
@@ -98,7 +98,7 @@ describe("StakeNeuronToVote", () => {
     it("should display SNS version of the button", async () => {
       const po = await renderAndExpand();
 
-      await expect(await po.getGotoNeuronsButtonText()).toBe("Stake CAT");
+      await expect(await po.getGotoNeuronsLinkText()).toBe("Stake CAT");
     });
 
     it("should navigate to sns neurons page", async () => {

--- a/frontend/src/tests/page-objects/StakeNeuronToVote.page-object.ts
+++ b/frontend/src/tests/page-objects/StakeNeuronToVote.page-object.ts
@@ -45,7 +45,7 @@ export class StakeNeuronToVotePo extends BasePageObject {
     return this.getGotoNeuronsLink().getText();
   }
 
-  clickGotoNeuronsLink(): Promise<string> {
+  getGotoNeuronsLinkHref(): Promise<string> {
     return this.getGotoNeuronsLink().getAttribute("href");
   }
 }

--- a/frontend/src/tests/page-objects/StakeNeuronToVote.page-object.ts
+++ b/frontend/src/tests/page-objects/StakeNeuronToVote.page-object.ts
@@ -41,7 +41,7 @@ export class StakeNeuronToVotePo extends BasePageObject {
     return this.getElement("stake-neuron-button");
   }
 
-  getGotoNeuronsButtonText(): Promise<string> {
+  getGotoNeuronsLinkText(): Promise<string> {
     return this.getGotoNeuronsLink().getText();
   }
 

--- a/frontend/src/tests/page-objects/StakeNeuronToVote.page-object.ts
+++ b/frontend/src/tests/page-objects/StakeNeuronToVote.page-object.ts
@@ -37,15 +37,15 @@ export class StakeNeuronToVotePo extends BasePageObject {
     return this.getDescription().getText();
   }
 
-  getGotoNeuronsButton(): ButtonPo {
-    return this.getButton("stake-neuron-button");
+  getGotoNeuronsLink(): PageObjectElement {
+    return this.getElement("stake-neuron-button");
   }
 
   getGotoNeuronsButtonText(): Promise<string> {
-    return this.getGotoNeuronsButton().getText();
+    return this.getGotoNeuronsLink().getText();
   }
 
-  clickGotoNeurons(): Promise<void> {
-    return this.getGotoNeuronsButton().click();
+  clickGotoNeuronsLink(): Promise<string> {
+    return this.getGotoNeuronsLink().getAttribute("href");
   }
 }


### PR DESCRIPTION
# Motivation

Replace `button` tag with `a` tag in the `Stake Token` button, to be consistent in the application.

# Changes

- `<button>` -> `<a>`
- apply button utility classes

# Tests

Tested manually that if works and feels the same.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary