### PR TITLE
Use ledgerCanisterId instead of universeId

### DIFF
--- a/frontend/src/lib/components/accounts/CkBTCAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCAccountsFooter.svelte
@@ -38,7 +38,7 @@
       return;
     }
 
-    await syncAccounts({ universeId: $selectedCkBTCUniverseIdStore });
+    await syncAccounts({ ledgerCanisterId: $selectedCkBTCUniverseIdStore });
   };
 </script>
 

--- a/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/CkBTCTransactionsList.svelte
@@ -92,7 +92,7 @@
   bind:this={transactions}
   {indexCanisterId}
   {account}
-  {universeId}
+  ledgerCanisterId={universeId}
   {token}
   {mapTransactions}
 />

--- a/frontend/src/lib/components/accounts/IcrcAccountsPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcAccountsPage.svelte
@@ -29,7 +29,7 @@
     }
 
     loading = true;
-    await syncWalletAccounts({ universeId });
+    await syncWalletAccounts({ ledgerCanisterId: universeId });
     loading = false;
   };
 

--- a/frontend/src/lib/components/accounts/IcrcAccountsPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcAccountsPage.svelte
@@ -45,7 +45,8 @@
   {#if loading}
     <SkeletonCard size="medium" />
   {:else if nonNullish(selectedUniverseId)}
-    <IcrcBalancesObserver {accounts} universeId={selectedUniverseId}>
+    <!-- TODO(dskloet) -->
+    <IcrcBalancesObserver {accounts} ledgerCanisterId={selectedUniverseId}>
       {#each accounts as account}
         <AccountCard {account} {token}
           >{account.name ?? $i18n.accounts.main}</AccountCard

--- a/frontend/src/lib/components/accounts/IcrcBalancesObserver.svelte
+++ b/frontend/src/lib/components/accounts/IcrcBalancesObserver.svelte
@@ -27,12 +27,13 @@
       })
       .filter(nonNullish);
 
+    // TODO(dskloet)
     icrcAccountsStore.update({
       accounts: {
         accounts,
         certified: $icrcAccountsStore[universeId.toText()].certified,
       },
-      universeId,
+      ledgerCanisterId: universeId,
     });
 
     reload?.();

--- a/frontend/src/lib/components/accounts/IcrcBalancesObserver.svelte
+++ b/frontend/src/lib/components/accounts/IcrcBalancesObserver.svelte
@@ -4,10 +4,10 @@
   import BalancesObserver from "$lib/components/accounts/BalancesObserver.svelte";
   import type { BalancesCallback } from "$lib/services/worker-balances.services";
   import type { Account } from "$lib/types/account";
-  import type { UniverseCanisterId } from "$lib/types/universe";
+  import type { Principal } from "@dfinity/principal";
   import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 
-  export let universeId: UniverseCanisterId;
+  export let ledgerCanisterId: Principal;
   export let accounts: Account[];
   export let reload: (() => void) | undefined = undefined;
 
@@ -15,7 +15,7 @@
     const accounts = balances
       .map(({ balance, accountIdentifier }) => {
         const selectedAccount = $icrcAccountsStore[
-          universeId.toText()
+          ledgerCanisterId.toText()
         ].accounts?.find(({ identifier }) => identifier === accountIdentifier);
 
         return nonNullish(selectedAccount)
@@ -27,13 +27,12 @@
       })
       .filter(nonNullish);
 
-    // TODO(dskloet)
     icrcAccountsStore.update({
       accounts: {
         accounts,
-        certified: $icrcAccountsStore[universeId.toText()].certified,
+        certified: $icrcAccountsStore[ledgerCanisterId.toText()].certified,
       },
-      ledgerCanisterId: universeId,
+      ledgerCanisterId,
     });
 
     reload?.();
@@ -42,7 +41,7 @@
   let data: BalancesObserverData;
   $: data = {
     accounts,
-    ledgerCanisterId: universeId.toText(),
+    ledgerCanisterId: ledgerCanisterId.toText(),
   };
 </script>
 

--- a/frontend/src/lib/components/accounts/IcrcTokenAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTokenAccountsFooter.svelte
@@ -46,7 +46,7 @@
       return;
     }
 
-    await syncAccounts({ universeId });
+    await syncAccounts({ ledgerCanisterId: universeId });
   };
 </script>
 

--- a/frontend/src/lib/components/accounts/IcrcTokenAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTokenAccountsFooter.svelte
@@ -31,7 +31,7 @@
     openIcrcTokenModal({
       type: "icrc-send",
       data: {
-        universeId,
+        ledgerCanisterId: universeId,
         token,
         loadTransactions: false,
       },

--- a/frontend/src/lib/components/accounts/IcrcTokenWalletFooter.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTokenWalletFooter.svelte
@@ -29,9 +29,8 @@
     }
     openIcrcTokenModal({
       type: "icrc-send",
-      // TODO(dskloet)
       data: {
-        universeId: ledgerCanisterId,
+        ledgerCanisterId,
         token,
         loadTransactions: false,
         sourceAccount: account,
@@ -48,7 +47,6 @@
     data-tid="open-new-icrc-token-transaction">{$i18n.accounts.send}</button
   >
 
-  <!-- TODO(dskloet) -->
   <ReceiveButton
     type="icrc-receive"
     {account}

--- a/frontend/src/lib/components/accounts/IcrcTokenWalletFooter.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTokenWalletFooter.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { isNullish } from "@dfinity/utils";
   import Footer from "$lib/components/layout/Footer.svelte";
-  import type { UniverseCanisterId } from "$lib/types/universe";
   import { toastsError } from "$lib/stores/toasts.store";
   import { openIcrcTokenModal } from "$lib/utils/modals.utils";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
@@ -10,8 +9,9 @@
   import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
   import IC_LOGO from "$lib/assets/icp.svg";
   import ReceiveButton from "$lib/components/accounts/ReceiveButton.svelte";
+  import type { Principal } from "@dfinity/principal";
 
-  export let universeId: UniverseCanisterId;
+  export let ledgerCanisterId: Principal;
   export let token: IcrcTokenMetadata;
   export let account: Account;
   export let reloadAccount: () => Promise<void>;
@@ -23,14 +23,15 @@
   };
 
   const openSendModal = () => {
-    if (isNullish(universeId) || isNullish(token)) {
+    if (isNullish(ledgerCanisterId) || isNullish(token)) {
       toastsError({ labelKey: "error.icrc_token_load" });
       return;
     }
     openIcrcTokenModal({
       type: "icrc-send",
+      // TODO(dskloet)
       data: {
-        universeId,
+        universeId: ledgerCanisterId,
         token,
         loadTransactions: false,
         sourceAccount: account,
@@ -47,12 +48,13 @@
     data-tid="open-new-icrc-token-transaction">{$i18n.accounts.send}</button
   >
 
+  <!-- TODO(dskloet) -->
   <ReceiveButton
     type="icrc-receive"
     {account}
     reload={reloadAccount}
     testId="receive-icrc"
-    {universeId}
+    universeId={ledgerCanisterId}
     logo={$selectedUniverseStore?.logo ?? IC_LOGO}
     tokenSymbol={token?.symbol}
   />

--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -156,8 +156,9 @@
     <section>
       {#if loaded && nonNullish(selectedUniverseId)}
         {#if nonNullish($selectedAccountStore.account) && nonNullish(token)}
+          <!-- TODO(dskloet) -->
           <IcrcBalancesObserver
-            universeId={selectedUniverseId}
+            ledgerCanisterId={selectedUniverseId}
             accounts={[$selectedAccountStore.account]}
             reload={reloadOnlyAccountFromStore}
           />

--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -135,7 +135,7 @@
     }
 
     // Maybe the accounts were just not loaded yet in store, so we try to load the accounts in store
-    await syncWalletAccounts({ universeId });
+    await syncWalletAccounts({ ledgerCanisterId: universeId });
 
     // And finally try to set the account again
     await loadAccount(universeId);

--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -18,7 +18,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { goto } from "$app/navigation";
   import { buildAccountsUrl } from "$lib/utils/navigation.utils";
-  import type { UniverseCanisterId } from "$lib/types/universe";
+  import type { Principal } from "@dfinity/principal";
   import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
   import IcrcBalancesObserver from "$lib/components/accounts/IcrcBalancesObserver.svelte";
   import WalletPageHeader from "$lib/components/accounts/WalletPageHeader.svelte";
@@ -29,7 +29,7 @@
 
   export let testId: string;
   export let accountIdentifier: string | undefined | null = undefined;
-  export let selectedUniverseId: UniverseCanisterId | undefined;
+  export let ledgerCanisterId: Principal | undefined;
   export let token: IcrcTokenMetadata | undefined = undefined;
   export let selectedAccountStore: Writable<WalletStore>;
   export let reloadTransactions: () => Promise<void>;
@@ -49,11 +49,11 @@
 
   // e.g. is called from "Receive" modal after user click "Done"
   export const reloadAccount = async () => {
-    if (isNullish(selectedUniverseId)) {
+    if (isNullish(ledgerCanisterId)) {
       return;
     }
 
-    await loadAccount(selectedUniverseId);
+    await loadAccount(ledgerCanisterId);
 
     // transactions?.reloadTransactions?.() returns a promise.
     // However, the UI displays skeletons while loading and the user can proceed with other operations during this time.
@@ -62,8 +62,8 @@
   };
 
   export const setSelectedAccount = () => {
-    const accounts = nonNullish(selectedUniverseId)
-      ? $icrcAccountsStore[selectedUniverseId.toText()]?.accounts ?? []
+    const accounts = nonNullish(ledgerCanisterId)
+      ? $icrcAccountsStore[ledgerCanisterId.toText()]?.accounts ?? []
       : [];
     const account = findAccountOrDefaultToMain({
       identifier: accountIdentifier,
@@ -76,7 +76,7 @@
   };
 
   export const loadAccount = async (
-    universeId: UniverseCanisterId
+    ledgerCanisterId: Principal
   ): Promise<{
     state: "loaded" | "not_found" | "unknown";
   }> => {
@@ -88,7 +88,9 @@
     }
 
     // Accounts are loaded in store but no account identifier is matching
-    if (hasAccounts($icrcAccountsStore[universeId.toText()]?.accounts ?? [])) {
+    if (
+      hasAccounts($icrcAccountsStore[ledgerCanisterId.toText()]?.accounts ?? [])
+    ) {
       toastsError({
         labelKey: replacePlaceholders($i18n.error.account_not_found, {
           $account_identifier: accountIdentifier ?? "",
@@ -105,14 +107,14 @@
   let loaded = false;
 
   const loadData = async ({
-    universeId,
+    ledgerCanisterId,
     isSignedIn,
   }: {
-    universeId: UniverseCanisterId | undefined;
+    ledgerCanisterId: Principal | undefined;
     isSignedIn: boolean;
   }) => {
     // Universe is not yet loaded
-    if (isNullish(universeId)) {
+    if (isNullish(ledgerCanisterId)) {
       return;
     }
 
@@ -126,7 +128,7 @@
     // It will also re-create a new component for the list of transactions which per extension will trigger fetching those
     loaded = false;
 
-    const { state } = await loadAccount(universeId);
+    const { state } = await loadAccount(ledgerCanisterId);
 
     // The account was loaded or was not found even though accounts are already loaded in store
     if (state !== "unknown") {
@@ -135,10 +137,10 @@
     }
 
     // Maybe the accounts were just not loaded yet in store, so we try to load the accounts in store
-    await syncWalletAccounts({ ledgerCanisterId: universeId });
+    await syncWalletAccounts({ ledgerCanisterId });
 
     // And finally try to set the account again
-    await loadAccount(universeId);
+    await loadAccount(ledgerCanisterId);
 
     loaded = true;
   };
@@ -146,7 +148,7 @@
   $: accountIdentifier,
     (async () =>
       await loadData({
-        universeId: selectedUniverseId,
+        ledgerCanisterId,
         isSignedIn: $authSignedInStore,
       }))();
 </script>
@@ -154,11 +156,10 @@
 <Island {testId}>
   <main class="legacy">
     <section>
-      {#if loaded && nonNullish(selectedUniverseId)}
+      {#if loaded && nonNullish(ledgerCanisterId)}
         {#if nonNullish($selectedAccountStore.account) && nonNullish(token)}
-          <!-- TODO(dskloet) -->
           <IcrcBalancesObserver
-            ledgerCanisterId={selectedUniverseId}
+            {ledgerCanisterId}
             accounts={[$selectedAccountStore.account]}
             reload={reloadOnlyAccountFromStore}
           />

--- a/frontend/src/lib/components/accounts/IcrcWalletTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletTransactionsList.svelte
@@ -71,7 +71,7 @@
     // That way the skeletons will be displayed again which provides the user a visual feedback about the fact that all transactions are realoded.
     // This is handy because the reload notably happens the "update balance" process - i.e. happens after the "busy spinner" has fade away.
     icrcTransactionsStore.resetAccount({
-      universeId,
+      canisterId: universeId,
       accountIdentifier: account.identifier,
     });
 

--- a/frontend/src/lib/components/accounts/IcrcWalletTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletTransactionsList.svelte
@@ -29,7 +29,7 @@
   import { nonNullish } from "@dfinity/utils";
 
   export let indexCanisterId: CanisterId;
-  export let universeId: UniverseCanisterId;
+  export let ledgerCanisterId: UniverseCanisterId;
   export let account: Account;
   export let token: IcrcTokenMetadata | undefined;
   export let mapTransactions = (
@@ -53,7 +53,7 @@
     loading = true;
     await loadWalletNextTransactions({
       account,
-      canisterId: universeId,
+      canisterId: ledgerCanisterId,
       indexCanisterId,
     });
     loading = false;
@@ -71,7 +71,7 @@
     // That way the skeletons will be displayed again which provides the user a visual feedback about the fact that all transactions are realoded.
     // This is handy because the reload notably happens the "update balance" process - i.e. happens after the "busy spinner" has fade away.
     icrcTransactionsStore.resetAccount({
-      canisterId: universeId,
+      canisterId: ledgerCanisterId,
       accountIdentifier: account.identifier,
     });
 
@@ -80,7 +80,7 @@
 
     await loadWalletTransactions({
       account,
-      canisterId: universeId,
+      canisterId: ledgerCanisterId,
       indexCanisterId,
     });
 
@@ -92,14 +92,14 @@
   let transactions: IcrcTransactionData[];
   $: transactions = getSortedTransactionsFromStore({
     store: $icrcTransactionsStore,
-    canisterId: universeId,
+    canisterId: ledgerCanisterId,
     account,
   });
 
   let completed: boolean;
   $: completed = isIcrcTransactionsCompleted({
     store: $icrcTransactionsStore,
-    canisterId: universeId,
+    canisterId: ledgerCanisterId,
     account,
   });
 
@@ -113,11 +113,12 @@
     transactions.length === 0 && loading ? [] : mappedTransactions;
 </script>
 
+<!-- TODO(dskloet) -->
 <IcrcWalletTransactionsObserver
   {indexCanisterId}
   {account}
   {completed}
-  {universeId}
+  universeId={ledgerCanisterId}
 >
   <IcrcTransactionsList
     on:nnsIntersect={loadNextTransactions}

--- a/frontend/src/lib/components/accounts/IcrcWalletTransactionsList.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletTransactionsList.svelte
@@ -113,12 +113,11 @@
     transactions.length === 0 && loading ? [] : mappedTransactions;
 </script>
 
-<!-- TODO(dskloet) -->
 <IcrcWalletTransactionsObserver
   {indexCanisterId}
   {account}
   {completed}
-  universeId={ledgerCanisterId}
+  {ledgerCanisterId}
 >
   <IcrcTransactionsList
     on:nnsIntersect={loadNextTransactions}

--- a/frontend/src/lib/components/accounts/IcrcWalletTransactionsObserver.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletTransactionsObserver.svelte
@@ -24,9 +24,8 @@
       return;
     }
 
-    // TODO(dskloet)
     addObservedIcrcTransactionsToStore({
-      universeId: ledgerCanisterId,
+      ledgerCanisterId,
       completed,
       transactions,
     });

--- a/frontend/src/lib/components/accounts/IcrcWalletTransactionsObserver.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletTransactionsObserver.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import type { CanisterId } from "$lib/types/canister";
-  import type { UniverseCanisterId } from "$lib/types/universe";
   import type { Account } from "$lib/types/account";
   import type { TransactionsObserverData } from "$lib/types/icrc.observer";
   import TransactionsObserver from "$lib/components/accounts/TransactionsObserver.svelte";
@@ -9,7 +8,7 @@
   import { addObservedIcrcTransactionsToStore } from "$lib/services/observer.services";
 
   export let indexCanisterId: CanisterId;
-  export let universeId: UniverseCanisterId;
+  export let ledgerCanisterId: CanisterId;
   export let account: Account;
   export let completed: boolean;
 
@@ -20,13 +19,14 @@
   };
 
   const callback: TransactionsCallback = ({ transactions }) => {
-    if (isNullish(universeId)) {
+    if (isNullish(ledgerCanisterId)) {
       // With current usage, can unlikely be undefined here
       return;
     }
 
+    // TODO(dskloet)
     addObservedIcrcTransactionsToStore({
-      universeId,
+      universeId: ledgerCanisterId,
       completed,
       transactions,
     });

--- a/frontend/src/lib/components/accounts/SnsWalletTransactionsObserver.svelte
+++ b/frontend/src/lib/components/accounts/SnsWalletTransactionsObserver.svelte
@@ -30,7 +30,11 @@
     }
 
     addObservedIcrcTransactionsToStore({
-      universeId,
+      // The SNS universeId is not a ledgerCanisterId but the ledgerCanisterId
+      // is only used as a key so it works fine and we want to delete
+      // SnsWalletTransactionsObserver in favor of
+      // IcrcWalletTransactionsObserver anyway.
+      ledgerCanisterId: universeId,
       completed,
       transactions,
     });

--- a/frontend/src/lib/modals/accounts/IcrcTokenAccountsModals.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcTokenAccountsModals.svelte
@@ -21,7 +21,7 @@
 {#if modal?.type === "icrc-send"}
   <IcrcTokenTransactionModal
     on:nnsClose={closeModal}
-    ledgerCanisterId={modal.data.universeId}
+    ledgerCanisterId={modal.data.ledgerCanisterId}
     token={modal.data.token}
     transactionFee={TokenAmountV2.fromUlps({
       amount: modal.data.token.fee,

--- a/frontend/src/lib/pages/CkBTCAccounts.svelte
+++ b/frontend/src/lib/pages/CkBTCAccounts.svelte
@@ -27,6 +27,6 @@
 
 <IcrcAccountsPage
   testId="ckbtc-accounts-body"
-  selectedUniverseId={$selectedCkBTCUniverseIdStore}
+  ledgerCanisterId={$selectedCkBTCUniverseIdStore}
   token={token?.token}
 ></IcrcAccountsPage>

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -37,7 +37,7 @@
       return;
     }
 
-    await loadAccounts({ universeId: $selectedCkBTCUniverseIdStore });
+    await loadAccounts({ ledgerCanisterId: $selectedCkBTCUniverseIdStore });
     await wallet.reloadAccount?.();
   };
 

--- a/frontend/src/lib/pages/CkBTCWallet.svelte
+++ b/frontend/src/lib/pages/CkBTCWallet.svelte
@@ -100,7 +100,7 @@
   testId="ckbtc-wallet-component"
   {accountIdentifier}
   token={token?.token}
-  selectedUniverseId={$selectedCkBTCUniverseIdStore}
+  ledgerCanisterId={$selectedCkBTCUniverseIdStore}
   {selectedAccountStore}
   bind:this={wallet}
   {reloadTransactions}

--- a/frontend/src/lib/pages/IcrcTokenAccounts.svelte
+++ b/frontend/src/lib/pages/IcrcTokenAccounts.svelte
@@ -13,6 +13,6 @@
 
 <IcrcAccountsPage
   testId="icrc-accounts-body"
-  selectedUniverseId={$selectedIcrcTokenUniverseIdStore}
+  ledgerCanisterId={$selectedIcrcTokenUniverseIdStore}
   {token}
 />

--- a/frontend/src/lib/pages/IcrcWallet.svelte
+++ b/frontend/src/lib/pages/IcrcWallet.svelte
@@ -37,7 +37,6 @@
   const reloadTransactions = () => transactions?.reloadTransactions?.();
 </script>
 
-<!-- TODO(dskloet) -->
 <IcrcWalletPage
   testId="icrc-wallet-component"
   {accountIdentifier}
@@ -52,7 +51,7 @@
       <IcrcWalletTransactionsList
         account={$selectedAccountStore.account}
         {indexCanisterId}
-        universeId={$selectedIcrcTokenUniverseIdStore}
+        ledgerCanisterId={$selectedIcrcTokenUniverseIdStore}
         {token}
         bind:this={transactions}
       />

--- a/frontend/src/lib/pages/IcrcWallet.svelte
+++ b/frontend/src/lib/pages/IcrcWallet.svelte
@@ -63,7 +63,7 @@
   <svelte:fragment slot="footer-actions">
     {#if nonNullish($selectedAccountStore.account) && nonNullish(token) && nonNullish($selectedIcrcTokenUniverseIdStore)}
       <IcrcTokenWalletFooter
-        universeId={$selectedIcrcTokenUniverseIdStore}
+        ledgerCanisterId={$selectedIcrcTokenUniverseIdStore}
         account={$selectedAccountStore.account}
         {token}
         {reloadAccount}

--- a/frontend/src/lib/pages/IcrcWallet.svelte
+++ b/frontend/src/lib/pages/IcrcWallet.svelte
@@ -37,11 +37,12 @@
   const reloadTransactions = () => transactions?.reloadTransactions?.();
 </script>
 
+<!-- TODO(dskloet) -->
 <IcrcWalletPage
   testId="icrc-wallet-component"
   {accountIdentifier}
   {token}
-  selectedUniverseId={$selectedIcrcTokenUniverseIdStore}
+  ledgerCanisterId={$selectedIcrcTokenUniverseIdStore}
   {selectedAccountStore}
   bind:this={wallet}
   {reloadTransactions}

--- a/frontend/src/lib/services/ckbtc-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts.services.ts
@@ -7,12 +7,13 @@ import type { Account } from "$lib/types/account";
 import type { UniverseCanisterId } from "$lib/types/universe";
 import type { Identity } from "@dfinity/agent";
 import type { IcrcBlockIndex } from "@dfinity/ledger-icrc";
+import type { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import { numberToE8s } from "../utils/token.utils";
 
 export const loadCkBTCAccounts = async (params: {
   handleError?: () => void;
-  universeId: UniverseCanisterId;
+  ledgerCanisterId: Principal;
 }): Promise<void> => loadAccounts(params);
 
 export const ckBTCTransferTokens = async ({
@@ -44,7 +45,8 @@ export const ckBTCTransferTokens = async ({
         ...params,
         canisterId: universeId,
       }),
-    reloadAccounts: async () => await loadAccounts({ universeId }),
+    reloadAccounts: async () =>
+      await loadAccounts({ ledgerCanisterId: universeId }),
     reloadTransactions: async () => Promise.resolve(),
   });
 };

--- a/frontend/src/lib/services/ckbtc-convert.services.ts
+++ b/frontend/src/lib/services/ckbtc-convert.services.ts
@@ -109,7 +109,9 @@ const reload = async ({
   // Reload:
   // - if provided, the transactions of the account for which the transfer was executed
   await Promise.all([
-    ...(loadAccounts ? [loadCkBTCAccounts({ universeId })] : []),
+    ...(loadAccounts
+      ? [loadCkBTCAccounts({ ledgerCanisterId: universeId })]
+      : []),
     ...(nonNullish(source)
       ? [
           loadWalletTransactions({

--- a/frontend/src/lib/services/ckbtc-tokens.services.ts
+++ b/frontend/src/lib/services/ckbtc-tokens.services.ts
@@ -1,6 +1,6 @@
 import {
-  CKBTC_UNIVERSE_CANISTER_ID,
-  CKTESTBTC_UNIVERSE_CANISTER_ID,
+  CKBTC_LEDGER_CANISTER_ID,
+  CKTESTBTC_LEDGER_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { loadToken } from "$lib/services/wallet-tokens.services";
 import {
@@ -14,10 +14,10 @@ export const loadCkBTCTokens = async () => {
   const enableCkBTCTest = get(ENABLE_CKTESTBTC);
   return Promise.all([
     enableCkBTC
-      ? loadToken({ universeId: CKBTC_UNIVERSE_CANISTER_ID })
+      ? loadToken({ ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID })
       : undefined,
     enableCkBTCTest
-      ? loadToken({ universeId: CKTESTBTC_UNIVERSE_CANISTER_ID })
+      ? loadToken({ ledgerCanisterId: CKTESTBTC_LEDGER_CANISTER_ID })
       : undefined,
   ]);
 };

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -118,7 +118,7 @@ export const loadIcrcAccount = ({
     onLoad: async ({ response: account, certified }) =>
       icrcAccountsStore.set({
         accounts: { accounts: [account], certified },
-        universeId: ledgerCanisterId,
+        ledgerCanisterId,
       }),
     onError: ({ error: err, certified }) => {
       if (!certified && notForceCallStrategy()) {

--- a/frontend/src/lib/services/observer.services.ts
+++ b/frontend/src/lib/services/observer.services.ts
@@ -1,14 +1,14 @@
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import type { PostMessageDataResponseTransaction } from "$lib/types/post-message.transactions";
-import type { UniverseCanisterId } from "$lib/types/universe";
+import type { Principal } from "@dfinity/principal";
 import { jsonReviver } from "@dfinity/utils";
 
 export const addObservedIcrcTransactionsToStore = ({
-  universeId,
+  ledgerCanisterId,
   completed,
   transactions,
 }: {
-  universeId: UniverseCanisterId;
+  ledgerCanisterId: Principal;
   completed: boolean;
   transactions: PostMessageDataResponseTransaction[];
 }) => {
@@ -24,7 +24,7 @@ export const addObservedIcrcTransactionsToStore = ({
       ...rest,
       accountIdentifier,
       transactions: JSON.parse(jsonTransactions, jsonReviver),
-      canisterId: universeId,
+      canisterId: ledgerCanisterId,
       completed,
     });
   }

--- a/frontend/src/lib/services/wallet-accounts.services.ts
+++ b/frontend/src/lib/services/wallet-accounts.services.ts
@@ -6,9 +6,9 @@ import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import type { Account } from "$lib/types/account";
-import type { UniverseCanisterId } from "$lib/types/universe";
 import { notForceCallStrategy } from "$lib/utils/env.utils";
 import { toToastError } from "$lib/utils/error.utils";
+import type { Principal } from "@dfinity/principal";
 
 /**
  * TODO: once sns are migrated to store this module can probably be reused and renamed to icrc-accounts.services
@@ -16,18 +16,18 @@ import { toToastError } from "$lib/utils/error.utils";
 
 export const loadAccounts = async ({
   handleError,
-  universeId,
+  ledgerCanisterId,
 }: {
   handleError?: () => void;
-  universeId: UniverseCanisterId;
+  ledgerCanisterId: Principal;
 }): Promise<void> => {
   return queryAndUpdate<Account[], unknown>({
     strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
-      getAccounts({ identity, certified, ledgerCanisterId: universeId }),
+      getAccounts({ identity, certified, ledgerCanisterId }),
     onLoad: ({ response: accounts, certified }) =>
       icrcAccountsStore.set({
-        universeId,
+        universeId: ledgerCanisterId,
         accounts: {
           accounts,
           certified,
@@ -42,7 +42,7 @@ export const loadAccounts = async ({
 
       // hide unproven data
       icrcAccountsStore.reset();
-      icrcTransactionsStore.resetUniverse(universeId);
+      icrcTransactionsStore.resetUniverse(ledgerCanisterId);
 
       toastsError(
         toToastError({
@@ -59,5 +59,5 @@ export const loadAccounts = async ({
 
 export const syncAccounts = async (params: {
   handleError?: () => void;
-  universeId: UniverseCanisterId;
+  ledgerCanisterId: Principal;
 }) => await Promise.all([loadAccounts(params), loadToken(params)]);

--- a/frontend/src/lib/services/wallet-accounts.services.ts
+++ b/frontend/src/lib/services/wallet-accounts.services.ts
@@ -24,7 +24,7 @@ export const loadAccounts = async ({
   return queryAndUpdate<Account[], unknown>({
     strategy: FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
-      getAccounts({ identity, certified, universeId }),
+      getAccounts({ identity, certified, ledgerCanisterId: universeId }),
     onLoad: ({ response: accounts, certified }) =>
       icrcAccountsStore.set({
         universeId,

--- a/frontend/src/lib/services/wallet-accounts.services.ts
+++ b/frontend/src/lib/services/wallet-accounts.services.ts
@@ -27,7 +27,7 @@ export const loadAccounts = async ({
       getAccounts({ identity, certified, ledgerCanisterId }),
     onLoad: ({ response: accounts, certified }) =>
       icrcAccountsStore.set({
-        universeId: ledgerCanisterId,
+        ledgerCanisterId,
         accounts: {
           accounts,
           certified,

--- a/frontend/src/lib/services/wallet-loader.services.ts
+++ b/frontend/src/lib/services/wallet-loader.services.ts
@@ -9,11 +9,11 @@ import type { Principal } from "@dfinity/principal";
 export const getAccounts = async ({
   identity,
   certified,
-  universeId,
+  ledgerCanisterId,
 }: {
   identity: Identity;
   certified: boolean;
-  universeId: Principal;
+  ledgerCanisterId: Principal;
 }): Promise<Account[]> => {
   // TODO: Support subaccounts
   const mainAccount: { owner: Principal; type: AccountType } = {
@@ -24,7 +24,7 @@ export const getAccounts = async ({
   const account = await getAccount({
     identity,
     certified,
-    canisterId: universeId,
+    canisterId: ledgerCanisterId,
     ...mainAccount,
   });
 

--- a/frontend/src/lib/services/wallet-tokens.services.ts
+++ b/frontend/src/lib/services/wallet-tokens.services.ts
@@ -4,21 +4,21 @@ import { queryAndUpdate } from "$lib/services/utils.services";
 import { toastsError } from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
-import type { UniverseCanisterId } from "$lib/types/universe";
 import { notForceCallStrategy } from "$lib/utils/env.utils";
+import type { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 
 export const loadToken = async ({
   handleError,
-  universeId,
+  ledgerCanisterId,
 }: {
   handleError?: () => void;
-  universeId: UniverseCanisterId;
+  ledgerCanisterId: Principal;
 }) => {
   // Currently we assume the token metadata does not change that often and might never change while the session is active
   // That's why, we load the token for a project only once as long as its data is already certified
   const storeData = get(tokensStore);
-  if (storeData[universeId.toText()]?.certified) {
+  if (storeData[ledgerCanisterId.toText()]?.certified) {
     return;
   }
 
@@ -29,12 +29,12 @@ export const loadToken = async ({
       getToken({
         identity,
         certified,
-        canisterId: universeId,
+        canisterId: ledgerCanisterId,
       }),
     onLoad: async ({ response: token, certified }) =>
       tokensStore.setToken({
         certified,
-        canisterId: universeId,
+        canisterId: ledgerCanisterId,
         token,
       }),
     onError: ({ error: err, certified }) => {
@@ -49,7 +49,7 @@ export const loadToken = async ({
       });
 
       // Hide unproven data
-      tokensStore.resetUniverse(universeId);
+      tokensStore.resetUniverse(ledgerCanisterId);
 
       handleError?.();
     },

--- a/frontend/src/lib/services/wallet-uncertified-accounts.services.ts
+++ b/frontend/src/lib/services/wallet-uncertified-accounts.services.ts
@@ -15,14 +15,13 @@ import { Principal } from "@dfinity/principal";
 /**
  * This function performs only an insecure "query" and does not toast the error but throw it so that all errors are collected by its caller.
  */
-// TODO(dskloet)
-const loadAccountsBalance = (universeId: UniverseCanisterId): Promise<void> => {
+const loadAccountsBalance = (ledgerCanisterId: Principal): Promise<void> => {
   return queryAndUpdate<Account[], unknown>({
     request: ({ certified, identity }) =>
-      getAccounts({ identity, certified, ledgerCanisterId: universeId }),
+      getAccounts({ identity, certified, ledgerCanisterId }),
     onLoad: ({ response: accounts, certified }) =>
       icrcAccountsStore.set({
-        ledgerCanisterId: universeId,
+        ledgerCanisterId,
         accounts: {
           accounts,
           certified,

--- a/frontend/src/lib/services/wallet-uncertified-accounts.services.ts
+++ b/frontend/src/lib/services/wallet-uncertified-accounts.services.ts
@@ -15,13 +15,14 @@ import { Principal } from "@dfinity/principal";
 /**
  * This function performs only an insecure "query" and does not toast the error but throw it so that all errors are collected by its caller.
  */
+// TODO(dskloet)
 const loadAccountsBalance = (universeId: UniverseCanisterId): Promise<void> => {
   return queryAndUpdate<Account[], unknown>({
     request: ({ certified, identity }) =>
       getAccounts({ identity, certified, ledgerCanisterId: universeId }),
     onLoad: ({ response: accounts, certified }) =>
       icrcAccountsStore.set({
-        universeId,
+        ledgerCanisterId: universeId,
         accounts: {
           accounts,
           certified,

--- a/frontend/src/lib/services/wallet-uncertified-accounts.services.ts
+++ b/frontend/src/lib/services/wallet-uncertified-accounts.services.ts
@@ -18,7 +18,7 @@ import { Principal } from "@dfinity/principal";
 const loadAccountsBalance = (universeId: UniverseCanisterId): Promise<void> => {
   return queryAndUpdate<Account[], unknown>({
     request: ({ certified, identity }) =>
-      getAccounts({ identity, certified, universeId }),
+      getAccounts({ identity, certified, ledgerCanisterId: universeId }),
     onLoad: ({ response: accounts, certified }) =>
       icrcAccountsStore.set({
         universeId,

--- a/frontend/src/lib/stores/icrc-accounts.store.ts
+++ b/frontend/src/lib/stores/icrc-accounts.store.ts
@@ -1,8 +1,6 @@
 import type { Account } from "$lib/types/account";
-import type {
-  UniverseCanisterId,
-  UniverseCanisterIdText,
-} from "$lib/types/universe";
+import type { UniverseCanisterIdText } from "$lib/types/universe";
+import type { Principal } from "@dfinity/principal";
 import type { Readable } from "svelte/store";
 import { writable } from "svelte/store";
 
@@ -16,11 +14,11 @@ type IcrcAccountStoreData = Record<UniverseCanisterIdText, IcrcAccounts>;
 export interface IcrcAccountsStore extends Readable<IcrcAccountStoreData> {
   set: (params: {
     accounts: IcrcAccounts;
-    universeId: UniverseCanisterId;
+    ledgerCanisterId: Principal;
   }) => void;
   update: (params: {
     accounts: IcrcAccounts;
-    universeId: UniverseCanisterId;
+    ledgerCanisterId: Principal;
   }) => void;
   reset: () => void;
 }
@@ -39,29 +37,29 @@ const initIcrcAccountsStore = (): IcrcAccountsStore => {
 
     set: ({
       accounts,
-      universeId,
+      ledgerCanisterId,
     }: {
       accounts: IcrcAccounts;
-      universeId: UniverseCanisterId;
+      ledgerCanisterId: Principal;
     }) => {
       update((currentState: IcrcAccountStoreData) => ({
         ...currentState,
-        [universeId.toText()]: accounts,
+        [ledgerCanisterId.toText()]: accounts,
       }));
     },
 
     update: ({
       accounts: { accounts, certified },
-      universeId,
+      ledgerCanisterId,
     }: {
       accounts: IcrcAccounts;
-      universeId: UniverseCanisterId;
+      ledgerCanisterId: Principal;
     }) => {
       update((currentState: IcrcAccountStoreData) => ({
         ...currentState,
-        [universeId.toText()]: {
+        [ledgerCanisterId.toText()]: {
           accounts: [
-            ...(currentState[universeId.toText()]?.accounts ?? []).filter(
+            ...(currentState[ledgerCanisterId.toText()]?.accounts ?? []).filter(
               ({ identifier }) =>
                 accounts.find(({ identifier: i }) => identifier === i) ===
                 undefined

--- a/frontend/src/lib/stores/icrc-transactions.store.ts
+++ b/frontend/src/lib/stores/icrc-transactions.store.ts
@@ -41,7 +41,7 @@ export interface IcrcTransactionsStore
   reset: () => void;
   resetUniverse: (canisterId: UniverseCanisterId) => void;
   resetAccount: (params: {
-    universeId: UniverseCanisterId;
+    canisterId: UniverseCanisterId;
     accountIdentifier: string;
   }) => void;
 }
@@ -115,21 +115,21 @@ const initIcrcTransactionsStore = (): IcrcTransactionsStore => {
     },
 
     resetAccount({
-      universeId,
+      canisterId,
       accountIdentifier,
     }: {
-      universeId: UniverseCanisterId;
+      canisterId: UniverseCanisterId;
       accountIdentifier: string;
     }) {
       update((currentState: IcrcTransactionsStoreData) => {
-        const projectState = currentState[universeId.toText()];
+        const projectState = currentState[canisterId.toText()];
         return {
           ...removeKeys({
             obj: currentState,
-            keysToRemove: [universeId.toText()],
+            keysToRemove: [canisterId.toText()],
           }),
           ...(nonNullish(projectState) && {
-            [universeId.toText()]: removeKeys({
+            [canisterId.toText()]: removeKeys({
               obj: projectState,
               keysToRemove: [accountIdentifier],
             }),

--- a/frontend/src/lib/types/icrc-accounts.modal.ts
+++ b/frontend/src/lib/types/icrc-accounts.modal.ts
@@ -1,4 +1,4 @@
-import type { UniverseCanisterId } from "$lib/types/universe";
+import type { Principal } from "@dfinity/principal";
 import type { Account } from "./account";
 import type { IcrcTokenMetadata } from "./icrc";
 
@@ -9,7 +9,7 @@ import type { IcrcTokenMetadata } from "./icrc";
 export type IcrcTokenModalType = "icrc-send";
 
 export type IcrcTokenTransactionModalData = {
-  universeId: UniverseCanisterId;
+  ledgerCanisterId: Principal;
   token: IcrcTokenMetadata;
   loadTransactions: boolean;
   sourceAccount?: Account;

--- a/frontend/src/tests/lib/components/accounts/CkBTCAccountsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCAccountsFooter.spec.ts
@@ -1,5 +1,8 @@
 import CkBTCAccountsFooter from "$lib/components/accounts/CkBTCAccountsFooter.svelte";
-import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import {
+  CKTESTBTC_LEDGER_CANISTER_ID,
+  CKTESTBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import * as services from "$lib/services/wallet-accounts.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
@@ -60,7 +63,7 @@ describe("CkBTCAccountsFooter", () => {
           accounts: [mockCkBTCMainAccount],
           certified: true,
         },
-        universeId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKTESTBTC_LEDGER_CANISTER_ID,
       });
 
       const { getByTestId } = render(CkBTCAccountsFooter);
@@ -84,7 +87,7 @@ describe("CkBTCAccountsFooter", () => {
           accounts: [mockCkBTCMainAccount],
           certified: true,
         },
-        universeId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKTESTBTC_LEDGER_CANISTER_ID,
       });
 
       tokensStore.setTokens(mockTokens);

--- a/frontend/src/tests/lib/components/accounts/IcrcBalancesObserver.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcBalancesObserver.spec.ts
@@ -1,4 +1,7 @@
-import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import {
+  CKTESTBTC_LEDGER_CANISTER_ID,
+  CKTESTBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { syncStore } from "$lib/stores/sync.store";
@@ -26,7 +29,7 @@ describe("IcrcBalancesObserver", () => {
   beforeEach(() => {
     const accounts: Account[] = [mockCkBTCMainAccount];
     icrcAccountsStore.set({
-      universeId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+      ledgerCanisterId: CKTESTBTC_LEDGER_CANISTER_ID,
       accounts: { accounts, certified: true },
     });
 

--- a/frontend/src/tests/lib/components/accounts/IcrcBalancesObserverTest.svelte
+++ b/frontend/src/tests/lib/components/accounts/IcrcBalancesObserverTest.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
   import IcrcBalancesObserver from "$lib/components/accounts/IcrcBalancesObserver.svelte";
   import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
-  import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+  import { CKTESTBTC_LEDGER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 
   export let reload: (() => void) | undefined = undefined;
 </script>
 
 <IcrcBalancesObserver
   accounts={[mockCkBTCMainAccount]}
-  universeId={CKTESTBTC_UNIVERSE_CANISTER_ID}
+  ledgerCanisterId={CKTESTBTC_LEDGER_CANISTER_ID}
   {reload}
 >
   <div data-tid="test-observer" />

--- a/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsList.spec.ts
@@ -1,5 +1,8 @@
 import IcrcWalletTransactionsList from "$lib/components/accounts/IcrcWalletTransactionsList.svelte";
-import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import {
+  CKBTC_LEDGER_CANISTER_ID,
+  CKBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
 import * as services from "$lib/services/wallet-transactions.services";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import type {
@@ -68,7 +71,7 @@ describe("IcrcWalletTransactionList", () => {
     const { container, component } = render(IcrcWalletTransactionsList, {
       props: {
         account: mockCkBTCMainAccount,
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID,
         indexCanisterId: mockCkBTCAdditionalCanisters.indexCanisterId,
         token: mockCkBTCToken,
         mapTransactions,

--- a/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsObserverTest.svelte
+++ b/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsObserverTest.svelte
@@ -3,14 +3,14 @@
   import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
   import {
     CKTESTBTC_INDEX_CANISTER_ID,
-    CKTESTBTC_UNIVERSE_CANISTER_ID,
+    CKTESTBTC_LEDGER_CANISTER_ID,
   } from "$lib/constants/ckbtc-canister-ids.constants";
 </script>
 
 <IcrcWalletTransactionsObserver
   account={mockCkBTCMainAccount}
   completed={true}
-  universeId={CKTESTBTC_UNIVERSE_CANISTER_ID}
+  ledgerCanisterId={CKTESTBTC_LEDGER_CANISTER_ID}
   indexCanisterId={CKTESTBTC_INDEX_CANISTER_ID}
 >
   <div data-tid="test-observer" />

--- a/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
+++ b/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
@@ -1,6 +1,6 @@
 import ProjectAccountsBalance from "$lib/components/universe/UniverseAccountsBalance.svelte";
-import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
-import { CKETH_UNIVERSE_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
+import { CKBTC_LEDGER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { CKETH_LEDGER_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
 import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
@@ -143,7 +143,7 @@ describe("UniverseAccountsBalance", () => {
           accounts: [mockCkBTCMainAccount],
           certified: true,
         },
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID,
       });
 
       const { getByTestId } = render(ProjectAccountsBalance, {
@@ -175,7 +175,7 @@ describe("UniverseAccountsBalance", () => {
           ],
           certified: true,
         },
-        universeId: CKETH_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
       });
 
       const { getByTestId } = render(ProjectAccountsBalance, {

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -1,9 +1,10 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import {
+  CKBTC_LEDGER_CANISTER_ID,
   CKBTC_UNIVERSE_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
-import { CKETH_UNIVERSE_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
+import { CKETH_LEDGER_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import { tokensListUserStore } from "$lib/derived/tokens-list-user.derived";
 import { authStore } from "$lib/stores/auth.store";
@@ -255,7 +256,7 @@ describe("tokens-list-user.derived", () => {
           accounts: [mockCkBTCMainAccount],
           certified: true,
         },
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID,
       });
       expect(get(tokensListUserStore)).toEqual([
         icpUserTokenLoading,
@@ -273,7 +274,7 @@ describe("tokens-list-user.derived", () => {
           accounts: [mockCkETHMainAccount],
           certified: true,
         },
-        universeId: CKETH_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
       });
       expect(get(tokensListUserStore)).toEqual([
         icpUserTokenLoading,
@@ -310,14 +311,14 @@ describe("tokens-list-user.derived", () => {
           accounts: [mockCkBTCMainAccount],
           certified: true,
         },
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID,
       });
       icrcAccountsStore.set({
         accounts: {
           accounts: [mockCkETHMainAccount],
           certified: true,
         },
-        universeId: CKETH_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
       });
       snsAccountsStore.setAccounts({
         accounts: [mockSnsMainAccount],

--- a/frontend/src/tests/lib/derived/universes-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-accounts.derived.spec.ts
@@ -1,5 +1,8 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
-import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import {
+  CKBTC_LEDGER_CANISTER_ID,
+  CKBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
 import { universesAccountsStore } from "$lib/derived/universes-accounts.derived";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
@@ -51,7 +54,7 @@ describe("universes-accounts", () => {
         accounts: [mockCkBTCMainAccount],
         certified: true,
       },
-      universeId: CKBTC_UNIVERSE_CANISTER_ID,
+      ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID,
     });
 
     const store = get(universesAccountsStore);
@@ -78,7 +81,7 @@ describe("universes-accounts", () => {
         accounts: [mockCkBTCMainAccount],
         certified: true,
       },
-      universeId: CKBTC_UNIVERSE_CANISTER_ID,
+      ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID,
     });
 
     const store = get(universesAccountsStore);

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -1,5 +1,8 @@
 import * as minterApi from "$lib/api/ckbtc-minter.api";
-import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import {
+  CKTESTBTC_LEDGER_CANISTER_ID,
+  CKTESTBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import CkBTCTransactionModal from "$lib/modals/accounts/CkBTCTransactionModal.svelte";
 import { ckBTCTransferTokens } from "$lib/services/ckbtc-accounts.services";
@@ -72,7 +75,7 @@ describe("CkBTCTransactionModal", () => {
         accounts: [mockCkBTCMainAccount],
         certified: true,
       },
-      universeId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+      ledgerCanisterId: CKTESTBTC_LEDGER_CANISTER_ID,
     });
 
     ckBTCInfoStore.setInfo({

--- a/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcrcTokenTransactionModal.spec.ts
@@ -61,7 +61,7 @@ describe("IcrcTokenTransactionModal", () => {
   it("should transfer tokens", async () => {
     // Used to choose the source account
     icrcAccountsStore.set({
-      universeId: ledgerCanisterId,
+      ledgerCanisterId,
       accounts: {
         accounts: [
           {

--- a/frontend/src/tests/lib/pages/CkBTCAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCAccounts.spec.ts
@@ -1,4 +1,7 @@
-import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import {
+  CKBTC_LEDGER_CANISTER_ID,
+  CKBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import CkBTCAccounts from "$lib/pages/CkBTCAccounts.svelte";
 import { syncAccounts } from "$lib/services/wallet-accounts.services";
@@ -68,7 +71,7 @@ describe("CkBTCAccounts", () => {
           accounts: [mockCkBTCMainAccount],
           certified: true,
         },
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID,
       });
     });
 

--- a/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/CkBTCWallet.spec.ts
@@ -2,7 +2,10 @@ import * as ckbtcMinterApi from "$lib/api/ckbtc-minter.api";
 import * as icrcIndexApi from "$lib/api/icrc-index.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import * as ckbtcLedgerApi from "$lib/api/wallet-ledger.api";
-import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import {
+  CKTESTBTC_LEDGER_CANISTER_ID,
+  CKTESTBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { WALLET_TRANSACTIONS_RELOAD_DELAY } from "$lib/constants/wallet.constants";
 import CkBTCWallet from "$lib/pages/CkBTCWallet.svelte";
@@ -255,7 +258,7 @@ describe("CkBTCWallet", () => {
           accounts: [mockCkBTCMainAccount],
           certified: true,
         },
-        universeId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKTESTBTC_LEDGER_CANISTER_ID,
       });
 
       tokensStore.setTokens(mockUniversesTokens);

--- a/frontend/src/tests/lib/pages/IcrcTokenAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcTokenAccounts.spec.ts
@@ -1,5 +1,6 @@
 import {
   CKETHSEPOLIA_INDEX_CANISTER_ID,
+  CKETHSEPOLIA_LEDGER_CANISTER_ID,
   CKETHSEPOLIA_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/cketh-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
@@ -66,7 +67,7 @@ describe("IcrcTokenAccounts", () => {
           accounts: [mockCkETHMainAccount],
           certified: true,
         },
-        universeId: CKETHSEPOLIA_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKETHSEPOLIA_LEDGER_CANISTER_ID,
       });
     });
 

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -3,6 +3,7 @@ import * as walletLedgerApi from "$lib/api/wallet-ledger.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import {
   CKETHSEPOLIA_INDEX_CANISTER_ID,
+  CKETHSEPOLIA_LEDGER_CANISTER_ID,
   CKETHSEPOLIA_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/cketh-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
@@ -234,7 +235,7 @@ describe("IcrcWallet", () => {
           accounts: [mockCkETHMainAccount],
           certified: true,
         },
-        universeId: CKETHSEPOLIA_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKETHSEPOLIA_LEDGER_CANISTER_ID,
       });
 
       tokensStore.setTokens(mockUniversesTokens);

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -185,7 +185,7 @@ describe("Wallet", () => {
     });
 
     icrcAccountsStore.set({
-      universeId: CKETH_UNIVERSE_CANISTER_ID,
+      ledgerCanisterId: CKETH_LEDGER_CANISTER_ID,
       accounts: {
         accounts: [
           {

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -1,7 +1,10 @@
 import * as agent from "$lib/api/agent.api";
 import * as minterApi from "$lib/api/ckbtc-minter.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
-import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import {
+  CKBTC_LEDGER_CANISTER_ID,
+  CKBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
 import * as ckbtcAccountsServices from "$lib/services/ckbtc-accounts.services";
 import { convertCkBTCToBtcIcrc2 } from "$lib/services/ckbtc-convert.services";
 import { loadWalletTransactions } from "$lib/services/wallet-transactions.services";
@@ -202,7 +205,7 @@ describe("ckbtc-convert-services", () => {
       });
 
       expect(loadCkBTCAccountsSpy).toBeCalledWith({
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID,
       });
 
       expect(approveTransferSpy).toBeCalledTimes(1);

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -258,7 +258,7 @@ describe("icrc-accounts-services", () => {
         balanceUlps: balanceE8s + amountE8s,
       };
       icrcAccountsStore.set({
-        universeId: ledgerCanisterId,
+        ledgerCanisterId,
         accounts: {
           accounts: [initialAccount],
           certified: true,

--- a/frontend/src/tests/lib/services/oberserver.services.spec.ts
+++ b/frontend/src/tests/lib/services/oberserver.services.spec.ts
@@ -36,7 +36,7 @@ describe("observer.services", () => {
     const oldestTxId = transaction.oldestTxId - 1n;
 
     addObservedIcrcTransactionsToStore({
-      universeId: rootCanisterIdMock,
+      ledgerCanisterId: rootCanisterIdMock,
       completed: true,
       transactions: [
         {

--- a/frontend/src/tests/lib/services/wallet-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-accounts.services.spec.ts
@@ -1,5 +1,6 @@
 import * as ckbtcLedgerApi from "$lib/api/wallet-ledger.api";
 import {
+  CKBTC_LEDGER_CANISTER_ID,
   CKBTC_UNIVERSE_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
@@ -42,7 +43,7 @@ describe("wallet-accounts-services", () => {
         .spyOn(ckbtcLedgerApi, "getAccount")
         .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
 
-      await loadAccounts({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
+      await loadAccounts({ ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID });
 
       await tick();
 
@@ -65,7 +66,7 @@ describe("wallet-accounts-services", () => {
 
       await loadAccounts({
         handleError: spy,
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKBTC_UNIVERSE_CANISTER_ID,
       });
 
       expect(spy).toBeCalled();
@@ -94,7 +95,7 @@ describe("wallet-accounts-services", () => {
         Promise.reject(undefined)
       );
 
-      await loadAccounts({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
+      await loadAccounts({ ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID });
 
       const store = get(icrcAccountsStore);
       expect(store[CKBTC_UNIVERSE_CANISTER_ID.toText()]).toBeUndefined();
@@ -122,7 +123,7 @@ describe("wallet-accounts-services", () => {
         .mockImplementation(() => Promise.resolve(mockCkBTCToken));
 
       await syncAccounts({
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID,
       });
 
       await tick();

--- a/frontend/src/tests/lib/services/wallet-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-accounts.services.spec.ts
@@ -80,7 +80,7 @@ describe("wallet-accounts-services", () => {
           accounts: [mockCkBTCMainAccount],
           certified: true,
         },
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID,
       });
 
       icrcTransactionsStore.addTransactions({

--- a/frontend/src/tests/lib/services/wallet-loader.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-loader.services.spec.ts
@@ -1,5 +1,5 @@
 import * as ledgerApi from "$lib/api/wallet-ledger.api";
-import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { CKBTC_LEDGER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { getAccounts } from "$lib/services/wallet-loader.services";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
@@ -19,14 +19,14 @@ describe("wallet-loader-services", () => {
       await getAccounts({
         identity: mockIdentity,
         certified: true,
-        universeId: CKBTC_UNIVERSE_CANISTER_ID,
+        ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID,
       });
 
       await waitFor(() =>
         expect(spyGetCkBTCAccount).toBeCalledWith({
           identity: mockIdentity,
           certified: true,
-          canisterId: CKBTC_UNIVERSE_CANISTER_ID,
+          canisterId: CKBTC_LEDGER_CANISTER_ID,
           owner: mockIdentity.getPrincipal(),
           type: "main",
         })

--- a/frontend/src/tests/lib/services/wallet-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-tokens.services.spec.ts
@@ -1,5 +1,8 @@
 import * as ledgerApi from "$lib/api/wallet-ledger.api";
-import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import {
+  CKBTC_LEDGER_CANISTER_ID,
+  CKBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
 import { loadToken } from "$lib/services/wallet-tokens.services";
 import { tokensStore } from "$lib/stores/tokens.store";
@@ -26,13 +29,13 @@ describe("wallet-tokens-services", () => {
         .spyOn(ledgerApi, "getToken")
         .mockResolvedValue(mockCkBTCToken);
 
-      await loadToken({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
+      await loadToken({ ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID });
 
       await waitFor(() =>
         expect(spyGetToken).toBeCalledWith({
           identity: mockIdentity,
           certified: true,
-          canisterId: CKBTC_UNIVERSE_CANISTER_ID,
+          canisterId: CKBTC_LEDGER_CANISTER_ID,
         })
       );
 
@@ -52,7 +55,7 @@ describe("wallet-tokens-services", () => {
   describe("loadToken already loaded", () => {
     beforeEach(() => {
       tokensStore.setToken({
-        canisterId: CKBTC_UNIVERSE_CANISTER_ID,
+        canisterId: CKBTC_LEDGER_CANISTER_ID,
         token: mockCkBTCToken,
         certified: true,
       });
@@ -63,7 +66,7 @@ describe("wallet-tokens-services", () => {
         .spyOn(ledgerApi, "getToken")
         .mockResolvedValue(mockCkBTCToken);
 
-      await loadToken({ universeId: CKBTC_UNIVERSE_CANISTER_ID });
+      await loadToken({ ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID });
 
       expect(spyGetToken).not.toBeCalled();
     });

--- a/frontend/src/tests/lib/stores/icrc-accounts.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icrc-accounts.store.spec.ts
@@ -1,4 +1,7 @@
-import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import {
+  CKBTC_LEDGER_CANISTER_ID,
+  CKBTC_UNIVERSE_CANISTER_ID,
+} from "$lib/constants/ckbtc-canister-ids.constants";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import type { Account } from "$lib/types/account";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
@@ -20,7 +23,7 @@ describe("icrc Accounts store", () => {
         accounts,
         certified: true,
       },
-      universeId: CKBTC_UNIVERSE_CANISTER_ID,
+      ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID,
     });
 
     const accountsInStore = get(icrcAccountsStore);
@@ -38,7 +41,7 @@ describe("icrc Accounts store", () => {
         accounts,
         certified: true,
       },
-      universeId: CKBTC_UNIVERSE_CANISTER_ID,
+      ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID,
     });
 
     icrcAccountsStore.reset();
@@ -56,7 +59,7 @@ describe("icrc Accounts store", () => {
         accounts,
         certified: true,
       },
-      universeId: mockPrincipal,
+      ledgerCanisterId: mockPrincipal,
     });
 
     const accountsInStore = get(icrcAccountsStore);
@@ -75,7 +78,7 @@ describe("icrc Accounts store", () => {
         accounts: [updateSnsSubAccount],
         certified: true,
       },
-      universeId: mockPrincipal,
+      ledgerCanisterId: mockPrincipal,
     });
 
     const updatedStore = get(icrcAccountsStore);

--- a/frontend/src/tests/lib/stores/icrc-transactions.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icrc-transactions.store.spec.ts
@@ -40,7 +40,7 @@ describe("icrc-transactions", () => {
     ).not.toBeUndefined();
 
     icrcTransactionsStore.resetAccount({
-      universeId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+      canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
       accountIdentifier: mockCkBTCMainAccount.identifier,
     });
 


### PR DESCRIPTION
# Motivation

For SNS universes we use the rootCanisterId as the universeId.
For most other universes, we use the ICRC ledger canister ID as the universeId.
To reduce code duplication we want to use the ICRC wallet components for the SNS wallet.
The ICRC wallet components assume the universe ID is the ledger canister ID and so the use both terms to mean the same.
But if we reuse those components for SNS there is a clear difference between universe ID and ledger canister ID.

So in this PR I'm renaming `universeId` to `ledgerCanisterId` in places where it's relevant for reuse by SNS.

The PR is large but it's split up into many commits which are each self-contained.
So it might be better to review per commit.

# Changes

Rename parameters and props to refer ledger canister IDs instead of universe IDs.

# Tests

Unit tests updated.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary