### PR TITLE
style: use `toolbar.base` instead of custom css

### DIFF
--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -127,6 +127,7 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/toolbar";
 
   .participate {
     display: flex;
@@ -136,20 +137,11 @@
   }
 
   [role="toolbar"] {
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    justify-content: center;
+    @include toolbar.in-bottom-sheet;
+
     padding: var(--padding-2x);
 
-    @include media.min-width(medium) {
-      align-items: center;
-      justify-content: center;
-    }
-
     @include media.min-width(large) {
-      align-items: flex-start;
-      justify-content: flex-start;
       padding: 0;
     }
   }

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -137,9 +137,13 @@
   }
 
   [role="toolbar"] {
-    @include toolbar.in-bottom-sheet;
+    @include toolbar.base;
 
     padding: var(--padding-2x);
+
+    @include media.min-width(small) {
+      justify-content: center;
+    }
 
     @include media.min-width(large) {
       padding: 0;


### PR DESCRIPTION
# Motivation

Apply `toolbar` mixin from [gix-components](https://github.com/dfinity/gix-components/pull/375/files#diff-f8bc5f50175daa2d613b1761e0238cb431acaffa1467bb90df250b8820967dd9R31) to fix it's position on mobile (when wrapped w/ a Tooltip).

# Changes

- Replace custom css w/ `toolbar.base`.
- Add alignment exception for tablet size (should be centered).

# Tests

Css changes only.

| Before | After |
|--------|--------|
| <img width="442" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/334cd38e-3e86-4420-80e0-d1a402ee03f0"> | <img width="441" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/28975d8a-72ed-409e-b1be-f22d6de870e0"> | 

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.