### PR TITLE
Bump build-push-action@v3 -> v4

### DIFF
--- a/.github/actions/build_nns_dapp/action.yaml
+++ b/.github/actions/build_nns_dapp/action.yaml
@@ -25,7 +25,7 @@ runs:
       shell: bash
       run: echo "{}" > global-config.json
     - name: Build wasms
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v4
       with:
         context: .
         file: Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,7 +275,7 @@ jobs:
         run: echo "{}" > global-config.json
       - name: Build wasms
         if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Provide empty global config
         run: echo '{}' > global-config.json
       - name: Build docker artifacts
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: Dockerfile


### PR DESCRIPTION
# Motivation
Nodejs v16 actions are deprecated on GitHub.

# Changes
* Update `build-push-action` to v4.

# Tests
- See CI

# Todos
- [ ] Add entry to changelog (if necessary).
  - Covered by an existing changelog entry