### PR TITLE
Make universeId prop optional on ReceiveModal

### DIFF
--- a/frontend/src/lib/components/accounts/IcrcTokenWalletFooter.svelte
+++ b/frontend/src/lib/components/accounts/IcrcTokenWalletFooter.svelte
@@ -52,7 +52,6 @@
     {account}
     reload={reloadAccount}
     testId="receive-icrc"
-    universeId={ledgerCanisterId}
     logo={$selectedUniverseStore?.logo ?? IC_LOGO}
     tokenSymbol={token?.symbol}
   />

--- a/frontend/src/lib/components/accounts/ReceiveButton.svelte
+++ b/frontend/src/lib/components/accounts/ReceiveButton.svelte
@@ -11,11 +11,11 @@
   export let account: Account | undefined = undefined;
   export let reload: (() => Promise<void>) | undefined = undefined;
   export let canSelectAccount = false;
-  export let universeId: UniverseCanisterId | undefined;
+  export let universeId: UniverseCanisterId | undefined = undefined;
   export let logo: string;
   export let tokenSymbol: string | undefined = undefined;
 
-  const openModal = () =>
+  const openModal = () => {
     openAccountsModal({
       type,
       data: {
@@ -27,6 +27,7 @@
         logo,
       },
     });
+  };
 </script>
 
 <button

--- a/frontend/src/lib/components/accounts/ReceiveSelectAccountDropdown.svelte
+++ b/frontend/src/lib/components/accounts/ReceiveSelectAccountDropdown.svelte
@@ -4,9 +4,10 @@
   import SelectAccountDropdown from "$lib/components/accounts/SelectAccountDropdown.svelte";
   import type { UniverseCanisterId } from "$lib/types/universe";
   import { createEventDispatcher } from "svelte";
+  import { nonNullish } from "@dfinity/utils";
 
   export let account: Account | undefined;
-  export let universeId: UniverseCanisterId;
+  export let universeId: UniverseCanisterId | undefined = undefined;
   export let canSelectAccount: boolean;
 
   let selectedAccount = account;
@@ -16,7 +17,7 @@
     (() => dispatcher("nnsSelectedAccount", selectedAccount))();
 </script>
 
-{#if canSelectAccount}
+{#if canSelectAccount && nonNullish(universeId)}
   <div class="source">
     <span class="label">{$i18n.accounts.receive_account}</span>
 

--- a/frontend/src/lib/modals/accounts/IcrcReceiveModal.svelte
+++ b/frontend/src/lib/modals/accounts/IcrcReceiveModal.svelte
@@ -20,7 +20,7 @@
     data);
 </script>
 
-{#if nonNullish(universeId) && nonNullish(tokenSymbol)}
+{#if nonNullish(tokenSymbol)}
   <ReceiveModal
     {account}
     on:nnsClose

--- a/frontend/src/lib/modals/accounts/ReceiveModal.svelte
+++ b/frontend/src/lib/modals/accounts/ReceiveModal.svelte
@@ -10,7 +10,7 @@
   import ReceiveSelectAccountDropdown from "$lib/components/accounts/ReceiveSelectAccountDropdown.svelte";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
 
-  export let universeId: UniverseCanisterId;
+  export let universeId: UniverseCanisterId | undefined = undefined;
   export let account: Account | undefined;
   export let qrCodeLabel: string;
   export let logo: string;

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -50,7 +50,6 @@
   import HardwareWalletShowActionButton from "$lib/components/accounts/HardwareWalletShowActionButton.svelte";
   import RenameSubAccountButton from "$lib/components/accounts/RenameSubAccountButton.svelte";
   import { nnsUniverseStore } from "$lib/derived/nns-universe.derived";
-  import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
   import IC_LOGO from "$lib/assets/icp.svg";
 
   $: if ($authSignedInStore) {
@@ -235,7 +234,6 @@
           type="nns-receive"
           account={$selectedAccountStore.account}
           reload={reloadAccount}
-          universeId={OWN_CANISTER_ID}
           logo={IC_LOGO}
         />
       </Footer>

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -211,7 +211,6 @@
           account={$selectedAccountStore.account}
           reload={reloadAccount}
           testId="receive-sns"
-          universeId={$snsOnlyProjectStore}
           logo={$selectedUniverseStore?.summary?.metadata.logo ?? IC_LOGO}
           tokenSymbol={$selectedUniverseStore?.summary?.token.symbol}
         />

--- a/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
@@ -9,6 +9,7 @@ import {
 import { renderModal } from "$tests/mocks/modal.mock";
 import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { Principal } from "@dfinity/principal";
 
 describe("ReceiveModal", () => {
   const reloadSpy = vi.fn();
@@ -26,9 +27,11 @@ describe("ReceiveModal", () => {
   const renderReceiveModal = async ({
     canSelectAccount = false,
     account = mockMainAccount,
+    universeId,
   }: {
     canSelectAccount?: boolean;
     account?: Account;
+    universeId: Principal;
   }) => {
     const { container } = await renderModal({
       component: ReceiveModal,
@@ -38,7 +41,7 @@ describe("ReceiveModal", () => {
         logo,
         logoArialLabel,
         reload: reloadSpy,
-        universeId: OWN_CANISTER_ID,
+        universeId,
         canSelectAccount,
         tokenSymbol,
       },
@@ -47,13 +50,17 @@ describe("ReceiveModal", () => {
   };
 
   it("should render a QR code", async () => {
-    const po = await renderReceiveModal({});
+    const po = await renderReceiveModal({
+      universeId: OWN_CANISTER_ID,
+    });
 
     expect(await po.hasQrCode()).toBe(true);
   });
 
   it("should render token symbol in title", async () => {
-    const po = await renderReceiveModal({});
+    const po = await renderReceiveModal({
+      universeId: OWN_CANISTER_ID,
+    });
 
     expect(await po.getModalTitle()).toBe(`Receive ${tokenSymbol}`);
   });
@@ -61,19 +68,24 @@ describe("ReceiveModal", () => {
   it("should render account identifier (without being shortened)", async () => {
     const po = await renderReceiveModal({
       account: mockMainAccount,
+      universeId: OWN_CANISTER_ID,
     });
 
     expect(await po.getAddress()).toBe(mockMainAccount.identifier);
   });
 
   it("should render a logo", async () => {
-    const po = await renderReceiveModal({});
+    const po = await renderReceiveModal({
+      universeId: OWN_CANISTER_ID,
+    });
 
     expect(await po.getLogoAltText()).toBe(logoArialLabel);
   });
 
   it("should reload account", async () => {
-    const po = await renderReceiveModal({});
+    const po = await renderReceiveModal({
+      universeId: OWN_CANISTER_ID,
+    });
 
     await po.clickFinish();
 
@@ -89,9 +101,10 @@ describe("ReceiveModal", () => {
 
     const po = await renderReceiveModal({
       canSelectAccount: true,
+      universeId: OWN_CANISTER_ID,
     });
 
-    expect(await po.getDropdownAccounts().isPresent()).toBe(true);
+    expect(await po.getSelectAccountDropdownPo().isPresent()).toBe(true);
   });
 
   it("should select account", async () => {
@@ -104,6 +117,7 @@ describe("ReceiveModal", () => {
     const po = await renderReceiveModal({
       canSelectAccount: true,
       account: undefined,
+      universeId: OWN_CANISTER_ID,
     });
 
     // Main account is selected by default
@@ -112,5 +126,24 @@ describe("ReceiveModal", () => {
     await po.select(mockSubAccount.identifier);
 
     expect(await po.getAddress()).toBe(mockSubAccount.identifier);
+  });
+
+  it("should not require universeId ", async () => {
+    icpAccountsStore.setForTesting({
+      main: mockMainAccount,
+      subAccounts: [mockSubAccount],
+      hardwareWallets: undefined,
+    });
+
+    const po = await renderReceiveModal({
+      canSelectAccount: true,
+      account: undefined,
+      universeId: undefined,
+    });
+
+    // universeId is only required to render the account picker.
+    // So the ReceiveModal render fine without universeId but it won't render
+    // the account picker.
+    expect(await po.getSelectAccountDropdownPo().isPresent()).toBe(false);
   });
 });

--- a/frontend/src/tests/page-objects/ReceiveModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ReceiveModal.page-object.ts
@@ -33,11 +33,11 @@ export class ReceiveModalPo extends ModalPo {
     return this.getText("qrcode-display-address");
   }
 
-  getDropdownAccounts() {
+  getSelectAccountDropdownPo() {
     return SelectAccountDropdownPo.under(this.root);
   }
 
   select(accountIdentifier: string) {
-    return this.getDropdownAccounts().select(accountIdentifier);
+    return this.getSelectAccountDropdownPo().select(accountIdentifier);
   }
 }


### PR DESCRIPTION
# Motivation

The `ReceiveModal` component has a prop for the `universeId`.
This is only used to list the available accounts when `canSelectAccount` is `true`.
But in most cases `canSelectAccount` is not set to true and `universeId` is ignored.

When we merge the ICRC and SNS wallet components, it can be confusing whether to use the `ledgerCanisterId` or the `rootCanisterId` where previously a `universeId` was required. So to avoid confusion, I'm removing the `universeId` on the `ReceiveModal` when it's not necessary.

# Changes

1. Make `universeId` optional on the `ReceiveModal` and related components, events and functions.
2. Only render the accounts picker when `canSelectAccount = true` and `universeId` is present.

Drive-by:
1. Add curly brackets on a multi-line function for convenience.
2. Fix the name of `getSelectAccountDropdownPo` to correctly reflect what it returns.

# Tests

Added a unit test with `universeId` absent

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary