### PR TITLE
Remove some unused i18n messages

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -119,7 +119,8 @@
     "adding_permissions": "There was an error adding permissions.",
     "canister_invalid_transaction": "Sorry, there was a problem with the transaction.",
     "qrcode_camera_error": "An error occurred while initializing the camera to read the QR code.",
-    "qrcode_token_incompatible": "The payment token you are attempting to use is not compatible with this transaction."
+    "qrcode_token_incompatible": "The payment token you are attempting to use is not compatible with this transaction.",
+    "icrc_no_universe": "An Icrc environment should be provided to execute this feature"
   },
   "warning": {
     "auth_sign_out": "You have been logged out because your session has expired.",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -620,7 +620,6 @@
     "no_notkeys": "No hotkeys",
     "add_hotkey_modal_title": "Add Hotkey",
     "enter_hotkey": "Enter Hotkey",
-    "remove_hotkey_success": "Hotkey removed successfully.",
     "invalid_hotkey": "Hotkey not valid. Refresh the page and try again.",
     "disburse_success": "Neuron disbursed successfully",
     "edit_percentage": "Edit percentage",
@@ -702,7 +701,6 @@
     "status": "Status",
     "status_open": "Accepting Participation",
     "status_adopted": "Starting Soon",
-    "enter_amount": "Enter Amount",
     "status_committed": "Completed",
     "status_aborted": "Aborted",
     "status_pending": "Upcoming swap",
@@ -732,7 +730,6 @@
     "connecting_sale_canister": "Retrieving swap required information"
   },
   "sns_neuron_detail": {
-    "header": "Neuron",
     "all_topics": "All topics",
     "vesting_period_tooltip": "This function is not available during your vesting period. Vesting will last another $remainingVesting",
     "community_fund_section": "Neurons' Fund",
@@ -811,7 +808,6 @@
     "get_exchange_rate": "Error getting the exchange rate of ICP to Cycles."
   },
   "error__sns": {
-    "init": "There was an error initializing some projects.",
     "undefined_project": "The requested project is invalid or throws an error.",
     "list_summaries": "There was an unexpected error while loading the summaries of all deployed projects.",
     "list_swap_commitments": "There was an unexpected error while loading the commitments of all deployed projects.",
@@ -880,7 +876,6 @@
   "universe": {
     "select_token": "Select Token",
     "select_nervous_system": "Select Nervous System",
-    "select": "Select",
     "universe_logo": "$universe logo"
   },
   "sns_types": {
@@ -951,7 +946,6 @@
     "block_explorer": "block explorer",
     "bitcoin_address_title": "Bitcoin Address:",
     "refresh_balance": "Check for incoming BTC",
-    "confirmations": "Confirmations",
     "btc_received": "BTC Received",
     "btc_sent": "BTC Sent",
     "btc_network": "BTC Network",
@@ -977,8 +971,7 @@
     "estimated_fee": "Sorry, the Bitcoin estimated fee cannot be fetched.",
     "retrieve_btc_min_amount": "The amount falls below the minimum of $amount ckBTC required for converting to BTC.",
     "retrieve_btc_min_amount_unknown": "The minimum amount of ckBTC required for converting to BTC is unknown.",
-    "wait_ckbtc_info_parameters_certified": "Please wait until the ckBTC parameters have been certified.",
-    "icrc_no_universe": "An Icrc environment should be provided to execute this feature"
+    "wait_ckbtc_info_parameters_certified": "Please wait until the ckBTC parameters have been certified."
   },
   "feature_flags_prompt": {
     "override_true": "Enter the number for the feature you want to enable.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -643,7 +643,6 @@ interface I18nNeuron_detail {
   no_notkeys: string;
   add_hotkey_modal_title: string;
   enter_hotkey: string;
-  remove_hotkey_success: string;
   invalid_hotkey: string;
   disburse_success: string;
   edit_percentage: string;
@@ -727,7 +726,6 @@ interface I18nSns_project_detail {
   status: string;
   status_open: string;
   status_adopted: string;
-  enter_amount: string;
   status_committed: string;
   status_aborted: string;
   status_pending: string;
@@ -759,7 +757,6 @@ interface I18nSns_sale {
 }
 
 interface I18nSns_neuron_detail {
-  header: string;
   all_topics: string;
   vesting_period_tooltip: string;
   community_fund_section: string;
@@ -845,7 +842,6 @@ interface I18nError__canister {
 }
 
 interface I18nError__sns {
-  init: string;
   undefined_project: string;
   list_summaries: string;
   list_swap_commitments: string;
@@ -920,7 +916,6 @@ interface I18nAuth_sns {
 interface I18nUniverse {
   select_token: string;
   select_nervous_system: string;
-  select: string;
   universe_logo: string;
 }
 
@@ -999,7 +994,6 @@ interface I18nCkbtc {
   block_explorer: string;
   bitcoin_address_title: string;
   refresh_balance: string;
-  confirmations: string;
   btc_received: string;
   btc_sent: string;
   btc_network: string;
@@ -1027,7 +1021,6 @@ interface I18nError__ckbtc {
   retrieve_btc_min_amount: string;
   retrieve_btc_min_amount_unknown: string;
   wait_ckbtc_info_parameters_certified: string;
-  icrc_no_universe: string;
 }
 
 interface I18nFeature_flags_prompt {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -124,6 +124,7 @@ interface I18nError {
   canister_invalid_transaction: string;
   qrcode_camera_error: string;
   qrcode_token_incompatible: string;
+  icrc_no_universe: string;
 }
 
 interface I18nWarning {

--- a/scripts/unused-i18n
+++ b/scripts/unused-i18n
@@ -4,9 +4,6 @@ set -euo pipefail
 I18N_FILE="frontend/src/lib/i18n/en.json"
 
 GRANDFATHERED_PATHS=(
-  neuron_detail.remove_hotkey_success
-  sns_project_detail.enter_amount
-  sns_neuron_detail.header
   time.day_plural
   time.hour
   time.hour_plural
@@ -14,8 +11,6 @@ GRANDFATHERED_PATHS=(
   time.minute_plural
   time.second
   time.second_plural
-  error__sns.init
-  universe.select
   sns_rewards_status.0
   sns_rewards_status.1
   sns_rewards_status.2
@@ -42,8 +37,6 @@ GRANDFATHERED_PATHS=(
   sns_status_description.3
   sns_status_description.4
   sns_status_description.5
-  ckbtc.confirmations
-  error__ckbtc.icrc_no_universe
 )
 
 all_i18n_paths() {


### PR DESCRIPTION
# Motivation

These messages appear to be unused. I checked the following before removing them:

* For `neuron_detail.remove_hotkey_success`, I looked at `git grep remove_hotkey_success`
* For `sns_project_detail.enter_amount`, I looked at ` git grep enter_amount`
* For `sns_neuron_detail.header`, I looked at `git grep -l sns_neuron_detail | xargs grep header`
* For `error__sns.init`, I looked at `git grep -l -w error__sns | xargs grep -w init`
* For `universe.select`, it's hard to grep for something with such generic words. I found that it was added in https://github.com/dfinity/nns-dapp/pull/1677 and it seems to already not be used there.
* For `ckbtc.confirmations`, I looked at `git grep -w confirmations frontend/src`
* For `error__ckbtc.icrc_no_universe`, I looked at `git grep icrc_no_universe`

# Changes

1. I removed the entries from `scripts/unused-i18n`.
2. Then I ran the script and ran the following command from its output:
```
cat <<-EOF | jq --argfile i18n frontend/src/lib/i18n/en.json -Rn '$i18n | delpaths([inputs | split(".")])' | sponge frontend/src/lib/i18n/en.json
        neuron_detail.remove_hotkey_success
        sns_project_detail.enter_amount
        sns_neuron_detail.header
        error__sns.init
        universe.select
        ckbtc.confirmations
        error__ckbtc.icrc_no_universe
        EOF
```
3. Then I ran `npm run i18n`

# Tests

Existing test pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary