### PR TITLE
GIX-1985: Remove ENABLE_MY_TOKENS from e2e tests

### DIFF
--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -1,17 +1,11 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test accounts requirements", async ({ page, context }) => {
   await page.goto("/accounts");
   await expect(page).toHaveTitle("My ICP Tokens / NNS Dapp");
-  // TODO: GIX-1985 Remove this once the feature flag is enabled by default
-  await setFeatureFlag({ page, featureFlag: "ENABLE_MY_TOKENS", value: true });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/ckbtc.spec.ts
+++ b/frontend/src/tests/e2e/ckbtc.spec.ts
@@ -1,17 +1,11 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test accounts requirements", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("My Tokens / NNS Dapp");
-  // TODO: GIX-1985 Remove this once the feature flag is enabled by default
-  await setFeatureFlag({ page, featureFlag: "ENABLE_MY_TOKENS", value: true });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/design.spec.ts
+++ b/frontend/src/tests/e2e/design.spec.ts
@@ -1,18 +1,12 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { setFeatureFlag, signInWithNewUser } from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser } from "$tests/utils/e2e.test-utils";
 import { expect, test, type Page } from "@playwright/test";
 
 test.describe("Design", () => {
   test("Login", async ({ page }) => {
     await page.goto("/accounts");
     await expect(page).toHaveTitle("My ICP Tokens / NNS Dapp");
-    // TODO: GIX-1985 Remove this once the feature flag is enabled by default
-    await setFeatureFlag({
-      page,
-      featureFlag: "ENABLE_MY_TOKENS",
-      value: true,
-    });
     // Wait for balance in the first row of the table to make sure the screenshot is taken after the app is loaded.
     const pageElement = PlaywrightPageObjectElement.fromPage(page);
     const appPo = new AppPo(pageElement);
@@ -30,12 +24,6 @@ test.describe("Design", () => {
   test("App loading spinner is removed", async ({ page }) => {
     await page.goto("/accounts");
     await expect(page).toHaveTitle("My ICP Tokens / NNS Dapp");
-    // TODO: GIX-1985 Remove this once the feature flag is enabled by default
-    await setFeatureFlag({
-      page,
-      featureFlag: "ENABLE_MY_TOKENS",
-      value: true,
-    });
 
     // Wait for the button to make sure the app is loaded
     await page.locator("[data-tid=login-button]").waitFor();
@@ -55,12 +43,6 @@ test.describe("Design", () => {
 
       await page.goto("/accounts");
       await expect(page).toHaveTitle("My ICP Tokens / NNS Dapp");
-      // TODO: GIX-1985 Remove this once the feature flag is enabled by default
-      await setFeatureFlag({
-        page,
-        featureFlag: "ENABLE_MY_TOKENS",
-        value: true,
-      });
 
       await signInWithNewUser({ page, context: browser.contexts()[0] });
     });

--- a/frontend/src/tests/e2e/disburse.spec.ts
+++ b/frontend/src/tests/e2e/disburse.spec.ts
@@ -1,17 +1,11 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test disburse neuron", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("My Tokens / NNS Dapp");
-  // TODO: GIX-1985 Remove this once the feature flag is enabled by default
-  await setFeatureFlag({ page, featureFlag: "ENABLE_MY_TOKENS", value: true });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -1,17 +1,11 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test merge neurons", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("My Tokens / NNS Dapp");
-  // TODO: GIX-1985 Remove this once the feature flag is enabled by default
-  await setFeatureFlag({ page, featureFlag: "ENABLE_MY_TOKENS", value: true });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/multi-tab-auth.spec.ts
+++ b/frontend/src/tests/e2e/multi-tab-auth.spec.ts
@@ -1,10 +1,6 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 const expectSignedOut = async (appPo: AppPo) => {
@@ -29,12 +25,6 @@ const expectSignedInTokensPage = async (appPo: AppPo) => {
 test("Test multi-tab auth", async ({ page: page1, context }) => {
   await page1.goto("/accounts");
   await expect(page1).toHaveTitle("My ICP Tokens / NNS Dapp");
-  // TODO: GIX-1985 Remove this once the feature flag is enabled by default
-  await setFeatureFlag({
-    page: page1,
-    featureFlag: "ENABLE_MY_TOKENS",
-    value: true,
-  });
   const appPo1 = new AppPo(PlaywrightPageObjectElement.fromPage(page1));
 
   const page2 = await context.newPage();

--- a/frontend/src/tests/e2e/neurons.spec.ts
+++ b/frontend/src/tests/e2e/neurons.spec.ts
@@ -2,18 +2,12 @@ import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { getNnsNeuronCardsIds } from "$tests/utils/e2e.nns-neuron.test-utils";
 import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test neuron voting", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("My Tokens / NNS Dapp");
-  // TODO: GIX-1985 Remove this once the feature flag is enabled by default
-  await setFeatureFlag({ page, featureFlag: "ENABLE_MY_TOKENS", value: true });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -2,19 +2,13 @@ import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { ProposalStatus, Topic } from "@dfinity/nns";
 import { expect, test } from "@playwright/test";
 
 test("Test neuron voting", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("My Tokens / NNS Dapp");
-  // TODO: GIX-1985 Remove this once the feature flag is enabled by default
-  await setFeatureFlag({ page, featureFlag: "ENABLE_MY_TOKENS", value: true });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -1,17 +1,11 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test SNS governance", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("My Tokens / NNS Dapp");
-  // TODO: GIX-1985 Remove this once the feature flag is enabled by default
-  await setFeatureFlag({ page, featureFlag: "ENABLE_MY_TOKENS", value: true });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/sns-participation.spec.ts
+++ b/frontend/src/tests/e2e/sns-participation.spec.ts
@@ -1,18 +1,12 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import type { ProjectCardPo } from "$tests/page-objects/ProjectCard.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test SNS participation", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("My Tokens / NNS Dapp");
-  // TODO: GIX-1985 Remove this once the feature flag is enabled by default
-  await setFeatureFlag({ page, featureFlag: "ENABLE_MY_TOKENS", value: true });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
   const appPo = new AppPo(pageElement);


### PR DESCRIPTION
# Motivation

Remove `ENABLE_MY_TOKENS` flag.

In this PR, remove setting the flag in the e2e tests.

# Changes

* Remove setting the flag in all e2e tests.

# Tests

Only test changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
