### PR TITLE
Pass time i18n messages explicitly

### DIFF
--- a/frontend/src/lib/utils/date.utils.ts
+++ b/frontend/src/lib/utils/date.utils.ts
@@ -33,7 +33,20 @@ export const daysToDuration = (days: number): string => {
   const { time } = get(i18n);
   return secondsToDuration({
     seconds: BigInt(Math.ceil(days * SECONDS_IN_DAY)),
-    i18n: time,
+    i18n: {
+      year: time.year,
+      year_plural: time.year_plural,
+      month: time.month,
+      month_plural: time.month_plural,
+      day: time.day,
+      day_plural: time.day_plural,
+      hour: time.hour,
+      hour_plural: time.hour_plural,
+      minute: time.minute,
+      minute_plural: time.minute_plural,
+      second: time.second,
+      second_plural: time.second_plural,
+    },
   });
 };
 

--- a/scripts/unused-i18n
+++ b/scripts/unused-i18n
@@ -7,13 +7,6 @@ GRANDFATHERED_PATHS=(
   neuron_detail.remove_hotkey_success
   sns_project_detail.enter_amount
   sns_neuron_detail.header
-  time.day_plural
-  time.hour
-  time.hour_plural
-  time.minute
-  time.minute_plural
-  time.second
-  time.second_plural
   error__sns.init
   universe.select
   sns_rewards_status.0


### PR DESCRIPTION
# Motivation

[Here](https://github.com/dfinity/nns-dapp/blob/853de68f0517859dd7ff48be1a4cff8a3ec5748e/frontend/src/lib/utils/date.utils.ts#L33-L36), we pass a section of our i18n messages to another repo.
It's not really clear what is required there and whether we are sending more than necessary.
And it makes it hard to detect those messages as used.

# Changes

1. Be explicit about which i18n messages we send to `secondsToDuration`.
2. Remove the messages that are now used explicitly from the grandfathered messages in `unused-i18n`.

# Tests

pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary