### PR TITLE
style: display tooltip on top of the button

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NeuronSelectPercentage.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronSelectPercentage.svelte
@@ -63,7 +63,7 @@
       {$i18n.core.cancel}
     </button>
     {#if nonNullish(disabledText)}
-      <Tooltip id="disabled-disburse-button-modal" text={disabledText}>
+      <Tooltip id="disabled-disburse-button-modal" text={disabledText} top>
         <button
           data-tid="select-maturity-percentage-button"
           class="primary"


### PR DESCRIPTION
# Motivation

Display on top the tooltip on the disabled `Disburse`-maturity button to fix it's visibility on mobile.

# Changes

- apply `top` to the Tooltip.

# Tests

| Before | After |
|--------|--------|
| <img width="389" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/22bdfc78-d82f-47d2-9888-a58e1b6e9039"> | <img width="392" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/fff54ae5-b05e-452c-90cd-91417fc4bd5d"> | 

# Todos

- [ ] Add entry to changelog (if necessary).
Not needed