### PR TITLE
Feat: Poll accounts in NnsAccounts

### DIFF
--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -24,9 +24,7 @@
   import { toastsError } from "$lib/stores/toasts.store";
 
   onMount(() => {
-    if (!$ENABLE_MY_TOKENS) {
-      pollAccounts();
-    }
+    pollAccounts();
   });
 
   onDestroy(() => {

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -37,6 +37,7 @@ import {
   mockAccountDetails,
   mockAccountsStoreData,
   mockHardwareWalletAccount,
+  mockHardwareWalletAccountDetails,
   mockMainAccount,
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
@@ -130,14 +131,20 @@ vi.mock("$lib/services/worker-balances.services", () => ({
 
 describe("Accounts", () => {
   const balanceIcrcToken = 314000000n;
-  const newSubaccountName = "test";
+  const subaccountName = "test";
+  let subaccountDetails = undefined;
+  let hardwareWalletDetails = undefined;
   const subaccountBalanceDefault = 0n;
   let subaccountBalance = subaccountBalanceDefault;
   const mainAccountBalanceDefault = 314000000n;
   let mainAccountBalance = mainAccountBalanceDefault;
+  const hardwareWalletBalanceDefault = 220000000n;
+  let hardwareWalletBalance = hardwareWalletBalanceDefault;
 
-  const renderComponent = () => {
+  const renderComponent = async () => {
     const { container } = render(Accounts);
+
+    await runResolvedPromises();
 
     return AccountsPo.under(new JestPageObjectElement(container));
   };
@@ -164,6 +171,9 @@ describe("Accounts", () => {
 
     subaccountBalance = subaccountBalanceDefault;
     mainAccountBalance = mainAccountBalanceDefault;
+    hardwareWalletBalance = hardwareWalletBalanceDefault;
+    subaccountDetails = undefined;
+    hardwareWalletDetails = undefined;
 
     vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockResolvedValue(mockToken);
     vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockResolvedValue(
@@ -177,21 +187,30 @@ describe("Accounts", () => {
           return mainAccountBalance;
         } else if (icpAccountIdentifier === mockSubAccount.identifier) {
           return subaccountBalance;
+        } else if (
+          icpAccountIdentifier === mockHardwareWalletAccount.identifier
+        ) {
+          return hardwareWalletBalance;
         }
         throw new Error(
           `Unexpected account identifier ${icpAccountIdentifier}`
         );
       }
     );
-    vi.spyOn(nnsDappApi, "queryAccount").mockResolvedValue({
-      ...mockAccountDetails,
-      sub_accounts: [
-        {
-          name: newSubaccountName,
-          sub_account: mockSubAccount.subAccount,
-          account_identifier: mockSubAccount.identifier,
-        },
-      ],
+    vi.spyOn(nnsDappApi, "queryAccount").mockImplementation(async () => {
+      return {
+        ...mockAccountDetails,
+        ...(subaccountDetails
+          ? {
+              sub_accounts: [subaccountDetails],
+            }
+          : {}),
+        ...(hardwareWalletDetails
+          ? {
+              hardware_wallet_accounts: [hardwareWalletDetails],
+            }
+          : {}),
+      };
     });
 
     vi.spyOn(snsSelectedTransactionFeeStore, "subscribe").mockImplementation(
@@ -578,6 +597,7 @@ describe("Accounts", () => {
         data: { universe: OWN_CANISTER_ID_TEXT },
         routeId: AppPath.Accounts,
       });
+      icpAccountsStore.resetForTesting();
     });
 
     describe("when tokens page is enabled", () => {
@@ -586,25 +606,17 @@ describe("Accounts", () => {
       });
 
       it("renders tokens table with NNS accounts", async () => {
-        icpAccountsStore.setForTesting({
-          main: {
-            ...mockMainAccount,
-            balanceUlps: mainAccountBalance,
-          },
-          subAccounts: [
-            {
-              ...mockSubAccount,
-              balanceUlps: 123456789000000n,
-            },
-          ],
-          hardwareWallets: [
-            {
-              ...mockHardwareWalletAccount,
-              balanceUlps: 222000000n,
-            },
-          ],
-        });
-        const po = renderComponent();
+        hardwareWalletBalance = 222000000n;
+        subaccountBalance = 123456789000000n;
+        subaccountDetails = {
+          name: subaccountName,
+          sub_account: mockSubAccount.subAccount,
+          account_identifier: mockSubAccount.identifier,
+        };
+        hardwareWalletDetails = {
+          ...mockHardwareWalletAccountDetails,
+        };
+        const po = await renderComponent();
 
         const tablePo = po.getNnsAccountsPo().getTokensTablePo();
         expect(await tablePo.getRowsData()).toEqual([
@@ -614,32 +626,24 @@ describe("Accounts", () => {
           },
           {
             balance: "1'234'567.89 ICP",
-            projectName: "test subaccount",
+            projectName: subaccountName,
           },
           {
             balance: "2.22 ICP",
-            projectName: "hardware wallet account test",
+            projectName: mockHardwareWalletAccountDetails.name,
           },
         ]);
       });
 
       it("renders 'Accounts' as tokens table first column", async () => {
-        const po = renderComponent();
+        const po = await renderComponent();
 
         const tablePo = po.getNnsAccountsPo().getTokensTablePo();
         expect(await tablePo.getFirstColumnHeader()).toEqual("Accounts");
       });
 
       it("user can add a new account", async () => {
-        icpAccountsStore.setForTesting({
-          main: {
-            ...mockMainAccount,
-            balanceUlps: mainAccountBalance,
-          },
-          subAccounts: [],
-          hardwareWallets: [],
-        });
-        const po = renderComponent();
+        const po = await renderComponent();
 
         const tablePo = po.getNnsAccountsPo().getTokensTablePo();
         expect(await tablePo.getRowsData()).toEqual([
@@ -656,7 +660,13 @@ describe("Accounts", () => {
         const modalPo = po.getAddAccountModalPo();
         expect(await modalPo.isPresent()).toBe(true);
 
-        await modalPo.addAccount(newSubaccountName);
+        subaccountDetails = {
+          name: subaccountName,
+          sub_account: mockSubAccount.subAccount,
+          account_identifier: mockSubAccount.identifier,
+        };
+
+        await modalPo.addAccount(subaccountName);
 
         await runResolvedPromises();
 
@@ -667,34 +677,26 @@ describe("Accounts", () => {
           },
           {
             balance: "0 ICP",
-            projectName: newSubaccountName,
+            projectName: subaccountName,
           },
         ]);
       });
 
       it("user can open receive modal and refresh balance", async () => {
-        icpAccountsStore.setForTesting({
-          main: {
-            ...mockMainAccount,
-            balanceUlps: mainAccountBalance,
-          },
-          subAccounts: [
-            {
-              ...mockSubAccount,
-              balanceUlps: subaccountBalance,
-            },
-          ],
-          hardwareWallets: [],
-        });
-        const po = renderComponent();
+        subaccountDetails = {
+          name: subaccountName,
+          sub_account: mockSubAccount.subAccount,
+          account_identifier: mockSubAccount.identifier,
+        };
+        const po = await renderComponent();
 
         const tablePo = po.getNnsAccountsPo().getTokensTablePo();
-        expect(await tablePo.getRowData(mockSubAccount.name)).toEqual({
+        expect(await tablePo.getRowData(subaccountName)).toEqual({
           balance: "0 ICP",
-          projectName: "test subaccount",
+          projectName: subaccountName,
         });
 
-        await tablePo.clickReceiveOnRow(mockSubAccount.name);
+        await tablePo.clickReceiveOnRow(subaccountName);
 
         const modalPo = po.getReceiveModalPo();
         expect(await modalPo.isPresent()).toBe(true);
@@ -707,22 +709,14 @@ describe("Accounts", () => {
         await runResolvedPromises();
 
         expect(await modalPo.isPresent()).toBe(false);
-        expect(await tablePo.getRowData(mockSubAccount.name)).toEqual({
+        expect(await tablePo.getRowData(subaccountName)).toEqual({
           balance: "2.20 ICP",
-          projectName: "test subaccount",
+          projectName: subaccountName,
         });
       });
 
       it("user can open the send modal from footer and make a transaction", async () => {
-        icpAccountsStore.setForTesting({
-          main: {
-            ...mockMainAccount,
-            balanceUlps: mainAccountBalance,
-          },
-          subAccounts: [],
-          hardwareWallets: [],
-        });
-        const po = renderComponent();
+        const po = await renderComponent();
 
         const tablePo = po.getNnsAccountsPo().getTokensTablePo();
         expect(await tablePo.getRowData("Main")).toEqual({
@@ -765,28 +759,20 @@ describe("Accounts", () => {
 
       it("user can open the send modal from tokens table and make a transaction", async () => {
         subaccountBalance = 220000000n;
-        icpAccountsStore.setForTesting({
-          main: {
-            ...mockMainAccount,
-            balanceUlps: mainAccountBalance,
-          },
-          subAccounts: [
-            {
-              ...mockSubAccount,
-              balanceUlps: subaccountBalance,
-            },
-          ],
-          hardwareWallets: [],
-        });
-        const po = renderComponent();
+        subaccountDetails = {
+          name: subaccountName,
+          sub_account: mockSubAccount.subAccount,
+          account_identifier: mockSubAccount.identifier,
+        };
+        const po = await renderComponent();
 
         const tablePo = po.getNnsAccountsPo().getTokensTablePo();
-        expect(await tablePo.getRowData(mockSubAccount.name)).toEqual({
+        expect(await tablePo.getRowData(subaccountName)).toEqual({
           balance: "2.20 ICP",
-          projectName: "test subaccount",
+          projectName: subaccountName,
         });
 
-        await tablePo.clickSendOnRow(mockSubAccount.name);
+        await tablePo.clickSendOnRow(subaccountName);
 
         const modalPo = po.getIcpTransactionModalPo();
         expect(await modalPo.isPresent()).toBe(true);
@@ -801,9 +787,9 @@ describe("Accounts", () => {
 
         await runResolvedPromises();
 
-        expect(await tablePo.getRowData(mockSubAccount.name)).toEqual({
+        expect(await tablePo.getRowData(subaccountName)).toEqual({
           balance: "1.20 ICP",
-          projectName: "test subaccount",
+          projectName: subaccountName,
         });
         expect(await modalPo.isPresent()).toBe(false);
         expect(icpLedgerApi.sendICP).toHaveBeenCalledTimes(1);

--- a/frontend/src/tests/mocks/icp-accounts.store.mock.ts
+++ b/frontend/src/tests/mocks/icp-accounts.store.mock.ts
@@ -65,8 +65,7 @@ export const mockSubAccountDetails: SubAccountDetails = {
 export const mockHardwareWalletAccountDetails: HardwareWalletAccountDetails = {
   name: "ledger test",
   principal: hardwareWalletPrincipal,
-  account_identifier:
-    "646f4d2d6fcb6fab5ba1547647526b666553467ecb5cb28c8d9ddf451c8f4c21",
+  account_identifier: mockHardwareWalletAccount.identifier,
 };
 
 export const mockAccountsStoreData = {


### PR DESCRIPTION
# Motivation

We want to pollAccounts when visiting the NnsAccounts. I don't remember why I removed the call when the tokens page was enabled, but it's not correct. We want to poll accounts also there.

This helps only in edge cases when the initial loading of the accounts fails. Probably why we haven't seen any user report about it.

# Changes

* Enable `pollAccounts` in NnsAccounts when ENABLE_MY_TOKENS is enabled also.

# Tests

* Use the mocked API data instead of setting the store. This also tests that `pollAccounts` works as expected in NnsAccounts.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
