### PR TITLE
chore: remove unnecessary center attr

### DIFF
--- a/frontend/src/lib/components/neurons/SelectNeuronsToMerge.svelte
+++ b/frontend/src/lib/components/neurons/SelectNeuronsToMerge.svelte
@@ -67,7 +67,6 @@
         {:else}
           <Tooltip
             id={`disabled-mergeable-neuron-${neuron.neuronId}`}
-            center
             text={translate({ labelKey: messageKey ?? "error.not_mergeable" })}
           >
             <NnsNeuronCard disabled role="checkbox" {neuron} />


### PR DESCRIPTION
# Motivation

Remove unnecessary (after the Tooltip update) `center` attribute usage.

# Changes

- --`center`

# Tests

Tested manually, looks the same:
<img width="602" alt="Screenshot 2024-02-07 at 09 51 09" src="https://github.com/dfinity/nns-dapp/assets/98811342/3051c746-5654-44dc-acba-f70e03649b04">


# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.