### PR TITLE
GIX-1985: Remove my tokens flag account route

### DIFF
--- a/frontend/src/lib/routes/Accounts.svelte
+++ b/frontend/src/lib/routes/Accounts.svelte
@@ -34,15 +34,14 @@
   import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
   import IcrcTokenAccountsFooter from "$lib/components/accounts/IcrcTokenAccountsFooter.svelte";
   import IcrcTokenAccountsModals from "$lib/modals/accounts/IcrcTokenAccountsModals.svelte";
-  import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
   import { goto } from "$app/navigation";
   import { AppPath } from "$lib/constants/routes.constants";
 
   // TODO: This component is mounted twice. Understand why and fix it.
 
   $: {
-    // When using the new Tokens table, the Accounts page is enabled only for NNS.
-    if ($ENABLE_MY_TOKENS && !$isNnsUniverseStore) {
+    // For now, the Accounts page is enabled only for NNS
+    if (!$isNnsUniverseStore) {
       goto(AppPath.Tokens, { replaceState: true });
     }
   }
@@ -128,7 +127,7 @@
 
 <TestIdWrapper testId="accounts-component">
   <!-- TODO: Remove the `main` element and the rest of unused elements when removing flag ENABLE_MY_TOKENS -->
-  <main class:noPadding={$ENABLE_MY_TOKENS}>
+  <main class="noPadding">
     <SummaryUniverse />
 
     {#if $isNnsUniverseStore}

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -2,82 +2,34 @@ import * as accountsApi from "$lib/api/accounts.api";
 import * as icpLedgerApi from "$lib/api/icp-ledger.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import * as nnsDappApi from "$lib/api/nns-dapp.api";
-import CKETH_LOGO from "$lib/assets/ckETH.svg";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
-import {
-  CKETH_INDEX_CANISTER_ID,
-  CKETH_UNIVERSE_CANISTER_ID,
-} from "$lib/constants/cketh-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import { pageStore } from "$lib/derived/page.derived";
-import {
-  snsProjectsCommittedStore,
-  snsProjectsStore,
-} from "$lib/derived/sns/sns-projects.derived";
-import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
 import Accounts from "$lib/routes/Accounts.svelte";
-import { uncertifiedLoadSnsAccountsBalances } from "$lib/services/sns-accounts-balance.services";
-import { uncertifiedLoadAccountsBalance } from "$lib/services/wallet-uncertified-accounts.services";
-import { authStore } from "$lib/stores/auth.store";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
-import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
-import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
-import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
-import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
-import en from "$tests/mocks/i18n.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountDetails,
-  mockAccountsStoreData,
   mockHardwareWalletAccount,
   mockHardwareWalletAccountDetails,
   mockMainAccount,
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
-import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
-import {
-  mockProjectSubscribe,
-  mockSnsFullProject,
-  mockSummary,
-  mockToken,
-} from "$tests/mocks/sns-projects.mock";
-import { mockTokens } from "$tests/mocks/tokens.mock";
-import { mockSnsSelectedTransactionFeeStoreSubscribe } from "$tests/mocks/transaction-fee.mock";
+import { mockToken } from "$tests/mocks/sns-projects.mock";
 import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
-import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import { SnsSwapLifecycle } from "@dfinity/sns";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
-import { fireEvent, waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
-import WalletTest from "../pages/AccountsTest.svelte";
 
 vi.mock("$lib/api/accounts.api");
 vi.mock("$lib/api/icp-ledger.api");
 vi.mock("$lib/api/icrc-ledger.api");
 vi.mock("$lib/api/nns-dapp.api");
-
-vi.mock("$lib/services/sns-accounts.services", () => {
-  return {
-    syncSnsAccounts: vi.fn().mockResolvedValue(undefined),
-  };
-});
-
-vi.mock("$lib/services/wallet-accounts.services", () => {
-  return {
-    syncAccounts: vi.fn().mockResolvedValue(undefined),
-  };
-});
 
 vi.mock("$lib/services/sns-accounts-balance.services", () => {
   return {
@@ -90,44 +42,6 @@ vi.mock("$lib/services/wallet-uncertified-accounts.services", () => {
     uncertifiedLoadAccountsBalance: vi.fn().mockResolvedValue(undefined),
   };
 });
-
-vi.mock("$lib/services/ckbtc-minter.services", () => {
-  return {
-    updateBalance: vi.fn().mockResolvedValue(undefined),
-  };
-});
-
-vi.mock("$lib/services/ckbtc-info.services", () => {
-  return {
-    loadCkBTCInfo: vi.fn().mockResolvedValue(undefined),
-  };
-});
-
-vi.mock("$lib/services/worker-transactions.services", () => ({
-  initTransactionsWorker: vi.fn(() =>
-    Promise.resolve({
-      startTransactionsTimer: () => {
-        // Do nothing
-      },
-      stopTransactionsTimer: () => {
-        // Do nothing
-      },
-    })
-  ),
-}));
-
-vi.mock("$lib/services/worker-balances.services", () => ({
-  initBalancesWorker: vi.fn(() =>
-    Promise.resolve({
-      startBalancesTimer: () => {
-        // Do nothing
-      },
-      stopBalancesTimer: () => {
-        // Do nothing
-      },
-    })
-  ),
-}));
 
 describe("Accounts", () => {
   const balanceIcrcToken = 314000000n;
@@ -152,25 +66,10 @@ describe("Accounts", () => {
     return AccountsPo.under(new JestPageObjectElement(container));
   };
 
-  beforeAll(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
-  });
-
-  vi.spyOn(snsProjectsCommittedStore, "subscribe").mockImplementation(
-    mockProjectSubscribe([mockSnsFullProject])
-  );
-
-  vi.spyOn(snsProjectsStore, "subscribe").mockImplementation(
-    mockProjectSubscribe([mockSnsFullProject])
-  );
-
   beforeEach(() => {
-    tokensStore.reset();
-    icrcAccountsStore.reset();
-    setCkETHCanisters();
-    overrideFeatureFlagsStore.reset();
-    // TODO: GIX-1985 Remove all the tests outside the describe once the feature flag is enabled by default.
-    overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", false);
+    vi.clearAllMocks();
+    resetIdentity();
+    icpAccountsStore.resetForTesting();
 
     subaccountBalance = subaccountBalanceDefault;
     mainAccountBalance = mainAccountBalanceDefault;
@@ -202,382 +101,11 @@ describe("Accounts", () => {
       return mockAccountDetails;
     });
 
-    vi.spyOn(snsSelectedTransactionFeeStore, "subscribe").mockImplementation(
-      mockSnsSelectedTransactionFeeStoreSubscribe()
-    );
-
-    setSnsProjects([
-      {
-        rootCanisterId: mockSnsFullProject.rootCanisterId,
-        lifecycle: SnsSwapLifecycle.Committed,
-      },
-    ]);
-
     // Reset to default value
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT },
       routeId: AppPath.Accounts,
     });
-
-    snsAccountsStore.setAccounts({
-      rootCanisterId: mockSnsFullProject.rootCanisterId,
-      certified: true,
-      accounts: [mockSnsMainAccount],
-    });
-
-    icpAccountsStore.setForTesting(mockAccountsStoreData);
-
-    icrcCanistersStore.setCanisters({
-      ledgerCanisterId: CKETH_UNIVERSE_CANISTER_ID,
-      indexCanisterId: CKETH_INDEX_CANISTER_ID,
-    });
-  });
-
-  it("should render NnsAccounts by default", () => {
-    const { queryByTestId } = render(Accounts);
-    expect(queryByTestId("accounts-body")).toBeInTheDocument();
-  });
-
-  it("should render nns name", () => {
-    const { getByTestId } = render(Accounts);
-
-    const titleRow = getByTestId("projects-summary");
-
-    expect(titleRow?.textContent?.includes(en.core.ic)).toBeTruthy();
-  });
-
-  it("should render icp project logo", () => {
-    const { getByTestId } = render(Accounts);
-
-    const logo = getByTestId("project-logo");
-    const img = logo.querySelector('[data-tid="logo"]');
-
-    expect(img?.getAttribute("alt") ?? "").toEqual(en.auth.ic_logo);
-  });
-
-  it("should open nns transaction modal", async () => {
-    const { getByTestId } = render(Accounts);
-
-    const button = getByTestId("open-new-transaction") as HTMLButtonElement;
-    await fireEvent.click(button);
-
-    await waitFor(() => {
-      expect(getByTestId("transaction-step-1")).toBeInTheDocument();
-    });
-  });
-
-  it("should open nns receive modal", async () => {
-    const { getByTestId, container } = render(WalletTest, {
-      props: { testComponent: Accounts },
-    });
-
-    fireEvent.click(getByTestId("receive-icp") as HTMLButtonElement);
-
-    await waitFor(() =>
-      expect(container.querySelector("div.modal")).not.toBeNull()
-    );
-  });
-
-  it("should open add account modal", async () => {
-    const { container, getByTestId, getByText } = render(Accounts);
-
-    const button = getByTestId("open-add-account-modal") as HTMLButtonElement;
-    await fireEvent.click(button);
-
-    await waitFor(() => {
-      expect(container.querySelector("div.modal")).not.toBeNull();
-
-      expect(
-        getByText(en.accounts.attach_hardware_title, { exact: false })
-      ).toBeInTheDocument();
-    });
-  });
-
-  it("should render sns accounts when a project is selected", async () => {
-    page.mock({
-      data: { universe: mockSnsFullProject.rootCanisterId.toText() },
-    });
-
-    const { queryByTestId } = render(Accounts);
-
-    expect(queryByTestId("sns-accounts-body")).toBeInTheDocument();
-
-    await waitFor(() =>
-      expect(queryByTestId("sns-accounts-body")).toBeInTheDocument()
-    );
-  });
-
-  it("should open sns transaction modal", async () => {
-    page.mock({
-      data: { universe: mockSnsFullProject.rootCanisterId.toText() },
-    });
-    setSnsProjects([
-      {
-        rootCanisterId: mockSnsFullProject.rootCanisterId,
-        lifecycle: SnsSwapLifecycle.Committed,
-      },
-    ]);
-    const { queryByTestId, getByTestId } = render(Accounts);
-
-    expect(queryByTestId("sns-accounts-body")).toBeInTheDocument();
-
-    await waitFor(() =>
-      expect(queryByTestId("open-new-sns-transaction")).toBeInTheDocument()
-    );
-
-    const button = getByTestId("open-new-sns-transaction") as HTMLButtonElement;
-    await fireEvent.click(button);
-
-    await waitFor(() => {
-      expect(getByTestId("transaction-step-1")).toBeInTheDocument();
-    });
-  });
-
-  it("should open sns receive modal", async () => {
-    page.mock({
-      data: { universe: mockSnsFullProject.rootCanisterId.toText() },
-    });
-
-    const { getByTestId, container } = render(WalletTest, {
-      props: { testComponent: Accounts },
-    });
-
-    fireEvent.click(getByTestId("receive-sns") as HTMLButtonElement);
-
-    await waitFor(() =>
-      expect(container.querySelector("div.modal")).not.toBeNull()
-    );
-
-    expect(getByTestId("logo").getAttribute("alt")).toEqual(
-      `${mockSnsFullProject.summary.metadata.name} project logo`
-    );
-  });
-
-  it("should load Sns accounts balances", async () => {
-    render(Accounts);
-
-    await waitFor(() =>
-      expect(uncertifiedLoadSnsAccountsBalances).toHaveBeenCalled()
-    );
-  });
-
-  it("should load ckBTC accounts balances", async () => {
-    render(Accounts);
-
-    await waitFor(() =>
-      expect(uncertifiedLoadAccountsBalance).toHaveBeenCalled()
-    );
-  });
-
-  it("should not load ckBTC accounts balances", async () => {
-    page.mock({
-      data: { universe: CKBTC_UNIVERSE_CANISTER_ID.toText() },
-      routeId: AppPath.Accounts,
-    });
-
-    render(Accounts);
-
-    await waitFor(() =>
-      expect(uncertifiedLoadAccountsBalance).toHaveBeenCalled()
-    );
-  });
-
-  it("should load ckETH accounts", async () => {
-    render(Accounts);
-
-    await waitFor(() =>
-      expect(uncertifiedLoadAccountsBalance).toHaveBeenCalled()
-    );
-  });
-
-  it("should not load ckETH accounts when universe ckETH is selected", async () => {
-    page.mock({
-      data: { universe: CKETH_UNIVERSE_CANISTER_ID.toText() },
-      routeId: AppPath.Accounts,
-    });
-
-    render(Accounts);
-
-    // TODO: "api for a check on the service" https://dfinity.atlassian.net/browse/GIX-2150
-    await waitFor(() =>
-      expect(uncertifiedLoadAccountsBalance).toHaveBeenCalled()
-    );
-  });
-
-  // TODO: redo https://dfinity.atlassian.net/browse/GIX-2150
-  // it("should load ckETH accounts", async () => {
-  //   overrideFeatureFlagsStore.setFlag("ENABLE_CKETH", true);
-  //
-  //   render(Accounts);
-  //
-  //   const mockAccount = {
-  //     identifier: encodeIcrcAccount({
-  //       owner: mockIdentity.getPrincipal(),
-  //     }),
-  //     principal: mockIdentity.getPrincipal(),
-  //     type: "main",
-  //     balanceUlps: balanceIcrcToken,
-  //   };
-  //
-  //   await waitFor(() => {
-  //     expect(
-  //         get(icrcAccountsStore)[CKETH_UNIVERSE_CANISTER_ID.toText()]
-  //     ).toEqual({
-  //       certified: false,
-  //       accounts: [mockAccount],
-  //     });
-  //   });
-  // });
-  //
-  // it("should make ckETH transactions from ckETH universe", async () => {
-  //   overrideFeatureFlagsStore.setFlag("ENABLE_CKETH", true);
-  //
-  //   page.mock({
-  //     data: { universe: CKETH_UNIVERSE_CANISTER_ID.toText() },
-  //     routeId: AppPath.Accounts,
-  //   });
-  //
-  //   const po = renderComponent();
-  //
-  //   await runResolvedPromises();
-  //
-  //   await po.clickCkETHSend();
-  //
-  //   const modalPo = po.getIcrcTokenTransactionModalPo();
-  //
-  //   expect(await modalPo.isPresent()).toBe(true);
-  //
-  //   const toAccount = {
-  //     owner: principal(2),
-  //   };
-  //   const amount = 2;
-  //
-  //   await modalPo.transferToAddress({
-  //     destinationAddress: encodeIcrcAccount(toAccount),
-  //     amount,
-  //   });
-  //
-  //   expect(icrcLedgerApi.icrcTransfer).toHaveBeenCalledTimes(1);
-  //   expect(icrcLedgerApi.icrcTransfer).toHaveBeenCalledWith({
-  //     identity: mockIdentity,
-  //     canisterId: CKETH_LEDGER_CANISTER_ID,
-  //     amount: 200_000_000n,
-  //     to: toAccount,
-  //     fee: mockCkETHToken.fee,
-  //   });
-  // });
-  //
-  // it("should render IcrcTokenAccounts and IcrcTokenAccountsFooter component with ckETH enabled and universe ckETH", async () => {
-  //   overrideFeatureFlagsStore.setFlag("ENABLE_CKETH", true);
-  //
-  //   page.mock({
-  //     data: { universe: CKETH_UNIVERSE_CANISTER_ID.toText() },
-  //     routeId: AppPath.Accounts,
-  //   });
-  //
-  //   const po = renderComponent();
-  //
-  //   expect(await po.getIcrcTokenAccountsPo().isPresent()).toBe(true);
-  //   expect(await po.getIcrcTokenAccountsFooterPo().isPresent()).toBe(true);
-  // });
-
-  it("should render sns project name", () => {
-    page.mock({
-      data: { universe: mockSnsFullProject.rootCanisterId.toText() },
-    });
-
-    const { getByTestId } = render(Accounts);
-
-    const titleRow = getByTestId("projects-summary");
-
-    expect(
-      titleRow?.textContent?.includes(mockSummary.metadata.name)
-    ).toBeTruthy();
-  });
-
-  it("should render sns project logo", () => {
-    page.mock({
-      data: { universe: mockSnsFullProject.rootCanisterId.toText() },
-    });
-
-    const { getByTestId } = render(Accounts);
-
-    const logo = getByTestId("project-logo");
-    const img = logo.querySelector('[data-tid="logo"]');
-
-    expect(img?.getAttribute("src") ?? "").toEqual(mockSummary.metadata.logo);
-  });
-
-  it("should render icrc project name", () => {
-    tokensStore.setTokens(mockTokens);
-
-    page.mock({
-      data: { universe: CKETH_UNIVERSE_CANISTER_ID.toText() },
-      routeId: AppPath.Accounts,
-    });
-
-    const { getByTestId } = render(Accounts);
-
-    const titleRow = getByTestId("projects-summary");
-
-    expect(titleRow?.textContent?.includes("ckETH")).toBeTruthy();
-  });
-
-  it("should render related icrc project logo", () => {
-    tokensStore.setTokens(mockTokens);
-
-    page.mock({
-      data: { universe: CKETH_UNIVERSE_CANISTER_ID.toText() },
-      routeId: AppPath.Accounts,
-    });
-
-    const { getByTestId } = render(Accounts);
-
-    const logo = getByTestId("project-logo");
-    const img = logo.querySelector('[data-tid="logo"]');
-
-    expect(img?.getAttribute("src") ?? "").toEqual(CKETH_LOGO);
-  });
-
-  it("should render project title", async () => {
-    page.mock({
-      data: { universe: mockSnsFullProject.rootCanisterId.toText() },
-    });
-
-    const { getByText } = render(Accounts);
-
-    await waitFor(() =>
-      expect(
-        getByText(mockSnsFullProject.summary.metadata.name)
-      ).toBeInTheDocument()
-    );
-  });
-
-  it("should render ckBTC name", () => {
-    page.mock({
-      data: { universe: CKBTC_UNIVERSE_CANISTER_ID.toText() },
-      routeId: AppPath.Accounts,
-    });
-
-    const { getByTestId } = render(Accounts);
-
-    const titleRow = getByTestId("projects-summary");
-
-    expect(titleRow?.textContent?.includes(en.ckbtc.title)).toBeTruthy();
-  });
-
-  it("should render icp project logo", () => {
-    page.mock({
-      data: { universe: CKBTC_UNIVERSE_CANISTER_ID.toText() },
-      routeId: AppPath.Accounts,
-    });
-
-    const { getByTestId } = render(Accounts);
-
-    const logo = getByTestId("project-logo");
-    const img = logo.querySelector('[data-tid="logo"]');
-
-    expect(img?.getAttribute("alt") ?? "").toEqual(en.ckbtc.logo);
   });
 
   describe("when NNS universe", () => {
@@ -586,14 +114,9 @@ describe("Accounts", () => {
         data: { universe: OWN_CANISTER_ID_TEXT },
         routeId: AppPath.Accounts,
       });
-      icpAccountsStore.resetForTesting();
     });
 
     describe("when tokens page is enabled", () => {
-      beforeEach(() => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
-      });
-
       it("renders tokens table with NNS accounts", async () => {
         hardwareWalletBalance = 222000000n;
         subaccountBalance = 123456789000000n;
@@ -803,32 +326,7 @@ describe("Accounts", () => {
     });
   });
 
-  it("should open icrc receive modal", async () => {
-    tokensStore.setTokens(mockTokens);
-
-    page.mock({
-      data: {
-        universe: CKETH_UNIVERSE_CANISTER_ID.toText(),
-        routeId: AppPath.Accounts,
-      },
-    });
-
-    const { getByTestId, container } = render(WalletTest, {
-      props: { testComponent: Accounts },
-    });
-
-    fireEvent.click(getByTestId("receive-icrc") as HTMLButtonElement);
-
-    await waitFor(() =>
-      expect(container.querySelector("div.modal")).not.toBeNull()
-    );
-
-    expect(getByTestId("logo").getAttribute("alt")).toEqual(`ckETH logo`);
-  });
-
   it("should redirect to Tokens page when tokens page is enabled and universe is not NNS", async () => {
-    overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
-
     page.mock({
       data: {
         universe: CKBTC_UNIVERSE_CANISTER_ID.toText(),
@@ -843,26 +341,7 @@ describe("Accounts", () => {
     expect(get(pageStore)?.path).toEqual(AppPath.Tokens);
   });
 
-  it("should not redirect to Tokens page when tokens page is not enabled and universe is not NNS", async () => {
-    overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", false);
-
-    page.mock({
-      data: {
-        universe: CKBTC_UNIVERSE_CANISTER_ID.toText(),
-        routeId: AppPath.Accounts,
-      },
-    });
-
-    expect(get(pageStore)?.path).toEqual(AppPath.Accounts);
-
-    render(Accounts);
-
-    expect(get(pageStore)?.path).toEqual(AppPath.Accounts);
-  });
-
   it("should not redirect to Tokens page when tokens page is enabled and universe is NNS", async () => {
-    overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
-
     page.mock({
       data: {
         universe: OWN_CANISTER_ID_TEXT,


### PR DESCRIPTION
# Motivation

Remove ENABLE_MY_TOKENS feature flag.

In this PR, remove using the flag in the Accounts route and related spec file.

# Changes

* Remove usage of `ENABLE_MY_TOKENS` in Accounts route.

# Tests

* Remove tests that required `ENABLE_MY_TOKENS` to be `false` in Accounts spec file.
* I also cleaned up the related setup.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
