### PR TITLE
Fix: check SNS neuron balances if force query

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -35,6 +35,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * QR-code reader incorrectly mirrored on `Samsung S23`.
+* Check SNS neuron balances to claim pending neurons.
 
 #### Security
 

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -108,7 +108,7 @@ export const syncSnsNeurons = async (
         certified,
       });
 
-      if (certified) {
+      if (certified || FORCE_CALL_STRATEGY === "query") {
         // be sure that the parameters are loaded
         await snsParametersRequest;
         const neuronMinimumStake = fromNullable(

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -33,7 +33,10 @@ import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { Account } from "$lib/types/account";
 import { nowInSeconds } from "$lib/utils/date.utils";
-import { notForceCallStrategy } from "$lib/utils/env.utils";
+import {
+  isForceCallStrategy,
+  notForceCallStrategy,
+} from "$lib/utils/env.utils";
 import { toToastError } from "$lib/utils/error.utils";
 import { ledgerErrorToToastError } from "$lib/utils/sns-ledger.utils";
 import {
@@ -108,7 +111,7 @@ export const syncSnsNeurons = async (
         certified,
       });
 
-      if (certified || FORCE_CALL_STRATEGY === "query") {
+      if (certified || isForceCallStrategy()) {
         // be sure that the parameters are loaded
         await snsParametersRequest;
         const neuronMinimumStake = fromNullable(

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -36,6 +36,7 @@ import {
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
 import { mockSnsToken, mockTokenStore } from "$tests/mocks/sns-projects.mock";
+import { mockedConstants } from "$tests/utils/mockable-constants.test-utils";
 import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
 import {
@@ -220,6 +221,45 @@ describe("sns-neurons-services", () => {
     });
 
     it("should claim neuron if find a subaccount without neuron", async () => {
+      const subaccount = neuronSubaccount({
+        controller: mockIdentity.getPrincipal(),
+        index: 1,
+      });
+      const neuronId: SnsNeuronId = { id: subaccount };
+      const neuron = {
+        ...mockSnsNeuron,
+        id: [neuronId] as [SnsNeuronId],
+      };
+      const spyQuery = vi
+        .spyOn(governanceApi, "querySnsNeurons")
+        .mockImplementation(() => Promise.resolve([neuron]));
+      const spyNeuronQuery = vi
+        .spyOn(governanceApi, "getSnsNeuron")
+        .mockImplementation(() => Promise.resolve(neuron));
+      const spyNeuronBalance = vi
+        .spyOn(governanceApi, "getNeuronBalance")
+        .mockImplementationOnce(() =>
+          Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s)
+        )
+        .mockImplementationOnce(() => Promise.resolve(200_000_000n))
+        .mockImplementation(() => Promise.resolve(0n));
+      const spyClaimNeuron = vi
+        .spyOn(governanceApi, "claimNeuron")
+        .mockImplementation(() => Promise.resolve(undefined));
+      await syncSnsNeurons(mockPrincipal);
+
+      await tick();
+      await tick();
+      const store = get(snsNeuronsStore);
+      expect(store[mockPrincipal.toText()]?.neurons).toHaveLength(1);
+      expect(spyQuery).toBeCalled();
+      expect(spyNeuronBalance).toBeCalled();
+      expect(spyClaimNeuron).toBeCalled();
+      expect(spyNeuronQuery).toBeCalled();
+    });
+
+    it("should claim neuron if find a subaccount without neuron for query calls if FORCE_CALL_STRATEGY is query", async () => {
+      mockedConstants.FORCE_CALL_STRATEGY = "query";
       const subaccount = neuronSubaccount({
         controller: mockIdentity.getPrincipal(),
         index: 1,

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -36,7 +36,10 @@ import {
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
 import { mockSnsToken, mockTokenStore } from "$tests/mocks/sns-projects.mock";
-import { mockedConstants } from "$tests/utils/mockable-constants.test-utils";
+import {
+  mockedConstants,
+  resetMockedConstants,
+} from "$tests/utils/mockable-constants.test-utils";
 import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
 import {
@@ -81,6 +84,7 @@ describe("sns-neurons-services", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetIdentity();
+    resetMockedConstants();
   });
 
   describe("syncSnsNeurons", () => {


### PR DESCRIPTION
# Motivation

There is a bug in mainnet.

If a user starts staking an SNS neuron, but loses connection after the transfer happens but before the claiming happens, the neuron isn't claimed when the user returns.

The reason was because we were checking the balances only on update calls. We lost that when we forced only query calls with `FORCE_CALL_STRATEGY`.

# Changes

* Check SNS neuron balances also if `FORCE_CALL_STRATEGY` forces only a `"query"` strategy.

# Tests

* I added the same test to claim a neuron forcing the strategy to `"query"`, the test failed. As expected with the bug.
* Then I added the fix to also check when `FORCE_CALL_STRATEGY` is `"query"` and it passed.

# Todos

- [x] Add entry to changelog (if necessary).
