### PR TITLE
Chore: Improve Ledger docs

### DIFF
--- a/frontend/src/lib/identities/ledger.identity.ts
+++ b/frontend/src/lib/identities/ledger.identity.ts
@@ -145,7 +145,14 @@ export class LedgerIdentity extends SignIdentity {
   }
 
   /**
-   * @returns The version of the `Internet Computer' app installed on the Ledger device.
+   * @returns The version of the `Internet Computer' app installed on the Ledger device and the device model used under the `targeId` key:
+   *
+   * 3110 => LNS
+   * 3300 => LNX
+   * 3310 => LNS+
+   * 3320 => stax
+   *
+   * PS: Another way to find the device model is under the `Transport` object, the `deviceModel` field.
    */
   public async getVersion(): Promise<ResponseVersion> {
     // See comment about `app` in function `showAddressAndPubKeyOnDevice`

--- a/frontend/src/lib/identities/ledger.identity.ts
+++ b/frontend/src/lib/identities/ledger.identity.ts
@@ -147,10 +147,12 @@ export class LedgerIdentity extends SignIdentity {
   /**
    * @returns The version of the `Internet Computer' app installed on the Ledger device and the device model used under the `targeId` key:
    *
-   * 3110 => LNS
-   * 3300 => LNX
-   * 3310 => LNS+
-   * 3320 => stax
+   * 0x3110???? => LNS
+   * 0x3300???? => LNX
+   * 0x3310???? => LNS+
+   * 0x3320???? => stax
+   *
+   * Source: https://github.com/LedgerHQ/blue-loader-python?tab=readme-ov-file#target-id
    *
    * PS: Another way to find the device model is under the `Transport` object, the `deviceModel` field.
    */


### PR DESCRIPTION
# Motivation

Remember how to get the Ledger device model in case we need it.

In this PR, I add a comment to the `getVersion` method. I thought that was the easiest way to keep track of that instead of some documentation somewhere else.

# Changes

* Extend comment in `LedgerIdentity#getVersion` method.

# Tests

No code changes.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
