### PR TITLE
Fix missing ballots issue

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -35,7 +35,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * QR-code reader incorrectly mirrored on `Samsung S23`.
-* Votable neurons being displayed as ineligible on the SNS proposal detail page.
+* Neurons that can vote being displayed as ineligible on the SNS proposal detail page.
 
 #### Security
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -35,6 +35,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * QR-code reader incorrectly mirrored on `Samsung S23`.
+* Votable neurons being displayed as ineligible on the SNS proposal detail page.
 
 #### Security
 

--- a/frontend/src/lib/components/neurons/SelectNeuronsToMerge.svelte
+++ b/frontend/src/lib/components/neurons/SelectNeuronsToMerge.svelte
@@ -67,7 +67,6 @@
         {:else}
           <Tooltip
             id={`disabled-mergeable-neuron-${neuron.neuronId}`}
-            center
             text={translate({ labelKey: messageKey ?? "error.not_mergeable" })}
           >
             <NnsNeuronCard disabled role="checkbox" {neuron} />

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -152,7 +152,14 @@
           !$authSignedInStore ? undefined : loadSnsParameters(universeId),
           loadSnsNervousSystemFunctions(universeId),
         ]);
-        // Reload proposal only after other data, to be sure that the user has some neurons to vote. Otherwise, the call will be skipped.
+        /*
+        Reload proposal only after `syncSnsNeurons` is done,
+        to be sure that the `reloadForBallots` flag is calculated correctly (based on user neuron presence).
+        When `reloadForBallots` is true, the proposal will be reloaded regardless of other conditions.
+        Otherwise, the proposal from snsProposalsStore will be used when:
+          - proposal data in the store is certified
+          - and user has no neurons for selected Sns.
+         */
         await reloadProposal();
       } catch (error) {
         toastsError({

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -152,7 +152,7 @@
           !$authSignedInStore ? undefined : loadSnsParameters(universeId),
           loadSnsNervousSystemFunctions(universeId),
         ]);
-        // Reload proposal only after other data, to be sure that the user has some neurons to vote. Otherwise, there is no need to reload.
+        // Reload proposal only after other data, to be sure that the user has some neurons to vote. Otherwise, the call will be skipped.
         await reloadProposal();
       } catch (error) {
         toastsError({

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -151,8 +151,9 @@
           //
           !$authSignedInStore ? undefined : loadSnsParameters(universeId),
           loadSnsNervousSystemFunctions(universeId),
-          reloadProposal(),
         ]);
+        // Reload proposal only after other data, to be sure that the user has some neurons to vote. Otherwise, there is no need to reload.
+        await reloadProposal();
       } catch (error) {
         toastsError({
           labelKey: "error.wrong_proposal_id",

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -70,6 +70,8 @@ describe("SnsProposals", () => {
       );
     });
 
+    // TODO(max): add tests that the neurons are being fetched before the proposals (pr: https://github.com/dfinity/nns-dapp/pull/4420/)
+
     describe("Matching results", () => {
       beforeEach(() => {
         fakeSnsGovernanceApi.addProposalWith({


### PR DESCRIPTION
# Motivation

Fix the issue when all user neurons are shown as ineligible to vote.

**HowTo reproduce:**
1. goto sns proposal list page
2. log-in
3. refresh the page
4. wait for 10 seconds (otherwise there could be no certified proposals in the `snsProposalsStore` store)
5. click on any proposal that you are eligible to vote on
6. check the ineligible neurons block

The problem is the calculation of the `reloadForBallots` flag that prevents the dapp from redundant proposals fetching. 
The proposal call is skipped when:
- `reloadForBallots` is false (when no neurons available)
- there is a `certified` version of the proposal data in the `snsProposalsStore`

If this logic is applied before the neurons being loaded, but after the `snsProposalsStore` being updated, the wrong neurons state is shown on the proposal page, because no ballots were loaded.

# Changes

- before loading full sns proposal details

# Tests

Not in this pr.

# Todos

- [x] Add entry to changelog (if necessary).