### PR TITLE
chore: Allow missing docs in autogenerated code

### DIFF
--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -2,6 +2,7 @@
 //! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-25_14-09+p2p-con/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
+#![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};

--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,7 +1,7 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
 //! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-25_14-09+p2p-con/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
-#![allow(clippy::missing_docs_in_private_items)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -2,6 +2,7 @@
 //! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-25_14-09+p2p-con/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
+#![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,7 +1,7 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
 //! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-25_14-09+p2p-con/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
-#![allow(clippy::missing_docs_in_private_items)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,7 +1,7 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
 //! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-25_14-09+p2p-con/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
-#![allow(clippy::missing_docs_in_private_items)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -2,6 +2,7 @@
 //! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-25_14-09+p2p-con/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
+#![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
+#![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -2,7 +2,7 @@
 //! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-25_14-09+p2p-con/rs/sns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
-#![allow(clippy::missing_docs_in_private_items)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
+#![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -2,7 +2,7 @@
 //! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-25_14-09+p2p-con/rs/rosetta-api/icrc1/ledger/ledger.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
-#![allow(clippy::missing_docs_in_private_items)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -2,7 +2,7 @@
 //! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-25_14-09+p2p-con/rs/sns/root/canister/root.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
-#![allow(clippy::missing_docs_in_private_items)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
+#![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -2,7 +2,7 @@
 //! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-25_14-09+p2p-con/rs/sns/swap/canister/swap.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
-#![allow(clippy::missing_docs_in_private_items)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
+#![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -2,7 +2,7 @@
 //! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-25_14-09+p2p-con/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
-#![allow(clippy::missing_docs_in_private_items)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
+#![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 

--- a/scripts/proposals/did2rs.header
+++ b/scripts/proposals/did2rs.header
@@ -1,5 +1,6 @@
 #![allow(clippy::all)]
 #![allow(missing_docs)]
+#![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};

--- a/scripts/proposals/did2rs.header
+++ b/scripts/proposals/did2rs.header
@@ -1,5 +1,5 @@
 #![allow(clippy::all)]
-#![allow(clippy::missing_docs_in_private_items)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code, unused_imports)]
 use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};

--- a/scripts/sns/aggregator/did2rs.header
+++ b/scripts/sns/aggregator/did2rs.header
@@ -1,6 +1,7 @@
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
+#![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 

--- a/scripts/sns/aggregator/did2rs.header
+++ b/scripts/sns/aggregator/did2rs.header
@@ -1,6 +1,6 @@
 #![allow(clippy::all)]
 #![allow(unused_imports)]
-#![allow(clippy::missing_docs_in_private_items)]
+#![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 


### PR DESCRIPTION
# Motivation
I am trying to address any missing documentation to help ease the code handover.  If I try to find missing documentation by increasing the sensitivity of the missing docs clippy, I get a huge number of warnings from autogenerated code.

# Changes
* In autogenerated code, allow missing documentation of all types, not just of private items.

# Tests
See CI

# Todos

- [ ] Add entry to changelog (if necessary).
  Too minor