### PR TITLE
GIX-1985: Remove my tokens flag NnsAccounts page

### DIFF
--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -1,19 +1,13 @@
 <script lang="ts">
-  import AccountCard from "$lib/components/accounts/AccountCard.svelte";
-  import NnsAddAccount from "$lib/components/accounts/NnsAddAccount.svelte";
   import { i18n } from "$lib/stores/i18n";
-  import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
-  import { isNullish, nonNullish } from "@dfinity/utils";
+  import { isNullish } from "@dfinity/utils";
   import { onDestroy, onMount } from "svelte";
   import {
     cancelPollAccounts,
     loadBalance,
     pollAccounts,
   } from "$lib/services/icp-accounts.services";
-  import { ICPToken } from "@dfinity/utils";
   import type { UserToken } from "$lib/types/tokens-page";
-  import { ENABLE_MY_TOKENS } from "$lib/stores/feature-flags.store";
   import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { IconAdd } from "@dfinity/gix-components";
@@ -82,56 +76,29 @@
   };
 </script>
 
-{#if $ENABLE_MY_TOKENS}
-  <TestIdWrapper testId="accounts-body">
-    <TokensTable
-      {userTokensData}
-      firstColumnHeader={$i18n.tokens.accounts_header}
-      on:nnsAction={handleAction}
+<TestIdWrapper testId="accounts-body">
+  <TokensTable
+    {userTokensData}
+    firstColumnHeader={$i18n.tokens.accounts_header}
+    on:nnsAction={handleAction}
+  >
+    <div
+      slot="last-row"
+      class="add-account-row"
+      data-tid="add-account-row"
+      on:click={openAddAccountModal}
+      on:keypress={openAddAccountModal}
+      role="button"
+      aria-label={$i18n.accounts.add_account}
+      tabindex="0"
     >
-      <div
-        slot="last-row"
-        class="add-account-row"
-        data-tid="add-account-row"
-        on:click={openAddAccountModal}
-        on:keypress={openAddAccountModal}
-        role="button"
-        aria-label={$i18n.accounts.add_account}
-        tabindex="0"
+      <!-- Skip tabindex the button because it's already in the row -->
+      <button tabindex="-1" class="ghost with-icon"
+        ><IconAdd />{$i18n.accounts.add_account}</button
       >
-        <!-- Skip tabindex the button because it's already in the row -->
-        <button tabindex="-1" class="ghost with-icon"
-          ><IconAdd />{$i18n.accounts.add_account}</button
-        >
-      </div>
-    </TokensTable>
-  </TestIdWrapper>
-{:else}
-  <div class="card-grid" data-tid="accounts-body">
-    {#if nonNullish($icpAccountsStore?.main)}
-      <!-- Workaround: Type checker does not get $accountsStore.main is defined here -->
-      {@const mainAccount = $icpAccountsStore.main}
-
-      <AccountCard account={mainAccount} token={ICPToken}
-        >{$i18n.accounts.main}</AccountCard
-      >
-      {#each $icpAccountsStore.subAccounts ?? [] as subAccount}
-        <AccountCard account={subAccount} token={ICPToken}
-          >{subAccount.name}</AccountCard
-        >
-      {/each}
-      {#each $icpAccountsStore.hardwareWallets ?? [] as walletAccount}
-        <AccountCard account={walletAccount} token={ICPToken}
-          >{walletAccount.name}</AccountCard
-        >
-      {/each}
-
-      <NnsAddAccount />
-    {:else}
-      <SkeletonCard size="medium" />
-    {/if}
-  </div>
-{/if}
+    </div>
+  </TokensTable>
+</TestIdWrapper>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/interaction";

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -4,17 +4,10 @@ import { SYNC_ACCOUNTS_RETRY_SECONDS } from "$lib/constants/accounts.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import NnsAccounts from "$lib/pages/NnsAccounts.svelte";
 import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import type { UserTokenData } from "$lib/types/tokens-page";
-import { formatTokenE8s } from "$lib/utils/token.utils";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
-import {
-  mockAccountDetails,
-  mockHardwareWalletAccount,
-  mockMainAccount,
-  mockSubAccount,
-} from "$tests/mocks/icp-accounts.store.mock";
+import { mockAccountDetails } from "$tests/mocks/icp-accounts.store.mock";
 import { createUserToken } from "$tests/mocks/tokens-page.mock";
 import { NnsAccountsPo } from "$tests/page-objects/NnsAccounts.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -23,7 +16,7 @@ import {
   runResolvedPromises,
 } from "$tests/utils/timers.test-utils";
 import { TokenAmount } from "@dfinity/utils";
-import { render, waitFor } from "@testing-library/svelte";
+import { render } from "@testing-library/svelte";
 import type { SpyInstance } from "vitest";
 
 vi.mock("$lib/api/nns-dapp.api");
@@ -38,20 +31,14 @@ describe("NnsAccounts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetIdentity();
-    icpAccountsStore.setForTesting({
-      main: mockMainAccount,
-      subAccounts: [],
-      hardwareWallets: [],
-      certified: true,
+    icpAccountsStore.resetForTesting();
+    // TODO: Move the pollAccounts to Accounts route when universe selected is NNS instead of the child.
+    vi.spyOn(nnsDappApi, "queryAccount").mockImplementation(async () => {
+      return mockAccountDetails;
     });
-    overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", false);
   });
 
   describe("when tokens flag is enabled", () => {
-    beforeEach(() => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", true);
-    });
-
     it("renders 'Accounts' as tokens table first column", async () => {
       const po = renderComponent();
 
@@ -107,159 +94,45 @@ describe("NnsAccounts", () => {
     });
   });
 
-  describe("when tokens flag is disabled", () => {
+  // TODO: Move the pollAccounts to Accounts route when universe selected is NNS instead of the child.
+  describe("when no accounts and user navigates away", () => {
+    let spyQueryAccount: SpyInstance;
     beforeEach(() => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", false);
+      vi.clearAllTimers();
+      vi.clearAllMocks();
+      cancelPollAccounts();
+      const now = Date.now();
+      vi.useFakeTimers().setSystemTime(now);
+      const mainBalanceE8s = 10_000_000n;
+      vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
+        mainBalanceE8s
+      );
+      spyQueryAccount = vi
+        .spyOn(nnsDappApi, "queryAccount")
+        .mockRejectedValue(new Error("connection error"));
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
     });
 
-    describe("when there are accounts", () => {
-      beforeEach(() => {
-        cancelPollAccounts();
-      });
+    it("should stop polling", async () => {
+      const { unmount } = render(NnsAccounts);
 
-      it("should render a main card", () => {
-        const { queryByTestId } = render(NnsAccounts);
+      await runResolvedPromises();
+      let expectedCalls = 1;
+      expect(spyQueryAccount).toBeCalledTimes(expectedCalls);
 
-        expect(queryByTestId("account-card")).not.toBeNull();
-      });
-
-      it("should render account icp in card too", () => {
-        const { container } = render(NnsAccounts);
-
-        const cardTitleRow = container.querySelector(
-          '[data-tid="account-card"] > div[data-tid="token-value-label"]'
-        );
-
-        expect(cardTitleRow?.textContent.trim()).toEqual(
-          `${formatTokenE8s({ value: mockMainAccount.balanceUlps })} ICP`
-        );
-      });
-
-      it("should render account identifier", () => {
-        const { getByText } = render(NnsAccounts);
-        getByText(mockMainAccount.identifier);
-      });
-
-      it("should render subaccount cards", () => {
-        icpAccountsStore.setForTesting({
-          main: mockMainAccount,
-          subAccounts: [mockSubAccount],
-          hardwareWallets: [],
-          certified: true,
-        });
-        const { queryAllByTestId } = render(NnsAccounts);
-
-        const cards = queryAllByTestId("account-card");
-
-        expect(cards).not.toBeNull();
-        expect(cards.length).toBe(2);
-      });
-
-      it("should render hardware wallet account cards", () => {
-        icpAccountsStore.setForTesting({
-          main: mockMainAccount,
-          subAccounts: [],
-          hardwareWallets: [mockHardwareWalletAccount],
-          certified: true,
-        });
-        const { queryAllByTestId } = render(NnsAccounts);
-
-        const cards = queryAllByTestId("account-card");
-
-        expect(cards).not.toBeNull();
-        expect(cards.length).toBe(2);
-      });
-    });
-
-    describe("summary", () => {
-      beforeAll(() => {
-        vi.clearAllMocks();
-        icpAccountsStore.setForTesting({
-          main: mockMainAccount,
-          subAccounts: [mockSubAccount],
-          hardwareWallets: [mockHardwareWalletAccount],
-          certified: true,
-        });
-      });
-
-      it("should contain a tooltip", () => {
-        const { container } = render(NnsAccounts);
-
-        expect(container.querySelector(".tooltip-wrapper")).toBeInTheDocument();
-      });
-    });
-
-    describe("when no accounts", () => {
-      beforeEach(() => {
-        icpAccountsStore.resetForTesting();
-        const mainBalanceE8s = 10_000_000n;
-        vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
-          mainBalanceE8s
-        );
-        vi.spyOn(nnsDappApi, "queryAccount").mockResolvedValue(
-          mockAccountDetails
-        );
-      });
-      it("should not render a token amount component nor zero", () => {
-        const { container } = render(NnsAccounts);
-
-        // The tooltip wraps the total amount
-        expect(
-          container.querySelector(".tooltip-wrapper")
-        ).not.toBeInTheDocument();
-      });
-
-      it("should load accounts", async () => {
-        const { queryByTestId } = render(NnsAccounts);
-
-        expect(queryByTestId("account-card")).toBeNull();
-
-        await waitFor(() =>
-          expect(queryByTestId("account-card")).not.toBeNull()
-        );
-      });
-    });
-
-    describe("when no accounts and user navigates away", () => {
-      let spyQueryAccount: SpyInstance;
-      beforeEach(() => {
-        icpAccountsStore.resetForTesting();
-        vi.clearAllTimers();
-        vi.clearAllMocks();
-        cancelPollAccounts();
-        const now = Date.now();
-        vi.useFakeTimers().setSystemTime(now);
-        const mainBalanceE8s = 10_000_000n;
-        vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
-          mainBalanceE8s
-        );
-        spyQueryAccount = vi
-          .spyOn(nnsDappApi, "queryAccount")
-          .mockRejectedValue(new Error("connection error"));
-        vi.spyOn(console, "error").mockImplementation(() => undefined);
-      });
-
-      it("should stop polling", async () => {
-        const { unmount } = render(NnsAccounts);
-
-        await runResolvedPromises();
-        let expectedCalls = 1;
+      let retryDelay = SYNC_ACCOUNTS_RETRY_SECONDS * 1000;
+      const callsBeforeLeaving = 3;
+      while (expectedCalls < callsBeforeLeaving) {
+        await advanceTime(retryDelay);
+        retryDelay *= 2;
+        expectedCalls += 1;
         expect(spyQueryAccount).toBeCalledTimes(expectedCalls);
+      }
+      unmount();
 
-        let retryDelay = SYNC_ACCOUNTS_RETRY_SECONDS * 1000;
-        const callsBeforeLeaving = 3;
-        while (expectedCalls < callsBeforeLeaving) {
-          await advanceTime(retryDelay);
-          retryDelay *= 2;
-          expectedCalls += 1;
-          expect(spyQueryAccount).toBeCalledTimes(expectedCalls);
-        }
-        unmount();
-
-        // Even after waiting a long time there shouldn't be more calls.
-        await advanceTime(99 * retryDelay);
-        expect(spyQueryAccount).toBeCalledTimes(expectedCalls);
-      });
+      // Even after waiting a long time there shouldn't be more calls.
+      await advanceTime(99 * retryDelay);
+      expect(spyQueryAccount).toBeCalledTimes(expectedCalls);
     });
   });
 });


### PR DESCRIPTION
# Motivation

Remove `ENABLE_MY_TOKENS` flag.

In this PR, remove the flag from NnsAccounts.

# Changes

* Remove the branch where `ENABLE_MY_TOKENS` is false in NnsAccounts.

# Tests

* Remove the tests of the branch were `ENABLE_MY_TOKENS` is false except for one moved to when `ENABLE_MY_TOKENS` is true. But no changes were needed.
* Change setup needed for the test. I changed resetting the accounts store by mocking a return of the NNS Dapp API. The NNS Accounts expects specific props that for testing make more sense to be passed. The logic of manipulating the data is in the parent Accounts route and therefore, it should also have the logic of fetching the data.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
