### PR TITLE
refactor: Move & rename

### DIFF
--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -1,6 +1,7 @@
 pub mod partitions;
 #[cfg(test)]
 pub mod tests;
+mod with_raw_memory;
 
 #[cfg(test)]
 use self::partitions::Partitions;
@@ -16,7 +17,7 @@ use crate::assets::Assets;
 use crate::perf::PerformanceCounts;
 
 use dfn_candid::Candid;
-use dfn_core::{api::trap_with, stable};
+use dfn_core::api::trap_with;
 use ic_stable_structures::{DefaultMemoryImpl, Memory};
 use on_wire::{FromWire, IntoWire};
 use std::cell::RefCell;
@@ -193,7 +194,7 @@ impl State {
     /// This way it is possible to roll back after deploying the new schema.
     pub fn restore() -> Self {
         match Self::schema_version_from_stable_memory() {
-            None => Self::restore_unversioned(),
+            None => Self::recover_from_raw_memory(),
             Some(version) => {
                 trap_with(&format!("Unknown schema version: {version:?}"));
                 unreachable!();
@@ -202,23 +203,6 @@ impl State {
     }
     /// Saves any unsaved state to stable memory.
     pub fn save(&self) {
-        self.save_unversioned()
-    }
-}
-
-// The unversioned schema.
-impl State {
-    /// Saves any unsaved state to stable memory.
-    fn save_unversioned(&self) {
-        let bytes = self.encode();
-        stable::set(&bytes);
-    }
-    /// Creates the state from stable memory in the `post_upgrade()` hook.
-    fn restore_unversioned() -> Self {
-        let bytes = stable::get();
-        State::decode(bytes).unwrap_or_else(|e| {
-            trap_with(&format!("Decoding stable memory failed. Error: {e:?}"));
-            unreachable!();
-        })
+        self.save_to_raw_memory()
     }
 }

--- a/rs/backend/src/state/with_raw_memory.rs
+++ b/rs/backend/src/state/with_raw_memory.rs
@@ -1,0 +1,23 @@
+//! State from/to stable memory in the classic "Candid in raw memory" format.
+use super::{StableState, State};
+use dfn_core::{api::trap_with, stable};
+use ic_cdk::println;
+
+impl State {
+    /// Save any unsaved state to stable memory in the `SchemaLabel::Map` format.
+    pub fn save_to_raw_memory(&self) {
+        println!("START state::save_to_raw_memory: ()");
+        let bytes = self.encode();
+        stable::set(&bytes);
+        println!("END state::save_to_raw_memory: ()");
+    }
+    /// Create the state from stable memory in the `SchemaLabel::Map` format.
+    pub fn recover_from_raw_memory() -> Self {
+        println!("state::recover_from_raw_memory: ()");
+        let bytes = stable::get();
+        State::decode(bytes).unwrap_or_else(|e| {
+            trap_with(&format!("Decoding stable memory failed. Error: {e:?}"));
+            unreachable!();
+        })
+    }
+}


### PR DESCRIPTION
# Motivation
There will shortly be several state save & restore commands, not just one.  To avoid cluttering up the main state.rs, the existing save/restore command is moved into its own file.

# Changes
- Move code.

# Tests
- Existing CI should suffice

# Todos

- [ ] Add entry to changelog (if necessary).
  Too minor