### PR TITLE
Chore: Upgrade gix-components

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -19,6 +19,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Add the token symbol in the send modals.
 * Add new boundary node proposals support.
 * Prevent the `1Password` extension from appearing in input fields.
+* Support HTML within toast messages.
 
 #### Changed
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "4.0.0-next-2024-02-07.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.0.0-next-2024-02-07.1.tgz",
-      "integrity": "sha512-ai0InDwVKASxVAsaD+A0KEX2sENhXI60aqqVe/CH4slMpGyi5AQ5Wp4L/Q+GiDDbJVYC686LFd+6BAXd21RPZA==",
+      "version": "4.0.0-next-2024-02-08",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.0.0-next-2024-02-08.tgz",
+      "integrity": "sha512-oTabYSqWhD6dIFT2BB3W3swZteOZIob6aHYuhKHkXMBag2nI4rqBg7vu/FB5hKpWHIZiW9Ri6bc/LarNVr07Rw==",
       "dependencies": {
         "dompurify": "^3.0.6",
         "html5-qrcode": "^2.3.8",
@@ -7063,9 +7063,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "4.0.0-next-2024-02-07.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.0.0-next-2024-02-07.1.tgz",
-      "integrity": "sha512-ai0InDwVKASxVAsaD+A0KEX2sENhXI60aqqVe/CH4slMpGyi5AQ5Wp4L/Q+GiDDbJVYC686LFd+6BAXd21RPZA==",
+      "version": "4.0.0-next-2024-02-08",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.0.0-next-2024-02-08.tgz",
+      "integrity": "sha512-oTabYSqWhD6dIFT2BB3W3swZteOZIob6aHYuhKHkXMBag2nI4rqBg7vu/FB5hKpWHIZiW9Ri6bc/LarNVr07Rw==",
       "requires": {
         "dompurify": "^3.0.6",
         "html5-qrcode": "^2.3.8",


### PR DESCRIPTION
# Motivation

Render html within toasts.

In this PR, I upgrade the gix-components dependency to use the new field `renderAsHtml` in the Toast message.

# Changes

## Automatic Changes

* package.lock.json running the script `npm run update:gix`

# Tests

Still passing.

# Todos

- [x] Add entry to changelog (if necessary).
