### PR TITLE
NNS1-2847: Use IcrcWalletPage in SnsWallet

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -25,6 +25,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Stable memory is owned by State structure to control access.
 * Voting power calculation formatting.
 * Voting rewards description.
+* Unify implementations of SNS token wallets with other (non-ICP) token wallets.
 
 #### Deprecated
 

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -1,230 +1,74 @@
 <script lang="ts">
-  import { authSignedInStore } from "$lib/derived/auth.derived";
-  import { goto } from "$app/navigation";
-  import { hasAccounts } from "$lib/utils/accounts.utils";
-  import { findAccountOrDefaultToMain } from "$lib/utils/accounts.utils";
-  import type { Principal } from "@dfinity/principal";
-  import { Spinner } from "@dfinity/gix-components";
-  import { setContext } from "svelte";
-  import { writable } from "svelte/store";
-  import { snsProjectAccountsStore } from "$lib/derived/sns/sns-project-accounts.derived";
-  import { syncSnsAccounts } from "$lib/services/sns-accounts.services";
-  import { debugSelectedAccountStore } from "$lib/derived/debug.derived";
-  import {
-    WALLET_CONTEXT_KEY,
-    type WalletContext,
-    type WalletStore,
-  } from "$lib/types/wallet.context";
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
-  import Footer from "$lib/components/layout/Footer.svelte";
-  import { i18n } from "$lib/stores/i18n";
-  import SnsTransactionModal from "$lib/modals/accounts/SnsTransactionModal.svelte";
-  import SnsTransactionsList from "$lib/components/accounts/SnsTransactionsList.svelte";
+  import { selectedIcrcTokenUniverseIdStore } from "$lib/derived/selected-universe.derived";
+  import { nonNullish } from "@dfinity/utils";
+  import IcrcWalletPage from "$lib/components/accounts/IcrcWalletPage.svelte";
   import NoTransactions from "$lib/components/accounts/NoTransactions.svelte";
-  import SignInGuard from "$lib/components/common/SignInGuard.svelte";
-  import Separator from "$lib/components/ui/Separator.svelte";
-  import { Island } from "@dfinity/gix-components";
-  import {
-    snsOnlyProjectStore,
-    snsProjectSelectedStore,
-  } from "$lib/derived/sns/sns-selected-project.derived";
-  import { TokenAmountV2, isNullish, nonNullish } from "@dfinity/utils";
-  import { selectedUniverseStore } from "$lib/derived/selected-universe.derived";
-  import { loadSnsAccountTransactions } from "$lib/services/sns-transactions.services";
-  import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { toastsError } from "$lib/stores/toasts.store";
-  import ReceiveButton from "$lib/components/accounts/ReceiveButton.svelte";
-  import { tokensStore } from "$lib/stores/tokens.store";
+  import { writable } from "svelte/store";
+  import type { WalletStore } from "$lib/types/wallet.context";
+  import IcrcWalletTransactionsList from "$lib/components/accounts/IcrcWalletTransactionsList.svelte";
+  import type { CanisterId } from "$lib/types/canister";
+  import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
-  import SnsBalancesObserver from "$lib/components/accounts/SnsBalancesObserver.svelte";
-  import WalletPageHeader from "$lib/components/accounts/WalletPageHeader.svelte";
-  import WalletPageHeading from "$lib/components/accounts/WalletPageHeading.svelte";
-  import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
-  import IC_LOGO from "$lib/assets/icp.svg";
-  import { toTokenAmountV2 } from "$lib/utils/token.utils";
-  import { AppPath } from "$lib/constants/routes.constants";
+  import { tokensStore } from "$lib/stores/tokens.store";
+  import IcrcTokenWalletFooter from "$lib/components/accounts/IcrcTokenWalletFooter.svelte";
 
-  let showModal: "send" | undefined = undefined;
-
-  const onSnsProjectChanged = async (
-    selectedProjectCanisterId: Principal | undefined
-  ) => {
-    if (selectedProjectCanisterId !== undefined) {
-      // Reload accounts always.
-      // Do not set to loading because we might use the account in the store.
-      await syncSnsAccounts({ rootCanisterId: selectedProjectCanisterId });
-    }
-  };
-
-  $: $authSignedInStore && onSnsProjectChanged($snsOnlyProjectStore);
+  export let accountIdentifier: string | undefined | null = undefined;
 
   const selectedAccountStore = writable<WalletStore>({
     account: undefined,
     neurons: [],
   });
 
-  debugSelectedAccountStore(selectedAccountStore);
-
-  setContext<WalletContext>(WALLET_CONTEXT_KEY, {
-    store: selectedAccountStore,
-  });
-
-  const goBack = (): Promise<void> => goto(AppPath.Tokens);
-
-  export let accountIdentifier: string | undefined | null = undefined;
-
-  const load = () => {
-    const accounts = $snsProjectAccountsStore ?? [];
-    const selectedAccount = findAccountOrDefaultToMain({
-      identifier: accountIdentifier,
-      accounts,
-    });
-    selectedAccountStore.set({
-      account: selectedAccount,
-      neurons: [],
-    });
-    // Accounts are loaded in store but no account identifier is matching
-    if (
-      hasAccounts($snsProjectAccountsStore ?? []) &&
-      isNullish($selectedAccountStore.account)
-    ) {
-      toastsError({
-        labelKey: replacePlaceholders($i18n.error.account_not_found, {
-          $account_identifier: accountIdentifier ?? "",
-        }),
-      });
-
-      goBack();
-    }
-  };
-
-  const reloadTransactions = async () => {
-    if (
-      isNullish($selectedAccountStore.account) ||
-      isNullish($snsOnlyProjectStore)
-    ) {
-      return;
-    }
-
-    await loadSnsAccountTransactions({
-      account: $selectedAccountStore.account,
-      canisterId: $snsOnlyProjectStore,
-    });
-  };
-
-  $: accountIdentifier, $snsProjectAccountsStore, load();
-
-  const reloadAccount = async () => {
-    try {
-      await Promise.all([
-        nonNullish($snsOnlyProjectStore)
-          ? syncSnsAccounts({ rootCanisterId: $snsOnlyProjectStore })
-          : Promise.resolve(),
-        reloadTransactions(),
-      ]);
-
-      // Apply reloaded values - balance - to UI
-      load();
-    } catch (err: unknown) {
-      toastsError({
-        labelKey: replacePlaceholders($i18n.error.account_not_reload, {
-          $account_identifier: accountIdentifier ?? "",
-        }),
-        err,
-      });
-    }
-  };
+  let indexCanisterId: CanisterId | undefined;
+  $: indexCanisterId = nonNullish($selectedIcrcTokenUniverseIdStore)
+    ? $icrcCanistersStore[$selectedIcrcTokenUniverseIdStore.toText()]
+        ?.indexCanisterId
+    : undefined;
 
   let token: IcrcTokenMetadata | undefined;
-  $: token = nonNullish($snsOnlyProjectStore)
-    ? $tokensStore[$snsOnlyProjectStore.toText()]?.token
+  $: token = nonNullish($selectedIcrcTokenUniverseIdStore)
+    ? $tokensStore[$selectedIcrcTokenUniverseIdStore.toText()]?.token
     : undefined;
+
+  let transactions: IcrcWalletTransactionsList;
+  let wallet: IcrcWalletPage;
+
+  const reloadAccount = async () => await wallet.reloadAccount?.();
+  const reloadTransactions = () => transactions?.reloadTransactions?.();
 </script>
 
-<TestIdWrapper testId="sns-wallet-component">
-  <Island>
-    <main class="legacy" data-tid="sns-wallet">
-      <section>
-        {#if nonNullish($snsOnlyProjectStore) && nonNullish($snsProjectSelectedStore) && (!$authSignedInStore || nonNullish($selectedAccountStore.account))}
-          {#if nonNullish($selectedAccountStore.account) && nonNullish(token)}
-            <SnsBalancesObserver
-              rootCanisterId={$snsOnlyProjectStore}
-              accounts={[$selectedAccountStore.account]}
-              ledgerCanisterId={$snsProjectSelectedStore.summary
-                .ledgerCanisterId}
-            />
-          {/if}
-          <WalletPageHeader
-            universe={$selectedUniverseStore}
-            walletAddress={$selectedAccountStore.account?.identifier}
-          />
-          <WalletPageHeading
-            balance={nonNullish($selectedAccountStore.account) &&
-            nonNullish(token)
-              ? TokenAmountV2.fromUlps({
-                  amount: $selectedAccountStore.account.balanceUlps,
-                  token,
-                })
-              : undefined}
-            accountName={$selectedAccountStore.account?.name ??
-              $i18n.accounts.main}
-          >
-            <SignInGuard />
-          </WalletPageHeading>
-
-          <Separator spacing="none" />
-
-          {#if nonNullish($selectedAccountStore.account)}
-            <SnsTransactionsList
-              rootCanisterId={$snsOnlyProjectStore}
-              account={$selectedAccountStore.account}
-              {token}
-            />
-          {:else}
-            <NoTransactions />
-          {/if}
-        {:else}
-          <Spinner />
-        {/if}
-      </section>
-    </main>
-
-    {#if nonNullish($selectedAccountStore.account)}
-      <Footer>
-        <button
-          class="primary"
-          on:click={() => (showModal = "send")}
-          data-tid="open-new-sns-transaction">{$i18n.accounts.send}</button
-        >
-
-        <ReceiveButton
-          type="icrc-receive"
-          account={$selectedAccountStore.account}
-          reload={reloadAccount}
-          testId="receive-sns"
-          logo={$selectedUniverseStore?.summary?.metadata.logo ?? IC_LOGO}
-          tokenSymbol={$selectedUniverseStore?.summary?.token.symbol}
-        />
-      </Footer>
+<IcrcWalletPage
+  testId="icrc-wallet-component"
+  {accountIdentifier}
+  {token}
+  ledgerCanisterId={$selectedIcrcTokenUniverseIdStore}
+  {selectedAccountStore}
+  bind:this={wallet}
+  {reloadTransactions}
+>
+  <svelte:fragment slot="page-content">
+    {#if nonNullish($selectedAccountStore.account) && nonNullish($selectedIcrcTokenUniverseIdStore) && nonNullish(indexCanisterId)}
+      <IcrcWalletTransactionsList
+        account={$selectedAccountStore.account}
+        {indexCanisterId}
+        ledgerCanisterId={$selectedIcrcTokenUniverseIdStore}
+        {token}
+        bind:this={transactions}
+      />
+    {:else}
+      <NoTransactions />
     {/if}
-  </Island>
+  </svelte:fragment>
 
-  {#if showModal && nonNullish($snsOnlyProjectStore)}
-    <SnsTransactionModal
-      on:nnsClose={() => (showModal = undefined)}
-      selectedAccount={$selectedAccountStore.account}
-      rootCanisterId={$snsOnlyProjectStore}
-      loadTransactions
-      {token}
-      transactionFee={toTokenAmountV2($snsSelectedTransactionFeeStore)}
-    />
-  {/if}
-</TestIdWrapper>
-
-<style lang="scss">
-  section {
-    display: flex;
-    flex-direction: column;
-    gap: var(--padding-4x);
-  }
-</style>
+  <svelte:fragment slot="footer-actions">
+    {#if nonNullish($selectedAccountStore.account) && nonNullish(token) && nonNullish($selectedIcrcTokenUniverseIdStore)}
+      <IcrcTokenWalletFooter
+        ledgerCanisterId={$selectedIcrcTokenUniverseIdStore}
+        account={$selectedAccountStore.account}
+        {token}
+        {reloadAccount}
+        {reloadTransactions}
+      />
+    {/if}
+  </svelte:fragment>
+</IcrcWalletPage>

--- a/frontend/src/lib/pages/SnsWallet.svelte
+++ b/frontend/src/lib/pages/SnsWallet.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { selectedIcrcTokenUniverseIdStore } from "$lib/derived/selected-universe.derived";
   import { nonNullish } from "@dfinity/utils";
   import IcrcWalletPage from "$lib/components/accounts/IcrcWalletPage.svelte";
   import NoTransactions from "$lib/components/accounts/NoTransactions.svelte";
@@ -7,7 +6,7 @@
   import type { WalletStore } from "$lib/types/wallet.context";
   import IcrcWalletTransactionsList from "$lib/components/accounts/IcrcWalletTransactionsList.svelte";
   import type { CanisterId } from "$lib/types/canister";
-  import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
+  import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import { tokensStore } from "$lib/stores/tokens.store";
   import IcrcTokenWalletFooter from "$lib/components/accounts/IcrcTokenWalletFooter.svelte";
@@ -19,15 +18,15 @@
     neurons: [],
   });
 
+  let ledgerCanisterId: CanisterId | undefined;
+  $: ledgerCanisterId = $snsProjectSelectedStore?.summary.ledgerCanisterId;
+
   let indexCanisterId: CanisterId | undefined;
-  $: indexCanisterId = nonNullish($selectedIcrcTokenUniverseIdStore)
-    ? $icrcCanistersStore[$selectedIcrcTokenUniverseIdStore.toText()]
-        ?.indexCanisterId
-    : undefined;
+  $: indexCanisterId = $snsProjectSelectedStore?.summary.indexCanisterId;
 
   let token: IcrcTokenMetadata | undefined;
-  $: token = nonNullish($selectedIcrcTokenUniverseIdStore)
-    ? $tokensStore[$selectedIcrcTokenUniverseIdStore.toText()]?.token
+  $: token = nonNullish(ledgerCanisterId)
+    ? $tokensStore[ledgerCanisterId.toText()]?.token
     : undefined;
 
   let transactions: IcrcWalletTransactionsList;
@@ -38,20 +37,20 @@
 </script>
 
 <IcrcWalletPage
-  testId="icrc-wallet-component"
+  testId="sns-wallet-component"
   {accountIdentifier}
   {token}
-  ledgerCanisterId={$selectedIcrcTokenUniverseIdStore}
+  {ledgerCanisterId}
   {selectedAccountStore}
   bind:this={wallet}
   {reloadTransactions}
 >
   <svelte:fragment slot="page-content">
-    {#if nonNullish($selectedAccountStore.account) && nonNullish($selectedIcrcTokenUniverseIdStore) && nonNullish(indexCanisterId)}
+    {#if nonNullish($selectedAccountStore.account) && nonNullish(ledgerCanisterId) && nonNullish(indexCanisterId)}
       <IcrcWalletTransactionsList
         account={$selectedAccountStore.account}
         {indexCanisterId}
-        ledgerCanisterId={$selectedIcrcTokenUniverseIdStore}
+        {ledgerCanisterId}
         {token}
         bind:this={transactions}
       />
@@ -61,9 +60,9 @@
   </svelte:fragment>
 
   <svelte:fragment slot="footer-actions">
-    {#if nonNullish($selectedAccountStore.account) && nonNullish(token) && nonNullish($selectedIcrcTokenUniverseIdStore)}
+    {#if nonNullish($selectedAccountStore.account) && nonNullish(token) && nonNullish(ledgerCanisterId)}
       <IcrcTokenWalletFooter
-        ledgerCanisterId={$selectedIcrcTokenUniverseIdStore}
+        {ledgerCanisterId}
         account={$selectedAccountStore.account}
         {token}
         {reloadAccount}

--- a/frontend/src/lib/routes/Wallet.svelte
+++ b/frontend/src/lib/routes/Wallet.svelte
@@ -37,10 +37,8 @@
 
   {#if $isCkBTCUniverseStore}
     <CkBTCAccountsModals />
-  {:else if $isIcrcTokenUniverseStore}
-    <IcrcTokenAccountsModals />
-    <AccountsModals />
   {:else}
+    <IcrcTokenAccountsModals />
     <AccountsModals />
   {/if}
 </TestIdWrapper>

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -80,15 +80,22 @@ export const loadSnsProjects = async (): Promise<void> => {
     );
     tokensStore.setTokens(
       aggregatorData
-        .map(({ icrc1_metadata, canister_ids: { root_canister_id } }) => ({
+        .map(({ icrc1_metadata, canister_ids }) => ({
           token: mapOptionalToken(convertIcrc1Metadata(icrc1_metadata)),
-          root_canister_id,
+          // TODO: Remove root_canister_id and only used ledger_canister_id.
+          root_canister_id: canister_ids.root_canister_id,
+          ledger_canister_id: canister_ids.ledger_canister_id,
         }))
         .filter(({ token }) => nonNullish(token))
         .reduce(
-          (acc, { root_canister_id, token }) => ({
+          (acc, { root_canister_id, ledger_canister_id, token }) => ({
             ...acc,
             [root_canister_id]: {
+              // Above filter ensure the token is not undefined therefore it can be safely cast
+              token: token as IcrcTokenMetadata,
+              certified: true,
+            },
+            [ledger_canister_id]: {
               // Above filter ensure the token is not undefined therefore it can be safely cast
               token: token as IcrcTokenMetadata,
               certified: true,

--- a/frontend/src/tests/lib/pages/AccountsTest.svelte
+++ b/frontend/src/tests/lib/pages/AccountsTest.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import AccountsModals from "$lib/modals/accounts/AccountsModals.svelte";
+  import IcrcTokenAccountsModals from "$lib/modals/accounts/IcrcTokenAccountsModals.svelte";
   import type { SvelteComponent } from "svelte";
   import { nonNullish } from "@dfinity/utils";
 
@@ -14,3 +15,4 @@
 {/if}
 
 <AccountsModals />
+<IcrcTokenAccountsModals />

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -343,7 +343,7 @@ describe("SnsWallet", () => {
       await runResolvedPromises();
       // IcrcWalletPage does not reload the balance, only the transactions, in
       // `reloadAccount`. Perhaps a bug?
-      // The the number of calls is still 2, rather than 4.
+      // The number of calls is still 2, rather than 4.
       expect(walletLedgerApi.getAccount).toHaveBeenCalledTimes(2);
       // IcrcWalletTransactionsList has a hard coded 4 second delay before it
       // fetches the transactions.

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -1,5 +1,6 @@
-import * as snsIndexApi from "$lib/api/sns-index.api";
-import * as snsLedgerApi from "$lib/api/sns-ledger.api";
+import * as icrcIndexApi from "$lib/api/icrc-index.api";
+import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
+import * as walletLedgerApi from "$lib/api/wallet-ledger.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
@@ -7,33 +8,37 @@ import SnsWallet from "$lib/pages/SnsWallet.svelte";
 import * as workerBalances from "$lib/services/worker-balances.services";
 import * as workerTransactions from "$lib/services/worker-transactions.services";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
-import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
+import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { Account } from "$lib/types/account";
 import { page } from "$mocks/$app/stores";
 import AccountsTest from "$tests/lib/pages/AccountsTest.svelte";
+import WalletTest from "$tests/lib/pages/WalletTest.svelte";
 import {
   mockIdentity,
   resetIdentity,
   setNoIdentity,
 } from "$tests/mocks/auth.store.mock";
-import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
+import { IcrcTokenTransactionModalPo } from "$tests/page-objects/IcrcTokenTransactionModal.page-object";
 import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
 import { SnsWalletPo } from "$tests/page-objects/SnsWallet.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
-import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import {
+  advanceTime,
+  runResolvedPromises,
+} from "$tests/utils/timers.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
+import { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
-vi.mock("$lib/api/sns-ledger.api");
-vi.mock("$lib/api/sns-index.api");
+vi.mock("$lib/api/icrc-index.api");
 
 let balancesObserverCallback;
 
@@ -79,40 +84,43 @@ describe("SnsWallet", () => {
 
   const rootCanisterId = rootCanisterIdMock;
   const rootCanisterIdText = rootCanisterId.toText();
+  const ledgerCanisterId = Principal.fromText("bw4dl-smaaa-aaaaa-qaacq-cai");
   const fee = 10_000n;
   const projectName = "Tetris";
 
   const renderComponent = async (props: { accountIdentifier?: string }) => {
-    const { container } = render(SnsWallet, props);
+    const { container } = render(WalletTest, {
+      ...props,
+      testComponent: SnsWallet,
+    });
     await runResolvedPromises();
     return SnsWalletPo.under(new JestPageObjectElement(container));
   };
 
   beforeEach(() => {
+    vi.useRealTimers();
     resetIdentity();
     vi.clearAllMocks();
-    snsAccountsStore.reset();
+    icrcAccountsStore.reset();
     tokensStore.reset();
     toastsStore.reset();
     overrideFeatureFlagsStore.setFlag("ENABLE_MY_TOKENS", false);
-    vi.spyOn(snsIndexApi, "getSnsTransactions").mockResolvedValue({
-      oldestTxId: 1_234n,
-      transactions: [mockIcrcTransactionWithId],
+    vi.mocked(icrcIndexApi.getTransactions).mockResolvedValue({
+      transactions: [],
     });
-    vi.spyOn(snsLedgerApi, "transactionFee").mockResolvedValue(fee);
-    vi.spyOn(snsLedgerApi, "getSnsToken").mockResolvedValue(testToken);
-    vi.spyOn(snsLedgerApi, "snsTransfer").mockResolvedValue(10n);
+    vi.spyOn(icrcLedgerApi, "icrcTransfer").mockResolvedValue(10n);
 
     setSnsProjects([
       {
         rootCanisterId,
+        ledgerCanisterId,
         lifecycle: SnsSwapLifecycle.Committed,
         projectName,
         tokenMetadata: testToken,
       },
     ]);
     tokensStore.setToken({
-      canisterId: rootCanisterId,
+      canisterId: ledgerCanisterId,
       token: {
         ...testToken,
         fee,
@@ -181,8 +189,8 @@ describe("SnsWallet", () => {
 
     beforeEach(() => {
       resolve = undefined;
-      vi.spyOn(snsLedgerApi, "getSnsAccounts").mockImplementation(() => {
-        return new Promise<Account[]>((r) => {
+      vi.spyOn(walletLedgerApi, "getAccount").mockImplementation(() => {
+        return new Promise<Account>((r) => {
           resolve = r;
         });
       });
@@ -195,7 +203,7 @@ describe("SnsWallet", () => {
       expect(await po.hasSpinner()).toBe(true);
 
       expect(resolve).toBeDefined();
-      resolve([mockSnsMainAccount]);
+      resolve(mockSnsMainAccount);
 
       await runResolvedPromises();
       expect(await po.hasSpinner()).toBe(false);
@@ -204,9 +212,9 @@ describe("SnsWallet", () => {
 
   describe("accounts loaded", () => {
     beforeEach(() => {
-      vi.spyOn(snsLedgerApi, "getSnsAccounts").mockResolvedValue([
-        mockSnsMainAccount,
-      ]);
+      vi.spyOn(walletLedgerApi, "getAccount").mockResolvedValue(
+        mockSnsMainAccount
+      );
     });
 
     it("should render sns project name", async () => {
@@ -228,12 +236,10 @@ describe("SnsWallet", () => {
     });
 
     it("should render a balance with token", async () => {
-      vi.spyOn(snsLedgerApi, "getSnsAccounts").mockResolvedValue([
-        {
-          ...mockSnsMainAccount,
-          balanceUlps: 2_233_000_000n,
-        },
-      ]);
+      vi.spyOn(walletLedgerApi, "getAccount").mockResolvedValue({
+        ...mockSnsMainAccount,
+        balanceUlps: 2_233_000_000n,
+      });
 
       const po = await renderComponent(props);
 
@@ -241,19 +247,22 @@ describe("SnsWallet", () => {
     });
 
     it("should open new transaction modal", async () => {
-      const po = await renderComponent(props);
+      const { walletPo: po, icrcTokenTransactionModalPo: modalPo } =
+        await renderWalletAndModals();
 
       await runResolvedPromises();
-      expect(await po.getSnsTransactionModalPo().isPresent()).toBe(false);
+      expect(await modalPo.isPresent()).toBe(false);
 
       await po.clickSendButton();
 
       await runResolvedPromises();
-      expect(await po.getSnsTransactionModalPo().isPresent()).toBe(true);
+      expect(await modalPo.isPresent()).toBe(true);
     });
 
     it("should make a new transaction", async () => {
-      const po = await renderComponent(props);
+      vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockResolvedValue(0n);
+      const { walletPo: po, icrcTokenTransactionModalPo: modalPo } =
+        await renderWalletAndModals();
 
       await po.clickSendButton();
 
@@ -261,19 +270,19 @@ describe("SnsWallet", () => {
         owner: principal(1),
       };
 
-      expect(snsLedgerApi.snsTransfer).toHaveBeenCalledTimes(0);
+      expect(icrcLedgerApi.icrcTransfer).toHaveBeenCalledTimes(0);
 
-      await po.getSnsTransactionModalPo().transferToAddress({
+      await modalPo.transferToAddress({
         destinationAddress: encodeIcrcAccount(destinationAccount),
         amount: 2,
       });
 
-      expect(snsLedgerApi.snsTransfer).toHaveBeenCalledTimes(1);
-      expect(snsLedgerApi.snsTransfer).toHaveBeenCalledWith({
+      expect(icrcLedgerApi.icrcTransfer).toHaveBeenCalledTimes(1);
+      expect(icrcLedgerApi.icrcTransfer).toHaveBeenCalledWith({
         identity: mockIdentity,
-        rootCanisterId,
+        canisterId: ledgerCanisterId,
         amount: 200000_000n,
-        fromSubaccount: undefined,
+        fromSubAccount: undefined,
         fee,
         to: destinationAccount,
       });
@@ -284,22 +293,23 @@ describe("SnsWallet", () => {
       testComponent: SnsWallet,
     };
 
-    const renderWalletAndModal = async (): Promise<{
+    const renderWalletAndModals = async (): Promise<{
       walletPo: SnsWalletPo;
       receiveModalPo: ReceiveModalPo;
+      icrcTokenTransactionModalPo: IcrcTokenTransactionModalPo;
     }> => {
       const { container } = render(AccountsTest, modalProps);
       await runResolvedPromises();
+      const element = new JestPageObjectElement(container);
       return {
-        walletPo: SnsWalletPo.under(new JestPageObjectElement(container)),
-        receiveModalPo: ReceiveModalPo.under(
-          new JestPageObjectElement(container)
-        ),
+        walletPo: SnsWalletPo.under(element),
+        receiveModalPo: ReceiveModalPo.under(element),
+        icrcTokenTransactionModalPo: IcrcTokenTransactionModalPo.under(element),
       };
     };
 
     it("should open receive modal with sns logo", async () => {
-      const { walletPo, receiveModalPo } = await renderWalletAndModal();
+      const { walletPo, receiveModalPo } = await renderWalletAndModals();
 
       runResolvedPromises();
       expect(await receiveModalPo.isPresent()).toBe(false);
@@ -313,24 +323,40 @@ describe("SnsWallet", () => {
     });
 
     it("should reload account after finish receiving tokens", async () => {
-      const { walletPo, receiveModalPo } = await renderWalletAndModal();
+      vi.useFakeTimers();
+      const { walletPo, receiveModalPo } = await renderWalletAndModals();
 
+      expect(await receiveModalPo.isPresent()).toBe(false);
       await walletPo.clickReceiveButton();
+      expect(await receiveModalPo.isPresent()).toBe(true);
 
       // Query + update
-      expect(snsLedgerApi.getSnsAccounts).toHaveBeenCalledTimes(2);
+      expect(walletLedgerApi.getAccount).toHaveBeenCalledTimes(2);
       // Transactions can only be fetched from the Index canister with `updated` calls for now.
-      expect(snsIndexApi.getSnsTransactions).toHaveBeenCalledTimes(1);
+      expect(icrcIndexApi.getTransactions).toHaveBeenCalledTimes(1);
+
+      // The Finish button is only rendered after the modal animation has finished.
+      expect(await receiveModalPo.getFinishButtonPo().isPresent()).toBe(false);
+      await advanceTime(50);
+      expect(await receiveModalPo.getFinishButtonPo().isPresent()).toBe(true);
 
       await receiveModalPo.clickFinish();
 
       await runResolvedPromises();
-      expect(snsLedgerApi.getSnsAccounts).toHaveBeenCalledTimes(4);
-      expect(snsIndexApi.getSnsTransactions).toHaveBeenCalledTimes(2);
+      // IcrcWalletPage does not reload the balance, only the transactions, in
+      // `reloadAccount`. Perhaps a bug?
+      // The the number of calls is still 2, rather than 4.
+      expect(walletLedgerApi.getAccount).toHaveBeenCalledTimes(2);
+      // IcrcWalletTransactionsList has a hard coded 4 second delay before it
+      // fetches the transactions.
+      await advanceTime(3500);
+      expect(icrcIndexApi.getTransactions).toHaveBeenCalledTimes(1);
+      await advanceTime(1000);
+      expect(icrcIndexApi.getTransactions).toHaveBeenCalledTimes(2);
     });
 
     it("should display receive modal information", async () => {
-      const { walletPo, receiveModalPo } = await renderWalletAndModal();
+      const { walletPo, receiveModalPo } = await renderWalletAndModals();
 
       await walletPo.clickReceiveButton();
 
@@ -390,6 +416,16 @@ describe("SnsWallet", () => {
           level: "error",
           text: 'Sorry, the account "invalid-account-identifier" was not found',
         },
+        // In the test, the IcrcWalletPage component thinks the
+        // ledgerCanisterId has changed, because it is derived from the URL,
+        // which has changed on back navigation. As a result, it tries to load
+        // the account again, and the same error is shown again. This happens
+        // before the test stops rendering the component as a result of the
+        // route having changed.
+        {
+          level: "error",
+          text: 'Sorry, the account "invalid-account-identifier" was not found',
+        },
       ]);
     });
 
@@ -434,12 +470,10 @@ describe("SnsWallet", () => {
       const oldBalance = 123_000_000n;
       const newBalance = 456_000_000n;
 
-      vi.spyOn(snsLedgerApi, "getSnsAccounts").mockResolvedValue([
-        {
-          ...mockSnsMainAccount,
-          balanceUlps: oldBalance,
-        },
-      ]);
+      vi.spyOn(walletLedgerApi, "getAccount").mockResolvedValue({
+        ...mockSnsMainAccount,
+        balanceUlps: oldBalance,
+      });
 
       const po = await renderComponent(props);
 

--- a/frontend/src/tests/lib/services/_public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns.services.spec.ts
@@ -243,13 +243,18 @@ describe("SNS public services", () => {
 
       await loadSnsProjects();
 
-      const rootCanisterId = aggregatorSnsMockDto.canister_ids.root_canister_id;
+      const ledgerCanisterId =
+        aggregatorSnsMockDto.canister_ids.ledger_canister_id;
 
       const tokens = get(tokensStore);
-      const token = tokens[rootCanisterId];
+      const token = tokens[ledgerCanisterId];
       expect(token).not.toBeUndefined();
       expect(token?.certified).toBeTruthy();
       expect(token?.token).toEqual(aggregatorTokenMock);
+
+      const rootCanisterId = aggregatorSnsMockDto.canister_ids.root_canister_id;
+      const tokenForRootCanister = tokens[rootCanisterId];
+      expect(tokenForRootCanister).toEqual(token);
     });
 
     it("should load and map total token supply", async () => {

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -60,6 +60,7 @@ const createQueryMetadataResponse = ({
 
 export const aggregatorSnsMockWith = ({
   rootCanisterId = "4nwps-saaaa-aaaaa-aabjq-cai",
+  ledgerCanisterId = "5bqmf-wyaaa-aaaaq-aaa5q-cai",
   lifecycle = SnsSwapLifecycle.Committed,
   restrictedCountries,
   directParticipantCount,
@@ -71,6 +72,7 @@ export const aggregatorSnsMockWith = ({
   nnsProposalId,
 }: {
   rootCanisterId?: string;
+  ledgerCanisterId?: string;
   lifecycle?: SnsSwapLifecycle;
   restrictedCountries?: string[];
   // TODO: Change to `undefined` or `number`.
@@ -87,6 +89,7 @@ export const aggregatorSnsMockWith = ({
   canister_ids: {
     ...aggregatorSnsMockDto.canister_ids,
     root_canister_id: rootCanisterId,
+    ledger_canister_id: ledgerCanisterId,
   },
   list_sns_canisters: {
     ...aggregatorSnsMockDto.list_sns_canisters,

--- a/frontend/src/tests/page-objects/ReceiveModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ReceiveModal.page-object.ts
@@ -1,3 +1,4 @@
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { SelectAccountDropdownPo } from "./SelectAccountDropdown.page-object";
@@ -9,8 +10,12 @@ export class ReceiveModalPo extends ModalPo {
     return new ReceiveModalPo(element.byTestId(ReceiveModalPo.TID));
   }
 
+  getFinishButtonPo(): ButtonPo {
+    return this.getButton("reload-receive-account");
+  }
+
   clickFinish(): Promise<void> {
-    return this.click("reload-receive-account");
+    return this.getFinishButtonPo().click();
   }
 
   waitForQrCode(): Promise<void> {

--- a/frontend/src/tests/page-objects/SnsWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsWallet.page-object.ts
@@ -1,7 +1,7 @@
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { IcrcTransactionsListPo } from "$tests/page-objects/IcrcTransactionsList.page-object";
+import { IcrcWalletFooterPo } from "$tests/page-objects/IcrcWalletFooter.page-object";
 import { SignInPo } from "$tests/page-objects/SignIn.page-object";
-import { SnsTransactionModalPo } from "$tests/page-objects/SnsTransactionModal.page-object";
 import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-object";
 import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
@@ -26,8 +26,8 @@ export class SnsWalletPo extends BasePageObject {
     return IcrcTransactionsListPo.under(this.root);
   }
 
-  getSnsTransactionModalPo(): SnsTransactionModalPo {
-    return SnsTransactionModalPo.under(this.root);
+  getIcrcWalletFooterPo(): IcrcWalletFooterPo {
+    return IcrcWalletFooterPo.under(this.root);
   }
 
   getSignInPo(): SignInPo {
@@ -35,11 +35,11 @@ export class SnsWalletPo extends BasePageObject {
   }
 
   getSendButtonPo(): ButtonPo {
-    return this.getButton("open-new-sns-transaction");
+    return this.getIcrcWalletFooterPo().getSendButtonPo();
   }
 
   getReceiveButtonPo(): ButtonPo {
-    return this.getButton("receive-sns");
+    return this.getIcrcWalletFooterPo().getReceiveButtonPo();
   }
 
   hasSignInButton(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/Wallet.page-object.ts
+++ b/frontend/src/tests/page-objects/Wallet.page-object.ts
@@ -1,6 +1,7 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { CkBTCWalletPo } from "$tests/page-objects/CkBTCWallet.page-object";
 import { NnsWalletPo } from "$tests/page-objects/NnsWallet.page-object";
+import { SnsWalletPo } from "$tests/page-objects/SnsWallet.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { IcrcTokenTransactionModalPo } from "./IcrcTokenTransactionModal.page-object";
 import { IcrcWalletPo } from "./IcrcWallet.page-object";
@@ -14,6 +15,10 @@ export class WalletPo extends BasePageObject {
 
   getNnsWalletPo(): NnsWalletPo {
     return NnsWalletPo.under(this.root);
+  }
+
+  getSnsWalletPo(): SnsWalletPo {
+    return SnsWalletPo.under(this.root);
   }
 
   getCkBTCWalletPo(): CkBTCWalletPo {

--- a/frontend/src/tests/utils/sns.test-utils.ts
+++ b/frontend/src/tests/utils/sns.test-utils.ts
@@ -10,6 +10,7 @@ import type { SnsNervousSystemFunction, SnsSwapLifecycle } from "@dfinity/sns";
 export const setSnsProjects = (
   params: {
     rootCanisterId?: Principal;
+    ledgerCanisterId?: Principal;
     lifecycle: SnsSwapLifecycle;
     certified?: boolean;
     restrictedCountries?: string[];
@@ -25,6 +26,7 @@ export const setSnsProjects = (
     return aggregatorSnsMockWith({
       rootCanisterId:
         params.rootCanisterId?.toText() ?? principal(index).toText(),
+      ledgerCanisterId: params.ledgerCanisterId?.toText(),
       lifecycle: params.lifecycle,
       restrictedCountries: params.restrictedCountries,
       directParticipantCount: params.directParticipantCount,


### PR DESCRIPTION
# Motivation

SnsWallet and IcrcWallet have entirely separate implementations even though they should have identical functionality.
The reason for this is that SNS universes are identified by the rootCanisterId while ICRC tokens are identified by the ledgerCanisterId. So at each level of they component hierarchy, tokens, accounts, balances, etc. are identified in a different way.
However if we convert the rootCanisterId to the SNS ledger canister ID, we should be able to reuse the IcrcWalletPage component and the entire hierarchy below it and then delete a lot of code.

Note: the new `SnsWallet.svelte` is based on `IcrcWallet.svelte` and not based on the old `SnsWallet.svelte`. So in the first commit, I made `SnsWallet.svelte` an exact copy of `IcrcWallet.svelte` so that in the next commit it's easy to see what the changes are relative to `IcrcWallet.svelte`.

Deleting code that became unused as a result will be done in separate PRs.

# Changes

1. Make `SnsWallet.svelte` a copy of `IcrcWallet.svelte` but with the ledger canister ID derived from the root canister ID instead of from the universe ID.
2. Include `<IcrcTokenAccountsModals />` in `Wallet.svelte` also for SNS wallets. Previously `SnsWallet` had `SnsTransactionModal` embedded, but `IcrcWalletPage` requires `IcrcTokenAccountsModals` to handle the transaction modal.
3. In `sns.services.ts`, put SNS tokens in the `tokensStore` keyed by ledger canister ID in addition to root canister ID. The tokens keyed by root canister will be removed in the future PR to make sure this is properly tested and anything depending on it depends on the ledger canister ID instead.

# Tests

1. Add `IcrcTokenAccountsModals` in `AccountsTest.svelte` to facilitate tests that open a transaction modal. Currently it only has `AccountsModals` which has the receive modals and the ICP transaction modal, but not the ICRC transaction modal. This wasn't needed before because SnsWallet had its own transaction modal embedded.
2. Adapt `SnsWallet.spec.ts` to how `IcrcWalletPage` works. Use ICRC mocks instead of SNS mocks and expecting slightly different behavior because the implementations of `SnsWallet` and `IcrcWallet` had already diverged.
3. Add a unit test for `Wallet.spec.ts` to make sure the transaction modal can be opened for the SNS wallet.
4. Add a unit test to test that SNS tokens are now keyed by ledger canister ID as well as root canister ID.
5. Update page objects to the new structure.
6. Support setting `ledgerCanisterId` with `setSnsProjects` because the ledger canister ID is now a lot more important to the implementation.
7. Tested manually ad https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [x] Add entry to changelog (if necessary).
