### PR TITLE
fix: Include omitted code

### DIFF
--- a/rs/backend/src/accounts_store/constructors.rs
+++ b/rs/backend/src/accounts_store/constructors.rs
@@ -1,5 +1,7 @@
 //! Account store constructors.
 use super::*;
+#[cfg(test)]
+use std::mem;
 
 impl From<AccountsDb> for AccountsStore {
     fn from(db: AccountsDb) -> Self {
@@ -19,8 +21,11 @@ impl AccountsStore {
     ///
     /// When recreating state post upgrade, the accounts store sans `accounts_db` is recovered from
     /// one virtual memory, then the `accounts_db` is added from another virtual memory.
+    ///
+    /// # Returns
+    /// - The original accounts database.  This is always an `AccountsDbAsProxy`.
     #[must_use]
-    pub fn replace_accounts_db(&mut self, accounts_db: AccountsDb) {
-        self.accounts_db = AccountsDbAsProxy::from(accounts_db);
+    pub fn replace_accounts_db(&mut self, accounts_db: AccountsDb) -> AccountsDbAsProxy {
+        mem::replace(&mut self.accounts_db, AccountsDbAsProxy::from(accounts_db))
     }
 }

--- a/rs/backend/src/accounts_store/constructors.rs
+++ b/rs/backend/src/accounts_store/constructors.rs
@@ -19,7 +19,8 @@ impl AccountsStore {
     ///
     /// When recreating state post upgrade, the accounts store sans `accounts_db` is recovered from
     /// one virtual memory, then the `accounts_db` is added from another virtual memory.
-    pub fn with_accounts_db(&mut self, accounts_db: AccountsDb) {
+    #[must_use]
+    pub fn replace_accounts_db(&mut self, accounts_db: AccountsDb) {
         self.accounts_db = AccountsDbAsProxy::from(accounts_db);
     }
 }

--- a/rs/backend/src/accounts_store/constructors.rs
+++ b/rs/backend/src/accounts_store/constructors.rs
@@ -9,3 +9,17 @@ impl From<AccountsDb> for AccountsStore {
         }
     }
 }
+
+#[cfg(test)]
+impl AccountsStore {
+    /// Adds an `accounts_db` to the store.
+    ///
+    /// Used when the `accounts_db` (per-user account data) and the rest of the accounts store
+    /// are stored in different virtual memories.
+    ///
+    /// When recreating state post upgrade, the accounts store sans `accounts_db` is recovered from
+    /// one virtual memory, then the `accounts_db` is added from another virtual memory.
+    pub fn with_accounts_db(&mut self, accounts_db: AccountsDb) {
+        self.accounts_db = AccountsDbAsProxy::from(accounts_db);
+    }
+}

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -96,17 +96,8 @@ impl State {
     #[cfg(test)]
     pub fn schema_label(&self) -> SchemaLabel {
         match &*self.partitions_maybe.borrow() {
-            PartitionsMaybe::Partitions(partitions) => {
-                println!(
-                    "State: schema_label for managed memory: {:?}",
-                    partitions.schema_label()
-                );
-                partitions.schema_label()
-            }
-            PartitionsMaybe::None(_memory) => {
-                println!("State: schema_label for raw memory is: Map");
-                SchemaLabel::Map
-            }
+            PartitionsMaybe::Partitions(partitions) => partitions.schema_label(),
+            PartitionsMaybe::None(_memory) => SchemaLabel::Map,
         }
     }
 }

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -92,6 +92,23 @@ impl State {
         self.performance.replace(performance.into_inner());
         self.partitions_maybe.replace(partitions_maybe);
     }
+    /// Gets the authoritative schema.  This is the schema that is in stable memory.
+    #[cfg(test)]
+    pub fn schema_label(&self) -> SchemaLabel {
+        match &*self.partitions_maybe.borrow() {
+            PartitionsMaybe::Partitions(partitions) => {
+                println!(
+                    "State: schema_label for managed memory: {:?}",
+                    partitions.schema_label()
+                );
+                partitions.schema_label()
+            }
+            PartitionsMaybe::None(_memory) => {
+                println!("State: schema_label for raw memory is: Map");
+                SchemaLabel::Map
+            }
+        }
+    }
 }
 
 pub trait StableState: Sized {


### PR DESCRIPTION
# Motivation
Code was accidentally omitted from #4425 

# Changes
- `replace_accounts_db()` now returns the original database, as intended.