### PR TITLE
refactor: Move II types into a dedicated file

### DIFF
--- a/rs/proposals/src/canisters/internet_identity.rs
+++ b/rs/proposals/src/canisters/internet_identity.rs
@@ -1,13 +1,13 @@
 //! Types taken from the Internet Identity
-//! 
+//!
 //! * Types used to decode argument payload of NNS function type 4 for II upgrades
 //!   Source: https://github.com/dfinity/internet-identity/blob/main/src/internet_identity_interface/src/lib.rs#L174
 //!   Note: The link above lacks versioning information.
 //!   TODO: Find out when this was last updated and potentially update these types automatically, as for other canisters.
+#![allow(missing_docs)] // Please see the original code upstream for details
 
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
-
 
 pub type AnchorNumber = u64;
 #[derive(CandidType, Serialize, Deserialize)]

--- a/rs/proposals/src/canisters/internet_identity.rs
+++ b/rs/proposals/src/canisters/internet_identity.rs
@@ -1,0 +1,54 @@
+//! Types taken from the Internet Identity
+//! 
+//! * Types used to decode argument payload of NNS function type 4 for II upgrades
+//!   Source: https://github.com/dfinity/internet-identity/blob/main/src/internet_identity_interface/src/lib.rs#L174
+//!   Note: The link above lacks versioning information.
+//!   TODO: Find out when this was last updated and potentially update these types automatically, as for other canisters.
+
+use candid::{CandidType, Deserialize};
+use serde::Serialize;
+
+
+pub type AnchorNumber = u64;
+#[derive(CandidType, Serialize, Deserialize)]
+#[allow(missing_docs)] // Please see the original code upstream for details
+pub struct InternetIdentityInit {
+    pub assigned_user_number_range: Option<(AnchorNumber, AnchorNumber)>,
+    pub archive_config: Option<ArchiveConfig>,
+    pub canister_creation_cycles_cost: Option<u64>,
+    pub register_rate_limit: Option<RateLimitConfig>,
+    pub max_num_latest_delegation_origins: Option<u64>,
+    pub migrate_storage_to_memory_manager: Option<bool>,
+}
+#[derive(CandidType, Serialize, Deserialize)]
+pub struct RateLimitConfig {
+    /// Time it takes for a rate limiting token to be replenished.
+    pub time_per_token_ns: u64,
+    /// How many tokens are at most generated (to accommodate peaks).
+    pub max_tokens: u64,
+}
+/// Configuration parameters of the archive to be used on the next deployment.
+#[derive(CandidType, Serialize, Deserialize)]
+pub struct ArchiveConfig {
+    /// Wasm module hash that is allowed to be deployed to the archive canister.
+    pub module_hash: [u8; 32],
+    /// Buffered archive entries limit. If reached, II will stop accepting new anchor operations
+    /// until the buffered operations are acknowledged by the archive.
+    pub entries_buffer_limit: u64,
+    /// Polling interval at which the archive should fetch buffered archive entries from II (in nanoseconds).
+    pub polling_interval_ns: u64,
+    /// Max number of archive entries to be fetched in a single call.
+    pub entries_fetch_limit: u16,
+    /// How the entries get transferred to the archive.
+    /// This is opt, so that the configuration parameter can be removed after switching from push to pull.
+    /// Defaults to Push (legacy mode).
+    pub archive_integration: Option<ArchiveIntegration>,
+}
+
+#[derive(CandidType, Serialize, Deserialize)]
+pub enum ArchiveIntegration {
+    #[serde(rename = "push")]
+    Push,
+    #[serde(rename = "pull")]
+    Pull,
+}

--- a/rs/proposals/src/canisters/mod.rs
+++ b/rs/proposals/src/canisters/mod.rs
@@ -2,3 +2,4 @@
 pub mod nns_governance;
 pub mod nns_registry;
 pub mod sns_wasm;
+pub mod internet_identity;

--- a/rs/proposals/src/canisters/mod.rs
+++ b/rs/proposals/src/canisters/mod.rs
@@ -1,5 +1,5 @@
 //! Code for interacting with other canisters.
+pub mod internet_identity;
 pub mod nns_governance;
 pub mod nns_registry;
 pub mod sns_wasm;
-pub mod internet_identity;

--- a/rs/proposals/src/canisters/nns_governance/internal.rs
+++ b/rs/proposals/src/canisters/nns_governance/internal.rs
@@ -2,6 +2,7 @@
 //!
 //! Note: These types should probably be published by the upstream in the `.did` file or in some lightweight
 //! library.
+#![allow(missing_docs)] // Please see the upstream canister code and documentation for details.
 
 /// A list of bitcoin networks.
 ///

--- a/rs/proposals/src/canisters/nns_registry/internal.rs
+++ b/rs/proposals/src/canisters/nns_registry/internal.rs
@@ -1,4 +1,5 @@
 //! Types that are needed but not exposed in the .did file
+#![allow(missing_docs)] // Please see the upstream canister code and documentation for details.
 
 pub type RemoveNodesFromSubnetPayload = super::api::RemoveNodesPayload;
 pub type UpdateFirewallRulesPayload = super::api::AddFirewallRulesPayload;

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -1,8 +1,9 @@
 use crate::canisters::nns_governance::api::{Action, ProposalInfo};
+use crate::canisters::internet_identity::{InternetIdentityInit};
 use crate::def::*;
 use candid::parser::types::{self as parser_types, IDLType, IDLTypes};
 use candid::types::{self as candid_types, Type};
-use candid::{CandidType, Deserialize, IDLArgs};
+use candid::{CandidType, IDLArgs};
 use ic_base_types::CanisterId;
 use ic_nns_constants::{GOVERNANCE_CANISTER_ID, IDENTITY_CANISTER_ID};
 use idl2json::candid_types::internal_candid_type_to_idl_type;
@@ -57,52 +58,6 @@ fn insert_into_cache(cache: &mut BTreeMap<u64, Json>, proposal_id: u64, payload_
     }
 
     cache.insert(proposal_id, payload_json);
-}
-
-/// Types used to decode argument payload of NNS function type 4 for II upgrades
-/// Source: https://github.com/dfinity/internet-identity/blob/main/src/internet_identity_interface/src/lib.rs#L174
-pub type AnchorNumber = u64;
-#[derive(CandidType, Serialize, Deserialize)]
-#[allow(missing_docs)] // Please see the original code upstream for details
-pub struct InternetIdentityInit {
-    pub assigned_user_number_range: Option<(AnchorNumber, AnchorNumber)>,
-    pub archive_config: Option<ArchiveConfig>,
-    pub canister_creation_cycles_cost: Option<u64>,
-    pub register_rate_limit: Option<RateLimitConfig>,
-    pub max_num_latest_delegation_origins: Option<u64>,
-    pub migrate_storage_to_memory_manager: Option<bool>,
-}
-#[derive(CandidType, Serialize, Deserialize)]
-pub struct RateLimitConfig {
-    /// Time it takes for a rate limiting token to be replenished.
-    pub time_per_token_ns: u64,
-    /// How many tokens are at most generated (to accommodate peaks).
-    pub max_tokens: u64,
-}
-/// Configuration parameters of the archive to be used on the next deployment.
-#[derive(CandidType, Serialize, Deserialize)]
-pub struct ArchiveConfig {
-    /// Wasm module hash that is allowed to be deployed to the archive canister.
-    pub module_hash: [u8; 32],
-    /// Buffered archive entries limit. If reached, II will stop accepting new anchor operations
-    /// until the buffered operations are acknowledged by the archive.
-    pub entries_buffer_limit: u64,
-    /// Polling interval at which the archive should fetch buffered archive entries from II (in nanoseconds).
-    pub polling_interval_ns: u64,
-    /// Max number of archive entries to be fetched in a single call.
-    pub entries_fetch_limit: u16,
-    /// How the entries get transferred to the archive.
-    /// This is opt, so that the configuration parameter can be removed after switching from push to pull.
-    /// Defaults to Push (legacy mode).
-    pub archive_integration: Option<ArchiveIntegration>,
-}
-
-#[derive(CandidType, Serialize, Deserialize)]
-pub enum ArchiveIntegration {
-    #[serde(rename = "push")]
-    Push,
-    #[serde(rename = "pull")]
-    Pull,
 }
 
 /// Best effort to determine the types of a canister arguments.

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -1,5 +1,5 @@
+use crate::canisters::internet_identity::InternetIdentityInit;
 use crate::canisters::nns_governance::api::{Action, ProposalInfo};
-use crate::canisters::internet_identity::{InternetIdentityInit};
 use crate::def::*;
 use candid::parser::types::{self as parser_types, IDLType, IDLTypes};
 use candid::types::{self as candid_types, Type};

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -63,6 +63,7 @@ fn insert_into_cache(cache: &mut BTreeMap<u64, Json>, proposal_id: u64, payload_
 /// Source: https://github.com/dfinity/internet-identity/blob/main/src/internet_identity_interface/src/lib.rs#L174
 pub type AnchorNumber = u64;
 #[derive(CandidType, Serialize, Deserialize)]
+#[allow(missing_docs)] // Please see the original code upstream for details
 pub struct InternetIdentityInit {
     pub assigned_user_number_range: Option<(AnchorNumber, AnchorNumber)>,
     pub archive_config: Option<ArchiveConfig>,

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -131,7 +131,7 @@ fn decode_arg(arg: &[u8], arg_types: IDLTypes) -> String {
     }
 }
 
-/// Check if the proposal has a payload, if yes, de-serializes it then converts it to JSON.
+/// Checks if the proposal has a payload.  If yes, de-serializes it then converts it to JSON.
 #[must_use]
 pub fn process_proposal_payload(proposal_info: &ProposalInfo) -> Json {
     if let Some(Action::ExecuteNnsFunction(f)) = proposal_info.proposal.as_ref().and_then(|p| p.action.as_ref()) {

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -26,6 +26,10 @@ thread_local! {
     static CACHED_PROPOSAL_PAYLOADS: RefCell<BTreeMap<u64, Json>> = RefCell::default();
 }
 
+/// Gets a proposal payload from cache, if available, else from the governance canister (and populates the cache).
+///
+/// # Errors
+/// - If the requested `proposal_id` does not exist in, or could not be retrieved from, the governance canister.
 pub async fn get_proposal_payload(proposal_id: u64) -> Result<Json, String> {
     if let Some(result) = CACHED_PROPOSAL_PAYLOADS.with(|c| c.borrow().get(&proposal_id).cloned()) {
         Ok(result)
@@ -55,8 +59,8 @@ fn insert_into_cache(cache: &mut BTreeMap<u64, Json>, proposal_id: u64, payload_
     cache.insert(proposal_id, payload_json);
 }
 
-// Source: https://github.com/dfinity/internet-identity/blob/main/src/internet_identity_interface/src/lib.rs#L174
-// Types used to decode arg's payload of nns_function type 4 for II upgrades
+/// Types used to decode argument payload of NNS function type 4 for II upgrades
+/// Source: https://github.com/dfinity/internet-identity/blob/main/src/internet_identity_interface/src/lib.rs#L174
 pub type AnchorNumber = u64;
 #[derive(CandidType, Serialize, Deserialize)]
 pub struct InternetIdentityInit {
@@ -69,26 +73,26 @@ pub struct InternetIdentityInit {
 }
 #[derive(CandidType, Serialize, Deserialize)]
 pub struct RateLimitConfig {
-    // time it takes for a rate limiting token to be replenished.
+    /// Time it takes for a rate limiting token to be replenished.
     pub time_per_token_ns: u64,
-    // How many tokens are at most generated (to accommodate peaks).
+    /// How many tokens are at most generated (to accommodate peaks).
     pub max_tokens: u64,
 }
 /// Configuration parameters of the archive to be used on the next deployment.
 #[derive(CandidType, Serialize, Deserialize)]
 pub struct ArchiveConfig {
-    // Wasm module hash that is allowed to be deployed to the archive canister.
+    /// Wasm module hash that is allowed to be deployed to the archive canister.
     pub module_hash: [u8; 32],
-    // Buffered archive entries limit. If reached, II will stop accepting new anchor operations
-    // until the buffered operations are acknowledged by the archive.
+    /// Buffered archive entries limit. If reached, II will stop accepting new anchor operations
+    /// until the buffered operations are acknowledged by the archive.
     pub entries_buffer_limit: u64,
-    // Polling interval at which the archive should fetch buffered archive entries from II (in nanoseconds).
+    /// Polling interval at which the archive should fetch buffered archive entries from II (in nanoseconds).
     pub polling_interval_ns: u64,
-    // Max number of archive entries to be fetched in a single call.
+    /// Max number of archive entries to be fetched in a single call.
     pub entries_fetch_limit: u16,
-    // How the entries get transferred to the archive.
-    // This is opt, so that the config parameter can be removed after switching from push to pull.
-    // Defaults to Push (legacy mode).
+    /// How the entries get transferred to the archive.
+    /// This is opt, so that the configuration parameter can be removed after switching from push to pull.
+    /// Defaults to Push (legacy mode).
     pub archive_integration: Option<ArchiveIntegration>,
 }
 
@@ -113,6 +117,7 @@ fn canister_arg_types(canister_id: Option<CanisterId>) -> IDLTypes {
     IDLTypes { args }
 }
 
+/// Converts the argument to JSON.
 fn decode_arg(arg: &[u8], arg_types: IDLTypes) -> String {
     // TODO: Test empty payload
     // TODO: Test existing payloads
@@ -126,7 +131,7 @@ fn decode_arg(arg: &[u8], arg_types: IDLTypes) -> String {
     }
 }
 
-// Check if the proposal has a payload, if yes, deserialize it then convert it to JSON.
+/// Check if the proposal has a payload, if yes, de-serializes it then converts it to JSON.
 #[must_use]
 pub fn process_proposal_payload(proposal_info: &ProposalInfo) -> Json {
     if let Some(Action::ExecuteNnsFunction(f)) = proposal_info.proposal.as_ref().and_then(|p| p.action.as_ref()) {
@@ -143,7 +148,7 @@ const IDL2JSON_OPTIONS: Idl2JsonOptions = Idl2JsonOptions {
     prog: Vec::new(), // These are the type definitions used in proposal payloads.  If we have them, it would be nice to use them.  Do we?
 };
 
-/// Convert a Candid `Type` to a candid `IDLType`. `idl2json` uses `IDLType`.
+/// Converts a Candid `Type` to a candid `IDLType`. `idl2json` uses `IDLType`.
 ///
 /// Notes:
 /// - `IDLType` does not exist in Candid `v10`.  This conversion may well not be needed in the future.

--- a/rs/proposals/src/tests/mod.rs
+++ b/rs/proposals/src/tests/mod.rs
@@ -1,3 +1,4 @@
+//! Tests that the proposals crate can indeed express proposals as JSON.
 use crate::tests::payloads::get_payloads;
 use crate::transform_payload_to_json;
 


### PR DESCRIPTION
# Motivation
The main body of the proposals crate contains types imported from Internet Identity.  It is not immediately obvious which types are from II and some of these types are no longer up to date.

# Changes
- Move the II types into a dedicated file, so that these are easy to recognize and can potentially be updated automatically.
- Add rustdocs

# Tests
- None.  There are no code changes, only a move, so existing functionality is completely unchanged.

# Todos

- [ ] Add entry to changelog (if necessary).
  Too minor