### PR TITLE
chore: Update checkout

### DIFF
--- a/.github/workflows/update-sns-aggregator-response.yml
+++ b/.github/workflows/update-sns-aggregator-response.yml
@@ -13,7 +13,7 @@ jobs:
   update-aggregator-response:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Update the SNS aggregator response files
         run: scripts/nns-dapp/test-replace-sns-aggregator-response.sh
       - name: Format the updated files


### PR DESCRIPTION
# Motivation
Checkout v3 uses nodejs v16, which is deprecated in GitHub.

# Changes
- Update checkout to v4.

# Tests
See CI

# Todos

- [ ] Add entry to changelog (if necessary).
  Too minor