### PR TITLE
NNS1-2851: Refactor uncertifiedLoadSnsesAccountsBalances

### DIFF
--- a/frontend/src/lib/services/sns-accounts-balance.services.ts
+++ b/frontend/src/lib/services/sns-accounts-balance.services.ts
@@ -1,60 +1,9 @@
-import { getSnsAccounts, getSnsToken } from "$lib/api/sns-ledger.api";
-import { queryAndUpdate } from "$lib/services/utils.services";
-import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { toastsError } from "$lib/stores/toasts.store";
-import { tokensStore } from "$lib/stores/tokens.store";
-import type { Account } from "$lib/types/account";
-import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import type { RootCanisterId, RootCanisterIdText } from "$lib/types/sns";
-
-const uncertifiedLoadSnsAccountsBalance = ({
-  rootCanisterId,
-}: {
-  rootCanisterId: RootCanisterId;
-}): Promise<void> => {
-  return queryAndUpdate<Account[], unknown>({
-    request: ({ certified, identity }) =>
-      getSnsAccounts({ rootCanisterId, identity, certified }),
-    onLoad: ({ response: accounts, certified }) =>
-      snsAccountsStore.setAccounts({
-        accounts,
-        rootCanisterId,
-        certified,
-      }),
-    onError: ({ error: err }) => {
-      console.error(err);
-      throw err;
-    },
-    logMessage: "Syncing Sns Accounts Balance",
-    strategy: "query",
-  });
-};
-
-const uncertifiedLoadSnsToken = ({
-  rootCanisterId,
-}: {
-  rootCanisterId: RootCanisterId;
-}): Promise<void> => {
-  return queryAndUpdate<IcrcTokenMetadata, unknown>({
-    request: ({ certified, identity }) =>
-      getSnsToken({ rootCanisterId, identity, certified }),
-    onLoad: ({ response: token, certified }) =>
-      tokensStore.setToken({
-        token,
-        canisterId: rootCanisterId,
-        certified,
-      }),
-    onError: ({ error: err }) => {
-      console.error(err);
-      throw err;
-    },
-    logMessage: "Syncing Sns Token",
-    strategy: "query",
-  });
-};
+import { loadSnsAccounts } from "./sns-accounts.services";
 
 /**
- * Load Sns projects accounts balances and tokens
+ * Load Sns projects accounts balances.
  *
  * ⚠️ WARNING: this feature only performs "query" calls. Effective "update" is performed when a Sns project is manually selected either through the token navigation switcher or accessed directly via the browser url.
  *
@@ -62,31 +11,28 @@ const uncertifiedLoadSnsToken = ({
  * @param {RootCanisterId[]} params.rootCanisterIds The list of root canister ids - Sns projects - for which the balance of the accounts should be fetched.
  * @param {RootCanisterIdText[] | undefined} params.excludeRootCanisterIds As the balance is also loaded by loadSnsAccounts() - to perform query and UPDATE call - this variable can be used to avoid to perform unnecessary query and per extension to override data in the balance store.
  */
-export const uncertifiedLoadSnsAccountsBalances = async ({
+export const uncertifiedLoadSnsesAccountsBalances = async ({
   rootCanisterIds,
   excludeRootCanisterIds = [],
 }: {
   rootCanisterIds: RootCanisterId[];
   excludeRootCanisterIds?: RootCanisterIdText[];
 }): Promise<void> => {
-  const results: PromiseSettledResult<[void, void]>[] =
-    await Promise.allSettled(
-      (
-        rootCanisterIds.filter(
-          (rootCanisterId) =>
-            !excludeRootCanisterIds.includes(rootCanisterId.toText())
-        ) ?? []
-      ).map((rootCanisterId) =>
-        Promise.all([
-          uncertifiedLoadSnsAccountsBalance({
-            rootCanisterId,
-          }),
-          uncertifiedLoadSnsToken({
-            rootCanisterId,
-          }),
-        ])
-      )
-    );
+  const results: PromiseSettledResult<[void]>[] = await Promise.allSettled(
+    (
+      rootCanisterIds.filter(
+        (rootCanisterId) =>
+          !excludeRootCanisterIds.includes(rootCanisterId.toText())
+      ) ?? []
+    ).map((rootCanisterId) =>
+      Promise.all([
+        loadSnsAccounts({
+          rootCanisterId,
+          strategy: "query",
+        }),
+      ])
+    )
+  );
 
   const error: boolean =
     results.find(({ status }) => status === "rejected") !== undefined;

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -27,7 +27,7 @@ export const loadSnsAccounts = async ({
   strategy?: QueryAndUpdateStrategy;
 }): Promise<void> => {
   return queryAndUpdate<Account[], unknown>({
-    strategy: strategy,
+    strategy,
     request: ({ certified, identity }) =>
       getSnsAccounts({ rootCanisterId, identity, certified }),
     onLoad: ({ response: accounts, certified }) =>

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -20,14 +20,14 @@ import { queryAndUpdate, type QueryAndUpdateStrategy } from "./utils.services";
 export const loadSnsAccounts = async ({
   rootCanisterId,
   handleError,
-  strategy,
+  strategy = FORCE_CALL_STRATEGY,
 }: {
   rootCanisterId: Principal;
   handleError?: () => void;
   strategy?: QueryAndUpdateStrategy;
 }): Promise<void> => {
   return queryAndUpdate<Account[], unknown>({
-    strategy: strategy ?? FORCE_CALL_STRATEGY,
+    strategy: strategy,
     request: ({ certified, identity }) =>
       getSnsAccounts({ rootCanisterId, identity, certified }),
     onLoad: ({ response: accounts, certified }) =>
@@ -39,7 +39,8 @@ export const loadSnsAccounts = async ({
     onError: ({ error: err, certified }) => {
       console.error(err);
 
-      if (certified !== true) {
+      // Ignore error on query call only if there will be an update call
+      if (certified !== true && strategy !== "query") {
         return;
       }
 

--- a/frontend/src/lib/services/sns-accounts.services.ts
+++ b/frontend/src/lib/services/sns-accounts.services.ts
@@ -15,17 +15,19 @@ import type { IcrcBlockIndex } from "@dfinity/ledger-icrc";
 import type { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import { loadSnsAccountTransactions } from "./sns-transactions.services";
-import { queryAndUpdate } from "./utils.services";
+import { queryAndUpdate, type QueryAndUpdateStrategy } from "./utils.services";
 
 export const loadSnsAccounts = async ({
   rootCanisterId,
   handleError,
+  strategy,
 }: {
   rootCanisterId: Principal;
   handleError?: () => void;
+  strategy?: QueryAndUpdateStrategy;
 }): Promise<void> => {
   return queryAndUpdate<Account[], unknown>({
-    strategy: FORCE_CALL_STRATEGY,
+    strategy: strategy ?? FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
       getSnsAccounts({ rootCanisterId, identity, certified }),
     onLoad: ({ response: accounts, certified }) =>

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -12,7 +12,7 @@
     snsProjectsCommittedStore,
     type SnsFullProject,
   } from "$lib/derived/sns/sns-projects.derived";
-  import { uncertifiedLoadSnsAccountsBalances } from "$lib/services/sns-accounts-balance.services";
+  import { uncertifiedLoadSnsesAccountsBalances } from "$lib/services/sns-accounts-balance.services";
   import type { Universe, UniverseCanisterIdText } from "$lib/types/universe";
   import { isArrayEmpty } from "$lib/utils/utils";
   import { uncertifiedLoadAccountsBalance } from "$lib/services/wallet-uncertified-accounts.services";
@@ -61,7 +61,7 @@
 
     loadSnsAccountsBalancesRequested = true;
 
-    await uncertifiedLoadSnsAccountsBalances({
+    await uncertifiedLoadSnsesAccountsBalances({
       rootCanisterIds: projects.map(({ rootCanisterId }) => rootCanisterId),
       excludeRootCanisterIds: [],
     });
@@ -122,7 +122,7 @@
       ({ rootCanisterId }) => rootCanisterId.toText() === universeId.toText()
     );
     if (isSnsProject) {
-      return uncertifiedLoadSnsAccountsBalances({
+      return uncertifiedLoadSnsesAccountsBalances({
         rootCanisterIds: [universeId],
         excludeRootCanisterIds: [],
       });

--- a/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
@@ -46,7 +46,7 @@ describe("sns-accounts-balance.services", () => {
       .spyOn(ledgerApi, "getSnsAccounts")
       .mockImplementation(() => Promise.resolve([mockSnsMainAccount]));
 
-    await services.uncertifiedLoadSnsAccountsBalances({
+    await services.uncertifiedLoadSnsesAccountsBalances({
       rootCanisterIds: [mockSnsMainAccount.principal],
     });
 
@@ -70,7 +70,7 @@ describe("sns-accounts-balance.services", () => {
       Promise.resolve([mockSnsMainAccount])
     );
 
-    await services.uncertifiedLoadSnsAccountsBalances({
+    await services.uncertifiedLoadSnsesAccountsBalances({
       rootCanisterIds: [mockSnsMainAccount.principal],
     });
 
@@ -90,7 +90,7 @@ describe("sns-accounts-balance.services", () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.spyOn(ledgerApi, "getSnsAccounts").mockRejectedValue(new Error());
 
-    await services.uncertifiedLoadSnsAccountsBalances({
+    await services.uncertifiedLoadSnsesAccountsBalances({
       rootCanisterIds: [mockSnsMainAccount.principal],
     });
 

--- a/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
@@ -61,31 +61,6 @@ describe("sns-accounts-balance.services", () => {
     expect(spyQuery).toBeCalled();
   });
 
-  it("should call api.getSnsToken and load it in store", async () => {
-    const spyQuery = vi
-      .spyOn(ledgerApi, "getSnsToken")
-      .mockImplementation(() => Promise.resolve(mockSnsToken));
-
-    vi.spyOn(ledgerApi, "getSnsAccounts").mockImplementation(() =>
-      Promise.resolve([mockSnsMainAccount])
-    );
-
-    await services.uncertifiedLoadSnsesAccountsBalances({
-      rootCanisterIds: [mockSnsMainAccount.principal],
-    });
-
-    await tick();
-
-    const store = get(tokensStore);
-
-    expect(store[mockSnsMainAccount.principal.toText()]).toEqual({
-      token: mockSnsToken,
-      certified: false,
-    });
-
-    expect(spyQuery).toBeCalled();
-  });
-
   it("should toast error", async () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.spyOn(ledgerApi, "getSnsAccounts").mockRejectedValue(new Error());

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -102,6 +102,46 @@ describe("sns-accounts-services", () => {
       spyQuery.mockClear();
     });
 
+    it("should not call error callback if query fails and update succeeds", async () => {
+      const spyQuery = vi
+        .spyOn(ledgerApi, "getSnsAccounts")
+        .mockImplementation(async ({ certified }) => {
+          if (certified) {
+            return [mockSnsMainAccount];
+          }
+          throw new Error();
+        });
+
+      const spy = vi.fn();
+
+      await services.loadSnsAccounts({
+        rootCanisterId: mockPrincipal,
+        handleError: spy,
+      });
+
+      expect(spy).not.toBeCalled();
+
+      spyQuery.mockClear();
+    });
+
+    it("should call error callback if query fails and only query is requested", async () => {
+      const spyQuery = vi
+        .spyOn(ledgerApi, "getSnsAccounts")
+        .mockRejectedValue(new Error());
+
+      const spy = vi.fn();
+
+      await services.loadSnsAccounts({
+        rootCanisterId: mockPrincipal,
+        handleError: spy,
+        strategy: "query",
+      });
+
+      expect(spy).toBeCalled();
+
+      spyQuery.mockClear();
+    });
+
     it("should empty store if update call fails", async () => {
       snsAccountsStore.setAccounts({
         rootCanisterId: mockPrincipal,

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -169,14 +169,6 @@ describe("Tokens route", () => {
           ];
         }
       );
-      vi.spyOn(snsLedgerApi, "getSnsToken").mockImplementation(
-        async ({ rootCanisterId }) => {
-          if (rootCanisterId.toText() === rootCanisterIdTetris.toText()) {
-            return tetrisToken;
-          }
-          return pacmanToken;
-        }
-      );
       vi.spyOn(icrcLedgerApi, "icrcTransfer").mockResolvedValue(1234n);
       vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockImplementation(
         async ({ canisterId }) => {
@@ -208,12 +200,13 @@ describe("Tokens route", () => {
           lifecycle: SnsSwapLifecycle.Committed,
         },
       ]);
+      // Tokens are loaded in SNS aggregator
       tokensStore.setTokens({
         [rootCanisterIdTetris.toText()]: {
-          token: mockSnsToken,
+          token: tetrisToken,
         },
         [rootCanisterIdPacman.toText()]: {
-          token: mockSnsToken,
+          token: pacmanToken,
         },
       });
       setCkETHCanisters();


### PR DESCRIPTION
# Motivation

Unify wallet implementations.

In this PR, change the implementation of `uncertifiedLoadSnsAccountsBalances` to use current service `loadSnsAccounts`.

This way merging api functions and stores later will be easier.

# Changes

* Rename `uncertifiedLoadSnsAccountsBalances` to `uncertifiedLoadSnsesAccountsBalances`. Notice the "Snses".
* `uncertifiedLoadSnsesAccountsBalances` uses `loadSnsAccounts` and doesn't load the SNS token because that's done by the aggregator service.
* Add optional `strategy` param to `loadSnsAccounts`.
* Rename usages of `uncertifiedLoadSnsAccountsBalances`.

# Tests

* Add test for `strategy` param in `laodSnsAccounts` and change expects on the test that calls `loadSnsAccounts` without `strategy`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.