### PR TITLE
NNS1-2851: Refactor uncertifiedLoadAccountsBalance

### DIFF
--- a/frontend/src/lib/services/wallet-accounts.services.ts
+++ b/frontend/src/lib/services/wallet-accounts.services.ts
@@ -1,5 +1,8 @@
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
-import { queryAndUpdate } from "$lib/services/utils.services";
+import {
+  queryAndUpdate,
+  type QueryAndUpdateStrategy,
+} from "$lib/services/utils.services";
 import { getAccounts } from "$lib/services/wallet-loader.services";
 import { loadToken } from "$lib/services/wallet-tokens.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
@@ -17,12 +20,14 @@ import type { Principal } from "@dfinity/principal";
 export const loadAccounts = async ({
   handleError,
   ledgerCanisterId,
+  strategy = FORCE_CALL_STRATEGY,
 }: {
   handleError?: () => void;
   ledgerCanisterId: Principal;
+  strategy?: QueryAndUpdateStrategy;
 }): Promise<void> => {
   return queryAndUpdate<Account[], unknown>({
-    strategy: FORCE_CALL_STRATEGY,
+    strategy,
     request: ({ certified, identity }) =>
       getAccounts({ identity, certified, ledgerCanisterId }),
     onLoad: ({ response: accounts, certified }) =>

--- a/frontend/src/lib/services/wallet-accounts.services.ts
+++ b/frontend/src/lib/services/wallet-accounts.services.ts
@@ -9,7 +9,6 @@ import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import type { Account } from "$lib/types/account";
-import { notForceCallStrategy } from "$lib/utils/env.utils";
 import { toToastError } from "$lib/utils/error.utils";
 import type { Principal } from "@dfinity/principal";
 
@@ -41,7 +40,8 @@ export const loadAccounts = async ({
     onError: ({ error: err, certified }) => {
       console.error(err);
 
-      if (!certified && notForceCallStrategy()) {
+      // Ignore error on query call only if there will be an update call
+      if (certified !== true && strategy !== "query") {
         return;
       }
 

--- a/frontend/src/lib/services/wallet-uncertified-accounts.services.ts
+++ b/frontend/src/lib/services/wallet-uncertified-accounts.services.ts
@@ -1,7 +1,8 @@
 import { toastsError } from "$lib/stores/toasts.store";
 import type { UniverseCanisterIdText } from "$lib/types/universe";
 import { Principal } from "@dfinity/principal";
-import { loadIcrcAccount, loadIcrcToken } from "./icrc-accounts.services";
+import { loadIcrcToken } from "./icrc-accounts.services";
+import { loadAccounts } from "./wallet-accounts.services";
 
 /**
  * Load Icrc accounts balances and token
@@ -27,9 +28,9 @@ export const uncertifiedLoadAccountsBalance = async ({
         ) ?? []
       ).map((universeId) =>
         Promise.all([
-          loadIcrcAccount({
+          loadAccounts({
+            // TODO: Use strategy `"query"`
             ledgerCanisterId: Principal.fromText(universeId),
-            certified: false,
           }),
           loadIcrcToken({
             ledgerCanisterId: Principal.fromText(universeId),

--- a/frontend/src/lib/services/wallet-uncertified-accounts.services.ts
+++ b/frontend/src/lib/services/wallet-uncertified-accounts.services.ts
@@ -1,62 +1,7 @@
-import { getToken } from "$lib/api/wallet-ledger.api";
-import { queryAndUpdate } from "$lib/services/utils.services";
-import { getAccounts } from "$lib/services/wallet-loader.services";
-import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { toastsError } from "$lib/stores/toasts.store";
-import { tokensStore } from "$lib/stores/tokens.store";
-import type { Account } from "$lib/types/account";
-import type { IcrcTokenMetadata } from "$lib/types/icrc";
-import type {
-  UniverseCanisterId,
-  UniverseCanisterIdText,
-} from "$lib/types/universe";
+import type { UniverseCanisterIdText } from "$lib/types/universe";
 import { Principal } from "@dfinity/principal";
-
-/**
- * This function performs only an insecure "query" and does not toast the error but throw it so that all errors are collected by its caller.
- */
-const loadAccountsBalance = (ledgerCanisterId: Principal): Promise<void> => {
-  return queryAndUpdate<Account[], unknown>({
-    request: ({ certified, identity }) =>
-      getAccounts({ identity, certified, ledgerCanisterId }),
-    onLoad: ({ response: accounts, certified }) =>
-      icrcAccountsStore.set({
-        ledgerCanisterId,
-        accounts: {
-          accounts,
-          certified,
-        },
-      }),
-    onError: ({ error: err }) => {
-      console.error(err);
-      throw err;
-    },
-    logMessage: "Syncing Accounts Balance",
-    strategy: "query",
-  });
-};
-
-/**
- * This function performs only an insecure "query" and does not toast the error but throw it so that all errors are collected by its caller.
- */
-const loadToken = (universeId: UniverseCanisterId): Promise<void> => {
-  return queryAndUpdate<IcrcTokenMetadata, unknown>({
-    request: ({ certified, identity }) =>
-      getToken({ identity, certified, canisterId: universeId }),
-    onLoad: ({ response: token, certified }) =>
-      tokensStore.setToken({
-        canisterId: universeId,
-        token,
-        certified,
-      }),
-    onError: ({ error: err }) => {
-      console.error(err);
-      throw err;
-    },
-    logMessage: "Syncing token",
-    strategy: "query",
-  });
-};
+import { loadIcrcAccount, loadIcrcToken } from "./icrc-accounts.services";
 
 /**
  * Load Icrc accounts balances and token
@@ -82,8 +27,14 @@ export const uncertifiedLoadAccountsBalance = async ({
         ) ?? []
       ).map((universeId) =>
         Promise.all([
-          loadAccountsBalance(Principal.fromText(universeId)),
-          loadToken(Principal.fromText(universeId)),
+          loadIcrcAccount({
+            ledgerCanisterId: Principal.fromText(universeId),
+            certified: false,
+          }),
+          loadIcrcToken({
+            ledgerCanisterId: Principal.fromText(universeId),
+            certified: false,
+          }),
         ])
       )
     );

--- a/frontend/src/lib/services/wallet-uncertified-accounts.services.ts
+++ b/frontend/src/lib/services/wallet-uncertified-accounts.services.ts
@@ -29,7 +29,7 @@ export const uncertifiedLoadAccountsBalance = async ({
       ).map((universeId) =>
         Promise.all([
           loadAccounts({
-            // TODO: Use strategy `"query"`
+            strategy: "query",
             ledgerCanisterId: Principal.fromText(universeId),
           }),
           loadIcrcToken({

--- a/frontend/src/tests/lib/services/wallet-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-accounts.services.spec.ts
@@ -11,7 +11,7 @@ import {
 } from "$lib/services/wallet-accounts.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
-import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockCkBTCMainAccount,
   mockCkBTCToken,
@@ -38,7 +38,7 @@ describe("wallet-accounts-services", () => {
       vi.spyOn(console, "error").mockImplementation(() => undefined);
     });
 
-    it("should call api.getCkBTCAccount and load neurons in store", async () => {
+    it("should call getAccount and load neurons in store", async () => {
       const spyQuery = vi
         .spyOn(ckbtcLedgerApi, "getAccount")
         .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
@@ -55,6 +55,32 @@ describe("wallet-accounts-services", () => {
       expect(spyQuery).toBeCalled();
 
       spyQuery.mockClear();
+    });
+
+    it("should use the strategy to set certified in api call and store", async () => {
+      const spyQuery = vi
+        .spyOn(ckbtcLedgerApi, "getAccount")
+        .mockResolvedValue(mockCkBTCMainAccount);
+
+      await loadAccounts({
+        ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID,
+        strategy: "query",
+      });
+
+      expect(
+        get(icrcAccountsStore)[CKBTC_UNIVERSE_CANISTER_ID.toText()].accounts
+      ).toHaveLength(1);
+      expect(
+        get(icrcAccountsStore)[CKBTC_UNIVERSE_CANISTER_ID.toText()].certified
+      ).toBe(false);
+      expect(spyQuery).toBeCalledTimes(1);
+      expect(spyQuery).toBeCalledWith({
+        canisterId: CKBTC_LEDGER_CANISTER_ID,
+        identity: mockIdentity,
+        certified: false,
+        owner: mockIdentity.getPrincipal(),
+        type: "main",
+      });
     });
 
     it("should call error callback", async () => {

--- a/frontend/src/tests/lib/services/wallet-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-accounts.services.spec.ts
@@ -100,6 +100,47 @@ describe("wallet-accounts-services", () => {
       spyQuery.mockClear();
     });
 
+    it("should call error callback if query fails strategy is query", async () => {
+      vi.spyOn(ckbtcLedgerApi, "getAccount").mockImplementation(
+        async ({ certified }) => {
+          if (certified) {
+            return mockCkBTCMainAccount;
+          }
+          throw new Error();
+        }
+      );
+
+      const spy = vi.fn();
+
+      await loadAccounts({
+        handleError: spy,
+        ledgerCanisterId: CKBTC_UNIVERSE_CANISTER_ID,
+        strategy: "query",
+      });
+
+      expect(spy).toBeCalled();
+    });
+
+    it("should not call error callback if query fails and update succeeds", async () => {
+      vi.spyOn(ckbtcLedgerApi, "getAccount").mockImplementation(
+        async ({ certified }) => {
+          if (certified) {
+            return mockCkBTCMainAccount;
+          }
+          throw new Error();
+        }
+      );
+
+      const spy = vi.fn();
+
+      await loadAccounts({
+        handleError: spy,
+        ledgerCanisterId: CKBTC_UNIVERSE_CANISTER_ID,
+      });
+
+      expect(spy).not.toBeCalled();
+    });
+
     it("should empty store if update call fails", async () => {
       icrcAccountsStore.set({
         accounts: {

--- a/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
@@ -1,3 +1,4 @@
+import * as icrcLegerApi from "$lib/api/icrc-ledger.api";
 import * as ledgerApi from "$lib/api/wallet-ledger.api";
 import {
   CKBTC_UNIVERSE_CANISTER_ID,
@@ -14,7 +15,6 @@ import {
   mockCkBTCMainAccount,
   mockCkBTCToken,
 } from "$tests/mocks/ckbtc-accounts.mock";
-import { tick } from "svelte";
 import { get } from "svelte/store";
 
 vi.mock("$lib/stores/toasts.store", () => {
@@ -26,9 +26,6 @@ vi.mock("$lib/stores/toasts.store", () => {
 describe("wallet-uncertified-accounts.services", () => {
   beforeEach(() => {
     resetIdentity();
-  });
-
-  afterEach(() => {
     vi.clearAllMocks();
 
     icrcAccountsStore.reset();
@@ -43,17 +40,13 @@ describe("wallet-uncertified-accounts.services", () => {
   };
 
   it("should call api.getAccounts and load balance in store", async () => {
-    vi.spyOn(ledgerApi, "getToken").mockImplementation(() =>
-      Promise.resolve(mockCkBTCToken)
-    );
+    vi.spyOn(icrcLegerApi, "queryIcrcToken").mockResolvedValue(mockCkBTCToken);
 
     const spyQuery = vi
       .spyOn(ledgerApi, "getAccount")
       .mockImplementation(() => Promise.resolve(mockCkBTCMainAccount));
 
     await services.uncertifiedLoadAccountsBalance(params);
-
-    await tick();
 
     const store = get(universesAccountsBalance);
     // Nns + ckBTC + ckTESTBTC
@@ -66,16 +59,14 @@ describe("wallet-uncertified-accounts.services", () => {
 
   it("should call api.getToken and load token in store", async () => {
     const spyQuery = vi
-      .spyOn(ledgerApi, "getToken")
-      .mockImplementation(() => Promise.resolve(mockCkBTCToken));
+      .spyOn(icrcLegerApi, "queryIcrcToken")
+      .mockResolvedValue(mockCkBTCToken);
 
     vi.spyOn(ledgerApi, "getAccount").mockImplementation(() =>
       Promise.resolve(mockCkBTCMainAccount)
     );
 
     await services.uncertifiedLoadAccountsBalance(params);
-
-    await tick();
 
     const store = get(ckBTCTokenStore);
     const token = {


### PR DESCRIPTION
# Motivation

Unify wallet implementations.

In this PR, refactor `uncertifiedLoadAccountsBalance` to use current services instead of creating new ones.

# Changes

* Change implementation of `uncertifiedLoadAccountsBalance`.

# Tests

Same functionality.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
