### PR TITLE
NNS1-2851: Remove loadCkBTCAccounts

### DIFF
--- a/frontend/src/lib/services/ckbtc-accounts.services.ts
+++ b/frontend/src/lib/services/ckbtc-accounts.services.ts
@@ -7,14 +7,8 @@ import type { Account } from "$lib/types/account";
 import type { UniverseCanisterId } from "$lib/types/universe";
 import type { Identity } from "@dfinity/agent";
 import type { IcrcBlockIndex } from "@dfinity/ledger-icrc";
-import type { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 import { numberToE8s } from "../utils/token.utils";
-
-export const loadCkBTCAccounts = async (params: {
-  handleError?: () => void;
-  ledgerCanisterId: Principal;
-}): Promise<void> => loadAccounts(params);
 
 export const ckBTCTransferTokens = async ({
   source,

--- a/frontend/src/lib/services/ckbtc-convert.services.ts
+++ b/frontend/src/lib/services/ckbtc-convert.services.ts
@@ -1,4 +1,5 @@
 import { NANO_SECONDS_IN_MINUTE } from "$lib/constants/constants";
+import { loadAccounts as loadWalletAccounts } from "$lib/services/wallet-accounts.services";
 import type { Account } from "$lib/types/account";
 import type { CanisterId } from "$lib/types/canister";
 import type { CkBTCAdditionalCanisters } from "$lib/types/ckbtc-canisters";
@@ -19,7 +20,6 @@ import { approveTransfer } from "../api/icrc-ledger.api";
 import { toastsError } from "../stores/toasts.store";
 import { numberToE8s } from "../utils/token.utils";
 import { getAuthenticatedIdentity } from "./auth.services";
-import { loadCkBTCAccounts } from "./ckbtc-accounts.services";
 import type { IcrcTransferTokensUserParams } from "./icrc-accounts.services";
 import { loadWalletTransactions } from "./wallet-transactions.services";
 
@@ -110,7 +110,7 @@ const reload = async ({
   // - if provided, the transactions of the account for which the transfer was executed
   await Promise.all([
     ...(loadAccounts
-      ? [loadCkBTCAccounts({ ledgerCanisterId: universeId })]
+      ? [loadWalletAccounts({ ledgerCanisterId: universeId })]
       : []),
     ...(nonNullish(source)
       ? [

--- a/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-convert.services.spec.ts
@@ -5,8 +5,8 @@ import {
   CKBTC_LEDGER_CANISTER_ID,
   CKBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
-import * as ckbtcAccountsServices from "$lib/services/ckbtc-accounts.services";
 import { convertCkBTCToBtcIcrc2 } from "$lib/services/ckbtc-convert.services";
+import * as walletAccountsServices from "$lib/services/wallet-accounts.services";
 import { loadWalletTransactions } from "$lib/services/wallet-transactions.services";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { ConvertBtcStep } from "$lib/types/ckbtc-convert";
@@ -28,11 +28,12 @@ import type { Mock } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 vi.mock("$lib/services/wallet-transactions.services");
+vi.mock("$lib/services/wallet-accounts.services");
 
 describe("ckbtc-convert-services", () => {
   const now = new Date("2019-02-03T12:34:56.789Z").getTime();
   const minterCanisterMock = mock<CkBTCMinterCanister>();
-  let loadCkBTCAccountsSpy;
+  let loadAccountsSpy;
 
   const params = {
     source: mockCkBTCMainAccount,
@@ -66,8 +67,8 @@ describe("ckbtc-convert-services", () => {
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
 
     vi.spyOn(console, "error").mockImplementation(() => undefined);
-    loadCkBTCAccountsSpy = vi
-      .spyOn(ckbtcAccountsServices, "loadCkBTCAccounts")
+    loadAccountsSpy = vi
+      .spyOn(walletAccountsServices, "loadAccounts")
       .mockResolvedValue(undefined);
 
     vi.useFakeTimers().setSystemTime(now);
@@ -140,7 +141,7 @@ describe("ckbtc-convert-services", () => {
       expect(approveTransferSpy).toBeCalledTimes(1);
       expect(retrieveBtcSpy).toBeCalledTimes(0);
       expect(loadWalletTransactions).toBeCalledTimes(0);
-      expect(loadCkBTCAccountsSpy).toBeCalledTimes(0);
+      expect(loadAccountsSpy).toBeCalledTimes(0);
     });
 
     it("should retrieve BTC with approval", async () => {
@@ -171,7 +172,7 @@ describe("ckbtc-convert-services", () => {
       expect(approveTransferSpy).toBeCalledTimes(1);
       expect(retrieveBtcSpy).toBeCalledTimes(1);
       expect(loadWalletTransactions).toBeCalledTimes(0);
-      expect(loadCkBTCAccountsSpy).toBeCalledTimes(0);
+      expect(loadAccountsSpy).toBeCalledTimes(0);
     });
 
     it("should reload account and transactions", async () => {
@@ -204,14 +205,14 @@ describe("ckbtc-convert-services", () => {
         indexCanisterId: mockCkBTCAdditionalCanisters.indexCanisterId,
       });
 
-      expect(loadCkBTCAccountsSpy).toBeCalledWith({
+      expect(loadAccountsSpy).toBeCalledWith({
         ledgerCanisterId: CKBTC_LEDGER_CANISTER_ID,
       });
 
       expect(approveTransferSpy).toBeCalledTimes(1);
       expect(retrieveBtcSpy).toBeCalledTimes(1);
       expect(loadWalletTransactions).toBeCalledTimes(1);
-      expect(loadCkBTCAccountsSpy).toBeCalledTimes(1);
+      expect(loadAccountsSpy).toBeCalledTimes(1);
     });
 
     it("succeeds", async () => {
@@ -243,7 +244,7 @@ describe("ckbtc-convert-services", () => {
       expect(approveTransferSpy).toBeCalledTimes(1);
       expect(retrieveBtcSpy).toBeCalledTimes(1);
       expect(loadWalletTransactions).toBeCalledTimes(1);
-      expect(loadCkBTCAccountsSpy).toBeCalledTimes(1);
+      expect(loadAccountsSpy).toBeCalledTimes(1);
 
       expect(await convertPromise).toEqual({ success: true });
       expect(spyOnToastsError).toBeCalledTimes(0);


### PR DESCRIPTION
# Motivation

Unify wallet implementations.

In this PR, remove the ckBTC service `loadCkBTCAccounts`.

# Changes

* Remove `loadCkBTCAccounts`.
* In ckBTC convert services use `loadAccounts` wallet service instead.

# Tests

* Rename and change the mock in the ckbtc-convert.services.spec

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
