### PR TITLE
NNS1-2851: Remove loadIcrcAccount service

### DIFF
--- a/frontend/src/lib/services/dev.services.ts
+++ b/frontend/src/lib/services/dev.services.ts
@@ -21,8 +21,8 @@ import type { Principal } from "@dfinity/principal";
 import { ICPToken, nonNullish, type Token } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { syncAccounts } from "./icp-accounts.services";
-import { loadIcrcAccount } from "./icrc-accounts.services";
 import { loadSnsAccounts } from "./sns-accounts.services";
+import { loadAccounts } from "./wallet-accounts.services";
 
 const getMainAccount = async (): Promise<IcpAccount> => {
   const { main }: IcpAccountsStoreData = get(icpAccountsStore);
@@ -118,7 +118,7 @@ export const getIcrcTokens = async ({
   token: Token;
 }) => {
   // Accounts are loaded when user visits the Accounts page, so we need to load them here.
-  await loadIcrcAccount({ ledgerCanisterId, certified: false });
+  await loadAccounts({ ledgerCanisterId });
   const store = get(icrcAccountsStore);
   const { accounts } = store[ledgerCanisterId.toText()];
   const main = accounts.find((account) => account.type === "main");
@@ -134,5 +134,5 @@ export const getIcrcTokens = async ({
   });
 
   // Reload accounts to sync tokens that have been transferred
-  await loadIcrcAccount({ ledgerCanisterId, certified: true });
+  await loadAccounts({ ledgerCanisterId });
 };

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -1,4 +1,5 @@
 import * as ledgerApi from "$lib/api/icrc-ledger.api";
+import * as walletApi from "$lib/api/wallet-ledger.api";
 import {
   getIcrcAccountIdentity,
   icrcTransferTokens,
@@ -29,13 +30,19 @@ describe("icrc-accounts-services", () => {
     icrcAccountsStore.reset();
 
     vi.spyOn(ledgerApi, "queryIcrcToken").mockResolvedValue(mockToken);
-    vi.spyOn(ledgerApi, "queryIcrcBalance").mockImplementation(
+    vi.spyOn(walletApi, "getAccount").mockImplementation(
       async ({ canisterId }) => {
         if (canisterId.toText() === ledgerCanisterId.toText()) {
-          return balanceE8s;
+          return {
+            ...mockIcrcMainAccount,
+            balanceUlps: balanceE8s,
+          };
         }
         if (canisterId.toText() === ledgerCanisterId2.toText()) {
-          return balanceE8s2;
+          return {
+            ...mockIcrcMainAccount,
+            balanceUlps: balanceE8s2,
+          };
         }
       }
     );

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -21,14 +21,6 @@ describe("icrc-accounts-services", () => {
   const ledgerCanisterId2 = principal(2);
   const balanceE8s = 314000000n;
   const balanceE8s2 = 222000000n;
-  const mockAccount = {
-    identifier: encodeIcrcAccount({
-      owner: mockIdentity.getPrincipal(),
-    }),
-    principal: mockIdentity.getPrincipal(),
-    type: "main",
-    balanceUlps: balanceE8s,
-  };
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -2,7 +2,6 @@ import * as ledgerApi from "$lib/api/icrc-ledger.api";
 import {
   getIcrcAccountIdentity,
   icrcTransferTokens,
-  loadIcrcAccount,
   loadIcrcToken,
 } from "$lib/services/icrc-accounts.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
@@ -151,54 +150,6 @@ describe("icrc-accounts-services", () => {
         certified: true,
         token: mockToken,
       });
-    });
-  });
-
-  describe("loadIcrcAccount", () => {
-    const userIcrcAccount = {
-      owner: mockIdentity.getPrincipal(),
-    };
-
-    it("loads account in store with balance from api", async () => {
-      expect(get(icrcAccountsStore)[ledgerCanisterId.toText()]).toBeUndefined();
-
-      await loadIcrcAccount({ ledgerCanisterId, certified: true });
-
-      expect(get(icrcAccountsStore)[ledgerCanisterId.toText()]).toEqual({
-        accounts: [mockAccount],
-        certified: true,
-      });
-      expect(ledgerApi.queryIcrcBalance).toHaveBeenCalledWith({
-        certified: false,
-        identity: mockIdentity,
-        canisterId: ledgerCanisterId,
-        account: userIcrcAccount,
-      });
-      expect(ledgerApi.queryIcrcBalance).toHaveBeenCalledWith({
-        certified: true,
-        identity: mockIdentity,
-        canisterId: ledgerCanisterId,
-        account: userIcrcAccount,
-      });
-      expect(ledgerApi.queryIcrcBalance).toHaveBeenCalledTimes(2);
-    });
-
-    it("loads account in store with balance from api with query", async () => {
-      expect(get(icrcAccountsStore)[ledgerCanisterId.toText()]).toBeUndefined();
-
-      await loadIcrcAccount({ ledgerCanisterId, certified: false });
-
-      expect(get(icrcAccountsStore)[ledgerCanisterId.toText()]).toEqual({
-        accounts: [mockAccount],
-        certified: false,
-      });
-      expect(ledgerApi.queryIcrcBalance).toHaveBeenCalledWith({
-        certified: false,
-        identity: mockIdentity,
-        canisterId: ledgerCanisterId,
-        account: userIcrcAccount,
-      });
-      expect(ledgerApi.queryIcrcBalance).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
# Motivation

Unify wallet implementations.

In this PR, remove the sercive `loadIcrcAccount` and use `loadAccounts` from wallet services instead.

# Changes

* Remove `loadIcrcAccount`.
* Use `loadAccounts` where `loadIcrcAccount` was being used.

# Tests

* Remove test for `loadIcrcAccount`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
