### PR TITLE
Add selectedTokenStore

### DIFF
--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
@@ -2,8 +2,7 @@
   import AmountDisplay from "../ic/AmountDisplay.svelte";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
   import { type Token, nonNullish, TokenAmountV2 } from "@dfinity/utils";
-  import { tokensStore } from "$lib/stores/tokens.store";
-  import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
+  import { selectedTokenStore } from "$lib/derived/selected-token.derived";
   import {
     getSnsNeuronStake,
     isUserHotkey,
@@ -21,7 +20,7 @@
   export let parameters: SnsNervousSystemParameters;
 
   let token: Token | undefined;
-  $: token = $tokensStore[$selectedUniverseIdStore.toText()].token;
+  $: token = $selectedTokenStore;
 
   let amount: TokenAmountV2 | undefined;
   $: amount =

--- a/frontend/src/lib/derived/selected-token.derived.ts
+++ b/frontend/src/lib/derived/selected-token.derived.ts
@@ -1,0 +1,21 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
+import { tokensStore, type TokensStore } from "$lib/stores/tokens.store";
+import type { Principal } from "@dfinity/principal";
+import type { Token } from "@dfinity/utils";
+import { ICPToken } from "@dfinity/utils";
+import { derived, type Readable } from "svelte/store";
+
+// Holds the token corresponding to the selected universe.
+export const selectedTokenStore: Readable<Token | undefined> = derived<
+  [Readable<Principal>, TokensStore],
+  Token | undefined
+>(
+  [selectedUniverseIdStore, tokensStore],
+  ([$selectedUniverseIdStore, $tokensStore]) => {
+    if ($selectedUniverseIdStore.toText() === OWN_CANISTER_ID_TEXT) {
+      return ICPToken;
+    }
+    return $tokensStore[$selectedUniverseIdStore.toText()]?.token;
+  }
+);

--- a/frontend/src/lib/modals/sns/neurons/SnsActiveDisbursementsModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsActiveDisbursementsModal.svelte
@@ -6,15 +6,14 @@
   import { createEventDispatcher } from "svelte";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import type { Token } from "@dfinity/utils";
-  import { tokensStore } from "$lib/stores/tokens.store";
-  import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
+  import { selectedTokenStore } from "$lib/derived/selected-token.derived";
   import { formatMaturity } from "$lib/utils/neuron.utils";
   import { totalDisbursingMaturity } from "$lib/utils/sns-neuron.utils";
 
   export let neuron: SnsNeuron;
 
   let token: Token | undefined;
-  $: token = $tokensStore[$selectedUniverseIdStore.toText()]?.token;
+  $: token = $selectedTokenStore;
 
   let symbol: string;
   $: symbol = token?.symbol ?? "";

--- a/frontend/src/tests/lib/derived/selected-token.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/selected-token.derived.spec.ts
@@ -1,0 +1,60 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { CKETH_LEDGER_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
+import { selectedTokenStore } from "$lib/derived/selected-token.derived";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { page } from "$mocks/$app/stores";
+import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
+import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
+import { Principal } from "@dfinity/principal";
+import { ICPToken } from "@dfinity/utils";
+import { get } from "svelte/store";
+
+describe("selectedTokenStore", () => {
+  beforeEach(() => {
+    page.mock({
+      data: { universe: OWN_CANISTER_ID_TEXT },
+    });
+    tokensStore.reset();
+  });
+
+  it("should return ICPToken for NNS universe", () => {
+    page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+
+    expect(get(selectedTokenStore)).toBe(ICPToken);
+  });
+
+  it("should return SNS token for SNS universe", () => {
+    const rootCanisterIdText = "dlbnd-beaaa-aaaaa-qaana-cai";
+    const rootCanisterId = Principal.fromText(rootCanisterIdText);
+    const token = {
+      ...mockSnsToken,
+      symbol: "YOYO",
+    };
+    tokensStore.setToken({
+      canisterId: rootCanisterId,
+      token,
+    });
+
+    page.mock({ data: { universe: rootCanisterIdText } });
+
+    expect(get(selectedTokenStore)).toBe(token);
+  });
+
+  it("should return ICRC token for ICRC universe", () => {
+    tokensStore.setToken({
+      canisterId: CKETH_LEDGER_CANISTER_ID,
+      token: mockCkETHToken,
+    });
+
+    page.mock({ data: { universe: CKETH_LEDGER_CANISTER_ID.toText() } });
+
+    expect(get(selectedTokenStore)).toBe(mockCkETHToken);
+  });
+
+  it("should return undefined for unknown token", () => {
+    const rootCanisterIdText = "dlbnd-beaaa-aaaaa-qaana-cai";
+    page.mock({ data: { universe: rootCanisterIdText } });
+
+    expect(get(selectedTokenStore)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Motivation

SNS tokens are in the `tokensStore` keyed by `rootCanisterId` and now also by `ledgerCanisterId`.
We want them only keyed by `ledgerCanisterId` so we need to change all the places that access by `rootCanisterId`.

In some places we use `$tokensStore[$selectedUniverseIdStore.toText()].token` to get the token for the current universe.

In this PR we provide a convenient `selectedTokenStore` which gives the token for the selected universe.
This can then, in the next PR, be changed to use the SNS `ledgerCanisterId` instead of `rootCanisterId`.

# Changes

1. Add `selectedTokensStore` which holds the token for the selected universe.
2. Use `selectedTokensStore` instead of `$tokensStore[$selectedUniverseIdStore.toText()].token` in `SnsNeuronPageHeading.svelte` and `SnsActiveDisbursementsModal.svelte`.

# Tests

Unit tests added for 

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary