### PR TITLE
chore: Update gh build-push-action, as nodev16 is deprecated

### DIFF
--- a/.github/actions/build_nns_dapp/action.yaml
+++ b/.github/actions/build_nns_dapp/action.yaml
@@ -25,7 +25,7 @@ runs:
       shell: bash
       run: echo "{}" > global-config.json
     - name: Build wasms
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         file: Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,7 +275,7 @@ jobs:
         run: echo "{}" > global-config.json
       - name: Build wasms
         if: steps.dockerfile_changed.outputs.dockerfile_changed == 'true'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Provide empty global config
         run: echo '{}' > global-config.json
       - name: Build docker artifacts
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -55,6 +55,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Update the GitHub `build-push-action` from v4 to v5.
+
 #### Deprecated
 
 #### Removed

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -55,7 +55,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
-* Update the GitHub `build-push-action` from v4 to v5.
+* Update the GitHub `build-push-action` from `v4` to `v5`.
 
 #### Deprecated
 


### PR DESCRIPTION
# Motivation
Node v16 is deprecated in GitHub actions:

![Screenshot from 2024-02-09 17-19-00](https://github.com/dfinity/nns-dapp/assets/5982633/d0ebf0cd-4e2e-4f3a-8fa7-38bad514351f)


# Changes

- Update the `build-push-action` from `v4` to `v5`.

# Tests
- See CI

# Todos

- [x] Add entry to changelog (if necessary).
