### PR TITLE
Feat: Add SNS Aggregator API service

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -22,6 +22,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Support HTML within toast messages.
 * Add `ENABLE_VOTING_INDICATION` feature flag.
 * Add "Manage Internet Identity" and "Source code" entries to account menu.
+* Client side caching of SNS Aggregator calls.
 
 #### Changed
 

--- a/frontend/src/lib/api-services/sns-aggregator.api-service.ts
+++ b/frontend/src/lib/api-services/sns-aggregator.api-service.ts
@@ -1,0 +1,36 @@
+import { querySnsProjects } from "$lib/api/sns-aggregator.api";
+import { SECONDS_IN_MINUTE } from "$lib/constants/constants";
+import type { CachedSnsDto } from "$lib/types/sns-aggregator";
+import { nowInSeconds } from "$lib/utils/date.utils";
+import { isNullish } from "@dfinity/utils";
+
+const cacheExpirationDurationSeconds = 5 * SECONDS_IN_MINUTE;
+
+interface SnsAggregatorCache {
+  data: Promise<CachedSnsDto[]>;
+  // When the neurons were cached.
+  timestampSeconds: number;
+}
+
+let snsAggregatorCache: SnsAggregatorCache | null = null;
+
+export const clearCache = () => {
+  snsAggregatorCache = null;
+};
+
+export const snsAggregatorApiService = {
+  async querySnsProjects() {
+    if (
+      isNullish(snsAggregatorCache) ||
+      nowInSeconds() - snsAggregatorCache.timestampSeconds >
+        cacheExpirationDurationSeconds
+    ) {
+      snsAggregatorCache = {
+        data: querySnsProjects(),
+        timestampSeconds: nowInSeconds(),
+      };
+    }
+
+    return snsAggregatorCache.data;
+  },
+};

--- a/frontend/src/lib/api-services/sns-aggregator.api-service.ts
+++ b/frontend/src/lib/api-services/sns-aggregator.api-service.ts
@@ -8,13 +8,14 @@ const cacheExpirationDurationSeconds = 5 * SECONDS_IN_MINUTE;
 
 interface SnsAggregatorCache {
   data: Promise<CachedSnsDto[]>;
-  // When the neurons were cached.
+  // When the data was cached.
   timestampSeconds: number;
 }
 
 let snsAggregatorCache: SnsAggregatorCache | null = null;
 
-export const clearCache = () => {
+// For testing purposes.
+export const clearSnsAggregatorCache = () => {
   snsAggregatorCache = null;
 };
 
@@ -26,7 +27,12 @@ export const snsAggregatorApiService = {
         cacheExpirationDurationSeconds
     ) {
       snsAggregatorCache = {
-        data: querySnsProjects(),
+        data: querySnsProjects().catch((err) => {
+          // If the request fails, we don't want to cache the error.
+          snsAggregatorCache = null;
+          // But we still want to throw the error for whoever called this function.
+          throw err;
+        }),
         timestampSeconds: nowInSeconds(),
       };
     }

--- a/frontend/src/lib/api-services/sns-aggregator.api-service.ts
+++ b/frontend/src/lib/api-services/sns-aggregator.api-service.ts
@@ -20,7 +20,7 @@ export const clearSnsAggregatorCache = () => {
 };
 
 export const snsAggregatorApiService = {
-  async querySnsProjects() {
+  querySnsProjects() {
     if (
       isNullish(snsAggregatorCache) ||
       nowInSeconds() - snsAggregatorCache.timestampSeconds >

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -1,5 +1,5 @@
+import { snsAggregatorApiService } from "$lib/api-services/sns-aggregator.api-service";
 import { queryProposals } from "$lib/api/proposals.api";
-import { querySnsProjects } from "$lib/api/sns-aggregator.api";
 import { getNervousSystemFunctions } from "$lib/api/sns-governance.api";
 import { buildAndStoreWrapper } from "$lib/api/sns-wrapper.api";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
@@ -25,7 +25,7 @@ import { getCurrentIdentity } from "../auth.services";
 
 export const loadSnsProjects = async (): Promise<void> => {
   try {
-    const aggregatorData = await querySnsProjects();
+    const aggregatorData = await snsAggregatorApiService.querySnsProjects();
     const identity = getCurrentIdentity();
     // We load the wrappers to avoid making calls to SNS-W and Root canister for each project.
     // The SNS Aggregator gives us the canister ids of the SNS projects.

--- a/frontend/src/tests/lib/api-services/sns-aggregator.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/sns-aggregator.api-service.spec.ts
@@ -43,19 +43,6 @@ describe("sns-aggregator api-service", () => {
     expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
   });
 
-  it("should return call api once for two parallel calls", async () => {
-    const [promise1, promise2] = [
-      snsAggregatorApiService.querySnsProjects(),
-      snsAggregatorApiService.querySnsProjects(),
-    ];
-
-    resolveFn(successData);
-    const [result1, result2] = await Promise.all([promise1, promise2]);
-
-    expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
-    expect(result1).toBe(result2);
-  });
-
   it("should call api once for simultaneous calls", async () => {
     const promise1 = snsAggregatorApiService.querySnsProjects();
     const promise2 = snsAggregatorApiService.querySnsProjects();

--- a/frontend/src/tests/lib/api-services/sns-aggregator.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/sns-aggregator.api-service.spec.ts
@@ -59,7 +59,7 @@ describe("sns-aggregator api-service", () => {
   it("should call api once for simultaneous calls", async () => {
     const promise1 = snsAggregatorApiService.querySnsProjects();
     const promise2 = snsAggregatorApiService.querySnsProjects();
-    expect(promise1).toStrictEqual(promise2);
+    expect(promise1).toBe(promise2);
 
     resolveFn(successData);
     expect(await promise1).toEqual(successData);

--- a/frontend/src/tests/lib/api-services/sns-aggregator.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/sns-aggregator.api-service.spec.ts
@@ -1,0 +1,120 @@
+import {
+  clearSnsAggregatorCache,
+  snsAggregatorApiService,
+} from "$lib/api-services/sns-aggregator.api-service";
+import * as aggregatorApi from "$lib/api/sns-aggregator.api";
+import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
+import { blockAllCallsTo } from "$tests/utils/module.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+
+vi.mock("$lib/api/sns-aggregator.api");
+
+const blockedPaths = ["$lib/api/sns-aggregator.api"];
+
+describe("sns-aggregator api-service", () => {
+  blockAllCallsTo(blockedPaths);
+
+  beforeEach(() => {
+    clearSnsAggregatorCache();
+  });
+
+  describe("querySnsProjects succeeds", () => {
+    beforeEach(() => {
+      vi.spyOn(aggregatorApi, "querySnsProjects").mockImplementation(() =>
+        Promise.resolve([aggregatorSnsMockDto, aggregatorSnsMockDto])
+      );
+    });
+
+    it("should return cached data if it's not expired", async () => {
+      const result = await snsAggregatorApiService.querySnsProjects();
+      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+
+      await runResolvedPromises();
+
+      const result2 = await snsAggregatorApiService.querySnsProjects();
+      expect(result).toBe(result2);
+      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return call api once for two parallel calls", async () => {
+      const [result, result2] = await Promise.all([
+        snsAggregatorApiService.querySnsProjects(),
+        snsAggregatorApiService.querySnsProjects(),
+      ]);
+
+      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+      expect(result).toBe(result2);
+    });
+
+    it("should call api once for simultaneous calls", async () => {
+      const promise1 = snsAggregatorApiService.querySnsProjects();
+      const promise2 = snsAggregatorApiService.querySnsProjects();
+      expect(promise1).toStrictEqual(promise2);
+      expect(await promise1).toEqual([
+        aggregatorSnsMockDto,
+        aggregatorSnsMockDto,
+      ]);
+      expect(await promise2).toEqual([
+        aggregatorSnsMockDto,
+        aggregatorSnsMockDto,
+      ]);
+      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+    });
+
+    it("should expire its cache after 5 minutes", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2020-8-1 21:55:00"));
+
+      const result = await snsAggregatorApiService.querySnsProjects();
+      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+
+      vi.setSystemTime(new Date("2020-8-1 21:59:59"));
+
+      const result2 = await snsAggregatorApiService.querySnsProjects();
+      expect(result).toBe(result2);
+      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+
+      vi.setSystemTime(new Date("2020-8-1 22:00:01"));
+
+      const result3 = await snsAggregatorApiService.querySnsProjects();
+      expect(result).not.toBe(result3);
+      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("querySnsProjects fails", () => {
+    beforeEach(() => {
+      vi.spyOn(aggregatorApi, "querySnsProjects")
+        .mockRejectedValueOnce(new Error("test"))
+        .mockResolvedValue([aggregatorSnsMockDto, aggregatorSnsMockDto]);
+    });
+
+    it("should invalidate cache if querySnsProjects fails", async () => {
+      const failCall = () => snsAggregatorApiService.querySnsProjects();
+      expect(failCall).rejects.toThrow();
+      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+
+      await runResolvedPromises();
+
+      const result = await snsAggregatorApiService.querySnsProjects();
+      expect(result).toEqual([aggregatorSnsMockDto, aggregatorSnsMockDto]);
+      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(2);
+    });
+
+    it("should use cached error until promise resolves", async () => {
+      const failCall = () => snsAggregatorApiService.querySnsProjects();
+      expect(failCall).rejects.toThrow();
+      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+
+      const failCallAgain = () => snsAggregatorApiService.querySnsProjects();
+      expect(failCallAgain).rejects.toThrow();
+      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+
+      await runResolvedPromises();
+
+      const result = await snsAggregatorApiService.querySnsProjects();
+      expect(result).toEqual([aggregatorSnsMockDto, aggregatorSnsMockDto]);
+      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/frontend/src/tests/lib/api-services/sns-aggregator.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/sns-aggregator.api-service.spec.ts
@@ -3,9 +3,9 @@ import {
   snsAggregatorApiService,
 } from "$lib/api-services/sns-aggregator.api-service";
 import * as aggregatorApi from "$lib/api/sns-aggregator.api";
+import type { CachedSnsDto } from "$lib/types/sns-aggregator";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
-import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 
 vi.mock("$lib/api/sns-aggregator.api");
 
@@ -14,107 +14,115 @@ const blockedPaths = ["$lib/api/sns-aggregator.api"];
 describe("sns-aggregator api-service", () => {
   blockAllCallsTo(blockedPaths);
 
+  const successData = [aggregatorSnsMockDto, aggregatorSnsMockDto];
+  let resolveFn = undefined;
+  let rejectFn = undefined;
+
   beforeEach(() => {
     clearSnsAggregatorCache();
+    vi.useRealTimers();
+    resolveFn = undefined;
+    rejectFn = undefined;
+    vi.spyOn(aggregatorApi, "querySnsProjects").mockImplementation(
+      () =>
+        new Promise<CachedSnsDto[]>((r, rej) => {
+          resolveFn = r;
+          rejectFn = rej;
+        })
+    );
   });
 
-  describe("querySnsProjects succeeds", () => {
-    beforeEach(() => {
-      vi.spyOn(aggregatorApi, "querySnsProjects").mockImplementation(() =>
-        Promise.resolve([aggregatorSnsMockDto, aggregatorSnsMockDto])
-      );
-    });
+  it("should return cached data if it's not expired", async () => {
+    const promise1 = snsAggregatorApiService.querySnsProjects();
+    resolveFn(successData);
+    const result1 = await promise1;
+    expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
 
-    it("should return cached data if it's not expired", async () => {
-      const result = await snsAggregatorApiService.querySnsProjects();
-      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
-
-      await runResolvedPromises();
-
-      const result2 = await snsAggregatorApiService.querySnsProjects();
-      expect(result).toBe(result2);
-      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
-    });
-
-    it("should return call api once for two parallel calls", async () => {
-      const [result, result2] = await Promise.all([
-        snsAggregatorApiService.querySnsProjects(),
-        snsAggregatorApiService.querySnsProjects(),
-      ]);
-
-      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
-      expect(result).toBe(result2);
-    });
-
-    it("should call api once for simultaneous calls", async () => {
-      const promise1 = snsAggregatorApiService.querySnsProjects();
-      const promise2 = snsAggregatorApiService.querySnsProjects();
-      expect(promise1).toStrictEqual(promise2);
-      expect(await promise1).toEqual([
-        aggregatorSnsMockDto,
-        aggregatorSnsMockDto,
-      ]);
-      expect(await promise2).toEqual([
-        aggregatorSnsMockDto,
-        aggregatorSnsMockDto,
-      ]);
-      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
-    });
-
-    it("should expire its cache after 5 minutes", async () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date("2020-8-1 21:55:00"));
-
-      const result = await snsAggregatorApiService.querySnsProjects();
-      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
-
-      vi.setSystemTime(new Date("2020-8-1 21:59:59"));
-
-      const result2 = await snsAggregatorApiService.querySnsProjects();
-      expect(result).toBe(result2);
-      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
-
-      vi.setSystemTime(new Date("2020-8-1 22:00:01"));
-
-      const result3 = await snsAggregatorApiService.querySnsProjects();
-      expect(result).not.toBe(result3);
-      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(2);
-    });
+    const result2 = await snsAggregatorApiService.querySnsProjects();
+    expect(result1).toBe(result2);
+    expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
   });
 
-  describe("querySnsProjects fails", () => {
-    beforeEach(() => {
-      vi.spyOn(aggregatorApi, "querySnsProjects")
-        .mockRejectedValueOnce(new Error("test"))
-        .mockResolvedValue([aggregatorSnsMockDto, aggregatorSnsMockDto]);
-    });
+  it("should return call api once for two parallel calls", async () => {
+    const [promise1, promise2] = [
+      snsAggregatorApiService.querySnsProjects(),
+      snsAggregatorApiService.querySnsProjects(),
+    ];
 
-    it("should invalidate cache if querySnsProjects fails", async () => {
-      const failCall = () => snsAggregatorApiService.querySnsProjects();
-      expect(failCall).rejects.toThrow();
-      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+    resolveFn(successData);
+    const [result1, result2] = await Promise.all([promise1, promise2]);
 
-      await runResolvedPromises();
+    expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+    expect(result1).toBe(result2);
+  });
 
-      const result = await snsAggregatorApiService.querySnsProjects();
-      expect(result).toEqual([aggregatorSnsMockDto, aggregatorSnsMockDto]);
-      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(2);
-    });
+  it("should call api once for simultaneous calls", async () => {
+    const promise1 = snsAggregatorApiService.querySnsProjects();
+    const promise2 = snsAggregatorApiService.querySnsProjects();
+    expect(promise1).toStrictEqual(promise2);
 
-    it("should use cached error until promise resolves", async () => {
-      const failCall = () => snsAggregatorApiService.querySnsProjects();
-      expect(failCall).rejects.toThrow();
-      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+    resolveFn(successData);
+    expect(await promise1).toEqual(successData);
+    expect(await promise2).toEqual(successData);
+    expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+  });
 
-      const failCallAgain = () => snsAggregatorApiService.querySnsProjects();
-      expect(failCallAgain).rejects.toThrow();
-      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+  it("should expire its cache after 5 minutes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2020-8-1 21:55:00"));
 
-      await runResolvedPromises();
+    const promise1 = snsAggregatorApiService.querySnsProjects();
 
-      const result = await snsAggregatorApiService.querySnsProjects();
-      expect(result).toEqual([aggregatorSnsMockDto, aggregatorSnsMockDto]);
-      expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(2);
-    });
+    resolveFn(successData);
+    const result = await promise1;
+    expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date("2020-8-1 21:59:59"));
+
+    const result2 = await snsAggregatorApiService.querySnsProjects();
+    expect(result).toBe(result2);
+    expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date("2020-8-1 22:00:01"));
+
+    const promise3 = snsAggregatorApiService.querySnsProjects();
+
+    resolveFn([aggregatorSnsMockDto]);
+    const result3 = await promise3;
+    expect(result).not.toBe(result3);
+    expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(2);
+  });
+
+  it("should invalidate cache if querySnsProjects fails", async () => {
+    const promise1 = snsAggregatorApiService.querySnsProjects();
+    const err = new Error("test 1");
+    rejectFn(err);
+    await expect(promise1).rejects.toThrow(err);
+
+    expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+
+    const promise2 = snsAggregatorApiService.querySnsProjects();
+    resolveFn(successData);
+    expect(await promise2).toEqual(successData);
+    expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(2);
+  });
+
+  it("should use cached error until promise resolves", async () => {
+    const promise1 = snsAggregatorApiService.querySnsProjects();
+    const promise2 = snsAggregatorApiService.querySnsProjects();
+
+    const err = new Error("test 1");
+    rejectFn(err);
+    await expect(promise2).rejects.toThrow(err);
+    await expect(promise1).rejects.toThrow(err);
+    expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(1);
+
+    const promise3 = snsAggregatorApiService.querySnsProjects();
+    resolveFn(successData);
+    expect(await promise3).toEqual([
+      aggregatorSnsMockDto,
+      aggregatorSnsMockDto,
+    ]);
+    expect(aggregatorApi.querySnsProjects).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/tests/lib/services/_public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns.services.spec.ts
@@ -1,3 +1,4 @@
+import { clearSnsAggregatorCache } from "$lib/api-services/sns-aggregator.api-service";
 import * as agent from "$lib/api/agent.api";
 import * as aggregatorApi from "$lib/api/sns-aggregator.api";
 import * as governanceApi from "$lib/api/sns-governance.api";
@@ -81,6 +82,7 @@ describe("SNS public services", () => {
 
   beforeEach(() => {
     tokensStore.reset();
+    clearSnsAggregatorCache();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 

--- a/frontend/src/tests/lib/services/app.services.spec.ts
+++ b/frontend/src/tests/lib/services/app.services.spec.ts
@@ -1,3 +1,4 @@
+import { clearSnsAggregatorCache } from "$lib/api-services/sns-aggregator.api-service";
 import * as agent from "$lib/api/agent.api";
 import * as aggregatorApi from "$lib/api/sns-aggregator.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
@@ -21,6 +22,7 @@ describe("app-services", () => {
     resetIdentity();
     toastsStore.reset();
     vi.clearAllMocks();
+    clearSnsAggregatorCache();
     vi.spyOn(LedgerCanister, "create").mockImplementation(
       (): LedgerCanister => mockLedgerCanister
     );


### PR DESCRIPTION
# Motivation

Requests to the aggregator happens twice during a short time and that triggers extra unnecessary calls.

In this PR, I introduce the SNS Aggregator API Service similar to the Governance API Service to cache calls and avoiding hitting the network unnecessarily.

# Changes

* Add a sns-aggregator api service.
* Use the sns-aggregator api service instead of the service directly in `loadSnsProjects.

# Tests

* Add a test for the sns-aggregator api service.
* Clear the sns aggregator api service after every test in sns.services and app.services spec files.

# Todos

- [x] Add entry to changelog (if necessary).
