### PR TITLE
NNS1-2849: Remove unused code from SnsIncreaseStakeNeuronModal

### DIFF
--- a/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
+++ b/frontend/src/lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte
@@ -5,8 +5,7 @@
   import type { WizardStep } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
   import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
-  import { createEventDispatcher, onMount } from "svelte";
-  import { loadSnsAccounts } from "$lib/services/sns-accounts.services";
+  import { createEventDispatcher } from "svelte";
   import { nonNullish } from "@dfinity/utils";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { toastsSuccess } from "$lib/stores/toasts.store";
@@ -31,21 +30,6 @@
     currentStep?.name === "Form"
       ? $i18n.neurons.top_up_neuron
       : $i18n.accounts.review_transaction;
-
-  onMount(async () => {
-    if (transactionFee !== undefined && governanceCanisterId !== undefined) {
-      return;
-    }
-
-    startBusy({
-      initiator: "load-sns-accounts",
-    });
-
-    await loadSnsAccounts({
-      rootCanisterId,
-      handleError: () => stopBusySpinner(),
-    });
-  });
 
   const dispatcher = createEventDispatcher();
   const increaseStake = async ({
@@ -84,25 +68,10 @@
 
   let transactionFee: TokenAmountV2 | undefined = undefined;
   $: transactionFee = toTokenAmountV2($snsSelectedTransactionFeeStore);
-
-  let loading = true;
-  $: loading =
-    transactionFee === undefined || governanceCanisterId === undefined;
-
-  const stopBusySpinner = () => stopBusy("load-sns-accounts");
-
-  $: loading,
-    (() => {
-      if (loading) {
-        return;
-      }
-
-      stopBusySpinner();
-    })();
 </script>
 
 <TestIdWrapper testId="sns-increase-stake-neuron-modal-component">
-  {#if !loading && nonNullish(governanceCanisterId) && nonNullish(transactionFee)}
+  {#if nonNullish(governanceCanisterId) && nonNullish(transactionFee)}
     <SnsNeuronTransactionModal
       {rootCanisterId}
       on:nnsSubmit={increaseStake}

--- a/frontend/src/tests/lib/modals/sns/SnsIncreaseStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/SnsIncreaseStakeNeuronModal.spec.ts
@@ -1,8 +1,6 @@
 import { AppPath } from "$lib/constants/routes.constants";
 import SnsIncreaseStakeNeuronModal from "$lib/modals/sns/neurons/SnsIncreaseStakeNeuronModal.svelte";
-import { loadSnsAccounts } from "$lib/services/sns-accounts.services";
 import { increaseStakeNeuron } from "$lib/services/sns-neurons.services";
-import { startBusy } from "$lib/stores/busy.store";
 import { snsAccountsStore } from "$lib/stores/sns-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
@@ -22,12 +20,7 @@ import {
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { ICPToken } from "@dfinity/utils";
-import {
-  fireEvent,
-  render,
-  waitFor,
-  type RenderResult,
-} from "@testing-library/svelte";
+import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 
 vi.mock("$lib/services/sns-neurons.services", () => {
@@ -80,37 +73,6 @@ describe("SnsIncreaseStakeNeuronModal", () => {
       data: { universe: rootCanisterId.toText() },
     });
     setSnsProjects([snsProjectParams]);
-  });
-
-  describe("accounts and params are not loaded", () => {
-    beforeEach(() => {
-      snsAccountsStore.reset();
-      tokensStore.reset();
-    });
-
-    it("should not display modal", async () => {
-      const { container } = await render(SnsIncreaseStakeNeuronModal, {
-        props,
-      });
-
-      expect(container.querySelector("div.modal")).toBeNull();
-    });
-
-    it("should call sync sns accounts on init", async () => {
-      await render(SnsIncreaseStakeNeuronModal, {
-        props,
-      });
-
-      expect(loadSnsAccounts).toBeCalled();
-    });
-
-    it("should display a spinner on init", async () => {
-      await render(SnsIncreaseStakeNeuronModal, {
-        props,
-      });
-
-      expect(startBusy).toHaveBeenCalled();
-    });
   });
 
   describe("accounts and params are loaded", () => {


### PR DESCRIPTION
# Motivation

SnsIncreaseStakeNeuronModal has code to call `loadSnsAccounts` but only if `transactionFee` or `governanceCanisterId` is not available. Both of these come from the aggregator data, which is always loaded on app init. And even if they weren't, calling `loadSnsAccounts` doesn't load the token or the project.

Previously, it would call `syncSnsAccount`, which would at least load the SNS token as well, but that was changed because we always have the SNS token from the aggregator data.

And the accounts are already loaded on the `SnsNeuronDetail` before you can open the `SnsIncreaseStakeNeuronModal`, and even if they weren't, the current code would never call `loadSnsAccounts` because it doesn't check if the accounts are loaded or not, and only checks `transactionFee` and `governanceCanisterId` which are always there because they come from the aggregator data.

# Changes

Remove the code that never triggers and that wouldn't be useful even if it did trigger.

# Tests

Remove the corresponding tests.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary