### PR TITLE
Chore: Upgrade Rust

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -57,6 +57,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Update the GitHub `build-push-action` from `v4` to `v5`.
+* Upgrade Rust to 1.76.0
 
 #### Deprecated
 

--- a/rs/sns_aggregator/src/fast_scheduler.rs
+++ b/rs/sns_aggregator/src/fast_scheduler.rs
@@ -53,7 +53,7 @@ impl FastScheduler {
     fn needs_update_iter(
         sns_cache: &'_ SnsCache,
         time_now_seconds: u64,
-    ) -> impl Iterator<Item = Option<&'_ SnsIndex>> + Sized + DoubleEndedIterator {
+    ) -> impl Sized + DoubleEndedIterator<Item = Option<&'_ SnsIndex>> {
         sns_cache.all_sns.iter().map(move |(index, canister_ids)| {
             let needs_update = canister_ids
                 .root_canister_id

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Please, from time to time, update this to the latest stable version on Rust Forge: https://forge.rust-lang.org/
-channel = "1.75.0"
+channel = "1.76.0"
 components = ["rustfmt", "clippy"]
 targets = [ "wasm32-unknown-unknown"]


### PR DESCRIPTION
# Motivation

Keep dependencies up to date.

In this PR, upgrade Rust to 1.76.0

# Changes

* Upgrade Rust.
* Fix lint issue.

# Tests

Still passing.

# Todos

- [ ] Add entry to changelog (if necessary).

