### PR TITLE
Chore: Remove unnecessary busy screens

### DIFF
--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -4,8 +4,6 @@
   import { Checkbox } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
   import type { Filter, SnsProposalTypeFilterId } from "$lib/types/filters";
-  import { onMount } from "svelte";
-  import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { isNullish } from "@dfinity/utils";
   import type {
     SnsProposalDecisionStatus,
@@ -30,21 +28,6 @@
 
   let loading: boolean;
   $: loading = isNullish(filters);
-
-  onMount(() => {
-    if (isNullish(filters)) {
-      startBusy({
-        initiator: "load-sns-filters",
-      });
-    }
-  });
-
-  $: loading,
-    (() => {
-      if (!loading) {
-        stopBusy("load-sns-accounts");
-      }
-    })();
 
   const dispatch = createEventDispatcher();
   const close = () => dispatch("nnsClose");
@@ -119,6 +102,10 @@
         {$i18n.core.filter}
       </button>
     </svelte:fragment>
+  </Modal>
+{:else}
+  <Modal {visible} on:nnsClose role="alert" testId="filter-modal">
+    <Spinner />
   </Modal>
 {/if}
 

--- a/frontend/src/lib/modals/common/FilterModal.svelte
+++ b/frontend/src/lib/modals/common/FilterModal.svelte
@@ -105,7 +105,10 @@
   </Modal>
 {:else}
   <Modal {visible} on:nnsClose role="alert" testId="filter-modal">
-    <Spinner />
+    <slot slot="title" name="title" />
+    <div class="spinner-wrapper">
+      <Spinner />
+    </div>
   </Modal>
 {/if}
 
@@ -121,5 +124,10 @@
     gap: var(--padding);
 
     margin: 0 var(--padding-2x);
+  }
+
+  .spinner-wrapper {
+    // Only to look good in the modal
+    min-height: 200px;
   }
 </style>

--- a/frontend/src/lib/stores/busy.store.ts
+++ b/frontend/src/lib/stores/busy.store.ts
@@ -41,11 +41,9 @@ export type BusyStateInitiatorType =
   | "add-sns-followee"
   | "remove-sns-followee"
   | "disburse-sns-neuron"
-  | "load-sns-filters"
   | "dev-add-sns-neuron-permissions"
   | "dev-add-sns-neuron-maturity"
   | "dev-add-nns-neuron-maturity"
-  | "load-sns-accounts"
   | "update-ckbtc-balance"
   | "reload-receive-account";
 

--- a/frontend/src/tests/lib/modals/common/FilterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/common/FilterModal.spec.ts
@@ -36,6 +36,14 @@ describe("FilterModal", () => {
     );
   });
 
+  it("should render a modal with spinner if filters are not loaded", () => {
+    const { queryByTestId } = render(FilterModal, {
+      props: { visible: true, filters: undefined },
+    });
+
+    expect(queryByTestId("spinner")).toBeInTheDocument();
+  });
+
   it("should forward close modal event", () =>
     new Promise<void>((done) => {
       const { queryByTestId, component } = render(FilterModal, {


### PR DESCRIPTION
# Motivation

Clean up unused code.

Looking at unused busy screen initiators a bug was found because the busy screen started was not the same being stopped in the FilterModal.

The bug was never encountered because the filters were always present when rendering the FilterModal.

Yet, in this PR we use a different approach and remove the unused initiators. Instead of showing a whole busy screen that won't allow the user to do anything, we show a spinner within a modal.

# Changes

* Remove using busy screens in FilterModal and instead render a modal component with a spinner if the filters are not present.

# Tests

* Add a test when the filters are not present.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.

