### PR TITLE
Remove cron for app deploy

### DIFF
--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -1,11 +1,6 @@
 # App deployments are non-production deployments to mainnet.  They are public, can be used as staging, but e.g. funds are real.
 name: Deploy to app
 on:
-  schedule:
-    # Run every Wednesday:
-    # Summer: 11 am Zurich time
-    # Winter: noon Zurich time
-    - cron: '0 10 * * 3'
   push:
     branches:
       - "deploy-to-app"

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -55,6 +55,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Removed
 
+* Remove periodic app subnet deployment of nns-dapp.
+
 #### Fixed
 
 #### Security


### PR DESCRIPTION
# Motivation

We have a workflow to release nns-dapp to an app subnet.
We don't use it often, and when we do, we use the manual dispatch.
Most of the time, the app is out of cycles.
No need to waste cycles on weekly deploys that we don't use.

# Changes

Remove the scheduled deploy and only leave the manual deploy trigger.

# Tests

no

# Todos

- [x] Add entry to changelog (if necessary).
