### PR TITLE
NNS1-2852: Remove getIcrcAccount and move getSnsAccounts

### DIFF
--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -1,21 +1,15 @@
 import { createAgent } from "$lib/api/agent.api";
 import type { SubAccountArray } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { HOST } from "$lib/constants/environment.constants";
-import type { Account, AccountType } from "$lib/types/account";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import { LedgerErrorKey } from "$lib/types/ledger.errors";
 import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import { mapOptionalToken } from "$lib/utils/icrc-tokens.utils";
 import type { Agent, Identity } from "@dfinity/agent";
-import type {
-  BalanceParams,
-  IcrcTokenMetadataResponse,
-  IcrcTokens,
-} from "@dfinity/ledger-icrc";
+import type { IcrcTokenMetadataResponse } from "@dfinity/ledger-icrc";
 import {
   IcrcLedgerCanister,
-  encodeIcrcAccount,
   type IcrcAccount,
   type IcrcBlockIndex,
   type TransferParams,
@@ -27,37 +21,7 @@ import {
   isNullish,
   nonNullish,
   toNullable,
-  uint8ArrayToArrayOfNumber,
 } from "@dfinity/utils";
-
-/**
- * @deprecated replace with getAccount function of wallet-ledger.api
- */
-export const getIcrcAccount = async ({
-  owner,
-  subaccount,
-  certified,
-  type,
-  getBalance,
-}: {
-  type: AccountType;
-  getBalance: (params: BalanceParams) => Promise<IcrcTokens>;
-} & IcrcAccount &
-  QueryParams): Promise<Account> => {
-  const account = { owner, subaccount };
-
-  const balanceUlps = await getBalance({ ...account, certified });
-
-  return {
-    identifier: encodeIcrcAccount(account),
-    principal: owner,
-    ...(nonNullish(subaccount) && {
-      subAccount: uint8ArrayToArrayOfNumber(new Uint8Array(subaccount)),
-    }),
-    balanceUlps,
-    type,
-  };
-};
 
 /**
  * @deprecated use queryIcrcToken

--- a/frontend/src/lib/api/sns-ledger.api.ts
+++ b/frontend/src/lib/api/sns-ledger.api.ts
@@ -1,28 +1,27 @@
 import {
-  getIcrcAccount,
   getIcrcToken,
   executeIcrcTransfer as transferIcrcApi,
   type IcrcTransferParams,
 } from "$lib/api/icrc-ledger.api";
-import type { Account } from "$lib/types/account";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import type { Identity } from "@dfinity/agent";
-import type { IcrcBlockIndex } from "@dfinity/ledger-icrc";
+import type { IcrcAccount, IcrcBlockIndex } from "@dfinity/ledger-icrc";
 import type { Principal } from "@dfinity/principal";
 import { wrapper } from "./sns-wrapper.api";
 
-export const getSnsAccounts = async ({
+export const querySnsBalance = async ({
   rootCanisterId,
   identity,
   certified,
+  account,
 }: {
   rootCanisterId: Principal;
   identity: Identity;
   certified: boolean;
-}): Promise<Account[]> => {
-  // TODO: Support subaccounts
-  logWithTimestamp("Getting sns accounts: call...");
+  account: IcrcAccount;
+}): Promise<bigint> => {
+  logWithTimestamp("Getting sns balance: call...");
 
   const { balance: getBalance } = await wrapper({
     identity,
@@ -30,16 +29,11 @@ export const getSnsAccounts = async ({
     certified,
   });
 
-  const mainAccount = await getIcrcAccount({
-    owner: identity.getPrincipal(),
-    type: "main",
-    certified,
-    getBalance,
-  });
+  const balance = await getBalance({ ...account });
 
-  logWithTimestamp("Getting sns accounts: done");
+  logWithTimestamp("Getting sns balance: done");
 
-  return [mainAccount];
+  return balance;
 };
 
 export const getSnsToken = async ({

--- a/frontend/src/tests/fakes/sns-ledger-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-ledger-api.fake.ts
@@ -76,7 +76,7 @@ const reset = () => {
   balances.clear();
 };
 
-export const addBalanceFor = ({
+export const setBalanceFor = ({
   identity = mockIdentity,
   rootCanisterId,
   balanceUlps,

--- a/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
@@ -2,7 +2,6 @@ import * as agent from "$lib/api/agent.api";
 import {
   approveTransfer,
   executeIcrcTransfer,
-  getIcrcAccount,
   getIcrcToken,
   icrcTransfer,
   queryIcrcBalance,
@@ -34,46 +33,6 @@ describe("icrc-ledger api", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe("getIcrcMainAccount", () => {
-    it("returns main account with balance and project token metadata", async () => {
-      const balanceSpy = vi.fn().mockResolvedValue(10_000_000n);
-
-      const account = await getIcrcAccount({
-        certified: true,
-        owner: mockIdentity.getPrincipal(),
-        type: "main",
-        getBalance: balanceSpy,
-      });
-
-      expect(account).not.toBeUndefined();
-
-      expect(account.balanceUlps).toEqual(10_000_000n);
-
-      expect(account.principal.toText()).toEqual(
-        mockIdentity.getPrincipal().toText()
-      );
-      expect(account.type).toEqual("main");
-
-      expect(balanceSpy).toBeCalled();
-    });
-
-    it("throws an error if no balance", () => {
-      const balanceSpy = async () => {
-        throw new Error();
-      };
-
-      const call = () =>
-        getIcrcAccount({
-          certified: true,
-          owner: mockIdentity.getPrincipal(),
-          type: "main",
-          getBalance: balanceSpy,
-        });
-
-      expect(call).rejects.toThrowError();
-    });
   });
 
   describe("getIcrcToken", () => {

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -26,6 +26,7 @@ import {
   mockAuthStoreSubscribe,
   mockIdentity,
 } from "$tests/mocks/auth.store.mock";
+import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import {
   createMockSnsNeuron,
   mockSnsNeuron,
@@ -78,9 +79,9 @@ describe("SnsNeuronDetail", () => {
       },
     ]);
 
-    fakeSnsLedgerApi.addAccountWith({
+    fakeSnsLedgerApi.addBalanceFor({
       rootCanisterId,
-      principal: mockIdentity.getPrincipal(),
+      balanceUlps: mockSnsMainAccount.balanceUlps,
     });
 
     page.mock({

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -79,7 +79,7 @@ describe("SnsNeuronDetail", () => {
       },
     ]);
 
-    fakeSnsLedgerApi.addBalanceFor({
+    fakeSnsLedgerApi.setBalanceFor({
       rootCanisterId,
       balanceUlps: mockSnsMainAccount.balanceUlps,
     });

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -59,9 +59,9 @@ describe("SnsNeurons", () => {
     vi.clearAllMocks();
     page.mock({ data: { universe: rootCanisterId.toText() } });
     resetIdentity();
-    vi.spyOn(ledgerApi, "getSnsAccounts").mockResolvedValue([
-      mockSnsMainAccount,
-    ]);
+    vi.spyOn(ledgerApi, "querySnsBalance").mockResolvedValue(
+      mockSnsMainAccount.balanceUlps
+    );
     vi.spyOn(ledgerApi, "getSnsToken").mockResolvedValue(mockSnsToken);
     vi.spyOn(ledgerApi, "transactionFee").mockResolvedValue(10_000n);
     snsParametersStore.setParameters({

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -10,6 +10,7 @@ import * as fakeSnsAggregatorApi from "$tests/fakes/sns-aggregator-api.fake";
 import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
 import * as fakeSnsLedgerApi from "$tests/fakes/sns-ledger-api.fake";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { NeuronsPo } from "$tests/page-objects/Neurons.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import type { HttpAgent } from "@dfinity/agent";
@@ -47,8 +48,9 @@ describe("Neurons", () => {
     fakeSnsGovernanceApi.addNeuronWith({
       rootCanisterId: testOpenSnsCanisterId,
     });
-    fakeSnsLedgerApi.addAccountWith({
+    fakeSnsLedgerApi.addBalanceFor({
       rootCanisterId: testCommittedSnsCanisterId,
+      balanceUlps: mockSnsMainAccount.balanceUlps,
     });
 
     fakeSnsAggregatorApi.addProjectWith({

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -48,7 +48,7 @@ describe("Neurons", () => {
     fakeSnsGovernanceApi.addNeuronWith({
       rootCanisterId: testOpenSnsCanisterId,
     });
-    fakeSnsLedgerApi.addBalanceFor({
+    fakeSnsLedgerApi.setBalanceFor({
       rootCanisterId: testCommittedSnsCanisterId,
       balanceUlps: mockSnsMainAccount.balanceUlps,
     });

--- a/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
@@ -37,14 +37,14 @@ describe("sns-accounts-balance.services", () => {
     metadataCertified: false,
   };
 
-  it("should call api.getSnsAccounts and load balance in store", async () => {
+  it("should call api.querySnsBalance and load balance in store", async () => {
     vi.spyOn(ledgerApi, "getSnsToken").mockImplementation(() =>
       Promise.resolve(mockSnsToken)
     );
 
     const spyQuery = vi
-      .spyOn(ledgerApi, "getSnsAccounts")
-      .mockImplementation(() => Promise.resolve([mockSnsMainAccount]));
+      .spyOn(ledgerApi, "querySnsBalance")
+      .mockResolvedValue(mockSnsMainAccount.balanceUlps);
 
     await services.uncertifiedLoadSnsesAccountsBalances({
       rootCanisterIds: [mockSnsMainAccount.principal],
@@ -63,7 +63,7 @@ describe("sns-accounts-balance.services", () => {
 
   it("should toast error", async () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.spyOn(ledgerApi, "getSnsAccounts").mockRejectedValue(new Error());
+    vi.spyOn(ledgerApi, "querySnsBalance").mockRejectedValue(new Error());
 
     await services.uncertifiedLoadSnsesAccountsBalances({
       rootCanisterIds: [mockSnsMainAccount.principal],

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -33,10 +33,10 @@ describe("sns-accounts-services", () => {
       vi.spyOn(console, "error").mockImplementation(() => undefined);
     });
 
-    it("should call api.getSnsAccounts and load neurons in store", async () => {
+    it("should call api.querySnsBalance and load neurons in store", async () => {
       const spyQuery = vi
-        .spyOn(ledgerApi, "getSnsAccounts")
-        .mockImplementation(() => Promise.resolve([mockSnsMainAccount]));
+        .spyOn(ledgerApi, "querySnsBalance")
+        .mockResolvedValue(mockSnsMainAccount.balanceUlps);
 
       await services.loadSnsAccounts({ rootCanisterId: mockPrincipal });
 
@@ -58,10 +58,10 @@ describe("sns-accounts-services", () => {
       spyQuery.mockClear();
     });
 
-    it("should call api.getSnsAccounts with only the strategy passed", async () => {
+    it("should call api.querySnsBalance with only the strategy passed", async () => {
       const spyQuery = vi
-        .spyOn(ledgerApi, "getSnsAccounts")
-        .mockImplementation(() => Promise.resolve([mockSnsMainAccount]));
+        .spyOn(ledgerApi, "querySnsBalance")
+        .mockResolvedValue(mockSnsMainAccount.balanceUlps);
 
       await services.loadSnsAccounts({
         rootCanisterId: mockPrincipal,
@@ -83,7 +83,7 @@ describe("sns-accounts-services", () => {
 
     it("should call error callback", async () => {
       const spyQuery = vi
-        .spyOn(ledgerApi, "getSnsAccounts")
+        .spyOn(ledgerApi, "querySnsBalance")
         .mockRejectedValue(new Error());
 
       const spy = vi.fn();
@@ -100,10 +100,10 @@ describe("sns-accounts-services", () => {
 
     it("should not call error callback if query fails and update succeeds", async () => {
       const spyQuery = vi
-        .spyOn(ledgerApi, "getSnsAccounts")
+        .spyOn(ledgerApi, "querySnsBalance")
         .mockImplementation(async ({ certified }) => {
           if (certified) {
-            return [mockSnsMainAccount];
+            return mockSnsMainAccount.balanceUlps;
           }
           throw new Error();
         });
@@ -122,7 +122,7 @@ describe("sns-accounts-services", () => {
 
     it("should call error callback if query fails and only query is requested", async () => {
       const spyQuery = vi
-        .spyOn(ledgerApi, "getSnsAccounts")
+        .spyOn(ledgerApi, "querySnsBalance")
         .mockRejectedValue(new Error());
 
       const spy = vi.fn();
@@ -153,8 +153,8 @@ describe("sns-accounts-services", () => {
       });
 
       const spyQuery = vi
-        .spyOn(ledgerApi, "getSnsAccounts")
-        .mockImplementation(() => Promise.reject(undefined));
+        .spyOn(ledgerApi, "querySnsBalance")
+        .mockRejectedValue(undefined);
 
       await services.loadSnsAccounts({ rootCanisterId: mockPrincipal });
 
@@ -177,8 +177,8 @@ describe("sns-accounts-services", () => {
       vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       spyAccounts = vi
-        .spyOn(ledgerApi, "getSnsAccounts")
-        .mockImplementation(() => Promise.resolve([mockSnsMainAccount]));
+        .spyOn(ledgerApi, "querySnsBalance")
+        .mockResolvedValue(mockSnsMainAccount.balanceUlps);
     });
 
     it("should call sns transfer tokens", async () => {

--- a/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts.services.spec.ts
@@ -48,11 +48,17 @@ describe("sns-accounts-services", () => {
         rootCanisterId: mockPrincipal,
         identity: mockIdentity,
         certified: false,
+        account: {
+          owner: mockIdentity.getPrincipal(),
+        },
       });
       expect(spyQuery).toBeCalledWith({
         rootCanisterId: mockPrincipal,
         identity: mockIdentity,
         certified: true,
+        account: {
+          owner: mockIdentity.getPrincipal(),
+        },
       });
 
       spyQuery.mockClear();
@@ -76,6 +82,9 @@ describe("sns-accounts-services", () => {
         rootCanisterId: mockPrincipal,
         identity: mockIdentity,
         certified: false,
+        account: {
+          owner: mockIdentity.getPrincipal(),
+        },
       });
 
       spyQuery.mockClear();

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -27,7 +27,6 @@ import {
 } from "$tests/mocks/ckbtc-accounts.mock";
 import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
-import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { TokensRoutePo } from "$tests/page-objects/TokensRoute.page-object";
@@ -133,22 +132,12 @@ describe("Tokens route", () => {
         }
       );
       vi.spyOn(snsLedgerApi, "snsTransfer").mockResolvedValue(undefined);
-      vi.spyOn(snsLedgerApi, "getSnsAccounts").mockImplementation(
+      vi.spyOn(snsLedgerApi, "querySnsBalance").mockImplementation(
         async ({ rootCanisterId }) => {
           if (rootCanisterId.toText() === rootCanisterIdTetris.toText()) {
-            return [
-              {
-                ...mockSnsMainAccount,
-                balanceUlps: tetrisBalanceE8s,
-              },
-            ];
+            return tetrisBalanceE8s;
           }
-          return [
-            {
-              ...mockSnsMainAccount,
-              balanceUlps: pacmanBalanceE8s,
-            },
-          ];
+          return pacmanBalanceE8s;
         }
       );
       vi.spyOn(icrcLedgerApi, "icrcTransfer").mockResolvedValue(1234n);


### PR DESCRIPTION
# Motivation

Unify wallet implementation.

In this PR, remove `getIcrcAccount` and move `getSnsAccounts` to a service.

Before, the `Account` was created at the api layer.

Now, the api layer exposes the function to get the balance and a service creates the `Account` type for SNSes.

# Changes

* Remove `getIcrcAccount` icrc-ledger api
* Move `getSnsAccounts` from sns-ledger api to sns-accounts services.
* Add api `querySnsBalance` in sns-ledger api.

# Tests

* Update sns-ledger-fake api.
* Update tests using sns-ledger-fake api.
* Remove test for `getIcrcAccount` in icrc-ledger api.
* Remove test for `getSnsAccounts` in sns-ledger api spec file.
* Add test for `querySnsBalance` in sns-ledger api spec file.
* Tests that mocked `getSnsAccounts` now mock `querySnsBalance`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
