### PR TITLE
Test that we show the project logo on the token wallet

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -39,6 +39,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+* Test that project logo (not token logo) is displayed on SNS wallet.
+
 #### Changed
 
 * Update the GitHub `build-push-action` from `v4` to `v5`.

--- a/frontend/src/lib/utils/universe.utils.ts
+++ b/frontend/src/lib/utils/universe.utils.ts
@@ -81,5 +81,6 @@ export const createUniverse = (summary: SnsSummary): Universe => ({
   canisterId: summary.rootCanisterId.toText(),
   summary,
   title: summary.metadata.name,
+  //logo: summary.token.logo,
   logo: summary.metadata.logo,
 });

--- a/frontend/src/lib/utils/universe.utils.ts
+++ b/frontend/src/lib/utils/universe.utils.ts
@@ -81,6 +81,5 @@ export const createUniverse = (summary: SnsSummary): Universe => ({
   canisterId: summary.rootCanisterId.toText(),
   summary,
   title: summary.metadata.name,
-  //logo: summary.token.logo,
   logo: summary.metadata.logo,
 });

--- a/frontend/src/tests/lib/pages/SnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsWallet.spec.ts
@@ -8,6 +8,7 @@ import * as workerBalances from "$lib/services/worker-balances.services";
 import * as workerTransactions from "$lib/services/worker-transactions.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
+import { aggregatorCanisterLogoPath } from "$lib/utils/sns-aggregator-converters.utils";
 import { page } from "$mocks/$app/stores";
 import AccountsTest from "$tests/lib/pages/AccountsTest.svelte";
 import WalletTest from "$tests/lib/pages/WalletTest.svelte";
@@ -452,6 +453,36 @@ describe("SnsWallet", () => {
 
       await runResolvedPromises();
       expect(await po.getWalletPageHeadingPo().getTitle()).toBe("4.56 OOO");
+    });
+
+    it("should use SNS project logo rather than token logo", async () => {
+      const tokenLogo = "http://token.logo";
+      const snsProjectLogo = aggregatorCanisterLogoPath(rootCanisterIdText);
+
+      setSnsProjects([
+        {
+          rootCanisterId,
+          ledgerCanisterId,
+          lifecycle: SnsSwapLifecycle.Committed,
+          projectName,
+          tokenMetadata: {
+            ...testToken,
+            logo: "http://token.logo",
+          },
+        },
+      ]);
+      const po = await renderComponent(props);
+
+      // This could be considered a bug because the wallet should be based on
+      // the token data rather than the project data. But before we fix this bug
+      // we want to make sure that SNSes have the ability to change the logo in
+      // their ledger canister metadata.
+      expect(
+        await po.getWalletPageHeaderPo().getUniversePageSummaryPo().getLogoUrl()
+      ).toBe(snsProjectLogo);
+      expect(
+        await po.getWalletPageHeaderPo().getUniversePageSummaryPo().getLogoUrl()
+      ).not.toBe(tokenLogo);
     });
   });
 });

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -40,8 +40,9 @@ const createQueryMetadataResponse = ({
   name,
   symbol,
   fee,
+  logo,
 }: Partial<
-  Pick<IcrcTokenMetadata, "name" | "symbol" | "fee">
+  Pick<IcrcTokenMetadata, "name" | "symbol" | "fee" | "logo">
 >): CachedSnsTokenMetadataDto =>
   mockQueryTokenResponse.map(([key, value]) => {
     if (key === IcrcMetadataResponseEntries.NAME) {
@@ -49,6 +50,9 @@ const createQueryMetadataResponse = ({
     }
     if (key === IcrcMetadataResponseEntries.SYMBOL) {
       return [key, { Text: symbol }];
+    }
+    if (key === IcrcMetadataResponseEntries.LOGO && "Text" in value) {
+      return [key, { Text: logo ?? value.Text }];
     }
     if (key === IcrcMetadataResponseEntries.DECIMALS && "Nat" in value) {
       return [key, { Nat: [Number(value.Nat)] }];

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -481,6 +481,7 @@ export const mockQueryTokenResponse: IcrcTokenMetadataResponse = [
   [IcrcMetadataResponseEntries.NAME, { Text: mockSnsToken.name }],
   [IcrcMetadataResponseEntries.SYMBOL, { Text: mockSnsToken.symbol }],
   [IcrcMetadataResponseEntries.FEE, { Nat: mockSnsToken.fee }],
+  [IcrcMetadataResponseEntries.LOGO, { Text: mockSnsToken.logo }],
 ];
 
 export const mockQueryMetadata: QuerySnsMetadata = {

--- a/frontend/src/tests/page-objects/UniversePageSummary.page-object.ts
+++ b/frontend/src/tests/page-objects/UniversePageSummary.page-object.ts
@@ -10,6 +10,13 @@ export class UniversePageSummaryPo extends BasePageObject {
     );
   }
 
+  async getLogoUrl(): Promise<string> {
+    return this.root
+      .byTestId("project-logo")
+      .querySelector("img")
+      .getAttribute("src");
+  }
+
   async getTitle(): Promise<string> {
     return (await this.getText()).trim();
   }

--- a/frontend/src/tests/page-objects/WalletPageHeader.page-object.ts
+++ b/frontend/src/tests/page-objects/WalletPageHeader.page-object.ts
@@ -10,8 +10,12 @@ export class WalletPageHeaderPo extends BasePageObject {
     return new WalletPageHeaderPo(element.byTestId(WalletPageHeaderPo.TID));
   }
 
+  getUniversePageSummaryPo(): UniversePageSummaryPo {
+    return UniversePageSummaryPo.under(this.root);
+  }
+
   getUniverse(): Promise<string> {
-    return UniversePageSummaryPo.under(this.root).getTitle();
+    return this.getUniversePageSummaryPo().getTitle();
   }
 
   getHashPo(): HashPo {


### PR DESCRIPTION
# Motivation

The SNS token logo in the ledger canister metadata can be different from the SNS project logo.
Currently in the wallet, we show the project logo but you could argue that we should show the token logo instead because the wallet is about tokens and also the wallet should probably act the same for SNS tokens as for non-SNS tokens.

But before we fix this, we want to make sure that SNSes can change their token logo if they want to.

So in this PR we add a test to make sure that we don't accidentally fix this until we should.

# Changes

1. Add a test to make sure the logo displayed on the SnsWallet is the project logo and not the token logo.
2. Support setting the token logo in `setSnsProjects`.
3. Support getting the token logo URL in page object.

# Tests

Tested by setting `logo: summary.token.logo` instead of `logo: summary.metadata.logo` in `frontend/src/lib/utils/universe.utils.ts` (as can be seen in the first commit) and seeing the test fail.

# Todos

- [x] Add entry to changelog (if necessary).
