### PR TITLE
Delete getSnsTokens

### DIFF
--- a/frontend/src/lib/api/dev.api.ts
+++ b/frontend/src/lib/api/dev.api.ts
@@ -24,7 +24,7 @@ import {
 } from "@dfinity/utils";
 import { createAgent } from "./agent.api";
 import { governanceCanister } from "./governance.api";
-import { initSns, wrapper } from "./sns-wrapper.api";
+import { wrapper } from "./sns-wrapper.api";
 
 export const testAccountPrincipal =
   "jg6qm-uw64t-m6ppo-oluwn-ogr5j-dc5pm-lgy2p-eh6px-hebcd-5v73i-nqe";
@@ -125,38 +125,6 @@ export const acquireICPTs = async ({
   return ledgerCanister.transfer({
     amount: e8s,
     to: AccountIdentifier.fromHex(accountIdentifier),
-  });
-};
-
-// TODO: Reuse the new `acquireIcrcTokens` instead of SNS specific function.
-export const acquireSnsTokens = async ({
-  account,
-  ulps,
-  rootCanisterId,
-}: {
-  account: Account;
-  ulps: bigint;
-  rootCanisterId: Principal;
-}): Promise<void> => {
-  assertTestnet();
-
-  const agent = await getTestAccountAgent();
-
-  const { transfer } = await initSns({
-    agent,
-    rootCanisterId,
-    certified: true,
-  });
-
-  await transfer({
-    amount: ulps,
-    to: {
-      owner: account.principal as Principal,
-      subaccount:
-        account.subAccount === undefined
-          ? []
-          : toNullable(arrayOfNumberToUint8Array(account.subAccount)),
-    },
   });
 };
 

--- a/frontend/src/lib/components/ic/GetTokensModal.svelte
+++ b/frontend/src/lib/components/ic/GetTokensModal.svelte
@@ -4,17 +4,12 @@
    */
   import { Dropdown, DropdownItem, Modal } from "@dfinity/gix-components";
   import Input from "$lib/components/ui/Input.svelte";
-  import {
-    getICPs,
-    getSnsTokens,
-    getBTC,
-    getIcrcTokens,
-  } from "$lib/services/dev.services";
+  import { getICPs, getBTC, getIcrcTokens } from "$lib/services/dev.services";
   import { Spinner } from "@dfinity/gix-components";
   import { toastsError } from "$lib/stores/toasts.store";
   import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
   import { Principal } from "@dfinity/principal";
-  import { nonNullish, type Token } from "@dfinity/utils";
+  import { isNullish, nonNullish, type Token } from "@dfinity/utils";
   import {
     getIcrcTokenTestAccountBalance,
     getTestIcpAccountBalance,
@@ -26,6 +21,7 @@
   import type { Universe } from "$lib/types/universe";
   import { universesStore } from "$lib/derived/universes.derived";
   import { tokensByUniverseIdStore } from "$lib/derived/tokens.derived";
+  import { snsLedgerCanisterIdsStore } from "$lib/derived/sns/sns-canisters.derived";
 
   let transferring = false;
 
@@ -109,10 +105,21 @@
               rootCanisterId.toText() === selectedUniverseId
           )
         ) {
-          await getSnsTokens({
-            tokens: inputValue,
-            rootCanisterId: Principal.fromText(selectedUniverseId),
-          });
+          const ledgerCanisterId =
+            $snsLedgerCanisterIdsStore[selectedUniverseId];
+          if (isNullish(selectedToken)) {
+            console.error(`token for ${selectedUniverseId} is undefined`);
+          } else if (isNullish(ledgerCanisterId)) {
+            console.error(
+              `ledgerCanisterId for ${selectedUniverseId} is undefined`
+            );
+          } else {
+            await getIcrcTokens({
+              tokens: inputValue,
+              token: selectedToken,
+              ledgerCanisterId,
+            });
+          }
         } else if (isUniverseCkBTC(selectedUniverseId)) {
           await getBTC({
             amount: inputValue,
@@ -148,7 +155,6 @@
     }
 
     transferring = false;
-    getSnsTokens;
   };
 
   const close = () => {


### PR DESCRIPTION
# Motivation

We have a test feature to get free tokens.
There is a function `getSnsTokens` to support this for SNS tokens.
But SNS tokens are just ICRC tokens so we can use `getIcrcTokens` instead.

# Changes

1. Add a derived store which maps root canister IDs to ledger canister IDs. (This will probably be used in more places to unify icrc accounts with sns accounts.)
2. Use `getIcrcTokens` instead of `getSnsTokens`.
3. Delete `getSnsTokens` and `acquireSnsTokens` which are now unused.

# Tests

Added a unit test for `snsLedgerCanisterIdsStore`.

Tested getting tokens (ckETH and SNS) manually.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary