### PR TITLE
Add snsLedgerCanisterIdsStore

### DIFF
--- a/frontend/src/lib/derived/sns/sns-canisters.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-canisters.derived.ts
@@ -1,0 +1,20 @@
+import { snsSummariesStore } from "$lib/stores/sns.store";
+import type { SnsSummary } from "$lib/types/sns";
+import type { Principal } from "@dfinity/principal";
+import { derived, type Readable } from "svelte/store";
+
+// Holds a Record mapping root canister ids ledger canister ids.
+export const snsLedgerCanisterIdsStore = derived<
+  Readable<SnsSummary[]>,
+  Record<string, Principal>
+>(
+  snsSummariesStore,
+  (summaries): Record<string, Principal> =>
+    summaries.reduce(
+      (acc, summary) => ({
+        ...acc,
+        [summary.rootCanisterId.toText()]: summary.ledgerCanisterId,
+      }),
+      {}
+    )
+);

--- a/frontend/src/tests/lib/derived/sns/sns-canisters.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-canisters.derived.spec.ts
@@ -1,0 +1,39 @@
+import { snsLedgerCanisterIdsStore } from "$lib/derived/sns/sns-canisters.derived";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { Principal } from "@dfinity/principal";
+import { get } from "svelte/store";
+
+describe("sns-canisters.derived", () => {
+  const batmanRootCanisterIdText = "aax3a-h4aaa-aaaaa-qaahq-cai";
+  const batmanRootCanisterId = Principal.fromText(batmanRootCanisterIdText);
+  const batmanLedgerCanisterIdText = "c2lt4-zmaaa-aaaaa-qaaiq-cai";
+  const batmanLedgerCanisterId = Principal.fromText(batmanLedgerCanisterIdText);
+  const robinRootCanisterIdText = "ctiya-peaaa-aaaaa-qaaja-cai";
+  const robinRootCanisterId = Principal.fromText(robinRootCanisterIdText);
+  const robinLedgerCanisterIdText = "cpmcr-yeaaa-aaaaa-qaala-cai";
+  const robinLedgerCanisterId = Principal.fromText(robinLedgerCanisterIdText);
+
+  beforeEach(() => {
+    resetSnsProjects();
+
+    setSnsProjects([
+      {
+        rootCanisterId: batmanRootCanisterId,
+        ledgerCanisterId: batmanLedgerCanisterId,
+      },
+      {
+        rootCanisterId: robinRootCanisterId,
+        ledgerCanisterId: robinLedgerCanisterId,
+      },
+    ]);
+  });
+
+  describe("snsLedgerCanisterIdsStore", () => {
+    it("should map root canister ids to ledger canister ids", () => {
+      expect(get(snsLedgerCanisterIdsStore)).toEqual({
+        [batmanRootCanisterIdText]: batmanLedgerCanisterId,
+        [robinRootCanisterIdText]: robinLedgerCanisterId,
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

In order to deprecate `snsAccountsStore` we'll need to know the ledger canister ID from the root canister ID in many places.

The `snsLedgerCanisterIdsStore` was introduced in https://github.com/dfinity/nns-dapp/pull/4477 but that PR is blocked because we still need to load SNS accounts after getting the tokens.

So I split this PR from that PR.

# Changes

Add a derived store which maps root canister IDs to ledger canister IDs.
This is not used yet.

# Tests

Add a unit test for the derived store.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary