### PR TITLE
NNS1-2852: Remove getIcrcToken

### DIFF
--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -7,7 +7,6 @@ import { nowInBigIntNanoSeconds } from "$lib/utils/date.utils";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
 import { mapOptionalToken } from "$lib/utils/icrc-tokens.utils";
 import type { Agent, Identity } from "@dfinity/agent";
-import type { IcrcTokenMetadataResponse } from "@dfinity/ledger-icrc";
 import {
   IcrcLedgerCanister,
   type IcrcAccount,
@@ -15,34 +14,12 @@ import {
   type TransferParams,
 } from "@dfinity/ledger-icrc";
 import type { Principal } from "@dfinity/principal";
-import type { QueryParams } from "@dfinity/utils";
 import {
   arrayOfNumberToUint8Array,
   isNullish,
   nonNullish,
   toNullable,
 } from "@dfinity/utils";
-
-/**
- * @deprecated use queryIcrcToken
- */
-export const getIcrcToken = async ({
-  certified,
-  getMetadata,
-}: {
-  certified: boolean;
-  getMetadata: (params: QueryParams) => Promise<IcrcTokenMetadataResponse>;
-}): Promise<IcrcTokenMetadata> => {
-  const metadata = await getMetadata({ certified });
-
-  const token = mapOptionalToken(metadata);
-
-  if (isNullish(token)) {
-    throw new LedgerErrorKey("error.icrc_token_load");
-  }
-
-  return token;
-};
 
 /**
  * Similar to `getIcrcToken` but it expects the canister id instead of the function that queries the metada.

--- a/frontend/src/lib/api/sns-ledger.api.ts
+++ b/frontend/src/lib/api/sns-ledger.api.ts
@@ -1,13 +1,15 @@
 import {
-  getIcrcToken,
   executeIcrcTransfer as transferIcrcApi,
   type IcrcTransferParams,
 } from "$lib/api/icrc-ledger.api";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
+import { LedgerErrorKey } from "$lib/types/ledger.errors";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
+import { mapOptionalToken } from "$lib/utils/icrc-tokens.utils";
 import type { Identity } from "@dfinity/agent";
 import type { IcrcAccount, IcrcBlockIndex } from "@dfinity/ledger-icrc";
 import type { Principal } from "@dfinity/principal";
+import { isNullish } from "@dfinity/utils";
 import { wrapper } from "./sns-wrapper.api";
 
 export const querySnsBalance = async ({
@@ -53,10 +55,13 @@ export const getSnsToken = async ({
     certified,
   });
 
-  const token = await getIcrcToken({
-    certified,
-    getMetadata,
-  });
+  const metadata = await getMetadata({});
+
+  const token = mapOptionalToken(metadata);
+
+  if (isNullish(token)) {
+    throw new LedgerErrorKey("error.icrc_token_load");
+  }
 
   logWithTimestamp("Getting sns token: done");
 

--- a/frontend/src/lib/api/sns-ledger.api.ts
+++ b/frontend/src/lib/api/sns-ledger.api.ts
@@ -2,14 +2,10 @@ import {
   executeIcrcTransfer as transferIcrcApi,
   type IcrcTransferParams,
 } from "$lib/api/icrc-ledger.api";
-import type { IcrcTokenMetadata } from "$lib/types/icrc";
-import { LedgerErrorKey } from "$lib/types/ledger.errors";
 import { logWithTimestamp } from "$lib/utils/dev.utils";
-import { mapOptionalToken } from "$lib/utils/icrc-tokens.utils";
 import type { Identity } from "@dfinity/agent";
 import type { IcrcAccount, IcrcBlockIndex } from "@dfinity/ledger-icrc";
 import type { Principal } from "@dfinity/principal";
-import { isNullish } from "@dfinity/utils";
 import { wrapper } from "./sns-wrapper.api";
 
 export const querySnsBalance = async ({
@@ -36,36 +32,6 @@ export const querySnsBalance = async ({
   logWithTimestamp("Getting sns balance: done");
 
   return balance;
-};
-
-export const getSnsToken = async ({
-  rootCanisterId,
-  identity,
-  certified,
-}: {
-  rootCanisterId: Principal;
-  identity: Identity;
-  certified: boolean;
-}): Promise<IcrcTokenMetadata> => {
-  logWithTimestamp("Getting sns token: call...");
-
-  const { ledgerMetadata: getMetadata } = await wrapper({
-    identity,
-    rootCanisterId: rootCanisterId.toText(),
-    certified,
-  });
-
-  const metadata = await getMetadata({});
-
-  const token = mapOptionalToken(metadata);
-
-  if (isNullish(token)) {
-    throw new LedgerErrorKey("error.icrc_token_load");
-  }
-
-  logWithTimestamp("Getting sns token: done");
-
-  return token;
 };
 
 export const transactionFee = async ({

--- a/frontend/src/tests/fakes/sns-ledger-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-ledger-api.fake.ts
@@ -1,6 +1,4 @@
-import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
-import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import { installImplAndBlockRest } from "$tests/utils/module.test-utils";
 import type { Identity } from "@dfinity/agent";
 import type { IcrcAccount } from "@dfinity/ledger-icrc";
@@ -10,7 +8,6 @@ const modulePath = "$lib/api/sns-ledger.api";
 const implementedFunctions = {
   querySnsBalance,
   transactionFee,
-  getSnsToken,
 };
 
 //////////////////////////////////////////////
@@ -54,18 +51,6 @@ async function transactionFee({
   certified: boolean;
 }): Promise<bigint> {
   return 10_000n;
-}
-
-async function getSnsToken({
-  identity: _,
-  rootCanisterId: __,
-  certified: ___,
-}: {
-  identity: Identity;
-  rootCanisterId: Principal;
-  certified: boolean;
-}): Promise<IcrcTokenMetadata> {
-  return mockSnsToken;
 }
 
 /////////////////////////////////

--- a/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
@@ -2,7 +2,6 @@ import * as agent from "$lib/api/agent.api";
 import {
   approveTransfer,
   executeIcrcTransfer,
-  getIcrcToken,
   icrcTransfer,
   queryIcrcBalance,
   queryIcrcToken,
@@ -33,35 +32,6 @@ describe("icrc-ledger api", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe("getIcrcToken", () => {
-    it("returns token metadata", async () => {
-      const metadataSpy = vi.fn().mockResolvedValue(mockQueryTokenResponse);
-
-      const token = await getIcrcToken({
-        certified: true,
-        getMetadata: metadataSpy,
-      });
-
-      expect(token).toEqual(mockSnsToken);
-
-      expect(metadataSpy).toBeCalled();
-    });
-
-    it("throws an error if no token", () => {
-      const metadataSpy = async () => {
-        throw new Error();
-      };
-
-      const call = () =>
-        getIcrcToken({
-          certified: true,
-          getMetadata: metadataSpy,
-        });
-
-      expect(call).rejects.toThrowError();
-    });
   });
 
   describe("execute transfer", () => {

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -9,7 +9,6 @@ import {
   createMockSnsNeuron,
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
-import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { SnsNeuronsPo } from "$tests/page-objects/SnsNeurons.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -62,7 +61,6 @@ describe("SnsNeurons", () => {
     vi.spyOn(ledgerApi, "querySnsBalance").mockResolvedValue(
       mockSnsMainAccount.balanceUlps
     );
-    vi.spyOn(ledgerApi, "getSnsToken").mockResolvedValue(mockSnsToken);
     vi.spyOn(ledgerApi, "transactionFee").mockResolvedValue(10_000n);
     snsParametersStore.setParameters({
       rootCanisterId,

--- a/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
@@ -6,10 +6,7 @@ import { toastsError } from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
-import {
-  mockSnsSummaryList,
-  mockSnsToken,
-} from "$tests/mocks/sns-projects.mock";
+import { mockSnsSummaryList } from "$tests/mocks/sns-projects.mock";
 import { tick } from "svelte";
 import { get } from "svelte/store";
 
@@ -38,10 +35,6 @@ describe("sns-accounts-balance.services", () => {
   };
 
   it("should call api.querySnsBalance and load balance in store", async () => {
-    vi.spyOn(ledgerApi, "getSnsToken").mockImplementation(() =>
-      Promise.resolve(mockSnsToken)
-    );
-
     const spyQuery = vi
       .spyOn(ledgerApi, "querySnsBalance")
       .mockResolvedValue(mockSnsMainAccount.balanceUlps);


### PR DESCRIPTION
# Motivation

Unify wallet implementations.

In this PR, remove `getIcrcToken` which was used only in getSnsToken and use the canister directly instead.

# Changes

* Remove `getIcrcToken` from icrc-ledger api functions.
*Remove `getSnsToken` from sns-ledger api functions.

# Tests

* Remove test for `getIcrcToken`.
* Remove test for `getSnsToken`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
