### PR TITLE
Simplify universesAccountsBalance derived store

### DIFF
--- a/frontend/src/lib/components/universe/UniverseAccountsBalance.svelte
+++ b/frontend/src/lib/components/universe/UniverseAccountsBalance.svelte
@@ -10,7 +10,7 @@
   export let universe: Universe;
 
   let balanceUlps: bigint | undefined;
-  $: balanceUlps = $universesAccountsBalance[universe.canisterId]?.balanceUlps;
+  $: balanceUlps = $universesAccountsBalance[universe.canisterId];
 
   let token: Token | undefined;
   $: token = $tokensByUniverseIdStore[universe.canisterId];

--- a/frontend/src/lib/derived/universes-accounts-balance.derived.ts
+++ b/frontend/src/lib/derived/universes-accounts-balance.derived.ts
@@ -1,57 +1,22 @@
-import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
-import {
-  icpAccountsStore,
-  type IcpAccountsStore,
-} from "$lib/stores/icp-accounts.store";
-import type { IcrcAccountsStore } from "$lib/stores/icrc-accounts.store";
-import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
-import {
-  snsAccountsStore,
-  type SnsAccountsStore,
-} from "$lib/stores/sns-accounts.store";
+import type { UniversesAccounts } from "$lib/derived/accounts-list.derived";
+import { universesAccountsStore } from "$lib/derived/universes-accounts.derived";
 import type { RootCanisterIdText } from "$lib/types/sns";
-import { sumAccounts, sumNnsAccounts } from "$lib/utils/accounts.utils";
-import { derived } from "svelte/store";
-
-export interface UniverseAccountsBalance {
-  balanceUlps: bigint | undefined;
-  certified: boolean;
-}
+import { sumAccounts } from "$lib/utils/accounts.utils";
+import { derived, type Readable } from "svelte/store";
 
 export type UniversesAccountsBalanceReadableStore = Record<
   RootCanisterIdText,
-  UniverseAccountsBalance
+  bigint | undefined
 >;
 
 export const universesAccountsBalance = derived<
-  [IcpAccountsStore, SnsAccountsStore, IcrcAccountsStore],
+  Readable<UniversesAccounts>,
   UniversesAccountsBalanceReadableStore
->(
-  [icpAccountsStore, snsAccountsStore, icrcAccountsStore],
-  ([$accountsStore, $snsAccountsStore, $icrcAccountsStore]) => ({
-    [OWN_CANISTER_ID_TEXT]: {
-      balanceUlps: sumNnsAccounts($accountsStore),
-      certified: $accountsStore.certified ?? false,
-    },
-    ...Object.entries($icrcAccountsStore).reduce(
-      (acc, [canisterId, { accounts, certified }]) => ({
-        ...acc,
-        [canisterId]: {
-          balanceUlps: sumAccounts(accounts),
-          certified,
-        },
-      }),
-      {}
-    ),
-    ...Object.entries($snsAccountsStore).reduce(
-      (acc, [rootCanisterId, { accounts, certified }]) => ({
-        ...acc,
-        [rootCanisterId]: {
-          balanceUlps: sumAccounts(accounts),
-          certified,
-        },
-      }),
-      {}
-    ),
-  })
+>(universesAccountsStore, ($universesAccountsStore) =>
+  Object.fromEntries(
+    Object.entries($universesAccountsStore).map(([universeId, accounts]) => [
+      universeId,
+      sumAccounts(accounts),
+    ])
+  )
 );

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -241,19 +241,6 @@ export const accountName = ({
 }): string =>
   account?.name ?? (account?.type === "main" ? mainName : account?.name ?? "");
 
-export const sumNnsAccounts = (
-  accounts: IcpAccountsStoreData | undefined
-): bigint | undefined =>
-  accounts?.main?.balanceUlps !== undefined
-    ? sumAmounts(
-        accounts?.main?.balanceUlps,
-        ...(accounts?.subAccounts || []).map(({ balanceUlps }) => balanceUlps),
-        ...(accounts?.hardwareWallets || []).map(
-          ({ balanceUlps }) => balanceUlps
-        )
-      )
-    : undefined;
-
 export function sumAccounts(acconts: Account[]): bigint;
 export function sumAccounts(acconts: Account[] | undefined): bigint | undefined;
 export function sumAccounts(

--- a/frontend/src/tests/lib/derived/universes-accounts-balance.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-accounts-balance.derived.spec.ts
@@ -31,14 +31,12 @@ describe("universes-accounts-balance.derived", () => {
 
   it("should derive a balance of Nns accounts", () => {
     const balances = get(universesAccountsBalance);
-    expect(balances[OWN_CANISTER_ID_TEXT].balanceUlps).toEqual(
-      mockMainAccount.balanceUlps
-    );
+    expect(balances[OWN_CANISTER_ID_TEXT]).toEqual(mockMainAccount.balanceUlps);
   });
 
   it("should derive a balance of Sns accounts", () => {
     const balances = get(universesAccountsBalance);
-    expect(balances[rootCanisterId.toText()].balanceUlps).toEqual(
+    expect(balances[rootCanisterId.toText()]).toEqual(
       mockSnsMainAccount.balanceUlps
     );
   });

--- a/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
@@ -55,7 +55,7 @@ describe("sns-accounts-balance.services", () => {
     const store = get(universesAccountsBalance);
     // Nns + 1 Sns
     expect(Object.keys(store)).toHaveLength(2);
-    expect(store[summary.rootCanisterId.toText()].balanceUlps).toEqual(
+    expect(store[summary.rootCanisterId.toText()]).toEqual(
       mockSnsMainAccount.balanceUlps
     );
     expect(spyQuery).toBeCalled();

--- a/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
@@ -50,7 +50,7 @@ describe("wallet-uncertified-accounts.services", () => {
     const store = get(universesAccountsBalance);
     // Nns + ckBTC + ckTESTBTC
     expect(Object.keys(store)).toHaveLength(3);
-    expect(store[CKBTC_UNIVERSE_CANISTER_ID.toText()].balanceUlps).toEqual(
+    expect(store[CKBTC_UNIVERSE_CANISTER_ID.toText()]).toEqual(
       mockCkBTCMainAccount.balanceUlps
     );
     expect(spyQuery).toBeCalled();

--- a/frontend/src/tests/lib/utils/accounts.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/accounts.utils.spec.ts
@@ -18,7 +18,6 @@ import {
   isAccountHardwareWallet,
   mainAccount,
   sumAccounts,
-  sumNnsAccounts,
   toIcpAccountIdentifier,
 } from "$lib/utils/accounts.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
@@ -657,43 +656,6 @@ describe("accounts-utils", () => {
           mainName: "main",
         })
       ).toBe("");
-    });
-  });
-
-  describe("sumNnsAccounts", () => {
-    it("should sum accounts balance", () => {
-      let totalBalance =
-        mockMainAccount.balanceUlps +
-        mockSubAccount.balanceUlps +
-        mockHardwareWalletAccount.balanceUlps;
-
-      expect(
-        sumNnsAccounts({
-          main: mockMainAccount,
-          subAccounts: [mockSubAccount],
-          hardwareWallets: [mockHardwareWalletAccount],
-        })
-      ).toEqual(totalBalance);
-
-      totalBalance = mockMainAccount.balanceUlps + mockSubAccount.balanceUlps;
-
-      expect(
-        sumNnsAccounts({
-          main: mockMainAccount,
-          subAccounts: [mockSubAccount],
-          hardwareWallets: [],
-        })
-      ).toEqual(totalBalance);
-
-      totalBalance = mockMainAccount.balanceUlps;
-
-      expect(
-        sumNnsAccounts({
-          main: mockMainAccount,
-          subAccounts: [],
-          hardwareWallets: [],
-        })
-      ).toEqual(totalBalance);
     });
   });
 


### PR DESCRIPTION
# Motivation

Readers of `universesAccountsBalance` never look at whether the data is `certified` and if we don't need to include that field, the store can trivially be derived from `universesAccountsStore`.

# Changes

1. Change `UniversesAccountsBalanceReadableStore` to just hold the balance and not whether it's `certified`.
2. Change the logic from assembling the data from 3 different accounts store to simply derive it from `universesAccountsStore`.
3. Change readers of `universesAccountsBalance` to use the value directly instead of having to get the `balanceUlps` field from it.
4. Remove `sumNnsAccounts` which became unused.

# Tests

updated

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary