### PR TITLE
Fix: Bug with neuron appearing

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -34,6 +34,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Bug where transferred SNS neurons appeared in the list of neurons after transferring them.
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/services/sns-neurons-check-balances.services.ts
+++ b/frontend/src/lib/services/sns-neurons-check-balances.services.ts
@@ -133,7 +133,7 @@ const findNeuronBySubaccount = async ({
       identity: new AnonymousIdentity(),
       rootCanisterId,
       neuronId,
-      // No need to check with update call, worst case, a neuron will appear in the UI that shouldn't.
+      // No need to check with update call, worst case, a neuron will appear in the UI that shouldn't or an extra call to refressh will be made.
       certified: false,
     });
   }
@@ -284,7 +284,7 @@ const checkNeuronsSubaccounts = async ({
       console.error(error);
     }
   }
-  // Not all neurons that the user has some permission need to be creeted in NNS Dapp.
+  // Not all neurons that the user has some permission need to be created in NNS Dapp.
   // Some of those neurons might need a refresh as well.
   // That's done in another function, here we only return them.
   const unvisitedNeurons = neurons.filter(

--- a/frontend/src/lib/services/sns-neurons-check-balances.services.ts
+++ b/frontend/src/lib/services/sns-neurons-check-balances.services.ts
@@ -266,7 +266,7 @@ const checkNeuronsSubaccounts = async ({
         const neuronId = fromNullable(neuron.id);
         if (neuronId !== undefined) {
           await refreshNeuron({ rootCanisterId, identity, neuronId });
-          loadNeuron({
+          await loadNeuron({
             rootCanisterId,
             neuronId: neuronId,
             certified: true,

--- a/frontend/src/lib/services/sns-neurons-check-balances.services.ts
+++ b/frontend/src/lib/services/sns-neurons-check-balances.services.ts
@@ -2,6 +2,7 @@ import {
   claimNeuron,
   getNeuronBalance,
   getSnsNeuron,
+  querySnsNeuron,
   refreshNeuron,
 } from "$lib/api/sns-governance.api";
 import { MAX_NEURONS_SUBACCOUNTS } from "$lib/constants/sns-neurons.constants";
@@ -19,7 +20,7 @@ import {
   type SnsNeuron,
   type SnsNeuronId,
 } from "@dfinity/sns";
-import { fromNullable } from "@dfinity/utils";
+import { fromNullable, isNullish } from "@dfinity/utils";
 
 const loadNeuron = async ({
   rootCanisterId,
@@ -130,19 +131,19 @@ const findNeuronBySubaccount =
  * A stateless SNS UI will perform the following operations every time it starts:
  * - It gets the list of neurons from the SNS Governance using list_neurons. This is done via an update call to confirm the correctness of the data.
  * - It calculates all its ns subaccounts and then checks their balances via query calls. This is where the ordering of ns subaccounts comes into play: the client just needs to check the ns subaccounts that are either already neuron accounts returned in 1. or have a balance different from 0.
- * - The SNS UI notifies the SNS Governance of all the neuron subaccounts that
+ * - The SNS UI notifies the SNS Governance of all the neuron subaccounts that the user has some permission and:
  *   - Have a balance different from 0 but the list of neurons doesn’t list them as neurons.
- *     - In this case, the client need to claim the neuron.
+ *     - In this case, the client needs to claim the neuron.
  *   - Have a balance different from the cached_neuron_stake_e8s returned by the SNS Governance
  *     - In this case, the client needs to refresh the neuron.
  *
  * SUMMARY:
  *
- * -------------------------------------------------
- * |              |  Balance 0     | Balance > 0   |
- * | found neuron |  check neuron stake vs balance |
- * | no neuron    |  stop checking | claim neuron  |
- * -------------------------------------------------
+ * -------------------------------------------------------------------
+ * |                                |  Balance 0     | Balance > 0   |
+ * | found neuron (with permission) |  check neuron stake vs balance |
+ * | no neuron                      |  stop checking | claim neuron  |
+ * -------------------------------------------------------------------
  *
  * @param {Object}
  * @param {Principal} params.rootCanisterId
@@ -185,9 +186,30 @@ const checkNeuronsSubaccounts = async ({
         certified: false,
         identity,
       });
-      const neuron = neurons.find(findNeuronBySubaccount(subaccount));
-      const neuronNotFound = neuron === undefined;
       const positiveBalance = currentBalance >= neuronMinimumStake;
+      let neuron = neurons.find(findNeuronBySubaccount(subaccount));
+      // At this point we don't know whether it's an unclaimed or transferred neuron.
+      if (isNullish(neuron) && positiveBalance) {
+        const neuronId: SnsNeuronId = { id: subaccount };
+        neuron = await querySnsNeuron({
+          identity,
+          rootCanisterId,
+          neuronId,
+          // No need to check with update call, worst case, a neuron will appear in the UI that shouldn't.
+          certified: false,
+        });
+      }
+      const identityPrincipal = identity.getPrincipal();
+      const hasUserSomePermission: boolean | undefined =
+        neuron?.permissions.some(({ principal }) => {
+          return principal[0]?.toText() === identityPrincipal.toText();
+        });
+      // Skip claiming or refreshing if the user has no permission.
+      // This might happen if the user staked the neuron in NNS Dapp and then transferred it.
+      if (hasUserSomePermission === false) {
+        continue;
+      }
+      const neuronNotFound = neuron === undefined;
       // Subaccount balance >= `neuron_minimum_stake_e8s` but no neuron found, claim it.
       if (positiveBalance && neuronNotFound) {
         await claimAndLoadNeuron({
@@ -225,6 +247,9 @@ const checkNeuronsSubaccounts = async ({
       console.error(error);
     }
   }
+  // Not all neurons that the user has some permission need to be creeted in NNS Dapp.
+  // Some of those neurons might need a refresh as well.
+  // That's done in another function, here we only return them.
   const unvisitedNeurons = neurons.filter(
     ({ id }) =>
       !visitedSubaccounts.has(
@@ -257,7 +282,7 @@ const checkNeurons = async ({
     if (neuronId !== undefined) {
       if (await neuronNeedsRefresh({ rootCanisterId, neuron, identity })) {
         await refreshNeuron({ rootCanisterId, identity, neuronId });
-        loadNeuron({
+        await loadNeuron({
           rootCanisterId,
           neuronId: neuronId,
           certified: true,

--- a/frontend/src/lib/services/sns-neurons-check-balances.services.ts
+++ b/frontend/src/lib/services/sns-neurons-check-balances.services.ts
@@ -199,10 +199,9 @@ const checkNeuronsSubaccounts = async ({
           certified: false,
         });
       }
-      const identityPrincipal = identity.getPrincipal();
       const hasUserSomePermission: boolean | undefined =
         neuron?.permissions.some(({ principal }) => {
-          return principal[0]?.toText() === identityPrincipal.toText();
+          return principal[0]?.toText() === controller.toText();
         });
       // Skip claiming or refreshing if the user has no permission.
       // This might happen if the user staked the neuron in NNS Dapp and then transferred it.

--- a/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
@@ -4,20 +4,63 @@ import {
   neuronNeedsRefresh,
 } from "$lib/services/sns-neurons-check-balances.services";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
+import { enumValues } from "$lib/utils/enum.utils";
+import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
 import {
   mockIdentity,
   mockPrincipal,
   resetIdentity,
 } from "$tests/mocks/auth.store.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
-import { neuronSubaccount, type SnsNeuronId } from "@dfinity/sns";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import {
+  SnsNeuronPermissionType,
+  neuronSubaccount,
+  type SnsNeuron,
+  type SnsNeuronId,
+} from "@dfinity/sns";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("sns-neurons-check-balances-services", () => {
+  const allPermissions = Int32Array.from(enumValues(SnsNeuronPermissionType));
+  const subaccount = neuronSubaccount({
+    controller: mockIdentity.getPrincipal(),
+    index: 0,
+  });
+  const neuronId: SnsNeuronId = { id: subaccount };
+  const userNeuron: SnsNeuron = {
+    ...mockSnsNeuron,
+    permissions: [
+      {
+        principal: [mockIdentity.getPrincipal()],
+        permission_type: allPermissions,
+      },
+    ],
+    id: [neuronId] as [SnsNeuronId],
+  };
+  const subaccountTransferredNeuron = neuronSubaccount({
+    controller: mockIdentity.getPrincipal(),
+    index: 1,
+  });
+  const transferredNeuronId: SnsNeuronId = {
+    id: subaccountTransferredNeuron,
+  };
+  const transferredNeuron: SnsNeuron = {
+    ...mockSnsNeuron,
+    permissions: [
+      {
+        principal: [principal(0)],
+        permission_type: allPermissions,
+      },
+    ],
+    id: [transferredNeuronId] as [SnsNeuronId],
+  };
+
   beforeEach(() => {
     resetIdentity();
   });
+
   describe("checkSnsNeuronBalances", () => {
     beforeEach(() => {
       vi.clearAllMocks();
@@ -26,27 +69,18 @@ describe("sns-neurons-check-balances-services", () => {
     });
 
     it("should check balance and not refresh when balance matches stake", async () => {
-      const subaccount = neuronSubaccount({
-        controller: mockIdentity.getPrincipal(),
-        index: 0,
-      });
-      const neuronId: SnsNeuronId = { id: subaccount };
-      const neuron = {
-        ...mockSnsNeuron,
-        id: [neuronId] as [SnsNeuronId],
-      };
       const spyQuery = vi
         .spyOn(governanceApi, "getSnsNeuron")
-        .mockImplementation(() => Promise.resolve(neuron));
+        .mockResolvedValue(userNeuron);
       const spyNeuronBalance = vi
         .spyOn(governanceApi, "getNeuronBalance")
         .mockImplementationOnce(() =>
-          Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s)
+          Promise.resolve(userNeuron.cached_neuron_stake_e8s)
         )
         .mockImplementation(() => Promise.resolve(0n));
       await checkSnsNeuronBalances({
         rootCanisterId: mockPrincipal,
-        neurons: [neuron],
+        neurons: [userNeuron],
         neuronMinimumStake: 100_000_000n,
       });
 
@@ -55,35 +89,29 @@ describe("sns-neurons-check-balances-services", () => {
     });
 
     it("should check balance and refresh when balance does not match stake and load the updated neuron in the store", async () => {
-      const subaccount = neuronSubaccount({
-        controller: mockIdentity.getPrincipal(),
-        index: 0,
-      });
-      const neuronId: SnsNeuronId = { id: subaccount };
-      const neuron = {
-        ...mockSnsNeuron,
-        id: [neuronId] as [SnsNeuronId],
-      };
-      const stake = neuron.cached_neuron_stake_e8s + 10_000n;
+      const stake = userNeuron.cached_neuron_stake_e8s + 10_000n;
       const updatedNeuron = {
-        ...neuron,
+        ...userNeuron,
         cached_neuron_stake_e8s: stake,
       };
       const spyNeuronQuery = vi
         .spyOn(governanceApi, "getSnsNeuron")
-        .mockImplementation(() => Promise.resolve(updatedNeuron));
+        .mockResolvedValue(updatedNeuron);
       const spyNeuronBalance = vi
         .spyOn(governanceApi, "getNeuronBalance")
-        .mockImplementationOnce(() =>
-          Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s + 10_000n)
-        )
-        .mockImplementation(() => Promise.resolve(0n));
+        .mockResolvedValueOnce(stake)
+        .mockResolvedValue(0n);
       const spyRefreshNeuron = vi
         .spyOn(governanceApi, "refreshNeuron")
-        .mockImplementation(() => Promise.resolve(undefined));
+        .mockResolvedValue(undefined);
+
+      expect(spyRefreshNeuron).not.toBeCalled();
+      expect(spyNeuronQuery).not.toBeCalled();
+      expect(spyNeuronBalance).not.toBeCalled();
+
       await checkSnsNeuronBalances({
         rootCanisterId: mockPrincipal,
-        neurons: [neuron],
+        neurons: [userNeuron],
         neuronMinimumStake: 100_000_000n,
       });
 
@@ -96,37 +124,185 @@ describe("sns-neurons-check-balances-services", () => {
     });
 
     it("should check balance and refresh when balance is 0 and does not match stake and load the updated neuron in the store", async () => {
-      const subaccount = neuronSubaccount({
-        controller: mockIdentity.getPrincipal(),
-        index: 0,
-      });
-      const neuronId: SnsNeuronId = { id: subaccount };
-      const neuron = {
-        ...mockSnsNeuron,
-        id: [neuronId] as [SnsNeuronId],
-      };
       const updatedNeuron = {
-        ...neuron,
+        ...userNeuron,
         cached_neuron_stake_e8s: 0n,
       };
       const spyNeuronQuery = vi
         .spyOn(governanceApi, "getSnsNeuron")
-        .mockImplementation(() => Promise.resolve(updatedNeuron));
+        .mockResolvedValue(updatedNeuron);
       const spyNeuronBalance = vi
         .spyOn(governanceApi, "getNeuronBalance")
-        .mockImplementation(() => Promise.resolve(0n));
+        .mockResolvedValue(0n);
       const spyRefreshNeuron = vi
         .spyOn(governanceApi, "refreshNeuron")
-        .mockImplementation(() => Promise.resolve(undefined));
+        .mockResolvedValue(undefined);
+
+      expect(spyRefreshNeuron).not.toBeCalled();
+      expect(spyNeuronQuery).not.toBeCalled();
+      expect(spyNeuronBalance).not.toBeCalled();
+
       await checkSnsNeuronBalances({
         rootCanisterId: mockPrincipal,
-        neurons: [neuron],
+        neurons: [userNeuron],
         neuronMinimumStake: 100_000_000n,
       });
 
       await waitFor(() => expect(spyRefreshNeuron).toBeCalled());
       expect(spyNeuronQuery).toBeCalled();
       expect(spyNeuronBalance).toBeCalled();
+
+      const store = get(snsNeuronsStore);
+      expect(store[mockPrincipal.toText()].neurons).toEqual([updatedNeuron]);
+    });
+
+    it("should not refresh nor load neurons where the user is not the controller anymore", async () => {
+      const cachedStakeMapper = {
+        [subaccountToHexString(subaccountTransferredNeuron)]:
+          transferredNeuron.cached_neuron_stake_e8s,
+        [subaccountToHexString(subaccount)]: userNeuron.cached_neuron_stake_e8s,
+      };
+      // Only the transferred neuron will be fetched because the other is passed as a parameter.
+      const spyNeuronQuery = vi
+        .spyOn(governanceApi, "querySnsNeuron")
+        .mockResolvedValue(transferredNeuron);
+      const spyNeuronBalance = vi
+        .spyOn(governanceApi, "getNeuronBalance")
+        .mockImplementation(async ({ neuronId }) => {
+          return cachedStakeMapper[subaccountToHexString(neuronId.id)] ?? 0n;
+        });
+      const spyRefreshNeuron = vi
+        .spyOn(governanceApi, "refreshNeuron")
+        .mockResolvedValue(undefined);
+
+      expect(spyRefreshNeuron).not.toBeCalled();
+      expect(spyNeuronQuery).not.toBeCalled();
+      expect(spyNeuronBalance).not.toBeCalled();
+
+      await checkSnsNeuronBalances({
+        rootCanisterId: mockPrincipal,
+        neurons: [userNeuron],
+        neuronMinimumStake: 100_000_000n,
+      });
+
+      expect(spyRefreshNeuron).not.toBeCalled();
+      // One for the subaccount with balance found.
+      expect(spyNeuronQuery).toBeCalledTimes(1);
+      // Three times: one for each subaccount with balance and one more to check that there are no more neurons with balance.
+      expect(spyNeuronBalance).toBeCalledTimes(3);
+      // No new neurons will be loaded because the user is not the controller anymore.
+      expect(get(snsNeuronsStore)[mockPrincipal.toText()]).toBeUndefined();
+    });
+
+    it("should claim a neuron where the user is the controller after finding a neuron that is not the controller of", async () => {
+      const unclaimedNeuronBalance = 500_000_000n;
+      const subaccountUnclaimedNeuron = neuronSubaccount({
+        controller: mockIdentity.getPrincipal(),
+        index: 2,
+      });
+      const unclaimedNeuronId: SnsNeuronId = {
+        id: subaccountUnclaimedNeuron,
+      };
+      const unclaimedNeuron: SnsNeuron = {
+        ...userNeuron,
+        id: [unclaimedNeuronId] as [SnsNeuronId],
+        cached_neuron_stake_e8s: unclaimedNeuronBalance,
+      };
+      const cachedStakeMapper = {
+        [subaccountToHexString(subaccountTransferredNeuron)]:
+          transferredNeuron.cached_neuron_stake_e8s,
+        [subaccountToHexString(subaccount)]: userNeuron.cached_neuron_stake_e8s,
+        [subaccountToHexString(subaccountUnclaimedNeuron)]:
+          unclaimedNeuron.cached_neuron_stake_e8s,
+      };
+      const queryNeuronMapper = {
+        [subaccountToHexString(subaccountTransferredNeuron)]: transferredNeuron,
+      };
+      // Only the transferred neuron will be fetched because the other is passed as a parameter.
+      const spyNeuronQuery = vi
+        .spyOn(governanceApi, "querySnsNeuron")
+        .mockImplementation(
+          async ({ neuronId }) =>
+            queryNeuronMapper[subaccountToHexString(neuronId.id)] ?? undefined
+        );
+      const spyNeuronGetter = vi
+        .spyOn(governanceApi, "getSnsNeuron")
+        .mockResolvedValue(unclaimedNeuron);
+      const spyNeuronBalance = vi
+        .spyOn(governanceApi, "getNeuronBalance")
+        .mockImplementation(async ({ neuronId }) => {
+          return cachedStakeMapper[subaccountToHexString(neuronId.id)] ?? 0n;
+        });
+      const spyClaimNeuron = vi
+        .spyOn(governanceApi, "claimNeuron")
+        .mockResolvedValue(unclaimedNeuronId);
+
+      expect(spyClaimNeuron).not.toBeCalled();
+      expect(spyNeuronGetter).not.toBeCalled();
+      expect(spyNeuronQuery).not.toBeCalled();
+      expect(spyNeuronBalance).not.toBeCalled();
+      await checkSnsNeuronBalances({
+        rootCanisterId: mockPrincipal,
+        neurons: [userNeuron],
+        neuronMinimumStake: 100_000_000n,
+      });
+
+      expect(spyClaimNeuron).toBeCalledTimes(1);
+      // One for each subaccount with balance found and the neuron was not present in the parameters.
+      expect(spyNeuronQuery).toBeCalledTimes(2);
+      expect(spyNeuronGetter).toBeCalledTimes(1);
+      // Four times: one for each subaccount with balance and one more to check that there are no more neurons with balance.
+      expect(spyNeuronBalance).toBeCalledTimes(4);
+      // The unclaimed neurons will be loaded.
+      expect(get(snsNeuronsStore)[mockPrincipal.toText()]?.neurons).toEqual([
+        unclaimedNeuron,
+      ]);
+    });
+
+    it("should refresh neurons not created in NNS Dapp and load them in store", async () => {
+      const nonNnsDappSubaccount = neuronSubaccount({
+        controller: principal(0),
+        index: 0,
+      });
+      const neuronId: SnsNeuronId = { id: nonNnsDappSubaccount };
+      const nonNnsDappNeuron: SnsNeuron = {
+        ...userNeuron,
+        id: [neuronId] as [SnsNeuronId],
+      };
+      const stake = nonNnsDappNeuron.cached_neuron_stake_e8s + 200_000_000n;
+      const updatedNeuron = {
+        ...nonNnsDappNeuron,
+        cached_neuron_stake_e8s: stake,
+      };
+      const cachedStakeMapper = {
+        [subaccountToHexString(nonNnsDappSubaccount)]: stake,
+        [subaccountToHexString(subaccount)]: userNeuron.cached_neuron_stake_e8s,
+      };
+      const spyNeuronQuery = vi
+        .spyOn(governanceApi, "getSnsNeuron")
+        .mockResolvedValue(updatedNeuron);
+      const spyNeuronBalance = vi
+        .spyOn(governanceApi, "getNeuronBalance")
+        .mockImplementation(
+          async ({ neuronId }) =>
+            cachedStakeMapper[subaccountToHexString(neuronId.id)] ?? 0n
+        );
+      const spyRefreshNeuron = vi
+        .spyOn(governanceApi, "refreshNeuron")
+        .mockResolvedValue(undefined);
+
+      expect(spyRefreshNeuron).not.toBeCalled();
+      expect(spyNeuronQuery).not.toBeCalled();
+      expect(spyNeuronBalance).not.toBeCalled();
+      await checkSnsNeuronBalances({
+        rootCanisterId: mockPrincipal,
+        neurons: [userNeuron, nonNnsDappNeuron],
+        neuronMinimumStake: 100_000_000n,
+      });
+
+      expect(spyRefreshNeuron).toBeCalledTimes(1);
+      expect(spyNeuronQuery).toBeCalledTimes(1);
+      expect(spyNeuronBalance).toBeCalledTimes(3);
 
       const store = get(snsNeuronsStore);
       expect(store[mockPrincipal.toText()].neurons).toEqual([updatedNeuron]);

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -218,9 +218,13 @@ describe("sns-neurons-services", () => {
         .mockImplementation(() => Promise.resolve(undefined));
       await syncSnsNeurons(mockPrincipal);
 
-      await tick();
-      const store = get(snsNeuronsStore);
-      expect(store[mockPrincipal.toText()]?.neurons).toHaveLength(1);
+      // Checking the neuron balances is done in the background.
+      // The `await` on `syncSnsNeurons` is not enough to wait for the balance check.
+      await waitFor(() =>
+        expect(
+          get(snsNeuronsStore)[mockPrincipal.toText()]?.neurons
+        ).toHaveLength(1)
+      );
       expect(spyQuery).toBeCalled();
       expect(spyNeuronBalance).toBeCalled();
       expect(spyRefreshNeuron).toBeCalled();

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -18,6 +18,7 @@ import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { snsParametersStore } from "$lib/stores/sns-parameters.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
+import { enumValues } from "$lib/utils/enum.utils";
 import {
   getSnsNeuronIdAsHexString,
   subaccountToHexString,
@@ -44,6 +45,7 @@ import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
 import {
+  SnsNeuronPermissionType,
   neuronSubaccount,
   type SnsNeuron,
   type SnsNeuronId,
@@ -82,6 +84,32 @@ vi.mock("$lib/services/sns-accounts.services", () => {
 });
 
 describe("sns-neurons-services", () => {
+  const allPermissions = Int32Array.from(enumValues(SnsNeuronPermissionType));
+  const subaccount = neuronSubaccount({
+    controller: mockIdentity.getPrincipal(),
+    index: 0,
+  });
+  const neuronId: SnsNeuronId = { id: subaccount };
+  const neuron: SnsNeuron = {
+    ...mockSnsNeuron,
+    id: [neuronId] as [SnsNeuronId],
+    permissions: [
+      {
+        principal: [mockIdentity.getPrincipal()],
+        permission_type: allPermissions,
+      },
+    ],
+  };
+  const nextSubaccount = neuronSubaccount({
+    controller: mockIdentity.getPrincipal(),
+    index: 1,
+  });
+  const nextNeuronId: SnsNeuronId = { id: nextSubaccount };
+  const nextNeuron: SnsNeuron = {
+    ...neuron,
+    id: [nextNeuronId] as [SnsNeuronId],
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     resetIdentity();
@@ -107,15 +135,6 @@ describe("sns-neurons-services", () => {
       });
 
       it("should call api.querySnsNeurons and load neurons in store", async () => {
-        const subaccount = neuronSubaccount({
-          controller: mockIdentity.getPrincipal(),
-          index: 0,
-        });
-        const neuronId: SnsNeuronId = { id: subaccount };
-        const neuron = {
-          ...mockSnsNeuron,
-          id: [neuronId] as [SnsNeuronId],
-        };
         const spyQuery = vi
           .spyOn(governanceApi, "querySnsNeurons")
           .mockImplementation(() => Promise.resolve([neuron]));
@@ -155,15 +174,6 @@ describe("sns-neurons-services", () => {
       });
 
       it("should call api.querySnsNeurons and load neurons in store", async () => {
-        const subaccount = neuronSubaccount({
-          controller: mockIdentity.getPrincipal(),
-          index: 0,
-        });
-        const neuronId: SnsNeuronId = { id: subaccount };
-        const neuron = {
-          ...mockSnsNeuron,
-          id: [neuronId] as [SnsNeuronId],
-        };
         const spyQuery = vi
           .spyOn(governanceApi, "querySnsNeurons")
           .mockImplementation(() => Promise.resolve([neuron]));
@@ -191,15 +201,6 @@ describe("sns-neurons-services", () => {
     });
 
     it("should refresh and refetch the neuron if balance doesn't match", async () => {
-      const subaccount = neuronSubaccount({
-        controller: mockIdentity.getPrincipal(),
-        index: 0,
-      });
-      const neuronId: SnsNeuronId = { id: subaccount };
-      const neuron = {
-        ...mockSnsNeuron,
-        id: [neuronId] as [SnsNeuronId],
-      };
       const spyQuery = vi
         .spyOn(governanceApi, "querySnsNeurons")
         .mockImplementation(() => Promise.resolve([neuron]));
@@ -227,37 +228,33 @@ describe("sns-neurons-services", () => {
     });
 
     it("should claim neuron if find a subaccount without neuron", async () => {
-      const subaccount = neuronSubaccount({
-        controller: mockIdentity.getPrincipal(),
-        index: 1,
-      });
-      const neuronId: SnsNeuronId = { id: subaccount };
-      const neuron = {
-        ...mockSnsNeuron,
-        id: [neuronId] as [SnsNeuronId],
-      };
+      // Neuron has not been claimed yet.
+      vi.spyOn(governanceApi, "querySnsNeuron").mockResolvedValue(undefined);
       const spyQuery = vi
         .spyOn(governanceApi, "querySnsNeurons")
         .mockImplementation(() => Promise.resolve([neuron]));
       const spyNeuronQuery = vi
         .spyOn(governanceApi, "getSnsNeuron")
-        .mockImplementation(() => Promise.resolve(neuron));
+        .mockImplementation(() => Promise.resolve(nextNeuron));
       const spyNeuronBalance = vi
         .spyOn(governanceApi, "getNeuronBalance")
         .mockImplementationOnce(() =>
-          Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s)
+          Promise.resolve(neuron.cached_neuron_stake_e8s)
         )
-        .mockImplementationOnce(() => Promise.resolve(200_000_000n))
+        .mockResolvedValueOnce(nextNeuron.cached_neuron_stake_e8s)
         .mockImplementation(() => Promise.resolve(0n));
       const spyClaimNeuron = vi
         .spyOn(governanceApi, "claimNeuron")
         .mockImplementation(() => Promise.resolve(undefined));
       await syncSnsNeurons(mockPrincipal);
 
-      await tick();
-      await tick();
-      const store = get(snsNeuronsStore);
-      expect(store[mockPrincipal.toText()]?.neurons).toHaveLength(1);
+      // Checking the neuron balances is done in the background.
+      // The `await` on `syncSnsNeurons` is not enough to wait for the balance check.
+      await waitFor(() =>
+        expect(
+          get(snsNeuronsStore)[mockPrincipal.toText()]?.neurons
+        ).toHaveLength(2)
+      );
       expect(spyQuery).toBeCalled();
       expect(spyNeuronBalance).toBeCalled();
       expect(spyClaimNeuron).toBeCalled();
@@ -266,37 +263,33 @@ describe("sns-neurons-services", () => {
 
     it("should claim neuron if find a subaccount without neuron for query calls if FORCE_CALL_STRATEGY is query", async () => {
       mockedConstants.FORCE_CALL_STRATEGY = "query";
-      const subaccount = neuronSubaccount({
-        controller: mockIdentity.getPrincipal(),
-        index: 1,
-      });
-      const neuronId: SnsNeuronId = { id: subaccount };
-      const neuron = {
-        ...mockSnsNeuron,
-        id: [neuronId] as [SnsNeuronId],
-      };
+      // Neuron has not been claimed yet.
+      vi.spyOn(governanceApi, "querySnsNeuron").mockResolvedValue(undefined);
       const spyQuery = vi
         .spyOn(governanceApi, "querySnsNeurons")
         .mockImplementation(() => Promise.resolve([neuron]));
       const spyNeuronQuery = vi
         .spyOn(governanceApi, "getSnsNeuron")
-        .mockImplementation(() => Promise.resolve(neuron));
+        .mockImplementation(() => Promise.resolve(nextNeuron));
       const spyNeuronBalance = vi
         .spyOn(governanceApi, "getNeuronBalance")
         .mockImplementationOnce(() =>
           Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s)
         )
-        .mockImplementationOnce(() => Promise.resolve(200_000_000n))
+        .mockResolvedValueOnce(nextNeuron.cached_neuron_stake_e8s)
         .mockImplementation(() => Promise.resolve(0n));
       const spyClaimNeuron = vi
         .spyOn(governanceApi, "claimNeuron")
         .mockImplementation(() => Promise.resolve(undefined));
       await syncSnsNeurons(mockPrincipal);
 
-      await tick();
-      await tick();
-      const store = get(snsNeuronsStore);
-      expect(store[mockPrincipal.toText()]?.neurons).toHaveLength(1);
+      // Checking the neuron balances is done in the background.
+      // The `await` on `syncSnsNeurons` is not enough to wait for the balance check.
+      await waitFor(() =>
+        expect(
+          get(snsNeuronsStore)[mockPrincipal.toText()]?.neurons
+        ).toHaveLength(2)
+      );
       expect(spyQuery).toBeCalled();
       expect(spyNeuronBalance).toBeCalled();
       expect(spyClaimNeuron).toBeCalled();
@@ -331,15 +324,6 @@ describe("sns-neurons-services", () => {
     });
 
     it("should call api.querySnsNeurons and load neurons in store", async () => {
-      const subaccount = neuronSubaccount({
-        controller: mockIdentity.getPrincipal(),
-        index: 0,
-      });
-      const neuronId: SnsNeuronId = { id: subaccount };
-      const neuron = {
-        ...mockSnsNeuron,
-        id: [neuronId] as [SnsNeuronId],
-      };
       const spyQuery = vi
         .spyOn(governanceApi, "querySnsNeurons")
         .mockImplementation(() => Promise.resolve([neuron]));
@@ -402,15 +386,6 @@ describe("sns-neurons-services", () => {
 
     it("should refresh neuron if balance does not match and load again", () =>
       new Promise<void>((done) => {
-        const subaccount = neuronSubaccount({
-          controller: mockIdentity.getPrincipal(),
-          index: 0,
-        });
-        const neuronId: SnsNeuronId = { id: subaccount };
-        const neuron = {
-          ...mockSnsNeuron,
-          id: [neuronId] as [SnsNeuronId],
-        };
         const stake = neuron.cached_neuron_stake_e8s + 10_000n;
         const updatedNeuron = {
           ...neuron,


### PR DESCRIPTION
# Motivation

A bug was raised in the forum where an SNS neuron was appearing even though the user transferred ownership of such a neuron.

The issue came from the background task that checks neuron subaccounts. The background task didn't consider whether the user has still some permission with the neuron and refreshes it and adds it to the store.

The fix is to try to query the neuron from the canister directly and then check the permissions before continuing with refresh or not refresh.

# Changes

* Add code in the main `checkNeuronsSubaccounts` to fetch the neuron when it wasn't passed and compare the permissions with the user's identity.

# Tests

* Add two tests regarding the bug. One simulating the bug and another one with an edge case to confirm that if a neuron without permissions is found, it doesn't break the loop of claiming neurons.
* Fix the tests in sns-neurons that were broken due to expecting the user to be the controller of the neuron.
* Add a missing test when a neuron that wasn't created in NNS Dapp needed to be refreshed.

# Todos

- [x] Add entry to changelog (if necessary).
