### PR TITLE
Upgrade to catch next version of ic-js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.1.1-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.1.1-next-2024-02-12.1.tgz",
-      "integrity": "sha512-B9mvACs36RTY3Z0qFUZ/eRgfgG8WP7QUhllTbAv1hvEZOoZ07QSi1XNXx+DrfyGUYdBcp8Pp7q0Xvp6IwFjyuA==",
+      "version": "2.2.0-next-2024-02-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.2.0-next-2024-02-14.tgz",
+      "integrity": "sha512-9fDhnpevwJXqU3PaZcdJoccKLe4TJEMFGX4+zs/3dZZLmExOmLZ+U9QgDqfaxY6tntboSur/ZT8AJ9NBt84CPQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.0.0-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.0-next-2024-02-12.1.tgz",
-      "integrity": "sha512-mMyYv+30oSTAw7Nw1SvEg7BR9bd4FjzbPot7zrE3GNlnVISY9G23m4A8+pd4vvklr2TMluaBeuLNWaHjPxeaew==",
+      "version": "3.0.1-next-2024-02-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.1-next-2024-02-14.tgz",
+      "integrity": "sha512-60d2ZXTxS4ysKTXtIKg2WXkJDeob7y8cy10h9aMVVj6HurKs674W4RQSzUnHpOZZajrwf9mxVyRYnC5y7w3sMw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "2.2.0-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.2.0-next-2024-02-12.1.tgz",
-      "integrity": "sha512-BIRqQNWCzpxBhy70bCiZwbvPUwz4jNGzsLWuRKEEARba4XsKzKzEu0S85Qfvsuu9fWyvpUGChMbdEG67oPhVMQ==",
+      "version": "2.2.1-next-2024-02-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.2.1-next-2024-02-14.tgz",
+      "integrity": "sha512-V64AsBI+AsIuLgP+kK8s8aaS3St5oQ0kfl7pQI4l87j2Q4W4Wm0cJuuorTuncMZxuc4HE+W8fafJgneoLu2qTA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.1.2-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.1.2-next-2024-02-12.1.tgz",
-      "integrity": "sha512-pMkO4TfHFj1neaLHzOjZNCbIGt6VRFYowINVHvHjZs6RACAOUZ3hBJX+DHKDjeUkcagoIFIJoPNoOmeMP07Aqw==",
+      "version": "2.2.0-next-2024-02-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.0-next-2024-02-14.tgz",
+      "integrity": "sha512-DJDlpX8wjdsuI/DV2PkRwtFD6mM4miMAGhhcsoUOFe2iwEaxFY2nYVMsHi+eLDxhPR8rMIsLgoRFfZgQiRW4cQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.1.1-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.1-next-2024-02-12.1.tgz",
-      "integrity": "sha512-+UkTuaqx6b4RWngiqKA1FnYCkjPBe3wmcY6gJCmsI1qHGjlLHzypbZq1txS9/dWhk75uLp6jvTS6U8hhuMmmzg==",
+      "version": "2.1.2-next-2024-02-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.2-next-2024-02-14.tgz",
+      "integrity": "sha512-R4j/+jsFEFI8UbWP/wQ/gSBPPq7swo7t/LMydzXctE62cRb4mKp6GgMSAN+MUFUtKIziqUXrPRWlGGpwar8hLA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "3.1.1-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.1.1-next-2024-02-12.1.tgz",
-      "integrity": "sha512-M9mXLljI+4sDIodewyUdlodfWr6TEdEWShw2dKqhuX2n9FljL8KyMqAf0nUXoXilDJzoPdsppQXy1Gq0kN2HLg==",
+      "version": "4.0.0-next-2024-02-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.0-next-2024-02-14.tgz",
+      "integrity": "sha512-yllq/VasznNY0AJqUw68RJ1QaQCALDqcLrVJqPZIXCd+6Sa4lOksY9dArn0eq7T1dvy8YdvmfgDi3qeDDQY3Lw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -358,9 +358,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.1-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-02-12.1.tgz",
-      "integrity": "sha512-shG5aDrBN6YZxIxY3r7chHFtVmw/Uw/0PmFeq4xtT5m7vD3NurTJaA+g7RlO4L+GI4uPwqycQXmFXSl9ILXTVg==",
+      "version": "1.0.1-next-2024-02-14.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-02-14.1.tgz",
+      "integrity": "sha512-Bzm8TMCAiUw5mTmhZ2wpk6mPWHn5+p4r7IAXgRcbcbY4xfC8xbTTie8hJCeSpQyYqXH2r7T3j1l/s6pV30Esaw==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "2.1.1-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.1-next-2024-02-12.1.tgz",
-      "integrity": "sha512-gPXpI/lCihgdWxsdrPZMJaYnwqR77k+L1THaIikX/rHhZIKdHwFSRiyNt3kXCt3T+LqYpSX/mdvcehhORNIUAg==",
+      "version": "2.1.2-next-2024-02-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.2-next-2024-02-14.tgz",
+      "integrity": "sha512-18j0Rj53dE3vb9gcxhg1yrZYjlOscUWV3TVNGgtYRyIChJenW4LQ65/G52S3zwLgVYQXWwK9YYoWeURnlLAfgg==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.1.0-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.0-next-2024-02-12.1.tgz",
-      "integrity": "sha512-57uv2hkBU01TBwRup+iqRXi/NUH7+pbXucGbWT0o8nEW2m6HIzYFG/HQg1mIsigB3bIsOHX5fuu/GIbIiF24Bw==",
+      "version": "2.1.1-next-2024-02-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.1-next-2024-02-14.tgz",
+      "integrity": "sha512-bQpPIB5purkev6OGd9yld7Jvcra4m1In/qWXCg8zupa4WyF0a4mxm0U42WhFCnR22SqvmBhEqEGyqNDHkUCZaw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7047,9 +7047,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.1.1-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.1.1-next-2024-02-12.1.tgz",
-      "integrity": "sha512-B9mvACs36RTY3Z0qFUZ/eRgfgG8WP7QUhllTbAv1hvEZOoZ07QSi1XNXx+DrfyGUYdBcp8Pp7q0Xvp6IwFjyuA==",
+      "version": "2.2.0-next-2024-02-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.2.0-next-2024-02-14.tgz",
+      "integrity": "sha512-9fDhnpevwJXqU3PaZcdJoccKLe4TJEMFGX4+zs/3dZZLmExOmLZ+U9QgDqfaxY6tntboSur/ZT8AJ9NBt84CPQ==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7057,9 +7057,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.0.0-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.0-next-2024-02-12.1.tgz",
-      "integrity": "sha512-mMyYv+30oSTAw7Nw1SvEg7BR9bd4FjzbPot7zrE3GNlnVISY9G23m4A8+pd4vvklr2TMluaBeuLNWaHjPxeaew==",
+      "version": "3.0.1-next-2024-02-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.1-next-2024-02-14.tgz",
+      "integrity": "sha512-60d2ZXTxS4ysKTXtIKg2WXkJDeob7y8cy10h9aMVVj6HurKs674W4RQSzUnHpOZZajrwf9mxVyRYnC5y7w3sMw==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7073,9 +7073,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "2.2.0-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.2.0-next-2024-02-12.1.tgz",
-      "integrity": "sha512-BIRqQNWCzpxBhy70bCiZwbvPUwz4jNGzsLWuRKEEARba4XsKzKzEu0S85Qfvsuu9fWyvpUGChMbdEG67oPhVMQ==",
+      "version": "2.2.1-next-2024-02-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.2.1-next-2024-02-14.tgz",
+      "integrity": "sha512-V64AsBI+AsIuLgP+kK8s8aaS3St5oQ0kfl7pQI4l87j2Q4W4Wm0cJuuorTuncMZxuc4HE+W8fafJgneoLu2qTA==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7089,30 +7089,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.1.2-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.1.2-next-2024-02-12.1.tgz",
-      "integrity": "sha512-pMkO4TfHFj1neaLHzOjZNCbIGt6VRFYowINVHvHjZs6RACAOUZ3hBJX+DHKDjeUkcagoIFIJoPNoOmeMP07Aqw==",
+      "version": "2.2.0-next-2024-02-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.0-next-2024-02-14.tgz",
+      "integrity": "sha512-DJDlpX8wjdsuI/DV2PkRwtFD6mM4miMAGhhcsoUOFe2iwEaxFY2nYVMsHi+eLDxhPR8rMIsLgoRFfZgQiRW4cQ==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.1.1-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.1-next-2024-02-12.1.tgz",
-      "integrity": "sha512-+UkTuaqx6b4RWngiqKA1FnYCkjPBe3wmcY6gJCmsI1qHGjlLHzypbZq1txS9/dWhk75uLp6jvTS6U8hhuMmmzg==",
+      "version": "2.1.2-next-2024-02-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.2-next-2024-02-14.tgz",
+      "integrity": "sha512-R4j/+jsFEFI8UbWP/wQ/gSBPPq7swo7t/LMydzXctE62cRb4mKp6GgMSAN+MUFUtKIziqUXrPRWlGGpwar8hLA==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "3.1.1-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-3.1.1-next-2024-02-12.1.tgz",
-      "integrity": "sha512-M9mXLljI+4sDIodewyUdlodfWr6TEdEWShw2dKqhuX2n9FljL8KyMqAf0nUXoXilDJzoPdsppQXy1Gq0kN2HLg==",
+      "version": "4.0.0-next-2024-02-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.0-next-2024-02-14.tgz",
+      "integrity": "sha512-yllq/VasznNY0AJqUw68RJ1QaQCALDqcLrVJqPZIXCd+6Sa4lOksY9dArn0eq7T1dvy8YdvmfgDi3qeDDQY3Lw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.1-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-02-12.1.tgz",
-      "integrity": "sha512-shG5aDrBN6YZxIxY3r7chHFtVmw/Uw/0PmFeq4xtT5m7vD3NurTJaA+g7RlO4L+GI4uPwqycQXmFXSl9ILXTVg==",
+      "version": "1.0.1-next-2024-02-14.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-02-14.1.tgz",
+      "integrity": "sha512-Bzm8TMCAiUw5mTmhZ2wpk6mPWHn5+p4r7IAXgRcbcbY4xfC8xbTTie8hJCeSpQyYqXH2r7T3j1l/s6pV30Esaw==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7126,17 +7126,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "2.1.1-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.1-next-2024-02-12.1.tgz",
-      "integrity": "sha512-gPXpI/lCihgdWxsdrPZMJaYnwqR77k+L1THaIikX/rHhZIKdHwFSRiyNt3kXCt3T+LqYpSX/mdvcehhORNIUAg==",
+      "version": "2.1.2-next-2024-02-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.2-next-2024-02-14.tgz",
+      "integrity": "sha512-18j0Rj53dE3vb9gcxhg1yrZYjlOscUWV3TVNGgtYRyIChJenW4LQ65/G52S3zwLgVYQXWwK9YYoWeURnlLAfgg==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.1.0-next-2024-02-12.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.0-next-2024-02-12.1.tgz",
-      "integrity": "sha512-57uv2hkBU01TBwRup+iqRXi/NUH7+pbXucGbWT0o8nEW2m6HIzYFG/HQg1mIsigB3bIsOHX5fuu/GIbIiF24Bw==",
+      "version": "2.1.1-next-2024-02-14",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.1-next-2024-02-14.tgz",
+      "integrity": "sha512-bQpPIB5purkev6OGd9yld7Jvcra4m1In/qWXCg8zupa4WyF0a4mxm0U42WhFCnR22SqvmBhEqEGyqNDHkUCZaw==",
       "requires": {}
     },
     "@esbuild/android-arm": {


### PR DESCRIPTION
# Motivation

We just released a new [version](https://github.com/dfinity/ic-js/releases/tag/2024.02.14-1600Z) of ic-js libs, this PR bump those dependencies to their next version.

In comparison to the libs already included in main, extending ICP `Subaccount.fromId` to accept more than 256 (see [PR](https://github.com/dfinity/ic-js/pull/526)) is the only notable change.