### PR TITLE
Update proposal rendering dependencies

### DIFF
--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-25_14-09+p2p-con/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-07_23-01+feature/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -484,6 +484,22 @@ pub struct MostRecentMonthlyNodeProviderRewards {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct GenesisNeuronAccount {
+    pub id: u64,
+    pub error_count: u64,
+    pub neuron_type: i32,
+    pub account_ids: Vec<String>,
+    pub tag_end_timestamp_seconds: Option<u64>,
+    pub amount_icp_e8s: u64,
+    pub tag_start_timestamp_seconds: Option<u64>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct GenesisNeuronAccounts {
+    pub genesis_neuron_accounts: Vec<GenesisNeuronAccount>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct GovernanceCachedMetrics {
     pub total_maturity_e8s_equivalent: u64,
     pub not_dissolving_neurons_e8s_buckets: Vec<(u64, f64)>,
@@ -774,6 +790,7 @@ pub struct Governance {
     pub making_sns_proposal: Option<MakingSnsProposal>,
     pub most_recent_monthly_node_provider_rewards: Option<MostRecentMonthlyNodeProviderRewards>,
     pub maturity_modulation_last_updated_at_timestamp_seconds: Option<u64>,
+    pub genesis_neuron_accounts: Option<GenesisNeuronAccounts>,
     pub wait_for_quiet_threshold_seconds: u64,
     pub metrics: Option<GovernanceCachedMetrics>,
     pub neuron_management_voting_period_seconds: Option<u64>,
@@ -961,6 +978,7 @@ pub struct MergeResponse {
 
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct MakeProposalResponse {
+    pub message: Option<String>,
     pub proposal_id: Option<NeuronId>,
 }
 

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-25_14-09+p2p-con/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-07_23-01+feature/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -51,12 +51,19 @@ pub struct AddFirewallRulesPayload {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct IPv4Config {
+    pub prefix_length: u32,
+    pub gateway_ip_addr: String,
+    pub ip_addr: String,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct AddNodePayload {
     pub prometheus_metrics_endpoint: String,
     pub http_endpoint: String,
     pub idkg_dealing_encryption_pk: Option<serde_bytes::ByteBuf>,
     pub domain: Option<String>,
-    pub public_ipv4_config: Option<Vec<String>>,
+    pub public_ipv4_config: Option<IPv4Config>,
     pub xnet_endpoint: String,
     pub chip_id: Option<serde_bytes::ByteBuf>,
     pub committee_signing_pk: serde_bytes::ByteBuf,
@@ -372,10 +379,8 @@ pub struct UpdateNodeDomainDirectlyPayload {
 
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateNodeIPv4ConfigDirectlyPayload {
+    pub ipv4_config: Option<IPv4Config>,
     pub node_id: Principal,
-    pub gateway_ip_addrs: Vec<String>,
-    pub prefix_length: u32,
-    pub ip_addr: String,
 }
 
 #[derive(Serialize, CandidType, Deserialize)]

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-01-25_14-09+p2p-con/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-07_23-01+feature/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.
Even with no changes, just updating the reference is good practice.

# Changes
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.
  * Note: The candid files under `declarations/nns-$CANISTER` are used as inputs.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants