### PR TITLE
NNS1-2851: Key accounts by ledgerCanisterId

### DIFF
--- a/frontend/src/lib/derived/universes-accounts.derived.ts
+++ b/frontend/src/lib/derived/universes-accounts.derived.ts
@@ -1,4 +1,7 @@
-import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import {
+  LEDGER_CANISTER_ID,
+  OWN_CANISTER_ID_TEXT,
+} from "$lib/constants/canister-ids.constants";
 import type { UniversesAccounts } from "$lib/derived/accounts-list.derived";
 import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
 import { snsLedgerCanisterIdsStore } from "$lib/derived/sns/sns-canisters.derived";
@@ -10,6 +13,9 @@ import type { Account } from "$lib/types/account";
 import type { Principal } from "@dfinity/principal";
 import { derived, type Readable } from "svelte/store";
 
+/**
+ * Returns a record of accounts keyed by rootCanisterId and ledgerCanisterId.
+ */
 export const universesAccountsStore = derived<
   [Readable<Account[]>, Readable<Record<string, Principal>>, IcrcAccountsStore],
   UniversesAccounts
@@ -27,6 +33,7 @@ export const universesAccountsStore = derived<
 
     return {
       [OWN_CANISTER_ID_TEXT]: $nnsAccountsListStore,
+      [LEDGER_CANISTER_ID.toText()]: $nnsAccountsListStore,
       ...Object.entries($icrcAccountsStore).reduce(
         (acc, [ledgerCanisterId, { accounts }]) => {
           const universeId =
@@ -34,6 +41,7 @@ export const universesAccountsStore = derived<
           return {
             ...acc,
             [universeId]: accounts,
+            [ledgerCanisterId]: accounts,
           };
         },
         {}

--- a/frontend/src/tests/lib/derived/universes-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-accounts.derived.spec.ts
@@ -1,4 +1,7 @@
-import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import {
+  LEDGER_CANISTER_ID,
+  OWN_CANISTER_ID_TEXT,
+} from "$lib/constants/canister-ids.constants";
 import {
   CKBTC_LEDGER_CANISTER_ID,
   CKBTC_UNIVERSE_CANISTER_ID,
@@ -37,6 +40,10 @@ describe("universes-accounts", () => {
       mockMainAccount,
       mockSubAccount,
     ]);
+    expect(store[LEDGER_CANISTER_ID.toText()]).toEqual([
+      mockMainAccount,
+      mockSubAccount,
+    ]);
   });
 
   it("should derive Sns accounts", () => {
@@ -58,6 +65,10 @@ describe("universes-accounts", () => {
 
     const store = get(universesAccountsStore);
     expect(store[rootCanisterId.toText()]).toEqual([
+      mockSnsMainAccount,
+      mockSnsSubAccount,
+    ]);
+    expect(store[ledgerCanisterId.toText()]).toEqual([
       mockSnsMainAccount,
       mockSnsSubAccount,
     ]);
@@ -112,7 +123,9 @@ describe("universes-accounts", () => {
     const store = get(universesAccountsStore);
     expect(store).toEqual({
       [OWN_CANISTER_ID_TEXT]: [mockMainAccount, mockSubAccount],
+      [LEDGER_CANISTER_ID.toText()]: [mockMainAccount, mockSubAccount],
       [rootCanisterId.toText()]: [mockSnsMainAccount, mockSnsSubAccount],
+      [snsLedgerCanisterId.toText()]: [mockSnsMainAccount, mockSnsSubAccount],
       [CKBTC_UNIVERSE_CANISTER_ID.toText()]: [mockCkBTCMainAccount],
     });
   });

--- a/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-accounts-balance.services.spec.ts
@@ -48,8 +48,8 @@ describe("sns-accounts-balance.services", () => {
     await tick();
 
     const store = get(universesAccountsBalance);
-    // Nns + 1 Sns
-    expect(Object.keys(store)).toHaveLength(2);
+    // 2 (ledger + root) Nns + 2 (ledger + root canister) x 1 Sns
+    expect(Object.keys(store)).toHaveLength(4);
     expect(store[rootCanisterId.toText()]).toEqual(
       mockSnsMainAccount.balanceUlps
     );

--- a/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/wallet-uncertified-accounts.services.spec.ts
@@ -48,8 +48,8 @@ describe("wallet-uncertified-accounts.services", () => {
     await services.uncertifiedLoadAccountsBalance(params);
 
     const store = get(universesAccountsBalance);
-    // Nns + ckBTC + ckTESTBTC
-    expect(Object.keys(store)).toHaveLength(3);
+    // 2 (ledger + root) Nns + ckBTC + ckTESTBTC
+    expect(Object.keys(store)).toHaveLength(4);
     expect(store[CKBTC_UNIVERSE_CANISTER_ID.toText()]).toEqual(
       mockCkBTCMainAccount.balanceUlps
     );


### PR DESCRIPTION
# Motivation

Remove SnsTransactionModal and use IcrcTransactionModal for SNSes.

The SelectAccountDropdown uses `universesAccountsStore` by rootCanisterId which in the case of IcrcTransactionModal it's also the ledger canister id.

In this PR, I add the ledgerCanisterId as key in the derived store `universesAccountsStore`.

# Changes

* Add the same value keyed by ledgerCanisterId in `universesAccountsStore`.

# Tests

* Add expects by ledgerCanisterId in the test for `universesAccountsStore`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
