### PR TITLE
Use fromEntries instead of reduce

### DIFF
--- a/frontend/src/lib/derived/tokens.derived.ts
+++ b/frontend/src/lib/derived/tokens.derived.ts
@@ -8,6 +8,7 @@ import {
 } from "$lib/derived/sns/sns-tokens.derived";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
+import { mapEntries } from "$lib/utils/utils";
 import { derived, type Readable } from "svelte/store";
 
 export const tokensByUniverseIdStore: Readable<
@@ -16,12 +17,10 @@ export const tokensByUniverseIdStore: Readable<
   [tokensStore, snsTokensByRootCanisterIdStore],
   ([$tokensStore, $snsTokensByRootCanisterIdStore]) => {
     return {
-      ...Object.fromEntries(
-        Object.entries($tokensStore).map(([universeId, tokenData]) => [
-          universeId,
-          tokenData.token,
-        ])
-      ),
+      ...mapEntries({
+        obj: $tokensStore,
+        mapFn: ([universeId, tokenData]) => [universeId, tokenData.token],
+      }),
       ...$snsTokensByRootCanisterIdStore,
     };
   }
@@ -33,13 +32,13 @@ export const tokensByLedgerCanisterIdStore: Readable<
   [tokensStore, snsTokensByLedgerCanisterIdStore],
   ([$tokensStore, $snsTokensByLedgerCanisterIdStore]) => {
     return {
-      ...Object.fromEntries(
-        Object.entries($tokensStore)
-          .filter(
-            ([universeId, _tokenData]) => universeId !== OWN_CANISTER_ID_TEXT
-          )
-          .map(([universeId, tokenData]) => [universeId, tokenData.token])
-      ),
+      ...mapEntries({
+        obj: $tokensStore,
+        mapFn: ([universeId, tokenData]) =>
+          universeId === OWN_CANISTER_ID_TEXT
+            ? undefined
+            : [universeId, tokenData.token],
+      }),
       ...$snsTokensByLedgerCanisterIdStore,
       [LEDGER_CANISTER_ID.toText()]: $tokensStore[OWN_CANISTER_ID_TEXT].token,
     };

--- a/frontend/src/lib/derived/universes-accounts-balance.derived.ts
+++ b/frontend/src/lib/derived/universes-accounts-balance.derived.ts
@@ -2,6 +2,7 @@ import type { UniversesAccounts } from "$lib/derived/accounts-list.derived";
 import { universesAccountsStore } from "$lib/derived/universes-accounts.derived";
 import type { RootCanisterIdText } from "$lib/types/sns";
 import { sumAccounts } from "$lib/utils/accounts.utils";
+import { mapEntries } from "$lib/utils/utils";
 import { derived, type Readable } from "svelte/store";
 
 export type UniversesAccountsBalanceReadableStore = Record<
@@ -13,10 +14,8 @@ export const universesAccountsBalance = derived<
   Readable<UniversesAccounts>,
   UniversesAccountsBalanceReadableStore
 >(universesAccountsStore, ($universesAccountsStore) =>
-  Object.fromEntries(
-    Object.entries($universesAccountsStore).map(([universeId, accounts]) => [
-      universeId,
-      sumAccounts(accounts),
-    ])
-  )
+  mapEntries({
+    obj: $universesAccountsStore,
+    mapFn: ([universeId, accounts]) => [universeId, sumAccounts(accounts)],
+  })
 );

--- a/frontend/src/lib/derived/universes-accounts.derived.ts
+++ b/frontend/src/lib/derived/universes-accounts.derived.ts
@@ -7,6 +7,7 @@ import {
   type IcrcAccountsStore,
 } from "$lib/stores/icrc-accounts.store";
 import type { Account } from "$lib/types/account";
+import { mapEntries } from "$lib/utils/utils";
 import type { Principal } from "@dfinity/principal";
 import { derived, type Readable } from "svelte/store";
 
@@ -16,28 +17,24 @@ export const universesAccountsStore = derived<
 >(
   [nnsAccountsListStore, snsLedgerCanisterIdsStore, icrcAccountsStore],
   ([$nnsAccountsListStore, $snsLedgerCanisterIdsStore, $icrcAccountsStore]) => {
-    const snsLedgerToRootCanisterId = Object.fromEntries(
-      Object.entries($snsLedgerCanisterIdsStore).map(
-        ([rootCanisterId, ledgerCanisterId]) => [
-          ledgerCanisterId.toText(),
-          rootCanisterId,
-        ]
-      )
-    );
+    const snsLedgerToRootCanisterId = mapEntries({
+      obj: $snsLedgerCanisterIdsStore,
+      mapFn: ([rootCanisterId, ledgerCanisterId]) => [
+        ledgerCanisterId.toText(),
+        rootCanisterId,
+      ],
+    });
 
     return {
       [OWN_CANISTER_ID_TEXT]: $nnsAccountsListStore,
-      ...Object.entries($icrcAccountsStore).reduce(
-        (acc, [ledgerCanisterId, { accounts }]) => {
+      ...mapEntries({
+        obj: $icrcAccountsStore,
+        mapFn: ([ledgerCanisterId, { accounts }]) => {
           const universeId =
             snsLedgerToRootCanisterId[ledgerCanisterId] ?? ledgerCanisterId;
-          return {
-            ...acc,
-            [universeId]: accounts,
-          };
+          return [universeId, accounts];
         },
-        {}
-      ),
+      }),
     };
   }
 );

--- a/frontend/src/lib/derived/universes-tokens.derived.ts
+++ b/frontend/src/lib/derived/universes-tokens.derived.ts
@@ -9,6 +9,7 @@ import type {
 } from "$lib/stores/tokens.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { UniverseCanisterIdText } from "$lib/types/universe";
+import { mapEntries } from "$lib/utils/utils";
 import { TokenAmountV2, nonNullish } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 
@@ -37,21 +38,20 @@ export const ckBTCTokenFeeStore = derived<
   ],
   Record<UniverseCanisterIdText, TokenAmountV2 | undefined>
 >([ckBTCTokenStore], ([$ckBTCTokenStore]) =>
-  Object.entries($ckBTCTokenStore).reduce(
-    (acc, [key, value]) => ({
-      ...acc,
-      [key]:
-        nonNullish(value) && nonNullish(value?.token)
-          ? TokenAmountV2.fromUlps({
-              amount: value.token.fee,
-              token: {
-                name: value.token.name,
-                symbol: value.token.symbol,
-                decimals: value.token.decimals,
-              },
-            })
-          : undefined,
-    }),
-    {}
-  )
+  mapEntries({
+    obj: $ckBTCTokenStore,
+    mapFn: ([key, value]) => [
+      key,
+      nonNullish(value) && nonNullish(value?.token)
+        ? TokenAmountV2.fromUlps({
+            amount: value.token.fee,
+            token: {
+              name: value.token.name,
+              symbol: value.token.symbol,
+              decimals: value.token.decimals,
+            },
+          })
+        : undefined,
+    ],
+  })
 );

--- a/frontend/src/lib/stores/sns-filters.store.ts
+++ b/frontend/src/lib/stores/sns-filters.store.ts
@@ -1,5 +1,6 @@
 import { StoreLocalStorageKey } from "$lib/constants/stores.constants";
 import type { Filter, SnsProposalTypeFilterId } from "$lib/types/filters";
+import { mapEntries } from "$lib/utils/utils";
 import type { Principal } from "@dfinity/principal";
 import type {
   SnsProposalDecisionStatus,
@@ -213,15 +214,15 @@ export const snsSelectedFiltersStore = derived<
   Readable<SnsFiltersStoreData>,
   SnsFiltersStoreData
 >(snsFiltersStore, ($snsFilters) =>
-  Object.entries($snsFilters).reduce(
-    (acc, [rootCanisterIdText, filters]) => ({
-      ...acc,
-      [rootCanisterIdText]: {
+  mapEntries({
+    obj: $snsFilters,
+    mapFn: ([rootCanisterIdText, filters]) => [
+      rootCanisterIdText,
+      {
         types: filters.types.filter(({ checked }) => checked),
         rewardStatus: filters.rewardStatus.filter(({ checked }) => checked),
         decisionStatus: filters.decisionStatus.filter(({ checked }) => checked),
       },
-    }),
-    {}
-  )
+    ],
+  })
 );

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -362,6 +362,22 @@ export const keyOfOptional = <T>({
   key: string | keyof T;
 }): T[keyof T] | undefined => obj?.[key as keyof T];
 
+// Transforms one Record<> into another Record<> by mapping the
+// entries with the provided function.
+// An entry can be filtered out by returning `undefined`.
+export const mapEntries = <V1, V2>({
+  obj,
+  mapFn,
+}: {
+  obj: Record<string, V1>;
+  mapFn: (entry: [string, V1]) => [string, V2] | undefined;
+}): Record<string, V2> =>
+  Object.fromEntries(
+    Object.entries(obj)
+      .map((entry) => mapFn(entry))
+      .filter((entry) => nonNullish(entry)) as Array<[string, V2]>
+  );
+
 /**
  * Returns whether an asset is PNG or not.
  *

--- a/frontend/src/tests/lib/utils/utils.spec.ts
+++ b/frontend/src/tests/lib/utils/utils.spec.ts
@@ -10,6 +10,7 @@ import {
   isDefined,
   isHash,
   isPngAsset,
+  mapEntries,
   poll,
   removeKeys,
   sameBufferData,
@@ -801,6 +802,55 @@ describe("utils", () => {
         c: 3,
       };
       expect(removeKeys({ obj, keysToRemove: ["b", "d"] })).toEqual(expected);
+    });
+  });
+
+  describe("mapEntries", () => {
+    it("maps the values", () => {
+      const obj = {
+        a: 1,
+        b: 2,
+      };
+      const expected = {
+        a: 2,
+        b: 4,
+      };
+      expect(mapEntries({ obj, mapFn: ([k, v]) => [k, v * 2] })).toEqual(
+        expected
+      );
+    });
+
+    it("maps the keys", () => {
+      const obj = {
+        a: 1,
+        b: 2,
+      };
+      const expected = {
+        aX: 1,
+        bX: 2,
+      };
+      expect(mapEntries({ obj, mapFn: ([k, v]) => [k + "X", v] })).toEqual(
+        expected
+      );
+    });
+
+    it("filters undefined entries", () => {
+      const obj = {
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4,
+      };
+      const expected = {
+        a: 1,
+        c: 3,
+      };
+      expect(
+        mapEntries({
+          obj,
+          mapFn: ([k, v]) => (v % 2 === 0 ? undefined : [k, v]),
+        })
+      ).toEqual(expected);
     });
   });
 


### PR DESCRIPTION
# Motivation

In some places we use `.reduce()` to construct an object out of entries.
`Object.fromEntries` is a cleaner more efficient way to do this.

# Changes

1. Add a util `mapEntries` to combine `Object.entries` and `Object.fromEntries`.
2. Use the util in a few places.

# Tests

Added unit tests for the new util.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary