### PR TITLE
Chore: Make prop mandatory in NnsAccounts

### DIFF
--- a/frontend/src/lib/pages/NnsAccounts.svelte
+++ b/frontend/src/lib/pages/NnsAccounts.svelte
@@ -25,8 +25,7 @@
     cancelPollAccounts();
   });
 
-  // TODO: Remove default value when we remove the feature flag
-  export let userTokensData: UserToken[] = [];
+  export let userTokensData: UserToken[];
 
   const openAddAccountModal = () => {
     openAccountsModal({

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -40,7 +40,7 @@ describe("NnsAccounts", () => {
 
   describe("when tokens flag is enabled", () => {
     it("renders 'Accounts' as tokens table first column", async () => {
-      const po = renderComponent();
+      const po = renderComponent([]);
 
       const tablePo = po.getTokensTablePo();
       expect(await tablePo.getFirstColumnHeader()).toEqual("Accounts");
@@ -114,7 +114,9 @@ describe("NnsAccounts", () => {
     });
 
     it("should stop polling", async () => {
-      const { unmount } = render(NnsAccounts);
+      const { unmount } = render(NnsAccounts, {
+        props: { userTokensData: [] },
+      });
 
       await runResolvedPromises();
       let expectedCalls = 1;


### PR DESCRIPTION
# Motivation

Make optional parameter mandatory.

The `userTokensData` was optional while the NnsAccounts rendered the accounts cards instead of the tokens table.

# Changes

* Make `userTokensData` mandatory in NnsAccounts.

# Tests

Still passing.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.