### PR TITLE
Remove mergeMaturity

### DIFF
--- a/frontend/src/lib/api-services/governance.api-service.ts
+++ b/frontend/src/lib/api-services/governance.api-service.ts
@@ -6,7 +6,6 @@ import {
   increaseDissolveDelay,
   joinCommunityFund,
   leaveCommunityFund,
-  mergeMaturity,
   mergeNeurons,
   queryKnownNeurons,
   queryLastestRewardEvent,
@@ -28,7 +27,6 @@ import {
   type ApiIncreaseDissolveDelayParams,
   type ApiManageHotkeyParams,
   type ApiManageNeuronParams,
-  type ApiMergeMaturityParams,
   type ApiMergeNeuronsParams,
   type ApiQueryNeuronParams,
   type ApiQueryParams,
@@ -168,10 +166,6 @@ export const governanceApiService = {
   },
   leaveCommunityFund(params: ApiManageNeuronParams) {
     return clearCacheAfter(leaveCommunityFund(params));
-  },
-  // @deprecated
-  mergeMaturity(params: ApiMergeMaturityParams) {
-    return clearCacheAfter(mergeMaturity(params));
   },
   mergeNeurons(params: ApiMergeNeuronsParams) {
     return clearCacheAfter(mergeNeurons(params));

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -165,22 +165,6 @@ export const disburse = async ({
   logWithTimestamp(`Disburse neuron (${hashCode(neuronId)}) complete.`);
 };
 
-export type ApiMergeMaturityParams = ApiManageNeuronParams & {
-  percentageToMerge: number;
-};
-
-export const mergeMaturity = async ({
-  neuronId,
-  percentageToMerge,
-  identity,
-}: ApiMergeMaturityParams): Promise<void> => {
-  logWithTimestamp(`Merge maturity (${hashCode(neuronId)}) call...`);
-  const { canister } = await governanceCanister({ identity });
-
-  await canister.mergeMaturity({ neuronId, percentageToMerge });
-  logWithTimestamp(`Merge maturity (${hashCode(neuronId)}) complete.`);
-};
-
 export type ApiStakeMaturityParams = ApiManageNeuronParams & {
   percentageToStake: number;
 };

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -4,7 +4,6 @@ import type { SubAccountArray } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { IS_TESTNET } from "$lib/constants/environment.constants";
 import {
   CANDID_PARSER_VERSION,
-  MIN_VERSION_STAKE_MATURITY_WORKAROUND,
   SNS_SUPPORT_VERSION,
 } from "$lib/constants/ledger-app.constants";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
@@ -646,39 +645,6 @@ export const disburse = async ({
       loadBalance({ accountIdentifier: toAccountId }),
       listNeurons(),
     ]);
-
-    return { success: true };
-  } catch (err) {
-    toastsShow(mapNeuronErrorToToastMessage(err));
-
-    return { success: false };
-  }
-};
-
-// TODO: Remove as soon as Stake Maturity is proven for Hardware Wallets
-export const mergeMaturity = async ({
-  neuronId,
-  percentageToMerge,
-}: {
-  neuronId: NeuronId;
-  percentageToMerge: number;
-}): Promise<{ success: boolean }> => {
-  try {
-    const identity: Identity =
-      await getIdentityOfControllerByNeuronId(neuronId);
-
-    await assertLedgerVersion({
-      identity,
-      minVersion: MIN_VERSION_STAKE_MATURITY_WORKAROUND,
-    });
-
-    await governanceApiService.mergeMaturity({
-      neuronId,
-      percentageToMerge,
-      identity,
-    });
-
-    await getAndLoadNeuron(neuronId);
 
     return { success: true };
   } catch (err) {

--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -717,36 +717,6 @@ describe("neurons api-service", () => {
     });
   });
 
-  describe("mergeMaturity", () => {
-    const params = {
-      neuronId,
-      identity: mockIdentity,
-      percentageToMerge: 0.2,
-    };
-
-    it("should call mergeMaturity api", () => {
-      governanceApiService.mergeMaturity(params);
-      expect(api.mergeMaturity).toHaveBeenCalledWith(params);
-      expect(api.mergeMaturity).toHaveBeenCalledTimes(1);
-    });
-
-    it("should invalidate the cache", async () => {
-      await shouldInvalidateCache({
-        apiFunc: api.mergeMaturity,
-        apiServiceFunc: governanceApiService.mergeMaturity,
-        params,
-      });
-    });
-
-    it("should invalidate the cache on failure", async () => {
-      await shouldInvalidateCacheOnFailure({
-        apiFunc: api.mergeMaturity,
-        apiServiceFunc: governanceApiService.mergeMaturity,
-        params,
-      });
-    });
-  });
-
   describe("mergeNeurons", () => {
     const params = {
       identity: mockIdentity,

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -5,7 +5,6 @@ import {
   increaseDissolveDelay,
   joinCommunityFund,
   leaveCommunityFund,
-  mergeMaturity,
   mergeNeurons,
   queryKnownNeurons,
   queryLastestRewardEvent,
@@ -310,39 +309,6 @@ describe("neurons-api", () => {
         disburse({
           identity: mockIdentity,
           toAccountId: mockMainAccount.identifier,
-          neuronId: 10n,
-        });
-      await expect(call).rejects.toThrow(error);
-    });
-  });
-
-  describe("mergeMaturity", () => {
-    it("merges a percentage of the maturity of a neuron successfully", async () => {
-      mockGovernanceCanister.mergeMaturity.mockImplementation(
-        vi.fn().mockResolvedValue(undefined)
-      );
-
-      await mergeMaturity({
-        identity: mockIdentity,
-        percentageToMerge: 50,
-        neuronId: 10n,
-      });
-
-      expect(mockGovernanceCanister.mergeMaturity).toBeCalled();
-    });
-
-    it("throws error when mergeMaturity fails", async () => {
-      const error = new Error();
-      mockGovernanceCanister.mergeMaturity.mockImplementation(
-        vi.fn(() => {
-          throw error;
-        })
-      );
-
-      const call = () =>
-        mergeMaturity({
-          identity: mockIdentity,
-          percentageToMerge: 50,
           neuronId: 10n,
         });
       await expect(call).rejects.toThrow(error);

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -145,7 +145,6 @@ describe("neurons-services", () => {
   const spyAutoStakeMaturity = vi.spyOn(api, "autoStakeMaturity");
   const spyLeaveCommunityFund = vi.spyOn(api, "leaveCommunityFund");
   const spyDisburse = vi.spyOn(api, "disburse");
-  const spyMergeMaturity = vi.spyOn(api, "mergeMaturity");
   const spyStakeMaturity = vi.spyOn(api, "stakeMaturity");
   const spySpawnNeuron = vi.spyOn(api, "spawnNeuron");
   const spyMergeNeurons = vi.spyOn(api, "mergeNeurons");
@@ -180,7 +179,6 @@ describe("neurons-services", () => {
     spyAutoStakeMaturity.mockResolvedValue();
     spyLeaveCommunityFund.mockResolvedValue();
     spyDisburse.mockResolvedValue();
-    spyMergeMaturity.mockResolvedValue();
     spyStakeMaturity.mockResolvedValue();
     spySpawnNeuron.mockImplementation(() =>
       Promise.resolve(newSpawnedNeuronId)

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -662,54 +662,6 @@ describe("neurons-services", () => {
     });
   });
 
-  describe("mergeMaturity", () => {
-    it("should merge maturity of the neuron", async () => {
-      neuronsStore.pushNeurons({ neurons, certified: true });
-      expect(spyMergeMaturity).not.toBeCalled();
-      const { success } = await services.mergeMaturity({
-        neuronId: controlledNeuron.neuronId,
-        percentageToMerge: 50,
-      });
-
-      expect(spyMergeMaturity).toBeCalledWith({
-        identity: mockIdentity,
-        neuronId: controlledNeuron.neuronId,
-        percentageToMerge: 50,
-      });
-      expect(spyMergeMaturity).toBeCalledTimes(1);
-      expect(success).toBe(true);
-    });
-
-    it("should not merge maturity if no identity", async () => {
-      setNoIdentity();
-
-      const { success } = await services.mergeMaturity({
-        neuronId: controlledNeuron.neuronId,
-        percentageToMerge: 50,
-      });
-
-      expectToastError(en.error.missing_identity);
-      expect(spyMergeMaturity).not.toBeCalled();
-      expect(success).toBe(false);
-    });
-
-    it("should not merge maturity if not controlled by user", async () => {
-      neuronsStore.pushNeurons({
-        neurons: [notControlledNeuron],
-        certified: true,
-      });
-
-      const { success } = await services.mergeMaturity({
-        neuronId: notControlledNeuron.neuronId,
-        percentageToMerge: 50,
-      });
-
-      expectToastError(en.error.not_authorized_neuron_action);
-      expect(spyMergeMaturity).not.toBeCalled();
-      expect(success).toBe(false);
-    });
-  });
-
   describe("stakeMaturity", () => {
     it("should stake maturity of the neuron", async () => {
       neuronsStore.pushNeurons({ neurons, certified: true });


### PR DESCRIPTION
# Motivation

Remove unused code.

The merge maturity functionality is not used anymore.

# Changes

* Remove mergeMaturity neuron service.
* Remove mergeMaturity api function.
* Remove mergeMaturity api service function.

# Tests

* Remove test for mergeMaturity neuron service.
* Remove test for mergeMaturity api function.
* Remove test for mergeMaturity api service function.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
