### PR TITLE
Remove get nervous system functions call

### DIFF
--- a/frontend/src/lib/api/sns-governance.api.ts
+++ b/frontend/src/lib/api/sns-governance.api.ts
@@ -5,7 +5,6 @@ import type { IcrcAccount } from "@dfinity/ledger-icrc";
 import type { Principal } from "@dfinity/principal";
 import type {
   SnsListProposalsParams,
-  SnsNervousSystemFunction,
   SnsNervousSystemParameters,
   SnsNeuron,
   SnsNeuronId,
@@ -360,29 +359,6 @@ export const claimNeuron = async ({
 
   logWithTimestamp(`Claiming neuron call complete.`);
   return neuronId;
-};
-
-export const getNervousSystemFunctions = async ({
-  rootCanisterId,
-  identity,
-  certified,
-}: {
-  rootCanisterId: Principal;
-  identity: Identity;
-  certified: boolean;
-}): Promise<SnsNervousSystemFunction[]> => {
-  logWithTimestamp(`Getting nervous system functions call...`);
-
-  const { listNervousSystemFunctions } = await wrapper({
-    identity,
-    rootCanisterId: rootCanisterId.toText(),
-    certified,
-  });
-
-  const { functions } = await listNervousSystemFunctions({});
-
-  logWithTimestamp(`Getting nervous system functions call complete.`);
-  return functions;
 };
 
 export const nervousSystemParameters = async ({

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
   import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
   import {
@@ -24,13 +23,6 @@
     createSnsNsFunctionsProjectStore,
     type SnsNervousSystemFunctionsProjectStore,
   } from "$lib/derived/sns-ns-functions-project.derived";
-
-  $: {
-    if (rootCanisterId !== undefined) {
-      // To render the topics of the followees we need to fetch all the topics.
-      loadSnsNervousSystemFunctions(rootCanisterId);
-    }
-  }
 
   const { store }: SelectedSnsNeuronContext =
     getContext<SelectedSnsNeuronContext>(SELECTED_SNS_NEURON_CONTEXT_KEY);

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -849,7 +849,6 @@
     "ledger_insufficient_funds": "Sorry, the account doesn't have enough funds for this transaction.",
     "sns_add_followee": "There was an error while adding a followee.",
     "sns_remove_followee": "There was an error while unfollowing the neuron.",
-    "sns_load_functions": "There was an error while loading the project topics.",
     "sns_add_hotkey": "There was an error adding the hotkey.",
     "sns_stake_maturity": "There was an error while staking the maturity of the neuron.",
     "sns_disburse_maturity": "There was an error while disbursing the maturity of the neuron."

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -17,7 +17,6 @@
   import { pageStore } from "$lib/derived/page.derived";
   import { loadSnsParameters } from "$lib/services/sns-parameters.services";
   import { syncSnsNeurons } from "$lib/services/sns-neurons.services";
-  import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
   import {
     getUniversalProposalStatus,
     mapProposalInfo,
@@ -150,7 +149,6 @@
             : syncSnsNeurons(universeId),
           //
           !$authSignedInStore ? undefined : loadSnsParameters(universeId),
-          loadSnsNervousSystemFunctions(universeId),
         ]);
         /*
         Reload proposal only after `syncSnsNeurons` is done,
@@ -193,7 +191,6 @@
   // preload sns functions for mapping
   let functionsStore: Readable<SnsNervousSystemFunction[] | undefined>;
   $: if (universeCanisterId) {
-    loadSnsNervousSystemFunctions(universeCanisterId);
     functionsStore = createSnsNsFunctionsProjectStore(universeCanisterId);
   }
 

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -2,7 +2,6 @@
   import { loadSnsProposals } from "$lib/services/$public/sns-proposals.services";
   import type { SnsProposalData } from "@dfinity/sns";
   import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
-  import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
   import type { SnsNervousSystemFunction } from "@dfinity/sns";
   import SnsProposalsList from "$lib/components/sns-proposals/SnsProposalsList.svelte";
   import {
@@ -24,6 +23,9 @@
   import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
   import type { Readable } from "svelte/store";
 
+  let nsFunctionsStore: Readable<SnsNervousSystemFunction[] | undefined>;
+  $: nsFunctionsStore = createSnsNsFunctionsProjectStore($snsOnlyProjectStore);
+
   let currentProjectCanisterId: Principal | undefined = undefined;
   const onSnsProjectChanged = async ({
     rootCanisterId,
@@ -40,7 +42,6 @@
     }
 
     currentProjectCanisterId = rootCanisterId;
-    await loadSnsNervousSystemFunctions(rootCanisterId);
     // The store should be updated at this point. But in case it's not (errors etc.),
     // we shouldn't update the filter.
     if (isNullish($nsFunctionsStore)) {
@@ -113,11 +114,6 @@
         $snsFilteredProposalsStore[currentProjectCanisterId.toText()]?.proposals
       )
     : undefined;
-
-  let nsFunctionsStore: Readable<SnsNervousSystemFunction[] | undefined>;
-  $: nsFunctionsStore = createSnsNsFunctionsProjectStore(
-    currentProjectCanisterId
-  );
 
   let disableInfiniteScroll: boolean;
   $: disableInfiniteScroll = nonNullish(currentProjectCanisterId)

--- a/frontend/src/lib/stores/sns-functions.store.ts
+++ b/frontend/src/lib/stores/sns-functions.store.ts
@@ -18,7 +18,6 @@ interface SnsFunctionProject extends SnsNervousSystemFunctions {
 
 export interface SnsNervousSystemFunctionsStore
   extends Readable<SnsNervousSystemFunctionsData> {
-  setProjectFunctions: (data: SnsFunctionProject) => void;
   setProjectsFunctions: (projects: SnsFunctionProject[]) => void;
   reset: () => void;
 }
@@ -26,7 +25,6 @@ export interface SnsNervousSystemFunctionsStore
 /**
  * A store that contains the nervous system functions for each sns project.
  *
- * - setProjectFunctions: replace the current list of functions for a specific sns project with a new list.
  * - setProjectsFunctions: replace the list of functions for multiple projects at once.
  */
 const initSnsFunctionsStore = (): SnsNervousSystemFunctionsStore => {
@@ -36,20 +34,6 @@ const initSnsFunctionsStore = (): SnsNervousSystemFunctionsStore => {
 
   return {
     subscribe,
-
-    setProjectFunctions({
-      rootCanisterId,
-      nsFunctions,
-      certified,
-    }: SnsFunctionProject) {
-      update((currentState: SnsNervousSystemFunctionsData) => ({
-        ...currentState,
-        [rootCanisterId.toText()]: {
-          certified,
-          nsFunctions,
-        },
-      }));
-    },
 
     setProjectsFunctions(wrappedFunctions: SnsFunctionProject[]) {
       update((currentState: SnsNervousSystemFunctionsData) =>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -883,7 +883,6 @@ interface I18nError__sns {
   ledger_insufficient_funds: string;
   sns_add_followee: string;
   sns_remove_followee: string;
-  sns_load_functions: string;
   sns_add_hotkey: string;
   sns_stake_maturity: string;
   sns_disburse_maturity: string;

--- a/frontend/src/tests/fakes/sns-governance-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-governance-api.fake.ts
@@ -34,7 +34,6 @@ const fakeFunctions = {
   querySnsNeurons,
   getSnsNeuron,
   nervousSystemParameters,
-  getNervousSystemFunctions,
   getNeuronBalance,
   refreshNeuron,
   claimNeuron,
@@ -189,18 +188,6 @@ async function nervousSystemParameters({
   certified: boolean;
 }): Promise<SnsNervousSystemParameters> {
   return snsNervousSystemParametersMock;
-}
-
-async function getNervousSystemFunctions({
-  rootCanisterId,
-  identity: _,
-  certified: __,
-}: {
-  rootCanisterId: Principal;
-  identity: Identity;
-  certified: boolean;
-}): Promise<SnsNervousSystemFunction[]> {
-  return nervousFunctions.get(rootCanisterId.toText()) || [];
 }
 
 async function getNeuronBalance({

--- a/frontend/src/tests/lib/api/sns-governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-governance.api.spec.ts
@@ -4,7 +4,6 @@ import {
   claimNeuron,
   disburse,
   disburseMaturity,
-  getNervousSystemFunctions,
   getNeuronBalance,
   getSnsNeuron,
   nervousSystemParameters,
@@ -347,17 +346,6 @@ describe("sns-api", () => {
     });
 
     expect(setTopicFolloweesSpy).toBeCalled();
-  });
-
-  it("should get nervous system functions", async () => {
-    const res = await getNervousSystemFunctions({
-      identity: mockIdentity,
-      rootCanisterId: rootCanisterIdMock,
-      certified: false,
-    });
-
-    expect(getFunctionsSpy).toBeCalled();
-    expect(res).toEqual([nervousSystemFunctionMock]);
   });
 
   it("should get nervous system parameters", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
@@ -1,5 +1,4 @@
 import SnsNeuronFollowingCard from "$lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte";
-import { loadSnsNervousSystemFunctions } from "$lib/services/$public/sns.services";
 import { authStore } from "$lib/stores/auth.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
@@ -20,11 +19,6 @@ import {
   type SnsNervousSystemFunction,
   type SnsNeuron,
 } from "@dfinity/sns";
-import { waitFor } from "@testing-library/svelte";
-
-vi.mock("$lib/services/$public/sns.services", () => ({
-  loadSnsNervousSystemFunctions: vi.fn(),
-}));
 
 describe("SnsNeuronFollowingCard", () => {
   beforeAll(() => {
@@ -85,14 +79,6 @@ describe("SnsNeuronFollowingCard", () => {
     afterEach(() => {
       vi.clearAllMocks();
       snsFunctionsStore.reset();
-    });
-
-    it("loads sns topics", async () => {
-      renderCard(controlledNeuron);
-
-      await waitFor(() =>
-        expect(loadSnsNervousSystemFunctions).toHaveBeenCalled()
-      );
     });
 
     it("renders followees and their topics", () => {
@@ -160,14 +146,6 @@ describe("SnsNeuronFollowingCard", () => {
 
     afterEach(() => {
       vi.clearAllMocks();
-    });
-
-    it("loads sns topics", async () => {
-      renderCard(uncontrolledNeuron);
-
-      await waitFor(() =>
-        expect(loadSnsNervousSystemFunctions).toHaveBeenCalled()
-      );
     });
 
     it("does not render button to follow neurons", () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
@@ -83,11 +83,13 @@ describe("SnsNeuronFollowingCard", () => {
 
     it("renders followees and their topics", () => {
       // Use same rootCanisterId as in `renderSelectedSnsNeuronContext`
-      snsFunctionsStore.setProjectFunctions({
-        rootCanisterId: rootCanisterIdMock,
-        nsFunctions: [function0, function1, function2],
-        certified: true,
-      });
+      snsFunctionsStore.setProjectsFunctions([
+        {
+          rootCanisterId: rootCanisterIdMock,
+          nsFunctions: [function0, function1, function2],
+          certified: true,
+        },
+      ]);
       const { getAllByText } = renderCard(neuronWithFollowees);
 
       [followee1, followee2].forEach((followee) => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/FollowSnsNeuronsButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/FollowSnsNeuronsButton.spec.ts
@@ -7,12 +7,6 @@ import { mockTokenStore } from "$tests/mocks/sns-projects.mock";
 import { fireEvent, render } from "@testing-library/svelte";
 import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
-vi.mock("$lib/services/$public/sns.services", () => {
-  return {
-    loadSnsNervousSystemFunctions: vi.fn(),
-  };
-});
-
 describe("FollowSnsNeuronsButton", () => {
   beforeAll(() => {
     vi.spyOn(snsTokenSymbolSelectedStore, "subscribe").mockImplementation(

--- a/frontend/src/tests/lib/derived/sns-ns-functions-project.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-ns-functions-project.derived.spec.ts
@@ -24,11 +24,13 @@ describe("nsFunctionsProjectStore", () => {
 
   it("returns the functions from snsFunctionsStore", () => {
     const rootCanisterId = rootCanisterIdMock;
-    snsFunctionsStore.setProjectFunctions({
-      rootCanisterId,
-      nsFunctions: [nervousSystemFunctionMock],
-      certified: true,
-    });
+    snsFunctionsStore.setProjectsFunctions([
+      {
+        rootCanisterId,
+        nsFunctions: [nervousSystemFunctionMock],
+        certified: true,
+      },
+    ]);
 
     const store = createSnsNsFunctionsProjectStore(rootCanisterId);
     expect(get(store)).toEqual([nervousSystemFunctionMock]);
@@ -37,11 +39,13 @@ describe("nsFunctionsProjectStore", () => {
   it("returns the functions from snsFunctionsStore when snsAggregatorStore has data", () => {
     snsAggregatorStore.setData([aggregatorProject]);
     const functions = aggregatorSnsMockDto.parameters.functions;
-    snsFunctionsStore.setProjectFunctions({
-      rootCanisterId,
-      nsFunctions: [nervousSystemFunctionMock],
-      certified: true,
-    });
+    snsFunctionsStore.setProjectsFunctions([
+      {
+        rootCanisterId,
+        nsFunctions: [nervousSystemFunctionMock],
+        certified: true,
+      },
+    ]);
 
     const store = createSnsNsFunctionsProjectStore(rootCanisterId);
     expect(get(store)).toEqual([nervousSystemFunctionMock]);
@@ -62,11 +66,13 @@ describe("nsFunctionsProjectStore", () => {
   });
 
   it("returns undefined if another project has ns functions but not this one", () => {
-    snsFunctionsStore.setProjectFunctions({
-      rootCanisterId,
-      nsFunctions: [nervousSystemFunctionMock],
-      certified: true,
-    });
+    snsFunctionsStore.setProjectsFunctions([
+      {
+        rootCanisterId,
+        nsFunctions: [nervousSystemFunctionMock],
+        certified: true,
+      },
+    ]);
     const storeWithNsFunctions =
       createSnsNsFunctionsProjectStore(rootCanisterId);
     expect(get(storeWithNsFunctions)).not.toBeUndefined();

--- a/frontend/src/tests/lib/modals/sns/FollowSnsNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/FollowSnsNeuronsModal.spec.ts
@@ -67,11 +67,13 @@ describe("FollowSnsNeuronsModal", () => {
       ...nervousSystemFunctionMock,
       id: 2n,
     };
-    snsFunctionsStore.setProjectFunctions({
-      rootCanisterId,
-      nsFunctions: [function0, function1, function2],
-      certified: true,
-    });
+    snsFunctionsStore.setProjectsFunctions([
+      {
+        rootCanisterId,
+        nsFunctions: [function0, function1, function2],
+        certified: true,
+      },
+    ]);
 
     const po = renderComponent({});
     expect(await po.getFollowTopicSectionPo(function0.id).isPresent()).toBe(

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -223,20 +223,22 @@ describe("SnsProposals", () => {
         ...proposals[1],
         action: functionId2,
       });
-      snsFunctionsStore.setProjectFunctions({
-        rootCanisterId,
-        nsFunctions: [
-          {
-            ...nervousSystemFunctionMock,
-            id: functionId1,
-          },
-          {
-            ...nervousSystemFunctionMock,
-            id: functionId2,
-          },
-        ],
-        certified: true,
-      });
+      snsFunctionsStore.setProjectsFunctions([
+        {
+          rootCanisterId,
+          nsFunctions: [
+            {
+              ...nervousSystemFunctionMock,
+              id: functionId1,
+            },
+            {
+              ...nervousSystemFunctionMock,
+              id: functionId2,
+            },
+          ],
+          certified: true,
+        },
+      ]);
     });
 
     it("should filter by status", async () => {

--- a/frontend/src/tests/lib/routes/Proposals.spec.ts
+++ b/frontend/src/tests/lib/routes/Proposals.spec.ts
@@ -18,12 +18,6 @@ import {
 import { waitFor } from "@testing-library/dom";
 import { fireEvent, render } from "@testing-library/svelte";
 
-vi.mock("$lib/services/$public/sns.services", () => {
-  return {
-    loadSnsNervousSystemFunctions: vi.fn().mockResolvedValue(undefined),
-  };
-});
-
 vi.mock("$lib/services/$public/proposals.services", () => {
   return {
     listProposals: vi.fn().mockResolvedValue(undefined),

--- a/frontend/src/tests/lib/services/_public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns.services.spec.ts
@@ -1,29 +1,22 @@
 import { clearSnsAggregatorCache } from "$lib/api-services/sns-aggregator.api-service";
 import * as agent from "$lib/api/agent.api";
 import * as aggregatorApi from "$lib/api/sns-aggregator.api";
-import * as governanceApi from "$lib/api/sns-governance.api";
 import { clearWrapperCache, wrapper } from "$lib/api/sns-wrapper.api";
-import {
-  loadSnsNervousSystemFunctions,
-  loadSnsProjects,
-} from "$lib/services/$public/sns.services";
+import { loadSnsProjects } from "$lib/services/$public/sns.services";
 import { authStore } from "$lib/stores/auth.store";
 import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
 import { snsTotalTokenSupplyStore } from "$lib/stores/sns-total-token-supply.store";
-import { toastsError } from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import {
   mockAuthStoreSubscribe,
   mockIdentity,
-  mockPrincipal,
 } from "$tests/mocks/auth.store.mock";
 import {
   aggregatorMockSnsesDataDto,
   aggregatorSnsMockDto,
   aggregatorSnsMockWith,
 } from "$tests/mocks/sns-aggregator.mock";
-import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import {
   deployedSnsMock,
@@ -35,7 +28,6 @@ import {
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import type { HttpAgent } from "@dfinity/agent";
 import { nonNullish } from "@dfinity/utils";
-import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 import { mock } from "vitest-mock-extended";
 
@@ -83,72 +75,6 @@ describe("SNS public services", () => {
     tokensStore.reset();
     clearSnsAggregatorCache();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
-  });
-
-  describe("loadSnsNervousSystemFunctions", () => {
-    beforeEach(() => {
-      snsFunctionsStore.reset();
-      vi.clearAllMocks();
-      vi.spyOn(authStore, "subscribe").mockImplementation(
-        mockAuthStoreSubscribe
-      );
-    });
-    it("should call sns api getNervousSystemFunctions and load the nervous system functions store", async () => {
-      const spyGetFunctions = vi
-        .spyOn(governanceApi, "getNervousSystemFunctions")
-        .mockImplementation(() => Promise.resolve([nervousSystemFunctionMock]));
-
-      await loadSnsNervousSystemFunctions(mockPrincipal);
-
-      const store = get(snsFunctionsStore);
-      await waitFor(() =>
-        expect(store[mockPrincipal.toText()]?.nsFunctions).toEqual([
-          nervousSystemFunctionMock,
-        ])
-      );
-      expect(spyGetFunctions).toBeCalled();
-    });
-
-    it("should not call api if nervous functions are in the snsFunctionsStore store and certified", async () => {
-      snsFunctionsStore.setProjectFunctions({
-        rootCanisterId: mockPrincipal,
-        nsFunctions: [nervousSystemFunctionMock],
-        certified: true,
-      });
-      const spyGetFunctions = vi
-        .spyOn(governanceApi, "getNervousSystemFunctions")
-        .mockImplementation(() => Promise.resolve([nervousSystemFunctionMock]));
-
-      await loadSnsNervousSystemFunctions(mockPrincipal);
-
-      expect(spyGetFunctions).not.toBeCalled();
-    });
-
-    it("should not call api if nervous functions are in the snsAggregator store", async () => {
-      const rootCanisterId = rootCanisterIdMock;
-      const aggregatorProject = aggregatorSnsMockWith({
-        rootCanisterId: rootCanisterId.toText(),
-      });
-      snsAggregatorStore.setData([aggregatorProject]);
-      const spyGetFunctions = vi.spyOn(
-        governanceApi,
-        "getNervousSystemFunctions"
-      );
-
-      await loadSnsNervousSystemFunctions(rootCanisterId);
-
-      expect(spyGetFunctions).not.toBeCalled();
-    });
-
-    it("should show a toast if api throws an error", async () => {
-      vi.spyOn(governanceApi, "getNervousSystemFunctions").mockImplementation(
-        () => Promise.reject("error")
-      );
-
-      await loadSnsNervousSystemFunctions(mockPrincipal);
-
-      await waitFor(() => expect(toastsError).toBeCalled());
-    });
   });
 
   describe("loadSnsProjects", () => {

--- a/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
@@ -70,11 +70,13 @@ describe("sns-vote-registration-services", () => {
     resetIdentity();
     vi.clearAllMocks();
 
-    snsFunctionsStore.setProjectFunctions({
-      rootCanisterId,
-      nsFunctions: [nervousSystemFunctionMock],
-      certified: true,
-    });
+    snsFunctionsStore.setProjectsFunctions([
+      {
+        rootCanisterId,
+        nsFunctions: [nervousSystemFunctionMock],
+        certified: true,
+      },
+    ]);
     snsProposalsStore.setProposals({
       rootCanisterId,
       certified: true,

--- a/frontend/src/tests/lib/stores/sns-functions.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-functions.store.spec.ts
@@ -12,11 +12,13 @@ describe("sns functions store", () => {
   });
 
   it("should set functions for one project", () => {
-    snsFunctionsStore.setProjectFunctions({
-      rootCanisterId: mockPrincipal,
-      nsFunctions: [nervousSystemFunctionMock],
-      certified: true,
-    });
+    snsFunctionsStore.setProjectsFunctions([
+      {
+        rootCanisterId: mockPrincipal,
+        nsFunctions: [nervousSystemFunctionMock],
+        certified: true,
+      },
+    ]);
     const store = get(snsFunctionsStore);
     expect(store[mockPrincipal.toText()]?.nsFunctions).toEqual([
       nervousSystemFunctionMock,
@@ -24,22 +26,26 @@ describe("sns functions store", () => {
   });
 
   it("should set functions for more than one project", () => {
-    snsFunctionsStore.setProjectFunctions({
-      rootCanisterId: mockPrincipal,
-      nsFunctions: [nervousSystemFunctionMock],
-      certified: true,
-    });
+    snsFunctionsStore.setProjectsFunctions([
+      {
+        rootCanisterId: mockPrincipal,
+        nsFunctions: [nervousSystemFunctionMock],
+        certified: true,
+      },
+    ]);
     const store = get(snsFunctionsStore);
     expect(store[mockPrincipal.toText()]?.nsFunctions).toEqual([
       nervousSystemFunctionMock,
     ]);
 
     const rootCanister2 = Principal.from("aaaaa-aa");
-    snsFunctionsStore.setProjectFunctions({
-      rootCanisterId: rootCanister2,
-      nsFunctions: [nervousSystemFunctionMock],
-      certified: true,
-    });
+    snsFunctionsStore.setProjectsFunctions([
+      {
+        rootCanisterId: rootCanister2,
+        nsFunctions: [nervousSystemFunctionMock],
+        certified: true,
+      },
+    ]);
     const store2 = get(snsFunctionsStore);
     expect(store2[rootCanister2.toText()]?.nsFunctions).toEqual([
       nervousSystemFunctionMock,
@@ -70,21 +76,25 @@ describe("sns functions store", () => {
   });
 
   it("should reset functions for more than one project", () => {
-    snsFunctionsStore.setProjectFunctions({
-      rootCanisterId: mockPrincipal,
-      nsFunctions: [nervousSystemFunctionMock],
-      certified: true,
-    });
+    snsFunctionsStore.setProjectsFunctions([
+      {
+        rootCanisterId: mockPrincipal,
+        nsFunctions: [nervousSystemFunctionMock],
+        certified: true,
+      },
+    ]);
     const store = get(snsFunctionsStore);
     expect(store[mockPrincipal.toText()]?.nsFunctions).toEqual([
       nervousSystemFunctionMock,
     ]);
 
-    snsFunctionsStore.setProjectFunctions({
-      rootCanisterId: mockPrincipal,
-      nsFunctions: [],
-      certified: true,
-    });
+    snsFunctionsStore.setProjectsFunctions([
+      {
+        rootCanisterId: mockPrincipal,
+        nsFunctions: [],
+        certified: true,
+      },
+    ]);
     const store2 = get(snsFunctionsStore);
     expect(store2[mockPrincipal.toText()]?.nsFunctions).toEqual([]);
   });


### PR DESCRIPTION
# Motivation

Remove `loadSnsNervousSystemFunctions`, because all sns nsFunction comes from the aggregator and `getNervousSystemFunctions` is never called.

# Changes

- removed `loadSnsNervousSystemFunctions` service.
- removed `getNervousSystemFunctions` api.
- removed `SnsFunctionsStore.setProjectFunctions` because it's a special case of `setProjectsFunctions`.

# Tests

- adjusted

# Todos

- [ ] Add entry to changelog (if necessary).
