### PR TITLE
Always stop before upgrading a canister, in testing scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,9 +119,6 @@ jobs:
       - name: Count upgrade cycles
         run: scripts/nns-dapp/estimate-upgrade-cycles | tee -a $GITHUB_STEP_SUMMARY
   test-upgrade-map:
-    # This test is flaky.
-    # TODO: Debug and re-enable before actually migrating the schema.
-    continue-on-error: true
     needs: build
     runs-on: ubuntu-20.04
     timeout-minutes: 40

--- a/scripts/nns-dapp/downgrade-upgrade-test
+++ b/scripts/nns-dapp/downgrade-upgrade-test
@@ -134,7 +134,9 @@ upgrade_nnsdapp() {
   # Check that the data is plausible
   # TODO: Check that the prestate is not empty; first we need to populate the state.
   # TODO: Consider storing all accounts data in a merkle tree so that we can check just the root hash.
+  dfx canister stop nns-dapp
   dfx canister install --upgrade-unchanged nns-dapp --wasm "$1" --mode upgrade --argument "$(cat nns-dapp-arg-local.did)" --yes
+  dfx canister start nns-dapp
   scripts/dfx-canister-check-wasm-hash --wasm "$1" --canister nns-dapp
   wait_for_migration
   poststate="$(get_upgrade_invariants)"

--- a/scripts/nns-dapp/migration-test.canister
+++ b/scripts/nns-dapp/migration-test.canister
@@ -141,7 +141,9 @@ upgrade_nnsdapp() {
   # Check that the data is plausible
   # TODO: Check that the prestate is not empty; first we need to populate the state.
   # TODO: Consider storing all accounts data in a merkle tree so that we can check just the root hash.
+  dfx canister stop nns-dapp
   dfx canister install --upgrade-unchanged nns-dapp --wasm "$wasm" --mode upgrade --argument "$argument" --yes
+  dfx canister start nns-dapp
   scripts/dfx-canister-check-wasm-hash --wasm "$wasm" --canister nns-dapp
   verify_healthy
   wait_for_migration

--- a/scripts/sns/aggregator/downgrade-upgrade-test
+++ b/scripts/sns/aggregator/downgrade-upgrade-test
@@ -26,7 +26,9 @@ verify_healthy() {
 
 # Installs the current build of sns_aggregator
 upgrade_canister() {
+  dfx canister stop sns_aggregator
   dfx canister install --upgrade-unchanged sns_aggregator --wasm "$1" --mode upgrade --yes
+  dfx canister start sns_aggregator
 }
 
 echo "Getting or building the local wasm..."


### PR DESCRIPTION
# Motivation

Fix the test-upgrade-map

# Changes

In testing scripts, always stop a canister before upgrade (and start after upgrade)

# Tests

The test-upgrade-map passes locally
