### PR TITLE
Upgrade next 2024 02 19 2

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.2.0-next-2024-02-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.2.0-next-2024-02-14.tgz",
-      "integrity": "sha512-9fDhnpevwJXqU3PaZcdJoccKLe4TJEMFGX4+zs/3dZZLmExOmLZ+U9QgDqfaxY6tntboSur/ZT8AJ9NBt84CPQ==",
+      "version": "2.2.0-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.2.0-next-2024-02-19.2.tgz",
+      "integrity": "sha512-bFVs5QIwXZ/dIIETEK6U3sNsA6r/CLRwTo+rgEw/JtfQV6rkiCF7SDm6qE3xnprqnm59JI6nIEZRVQKTohn+ZA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.0.1-next-2024-02-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.1-next-2024-02-14.tgz",
-      "integrity": "sha512-60d2ZXTxS4ysKTXtIKg2WXkJDeob7y8cy10h9aMVVj6HurKs674W4RQSzUnHpOZZajrwf9mxVyRYnC5y7w3sMw==",
+      "version": "3.0.1-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.1-next-2024-02-19.2.tgz",
+      "integrity": "sha512-UosW7MQCYbc3Ksm5UhPnFxLJ5r0rNy8oCNflCEXac0KHEHaQ5blSEJr2/qpavajGsTcyz+Na6NkWqzWJJncElg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "2.2.1-next-2024-02-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.2.1-next-2024-02-14.tgz",
-      "integrity": "sha512-V64AsBI+AsIuLgP+kK8s8aaS3St5oQ0kfl7pQI4l87j2Q4W4Wm0cJuuorTuncMZxuc4HE+W8fafJgneoLu2qTA==",
+      "version": "2.2.1-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.2.1-next-2024-02-19.2.tgz",
+      "integrity": "sha512-2yrBwedOeaN4ThE9M7t4EbOWA7MrwLES8a68Cq4bYc8u9Ea2KKu10+PjwpVnva/jR6HRqWFsE/IcMOM/8U5dqA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.2.0-next-2024-02-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.0-next-2024-02-14.tgz",
-      "integrity": "sha512-DJDlpX8wjdsuI/DV2PkRwtFD6mM4miMAGhhcsoUOFe2iwEaxFY2nYVMsHi+eLDxhPR8rMIsLgoRFfZgQiRW4cQ==",
+      "version": "2.2.0-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.0-next-2024-02-19.2.tgz",
+      "integrity": "sha512-aekIZd+5OiyvmJjhPoosAGsJEn/b8uquUuwt9ks7b+yBMt2cMOk3WXj13ZLW2sB6bAjtNzO/sldIjj2gq9LCpg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.1.2-next-2024-02-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.2-next-2024-02-14.tgz",
-      "integrity": "sha512-R4j/+jsFEFI8UbWP/wQ/gSBPPq7swo7t/LMydzXctE62cRb4mKp6GgMSAN+MUFUtKIziqUXrPRWlGGpwar8hLA==",
+      "version": "2.1.2-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.2-next-2024-02-19.2.tgz",
+      "integrity": "sha512-31ujgZBkhSiQmm7MneQo09igTunb3SlY+2ankV+RgLQzUomyDWizCaGjL8gNYqKhprNgXnc6mhGYDOjcsIdI+Q==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "4.0.0-next-2024-02-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.0-next-2024-02-14.tgz",
-      "integrity": "sha512-yllq/VasznNY0AJqUw68RJ1QaQCALDqcLrVJqPZIXCd+6Sa4lOksY9dArn0eq7T1dvy8YdvmfgDi3qeDDQY3Lw==",
+      "version": "4.0.0-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.0-next-2024-02-19.2.tgz",
+      "integrity": "sha512-eOcIY3fMGaqS7cdJHcrI978u98GZ4LEUE5kMCde5xTNThfe9mzNBdFHQkspKni6J2cLzdIzmigsR6YicwLUTYw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -358,9 +358,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.1-next-2024-02-14.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-02-14.1.tgz",
-      "integrity": "sha512-Bzm8TMCAiUw5mTmhZ2wpk6mPWHn5+p4r7IAXgRcbcbY4xfC8xbTTie8hJCeSpQyYqXH2r7T3j1l/s6pV30Esaw==",
+      "version": "1.0.1-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-02-19.2.tgz",
+      "integrity": "sha512-qGxYCwJWtW669ncY7MCxjaXFlb0z5wSs99hKADbvnOcXvVW5/jKvBk0Ap4g8AAp3eT6WQbeGrYvgrfjj2v2x8w==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "2.1.2-next-2024-02-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.2-next-2024-02-14.tgz",
-      "integrity": "sha512-18j0Rj53dE3vb9gcxhg1yrZYjlOscUWV3TVNGgtYRyIChJenW4LQ65/G52S3zwLgVYQXWwK9YYoWeURnlLAfgg==",
+      "version": "2.1.2-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.2-next-2024-02-19.2.tgz",
+      "integrity": "sha512-A3R0qlqyim9rXm3G5VHiRzjk3vxO85UV73H1JLECXMj+4CX0jg8ZIkIYCifqtLR2+gIVD62sTBN/K++iJPVuUA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.1.1-next-2024-02-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.1-next-2024-02-14.tgz",
-      "integrity": "sha512-bQpPIB5purkev6OGd9yld7Jvcra4m1In/qWXCg8zupa4WyF0a4mxm0U42WhFCnR22SqvmBhEqEGyqNDHkUCZaw==",
+      "version": "2.1.1-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.1-next-2024-02-19.2.tgz",
+      "integrity": "sha512-iivowGRmDusj2EXtS9jtNX83C4fwkBVlWxJicU0OZYB1/2oNvsKFnd+cwpCdk3S6Wr4CHQHP+p4LuLCDXVpL/A==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7047,9 +7047,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.2.0-next-2024-02-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.2.0-next-2024-02-14.tgz",
-      "integrity": "sha512-9fDhnpevwJXqU3PaZcdJoccKLe4TJEMFGX4+zs/3dZZLmExOmLZ+U9QgDqfaxY6tntboSur/ZT8AJ9NBt84CPQ==",
+      "version": "2.2.0-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.2.0-next-2024-02-19.2.tgz",
+      "integrity": "sha512-bFVs5QIwXZ/dIIETEK6U3sNsA6r/CLRwTo+rgEw/JtfQV6rkiCF7SDm6qE3xnprqnm59JI6nIEZRVQKTohn+ZA==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7057,9 +7057,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.0.1-next-2024-02-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.1-next-2024-02-14.tgz",
-      "integrity": "sha512-60d2ZXTxS4ysKTXtIKg2WXkJDeob7y8cy10h9aMVVj6HurKs674W4RQSzUnHpOZZajrwf9mxVyRYnC5y7w3sMw==",
+      "version": "3.0.1-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.1-next-2024-02-19.2.tgz",
+      "integrity": "sha512-UosW7MQCYbc3Ksm5UhPnFxLJ5r0rNy8oCNflCEXac0KHEHaQ5blSEJr2/qpavajGsTcyz+Na6NkWqzWJJncElg==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7073,9 +7073,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "2.2.1-next-2024-02-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.2.1-next-2024-02-14.tgz",
-      "integrity": "sha512-V64AsBI+AsIuLgP+kK8s8aaS3St5oQ0kfl7pQI4l87j2Q4W4Wm0cJuuorTuncMZxuc4HE+W8fafJgneoLu2qTA==",
+      "version": "2.2.1-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.2.1-next-2024-02-19.2.tgz",
+      "integrity": "sha512-2yrBwedOeaN4ThE9M7t4EbOWA7MrwLES8a68Cq4bYc8u9Ea2KKu10+PjwpVnva/jR6HRqWFsE/IcMOM/8U5dqA==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7089,30 +7089,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.2.0-next-2024-02-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.0-next-2024-02-14.tgz",
-      "integrity": "sha512-DJDlpX8wjdsuI/DV2PkRwtFD6mM4miMAGhhcsoUOFe2iwEaxFY2nYVMsHi+eLDxhPR8rMIsLgoRFfZgQiRW4cQ==",
+      "version": "2.2.0-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.0-next-2024-02-19.2.tgz",
+      "integrity": "sha512-aekIZd+5OiyvmJjhPoosAGsJEn/b8uquUuwt9ks7b+yBMt2cMOk3WXj13ZLW2sB6bAjtNzO/sldIjj2gq9LCpg==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.1.2-next-2024-02-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.2-next-2024-02-14.tgz",
-      "integrity": "sha512-R4j/+jsFEFI8UbWP/wQ/gSBPPq7swo7t/LMydzXctE62cRb4mKp6GgMSAN+MUFUtKIziqUXrPRWlGGpwar8hLA==",
+      "version": "2.1.2-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.2-next-2024-02-19.2.tgz",
+      "integrity": "sha512-31ujgZBkhSiQmm7MneQo09igTunb3SlY+2ankV+RgLQzUomyDWizCaGjL8gNYqKhprNgXnc6mhGYDOjcsIdI+Q==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "4.0.0-next-2024-02-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.0-next-2024-02-14.tgz",
-      "integrity": "sha512-yllq/VasznNY0AJqUw68RJ1QaQCALDqcLrVJqPZIXCd+6Sa4lOksY9dArn0eq7T1dvy8YdvmfgDi3qeDDQY3Lw==",
+      "version": "4.0.0-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.0-next-2024-02-19.2.tgz",
+      "integrity": "sha512-eOcIY3fMGaqS7cdJHcrI978u98GZ4LEUE5kMCde5xTNThfe9mzNBdFHQkspKni6J2cLzdIzmigsR6YicwLUTYw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.1-next-2024-02-14.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-02-14.1.tgz",
-      "integrity": "sha512-Bzm8TMCAiUw5mTmhZ2wpk6mPWHn5+p4r7IAXgRcbcbY4xfC8xbTTie8hJCeSpQyYqXH2r7T3j1l/s6pV30Esaw==",
+      "version": "1.0.1-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-02-19.2.tgz",
+      "integrity": "sha512-qGxYCwJWtW669ncY7MCxjaXFlb0z5wSs99hKADbvnOcXvVW5/jKvBk0Ap4g8AAp3eT6WQbeGrYvgrfjj2v2x8w==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7126,17 +7126,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "2.1.2-next-2024-02-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.2-next-2024-02-14.tgz",
-      "integrity": "sha512-18j0Rj53dE3vb9gcxhg1yrZYjlOscUWV3TVNGgtYRyIChJenW4LQ65/G52S3zwLgVYQXWwK9YYoWeURnlLAfgg==",
+      "version": "2.1.2-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-2.1.2-next-2024-02-19.2.tgz",
+      "integrity": "sha512-A3R0qlqyim9rXm3G5VHiRzjk3vxO85UV73H1JLECXMj+4CX0jg8ZIkIYCifqtLR2+gIVD62sTBN/K++iJPVuUA==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.1.1-next-2024-02-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.1-next-2024-02-14.tgz",
-      "integrity": "sha512-bQpPIB5purkev6OGd9yld7Jvcra4m1In/qWXCg8zupa4WyF0a4mxm0U42WhFCnR22SqvmBhEqEGyqNDHkUCZaw==",
+      "version": "2.1.1-next-2024-02-19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.1-next-2024-02-19.2.tgz",
+      "integrity": "sha512-iivowGRmDusj2EXtS9jtNX83C4fwkBVlWxJicU0OZYB1/2oNvsKFnd+cwpCdk3S6Wr4CHQHP+p4LuLCDXVpL/A==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/lib/api/sns-governance.api.ts
+++ b/frontend/src/lib/api/sns-governance.api.ts
@@ -12,6 +12,7 @@ import type {
   SnsProposalId,
   SnsVote,
 } from "@dfinity/sns";
+import { isNullish } from "@dfinity/utils";
 import { wrapper } from "./sns-wrapper.api";
 
 export const querySnsNeurons = async ({
@@ -553,10 +554,15 @@ export const queryProposals = async ({
     certified,
   });
 
-  const proposals = await listProposals(params);
+  const response = await listProposals(params);
+
+  if (isNullish(response.include_ballots_by_caller)) {
+    // Normalise the response for all canister versions, since the old versions do not return this field.
+    response.include_ballots_by_caller = [false];
+  }
 
   logWithTimestamp(`Getting proposals call complete.`);
-  return proposals;
+  return response;
 };
 
 export const queryProposal = async ({

--- a/frontend/src/lib/services/$public/sns-proposals.services.ts
+++ b/frontend/src/lib/services/$public/sns-proposals.services.ts
@@ -26,6 +26,7 @@ import { toExcludeTypeParameter } from "$lib/utils/sns-proposals.utils";
 import { NeuronState } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import type {
+  SnsListProposalsResponse,
   SnsNervousSystemFunction,
   SnsNeuron,
   SnsNeuronId,
@@ -154,7 +155,7 @@ export const loadSnsProposals = async ({
     filter: filters?.types ?? [],
     snsFunctions,
   });
-  return queryAndUpdate<SnsProposalData[], unknown>({
+  return queryAndUpdate<SnsListProposalsResponse, unknown>({
     identityType: "current",
     request: ({ certified, identity }) =>
       queryProposals({
@@ -170,7 +171,8 @@ export const loadSnsProposals = async ({
         certified,
         rootCanisterId,
       }),
-    onLoad: ({ response: proposals, certified }) => {
+    onLoad: ({ response, certified }) => {
+      const { proposals } = response;
       snsProposalsStore.addProposals({
         rootCanisterId,
         proposals,

--- a/frontend/src/tests/fakes/sns-governance-api.fake.ts
+++ b/frontend/src/tests/fakes/sns-governance-api.fake.ts
@@ -24,6 +24,7 @@ import type {
 import {
   SnsGovernanceError,
   neuronSubaccount,
+  type SnsListProposalsResponse,
   type SnsNeuron,
 } from "@dfinity/sns";
 import { fromNullable, isNullish, toNullable } from "@dfinity/utils";
@@ -50,14 +51,26 @@ const fakeFunctions = {
 // Maps a key representing identity + rootCanisterId (`mapKey` function) to a list of neurons
 const neurons: Map<string, SnsNeuron[]> = new Map();
 // Maps a key representing identity + rootCanisterId (`mapKey` function) to a list of proposals
-const proposals: Map<string, SnsProposalData[]> = new Map();
+const proposals: Map<string, SnsListProposalsResponse> = new Map();
 // Maps a key representing rootCanisterId to a list of nervous system functions
 const nervousFunctions: Map<string, SnsNervousSystemFunction[]> = new Map();
 
-type KeyParams = { identity: Identity; rootCanisterId: Principal };
+type KeyParams = {
+  identity: Identity;
+  rootCanisterId: Principal;
+  includeBallotsByCaller?: boolean;
+};
 
-const mapKey = ({ identity, rootCanisterId }: KeyParams) =>
-  JSON.stringify([identity.getPrincipal().toText(), rootCanisterId.toText()]);
+const mapKey = ({
+  identity,
+  rootCanisterId,
+  includeBallotsByCaller,
+}: KeyParams) =>
+  JSON.stringify([
+    identity.getPrincipal().toText(),
+    rootCanisterId.toText(),
+    includeBallotsByCaller,
+  ]);
 
 const getNeurons = (keyParams: KeyParams) => {
   const key = mapKey(keyParams);
@@ -106,14 +119,21 @@ const copyNeuron = (neuron: SnsNeuron): SnsNeuron =>
     permissions: neuron.permissions.map((entry) => ({ ...entry })),
   };
 
-const getProposals = (keyParams: KeyParams) => {
+const getProposals = (keyParams: KeyParams): SnsListProposalsResponse => {
   const key = mapKey(keyParams);
-  let proposalsList = proposals.get(key);
-  if (isNullish(proposalsList)) {
-    proposalsList = [];
-    proposals.set(key, proposalsList);
+
+  if (isNullish(proposals.get(key))) {
+    const defaultResponse = isNullish(keyParams.includeBallotsByCaller)
+      ? ({ proposals: [] } as unknown as SnsListProposalsResponse)
+      : {
+          proposals: [],
+          include_ballots_by_caller: [keyParams.includeBallotsByCaller] as [
+            boolean,
+          ],
+        };
+    proposals.set(key, defaultResponse);
   }
-  return proposalsList;
+  return proposals.get(key);
 };
 
 const getNervousFunctions = (rootCanisterId: Principal) => {
@@ -291,8 +311,13 @@ async function queryProposals({
   identity: Identity;
   certified: boolean;
   params: SnsListProposalsParams;
-}): Promise<SnsProposalData[]> {
-  return proposals.get(mapKey({ identity, rootCanisterId })) || [];
+}): Promise<SnsListProposalsResponse> {
+  return (
+    proposals.get(mapKey({ identity, rootCanisterId })) || {
+      proposals: [],
+      include_ballots_by_caller: [false],
+    }
+  );
 }
 
 /**
@@ -311,7 +336,7 @@ async function queryProposal({
 }): Promise<SnsProposalData> {
   const proposal = proposals
     .get(mapKey({ identity, rootCanisterId }))
-    .find(({ id }) => fromNullable(id).id === proposalId.id);
+    .proposals.find(({ id }) => fromNullable(id).id === proposalId.id);
   if (isNullish(proposal)) {
     throw new SnsGovernanceError(
       `No proposal for given proposalId ${proposalId.id}`
@@ -472,12 +497,18 @@ export const setNeuronWith = ({
 export const addProposalWith = ({
   identity = mockIdentity,
   rootCanisterId,
+  includeBallotsByCaller,
   ...proposalParams
 }: {
   identity?: Identity;
   rootCanisterId: Principal;
+  includeBallotsByCaller?: boolean;
 } & Partial<SnsProposalData>): SnsProposalData => {
-  const proposalsList = getProposals({ identity, rootCanisterId });
+  const { proposals: proposalsList } = getProposals({
+    identity,
+    rootCanisterId,
+    includeBallotsByCaller,
+  });
   const index = proposalsList.length;
   const defaultProposalId = { id: BigInt(index + 1) };
   const proposal: SnsProposalData = {

--- a/frontend/src/tests/lib/api/sns-governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-governance.api.spec.ts
@@ -85,7 +85,7 @@ describe("sns-api", () => {
   const stakeMaturitySpy = vi.fn().mockResolvedValue(undefined);
   const registerVoteSpy = vi.fn().mockResolvedValue(undefined);
   const autoStakeMaturitySpy = vi.fn().mockResolvedValue(undefined);
-  const listProposalsSpy = vi.fn().mockResolvedValue(proposals);
+  const listProposalsSpy = vi.fn().mockResolvedValue({ proposals });
   const getProposalSpy = vi.fn().mockResolvedValue(mockSnsProposal);
   const disburseMaturitySpy = vi.fn().mockResolvedValue(undefined);
   const nervousSystemFunctionsMock: SnsListNervousSystemFunctionsResponse = {
@@ -368,10 +368,24 @@ describe("sns-api", () => {
     });
 
     expect(listProposalsSpy).toBeCalled();
-    expect(res).toEqual(proposals);
+    expect(res).toEqual(expect.objectContaining({ proposals }));
   });
 
-  it("should get proposals", async () => {
+  it("should solve missing flag for outdated canisters", async () => {
+    const res = await queryProposals({
+      identity: mockIdentity,
+      rootCanisterId: rootCanisterIdMock,
+      certified: false,
+      params: {},
+    });
+
+    expect(listProposalsSpy).toBeCalled();
+    expect(res).toEqual(
+      expect.objectContaining({ include_ballots_by_caller: [false] })
+    );
+  });
+
+  it("should get a proposal", async () => {
     const proposalId: SnsProposalId = {
       id: 2n,
     };

--- a/frontend/src/tests/lib/services/_public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/_public/sns-proposals.services.spec.ts
@@ -59,7 +59,7 @@ describe("sns-proposals services", () => {
   describe("loadSnsProposals", () => {
     const queryProposalsSpy = vi
       .spyOn(api, "queryProposals")
-      .mockResolvedValue(proposals);
+      .mockResolvedValue({ proposals, include_ballots_by_caller: [true] });
 
     describe("not logged in", () => {
       beforeEach(() => {


### PR DESCRIPTION
# Motivation

Upgrade ic-js to get `include_ballots_by_caller` flag in sns `listProposals` response.

# Changes

- `npm run upgrade:next`
- process a [fallback case](https://github.com/dfinity/nns-dapp/compare/upgrade-next-2024-02-19-2?expand=1#diff-be6fbee27fa53bf1e9156af390a6d1f8528258c94e49e24e531742cc15800a38R559) for outdated canisters

# Tests

- update sns governance fake api
- should solve missing flag for outdated canisters

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet
