### PR TITLE
Bump gix next version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -278,11 +278,11 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "4.0.0-next-2024-02-08.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.0.0-next-2024-02-08.1.tgz",
-      "integrity": "sha512-LRK0v4ScrCQ+RCSo0yPrPYdxS83cZphYyTpSGsovwA7EkBiSiMRBlrRH8HhT745cWgoZcgKMXlfTyVkfhog9gg==",
+      "version": "4.1.0-next-2024-02-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.1.0-next-2024-02-19.tgz",
+      "integrity": "sha512-0J+6Paxn4D8JPs/DC4kTGrvfOo/SlESJsrbgcD2Xqw1ZLuioG8RaSpsgvz8Ydw+EUO58IHWh+mp7M5e5ysve5w==",
       "dependencies": {
-        "dompurify": "^3.0.6",
+        "dompurify": "^3.0.8",
         "html5-qrcode": "^2.3.8",
         "qr-creator": "^1.0.0"
       },
@@ -2831,9 +2831,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
-      "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.8.tgz",
+      "integrity": "sha512-b7uwreMYL2eZhrSCRC4ahLTeZcPZxSmYfmcQGXGkXiZSNW1X85v+SDM5KsWcpivIiUBH47Ji7NtyUdpLeF5JZQ=="
     },
     "node_modules/dotenv": {
       "version": "16.3.1",
@@ -7063,11 +7063,11 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "4.0.0-next-2024-02-08.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.0.0-next-2024-02-08.1.tgz",
-      "integrity": "sha512-LRK0v4ScrCQ+RCSo0yPrPYdxS83cZphYyTpSGsovwA7EkBiSiMRBlrRH8HhT745cWgoZcgKMXlfTyVkfhog9gg==",
+      "version": "4.1.0-next-2024-02-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.1.0-next-2024-02-19.tgz",
+      "integrity": "sha512-0J+6Paxn4D8JPs/DC4kTGrvfOo/SlESJsrbgcD2Xqw1ZLuioG8RaSpsgvz8Ydw+EUO58IHWh+mp7M5e5ysve5w==",
       "requires": {
-        "dompurify": "^3.0.6",
+        "dompurify": "^3.0.8",
         "html5-qrcode": "^2.3.8",
         "qr-creator": "^1.0.0"
       }
@@ -8784,9 +8784,9 @@
       }
     },
     "dompurify": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
-      "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.8.tgz",
+      "integrity": "sha512-b7uwreMYL2eZhrSCRC4ahLTeZcPZxSmYfmcQGXGkXiZSNW1X85v+SDM5KsWcpivIiUBH47Ji7NtyUdpLeF5JZQ=="
     },
     "dotenv": {
       "version": "16.3.1",


### PR DESCRIPTION
# Motivation

I've released gix-cmp [v4.1.0](https://github.com/dfinity/gix-components/releases/tag/v4.1.0) so this PR bumps the library to catch-up with the new next version number of the ui kit.