### PR TITLE
chore: Update github actions automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
       - dependency-name: "semver"
       - dependency-name: "crates-io"
     rebase-strategy: "disabled"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# Motivation
In the last month I have had to make 8 PRs to update GitHub actions.  Seven of those were simple bumps and could have been automated.  One was a breaking change.  Let's automate more of this boring work.

# Changes
- Configure Dependabot to make PRs to update GitHub actions.

# Tests
- I have added this same Dependabot configuration to one of my personal projects and it has worked as expected.

# Todos

- [ ] Add entry to changelog (if necessary).