### PR TITLE
NNS1-2862: Add index canister ID to envVars

### DIFF
--- a/frontend/src/lib/constants/canister-ids.constants.ts
+++ b/frontend/src/lib/constants/canister-ids.constants.ts
@@ -7,6 +7,7 @@ const envVars = getEnvVars();
 export const OWN_CANISTER_ID_TEXT = envVars?.ownCanisterId ?? "";
 export const OWN_CANISTER_ID = Principal.fromText(OWN_CANISTER_ID_TEXT);
 export const LEDGER_CANISTER_ID = Principal.fromText(envVars.ledgerCanisterId);
+export const INDEX_CANISTER_ID = Principal.fromText(envVars.indexCanisterId);
 export const GOVERNANCE_CANISTER_ID = Principal.fromText(
   envVars.governanceCanisterId
 );

--- a/frontend/src/lib/utils/env-vars.utils.ts
+++ b/frontend/src/lib/utils/env-vars.utils.ts
@@ -18,6 +18,7 @@ type EnvironmentVars = {
   governanceCanisterId: string;
   identityServiceUrl: string;
   ledgerCanisterId: string;
+  indexCanisterId: string;
   ownCanisterId: string;
   // Environments without SNS aggregator are valid
   snsAggregatorUrl?: string;
@@ -35,6 +36,7 @@ const mandatoryEnvVarKeys: EnvironmentVars = {
   governanceCanisterId: "",
   identityServiceUrl: "",
   ledgerCanisterId: "",
+  indexCanisterId: "",
   ownCanisterId: "",
   wasmCanisterId: "",
 };
@@ -121,6 +123,9 @@ const getBuildEnvVars = (): EnvironmentVars => {
     ),
     ledgerCanisterId: convertEmtpyStringToUndefined(
       import.meta.env.VITE_LEDGER_CANISTER_ID
+    ),
+    indexCanisterId: convertEmtpyStringToUndefined(
+      import.meta.env.VITE_INDEX_CANISTER_ID
     ),
     ownCanisterId: convertEmtpyStringToUndefined(
       import.meta.env.VITE_OWN_CANISTER_ID

--- a/frontend/src/tests/lib/utils/env-vars.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/env-vars.utils.spec.ts
@@ -32,6 +32,7 @@ describe("env-vars-utils", () => {
       "http://bd3sg-teaaa-aaaaa-qaaba-cai.localhost:8080"
     );
     vi.stubEnv("VITE_CKBTC_LEDGER_CANISTER_ID", "oz7p6-neaaa-aaaaa-qabfa-cai");
+    vi.stubEnv("VITE_INDEX_CANISTER_ID", "mecbw-6maaa-aaaaa-qabkq-cai");
     vi.stubEnv("VITE_CKBTC_MINTER_CANISTER_ID", "o66jk-a4aaa-aaaaa-qabfq-cai");
     vi.stubEnv("VITE_CKBTC_INDEX_CANISTER_ID", "olzyh-buaaa-aaaaa-qabga-cai");
     vi.stubEnv("VITE_CKETH_LEDGER_CANISTER_ID", "omy6t-mmaaa-aaaaa-qabgq-cai");
@@ -53,6 +54,7 @@ describe("env-vars-utils", () => {
     host: "http://localhost:8080",
     identityServiceUrl: "http://qhbym-qaaaa-aaaaa-aaafq-cai.localhost:8080",
     ledgerCanisterId: "ryjl3-tyaaa-aaaaa-aaaba-cai",
+    indexCanisterId: "mecbw-6maaa-aaaaa-qabkq-cai",
     ownCanisterId: "qsgjb-riaaa-aaaaa-aaaga-cai",
     snsAggregatorUrl: "http://bd3sg-teaaa-aaaaa-qaaba-cai.localhost:8080",
     tvlCanisterId: undefined,
@@ -77,6 +79,22 @@ describe("env-vars-utils", () => {
 
     expect(() => getEnvVars()).toThrowError(
       "Missing mandatory environment variables: ledgerCanisterId"
+    );
+  });
+
+  it("should return the correct index canister ID", () => {
+    const indexCanisterId = principal(543).toText();
+    vi.stubEnv("VITE_INDEX_CANISTER_ID", indexCanisterId);
+    expect(getEnvVars()).toEqual({
+      ...defaultExpectedEnvVars,
+      indexCanisterId,
+    });
+  });
+
+  it("index canister ID is mandatory", () => {
+    vi.stubEnv("VITE_INDEX_CANISTER_ID", "");
+    expect(() => getEnvVars()).toThrowError(
+      "Missing mandatory environment variables: indexCanisterId"
     );
   });
 

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -51,6 +51,7 @@ vi.mock("./src/lib/utils/env-vars.utils.ts", () => ({
     governanceCanisterId: "rrkah-fqaaa-aaaaa-aaaaq-cai",
     identityServiceUrl: "http://localhost:8000/",
     ledgerCanisterId: "ryjl3-tyaaa-aaaaa-aaaba-cai",
+    indexCanisterId: "ryjl3-tyaaa-aaaaa-aaaba-cai",
     ownCanisterId: "qhbym-qaaaa-aaaaa-aaafq-cai",
     // Environments without SNS aggregator are valid
     snsAggregatorUrl:


### PR DESCRIPTION
# Motivation

We want to read ICP transactions from the ICP index canister.
For this we need to know the canister ID.

# Changes

Create index canister ID constant from environment.

# Tests

Unit tests added.

# Todos

- [ ] Add entry to changelog (if necessary).
covered