### PR TITLE
NNS1-2869: Add mapIcpTransaction

### DIFF
--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -49,24 +49,18 @@ const getTransactionType = ({
   if (swapCanisterAccounts.has(data.from)) {
     return AccountTransactionType.RefundSwap;
   }
-  if (memo > 0n) {
-    if (memo === CREATE_CANISTER_MEMO) {
-      return AccountTransactionType.CreateCanister;
-    }
-    if (memo === TOP_UP_CANISTER_MEMO) {
-      return AccountTransactionType.TopUpCanister;
-    }
-    // Stake neuron transactions have a memo.
-    if (
-      neurons.some((neuron) => neuron.fullNeuron?.accountIdentifier === data.to)
-    ) {
-      return AccountTransactionType.StakeNeuron;
-    }
-    // Top up neuron transactions have no memo.
-  } else if (
+  if (memo === CREATE_CANISTER_MEMO) {
+    return AccountTransactionType.CreateCanister;
+  }
+  if (memo === TOP_UP_CANISTER_MEMO) {
+    return AccountTransactionType.TopUpCanister;
+  }
+  if (
     neurons.some((neuron) => neuron.fullNeuron?.accountIdentifier === data.to)
   ) {
-    return AccountTransactionType.TopUpNeuron;
+    return memo > 0n
+      ? AccountTransactionType.StakeNeuron
+      : AccountTransactionType.TopUpNeuron;
   }
 
   // Send is the default transaction type
@@ -107,7 +101,6 @@ const getTransactionInformation = (
   };
 };
 
-// TODO: Map to self transactions
 export const mapIcpTransaction = ({
   transaction,
   accountIdentifier,
@@ -149,7 +142,6 @@ export const mapIcpTransaction = ({
     });
     const otherParty = isReceive ? txInfo.from : txInfo.to;
 
-    // Timestamp is in nano seconds
     const createdTimestampNanos = fromNullable(
       transaction.transaction.created_at_time
     )?.timestamp_nanos;

--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -91,8 +91,9 @@ const getTransactionInformation = (
   return {
     from: "from" in data ? data.from : undefined,
     to: "to" in data ? data.to : undefined,
-    // The only type without `ammunt` is the Approve transaction.
+    // The only type without `amount` is the Approve transaction.
     // For Approve transactions, the balance doesn't change, so we show amount 0.
+    // This is different than ICRC transactions, where thers is an `amount` field.
     amount: "amount" in data ? data.amount.e8s : 0n,
     fee: "fee" in data ? data.fee.e8s : 0n,
   };

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -1,0 +1,432 @@
+import {
+  CREATE_CANISTER_MEMO,
+  TOP_UP_CANISTER_MEMO,
+} from "$lib/constants/api.constants";
+import { NANO_SECONDS_IN_MILLISECOND } from "$lib/constants/constants";
+import type { UiTransaction } from "$lib/types/transaction";
+import { mapIcpTransaction } from "$lib/utils/icp-transactions.utils";
+import en from "$tests/mocks/i18n.mock";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
+import type { Operation, TransactionWithId } from "@dfinity/ledger-icp";
+import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
+
+describe("icp-transactions.utils", () => {
+  const defaultTimestamp = new Date("2023-01-01T00:00:00.000Z");
+  const to = "12345";
+  const from = "56789";
+  const amount = 200_000_000n;
+  const fee = 10_000n;
+  const transactionId = 1234n;
+  const createTransactionWithId = ({
+    memo,
+    operation,
+    timestamp = defaultTimestamp,
+  }: {
+    operation: Operation;
+    memo?: bigint;
+    timestamp?: Date;
+  }): TransactionWithId => ({
+    id: transactionId,
+    transaction: {
+      memo: memo ?? 0n,
+      icrc1_memo: [],
+      operation,
+      created_at_time: [
+        {
+          timestamp_nanos:
+            BigInt(timestamp.getTime()) * BigInt(NANO_SECONDS_IN_MILLISECOND),
+        },
+      ],
+    },
+  });
+  const defaultTransferOperation: Operation = {
+    Transfer: {
+      to,
+      fee: { e8s: fee },
+      from,
+      amount: { e8s: amount },
+      spender: [],
+    },
+  };
+  const defaultUiTransaction: UiTransaction = {
+    domKey: `${transactionId}-1`,
+    isIncoming: false,
+    otherParty: to,
+    tokenAmount: TokenAmountV2.fromUlps({
+      amount: amount + fee,
+      token: ICPToken,
+    }),
+    isReimbursement: false,
+    isPending: false,
+    isFailed: false,
+    headline: "Sent",
+    timestamp: defaultTimestamp,
+  };
+  const toSelfOperation: Operation = {
+    Transfer: {
+      to: from,
+      fee: { e8s: fee },
+      from,
+      amount: { e8s: amount },
+      spender: [],
+    },
+  };
+
+  describe("mapIcpTransaction", () => {
+    it("maps stake neuron transaction", () => {
+      const neuron = mockNeuron;
+      const transaction = createTransactionWithId({
+        operation: {
+          Transfer: {
+            to: neuron.fullNeuron.accountIdentifier,
+            fee: { e8s: fee },
+            from,
+            amount: { e8s: amount },
+            spender: [],
+          },
+        },
+        memo: 12345n,
+      });
+      const expectedUiTransaction: UiTransaction = {
+        ...defaultUiTransaction,
+        otherParty: neuron.fullNeuron.accountIdentifier,
+        headline: "Staked",
+      };
+
+      expect(
+        mapIcpTransaction({
+          transaction,
+          accountIdentifier: from,
+          toSelfTransaction: false,
+          neurons: [neuron],
+          swapCanisterAccounts: new Set<string>(),
+          i18n: en,
+        })
+      ).toEqual(expectedUiTransaction);
+    });
+
+    it("maps top up neuron transaction", () => {
+      const neuron = mockNeuron;
+      const transaction = createTransactionWithId({
+        operation: {
+          Transfer: {
+            to: neuron.fullNeuron.accountIdentifier,
+            fee: { e8s: fee },
+            from,
+            amount: { e8s: amount },
+            spender: [],
+          },
+        },
+        memo: 0n,
+      });
+      const expectedUiTransaction: UiTransaction = {
+        ...defaultUiTransaction,
+        otherParty: neuron.fullNeuron.accountIdentifier,
+        headline: "Top-up Neuron",
+      };
+
+      expect(
+        mapIcpTransaction({
+          transaction,
+          accountIdentifier: from,
+          toSelfTransaction: false,
+          neurons: [neuron],
+          swapCanisterAccounts: new Set<string>(),
+          i18n: en,
+        })
+      ).toEqual(expectedUiTransaction);
+    });
+
+    it("maps create canister transaction", () => {
+      const transaction = createTransactionWithId({
+        operation: defaultTransferOperation,
+        memo: CREATE_CANISTER_MEMO,
+      });
+      const expectedUiTransaction: UiTransaction = {
+        ...defaultUiTransaction,
+        headline: "Create Canister",
+      };
+
+      expect(
+        mapIcpTransaction({
+          transaction,
+          accountIdentifier: from,
+          toSelfTransaction: false,
+          neurons: [],
+          swapCanisterAccounts: new Set<string>(),
+          i18n: en,
+        })
+      ).toEqual(expectedUiTransaction);
+    });
+
+    it("maps top up canister transaction", () => {
+      const transaction = createTransactionWithId({
+        operation: defaultTransferOperation,
+        memo: TOP_UP_CANISTER_MEMO,
+      });
+      const expectedUiTransaction: UiTransaction = {
+        ...defaultUiTransaction,
+        headline: "Top-up Canister",
+      };
+
+      expect(
+        mapIcpTransaction({
+          transaction,
+          accountIdentifier: from,
+          toSelfTransaction: false,
+          neurons: [],
+          swapCanisterAccounts: new Set<string>(),
+          i18n: en,
+        })
+      ).toEqual(expectedUiTransaction);
+    });
+
+    it("maps swap participation transaction", () => {
+      const transaction = createTransactionWithId({
+        operation: defaultTransferOperation,
+      });
+      const expectedUiTransaction: UiTransaction = {
+        ...defaultUiTransaction,
+        headline: "Decentralization Swap",
+      };
+
+      expect(
+        mapIcpTransaction({
+          transaction,
+          accountIdentifier: from,
+          toSelfTransaction: false,
+          neurons: [],
+          swapCanisterAccounts: new Set<string>([to]),
+          i18n: en,
+        })
+      ).toEqual(expectedUiTransaction);
+    });
+
+    it("maps swap participation refund transaction", () => {
+      const transaction = createTransactionWithId({
+        operation: defaultTransferOperation,
+      });
+      const expectedUiTransaction: UiTransaction = {
+        ...defaultUiTransaction,
+        headline: "Swap Refund",
+        isIncoming: true,
+        otherParty: from,
+        tokenAmount: TokenAmountV2.fromUlps({
+          amount,
+          token: ICPToken,
+        }),
+      };
+
+      expect(
+        mapIcpTransaction({
+          transaction,
+          accountIdentifier: to,
+          toSelfTransaction: false,
+          neurons: [],
+          swapCanisterAccounts: new Set<string>([from]),
+          i18n: en,
+        })
+      ).toEqual(expectedUiTransaction);
+    });
+
+    it("maps sent transaction", () => {
+      const transaction = createTransactionWithId({
+        operation: defaultTransferOperation,
+      });
+      const expectedUiTransaction: UiTransaction = {
+        ...defaultUiTransaction,
+        headline: "Sent",
+      };
+
+      expect(
+        mapIcpTransaction({
+          transaction,
+          accountIdentifier: from,
+          toSelfTransaction: false,
+          neurons: [],
+          swapCanisterAccounts: new Set<string>(),
+          i18n: en,
+        })
+      ).toEqual(expectedUiTransaction);
+    });
+
+    it("maps received transaction", () => {
+      const transaction = createTransactionWithId({
+        operation: defaultTransferOperation,
+      });
+      const expectedUiTransaction: UiTransaction = {
+        ...defaultUiTransaction,
+        isIncoming: true,
+        otherParty: from,
+        headline: "Received",
+        tokenAmount: TokenAmountV2.fromUlps({
+          amount,
+          token: ICPToken,
+        }),
+      };
+
+      expect(
+        mapIcpTransaction({
+          transaction,
+          accountIdentifier: to,
+          toSelfTransaction: false,
+          neurons: [],
+          swapCanisterAccounts: new Set<string>(),
+          i18n: en,
+        })
+      ).toEqual(expectedUiTransaction);
+    });
+
+    it("maps toSelf transaction as Received", () => {
+      const transaction = createTransactionWithId({
+        operation: toSelfOperation,
+      });
+      const expectedUiTransaction: UiTransaction = {
+        ...defaultUiTransaction,
+        headline: "Received",
+        domKey: `${transactionId}-0`,
+        otherParty: from,
+        tokenAmount: TokenAmountV2.fromUlps({
+          amount,
+          token: ICPToken,
+        }),
+        isIncoming: true,
+      };
+
+      expect(
+        mapIcpTransaction({
+          transaction,
+          accountIdentifier: from,
+          toSelfTransaction: true,
+          neurons: [],
+          swapCanisterAccounts: new Set<string>(),
+          i18n: en,
+        })
+      ).toEqual(expectedUiTransaction);
+    });
+
+    it("maps toSelf transaction as Sent", () => {
+      const transaction = createTransactionWithId({
+        operation: toSelfOperation,
+      });
+      const expectedUiTransaction: UiTransaction = {
+        ...defaultUiTransaction,
+        headline: "Sent",
+        domKey: `${transactionId}-1`,
+        otherParty: from,
+      };
+
+      expect(
+        mapIcpTransaction({
+          transaction,
+          accountIdentifier: from,
+          toSelfTransaction: false,
+          neurons: [],
+          swapCanisterAccounts: new Set<string>(),
+          i18n: en,
+        })
+      ).toEqual(expectedUiTransaction);
+    });
+
+    it("maps approve transaction", () => {
+      const transaction = createTransactionWithId({
+        operation: {
+          Approve: {
+            fee: { e8s: fee },
+            from,
+            spender: to,
+            expires_at: [],
+            allowance: { e8s: amount },
+            expected_allowance: [],
+          },
+        },
+      });
+      const expectedUiTransaction: UiTransaction = {
+        ...defaultUiTransaction,
+        headline: "Approve transfer",
+        tokenAmount: TokenAmountV2.fromUlps({
+          amount: fee,
+          token: ICPToken,
+        }),
+        // TODO: Should the other party be the spender?
+        // This is how we show it for ICRC transactions.
+        otherParty: undefined,
+      };
+
+      expect(
+        mapIcpTransaction({
+          transaction,
+          accountIdentifier: from,
+          toSelfTransaction: false,
+          neurons: [],
+          swapCanisterAccounts: new Set<string>(),
+          i18n: en,
+        })
+      ).toEqual(expectedUiTransaction);
+    });
+
+    it("maps Burn transaction", () => {
+      const transaction = createTransactionWithId({
+        operation: {
+          Burn: {
+            from,
+            spender: [],
+            amount: { e8s: amount },
+          },
+        },
+      });
+      const expectedUiTransaction: UiTransaction = {
+        ...defaultUiTransaction,
+        headline: "Sent",
+        tokenAmount: TokenAmountV2.fromUlps({
+          amount,
+          token: ICPToken,
+        }),
+        otherParty: undefined,
+      };
+
+      expect(
+        mapIcpTransaction({
+          transaction,
+          accountIdentifier: from,
+          toSelfTransaction: false,
+          neurons: [],
+          swapCanisterAccounts: new Set<string>(),
+          i18n: en,
+        })
+      ).toEqual(expectedUiTransaction);
+    });
+
+    it("maps Mint transaction", () => {
+      const transaction = createTransactionWithId({
+        operation: {
+          Mint: {
+            to: from,
+            amount: { e8s: amount },
+          },
+        },
+      });
+      const expectedUiTransaction: UiTransaction = {
+        ...defaultUiTransaction,
+        headline: "Received",
+        isIncoming: true,
+        tokenAmount: TokenAmountV2.fromUlps({
+          amount,
+          token: ICPToken,
+        }),
+        otherParty: undefined,
+      };
+
+      expect(
+        mapIcpTransaction({
+          transaction,
+          accountIdentifier: from,
+          toSelfTransaction: false,
+          neurons: [],
+          swapCanisterAccounts: new Set<string>(),
+          i18n: en,
+        })
+      ).toEqual(expectedUiTransaction);
+    });
+  });
+});

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -6,7 +6,6 @@ import { NANO_SECONDS_IN_MILLISECOND } from "$lib/constants/constants";
 import type { UiTransaction } from "$lib/types/transaction";
 import { mapIcpTransaction } from "$lib/utils/icp-transactions.utils";
 import en from "$tests/mocks/i18n.mock";
-import { mockNeuron } from "$tests/mocks/neurons.mock";
 import type { Operation, TransactionWithId } from "@dfinity/ledger-icp";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 
@@ -74,22 +73,12 @@ describe("icp-transactions.utils", () => {
 
   describe("mapIcpTransaction", () => {
     it("maps stake neuron transaction", () => {
-      const neuron = mockNeuron;
       const transaction = createTransactionWithId({
-        operation: {
-          Transfer: {
-            to: neuron.fullNeuron.accountIdentifier,
-            fee: { e8s: fee },
-            from,
-            amount: { e8s: amount },
-            spender: [],
-          },
-        },
+        operation: defaultTransferOperation,
         memo: 12345n,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
-        otherParty: neuron.fullNeuron.accountIdentifier,
         headline: "Staked",
       };
 
@@ -98,7 +87,7 @@ describe("icp-transactions.utils", () => {
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
-          neurons: [neuron],
+          neuronAccounts: new Set<string>([to]),
           swapCanisterAccounts: new Set<string>(),
           i18n: en,
         })
@@ -106,22 +95,12 @@ describe("icp-transactions.utils", () => {
     });
 
     it("maps top up neuron transaction", () => {
-      const neuron = mockNeuron;
       const transaction = createTransactionWithId({
-        operation: {
-          Transfer: {
-            to: neuron.fullNeuron.accountIdentifier,
-            fee: { e8s: fee },
-            from,
-            amount: { e8s: amount },
-            spender: [],
-          },
-        },
+        operation: defaultTransferOperation,
         memo: 0n,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
-        otherParty: neuron.fullNeuron.accountIdentifier,
         headline: "Top-up Neuron",
       };
 
@@ -130,7 +109,7 @@ describe("icp-transactions.utils", () => {
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
-          neurons: [neuron],
+          neuronAccounts: new Set<string>([to]),
           swapCanisterAccounts: new Set<string>(),
           i18n: en,
         })
@@ -152,7 +131,7 @@ describe("icp-transactions.utils", () => {
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
-          neurons: [],
+          neuronAccounts: new Set<string>(),
           swapCanisterAccounts: new Set<string>(),
           i18n: en,
         })
@@ -174,7 +153,7 @@ describe("icp-transactions.utils", () => {
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
-          neurons: [],
+          neuronAccounts: new Set<string>(),
           swapCanisterAccounts: new Set<string>(),
           i18n: en,
         })
@@ -195,7 +174,7 @@ describe("icp-transactions.utils", () => {
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
-          neurons: [],
+          neuronAccounts: new Set<string>(),
           swapCanisterAccounts: new Set<string>([to]),
           i18n: en,
         })
@@ -222,7 +201,7 @@ describe("icp-transactions.utils", () => {
           transaction,
           accountIdentifier: to,
           toSelfTransaction: false,
-          neurons: [],
+          neuronAccounts: new Set<string>(),
           swapCanisterAccounts: new Set<string>([from]),
           i18n: en,
         })
@@ -243,7 +222,7 @@ describe("icp-transactions.utils", () => {
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
-          neurons: [],
+          neuronAccounts: new Set<string>(),
           swapCanisterAccounts: new Set<string>(),
           i18n: en,
         })
@@ -270,7 +249,7 @@ describe("icp-transactions.utils", () => {
           transaction,
           accountIdentifier: to,
           toSelfTransaction: false,
-          neurons: [],
+          neuronAccounts: new Set<string>(),
           swapCanisterAccounts: new Set<string>(),
           i18n: en,
         })
@@ -298,7 +277,7 @@ describe("icp-transactions.utils", () => {
           transaction,
           accountIdentifier: from,
           toSelfTransaction: true,
-          neurons: [],
+          neuronAccounts: new Set<string>(),
           swapCanisterAccounts: new Set<string>(),
           i18n: en,
         })
@@ -321,7 +300,7 @@ describe("icp-transactions.utils", () => {
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
-          neurons: [],
+          neuronAccounts: new Set<string>(),
           swapCanisterAccounts: new Set<string>(),
           i18n: en,
         })
@@ -358,7 +337,7 @@ describe("icp-transactions.utils", () => {
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
-          neurons: [],
+          neuronAccounts: new Set<string>(),
           swapCanisterAccounts: new Set<string>(),
           i18n: en,
         })
@@ -390,7 +369,7 @@ describe("icp-transactions.utils", () => {
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
-          neurons: [],
+          neuronAccounts: new Set<string>(),
           swapCanisterAccounts: new Set<string>(),
           i18n: en,
         })
@@ -422,7 +401,7 @@ describe("icp-transactions.utils", () => {
           transaction,
           accountIdentifier: from,
           toSelfTransaction: false,
-          neurons: [],
+          neuronAccounts: new Set<string>(),
           swapCanisterAccounts: new Set<string>(),
           i18n: en,
         })


### PR DESCRIPTION
# Motivation

Read ICP transactions from ICP Index canister.

In this PR, introduce the helper that transforms the type of the canister to the transaction type in the UI.

# Changes

* New icp-transactions util mapIcpTransaction.

# Tests

* Add test for new util.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary yet.