### PR TITLE
New actionable nns proposals store

### DIFF
--- a/frontend/src/lib/stores/actionable-nns-proposals.store.ts
+++ b/frontend/src/lib/stores/actionable-nns-proposals.store.ts
@@ -14,6 +14,7 @@ export interface ActionableNnsProposalsStore
 /**
  * A store that contains proposals that can be voted on by the user (ballots w/ state 0).
  * Better keep nns and sns stores separate, as they should be available for "Actionable Proposals" tab.
+ * This can't be derived from proposalsStore because that store contains only proposals that match the selected filter, while this store contains proposals regardless of the filter.
  */
 const initActionableNnsProposalsStore = (): ActionableNnsProposalsStore => {
   const { subscribe, set } = writable<ActionableNnsProposalsStoreData>({

--- a/frontend/src/lib/stores/actionable-nns-proposals.store.ts
+++ b/frontend/src/lib/stores/actionable-nns-proposals.store.ts
@@ -1,0 +1,39 @@
+import type { ProposalInfo } from "@dfinity/nns";
+import { writable, type Readable } from "svelte/store";
+
+export interface ActionableNnsProposalsStoreData {
+  proposals: ProposalInfo[] | undefined;
+}
+
+export interface ActionableNnsProposalsStore
+  extends Readable<ActionableNnsProposalsStoreData> {
+  setProposals: (proposals: ProposalInfo[]) => void;
+  reset: () => void;
+}
+
+/**
+ * A store that contains proposals that can be voted on by the user (ballots w/ state 0).
+ * Better keep nns and sns stores separate, as they should be available for "Actionable Proposals" tab.
+ *
+ * The update can't be merged with the current state because the proposals status can be updated.
+ * - setProposals: replace the current list of proposals with a new list
+ */
+const initActionableNnsProposalsStore = (): ActionableNnsProposalsStore => {
+  const { subscribe, set } = writable<ActionableNnsProposalsStoreData>({
+    proposals: undefined,
+  });
+
+  return {
+    subscribe,
+
+    setProposals(proposals: ProposalInfo[]) {
+      set({ proposals: [...proposals] });
+    },
+
+    reset(): void {
+      set({ proposals: undefined });
+    },
+  };
+};
+
+export const actionableNnsProposalsStore = initActionableNnsProposalsStore();

--- a/frontend/src/lib/stores/actionable-nns-proposals.store.ts
+++ b/frontend/src/lib/stores/actionable-nns-proposals.store.ts
@@ -14,9 +14,6 @@ export interface ActionableNnsProposalsStore
 /**
  * A store that contains proposals that can be voted on by the user (ballots w/ state 0).
  * Better keep nns and sns stores separate, as they should be available for "Actionable Proposals" tab.
- *
- * The update can't be merged with the current state because the proposals status can be updated.
- * - setProposals: replace the current list of proposals with a new list
  */
 const initActionableNnsProposalsStore = (): ActionableNnsProposalsStore => {
   const { subscribe, set } = writable<ActionableNnsProposalsStoreData>({

--- a/frontend/src/tests/lib/stores/actionable-nns-proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/actionable-nns-proposals.store.spec.ts
@@ -1,0 +1,25 @@
+import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
+import { mockProposalInfo } from "$tests/mocks/proposal.mock";
+import { get } from "svelte/store";
+
+describe("actionable Nns proposals store", () => {
+  beforeEach(() => {
+    actionableNnsProposalsStore.reset();
+  });
+
+  it("should push proposal", () => {
+    actionableNnsProposalsStore.setProposals([mockProposalInfo]);
+    expect(get(actionableNnsProposalsStore).proposals).toEqual([
+      mockProposalInfo,
+    ]);
+  });
+
+  it("should reset proposals", () => {
+    actionableNnsProposalsStore.setProposals([mockProposalInfo]);
+    expect(get(actionableNnsProposalsStore).proposals).toEqual([
+      mockProposalInfo,
+    ]);
+    actionableNnsProposalsStore.reset();
+    expect(get(actionableNnsProposalsStore).proposals).toEqual(undefined);
+  });
+});


### PR DESCRIPTION
# Motivation

Add `actionableNnsProposalsStore` to store proposals that user can vote for. Will be used for displaying voting proposal count and in "Actionable Proposals" tab.

# Changes

- add a store

# Tests

- test the new store

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet