### PR TITLE
Re-enable disabled wasm download test

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -279,9 +279,6 @@ jobs:
           } >&2
           # TODO: Verify that the commits contain the expected changes.
   download-nns-dapp-ci-wasm:
-    # We require a successful CI run on main before this can pass again.
-    # TODO: remove
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# Motivation

This test had to be disabled to unbreak CI.
Now that CI is fixed, it can be enabled again.

# Changes

Re-enable the `download-nns-dapp-ci-wasm` test on CI.

# Tests

pass
https://github.com/dfinity/nns-dapp/actions/runs/7989111051/job/21815071000?pr=4522
https://github.com/dfinity/nns-dapp/actions/runs/7989111051/job/21815071671?pr=4522

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary