### PR TITLE
feat: Use State::from instead of restore()

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -20,6 +20,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Minor wording and style changes on the neuron detail page.
+* Enable loading state from stable structures.
 
 #### Deprecated
 

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -15,6 +15,7 @@ use dfn_candid::{candid, candid_one};
 use dfn_core::{over, over_async};
 use ic_cdk::println;
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade};
+use ic_stable_structures::DefaultMemoryImpl;
 use icp_ledger::AccountIdentifier;
 pub use serde::Serialize;
 
@@ -75,7 +76,9 @@ fn post_upgrade(args: Option<CanisterArguments>) {
     // as the storage is about to be wiped out and replaced with stable memory.
     let counter_before = PerformanceCount::new("post_upgrade start");
     STATE.with(|s| {
-        s.replace(State::restore());
+        let stable_memory = DefaultMemoryImpl::default();
+        let state = State::from(stable_memory);
+        s.replace(state);
     });
     perf::save_instruction_count(counter_before);
     perf::record_instruction_count("post_upgrade after state_recovery");

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -18,7 +18,7 @@ use crate::perf::PerformanceCounts;
 use dfn_candid::Candid;
 use dfn_core::api::trap_with;
 use ic_cdk::println;
-use ic_stable_structures::{DefaultMemoryImpl, Memory};
+use ic_stable_structures::DefaultMemoryImpl;
 use on_wire::{FromWire, IntoWire};
 use std::cell::RefCell;
 
@@ -214,43 +214,6 @@ impl StableState for State {
 
 // Methods called on pre_upgrade and post_upgrade.
 impl State {
-    /// The schema version, determined by the last version that was saved to stable memory.
-    fn schema_version_from_stable_memory() -> Option<SchemaLabel> {
-        let memory = DefaultMemoryImpl::default();
-        Self::schema_version_from_memory(&memory)
-    }
-
-    /// The schema version, as stored in an arbitrary memory.
-    fn schema_version_from_memory<M>(memory: &M) -> Option<SchemaLabel>
-    where
-        M: Memory,
-    {
-        let mut schema_label_bytes = [0u8; SchemaLabel::MAX_BYTES];
-        memory.read(0, &mut schema_label_bytes);
-        SchemaLabel::try_from(&schema_label_bytes[..]).ok()
-    }
-
-    /// Creates the state from stable memory in the `post_upgrade()` hook.
-    ///
-    /// Note: The stable memory may have been created by any of these schemas:
-    /// - The previous schema, when first migrating from the previous schema to the current schema.
-    /// - The current schema, if upgrading without changing the schema.
-    /// - The next schema, if a new schema was deployed and we need to roll back.
-    ///
-    /// Note: Changing the schema requires at least two deployments:
-    /// - Deploy a release with a parser for the new schema.
-    /// - Then, deploy a release that writes the new schema.
-    /// This way it is possible to roll back after deploying the new schema.
-    #[must_use]
-    pub fn restore() -> Self {
-        match Self::schema_version_from_stable_memory() {
-            None => Self::recover_from_raw_memory(),
-            Some(version) => {
-                trap_with(&format!("Unknown schema version: {version:?}"));
-                unreachable!();
-            }
-        }
-    }
     /// Saves any unsaved state to stable memory.
     pub fn save(&self) {
         let schema = self.schema_label();

--- a/rs/backend/src/state/tests.rs
+++ b/rs/backend/src/state/tests.rs
@@ -1,8 +1,8 @@
 use crate::{
-    accounts_store::schema::{AccountsDbTrait, SchemaLabel, SchemaLabelBytes},
+    accounts_store::schema::{AccountsDbTrait, SchemaLabel},
     state::{
         partitions::{Partitions, PartitionsMaybe},
-        AssetHashes, Assets, Memory, PerformanceCounts, StableState, State,
+        AssetHashes, Assets, PerformanceCounts, StableState, State,
     },
 };
 use ic_stable_structures::{DefaultMemoryImpl, VectorMemory};
@@ -34,22 +34,6 @@ fn state_heap_contents_can_be_serialized_and_deserialized() {
     // It's nice if we keep these:
     assert_eq!(toy_state.assets, parsed.assets, "Assets have changed");
     assert_eq!(toy_state.asset_hashes, parsed.asset_hashes, "Asset hashes have changed");
-}
-
-#[test]
-fn schema_can_be_read_from_memory() {
-    let memory: VectorMemory = VectorMemory::default();
-    memory.grow(1);
-    // Pre-populate the memory so that it contains more than just the schema.
-    memory.write(0, &[0xa5u8; 1000]);
-    // Without a checksummed schema, we should get schema None.
-    assert_eq!(None, State::schema_version_from_memory(&memory));
-    // With a checksummed schema, we should get the schema.
-    for schema in SchemaLabel::iter() {
-        let schema_bytes = SchemaLabelBytes::from(schema);
-        memory.write(0, &schema_bytes);
-        assert_eq!(Some(schema), State::schema_version_from_memory(&memory));
-    }
 }
 
 #[test]


### PR DESCRIPTION
# Motivation
In previous PRs, `State::from(memory)` was defined.  This recovers state from memory from either managed virtual memory or raw memory.  This `from(memory)` function supersedes `State::restore()` which recovers memory only from raw memory.

Note: `restore()` took no arguments as it read the global stable memory state object.  This makes it impossible to test outside a   canister, while the `from(memory)` function can be tested against memory that is passed in.  There is a gap in the logic when using raw memory with the old API, as that still uses the global object, but the plan is to delete that code path once we no longer use raw memory.

# Changes
- Replace the call to `restore()` with one to `from(memory)`
- Delete now unused code.

# Tests
- There is an existing e2e test that verifies that this canister can be downgraded to current prod and back again.
- The `from(memory)` function already exists and has unit tests for managed memory.  For raw memory, we have to rely on the e2e tests.

# Todos

- [x] Add entry to changelog (if necessary).
