### PR TITLE
NNS1-2866: Add icpTransactionsStore

### DIFF
--- a/frontend/src/lib/stores/icp-transactions.store.ts
+++ b/frontend/src/lib/stores/icp-transactions.store.ts
@@ -1,0 +1,143 @@
+import type { GetTransactionsResponse } from "$lib/api/icrc-index.api";
+import type { IcrcAccountIdentifierText } from "$lib/types/icrc";
+import type {
+  UniverseCanisterId,
+  UniverseCanisterIdText,
+} from "$lib/types/universe";
+import { getUniqueTransactions } from "$lib/utils/icrc-transactions.utils";
+import { removeKeys } from "$lib/utils/utils";
+import type { IcrcTransactionWithId } from "@dfinity/ledger-icrc";
+import type { Principal } from "@dfinity/principal";
+import { nonNullish } from "@dfinity/utils";
+import { writable, type Readable } from "svelte/store";
+
+// Each Icrc Account - Sns or ckBTC - is an entry in this store.
+// We use the account string representation as the key to identify the transactions.
+export type IcrcTransactions = Record<
+  IcrcAccountIdentifierText,
+  {
+    transactions: IcrcTransactionWithId[];
+    oldestTxId?: bigint;
+    completed: boolean;
+  }
+>;
+
+// Each universe - except Nns - is an entry in this store.
+// We use the root canister id and then the account identifier as the key to identify the transactions.
+export type IcrcTransactionsStoreData = Record<
+  UniverseCanisterIdText,
+  IcrcTransactions
+>;
+
+export interface IcrcTransactionsStore
+  extends Readable<IcrcTransactionsStoreData> {
+  addTransactions: (
+    data: {
+      accountIdentifier: string;
+      canisterId: UniverseCanisterId;
+      completed: boolean;
+    } & GetTransactionsResponse
+  ) => void;
+  reset: () => void;
+  resetUniverse: (canisterId: UniverseCanisterId) => void;
+  resetAccount: (params: {
+    canisterId: UniverseCanisterId;
+    accountIdentifier: string;
+  }) => void;
+}
+
+/**
+ * A store that contains the transactions for each account in sns projects.
+ *
+ * - addTransactions: adds new transactions for a specific account in a specific sns project. If the state does not exist, it will be created.
+ * - reset: reset the store to an empty state.
+ * - resetProject: removed the transactions for a specific project.
+ */
+const initIcrcTransactionsStore = (): IcrcTransactionsStore => {
+  const { subscribe, update, set } = writable<IcrcTransactionsStoreData>({});
+
+  return {
+    subscribe,
+
+    addTransactions({
+      accountIdentifier,
+      canisterId,
+      transactions,
+      oldestTxId,
+      completed,
+    }: {
+      accountIdentifier: string;
+      canisterId: Principal;
+      transactions: IcrcTransactionWithId[];
+      oldestTxId?: bigint;
+      completed: boolean;
+    }) {
+      update((currentState: IcrcTransactionsStoreData) => {
+        const projectState = currentState[canisterId.toText()];
+        const accountState = projectState?.[accountIdentifier];
+        const allTransactions = getUniqueTransactions([
+          ...(accountState?.transactions ?? []),
+          ...transactions,
+        ]);
+        // Ids are in increasing order. We want to keep the oldest id.
+        const newOldestTxId =
+          oldestTxId === undefined
+            ? accountState?.oldestTxId
+            : oldestTxId <= (accountState?.oldestTxId ?? oldestTxId)
+            ? oldestTxId
+            : accountState?.oldestTxId;
+        return {
+          ...currentState,
+          [canisterId.toText()]: {
+            ...projectState,
+            [accountIdentifier]: {
+              transactions: allTransactions,
+              oldestTxId: newOldestTxId,
+              completed,
+            },
+          },
+        };
+      });
+    },
+
+    // Used in tests
+    reset() {
+      set({});
+    },
+
+    resetUniverse(canisterId: UniverseCanisterId) {
+      update((currentState: IcrcTransactionsStoreData) =>
+        removeKeys({
+          obj: currentState,
+          keysToRemove: [canisterId.toText()],
+        })
+      );
+    },
+
+    resetAccount({
+      canisterId,
+      accountIdentifier,
+    }: {
+      canisterId: UniverseCanisterId;
+      accountIdentifier: string;
+    }) {
+      update((currentState: IcrcTransactionsStoreData) => {
+        const projectState = currentState[canisterId.toText()];
+        return {
+          ...removeKeys({
+            obj: currentState,
+            keysToRemove: [canisterId.toText()],
+          }),
+          ...(nonNullish(projectState) && {
+            [canisterId.toText()]: removeKeys({
+              obj: projectState,
+              keysToRemove: [accountIdentifier],
+            }),
+          }),
+        };
+      });
+    },
+  };
+};
+
+export const icrcTransactionsStore = initIcrcTransactionsStore();

--- a/frontend/src/lib/stores/icrc-transactions.store.ts
+++ b/frontend/src/lib/stores/icrc-transactions.store.ts
@@ -4,7 +4,7 @@ import type {
   UniverseCanisterId,
   UniverseCanisterIdText,
 } from "$lib/types/universe";
-import { getUniqueTransactions } from "$lib/utils/icrc-transactions.utils";
+import { getUniqueTransactions } from "$lib/utils/transactions.utils";
 import { removeKeys } from "$lib/utils/utils";
 import type { IcrcTransactionWithId } from "@dfinity/ledger-icrc";
 import type { Principal } from "@dfinity/principal";

--- a/frontend/src/lib/utils/icrc-transactions.utils.ts
+++ b/frontend/src/lib/utils/icrc-transactions.utils.ts
@@ -456,20 +456,3 @@ export const isIcrcTransactionsCompleted = ({
   account: Account;
 }): boolean =>
   Boolean(store[canisterId.toText()]?.[account.identifier]?.completed);
-
-/**
- * Dedupe transactions based on ID.
- */
-export const getUniqueTransactions = (
-  transactions: IcrcTransactionWithId[]
-): IcrcTransactionWithId[] => {
-  const txIds = new Set<bigint>();
-  const result: IcrcTransactionWithId[] = [];
-  for (const tx of transactions) {
-    if (!txIds.has(tx.id)) {
-      txIds.add(tx.id);
-      result.push(tx);
-    }
-  }
-  return result;
-};

--- a/frontend/src/lib/utils/transactions.utils.ts
+++ b/frontend/src/lib/utils/transactions.utils.ts
@@ -250,3 +250,20 @@ export const isTransactionNetworkBtc = (
 ): boolean =>
   TransactionNetwork.BTC_MAINNET === network ||
   TransactionNetwork.BTC_TESTNET === network;
+
+/**
+ * Dedupe transactions based on ID.
+ */
+export const getUniqueTransactions = <TransactionWithId extends { id: bigint }>(
+  transactions: TransactionWithId[]
+): TransactionWithId[] => {
+  const txIds = new Set<bigint>();
+  const result: TransactionWithId[] = [];
+  for (const tx of transactions) {
+    if (!txIds.has(tx.id)) {
+      txIds.add(tx.id);
+      result.push(tx);
+    }
+  }
+  return result;
+};

--- a/frontend/src/tests/lib/stores/icp-transactions.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icp-transactions.store.spec.ts
@@ -1,88 +1,60 @@
-import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
-import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
-import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
-import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
+import { icpTransactionsStore } from "$lib/stores/icp-transactions.store";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
+import { mockTransactionWithId } from "$tests/mocks/icp-transactions.mock";
 import { get } from "svelte/store";
 
-describe("icrc-transactions", () => {
+describe("icp-transactions.store", () => {
   it("should reset account", () => {
     const otherAccountIdentifier = "otherAccountIdentifier";
 
-    icrcTransactionsStore.addTransactions({
-      canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
-      transactions: [mockIcrcTransactionWithId],
-      accountIdentifier: mockCkBTCMainAccount.identifier,
+    icpTransactionsStore.addTransactions({
+      transactions: [mockTransactionWithId],
+      accountIdentifier: mockMainAccount.identifier,
       oldestTxId: 10n,
       completed: false,
     });
 
-    const accounts = get(icrcTransactionsStore);
-    expect(
-      accounts[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]
-    ).not.toBeUndefined();
-    expect(
-      accounts[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()][
-        mockCkBTCMainAccount.identifier
-      ]
-    ).not.toBeUndefined();
+    const accounts = get(icpTransactionsStore);
+    expect(accounts[mockMainAccount.identifier]).not.toBeUndefined();
 
-    icrcTransactionsStore.addTransactions({
-      canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
-      transactions: [mockIcrcTransactionWithId],
+    icpTransactionsStore.addTransactions({
+      transactions: [mockTransactionWithId],
       accountIdentifier: otherAccountIdentifier,
       oldestTxId: 10n,
       completed: false,
     });
 
-    const accounts2 = get(icrcTransactionsStore);
-    expect(
-      accounts2[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()][otherAccountIdentifier]
-    ).not.toBeUndefined();
+    const accounts2 = get(icpTransactionsStore);
+    expect(accounts2[otherAccountIdentifier]).not.toBeUndefined();
 
-    icrcTransactionsStore.resetAccount({
-      canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
-      accountIdentifier: mockCkBTCMainAccount.identifier,
+    icpTransactionsStore.resetAccount({
+      accountIdentifier: mockMainAccount.identifier,
     });
 
-    const accounts3 = get(icrcTransactionsStore);
-    expect(
-      accounts3[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]
-    ).not.toBeUndefined();
-    expect(
-      accounts3[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()][
-        mockCkBTCMainAccount.identifier
-      ]
-    ).toBeUndefined();
+    const accounts3 = get(icpTransactionsStore);
+    expect(accounts3).not.toBeUndefined();
+    expect(accounts3[mockMainAccount.identifier]).toBeUndefined();
   });
 
   it("should dedupe transactions", () => {
-    const canisterId = CKTESTBTC_UNIVERSE_CANISTER_ID;
-    const identifier = mockCkBTCMainAccount.identifier;
+    const identifier = mockMainAccount.identifier;
 
-    icrcTransactionsStore.addTransactions({
-      canisterId,
-      transactions: [mockIcrcTransactionWithId],
+    icpTransactionsStore.addTransactions({
+      transactions: [mockTransactionWithId],
       accountIdentifier: identifier,
       oldestTxId: 10n,
       completed: false,
     });
 
-    expect(
-      get(icrcTransactionsStore)[canisterId.toText()][identifier].transactions
-        .length
-    ).toBe(1);
+    expect(get(icpTransactionsStore)[identifier].transactions.length).toBe(1);
 
-    icrcTransactionsStore.addTransactions({
-      canisterId,
-      transactions: [mockIcrcTransactionWithId, mockIcrcTransactionWithId],
+    icpTransactionsStore.addTransactions({
+      transactions: [mockTransactionWithId, mockTransactionWithId],
       accountIdentifier: identifier,
       oldestTxId: 10n,
       completed: false,
     });
 
-    expect(
-      get(icrcTransactionsStore)[canisterId.toText()][identifier].transactions
-        .length
-    ).toBe(1);
+    expect(get(icpTransactionsStore)[identifier].transactions.length).toBe(1);
   });
 });

--- a/frontend/src/tests/lib/stores/icp-transactions.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icp-transactions.store.spec.ts
@@ -1,0 +1,88 @@
+import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
+import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
+import { mockIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
+import { get } from "svelte/store";
+
+describe("icrc-transactions", () => {
+  it("should reset account", () => {
+    const otherAccountIdentifier = "otherAccountIdentifier";
+
+    icrcTransactionsStore.addTransactions({
+      canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+      transactions: [mockIcrcTransactionWithId],
+      accountIdentifier: mockCkBTCMainAccount.identifier,
+      oldestTxId: 10n,
+      completed: false,
+    });
+
+    const accounts = get(icrcTransactionsStore);
+    expect(
+      accounts[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]
+    ).not.toBeUndefined();
+    expect(
+      accounts[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()][
+        mockCkBTCMainAccount.identifier
+      ]
+    ).not.toBeUndefined();
+
+    icrcTransactionsStore.addTransactions({
+      canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+      transactions: [mockIcrcTransactionWithId],
+      accountIdentifier: otherAccountIdentifier,
+      oldestTxId: 10n,
+      completed: false,
+    });
+
+    const accounts2 = get(icrcTransactionsStore);
+    expect(
+      accounts2[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()][otherAccountIdentifier]
+    ).not.toBeUndefined();
+
+    icrcTransactionsStore.resetAccount({
+      canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
+      accountIdentifier: mockCkBTCMainAccount.identifier,
+    });
+
+    const accounts3 = get(icrcTransactionsStore);
+    expect(
+      accounts3[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()]
+    ).not.toBeUndefined();
+    expect(
+      accounts3[CKTESTBTC_UNIVERSE_CANISTER_ID.toText()][
+        mockCkBTCMainAccount.identifier
+      ]
+    ).toBeUndefined();
+  });
+
+  it("should dedupe transactions", () => {
+    const canisterId = CKTESTBTC_UNIVERSE_CANISTER_ID;
+    const identifier = mockCkBTCMainAccount.identifier;
+
+    icrcTransactionsStore.addTransactions({
+      canisterId,
+      transactions: [mockIcrcTransactionWithId],
+      accountIdentifier: identifier,
+      oldestTxId: 10n,
+      completed: false,
+    });
+
+    expect(
+      get(icrcTransactionsStore)[canisterId.toText()][identifier].transactions
+        .length
+    ).toBe(1);
+
+    icrcTransactionsStore.addTransactions({
+      canisterId,
+      transactions: [mockIcrcTransactionWithId, mockIcrcTransactionWithId],
+      accountIdentifier: identifier,
+      oldestTxId: 10n,
+      completed: false,
+    });
+
+    expect(
+      get(icrcTransactionsStore)[canisterId.toText()][identifier].transactions
+        .length
+    ).toBe(1);
+  });
+});

--- a/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icrc-transactions.utils.spec.ts
@@ -4,7 +4,6 @@ import type { IcrcTransactionData } from "$lib/types/transaction";
 import {
   getOldestTxIdFromStore,
   getSortedTransactionsFromStore,
-  getUniqueTransactions,
   isIcrcTransactionsCompleted,
   mapCkbtcPendingUtxo,
   mapCkbtcTransaction,
@@ -1080,56 +1079,6 @@ describe("icrc-transaction utils", () => {
           account: mockSnsSubAccount,
         })
       ).toBe(true);
-    });
-  });
-
-  describe("getUniqueTransactions", () => {
-    const mainAccount = {
-      owner: mockPrincipal,
-      subaccount: [] as [] | [Uint8Array],
-    };
-    const subAccount = {
-      owner: mockPrincipal,
-      subaccount: [new Uint8Array([1, 2, 3])] as [] | [Uint8Array],
-    };
-    const txA = createIcrcTransactionWithId({
-      id: 1n,
-      from: mainAccount,
-      to: subAccount,
-    });
-    const txB = createIcrcTransactionWithId({
-      id: 2n,
-      from: subAccount,
-      to: mainAccount,
-    });
-    const txC = createIcrcTransactionWithId({
-      id: 3n,
-      from: mainAccount,
-      to: mainAccount,
-    });
-
-    it("empty array", () => {
-      expect(getUniqueTransactions([])).toEqual([]);
-    });
-
-    it("singleton array", () => {
-      const transactions = [txA];
-      expect(getUniqueTransactions(transactions)).toEqual(transactions);
-    });
-
-    it("duplicate transactions", () => {
-      const transactions = [txA, txA];
-      expect(getUniqueTransactions(transactions)).toEqual([txA]);
-    });
-
-    it("multiple different transactions", () => {
-      const transactions = [txA, txB, txC];
-      expect(getUniqueTransactions(transactions)).toEqual(transactions);
-    });
-
-    it("non-consecutive duplicate transactions", () => {
-      const transactions = [txA, txB, txC, txA, txC, txB, txA, txC];
-      expect(getUniqueTransactions(transactions)).toEqual([txA, txB, txC]);
     });
   });
 });

--- a/frontend/src/tests/mocks/icp-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icp-transactions.mock.ts
@@ -1,0 +1,25 @@
+import { mockMainAccount, mockSubAccount } from "./icp-accounts.store.mock";
+import type {
+  Transaction,
+  TransactionWithId,
+} from "@dfinity/ledger-icp";
+
+export const mockTransactionTransfer: Transaction = {
+  memo: 0n,
+  icrc1_memo: [],
+  operation: {
+    Transfer: {
+    to: mockSubAccount.identifier,
+    fee: {e8s: 10_000n},
+    from: mockMainAccount.identifier,
+    amount: {e8s: 100_000_000n},
+    spender: [],
+    },
+  },
+  created_at_time: [{ timestamp_nanos: 234n }],
+};
+
+export const mockTransactionWithId: TransactionWithId = {
+  id: 234n,
+  transaction: mockTransactionTransfer,
+};

--- a/frontend/src/tests/mocks/icp-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icp-transactions.mock.ts
@@ -1,19 +1,16 @@
+import type { Transaction, TransactionWithId } from "@dfinity/ledger-icp";
 import { mockMainAccount, mockSubAccount } from "./icp-accounts.store.mock";
-import type {
-  Transaction,
-  TransactionWithId,
-} from "@dfinity/ledger-icp";
 
 export const mockTransactionTransfer: Transaction = {
   memo: 0n,
   icrc1_memo: [],
   operation: {
     Transfer: {
-    to: mockSubAccount.identifier,
-    fee: {e8s: 10_000n},
-    from: mockMainAccount.identifier,
-    amount: {e8s: 100_000_000n},
-    spender: [],
+      to: mockSubAccount.identifier,
+      fee: { e8s: 10_000n },
+      from: mockMainAccount.identifier,
+      amount: { e8s: 100_000_000n },
+      spender: [],
     },
   },
   created_at_time: [{ timestamp_nanos: 234n }],


### PR DESCRIPTION
# Motivation

Read ICP transactions from ICP Index canister.

In this PR, introduce the `icpTransactionsStore`.

It is modeled after the `icrcTransactionsStore` but
* it uses different types, and
* is not keyed by universe ID

I recommend reviewing the second commit separately so you can see the difference between the ICRC and ICP store.

# Changes

1. Copied `icrc-transactions.store.ts` and `icrc-transaction-store.spec.ts`.
2. Make relevant changes.
3. Make `getUniqueTransactions` generic and move it to a different file.

# Tests

Unit tests copied from ICRC store and adjusted.
Unit tests for `getUniqueTransactions`, moved to another file.

# Todos

- [ ] Add entry to changelog (if necessary).
covered