### PR TITLE
NNS1-2869: Add mapToSelfTransactions

### DIFF
--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -21,6 +21,34 @@ import {
 } from "@dfinity/utils";
 import { transactionName } from "./transactions.utils";
 
+const isToSelf = (transaction: Transaction): boolean => {
+  if ("Transfer" in transaction.operation) {
+    const data = transaction.operation.Transfer;
+    return data.to === data.from;
+  }
+  return false;
+};
+
+/**
+ * Duplicates transactions made from and to the same account such that one of
+ * the transactions has toSelfTransaction set to true and the other to false.
+ */
+export const mapToSelfTransactions = (
+  transactions: TransactionWithId[]
+): { transaction: TransactionWithId; toSelfTransaction: boolean }[] => {
+  const resultTransactions = transactions.flatMap((transaction) => {
+    const tx = {
+      transaction: { ...transaction },
+      toSelfTransaction: false,
+    };
+    if (isToSelf(transaction.transaction)) {
+      return [{ ...tx, toSelfTransaction: true }, tx];
+    }
+    return [tx];
+  });
+  return resultTransactions;
+};
+
 // TODO: Support icrc_memo which is not used at the moment in NNS dapp.
 const getTransactionType = ({
   transaction: { operation, memo },

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -4,7 +4,10 @@ import {
 } from "$lib/constants/api.constants";
 import { NANO_SECONDS_IN_MILLISECOND } from "$lib/constants/constants";
 import type { UiTransaction } from "$lib/types/transaction";
-import { mapIcpTransaction } from "$lib/utils/icp-transactions.utils";
+import {
+  mapIcpTransaction,
+  mapToSelfTransactions,
+} from "$lib/utils/icp-transactions.utils";
 import en from "$tests/mocks/i18n.mock";
 import type { Operation, TransactionWithId } from "@dfinity/ledger-icp";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
@@ -406,6 +409,51 @@ describe("icp-transactions.utils", () => {
           i18n: en,
         })
       ).toEqual(expectedUiTransaction);
+    });
+  });
+
+  describe("mapToSelfTransactions", () => {
+    it("duplicateds toSelf transactions", () => {
+      const transaction = createTransactionWithId({
+        operation: toSelfOperation,
+      });
+
+      expect(mapToSelfTransactions([transaction])).toEqual([
+        {
+          transaction,
+          toSelfTransaction: true,
+        },
+        {
+          transaction,
+          toSelfTransaction: false,
+        },
+      ]);
+    });
+
+    it("doesn't duplicate not to self transactoins", () => {
+      const transaction = createTransactionWithId({
+        operation: toSelfOperation,
+      });
+      const notToSelfTransaction = createTransactionWithId({
+        operation: defaultTransferOperation,
+      });
+
+      expect(
+        mapToSelfTransactions([transaction, notToSelfTransaction])
+      ).toEqual([
+        {
+          transaction,
+          toSelfTransaction: true,
+        },
+        {
+          transaction,
+          toSelfTransaction: false,
+        },
+        {
+          transaction: notToSelfTransaction,
+          toSelfTransaction: false,
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
# Motivation

Fetch ICP wallet transactions from ICP Index instead of NNS Dapp canister.

In this PR, introduce the helper `mapToSelfTransactions` that duplicates transactions to and from the same wallet. A pattern needed for the required UX on transactions to self.

# Changes

* New icp-transactions util `mapToSelfTransactions`.

# Tests

* Add tests for the new util `mapToSelfTransactions`.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.