### PR TITLE
Include index canister when importing canister IDs

### DIFF
--- a/scripts/canister_ids
+++ b/scripts/canister_ids
@@ -142,6 +142,7 @@ if [ "$command" = "import-from-index-html" ]; then
   snsAggregatorUrl="$(get_value_from_html data-sns-aggregator-url "$tmp_index_html")"
   snsAggregator="$(canister_id_from_url "$snsAggregatorUrl")"
 
+  nnsIndex="$(get_value_from_html data-index-canister-id "$tmp_index_html")"
   ckbtcIndex="$(get_value_from_html data-ckbtc-index-canister-id "$tmp_index_html")"
   ckbtcLedger="$(get_value_from_html data-ckbtc-ledger-canister-id "$tmp_index_html")"
   ckbtcMinter="$(get_value_from_html data-ckbtc-minter-canister-id "$tmp_index_html")"
@@ -152,6 +153,7 @@ if [ "$command" = "import-from-index-html" ]; then
 
   tmp_file="$(mktemp)"
   jq '
+    .["nns-index"][$network] = $nnsIndex |
     .ckbtc_index[$network] = $ckbtcIndex |
     .ckbtc_ledger[$network] = $ckbtcLedger |
     .ckbtc_minter[$network] = $ckbtcMinter |
@@ -162,6 +164,7 @@ if [ "$command" = "import-from-index-html" ]; then
     .["nns-dapp"][$network] = $nnsDapp |
     .sns_aggregator[$network] = $snsAggregator' \
     --arg network "$NETWORK" \
+    --arg nnsIndex "$nnsIndex" \
     --arg ckbtcIndex "$ckbtcIndex" \
     --arg ckbtcLedger "$ckbtcLedger" \
     --arg ckbtcMinter "$ckbtcMinter" \

--- a/scripts/canister_ids.test
+++ b/scripts/canister_ids.test
@@ -44,6 +44,7 @@ cat >"$test_index_html" <<-EOF
         data-governance-canister-id="rrkah-fqaaa-aaaaa-aaaaq-cai"
         data-host="https://fubar.dfinity.network"
         data-identity-service-url="https://wqmuk-5qaaa-aaaaa-aaaqq-cai.fubar.dfinity.network"
+        data-index-canister-id="bkyz2-fmaaa-aaaaa-qaaaq-cai"
         data-ledger-canister-id="ryjl3-tyaaa-aaaaa-aaaba-cai"
         data-own-canister-id="lf43c-fyaaa-aaaaa-aacva-cai"
         data-robots="&lt;meta name=&quot;robots&quot; content=&quot;noindex, nofollow&quot; /&gt;"
@@ -145,6 +146,9 @@ if ! diff "$test_json_file" <(
   },
   "nns-governance": {
     "mainnet": "rrkah-fqaaa-aaaaa-aaaaq-cai"
+  },
+  "nns-index": {
+    "staging": "bkyz2-fmaaa-aaaaa-qaaaq-cai"
   },
   "ckbtc_index": {
     "staging": "tqtu6-byaaa-aaaaa-aaana-cai"


### PR DESCRIPTION
# Motivation

NNS dapp now requires the index canister ID in its arguments.
When installing on DevEnv, we need this canister ID in `canister_ids.json`.

# Changes

Update `scripts/canister_ids` to include the index canister ID when importing IDs from a URL.

# Tests

* Test updated.
* Ran manually, then ran `DFX_NETWORK=devenv_dskloet ./config.sh` and check the index canister ID in the output.

# Todos

- [ ] Add entry to changelog (if necessary).
covered