### PR TITLE
NNS1-2865: icp-index api getTransactions

### DIFF
--- a/frontend/src/lib/api/icp-index.api.ts
+++ b/frontend/src/lib/api/icp-index.api.ts
@@ -1,0 +1,70 @@
+import { INDEX_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { HOST } from "$lib/constants/environment.constants";
+import { logWithTimestamp } from "$lib/utils/dev.utils";
+import type { Agent, Identity } from "@dfinity/agent";
+import {
+  IndexCanister,
+  type GetAccountIdentifierTransactionsResponse,
+} from "@dfinity/ledger-icp";
+import { fromNullable } from "@dfinity/utils";
+import { createAgent } from "./agent.api";
+
+export interface GetTransactionsParams {
+  identity: Identity;
+  accountIdentifier: string;
+  start?: bigint;
+  maxResults: bigint;
+}
+
+export interface GetTransactionsResponse
+  extends Omit<GetAccountIdentifierTransactionsResponse, "oldest_tx_id"> {
+  oldestTxId?: bigint;
+}
+
+export const getTransactions = async ({
+  identity,
+  maxResults,
+  start,
+  accountIdentifier,
+}: GetTransactionsParams): Promise<GetTransactionsResponse> => {
+  logWithTimestamp("Get account transactions call...");
+  const {
+    canister: { getTransactions },
+  } = await indexCanister({ identity });
+
+  const { oldest_tx_id, ...rest } = await getTransactions({
+    maxResults,
+    start,
+    accountIdentifier,
+  });
+
+  logWithTimestamp("Get account transactions call complete.");
+  return {
+    oldestTxId: fromNullable(oldest_tx_id),
+    ...rest,
+  };
+};
+
+const indexCanister = async ({
+  identity,
+}: {
+  identity: Identity;
+}): Promise<{
+  canister: IndexCanister;
+  agent: Agent;
+}> => {
+  const agent = await createAgent({
+    identity,
+    host: HOST,
+  });
+
+  const canister = IndexCanister.create({
+    agent,
+    canisterId: INDEX_CANISTER_ID,
+  });
+
+  return {
+    canister,
+    agent,
+  };
+};

--- a/frontend/src/tests/lib/api/icp-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-index.api.spec.ts
@@ -1,0 +1,124 @@
+import * as agent from "$lib/api/agent.api";
+import { getTransactions } from "$lib/api/icp-index.api";
+import { mockIdentity } from "$tests/mocks/auth.store.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
+import type { HttpAgent } from "@dfinity/agent";
+import {
+  IndexCanister,
+  type GetAccountIdentifierTransactionsResponse,
+  type TransactionWithId,
+} from "@dfinity/ledger-icp";
+import { mock } from "vitest-mock-extended";
+
+describe("icp-index.api", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.clearAllTimers();
+    vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
+  });
+
+  describe("icp-index api", () => {
+    const { identifier: accountIdentifier } = mockMainAccount;
+
+    const defaultTransactinoWithId: TransactionWithId = {
+      id: 1234n,
+      transaction: {
+        memo: 0n,
+        icrc1_memo: [],
+        operation: {
+          Transfer: {
+            to: "1234",
+            fee: { e8s: 10_000n },
+            from: "56789",
+            amount: { e8s: 100_000_000n },
+            spender: [],
+          },
+        },
+        created_at_time: [],
+      },
+    };
+    const defaultResponse: GetAccountIdentifierTransactionsResponse = {
+      transactions: [defaultTransactinoWithId],
+      oldest_tx_id: [1234n],
+      balance: 200_000_000n,
+    };
+    let currentResponse = defaultResponse;
+    const indexCanisterMock = mock<IndexCanister>();
+
+    beforeEach(() => {
+      currentResponse = defaultResponse;
+      indexCanisterMock.getTransactions.mockImplementation(
+        async () => currentResponse
+      );
+      vi.spyOn(IndexCanister, "create").mockImplementation(
+        (): IndexCanister => indexCanisterMock
+      );
+    });
+
+    describe("getTransactions", () => {
+      it("should call the index canister method to get transactions", async () => {
+        const maxResults = 20n;
+        expect(IndexCanister.create).toHaveBeenCalledTimes(0);
+
+        const response = await getTransactions({
+          identity: mockIdentity,
+          maxResults,
+          accountIdentifier,
+        });
+
+        expect(IndexCanister.create).toHaveBeenCalledTimes(1);
+        expect(indexCanisterMock.getTransactions).toHaveBeenCalledWith({
+          start: undefined,
+          accountIdentifier,
+          maxResults,
+        });
+        expect(response).toEqual({
+          oldestTxId: defaultResponse.oldest_tx_id[0],
+          transactions: [defaultTransactinoWithId],
+          balance: defaultResponse.balance,
+        });
+      });
+
+      it("should pass the start parameter", async () => {
+        const maxResults = 20n;
+        const start = 1234n;
+        expect(IndexCanister.create).toHaveBeenCalledTimes(0);
+
+        await getTransactions({
+          identity: mockIdentity,
+          maxResults,
+          accountIdentifier,
+          start,
+        });
+
+        expect(IndexCanister.create).toHaveBeenCalledTimes(1);
+        expect(indexCanisterMock.getTransactions).toHaveBeenCalledWith({
+          start,
+          accountIdentifier,
+          maxResults,
+        });
+      });
+
+      it("should return undefined old tx index if not present in response", async () => {
+        const maxResults = 20n;
+        currentResponse = {
+          ...defaultResponse,
+          oldest_tx_id: [],
+        };
+        expect(IndexCanister.create).toHaveBeenCalledTimes(0);
+
+        const response = await getTransactions({
+          identity: mockIdentity,
+          maxResults,
+          accountIdentifier,
+        });
+
+        expect(response).toEqual({
+          oldestTxId: undefined,
+          transactions: [defaultTransactinoWithId],
+          balance: defaultResponse.balance,
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

Fetch ICP transactions from the ICP Index canister.

In this PR, add an api function to fetch the transactions from the ICP Index canister.

# Changes

* New api file icp-index and function `getTransactions`.

# Tests

* I tested it manually as part of #4511 
* Test for the new api function.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.