### PR TITLE
NNS1-2866: Add icp-transactions services

### DIFF
--- a/frontend/src/lib/constants/constants.ts
+++ b/frontend/src/lib/constants/constants.ts
@@ -2,7 +2,7 @@ export const DEFAULT_LIST_PAGINATION_LIMIT = 100;
 export const DEFAULT_TRANSACTION_PAGE_LIMIT = 100;
 // Use a different limit for Icrc transactions
 // the Index canister needs to query the Icrc Ledger canister for each transaction - i.e. it needs an update call
-export const DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT = 20;
+export const DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT = 20;
 
 /**
  * The infinite scroll observe an element that finds place after x % of last page.

--- a/frontend/src/lib/services/icp-transactions.services.ts
+++ b/frontend/src/lib/services/icp-transactions.services.ts
@@ -1,5 +1,5 @@
 import { getTransactions } from "$lib/api/icp-index.api";
-import { DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
+import { DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import { icpTransactionsStore } from "$lib/stores/icp-transactions.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { toToastError } from "$lib/utils/error.utils";
@@ -16,7 +16,7 @@ export const loadIcpAccountTransactions = async ({
   start,
 }: LoadIcrcAccountTransactionsParams) => {
   try {
-    const maxResults = DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT;
+    const maxResults = DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT;
     const identity = await getCurrentIdentity();
     const { transactions, oldestTxId } = await getTransactions({
       accountIdentifier,

--- a/frontend/src/lib/services/icp-transactions.services.ts
+++ b/frontend/src/lib/services/icp-transactions.services.ts
@@ -1,0 +1,50 @@
+import { getTransactions } from "$lib/api/icp-index.api";
+import { DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
+import { icpTransactionsStore } from "$lib/stores/icp-transactions.store";
+import { toastsError } from "$lib/stores/toasts.store";
+import { toToastError } from "$lib/utils/error.utils";
+import { get } from "svelte/store";
+import { getCurrentIdentity } from "./auth.services";
+
+export interface LoadIcrcAccountTransactionsParams {
+  accountIdentifier: string;
+  start?: bigint;
+}
+
+export const loadIcpAccountTransactions = async ({
+  accountIdentifier,
+  start,
+}: LoadIcrcAccountTransactionsParams) => {
+  try {
+    const maxResults = DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT;
+    const identity = await getCurrentIdentity();
+    const { transactions, oldestTxId } = await getTransactions({
+      accountIdentifier,
+      identity,
+      maxResults: BigInt(maxResults),
+      start,
+    });
+    // If API returns less than the maxResults, we reached the end of the list.
+    const completed = transactions.length < maxResults;
+    icpTransactionsStore.addTransactions({
+      accountIdentifier,
+      transactions,
+      completed,
+      oldestTxId,
+    });
+  } catch (err) {
+    toastsError(
+      toToastError({ fallbackErrorLabelKey: "error.fetch_transactions", err })
+    );
+  }
+};
+
+export const loadIcpAccountNextTransactions = async (
+  accountIdentifier: string
+) => {
+  const store = get(icpTransactionsStore);
+  return loadIcpAccountTransactions({
+    accountIdentifier,
+    start: store[accountIdentifier]?.oldestTxId,
+  });
+};

--- a/frontend/src/lib/services/icrc-transactions.services.ts
+++ b/frontend/src/lib/services/icrc-transactions.services.ts
@@ -1,5 +1,5 @@
 import { getTransactions } from "$lib/api/icrc-index.api";
-import { DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
+import { DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import { getIcrcAccountIdentity } from "$lib/services/icrc-accounts.services";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { toastsError } from "$lib/stores/toasts.store";
@@ -26,7 +26,7 @@ export const loadIcrcAccountTransactions = async ({
   try {
     const identity = await getIcrcAccountIdentity(account);
     const snsAccount = decodeIcrcAccount(account.identifier);
-    const maxResults = DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT;
+    const maxResults = DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT;
     const { transactions, oldestTxId } = await getTransactions({
       identity,
       account: snsAccount,

--- a/frontend/src/lib/worker-services/icrc-transactions.worker-services.ts
+++ b/frontend/src/lib/worker-services/icrc-transactions.worker-services.ts
@@ -1,5 +1,5 @@
 import type { GetTransactionsResponse } from "$lib/api/icrc-index.api";
-import { DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
+import { DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 
 import type { IcrcAccountIdentifierText } from "$lib/types/icrc";
 import type {
@@ -164,7 +164,7 @@ const getIcrcTransactions = async ({
       indexCanisterId,
       identity,
       account: decodeIcrcAccount(accountIdentifier),
-      maxResults: BigInt(DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT),
+      maxResults: BigInt(DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT),
       start,
       fetchRootKey,
       host,

--- a/frontend/src/tests/lib/api/icp-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-index.api.spec.ts
@@ -2,11 +2,11 @@ import * as agent from "$lib/api/agent.api";
 import { getTransactions } from "$lib/api/icp-index.api";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
+import { defaultTransactinoWithId } from "$tests/mocks/transaction.mock";
 import type { HttpAgent } from "@dfinity/agent";
 import {
   IndexCanister,
   type GetAccountIdentifierTransactionsResponse,
-  type TransactionWithId,
 } from "@dfinity/ledger-icp";
 import { mock } from "vitest-mock-extended";
 
@@ -19,24 +19,6 @@ describe("icp-index.api", () => {
 
   describe("icp-index api", () => {
     const { identifier: accountIdentifier } = mockMainAccount;
-
-    const defaultTransactinoWithId: TransactionWithId = {
-      id: 1234n,
-      transaction: {
-        memo: 0n,
-        icrc1_memo: [],
-        operation: {
-          Transfer: {
-            to: "1234",
-            fee: { e8s: 10_000n },
-            from: "56789",
-            amount: { e8s: 100_000_000n },
-            spender: [],
-          },
-        },
-        created_at_time: [],
-      },
-    };
     const defaultResponse: GetAccountIdentifierTransactionsResponse = {
       transactions: [defaultTransactinoWithId],
       oldest_tx_id: [1234n],

--- a/frontend/src/tests/lib/api/icp-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icp-index.api.spec.ts
@@ -2,7 +2,7 @@ import * as agent from "$lib/api/agent.api";
 import { getTransactions } from "$lib/api/icp-index.api";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
-import { defaultTransactinoWithId } from "$tests/mocks/transaction.mock";
+import { mockTransactionWithId } from "$tests/mocks/transaction.mock";
 import type { HttpAgent } from "@dfinity/agent";
 import {
   IndexCanister,
@@ -20,7 +20,7 @@ describe("icp-index.api", () => {
   describe("icp-index api", () => {
     const { identifier: accountIdentifier } = mockMainAccount;
     const defaultResponse: GetAccountIdentifierTransactionsResponse = {
-      transactions: [defaultTransactinoWithId],
+      transactions: [mockTransactionWithId],
       oldest_tx_id: [1234n],
       balance: 200_000_000n,
     };
@@ -56,7 +56,7 @@ describe("icp-index.api", () => {
         });
         expect(response).toEqual({
           oldestTxId: defaultResponse.oldest_tx_id[0],
-          transactions: [defaultTransactinoWithId],
+          transactions: [mockTransactionWithId],
           balance: defaultResponse.balance,
         });
       });
@@ -97,7 +97,7 @@ describe("icp-index.api", () => {
 
         expect(response).toEqual({
           oldestTxId: undefined,
-          transactions: [defaultTransactinoWithId],
+          transactions: [mockTransactionWithId],
           balance: defaultResponse.balance,
         });
       });

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -1,3 +1,7 @@
+import {
+  advanceTime,
+  runResolvedPromises,
+} from "$defaultTransactionWithIdutils";
 import * as accountsApi from "$lib/api/accounts.api";
 import * as ledgerApi from "$lib/api/icp-ledger.api";
 import * as nnsDappApi from "$lib/api/nns-dapp.api";
@@ -22,10 +26,6 @@ import { IcpTransactionModalPo } from "$tests/page-objects/IcpTransactionModal.p
 import { NnsWalletPo } from "$tests/page-objects/NnsWallet.page-object";
 import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import {
-  advanceTime,
-  runResolvedPromises,
-} from "$tests/utils/timers.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { Principal } from "@dfinity/principal";
 import { render } from "@testing-library/svelte";
@@ -54,6 +54,7 @@ describe("NnsWallet", () => {
     vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
       mainBalanceE8s
     );
+    defaultTransactionWithId;
     vi.spyOn(accountsApi, "getTransactions").mockResolvedValue([]);
 
     page.mock({

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -1,7 +1,3 @@
-import {
-  advanceTime,
-  runResolvedPromises,
-} from "$defaultTransactionWithIdutils";
 import * as accountsApi from "$lib/api/accounts.api";
 import * as ledgerApi from "$lib/api/icp-ledger.api";
 import * as nnsDappApi from "$lib/api/nns-dapp.api";
@@ -26,6 +22,10 @@ import { IcpTransactionModalPo } from "$tests/page-objects/IcpTransactionModal.p
 import { NnsWalletPo } from "$tests/page-objects/NnsWallet.page-object";
 import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import {
+  advanceTime,
+  runResolvedPromises,
+} from "$tests/utils/timers.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { Principal } from "@dfinity/principal";
 import { render } from "@testing-library/svelte";
@@ -54,7 +54,6 @@ describe("NnsWallet", () => {
     vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
       mainBalanceE8s
     );
-    defaultTransactionWithId;
     vi.spyOn(accountsApi, "getTransactions").mockResolvedValue([]);
 
     page.mock({

--- a/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
@@ -1,5 +1,5 @@
 import * as indexApi from "$lib/api/icp-index.api";
-import { DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
+import { DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import {
   loadIcpAccountNextTransactions,
   loadIcpAccountTransactions,
@@ -8,7 +8,7 @@ import { icpTransactionsStore } from "$lib/stores/icp-transactions.store";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
-import { defaultTransactinoWithId } from "$tests/mocks/transaction.mock";
+import { mockTransactionWithId } from "$tests/mocks/transaction.mock";
 import { toastsStore } from "@dfinity/gix-components";
 import type { TransactionWithId } from "@dfinity/ledger-icp";
 import { get } from "svelte/store";
@@ -32,13 +32,13 @@ describe("icp-transactions services", () => {
       const spyGetTransactions = vi
         .spyOn(indexApi, "getTransactions")
         .mockResolvedValueOnce({
-          oldestTxId: 1_234n,
-          transactions: [defaultTransactinoWithId],
+          oldestTxId: mockTransactionWithId.id,
+          transactions: [mockTransactionWithId],
           balance: 200_000_000n,
         })
         .mockResolvedValueOnce({
-          oldestTxId: 5_678n,
-          transactions: [defaultTransactinoWithId],
+          oldestTxId: mockTransactionWithId.id,
+          transactions: [mockTransactionWithId],
           balance: 300_000_000n,
         });
       const start = 1_234n;
@@ -53,12 +53,12 @@ describe("icp-transactions services", () => {
       expect(spyGetTransactions).toBeCalledWith({
         identity: mockIdentity,
         accountIdentifier,
-        maxResults: BigInt(DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT),
+        maxResults: BigInt(DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT),
         start,
       });
 
       expect(get(icpTransactionsStore)[accountIdentifier]).toEqual({
-        transactions: [defaultTransactinoWithId],
+        transactions: [mockTransactionWithId],
         oldestTxId: 1_234n,
         completed: true,
       });
@@ -70,21 +70,21 @@ describe("icp-transactions services", () => {
 
       // Previous state is not overwritten
       expect(get(icpTransactionsStore)[accountIdentifier]).toEqual({
-        transactions: [defaultTransactinoWithId],
+        transactions: [mockTransactionWithId],
         oldestTxId: 1_234n,
         completed: true,
       });
       // New state is added
       expect(get(icpTransactionsStore)[accountIdentifier2]).toEqual({
-        transactions: [defaultTransactinoWithId],
+        transactions: [mockTransactionWithId],
         oldestTxId: 5_678n,
         completed: true,
       });
     });
 
     it("sets complete to false", async () => {
-      const transactions = new Array(DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT).fill(
-        defaultTransactinoWithId
+      const transactions = new Array(DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT).fill(
+        mockTransactionWithId
       );
       vi.spyOn(indexApi, "getTransactions").mockResolvedValue({
         oldestTxId: 1_234n,
@@ -129,11 +129,11 @@ describe("icp-transactions services", () => {
       const recentTransactionId = 200n;
       const recentTransaction: TransactionWithId = {
         id: recentTransactionId,
-        transaction: { ...defaultTransactinoWithId.transaction },
+        transaction: { ...mockTransactionWithId.transaction },
       };
       const oldTransaction = {
         id: oldTransactionId,
-        transaction: { ...defaultTransactinoWithId.transaction },
+        transaction: { ...mockTransactionWithId.transaction },
       };
       const spyGetTransactions = vi
         .spyOn(indexApi, "getTransactions")
@@ -158,7 +158,7 @@ describe("icp-transactions services", () => {
       expect(spyGetTransactions).toBeCalledWith({
         identity: mockIdentity,
         accountIdentifier,
-        maxResults: BigInt(DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT),
+        maxResults: BigInt(DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT),
         start: recentTransactionId,
       });
 
@@ -173,8 +173,8 @@ describe("icp-transactions services", () => {
       const spyGetTransactions = vi
         .spyOn(indexApi, "getTransactions")
         .mockResolvedValue({
-          oldestTxId: defaultTransactinoWithId.id,
-          transactions: [defaultTransactinoWithId],
+          oldestTxId: mockTransactionWithId.id,
+          transactions: [mockTransactionWithId],
           balance: 200_000_000n,
         });
 
@@ -186,7 +186,7 @@ describe("icp-transactions services", () => {
       expect(spyGetTransactions).toBeCalledWith({
         identity: mockIdentity,
         accountIdentifier,
-        maxResults: BigInt(DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT),
+        maxResults: BigInt(DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT),
         start: undefined,
       });
     });

--- a/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
@@ -1,0 +1,210 @@
+import * as indexApi from "$lib/api/icp-index.api";
+import { DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
+import {
+  loadIcpAccountNextTransactions,
+  loadIcpAccountTransactions,
+} from "$lib/services/icp-transactions.services";
+import { icpTransactionsStore } from "$lib/stores/icp-transactions.store";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
+import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
+import { defaultTransactinoWithId } from "$tests/mocks/transaction.mock";
+import { toastsStore } from "@dfinity/gix-components";
+import type { TransactionWithId } from "@dfinity/ledger-icp";
+import { get } from "svelte/store";
+
+vi.mock("$lib/api/icp-index.api");
+
+describe("icp-transactions services", () => {
+  const accountIdentifier = mockMainAccount.identifier;
+  const accountIdentifier2 = mockSnsMainAccount.identifier;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetIdentity();
+    icpTransactionsStore.reset();
+    toastsStore.reset();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  describe("loadIcpAccountTransactions", () => {
+    it("loads transactions in the store by account identifier from the api data", async () => {
+      const spyGetTransactions = vi
+        .spyOn(indexApi, "getTransactions")
+        .mockResolvedValueOnce({
+          oldestTxId: 1_234n,
+          transactions: [defaultTransactinoWithId],
+          balance: 200_000_000n,
+        })
+        .mockResolvedValueOnce({
+          oldestTxId: 5_678n,
+          transactions: [defaultTransactinoWithId],
+          balance: 300_000_000n,
+        });
+      const start = 1_234n;
+
+      expect(spyGetTransactions).not.toBeCalled();
+      await loadIcpAccountTransactions({
+        accountIdentifier,
+        start,
+      });
+
+      expect(spyGetTransactions).toBeCalledTimes(1);
+      expect(spyGetTransactions).toBeCalledWith({
+        identity: mockIdentity,
+        accountIdentifier,
+        maxResults: BigInt(DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT),
+        start,
+      });
+
+      expect(get(icpTransactionsStore)[accountIdentifier]).toEqual({
+        transactions: [defaultTransactinoWithId],
+        oldestTxId: 1_234n,
+        completed: true,
+      });
+
+      await loadIcpAccountTransactions({
+        accountIdentifier: accountIdentifier2,
+        start,
+      });
+
+      // Previous state is not overwritten
+      expect(get(icpTransactionsStore)[accountIdentifier]).toEqual({
+        transactions: [defaultTransactinoWithId],
+        oldestTxId: 1_234n,
+        completed: true,
+      });
+      // New state is added
+      expect(get(icpTransactionsStore)[accountIdentifier2]).toEqual({
+        transactions: [defaultTransactinoWithId],
+        oldestTxId: 5_678n,
+        completed: true,
+      });
+    });
+
+    it("sets complete to false", async () => {
+      const transactions = new Array(DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT).fill(
+        defaultTransactinoWithId
+      );
+      vi.spyOn(indexApi, "getTransactions").mockResolvedValue({
+        oldestTxId: 1_234n,
+        transactions: transactions,
+        balance: 200_000_000n,
+      });
+
+      await loadIcpAccountTransactions({
+        accountIdentifier,
+        start: undefined,
+      });
+
+      expect(get(icpTransactionsStore)[accountIdentifier].completed).toBe(
+        false
+      );
+    });
+
+    it("toasts error if api fails", async () => {
+      vi.spyOn(indexApi, "getTransactions").mockRejectedValue(
+        new Error("Something happened")
+      );
+      const start = 1_234n;
+
+      expect(get(toastsStore)).toHaveLength(0);
+
+      await loadIcpAccountTransactions({
+        accountIdentifier,
+        start,
+      });
+
+      expect(get(toastsStore)).toHaveLength(1);
+      expect(get(toastsStore)[0]).toMatchObject({
+        level: "error",
+        text: "Sorry, there was an error loading the transactions for this account. Something happened",
+      });
+    });
+  });
+
+  describe("loadIcpAccountNextTransactions", () => {
+    it("uses oldest transaction id as start and results in store", async () => {
+      const oldTransactionId = 100n;
+      const recentTransactionId = 200n;
+      const recentTransaction: TransactionWithId = {
+        id: recentTransactionId,
+        transaction: { ...defaultTransactinoWithId.transaction },
+      };
+      const oldTransaction = {
+        id: oldTransactionId,
+        transaction: { ...defaultTransactinoWithId.transaction },
+      };
+      const spyGetTransactions = vi
+        .spyOn(indexApi, "getTransactions")
+        .mockResolvedValue({
+          oldestTxId: oldTransactionId,
+          transactions: [oldTransaction],
+          balance: 200_000_000n,
+        });
+
+      icpTransactionsStore.addTransactions({
+        accountIdentifier,
+        transactions: [recentTransaction],
+        oldestTxId: recentTransactionId,
+        completed: false,
+      });
+
+      expect(spyGetTransactions).not.toBeCalled();
+
+      await loadIcpAccountNextTransactions(accountIdentifier);
+
+      expect(spyGetTransactions).toBeCalledTimes(1);
+      expect(spyGetTransactions).toBeCalledWith({
+        identity: mockIdentity,
+        accountIdentifier,
+        maxResults: BigInt(DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT),
+        start: recentTransactionId,
+      });
+
+      expect(get(icpTransactionsStore)[accountIdentifier]).toEqual({
+        transactions: [recentTransaction, oldTransaction],
+        oldestTxId: oldTransactionId,
+        completed: true,
+      });
+    });
+
+    it("passes start undefined if no transactions in store", async () => {
+      const spyGetTransactions = vi
+        .spyOn(indexApi, "getTransactions")
+        .mockResolvedValue({
+          oldestTxId: defaultTransactinoWithId.id,
+          transactions: [defaultTransactinoWithId],
+          balance: 200_000_000n,
+        });
+
+      expect(spyGetTransactions).not.toBeCalled();
+
+      await loadIcpAccountNextTransactions(accountIdentifier);
+
+      expect(spyGetTransactions).toBeCalledTimes(1);
+      expect(spyGetTransactions).toBeCalledWith({
+        identity: mockIdentity,
+        accountIdentifier,
+        maxResults: BigInt(DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT),
+        start: undefined,
+      });
+    });
+
+    it("toasts error if api fails", async () => {
+      vi.spyOn(indexApi, "getTransactions").mockRejectedValue(
+        new Error("Something happened")
+      );
+
+      expect(get(toastsStore)).toHaveLength(0);
+
+      await loadIcpAccountNextTransactions(accountIdentifier);
+
+      expect(get(toastsStore)).toHaveLength(1);
+      expect(get(toastsStore)[0]).toMatchObject({
+        level: "error",
+        text: "Sorry, there was an error loading the transactions for this account. Something happened",
+      });
+    });
+  });
+});

--- a/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
@@ -29,16 +29,24 @@ describe("icp-transactions services", () => {
 
   describe("loadIcpAccountTransactions", () => {
     it("loads transactions in the store by account identifier from the api data", async () => {
+      const transaction1 = {
+        id: 1_234n,
+        transaction: { ...mockTransactionWithId.transaction },
+      };
+      const transaction2 = {
+        id: 5_678n,
+        transaction: { ...mockTransactionWithId.transaction },
+      };
       const spyGetTransactions = vi
         .spyOn(indexApi, "getTransactions")
         .mockResolvedValueOnce({
-          oldestTxId: mockTransactionWithId.id,
-          transactions: [mockTransactionWithId],
+          oldestTxId: transaction1.id,
+          transactions: [transaction1],
           balance: 200_000_000n,
         })
         .mockResolvedValueOnce({
-          oldestTxId: mockTransactionWithId.id,
-          transactions: [mockTransactionWithId],
+          oldestTxId: transaction2.id,
+          transactions: [transaction2],
           balance: 300_000_000n,
         });
       const start = 1_234n;
@@ -59,7 +67,7 @@ describe("icp-transactions services", () => {
 
       expect(get(icpTransactionsStore)[accountIdentifier]).toEqual({
         transactions: [mockTransactionWithId],
-        oldestTxId: 1_234n,
+        oldestTxId: transaction1.id,
         completed: true,
       });
 
@@ -70,14 +78,14 @@ describe("icp-transactions services", () => {
 
       // Previous state is not overwritten
       expect(get(icpTransactionsStore)[accountIdentifier]).toEqual({
-        transactions: [mockTransactionWithId],
-        oldestTxId: 1_234n,
+        transactions: [transaction1],
+        oldestTxId: transaction1.id,
         completed: true,
       });
       // New state is added
       expect(get(icpTransactionsStore)[accountIdentifier2]).toEqual({
-        transactions: [mockTransactionWithId],
-        oldestTxId: 5_678n,
+        transactions: [transaction2],
+        oldestTxId: transaction2.id,
         completed: true,
       });
     });

--- a/frontend/src/tests/lib/services/icrc-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-transactions.services.spec.ts
@@ -1,5 +1,5 @@
 import * as indexApi from "$lib/api/icrc-index.api";
-import { DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
+import { DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import {
   loadIcrcAccountNextTransactions,
   loadIcrcAccountTransactions,
@@ -55,7 +55,7 @@ describe("icrc-transactions services", () => {
       expect(spyGetTransactions).toBeCalledWith({
         identity: mockIdentity,
         account,
-        maxResults: BigInt(DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT),
+        maxResults: BigInt(DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT),
         indexCanisterId,
         start,
       });
@@ -150,7 +150,7 @@ describe("icrc-transactions services", () => {
       expect(spyGetTransactions).toBeCalledWith({
         identity: mockIdentity,
         account,
-        maxResults: BigInt(DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT),
+        maxResults: BigInt(DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT),
         indexCanisterId,
         start: oldestTransaction.id,
       });
@@ -189,7 +189,7 @@ describe("icrc-transactions services", () => {
       expect(spyGetTransactions).toBeCalledWith({
         identity: mockIdentity,
         account,
-        maxResults: BigInt(DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT),
+        maxResults: BigInt(DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT),
         indexCanisterId,
         start: undefined,
       });

--- a/frontend/src/tests/lib/worker-services/icrc-transactions.worker-services.spec.ts
+++ b/frontend/src/tests/lib/worker-services/icrc-transactions.worker-services.spec.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
+import { DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import { HOST } from "$lib/constants/environment.constants";
 import type { PostMessageDataRequestTransactions } from "$lib/types/post-message.transactions";
 import { getIcrcAccountsTransactions } from "$lib/worker-services/icrc-transactions.worker-services";
@@ -147,7 +147,7 @@ describe("transactions.worker-services", () => {
   it("should fetch recursively all transactions", async () => {
     const mostRecentTxId = 100n;
 
-    const ids = [...Array(DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT + 5)]
+    const ids = [...Array(DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT + 5)]
       .map((_, i) => BigInt(i) + mostRecentTxId)
       .reverse();
     const transactions = ids.map((id) => ({ transaction, id }));
@@ -163,7 +163,7 @@ describe("transactions.worker-services", () => {
             return {
               transactions: transactions.slice(
                 0,
-                DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT
+                DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT
               ),
               oldest_tx_id: [],
             };
@@ -171,7 +171,7 @@ describe("transactions.worker-services", () => {
 
           return {
             transactions: transactions.slice(
-              DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT
+              DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT
             ),
             oldest_tx_id: [],
           };
@@ -210,7 +210,7 @@ describe("transactions.worker-services", () => {
   });
 
   it("should return most recent transaction id", async () => {
-    const ids = [...Array(DEFAULT_ICRC_TRANSACTION_PAGE_LIMIT)]
+    const ids = [...Array(DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT)]
       .map((_, i) => BigInt(i) + 250n)
       .reverse();
     const transactions = ids.map((id) => ({ transaction, id }));

--- a/frontend/src/tests/mocks/transaction.mock.ts
+++ b/frontend/src/tests/mocks/transaction.mock.ts
@@ -100,7 +100,7 @@ export const createMockUiTransaction = ({
   timestamp,
 });
 
-export const defaultTransactinoWithId: TransactionWithId = {
+export const mockTransactionWithId: TransactionWithId = {
   id: 1234n,
   transaction: {
     memo: 0n,

--- a/frontend/src/tests/mocks/transaction.mock.ts
+++ b/frontend/src/tests/mocks/transaction.mock.ts
@@ -1,6 +1,7 @@
 import type { Transaction as NnsTransaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import type { Transaction, UiTransaction } from "$lib/types/transaction";
 import { AccountTransactionType } from "$lib/types/transaction";
+import type { TransactionWithId } from "@dfinity/ledger-icp";
 import { TokenAmount } from "@dfinity/utils";
 import { mockMainAccount, mockSubAccount } from "./icp-accounts.store.mock";
 import { mockSnsToken } from "./sns-projects.mock";
@@ -98,3 +99,21 @@ export const createMockUiTransaction = ({
   tokenAmount,
   timestamp,
 });
+
+export const defaultTransactinoWithId: TransactionWithId = {
+  id: 1234n,
+  transaction: {
+    memo: 0n,
+    icrc1_memo: [],
+    operation: {
+      Transfer: {
+        to: "1234",
+        fee: { e8s: 10_000n },
+        from: "56789",
+        amount: { e8s: 100_000_000n },
+        spender: [],
+      },
+    },
+    created_at_time: [],
+  },
+};


### PR DESCRIPTION
# Motivation

Fetch the ICP transactions from ICP Index canister instead of NNS dapp canister.

In this PR, introduce two services used to fetch the transactions and load them in the store.

They will be used in the page component in another PR.

# Changes

* Add icp-transactions services `loadIcpAccountTransactions` and `loadIcpAccountNextTransactions`.

# Tests

* Move a mock to the mocks file.
* Add tests for the new icp-transactions services.

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary,
