### PR TITLE
Wait before installing canister on CI

### DIFF
--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -82,6 +82,12 @@ runs:
         popd
         dfx identity use snsdemo8
         dfx-sns-demo-healthcheck
+    - name: Wait before installing canisters
+      if: ${{ inputs.nns_dapp_wasm }} || ${{ inputs.sns_aggregator_wasm }}
+      run: |
+        # If we don't wait 20 seconds now, the first attempt below will take
+        # 5 minutes to time out.
+        sleep 20
     - name: Install nns-dapp
       if: ${{ inputs.nns_dapp_wasm }}
       shell: bash
@@ -90,9 +96,6 @@ runs:
         export DFX_NETWORK=local
         ./config.sh
         echo "Install:"
-        # If we don't wait 20 seconds now, the first attempt below will take
-        # 5 minutes to time out.
-        sleep 20
         # Retry to work around canister install timing out on dfx 0.15.3.
         # TODO: Remove loop if no longer necessary.
         for ((try = 0; try < 5; try++)); do

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -84,6 +84,7 @@ runs:
         dfx-sns-demo-healthcheck
     - name: Wait before installing canisters
       if: ${{ inputs.nns_dapp_wasm }} || ${{ inputs.sns_aggregator_wasm }}
+      shell: bash
       run: |
         # If we don't wait 20 seconds now, the first attempt below will take
         # 5 minutes to time out.

--- a/.github/actions/start_dfx_snapshot/action.yaml
+++ b/.github/actions/start_dfx_snapshot/action.yaml
@@ -90,6 +90,9 @@ runs:
         export DFX_NETWORK=local
         ./config.sh
         echo "Install:"
+        # If we don't wait 20 seconds now, the first attempt below will take
+        # 5 minutes to time out.
+        sleep 20
         # Retry to work around canister install timing out on dfx 0.15.3.
         # TODO: Remove loop if no longer necessary.
         for ((try = 0; try < 5; try++)); do

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -45,6 +45,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Upgraded `ic-js` dependencies to utilize `agent-js` patched version `v1.0.1`.
+* Avoid a 5 minute timeout in CI by waiting 20 seconds instead.
 
 #### Deprecated
 


### PR DESCRIPTION
# Motivation

Since we upgraded from dfx version 0.14.4 to 0.15.3, if we try to install a canister immediate after starting an snsdemo snapshot, this times out. So in https://github.com/dfinity/nns-dapp/pull/4161 we added a retry loop to make sure the installation succeeds.

While I was fixing CI yesterday (for https://github.com/dfinity/nns-dapp/pull/4518), I realized that this first timeout takes all of 5 minutes and can be avoided with a 20 second sleep. See for example this run (where I've added calls to `date`) that shows the 5 minute timeout:

https://github.com/dfinity/nns-dapp/actions/runs/7987325846/job/21809703130
```
Install:
Wed Feb 21 10:13:51 UTC 2024
Reinstalling code for canister nns-dapp, with canister ID qsgjb-riaaa-aaaaa-aaaga-cai
Error: Failed to install wasm module to canister 'nns-dapp'.
Caused by: Failed to install wasm module to canister 'nns-dapp'.
  Failed during wasm installation call: The request timed out.
Wed Feb 21 10:18:50 UTC 2024
Wed Feb 21 10:18:55 UTC 2024
Reinstalling code for canister nns-dapp, with canister ID qsgjb-riaaa-aaaaa-aaaga-cai
Wed Feb 21 10:18:59 UTC 2024
```

Unfortunately there doesn't seem to be a good way to explicitly wait for the replica to be ready. See review comments below.

# Changes

Wait 20 seconds after starting the snapshot before installing a canister.

# Tests

CI passes and no longer relies on retrying after timeout:
https://github.com/dfinity/nns-dapp/actions/runs/8001943080/job/21854257993?pr=4531

End-to-end tests now take 4m:
<img width="571" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/c38be585-c5a0-4e00-80cd-820fe0a3f492">

compared to 9m before:
<img width="593" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/a7ccc07c-e894-4dd2-9669-a3529a383b1f">


# Todos

- [x] Add entry to changelog (if necessary).
