### PR TITLE
Fix: Install formatting dependencies

### DIFF
--- a/.github/actions/format/action.yaml
+++ b/.github/actions/format/action.yaml
@@ -6,16 +6,16 @@ runs:
   steps:
     - name: Get cargo sort version
       shell: bash
-      run: jq -r '"CARGO_SORT_VERSION=\(.defaults.build.config.CARGO_SORT_VERSION)"' dfx.json | tee -a $GITHUB_ENV
+      run: jq -r '"CARGO_SORT_VERSION=\(.defaults.build.config.CARGO_SORT_VERSION)"' dfx.json >> $GITHUB_ENV
     - name: Get node version
       shell: bash
-      run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json | tee -a $GITHUB_ENV
+      run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
     - name: Get yq version
       shell: bash
-      run: jq -r '"YQ_VERSION=\(.defaults.build.config.YQ_VERSION)"' dfx.json | tee -a $GITHUB_ENV
+      run: jq -r '"YQ_VERSION=\(.defaults.build.config.YQ_VERSION)"' dfx.json >> $GITHUB_ENV
     - name: Get shfmt version
       shell: bash
-      run: jq -r '"SHFMT_VERSION=\(.defaults.build.config.SHFMT_VERSION)"' dfx.json | tee -a $GITHUB_ENV
+      run: jq -r '"SHFMT_VERSION=\(.defaults.build.config.SHFMT_VERSION)"' dfx.json >> $GITHUB_ENV
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}

--- a/.github/actions/format/action.yaml
+++ b/.github/actions/format/action.yaml
@@ -21,7 +21,7 @@ runs:
         node-version: ${{ env.NODE_VERSION }}
     - name: Install shfmt
       shell: bash
-      run: GO111MODULE=on go install "mvdan.cc/sh/v3/cmd/shfmt@v${{ SHFMT_VERSION }}"
+      run: GO111MODULE=on go install "mvdan.cc/sh/v3/cmd/shfmt@v${{ env.SHFMT_VERSION }}"
     - name: Install yq
       shell: bash
       run: curl -sSL "https://github.com/mikefarah/yq/releases/download/v${{ env.YQ_VERSION }}/yq_linux_amd64" | install -m 755 /dev/stdin /usr/local/bin/yq

--- a/.github/actions/format/action.yaml
+++ b/.github/actions/format/action.yaml
@@ -21,7 +21,7 @@ runs:
         node-version: ${{ env.NODE_VERSION }}
     - name: Install shfmt
       shell: bash
-      run: cd /tmp && GO111MODULE=on GOBIN=/usr/local/bin/ go install "mvdan.cc/sh/v3/cmd/shfmt@v${{ env.SHFMT_VERSION }}"
+      run: curl -sSL "https://github.com/mvdan/sh/releases/download/v${{ env.SHFMT_VERSION }}/shfmt_v${{ env.SHFMT_VERSION }}_linux_amd64" | install -m 755 /dev/stdin /usr/local/bin/shfmt
     - name: Install yq
       shell: bash
       run: curl -sSL "https://github.com/mikefarah/yq/releases/download/v${{ env.YQ_VERSION }}/yq_linux_amd64" | install -m 755 /dev/stdin /usr/local/bin/yq

--- a/.github/actions/format/action.yaml
+++ b/.github/actions/format/action.yaml
@@ -6,16 +6,16 @@ runs:
   steps:
     - name: Get cargo sort version
       shell: bash
-      run: jq -r '"CARGO_SORT_VERSION=\(.defaults.build.config.CARGO_SORT_VERSION)"' dfx.json >> $GITHUB_ENV
+      run: jq -r '"CARGO_SORT_VERSION=\(.defaults.build.config.CARGO_SORT_VERSION)"' dfx.json | tee -a $GITHUB_ENV
     - name: Get node version
       shell: bash
-      run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
+      run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json | tee -a $GITHUB_ENV
     - name: Get yq version
       shell: bash
-      run: jq -r '"YQ_VERSION=\(.defaults.build.config.YQ_VERSION)"' dfx.json >> $GITHUB_ENV
+      run: jq -r '"YQ_VERSION=\(.defaults.build.config.YQ_VERSION)"' dfx.json | tee -a $GITHUB_ENV
     - name: Get shfmt version
       shell: bash
-      run: jq -r '"SHFMT_VERSION=\(.defaults.build.config.SHFMT_VERSION)"' dfx.json >> $GITHUB_ENV
+      run: jq -r '"SHFMT_VERSION=\(.defaults.build.config.SHFMT_VERSION)"' dfx.json | tee -a $GITHUB_ENV
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}

--- a/.github/actions/format/action.yaml
+++ b/.github/actions/format/action.yaml
@@ -21,7 +21,7 @@ runs:
         node-version: ${{ env.NODE_VERSION }}
     - name: Install shfmt
       shell: bash
-      run: GO111MODULE=on go install "mvdan.cc/sh/v3/cmd/shfmt@v${{ env.SHFMT_VERSION }}"
+      run: GO111MODULE=on GOBIN=/usr/local/bin/ go install "mvdan.cc/sh/v3/cmd/shfmt@v${{ env.SHFMT_VERSION }}"
     - name: Install yq
       shell: bash
       run: curl -sSL "https://github.com/mikefarah/yq/releases/download/v${{ env.YQ_VERSION }}/yq_linux_amd64" | install -m 755 /dev/stdin /usr/local/bin/yq

--- a/.github/actions/format/action.yaml
+++ b/.github/actions/format/action.yaml
@@ -1,0 +1,25 @@
+name: 'Format all the code'
+description: |
+  Formats the code with `scripts/fmt`, installing all required dependencies.
+runs:
+  using: "composite"
+  steps:
+    - name: Get cargo sort version
+      run: jq -r '"CARGO_SORT_VERSION=\(.defaults.build.config.CARGO_SORT_VERSION)"' dfx.json >> $GITHUB_ENV
+    - name: Get node version
+      run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
+    - name: Get yq version
+      run: jq -r '"YQ_VERSION=\(.defaults.build.config.YQ_VERSION)"' dfx.json >> $GITHUB_ENV
+    - name: Get shfmt version
+      run: jq -r '"SHFMT_VERSION=\(.defaults.build.config.SHFMT_VERSION)"' dfx.json >> $GITHUB_ENV
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+    - name: Install shfmt
+      run: GO111MODULE=on go install "mvdan.cc/sh/v3/cmd/shfmt@v${{ SHFMT_VERSION }}"
+    - name: Install yq
+      run: curl -sSL "https://github.com/mikefarah/yq/releases/download/v${{ env.YQ_VERSION }}/yq_linux_amd64" | install -m 755 /dev/stdin /usr/local/bin/yq
+    - name: Install cargo dependency sorter
+      run: cargo install "cargo-sort@${{ env.CARGO_SORT_VERSION }}"
+    - name: Format
+      run: ./scripts/fmt

--- a/.github/actions/format/action.yaml
+++ b/.github/actions/format/action.yaml
@@ -19,9 +19,12 @@ runs:
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
+        #    - name: Install shfmt
+        #shell: bash
+        #run: GO111MODULE=on GOBIN=/usr/local/bin/ go install "mvdan.cc/sh/v3/cmd/shfmt@v${{ env.SHFMT_VERSION }}"
     - name: Install shfmt
       shell: bash
-      run: GO111MODULE=on GOBIN=/usr/local/bin/ go install "mvdan.cc/sh/v3/cmd/shfmt@v${{ env.SHFMT_VERSION }}"
+      run: sudo snap install --classic shfmt
     - name: Install yq
       shell: bash
       run: curl -sSL "https://github.com/mikefarah/yq/releases/download/v${{ env.YQ_VERSION }}/yq_linux_amd64" | install -m 755 /dev/stdin /usr/local/bin/yq

--- a/.github/actions/format/action.yaml
+++ b/.github/actions/format/action.yaml
@@ -5,21 +5,29 @@ runs:
   using: "composite"
   steps:
     - name: Get cargo sort version
+      shell: bash
       run: jq -r '"CARGO_SORT_VERSION=\(.defaults.build.config.CARGO_SORT_VERSION)"' dfx.json >> $GITHUB_ENV
     - name: Get node version
+      shell: bash
       run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
     - name: Get yq version
+      shell: bash
       run: jq -r '"YQ_VERSION=\(.defaults.build.config.YQ_VERSION)"' dfx.json >> $GITHUB_ENV
     - name: Get shfmt version
+      shell: bash
       run: jq -r '"SHFMT_VERSION=\(.defaults.build.config.SHFMT_VERSION)"' dfx.json >> $GITHUB_ENV
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
     - name: Install shfmt
+      shell: bash
       run: GO111MODULE=on go install "mvdan.cc/sh/v3/cmd/shfmt@v${{ SHFMT_VERSION }}"
     - name: Install yq
+      shell: bash
       run: curl -sSL "https://github.com/mikefarah/yq/releases/download/v${{ env.YQ_VERSION }}/yq_linux_amd64" | install -m 755 /dev/stdin /usr/local/bin/yq
     - name: Install cargo dependency sorter
+      shell: bash
       run: cargo install "cargo-sort@${{ env.CARGO_SORT_VERSION }}"
     - name: Format
+      shell: bash
       run: ./scripts/fmt

--- a/.github/actions/format/action.yaml
+++ b/.github/actions/format/action.yaml
@@ -19,12 +19,9 @@ runs:
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
-        #    - name: Install shfmt
-        #shell: bash
-        #run: GO111MODULE=on GOBIN=/usr/local/bin/ go install "mvdan.cc/sh/v3/cmd/shfmt@v${{ env.SHFMT_VERSION }}"
     - name: Install shfmt
       shell: bash
-      run: sudo snap install --classic shfmt
+      run: cd /tmp && GO111MODULE=on GOBIN=/usr/local/bin/ go install "mvdan.cc/sh/v3/cmd/shfmt@v${{ env.SHFMT_VERSION }}"
     - name: Install yq
       shell: bash
       run: curl -sSL "https://github.com/mikefarah/yq/releases/download/v${{ env.YQ_VERSION }}/yq_linux_amd64" | install -m 755 /dev/stdin /usr/local/bin/yq

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,22 +15,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Get cargo sort version
-        run: jq -r '"CARGO_SORT_VERSION=\(.defaults.build.config.CARGO_SORT_VERSION)"' dfx.json >> $GITHUB_ENV
-      - name: Get node version
-        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - name: Install shfmt
-        run: sudo snap install --classic shfmt
-      - name: Install yq
-        run: sudo snap install yq
-      - name: Install cargo dependency sorter
-        run: cargo install cargo-sort@${{ env.CARGO_SORT_VERSION }}
       - name: Format
-        run: ./scripts/fmt
-      - name: Check formatted
+        uses: .github/actions/format
+      - name: Check that code was already formatted
         run: |
           test -z "$(git status --porcelain)" || {
                   echo "FIX: Please run ./scripts/fmt"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Format
-        uses: .github/actions/format
+        uses: ./.github/actions/format
       - name: Check that code was already formatted
         run: |
           test -z "$(git status --porcelain)" || {

--- a/.github/workflows/update-sns-aggregator-response.yml
+++ b/.github/workflows/update-sns-aggregator-response.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Update the SNS aggregator response files
         run: scripts/nns-dapp/replace-sns-aggregator-response.sh
       - name: Format
-        uses: .github/actions/format
+        uses: ./.github/actions/format
       - name: Create Pull Request
         id: cpr
         # Note: If there were no changes, this step creates no PR.

--- a/.github/workflows/update-sns-aggregator-response.yml
+++ b/.github/workflows/update-sns-aggregator-response.yml
@@ -17,12 +17,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update the SNS aggregator response files
         run: scripts/nns-dapp/replace-sns-aggregator-response.sh
-      - name: Get cargo sort version
-        run: jq -r '"CARGO_SORT_VERSION=\(.defaults.build.config.CARGO_SORT_VERSION)"' dfx.json >> $GITHUB_ENV
-      - name: Install cargo dependency sorter
-        run: cargo install cargo-sort@${{ env.CARGO_SORT_VERSION }}
-      - name: Format the updated files
-        run: scripts/fmt
+      - name: Format
+        uses: .github/actions/format
       - name: Create Pull Request
         id: cpr
         # Note: If there were no changes, this step creates no PR.

--- a/.github/workflows/update-sns-aggregator-response.yml
+++ b/.github/workflows/update-sns-aggregator-response.yml
@@ -9,6 +9,7 @@ on:
     branches:
       # Run when the development branch for this workflow is updated.
       - update-aggregator-response
+      - fix-cargo-sort
 jobs:
   update-aggregator-response:
     runs-on: ubuntu-latest
@@ -16,6 +17,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update the SNS aggregator response files
         run: scripts/nns-dapp/replace-sns-aggregator-response.sh
+      - name: Get cargo sort version
+        run: jq -r '"CARGO_SORT_VERSION=\(.defaults.build.config.CARGO_SORT_VERSION)"' dfx.json >> $GITHUB_ENV
+      - name: Install cargo dependency sorter
+        run: cargo install cargo-sort@${{ env.CARGO_SORT_VERSION }}
       - name: Format the updated files
         run: scripts/fmt
       - name: Create Pull Request

--- a/dfx.json
+++ b/dfx.json
@@ -348,6 +348,8 @@
     },
     "build": {
       "config": {
+        "YQ_VERSION": "4.33.3",
+        "SHFMT_VERSION": "3.5.1",
         "NODE_VERSION": "18.14.2",
         "IC_WASM_VERSION": "0.6.0",
         "IDL2JSON_VERSION": "0.8.8",


### PR DESCRIPTION
# Motivation
A scheduled workflow run failed because it failed to format the code due to missing dependencies.

The dependencies are installed correctly for the formatting check, so that code can be extracted as an action and reused.

# Changes
- Create a GitHub action to format the code, installing any required dependencies first.
  - Moved the dependency installation code from the formatting check to the new action.
  - Locked the dependency versions, where this was not already done.
  - Called the new action in the formatting checker and in the aggregator update workflow.

# Tests


# Todos

- [ ] Add entry to changelog (if necessary).
