### PR TITLE
E2E: Check transactions after merging neurons

### DIFF
--- a/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
+++ b/frontend/src/lib/modals/neurons/IncreaseNeuronStakeModal.svelte
@@ -68,6 +68,7 @@
 <!-- That would be an edge case that would not happen becuase then the button won't even be there -->
 {#if neuron.fullNeuron?.accountIdentifier !== undefined}
   <TransactionModal
+    testId="increase-neuron-stake-modal-component"
     rootCanisterId={OWN_CANISTER_ID}
     on:nnsSubmit={topUp}
     on:nnsClose

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -12,7 +12,7 @@ test("Test merge neurons", async ({ page, context }) => {
   const appPo = new AppPo(pageElement);
 
   step("Get some ICP");
-  await appPo.getIcpTokens(10);
+  await appPo.getIcpTokens(20);
 
   step("Go to the neurons tab");
   await appPo.goToNeurons();
@@ -21,10 +21,10 @@ test("Test merge neurons", async ({ page, context }) => {
   const footerPo = appPo.getNeuronsPo().getNnsNeuronsFooterPo();
   const neuronsPo = appPo.getNeuronsPo().getNnsNeuronsPo();
 
-  const stake1 = 1;
+  const initialStake1 = 1;
   const dissolveDelayDays1 = 3 * 365;
   await footerPo.stakeNeuron({
-    amount: stake1,
+    amount: initialStake1,
     dissolveDelayDays: dissolveDelayDays1,
   });
   const neuronId1 = (await neuronsPo.getNeuronIds())[0];
@@ -39,13 +39,24 @@ test("Test merge neurons", async ({ page, context }) => {
   const neuronId2 = (await neuronsPo.getNeuronIds())[0];
 
   expect(await (await neuronsPo.getNeuronCardPo(neuronId1)).getBalance()).toBe(
-    stake1
+    initialStake1
   );
   expect(await (await neuronsPo.getNeuronCardPo(neuronId2)).getBalance()).toBe(
     stake2
   );
 
+  step("Increase stake on first neuron");
+  const finalStake1 = 3;
+  await appPo.goToNeuronDetails(neuronId1);
+  await appPo
+    .getNeuronDetailPo()
+    .getNnsNeuronDetailPo()
+    .increaseStake({ amount: finalStake1 - initialStake1 });
+  await appPo.goBack();
+
   step("Merge neurons");
+  await appPo.goToNeurons();
+
   await footerPo.mergeNeurons({
     sourceNeurondId: neuronId1,
     targetNeuronId: neuronId2,
@@ -53,8 +64,42 @@ test("Test merge neurons", async ({ page, context }) => {
 
   const transactionFee = 0.0001;
   expect(await (await neuronsPo.getNeuronCardPo(neuronId2)).getBalance()).toBe(
-    stake1 + stake2 - transactionFee
+    finalStake1 + stake2 - transactionFee
   );
 
   expect(await neuronsPo.getNeuronIds()).not.toContain(neuronId1);
+
+  step("Check transaction descriptions");
+  // Make sure that we still recognize transactions for neurons that we no
+  // longer display correctly as Stake/Top-up.
+  // Reload the page in case we would only know the neuron because it was still
+  // in the store from before.
+  await page.goto("/");
+  await appPo
+    .getTokensPo()
+    .getTokensPagePo()
+    .getTokensTable()
+    .getRowByName("Internet Computer")
+    .click();
+  await appPo
+    .getAccountsPo()
+    .getNnsAccountsPo()
+    .getTokensTablePo()
+    .getRowByName("Main")
+    .click();
+  const transactionList = appPo
+    .getWalletPo()
+    .getNnsWalletPo()
+    .getTransactionListPo();
+  await transactionList.waitForLoaded();
+  const transactions = await transactionList.getTransactionCardPos();
+  expect(await Promise.all(transactions.map((tx) => tx.getHeadline()))).toEqual(
+    ["Top-up Neuron", "Staked", "Staked", "Received"]
+  );
+  expect(await Promise.all(transactions.map((tx) => tx.getAmount()))).toEqual([
+    "-2.0001",
+    "-7.0001",
+    "-1.0001",
+    "+20.00",
+  ]);
 });

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -52,6 +52,7 @@ test("Test merge neurons", async ({ page, context }) => {
     .getNeuronDetailPo()
     .getNnsNeuronDetailPo()
     .increaseStake({ amount: finalStake1 - initialStake1 });
+  // Go back to make the menu visible again.
   await appPo.goBack();
 
   step("Merge neurons");

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -52,7 +52,7 @@ test("Test merge neurons", async ({ page, context }) => {
     .getNeuronDetailPo()
     .getNnsNeuronDetailPo()
     .increaseStake({ amount: finalStake1 - initialStake1 });
-  // Go back to make the menu visible again.
+  // Go back to make the menu button visible again.
   await appPo.goBack();
 
   step("Merge neurons");

--- a/frontend/src/tests/page-objects/IncreaseNeuronStakeModal.page-object.ts
+++ b/frontend/src/tests/page-objects/IncreaseNeuronStakeModal.page-object.ts
@@ -1,6 +1,4 @@
-import { ConfirmDisburseNeuronPo } from "$tests/page-objects/ConfirmDisburseNeuron.page-object";
 import { TransactionModalBasePo } from "$tests/page-objects/TransactionModal.page-object";
-import { NnsDestinationAddressPo } from "$tests/page-objects/NnsDestinationAddress.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class IncreaseNeuronStakeModalPo extends TransactionModalBasePo {
@@ -12,11 +10,10 @@ export class IncreaseNeuronStakeModalPo extends TransactionModalBasePo {
     );
   }
 
-  async increaseStake({amount}: {amount: number}): Promise<void> {
+  async increaseStake({ amount }: { amount: number }): Promise<void> {
     const form = this.getTransactionFormPo();
     await form.enterAmount(amount);
     await form.clickContinue();
     await this.getTransactionReviewPo().clickSend();
   }
 }
-

--- a/frontend/src/tests/page-objects/IncreaseNeuronStakeModal.page-object.ts
+++ b/frontend/src/tests/page-objects/IncreaseNeuronStakeModal.page-object.ts
@@ -1,0 +1,22 @@
+import { ConfirmDisburseNeuronPo } from "$tests/page-objects/ConfirmDisburseNeuron.page-object";
+import { TransactionModalBasePo } from "$tests/page-objects/TransactionModal.page-object";
+import { NnsDestinationAddressPo } from "$tests/page-objects/NnsDestinationAddress.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class IncreaseNeuronStakeModalPo extends TransactionModalBasePo {
+  private static readonly TID = "increase-neuron-stake-modal-component";
+
+  static under(element: PageObjectElement): IncreaseNeuronStakeModalPo {
+    return new IncreaseNeuronStakeModalPo(
+      element.byTestId(IncreaseNeuronStakeModalPo.TID)
+    );
+  }
+
+  async increaseStake({amount}: {amount: number}): Promise<void> {
+    const form = this.getTransactionFormPo();
+    await form.enterAmount(amount);
+    await form.clickContinue();
+    await this.getTransactionReviewPo().clickSend();
+  }
+}
+

--- a/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronDetail.page-object.ts
@@ -70,4 +70,11 @@ export class NnsNeuronDetailPo extends BasePageObject {
   getAdvancedSectionPo(): NnsNeuronAdvancedSectionPo {
     return NnsNeuronAdvancedSectionPo.under(this.root);
   }
+
+  async increaseStake({ amount }: { amount: number }): Promise<void> {
+    await this.getVotingPowerSectionPo().getStakeItemActionPo().clickIncrease();
+    const modal = this.getNnsNeuronModalsPo().getIncreaseNeuronStakeModalPo();
+    await modal.increaseStake({ amount });
+    await modal.waitForAbsent();
+  }
 }

--- a/frontend/src/tests/page-objects/NnsNeuronModals.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronModals.page-object.ts
@@ -1,4 +1,5 @@
 import { DisburseNnsNeuronModalPo } from "$tests/page-objects/DisburseNnsNeuronModal.page-object";
+import { IncreaseNeuronStakeModalPo } from "$tests/page-objects/IncreaseNeuronStakeModal.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -11,5 +12,9 @@ export class NnsNeuronModalsPo extends BasePageObject {
 
   getDisburseNnsNeuronModalPo(): DisburseNnsNeuronModalPo {
     return DisburseNnsNeuronModalPo.under(this.root);
+  }
+
+  getIncreaseNeuronStakeModalPo(): IncreaseNeuronStakeModalPo {
+    return IncreaseNeuronStakeModalPo.under(this.root);
   }
 }


### PR DESCRIPTION
# Motivation

We will load transactions from the index canister instead of from nns-dapp.
We want to make sure transactions are still rendered correctly.
In particular we want to make sure that stake transactions on a neuron with (later) 0 stake are still recognized.

# Changes

1. Extend the e2e test that merges neurons to check that the stake/increase stake transactions are still recognized after merging.
2. Add test IDs and page objects.

# Tests

test only

# Todos

- [ ] Add entry to changelog (if necessary).
covered