### PR TITLE
New actionable proposals services

### DIFF
--- a/frontend/src/lib/services/actionable-proposals.services.ts
+++ b/frontend/src/lib/services/actionable-proposals.services.ts
@@ -1,0 +1,67 @@
+import { queryProposals as queryNnsProposals } from "$lib/api/proposals.api";
+import { getCurrentIdentity } from "$lib/services/auth.services";
+import { listNeurons } from "$lib/services/neurons.services";
+import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
+import { definedNeuronsStore, neuronsStore } from "$lib/stores/neurons.store";
+import type { ProposalsFiltersStore } from "$lib/stores/proposals.store";
+import type { ProposalInfo } from "@dfinity/nns";
+import {
+  ProposalRewardStatus,
+  votableNeurons,
+  type NeuronInfo,
+} from "@dfinity/nns";
+import { isNullish, nonNullish } from "@dfinity/utils";
+import { get } from "svelte/store";
+
+/**
+ * Fetch all proposals that are accepting votes and put them in the store.
+ */
+export const updateActionableProposals = async (): Promise<void> => {
+  if (nonNullish(get(actionableNnsProposalsStore).proposals)) {
+    // The proposals state does not update frequently, so we don't need to re-fetch.
+    // The store will be reset after the user registers a vote.
+    return;
+  }
+
+  const neurons: NeuronInfo[] = await queryNeurons();
+  if (neurons.length === 0) {
+    actionableNnsProposalsStore.setProposals([]);
+    return;
+  }
+
+  // Load max 100 proposals (DEFAULT_LIST_PAGINATION_LIMIT) solve when more than 100 proposals with UI (display 99 cards + some CTA).
+  const proposals = await queryProposals();
+  // Filter proposals that have at least one votable neuron
+  const votableProposals = proposals.filter(
+    (proposal) => votableNeurons({ neurons, proposal }).length > 0
+  );
+
+  actionableNnsProposalsStore.setProposals(votableProposals);
+};
+
+const queryNeurons = async (): Promise<NeuronInfo[]> => {
+  // Rely on the neurons store to avoid fetching neurons twice.Expecting the store to be managed outside of this function (e.g. on stake, disburse a neuron).
+  if (isNullish(get(neuronsStore)?.neurons)) {
+    // It's safe to populate the `neuronsStore` because it will be updated before neurons manipulations.
+    await listNeurons({ strategy: "query" });
+  }
+  return get(definedNeuronsStore);
+};
+
+const queryProposals = (): Promise<ProposalInfo[]> => {
+  const identity = getCurrentIdentity();
+  const filters: ProposalsFiltersStore = {
+    // We just want to fetch proposals that are accepting votes, so we don't need to filter by rest of the filters.
+    rewards: [ProposalRewardStatus.AcceptVotes],
+    topics: [],
+    status: [],
+    excludeVotedProposals: false,
+    lastAppliedFilter: undefined,
+  };
+  return queryNnsProposals({
+    beforeProposal: undefined,
+    identity,
+    filters,
+    certified: false,
+  });
+};

--- a/frontend/src/lib/services/actionable-proposals.services.ts
+++ b/frontend/src/lib/services/actionable-proposals.services.ts
@@ -16,7 +16,7 @@ import { get } from "svelte/store";
 /**
  * Fetch all proposals that are accepting votes and put them in the store.
  */
-export const updateActionableProposals = async (): Promise<void> => {
+export const loadActionableProposals = async (): Promise<void> => {
   if (nonNullish(get(actionableNnsProposalsStore).proposals)) {
     // The proposals state does not update frequently, so we don't need to re-fetch.
     // The store will be reset after the user registers a vote.

--- a/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
@@ -1,6 +1,6 @@
 import * as governanceApi from "$lib/api/governance.api";
 import * as api from "$lib/api/proposals.api";
-import { updateActionableProposals } from "$lib/services/actionable-proposals.services";
+import { loadActionableProposals } from "$lib/services/actionable-proposals.services";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { authStore } from "$lib/stores/auth.store";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
@@ -57,7 +57,7 @@ describe("actionable-proposals.services", () => {
     it("should query user neurons", async () => {
       expect(spyQueryNeurons).not.toHaveBeenCalled();
 
-      await updateActionableProposals();
+      await loadActionableProposals();
 
       expect(spyQueryNeurons).toHaveBeenCalledTimes(1);
       expect(spyQueryNeurons).toHaveBeenCalledWith(
@@ -70,7 +70,7 @@ describe("actionable-proposals.services", () => {
     it("should query the canister to get list proposals with accept rewards status", async () => {
       expect(spyQueryProposals).not.toHaveBeenCalled();
 
-      await updateActionableProposals();
+      await loadActionableProposals();
 
       expect(spyQueryProposals).toHaveBeenCalledTimes(1);
       expect(spyQueryProposals).toHaveBeenCalledWith(
@@ -91,7 +91,7 @@ describe("actionable-proposals.services", () => {
     it("should update actionable nns proposals store with votable proposals only", async () => {
       expect(spyQueryProposals).not.toHaveBeenCalled();
 
-      await updateActionableProposals();
+      await loadActionableProposals();
 
       const { proposals } = get(actionableNnsProposalsStore);
       expect(proposals).toHaveLength(1);

--- a/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
@@ -70,7 +70,7 @@ describe("actionable-proposals.services", () => {
       );
     });
 
-    it("should preserve neurons in the neuron store", async () => {
+    it("should load neurons in the neuron store", async () => {
       expect(get(neuronsStore)).toEqual(
         expect.objectContaining({ neurons: undefined })
       );

--- a/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
@@ -1,0 +1,101 @@
+import * as governanceApi from "$lib/api/governance.api";
+import * as api from "$lib/api/proposals.api";
+import { updateActionableProposals } from "$lib/services/actionable-proposals.services";
+import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
+import { authStore } from "$lib/stores/auth.store";
+import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { mockProposalInfo } from "$tests/mocks/proposal.mock";
+import type { NeuronInfo, ProposalInfo } from "@dfinity/nns";
+import { ProposalRewardStatus, Vote } from "@dfinity/nns";
+import { get } from "svelte/store";
+
+describe("actionable-proposals.services", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("updateActionableProposals", () => {
+    const neuronId = 0n;
+    const neuron1: NeuronInfo = {
+      ...mockNeuron,
+      neuronId,
+      recentBallots: [
+        {
+          vote: Vote.Yes,
+          proposalId: 1n,
+        },
+      ],
+    };
+    const votableProposal: ProposalInfo = {
+      ...mockProposalInfo,
+      id: 0n,
+    };
+    const votedProposal: ProposalInfo = {
+      ...mockProposalInfo,
+      id: 1n,
+    };
+    let spyQueryProposals;
+    let spyQueryNeurons;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      actionableNnsProposalsStore.reset();
+      vi.spyOn(authStore, "subscribe").mockImplementation(
+        mockAuthStoreSubscribe
+      );
+      spyQueryProposals = vi
+        .spyOn(api, "queryProposals")
+        .mockImplementation(() =>
+          Promise.resolve([votableProposal, votedProposal])
+        );
+      spyQueryNeurons = vi
+        .spyOn(governanceApi, "queryNeurons")
+        .mockResolvedValue([neuron1]);
+    });
+
+    it("should query user neurons", async () => {
+      expect(spyQueryNeurons).not.toHaveBeenCalled();
+
+      await updateActionableProposals();
+
+      expect(spyQueryNeurons).toHaveBeenCalledTimes(1);
+      expect(spyQueryNeurons).toHaveBeenCalledWith(
+        expect.objectContaining({
+          certified: false,
+        })
+      );
+    });
+
+    it("should query the canister to get list proposals with accept rewards status", async () => {
+      expect(spyQueryProposals).not.toHaveBeenCalled();
+
+      await updateActionableProposals();
+
+      expect(spyQueryProposals).toHaveBeenCalledTimes(1);
+      expect(spyQueryProposals).toHaveBeenCalledWith(
+        expect.objectContaining({
+          beforeProposal: undefined,
+          certified: false,
+          filters: expect.objectContaining({
+            excludeVotedProposals: false,
+            lastAppliedFilter: undefined,
+            rewards: Array[ProposalRewardStatus.AcceptVotes],
+            status: [],
+            topics: [],
+          }),
+        })
+      );
+    });
+
+    it("should update actionable nns proposals store with votable proposals only", async () => {
+      expect(spyQueryProposals).not.toHaveBeenCalled();
+
+      await updateActionableProposals();
+
+      const { proposals } = get(actionableNnsProposalsStore);
+      expect(proposals).toHaveLength(1);
+      expect(proposals).toEqual([votableProposal]);
+    });
+  });
+});

--- a/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
@@ -77,13 +77,13 @@ describe("actionable-proposals.services", () => {
         expect.objectContaining({
           beforeProposal: undefined,
           certified: false,
-          filters: expect.objectContaining({
+          filters: {
             excludeVotedProposals: false,
             lastAppliedFilter: undefined,
-            rewards: Array[ProposalRewardStatus.AcceptVotes],
+            rewards: [ProposalRewardStatus.AcceptVotes],
             status: [],
             topics: [],
-          }),
+          },
         })
       );
     });


### PR DESCRIPTION
# Motivation

Add `updateActionableProposals` to fill the `actionableNnsProposalsStore`.

# Changes

- `updateActionableProposals` service

# Tests

- `updateActionableProposals` service

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary