### PR TITLE
NNS1-2868: Load transactions in NnsWallet

### DIFF
--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -196,7 +196,7 @@
       accounts,
     });
     if (nonNullish(account)) {
-      // The accounts from II have no principal.
+      // The accounts from the II identity have no principal at the moment.
       const accountPrincipal =
         account.principal ?? $authStore.identity?.getPrincipal();
       // Set the swapCanistersStore only once we have an account.
@@ -292,7 +292,7 @@
             {#if $ENABLE_ICP_INDEX}
               <UiTransactionsList
                 transactions={uiTransactions ?? []}
-                loading={false || isNullish(uiTransactions)}
+                loading={false}
                 completed={false}
               />
             {:else}

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -123,7 +123,7 @@
     }
   };
 
-  const reloadTransactions = async (
+  const reloadTransactions = (
     accountIdentifier: AccountIdentifierText
   ): Promise<void> => {
     if ($ENABLE_ICP_INDEX) {

--- a/frontend/src/lib/routes/Wallet.svelte
+++ b/frontend/src/lib/routes/Wallet.svelte
@@ -22,10 +22,6 @@
   layoutTitleStore.set({
     title: $i18n.wallet.title,
   });
-
-  $: {
-    console.log("in da Wallet", accountIdentifier);
-  }
 </script>
 
 <TestIdWrapper testId="wallet-component">

--- a/frontend/src/lib/routes/Wallet.svelte
+++ b/frontend/src/lib/routes/Wallet.svelte
@@ -22,6 +22,10 @@
   layoutTitleStore.set({
     title: $i18n.wallet.title,
   });
+
+  $: {
+    console.log("in da Wallet", accountIdentifier);
+  }
 </script>
 
 <TestIdWrapper testId="wallet-component">

--- a/frontend/src/lib/stores/neurons.store.ts
+++ b/frontend/src/lib/stores/neurons.store.ts
@@ -3,6 +3,7 @@ import {
   sortNeuronsByCreatedTimestamp,
 } from "$lib/utils/neuron.utils";
 import type { NeuronInfo } from "@dfinity/nns";
+import { nonNullish } from "@dfinity/utils";
 import { derived, writable, type Readable } from "svelte/store";
 
 export interface NeuronsStore {
@@ -95,4 +96,14 @@ export const sortedNeuronStore: Readable<NeuronInfo[]> = derived(
   definedNeuronsStore,
   (initializedNeuronsStore) =>
     sortNeuronsByCreatedTimestamp(initializedNeuronsStore)
+);
+
+export const neuronAccountsStore: Readable<Set<string>> = derived(
+  neuronsStore,
+  ($neuronsStore) =>
+    new Set(
+      $neuronsStore.neurons
+        ?.map(({ fullNeuron }) => fullNeuron?.accountIdentifier)
+        .filter(nonNullish) || []
+    )
 );

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -309,7 +309,7 @@ describe("NnsWallet", () => {
       expect(await transactionCardsPos[0].getHeadline()).toBe("Staked");
     });
 
-    it.only("should render 'Decentralized Swap' transaction from ICP Index canister", async () => {
+    it("should render 'Decentralized Swap' transaction from ICP Index canister", async () => {
       overrideFeatureFlagsStore.setFlag("ENABLE_ICP_INDEX", true);
       const rootCanisterId = principal(0);
       const swapCanisterId = principal(1);

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -1,4 +1,7 @@
+import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
 import * as accountsApi from "$lib/api/accounts.api";
+import * as governanceApi from "$lib/api/governance.api";
+import * as indexApi from "$lib/api/icp-index.api";
 import * as ledgerApi from "$lib/api/icp-ledger.api";
 import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import type { Transaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
@@ -8,7 +11,10 @@ import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import NnsWallet from "$lib/pages/NnsWallet.svelte";
 import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+import { icpTransactionsStore } from "$lib/stores/icp-transactions.store";
+import { neuronsStore } from "$lib/stores/neurons.store";
 import { page } from "$mocks/$app/stores";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import {
@@ -18,6 +24,8 @@ import {
   mockMainAccount,
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { defaultTransactionWithId } from "$tests/mocks/transaction.mock";
 import { IcpTransactionModalPo } from "$tests/page-objects/IcpTransactionModal.page-object";
 import { NnsWalletPo } from "$tests/page-objects/NnsWallet.page-object";
 import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
@@ -27,6 +35,7 @@ import {
   runResolvedPromises,
 } from "$tests/utils/timers.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
+import type { TransactionWithId } from "@dfinity/ledger-icp";
 import { Principal } from "@dfinity/principal";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -36,30 +45,42 @@ import AccountsTest from "./AccountsTest.svelte";
 vi.mock("$lib/api/nns-dapp.api");
 vi.mock("$lib/api/accounts.api");
 vi.mock("$lib/api/icp-ledger.api");
+vi.mock("$lib/api/icp-index.api");
+vi.mock("$lib/api/governance.api");
 
 describe("NnsWallet", () => {
   const props = {
     accountIdentifier: mockMainAccount.identifier,
   };
   const mainBalanceE8s = 10_000_000n;
+  const accountTransactions = [defaultTransactionWithId];
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.clearAllTimers();
     cancelPollAccounts();
     icpAccountsStore.resetForTesting();
+    neuronsStore.reset();
+    resetNeuronsApiService();
+    icpTransactionsStore.reset();
     toastsStore.reset();
     resetIdentity();
 
     vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
       mainBalanceE8s
     );
+    vi.spyOn(indexApi, "getTransactions").mockResolvedValue({
+      transactions: accountTransactions,
+      oldestTxId: 1234n,
+      balance: mainBalanceE8s,
+    });
     vi.spyOn(accountsApi, "getTransactions").mockResolvedValue([]);
 
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT },
       routeId: AppPath.Wallet,
     });
+    overrideFeatureFlagsStore.reset();
   });
 
   const renderWallet = async (props) => {
@@ -239,6 +260,50 @@ describe("NnsWallet", () => {
       const po = await renderWallet(props);
 
       expect(await po.getWalletPageHeadingPo().getTitle()).toBe("4.32 ICP");
+    });
+
+    it("should render transactions from ICP Index canister", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_ICP_INDEX", true);
+
+      const po = await renderWallet(props);
+
+      expect(
+        await po.getUiTransactionsListPo().getTransactionCardPos()
+      ).toHaveLength(accountTransactions.length);
+    });
+
+    it("should render 'Staked' transaction from ICP Index canister", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_ICP_INDEX", true);
+      const stakeNeuronTransaction: TransactionWithId = {
+        id: 1234n,
+        transaction: {
+          memo: 123456n,
+          icrc1_memo: [],
+          created_at_time: [{ timestamp_nanos: 1234n }],
+          operation: {
+            Transfer: {
+              from: mockMainAccount.identifier,
+              to: mockNeuron.fullNeuron.accountIdentifier,
+              amount: { e8s: 200_000_000n },
+              fee: { e8s: 10_000n },
+              spender: [],
+            },
+          },
+        },
+      };
+      vi.spyOn(indexApi, "getTransactions").mockResolvedValue({
+        transactions: [stakeNeuronTransaction],
+        oldestTxId: 1234n,
+        balance: mainBalanceE8s,
+      });
+      vi.spyOn(governanceApi, "queryNeurons").mockResolvedValue([mockNeuron]);
+
+      const po = await renderWallet(props);
+
+      const transactionCardsPos = await po
+        .getUiTransactionsListPo()
+        .getTransactionCardPos();
+      expect(await transactionCardsPos[0].getHeadline()).toBe("Staked");
     });
 
     it("should enable new transaction action for route and store", async () => {

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -309,7 +309,7 @@ describe("NnsWallet", () => {
       expect(await transactionCardsPos[0].getHeadline()).toBe("Staked");
     });
 
-    it("should render 'Decentralized Swap' transaction from ICP Index canister", async () => {
+    it("should render 'Decentralization Swap' transaction from ICP Index canister", async () => {
       overrideFeatureFlagsStore.setFlag("ENABLE_ICP_INDEX", true);
       const rootCanisterId = principal(0);
       const swapCanisterId = principal(1);

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -25,7 +25,7 @@ import {
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
-import { defaultTransactionWithId } from "$tests/mocks/transaction.mock";
+import { mockTransactionWithId } from "$tests/mocks/transaction.mock";
 import { IcpTransactionModalPo } from "$tests/page-objects/IcpTransactionModal.page-object";
 import { NnsWalletPo } from "$tests/page-objects/NnsWallet.page-object";
 import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
@@ -53,7 +53,7 @@ describe("NnsWallet", () => {
     accountIdentifier: mockMainAccount.identifier,
   };
   const mainBalanceE8s = 10_000_000n;
-  const accountTransactions = [defaultTransactionWithId];
+  const accountTransactions = [mockTransactionWithId];
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/tests/lib/stores/neurons.store.spec.ts
+++ b/frontend/src/tests/lib/stores/neurons.store.spec.ts
@@ -1,5 +1,6 @@
 import {
   definedNeuronsStore,
+  neuronAccountsStore,
   neuronsStore,
   sortedNeuronStore,
 } from "$lib/stores/neurons.store";
@@ -121,6 +122,41 @@ describe("neurons-store", () => {
         neurons[0],
         neurons[1],
       ]);
+    });
+  });
+
+  describe("neuronAccountsStore", () => {
+    it("should return the set of neuron accounts", () => {
+      const accountIdentifier1 = "12345";
+      const accountIdentifier2 = "54321";
+      const accountIdentifier3 = "67890";
+      const neurons = [
+        {
+          ...mockNeuron,
+          fullNeuron: {
+            ...mockNeuron.fullNeuron,
+            accountIdentifier: accountIdentifier1,
+          },
+        },
+        {
+          ...mockNeuron,
+          fullNeuron: {
+            ...mockNeuron.fullNeuron,
+            accountIdentifier: accountIdentifier2,
+          },
+        },
+        {
+          ...mockNeuron,
+          fullNeuron: {
+            ...mockNeuron.fullNeuron,
+            accountIdentifier: accountIdentifier3,
+          },
+        },
+      ];
+      neuronsStore.setNeurons({ neurons: [...neurons], certified: true });
+      expect(get(neuronAccountsStore)).toEqual(
+        new Set([accountIdentifier1, accountIdentifier2, accountIdentifier3])
+      );
     });
   });
 });

--- a/frontend/src/tests/lib/stores/neurons.store.spec.ts
+++ b/frontend/src/tests/lib/stores/neurons.store.spec.ts
@@ -153,7 +153,7 @@ describe("neurons-store", () => {
           },
         },
       ];
-      neuronsStore.setNeurons({ neurons: [...neurons], certified: true });
+      neuronsStore.setNeurons({ neurons, certified: true });
       expect(get(neuronAccountsStore)).toEqual(
         new Set([accountIdentifier1, accountIdentifier2, accountIdentifier3])
       );

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -66,6 +66,7 @@ const createQueryMetadataResponse = ({
 export const aggregatorSnsMockWith = ({
   rootCanisterId = "4nwps-saaaa-aaaaa-aabjq-cai",
   ledgerCanisterId = "5bqmf-wyaaa-aaaaq-aaa5q-cai",
+  swapCanisterId = "5ux5i-xqaaa-aaaaq-aaa6a-cai",
   lifecycle = SnsSwapLifecycle.Committed,
   restrictedCountries,
   directParticipantCount,
@@ -78,6 +79,7 @@ export const aggregatorSnsMockWith = ({
 }: {
   rootCanisterId?: string;
   ledgerCanisterId?: string;
+  swapCanisterId?: string;
   lifecycle?: SnsSwapLifecycle;
   restrictedCountries?: string[];
   // TODO: Change to `undefined` or `number`.
@@ -95,6 +97,7 @@ export const aggregatorSnsMockWith = ({
     ...aggregatorSnsMockDto.canister_ids,
     root_canister_id: rootCanisterId,
     ledger_canister_id: ledgerCanisterId,
+    swap_canister_id: swapCanisterId,
   },
   list_sns_canisters: {
     ...aggregatorSnsMockDto.list_sns_canisters,

--- a/frontend/src/tests/page-objects/NnsWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsWallet.page-object.ts
@@ -6,6 +6,7 @@ import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-ob
 import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { UiTransactionsListPo } from "./UiTransactionsList.page-object";
 
 export class NnsWalletPo extends BasePageObject {
   private static readonly TID = "nns-wallet-component";
@@ -28,6 +29,10 @@ export class NnsWalletPo extends BasePageObject {
 
   getTransactionListPo(): TransactionListPo {
     return TransactionListPo.under(this.root);
+  }
+
+  getUiTransactionsListPo(): UiTransactionsListPo {
+    return UiTransactionsListPo.under(this.root);
   }
 
   getSignInPo(): SignInPo {

--- a/frontend/src/tests/utils/sns.test-utils.ts
+++ b/frontend/src/tests/utils/sns.test-utils.ts
@@ -11,6 +11,7 @@ export const setSnsProjects = (
   params: {
     rootCanisterId?: Principal;
     ledgerCanisterId?: Principal;
+    swapCanisterId?: Principal;
     lifecycle?: SnsSwapLifecycle;
     certified?: boolean;
     restrictedCountries?: string[];
@@ -27,6 +28,7 @@ export const setSnsProjects = (
       rootCanisterId:
         params.rootCanisterId?.toText() ?? principal(index).toText(),
       ledgerCanisterId: params.ledgerCanisterId?.toText(),
+      swapCanisterId: params.swapCanisterId?.toText(),
       lifecycle: params.lifecycle ?? SnsSwapLifecycle.Committed,
       restrictedCountries: params.restrictedCountries,
       directParticipantCount: params.directParticipantCount,


### PR DESCRIPTION
# Motivation

Fetch the ICP transactions from ICP Index canister not the NNS dapp canister.

In this PR, load the transactions in NnsWallet from ICP. Only loads the first page.

In upcoming PRs: loading and paging functionality.

# Changes

* Load the transactions from ICP Index in NnsWallet as well as the neurons.
* Create a list of UiTransction from the Index type and pass it to UiTransactionsList in NnsWallet.
* New derived store `neuronAccountsStore`.

# Tests

* Add a test that the transactions are rendered with the flag enabled.
* Add a test that a "stake" transaction is rendered with the flag enabled. This is to test that NnsWallet also loads the neurons.
* Add a test that a "Decentralization Swap" transaction is rendered with the flag enabled. This is to test that NnsWallet checks the aggregator data to calculate transaction types. 

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.
