### PR TITLE
Fix flaky merge neurons e2e test

### DIFF
--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -57,8 +57,10 @@ export class TokensTableRowPo extends BasePageObject {
     return Number(await AmountDisplayPo.under(this.root).getAmount());
   }
 
-  waitForBalance(): Promise<void> {
-    return this.root
+  async waitForBalance(): Promise<void> {
+    await this.root
+      .byTestId("token-value-label").waitFor();
+    await this.root
       .byTestId("token-value-label")
       .byTestId("spinner")
       .waitForAbsent();
@@ -89,6 +91,11 @@ export class TokensTableRowPo extends BasePageObject {
 
   hasSendButton(): Promise<boolean> {
     return this.getSendButton().isPresent();
+  }
+
+  async click(testId?: string): Promise<void> {
+    await this.waitForBalance();
+    return super.click(testId);
   }
 
   clickSend(): Promise<void> {

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -58,8 +58,7 @@ export class TokensTableRowPo extends BasePageObject {
   }
 
   async waitForBalance(): Promise<void> {
-    await this.root
-      .byTestId("token-value-label").waitFor();
+    await this.root.byTestId("token-value-label").waitFor();
     await this.root
       .byTestId("token-value-label")
       .byTestId("spinner")


### PR DESCRIPTION
# Motivation

The `merge-neurons` e2e test became flaky after this recent https://github.com/dfinity/nns-dapp/pull/4542
https://github.com/dfinity/nns-dapp/actions/runs/8016517254/job/21898719819?pr=4545

What happened is that we click on the "Internet Computer" row in the tokens table before the balance is loaded.
Even if we explicitly wait for the balance to be loaded, this didn't fix the issue because `waitForBalance` waits for the spinner to be absent but it could be called before the spinner has even appeared.

# Changes

1. Fix `TokenTableRow.waitForBalance` to make sure that the element that would hold the spinner is rendered before waiting for the spinner to be absent.
2. Override `TokensTableRow.click` to make sure the balance is rendered before clicking.

# Tests

I was able to reproduce the failure locally and with the fix it passed 20 times in a row.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary