### PR TITLE
NNS1-2871: Add sort transactions util

### DIFF
--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -49,6 +49,20 @@ export const mapToSelfTransactions = (
   return resultTransactions;
 };
 
+export const sortTransactionsByTimestamp = (
+  transactions: TransactionWithId[]
+): TransactionWithId[] =>
+  transactions.sort((a, b) => {
+    const aTimestamp = fromNullable(a.transaction.created_at_time)
+      ?.timestamp_nanos;
+    const bTimestamp = fromNullable(b.transaction.created_at_time)
+      ?.timestamp_nanos;
+    if (aTimestamp === undefined || bTimestamp === undefined) {
+      return 0;
+    }
+    return aTimestamp > bTimestamp ? -1 : 1;
+  });
+
 // TODO: Support icrc_memo which is not used at the moment in NNS dapp.
 const getTransactionType = ({
   transaction: { operation, memo },

--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -49,7 +49,7 @@ export const mapToSelfTransactions = (
   return resultTransactions;
 };
 
-export const sortTransactionsById = (
+export const sortTransactionsByIdDescendingOrder = (
   transactions: TransactionWithId[]
 ): TransactionWithId[] => transactions.sort((a, b) => (a.id > b.id ? -1 : 1));
 

--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -49,19 +49,9 @@ export const mapToSelfTransactions = (
   return resultTransactions;
 };
 
-export const sortTransactionsByTimestamp = (
+export const sortTransactionsById = (
   transactions: TransactionWithId[]
-): TransactionWithId[] =>
-  transactions.sort((a, b) => {
-    const aTimestamp = fromNullable(a.transaction.created_at_time)
-      ?.timestamp_nanos;
-    const bTimestamp = fromNullable(b.transaction.created_at_time)
-      ?.timestamp_nanos;
-    if (aTimestamp === undefined || bTimestamp === undefined) {
-      return 0;
-    }
-    return aTimestamp > bTimestamp ? -1 : 1;
-  });
+): TransactionWithId[] => transactions.sort((a, b) => (a.id > b.id ? -1 : 1));
 
 // TODO: Support icrc_memo which is not used at the moment in NNS dapp.
 const getTransactionType = ({

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -7,8 +7,10 @@ import type { UiTransaction } from "$lib/types/transaction";
 import {
   mapIcpTransaction,
   mapToSelfTransactions,
+  sortTransactionsByTimestamp,
 } from "$lib/utils/icp-transactions.utils";
 import en from "$tests/mocks/i18n.mock";
+import { mockTransactionWithId } from "$tests/mocks/icp-transactions.mock";
 import type { Operation, TransactionWithId } from "@dfinity/ledger-icp";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 
@@ -453,6 +455,56 @@ describe("icp-transactions.utils", () => {
           transaction: notToSelfTransaction,
           toSelfTransaction: false,
         },
+      ]);
+    });
+  });
+
+  describe("sortTransactionsByTimestamp", () => {
+    const firstTransaction = createTransactionWithId({
+      operation: defaultTransferOperation,
+      timestamp: new Date("2023-01-01T00:00:00.000Z"),
+    });
+    const secondTransaction = createTransactionWithId({
+      operation: defaultTransferOperation,
+      timestamp: new Date("2023-01-02T00:00:00.000Z"),
+    });
+    const thirdTransaction = createTransactionWithId({
+      operation: defaultTransferOperation,
+      timestamp: new Date("2023-01-03T00:00:00.000Z"),
+    });
+    it("sorts transactions most recent first", () => {
+      const transactions = [
+        secondTransaction,
+        thirdTransaction,
+        firstTransaction,
+      ];
+      expect(sortTransactionsByTimestamp(transactions)).toEqual([
+        thirdTransaction,
+        secondTransaction,
+        firstTransaction,
+      ]);
+    });
+
+    it("leaves the transaction in the same position if no created_at_time is present", () => {
+      const transactionWithoutTimestamp: TransactionWithId = {
+        id: 999n,
+        transaction: {
+          ...mockTransactionWithId.transaction,
+          created_at_time: [],
+        },
+      };
+
+      const transactions = [
+        secondTransaction,
+        thirdTransaction,
+        transactionWithoutTimestamp,
+        firstTransaction,
+      ];
+      expect(sortTransactionsByTimestamp(transactions)).toEqual([
+        thirdTransaction,
+        secondTransaction,
+        transactionWithoutTimestamp,
+        firstTransaction,
       ]);
     });
   });

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -7,7 +7,7 @@ import type { UiTransaction } from "$lib/types/transaction";
 import {
   mapIcpTransaction,
   mapToSelfTransactions,
-  sortTransactionsById,
+  sortTransactionsByIdDescendingOrder,
 } from "$lib/utils/icp-transactions.utils";
 import en from "$tests/mocks/i18n.mock";
 import type { Operation, TransactionWithId } from "@dfinity/ledger-icp";
@@ -460,7 +460,7 @@ describe("icp-transactions.utils", () => {
     });
   });
 
-  describe("sortTransactionsById", () => {
+  describe("sortTransactionsByIdDescendingOrder", () => {
     const firstTransaction = createTransactionWithId({
       operation: defaultTransferOperation,
       id: 10n,
@@ -479,7 +479,7 @@ describe("icp-transactions.utils", () => {
         thirdTransaction,
         firstTransaction,
       ];
-      expect(sortTransactionsById(transactions)).toEqual([
+      expect(sortTransactionsByIdDescendingOrder(transactions)).toEqual([
         thirdTransaction,
         secondTransaction,
         firstTransaction,

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -7,10 +7,9 @@ import type { UiTransaction } from "$lib/types/transaction";
 import {
   mapIcpTransaction,
   mapToSelfTransactions,
-  sortTransactionsByTimestamp,
+  sortTransactionsById,
 } from "$lib/utils/icp-transactions.utils";
 import en from "$tests/mocks/i18n.mock";
-import { mockTransactionWithId } from "$tests/mocks/icp-transactions.mock";
 import type { Operation, TransactionWithId } from "@dfinity/ledger-icp";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 
@@ -22,15 +21,17 @@ describe("icp-transactions.utils", () => {
   const fee = 10_000n;
   const transactionId = 1234n;
   const createTransactionWithId = ({
+    id = transactionId,
     memo,
     operation,
     timestamp = defaultTimestamp,
   }: {
+    id?: bigint;
     operation: Operation;
     memo?: bigint;
     timestamp?: Date;
   }): TransactionWithId => ({
-    id: transactionId,
+    id,
     transaction: {
       memo: memo ?? 0n,
       icrc1_memo: [],
@@ -459,18 +460,18 @@ describe("icp-transactions.utils", () => {
     });
   });
 
-  describe("sortTransactionsByTimestamp", () => {
+  describe("sortTransactionsById", () => {
     const firstTransaction = createTransactionWithId({
       operation: defaultTransferOperation,
-      timestamp: new Date("2023-01-01T00:00:00.000Z"),
+      id: 10n,
     });
     const secondTransaction = createTransactionWithId({
       operation: defaultTransferOperation,
-      timestamp: new Date("2023-01-02T00:00:00.000Z"),
+      id: 20n,
     });
     const thirdTransaction = createTransactionWithId({
       operation: defaultTransferOperation,
-      timestamp: new Date("2023-01-03T00:00:00.000Z"),
+      id: 30n,
     });
     it("sorts transactions most recent first", () => {
       const transactions = [
@@ -478,32 +479,9 @@ describe("icp-transactions.utils", () => {
         thirdTransaction,
         firstTransaction,
       ];
-      expect(sortTransactionsByTimestamp(transactions)).toEqual([
+      expect(sortTransactionsById(transactions)).toEqual([
         thirdTransaction,
         secondTransaction,
-        firstTransaction,
-      ]);
-    });
-
-    it("leaves the transaction in the same position if no created_at_time is present", () => {
-      const transactionWithoutTimestamp: TransactionWithId = {
-        id: 999n,
-        transaction: {
-          ...mockTransactionWithId.transaction,
-          created_at_time: [],
-        },
-      };
-
-      const transactions = [
-        secondTransaction,
-        thirdTransaction,
-        transactionWithoutTimestamp,
-        firstTransaction,
-      ];
-      expect(sortTransactionsByTimestamp(transactions)).toEqual([
-        thirdTransaction,
-        secondTransaction,
-        transactionWithoutTimestamp,
         firstTransaction,
       ]);
     });


### PR DESCRIPTION
# Motivation

Fetch the ICP transactoins from the ICP Index instead of NNS dapp canister.

In this PR, introce a helper to sort the transactions by created time.

This will be used when we introduce pagination.

# Changes

* New icp transaction util `sortTransactionsByTimestamp`.

# Tests

* Test new util.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
