### PR TITLE
New actionable sns proposals service

### DIFF
--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -143,7 +143,7 @@
         updating = true;
 
         await Promise.all([
-          // skip neurons call when not signedIn or when neurons are not ready
+          // skip neurons call when not signedIn or when neurons are ready
           neuronsReady || !$authSignedInStore
             ? undefined
             : syncSnsNeurons(universeId),

--- a/frontend/src/lib/services/actionable-sns-proposals.services.ts
+++ b/frontend/src/lib/services/actionable-sns-proposals.services.ts
@@ -1,0 +1,119 @@
+import { queryProposals, querySnsNeurons } from "$lib/api/sns-governance.api";
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { DEFAULT_SNS_PROPOSALS_PAGE_SIZE } from "$lib/constants/sns-proposals.constants";
+import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
+import { getAuthenticatedIdentity } from "$lib/services/auth.services";
+import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
+import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
+import { votableSnsNeurons } from "$lib/utils/sns-neuron.utils";
+import type { Identity } from "@dfinity/agent";
+import { Principal } from "@dfinity/principal";
+import type { SnsListProposalsResponse, SnsNeuron } from "@dfinity/sns";
+import { SnsProposalRewardStatus } from "@dfinity/sns";
+import { fromDefinedNullable, nonNullish } from "@dfinity/utils";
+import { get } from "svelte/store";
+
+export const updateActionableSnsProposals = async () => {
+  const canisterIds = get(selectableUniversesStore)
+    // skip nns
+    .filter(({ canisterId }) => canisterId !== OWN_CANISTER_ID_TEXT)
+    .map(({ canisterId }) => canisterId);
+
+  await Promise.all(
+    canisterIds.map((canisterId) => updateActionableProposalsForSns(canisterId))
+  );
+};
+
+const updateActionableProposalsForSns = async (
+  rootCanisterId: string
+): Promise<void> => {
+  try {
+    const storeValue = get(actionableSnsProposalsStore)[rootCanisterId];
+    if (nonNullish(storeValue)) {
+      // The proposals state does not update frequently, so we don't need to re-fetch.
+      // The store will be reset after the user registers a vote.
+      return;
+    }
+
+    const identity = await getAuthenticatedIdentity();
+    const neurons =
+      get(snsNeuronsStore)[rootCanisterId]?.neurons ??
+      // Fetch neurons if they are not in the store, but do not populate the store.
+      // Otherwise, it will skip calling of the `syncSnsNeurons` function to check neurons stake against the balance of the subaccount.
+      (await queryNeurons({
+        rootCanisterId,
+        identity,
+      }));
+    if (neurons.length === 0) {
+      // No need to fetch proposals if there are no neurons to vote with.
+      // Expected to be the case for majority of the projects, since not everyone has neurons for every project.
+      return;
+    }
+
+    const { proposals: allProposals, include_ballots_by_caller } =
+      await querySnsProposals({
+        rootCanisterId,
+        identity,
+      });
+    if (!fromDefinedNullable(include_ballots_by_caller)) {
+      // It's not possible to filter out proposals that are votable w/o ballots
+      return;
+    }
+
+    const votableProposals = allProposals.filter(
+      (proposal) =>
+        votableSnsNeurons({
+          neurons,
+          proposal,
+          identity,
+        }).length > 0
+    );
+
+    actionableSnsProposalsStore.setProposals({
+      rootCanisterId: Principal.fromText(rootCanisterId),
+      proposals: votableProposals,
+    });
+  } catch (err) {
+    console.error(err);
+  }
+};
+
+const queryNeurons = async ({
+  rootCanisterId,
+  identity,
+}: {
+  rootCanisterId: string;
+  identity: Identity;
+}): Promise<SnsNeuron[]> => {
+  const storeNeurons = get(snsNeuronsStore)[rootCanisterId];
+  if (nonNullish(storeNeurons?.neurons)) {
+    return storeNeurons.neurons;
+  }
+
+  return await querySnsNeurons({
+    identity,
+    rootCanisterId: Principal.fromText(rootCanisterId),
+    certified: false,
+  });
+};
+
+/** Fetches proposals that accept votes */
+const querySnsProposals = async ({
+  rootCanisterId,
+  identity,
+}: {
+  rootCanisterId: string;
+  identity: Identity;
+}): Promise<SnsListProposalsResponse> => {
+  return queryProposals({
+    params: {
+      limit: DEFAULT_SNS_PROPOSALS_PAGE_SIZE,
+      includeRewardStatus: [
+        SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
+      ],
+    },
+    identity,
+    certified: false,
+    rootCanisterId: Principal.fromText(rootCanisterId),
+  });
+};

--- a/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
@@ -1,0 +1,228 @@
+import * as api from "$lib/api/sns-governance.api";
+import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
+import { updateActionableSnsProposals } from "$lib/services/actionable-sns-proposals.services";
+import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
+import { authStore } from "$lib/stores/auth.store";
+import { enumValues } from "$lib/utils/enum.utils";
+import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
+import {
+  mockAuthStoreSubscribe,
+  mockIdentity,
+  resetIdentity,
+} from "$tests/mocks/auth.store.mock";
+import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
+import {
+  mockProjectSubscribe,
+  mockSnsFullProject,
+  principal,
+} from "$tests/mocks/sns-projects.mock";
+import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
+import type { Principal } from "@dfinity/principal";
+import {
+  SnsNeuronPermissionType,
+  SnsProposalDecisionStatus,
+  SnsProposalRewardStatus,
+  SnsVote,
+  neuronSubaccount,
+  type SnsListProposalsResponse,
+  type SnsNeuron,
+  type SnsNeuronId,
+  type SnsProposalData,
+} from "@dfinity/sns";
+import { get } from "svelte/store";
+
+describe("actionable-sns-proposals.services", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("updateActionableSnsProposals", () => {
+    const allPermissions = Int32Array.from(enumValues(SnsNeuronPermissionType));
+    const subaccount = neuronSubaccount({
+      controller: mockIdentity.getPrincipal(),
+      index: 0,
+    });
+    const neuronId: SnsNeuronId = { id: subaccount };
+    const neuron: SnsNeuron = {
+      ...mockSnsNeuron,
+      created_timestamp_seconds: 0n,
+      id: [neuronId] as [SnsNeuronId],
+      permissions: [
+        {
+          principal: [mockIdentity.getPrincipal()],
+          permission_type: allPermissions,
+        },
+      ],
+    };
+    const neuronIdHex = getSnsNeuronIdAsHexString(neuron);
+    const votableProposal: SnsProposalData = {
+      ...createSnsProposal({
+        proposalId: 0n,
+        createdAt: 1n,
+        status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+        rewardStatus:
+          SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
+        ballots: [
+          [
+            neuronIdHex,
+            {
+              vote: SnsVote.Unspecified,
+              cast_timestamp_seconds: 123n,
+              voting_power: 10000n,
+            },
+          ],
+        ],
+      }),
+    };
+    const votedProposal: SnsProposalData = {
+      ...createSnsProposal({
+        proposalId: 1n,
+        createdAt: 1n,
+        status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+        rewardStatus:
+          SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
+        ballots: [
+          [
+            neuronIdHex,
+            {
+              vote: SnsVote.Yes,
+              cast_timestamp_seconds: 123n,
+              voting_power: 10000n,
+            },
+          ],
+        ],
+      }),
+    };
+    const rootCanisterId1 = principal(0);
+    const rootCanisterId2 = principal(1);
+
+    const mockSnsProjectsCommittedStore = (rootCanisterIds: Principal[]) =>
+      vi.spyOn(snsProjectsCommittedStore, "subscribe").mockImplementation(
+        mockProjectSubscribe(
+          rootCanisterIds.map((rootCanisterId) => ({
+            ...mockSnsFullProject,
+            rootCanisterId,
+          }))
+        )
+      );
+
+    let spyQuerySnsProposals;
+    let spyQuerySnsNeurons;
+    let includeBallotsByCaller = true;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      actionableSnsProposalsStore.resetForTesting();
+
+      resetIdentity();
+      vi.spyOn(authStore, "subscribe").mockImplementation(
+        mockAuthStoreSubscribe
+      );
+
+      vi.spyOn(snsProjectsCommittedStore, "subscribe").mockClear();
+
+      spyQuerySnsNeurons = vi
+        .spyOn(api, "querySnsNeurons")
+        .mockImplementation(() => Promise.resolve([neuron]));
+      includeBallotsByCaller = true;
+      spyQuerySnsProposals = vi.spyOn(api, "queryProposals").mockImplementation(
+        async () =>
+          ({
+            proposals: [votableProposal, votedProposal],
+            include_ballots_by_caller: [includeBallotsByCaller],
+          }) as SnsListProposalsResponse
+      );
+    });
+
+    it("should query user neurons per sns", async () => {
+      mockSnsProjectsCommittedStore([rootCanisterId1, rootCanisterId2]);
+      expect(spyQuerySnsNeurons).not.toHaveBeenCalled();
+
+      await updateActionableSnsProposals();
+
+      expect(spyQuerySnsNeurons).toHaveBeenCalledTimes(2);
+      expect(spyQuerySnsNeurons).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rootCanisterId: rootCanisterId1,
+          certified: false,
+        })
+      );
+      expect(spyQuerySnsNeurons).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rootCanisterId: rootCanisterId2,
+          certified: false,
+        })
+      );
+    });
+
+    it("should query proposals per sns with accept rewards status only", async () => {
+      mockSnsProjectsCommittedStore([rootCanisterId1, rootCanisterId2]);
+      expect(spyQuerySnsProposals).not.toHaveBeenCalled();
+
+      await updateActionableSnsProposals();
+
+      expect(spyQuerySnsProposals).toHaveBeenCalledTimes(2);
+      const expectedFilterParams = {
+        includeRewardStatus: [
+          SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
+        ],
+        limit: 20,
+      };
+      expect(spyQuerySnsProposals).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rootCanisterId: rootCanisterId1,
+          certified: false,
+          params: expectedFilterParams,
+        })
+      );
+      expect(spyQuerySnsProposals).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rootCanisterId: rootCanisterId2,
+          certified: false,
+          params: expectedFilterParams,
+        })
+      );
+    });
+
+    it("should update the store with actionable proposal only", async () => {
+      mockSnsProjectsCommittedStore([rootCanisterId1, rootCanisterId2]);
+      expect(spyQuerySnsProposals).not.toHaveBeenCalled();
+
+      await updateActionableSnsProposals();
+
+      expect(get(actionableSnsProposalsStore)).toEqual({
+        [rootCanisterId1.toText()]: [votableProposal],
+        [rootCanisterId2.toText()]: [votableProposal],
+      });
+    });
+
+    it("should not query data when already in the store", async () => {
+      mockSnsProjectsCommittedStore([rootCanisterId1]);
+
+      expect(spyQuerySnsNeurons).not.toHaveBeenCalled();
+      expect(spyQuerySnsProposals).not.toHaveBeenCalled();
+
+      await updateActionableSnsProposals();
+
+      expect(spyQuerySnsNeurons).toHaveBeenCalledTimes(1);
+      expect(spyQuerySnsProposals).toHaveBeenCalledTimes(1);
+
+      await updateActionableSnsProposals();
+
+      expect(spyQuerySnsNeurons).toHaveBeenCalledTimes(1);
+      expect(spyQuerySnsProposals).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not query proposals when the user has no neurons", async () => {
+      mockSnsProjectsCommittedStore([rootCanisterId1]);
+      spyQuerySnsNeurons = vi
+        .spyOn(api, "querySnsNeurons")
+        .mockImplementation(() => Promise.resolve([]));
+
+      await updateActionableSnsProposals();
+
+      expect(spyQuerySnsNeurons).toHaveBeenCalledTimes(1);
+      expect(spyQuerySnsProposals).toHaveBeenCalledTimes(0);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

Add a `updateActionableSnsProposals` service to query actionable proposals.

# Changes

- `updateActionableSnsProposals`
- fixed a comment in `SnsProposalDetail` component while evaluating a possibility to reuse `loadProposals` function.

# Tests

- `updateActionableSnsProposals`

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
