### PR TITLE
doc: Document or eliminate panics

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -729,6 +729,10 @@ impl AccountsStore {
         .unwrap_or_else(|_| unreachable!("Not impossible, but centuries in the future"));
     }
 
+    /// Initializes the `block_height_synced_up_to` value.
+    ///
+    /// # Panics
+    /// - Panics if the `block_height_synced_up_to` value has already been initialized.
     pub fn init_block_height_synced_up_to(&mut self, block_height: BlockIndex) {
         assert!(
             self.block_height_synced_up_to.is_none(),

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -1691,7 +1691,7 @@ impl Account {
             .hardware_wallet_accounts
             .iter_mut()
             .find(|a| account_identifier == AccountIdentifier::from(a.principal))
-            .unwrap();
+            .expect("This account does not have a hardware wallet with the given identifier.");
 
         account.transactions.push(transaction_index);
     }

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -575,14 +575,9 @@ impl AccountsStore {
 
         if !Self::validate_account_name(&request.name) {
             RegisterHardwareWalletResponse::NameTooLong
-        } else if self.accounts_db.db_get_account(&account_identifier.to_vec()).is_some() {
+        } else if let Some(mut account) = self.accounts_db.db_get_account(&account_identifier.to_vec()).clone() {
             let hardware_wallet_account_identifier = AccountIdentifier::from(request.principal);
 
-            let mut account = self
-                .accounts_db
-                .db_get_account(&account_identifier.to_vec())
-                .unwrap()
-                .clone();
             if account.hardware_wallet_accounts.len() == (u8::MAX as usize) {
                 RegisterHardwareWalletResponse::HardwareWalletLimitExceeded
             } else if account

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -683,7 +683,8 @@ impl AccountsStore {
                             default_transaction_type,
                         ));
                         self.process_transaction_type(
-                            transaction_type.unwrap(),
+                            transaction_type
+                                .unwrap_or_else(|| unreachable!("Transaction type is set to Some a few lines above")),
                             principal,
                             from,
                             to,

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -723,7 +723,7 @@ impl AccountsStore {
         self.last_ledger_sync_timestamp_nanos = u64::try_from(
             dfn_core::api::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
+                .unwrap_or_else(|err| unreachable!("The current time is well after the Unix epoch. Error: {err}"))
                 .as_nanos(),
         )
         .unwrap_or_else(|_| unreachable!("Not impossible, but centuries in the future"));

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -1003,7 +1003,7 @@ impl AccountsStore {
     }
 
     pub fn prune_transactions(&mut self, count_to_prune: u32) -> u32 {
-        let count_to_prune = min(count_to_prune, u32::try_from(self.transactions.len()).unwrap_or_else(|_| unreachable!("The number of transactions is well below 2**32.  It will get there, but not before we switch to the ledger index and this code is deleted.")));
+        let count_to_prune = min(count_to_prune, u32::try_from(self.transactions.len()).unwrap_or_else(|_| unreachable!("The number of transactions is well below 2**32.  Transactions are pruned if the heap, where they are stored, exceeds 1Gb of data.")));
 
         if count_to_prune > 0 {
             let transactions: Vec<_> = self
@@ -1013,6 +1013,7 @@ impl AccountsStore {
                 })
                 .collect();
 
+            // Note: This SHOULD always be true, as transactions.len() should equal count_to_prune and we have already checked that that is greater than 0.
             if let Some(min_transaction_index) = self
                 .transactions
                 .front()

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -1648,10 +1648,16 @@ impl Account {
         self.default_account_transactions.push(transaction_index);
     }
 
+    /// Records a transaction in a sub-account.
+    ///
+    /// TODO: Once we use the ledger index canister, this can be deleted.
+    ///
+    /// # Panics
+    /// - If we are unable to get a lock on the sub-accounts map.  This may happen if a previous update call locked the map, but has made an async call and so hasn't released the lock yet.
     pub fn append_sub_account_transaction(&mut self, sub_account: u8, transaction_index: TransactionIndex) {
         self.sub_accounts
             .get_mut(&sub_account)
-            .unwrap()
+            .expect("Unable to lock the sub-account transactions map")
             .transactions
             .push(transaction_index);
     }

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -1662,6 +1662,12 @@ impl Account {
             .push(transaction_index);
     }
 
+    /// Records a transaction in a hardware wallet account.
+    ///
+    /// TODO: Use the index canister instead.
+    ///
+    /// # Panics
+    /// - If the account does not have a hardware wallet sub-account with the given identifier.
     pub fn append_hardware_wallet_transaction(
         &mut self,
         account_identifier: AccountIdentifier,

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -494,9 +494,6 @@ impl AccountsStore {
     }
 
     /// Creates a sub-account for the given user.
-    ///
-    /// # Panics
-    /// - Panics if the user already has the maximum number of sub-accounts.
     pub fn create_sub_account(&mut self, caller: PrincipalId, sub_account_name: String) -> CreateSubAccountResponse {
         self.assert_pre_migration_limit();
         let account_identifier = AccountIdentifier::from(caller);
@@ -507,7 +504,7 @@ impl AccountsStore {
             let response = if account.sub_accounts.len() < (u8::MAX as usize) {
                 let sub_account_id = (1..u8::MAX)
                     .find(|i| !account.sub_accounts.contains_key(i))
-                    .unwrap_or_else(|| panic!("User {caller} already has the maximum number of sub-accounts"));
+                    .unwrap_or_else(|| unreachable!("User {caller} already has the maximum number of sub-accounts.  But we already checked for that."));
 
                 let sub_account = convert_byte_to_sub_account(sub_account_id);
                 let sub_account_identifier = AccountIdentifier::new(caller, Some(sub_account));

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -1057,7 +1057,7 @@ impl AccountsStore {
         let timestamp_now_nanos = u64::try_from(
             dfn_core::api::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
+                .unwrap_or_else(|err| unreachable!("Hey, we are back in the sixties!  Seriously, if we get here, the system time is before the Unix epoch.  This should be impossible.  Error: {err}"))
                 .as_nanos(),
         )
         .unwrap_or_else(|_| {

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -782,7 +782,7 @@ impl AccountsStore {
             .map(|transaction_index| {
                 let transaction = self.get_transaction(*transaction_index).unwrap_or_else(|| {
                     unreachable!(
-                        "The per-user transaction lists contain only entries that are in the global transaction list"
+                        "If transaction {transaction_index} is in the list for user {caller}, it must also be in the global transaction list."
                     )
                 });
                 let transaction_type = transaction.transaction_type;

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -501,11 +501,7 @@ impl AccountsStore {
         if !Self::validate_account_name(&sub_account_name) {
             CreateSubAccountResponse::NameTooLong
         } else if let Some(mut account) = self.accounts_db.db_get_account(&account_identifier.to_vec()) {
-            let response = if account.sub_accounts.len() < (u8::MAX as usize) {
-                let sub_account_id = (1..u8::MAX)
-                    .find(|i| !account.sub_accounts.contains_key(i))
-                    .unwrap_or_else(|| unreachable!("User {caller} already has the maximum number of sub-accounts.  But we already checked for that."));
-
+            let response = if let Some(sub_account_id) = (1..u8::MAX).find(|i| !account.sub_accounts.contains_key(i)) {
                 let sub_account = convert_byte_to_sub_account(sub_account_id);
                 let sub_account_identifier = AccountIdentifier::new(caller, Some(sub_account));
                 let named_sub_account = NamedSubAccount::new(sub_account_name.clone(), sub_account_identifier);

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -988,9 +988,13 @@ impl AccountsStore {
         self.multi_part_transactions_processor.take_next()
     }
 
+    /// Records that a neuron has been created for the given account.
+    ///
+    /// # Panics
+    /// - If the account does not exist.
     pub fn mark_neuron_created(&mut self, principal: &PrincipalId, memo: Memo, neuron_id: NeuronId) {
         let account_identifier = Self::generate_stake_neuron_address(principal, memo);
-        self.neuron_accounts.get_mut(&account_identifier).unwrap().neuron_id = Some(neuron_id);
+        self.neuron_accounts.get_mut(&account_identifier).unwrap_or_else(|| panic!("Failed to mark neuron created for account {account_identifier} as the account has no neuron_accounts entry.")).neuron_id = Some(neuron_id);
     }
 
     pub fn mark_neuron_topped_up(&mut self) {

--- a/rs/backend/src/arguments.rs
+++ b/rs/backend/src/arguments.rs
@@ -164,7 +164,7 @@ impl TemplateEngine {
         let args = key_val_pairs.iter().cloned().collect();
         // Please see .populate() to learn what this regex does.
         #[allow(clippy::expect_used)]
-        let regex = Regex::new(r"\$\{\{([_0-9A-Z]+)\}\}|<!-- *([_0-9A-Z]+) *-->").expect("Invalid regex");
+        let regex = Regex::new(r"\$\{\{([_0-9A-Z]+)\}\}|<!-- *([_0-9A-Z]+) *-->").unwrap_or_else(|err| unreachable!("This is a fixed regex.  It is exercised in tests, so it cannot not fail to parse in production.  Error: {:?}", err));
         TemplateEngine { args, regex }
     }
 

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -318,7 +318,6 @@ fn security_headers() -> Vec<HeaderField> {
     ]
 }
 
-///
 fn make_asset_certificate_header(asset_hashes: &AssetHashes, asset_name: &str) -> (String, String) {
     let certificate = dfn_core::api::data_certificate().unwrap_or_else(|| {
         dfn_core::api::trap_with("data certificate is only available in query calls");

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -318,6 +318,7 @@ fn security_headers() -> Vec<HeaderField> {
     ]
 }
 
+///
 fn make_asset_certificate_header(asset_hashes: &AssetHashes, asset_name: &str) -> (String, String) {
     let certificate = dfn_core::api::data_certificate().unwrap_or_else(|| {
         dfn_core::api::trap_with("data certificate is only available in query calls");

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -387,6 +387,9 @@ pub fn init_assets() {
 /// Note: The `Vec` is mutated during decompression, so pass by reference is inefficient
 ///       as it would force the data to be copied into a new vector, even when the
 ///       original is no longer needed.
+///
+/// # Panics
+/// - If the decompression fails or the tarball cannot be parsed.
 #[allow(clippy::needless_pass_by_value)]
 pub fn insert_tar_xz(compressed: Vec<u8>) {
     println!("Inserting assets...");

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -394,7 +394,8 @@ pub fn insert_tar_xz(compressed: Vec<u8>) {
     println!("Inserting assets...");
     let mut num_assets = 0;
     let mut decompressed = Vec::new();
-    lzma_rs::xz_decompress(&mut compressed.as_ref(), &mut decompressed).expect("Failed to decompress xz encoded assets.");
+    lzma_rs::xz_decompress(&mut compressed.as_ref(), &mut decompressed)
+        .expect("Failed to decompress xz encoded assets.");
     let mut tar: tar::Archive<&[u8]> = tar::Archive::new(decompressed.as_ref());
     let arguments_html = CANISTER_ARGUMENTS.with(|args| args.borrow().to_html());
     let template_engine = CANISTER_ARGUMENTS.with(|args| TemplateEngine::new(&args.borrow().args));
@@ -406,7 +407,14 @@ pub fn insert_tar_xz(compressed: Vec<u8>) {
                 continue;
             }
 
-            let name_bytes = entry.path_bytes().into_owned().strip_prefix(b".").expect("A filename in the tarball does not start with '.' but we expect every path to start with './'!").to_vec();
+            let name_bytes = entry
+                .path_bytes()
+                .into_owned()
+                .strip_prefix(b".")
+                .expect(
+                    "A filename in the tarball does not start with '.' but we expect every path to start with './'!",
+                )
+                .to_vec();
 
             let name = String::from_utf8(name_bytes.clone()).unwrap_or_else(|e| {
                 dfn_core::api::trap_with(&format!(
@@ -418,7 +426,9 @@ pub fn insert_tar_xz(compressed: Vec<u8>) {
             });
 
             let mut bytes = Vec::new();
-            entry.read_to_end(&mut bytes).expect("Failed to read an entry from the tarball.");
+            entry
+                .read_to_end(&mut bytes)
+                .expect("Failed to read an entry from the tarball.");
 
             if name.ends_with("index.html.gz") {
                 let mut html = gunzip_string(&bytes);

--- a/rs/backend/src/assets.rs
+++ b/rs/backend/src/assets.rs
@@ -394,19 +394,19 @@ pub fn insert_tar_xz(compressed: Vec<u8>) {
     println!("Inserting assets...");
     let mut num_assets = 0;
     let mut decompressed = Vec::new();
-    lzma_rs::xz_decompress(&mut compressed.as_ref(), &mut decompressed).unwrap();
+    lzma_rs::xz_decompress(&mut compressed.as_ref(), &mut decompressed).expect("Failed to decompress xz encoded assets.");
     let mut tar: tar::Archive<&[u8]> = tar::Archive::new(decompressed.as_ref());
     let arguments_html = CANISTER_ARGUMENTS.with(|args| args.borrow().to_html());
     let template_engine = CANISTER_ARGUMENTS.with(|args| TemplateEngine::new(&args.borrow().args));
     STATE.with(|state| {
-        for entry in tar.entries().unwrap() {
-            let mut entry = entry.unwrap();
+        for entry in tar.entries().expect("Failed to get entry from tarball.") {
+            let mut entry = entry.expect("Invalid entry in tarball.");
 
             if !entry.header().entry_type().is_file() {
                 continue;
             }
 
-            let name_bytes = entry.path_bytes().into_owned().strip_prefix(b".").unwrap().to_vec();
+            let name_bytes = entry.path_bytes().into_owned().strip_prefix(b".").expect("A filename in the tarball does not start with '.' but we expect every path to start with './'!").to_vec();
 
             let name = String::from_utf8(name_bytes.clone()).unwrap_or_else(|e| {
                 dfn_core::api::trap_with(&format!(
@@ -418,7 +418,7 @@ pub fn insert_tar_xz(compressed: Vec<u8>) {
             });
 
             let mut bytes = Vec::new();
-            entry.read_to_end(&mut bytes).unwrap();
+            entry.read_to_end(&mut bytes).expect("Failed to read an entry from the tarball.");
 
             if name.ends_with("index.html.gz") {
                 let mut html = gunzip_string(&bytes);

--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -37,7 +37,7 @@ impl MultiPartTransactionsProcessor {
     #[must_use]
     pub fn get_queue_length(&self) -> u32 {
         u32::try_from(self.queue.len())
-            .expect("MultiPartTransactionsProcessor queue length has length greater than u32::MAX")
+            .unwrap_or_else(|err| unreachable!("MultiPartTransactionsProcessor queue length has length greater than u32::MAX.  Transactions are pruned by the periodic_tasks_runner if they consume more than 1Gb of data, so this should never happen. Error: {:?}", err))
     }
 
     #[cfg(test)]

--- a/rs/backend/src/state/partitions.rs
+++ b/rs/backend/src/state/partitions.rs
@@ -179,7 +179,7 @@ impl Partitions {
     pub fn growing_write(&self, memory_id: MemoryId, offset: u64, bytes: &[u8]) {
         let memory = self.get(memory_id);
         let min_pages: u64 = u64::try_from(bytes.len())
-            .expect("Buffer for growing_write is longer than 2**64.")
+            .unwrap_or_else(|err| unreachable!("Buffer for growing_write is longer than 2**64 bytes?? Err: {err}"))
             .saturating_add(offset)
             .div_ceil(WASM_PAGE_SIZE_IN_BYTES as u64);
         let current_pages = memory.size();

--- a/rs/backend/src/state/partitions.rs
+++ b/rs/backend/src/state/partitions.rs
@@ -192,8 +192,9 @@ impl Partitions {
     /// Reads the exact number of bytes needed to fill `buffer`.
     pub fn read_exact(&self, memory_id: MemoryId, offset: u64, buffer: &mut [u8]) -> Result<(), String> {
         let memory = self.get(memory_id);
-        let bytes_in_memory =
-            memory.size() * u64::try_from(WASM_PAGE_SIZE_IN_BYTES).expect("Wasm page size is too large");
+        let bytes_in_memory = memory.size()
+            * u64::try_from(WASM_PAGE_SIZE_IN_BYTES)
+                .unwrap_or_else(|err| unreachable!("Wasm page size is fixed and well within the range of u64: {err}"));
         if offset.saturating_add(u64::try_from(buffer.len()).expect("Buffer for read_exact is longer than 2**64."))
             > bytes_in_memory
         {

--- a/rs/backend/src/state/partitions.rs
+++ b/rs/backend/src/state/partitions.rs
@@ -195,8 +195,9 @@ impl Partitions {
         let bytes_in_memory = memory.size()
             * u64::try_from(WASM_PAGE_SIZE_IN_BYTES)
                 .unwrap_or_else(|err| unreachable!("Wasm page size is fixed and well within the range of u64: {err}"));
-        if offset.saturating_add(u64::try_from(buffer.len()).expect("Buffer for read_exact is longer than 2**64."))
-            > bytes_in_memory
+        if offset.saturating_add(u64::try_from(buffer.len()).unwrap_or_else(|err| {
+            unreachable!("Buffer for read_exact is longer than 2**64.  This seems extremely implausible.  Err: {err}")
+        })) > bytes_in_memory
         {
             return Err(format!("Out of bounds memory access: Failed to read exactly {} bytes at offset {} as memory size is only {} bytes.", buffer.len(), offset, bytes_in_memory));
         }

--- a/rs/backend/src/state/partitions/schemas.rs
+++ b/rs/backend/src/state/partitions/schemas.rs
@@ -37,6 +37,10 @@ impl Partitions {
     /// Gets the memory partitioned appropriately for the given schema.
     ///
     /// If a schema uses raw memory, the memory is returned.
+    ///
+    /// # Panics
+    /// - If the schema label is not supported:
+    ///   - The `Map` schema does not use partitions, so may not be used with this method.
     #[must_use]
     pub fn new_with_schema(memory: DefaultMemoryImpl, schema: SchemaLabel) -> Partitions {
         match schema {

--- a/rs/backend/src/state/partitions/schemas.rs
+++ b/rs/backend/src/state/partitions/schemas.rs
@@ -20,6 +20,10 @@ impl Partitions {
         self.growing_write(PartitionType::Metadata.memory_id(), 0, &schema_label_bytes[..]);
     }
     /// Gets the schema label from the metadata partition.
+    ///
+    /// # Panics
+    /// - If the metadata partition has no schema label.
+    /// - If the schema label is not supported.
     #[must_use]
     pub fn schema_label(&self) -> SchemaLabel {
         let mut schema_label_bytes = [0u8; SchemaLabel::MAX_BYTES];

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -117,7 +117,6 @@ pub fn process_proposal_payload(proposal_info: &ProposalInfo) -> Json {
             serde_json::to_string(&format!("{error_msg}: {e:.400}")).unwrap_or_else(|_| format!("\"{error_msg}\""))
         })
     } else {
-        #[allow(clippy::unwrap_used)]
         serde_json::to_string("Proposal has no payload")
             .unwrap_or_else(|err| unreachable!("Surely a fixed string can be serialized as JSON?  Err: {err:?}"))
     }

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -118,7 +118,8 @@ pub fn process_proposal_payload(proposal_info: &ProposalInfo) -> Json {
         })
     } else {
         #[allow(clippy::unwrap_used)]
-        serde_json::to_string("Proposal has no payload").unwrap()
+        serde_json::to_string("Proposal has no payload")
+            .unwrap_or_else(|err| unreachable!("Surely a fixed string can be serialized as JSON?  Err: {err:?}"))
     }
 }
 

--- a/rs/sns_aggregator/src/assets.rs
+++ b/rs/sns_aggregator/src/assets.rs
@@ -242,8 +242,8 @@ fn update_root_hash(a: &AssetHashes) {
 /// - Returns 404 if the asset is not found.
 ///
 /// # Panics
-/// - If the asset certificate header cannot be created. (Likely to be observed as HTTP code 500)
-///   - Note: Certificates are available to query calls only, so technically if a request is made as an update call, this is
+/// - If the asset certificate cannot be added as an HTTP header. (Likely to be observed as HTTP code 500)
+///   - Note: Static asset certificates are available to query calls only, so technically if a request is made as an update call, this is
 ///     the caller's fault, or at least a difference in expected behaviour, not a server implementation error.
 #[allow(clippy::expect_used)] // This is a query call, so panicking may be correct.
 #[allow(clippy::needless_pass_by_value)]

--- a/rs/sns_aggregator/src/assets.rs
+++ b/rs/sns_aggregator/src/assets.rs
@@ -166,7 +166,13 @@ fn security_headers() -> Vec<HeaderField> {
 }
 
 /// Generates a header used by clients to verify the integrity of the data.
-fn make_asset_certificate_header(asset_hashes: &AssetHashes, asset_name: &str) -> Result<(String, String), String> {
+///
+/// # Panics
+/// - If the data certificate is not available.
+///
+/// # Errors
+/// - If the certificate cannot be serialized.
+fn make_asset_certificate_header(asset_hashes: &AssetHashes, asset_name: &str) -> Result<HeaderField, String> {
     let certificate = ic_cdk::api::data_certificate()
         .ok_or_else(|| "data certificate is only available in query calls".to_string())?;
     let witness = asset_hashes.0.witness(asset_name.as_bytes());

--- a/rs/sns_aggregator/src/assets.rs
+++ b/rs/sns_aggregator/src/assets.rs
@@ -237,6 +237,14 @@ fn update_root_hash(a: &AssetHashes) {
 }
 
 /// Responds to an HTTP request for an asset.
+///
+/// # Errors
+/// - Returns 404 if the asset is not found.
+///
+/// # Panics
+/// - If the asset certificate header cannot be created. (Likely to be observed as HTTP code 500)
+///   - Note: Certificates are available to query calls only, so technically if a request is made as an update call, this is
+///     the caller's fault, or at least a difference in expected behaviour, not a server implementation error.
 #[allow(clippy::expect_used)] // This is a query call, so panicking may be correct.
 #[allow(clippy::needless_pass_by_value)]
 // The signature is standard, we cannot change it.  It would be nice if this standard signature were defined in a trait that we could apply to a main struct, though!

--- a/scripts/lint-rs
+++ b/scripts/lint-rs
@@ -3,4 +3,4 @@ set -euo pipefail
 # Craete an empty assets file, if there is none.
 test -e assets.tar.xz || touch assets.tar.xz
 # Lint the rust code
-cargo clippy --locked --target wasm32-unknown-unknown --all-features -- -D warnings -W clippy::pedantic -A clippy::module-name-repetitions -A clippy::struct-field-names -A clippy::missing_errors_doc -A clippy::missing_panics_doc
+cargo clippy --locked --target wasm32-unknown-unknown --all-features -- -D warnings -W clippy::pedantic -A clippy::module-name-repetitions -A clippy::struct-field-names -A clippy::missing_errors_doc


### PR DESCRIPTION
# Motivation
Potential panics should be documented.

# Changes
- Stop ignoring linter errors for missing panic documentation.
- Where panics can be eliminated in a couple of lines of code, do so.
- Where panics are in fact not possible or require more memory than the state of the universe, use `unreachable!("some explanation")` to communicate this.
- Document the remaining panics.

# Tests
Existing CI should suffice

# Todos

- [ ] Add entry to changelog (if necessary).
