### PR TITLE
NNS1-2871: Fix meaning of oldestTxId from ICP Index

### DIFF
--- a/frontend/src/lib/services/icp-transactions.services.ts
+++ b/frontend/src/lib/services/icp-transactions.services.ts
@@ -3,7 +3,7 @@ import { DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import { icpTransactionsStore } from "$lib/stores/icp-transactions.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { toToastError } from "$lib/utils/error.utils";
-import { sortTransactionsById } from "$lib/utils/icp-transactions.utils";
+import { sortTransactionsByIdDescendingOrder } from "$lib/utils/icp-transactions.utils";
 import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { getCurrentIdentity } from "./auth.services";
@@ -47,10 +47,12 @@ export const loadIcpAccountNextTransactions = async (
 ) => {
   const store = get(icpTransactionsStore);
 
-  const sortedTransactions = nonNullish(store[accountIdentifier])
-    ? sortTransactionsById(store[accountIdentifier].transactions).reverse()
+  const sortedTransactionsAscendingOrder = nonNullish(store[accountIdentifier])
+    ? sortTransactionsByIdDescendingOrder(
+        store[accountIdentifier].transactions
+      ).reverse()
     : [];
-  const lastTxIdStore = sortedTransactions[0]?.id;
+  const lastTxIdStore = sortedTransactionsAscendingOrder[0]?.id;
   return loadIcpAccountTransactions({
     accountIdentifier,
     start: lastTxIdStore,

--- a/frontend/src/lib/services/icp-transactions.services.ts
+++ b/frontend/src/lib/services/icp-transactions.services.ts
@@ -27,7 +27,6 @@ export const loadIcpAccountTransactions = async ({
       start,
     });
 
-    // If API returns less than the maxResults, we reached the end of the list.
     const completed = transactions.some(({ id }) => id === oldestTxId);
     icpTransactionsStore.addTransactions({
       accountIdentifier,

--- a/frontend/src/lib/services/icp-transactions.services.ts
+++ b/frontend/src/lib/services/icp-transactions.services.ts
@@ -3,7 +3,7 @@ import { DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import { icpTransactionsStore } from "$lib/stores/icp-transactions.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { toToastError } from "$lib/utils/error.utils";
-import type { TransactionWithId } from "@dfinity/ledger-icp";
+import { sortTransactionsById } from "$lib/utils/icp-transactions.utils";
 import { nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { getCurrentIdentity } from "./auth.services";
@@ -42,17 +42,13 @@ export const loadIcpAccountTransactions = async ({
   }
 };
 
-const sortTransactionsByIdAscendingOrder = (
-  transactions: TransactionWithId[]
-): TransactionWithId[] => transactions.sort((a, b) => Number(a.id - b.id));
-
 export const loadIcpAccountNextTransactions = async (
   accountIdentifier: string
 ) => {
   const store = get(icpTransactionsStore);
 
   const sortedTransactions = nonNullish(store[accountIdentifier])
-    ? sortTransactionsByIdAscendingOrder(store[accountIdentifier].transactions)
+    ? sortTransactionsById(store[accountIdentifier].transactions).reverse()
     : [];
   const lastTxIdStore = sortedTransactions[0]?.id;
   return loadIcpAccountTransactions({

--- a/frontend/src/lib/services/icp-transactions.services.ts
+++ b/frontend/src/lib/services/icp-transactions.services.ts
@@ -46,12 +46,10 @@ export const loadIcpAccountNextTransactions = async (
 ) => {
   const store = get(icpTransactionsStore);
 
-  const sortedTransactionsAscendingOrder = nonNullish(store[accountIdentifier])
-    ? sortTransactionsByIdDescendingOrder(
-        store[accountIdentifier].transactions
-      ).reverse()
+  const sortedTransactionsDescendingOrder = nonNullish(store[accountIdentifier])
+    ? sortTransactionsByIdDescendingOrder(store[accountIdentifier].transactions)
     : [];
-  const lastTxIdStore = sortedTransactionsAscendingOrder[0]?.id;
+  const lastTxIdStore = sortedTransactionsDescendingOrder.at(-1)?.id;
   return loadIcpAccountTransactions({
     accountIdentifier,
     start: lastTxIdStore,

--- a/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-transactions.services.spec.ts
@@ -91,15 +91,15 @@ describe("icp-transactions services", () => {
     });
 
     it("sets complete to false when oldest is not present in results", async () => {
-      const indexBuffer = 10n;
+      const indexOffset = 10n;
       const transactions = new Array(DEFAULT_INDEX_TRANSACTION_PAGE_LIMIT)
         .fill(mockTransactionWithId)
         .map((transaction, index) => ({
-          id: BigInt(index) + indexBuffer,
+          id: BigInt(index) + indexOffset,
           transaction: { ...transaction.transaction },
         }));
       vi.spyOn(indexApi, "getTransactions").mockResolvedValue({
-        oldestTxId: indexBuffer - 1n,
+        oldestTxId: indexOffset - 1n,
         transactions: transactions,
         balance: 200_000_000n,
       });

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -2,7 +2,6 @@ import {
   CREATE_CANISTER_MEMO,
   TOP_UP_CANISTER_MEMO,
 } from "$lib/constants/api.constants";
-import { NANO_SECONDS_IN_MILLISECOND } from "$lib/constants/constants";
 import type { UiTransaction } from "$lib/types/transaction";
 import {
   mapIcpTransaction,
@@ -10,7 +9,8 @@ import {
   sortTransactionsByIdDescendingOrder,
 } from "$lib/utils/icp-transactions.utils";
 import en from "$tests/mocks/i18n.mock";
-import type { Operation, TransactionWithId } from "@dfinity/ledger-icp";
+import { createTransactionWithId } from "$tests/mocks/icp-transactions.mock";
+import type { Operation } from "@dfinity/ledger-icp";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 
 describe("icp-transactions.utils", () => {
@@ -20,30 +20,6 @@ describe("icp-transactions.utils", () => {
   const amount = 200_000_000n;
   const fee = 10_000n;
   const transactionId = 1234n;
-  const createTransactionWithId = ({
-    id = transactionId,
-    memo,
-    operation,
-    timestamp = defaultTimestamp,
-  }: {
-    id?: bigint;
-    operation: Operation;
-    memo?: bigint;
-    timestamp?: Date;
-  }): TransactionWithId => ({
-    id,
-    transaction: {
-      memo: memo ?? 0n,
-      icrc1_memo: [],
-      operation,
-      created_at_time: [
-        {
-          timestamp_nanos:
-            BigInt(timestamp.getTime()) * BigInt(NANO_SECONDS_IN_MILLISECOND),
-        },
-      ],
-    },
-  });
   const defaultTransferOperation: Operation = {
     Transfer: {
       to,
@@ -82,6 +58,7 @@ describe("icp-transactions.utils", () => {
       const transaction = createTransactionWithId({
         operation: defaultTransferOperation,
         memo: 12345n,
+        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -104,6 +81,7 @@ describe("icp-transactions.utils", () => {
       const transaction = createTransactionWithId({
         operation: defaultTransferOperation,
         memo: 0n,
+        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -126,6 +104,7 @@ describe("icp-transactions.utils", () => {
       const transaction = createTransactionWithId({
         operation: defaultTransferOperation,
         memo: CREATE_CANISTER_MEMO,
+        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -148,6 +127,7 @@ describe("icp-transactions.utils", () => {
       const transaction = createTransactionWithId({
         operation: defaultTransferOperation,
         memo: TOP_UP_CANISTER_MEMO,
+        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -169,6 +149,7 @@ describe("icp-transactions.utils", () => {
     it("maps swap participation transaction", () => {
       const transaction = createTransactionWithId({
         operation: defaultTransferOperation,
+        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -190,6 +171,7 @@ describe("icp-transactions.utils", () => {
     it("maps swap participation refund transaction", () => {
       const transaction = createTransactionWithId({
         operation: defaultTransferOperation,
+        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -217,6 +199,7 @@ describe("icp-transactions.utils", () => {
     it("maps sent transaction", () => {
       const transaction = createTransactionWithId({
         operation: defaultTransferOperation,
+        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -238,6 +221,7 @@ describe("icp-transactions.utils", () => {
     it("maps received transaction", () => {
       const transaction = createTransactionWithId({
         operation: defaultTransferOperation,
+        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -265,6 +249,7 @@ describe("icp-transactions.utils", () => {
     it("maps toSelf transaction as Received", () => {
       const transaction = createTransactionWithId({
         operation: toSelfOperation,
+        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -293,6 +278,7 @@ describe("icp-transactions.utils", () => {
     it("maps toSelf transaction as Sent", () => {
       const transaction = createTransactionWithId({
         operation: toSelfOperation,
+        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -325,6 +311,7 @@ describe("icp-transactions.utils", () => {
             expected_allowance: [],
           },
         },
+        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -359,6 +346,7 @@ describe("icp-transactions.utils", () => {
             amount: { e8s: amount },
           },
         },
+        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -390,6 +378,7 @@ describe("icp-transactions.utils", () => {
             amount: { e8s: amount },
           },
         },
+        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,

--- a/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/icp-transactions.utils.spec.ts
@@ -52,13 +52,27 @@ describe("icp-transactions.utils", () => {
       spender: [],
     },
   };
+  const createTransaction = ({
+    operation,
+    memo,
+    id = transactionId,
+  }: {
+    id?: bigint;
+    operation: Operation;
+    memo?: bigint;
+  }) =>
+    createTransactionWithId({
+      id,
+      timestamp: defaultTimestamp,
+      operation,
+      memo,
+    });
 
   describe("mapIcpTransaction", () => {
     it("maps stake neuron transaction", () => {
-      const transaction = createTransactionWithId({
+      const transaction = createTransaction({
         operation: defaultTransferOperation,
         memo: 12345n,
-        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -78,10 +92,9 @@ describe("icp-transactions.utils", () => {
     });
 
     it("maps top up neuron transaction", () => {
-      const transaction = createTransactionWithId({
+      const transaction = createTransaction({
         operation: defaultTransferOperation,
         memo: 0n,
-        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -101,10 +114,9 @@ describe("icp-transactions.utils", () => {
     });
 
     it("maps create canister transaction", () => {
-      const transaction = createTransactionWithId({
+      const transaction = createTransaction({
         operation: defaultTransferOperation,
         memo: CREATE_CANISTER_MEMO,
-        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -124,10 +136,9 @@ describe("icp-transactions.utils", () => {
     });
 
     it("maps top up canister transaction", () => {
-      const transaction = createTransactionWithId({
+      const transaction = createTransaction({
         operation: defaultTransferOperation,
         memo: TOP_UP_CANISTER_MEMO,
-        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -147,9 +158,8 @@ describe("icp-transactions.utils", () => {
     });
 
     it("maps swap participation transaction", () => {
-      const transaction = createTransactionWithId({
+      const transaction = createTransaction({
         operation: defaultTransferOperation,
-        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -169,9 +179,8 @@ describe("icp-transactions.utils", () => {
     });
 
     it("maps swap participation refund transaction", () => {
-      const transaction = createTransactionWithId({
+      const transaction = createTransaction({
         operation: defaultTransferOperation,
-        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -197,9 +206,8 @@ describe("icp-transactions.utils", () => {
     });
 
     it("maps sent transaction", () => {
-      const transaction = createTransactionWithId({
+      const transaction = createTransaction({
         operation: defaultTransferOperation,
-        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -219,9 +227,8 @@ describe("icp-transactions.utils", () => {
     });
 
     it("maps received transaction", () => {
-      const transaction = createTransactionWithId({
+      const transaction = createTransaction({
         operation: defaultTransferOperation,
-        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -247,9 +254,8 @@ describe("icp-transactions.utils", () => {
     });
 
     it("maps toSelf transaction as Received", () => {
-      const transaction = createTransactionWithId({
+      const transaction = createTransaction({
         operation: toSelfOperation,
-        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -276,9 +282,8 @@ describe("icp-transactions.utils", () => {
     });
 
     it("maps toSelf transaction as Sent", () => {
-      const transaction = createTransactionWithId({
+      const transaction = createTransaction({
         operation: toSelfOperation,
-        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -300,7 +305,7 @@ describe("icp-transactions.utils", () => {
     });
 
     it("maps approve transaction", () => {
-      const transaction = createTransactionWithId({
+      const transaction = createTransaction({
         operation: {
           Approve: {
             fee: { e8s: fee },
@@ -311,7 +316,6 @@ describe("icp-transactions.utils", () => {
             expected_allowance: [],
           },
         },
-        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -338,7 +342,7 @@ describe("icp-transactions.utils", () => {
     });
 
     it("maps Burn transaction", () => {
-      const transaction = createTransactionWithId({
+      const transaction = createTransaction({
         operation: {
           Burn: {
             from,
@@ -346,7 +350,6 @@ describe("icp-transactions.utils", () => {
             amount: { e8s: amount },
           },
         },
-        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -371,14 +374,13 @@ describe("icp-transactions.utils", () => {
     });
 
     it("maps Mint transaction", () => {
-      const transaction = createTransactionWithId({
+      const transaction = createTransaction({
         operation: {
           Mint: {
             to: from,
             amount: { e8s: amount },
           },
         },
-        id: transactionId,
       });
       const expectedUiTransaction: UiTransaction = {
         ...defaultUiTransaction,
@@ -406,7 +408,7 @@ describe("icp-transactions.utils", () => {
 
   describe("mapToSelfTransactions", () => {
     it("duplicateds toSelf transactions", () => {
-      const transaction = createTransactionWithId({
+      const transaction = createTransaction({
         operation: toSelfOperation,
       });
 
@@ -423,10 +425,10 @@ describe("icp-transactions.utils", () => {
     });
 
     it("doesn't duplicate not to self transactoins", () => {
-      const transaction = createTransactionWithId({
+      const transaction = createTransaction({
         operation: toSelfOperation,
       });
-      const notToSelfTransaction = createTransactionWithId({
+      const notToSelfTransaction = createTransaction({
         operation: defaultTransferOperation,
       });
 
@@ -450,15 +452,15 @@ describe("icp-transactions.utils", () => {
   });
 
   describe("sortTransactionsByIdDescendingOrder", () => {
-    const firstTransaction = createTransactionWithId({
+    const firstTransaction = createTransaction({
       operation: defaultTransferOperation,
       id: 10n,
     });
-    const secondTransaction = createTransactionWithId({
+    const secondTransaction = createTransaction({
       operation: defaultTransferOperation,
       id: 20n,
     });
-    const thirdTransaction = createTransactionWithId({
+    const thirdTransaction = createTransaction({
       operation: defaultTransferOperation,
       id: 30n,
     });

--- a/frontend/src/tests/mocks/icp-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icp-transactions.mock.ts
@@ -1,4 +1,9 @@
-import type { Transaction, TransactionWithId } from "@dfinity/ledger-icp";
+import { NANO_SECONDS_IN_MILLISECOND } from "$lib/constants/constants";
+import type {
+  Operation,
+  Transaction,
+  TransactionWithId,
+} from "@dfinity/ledger-icp";
 import { mockMainAccount, mockSubAccount } from "./icp-accounts.store.mock";
 
 export const mockTransactionTransfer: Transaction = {
@@ -15,6 +20,32 @@ export const mockTransactionTransfer: Transaction = {
   },
   created_at_time: [{ timestamp_nanos: 234n }],
 };
+
+const defaultTimestamp = new Date("2023-01-01T00:00:00.000Z");
+export const createTransactionWithId = ({
+  memo,
+  operation = mockTransactionTransfer.operation,
+  timestamp = defaultTimestamp,
+  id = 1234n,
+}: {
+  operation?: Operation;
+  memo?: bigint;
+  timestamp?: Date;
+  id?: bigint;
+}): TransactionWithId => ({
+  id,
+  transaction: {
+    memo: memo ?? 0n,
+    icrc1_memo: [],
+    operation,
+    created_at_time: [
+      {
+        timestamp_nanos:
+          BigInt(timestamp.getTime()) * BigInt(NANO_SECONDS_IN_MILLISECOND),
+      },
+    ],
+  },
+});
 
 export const mockTransactionWithId: TransactionWithId = {
   id: 234n,


### PR DESCRIPTION
# Motivation

Fetch ICP transactions from ICP Index canister.

In this PR, I fix a misunderstanding with the field `oldestTxId` of the response.

The meaning is not the oldest tx id of that specific page, but of the user.

# Changes

* Adapt code to fetch next page `loadIcpAccountNextTransactions` to the new meaning.
* Adap code to set `complete` in the store in `loadIcpAccountTransactions`.

# Tests

* Change and add tests with the new meaning.

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.
