### PR TITLE
feat: Enable data migration on demand

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,36 @@ jobs:
         with:
           name: test-upgrade-stable-dfx.log
           path: test-upgrade-stable-dfx.log
+  test-upgrade-map-stable:
+    needs: build
+    runs-on: ubuntu-20.04
+    timeout-minutes: 40
+    steps:
+      - name: Checkout nns-dapp
+        uses: actions/checkout@v4
+      - name: Get nns-dapp_test
+        uses: actions/download-artifact@v4
+        with:
+          name: out
+          path: out
+      - name: Install ic-wasm
+        uses: ./.github/actions/install_ic_wasm
+      - name: Install dfx
+        uses: dfinity/setup-dfx@main
+      - name: Install tools
+        run: |
+          sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
+          cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)" && idl2json --version
+      - name: Start dfx
+        run: dfx start --clean --background &>test-upgrade-stable-dfx.log
+      - name: Upgrade nns-dapp from Map to AccountsInStableMemory and back again
+        run: ./scripts/nns-dapp/migration-test --schema1 Map --schema2 AccountsInStableMemory --accounts 10000
+      - name: Upload dfx logs
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-upgrade-stable-dfx.log
+          path: test-upgrade-stable-dfx.log
   test-test-account-api:
     needs: build
     runs-on: ubuntu-20.04
@@ -525,7 +555,7 @@ jobs:
           ) | tee -a $GITHUB_STEP_SUMMARY
           (( wasm_size <= max_size )) || { echo "The WASM is too large" ; exit 1 ; }
   build-pass:
-    needs: ["build", "test-playwright-e2e-shard-1-of-2", "test-playwright-e2e-shard-2-of-2", "test-rest", "network_independent_wasm", "aggregator_test", "assets", "test-downgrade-upgrade", "test-test-account-api", "test-upgrade-map", "test-upgrade-stable"]
+    needs: ["build", "test-playwright-e2e-shard-1-of-2", "test-playwright-e2e-shard-2-of-2", "test-rest", "network_independent_wasm", "aggregator_test", "assets", "test-downgrade-upgrade", "test-test-account-api", "test-upgrade-map", "test-upgrade-stable", "test-upgrade-map-stable"]
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -21,6 +21,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Minor wording and style changes on the neuron detail page.
 * Enable loading state from stable structures.
+* Enable migrating state to and from stable structures.
 
 #### Deprecated
 

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -4,7 +4,6 @@ use crate::multi_part_transactions_processor::{MultiPartTransactionToBeProcessed
 use crate::state::StableState;
 use crate::stats::Stats;
 use candid::CandidType;
-use core::fmt;
 use dfn_candid::Candid;
 use histogram::AccountsStoreHistogram;
 use ic_base_types::{CanisterId, PrincipalId};
@@ -18,21 +17,24 @@ use icp_ledger::Operation::{self, Approve, Burn, Mint, Transfer, TransferFrom};
 use icp_ledger::{AccountIdentifier, BlockIndex, Memo, Subaccount, Tokens};
 use itertools::Itertools;
 use on_wire::{FromWire, IntoWire};
-use schema::{
-    map::AccountsDbAsMap,
-    proxy::{AccountsDb, AccountsDbAsProxy},
-    AccountsDbBTreeMapTrait, AccountsDbTrait, SchemaLabel,
-};
 use serde::Deserialize;
 use std::borrow::Cow;
 use std::cmp::{min, Ordering};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::fmt;
 use std::ops::{RangeBounds, RangeTo};
 use std::time::{Duration, SystemTime};
 
 pub mod constructors;
 pub mod histogram;
 pub mod schema;
+use schema::{
+    map::AccountsDbAsMap,
+    proxy::{AccountsDb, AccountsDbAsProxy},
+    AccountsDbBTreeMapTrait, AccountsDbTrait,
+};
+
+use self::schema::SchemaLabel;
 
 type TransactionIndex = u64;
 
@@ -355,13 +357,6 @@ pub enum DetachCanisterResponse {
 }
 
 impl AccountsStore {
-    /// Starts migrating accounts to the new db.
-    pub fn start_migrating_accounts_to(&mut self, accounts_db: AccountsDb) {
-        self.accounts_db.start_migrating_accounts_to(accounts_db);
-    }
-    pub fn step_migration(&mut self) {
-        self.accounts_db.step_migration();
-    }
     #[must_use]
     pub fn get_account(&self, caller: PrincipalId) -> Option<AccountDetails> {
         let account_identifier = AccountIdentifier::from(caller);

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -4,6 +4,7 @@ use crate::multi_part_transactions_processor::{MultiPartTransactionToBeProcessed
 use crate::state::StableState;
 use crate::stats::Stats;
 use candid::CandidType;
+use core::fmt;
 use dfn_candid::Candid;
 use histogram::AccountsStoreHistogram;
 use ic_base_types::{CanisterId, PrincipalId};
@@ -17,24 +18,21 @@ use icp_ledger::Operation::{self, Approve, Burn, Mint, Transfer, TransferFrom};
 use icp_ledger::{AccountIdentifier, BlockIndex, Memo, Subaccount, Tokens};
 use itertools::Itertools;
 use on_wire::{FromWire, IntoWire};
+use schema::{
+    map::AccountsDbAsMap,
+    proxy::{AccountsDb, AccountsDbAsProxy},
+    AccountsDbBTreeMapTrait, AccountsDbTrait, SchemaLabel,
+};
 use serde::Deserialize;
 use std::borrow::Cow;
 use std::cmp::{min, Ordering};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
-use std::fmt;
 use std::ops::{RangeBounds, RangeTo};
 use std::time::{Duration, SystemTime};
 
 pub mod constructors;
 pub mod histogram;
 pub mod schema;
-use schema::{
-    map::AccountsDbAsMap,
-    proxy::{AccountsDb, AccountsDbAsProxy},
-    AccountsDbBTreeMapTrait, AccountsDbTrait,
-};
-
-use self::schema::SchemaLabel;
 
 type TransactionIndex = u64;
 
@@ -357,6 +355,13 @@ pub enum DetachCanisterResponse {
 }
 
 impl AccountsStore {
+    /// Starts migrating accounts to the new db.
+    pub fn start_migrating_accounts_to(&mut self, accounts_db: AccountsDb) {
+        self.accounts_db.start_migrating_accounts_to(accounts_db);
+    }
+    pub fn step_migration(&mut self) {
+        self.accounts_db.step_migration();
+    }
     #[must_use]
     pub fn get_account(&self, caller: PrincipalId) -> Option<AccountDetails> {
         let account_identifier = AccountIdentifier::from(caller);

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -357,6 +357,13 @@ pub enum DetachCanisterResponse {
 }
 
 impl AccountsStore {
+    /// Starts migrating accounts to the new db.
+    pub fn start_migrating_accounts_to(&mut self, accounts_db: AccountsDb) {
+        self.accounts_db.start_migrating_accounts_to(accounts_db);
+    }
+    pub fn step_migration(&mut self) {
+        self.accounts_db.step_migration();
+    }
     #[must_use]
     pub fn get_account(&self, caller: PrincipalId) -> Option<AccountDetails> {
         let account_identifier = AccountIdentifier::from(caller);

--- a/rs/backend/src/accounts_store/schema/proxy.rs
+++ b/rs/backend/src/accounts_store/schema/proxy.rs
@@ -42,7 +42,6 @@ struct Migration {
     /// The database being migrated to
     db: AccountsDb,
     /// The next account to migrate.
-    #[cfg(test)]
     next_to_migrate: Option<Vec<u8>>,
 }
 

--- a/rs/backend/src/accounts_store/schema/proxy/migration.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/migration.rs
@@ -1,8 +1,5 @@
 //! Code for migration from the authoritative database to a new database.
-#[cfg(test)]
-use super::{AccountsDb, Migration};
-use super::{AccountsDbAsProxy, AccountsDbTrait};
-#[cfg(test)]
+use super::{AccountsDb, AccountsDbAsProxy, AccountsDbTrait, Migration};
 use ic_cdk::println;
 
 impl AccountsDbAsProxy {
@@ -37,7 +34,6 @@ impl AccountsDbAsProxy {
     ///
     /// # Panics
     /// - If the new database is not empty.
-    #[cfg(test)]
     pub fn start_migrating_accounts_to(&mut self, accounts_db: AccountsDb) {
         assert!(
             accounts_db.db_accounts_len() == 0,
@@ -55,7 +51,6 @@ impl AccountsDbAsProxy {
     }
 
     /// Advances the migration by one step.
-    #[cfg(test)]
     pub fn step_migration(&mut self) {
         if let Some(migration) = &mut self.migration {
             if let Some(next_to_migrate) = &migration.next_to_migrate {
@@ -72,7 +67,6 @@ impl AccountsDbAsProxy {
     }
 
     /// Completes any migration in progress.
-    #[cfg(test)]
     pub fn complete_migration(&mut self) {
         if let Some(migration) = self.migration.take() {
             println!(

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -99,7 +99,7 @@ fn post_upgrade(args_maybe: Option<CanisterArguments>) {
     perf::record_instruction_count("post_upgrade after state_recovery");
     set_canister_arguments(args_maybe);
     perf::record_instruction_count("post_upgrade after set_canister_arguments");
-    assets::init_assets(); // TODO: Move this inside State::from (and State::new_with_memory)
+    assets::init_assets();
     perf::record_instruction_count("post_upgrade stop");
     println!("END   post-upgrade");
 }

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -19,6 +19,10 @@ const PRUNE_TRANSACTIONS_COUNT: u32 = 1000;
 pub async fn run_periodic_tasks() {
     ledger_sync::sync_transactions().await;
 
+    STATE.with(|state| {
+        state.accounts_store.borrow_mut().step_migration();
+    });
+
     let maybe_transaction_to_process =
         STATE.with(|s| s.accounts_store.borrow_mut().try_take_next_transaction_to_process());
     if let Some((block_height, transaction_to_process)) = maybe_transaction_to_process {

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -172,18 +172,8 @@ impl State {
                 SchemaLabel::AccountsInStableMemory => {
                     let mut partitions_maybe = self.partitions_maybe.borrow_mut();
                     // If the memory isn't partitioned, partition it now.
-                    if let PartitionsMaybe::None(memory) = &*partitions_maybe {
-                        println!("start_migration_to: Partitioning memory for schema {schema:?}.");
-                        let memory = Partitions::copy_memory_reference(memory);
-                        *partitions_maybe = PartitionsMaybe::Partitions(Partitions::new_with_schema(memory, schema));
-                    };
-                    let vm = match &*partitions_maybe {
-                        PartitionsMaybe::Partitions(partitions) => partitions.get(PartitionType::Accounts.memory_id()),
-                        PartitionsMaybe::None(_) => {
-                            trap_with("Cannot fail as we just created the partitions");
-                            unreachable!()
-                        }
-                    };
+                    let partitions = partitions_maybe.get_or_format(schema);
+                    let vm = partitions.get(PartitionType::Accounts.memory_id());
                     AccountsDb::UnboundedStableBTreeMap(AccountsDbAsUnboundedStableBTreeMap::new(vm))
                 }
             };

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -154,9 +154,10 @@ impl State {
     /// Applies the specified arguments, if provided
     #[must_use]
     pub fn with_arguments_maybe(self, arguments_maybe: Option<&CanisterArguments>) -> Self {
-        match arguments_maybe {
-            Some(arguments) => self.with_arguments(arguments),
-            None => self,
+        if let Some(arguments) = arguments_maybe {
+            self.with_arguments(arguments)
+        } else {
+            self
         }
     }
     /// Starts a migration, if needed.

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -166,6 +166,7 @@ impl State {
         if schema_now == schema {
             println!("start_migration_to: No migration needed.  Schema is already {schema:?}.");
         } else {
+            // Create a new, empty, accounts database with the new schema, then start migrating to it.
             let new_accounts_db = match schema {
                 SchemaLabel::Map => AccountsDb::Map(AccountsDbAsMap::default()),
                 SchemaLabel::AccountsInStableMemory => {

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -146,8 +146,6 @@ impl State {
     /// Applies the specified arguments to the state.
     #[must_use]
     pub fn with_arguments(mut self, arguments: &CanisterArguments) -> Self {
-        // TODO: If a migration is needed, kick it off.
-        // TODO: Initialize assets and asset_hashes
         if let Some(schema) = arguments.schema {
             self.start_migration_to(schema);
         }

--- a/rs/backend/src/state/partitions/schemas.rs
+++ b/rs/backend/src/state/partitions/schemas.rs
@@ -1,8 +1,6 @@
 //! Sets up memory for a given schema.
-use super::DefaultMemoryImpl;
-use super::{PartitionType, Partitions};
 use crate::accounts_store::schema::SchemaLabelBytes;
-use crate::state::SchemaLabel;
+use crate::state::{DefaultMemoryImpl, PartitionType, Partitions, SchemaLabel};
 use ic_cdk::println;
 #[cfg(test)]
 mod tests;

--- a/rs/backend/src/state/partitions/schemas.rs
+++ b/rs/backend/src/state/partitions/schemas.rs
@@ -1,6 +1,8 @@
 //! Sets up memory for a given schema.
+use super::DefaultMemoryImpl;
+use super::{PartitionType, Partitions};
 use crate::accounts_store::schema::SchemaLabelBytes;
-use crate::state::{DefaultMemoryImpl, PartitionType, Partitions, SchemaLabel};
+use crate::state::SchemaLabel;
 use ic_cdk::println;
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
# Motivation
In main we currently have:
- The ability to create a canister with accounts stored in EITHER stable structures OR on the heap.
- Functions to migrate data step by step, exercised in unit tests.

We would like to enable migration for a canister.

# Changes
- Use a timer to exercise the existing migration-stepping command, if we need to migrate.

# Tests
- We use the standard the upgrade-downgrade test to verify that migration across schemas works in an e2e test.

# Todos

- [ ] Add entry to changelog (if necessary).
 TODO before merging
