### PR TITLE
NNS1-2872: Add pagination to ICP transactions

### DIFF
--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -64,7 +64,7 @@
   import {
     mapIcpTransaction,
     mapToSelfTransactions,
-    sortTransactionsByTimestamp,
+    sortTransactionsByIdDescendingOrder,
   } from "$lib/utils/icp-transactions.utils";
   import UiTransactionsList from "$lib/components/accounts/UiTransactionsList.svelte";
   import { neuronAccountsStore } from "$lib/stores/neurons.store";
@@ -132,7 +132,7 @@
       nonNullish(transactionsStore[account.identifier])
     ) {
       return mapToSelfTransactions(
-        sortTransactionsByTimestamp(
+        sortTransactionsByIdDescendingOrder(
           transactionsStore[account.identifier].transactions
         )
       )

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -94,6 +94,7 @@
     account: $selectedAccountStore.account,
     transactionsStore: $icpTransactionsStore,
   });
+
   const getCompletedFromStore = ({
     account,
     transactionsStore,
@@ -109,6 +110,7 @@
     }
     return false;
   };
+
   let uiTransactions: UiTransaction[] | undefined;
   $: uiTransactions = makeUiTransactions({
     account: $selectedAccountStore.account,


### PR DESCRIPTION
# Motivation

Fetch the ICP transactions from ICP index canister instead of NNS dapp.

In this PR, introduce pagination for transactions with infinite scrolling in the wallet page.

PENDING: Show a nice initial loading indicator in the first load.

# Changes

## Changes in NnsWallet

* Sort the transactions before rendering them.
* Call an internal `loadNextTransactions` on nnsIntersect.
* New variables to show loading and disable pagination on complete.

# Tests

* Test `"should render second page of transactions from ICP Index canister"`

# Todos

- [ ] Add entry to changelog (if necessary).

Not yet necessary.

