### PR TITLE
Add icpAccountDetailsStore

### DIFF
--- a/frontend/src/lib/stores/icp-account-details.store.ts
+++ b/frontend/src/lib/stores/icp-account-details.store.ts
@@ -1,0 +1,28 @@
+import type { AccountDetails } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import { writable, type Readable } from "svelte/store";
+
+export interface IcpAccountDetailsStoreData {
+  accountDetails: AccountDetails;
+  certified: boolean;
+}
+
+export interface IcpAccountDetailsStore
+  extends Readable<IcpAccountDetailsStoreData | undefined> {
+  set: (accountDetails: IcpAccountDetailsStoreData | undefined) => void;
+  reset: () => void;
+}
+
+const initIpcAccountDetailsStore = (): IcpAccountDetailsStore => {
+  const initialStoreData = undefined;
+  const { subscribe, set } = writable<IcpAccountDetailsStoreData | undefined>(
+    initialStoreData
+  );
+
+  return {
+    subscribe,
+    set,
+    reset: () => set(initialStoreData),
+  };
+};
+
+export const icpAccountDetailsStore = initIpcAccountDetailsStore();

--- a/frontend/src/tests/lib/stores/icp-account-details.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icp-account-details.store.spec.ts
@@ -1,0 +1,56 @@
+import type {
+  AccountDetails,
+  HardwareWalletAccountDetails,
+  SubAccountDetails,
+} from "$lib/canisters/nns-dapp/nns-dapp.types";
+import { icpAccountDetailsStore } from "$lib/stores/icp-account-details.store";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { get } from "svelte/store";
+
+describe("icpAccountDetailsStore", () => {
+  const hardwareWalletAccount: HardwareWalletAccountDetails = {
+    principal: principal(43),
+    name: "My Nano S",
+    account_identifier: "hardwareWalletAccountIdentifier",
+  };
+
+  const subAccount: SubAccountDetails = {
+    name: "My subaccount",
+    sub_account: [54, 65, 76, 87],
+    account_identifier: "subAccountIdentifier",
+  };
+
+  const accountDetails: AccountDetails = {
+    principal: principal(10),
+    account_identifier: "mainAccountIdentifier",
+    hardware_wallet_accounts: [hardwareWalletAccount],
+    sub_accounts: [subAccount],
+  };
+
+  const accountDetailsData = {
+    accountDetails,
+    certified: true,
+  };
+
+  beforeEach(() => {
+    icpAccountDetailsStore.reset();
+  });
+
+  it("should be initialized to undefined", () => {
+    expect(get(icpAccountDetailsStore)).toBeUndefined();
+  });
+
+  it("should set data", () => {
+    icpAccountDetailsStore.set(accountDetailsData);
+
+    expect(get(icpAccountDetailsStore)).toEqual(accountDetailsData);
+  });
+
+  it("should reset data", () => {
+    icpAccountDetailsStore.set(accountDetailsData);
+
+    expect(get(icpAccountDetailsStore)).toBeDefined();
+    icpAccountDetailsStore.reset();
+    expect(get(icpAccountDetailsStore)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Motivation

The current `icpAccountStore` holds a combination of accounts and balances in a single store. This means all the data has to be loaded together and if we just want to change a balances, we have to manipulate the data in the store, which can interfere with loading the accounts.

The cleaner way is to have a separate store for accounts and a separate store for balances and a derived store which merged both into accounts with balances. That way when we update a balance in the balances store, it will just automatically recreate the accounts with balances.

In this PR, I'm only adding a new store for `AccountDetails` as they are loaded from the nns-dapp. In a later PR this will be use as described above.

# Changes

Add `icpAccountDetailsStore`.

# Tests

Add unit tests for `icpAccountDetailsStore`.
Tested manually in a separate branch.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet