### PR TITLE
NNS1-2857: Add icpAccountBalancesStore

### DIFF
--- a/frontend/src/lib/stores/icp-account-balances.store.ts
+++ b/frontend/src/lib/stores/icp-account-balances.store.ts
@@ -1,3 +1,4 @@
+import type { AccountIdentifierString } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { writable, type Readable } from "svelte/store";
 
 export interface IcpAccountBalanceStoreData {
@@ -7,7 +8,7 @@ export interface IcpAccountBalanceStoreData {
 
 // The key is the ICP account identifier.
 export type IcpAccountBalancesStoreData = Record<
-  string,
+  AccountIdentifierString,
   IcpAccountBalanceStoreData
 >;
 

--- a/frontend/src/lib/stores/icp-account-balances.store.ts
+++ b/frontend/src/lib/stores/icp-account-balances.store.ts
@@ -1,0 +1,56 @@
+import { writable, type Readable } from "svelte/store";
+
+export interface IcpAccountBalanceStoreData {
+  balanceE8s: bigint;
+  certified: boolean;
+}
+
+// The key is the ICP account identifier.
+export type IcpAccountBalancesStoreData = Record<
+  string,
+  IcpAccountBalanceStoreData
+>;
+
+export interface IcpAccountBalancesStore
+  extends Readable<IcpAccountBalancesStoreData> {
+  setBalance: ({
+    accountIdentifier,
+    balanceE8s,
+    certified,
+  }: {
+    accountIdentifier: string;
+    balanceE8s: bigint;
+    certified: boolean;
+  }) => void;
+  reset: () => void;
+}
+
+const initIpcAccountBalancesStore = (): IcpAccountBalancesStore => {
+  const initialStoreData = {};
+  const { subscribe, set, update } =
+    writable<IcpAccountBalancesStoreData>(initialStoreData);
+
+  return {
+    subscribe,
+    setBalance({
+      accountIdentifier,
+      balanceE8s,
+      certified,
+    }: {
+      accountIdentifier: string;
+      balanceE8s: bigint;
+      certified: boolean;
+    }) {
+      update((storeData) => ({
+        ...storeData,
+        [accountIdentifier]: {
+          balanceE8s,
+          certified,
+        },
+      }));
+    },
+    reset: () => set(initialStoreData),
+  };
+};
+
+export const icpAccountBalancesStore = initIpcAccountBalancesStore();

--- a/frontend/src/lib/stores/icp-account-balances.store.ts
+++ b/frontend/src/lib/stores/icp-account-balances.store.ts
@@ -6,7 +6,6 @@ export interface IcpAccountBalanceStoreData {
   certified: boolean;
 }
 
-// The key is the ICP account identifier.
 export type IcpAccountBalancesStoreData = Record<
   AccountIdentifierString,
   IcpAccountBalanceStoreData

--- a/frontend/src/tests/lib/stores/icp-account-balances.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icp-account-balances.store.spec.ts
@@ -1,0 +1,54 @@
+import { icpAccountBalancesStore } from "$lib/stores/icp-account-balances.store";
+import { get } from "svelte/store";
+
+describe("icpAccountBalancesStore", () => {
+  const mainAccountIdentifier = "mainAccountIdentifier";
+  const mainAccountBalance = 100_000_000n;
+  const subAccountIdentifier = "subAccountIdentifier";
+  const subAccountBalance = 200_000_000n;
+
+  beforeEach(() => {
+    icpAccountBalancesStore.reset();
+  });
+
+  it("should be initialized to empty", () => {
+    expect(get(icpAccountBalancesStore)).toEqual({});
+  });
+
+  it("should set balance", () => {
+    icpAccountBalancesStore.setBalance({
+      accountIdentifier: mainAccountIdentifier,
+      balanceE8s: mainAccountBalance,
+      certified: true,
+    });
+
+    icpAccountBalancesStore.setBalance({
+      accountIdentifier: subAccountIdentifier,
+      balanceE8s: subAccountBalance,
+      certified: true,
+    });
+
+    expect(get(icpAccountBalancesStore)).toEqual({
+      [mainAccountIdentifier]: {
+        balanceE8s: mainAccountBalance,
+        certified: true,
+      },
+      [subAccountIdentifier]: {
+        balanceE8s: subAccountBalance,
+        certified: true,
+      },
+    });
+  });
+
+  it("should reset data", () => {
+    icpAccountBalancesStore.setBalance({
+      accountIdentifier: mainAccountIdentifier,
+      balanceE8s: mainAccountBalance,
+      certified: true,
+    });
+
+    expect(get(icpAccountBalancesStore)).not.toEqual({});
+    icpAccountBalancesStore.reset();
+    expect(get(icpAccountBalancesStore)).toEqual({});
+  });
+});


### PR DESCRIPTION
# Motivation

The current icpAccountStore holds a combination of accounts and balances in a single store. This means all the data has to be loaded together and if we just want to change a balances, we have to manipulate the data in the store, which can interfere with loading the accounts.

The cleaner way is to have a separate store for accounts and a separate store for balances and a derived store which merged both into accounts with balances. That way when we update a balance in the balances store, it will just automatically recreate the accounts with balances.

In this PR, I'm only adding a new store for account balances (separate from accounts). In a later PR this will be used as described above.

# Changes

Add `icpAccountBalancesStore` which holds a record of `balanceE8s` for each ICP account identifier of the user.

# Tests

Unit tests added for `icpAccountBalancesStore`.
Tested manually in another branch.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet