### PR TITLE
NNS1-2857: Add derived icpAccountsStore

### DIFF
--- a/frontend/src/lib/derived/icp-accounts.derived.ts
+++ b/frontend/src/lib/derived/icp-accounts.derived.ts
@@ -1,0 +1,95 @@
+import type {
+  AccountDetails,
+  HardwareWalletAccountDetails,
+  SubAccountDetails,
+} from "$lib/canisters/nns-dapp/nns-dapp.types";
+import { ENABLE_ICP_ICRC } from "$lib/stores/feature-flags.store";
+import {
+  icpAccountBalancesStore,
+  type IcpAccountBalancesStore,
+} from "$lib/stores/icp-account-balances.store";
+import {
+  icpAccountDetailsStore,
+  type IcpAccountDetailsStore,
+} from "$lib/stores/icp-account-details.store";
+import type { AccountType, IcpAccount } from "$lib/types/account";
+import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
+import {
+  arrayOfNumberToUint8Array,
+  isNullish,
+  nonNullish,
+} from "@dfinity/utils";
+import { derived, type Readable } from "svelte/store";
+
+export interface IcpAccountsStoreData {
+  main?: IcpAccount;
+  subAccounts?: IcpAccount[];
+  hardwareWallets?: IcpAccount[];
+}
+
+export type IcpAccountsStore = Readable<IcpAccountsStoreData>;
+
+export const icpAccountsStore = derived<
+  [IcpAccountDetailsStore, IcpAccountBalancesStore, Readable<boolean>],
+  IcpAccountsStoreData
+>(
+  [icpAccountDetailsStore, icpAccountBalancesStore, ENABLE_ICP_ICRC],
+  ([icpAccountDetails, icpAccountBalances, icrcEnabled]) => {
+    const initialAccounts: IcpAccountsStoreData = {
+      main: undefined,
+      subAccounts: undefined,
+      hardwareWallets: undefined,
+    };
+
+    if (isNullish(icpAccountDetails)) {
+      return initialAccounts;
+    }
+
+    const { accountDetails } = icpAccountDetails;
+
+    const mapAccount =
+      (type: AccountType) =>
+      (
+        account:
+          | AccountDetails
+          | HardwareWalletAccountDetails
+          | SubAccountDetails
+      ): IcpAccount => ({
+        identifier: icrcEnabled
+          ? encodeIcrcAccount({
+              owner:
+                "principal" in account
+                  ? account.principal
+                  : accountDetails.principal,
+              ...("sub_account" in account && {
+                subaccount: arrayOfNumberToUint8Array(account.sub_account),
+              }),
+            })
+          : account.account_identifier,
+        icpIdentifier: account.account_identifier,
+        balanceUlps: icpAccountBalances[account.account_identifier]?.balanceE8s,
+        type,
+        ...("sub_account" in account && { subAccount: account.sub_account }),
+        ...("name" in account && { name: account.name }),
+        ...("principal" in account && { principal: account.principal }),
+      });
+
+    const main = mapAccount("main")(accountDetails);
+    if (isNullish(main.balanceUlps)) {
+      return initialAccounts;
+    }
+
+    const subAccounts = accountDetails.sub_accounts
+      .map(mapAccount("subAccount"))
+      .filter(({ balanceUlps }) => nonNullish(balanceUlps));
+    const hardwareWallets = accountDetails.hardware_wallet_accounts
+      .map(mapAccount("hardwareWallet"))
+      .filter(({ balanceUlps }) => nonNullish(balanceUlps));
+
+    return {
+      main,
+      subAccounts,
+      hardwareWallets,
+    } as IcpAccountsStoreData;
+  }
+);

--- a/frontend/src/tests/lib/derived/icp-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-accounts.derived.spec.ts
@@ -64,7 +64,7 @@ describe("icpAccountsStore", () => {
     });
   });
 
-  it("should derived main account and balance", () => {
+  it("should derive main account and balance", () => {
     icpAccountDetailsStore.set({
       accountDetails: {
         ...accountDetails,
@@ -93,7 +93,7 @@ describe("icpAccountsStore", () => {
     });
   });
 
-  it("should derived all accounts and balances", () => {
+  it("should derive all accounts and balances", () => {
     icpAccountDetailsStore.set(accountDetailsData);
 
     icpAccountBalancesStore.setBalance({

--- a/frontend/src/tests/lib/derived/icp-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-accounts.derived.spec.ts
@@ -1,0 +1,145 @@
+import type {
+  AccountDetails,
+  HardwareWalletAccountDetails,
+  SubAccountDetails,
+} from "$lib/canisters/nns-dapp/nns-dapp.types";
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
+import { icpAccountBalancesStore } from "$lib/stores/icp-account-balances.store";
+import { icpAccountDetailsStore } from "$lib/stores/icp-account-details.store";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { get } from "svelte/store";
+
+describe("icpAccountsStore", () => {
+  const mainAccountIdentifier = "mainAccountIdentifier";
+  const subAccountIdentifier = "subAccountIdentifier";
+  const hardwareWalletAccountIdentifier = "hardwareWalletAccountIdentifier";
+
+  const mainAccountBalance = 100_000_000n;
+  const subAccountBalance = 200_000_000n;
+  const hardwareWalletAccountBalance = 500_000_000n;
+
+  const mainAccountPrincipal = principal(11);
+  const hardwareWalletAccountPrincipal = principal(42);
+
+  const subAccountName = "My subaccount";
+  const hardwareWalletAccountName = "My Nano S";
+  const subAccountArray = [54, 65, 76, 87];
+
+  const hardwareWalletAccount: HardwareWalletAccountDetails = {
+    principal: hardwareWalletAccountPrincipal,
+    name: hardwareWalletAccountName,
+    account_identifier: hardwareWalletAccountIdentifier,
+  };
+
+  const subAccount: SubAccountDetails = {
+    name: subAccountName,
+    sub_account: subAccountArray,
+    account_identifier: subAccountIdentifier,
+  };
+
+  const accountDetails: AccountDetails = {
+    principal: mainAccountPrincipal,
+    account_identifier: mainAccountIdentifier,
+    hardware_wallet_accounts: [hardwareWalletAccount],
+    sub_accounts: [subAccount],
+  };
+
+  const accountDetailsData = {
+    accountDetails,
+    certified: true,
+  };
+
+  beforeEach(() => {
+    icpAccountDetailsStore.reset();
+    icpAccountBalancesStore.reset();
+  });
+
+  it("should be initialized to empty", () => {
+    expect(get(icpAccountsStore)).toEqual({
+      main: undefined,
+      subAccounts: undefined,
+      hardwareWallets: undefined,
+    });
+  });
+
+  it("should derived main account and balance", () => {
+    icpAccountDetailsStore.set({
+      accountDetails: {
+        ...accountDetails,
+        sub_accounts: [],
+        hardware_wallet_accounts: [],
+      },
+      certified: true,
+    });
+
+    icpAccountBalancesStore.setBalance({
+      accountIdentifier: mainAccountIdentifier,
+      balanceE8s: mainAccountBalance,
+      certified: true,
+    });
+
+    expect(get(icpAccountsStore)).toEqual({
+      main: {
+        balanceUlps: mainAccountBalance,
+        icpIdentifier: mainAccountIdentifier,
+        identifier: mainAccountIdentifier,
+        principal: mainAccountPrincipal,
+        type: "main",
+      },
+      subAccounts: [],
+      hardwareWallets: [],
+    });
+  });
+
+  it("should derived all accounts and balances", () => {
+    icpAccountDetailsStore.set(accountDetailsData);
+
+    icpAccountBalancesStore.setBalance({
+      accountIdentifier: mainAccountIdentifier,
+      balanceE8s: mainAccountBalance,
+      certified: true,
+    });
+
+    icpAccountBalancesStore.setBalance({
+      accountIdentifier: subAccountIdentifier,
+      balanceE8s: subAccountBalance,
+      certified: true,
+    });
+
+    icpAccountBalancesStore.setBalance({
+      accountIdentifier: hardwareWalletAccountIdentifier,
+      balanceE8s: hardwareWalletAccountBalance,
+      certified: true,
+    });
+
+    expect(get(icpAccountsStore)).toEqual({
+      main: {
+        balanceUlps: mainAccountBalance,
+        icpIdentifier: mainAccountIdentifier,
+        identifier: mainAccountIdentifier,
+        principal: mainAccountPrincipal,
+        type: "main",
+      },
+      subAccounts: [
+        {
+          balanceUlps: subAccountBalance,
+          icpIdentifier: subAccountIdentifier,
+          identifier: subAccountIdentifier,
+          name: subAccountName,
+          subAccount: subAccountArray,
+          type: "subAccount",
+        },
+      ],
+      hardwareWallets: [
+        {
+          balanceUlps: hardwareWalletAccountBalance,
+          icpIdentifier: hardwareWalletAccountIdentifier,
+          identifier: hardwareWalletAccountIdentifier,
+          name: hardwareWalletAccountName,
+          principal: hardwareWalletAccountPrincipal,
+          type: "hardwareWallet",
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

The current icpAccountStore holds a combination of accounts and balances in a single store. This means all the data has to be loaded together and if we just want to change a balances, we have to manipulate the data in the store, which can interfere with loading the accounts.

The cleaner way is to have a separate store for accounts and a separate store for balances and a derived store which merged both into accounts with balances. That way when we update a balance in the balances store, it will just automatically recreate the accounts with balances.

In this PR, I'm adding the derived `icpAccountsStore` which is derived from the `icpAccountDetailsStore` and the `icpAccountBalancesStore`. It is designed to be a drop-in replacement for the existing non-derived `icpAccountsStore` so it has the same initial value (except for the `certified` field).

The code for `mapAccount` is mostly copied from the `mapAccount` function in `icp-accounts.services.ts` [here](https://github.com/dfinity/nns-dapp/blob/67bedd56e88351825a50c5d03578d5b634067cbf/frontend/src/lib/services/icp-accounts.services.ts#L118-L140).

The store will be used an another PR when the stores that it is derived from are actually populated.

# Changes

Add derived `icpAccountsStore`.

# Tests

Add unit tests for `icpAccountsStore`.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet