### PR TITLE
Display actionable proposals

### DIFF
--- a/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  export let count: number;
+</script>
+
+<span data-tid="actionable-proposal-count-badge-component" class="tag"
+  >{count}</span
+>
+
+<style lang="scss">
+  span {
+    background: var(--primary);
+    color: var(--primary-contrast);
+    border-radius: var(--padding-8x);
+  }
+</style>

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -40,9 +40,8 @@
     });
 
   let actionableProposalCount: number | undefined = undefined;
-  $: actionableProposalCount = $actionableProposalIndicationEnabledStore
-    ? $actionableProposalCountStore[universe.canisterId]
-    : undefined;
+  $: actionableProposalCount =
+    $actionableProposalCountStore[universe.canisterId];
 </script>
 
 <Card

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -7,6 +7,12 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import { isSelectedPath } from "$lib/utils/navigation.utils";
   import type { Universe } from "$lib/types/universe";
+  import { nonNullish } from "@dfinity/utils";
+  import {
+    actionableProposalCountStore,
+    actionableProposalIndicationEnabledStore,
+  } from "$lib/derived/actionable-proposals.derived";
+  import ActionableProposalCountBadge from "$lib/components/proposals/ActionableProposalCountBadge.svelte";
 
   export let selected: boolean;
   export let role: "link" | "button" | "dropdown" = "link";
@@ -32,6 +38,13 @@
       currentPath: $pageStore.path,
       paths: [AppPath.Accounts, AppPath.Wallet],
     });
+
+  let actionableProposalCount: number | undefined = undefined;
+  $: actionableProposalCount = $actionableProposalIndicationEnabledStore
+    ? $actionableProposalCountStore[universe.canisterId]
+    : undefined;
+
+  ActionableProposalCountBadge;
 </script>
 
 <Card
@@ -50,7 +63,14 @@
       class={`content ${role}`}
       class:balance={displayProjectAccountsBalance}
     >
-      <span class="name">{universe.title}</span>
+      <span class="name">
+        {universe.title}
+        {#if nonNullish(actionableProposalCount)}
+          <ActionableProposalCountBadge
+            >{actionableProposalCount}</ActionableProposalCountBadge
+          >
+        {/if}
+      </span>
       {#if displayProjectAccountsBalance}
         <UniverseAccountsBalance {universe} />
       {/if}
@@ -102,5 +122,10 @@
   .name {
     @include fonts.standard(true);
     @include text.clamp(2);
+
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--padding);
   }
 </style>

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -8,11 +8,9 @@
   import { isSelectedPath } from "$lib/utils/navigation.utils";
   import type { Universe } from "$lib/types/universe";
   import { nonNullish } from "@dfinity/utils";
-  import {
-    actionableProposalCountStore,
-    actionableProposalIndicationEnabledStore,
-  } from "$lib/derived/actionable-proposals.derived";
+  import { actionableProposalCountStore } from "$lib/derived/actionable-proposals.derived";
   import ActionableProposalCountBadge from "$lib/components/proposals/ActionableProposalCountBadge.svelte";
+  import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
 
   export let selected: boolean;
   export let role: "link" | "button" | "dropdown" = "link";
@@ -40,8 +38,9 @@
     });
 
   let actionableProposalCount: number | undefined = undefined;
-  $: actionableProposalCount =
-    $actionableProposalCountStore[universe.canisterId];
+  $: actionableProposalCount = ENABLE_VOTING_INDICATION
+    ? $actionableProposalCountStore[universe.canisterId]
+    : undefined;
 </script>
 
 <Card

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -38,7 +38,7 @@
     });
 
   let actionableProposalCount: number | undefined = undefined;
-  $: actionableProposalCount = ENABLE_VOTING_INDICATION
+  $: actionableProposalCount = $ENABLE_VOTING_INDICATION
     ? $actionableProposalCountStore[universe.canisterId]
     : undefined;
 </script>

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -43,8 +43,6 @@
   $: actionableProposalCount = $actionableProposalIndicationEnabledStore
     ? $actionableProposalCountStore[universe.canisterId]
     : undefined;
-
-  ActionableProposalCountBadge;
 </script>
 
 <Card
@@ -66,9 +64,7 @@
       <span class="name">
         {universe.title}
         {#if nonNullish(actionableProposalCount)}
-          <ActionableProposalCountBadge
-            >{actionableProposalCount}</ActionableProposalCountBadge
-          >
+          <ActionableProposalCountBadge count={actionableProposalCount} />
         {/if}
       </span>
       {#if displayProjectAccountsBalance}

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -61,7 +61,7 @@
     >
       <span class="name">
         {universe.title}
-        {#if nonNullish(actionableProposalCount)}
+        {#if nonNullish(actionableProposalCount) && actionableProposalCount > 0}
           <ActionableProposalCountBadge count={actionableProposalCount} />
         {/if}
       </span>

--- a/frontend/src/lib/components/universe/SelectUniverseNav.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNav.svelte
@@ -13,9 +13,12 @@
   let list = false;
 
   $: list = innerWidth > BREAKPOINT_LARGE;
-  $: $ENABLE_VOTING_INDICATION &&
-    $actionableProposalIndicationEnabledStore &&
+  $: if (
+    $ENABLE_VOTING_INDICATION &&
+    $actionableProposalIndicationEnabledStore
+  ) {
     loadActionableProposals();
+  }
   $: if (
     $ENABLE_VOTING_INDICATION &&
     $actionableProposalIndicationEnabledStore &&

--- a/frontend/src/lib/components/universe/SelectUniverseNav.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNav.svelte
@@ -3,11 +3,11 @@
   import SelectUniverseNavList from "$lib/components/universe/SelectUniverseNavList.svelte";
   import SelectUniverseDropdown from "$lib/components/universe/SelectUniverseDropdown.svelte";
   import { titleTokenSelectorStore } from "$lib/derived/title-token-selector.derived";
-  import { updateActionableSnsProposals } from "$lib/services/$public/sns-actionable-proposals.services";
-  import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
   import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
-  import { actionableProposalIndicationEnabledStore } from "$lib/derived/actionable-proposal.derived";
-  import { updateActionableProposals } from "$lib/services/$public/actionable-proposals.services";
+  import { actionableProposalIndicationEnabledStore } from "$lib/derived/actionable-proposals.derived";
+  import { loadActionableProposals } from "$lib/services/actionable-proposals.services";
+  import { loadActionableSnsProposals } from "$lib/services/actionable-sns-proposals.services";
+  import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 
   let innerWidth = 0;
   let list = false;
@@ -15,13 +15,14 @@
   $: list = innerWidth > BREAKPOINT_LARGE;
   $: $ENABLE_VOTING_INDICATION &&
     $actionableProposalIndicationEnabledStore &&
-    updateActionableProposals();
+    loadActionableProposals();
   $: if (
     $ENABLE_VOTING_INDICATION &&
     $actionableProposalIndicationEnabledStore &&
-    $selectableUniversesStore.length > 1
+    // Check for length in case the sns list is not yet loaded
+    $snsProjectsCommittedStore.length > 1
   ) {
-    updateActionableSnsProposals();
+    loadActionableSnsProposals();
   }
 </script>
 

--- a/frontend/src/lib/components/universe/SelectUniverseNav.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNav.svelte
@@ -13,11 +13,11 @@
   let list = false;
 
   $: list = innerWidth > BREAKPOINT_LARGE;
-  $: ENABLE_VOTING_INDICATION &&
+  $: $ENABLE_VOTING_INDICATION &&
     $actionableProposalIndicationEnabledStore &&
     loadActionableProposals();
   $: if (
-    ENABLE_VOTING_INDICATION &&
+    $ENABLE_VOTING_INDICATION &&
     $actionableProposalIndicationEnabledStore &&
     // Check for the length in case the sns list is not yet loaded
     $snsProjectsCommittedStore.length > 0

--- a/frontend/src/lib/components/universe/SelectUniverseNav.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNav.svelte
@@ -7,13 +7,17 @@
   import { loadActionableProposals } from "$lib/services/actionable-proposals.services";
   import { loadActionableSnsProposals } from "$lib/services/actionable-sns-proposals.services";
   import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
+  import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
 
   let innerWidth = 0;
   let list = false;
 
   $: list = innerWidth > BREAKPOINT_LARGE;
-  $: $actionableProposalIndicationEnabledStore && loadActionableProposals();
+  $: ENABLE_VOTING_INDICATION &&
+    $actionableProposalIndicationEnabledStore &&
+    loadActionableProposals();
   $: if (
+    ENABLE_VOTING_INDICATION &&
     $actionableProposalIndicationEnabledStore &&
     // Check for the length in case the sns list is not yet loaded
     $snsProjectsCommittedStore.length > 0

--- a/frontend/src/lib/components/universe/SelectUniverseNav.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNav.svelte
@@ -3,11 +3,26 @@
   import SelectUniverseNavList from "$lib/components/universe/SelectUniverseNavList.svelte";
   import SelectUniverseDropdown from "$lib/components/universe/SelectUniverseDropdown.svelte";
   import { titleTokenSelectorStore } from "$lib/derived/title-token-selector.derived";
+  import { updateActionableSnsProposals } from "$lib/services/$public/sns-actionable-proposals.services";
+  import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
+  import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
+  import { actionableProposalIndicationEnabledStore } from "$lib/derived/actionable-proposal.derived";
+  import { updateActionableProposals } from "$lib/services/$public/actionable-proposals.services";
 
   let innerWidth = 0;
   let list = false;
 
   $: list = innerWidth > BREAKPOINT_LARGE;
+  $: $ENABLE_VOTING_INDICATION &&
+    $actionableProposalIndicationEnabledStore &&
+    updateActionableProposals();
+  $: if (
+    $ENABLE_VOTING_INDICATION &&
+    $actionableProposalIndicationEnabledStore &&
+    $selectableUniversesStore.length > 1
+  ) {
+    updateActionableSnsProposals();
+  }
 </script>
 
 <svelte:window bind:innerWidth />

--- a/frontend/src/lib/components/universe/SelectUniverseNav.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNav.svelte
@@ -15,8 +15,8 @@
   $: $actionableProposalIndicationEnabledStore && loadActionableProposals();
   $: if (
     $actionableProposalIndicationEnabledStore &&
-    // Check for length in case the sns list is not yet loaded
-    $snsProjectsCommittedStore.length > 1
+    // Check for the length in case the sns list is not yet loaded
+    $snsProjectsCommittedStore.length > 0
   ) {
     loadActionableSnsProposals();
   }

--- a/frontend/src/lib/components/universe/SelectUniverseNav.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNav.svelte
@@ -3,7 +3,6 @@
   import SelectUniverseNavList from "$lib/components/universe/SelectUniverseNavList.svelte";
   import SelectUniverseDropdown from "$lib/components/universe/SelectUniverseDropdown.svelte";
   import { titleTokenSelectorStore } from "$lib/derived/title-token-selector.derived";
-  import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
   import { actionableProposalIndicationEnabledStore } from "$lib/derived/actionable-proposals.derived";
   import { loadActionableProposals } from "$lib/services/actionable-proposals.services";
   import { loadActionableSnsProposals } from "$lib/services/actionable-sns-proposals.services";
@@ -13,11 +12,8 @@
   let list = false;
 
   $: list = innerWidth > BREAKPOINT_LARGE;
-  $: $ENABLE_VOTING_INDICATION &&
-    $actionableProposalIndicationEnabledStore &&
-    loadActionableProposals();
+  $: $actionableProposalIndicationEnabledStore && loadActionableProposals();
   $: if (
-    $ENABLE_VOTING_INDICATION &&
     $actionableProposalIndicationEnabledStore &&
     // Check for length in case the sns list is not yet loaded
     $snsProjectsCommittedStore.length > 1

--- a/frontend/src/lib/derived/actionable-proposals.derived.ts
+++ b/frontend/src/lib/derived/actionable-proposals.derived.ts
@@ -6,7 +6,6 @@ import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposal
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
 import { isSelectedPath } from "$lib/utils/navigation.utils";
 import { mapEntries } from "$lib/utils/utils";
-import { isNullish } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 
 export interface ActionableProposalCountData {
@@ -19,13 +18,11 @@ export const actionableProposalIndicationEnabledStore: Readable<boolean> =
   derived(
     [pageStore, authSignedInStore],
     ([{ path: currentPath }, isSignedIn]) =>
-      isNullish(currentPath)
-        ? false
-        : isSignedIn &&
-          isSelectedPath({
-            currentPath,
-            paths: [AppPath.Proposals],
-          })
+      isSignedIn &&
+      isSelectedPath({
+        currentPath,
+        paths: [AppPath.Proposals],
+      })
   );
 
 /** A store that contains the count of proposals that can be voted on by the user mapped by canister id (nns + snses) */

--- a/frontend/src/lib/derived/actionable-proposals.derived.ts
+++ b/frontend/src/lib/derived/actionable-proposals.derived.ts
@@ -4,10 +4,11 @@ import { authSignedInStore } from "$lib/derived/auth.derived";
 import { pageStore } from "$lib/derived/page.derived";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
+import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
 import { isSelectedPath } from "$lib/utils/navigation.utils";
 import { mapEntries } from "$lib/utils/utils";
 import { isNullish } from "@dfinity/utils";
-import { derived, type Readable } from "svelte/store";
+import { derived, get, type Readable } from "svelte/store";
 
 export interface ActionableProposalCountData {
   // We use the root canister id as the key to identify the proposals for a specific project.
@@ -19,7 +20,7 @@ export const actionableProposalIndicationEnabledStore: Readable<boolean> =
   derived(
     [pageStore, authSignedInStore],
     ([{ path: currentPath }, isSignedIn]) =>
-      isNullish(currentPath)
+      isNullish(currentPath) || !get(ENABLE_VOTING_INDICATION)
         ? false
         : isSignedIn &&
           isSelectedPath({

--- a/frontend/src/lib/derived/actionable-proposals.derived.ts
+++ b/frontend/src/lib/derived/actionable-proposals.derived.ts
@@ -4,11 +4,10 @@ import { authSignedInStore } from "$lib/derived/auth.derived";
 import { pageStore } from "$lib/derived/page.derived";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
-import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
 import { isSelectedPath } from "$lib/utils/navigation.utils";
 import { mapEntries } from "$lib/utils/utils";
 import { isNullish } from "@dfinity/utils";
-import { derived, get, type Readable } from "svelte/store";
+import { derived, type Readable } from "svelte/store";
 
 export interface ActionableProposalCountData {
   // We use the root canister id as the key to identify the proposals for a specific project.
@@ -20,7 +19,7 @@ export const actionableProposalIndicationEnabledStore: Readable<boolean> =
   derived(
     [pageStore, authSignedInStore],
     ([{ path: currentPath }, isSignedIn]) =>
-      isNullish(currentPath) || !get(ENABLE_VOTING_INDICATION)
+      isNullish(currentPath)
         ? false
         : isSignedIn &&
           isSelectedPath({

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -18,12 +18,12 @@ import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { nnsUniverseMock } from "$tests/mocks/universe.mock";
 import { SelectUniverseCardPo } from "$tests/page-objects/SelectUniverseCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import { Principal } from "@dfinity/principal";
 import {
   resetAccountsForTesting,
   setAccountsForTesting,
 } from "$tests/utils/accounts.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { Principal } from "@dfinity/principal";
 import { render } from "@testing-library/svelte";
 import { describe } from "vitest";
 

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -1,6 +1,7 @@
 import SelectUniverseCard from "$lib/components/universe/SelectUniverseCard.svelte";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
+import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
 import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import type { Universe } from "$lib/types/universe";
 import { createUniverse } from "$lib/utils/universe.utils";
@@ -13,9 +14,11 @@ import {
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
 import { mockSummary } from "$tests/mocks/sns-projects.mock";
+import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { nnsUniverseMock } from "$tests/mocks/universe.mock";
 import { SelectUniverseCardPo } from "$tests/page-objects/SelectUniverseCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { Principal } from "@dfinity/principal";
 import { render } from "@testing-library/svelte";
 
 describe("SelectUniverseCard", () => {
@@ -208,6 +211,27 @@ describe("SelectUniverseCard", () => {
         });
         expect(await po.getUniverseAccountsBalancePo().isPresent()).toBe(true);
         expect(await po.getUniverseAccountsBalancePo().isLoaded()).toBe(false);
+      });
+
+      it.only("should display actionable proposal count", async () => {
+        page.mock({
+          data: { universe: OWN_CANISTER_ID_TEXT },
+          routeId: AppPath.Proposals,
+        });
+
+        actionableSnsProposalsStore.setProposals({
+          rootCanisterId: Principal.from(mockSnsUniverse.canisterId),
+          proposals: [mockSnsProposal, mockSnsProposal],
+        });
+
+        const po = renderComponent({
+          props: { universe: mockSnsUniverse, selected: false },
+        });
+
+        expect(await po.getActionableProposalCountBadgePo().isPresent()).toBe(
+          true
+        );
+        expect(await po.getActionableProposalCount()).toBe("2");
       });
     });
 

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -235,6 +235,26 @@ describe("SelectUniverseCard", () => {
         expect(await po.getActionableProposalCount()).toBe("2");
       });
 
+      it("should not display actionable proposal count when it's 0", async () => {
+        page.mock({
+          data: { universe: OWN_CANISTER_ID_TEXT },
+          routeId: AppPath.Proposals,
+        });
+
+        actionableSnsProposalsStore.setProposals({
+          rootCanisterId: Principal.from(mockSnsUniverse.canisterId),
+          proposals: [],
+        });
+
+        const po = renderComponent({
+          props: { universe: mockSnsUniverse, selected: false },
+        });
+
+        expect(await po.getActionableProposalCountBadgePo().isPresent()).toBe(
+          false
+        );
+      });
+
       it("should not display actionable proposal count when no data", async () => {
         page.mock({
           data: { universe: OWN_CANISTER_ID_TEXT },

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -159,6 +159,7 @@ describe("SelectUniverseCard", () => {
     describe("when signed in", () => {
       beforeEach(() => {
         resetIdentity();
+        actionableSnsProposalsStore.resetForTesting();
       });
 
       it("should display balance if selected", async () => {
@@ -213,7 +214,7 @@ describe("SelectUniverseCard", () => {
         expect(await po.getUniverseAccountsBalancePo().isLoaded()).toBe(false);
       });
 
-      it.only("should display actionable proposal count", async () => {
+      it("should display actionable proposal count", async () => {
         page.mock({
           data: { universe: OWN_CANISTER_ID_TEXT },
           routeId: AppPath.Proposals,

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -234,6 +234,21 @@ describe("SelectUniverseCard", () => {
         );
         expect(await po.getActionableProposalCount()).toBe("2");
       });
+
+      it("should not display actionable proposal count when no data", async () => {
+        page.mock({
+          data: { universe: OWN_CANISTER_ID_TEXT },
+          routeId: AppPath.Proposals,
+        });
+
+        const po = renderComponent({
+          props: { universe: mockSnsUniverse, selected: false },
+        });
+
+        expect(await po.getActionableProposalCountBadgePo().isPresent()).toBe(
+          false
+        );
+      });
     });
 
     describe("when not signed in", () => {

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
@@ -101,7 +101,7 @@ describe("SelectUniverseNav", () => {
   const spyQuerySnsProposals = vi
     .spyOn(snsGovernanceApi, "queryProposals")
     .mockImplementation(
-      async ({ rootCanisterId }) =>
+      async () =>
         ({
           proposals: [votableSnsProposal1, votableSnsProposal2],
           include_ballots_by_caller: [true],

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
@@ -185,7 +185,7 @@ describe("SelectUniverseNav", () => {
     const po = await renderComponent();
     await runResolvedPromises();
 
-    // nns is selected by default
+    // nns is the current universe
     expect(
       await po.getSelectUniverseCardPo().getActionableProposalCount()
     ).toEqual("1");

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
@@ -1,0 +1,74 @@
+import SelectUniverseNav from "$lib/components/universe/SelectUniverseNav.svelte";
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { AppPath } from "$lib/constants/routes.constants";
+import * as actionableProposalsServices from "$lib/services/actionable-proposals.services";
+import * as actionableSnsProposalsServices from "$lib/services/actionable-sns-proposals.services";
+import { page } from "$mocks/$app/stores";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { SelectUniverseDropdownPo } from "$tests/page-objects/SelectUniverseDropdown.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { SnsSwapLifecycle } from "@dfinity/sns";
+import { render } from "@testing-library/svelte";
+
+describe("SelectUniverseNav", () => {
+  const spyLoadActionableProposals = vi.spyOn(
+    actionableProposalsServices,
+    "loadActionableProposals"
+  );
+  const spyLoadActionableSnsProposals = vi.spyOn(
+    actionableSnsProposalsServices,
+    "loadActionableSnsProposals"
+  );
+  const renderComponent = () => {
+    const { container } = render(SelectUniverseNav);
+    return SelectUniverseDropdownPo.under(new JestPageObjectElement(container));
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetSnsProjects();
+    resetIdentity();
+
+    page.mock({
+      data: { universe: OWN_CANISTER_ID_TEXT },
+      routeId: AppPath.Proposals,
+    });
+  });
+
+  afterAll(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render select universe component", async () => {
+    const po = await renderComponent();
+    expect(await po.getSelectUniverseCardPo().isPresent()).toEqual(true);
+  });
+
+  it("should load Nns neurons and proposals", async () => {
+    expect(spyLoadActionableProposals).toHaveBeenCalledTimes(0);
+    await renderComponent();
+    await runResolvedPromises();
+    expect(spyLoadActionableProposals).toHaveBeenCalledTimes(1);
+  });
+
+  it("should load actionable Sns proposals", async () => {
+    expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(0);
+    setSnsProjects([{ lifecycle: SnsSwapLifecycle.Committed }]);
+    await renderComponent();
+    await runResolvedPromises();
+    expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(1);
+  });
+
+  it("should load actionable Sns proposals after sns list update", async () => {
+    expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(0);
+    await renderComponent();
+    await runResolvedPromises();
+    expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(0);
+
+    setSnsProjects([{ lifecycle: SnsSwapLifecycle.Committed }]);
+    await runResolvedPromises();
+    expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
@@ -1,18 +1,112 @@
+import * as governanceApi from "$lib/api/governance.api";
+import * as api from "$lib/api/proposals.api";
+import * as snsGovernanceApi from "$lib/api/sns-governance.api";
 import SelectUniverseNav from "$lib/components/universe/SelectUniverseNav.svelte";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import * as actionableProposalsServices from "$lib/services/actionable-proposals.services";
 import * as actionableSnsProposalsServices from "$lib/services/actionable-sns-proposals.services";
+import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
+import { neuronsStore } from "$lib/stores/neurons.store";
+import { enumValues } from "$lib/utils/enum.utils";
+import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { page } from "$mocks/$app/stores";
-import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { mockProposalInfo } from "$tests/mocks/proposal.mock";
+import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
+import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { SelectUniverseDropdownPo } from "$tests/page-objects/SelectUniverseDropdown.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import { SnsSwapLifecycle } from "@dfinity/sns";
+import type { NeuronInfo, ProposalInfo } from "@dfinity/nns";
+import {
+  SnsNeuronPermissionType,
+  SnsProposalDecisionStatus,
+  SnsProposalRewardStatus,
+  SnsSwapLifecycle,
+  SnsVote,
+  neuronSubaccount,
+  type SnsBallot,
+  type SnsListProposalsResponse,
+  type SnsNeuron,
+  type SnsNeuronId,
+  type SnsProposalData,
+} from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
 describe("SelectUniverseNav", () => {
+  const neuron: NeuronInfo = {
+    ...mockNeuron,
+    neuronId: 0n,
+    recentBallots: [],
+  };
+  const votableProposal: ProposalInfo = {
+    ...mockProposalInfo,
+
+    id: 0n,
+  };
+  let spyQueryProposals = vi
+    .spyOn(api, "queryProposals")
+    .mockResolvedValue([votableProposal]);
+  let spyQueryNeurons = vi
+    .spyOn(governanceApi, "queryNeurons")
+    .mockResolvedValue([neuron]);
+  const subaccount = neuronSubaccount({
+    controller: mockIdentity.getPrincipal(),
+    index: 0,
+  });
+  const snsNeuronId: SnsNeuronId = { id: subaccount };
+  const allPermissions = Int32Array.from(enumValues(SnsNeuronPermissionType));
+  const snsNeuron: SnsNeuron = {
+    ...mockSnsNeuron,
+    created_timestamp_seconds: 0n,
+    id: [snsNeuronId] as [SnsNeuronId],
+    permissions: [
+      {
+        principal: [mockIdentity.getPrincipal()],
+        permission_type: allPermissions,
+      },
+    ],
+  };
+  const snsNeuronIdHex = getSnsNeuronIdAsHexString(snsNeuron);
+  const votableSnsProposalProps = {
+    proposalId: 0n,
+    createdAt: 1n,
+    status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+    rewardStatus: SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
+    ballots: [
+      [
+        snsNeuronIdHex,
+        {
+          vote: SnsVote.Unspecified,
+          cast_timestamp_seconds: 123n,
+          voting_power: 10000n,
+        },
+      ],
+    ] as [string, SnsBallot][],
+  };
+  const votableSnsProposal1: SnsProposalData = createSnsProposal({
+    ...votableSnsProposalProps,
+    proposalId: 0n,
+  });
+  const votableSnsProposal2: SnsProposalData = createSnsProposal({
+    ...votableSnsProposalProps,
+    proposalId: 1n,
+  });
+  const spyQuerySnsNeurons = vi
+    .spyOn(snsGovernanceApi, "querySnsNeurons")
+    .mockResolvedValue([snsNeuron]);
+  const spyQuerySnsProposals = vi
+    .spyOn(snsGovernanceApi, "queryProposals")
+    .mockImplementation(
+      async ({ rootCanisterId }) =>
+        ({
+          proposals: [votableSnsProposal1, votableSnsProposal2],
+          include_ballots_by_caller: [true],
+        }) as SnsListProposalsResponse
+    );
   const spyLoadActionableProposals = vi.spyOn(
     actionableProposalsServices,
     "loadActionableProposals"
@@ -29,8 +123,22 @@ describe("SelectUniverseNav", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetSnsProjects();
-    resetIdentity();
+    neuronsStore.reset();
+    actionableNnsProposalsStore.reset();
 
+    spyQueryNeurons.mockClear();
+    spyQueryProposals.mockClear();
+    spyQuerySnsNeurons.mockClear();
+    spyQuerySnsProposals.mockClear();
+
+    spyQueryProposals = vi
+      .spyOn(api, "queryProposals")
+      .mockResolvedValue([votableProposal]);
+    spyQueryNeurons = vi
+      .spyOn(governanceApi, "queryNeurons")
+      .mockResolvedValue([neuron]);
+
+    resetIdentity();
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT },
       routeId: AppPath.Proposals,
@@ -70,5 +178,27 @@ describe("SelectUniverseNav", () => {
     setSnsProjects([{ lifecycle: SnsSwapLifecycle.Committed }]);
     await runResolvedPromises();
     expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(1);
+  });
+
+  it("should display actionable proposal count", async () => {
+    setSnsProjects([{ lifecycle: SnsSwapLifecycle.Committed }]);
+    const po = await renderComponent();
+    await runResolvedPromises();
+
+    // nns is selected by default
+    expect(
+      await po.getSelectUniverseCardPo().getActionableProposalCount()
+    ).toEqual("1");
+
+    // open project list
+    await po.getSelectUniverseCardPo().click();
+    expect(await po.getSelectUniverseListPo().isPresent()).toBe(true);
+    // nns is the first card
+    const cardPos = await po
+      .getSelectUniverseListPo()
+      .getSelectUniverseCardPos();
+    expect(cardPos.length).toEqual(2);
+    expect(await cardPos[0].getActionableProposalCount()).toEqual("1");
+    expect(await cardPos[1].getActionableProposalCount()).toEqual("2");
   });
 });

--- a/frontend/src/tests/page-objects/ActionableProposalCountBadge.page-object.ts
+++ b/frontend/src/tests/page-objects/ActionableProposalCountBadge.page-object.ts
@@ -1,0 +1,12 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ActionableProposalCountBadgePo extends BasePageObject {
+  private static readonly TID = "actionable-proposal-count-badge-component";
+
+  static under(element: PageObjectElement): ActionableProposalCountBadgePo {
+    return new ActionableProposalCountBadgePo(
+      element.byTestId(ActionableProposalCountBadgePo.TID)
+    );
+  }
+}

--- a/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
@@ -42,8 +42,8 @@ export class SelectUniverseCardPo extends CardPo {
     return UniverseLogoPo.under(this.root);
   }
 
-  getName(): Promise<string> {
-    return this.root.querySelector("span.name").getText();
+  async getName(): Promise<string> {
+    return (await this.root.querySelector("span.name").getText()).trim();
   }
 
   getLogoAltText(): Promise<string> {

--- a/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
@@ -1,3 +1,4 @@
+import { ActionableProposalCountBadgePo } from "$tests/page-objects/ActionableProposalCountBadge.page-object";
 import { CardPo } from "$tests/page-objects/Card.page-object";
 import { UniverseAccountsBalancePo } from "$tests/page-objects/UniverseAccountsBalance.page-object";
 import { UniverseLogoPo } from "$tests/page-objects/UniverseLogo.page-object";
@@ -59,5 +60,13 @@ export class SelectUniverseCardPo extends CardPo {
 
   hasBalance(): Promise<boolean> {
     return this.getUniverseAccountsBalancePo().isPresent();
+  }
+
+  getActionableProposalCountBadgePo(): ActionableProposalCountBadgePo {
+    return ActionableProposalCountBadgePo.under(this.root);
+  }
+
+  getActionableProposalCount(): Promise<string> {
+    return this.getActionableProposalCountBadgePo().getText();
   }
 }


### PR DESCRIPTION
# Motivation

Load and display the actionable proposal count (APC).

# Changes

- use `ENABLE_VOTING_INDICATION` flag in the `actionableProposalIndicationEnabledStore` to not pollute the components.
- load APC from `SelectUniverseNav`
- new `ActionableProposalCountBadge` component
- render APC on in `SelectUniverseCard` component

# Tests

- `ActionableProposalCountBadge` page object
- `SelectUniverseCard` should display actionable proposal count
- `SelectUniverseCard` should not display actionable proposal count when no data
- `SelectUniverseNav` should load APC

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet