### PR TITLE
feat: Timer counter

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Add `ENABLE_ICP_INDEX` feature flag.
+* Add metrics and logging for schema migration.
 
 #### Changed
 

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -7,6 +7,7 @@ use candid::CandidType;
 use dfn_candid::Candid;
 use histogram::AccountsStoreHistogram;
 use ic_base_types::{CanisterId, PrincipalId};
+use ic_cdk::println;
 use ic_crypto_sha::Sha256;
 use ic_ledger_core::timestamp::TimeStamp;
 use ic_ledger_core::tokens::SignedTokens;

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -1621,8 +1621,10 @@ impl StableState for AccountsStore {
         }
 
         let accounts_db_stats = if let Some(counts) = accounts_db_stats_maybe {
+            println!("Using de-serialized accounts_db stats");
             counts
         } else {
+            println!("Re-counting accounts_db stats...");
             let mut sub_accounts_count: u64 = 0;
             let mut hardware_wallet_accounts_count: u64 = 0;
             for account in accounts.values() {

--- a/rs/backend/src/perf.rs
+++ b/rs/backend/src/perf.rs
@@ -36,6 +36,9 @@ impl PerformanceCount {
 pub struct PerformanceCounts {
     pub instruction_counts: VecDeque<PerformanceCount>,
     pub exceptional_transactions: Option<VecDeque<u64>>,
+    // TODO: Delete this once the stable memory migration is complete.  This is used purely to get
+    // an idea of how long migration is likely to take.
+    pub periodic_tasks_run: Option<u32>,
 }
 
 impl PerformanceCounts {
@@ -55,6 +58,7 @@ impl PerformanceCounts {
                 .as_ref()
                 .map_or(0, |x| u32::try_from(x.len()).unwrap_or(u32::MAX)),
         );
+        stats.periodic_tasks_run = self.periodic_tasks_run;
     }
 
     /// The maximum number of exceptional transaction IDs we store.
@@ -68,6 +72,10 @@ impl PerformanceCounts {
             exceptional_transactions.push_front(transaction_id);
             exceptional_transactions.truncate(Self::MAX_EXCEPTIONAL_TRANSACTIONS);
         }
+    }
+
+    pub fn increment_periodic_tasks_run(&mut self) {
+        self.periodic_tasks_run = Some(self.periodic_tasks_run.unwrap_or(0) + 1);
     }
 
     /// Generates sample data for use in tests

--- a/rs/backend/src/perf.rs
+++ b/rs/backend/src/perf.rs
@@ -38,7 +38,7 @@ pub struct PerformanceCounts {
     pub exceptional_transactions: Option<VecDeque<u64>>,
     // TODO[NNS1-2913]: Delete this once the stable memory migration is complete.  This is used purely to get
     // an idea of how long, in wall clock time, migration is likely to take.
-    pub periodic_tasks_run: Option<u32>,
+    pub periodic_tasks_count: Option<u32>,
 }
 
 impl PerformanceCounts {
@@ -58,7 +58,7 @@ impl PerformanceCounts {
                 .as_ref()
                 .map_or(0, |x| u32::try_from(x.len()).unwrap_or(u32::MAX)),
         );
-        stats.periodic_tasks_run = self.periodic_tasks_run;
+        stats.periodic_tasks_count = self.periodic_tasks_count;
     }
 
     /// The maximum number of exceptional transaction IDs we store.
@@ -75,7 +75,7 @@ impl PerformanceCounts {
     }
 
     pub fn increment_periodic_tasks_run(&mut self) {
-        self.periodic_tasks_run = Some(self.periodic_tasks_run.unwrap_or(0) + 1);
+        self.periodic_tasks_count = Some(self.periodic_tasks_count.unwrap_or(0) + 1);
     }
 
     /// Generates sample data for use in tests

--- a/rs/backend/src/perf.rs
+++ b/rs/backend/src/perf.rs
@@ -36,8 +36,8 @@ impl PerformanceCount {
 pub struct PerformanceCounts {
     pub instruction_counts: VecDeque<PerformanceCount>,
     pub exceptional_transactions: Option<VecDeque<u64>>,
-    // TODO: Delete this once the stable memory migration is complete.  This is used purely to get
-    // an idea of how long migration is likely to take.
+    // TODO[NNS1-2913]: Delete this once the stable memory migration is complete.  This is used purely to get
+    // an idea of how long, in wall clock time, migration is likely to take.
     pub periodic_tasks_run: Option<u32>,
 }
 

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -20,6 +20,7 @@ pub async fn run_periodic_tasks() {
     ledger_sync::sync_transactions().await;
 
     STATE.with(|state| {
+        state.performance.borrow_mut().increment_periodic_tasks_run();
         state.accounts_store.borrow_mut().step_migration();
     });
 

--- a/rs/backend/src/stats.rs
+++ b/rs/backend/src/stats.rs
@@ -122,7 +122,7 @@ pub fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
     w.encode_gauge(
         "periodic_tasks_run",
         f64::from(stats.periodic_tasks_run.unwrap_or(0)),
-        "The number of times the periodic tasks runner has run without traipping since the last upgrade.",
+        "The number of times the periodic tasks runner has run.",
         // Note: The counter is always incremented, however on trap the increment is lost.
     )?;
     Ok(())

--- a/rs/backend/src/stats.rs
+++ b/rs/backend/src/stats.rs
@@ -53,7 +53,7 @@ pub struct Stats {
     pub exceptional_transactions_count: Option<u32>,
     // TODO[NNS1-2913]: Delete this once the stable memory migration is complete.  This is used purely to get
     // an idea of how long, in wall clock time, migration is likely to take.
-    pub periodic_tasks_run: Option<u32>,
+    pub periodic_tasks_count: Option<u32>,
 }
 
 #[allow(clippy::cast_precision_loss)] // We are converting u64 to f64
@@ -120,10 +120,10 @@ pub fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         "The number of exceptional transactions in the canister log.",
     )?;
     w.encode_gauge(
-        "periodic_tasks_run",
-        f64::from(stats.periodic_tasks_run.unwrap_or(0)),
-        "The number of times the periodic tasks runner has run.",
-        // Note: The counter is always incremented, however on trap the increment is lost.
+        "periodic_tasks_count",
+        f64::from(stats.periodic_tasks_count.unwrap_or(0)),
+        "The number of times the periodic tasks runner has run successfully (ignoring async tasks).",
+        // Note: The counter is always incremented, however on Wasm trap (e.g. `ic_cdk::trap` or Rust `panic!`) the increment is lost.
     )?;
     Ok(())
 }

--- a/rs/backend/src/stats.rs
+++ b/rs/backend/src/stats.rs
@@ -51,8 +51,8 @@ pub struct Stats {
     pub schema: Option<u32>,              // The numeric form of a SchemaLabel.
     pub migration_countdown: Option<u32>, // When non-zero, a migration is in progress.
     pub exceptional_transactions_count: Option<u32>,
-    // TODO: Delete this once the stable memory migration is complete.  This is used purely to get
-    // an idea of how long migration is likely to take.
+    // TODO[NNS1-2913]: Delete this once the stable memory migration is complete.  This is used purely to get
+    // an idea of how long, in wall clock time, migration is likely to take.
     pub periodic_tasks_run: Option<u32>,
 }
 

--- a/rs/backend/src/stats.rs
+++ b/rs/backend/src/stats.rs
@@ -51,6 +51,9 @@ pub struct Stats {
     pub schema: Option<u32>,              // The numeric form of a SchemaLabel.
     pub migration_countdown: Option<u32>, // When non-zero, a migration is in progress.
     pub exceptional_transactions_count: Option<u32>,
+    // TODO: Delete this once the stable memory migration is complete.  This is used purely to get
+    // an idea of how long migration is likely to take.
+    pub periodic_tasks_run: Option<u32>,
 }
 
 #[allow(clippy::cast_precision_loss)] // We are converting u64 to f64
@@ -115,6 +118,12 @@ pub fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         "exceptional_transactions_count",
         f64::from(stats.exceptional_transactions_count.unwrap_or(0)),
         "The number of exceptional transactions in the canister log.",
+    )?;
+    w.encode_gauge(
+        "periodic_tasks_run_since_upgrade",
+        f64::from(stats.periodic_tasks_run.unwrap_or(0)),
+        "The number of times the periodic tasks runner has run without traipping since the last upgrade.",
+        // Note: The counter is always incremented, however on trap the increment is lost.
     )?;
     Ok(())
 }

--- a/rs/backend/src/stats.rs
+++ b/rs/backend/src/stats.rs
@@ -120,7 +120,7 @@ pub fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         "The number of exceptional transactions in the canister log.",
     )?;
     w.encode_gauge(
-        "periodic_tasks_run_since_upgrade",
+        "periodic_tasks_run",
         f64::from(stats.periodic_tasks_run.unwrap_or(0)),
         "The number of times the periodic tasks runner has run without traipping since the last upgrade.",
         // Note: The counter is always incremented, however on trap the increment is lost.

--- a/scripts/nns-dapp/e2e-test-metrics-present.keys
+++ b/scripts/nns-dapp/e2e-test-metrics-present.keys
@@ -7,6 +7,7 @@ nns_dapp_migration_countdown
 nns_dapp_schema
 nns_dapp_stable_memory_size_gib
 nns_dapp_wasm_memory_size_gib
+periodic_tasks_run
 seconds_since_last_ledger_sync
 sub_accounts_count
 transactions_count

--- a/scripts/nns-dapp/e2e-test-metrics-present.keys
+++ b/scripts/nns-dapp/e2e-test-metrics-present.keys
@@ -7,7 +7,7 @@ nns_dapp_migration_countdown
 nns_dapp_schema
 nns_dapp_stable_memory_size_gib
 nns_dapp_wasm_memory_size_gib
-periodic_tasks_run
+periodic_tasks_count
 seconds_since_last_ledger_sync
 sub_accounts_count
 transactions_count


### PR DESCRIPTION
# Motivation
Pre-migration to stable structures, we would like to de-risk by checking that assumptions about mainnet operation are correct:

- That the frequency of the upgrade counter is as expected; it could be run less frequently due to NNS subnet load.
- That stats are persisted across upgrades, not recomputed.

# Changes
- Add a counter for the periodic tasks runner top the metrics.
- Add logging that states whether stats were re-computed or read from persisted state.

Note: These can both be deleted once the assumptions have been confirmed; they have no long term value.

# Tests
- There is an existing test that checks that the expected metrics are exposed; the periodic task run counter has been added to the list of expected metrics.
- Not tested: That the counter increments and that the logging line actually logs.  In both cases, the logic is pretty obvious, and even if it has an error, it doesn't matter.  It just delays stable memory migration.

# Todos

- [ ] Add entry to changelog (if necessary).
  TODO before merging
