### PR TITLE
NNS1-2857: Utility to (re)set accounts for testing

### DIFF
--- a/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/NnsDestinationAddress.spec.ts
@@ -1,11 +1,11 @@
 import NnsDestinationAddress from "$lib/components/accounts/NnsDestinationAddress.svelte";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
   mockMainAccount,
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
 import { NnsDestinationAddressPo } from "$tests/page-objects/NnsDestinationAddress.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { allowLoggingInOneTestForDebugging } from "$tests/utils/console.test-utils";
 import { render } from "@testing-library/svelte";
 import type { Mock } from "vitest";
@@ -31,7 +31,7 @@ describe("NnsDestinationAddress", () => {
     allowLoggingInOneTestForDebugging();
     vi.restoreAllMocks();
 
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [mockSubAccount1, mockSubAccount2],
       hardwareWallets: [],

--- a/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectAccountDropdown.spec.ts
@@ -1,6 +1,5 @@
 import SelectAccountDropdown from "$lib/components/accounts/SelectAccountDropdown.svelte";
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { isAccountHardwareWallet } from "$lib/utils/accounts.utils";
 import {
@@ -10,6 +9,10 @@ import {
 } from "$tests/mocks/icp-accounts.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 
@@ -22,7 +25,7 @@ describe("SelectAccountDropdown", () => {
   describe("no accounts", () => {
     beforeEach(() => {
       vi.clearAllMocks();
-      icpAccountsStore.resetForTesting();
+      resetAccountsForTesting();
     });
 
     const props = { rootCanisterId: OWN_CANISTER_ID };
@@ -42,7 +45,7 @@ describe("SelectAccountDropdown", () => {
     const hardwareWallets = [mockHardwareWalletAccount];
 
     beforeEach(() => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
         subAccounts,
         hardwareWallets,

--- a/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
@@ -1,6 +1,5 @@
 import NnsAvailableMaturityItemAction from "$lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte";
 import { authStore } from "$lib/stores/auth.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
   mockAuthStoreSubscribe,
   mockIdentity,
@@ -13,6 +12,10 @@ import {
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsAvailableMaturityItemActionPo } from "$tests/page-objects/NnsAvailableMaturityItemAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import type { NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
@@ -33,7 +36,7 @@ describe("NnsAvailableMaturityItemAction", () => {
 
   beforeEach(() => {
     vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
   });
 
   it("should render available maturity", async () => {
@@ -63,7 +66,7 @@ describe("NnsAvailableMaturityItemAction", () => {
   });
 
   it("should render buttons if controlled by attached hardware wallet", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],
       hardwareWallets: [mockHardwareWalletAccount],

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -4,7 +4,6 @@ import {
   SECONDS_IN_MONTH,
 } from "$lib/constants/constants";
 import { authStore } from "$lib/stores/auth.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { nnsLatestRewardEventStore } from "$lib/stores/nns-latest-reward-event.store";
 import {
   mockAuthStoreSubscribe,
@@ -20,6 +19,10 @@ import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
 import { NnsNeuronAdvancedSectionPo } from "$tests/page-objects/NnsNeuronAdvancedSection.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import { normalizeWhitespace } from "$tests/utils/utils.test-utils";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
@@ -49,7 +52,7 @@ describe("NnsNeuronAdvancedSection", () => {
     vi.useFakeTimers();
     vi.setSystemTime(nowInSeconds * 1000);
     vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
   });
 
   it("should render neuron data", async () => {
@@ -93,7 +96,7 @@ describe("NnsNeuronAdvancedSection", () => {
   });
 
   it("should render actions if user is the controller", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: identityMainAccount,
       subAccounts: [],
       hardwareWallets: [],
@@ -124,7 +127,7 @@ describe("NnsNeuronAdvancedSection", () => {
   });
 
   it("should render enabled join neurons' fund if user is the controller", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],
       hardwareWallets: [],
@@ -143,7 +146,7 @@ describe("NnsNeuronAdvancedSection", () => {
   });
 
   it("should render enabled join neurons' fund if user is hotkey", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],
       hardwareWallets: [],
@@ -163,7 +166,7 @@ describe("NnsNeuronAdvancedSection", () => {
   });
 
   it("should render not render join neurons' fund if user is a hotkey but controller is the attached hardware wallet", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],
       hardwareWallets: [mockHardwareWalletAccount],
@@ -194,7 +197,7 @@ describe("NnsNeuronAdvancedSection", () => {
   });
 
   it("should render split button but not join neurons' fund if neuron is controlled by hardware wallet", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],
       hardwareWallets: [mockHardwareWalletAccount],

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
@@ -1,7 +1,6 @@
 import NnsNeuronDissolveDelayItemAction from "$lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte";
 import { SECONDS_IN_MONTH, SECONDS_IN_YEAR } from "$lib/constants/constants";
 import { authStore } from "$lib/stores/auth.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
   mockAuthStoreSubscribe,
   mockIdentity,
@@ -13,6 +12,10 @@ import {
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronDissolveDelayItemActionPo } from "$tests/page-objects/NnsNeuronDissolveDelayItemAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
@@ -40,7 +43,7 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
   };
 
   beforeEach(() => {
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
     vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
   });
 
@@ -118,7 +121,7 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
   });
 
   it("should render increase dissolve delay button if controlled by hardware wallet", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],
       hardwareWallets: [mockHardwareWalletAccount],

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
@@ -1,7 +1,6 @@
 import NnsNeuronPageHeading from "$lib/components/neuron-detail/NnsNeuronPageHeading.svelte";
 import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
 import { authStore } from "$lib/stores/auth.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
   mockAuthStoreSubscribe,
   mockIdentity,
@@ -13,6 +12,10 @@ import {
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronPageHeadingPo } from "$tests/page-objects/NnsNeuronPageHeading.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import type { NeuronInfo } from "@dfinity/nns";
 import { NeuronType } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
@@ -26,7 +29,7 @@ describe("NnsNeuronPageHeading", () => {
 
   beforeEach(() => {
     vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
   });
 
   it("should render the neuron's stake", async () => {
@@ -75,7 +78,7 @@ describe("NnsNeuronPageHeading", () => {
   });
 
   it("should render hotkey tag if user is a hotkey and not controlled by a hardware wallet", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],
       hardwareWallets: [],
@@ -93,7 +96,7 @@ describe("NnsNeuronPageHeading", () => {
   });
 
   it("should render hotkey and Neurons' Fund tag", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],
       hardwareWallets: [],
@@ -115,7 +118,7 @@ describe("NnsNeuronPageHeading", () => {
   });
 
   it("should render hardware wallet tag and not hotkey if neuron is controlled by a hardware wallet", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],
       hardwareWallets: [mockHardwareWalletAccount],
@@ -133,7 +136,7 @@ describe("NnsNeuronPageHeading", () => {
   });
 
   it("should render neuron type tag", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],
     });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
@@ -1,7 +1,6 @@
 import NnsNeuronStateItemAction from "$lib/components/neuron-detail/NnsNeuronStateItemAction.svelte";
 import { SECONDS_IN_FOUR_YEARS } from "$lib/constants/constants";
 import { authStore } from "$lib/stores/auth.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
   mockAuthStoreSubscribe,
   mockIdentity,
@@ -13,6 +12,7 @@ import {
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronStateItemActionPo } from "$tests/page-objects/NnsNeuronStateItemAction.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 import NeuronContextActionsTest from "./NeuronContextActionsTest.svelte";
@@ -94,7 +94,7 @@ describe("NnsNeuronStateItemAction", () => {
   });
 
   it("should render dissolve button if hardware wallet is the controller", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],
       hardwareWallets: [mockHardwareWalletAccount],

--- a/frontend/src/tests/lib/components/neuron-detail/actions/DisburseButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/DisburseButton.spec.ts
@@ -1,8 +1,8 @@
 import DisburseButton from "$lib/components/neuron-detail/actions/DisburseButton.svelte";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import en from "$tests/mocks/i18n.mock";
 import { mockAccountsStoreData } from "$tests/mocks/icp-accounts.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { fireEvent, render } from "@testing-library/svelte";
 import NeuronContextTest from "../NeuronContextTest.svelte";
 
@@ -24,7 +24,7 @@ describe("DisburseButton", () => {
 
   it("opens disburse nns neuron modal", async () => {
     // To avoid that the modal requests the accounts
-    icpAccountsStore.setForTesting(mockAccountsStoreData);
+    setAccountsForTesting(mockAccountsStoreData);
     const { container, queryByTestId } = render(NeuronContextTest, {
       props: {
         neuron: mockNeuron,

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -1,7 +1,6 @@
 import NnsNeuronCard from "$lib/components/neurons/NnsNeuronCard.svelte";
 import { SECONDS_IN_YEAR } from "$lib/constants/constants";
 import { authStore } from "$lib/stores/auth.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { formatTokenE8s } from "$lib/utils/token.utils";
 import {
   mockAuthStoreSubscribe,
@@ -15,6 +14,10 @@ import {
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronCardPo } from "$tests/page-objects/NnsNeuronCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import type { Neuron } from "@dfinity/nns";
 import { NeuronState, NeuronType } from "@dfinity/nns";
 import { fireEvent, render } from "@testing-library/svelte";
@@ -25,7 +28,7 @@ describe("NnsNeuronCard", () => {
     vi.useFakeTimers().setSystemTime(nowInSeconds * 1000);
     vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
 
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
   });
 
   it("renders a Card", () => {
@@ -137,7 +140,7 @@ describe("NnsNeuronCard", () => {
   });
 
   it("renders the hardware wallet label and not hotkey when neuron is controlled by hardware wallet", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],
       hardwareWallets: [mockHardwareWalletAccount],
@@ -161,7 +164,7 @@ describe("NnsNeuronCard", () => {
   });
 
   it("renders neuron type tag when not default", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],
     });

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronsFooter.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronsFooter.spec.ts
@@ -1,6 +1,5 @@
 import NnsNeuronsFooter from "$lib/components/neurons/NnsNeuronsFooter.svelte";
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
 import en from "$tests/mocks/i18n.mock";
@@ -11,6 +10,7 @@ import {
   mockNeuron,
 } from "$tests/mocks/neurons.mock";
 import { mockVoteRegistration } from "$tests/mocks/proposal.mock";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { NeuronState } from "@dfinity/nns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 
@@ -47,7 +47,7 @@ describe("NnsNeurons", () => {
 
     it("should open stake neuron modal", async () => {
       // To avoid that the modal requests the accounts
-      icpAccountsStore.setForTesting(mockAccountsStoreData);
+      setAccountsForTesting(mockAccountsStoreData);
       const { queryByTestId, queryByText, getByTestId } =
         render(NnsNeuronsFooter);
 

--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -1,7 +1,6 @@
 import ParticipateButton from "$lib/components/project-detail/ParticipateButton.svelte";
 import { NOT_LOADED } from "$lib/constants/stores.constants";
 import { authStore } from "$lib/stores/auth.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
 import { userCountryStore } from "$lib/stores/user-country.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
@@ -25,6 +24,7 @@ import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { renderContextCmp, snsTicketMock } from "$tests/mocks/sns.mock";
 import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/svelte";
@@ -105,7 +105,7 @@ describe("ParticipateButton", () => {
 
       // When the modal appears, it will trigger `pollAccounts`
       // which trigger api calls if accounts are not loaded.
-      icpAccountsStore.setForTesting(mockAccountsStoreData);
+      setAccountsForTesting(mockAccountsStoreData);
 
       const { getByTestId } = renderContextCmp({
         summary: mockSnsFullProject.summary,

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -1,7 +1,6 @@
 import SelectUniverseCard from "$lib/components/universe/SelectUniverseCard.svelte";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import type { Universe } from "$lib/types/universe";
 import { createUniverse } from "$lib/utils/universe.utils";
 import { page } from "$mocks/$app/stores";
@@ -16,6 +15,10 @@ import { mockSummary } from "$tests/mocks/sns-projects.mock";
 import { nnsUniverseMock } from "$tests/mocks/universe.mock";
 import { SelectUniverseCardPo } from "$tests/page-objects/SelectUniverseCard.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import { render } from "@testing-library/svelte";
 
 describe("SelectUniverseCard", () => {
@@ -29,7 +32,7 @@ describe("SelectUniverseCard", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
     resetIdentity();
   });
 
@@ -132,7 +135,7 @@ describe("SelectUniverseCard", () => {
 
   describe("project-balance", () => {
     beforeEach(() => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: {
           ...mockMainAccount,
           balanceUlps: 100_000_000n,

--- a/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
@@ -1,13 +1,13 @@
 import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { get } from "svelte/store";
 
 describe("accounts", () => {
   describe("nnsAccountsListStore", () => {
     it("returns nns accounts in an array", () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
         subAccounts: [mockSnsMainAccount],
         hardwareWallets: [],

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -1,7 +1,6 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import { icpTokensListUser } from "$lib/derived/icp-tokens-list-user.derived";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
   UserTokenAction,
   type UserTokenData,
@@ -17,6 +16,10 @@ import {
   createIcpUserToken,
   icpTokenBase,
 } from "$tests/mocks/tokens-page.mock";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import { TokenAmountV2 } from "@dfinity/utils";
 import { get } from "svelte/store";
 
@@ -75,7 +78,7 @@ describe("icp-tokens-list-user.derived", () => {
 
   describe("icpTokensListVisitors", () => {
     beforeEach(() => {
-      icpAccountsStore.resetForTesting();
+      resetAccountsForTesting();
     });
 
     it("should return empty if no accounts", () => {
@@ -83,14 +86,14 @@ describe("icp-tokens-list-user.derived", () => {
     });
 
     it("should return only main if no subaccounts and no subaccounts", () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
       });
       expect(get(icpTokensListUser)).toEqual([mainUserTokenData]);
     });
 
     it("should return subaccounts and main", () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
       });
@@ -101,7 +104,7 @@ describe("icp-tokens-list-user.derived", () => {
     });
 
     it("should return hardware wallets, subaccounts and main", () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
         hardwareWallets: [mockHardwareWalletAccount],

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -8,7 +8,6 @@ import { CKETH_LEDGER_CANISTER_ID } from "$lib/constants/cketh-canister-ids.cons
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import { tokensListUserStore } from "$lib/derived/tokens-list-user.derived";
 import { authStore } from "$lib/stores/auth.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import {
@@ -38,6 +37,10 @@ import {
   createIcpUserToken,
   icpTokenBase,
 } from "$tests/mocks/tokens-page.mock";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
 import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
@@ -190,7 +193,7 @@ describe("tokens-list-user.derived", () => {
 
   describe("tokensListUserStore", () => {
     beforeEach(() => {
-      icpAccountsStore.resetForTesting();
+      resetAccountsForTesting();
       icrcAccountsStore.reset();
       tokensStore.reset();
       authStore.setForTesting(mockIdentity);
@@ -242,7 +245,7 @@ describe("tokens-list-user.derived", () => {
     });
 
     it("should return balance and goToDetail action if ICP balance is present", () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
       });
       expect(get(tokensListUserStore)).toEqual([
@@ -307,7 +310,7 @@ describe("tokens-list-user.derived", () => {
     });
 
     it("should return all balances and actions if all balances are present", () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
       });
       icrcAccountsStore.set({

--- a/frontend/src/tests/lib/derived/universes-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-accounts.derived.spec.ts
@@ -4,7 +4,6 @@ import {
   CKBTC_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { universesAccountsStore } from "$lib/derived/universes-accounts.derived";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { mockCkBTCMainAccount } from "$tests/mocks/ckbtc-accounts.mock";
 import {
@@ -16,6 +15,7 @@ import {
   mockSnsSubAccount,
 } from "$tests/mocks/sns-accounts.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { get } from "svelte/store";
 
@@ -26,7 +26,7 @@ describe("universes-accounts", () => {
   });
 
   it("should derive Nns accounts", () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [mockSubAccount],
       hardwareWallets: [],
@@ -79,7 +79,7 @@ describe("universes-accounts", () => {
   });
 
   it("should derive all accounts", () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [mockSubAccount],
       hardwareWallets: [],

--- a/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/ReceiveModal.spec.ts
@@ -1,6 +1,5 @@
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import ReceiveModal from "$lib/modals/accounts/ReceiveModal.svelte";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import type { Account } from "$lib/types/account";
 import {
   mockMainAccount,
@@ -9,6 +8,10 @@ import {
 import { renderModal } from "$tests/mocks/modal.mock";
 import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import type { Principal } from "@dfinity/principal";
 
 describe("ReceiveModal", () => {
@@ -16,7 +19,7 @@ describe("ReceiveModal", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
   });
 
   const qrCodeLabel = "test QR code";
@@ -93,7 +96,7 @@ describe("ReceiveModal", () => {
   });
 
   it("should render a dropdown to select account", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: undefined,
       hardwareWallets: undefined,
@@ -108,7 +111,7 @@ describe("ReceiveModal", () => {
   });
 
   it("should select account", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [mockSubAccount],
       hardwareWallets: undefined,
@@ -129,7 +132,7 @@ describe("ReceiveModal", () => {
   });
 
   it("should not require universeId ", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [mockSubAccount],
       hardwareWallets: undefined,

--- a/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
@@ -7,7 +7,6 @@ import { pageStore } from "$lib/derived/page.derived";
 import DisburseNnsNeuronModal from "$lib/modals/neurons/DisburseNnsNeuronModal.svelte";
 import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
 import { disburse } from "$lib/services/neurons.services";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountDetails,
@@ -19,6 +18,10 @@ import { renderModal } from "$tests/mocks/modal.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { DisburseNnsNeuronModalPo } from "$tests/page-objects/DisburseNnsNeuronModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import {
   advanceTime,
   runResolvedPromises,
@@ -60,7 +63,7 @@ describe("DisburseNnsNeuronModal", () => {
 
   describe("when accounts are loaded", () => {
     beforeEach(() => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         ...mockAccountsStoreData,
         subAccounts: [mockSubAccount],
       });
@@ -127,7 +130,7 @@ describe("DisburseNnsNeuronModal", () => {
 
   describe("when accounts store is empty", () => {
     beforeEach(() => {
-      icpAccountsStore.resetForTesting();
+      resetAccountsForTesting();
     });
 
     it("should fetch accounts and render account selector", async () => {
@@ -168,7 +171,7 @@ describe("DisburseNnsNeuronModal", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: SpyInstance;
     beforeEach(() => {
-      icpAccountsStore.resetForTesting();
+      resetAccountsForTesting();
       vi.clearAllTimers();
       vi.clearAllMocks();
       const now = Date.now();

--- a/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
@@ -3,7 +3,6 @@ import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import IncreaseNeuronStakeModal from "$lib/modals/neurons/IncreaseNeuronStakeModal.svelte";
 import { topUpNeuron } from "$lib/services/neurons.services";
 import { authStore } from "$lib/stores/auth.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountDetails,
@@ -11,6 +10,10 @@ import {
 } from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import { fireEvent } from "@testing-library/dom";
 import { waitFor } from "@testing-library/svelte";
 
@@ -37,7 +40,7 @@ describe("IncreaseNeuronStakeModal", () => {
 
   describe("when accounts store is empty", () => {
     beforeEach(() => {
-      icpAccountsStore.resetForTesting();
+      resetAccountsForTesting();
     });
 
     it("should fetch accounts and render account selector", async () => {
@@ -61,7 +64,7 @@ describe("IncreaseNeuronStakeModal", () => {
 
   describe("when accounts are loaded", () => {
     beforeEach(() => {
-      icpAccountsStore.setForTesting(mockAccountsStoreData);
+      setAccountsForTesting(mockAccountsStoreData);
     });
 
     it("should call top up neuron", async () => {

--- a/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/MergeNeuronsModal.spec.ts
@@ -4,7 +4,6 @@ import { mergeNeurons } from "$lib/api/governance.api";
 import MergeNeuronsModal from "$lib/modals/neurons/MergeNeuronsModal.svelte";
 import * as authServices from "$lib/services/auth.services";
 import { listNeurons } from "$lib/services/neurons.services";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import type { Account } from "$lib/types/account";
 import * as fakeGovernanceApi from "$tests/fakes/governance-api.fake";
@@ -17,6 +16,10 @@ import {
 import { renderModal } from "$tests/mocks/modal.mock";
 import { MergeNeuronsModalPo } from "$tests/page-objects/MergeNeuronsModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { NeuronState, type NeuronInfo } from "@dfinity/nns";
@@ -45,7 +48,7 @@ describe("MergeNeuronsModal", () => {
       testIdentity
     );
     vi.clearAllMocks();
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
     neuronsStore.reset();
     resetNeuronsApiService();
     toastsStore.reset();
@@ -77,7 +80,7 @@ describe("MergeNeuronsModal", () => {
     neurons: fakeGovernanceApi.FakeNeuronParams[],
     hardwareWalletAccounts: Account[] = []
   ): Promise<MergeNeuronsModalPo> => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: { ...mockMainAccount, principal: testIdentity.getPrincipal() },
       hardwareWallets: hardwareWalletAccounts,
     });

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -25,6 +25,10 @@ import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsStakeNeuronModalPo } from "$tests/page-objects/NnsStakeNeuronModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
+import {
   advanceTime,
   runResolvedPromises,
 } from "$tests/utils/timers.test-utils";
@@ -108,7 +112,7 @@ describe("NnsStakeNeuronModal", () => {
   describe("main account selection", () => {
     beforeEach(() => {
       neuronsStore.setNeurons({ neurons: [newNeuron], certified: true });
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         ...mockAccountsStoreData,
         subAccounts: [mockSubAccount],
       });
@@ -329,7 +333,7 @@ describe("NnsStakeNeuronModal", () => {
   describe("hardware wallet account selection", () => {
     beforeEach(() => {
       neuronsStore.setNeurons({ neurons: [], certified: true });
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         ...mockAccountsStoreData,
         hardwareWallets: [mockHardwareWalletAccount],
       });
@@ -400,7 +404,7 @@ describe("NnsStakeNeuronModal", () => {
 
     beforeEach(() => {
       neuronsStore.setNeurons({ neurons: [newNeuron], certified: true });
-      icpAccountsStore.resetForTesting();
+      resetAccountsForTesting();
       const mainBalanceE8s = 10_000_000n;
       vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
         mainBalanceE8s
@@ -443,7 +447,7 @@ describe("NnsStakeNeuronModal", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: SpyInstance;
     beforeEach(() => {
-      icpAccountsStore.resetForTesting();
+      resetAccountsForTesting();
       vi.clearAllTimers();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);

--- a/frontend/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/SpawnNeuronModal.spec.ts
@@ -1,6 +1,5 @@
 import SpawnNeuronModal from "$lib/modals/neurons/SpawnNeuronModal.svelte";
 import { spawnNeuron } from "$lib/services/neurons.services";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { formattedMaturity } from "$lib/utils/neuron.utils";
 import {
   mockHardwareWalletAccount,
@@ -8,6 +7,7 @@ import {
 } from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { fireEvent } from "@testing-library/svelte";
 
 vi.mock("$lib/services/neurons.services", () => {
@@ -27,7 +27,7 @@ describe("SpawnNeuronModal", () => {
   };
 
   beforeAll(() =>
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       hardwareWallets: [mockHardwareWalletAccount],
     })

--- a/frontend/src/tests/lib/modals/neurons/SplitNnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/SplitNnsNeuronModal.spec.ts
@@ -1,13 +1,13 @@
 import SplitNeuronModal from "$lib/modals/neurons/SplitNnsNeuronModal.svelte";
 import { splitNeuron } from "$lib/services/neurons.services";
 import * as busyServices from "$lib/stores/busy.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import {
   mockHardwareWalletAccount,
   mockMainAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import type { NeuronInfo } from "@dfinity/nns";
 import { fireEvent } from "@testing-library/dom";
 import type { RenderResult } from "@testing-library/svelte";
@@ -61,7 +61,7 @@ describe("SplitNeuronModal", () => {
   });
 
   it("should start busy screen with message if controlled by HW", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       hardwareWallets: [mockHardwareWalletAccount],
     });

--- a/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/ParticipateSwapModal.spec.ts
@@ -5,7 +5,6 @@ import ParticipateSwapModal from "$lib/modals/sns/sale/ParticipateSwapModal.svel
 import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
 import { initiateSnsSaleParticipation } from "$lib/services/sns-sale.services";
 import { authStore } from "$lib/stores/auth.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
 import {
   PROJECT_DETAIL_CONTEXT_KEY,
@@ -34,6 +33,10 @@ import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { ParticipateSwapModalPo } from "$tests/page-objects/ParticipateSwapModal.page-object";
 import type { TransactionReviewPo } from "$tests/page-objects/TransactionReview.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import {
   advanceTime,
   runResolvedPromises,
@@ -71,7 +74,7 @@ describe("ParticipateSwapModal", () => {
     vi.clearAllMocks();
     vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
     vi.mocked(initiateSnsSaleParticipation).mockClear();
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
     snsTicketsStore.setNoTicket(rootCanisterIdMock);
   });
 
@@ -134,7 +137,7 @@ describe("ParticipateSwapModal", () => {
 
   describe("when hardware wallet account is available", () => {
     beforeEach(() => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
         hardwareWallets: [mockHardwareWalletAccount],
@@ -154,7 +157,7 @@ describe("ParticipateSwapModal", () => {
 
   describe("when accounts are available", () => {
     beforeEach(() => {
-      icpAccountsStore.setForTesting(mockAccountsStoreData);
+      setAccountsForTesting(mockAccountsStoreData);
     });
 
     const participate = async (po: ParticipateSwapModalPo) => {
@@ -285,7 +288,7 @@ describe("ParticipateSwapModal", () => {
     let resolveQueryAccounts;
 
     beforeEach(() => {
-      icpAccountsStore.resetForTesting();
+      resetAccountsForTesting();
       queryAccountBalanceSpy = vi
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockResolvedValue(mainBalanceE8s);
@@ -355,7 +358,7 @@ describe("ParticipateSwapModal", () => {
   describe("when no accounts and user navigates away", () => {
     let spyQueryAccount: SpyInstance;
     beforeEach(() => {
-      icpAccountsStore.resetForTesting();
+      resetAccountsForTesting();
       vi.clearAllTimers();
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -2,7 +2,6 @@ import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
 import TransactionModal from "$lib/modals/transaction/TransactionModal.svelte";
 import { authStore } from "$lib/stores/auth.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import type { Account } from "$lib/types/account";
 import type { ValidateAmountFn } from "$lib/types/transaction";
@@ -21,6 +20,7 @@ import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { TransactionModalPo } from "$tests/page-objects/TransactionModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { queryToggleById } from "$tests/utils/toggle.test-utils";
 import { clickByTestId } from "$tests/utils/utils.test-utils";
@@ -82,7 +82,7 @@ describe("TransactionModal", () => {
     resetSnsProjects();
     icrcAccountsStore.reset();
 
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [mockSubAccount],
       hardwareWallets: [mockHardwareWalletAccount],

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -4,13 +4,13 @@ import { SYNC_ACCOUNTS_RETRY_SECONDS } from "$lib/constants/accounts.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import NnsAccounts from "$lib/pages/NnsAccounts.svelte";
 import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import type { UserTokenData } from "$lib/types/tokens-page";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockAccountDetails } from "$tests/mocks/icp-accounts.store.mock";
 import { createUserToken } from "$tests/mocks/tokens-page.mock";
 import { NnsAccountsPo } from "$tests/page-objects/NnsAccounts.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { resetAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import {
   advanceTime,
   runResolvedPromises,
@@ -31,7 +31,7 @@ describe("NnsAccounts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetIdentity();
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
     // TODO: Move the pollAccounts to Accounts route when universe selected is NNS instead of the child.
     vi.spyOn(nnsDappApi, "queryAccount").mockImplementation(async () => {
       return mockAccountDetails;

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -12,7 +12,6 @@ import { pageStore } from "$lib/derived/page.derived";
 import NnsWallet from "$lib/pages/NnsWallet.svelte";
 import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icpTransactionsStore } from "$lib/stores/icp-transactions.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { getSwapCanisterAccount } from "$lib/utils/sns.utils";
@@ -33,6 +32,10 @@ import { IcpTransactionModalPo } from "$tests/page-objects/IcpTransactionModal.p
 import { NnsWalletPo } from "$tests/page-objects/NnsWallet.page-object";
 import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import {
   advanceTime,
@@ -70,7 +73,7 @@ describe("NnsWallet", () => {
     vi.clearAllMocks();
     vi.clearAllTimers();
     cancelPollAccounts();
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
     neuronsStore.reset();
     resetNeuronsApiService();
     icpTransactionsStore.reset();
@@ -249,7 +252,7 @@ describe("NnsWallet", () => {
 
   describe("accounts loaded", () => {
     beforeEach(() => {
-      icpAccountsStore.setForTesting(mockAccountsStoreData);
+      setAccountsForTesting(mockAccountsStoreData);
     });
 
     it("should render nns project name", async () => {
@@ -261,7 +264,7 @@ describe("NnsWallet", () => {
     });
 
     it("should render a balance with token in summary", async () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         ...mockAccountsStoreData,
         main: {
           ...mockMainAccount,
@@ -609,7 +612,7 @@ describe("NnsWallet", () => {
 
   describe("accounts loaded (Subaccount)", () => {
     beforeEach(() => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         ...mockAccountsStoreData,
         subAccounts: [mockSubAccount],
       });
@@ -631,7 +634,7 @@ describe("NnsWallet", () => {
     const testHwPrincipal = Principal.fromText(testHwPrincipalText);
 
     beforeEach(() => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         ...mockAccountsStoreData,
         hardwareWallets: [
           {

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -12,7 +12,6 @@ import { pageStore } from "$lib/derived/page.derived";
 import ProjectDetail from "$lib/pages/ProjectDetail.svelte";
 import { cancelPollGetOpenTicket } from "$lib/services/sns-sale.services";
 import { authStore } from "$lib/stores/auth.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { getOrCreateSnsFinalizationStatusStore } from "$lib/stores/sns-finalization-status.store";
 import { snsSwapMetricsStore } from "$lib/stores/sns-swap-metrics.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
@@ -40,6 +39,7 @@ import {
 import { snsTicketMock } from "$tests/mocks/sns.mock";
 import { ProjectDetailPo } from "$tests/page-objects/ProjectDetail.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import {
@@ -486,7 +486,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
 
         beforeEach(() => {
           // Do not rely on the `loadAccounts` from the modal.
-          icpAccountsStore.setForTesting({
+          setAccountsForTesting({
             main: mockMainAccount,
             subAccounts: [],
             hardwareWallets: [],

--- a/frontend/src/tests/lib/routes/Accounts.spec.ts
+++ b/frontend/src/tests/lib/routes/Accounts.spec.ts
@@ -8,7 +8,6 @@ import { AppPath } from "$lib/constants/routes.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import Accounts from "$lib/routes/Accounts.svelte";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { page } from "$mocks/$app/stores";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
@@ -21,6 +20,7 @@ import {
 import { mockToken } from "$tests/mocks/sns-projects.mock";
 import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { resetAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
@@ -57,7 +57,7 @@ describe("Accounts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetIdentity();
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
 
     subaccountBalance = subaccountBalanceDefault;
     mainAccountBalance = mainAccountBalanceDefault;

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -9,7 +9,6 @@ import {
 import { AppPath } from "$lib/constants/routes.constants";
 import Wallet from "$lib/routes/Wallet.svelte";
 import { authStore } from "$lib/stores/auth.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
@@ -28,6 +27,7 @@ import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { mockSnsFullProject, principal } from "$tests/mocks/sns-projects.mock";
 import { WalletPo } from "$tests/page-objects/Wallet.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
@@ -90,7 +90,7 @@ describe("Wallet", () => {
       },
     ]);
     setCkETHCanisters();
-    icpAccountsStore.setForTesting(mockAccountsStoreData);
+    setAccountsForTesting(mockAccountsStoreData);
     vi.spyOn(icrcLedgerApi, "icrcTransfer").mockResolvedValue(1234n);
     vi.mocked(ckbtcMinterApi.retrieveBtcStatusV2ByAccount).mockResolvedValue(
       []

--- a/frontend/src/tests/lib/services/busy.services.spec.ts
+++ b/frontend/src/tests/lib/services/busy.services.spec.ts
@@ -1,12 +1,12 @@
 import { startBusyNeuron } from "$lib/services/busy.services";
 import * as busyStore from "$lib/stores/busy.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import {
   mockHardwareWalletAccount,
   mockMainAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 
 describe("busy-services", () => {
   const startBusySpy = vi
@@ -18,7 +18,7 @@ describe("busy-services", () => {
   });
 
   it("call start busy without message if neuron is not controlled by hardware wallet", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
     });
     const neuron = {
@@ -38,7 +38,7 @@ describe("busy-services", () => {
   });
 
   it("call start busy with message if neuron controlled by hardware wallet", async () => {
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       main: mockMainAccount,
       hardwareWallets: [mockHardwareWalletAccount],
     });

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -51,6 +51,10 @@ import {
   mockSnsSubAccount,
 } from "$tests/mocks/sns-accounts.mock";
 import { mockSentToSubAccountTransaction } from "$tests/mocks/transaction.mock";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import {
   advanceTime,
@@ -87,7 +91,7 @@ describe("icp-accounts.services", () => {
     vi.spyOn(console, "error").mockReturnValue();
     vi.clearAllMocks();
     toastsStore.reset();
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
     overrideFeatureFlagsStore.reset();
     resetIdentity();
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockImplementation(
@@ -552,7 +556,7 @@ describe("icp-accounts.services", () => {
       const queryAccountBalanceSpy = vi
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockResolvedValue(newBalanceE8s);
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
       });
       expect(get(icpAccountsStore).main.balanceUlps).toEqual(
@@ -585,7 +589,7 @@ describe("icp-accounts.services", () => {
           }
           throw new Error("test");
         });
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
       });
       await loadBalance({ accountIdentifier: mockMainAccount.identifier });
@@ -599,7 +603,7 @@ describe("icp-accounts.services", () => {
       const queryAccountBalanceSpy = vi
         .spyOn(ledgerApi, "queryAccountBalance")
         .mockRejectedValue(error);
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
       });
       await loadBalance({ accountIdentifier: mockMainAccount.identifier });
@@ -851,7 +855,7 @@ describe("icp-accounts.services", () => {
     });
 
     it("should sync destination balances after transfer ICP to own account", async () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
       });
@@ -1086,7 +1090,7 @@ describe("icp-accounts.services", () => {
 
   describe("getAccountIdentity", () => {
     it("returns user identity if main account", async () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
       });
       const expectedIdentity = await getAccountIdentity(
@@ -1096,7 +1100,7 @@ describe("icp-accounts.services", () => {
     });
 
     it("returns user identity if main account", async () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
       });
@@ -1107,7 +1111,7 @@ describe("icp-accounts.services", () => {
     });
 
     it("returns calls for hardware walleet identity if hardware wallet account", async () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
         hardwareWallets: [mockHardwareWalletAccount],
@@ -1122,7 +1126,7 @@ describe("icp-accounts.services", () => {
 
   describe("getAccountIdentityByPrincipal", () => {
     it("returns user identity if main account", async () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
       });
       const expectedIdentity = await getAccountIdentityByPrincipal(
@@ -1132,7 +1136,7 @@ describe("icp-accounts.services", () => {
     });
 
     it("returns calls for hardware walleet identity if hardware wallet account", async () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
         hardwareWallets: [mockHardwareWalletAccount],
@@ -1145,7 +1149,7 @@ describe("icp-accounts.services", () => {
     });
 
     it("returns null if no main account nor hardware wallet account", async () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
         hardwareWallets: [mockHardwareWalletAccount],
       });
@@ -1169,7 +1173,7 @@ describe("icp-accounts.services", () => {
     };
 
     beforeEach(() => {
-      icpAccountsStore.resetForTesting();
+      resetAccountsForTesting();
       vi.clearAllTimers();
       vi.clearAllMocks();
       cancelPollAccounts();

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -13,7 +13,6 @@ import * as services from "$lib/services/neurons.services";
 import { toggleAutoStakeMaturity } from "$lib/services/neurons.services";
 import * as busyStore from "$lib/stores/busy.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { definedNeuronsStore, neuronsStore } from "$lib/stores/neurons.store";
 import { NotAuthorizedNeuronError } from "$lib/types/neurons.errors";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -33,6 +32,10 @@ import {
 } from "$tests/mocks/icp-accounts.store.mock";
 import { MockLedgerIdentity } from "$tests/mocks/ledger.identity.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
+import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import type { Identity } from "@dfinity/agent";
 import { AnonymousIdentity } from "@dfinity/agent";
 import { toastsStore } from "@dfinity/gix-components";
@@ -161,7 +164,7 @@ describe("neurons-services", () => {
     spyGetNeuron.mockClear();
     vi.clearAllMocks();
     neuronsStore.reset();
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
     resetAccountIdentity();
     toastsStore.reset();
     resetNeuronsApiService();
@@ -862,7 +865,7 @@ describe("neurons-services", () => {
         ...mockHardwareWalletAccount,
         principal: smallerVersionIdentity.getPrincipal(),
       };
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
         hardwareWallets: [hwAccount],
       });
@@ -959,7 +962,7 @@ describe("neurons-services", () => {
     });
 
     it("should simulate merging neurons if HW controlled", async () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
         hardwareWallets: [mockHardwareWalletAccount],
       });
@@ -1293,7 +1296,7 @@ describe("neurons-services", () => {
         ...mockHardwareWalletAccount,
         principal: smallerVersionIdentity.getPrincipal(),
       };
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
         hardwareWallets: [hwAccount],
       });

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -47,6 +47,10 @@ import {
 } from "$tests/mocks/sns.api.mock";
 import { snsTicketMock } from "$tests/mocks/sns.mock";
 import {
+  resetAccountsForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
+import {
   advanceTime,
   runResolvedPromises,
 } from "$tests/utils/timers.test-utils";
@@ -166,7 +170,7 @@ describe("sns-api", () => {
     vi.clearAllMocks();
 
     snsTicketsStore.reset();
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
     tokensStore.reset();
 
     spyOnNewSaleTicketApi.mockResolvedValue(testSnsTicket.ticket);
@@ -998,7 +1002,7 @@ describe("sns-api", () => {
       vi.useFakeTimers().setSystemTime(now);
     });
     it("should call postprocess and APIs", async () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
       });
       const postprocessSpy = vi.fn().mockResolvedValue(undefined);
@@ -1025,7 +1029,7 @@ describe("sns-api", () => {
     });
 
     it("should update account's balance in the store", async () => {
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
       });
       const postprocessSpy = vi.fn().mockResolvedValue(undefined);
@@ -1051,7 +1055,7 @@ describe("sns-api", () => {
         owner: mockIdentity.getPrincipal(),
         subaccount: arrayOfNumberToUint8Array(mockSubAccount.subAccount),
       });
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
       });

--- a/frontend/src/tests/lib/stores/icp-accounts.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icp-accounts.store.spec.ts
@@ -5,6 +5,11 @@ import {
   mockMainAccount,
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
+import {
+  resetAccountsForTesting,
+  setAccountBalanceForTesting,
+  setAccountsForTesting,
+} from "$tests/utils/accounts.test-utils";
 import { get } from "svelte/store";
 
 describe("icpAccountsStore", () => {
@@ -16,31 +21,13 @@ describe("icpAccountsStore", () => {
     expect(initState.hardwareWallets).toBeUndefined();
   };
 
-  // Convenience functions for tests that don't care about the functionality of
-  // the queued store to handle out of order responses.
-  const accountsStoreSet = (accounts: IcpAccountsStoreData) => {
-    const mutableStore = icpAccountsStore.getSingleMutationIcpAccountsStore();
-    mutableStore.set(accounts);
-  };
-
-  const accountsStoreSetBalance = ({
-    accountIdentifier,
-    balanceE8s,
-  }: {
-    accountIdentifier: string;
-    balanceE8s: bigint;
-  }) => {
-    const mutableStore = icpAccountsStore.getSingleMutationIcpAccountsStore();
-    mutableStore.setBalance({ accountIdentifier, balanceE8s, certified: true });
-  };
-
   const accountsStoreReset = () => {
     const mutableStore = icpAccountsStore.getSingleMutationIcpAccountsStore();
     mutableStore.reset({ certified: true });
   };
 
   beforeEach(() => {
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
   });
 
   it("initializes to undefined", () => {
@@ -48,7 +35,7 @@ describe("icpAccountsStore", () => {
   });
 
   it("should set main account", () => {
-    accountsStoreSet({ main: mockMainAccount, subAccounts: [] });
+    setAccountsForTesting({ main: mockMainAccount, subAccounts: [] });
 
     const { main } = get(icpAccountsStore);
     expect(main).toEqual(mockMainAccount);
@@ -58,7 +45,7 @@ describe("icpAccountsStore", () => {
     const { certified: initialCertified } = get(icpAccountsStore);
     expect(initialCertified).toBe(undefined);
 
-    accountsStoreSet({
+    setAccountsForTesting({
       main: mockMainAccount,
       subAccounts: [],
       certified: true,
@@ -69,7 +56,7 @@ describe("icpAccountsStore", () => {
   });
 
   it("should reset account store", () => {
-    accountsStoreSet({ main: mockMainAccount, subAccounts: [] });
+    setAccountsForTesting({ main: mockMainAccount, subAccounts: [] });
     accountsStoreReset();
     expectStoreInitialValues();
   });
@@ -106,13 +93,13 @@ describe("icpAccountsStore", () => {
 
   describe("setBalance", () => {
     it("should set balance for main account", () => {
-      accountsStoreSet({ main: mockMainAccount, subAccounts: [] });
+      setAccountsForTesting({ main: mockMainAccount, subAccounts: [] });
 
       expect(get(icpAccountsStore)?.main.balanceUlps).toEqual(
         mockMainAccount.balanceUlps
       );
       const newBalanceE8s = 100n;
-      accountsStoreSetBalance({
+      setAccountBalanceForTesting({
         accountIdentifier: mockMainAccount.identifier,
         balanceE8s: newBalanceE8s,
       });
@@ -121,7 +108,7 @@ describe("icpAccountsStore", () => {
     });
 
     it("should set balance for subaccount", () => {
-      accountsStoreSet({
+      setAccountsForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
       });
@@ -130,7 +117,7 @@ describe("icpAccountsStore", () => {
         mockSubAccount.balanceUlps
       );
       const newBalanceE8s = 100n;
-      accountsStoreSetBalance({
+      setAccountBalanceForTesting({
         accountIdentifier: mockSubAccount.identifier,
         balanceE8s: newBalanceE8s,
       });
@@ -141,7 +128,7 @@ describe("icpAccountsStore", () => {
     });
 
     it("should set balance for hw account", () => {
-      accountsStoreSet({
+      setAccountsForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
         hardwareWallets: [mockHardwareWalletAccount],
@@ -151,7 +138,7 @@ describe("icpAccountsStore", () => {
         mockHardwareWalletAccount.balanceUlps
       );
       const newBalanceE8s = 100n;
-      accountsStoreSetBalance({
+      setAccountBalanceForTesting({
         accountIdentifier: mockHardwareWalletAccount.identifier,
         balanceE8s: newBalanceE8s,
       });
@@ -162,14 +149,14 @@ describe("icpAccountsStore", () => {
     });
 
     it("should not set balance if identifier doesn't match", () => {
-      accountsStoreSet({
+      setAccountsForTesting({
         main: mockMainAccount,
         subAccounts: [mockSubAccount],
         hardwareWallets: [mockHardwareWalletAccount],
       });
 
       const newBalanceE8s = 100n;
-      accountsStoreSetBalance({
+      setAccountBalanceForTesting({
         accountIdentifier: "not-matching-identifier",
         balanceE8s: newBalanceE8s,
       });

--- a/frontend/src/tests/routes/app/accounts/page.spec.ts
+++ b/frontend/src/tests/routes/app/accounts/page.spec.ts
@@ -2,13 +2,13 @@ import * as ledgerApi from "$lib/api/icp-ledger.api";
 import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { page } from "$mocks/$app/stores";
 import AccountsPage from "$routes/(app)/(u)/(list)/accounts/+page.svelte";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { mockAccountDetails } from "$tests/mocks/icp-accounts.store.mock";
 import { AccountsPlusPagePo } from "$tests/page-objects/AccountsPlusPage.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { resetAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { render } from "@testing-library/svelte";
 
 vi.mock("$lib/api/icp-ledger.api");
@@ -23,7 +23,7 @@ describe("Accounts page", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    icpAccountsStore.resetForTesting();
+    resetAccountsForTesting();
     vi.spyOn(nnsDappApi, "queryAccount").mockResolvedValue(mockAccountDetails);
     vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(314000000n);
   });

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -10,7 +10,6 @@ import {
   CKETH_UNIVERSE_CANISTER_ID,
 } from "$lib/constants/cketh-canister-ids.constants";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { numberToUlps } from "$lib/utils/token.utils";
@@ -30,6 +29,7 @@ import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { TokensRoutePo } from "$tests/page-objects/TokensRoute.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
@@ -156,7 +156,7 @@ describe("Tokens route", () => {
         },
       ]);
       setCkETHCanisters();
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: { ...mockMainAccount, balanceUlps: icpBalanceE8s },
       });
     });

--- a/frontend/src/tests/routes/app/wallet/page.spec.ts
+++ b/frontend/src/tests/routes/app/wallet/page.spec.ts
@@ -1,7 +1,6 @@
 import * as accountsApi from "$lib/api/accounts.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { page } from "$mocks/$app/stores";
 import WalletPage from "$routes/(app)/(u)/(detail)/wallet/+page.svelte";
 import { resetIdentity } from "$tests/mocks/auth.store.mock";
@@ -11,6 +10,7 @@ import {
 } from "$tests/mocks/icp-accounts.store.mock";
 import { WalletPo } from "$tests/page-objects/Wallet.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { render } from "@testing-library/svelte";
 
 describe("Wallet page", () => {
@@ -38,7 +38,7 @@ describe("Wallet page", () => {
 
   it("should pass the account identifier", async () => {
     const testAccountIdentifier = "test-account";
-    icpAccountsStore.setForTesting({
+    setAccountsForTesting({
       ...mockAccountsStoreData,
       subAccounts: [
         {

--- a/frontend/src/tests/utils/accounts.test-utils.ts
+++ b/frontend/src/tests/utils/accounts.test-utils.ts
@@ -1,3 +1,7 @@
+import {
+  icpAccountsStore,
+  type IcpAccountsStoreData,
+} from "$lib/stores/icp-accounts.store";
 import { fireEvent, waitFor, type RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 
@@ -28,4 +32,23 @@ export const selectSegmentBTC = async (container: HTMLElement) => {
   expect(button).not.toBeNull();
 
   await fireEvent.click(button);
+};
+
+export const setAccountsForTesting = (data: IcpAccountsStoreData) => {
+  icpAccountsStore.setForTesting(data);
+};
+
+export const setAccountBalanceForTesting = ({
+  accountIdentifier,
+  balanceE8s,
+}: {
+  accountIdentifier: string;
+  balanceE8s: bigint;
+}) => {
+  const mutableStore = icpAccountsStore.getSingleMutationIcpAccountsStore();
+  mutableStore.setBalance({ accountIdentifier, balanceE8s, certified: true });
+};
+
+export const resetAccountsForTesting = () => {
+  icpAccountsStore.resetForTesting();
 };

--- a/frontend/src/tests/workflows/CreateSubaccount.spec.ts
+++ b/frontend/src/tests/workflows/CreateSubaccount.spec.ts
@@ -5,7 +5,6 @@ import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import Accounts from "$lib/routes/Accounts.svelte";
 import { authStore } from "$lib/stores/auth.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { page } from "$mocks/$app/stores";
 import {
   mockAuthStoreSubscribe,
@@ -18,6 +17,7 @@ import {
 } from "$tests/mocks/icp-accounts.store.mock";
 import { AccountsPo } from "$tests/page-objects/Accounts.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import type { HttpAgent } from "@dfinity/agent";
 import { render } from "@testing-library/svelte";
 import { mock } from "vitest-mock-extended";
@@ -55,7 +55,7 @@ describe("Accounts", () => {
   describe("when tokens page flag is enabled", async () => {
     it("should create a subaccount in NNS", async () => {
       page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
-      icpAccountsStore.setForTesting({
+      setAccountsForTesting({
         main: mockMainAccount,
         subAccounts: [],
         hardwareWallets: [],


### PR DESCRIPTION
# Motivation

We want to switch from using the direct `icpAccountsStore` from using the derived `icpAccountsStore`. This means we have to change how the data is set up in a lot of tests.

In this PR I'm adding a utility to set up the accounts for testing. If we use that utility in every test, then we only have to change code in 1 place when we change how the tests need to be set up.

# Changes

1. Add test utility functions to manipulate `icpAccountsStore` in `frontend/src/tests/utils/accounts.test-utils.ts`.
2. Use it in every test that sets up the `icpAccountsStore`.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet