### PR TITLE
feat: Notify slack on failed reproduction

### DIFF
--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       # This is the recommended development branch for this workflow; pushing it will trigger a build.
       - reproducible
+      - notify-slack-on-failed-reproduction
     tags:
       # The tag used when preparing a release.
       - release-candidate

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -88,12 +88,6 @@ jobs:
           # If the assets hashes differ, the Wasm hashes will also
           # differ, so we only check the Wasm hashes.
           (( $(cat hashes/nns-dapp-wasm_*.txt | sort | uniq | wc -l) == 1 ))
-      - name: Notify Slack on failure
-        uses: dfinity/internet-identity/.github/actions/slack@release-2023-08-28
-        if: ${{ failure() }}
-        with:
-          WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MESSAGE: "Reproducible build failed"
   check_passes:
     needs: ["docker_build", "compare_hashes"]
     if: ${{ always() }}

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -11,7 +11,6 @@ on:
     branches:
       # This is the recommended development branch for this workflow; pushing it will trigger a build.
       - reproducible
-      - notify-slack-on-failed-reproduction
     tags:
       # The tag used when preparing a release.
       - release-candidate

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -109,4 +109,4 @@ jobs:
         if: ${{ failure() }}
         with:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MESSAGE: "Proposals update failed"
+          MESSAGE: "Reproducible docker build test failed for ${{ github.ref_name }}"

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -1,4 +1,11 @@
-name: Reproducible
+name: Reproducible Docker Builds
+# Simulates end users verifying builds published by Dfinity:
+# - Runs docker builds on various different operating systems, with an empty docker cache.
+#   Note: This makes builds slow but is more representative of the end user experience.  The cache we
+#   use in most CI builds may diverge from that created by an end user.  We would want to detect that.
+# - Verifies that all these builds yield the same artifacts.
+# - NOT DONE: Verify that these builds from scratch match our main CI build.
+#   Idea: We could trigger this workflow when we create a release and compare these builds with the artifacts in the release.
 on:
   push:
     branches:
@@ -88,3 +95,18 @@ jobs:
         with:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           MESSAGE: "Reproducible build failed"
+  check_passes:
+    needs: ["docker_build", "compare_hashes"]
+    if: ${{ always() }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/needs_success
+        with:
+          needs: '${{ toJson(needs) }}'
+      - name: Notify Slack on failure
+        uses: dfinity/internet-identity/.github/actions/slack@release-2023-08-28
+        if: ${{ failure() }}
+        with:
+          WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          MESSAGE: "Proposals update failed"

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -81,3 +81,9 @@ jobs:
           # If the assets hashes differ, the Wasm hashes will also
           # differ, so we only check the Wasm hashes.
           (( $(cat hashes/nns-dapp-wasm_*.txt | sort | uniq | wc -l) == 1 ))
+      - name: Notify Slack on failure
+        uses: dfinity/internet-identity/.github/actions/slack@release-2023-08-28
+        if: ${{ failure() }}
+        with:
+          WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          MESSAGE: "Reproducible build failed"

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -1,11 +1,10 @@
 name: Reproducible Docker Builds
 # Simulates end users verifying builds published by Dfinity:
 # - Runs docker builds on various different operating systems, with an empty docker cache.
-#   Note: This makes builds slow but is more representative of the end user experience.  The cache we
-#   use in most CI builds may diverge from that created by an end user.  We would want to detect that.
+#   Note: This makes builds slow but is more representative of the end user experience.
 # - Verifies that all these builds yield the same artifacts.
-# - NOT DONE: Verify that these builds from scratch match our main CI build.
-#   Idea: We could trigger this workflow when we create a release and compare these builds with the artifacts in the release.
+# - NOT DONE: Verify that these builds match our release artifacts.  This would correspond to third
+#   party verifiers getting consistent hashes that differ from our release.
 on:
   push:
     branches:

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -47,12 +47,14 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Dependabot configuration to update GitHub actions.
 * Add `NNS_INDEX_CANISTER_ID` to the configuration.
+* Notify the maintainers if the docker build is not reproducible.
 
 #### Changed
 
 * Upgraded `ic-js` dependencies to utilize `agent-js` patched version `v1.0.1`.
 * Avoid a 5 minute timeout in CI by waiting 20 seconds instead.
 * Fixed the formatting command in the `update-aggregator-response` GitHub workflow.
+* Disambiguated the title of the docker reproducibility check.
 
 #### Deprecated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@
 FROM --platform=linux/amd64 ubuntu:20.04 as check-environment
 SHELL ["bash", "-c"]
 ENV TZ=UTC
-RUN BADCODE
 RUN awk -v gigs=4 '/^MemTotal:/{if ($2 < (gigs*1024 * 1024)){ printf "Insufficient RAM.  Please provide Docker with at least %dGB of RAM\n", gigs; exit 1 }}' /proc/meminfo
 
 # Operating system with basic tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@
 FROM --platform=linux/amd64 ubuntu:20.04 as check-environment
 SHELL ["bash", "-c"]
 ENV TZ=UTC
+RUN BADCODE
 RUN awk -v gigs=4 '/^MemTotal:/{if ($2 < (gigs*1024 * 1024)){ printf "Insufficient RAM.  Please provide Docker with at least %dGB of RAM\n", gigs; exit 1 }}' /proc/meminfo
 
 # Operating system with basic tools


### PR DESCRIPTION
# Motivation
We would like to report failures in reproducible docker builds in slack.

# Changes
- Rename the title of the docker build workflow.
  - At the time it was written there was only one reproducible builds test but now there are two, leading to confusion.
- Add a job to the workflow that checks that the other jobs complete successfully.  If not, it posts a message to slack.

# Tests
Tested manually thus:
- Injected an error into the Dockerfile
- Forced the workflow to run (by pushing to a branch specified as a push trigger in the workflow)
- Observed:
  - All 4 docker builds completed.  The docker build step did not bail out as soon as one build failed.  This is as before, is expected and desired.  If builds fail on one platform but succeed on others, this is useful information.
  - The hash comparison job was skipped.  This is unchanged and is as desired.
  - The final check job ran and [posted a message to slack](https://dfinity.slack.com/archives/C05G2RZFJAJ/p1709131039360009).

# Todos

- [x] Add entry to changelog (if necessary).
