### PR TITLE
Make dfx install again

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -52,8 +52,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
-* Adapted Dockerfile to the new `dfx` installation procedure:
-  * Added `/root/.local/share/dfx/bin` to `PATH`.
-  * When installing `dfx`, set a new environment variable: `DFXVM_INIT_YES=true`
+* Adapted Dockerfile to the new `dfx` installation procedure.
 
 #### Security

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -52,4 +52,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Adapted Dockerfile to the new `dfx` installation procedure:
+  * Added `/root/.local/share/dfx/bin` to `PATH`.
+  * When installing `dfx`, set a new environment variable: `DFXVM_INIT_YES=true`
+
 #### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ COPY rs/sns_aggregator/Cargo.toml rs/sns_aggregator/Cargo.toml
 RUN mkdir -p rs/backend/src/bin rs/proposals/src rs/sns_aggregator/src && touch rs/backend/src/lib.rs rs/proposals/src/lib.rs rs/sns_aggregator/src/lib.rs && echo 'fn main(){}' | tee rs/backend/src/main.rs > rs/backend/src/bin/nns-dapp-check-args.rs && cargo build --target wasm32-unknown-unknown --release --package nns-dapp && rm -f target/wasm32-unknown-unknown/release/*wasm
 # Install dfx
 WORKDIR /
+# dfx is installed in `$HOME/.local/share/dfx/bin` but we can't reference `$HOME` here so we hardcode `/root`.
 ENV PATH="/root/.local/share/dfx/bin:${PATH}"
 RUN DFXVM_INIT_YES=true DFX_VERSION="$(cat config/dfx_version)" sh -c "$(curl -fsSL https://sdk.dfinity.org/install.sh)" && dfx --version
 # TODO: Make didc support binstall, then use cargo binstall --no-confirm didc here.

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,8 @@ COPY rs/sns_aggregator/Cargo.toml rs/sns_aggregator/Cargo.toml
 RUN mkdir -p rs/backend/src/bin rs/proposals/src rs/sns_aggregator/src && touch rs/backend/src/lib.rs rs/proposals/src/lib.rs rs/sns_aggregator/src/lib.rs && echo 'fn main(){}' | tee rs/backend/src/main.rs > rs/backend/src/bin/nns-dapp-check-args.rs && cargo build --target wasm32-unknown-unknown --release --package nns-dapp && rm -f target/wasm32-unknown-unknown/release/*wasm
 # Install dfx
 WORKDIR /
-RUN DFX_VERSION="$(cat config/dfx_version)" sh -c "$(curl -fsSL https://sdk.dfinity.org/install.sh)" && dfx --version
+ENV PATH="/root/.local/share/dfx/bin:${PATH}"
+RUN DFXVM_INIT_YES=true DFX_VERSION="$(cat config/dfx_version)" sh -c "$(curl -fsSL https://sdk.dfinity.org/install.sh)" && dfx --version
 # TODO: Make didc support binstall, then use cargo binstall --no-confirm didc here.
 RUN set +x && curl -Lf --retry 5 "https://github.com/dfinity/candid/releases/download/$(cat config/didc_version)/didc-linux64" | install -m 755 /dev/stdin "/usr/local/bin/didc" && didc --version
 RUN curl -L --proto '=https' --tlsv1.2 -sSf "https://github.com/cargo-bins/cargo-binstall/releases/download/v$(cat config/binstall_version)/cargo-binstall-x86_64-unknown-linux-musl.tgz" | tar -xvzf -


### PR DESCRIPTION
# Motivation

The `dfx` installation procedure changed. This is breaking `./scripts/docker-build`.

# Changes

In `Dockerfile`:

1. Add `/root/.local/share/dfx/bin` to `PATH`.
2. When installing `dfx`, set a new environment variable: `DFXVM_INIT_YES=true`

Ideally, in 1, we would like to say `${HOME}/` instead of hard-coding `/root/`. I will figure out whether that is possible later, and if it is, do a second PR. For now, we want to unblock things. One thing that is blocked is seeing whether the `upload-artifact` fixes were also applied to the `Reproducible` workflow.

These changes are indicated in the following places:

* [forum]: Here, other users experienced similar problems.
* [Slack]: Here, Eric Swanson advises us to make these changes.

[forum]: https://forum.dfinity.org/t/how-do-i-install-dfx-17-0-non-interactively
[Slack]: https://dfinity.slack.com/archives/CGA566TPV/p1708447484211489

# Tests

Before this change,

```
./scripts/docker-build
```

would fail. After this change, it successfully prints out WASM hashes.

The fail output indicates that installing dfx exploded:

```
> [builder 17/22] RUN DFX_VERSION="$(cat config/dfx_version)" sh -c "$(curl -fsSL https://sdk.dfinity.org/install.sh)" && dfx --version:
#0 0.763 Executing dfxvm install script, commit: edf3c3c87ab977366212adaadd6fdb987de396d3
#0 0.770 Downloading latest release...
#0 2.861 Checking integrity of tarball...
#0 2.902 dfxvm-x86_64-unknown-linux-gnu.tar.gz: OK
#0 3.026 error: failed to interact with console
#0 3.026 error:     caused by: IO error: not a terminal
#0 3.026 error:     caused by: not a terminal
#0 3.026 
#0 3.026 Welcome to dfxvm!
```

# Todos

- [x] Add entry to changelog (if necessary).

# Related Bugs

* http://go/jira/NNS1-2897
* http://go/jira/NNS1-2914