### PR TITLE
++

### DIFF
--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -41,7 +41,10 @@ jobs:
         # - uses: docker-practice/actions-setup-docker@master
         # to be used until this PR is merged:
         # https://github.com/docker-practice/actions-setup-docker/pull/29
-        timeout-minutes: 12
+        with:
+          docker_version: "24.0"
+          docker_channel: "stable"
+        timeout-minutes: 20
       - name: Checkout
         uses: actions/checkout@v4
       # Helps with debugging

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -63,12 +63,17 @@ jobs:
       - name: 'Upload hashes'
         uses: actions/upload-artifact@v4
         with:
-          name: hashes
+          name: hashes_${{ matrix.os }}_${{ matrix.time }}
           path: hashes/*.txt
   compare_hashes:
     runs-on: ubuntu-latest
     needs: [docker_build]
     steps:
+      - name: Merge Hashes
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: hashes
+          pattern: hashes_*
       - name: Get hashes
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # - macos-11 - Docker fails to start. Too old and no longer maintained properly?
           - ubuntu-20.04
           - ubuntu-22.04
+          - macos-11
           - macos-12
           - macos-13
           - macos-14
@@ -35,7 +35,11 @@ jobs:
             echo "/usr/local/bin" >> $GITHUB_PATH
             echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
           fi
-      - uses: docker-practice/actions-setup-docker@master
+      - uses: better0fdead/actions-setup-docker@better0fdead/increase-timeout
+        # Note: The above is a fork of:
+        # - uses: docker-practice/actions-setup-docker@master
+        # to be used until this PR is merged:
+        # https://github.com/docker-practice/actions-setup-docker/pull/29
         timeout-minutes: 12
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -75,6 +75,7 @@ jobs:
   compare_hashes:
     runs-on: ubuntu-latest
     needs: [docker_build]
+    if: ${{ always() }}
     steps:
       - name: Merge Hashes
         uses: actions/upload-artifact/merge@v4

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -19,7 +19,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
+        os:
+          # - macos-11 - Docker fails to start. Too old and no longer maintained properly?
+          - ubuntu-20.04
+          - ubuntu-22.04
+          - macos-12
+          - macos-13
+          - macos-14
     steps:
       - name: Unbork mac
         run: |

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -20,12 +20,12 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          # - macos-14 - rus on mac silicon & doesn't support docker properly.
           - ubuntu-20.04
           - ubuntu-22.04
           - macos-11
           - macos-12
           - macos-13
-          - macos-14
     steps:
       - name: Unbork mac
         run: |

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -35,7 +35,8 @@ jobs:
             echo "/usr/local/bin" >> $GITHUB_PATH
             echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
           fi
-      - uses: better0fdead/actions-setup-docker@better0fdead/increase-timeout
+      - uses: docker-practice/actions-setup-docker@1.0.11
+        #- uses: better0fdead/actions-setup-docker@better0fdead/increase-timeout
         # Note: The above is a fork of:
         # - uses: docker-practice/actions-setup-docker@master
         # to be used until this PR is merged:

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       # This is the recommended development branch for this workflow; pushing it will trigger a build.
       - reproducible
+      - fix-upload-artifacts-in-docker-repro
     tags:
       # The tag used when preparing a release.
       - release-candidate

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -35,7 +35,7 @@ jobs:
             echo "/usr/local/bin" >> $GITHUB_PATH
             echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
           fi
-      - uses: docker-practice/actions-setup-docker@1.0.11
+      - uses: bitdivine/actions-setup-docker@master
         #- uses: better0fdead/actions-setup-docker@better0fdead/increase-timeout
         # Note: The above is a fork of:
         # - uses: docker-practice/actions-setup-docker@master


### PR DESCRIPTION
# Motivation

<!-- Describe the motivation that lead to the PR -->

# Changes
- Update the way artefacts are merged
  - Note: upload-artifact@v4 has a breaking change that forces this.
- Update the list of mac builders
  - Disabled macos-11 because docker [fails to start on macos-11](https://github.com/dfinity/nns-dapp/actions/runs/8083906200/job/22116542351).  Presumably the OS is too old and teh docker integration is no longer maintained correctly.
  - Kept macos-12
  - Added macos-13 and macos-14
- Run the hash comparison test regardless of how many builds succeeded.
  - Note: The overall workflow will still fail if one build fails, but there will be more information available from the run.  E.g. a workflow run could be summarized as:  "3 of 4 builds succeeded, those 3 hashes are the same.  But the workflow fails on account of that one failed build."

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
