### PR TITLE
NNS1-2857: Make icpAccountBalancesStore a queued store

### DIFF
--- a/frontend/src/lib/stores/icp-account-balances.store.ts
+++ b/frontend/src/lib/stores/icp-account-balances.store.ts
@@ -1,5 +1,7 @@
 import type { AccountIdentifierString } from "$lib/canisters/nns-dapp/nns-dapp.types";
-import { writable, type Readable } from "svelte/store";
+import type { QueryAndUpdateStrategy } from "$lib/services/utils.services";
+import type { Readable } from "svelte/store";
+import { queuedStore } from "./queued-store";
 
 export interface IcpAccountBalanceStoreData {
   balanceE8s: bigint;
@@ -11,8 +13,14 @@ export type IcpAccountBalancesStoreData = Record<
   IcpAccountBalanceStoreData
 >;
 
-export interface IcpAccountBalancesStore
-  extends Readable<IcpAccountBalancesStoreData> {
+export interface SingleMutationIcpAccountBalancesStore {
+  set: ({
+    data,
+    certified,
+  }: {
+    data: IcpAccountBalancesStoreData;
+    certified: boolean;
+  }) => void;
   setBalance: ({
     accountIdentifier,
     balanceE8s,
@@ -22,34 +30,71 @@ export interface IcpAccountBalancesStore
     balanceE8s: bigint;
     certified: boolean;
   }) => void;
-  reset: () => void;
+  reset: ({ certified }: { certified: boolean }) => void;
+  cancel: () => void;
+}
+
+export interface IcpAccountBalancesStore
+  extends Readable<IcpAccountBalancesStoreData> {
+  getSingleMutationIcpAccountBalancesStore: (
+    strategy?: QueryAndUpdateStrategy | undefined
+  ) => SingleMutationIcpAccountBalancesStore;
+  resetForTesting: () => void;
+  // Set the store contents if you don't care about the queryAndUpdate race
+  // condition.
+  setForTesting: (data: IcpAccountBalancesStoreData) => void;
 }
 
 const initIpcAccountBalancesStore = (): IcpAccountBalancesStore => {
   const initialStoreData = {};
-  const { subscribe, set, update } =
-    writable<IcpAccountBalancesStoreData>(initialStoreData);
+
+  const { subscribe, getSingleMutationStore, resetForTesting } =
+    queuedStore<IcpAccountBalancesStoreData>(initialStoreData);
+
+  const getSingleMutationIcpAccountBalancesStore = (
+    strategy?: QueryAndUpdateStrategy | undefined
+  ): SingleMutationIcpAccountBalancesStore => {
+    const { set, update, cancel } = getSingleMutationStore(strategy);
+
+    return {
+      set,
+
+      setBalance({
+        accountIdentifier,
+        balanceE8s,
+        certified,
+      }: {
+        accountIdentifier: string;
+        balanceE8s: bigint;
+        certified: boolean;
+      }) {
+        update({
+          mutation: (storeData) => ({
+            ...storeData,
+            [accountIdentifier]: {
+              balanceE8s,
+              certified,
+            },
+          }),
+          certified,
+        });
+      },
+      reset: ({ certified }: { certified: boolean }) =>
+        set({ data: initialStoreData, certified }),
+
+      cancel,
+    };
+  };
 
   return {
     subscribe,
-    setBalance({
-      accountIdentifier,
-      balanceE8s,
-      certified,
-    }: {
-      accountIdentifier: string;
-      balanceE8s: bigint;
-      certified: boolean;
-    }) {
-      update((storeData) => ({
-        ...storeData,
-        [accountIdentifier]: {
-          balanceE8s,
-          certified,
-        },
-      }));
+    getSingleMutationIcpAccountBalancesStore,
+    resetForTesting,
+
+    setForTesting(data: IcpAccountBalancesStoreData) {
+      const mutableStore = getSingleMutationIcpAccountBalancesStore();
+      mutableStore.set({ data, certified: true });
     },
-    reset: () => set(initialStoreData),
   };
 };
 

--- a/frontend/src/tests/lib/derived/icp-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-accounts.derived.spec.ts
@@ -50,10 +50,20 @@ describe("icpAccountsStore", () => {
     certified: true,
   };
 
+  const setBalance = ({ accountIdentifier, balanceE8s, certified }) => {
+    const mutableStore =
+      icpAccountBalancesStore.getSingleMutationIcpAccountBalancesStore();
+    mutableStore.setBalance({
+      accountIdentifier,
+      balanceE8s,
+      certified,
+    });
+  };
+
   beforeEach(() => {
     overrideFeatureFlagsStore.reset();
     icpAccountDetailsStore.reset();
-    icpAccountBalancesStore.reset();
+    icpAccountBalancesStore.resetForTesting();
   });
 
   it("should be initialized to empty", () => {
@@ -74,7 +84,7 @@ describe("icpAccountsStore", () => {
       certified: true,
     });
 
-    icpAccountBalancesStore.setBalance({
+    setBalance({
       accountIdentifier: mainAccountIdentifier,
       balanceE8s: mainAccountBalance,
       certified: true,
@@ -96,19 +106,19 @@ describe("icpAccountsStore", () => {
   it("should derive all accounts and balances", () => {
     icpAccountDetailsStore.set(accountDetailsData);
 
-    icpAccountBalancesStore.setBalance({
+    setBalance({
       accountIdentifier: mainAccountIdentifier,
       balanceE8s: mainAccountBalance,
       certified: true,
     });
 
-    icpAccountBalancesStore.setBalance({
+    setBalance({
       accountIdentifier: subAccountIdentifier,
       balanceE8s: subAccountBalance,
       certified: true,
     });
 
-    icpAccountBalancesStore.setBalance({
+    setBalance({
       accountIdentifier: hardwareWalletAccountIdentifier,
       balanceE8s: hardwareWalletAccountBalance,
       certified: true,
@@ -150,19 +160,19 @@ describe("icpAccountsStore", () => {
 
     icpAccountDetailsStore.set(accountDetailsData);
 
-    icpAccountBalancesStore.setBalance({
+    setBalance({
       accountIdentifier: mainAccountIdentifier,
       balanceE8s: mainAccountBalance,
       certified: true,
     });
 
-    icpAccountBalancesStore.setBalance({
+    setBalance({
       accountIdentifier: subAccountIdentifier,
       balanceE8s: subAccountBalance,
       certified: true,
     });
 
-    icpAccountBalancesStore.setBalance({
+    setBalance({
       accountIdentifier: hardwareWalletAccountIdentifier,
       balanceE8s: hardwareWalletAccountBalance,
       certified: true,


### PR DESCRIPTION
# Motivation

We are trying to replace `icpAccountsStore` with a store that's derived from `icpAccountDetailsStore` and `icpAccountBalancesStore`.

`icpAccountsStore` is currently a `queuedStore` which allows it to order queries and updates in the correct order such that old data does not override new data when a new query is made before an old update finishes.

I thought with the simplification brought be the refactoring we would no longer need to use queued stores here but on more careful consideration it will still be possible (especially in fast e2e tests) that an old balance result comes back after a new balance has been queried.

So the new `icpAccountBalancesStore` should also be a `queudStore` just like the old `icpAccountsStore`.

# Changes

Change `icpAccountBalancesStore` to be a `queuedStore`.
See the current queued [icpAccountsStore](https://github.com/dfinity/nns-dapp/blob/85b176bfaed747e470e72d1852b2c880569a33ef/frontend/src/lib/stores/icp-accounts.store.ts#L47) for comparison.

# Tests

Unit test have been updated.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet used