### PR TITLE
fix: The reproducible workflow is no longer messed up because of breaking changes in the upload-artifacts step

### DIFF
--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -69,12 +69,17 @@ jobs:
       - name: 'Upload hashes'
         uses: actions/upload-artifact@v4
         with:
-          name: hashes
+          name: hashes_${{ matrix.os }}_${{ matrix.time }}
           path: hashes/*.txt
   compare_hashes:
     runs-on: ubuntu-latest
     needs: [docker_build]
     steps:
+      - name: Merge Hashes
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: hashes
+          pattern: hashes_*
       - name: Get hashes
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       # This is the recommended development branch for this workflow; pushing it will trigger a build.
       - reproducible
+      - merge-docker-build-artifacts
     tags:
       # The tag used when preparing a release.
       - release-candidate

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -24,7 +24,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
+        os:
+          # - macos-11
+          # - macos-12
+          - ubuntu-20.04
+          - ubuntu-22.04
     steps:
       - name: Unbork mac
         run: |

--- a/.github/workflows/reproducible.yaml
+++ b/.github/workflows/reproducible.yaml
@@ -10,7 +10,6 @@ on:
     branches:
       # This is the recommended development branch for this workflow; pushing it will trigger a build.
       - reproducible
-      - merge-docker-build-artifacts
     tags:
       # The tag used when preparing a release.
       - release-candidate

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -64,5 +64,6 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Adapted Dockerfile to the new `dfx` installation procedure.
+* Adapted the docker reproducibility test to work with `upload-artifact@v4`.
 
 #### Security


### PR DESCRIPTION
# Motivation
`uplaod-artifact@v4` contains a breaking change in the way artifacts are merged.  The [release notes](https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new) describe how to merge with v4.

# Changes
- Update the way artefacts are merged
  - Note: upload-artifact@v4 has a breaking change that forces this.
- Disable mac builders
  - Mac builds are broken at the moment; this is being addressed.

# Tests
- See CI.  I have added the working branch for this PR as a workflow trigger, so the workflow run can be seen there.

# Todos

- [ ] Add entry to changelog (if necessary).
