### PR TITLE
NNS1-2857: Use NNS subaccount in accounts-list.derived.spec.ts

### DIFF
--- a/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/accounts-list.derived.spec.ts
@@ -1,6 +1,8 @@
 import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
-import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
-import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
+import {
+  mockMainAccount,
+  mockSubAccount,
+} from "$tests/mocks/icp-accounts.store.mock";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { get } from "svelte/store";
 
@@ -9,12 +11,12 @@ describe("accounts", () => {
     it("returns nns accounts in an array", () => {
       setAccountsForTesting({
         main: mockMainAccount,
-        subAccounts: [mockSnsMainAccount],
+        subAccounts: [mockSubAccount],
         hardwareWallets: [],
       });
 
       const accounts = get(nnsAccountsListStore);
-      expect(accounts).toEqual([mockMainAccount, mockSnsMainAccount]);
+      expect(accounts).toEqual([mockMainAccount, mockSubAccount]);
     });
   });
 });


### PR DESCRIPTION
# Motivation

This test fails with a refactoring that I'm doing.
But it's using an SNS account as an NNS account so this shouldn't work in the first place.

# Changes

Use `mockSubAccount` instead of `mockSnsMainAccount` as the NNS subaccount used in `frontend/src/tests/lib/derived/accounts-list.derived.spec.ts`.

# Tests

Still passes and like this also passes with the refactoring I have in another branch.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary