### PR TITLE
NNS1-2857: Remove icp-accounts.store.ts and fix imports

### DIFF
--- a/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
+++ b/frontend/src/lib/components/accounts/NnsAccountsFooter.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import { i18n } from "$lib/stores/i18n";
   import Footer from "$lib/components/layout/Footer.svelte";
   import { nonNullish } from "@dfinity/utils";

--- a/frontend/src/lib/components/accounts/NnsAddAccount.svelte
+++ b/frontend/src/lib/components/accounts/NnsAddAccount.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import { i18n } from "$lib/stores/i18n";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import AddAccountModal from "$lib/modals/accounts/AddAccountModal.svelte";

--- a/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.svelte
@@ -2,7 +2,7 @@
   import type { NeuronInfo } from "@dfinity/nns";
   import { onMount } from "svelte";
   import { listKnownNeurons } from "$lib/services/known-neurons.services";
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
   import {

--- a/frontend/src/lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte
@@ -11,7 +11,7 @@
   import CommonItemAction from "../ui/CommonItemAction.svelte";
   import TooltipIcon from "../ui/TooltipIcon.svelte";
   import { authStore } from "$lib/stores/auth.store";
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 
   export let neuron: NeuronInfo;
 

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte
@@ -22,7 +22,7 @@
   import JoinCommunityFundCheckbox from "./actions/JoinCommunityFundCheckbox.svelte";
   import SplitNnsNeuronButton from "./actions/SplitNnsNeuronButton.svelte";
   import { authStore } from "$lib/stores/auth.store";
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 
   export let neuron: NeuronInfo;
 

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte
@@ -14,7 +14,7 @@
   import { secondsToDuration, ICPToken } from "@dfinity/utils";
   import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
   import { authStore } from "$lib/stores/auth.store";
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import DissolveDelayBonusText from "./DissolveDelayBonusText.svelte";
 
   export let neuron: NeuronInfo;

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronHotkeysCard.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronHotkeysCard.svelte
@@ -4,7 +4,7 @@
   import { IconClose, IconWarning, Value } from "@dfinity/gix-components";
   import { startBusyNeuron } from "$lib/services/busy.services";
   import { removeHotkey } from "$lib/services/neurons.services";
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import { authStore } from "$lib/stores/auth.store";
   import { stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -13,7 +13,7 @@
   import PageHeading from "../common/PageHeading.svelte";
   import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
   import { authStore } from "$lib/stores/auth.store";
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import HeadingSubtitle from "../common/HeadingSubtitle.svelte";
   import { Tag } from "@dfinity/gix-components";
 

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronStateItemAction.svelte
@@ -14,7 +14,7 @@
   import DissolveActionButton from "./actions/DissolveActionButton.svelte";
   import CommonItemAction from "../ui/CommonItemAction.svelte";
   import { authStore } from "$lib/stores/auth.store";
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import AgeBonusText from "./AgeBonusText.svelte";
 
   export let neuron: NeuronInfo;

--- a/frontend/src/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.svelte
+++ b/frontend/src/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.svelte
@@ -11,7 +11,7 @@
   } from "$lib/types/nns-neuron-detail.context";
   import { openNnsNeuronModal } from "$lib/utils/modals.utils";
   import { authStore } from "$lib/stores/auth.store";
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import AutoStakeMaturity from "./AutoStakeMaturity.svelte";
 
   export let neuron: NeuronInfo;

--- a/frontend/src/lib/components/neurons/NnsNeuronCardTitle.svelte
+++ b/frontend/src/lib/components/neurons/NnsNeuronCardTitle.svelte
@@ -3,7 +3,7 @@
   import { i18n } from "$lib/stores/i18n";
   import { getNeuronTags, type NeuronTagData } from "$lib/utils/neuron.utils";
   import { authStore } from "$lib/stores/auth.store";
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import NeuronTag from "$lib/components/ui/NeuronTag.svelte";
 
   export let neuron: NeuronInfo;

--- a/frontend/src/lib/components/neurons/SelectNeuronsToMerge.svelte
+++ b/frontend/src/lib/components/neurons/SelectNeuronsToMerge.svelte
@@ -2,7 +2,7 @@
   import type { NeuronId } from "@dfinity/nns";
   import { createEventDispatcher } from "svelte";
   import { MAX_NEURONS_MERGED } from "$lib/constants/neurons.constants";
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import { i18n } from "$lib/stores/i18n";
   import { definedNeuronsStore } from "$lib/stores/neurons.store";
   import { translate } from "$lib/utils/i18n.utils";

--- a/frontend/src/lib/derived/accounts-list.derived.ts
+++ b/frontend/src/lib/derived/accounts-list.derived.ts
@@ -2,7 +2,7 @@
  * A derived store that returns the accounts as an array of accounts.
  */
 
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import type { Account } from "$lib/types/account";
 import type { UniverseCanisterIdText } from "$lib/types/universe";
 import { derived, type Readable } from "svelte/store";

--- a/frontend/src/lib/derived/debug.derived.ts
+++ b/frontend/src/lib/derived/debug.derived.ts
@@ -1,7 +1,7 @@
 import type { Transaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import { canistersStore } from "$lib/stores/canisters.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { icrcCanistersStore } from "$lib/stores/icrc-canisters.store";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";

--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -1,9 +1,9 @@
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
-import { i18n } from "$lib/stores/i18n";
 import {
   icpAccountsStore,
   type IcpAccountsStore,
-} from "$lib/stores/icp-accounts.store";
+} from "$lib/derived/icp-accounts.derived";
+import { i18n } from "$lib/stores/i18n";
 import type { Account, AccountType } from "$lib/types/account";
 import { UserTokenAction, type UserToken } from "$lib/types/tokens-page";
 import type { Universe } from "$lib/types/universe";

--- a/frontend/src/lib/modals/neurons/NewFolloweeModal.svelte
+++ b/frontend/src/lib/modals/neurons/NewFolloweeModal.svelte
@@ -6,7 +6,7 @@
   import { Spinner } from "@dfinity/gix-components";
   import { listKnownNeurons } from "$lib/services/known-neurons.services";
   import { addFollowee } from "$lib/services/neurons.services";
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import { authStore } from "$lib/stores/auth.store";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { i18n } from "$lib/stores/i18n";

--- a/frontend/src/lib/modals/neurons/SpawnNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SpawnNeuronModal.svelte
@@ -20,7 +20,7 @@
   import ConfirmSpawnHW from "$lib/components/neuron-detail/ConfirmSpawnHW.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
   import { goto } from "$app/navigation";
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 
   export let neuron: NeuronInfo;
 

--- a/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
+++ b/frontend/src/lib/modals/neurons/SplitNnsNeuronModal.svelte
@@ -19,7 +19,7 @@
   import { splitNeuron } from "$lib/services/neurons.services";
   import { toastsError, toastsSuccess } from "$lib/stores/toasts.store";
   import { mainTransactionFeeE8sStore } from "$lib/derived/main-transaction-fee.derived";
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 
   export let neuron: NeuronInfo;
 

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -12,7 +12,7 @@
     loadBalance,
     pollAccounts,
   } from "$lib/services/icp-accounts.services";
-  import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import { Island, Spinner } from "@dfinity/gix-components";
   import { toastsError } from "$lib/stores/toasts.store";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";

--- a/frontend/src/lib/services/busy.services.ts
+++ b/frontend/src/lib/services/busy.services.ts
@@ -1,5 +1,5 @@
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { startBusy, type BusyStateInitiatorType } from "$lib/stores/busy.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { isNeuronControlledByHardwareWallet } from "$lib/utils/neuron.utils";
 import type { NeuronId } from "@dfinity/nns";
 import { get } from "svelte/store";

--- a/frontend/src/lib/services/dev.services.ts
+++ b/frontend/src/lib/services/dev.services.ts
@@ -5,9 +5,9 @@ import {
   receiveMockBtc,
 } from "$lib/api/dev.api";
 import { CKBTC_MINTER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
+import type { IcpAccountsStoreData } from "$lib/derived/icp-accounts.derived";
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { getAuthenticatedIdentity } from "$lib/services/auth.services";
-import type { IcpAccountsStoreData } from "$lib/stores/icp-accounts.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import type { IcpAccount } from "$lib/types/account";
 import { numberToUlps } from "$lib/utils/token.utils";

--- a/frontend/src/lib/services/icp-accounts.services.ts
+++ b/frontend/src/lib/services/icp-accounts.services.ts
@@ -21,6 +21,7 @@ import {
 import { DEFAULT_TRANSACTION_PAGE_LIMIT } from "$lib/constants/constants";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { mainTransactionFeeE8sStore } from "$lib/derived/main-transaction-fee.derived";
 import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/icp-ledger.services.proxy";
@@ -33,7 +34,6 @@ import {
   icpAccountDetailsStore,
   type IcpAccountDetailsStoreData,
 } from "$lib/stores/icp-account-details.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import type { Account, AccountIdentifierText } from "$lib/types/account";
 import type { NewTransaction } from "$lib/types/transaction";

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -7,11 +7,11 @@ import {
   SNS_SUPPORT_VERSION,
 } from "$lib/constants/ledger-app.constants";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { mainTransactionFeeE8sStore } from "$lib/derived/main-transaction-fee.derived";
 import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/icp-ledger.services.proxy";
 import { startBusy, stopBusy } from "$lib/stores/busy.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { definedNeuronsStore, neuronsStore } from "$lib/stores/neurons.store";
 import {
   toastsError,

--- a/frontend/src/lib/services/seed-neurons.services.ts
+++ b/frontend/src/lib/services/seed-neurons.services.ts
@@ -1,9 +1,9 @@
 import { createAgent } from "$lib/api/agent.api";
 import { HOST } from "$lib/constants/environment.constants";
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { Secp256k1PublicKey } from "$lib/keys/secp256k1";
 import { getLedgerIdentityProxy } from "$lib/proxy/icp-ledger.services.proxy";
 import { startBusy, stopBusy } from "$lib/stores/busy.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { toastsError, toastsShow } from "$lib/stores/toasts.store";
 import { mapNeuronErrorToToastMessage } from "$lib/utils/error.utils";
 import { translate } from "$lib/utils/i18n.utils";

--- a/frontend/src/lib/stores/icp-accounts.store.ts
+++ b/frontend/src/lib/stores/icp-accounts.store.ts
@@ -1,7 +1,0 @@
-export {
-  icpAccountsStore,
-  type IcpAccountsStore,
-  type IcpAccountsStoreData,
-} from "$lib/derived/icp-accounts.derived";
-
-// TODO: Remove this and make clients use `$lib/derived/icp-accounts.derived` directly.

--- a/frontend/src/lib/utils/accounts.utils.ts
+++ b/frontend/src/lib/utils/accounts.utils.ts
@@ -1,5 +1,5 @@
 import type { UniversesAccounts } from "$lib/derived/accounts-list.derived";
-import type { IcpAccountsStoreData } from "$lib/stores/icp-accounts.store";
+import type { IcpAccountsStoreData } from "$lib/derived/icp-accounts.derived";
 import type {
   Account,
   AccountIdentifierText,

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -18,7 +18,7 @@ import {
   TOPICS_TO_FOLLOW_NNS,
 } from "$lib/constants/neurons.constants";
 import { DEPRECATED_TOPICS } from "$lib/constants/proposals.constants";
-import type { IcpAccountsStoreData } from "$lib/stores/icp-accounts.store";
+import type { IcpAccountsStoreData } from "$lib/derived/icp-accounts.derived";
 import type { NeuronsStore } from "$lib/stores/neurons.store";
 import type { VoteRegistrationStoreData } from "$lib/stores/vote-registration.store";
 import type { Account } from "$lib/types/account";

--- a/frontend/src/tests/lib/components/accounts/SelectDestinationAddress.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/SelectDestinationAddress.spec.ts
@@ -1,6 +1,6 @@
 import SelectDestinationAddress from "$lib/components/accounts/SelectDestinationAddress.svelte";
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import {
   mockAccountsStoreSubscribe,

--- a/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
+++ b/frontend/src/tests/lib/components/universe/UniverseAccountsBalance.spec.ts
@@ -1,8 +1,8 @@
 import ProjectAccountsBalance from "$lib/components/universe/UniverseAccountsBalance.svelte";
 import { CKBTC_LEDGER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { CKETH_LEDGER_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { formatTokenE8s } from "$lib/utils/token.utils";

--- a/frontend/src/tests/lib/derived/universes-accounts-balance.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/universes-accounts-balance.derived.spec.ts
@@ -1,6 +1,6 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { universesAccountsBalance } from "$lib/derived/universes-accounts-balance.derived";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import {
   mockAccountsStoreSubscribe,

--- a/frontend/src/tests/lib/modals/accounts/IcpTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcpTransactionModal.spec.ts
@@ -1,7 +1,7 @@
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import IcpTransactionModal from "$lib/modals/accounts/IcpTransactionModal.svelte";
 import { transferICP } from "$lib/services/icp-accounts.services";
 import { authStore } from "$lib/stores/auth.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountsStoreSubscribe,

--- a/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddCyclesModal.spec.ts
@@ -1,8 +1,8 @@
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import {
   getIcpToCyclesExchangeRate,
   topUpCanister,
 } from "$lib/services/canisters.services";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { toastsSuccess } from "$lib/stores/toasts.store";
 import { mockCanister } from "$tests/mocks/canisters.mock";
 import {

--- a/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/CreateCanisterModal.spec.ts
@@ -2,12 +2,12 @@ import {
   MAX_CANISTER_NAME_LENGTH,
   NEW_CANISTER_MIN_T_CYCLES,
 } from "$lib/constants/canisters.constants";
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import CreateCanisterModal from "$lib/modals/canisters/CreateCanisterModal.svelte";
 import {
   createCanister,
   getIcpToCyclesExchangeRate,
 } from "$lib/services/canisters.services";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { toastsShow } from "$lib/stores/toasts.store";
 import { mockCanister } from "$tests/mocks/canisters.mock";
 import en from "$tests/mocks/i18n.mock";

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeMaturityModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeMaturityModal.spec.ts
@@ -1,6 +1,6 @@
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import NnsStakeMaturityModal from "$lib/modals/neurons/NnsStakeMaturityModal.svelte";
 import { stakeMaturity } from "$lib/services/neurons.services";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { formattedMaturity } from "$lib/utils/neuron.utils";
 import {
   mockAccountsStoreSubscribe,

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -3,6 +3,7 @@ import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import type { AccountDetails } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { SYNC_ACCOUNTS_RETRY_SECONDS } from "$lib/constants/accounts.constants";
 import { SECONDS_IN_DAY } from "$lib/constants/constants";
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import NnsStakeNeuronModal from "$lib/modals/neurons/NnsStakeNeuronModal.svelte";
 import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
 import {
@@ -10,7 +11,6 @@ import {
   stakeNeuron,
   updateDelay,
 } from "$lib/services/neurons.services";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {

--- a/frontend/src/tests/lib/services/dev.services.spec.ts
+++ b/frontend/src/tests/lib/services/dev.services.spec.ts
@@ -1,5 +1,5 @@
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { getICPs } from "$lib/services/dev.services";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { mockAccountsStoreSubscribe } from "$tests/mocks/icp-accounts.store.mock";
 
 describe("dev-services", () => {

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -1,5 +1,6 @@
 import * as ledgerApi from "$lib/api/icp-ledger.api";
 import { SALE_PARTICIPATION_RETRY_SECONDS } from "$lib/constants/sns.constants";
+import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import {
   importInitSnsWrapper,
@@ -15,7 +16,6 @@ import {
 } from "$lib/services/sns-sale.services";
 import { authStore } from "$lib/stores/auth.store";
 import * as busyStore from "$lib/stores/busy.store";
-import { icpAccountsStore } from "$lib/stores/icp-accounts.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
 import * as toastsStore from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -13,7 +13,7 @@ import {
   TOPICS_TO_FOLLOW_NNS,
 } from "$lib/constants/neurons.constants";
 import { DEPRECATED_TOPICS } from "$lib/constants/proposals.constants";
-import type { IcpAccountsStoreData } from "$lib/stores/icp-accounts.store";
+import type { IcpAccountsStoreData } from "$lib/derived/icp-accounts.derived";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import { enumValues } from "$lib/utils/enum.utils";

--- a/frontend/src/tests/mocks/icp-accounts.store.mock.ts
+++ b/frontend/src/tests/mocks/icp-accounts.store.mock.ts
@@ -3,7 +3,7 @@ import type {
   HardwareWalletAccountDetails,
   SubAccountDetails,
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
-import type { IcpAccountsStoreData } from "$lib/stores/icp-accounts.store";
+import type { IcpAccountsStoreData } from "$lib/derived/icp-accounts.derived";
 import type { Account, IcpAccount } from "$lib/types/account";
 import { Principal } from "@dfinity/principal";
 import type { Subscriber } from "svelte/store";


### PR DESCRIPTION
# Motivation

In https://github.com/dfinity/nns-dapp/pull/4566 we made `frontend/src/lib/stores/icp-accounts.store.ts` temporarily export `$lib/derived/icp-accounts.derived` so we didn't have to update all the imports yet.

# Changes

1. Remove `frontend/src/lib/stores/icp-accounts.store.ts`.
2. Fix all the imports to point to `$lib/derived/icp-accounts.derived`.

# Tests

Still pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary