### PR TITLE
Remove duplicate syncAccounts test

### DIFF
--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -510,44 +510,6 @@ describe("icp-accounts.services", () => {
         .mockResolvedValue(undefined);
     });
 
-    it("should sync accounts", async () => {
-      const mockAccounts = {
-        main: {
-          ...mockMainAccount,
-          balanceUlps: mainBalanceE8s,
-        },
-        subAccounts: [],
-        hardwareWallets: [],
-      };
-      await syncAccounts();
-
-      expect(queryAccountSpy).toHaveBeenCalledTimes(2);
-      expect(queryAccountBalanceSpy).toHaveBeenCalledWith({
-        identity: mockIdentity,
-        icpAccountIdentifier: mockAccountDetails.account_identifier,
-        certified: true,
-      });
-      expect(queryAccountBalanceSpy).toHaveBeenCalledWith({
-        identity: mockIdentity,
-        icpAccountIdentifier: mockAccountDetails.account_identifier,
-        certified: false,
-      });
-      expect(queryAccountBalanceSpy).toBeCalledTimes(2);
-
-      const accounts = get(icpAccountsStore);
-      expect(accounts).toEqual(mockAccounts);
-      expect(get(icpAccountDetailsStore)).toEqual({
-        accountDetails: mockAccountDetails,
-        certified: true,
-      });
-      expect(get(icpAccountBalancesStore)).toEqual({
-        [mockAccountDetails.account_identifier]: {
-          balanceE8s: mainBalanceE8s,
-          certified: true,
-        },
-      });
-    });
-
     it("should add a subaccount", async () => {
       await addSubAccount({
         name: "test subaccount",

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -495,16 +495,14 @@ describe("icp-accounts.services", () => {
   describe("services", () => {
     const mainBalanceE8s = 10_000_000n;
 
-    let queryAccountBalanceSpy: SpyInstance;
-    let queryAccountSpy: SpyInstance;
     let spyCreateSubAccount: SpyInstance;
     beforeEach(() => {
-      queryAccountBalanceSpy = vi
-        .spyOn(ledgerApi, "queryAccountBalance")
-        .mockResolvedValue(mainBalanceE8s);
-      queryAccountSpy = vi
-        .spyOn(nnsdappApi, "queryAccount")
-        .mockResolvedValue(mockAccountDetails);
+      vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
+        mainBalanceE8s
+      );
+      vi.spyOn(nnsdappApi, "queryAccount").mockResolvedValue(
+        mockAccountDetails
+      );
       spyCreateSubAccount = vi
         .spyOn(accountsApi, "createSubAccount")
         .mockResolvedValue(undefined);


### PR DESCRIPTION
# Motivation

These 2 tests are identical, except that one has the setup inside the test and the other has the setup in the `beforeEach` before it:
https://github.com/dfinity/nns-dapp/blob/c2d47f25488e68194e9945c4873402937f0ae7d5/frontend/src/tests/lib/services/icp-accounts.services.spec.ts#L713
https://github.com/dfinity/nns-dapp/blob/c2d47f25488e68194e9945c4873402937f0ae7d5/frontend/src/tests/lib/services/icp-accounts.services.spec.ts#L398

The newest one was added in [this PR](https://github.com/dfinity/nns-dapp/pull/1969).
I checked with @lmuntaner and he confirmed that he probably wanted to remove the one in the `describe("services"`.

# Changes

Remove the duplicate test.

# Tests

removed

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary