### PR TITLE
NNS1-2857: Fix double reloading of transactions

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -37,6 +37,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Bug where transferred SNS neurons appeared in the list of neurons after transferring them.
 * Bug when the "Manage Internet Identity" link always uses `internetcomputer.org` domain.
+* Don't reload transactions multiple times when closing the receive modal.
 
 #### Security
 

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -269,12 +269,12 @@
   const reloadAccount = async () => {
     try {
       if (nonNullish($selectedAccountStore.account)) {
-        await Promise.all([
-          loadBalance({
-            accountIdentifier: $selectedAccountStore.account.identifier,
-          }),
-          reloadTransactions($selectedAccountStore.account.identifier),
-        ]);
+        await loadBalance({
+          accountIdentifier: $selectedAccountStore.account.identifier,
+        });
+        // Reloading the balance results in reloading the transactions in
+        // accountDidUpdate so we don't reload transactions here to avoid doing
+        // it twice.
       }
     } catch (err: unknown) {
       toastsError({

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -643,6 +643,16 @@ describe("NnsWallet", () => {
         ...expectedQueryBalanceParams,
       });
 
+      // New balance should be displayed.
+      expect(await walletPo.getWalletPageHeadingPo().getTitle()).toBe(
+        oldBalanceFormatted
+      );
+      resolveQueryBalance(newBalance);
+      await runResolvedPromises();
+      expect(await walletPo.getWalletPageHeadingPo().getTitle()).toBe(
+        newBalanceFormatted
+      );
+
       // Transactions should be reloaded.
       expect(accountsApi.getTransactions).toBeCalledTimes(2);
       const expectedGetTransactionParams = {
@@ -659,16 +669,6 @@ describe("NnsWallet", () => {
         ...expectedGetTransactionParams,
       });
 
-      // New balance should be displayed.
-      expect(await walletPo.getWalletPageHeadingPo().getTitle()).toBe(
-        oldBalanceFormatted
-      );
-      resolveQueryBalance(newBalance);
-      await runResolvedPromises();
-      expect(await walletPo.getWalletPageHeadingPo().getTitle()).toBe(
-        newBalanceFormatted
-      );
-
       // New transactions should be displayed.
       expect(
         await walletPo.getTransactionListPo().getTransactionCardPos()
@@ -684,11 +684,10 @@ describe("NnsWallet", () => {
         await walletPo.getTransactionListPo().getTransactionCardPos()
       ).toHaveLength(1);
 
-      // The updated balance causes one the transactions to be loaded once more.
-      // This is not what should happen but it's what currently happens so we
-      // expect it here to remind us to change the expectation when the behavior
-      // is fixed.
-      expect(accountsApi.getTransactions).toBeCalledTimes(4);
+      // Reloading the balance should not have resulted in additional calls to
+      // getTransactions.
+      expect(accountsApi.getTransactions).toBeCalledTimes(2);
+      expect(ledgerApi.queryAccountBalance).toBeCalledTimes(2);
     });
 
     it("should navigate to accounts when account identifier is missing", async () => {


### PR DESCRIPTION
# Motivation

Fix the issue of double transaction reloading discovered in https://github.com/dfinity/nns-dapp/pull/4581

# Changes

Don't explicitly reload transactions when closing the receive modal because reloading the balance also results in reloading transactions.

# Tests

1. Change the test to expect the transactions to be reloaded only after the balance has reloaded.
2. Expect no additional calls to `getTransactions` like there were before.

# Todos

- [x] Add entry to changelog (if necessary).
