### PR TITLE
Upgrade ic-js next

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.2.1-next-2024-02-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.2.1-next-2024-02-21.1.tgz",
-      "integrity": "sha512-SzO45SKr+j2xcey+x6VeuTmOozyGJD+jvYjwOabT/joeYFZiHMdA9z7+gjcjtS05D9NwBCkmA3tYaBVIbe8pag==",
+      "version": "2.2.1-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.2.1-next-2024-03-04.2.tgz",
+      "integrity": "sha512-J6M9O4AydkTeffK31gCh0f5wuD/N2thoe5j582xbDy6sATF9qapVmJ3ECrpHeo/wrymp0Gd8GSitSObS4S16DQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.0.2-next-2024-02-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.2-next-2024-02-21.1.tgz",
-      "integrity": "sha512-rCH3DcTwcio5sa/SXaC5v5Rn8RZw1n0iTHSlyl3xOxFVDqUspX8YUVItlF5s0KR78Qm0+P1lvy6wAh91OvLqbg==",
+      "version": "3.0.2-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.2-next-2024-03-04.2.tgz",
+      "integrity": "sha512-sN9qXM7RdulvPNbaIQ5sWsT2onNa3iLSlEpqXyiqgXCVYoaqvrphM4IvWUv9qBb+z5Ygqhk0x9wI9X4rY15gsg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "2.2.2-next-2024-02-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.2.2-next-2024-02-21.1.tgz",
-      "integrity": "sha512-INbRAFRb+N8789+H20uL7SDH4kstQXHezeou0H/jehvBnbgNQfmS8xv8DuBGV4/25d9GWvT0VpQHjUlmX814DA==",
+      "version": "2.2.2-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.2.2-next-2024-03-04.2.tgz",
+      "integrity": "sha512-lnL8C9QfECVXtyphMRt7UWePCC7NHmSLPn3qAQP8VOBv+9BaUDtUEIdeB967MLSTuDVYY8+xlW9OLdJ/gAOdBw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.2.1-next-2024-02-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.1-next-2024-02-21.1.tgz",
-      "integrity": "sha512-LTUx0+t4ajsmgapEOAgWzIXJiW2MeSDzZRC5Ps1v0SWgQ1HhNp4n5wcr0JTX1cjiO9V0303yyLBYfaJPaqLybQ==",
+      "version": "2.2.1-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.1-next-2024-03-04.2.tgz",
+      "integrity": "sha512-SRzTQFOJL/bY85Qz/3ifxDDorehg+IppMBqxZ2CUPfdGYyYokP9W90CIlHkOa8QA/NEVYQsfD9v9SPA2Ha9sTg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.1.3-next-2024-02-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.3-next-2024-02-21.1.tgz",
-      "integrity": "sha512-8SxODzSmkaVrAMU8jGTPqyfhFKcZkQeHkHDGvSsYdf5zjcRAO3+DgMb0F4P/UsWJy7ohGeyfcSGeuzfE1fzjRQ==",
+      "version": "2.1.3-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.3-next-2024-03-04.2.tgz",
+      "integrity": "sha512-UHZzcZb2b96Xx2zChs/VzmipEgaOgnT8/g7l2XrgdqAuOsf1J5Dq14xnRPK1GnB3B6V0wrFY414RRkD9FDDeFQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "4.0.1-next-2024-02-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.1-next-2024-02-21.1.tgz",
-      "integrity": "sha512-6QpgE1+ztFqpAg+J3q0yz0/uGvFg8vM+pcF9TAp+m1r2wUjSUq+eQtFgSfwNRCxHUf/lZ4bZ1H2Gl6/CnrVwEQ==",
+      "version": "4.0.1-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.1-next-2024-03-04.2.tgz",
+      "integrity": "sha512-SCOQ+NrRSgheuhw6UJRTia+IQv+DRC95UidkadYiKfK9CksTWkFZaB84SpVn2GbwMljEr5fFExYt6ZWVxLplrg==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -358,9 +358,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.1-next-2024-02-21.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-02-21.2.tgz",
-      "integrity": "sha512-nNqeulg4qQ6Pbsw/0wIumoXPkLDmguE2icibvQyoiYKNOwMX6/q5+h8EAyFetdMhB59Rqmy78jgM30Hrvij2Og==",
+      "version": "1.0.1-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-03-04.2.tgz",
+      "integrity": "sha512-zANCTcZyVf6gDboM9NJbferuV6AlEBvNkAXAY5tJUIsBNt9enDCdJtphRj5MqoK73ox/wcBrywCSbRDfIyzGNg==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.0.0-next-2024-02-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.0-next-2024-02-21.1.tgz",
-      "integrity": "sha512-uBq2bsoVpnbzk8EcKO1PayADUX5afrubPZpsBSWElkuXAeCcXu4mqa4yVP+j0G3XMymgY0i+wIvU9nmyYFAAOg==",
+      "version": "3.0.0-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.0-next-2024-03-04.2.tgz",
+      "integrity": "sha512-6z3C1jgRC4RvUYqSnRWeTpClf49AoJnncgU/z/yDE5YFGP5R1JZArjL9hxl3jJOCuBxqxaWpIRYf+recWOXWww==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.1.2-next-2024-02-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.2-next-2024-02-21.1.tgz",
-      "integrity": "sha512-rqJF+kGuY2WXzflZbmlEnPaZY2dysU/8SyO7rupKLNKtWAa3qMuf+NbFEZ112Isdo5Wq40qhlBQvo5eb9FV5Uw==",
+      "version": "2.1.2-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.2-next-2024-03-04.2.tgz",
+      "integrity": "sha512-7bqiDwx2vtkYMsq8SiL5HlQH7xQSdLQtqT6r3vzLvjVlkpYPotZF82YB6KfN66V8fz9ymCnXwHQUxfyc9uF4RA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7047,9 +7047,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.2.1-next-2024-02-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.2.1-next-2024-02-21.1.tgz",
-      "integrity": "sha512-SzO45SKr+j2xcey+x6VeuTmOozyGJD+jvYjwOabT/joeYFZiHMdA9z7+gjcjtS05D9NwBCkmA3tYaBVIbe8pag==",
+      "version": "2.2.1-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.2.1-next-2024-03-04.2.tgz",
+      "integrity": "sha512-J6M9O4AydkTeffK31gCh0f5wuD/N2thoe5j582xbDy6sATF9qapVmJ3ECrpHeo/wrymp0Gd8GSitSObS4S16DQ==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7057,9 +7057,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.0.2-next-2024-02-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.2-next-2024-02-21.1.tgz",
-      "integrity": "sha512-rCH3DcTwcio5sa/SXaC5v5Rn8RZw1n0iTHSlyl3xOxFVDqUspX8YUVItlF5s0KR78Qm0+P1lvy6wAh91OvLqbg==",
+      "version": "3.0.2-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.2-next-2024-03-04.2.tgz",
+      "integrity": "sha512-sN9qXM7RdulvPNbaIQ5sWsT2onNa3iLSlEpqXyiqgXCVYoaqvrphM4IvWUv9qBb+z5Ygqhk0x9wI9X4rY15gsg==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7073,9 +7073,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "2.2.2-next-2024-02-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.2.2-next-2024-02-21.1.tgz",
-      "integrity": "sha512-INbRAFRb+N8789+H20uL7SDH4kstQXHezeou0H/jehvBnbgNQfmS8xv8DuBGV4/25d9GWvT0VpQHjUlmX814DA==",
+      "version": "2.2.2-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.2.2-next-2024-03-04.2.tgz",
+      "integrity": "sha512-lnL8C9QfECVXtyphMRt7UWePCC7NHmSLPn3qAQP8VOBv+9BaUDtUEIdeB967MLSTuDVYY8+xlW9OLdJ/gAOdBw==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7089,30 +7089,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.2.1-next-2024-02-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.1-next-2024-02-21.1.tgz",
-      "integrity": "sha512-LTUx0+t4ajsmgapEOAgWzIXJiW2MeSDzZRC5Ps1v0SWgQ1HhNp4n5wcr0JTX1cjiO9V0303yyLBYfaJPaqLybQ==",
+      "version": "2.2.1-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.1-next-2024-03-04.2.tgz",
+      "integrity": "sha512-SRzTQFOJL/bY85Qz/3ifxDDorehg+IppMBqxZ2CUPfdGYyYokP9W90CIlHkOa8QA/NEVYQsfD9v9SPA2Ha9sTg==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.1.3-next-2024-02-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.3-next-2024-02-21.1.tgz",
-      "integrity": "sha512-8SxODzSmkaVrAMU8jGTPqyfhFKcZkQeHkHDGvSsYdf5zjcRAO3+DgMb0F4P/UsWJy7ohGeyfcSGeuzfE1fzjRQ==",
+      "version": "2.1.3-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.3-next-2024-03-04.2.tgz",
+      "integrity": "sha512-UHZzcZb2b96Xx2zChs/VzmipEgaOgnT8/g7l2XrgdqAuOsf1J5Dq14xnRPK1GnB3B6V0wrFY414RRkD9FDDeFQ==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "4.0.1-next-2024-02-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.1-next-2024-02-21.1.tgz",
-      "integrity": "sha512-6QpgE1+ztFqpAg+J3q0yz0/uGvFg8vM+pcF9TAp+m1r2wUjSUq+eQtFgSfwNRCxHUf/lZ4bZ1H2Gl6/CnrVwEQ==",
+      "version": "4.0.1-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.1-next-2024-03-04.2.tgz",
+      "integrity": "sha512-SCOQ+NrRSgheuhw6UJRTia+IQv+DRC95UidkadYiKfK9CksTWkFZaB84SpVn2GbwMljEr5fFExYt6ZWVxLplrg==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.1-next-2024-02-21.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-02-21.2.tgz",
-      "integrity": "sha512-nNqeulg4qQ6Pbsw/0wIumoXPkLDmguE2icibvQyoiYKNOwMX6/q5+h8EAyFetdMhB59Rqmy78jgM30Hrvij2Og==",
+      "version": "1.0.1-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-03-04.2.tgz",
+      "integrity": "sha512-zANCTcZyVf6gDboM9NJbferuV6AlEBvNkAXAY5tJUIsBNt9enDCdJtphRj5MqoK73ox/wcBrywCSbRDfIyzGNg==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7126,17 +7126,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.0.0-next-2024-02-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.0-next-2024-02-21.1.tgz",
-      "integrity": "sha512-uBq2bsoVpnbzk8EcKO1PayADUX5afrubPZpsBSWElkuXAeCcXu4mqa4yVP+j0G3XMymgY0i+wIvU9nmyYFAAOg==",
+      "version": "3.0.0-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.0-next-2024-03-04.2.tgz",
+      "integrity": "sha512-6z3C1jgRC4RvUYqSnRWeTpClf49AoJnncgU/z/yDE5YFGP5R1JZArjL9hxl3jJOCuBxqxaWpIRYf+recWOXWww==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.1.2-next-2024-02-21.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.2-next-2024-02-21.1.tgz",
-      "integrity": "sha512-rqJF+kGuY2WXzflZbmlEnPaZY2dysU/8SyO7rupKLNKtWAa3qMuf+NbFEZ112Isdo5Wq40qhlBQvo5eb9FV5Uw==",
+      "version": "2.1.2-next-2024-03-04.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.2-next-2024-03-04.2.tgz",
+      "integrity": "sha512-7bqiDwx2vtkYMsq8SiL5HlQH7xQSdLQtqT6r3vzLvjVlkpYPotZF82YB6KfN66V8fz9ymCnXwHQUxfyc9uF4RA==",
       "requires": {}
     },
     "@esbuild/android-arm": {


### PR DESCRIPTION
# Motivation

Integrate next version of ic-js libraries.

# Notes

At the time of this PR, those following changes were the following merged in ic-js main.

> ## Breaking Changes
> 
> - Fix typo in `ic-management` interfaces (`senderCanisterVerion` -> `senderCanisterVersion`).
> 
> ## Features
> 
> - Add support for `bitcoin_get_utxos` and `bitcoin_get_utxos_query` features to `@dfinity/ic-management` library.
> - Add `balance` to ICRC `IndexCanister` which returns the balance for a given account. (1)
> - Extend `getTransactions` of the ICRC `IndexCanister` to support `query`. (1)
> 
> ### Notes
> 
> (1) The new features supported `@dfinity/ledger-icrc` requires the related Index canister to be upgraded to the so called `index-ng` WASM.

