### PR TITLE
Remove ENABLE_ICP_ICRC functionality

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -23,6 +23,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Removed
 
+* Removed unreleased feature flag `ENABLE_ICP_ICRC`.
+
 #### Fixed
 
 * Don't reload transactions multiple times when closing the receive modal.

--- a/frontend/src/lib/services/dev.services.ts
+++ b/frontend/src/lib/services/dev.services.ts
@@ -9,7 +9,7 @@ import type { IcpAccountsStoreData } from "$lib/derived/icp-accounts.derived";
 import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { getAuthenticatedIdentity } from "$lib/services/auth.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
-import type { IcpAccount } from "$lib/types/account";
+import type { Account } from "$lib/types/account";
 import { numberToUlps } from "$lib/utils/token.utils";
 import type { Principal } from "@dfinity/principal";
 import { ICPToken, nonNullish, type Token } from "@dfinity/utils";
@@ -17,7 +17,7 @@ import { get } from "svelte/store";
 import { syncAccounts } from "./icp-accounts.services";
 import { loadAccounts } from "./icrc-accounts.services";
 
-const getMainAccount = async (): Promise<IcpAccount> => {
+const getMainAccount = async (): Promise<Account> => {
   const { main }: IcpAccountsStoreData = get(icpAccountsStore);
   if (nonNullish(main)) {
     return main;

--- a/frontend/src/lib/types/account.ts
+++ b/frontend/src/lib/types/account.ts
@@ -24,9 +24,3 @@ export interface Account {
   subAccount?: SubAccountArray;
   type: AccountType;
 }
-
-export interface IcpAccount extends Account {
-  // TODO: IcpAccountIdentifierText to be ultimately removed
-  // @deprecated
-  icpIdentifier?: IcpAccountIdentifierText;
-}

--- a/frontend/src/tests/lib/derived/icp-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-accounts.derived.spec.ts
@@ -93,7 +93,6 @@ describe("icpAccountsStore", () => {
     expect(get(icpAccountsStore)).toEqual({
       main: {
         balanceUlps: mainAccountBalance,
-        icpIdentifier: mainAccountIdentifier,
         identifier: mainAccountIdentifier,
         principal: mainAccountPrincipal,
         type: "main",
@@ -127,7 +126,6 @@ describe("icpAccountsStore", () => {
     expect(get(icpAccountsStore)).toEqual({
       main: {
         balanceUlps: mainAccountBalance,
-        icpIdentifier: mainAccountIdentifier,
         identifier: mainAccountIdentifier,
         principal: mainAccountPrincipal,
         type: "main",
@@ -135,7 +133,6 @@ describe("icpAccountsStore", () => {
       subAccounts: [
         {
           balanceUlps: subAccountBalance,
-          icpIdentifier: subAccountIdentifier,
           identifier: subAccountIdentifier,
           name: subAccountName,
           subAccount: subAccountArray,
@@ -145,63 +142,7 @@ describe("icpAccountsStore", () => {
       hardwareWallets: [
         {
           balanceUlps: hardwareWalletAccountBalance,
-          icpIdentifier: hardwareWalletAccountIdentifier,
           identifier: hardwareWalletAccountIdentifier,
-          name: hardwareWalletAccountName,
-          principal: hardwareWalletAccountPrincipal,
-          type: "hardwareWallet",
-        },
-      ],
-    });
-  });
-
-  it("should use ICRC-1 identifiers with ENABLE_ICP_ICRC", () => {
-    overrideFeatureFlagsStore.setFlag("ENABLE_ICP_ICRC", true);
-
-    icpAccountDetailsStore.set(accountDetailsData);
-
-    setBalance({
-      accountIdentifier: mainAccountIdentifier,
-      balanceE8s: mainAccountBalance,
-      certified: true,
-    });
-
-    setBalance({
-      accountIdentifier: subAccountIdentifier,
-      balanceE8s: subAccountBalance,
-      certified: true,
-    });
-
-    setBalance({
-      accountIdentifier: hardwareWalletAccountIdentifier,
-      balanceE8s: hardwareWalletAccountBalance,
-      certified: true,
-    });
-
-    expect(get(icpAccountsStore)).toEqual({
-      main: {
-        balanceUlps: mainAccountBalance,
-        icpIdentifier: mainAccountIdentifier,
-        identifier: mainAccountPrincipal.toText(),
-        principal: mainAccountPrincipal,
-        type: "main",
-      },
-      subAccounts: [
-        {
-          balanceUlps: subAccountBalance,
-          icpIdentifier: subAccountIdentifier,
-          // Principal + checksum + subaccount array
-          identifier: `${mainAccountPrincipal.toText()}-42xschi.54657687`,
-          name: subAccountName,
-          subAccount: subAccountArray,
-          type: "subAccount",
-        },
-      ],
-      hardwareWallets: [
-        {
-          balanceUlps: hardwareWalletAccountBalance,
-          icpIdentifier: hardwareWalletAccountIdentifier,
-          identifier: hardwareWalletAccountPrincipal.toText(),
           name: hardwareWalletAccountName,
           principal: hardwareWalletAccountPrincipal,
           type: "hardwareWallet",

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -701,7 +701,7 @@ describe("NnsWallet", () => {
       // Balance should be reloaded.
       expect(ledgerApi.queryAccountBalance).toBeCalledTimes(2);
       const expectedQueryBalanceParams = {
-        icpAccountIdentifier: mockAccountsStoreData.main.icpIdentifier,
+        icpAccountIdentifier: mockAccountsStoreData.main.identifier,
         identity: mockIdentity,
       };
       expect(ledgerApi.queryAccountBalance).toBeCalledWith({

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -378,7 +378,7 @@ describe("NnsWallet", () => {
       // Balance should be reloaded.
       expect(ledgerApi.queryAccountBalance).toBeCalledTimes(2);
       const expectedQueryBalanceParams = {
-        icpAccountIdentifier: mockAccountsStoreData.main.icpIdentifier,
+        icpAccountIdentifier: mockAccountsStoreData.main.identifier,
         identity: mockIdentity,
       };
       expect(ledgerApi.queryAccountBalance).toBeCalledWith({

--- a/frontend/src/tests/mocks/icp-accounts.store.mock.ts
+++ b/frontend/src/tests/mocks/icp-accounts.store.mock.ts
@@ -4,14 +4,12 @@ import type {
   SubAccountDetails,
 } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import type { IcpAccountsStoreData } from "$lib/derived/icp-accounts.derived";
-import type { Account, IcpAccount } from "$lib/types/account";
+import type { Account } from "$lib/types/account";
 import { Principal } from "@dfinity/principal";
 import type { Subscriber } from "svelte/store";
 
-export const mockMainAccount: IcpAccount = {
+export const mockMainAccount: Account = {
   identifier:
-    "d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f",
-  icpIdentifier:
     "d4685b31b51450508aff0331584df7692a84467b680326f5c5f7d30ae711682f",
   balanceUlps: 123456789010000n,
   principal: Principal.fromText("aaaaa-aa"),
@@ -23,10 +21,8 @@ export const mockSubAccountArray = [
   0, 0, 0, 0, 0, 1,
 ];
 
-export const mockSubAccount: IcpAccount = {
+export const mockSubAccount: Account = {
   identifier:
-    "d0654c53339c85e0e5fff46a2d800101bc3d896caef34e1a0597426792ff9f32",
-  icpIdentifier:
     "d0654c53339c85e0e5fff46a2d800101bc3d896caef34e1a0597426792ff9f32",
   balanceUlps: 123456789010000n,
   subAccount: mockSubAccountArray,
@@ -38,10 +34,8 @@ const hardwareWalletPrincipal = Principal.fromText(
   "2vtpp-r6lcd-cbfas-qbabv-wxrv5-lsrkj-c4dtb-6ets3-srlqe-xpuzf-vqe"
 );
 
-export const mockHardwareWalletAccount: IcpAccount = {
+export const mockHardwareWalletAccount: Account = {
   identifier:
-    "646f4d2d6fcb6fab5ba1547647526b666553467ecb5cb28c8d9ddf451c8f4c21",
-  icpIdentifier:
     "646f4d2d6fcb6fab5ba1547647526b666553467ecb5cb28c8d9ddf451c8f4c21",
   balanceUlps: 123456789010000n,
   principal: hardwareWalletPrincipal,


### PR DESCRIPTION
# Motivation

Feature flag `ENABLE_ICP_ICRC` was added to display ICRC-1 account identifiers for ICP accounts instead of ICP account identifiers.
But we never figured out a good way to still also access the ICP account identifier, which would be necessary because transactions to/from are ICP account identifiers.

Since we haven't done anything with this for 8 months, it's better to just remove it as it's slowing down development.

# Changes

1. Remove logic conditional on `ENABLE_ICP_ICRC` (added in https://github.com/dfinity/nns-dapp/pull/2917)
2. Remove type `IcpAccount` which was added for this purpose in the same PR.

# Tests

Removed and updated.

# Todos

- [x] Add entry to changelog (if necessary).
