### PR TITLE
Add "includeBallotsByCaller" to actionable sns proposals store

### DIFF
--- a/frontend/src/lib/derived/actionable-proposals.derived.ts
+++ b/frontend/src/lib/derived/actionable-proposals.derived.ts
@@ -33,7 +33,8 @@ export const actionableProposalCountStore: Readable<ActionableProposalCountData>
       [OWN_CANISTER_ID_TEXT]: nnsProposals?.length,
       ...mapEntries({
         obj: actionableSnsProposals,
-        mapFn: ([canisterId, proposals]) => [canisterId, proposals.length],
+        mapFn: ([canisterId, { proposals, includeBallotsByCaller }]) =>
+          includeBallotsByCaller ? [canisterId, proposals.length] : undefined,
       }),
     })
   );

--- a/frontend/src/lib/services/actionable-sns-proposals.services.ts
+++ b/frontend/src/lib/services/actionable-sns-proposals.services.ts
@@ -9,7 +9,7 @@ import type { Identity } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import type { SnsListProposalsResponse, SnsNeuron } from "@dfinity/sns";
 import { SnsProposalRewardStatus } from "@dfinity/sns";
-import { fromDefinedNullable, nonNullish } from "@dfinity/utils";
+import { fromNullable, nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 export const loadActionableSnsProposals = async () => {
@@ -56,23 +56,25 @@ const loadActionableProposalsForSns = async (
         rootCanisterId: rootCanisterIdText,
         identity,
       });
-    if (!fromDefinedNullable(include_ballots_by_caller)) {
-      // It's not possible to filter out proposals that are votable w/o ballots
-      return;
-    }
 
-    const votableProposals = allProposals.filter(
-      (proposal) =>
-        votableSnsNeurons({
-          neurons,
-          proposal,
-          identity,
-        }).length > 0
-    );
+    const includeBallotsByCaller =
+      fromNullable(include_ballots_by_caller) ?? false;
+    // It's not possible to filter out votable proposals w/o ballots
+    const votableProposals = includeBallotsByCaller
+      ? allProposals.filter(
+          (proposal) =>
+            votableSnsNeurons({
+              neurons,
+              proposal,
+              identity,
+            }).length > 0
+        )
+      : [];
 
-    actionableSnsProposalsStore.setProposals({
+    actionableSnsProposalsStore.set({
       rootCanisterId,
       proposals: votableProposals,
+      includeBallotsByCaller,
     });
   } catch (err) {
     console.error(err);

--- a/frontend/src/lib/stores/actionable-sns-proposals.store.ts
+++ b/frontend/src/lib/stores/actionable-sns-proposals.store.ts
@@ -6,14 +6,18 @@ import { writable, type Readable } from "svelte/store";
 export interface ActionableSnsProposalsStoreData {
   // Each SNS Project is an entry in this Store.
   // We use the root canister id as the key to identify the proposals for a specific project.
-  [rootCanisterId: string]: SnsProposalData[];
+  [rootCanisterId: string]: {
+    proposals: SnsProposalData[];
+    includeBallotsByCaller: boolean;
+  };
 }
 
 export interface ActionableSnsProposalsStore
   extends Readable<ActionableSnsProposalsStoreData> {
-  setProposals: (data: {
+  set: (data: {
     rootCanisterId: Principal;
     proposals: SnsProposalData[];
+    includeBallotsByCaller: boolean;
   }) => void;
   resetForSns: (rootCanisterId: Principal) => void;
   resetForTesting: () => void;
@@ -30,16 +34,21 @@ const initActionableSnsProposalsStore = (): ActionableSnsProposalsStore => {
   return {
     subscribe,
 
-    setProposals({
+    set({
       rootCanisterId,
       proposals,
+      includeBallotsByCaller,
     }: {
       rootCanisterId: Principal;
       proposals: SnsProposalData[];
+      includeBallotsByCaller: boolean;
     }) {
       update((currentState: ActionableSnsProposalsStoreData) => ({
         ...currentState,
-        [rootCanisterId.toText()]: proposals,
+        [rootCanisterId.toText()]: {
+          proposals,
+          includeBallotsByCaller,
+        },
       }));
     },
 

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -228,9 +228,10 @@ describe("SelectUniverseCard", () => {
             routeId: AppPath.Proposals,
           });
 
-          actionableSnsProposalsStore.setProposals({
+          actionableSnsProposalsStore.set({
             rootCanisterId: Principal.from(mockSnsUniverse.canisterId),
             proposals: [mockSnsProposal, mockSnsProposal],
+            includeBallotsByCaller: true,
           });
 
           const po = renderComponent({
@@ -249,9 +250,10 @@ describe("SelectUniverseCard", () => {
             routeId: AppPath.Proposals,
           });
 
-          actionableSnsProposalsStore.setProposals({
+          actionableSnsProposalsStore.set({
             rootCanisterId: Principal.from(mockSnsUniverse.canisterId),
             proposals: [mockSnsProposal, mockSnsProposal],
+            includeBallotsByCaller: true,
           });
 
           const po = renderComponent({
@@ -277,9 +279,10 @@ describe("SelectUniverseCard", () => {
             routeId: AppPath.Proposals,
           });
 
-          actionableSnsProposalsStore.setProposals({
+          actionableSnsProposalsStore.set({
             rootCanisterId: Principal.from(mockSnsUniverse.canisterId),
             proposals: [],
+            includeBallotsByCaller: true,
           });
 
           const po = renderComponent({

--- a/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
@@ -77,13 +77,15 @@ describe("actionable proposals derived stores", () => {
       });
 
       actionableNnsProposalsStore.setProposals(nnsProposals);
-      actionableSnsProposalsStore.setProposals({
+      actionableSnsProposalsStore.set({
         rootCanisterId: principal0,
         proposals: snsProposals,
+        includeBallotsByCaller: true,
       });
-      actionableSnsProposalsStore.setProposals({
+      actionableSnsProposalsStore.set({
         rootCanisterId: principal1,
         proposals: [],
+        includeBallotsByCaller: true,
       });
 
       expect(get(actionableProposalCountStore)).toEqual({

--- a/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
@@ -65,6 +65,7 @@ describe("actionable proposals derived stores", () => {
     const snsProposals = [mockSnsProposal];
     const principal0 = principal(0);
     const principal1 = principal(1);
+    const principal2 = principal(2);
 
     beforeEach(() => {
       actionableNnsProposalsStore.reset();
@@ -86,6 +87,11 @@ describe("actionable proposals derived stores", () => {
         rootCanisterId: principal1,
         proposals: [],
         includeBallotsByCaller: true,
+      });
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal2,
+        proposals: [],
+        includeBallotsByCaller: false,
       });
 
       expect(get(actionableProposalCountStore)).toEqual({

--- a/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
@@ -187,8 +187,14 @@ describe("actionable-sns-proposals.services", () => {
       await loadActionableSnsProposals();
 
       expect(get(actionableSnsProposalsStore)).toEqual({
-        [rootCanisterId1.toText()]: [votableProposal1],
-        [rootCanisterId2.toText()]: [votableProposal2],
+        [rootCanisterId1.toText()]: {
+          proposals: [votableProposal1],
+          includeBallotsByCaller: true,
+        },
+        [rootCanisterId2.toText()]: {
+          proposals: [votableProposal2],
+          includeBallotsByCaller: true,
+        },
       });
     });
 
@@ -227,7 +233,12 @@ describe("actionable-sns-proposals.services", () => {
 
       await loadActionableSnsProposals();
 
-      expect(get(actionableSnsProposalsStore)).toEqual({});
+      expect(get(actionableSnsProposalsStore)).toEqual({
+        [rootCanisterId1.toText()]: {
+          proposals: [],
+          includeBallotsByCaller: false,
+        },
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
@@ -129,7 +129,10 @@ describe("actionable-sns-proposals.services", () => {
               rootCanisterId.toText() === rootCanisterId1.toText()
                 ? [votableProposal1, votedProposal]
                 : [votableProposal2, votedProposal],
-            include_ballots_by_caller: [includeBallotsByCaller],
+            // Upgraded canisters return always include_ballots_by_caller: [true], and by old canisters it's not presented.
+            include_ballots_by_caller: includeBallotsByCaller
+              ? [includeBallotsByCaller]
+              : undefined,
           }) as SnsListProposalsResponse
       );
     });

--- a/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
@@ -181,8 +181,14 @@ describe("sns-vote-registration-services", () => {
       });
 
       expect(get(actionableSnsProposalsStore)).toEqual({
-        [rootCanisterId.toText()]: [proposal],
-        [rootCanisterId2.toText()]: [proposal],
+        [rootCanisterId.toText()]: {
+          proposals: [proposal],
+          includeBallotsByCaller: true,
+        },
+        [rootCanisterId2.toText()]: {
+          proposals: [proposal],
+          includeBallotsByCaller: true,
+        },
       });
 
       await callRegisterVote({
@@ -193,7 +199,10 @@ describe("sns-vote-registration-services", () => {
       });
 
       expect(get(actionableSnsProposalsStore)).toEqual({
-        [rootCanisterId2.toText()]: [proposal],
+        [rootCanisterId2.toText()]: {
+          proposals: [proposal],
+          includeBallotsByCaller: true,
+        },
       });
     });
 

--- a/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
@@ -169,13 +169,15 @@ describe("sns-vote-registration-services", () => {
     it("should reset actionable proposals for sns after voting", async () => {
       vi.spyOn(snsGovernanceApi, "registerVote").mockResolvedValue();
       const rootCanisterId2 = principal(13);
-      actionableSnsProposalsStore.setProposals({
+      actionableSnsProposalsStore.set({
         rootCanisterId,
         proposals: [proposal],
+        includeBallotsByCaller: true,
       });
-      actionableSnsProposalsStore.setProposals({
+      actionableSnsProposalsStore.set({
         rootCanisterId: rootCanisterId2,
         proposals: [proposal],
+        includeBallotsByCaller: true,
       });
 
       expect(get(actionableSnsProposalsStore)).toEqual({

--- a/frontend/src/tests/lib/stores/actionable-sns-proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/actionable-sns-proposals.store.spec.ts
@@ -1,6 +1,6 @@
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
+import { principal } from "$tests/mocks/sns-projects.mock";
 import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
-import { Principal } from "@dfinity/principal";
 import type { SnsProposalData } from "@dfinity/sns";
 import { get } from "svelte/store";
 
@@ -13,8 +13,9 @@ describe("actionableSnsProposalsStore", () => {
     ...mockSnsProposal,
     id: [{ id: 2n }],
   };
-  const principal1 = Principal.fromText("bw4dl-smaaa-aaaaa-qaacq-cai");
-  const principal2 = Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai");
+  const principal1 = principal(0);
+  const principal2 = principal(1);
+  const principal3 = principal(2);
   beforeEach(() => {
     actionableSnsProposalsStore.resetForTesting();
   });
@@ -30,6 +31,11 @@ describe("actionableSnsProposalsStore", () => {
       proposals: [snsProposal2],
       includeBallotsByCaller: true,
     });
+    actionableSnsProposalsStore.set({
+      rootCanisterId: principal3,
+      proposals: [],
+      includeBallotsByCaller: false,
+    });
 
     expect(get(actionableSnsProposalsStore)[principal1.toText()]).toEqual({
       proposals: [snsProposal1],
@@ -38,6 +44,10 @@ describe("actionableSnsProposalsStore", () => {
     expect(get(actionableSnsProposalsStore)[principal2.toText()]).toEqual({
       proposals: [snsProposal2],
       includeBallotsByCaller: true,
+    });
+    expect(get(actionableSnsProposalsStore)[principal3.toText()]).toEqual({
+      proposals: [],
+      includeBallotsByCaller: false,
     });
   });
 

--- a/frontend/src/tests/lib/stores/actionable-sns-proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/actionable-sns-proposals.store.spec.ts
@@ -31,12 +31,14 @@ describe("actionableSnsProposalsStore", () => {
       includeBallotsByCaller: true,
     });
 
-    expect(get(actionableSnsProposalsStore)[principal1.toText()]).toEqual([
-      snsProposal1,
-    ]);
-    expect(get(actionableSnsProposalsStore)[principal2.toText()]).toEqual([
-      snsProposal2,
-    ]);
+    expect(get(actionableSnsProposalsStore)[principal1.toText()]).toEqual({
+      proposals: [snsProposal1],
+      includeBallotsByCaller: true,
+    });
+    expect(get(actionableSnsProposalsStore)[principal2.toText()]).toEqual({
+      proposals: [snsProposal2],
+      includeBallotsByCaller: true,
+    });
   });
 
   it("should reset data by sns", () => {
@@ -54,8 +56,9 @@ describe("actionableSnsProposalsStore", () => {
     expect(
       get(actionableSnsProposalsStore)[principal1.toText()]
     ).toBeUndefined();
-    expect(get(actionableSnsProposalsStore)[principal2.toText()]).toEqual([
-      snsProposal2,
-    ]);
+    expect(get(actionableSnsProposalsStore)[principal2.toText()]).toEqual({
+      proposals: [snsProposal2],
+      includeBallotsByCaller: true,
+    });
   });
 });

--- a/frontend/src/tests/lib/stores/actionable-sns-proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/actionable-sns-proposals.store.spec.ts
@@ -20,13 +20,15 @@ describe("actionableSnsProposalsStore", () => {
   });
 
   it("should store sns proposals", () => {
-    actionableSnsProposalsStore.setProposals({
+    actionableSnsProposalsStore.set({
       rootCanisterId: principal1,
       proposals: [snsProposal1],
+      includeBallotsByCaller: true,
     });
-    actionableSnsProposalsStore.setProposals({
+    actionableSnsProposalsStore.set({
       rootCanisterId: principal2,
       proposals: [snsProposal2],
+      includeBallotsByCaller: true,
     });
 
     expect(get(actionableSnsProposalsStore)[principal1.toText()]).toEqual([
@@ -38,13 +40,15 @@ describe("actionableSnsProposalsStore", () => {
   });
 
   it("should reset data by sns", () => {
-    actionableSnsProposalsStore.setProposals({
+    actionableSnsProposalsStore.set({
       rootCanisterId: principal1,
       proposals: [snsProposal1],
+      includeBallotsByCaller: true,
     });
-    actionableSnsProposalsStore.setProposals({
+    actionableSnsProposalsStore.set({
       rootCanisterId: principal2,
       proposals: [snsProposal2],
+      includeBallotsByCaller: true,
     });
     actionableSnsProposalsStore.resetForSns(principal1);
     expect(


### PR DESCRIPTION
# Motivation

Currently, we store `undefined` for the snses w/o ballots support, which is totally enough to display proposal count.
This pr adds a flag `includeBallotsByCaller: bool` (returned by `listProposals` call) to the `actionableSnsProposalsStore`, allowing it to be used later to determine which message needs to be displayed:

- `undefined` - data has not been loaded yet
- `{ includeBallotsByCaller: true, proposals: [] }` - no actionable proposals
- `{ includeBallotsByCaller: false, proposals: [] }` - actionable proposals not supported

# Changes

- rename method `setProposals` to `set`
- add `includeBallotsByCaller` to the `actionableProposalsStore`
   Instead of `[rootCanisterId]: undefined`, sns w/o ballots support well be stored as `[rootCanisterId]: { proposals: [], includeBallotsByCaller: false }`
- update logic in `actionableProposalsDerivedStore` to rely on this flag

# Tests

- adjusted to the new arguments / store structure

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary