### PR TITLE
Upgrade next version following ic-js release

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.2.1-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.2.1-next-2024-03-04.3.tgz",
-      "integrity": "sha512-cQob1neAgYeWfndruEB/azpHIrPCPuLrxhFz1PANy7teJlxzMxTX91yJVIIWP3hYbcdaG2d0tKNFbDi2EcKLLw==",
+      "version": "2.2.1-next-2024-03-05.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.2.1-next-2024-03-05.2.tgz",
+      "integrity": "sha512-uCHwge25jrSgJoIcf6kr7iHpBfvKQVcHSzSAje2kcmMHpeYZ84uxH46WeUUDzY8MurQmOqu8AqBFBOwLEv4Pcw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.0.2-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.2-next-2024-03-04.3.tgz",
-      "integrity": "sha512-+53Ub0/+SpaCzg197v6ZmYF+YVCFIMHjf0L8rDKRgb+naHgC5fzTdrvbRTmdKMHb7eHNEVQOj3DGbentMAWpIA==",
+      "version": "3.0.2-next-2024-03-05.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.2-next-2024-03-05.3.tgz",
+      "integrity": "sha512-yGyTUpBFOpQUe1gtxdpslfBxnAj78fUz66GD01zm+RaAx/Mrl74LpzAumu5bbjLIxrsXFdaM+xucWKR1aW7s8w==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "2.2.2-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.2.2-next-2024-03-04.3.tgz",
-      "integrity": "sha512-vM1Z9yie4kB7e+OHPprBzg8FoKT7tzPArZL6a9yCdnvBXzEXpW/+kpyhDAbRtpGbZcYrh8n/NBGeiffSVuTQaw==",
+      "version": "3.0.0-next-2024-03-05",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.0.0-next-2024-03-05.tgz",
+      "integrity": "sha512-KB1MH2XfFoPDaqTN4U6tiNGWf5cFjSbUlrLBmmMgMQNbRIXS5LZ8SX0KawGS+Oco/sXucS3ZK0sBzU25hBBuQw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.2.1-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.1-next-2024-03-04.3.tgz",
-      "integrity": "sha512-HmGZX0UYCBx66DJsISGIAJ+AORvlzIJmUtuW/Tj2ZFxgleb6MUlm2dCjjS94wDd9ubPAlZpDXw/Tn85zYDqyIA==",
+      "version": "2.2.1-next-2024-03-05.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.1-next-2024-03-05.3.tgz",
+      "integrity": "sha512-TKHcUQ/cpbglnN2mXTu+dZ+6LSGaZjDVotNmkjp9fyj0ZaCJBLEwFizAJYUgAg80dTNHjMRr653kq2AXgb4TIw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.1.3-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.3-next-2024-03-04.3.tgz",
-      "integrity": "sha512-BR6EiEYx0560Z5P9HDJ4iMcVW+q7hPtQnHYMyAq761q412gnnIee9PDmPcD0SwavHQ39YmdHlXdLNo3Fs0uAIQ==",
+      "version": "2.2.0-next-2024-03-05",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.0-next-2024-03-05.tgz",
+      "integrity": "sha512-i0rOHLtBpqvstJdcl7Fa5khxDKr4d5Fskp/3B6E8k0sfIHydFLJOEl5E18LRT8IRP9GN43v3a2euBJCDtDK5bQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "4.0.1-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.1-next-2024-03-04.3.tgz",
-      "integrity": "sha512-fmZGII7uAJWN05QBLrnlNM0qyb1YptdWQqphpEaGn0wuWUPHAyuW9v9Spa3w8Z3Qo16BUc4tT5CUOwQDKtn2TQ==",
+      "version": "4.0.1-next-2024-03-05.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.1-next-2024-03-05.3.tgz",
+      "integrity": "sha512-332Dw9ExcNyyNDe9jRnZipBsFl4AmTam+63jTt2B6yv4CQNFfyTm+yl6Z3r6W9RLasqvpPYPImHLoCG9B1smFg==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -358,9 +358,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.1-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-03-04.3.tgz",
-      "integrity": "sha512-eX2VANw17Gv4Y15ECOmQU92SNilbycM7Xxl+6pBcJjYqbN7Buas1tt0noPJ8prrjUBDfPviHhcpj1T/+zaP2vA==",
+      "version": "1.0.1-next-2024-03-05.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-03-05.3.tgz",
+      "integrity": "sha512-ONpomyj5wom2nHsa46qB5NrnPyOa22z4p4/R8HtbB8xiD1FBkeKFG5uMjlh35KDhP7cj2mR/dClxuJylyxPb/Q==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.0.0-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.0-next-2024-03-04.3.tgz",
-      "integrity": "sha512-ZaxqkHaXGtJjdhHvJYp4yZiD9OOtFUigNKd+ewQPuI/E4nRQnOqbZFAeHVkc2mKQOl7iz/PAU+7hSPgV+UiuAA==",
+      "version": "3.0.1-next-2024-03-05",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.1-next-2024-03-05.tgz",
+      "integrity": "sha512-/wpV6XA2g0ZBGOFxjllftU16krkbsgVANKJgve8k999p9B9bXvRN4sC0hBnZzh1XP3zv6dP4ACPq5SpEJcKZJw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.1.2-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.2-next-2024-03-04.3.tgz",
-      "integrity": "sha512-5+sIBv7XoMD7ui4Cvx7SHYmlE0MR5PAM8Seul1WotMEEe3JIys7pqSavZ/YA/ubpFPa+q0RiYvOEP+7GIEsa9g==",
+      "version": "2.1.2-next-2024-03-05.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.2-next-2024-03-05.3.tgz",
+      "integrity": "sha512-ZFnAGsckgepLrRyLncwfL5qkjAnzXFkksm6dgGQ/EqBoESMHnQsyIrySxiEVI+tir7RsB7JIEF/JGddbHaUjPA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7047,9 +7047,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.2.1-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.2.1-next-2024-03-04.3.tgz",
-      "integrity": "sha512-cQob1neAgYeWfndruEB/azpHIrPCPuLrxhFz1PANy7teJlxzMxTX91yJVIIWP3hYbcdaG2d0tKNFbDi2EcKLLw==",
+      "version": "2.2.1-next-2024-03-05.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.2.1-next-2024-03-05.2.tgz",
+      "integrity": "sha512-uCHwge25jrSgJoIcf6kr7iHpBfvKQVcHSzSAje2kcmMHpeYZ84uxH46WeUUDzY8MurQmOqu8AqBFBOwLEv4Pcw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7057,9 +7057,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.0.2-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.2-next-2024-03-04.3.tgz",
-      "integrity": "sha512-+53Ub0/+SpaCzg197v6ZmYF+YVCFIMHjf0L8rDKRgb+naHgC5fzTdrvbRTmdKMHb7eHNEVQOj3DGbentMAWpIA==",
+      "version": "3.0.2-next-2024-03-05.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.2-next-2024-03-05.3.tgz",
+      "integrity": "sha512-yGyTUpBFOpQUe1gtxdpslfBxnAj78fUz66GD01zm+RaAx/Mrl74LpzAumu5bbjLIxrsXFdaM+xucWKR1aW7s8w==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7073,9 +7073,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "2.2.2-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-2.2.2-next-2024-03-04.3.tgz",
-      "integrity": "sha512-vM1Z9yie4kB7e+OHPprBzg8FoKT7tzPArZL6a9yCdnvBXzEXpW/+kpyhDAbRtpGbZcYrh8n/NBGeiffSVuTQaw==",
+      "version": "3.0.0-next-2024-03-05",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.0.0-next-2024-03-05.tgz",
+      "integrity": "sha512-KB1MH2XfFoPDaqTN4U6tiNGWf5cFjSbUlrLBmmMgMQNbRIXS5LZ8SX0KawGS+Oco/sXucS3ZK0sBzU25hBBuQw==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7089,30 +7089,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.2.1-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.1-next-2024-03-04.3.tgz",
-      "integrity": "sha512-HmGZX0UYCBx66DJsISGIAJ+AORvlzIJmUtuW/Tj2ZFxgleb6MUlm2dCjjS94wDd9ubPAlZpDXw/Tn85zYDqyIA==",
+      "version": "2.2.1-next-2024-03-05.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.1-next-2024-03-05.3.tgz",
+      "integrity": "sha512-TKHcUQ/cpbglnN2mXTu+dZ+6LSGaZjDVotNmkjp9fyj0ZaCJBLEwFizAJYUgAg80dTNHjMRr653kq2AXgb4TIw==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.1.3-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.1.3-next-2024-03-04.3.tgz",
-      "integrity": "sha512-BR6EiEYx0560Z5P9HDJ4iMcVW+q7hPtQnHYMyAq761q412gnnIee9PDmPcD0SwavHQ39YmdHlXdLNo3Fs0uAIQ==",
+      "version": "2.2.0-next-2024-03-05",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.0-next-2024-03-05.tgz",
+      "integrity": "sha512-i0rOHLtBpqvstJdcl7Fa5khxDKr4d5Fskp/3B6E8k0sfIHydFLJOEl5E18LRT8IRP9GN43v3a2euBJCDtDK5bQ==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "4.0.1-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.1-next-2024-03-04.3.tgz",
-      "integrity": "sha512-fmZGII7uAJWN05QBLrnlNM0qyb1YptdWQqphpEaGn0wuWUPHAyuW9v9Spa3w8Z3Qo16BUc4tT5CUOwQDKtn2TQ==",
+      "version": "4.0.1-next-2024-03-05.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.1-next-2024-03-05.3.tgz",
+      "integrity": "sha512-332Dw9ExcNyyNDe9jRnZipBsFl4AmTam+63jTt2B6yv4CQNFfyTm+yl6Z3r6W9RLasqvpPYPImHLoCG9B1smFg==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.1-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-03-04.3.tgz",
-      "integrity": "sha512-eX2VANw17Gv4Y15ECOmQU92SNilbycM7Xxl+6pBcJjYqbN7Buas1tt0noPJ8prrjUBDfPviHhcpj1T/+zaP2vA==",
+      "version": "1.0.1-next-2024-03-05.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-03-05.3.tgz",
+      "integrity": "sha512-ONpomyj5wom2nHsa46qB5NrnPyOa22z4p4/R8HtbB8xiD1FBkeKFG5uMjlh35KDhP7cj2mR/dClxuJylyxPb/Q==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7126,17 +7126,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.0.0-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.0-next-2024-03-04.3.tgz",
-      "integrity": "sha512-ZaxqkHaXGtJjdhHvJYp4yZiD9OOtFUigNKd+ewQPuI/E4nRQnOqbZFAeHVkc2mKQOl7iz/PAU+7hSPgV+UiuAA==",
+      "version": "3.0.1-next-2024-03-05",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.1-next-2024-03-05.tgz",
+      "integrity": "sha512-/wpV6XA2g0ZBGOFxjllftU16krkbsgVANKJgve8k999p9B9bXvRN4sC0hBnZzh1XP3zv6dP4ACPq5SpEJcKZJw==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.1.2-next-2024-03-04.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.2-next-2024-03-04.3.tgz",
-      "integrity": "sha512-5+sIBv7XoMD7ui4Cvx7SHYmlE0MR5PAM8Seul1WotMEEe3JIys7pqSavZ/YA/ubpFPa+q0RiYvOEP+7GIEsa9g==",
+      "version": "2.1.2-next-2024-03-05.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.2-next-2024-03-05.3.tgz",
+      "integrity": "sha512-ZFnAGsckgepLrRyLncwfL5qkjAnzXFkksm6dgGQ/EqBoESMHnQsyIrySxiEVI+tir7RsB7JIEF/JGddbHaUjPA==",
       "requires": {}
     },
     "@esbuild/android-arm": {


### PR DESCRIPTION
# Motivation

ic-js [2024.03.05-1130Z](https://github.com/dfinity/ic-js/releases/tag/2024.03.05-1130Z) has been released. This PR bumps NNS-dapp with the `next` versions that have been released after publication. 

# Changes

- bump ic-js dependencies