### PR TITLE
feat: Migrate to stable structures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
           nns_dapp_wasm: 'nns-dapp_test.wasm.gz'
           logfile: 'dfx-test-downgrade-upgrade.log'
       - name: Downgrade nns-dapp to prod and upgrade back again
-        run: ./scripts/nns-dapp/downgrade-upgrade-test -w nns-dapp_test.wasm.gz
+        run: ./scripts/nns-dapp/downgrade-upgrade-test -w nns-dapp_test.wasm.gz --accounts 100 --chunk 30
       - name: Count upgrade cycles
         run: scripts/nns-dapp/estimate-upgrade-cycles | tee -a $GITHUB_STEP_SUMMARY
   test-upgrade-map:

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Load ICP transactions from ICP index canister instead of nns-dapp.
+* Store account data in stable structures instead of on the heap.
 * More readable error messages if `assert_eq` fails in tests.
 * Main navigation text changes.
 * Minor text changes.

--- a/config.sh
+++ b/config.sh
@@ -214,7 +214,7 @@ cat <<EOF >"$CANDID_ARGS_FILE"
   args = vec {
 $(jq -r 'to_entries | .[] | "    record{ 0=\(.key | tojson); 1=\(.value | tostring | tojson) };"' "$JSON_OUT")
   };
-  schema = opt variant { Map };
+  schema = opt variant { AccountsInStableMemory };
 })
 EOF
 

--- a/rs/backend/src/accounts_store/schema.rs
+++ b/rs/backend/src/accounts_store/schema.rs
@@ -127,7 +127,7 @@ pub enum SchemaLabel {
 
 impl Default for SchemaLabel {
     fn default() -> Self {
-        Self::Map
+        Self::AccountsInStableMemory
     }
 }
 

--- a/scripts/nns-dapp/test-config-assets/app/arg.did
+++ b/scripts/nns-dapp/test-config-assets/app/arg.did
@@ -20,5 +20,5 @@
     record{ 0="TVL_CANISTER_ID"; 1="ewh3f-3qaaa-aaaap-aazjq-cai" };
     record{ 0="WASM_CANISTER_ID"; 1="qaa6y-5yaaa-aaaaa-aaafa-cai" };
   };
-  schema = opt variant { Map };
+  schema = opt variant { AccountsInStableMemory };
 })

--- a/scripts/nns-dapp/test-config-assets/local/arg.did
+++ b/scripts/nns-dapp/test-config-assets/local/arg.did
@@ -16,5 +16,5 @@
     record{ 0="TVL_CANISTER_ID"; 1="" };
     record{ 0="WASM_CANISTER_ID"; 1="qaa6y-5yaaa-aaaaa-aaafa-cai" };
   };
-  schema = opt variant { Map };
+  schema = opt variant { AccountsInStableMemory };
 })

--- a/scripts/nns-dapp/test-config-assets/mainnet/arg.did
+++ b/scripts/nns-dapp/test-config-assets/mainnet/arg.did
@@ -22,5 +22,5 @@
     record{ 0="TVL_CANISTER_ID"; 1="ewh3f-3qaaa-aaaap-aazjq-cai" };
     record{ 0="WASM_CANISTER_ID"; 1="qaa6y-5yaaa-aaaaa-aaafa-cai" };
   };
-  schema = opt variant { Map };
+  schema = opt variant { AccountsInStableMemory };
 })


### PR DESCRIPTION
# Motivation
We would like to move accounts to stable structures.

# Changes
- Make accounts in stable memory the default.  On deployment, this will start a migration.

# Tests
- See CI

# Todos

- [x] Add entry to changelog (if necessary).