### PR TITLE
NNS1-2904: Enable ENABLE_ICP_INDEX in relevant e2e tests

### DIFF
--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -1,11 +1,16 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  setFeatureFlag,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test accounts requirements", async ({ page, context }) => {
   await page.goto("/accounts");
   await expect(page).toHaveTitle("My ICP Tokens / NNS Dapp");
+  await setFeatureFlag({ page, featureFlag: "ENABLE_ICP_INDEX", value: true });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
@@ -86,7 +91,7 @@ test("Test accounts requirements", async ({ page, context }) => {
   const transactionList = appPo
     .getWalletPo()
     .getNnsWalletPo()
-    .getTransactionListPo();
+    .getUiTransactionsListPo();
   await transactionList.waitForLoaded();
   const transactions = await transactionList.getTransactionCardPos();
   expect(transactions).toHaveLength(1);

--- a/frontend/src/tests/e2e/canisters.spec.ts
+++ b/frontend/src/tests/e2e/canisters.spec.ts
@@ -1,11 +1,16 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  setFeatureFlag,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test canisters", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("My Tokens / NNS Dapp");
+  await setFeatureFlag({ page, featureFlag: "ENABLE_ICP_INDEX", value: true });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
@@ -47,7 +52,7 @@ test("Test canisters", async ({ page, context }) => {
   const transactionList = appPo
     .getWalletPo()
     .getNnsWalletPo()
-    .getTransactionListPo();
+    .getUiTransactionsListPo();
   await transactionList.waitForLoaded();
   const transactions = await transactionList.getTransactionCardPos();
   expect(await Promise.all(transactions.map((tx) => tx.getHeadline()))).toEqual(

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -1,11 +1,16 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  setFeatureFlag,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test merge neurons", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("My Tokens / NNS Dapp");
+  await setFeatureFlag({ page, featureFlag: "ENABLE_ICP_INDEX", value: true });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);
@@ -80,7 +85,7 @@ test("Test merge neurons", async ({ page, context }) => {
   const transactionList = appPo
     .getWalletPo()
     .getNnsWalletPo()
-    .getTransactionListPo();
+    .getUiTransactionsListPo();
   await transactionList.waitForLoaded();
   const transactions = await transactionList.getTransactionCardPos();
   expect(await Promise.all(transactions.map((tx) => tx.getHeadline()))).toEqual(


### PR DESCRIPTION
# Motivation

We want to enable ENABLE_ICP_INDEX. A few end-to-end tests require minor changes to continue passing.

# Changes

1. Enable ENABLE_ICP_INDEX in those e2e tests that require changes to pass.

# Tests

Pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary