### PR TITLE
Make selectOption work when fake timers are enabled

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -53,5 +53,6 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Adapted the docker reproducibility test to work with `upload-artifact@v4`.
+* Make `JestPageObjectElement.selectOption` work with fake timers.
 
 #### Security

--- a/frontend/src/tests/page-objects/jest.page-object.ts
+++ b/frontend/src/tests/page-objects/jest.page-object.ts
@@ -1,4 +1,5 @@
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { areFakeTimersEnabled } from "$tests/utils/timers.test-utils";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { fireEvent, waitFor } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
@@ -144,7 +145,10 @@ export class JestPageObjectElement implements PageObjectElement {
 
   async selectOption(text: string): Promise<void> {
     await this.waitFor();
-    return userEvent.selectOptions(this.getElement(), text);
+    const userEventToUse = areFakeTimersEnabled()
+      ? userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+      : userEvent;
+    return userEventToUse.selectOptions(this.getElement(), text);
   }
 
   async isVisible(): Promise<boolean> {

--- a/frontend/src/tests/utils/timers.test-utils.ts
+++ b/frontend/src/tests/utils/timers.test-utils.ts
@@ -23,3 +23,12 @@ export const advanceTime = async (millis?: number): Promise<void> => {
   }
   await runResolvedPromises();
 };
+
+export const areFakeTimersEnabled = (): boolean => {
+  try {
+    vi.getTimerCount();
+    return true;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
# Motivation

While cleaning up a test in another branch, I discovered that `userEvent.selectOption` doesn't work when fake timers are enabled.

I found a work-around here: https://github.com/testing-library/user-event/issues/833
```
userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
```

It also seems that `vitest` does not expose a way to test if fake timers are enabled, but fake timers specific method throw if fake timers are not enabled so this can be used to detect if fake timers are enabled.

# Changes

1. Add a function `areFakeTimersEnabled` to check if fake timers are enabled.
2. If fake timers are enabled, use the work-around to use `userEvent.selectOption` in `JestPageObjectElement.selectOption`.

# Tests

Used in another branch to stop a test from timing out after enabling fake timers.

# Todos

- [x] Add entry to changelog (if necessary).
