### PR TITLE
Update changelog after release

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,19 +17,13 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
-* Refactored `icpAccountsStore` to be derived from separate stores.
 * More readable error messages if `assert_eq` fails in tests.
-* Wording changes for ineligible neurons description.
 
 #### Deprecated
 
 #### Removed
 
-* Removed unreleased feature flag `ENABLE_ICP_ICRC`.
-
 #### Fixed
-
-* Don't reload transactions multiple times when closing the receive modal.
 
 #### Security
 
@@ -39,13 +33,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
-* Notify the maintainers if the docker build is not reproducible.
-
 #### Changed
-
-* Disambiguated the title of the docker reproducibility check.
-* Change the number of accounts tested in `test-upgrade-map-stable` from 1000 to 20.
-* Andrew will be making the release forum posts.
 
 #### Deprecated
 
@@ -53,7 +41,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
-* Adapted the docker reproducibility test to work with `upload-artifact@v4`.
 * Make `JestPageObjectElement.selectOption` work with fake timers.
 
 #### Security

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -11,6 +11,40 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 Unreleased changes are added to `CHANGELOG-Nns-Dapp-unreleased.md` and moved
 here after a successful release.
 
+## Proposal 128297
+
+### Application
+
+#### Changed
+
+* Refactored `icpAccountsStore` to be derived from separate stores.
+* Wording changes for ineligible neurons description.
+
+#### Removed
+
+* Removed unreleased feature flag `ENABLE_ICP_ICRC`.
+
+#### Fixed
+
+* Don't reload transactions multiple times when closing the receive modal.
+* Reload balance when opening NNS wallet.
+
+### Operations
+
+#### Added
+
+* Notify the maintainers if the docker build is not reproducible.
+
+#### Changed
+
+* Disambiguated the title of the docker reproducibility check.
+* Change the number of accounts tested in `test-upgrade-map-stable` from 1000 to 20.
+* Andrew will be making the release forum posts.
+
+#### Fixed
+
+* Adapted the docker reproducibility test to work with `upload-artifact@v4`.
+
 ## Proposal 128153
 
 ### Application

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4081,7 +4081,7 @@ dependencies = [
 
 [[package]]
 name = "nns-dapp"
-version = "2.0.68"
+version = "2.0.69"
 dependencies = [
  "anyhow",
  "base64 0.21.5",
@@ -4669,7 +4669,7 @@ dependencies = [
 
 [[package]]
 name = "proposals"
-version = "2.0.68"
+version = "2.0.69"
 dependencies = [
  "anyhow",
  "candid 0.8.4",
@@ -5346,7 +5346,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "sns_aggregator"
-version = "2.0.68"
+version = "2.0.69"
 dependencies = [
  "anyhow",
  "base64 0.21.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.68"
+version = "2.0.69"
 
 [workspace.dependencies]
 ic-cdk = "0.9.2"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/nns-dapp",
-  "version": "2.0.68",
+  "version": "2.0.69",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/nns-dapp",
-      "version": "2.0.68",
+      "version": "2.0.69",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@dfinity/agent": "^1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns-dapp",
-  "version": "2.0.68",
+  "version": "2.0.69",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {


### PR DESCRIPTION
# Motivation

A release has been deployed to production.

# Changes

- Changelog - split out the changes included in the release + [custom fix entry](https://github.com/dfinity/nns-dapp/pull/4609/files#diff-9d543e5d87a67ec57eb53931d029ba6ce9b0aa358aea50f2e61c928f5f51253eR30).
- Increment the patch version of the nns-dapp.