### PR TITLE
Display actionable not supported indicator

### DIFF
--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -73,7 +73,7 @@
           {#if nonNullish(actionableProposalCount) && actionableProposalCount > 0}
             <ActionableProposalCountBadge count={actionableProposalCount} />
           {:else if actionableProposalSupported === false}
-            <span class="not-supported" data-tid="not-supported-badge" />
+            <span class="not-supported-badge" data-tid="not-supported-badge" />
           {/if}
         {/if}
       </span>
@@ -135,7 +135,7 @@
     gap: var(--padding);
   }
 
-  .not-supported {
+  .not-supported-badge {
     // extra gap to align with the count badge
     margin: var(--padding);
 

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -135,6 +135,9 @@
   }
 
   .not-supported {
+    // extra gap to align with the count badge
+    margin: var(--padding);
+
     width: var(--padding);
     height: var(--padding);
     border-radius: var(--padding);

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -13,6 +13,7 @@
   } from "$lib/derived/actionable-proposals.derived";
   import ActionableProposalCountBadge from "$lib/components/proposals/ActionableProposalCountBadge.svelte";
   import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
+  import { nonNullish } from "@dfinity/utils";
 
   export let selected: boolean;
   export let role: "link" | "button" | "dropdown" = "link";
@@ -69,7 +70,7 @@
       <span class="name">
         {universe.title}
         {#if $ENABLE_VOTING_INDICATION}
-          {#if actionableProposalCount ?? 0 > 0}
+          {#if nonNullish(actionableProposalCount) && actionableProposalCount > 0}
             <ActionableProposalCountBadge count={actionableProposalCount} />
           {:else if actionableProposalSupported === false}
             <span class="not-supported" data-tid="not-supported-badge" />

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -72,7 +72,7 @@
           {#if actionableProposalCount ?? 0 > 0}
             <ActionableProposalCountBadge count={actionableProposalCount} />
           {:else if actionableProposalSupported === false}
-            <span class="not-supported" />
+            <span class="not-supported" data-tid="not-supported-badge" />
           {/if}
         {/if}
       </span>

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -7,8 +7,10 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import { isSelectedPath } from "$lib/utils/navigation.utils";
   import type { Universe } from "$lib/types/universe";
-  import { nonNullish } from "@dfinity/utils";
-  import { actionableProposalCountStore } from "$lib/derived/actionable-proposals.derived";
+  import {
+    actionableProposalCountStore,
+    actionableProposalSupportedStore,
+  } from "$lib/derived/actionable-proposals.derived";
   import ActionableProposalCountBadge from "$lib/components/proposals/ActionableProposalCountBadge.svelte";
   import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
 
@@ -41,6 +43,11 @@
   $: actionableProposalCount = $ENABLE_VOTING_INDICATION
     ? $actionableProposalCountStore[universe.canisterId]
     : undefined;
+
+  let actionableProposalSupported: boolean | undefined = undefined;
+  $: actionableProposalSupported = $ENABLE_VOTING_INDICATION
+    ? $actionableProposalSupportedStore[universe.canisterId]
+    : undefined;
 </script>
 
 <Card
@@ -61,8 +68,12 @@
     >
       <span class="name">
         {universe.title}
-        {#if nonNullish(actionableProposalCount) && actionableProposalCount > 0}
-          <ActionableProposalCountBadge count={actionableProposalCount} />
+        {#if $ENABLE_VOTING_INDICATION}
+          {#if actionableProposalCount ?? 0 > 0}
+            <ActionableProposalCountBadge count={actionableProposalCount} />
+          {:else if actionableProposalSupported === false}
+            <span class="not-supported" />
+          {/if}
         {/if}
       </span>
       {#if displayProjectAccountsBalance}
@@ -121,5 +132,12 @@
     justify-content: space-between;
     align-items: center;
     gap: var(--padding);
+  }
+
+  .not-supported {
+    width: var(--padding);
+    height: var(--padding);
+    border-radius: var(--padding);
+    background: var(--background);
   }
 </style>

--- a/frontend/src/lib/derived/actionable-proposals.derived.ts
+++ b/frontend/src/lib/derived/actionable-proposals.derived.ts
@@ -38,3 +38,22 @@ export const actionableProposalCountStore: Readable<ActionableProposalCountData>
       }),
     })
   );
+
+export interface ActionableProposalSupportData {
+  // We use the root canister id as the key to identify the actionable proposals support for a specific project.
+  [rootCanisterId: string]: boolean | undefined;
+}
+
+/** A store that contains the project actionable proposals support state mapped by canister id (nns + snses) */
+export const actionableProposalSupportedStore: Readable<ActionableProposalSupportData> =
+  derived([actionableSnsProposalsStore], ([actionableSnsProposals]) => ({
+    // NNS already returns ballots
+    [OWN_CANISTER_ID_TEXT]: true,
+    ...mapEntries({
+      obj: actionableSnsProposals,
+      mapFn: ([canisterId, { includeBallotsByCaller }]) => [
+        canisterId,
+        includeBallotsByCaller === true,
+      ],
+    }),
+  }));

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -307,6 +307,32 @@ describe("SelectUniverseCard", () => {
           expect(await po.getActionableProposalCountBadgePo().isPresent()).toBe(
             false
           );
+          expect(
+            await po.getActionableProposalNotSupportedBadge().isPresent()
+          ).toBe(false);
+        });
+
+        it("should display not supported indicator", async () => {
+          page.mock({
+            data: { universe: mockSnsUniverse.canisterId },
+            routeId: AppPath.Proposals,
+          });
+          actionableSnsProposalsStore.set({
+            rootCanisterId: Principal.from(mockSnsUniverse.canisterId),
+            proposals: [mockSnsProposal, mockSnsProposal],
+            includeBallotsByCaller: undefined,
+          });
+
+          const po = renderComponent({
+            props: { universe: mockSnsUniverse, selected: false },
+          });
+
+          expect(await po.getActionableProposalCountBadgePo().isPresent()).toBe(
+            false
+          );
+          expect(
+            await po.getActionableProposalNotSupportedBadge().isPresent()
+          ).toBe(true);
         });
       });
     });

--- a/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
@@ -3,6 +3,7 @@ import { AppPath } from "$lib/constants/routes.constants";
 import {
   actionableProposalCountStore,
   actionableProposalIndicationEnabledStore,
+  actionableProposalSupportedStore,
 } from "$lib/derived/actionable-proposals.derived";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
@@ -98,6 +99,53 @@ describe("actionable proposals derived stores", () => {
         [OWN_CANISTER_ID_TEXT]: nnsProposals.length,
         [principal0.toText()]: snsProposals.length,
         [principal1.toText()]: 0,
+      });
+    });
+  });
+
+  describe("actionableProposalSupportedStore", () => {
+    const nnsProposals: ProposalInfo[] = [
+      {
+        ...mockProposalInfo,
+        id: 0n,
+      },
+      {
+        ...mockProposalInfo,
+        id: 1n,
+      },
+    ];
+    const snsProposals = [mockSnsProposal];
+    const principal0 = principal(0);
+    const principal1 = principal(1);
+
+    beforeEach(() => {
+      actionableNnsProposalsStore.reset();
+      actionableSnsProposalsStore.resetForTesting();
+    });
+
+    it("returns true for nns", async () => {
+      expect(get(actionableProposalSupportedStore)).toEqual({
+        [OWN_CANISTER_ID_TEXT]: true,
+      });
+    });
+
+    it("returns actionable proposal support", async () => {
+      actionableNnsProposalsStore.setProposals(nnsProposals);
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal0,
+        proposals: snsProposals,
+        includeBallotsByCaller: true,
+      });
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal1,
+        proposals: [],
+        includeBallotsByCaller: false,
+      });
+
+      expect(get(actionableProposalSupportedStore)).toEqual({
+        [OWN_CANISTER_ID_TEXT]: true,
+        [principal0.toText()]: true,
+        [principal1.toText()]: false,
       });
     });
   });

--- a/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
@@ -218,16 +218,17 @@ describe("actionable-sns-proposals.services", () => {
       expect(spyQuerySnsProposals).toHaveBeenCalledTimes(1);
     });
 
-    it("should not query proposals when the user has no neurons", async () => {
+    it("should not query neurons when the sns doesn't support ballots", async () => {
       mockSnsProjectsCommittedStore([rootCanisterId1]);
-      spyQuerySnsNeurons = vi
-        .spyOn(api, "querySnsNeurons")
-        .mockImplementation(() => Promise.resolve([]));
+      includeBallotsByCaller = false;
+
+      expect(spyQuerySnsProposals).toHaveBeenCalledTimes(0);
+      expect(spyQuerySnsNeurons).toHaveBeenCalledTimes(0);
 
       await loadActionableSnsProposals();
 
-      expect(spyQuerySnsNeurons).toHaveBeenCalledTimes(1);
-      expect(spyQuerySnsProposals).toHaveBeenCalledTimes(0);
+      expect(spyQuerySnsProposals).toHaveBeenCalledTimes(1);
+      expect(spyQuerySnsNeurons).toHaveBeenCalledTimes(0);
     });
 
     it("should not update the store when api doesn't support ballots", async () => {

--- a/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
@@ -66,6 +66,10 @@ export class SelectUniverseCardPo extends CardPo {
     return ActionableProposalCountBadgePo.under(this.root);
   }
 
+  getActionableProposalNotSupportedBadge(): PageObjectElement {
+    return this.root.byTestId("not-supported-badge");
+  }
+
   getActionableProposalCount(): Promise<string> {
     return this.getActionableProposalCountBadgePo().getText();
   }


### PR DESCRIPTION
# Motivation

Display a tiny indicator next to Snses that don't support actionable proposals.
Currently not visible on mobile because of using the same colours. Will be fixed in a separate pr.

<img width="236" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/593302b9-9398-4a26-82ae-b19b5bc8f074">

# Changes

- change the loading order for actionable sns proposal list:
   - from: fetch neurons, when some neurons fetch proposals
   - to: fetch proposals, when ballots support fetch neurons
- new derived store `actionableProposalSupportedStore`;
- display `"not-supported-badge"`, when `actionableProposalSupportedStore[canisterId] === false` ;

# Tests

- SelectUniverseCard should display no-support indicator

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet

# Screenshots

| 🌞 | 🌚 |
|--------|--------|
| <img width="280" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/3f181a74-2827-4772-8cc5-2c1b221294a2"> | <img width="272" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/5c383aba-e634-48c4-aa69-a3355e1b0852"> | 



