### PR TITLE
feat: Async migration

### DIFF
--- a/rs/backend/nns-dapp-exports-production.txt
+++ b/rs/backend/nns-dapp-exports-production.txt
@@ -21,4 +21,5 @@ canister_update get_proposal_payload
 canister_update register_hardware_wallet
 canister_update rename_canister
 canister_update rename_sub_account
+canister_update step_migration
 main

--- a/rs/backend/nns-dapp-exports-test.txt
+++ b/rs/backend/nns-dapp-exports-test.txt
@@ -23,4 +23,5 @@ canister_update get_proposal_payload
 canister_update register_hardware_wallet
 canister_update rename_canister
 canister_update rename_sub_account
+canister_update step_migration
 main

--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -280,7 +280,7 @@ service: (opt Config) -> {
     add_stable_asset: (asset: blob) -> ();
     add_assets_tar_xz: (asset: blob) -> ();
 
-    step_migration: () -> ();
+    step_migration: (nat32) -> ();
 
     // Methods available in the test build only:
     get_toy_account: (nat64) -> (GetAccountResponse) query;

--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -280,6 +280,8 @@ service: (opt Config) -> {
     add_stable_asset: (asset: blob) -> ();
     add_assets_tar_xz: (asset: blob) -> ();
 
+    step_migration: () -> ();
+
     // Methods available in the test build only:
     get_toy_account: (nat64) -> (GetAccountResponse) query;
 }

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -362,8 +362,11 @@ impl AccountsStore {
     pub fn start_migrating_accounts_to(&mut self, accounts_db: AccountsDb) {
         self.accounts_db.start_migrating_accounts_to(accounts_db);
     }
-    pub fn step_migration(&mut self) {
-        self.accounts_db.step_migration();
+    /// Advances the migration by one step.
+    ///
+    /// Note: This is a pass-through to the underlying `AccountsDb::step_migration`.  Please see that for further details.
+    pub fn step_migration(&mut self, step_size: u32) {
+        self.accounts_db.step_migration(step_size);
     }
     #[must_use]
     pub fn get_account(&self, caller: PrincipalId) -> Option<AccountDetails> {

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -358,6 +358,11 @@ pub enum DetachCanisterResponse {
 }
 
 impl AccountsStore {
+    /// Determines whether a migration is being performed.
+    #[must_use]
+    pub fn migration_in_progress(&self) -> bool {
+        self.accounts_db.migration_in_progress()
+    }
     /// Starts migrating accounts to the new db.
     pub fn start_migrating_accounts_to(&mut self, accounts_db: AccountsDb) {
         self.accounts_db.start_migrating_accounts_to(accounts_db);

--- a/rs/backend/src/accounts_store/schema/proxy/migration.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/migration.rs
@@ -51,12 +51,15 @@ impl AccountsDbAsProxy {
     }
 
     /// Advances the migration by one step.
-    pub fn step_migration(&mut self) {
+    ///
+    /// # Arguments
+    /// - `step_size`: The maximum number of accounts to migrate on this step.
+    pub fn step_migration(&mut self, step_size: u32) {
         if let Some(migration) = &mut self.migration {
             if let Some(next_to_migrate) = &migration.next_to_migrate {
                 println!("Stepping migration: {:?} -> {:?}", self.authoritative_db, migration.db);
                 let mut range = self.authoritative_db.range(next_to_migrate.clone()..);
-                for (key, account) in (&mut range).take(Self::MIGRATION_STEP_SIZE as usize) {
+                for (key, account) in (&mut range).take(usize::try_from(step_size).unwrap_or(usize::MAX)) {
                     migration.db.db_insert_account(&key, account);
                 }
                 migration.next_to_migrate = range.next().map(|(key, _account)| key.clone());

--- a/rs/backend/src/accounts_store/schema/proxy/migration.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/migration.rs
@@ -3,10 +3,10 @@ use super::{AccountsDb, AccountsDbAsProxy, AccountsDbTrait, Migration};
 use ic_cdk::println;
 
 impl AccountsDbAsProxy {
-    /// The default number of accounts to move per heartbeat.
+    /// The default number of accounts to move in a migration step.
     pub const MIGRATION_STEP_SIZE: u32 = 10;
-    /// The maximum number of accounts to move per heartbeat.
-    pub const MIGRATION_STEP_SIZE_MAX: u32 = 100;
+    /// The maximum number of accounts to move in a migration step.
+    pub const MIGRATION_STEP_SIZE_MAX: u32 = 1000;
     /// The progress meter count reserved for finalizing a migration.
     /// Note: This must be positive and should correspond to a reasonable estimate of the number of blocks needed to complete the migration.
     pub const MIGRATION_FINALIZATION_BLOCKS: u32 = 1;

--- a/rs/backend/src/accounts_store/schema/proxy/migration.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/migration.rs
@@ -11,6 +11,12 @@ impl AccountsDbAsProxy {
     /// Note: This must be positive and should correspond to a reasonable estimate of the number of blocks needed to complete the migration.
     pub const MIGRATION_FINALIZATION_BLOCKS: u32 = 1;
 
+    /// Determines whether a migration is in progress.
+    #[must_use]
+    pub fn migration_in_progress(&self) -> bool {
+        self.migration.is_some()
+    }
+
     /// Migration countdown; when it reaches zero, the migration is complete.
     ///
     /// Note: This is a rough estimate of the number of blocks needed to complete the migration.

--- a/rs/backend/src/accounts_store/schema/proxy/migration.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/migration.rs
@@ -4,7 +4,7 @@ use ic_cdk::println;
 
 impl AccountsDbAsProxy {
     /// The default number of accounts to move in a migration step.
-    pub const MIGRATION_STEP_SIZE: u32 = 10;
+    pub const MIGRATION_STEP_SIZE: u32 = 20;
     /// The maximum number of accounts to move in a migration step.
     pub const MIGRATION_STEP_SIZE_MAX: u32 = 1000;
     /// The progress meter count reserved for finalizing a migration.

--- a/rs/backend/src/accounts_store/schema/proxy/tests.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/tests.rs
@@ -44,18 +44,18 @@ fn migration_steps_should_work(accounts_db: &mut AccountsDbAsProxy, new_accounts
         if expected_accounts_in_new_db == reference_db.db_accounts_len() {
             break;
         } else {
-            accounts_db.step_migration();
+            accounts_db.step_migration(AccountsDbAsProxy::MIGRATION_STEP_SIZE);
         }
     }
     // The next step should complete the migration.
-    accounts_db.step_migration();
+    accounts_db.step_migration(AccountsDbAsProxy::MIGRATION_STEP_SIZE);
     assert_eq!(*accounts_db, reference_db);
     assert!(
         accounts_db.migration.is_none(),
         "After completing a migration, there should be no migration in progress"
     );
     // Further steps are not needed but should be harmless.
-    accounts_db.step_migration();
+    accounts_db.step_migration(AccountsDbAsProxy::MIGRATION_STEP_SIZE);
     assert!(
         accounts_db.migration.is_none(),
         "Further steps should not create another migration"
@@ -106,7 +106,7 @@ impl Operation {
         R: Rng + ?Sized,
     {
         match self {
-            Operation::StepMigration => accounts_db.step_migration(),
+            Operation::StepMigration => accounts_db.step_migration(AccountsDbAsProxy::MIGRATION_STEP_SIZE),
             Operation::Insert => {
                 let key = rng.gen::<[u8; 32]>();
                 let account = toy_account(rng.gen(), rng.gen_range(0..5));

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -315,27 +315,27 @@ pub fn canister_heartbeat() {
 /// Steps the migration.
 #[export_name = "canister_update step_migration"]
 pub fn step_migration() {
-    over(candid, step_migration_impl);
+    over(candid_one, step_migration_impl);
 }
 
-fn step_migration_impl(_: ()) -> () {
+fn step_migration_impl(step_size: u32) -> () {
     STATE.with(|s| {
-        s.accounts_store
-            .borrow_mut()
-            .step_migration(AccountsDbAsProxy::MIGRATION_STEP_SIZE);
+        s.accounts_store.borrow_mut().step_migration(step_size);
     });
 }
 
 /// Calls step_migration without panicking and rolling back if anything goes wrong.
-async fn call_step_migration() -> Result<(), (RejectionCode, String)> {
-    ic_cdk::api::call::call(ic_cdk::id(), "step_migration", ()).await
+async fn call_step_migration(step_size: u32) -> Result<(), (RejectionCode, String)> {
+    ic_cdk::api::call::call(ic_cdk::id(), "step_migration", (step_size,)).await
 }
 
 /// Calls step migration and logs any errors.
 async fn call_and_log_step_migration() {
-    call_step_migration().await.unwrap_or_else(|(code, msg)| {
-        println!("step_migration failed: {code:?} {msg}");
-    });
+    call_step_migration(AccountsDbAsProxy::MIGRATION_STEP_SIZE)
+        .await
+        .unwrap_or_else(|(code, msg)| {
+            println!("step_migration failed: {code:?} {msg}");
+        });
 }
 
 /// Add an asset to be served by the canister.

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -322,6 +322,11 @@ pub fn step_migration() {
 }
 
 fn step_migration_impl(step_size: u32) {
+    let caller = ic_cdk::caller();
+    let own_canister_id = ic_cdk::api::id();
+    if caller != own_canister_id {
+        dfn_core::api::trap_with("Only the canister itself may call step_migration");
+    }
     STATE.with(|s| {
         s.accounts_store.borrow_mut().step_migration(step_size);
     });

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -13,6 +13,7 @@ use ic_nns_governance::pb::v1::{claim_or_refresh_neuron_from_account_response, C
 use icp_ledger::{
     AccountBalanceArgs, AccountIdentifier, BlockIndex, Memo, SendArgs, Subaccount, Tokens, DEFAULT_TRANSFER_FEE,
 };
+use nns_dapp::accounts_store::schema::proxy::AccountsDbAsProxy;
 
 const PRUNE_TRANSACTIONS_COUNT: u32 = 1000;
 
@@ -21,7 +22,7 @@ pub async fn run_periodic_tasks() {
 
     STATE.with(|state| {
         state.performance.borrow_mut().increment_periodic_tasks_run();
-        state.accounts_store.borrow_mut().step_migration();
+        state.accounts_store.borrow_mut().step_migration(AccountsDbAsProxy::MIGRATION_STEP_SIZE);
     });
 
     let maybe_transaction_to_process =

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -13,8 +13,6 @@ use ic_nns_governance::pb::v1::{claim_or_refresh_neuron_from_account_response, C
 use icp_ledger::{
     AccountBalanceArgs, AccountIdentifier, BlockIndex, Memo, SendArgs, Subaccount, Tokens, DEFAULT_TRANSFER_FEE,
 };
-use nns_dapp::accounts_store::schema::proxy::AccountsDbAsProxy;
-
 const PRUNE_TRANSACTIONS_COUNT: u32 = 1000;
 
 pub async fn run_periodic_tasks() {
@@ -22,7 +20,6 @@ pub async fn run_periodic_tasks() {
 
     STATE.with(|state| {
         state.performance.borrow_mut().increment_periodic_tasks_run();
-        state.accounts_store.borrow_mut().step_migration(AccountsDbAsProxy::MIGRATION_STEP_SIZE);
     });
 
     let maybe_transaction_to_process =


### PR DESCRIPTION
# Motivation
If there are several sequential large accounts, migration may fail to move that batch of accounts to stable memory in one call and the migration step will be rolled back.  The migration will keep trying and keep failing.  As transactions are also processed by the periodic runner, transactions would also be rolled back and be stalled permanently until we upgrade.  While fairly unlikely given the conservatively small number of accounts migrated in every step, it is still an unnecessary risk.

# Changes
- Run migration separately from transactions, in a way that does not cause transactions to fail if migration fails.
  - This is done by adding an API method to perform a migration step.  That method is called on the canister itself.  That way, if the migration step panics the periodic task can handle the error.
  - Note: The migration method is left exposed with a capped step size.  I think it is not harmful and could be interesting.
- If the normal migration step fails, single step.

# Tests
- The existing migration e2e test still passes.
- If I add a panic to `step_migration()` if the step size is greater than 1, the migration still succeeds, albeit slowly.

# Todos

- [ ] Add entry to changelog (if necessary).
  Please let me know if this is wanted.  NNS team's rules apply now.