### PR TITLE
Update IC candid files to release-2024-03-06_23-01+p2p

### DIFF
--- a/declarations/nns_governance/nns_governance.did
+++ b/declarations/nns_governance/nns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-28_23-01+p2p-hotfix/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-06_23-01+p2p/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record { hash : vec nat8 };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
@@ -124,6 +124,7 @@ type CreateServiceNervousSystem = record {
   swap_parameters : opt SwapParameters;
   initial_token_distribution : opt InitialTokenDistribution;
 };
+type Decimal = record { human_readable : opt text };
 type DerivedProposalInformation = record {
   swap_background_information : opt SwapBackgroundInformation;
 };
@@ -326,6 +327,7 @@ type NetworkEconomics = record {
   neuron_spawn_dissolve_delay_seconds : nat64;
   minimum_icp_xdr_rate : nat64;
   maximum_node_provider_rewards_e8s : nat64;
+  neurons_fund_economics : opt NeuronsFundEconomics;
 };
 type Neuron = record {
   id : opt NeuronId;
@@ -405,6 +407,15 @@ type NeuronsFundData = record {
   final_neurons_fund_participation : opt NeuronsFundParticipation;
   initial_neurons_fund_participation : opt NeuronsFundParticipation;
   neurons_fund_refunds : opt NeuronsFundSnapshot;
+};
+type NeuronsFundEconomics = record {
+  neurons_fund_matched_funding_curve_coefficients : opt NeuronsFundMatchedFundingCurveCoefficients;
+  max_theoretical_neurons_fund_participation_amount_xdr : opt Decimal;
+};
+type NeuronsFundMatchedFundingCurveCoefficients = record {
+  contribution_threshold_xdr : opt Decimal;
+  one_third_participation_milestone_xdr : opt Decimal;
+  full_participation_milestone_xdr : opt Decimal;
 };
 type NeuronsFundNeuron = record {
   hotkey_principal : opt text;

--- a/declarations/nns_ledger/nns_ledger.did
+++ b/declarations/nns_ledger/nns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-28_23-01+p2p-hotfix/rs/rosetta-api/icp_ledger/ledger.did>
+//! Candid for canister `nns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-06_23-01+p2p/rs/rosetta-api/icp_ledger/ledger.did>
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.

--- a/declarations/nns_registry/nns_registry.did
+++ b/declarations/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-28_23-01+p2p-hotfix/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-06_23-01+p2p/rs/registry/canister/canister/registry.did>
 type AddApiBoundaryNodePayload = record { node_id : principal; version : text };
 type AddFirewallRulesPayload = record {
   expected_hash : text;

--- a/declarations/sns_governance/sns_governance.did
+++ b/declarations/sns_governance/sns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-28_23-01+p2p-hotfix/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-06_23-01+p2p/rs/sns/governance/canister/governance.did>
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;

--- a/declarations/sns_ledger/sns_ledger.did
+++ b/declarations/sns_ledger/sns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-28_23-01+p2p-hotfix/rs/rosetta-api/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-06_23-01+p2p/rs/rosetta-api/icrc1/ledger/ledger.did>
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.

--- a/declarations/sns_root/sns_root.did
+++ b/declarations/sns_root/sns_root.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-28_23-01+p2p-hotfix/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-06_23-01+p2p/rs/sns/root/canister/root.did>
 type CanisterCallError = record { code : opt int32; description : text };
 type CanisterIdRecord = record { canister_id : principal };
 type CanisterInstallMode = variant { reinstall; upgrade; install };

--- a/declarations/sns_swap/sns_swap.did
+++ b/declarations/sns_swap/sns_swap.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-28_23-01+p2p-hotfix/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-06_23-01+p2p/rs/sns/swap/canister/swap.did>
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;

--- a/declarations/sns_wasm/sns_wasm.did
+++ b/declarations/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-28_23-01+p2p-hotfix/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-06_23-01+p2p/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record { hash : vec nat8; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };

--- a/dfx.json
+++ b/dfx.json
@@ -355,7 +355,7 @@
         "DIDC_VERSION": "2024-02-27",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-03-06",
-        "IC_COMMIT": "release-2024-02-28_23-01+p2p-hotfix"
+        "IC_COMMIT": "release-2024-03-06_23-01+p2p"
       },
       "packtool": ""
     }


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
Even with no changes, just updating the reference is good practice.

# Changes
## Changes made by a bot triggered by github-merge-queue
- Update the version of `ic` specified in `dfx.json`.
- Update the NNS candid files to the versions in that commit.

# Tests
- See CI
- [ ] Check for breaking changes in the APIs and schedule any required follow-on work.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants