### PR TITLE
fix: Log less

### DIFF
--- a/rs/backend/src/accounts_store/schema/proxy.rs
+++ b/rs/backend/src/accounts_store/schema/proxy.rs
@@ -5,7 +5,6 @@ use super::accounts_in_unbounded_stable_btree_map::{AccountsDbAsUnboundedStableB
 use super::{map::AccountsDbAsMap, Account, AccountsDbBTreeMapTrait, AccountsDbTrait, SchemaLabel};
 use core::fmt;
 use core::ops::RangeBounds;
-use ic_cdk::println;
 #[cfg(test)]
 use ic_stable_structures::DefaultMemoryImpl;
 use std::collections::BTreeMap;
@@ -118,8 +117,7 @@ impl AccountsDbTrait for AccountsDbAsProxy {
     }
     /// The authoritative schema label.
     fn schema_label(&self) -> SchemaLabel {
-        let schema_label = self.authoritative_db.schema_label();
-        schema_label
+        self.authoritative_db.schema_label()
     }
     /// Iterates over a range of accounts in the authoritative db.
     fn range(&self, key_range: impl RangeBounds<Vec<u8>>) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_> {

--- a/rs/backend/src/accounts_store/schema/proxy.rs
+++ b/rs/backend/src/accounts_store/schema/proxy.rs
@@ -119,7 +119,6 @@ impl AccountsDbTrait for AccountsDbAsProxy {
     /// The authoritative schema label.
     fn schema_label(&self) -> SchemaLabel {
         let schema_label = self.authoritative_db.schema_label();
-        println!("AccountsDb::Proxy: authoritative schema label: {schema_label:#?}");
         schema_label
     }
     /// Iterates over a range of accounts in the authoritative db.


### PR DESCRIPTION
# Motivation
When migrating, the logs include two lines for ever migration step.  One is intentional, the other isn't.
```
2024-03-13 10:00:31.083847515 UTC: [Canister bkyz2-fmaaa-aaaaa-qaaaq-cai] Stepping migration: UnboundedStableBTreeMap(AccountsDbAsUnboundedStableBTreeMap { accounts: StableBTreeMap{.. 1000 entries} }) -> Map(AccountsDbAsMap{... 920 entries})
2024-03-13 10:00:31.083847515 UTC: [Canister bkyz2-fmaaa-aaaaa-qaaaq-cai] AccountsDb::Proxy: authoritative schema label: AccountsInStableMemory
2024-03-13 10:00:31.699877773 UTC: [Canister bkyz2-fmaaa-aaaaa-qaaaq-cai] Stepping migration: UnboundedStableBTreeMap(AccountsDbAsUnboundedStableBTreeMap { accounts: StableBTreeMap{.. 1000 entries} }) -> Map(AccountsDbAsMap{... 940 entries})
2024-03-13 10:00:32.317025421 UTC: [Canister bkyz2-fmaaa-aaaaa-qaaaq-cai] AccountsDb::Proxy: authoritative schema label: AccountsInStableMemory
```

# Changes
- Delete the log message giving the authoritative schema.

# Tests
None

# Todos

- [ ] Add entry to changelog (if necessary).
