### PR TITLE
Update snsdemo to release-2024-03-13

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -354,7 +354,7 @@
         "BINSTALL_VERSION": "1.3.0",
         "DIDC_VERSION": "2024-02-27",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2024-03-06",
+        "SNSDEMO_RELEASE": "release-2024-03-13",
         "IC_COMMIT": "release-2024-02-28_23-01+p2p-hotfix"
       },
       "packtool": ""


### PR DESCRIPTION
# Motivation
We would like to keep the testing environment, provided by snsdemo, up to date.

# Changes
* Updated `snsdemo` version in `dfx.json`.

# Tests
CI should pass.