### PR TITLE
Display actionable sns proposals

### DIFF
--- a/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
@@ -11,6 +11,9 @@
   import FiltersButton from "../ui/FiltersButton.svelte";
   import SnsFilterRewardsModal from "$lib/modals/sns/proposals/SnsFilterRewardsModal.svelte";
   import SnsFilterTypesModal from "$lib/modals/sns/proposals/SnsFilterTypesModal.svelte";
+  import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
+  import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
+  import ActionableProposalsSegment from "$lib/components/proposals/ActionableProposalsSegment.svelte";
 
   let modal: "types" | "rewards" | "status" | undefined = undefined;
 
@@ -29,34 +32,41 @@
 </script>
 
 <div class="proposal-filters">
-  <FiltersWrapper>
-    <FiltersButton
-      testId="filters-by-types"
-      totalFilters={filtersStore?.types.length ?? 0}
-      activeFilters={filtersStore?.types.filter(({ checked }) => checked)
-        .length ?? 0}
-      on:nnsFilter={() => openFilters("types")}
-    >
-      {$i18n.voting.types}
-    </FiltersButton>
-    <FiltersButton
-      testId="filters-by-rewards"
-      totalFilters={filtersStore?.rewardStatus.length ?? 0}
-      activeFilters={filtersStore?.rewardStatus.filter(({ checked }) => checked)
-        .length ?? 0}
-      on:nnsFilter={() => openFilters("rewards")}
-      >{$i18n.voting.rewards}</FiltersButton
-    >
-    <FiltersButton
-      testId="filters-by-status"
-      totalFilters={filtersStore?.decisionStatus.length ?? 0}
-      activeFilters={filtersStore?.decisionStatus.filter(
-        ({ checked }) => checked
-      ).length ?? 0}
-      on:nnsFilter={() => openFilters("status")}
-      >{$i18n.voting.status}</FiltersButton
-    >
-  </FiltersWrapper>
+  {#if $ENABLE_VOTING_INDICATION}
+    <ActionableProposalsSegment />
+  {/if}
+
+  {#if !$ENABLE_VOTING_INDICATION || $actionableProposalsSegmentStore.selected !== "actionable"}
+    <FiltersWrapper>
+      <FiltersButton
+        testId="filters-by-types"
+        totalFilters={filtersStore?.types.length ?? 0}
+        activeFilters={filtersStore?.types.filter(({ checked }) => checked)
+          .length ?? 0}
+        on:nnsFilter={() => openFilters("types")}
+      >
+        {$i18n.voting.types}
+      </FiltersButton>
+      <FiltersButton
+        testId="filters-by-rewards"
+        totalFilters={filtersStore?.rewardStatus.length ?? 0}
+        activeFilters={filtersStore?.rewardStatus.filter(
+          ({ checked }) => checked
+        ).length ?? 0}
+        on:nnsFilter={() => openFilters("rewards")}
+        >{$i18n.voting.rewards}</FiltersButton
+      >
+      <FiltersButton
+        testId="filters-by-status"
+        totalFilters={filtersStore?.decisionStatus.length ?? 0}
+        activeFilters={filtersStore?.decisionStatus.filter(
+          ({ checked }) => checked
+        ).length ?? 0}
+        on:nnsFilter={() => openFilters("status")}
+        >{$i18n.voting.status}</FiltersButton
+      >
+    </FiltersWrapper>
+  {/if}
 </div>
 
 {#if modal === "types"}
@@ -84,7 +94,18 @@
 {/if}
 
 <style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+
   .proposal-filters {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding);
     margin-bottom: var(--padding-3x);
+
+    @include media.min-width(medium) {
+      flex-direction: row;
+      flex-wrap: wrap;
+      align-items: center;
+    }
   }
 </style>

--- a/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
@@ -10,8 +10,8 @@
   import SnsProposalsFilters from "./SnsProposalsFilters.svelte";
   import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
   import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
-  import NnsProposalCard from "$lib/components/proposals/NnsProposalCard.svelte";
   import { fade } from "svelte/transition";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let proposals: SnsProposalData[] | undefined;
   export let actionableProposals: SnsProposalData[] | undefined;
@@ -20,46 +20,48 @@
   export let loadingNextPage = false;
 </script>
 
-<SnsProposalsFilters />
+<TestIdWrapper testId="sns-proposal-list-component">
+  <SnsProposalsFilters />
 
-{#if !$ENABLE_VOTING_INDICATION || $actionableProposalsSegmentStore.selected !== "actionable"}
-  <div in:fade data-tid="all-proposal-list">
-    {#if proposals === undefined}
-      <LoadingProposals />
-    {:else if proposals.length === 0}
-      <NoProposals />
-    {:else}
-      <ListLoader loading={loadingNextPage}>
-        <InfiniteScroll
-          layout="grid"
-          on:nnsIntersect
-          disabled={disableInfiniteScroll}
-        >
-          {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
-            <SnsProposalCard {proposalData} {nsFunctions} />
-          {/each}
-        </InfiniteScroll>
-      </ListLoader>
-    {/if}
-  </div>
-{/if}
-
-{#if $ENABLE_VOTING_INDICATION && $actionableProposalsSegmentStore.selected === "actionable"}
-  {#if actionableProposals === undefined}
-    <!-- TODO(max): TBD SignIn vs No vs NotSupported -->
-    <LoadingProposals />
-  {:else if actionableProposals.length === 0}
-    <!-- TODO(max): TBD custom screen -->
-    <NoProposals />
-  {:else}
-    <div in:fade data-tid="actionable-proposal-list">
-      <ListLoader loading={isNullish(actionableProposals)}>
-        <InfiniteScroll layout="grid" disabled>
-          {#each actionableProposals as proposalData (fromNullable(proposalData.id)?.id)}
-            <SnsProposalCard {proposalData} {nsFunctions} />
-          {/each}
-        </InfiniteScroll>
-      </ListLoader>
+  {#if !$ENABLE_VOTING_INDICATION || $actionableProposalsSegmentStore.selected !== "actionable"}
+    <div in:fade data-tid="all-proposal-list">
+      {#if proposals === undefined}
+        <LoadingProposals />
+      {:else if proposals.length === 0}
+        <NoProposals />
+      {:else}
+        <ListLoader loading={loadingNextPage}>
+          <InfiniteScroll
+            layout="grid"
+            on:nnsIntersect
+            disabled={disableInfiniteScroll}
+          >
+            {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
+              <SnsProposalCard {proposalData} {nsFunctions} />
+            {/each}
+          </InfiniteScroll>
+        </ListLoader>
+      {/if}
     </div>
   {/if}
-{/if}
+
+  {#if $ENABLE_VOTING_INDICATION && $actionableProposalsSegmentStore.selected === "actionable"}
+    {#if actionableProposals === undefined}
+      <!-- TODO(max): TBD SignIn vs No vs NotSupported -->
+      <LoadingProposals />
+    {:else if actionableProposals.length === 0}
+      <!-- TODO(max): TBD custom screen -->
+      <NoProposals />
+    {:else}
+      <div in:fade data-tid="actionable-proposal-list">
+        <ListLoader loading={isNullish(actionableProposals)}>
+          <InfiniteScroll layout="grid" disabled>
+            {#each actionableProposals as proposalData (fromNullable(proposalData.id)?.id)}
+              <SnsProposalCard {proposalData} {nsFunctions} />
+            {/each}
+          </InfiniteScroll>
+        </ListLoader>
+      </div>
+    {/if}
+  {/if}
+</TestIdWrapper>

--- a/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
@@ -9,12 +9,11 @@
   import ListLoader from "../proposals/ListLoader.svelte";
   import SnsProposalsFilters from "./SnsProposalsFilters.svelte";
   import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
-  import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
   import { fade } from "svelte/transition";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let proposals: SnsProposalData[] | undefined;
-  export let actionableProposals: SnsProposalData[] | undefined;
+  export let isActionable: boolean;
   export let nsFunctions: SnsNervousSystemFunction[] | undefined;
   export let disableInfiniteScroll = false;
   export let loadingNextPage = false;
@@ -23,7 +22,7 @@
 <TestIdWrapper testId="sns-proposal-list-component">
   <SnsProposalsFilters />
 
-  {#if !$ENABLE_VOTING_INDICATION || $actionableProposalsSegmentStore.selected !== "actionable"}
+  {#if !$ENABLE_VOTING_INDICATION || !isActionable}
     <div in:fade data-tid="all-proposal-list">
       {#if proposals === undefined}
         <LoadingProposals />
@@ -45,18 +44,18 @@
     </div>
   {/if}
 
-  {#if $ENABLE_VOTING_INDICATION && $actionableProposalsSegmentStore.selected === "actionable"}
-    {#if actionableProposals === undefined}
+  {#if $ENABLE_VOTING_INDICATION && isActionable}
+    {#if proposals === undefined}
       <!-- TODO(max): TBD SignIn vs No vs NotSupported -->
       <LoadingProposals />
-    {:else if actionableProposals.length === 0}
+    {:else if proposals.length === 0}
       <!-- TODO(max): TBD custom screen -->
       <NoProposals />
     {:else}
       <div in:fade data-tid="actionable-proposal-list">
-        <ListLoader loading={isNullish(actionableProposals)}>
+        <ListLoader loading={isNullish(proposals)}>
           <InfiniteScroll layout="grid" disabled>
-            {#each actionableProposals as proposalData (fromNullable(proposalData.id)?.id)}
+            {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
               <SnsProposalCard {proposalData} {nsFunctions} />
             {/each}
           </InfiniteScroll>

--- a/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
@@ -3,33 +3,63 @@
   import SnsProposalCard from "$lib/components/sns-proposals/SnsProposalCard.svelte";
   import { InfiniteScroll } from "@dfinity/gix-components";
   import type { SnsNervousSystemFunction } from "@dfinity/sns";
-  import { fromNullable } from "@dfinity/utils";
+  import { fromNullable, isNullish } from "@dfinity/utils";
   import NoProposals from "../proposals/NoProposals.svelte";
   import LoadingProposals from "../proposals/LoadingProposals.svelte";
   import ListLoader from "../proposals/ListLoader.svelte";
   import SnsProposalsFilters from "./SnsProposalsFilters.svelte";
+  import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
+  import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
+  import NnsProposalCard from "$lib/components/proposals/NnsProposalCard.svelte";
+  import { fade } from "svelte/transition";
 
   export let proposals: SnsProposalData[] | undefined;
+  export let actionableProposals: SnsProposalData[] | undefined;
   export let nsFunctions: SnsNervousSystemFunction[] | undefined;
   export let disableInfiniteScroll = false;
   export let loadingNextPage = false;
 </script>
 
 <SnsProposalsFilters />
-{#if proposals === undefined}
-  <LoadingProposals />
-{:else if proposals.length === 0}
-  <NoProposals />
-{:else}
-  <ListLoader loading={loadingNextPage}>
-    <InfiniteScroll
-      layout="grid"
-      on:nnsIntersect
-      disabled={disableInfiniteScroll}
-    >
-      {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
-        <SnsProposalCard {proposalData} {nsFunctions} />
-      {/each}
-    </InfiniteScroll>
-  </ListLoader>
+
+{#if !$ENABLE_VOTING_INDICATION || $actionableProposalsSegmentStore.selected !== "actionable"}
+  <div in:fade data-tid="all-proposal-list">
+    {#if proposals === undefined}
+      <LoadingProposals />
+    {:else if proposals.length === 0}
+      <NoProposals />
+    {:else}
+      <ListLoader loading={loadingNextPage}>
+        <InfiniteScroll
+          layout="grid"
+          on:nnsIntersect
+          disabled={disableInfiniteScroll}
+        >
+          {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
+            <SnsProposalCard {proposalData} {nsFunctions} />
+          {/each}
+        </InfiniteScroll>
+      </ListLoader>
+    {/if}
+  </div>
+{/if}
+
+{#if $ENABLE_VOTING_INDICATION && $actionableProposalsSegmentStore.selected === "actionable"}
+  {#if actionableProposals === undefined}
+    <!-- TODO(max): TBD SignIn vs No vs NotSupported -->
+    <LoadingProposals />
+  {:else if actionableProposals.length === 0}
+    <!-- TODO(max): TBD custom screen -->
+    <NoProposals />
+  {:else}
+    <div in:fade data-tid="actionable-proposal-list">
+      <ListLoader loading={isNullish(actionableProposals)}>
+        <InfiniteScroll layout="grid" disabled>
+          {#each actionableProposals as proposalData (fromNullable(proposalData.id)?.id)}
+            <SnsProposalCard {proposalData} {nsFunctions} />
+          {/each}
+        </InfiniteScroll>
+      </ListLoader>
+    </div>
+  {/if}
 {/if}

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -23,6 +23,7 @@
   import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
   import type { Readable } from "svelte/store";
   import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
+  import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
 
   let nsFunctionsStore: Readable<SnsNervousSystemFunction[] | undefined>;
   $: nsFunctionsStore = createSnsNsFunctionsProjectStore($snsOnlyProjectStore);
@@ -125,11 +126,14 @@
   $: disableInfiniteScroll = nonNullish(currentProjectCanisterId)
     ? $snsProposalsStore[currentProjectCanisterId.toText()]?.completed ?? false
     : false;
+
+  let isActionable: boolean;
+  $: isActionable = $actionableProposalsSegmentStore.selected === "actionable";
 </script>
 
 <SnsProposalsList
-  {proposals}
-  {actionableProposals}
+  proposals={isActionable ? actionableProposals : proposals}
+  {isActionable}
   nsFunctions={$nsFunctionsStore}
   on:nnsIntersect={loadNextPage}
   {disableInfiniteScroll}

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -22,6 +22,7 @@
   import type { Principal } from "@dfinity/principal";
   import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
   import type { Readable } from "svelte/store";
+  import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
 
   let nsFunctionsStore: Readable<SnsNervousSystemFunction[] | undefined>;
   $: nsFunctionsStore = createSnsNsFunctionsProjectStore($snsOnlyProjectStore);
@@ -115,6 +116,11 @@
       )
     : undefined;
 
+  let actionableProposals: SnsProposalData[] | undefined;
+  $: actionableProposals = nonNullish(currentProjectCanisterId)
+    ? $actionableSnsProposalsStore[currentProjectCanisterId.toText()]?.proposals
+    : undefined;
+
   let disableInfiniteScroll: boolean;
   $: disableInfiniteScroll = nonNullish(currentProjectCanisterId)
     ? $snsProposalsStore[currentProjectCanisterId.toText()]?.completed ?? false
@@ -123,6 +129,7 @@
 
 <SnsProposalsList
   {proposals}
+  {actionableProposals}
   nsFunctions={$nsFunctionsStore}
   on:nnsIntersect={loadNextPage}
   {disableInfiniteScroll}

--- a/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
@@ -194,7 +194,9 @@ describe("NnsProposalsFilters", () => {
         it("should switch segment on click", async () => {
           const po = await renderComponent();
           const segmentPo = po.getActionableProposalsSegmentPo();
-          expect(po.getActionableProposalsSegmentPo()).toEqual(true);
+          expect(
+            await po.getActionableProposalsSegmentPo().isPresent()
+          ).toEqual(true);
           expect(await segmentPo.isActionableProposalsSelected()).toEqual(
             false
           );

--- a/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
@@ -187,14 +187,23 @@ describe("NnsProposalsFilters", () => {
           ).toEqual(true);
         });
 
-        it("should be clickable", async () => {
+        it("should switch segment on click", async () => {
           const po = await renderComponent();
           const segmentPo = po.getActionableProposalsSegmentPo();
+          expect(po.getActionableProposalsSegmentPo()).toEqual(true);
+          expect(await segmentPo.isActionableProposalsSelected()).toEqual(
+            false
+          );
+
           await segmentPo.clickActionableProposals();
+          expect(await segmentPo.isAllProposalsSelected()).toEqual(false);
           expect(await segmentPo.isActionableProposalsSelected()).toEqual(true);
 
           await segmentPo.clickAllProposals();
           expect(await segmentPo.isAllProposalsSelected()).toEqual(true);
+          expect(await segmentPo.isActionableProposalsSelected()).toEqual(
+            false
+          );
         });
 
         it("should hide and show proposal filters", async () => {
@@ -239,16 +248,6 @@ describe("NnsProposalsFilters", () => {
           expect(
             await po.getActionableProposalsSegmentPo().isAllProposalsSelected()
           ).toEqual(true);
-        });
-
-        it("should be clickable", async () => {
-          const po = await renderComponent();
-          const segmentPo = po.getActionableProposalsSegmentPo();
-          await segmentPo.clickActionableProposals();
-          expect(await segmentPo.isActionableProposalsSelected()).toEqual(true);
-
-          await segmentPo.clickAllProposals();
-          expect(await segmentPo.isAllProposalsSelected()).toEqual(true);
         });
 
         it("should hide and show proposal filters", async () => {

--- a/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
@@ -165,6 +165,10 @@ describe("NnsProposalsFilters", () => {
     });
 
     describe("when feature flag true", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_VOTING_INDICATION", true);
+      });
+
       describe("when signed out", () => {
         beforeEach(() => {
           authStoreMock.next({

--- a/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
@@ -194,9 +194,7 @@ describe("NnsProposalsFilters", () => {
         it("should switch segment on click", async () => {
           const po = await renderComponent();
           const segmentPo = po.getActionableProposalsSegmentPo();
-          expect(
-            await po.getActionableProposalsSegmentPo().isPresent()
-          ).toEqual(true);
+          expect(await segmentPo.isAllProposalsSelected()).toEqual(true);
           expect(await segmentPo.isActionableProposalsSelected()).toEqual(
             false
           );

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalsFilters.spec.ts
@@ -13,6 +13,11 @@ describe("SnsProposalsFilters", () => {
     return SnsProposalFiltersPo.under(new JestPageObjectElement(container));
   };
 
+  beforeEach(() => {
+    overrideFeatureFlagsStore.setFlag("ENABLE_VOTING_INDICATION", false);
+    proposalsFiltersStore.reset();
+  });
+
   it("should render filter buttons", async () => {
     const po = await renderComponent();
 
@@ -50,11 +55,14 @@ describe("SnsProposalsFilters", () => {
 
   describe("actionable proposals", () => {
     beforeEach(() => {
-      overrideFeatureFlagsStore.reset();
       proposalsFiltersStore.reset();
     });
 
-    describe("when feature flag true", () => {
+    describe('when "ENABLE_VOTING_INDICATION" feature flag true', () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_VOTING_INDICATION", true);
+      });
+
       it("should render actionable proposals segment", async () => {
         const po = await renderComponent();
 
@@ -70,14 +78,20 @@ describe("SnsProposalsFilters", () => {
         ).toEqual(true);
       });
 
-      it("should be clickable", async () => {
+      it("should switch proposal lists on segment change", async () => {
         const po = await renderComponent();
         const segmentPo = po.getActionableProposalsSegmentPo();
+
+        expect(await segmentPo.isAllProposalsSelected()).toEqual(true);
+        expect(await segmentPo.isActionableProposalsSelected()).toEqual(false);
+
         await segmentPo.clickActionableProposals();
+        expect(await segmentPo.isAllProposalsSelected()).toEqual(false);
         expect(await segmentPo.isActionableProposalsSelected()).toEqual(true);
 
         await segmentPo.clickAllProposals();
         expect(await segmentPo.isAllProposalsSelected()).toEqual(true);
+        expect(await segmentPo.isActionableProposalsSelected()).toEqual(false);
       });
 
       it("should hide and show proposal filters", async () => {
@@ -101,7 +115,7 @@ describe("SnsProposalsFilters", () => {
     });
   });
 
-  describe("when feature flag is false", () => {
+  describe('when "ENABLE_VOTING_INDICATION" feature flag is false', () => {
     beforeEach(() => {
       overrideFeatureFlagsStore.setFlag("ENABLE_VOTING_INDICATION", false);
     });

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalsFilters.spec.ts
@@ -1,4 +1,6 @@
 import SnsProposalsFilters from "$lib/components/sns-proposals/SnsProposalsFilters.svelte";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import { proposalsFiltersStore } from "$lib/stores/proposals.store";
 import { SnsProposalFiltersPo } from "$tests/page-objects/SnsProposalFilters.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
@@ -44,5 +46,78 @@ describe("SnsProposalsFilters", () => {
     await po.clickFiltersByRewardsButton();
     await runResolvedPromises();
     expect(await po.getFilterModalPo().isPresent()).toBe(true);
+  });
+
+  describe("actionable proposals", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.reset();
+      proposalsFiltersStore.reset();
+    });
+
+    describe("when feature flag true", () => {
+      it("should render actionable proposals segment", async () => {
+        const po = await renderComponent();
+
+        expect(await po.getActionableProposalsSegmentPo().isPresent()).toEqual(
+          true
+        );
+      });
+
+      it('should "all" be preselected by default', async () => {
+        const po = await renderComponent();
+        expect(
+          await po.getActionableProposalsSegmentPo().isAllProposalsSelected()
+        ).toEqual(true);
+      });
+
+      it("should be clickable", async () => {
+        const po = await renderComponent();
+        const segmentPo = po.getActionableProposalsSegmentPo();
+        await segmentPo.clickActionableProposals();
+        expect(await segmentPo.isActionableProposalsSelected()).toEqual(true);
+
+        await segmentPo.clickAllProposals();
+        expect(await segmentPo.isAllProposalsSelected()).toEqual(true);
+      });
+
+      it("should hide and show proposal filters", async () => {
+        const po = await renderComponent();
+        const segmentPo = po.getActionableProposalsSegmentPo();
+
+        expect(await po.getFilterByTypesButton().isPresent()).toEqual(true);
+        expect(await po.getFilterByStatusButton().isPresent()).toEqual(true);
+        expect(await po.getFilterByRewardsButton().isPresent()).toEqual(true);
+
+        await segmentPo.clickActionableProposals();
+        expect(await po.getFilterByTypesButton().isPresent()).toEqual(false);
+        expect(await po.getFilterByStatusButton().isPresent()).toEqual(false);
+        expect(await po.getFilterByRewardsButton().isPresent()).toEqual(false);
+
+        await segmentPo.clickAllProposals();
+        expect(await po.getFilterByTypesButton().isPresent()).toEqual(true);
+        expect(await po.getFilterByStatusButton().isPresent()).toEqual(true);
+        expect(await po.getFilterByRewardsButton().isPresent()).toEqual(true);
+      });
+    });
+  });
+
+  describe("when feature flag is false", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_VOTING_INDICATION", false);
+    });
+
+    it("should not render actionable proposals segment", async () => {
+      const po = await renderComponent();
+      expect(await po.getActionableProposalsSegmentPo().isPresent()).toEqual(
+        false
+      );
+    });
+
+    it("should render proposal filters", async () => {
+      const po = await renderComponent();
+      expect(await po.getFilterByTypesButton().isPresent()).toEqual(true);
+      expect(await po.getFilterByStatusButton().isPresent()).toEqual(true);
+      expect(await po.getFilterByRewardsButton().isPresent()).toEqual(true);
+    });
   });
 });

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalsList.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalsList.spec.ts
@@ -22,6 +22,7 @@ describe("SnsProposalsList", () => {
     const { queryAllByTestId } = render(SnsProposalsList, {
       props: {
         proposals,
+        actionableProposals: undefined,
         nsFunctions: [],
       },
     });
@@ -33,6 +34,7 @@ describe("SnsProposalsList", () => {
     const { queryByTestId } = render(SnsProposalsList, {
       props: {
         proposals,
+        actionableProposals: undefined,
         nsFunctions: [],
         loadingNextPage: true,
       },
@@ -47,6 +49,7 @@ describe("SnsProposalsList", () => {
     const { queryByTestId } = render(SnsProposalsList, {
       props: {
         proposals: undefined,
+        actionableProposals: undefined,
         nsFunctions: [],
       },
     });
@@ -58,6 +61,7 @@ describe("SnsProposalsList", () => {
     const { queryByTestId } = render(SnsProposalsList, {
       props: {
         proposals: [],
+        actionableProposals: undefined,
         nsFunctions: [],
       },
     });

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalsList.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalsList.spec.ts
@@ -1,7 +1,9 @@
 import SnsProposalsList from "$lib/components/sns-proposals/SnsProposalsList.svelte";
+import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
 import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import type { SnsProposalData } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
+import { beforeEach, describe } from "vitest";
 
 describe("SnsProposalsList", () => {
   const proposal1: SnsProposalData = {
@@ -18,11 +20,15 @@ describe("SnsProposalsList", () => {
   };
   const proposals = [proposal1, proposal2, proposal3];
 
+  beforeEach(() => {
+    actionableProposalsSegmentStore.resetForTesting();
+  });
+
   it("should render a proposal card per proposal", () => {
     const { queryAllByTestId } = render(SnsProposalsList, {
       props: {
         proposals,
-        actionableProposals: undefined,
+        isActionable: false,
         nsFunctions: [],
       },
     });
@@ -34,7 +40,7 @@ describe("SnsProposalsList", () => {
     const { queryByTestId } = render(SnsProposalsList, {
       props: {
         proposals,
-        actionableProposals: undefined,
+        isActionable: false,
         nsFunctions: [],
         loadingNextPage: true,
       },
@@ -49,7 +55,7 @@ describe("SnsProposalsList", () => {
     const { queryByTestId } = render(SnsProposalsList, {
       props: {
         proposals: undefined,
-        actionableProposals: undefined,
+        isActionable: false,
         nsFunctions: [],
       },
     });
@@ -61,11 +67,25 @@ describe("SnsProposalsList", () => {
     const { queryByTestId } = render(SnsProposalsList, {
       props: {
         proposals: [],
-        actionableProposals: undefined,
+        isActionable: false,
         nsFunctions: [],
       },
     });
 
     expect(queryByTestId("no-proposals-msg")).toBeInTheDocument();
+  });
+
+  describe("actionable proposals", () => {
+    it("should render skeletons while proposals are loading", async () => {
+      const { queryByTestId } = render(SnsProposalsList, {
+        props: {
+          proposals: undefined,
+          isActionable: true,
+          nsFunctions: [],
+        },
+      });
+
+      expect(queryByTestId("proposals-loading")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -354,14 +354,16 @@ describe("NnsProposals", () => {
       expect(await po.getActionableProposalList().isPresent()).toEqual(false);
     });
 
-    it("should switch proposal lists on actionable toggle", async () => {
+    it("should switch proposal lists on actionable segment change", async () => {
       const po = await renderComponent();
+      expect(await po.getAllProposalList().isPresent()).toEqual(true);
+      expect(await po.getActionableProposalList().isPresent()).toEqual(false);
+
       await po
         .getNnsProposalFiltersPo()
         .getActionableProposalsSegmentPo()
         .clickActionableProposals();
       await runResolvedPromises();
-
       expect(await po.getAllProposalList().isPresent()).toEqual(false);
       expect(await po.getActionableProposalList().isPresent()).toEqual(true);
 

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -462,38 +462,6 @@ describe("SnsProposals", () => {
         expect(await po.getAllProposalList().isPresent()).toEqual(true);
         expect(await po.getActionableProposalList().isPresent()).toEqual(false);
       });
-
-      it("should render spinner while loading actionable", async () => {
-        actionableSnsProposalsStore.resetForTesting();
-
-        const po = await renderComponent();
-        await po
-          .getSnsProposalFiltersPo()
-          .getActionableProposalsSegmentPo()
-          .clickActionableProposals();
-        await runResolvedPromises();
-
-        expect(await po.getSkeletonCardPo().isPresent()).toEqual(true);
-
-        mockActionableProposalsLoadingDone();
-        await runResolvedPromises();
-
-        expect(await po.getSkeletonCardPo().isPresent()).toEqual(false);
-      });
-
-      it("should display not supported page", async () => {
-        // TODO(max): TBD
-      });
-
-      describe("when signOut", () => {
-        beforeEach(() => {
-          setNoIdentity();
-        });
-
-        it("should display login CTA", async () => {
-          // TODO(max): TBD
-        });
-      });
     });
   });
 });

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -462,6 +462,23 @@ describe("SnsProposals", () => {
         expect(await po.getAllProposalList().isPresent()).toEqual(true);
         expect(await po.getActionableProposalList().isPresent()).toEqual(false);
       });
+
+      it("should display actionable proposals", async () => {
+        const po = await renderComponent();
+
+        expect((await po.getProposalCardPos()).length).toEqual(0);
+
+        await po
+          .getSnsProposalFiltersPo()
+          .getActionableProposalsSegmentPo()
+          .clickActionableProposals();
+        await runResolvedPromises();
+
+        expect((await po.getProposalCardPos()).length).toEqual(1);
+        expect(
+          await (await po.getProposalCardPos())[0].getProposalId()
+        ).toEqual("ID: 10");
+      });
     });
   });
 });

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -442,8 +442,11 @@ describe("SnsProposals", () => {
         expect(await po.getActionableProposalList().isPresent()).toEqual(false);
       });
 
-      it("should switch proposal lists on actionable toggle", async () => {
+      it("should switch proposal lists on actionable segment change", async () => {
         const po = await renderComponent();
+        expect(await po.getAllProposalList().isPresent()).toEqual(true);
+        expect(await po.getActionableProposalList().isPresent()).toEqual(false);
+
         await po
           .getSnsProposalFiltersPo()
           .getActionableProposalsSegmentPo()

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -435,6 +435,10 @@ describe("SnsProposals", () => {
     });
 
     describe("when feature flag true", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_VOTING_INDICATION", true);
+      });
+
       it("should render all proposals by default", async () => {
         const po = await renderComponent();
 

--- a/frontend/src/tests/page-objects/SnsProposalFilters.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalFilters.page-object.ts
@@ -1,3 +1,4 @@
+import { ActionableProposalsSegmentPo } from "$tests/page-objects/ActionableProposalsSegment.page-object";
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { FilterModalPo } from "$tests/page-objects/FilterModal.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
@@ -36,5 +37,9 @@ export class SnsProposalFiltersPo extends BasePageObject {
 
   getFilterModalPo(): FilterModalPo {
     return FilterModalPo.under(this.root);
+  }
+
+  getActionableProposalsSegmentPo(): ActionableProposalsSegmentPo {
+    return ActionableProposalsSegmentPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/SnsProposalList.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalList.page-object.ts
@@ -1,3 +1,4 @@
+import { ProposalCardPo } from "$tests/page-objects/ProposalCard.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { SnsProposalFiltersPo } from "$tests/page-objects/SnsProposalFilters.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
@@ -34,5 +35,9 @@ export class SnsProposalListPo extends BasePageObject {
     return (
       (await this.isPresent()) && !(await this.getSkeletonCardPo().isPresent())
     );
+  }
+
+  getProposalCardPos(): Promise<ProposalCardPo[]> {
+    return ProposalCardPo.allUnder(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/SnsProposalList.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalList.page-object.ts
@@ -1,0 +1,38 @@
+import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
+import { SnsProposalFiltersPo } from "$tests/page-objects/SnsProposalFilters.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class SnsProposalListPo extends BasePageObject {
+  private static readonly TID = "sns-proposal-list-component";
+
+  static under(element: PageObjectElement): SnsProposalListPo {
+    return new SnsProposalListPo(element.byTestId(SnsProposalListPo.TID));
+  }
+
+  getSkeletonCardPo(): SkeletonCardPo {
+    return SkeletonCardPo.under(this.root);
+  }
+
+  getAllProposalList(): PageObjectElement {
+    return this.root.byTestId("all-proposal-list");
+  }
+
+  getActionableProposalList(): PageObjectElement {
+    return this.root.byTestId("actionable-proposal-list");
+  }
+
+  getSnsProposalFiltersPo(): SnsProposalFiltersPo {
+    return SnsProposalFiltersPo.under(this.root);
+  }
+
+  hasSpinner(): Promise<boolean> {
+    return this.isPresent("spinner");
+  }
+
+  async isContentLoaded(): Promise<boolean> {
+    return (
+      (await this.isPresent()) && !(await this.getSkeletonCardPo().isPresent())
+    );
+  }
+}


### PR DESCRIPTION
# Motivation

Display actionable proposals on sns proposals page. Current proposal filters should not be available when actionable proposals are selected. More states (not supported, sign-out, empty) will be implemented in a separate PR.

# Changes

- add actionable segment to sns proposals page
- switch between all and actionable based on segment state

# Tests

- actionable segment in SnsProposalsFilters
- add `SnsProposalListPo`
- actionable list on sns proposals page

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.

# Screenshots

<img width="1480" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/d1069359-9a07-491f-b278-8db54b5d7973">
<img width="1503" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/9cc2430b-c87f-4de4-9737-02160d45cf63">
