### PR TITLE
Update aggregator candid bindings

### DIFF
--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_governance --out ic_sns_governance.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-07_23-01+feature/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-28_23-01+p2p-hotfix/rs/sns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
@@ -155,6 +155,52 @@ pub struct GovernanceError {
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Subaccount {
+    pub subaccount: serde_bytes::ByteBuf,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Account {
+    pub owner: Option<Principal>,
+    pub subaccount: Option<Subaccount>,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Decimal {
+    pub human_readable: Option<String>,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Tokens {
+    pub e8s: Option<u64>,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct ValuationFactors {
+    pub xdrs_per_icp: Option<Decimal>,
+    pub icps_per_token: Option<Decimal>,
+    pub tokens: Option<Tokens>,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Valuation {
+    pub token: Option<i32>,
+    pub account: Option<Account>,
+    pub valuation_factors: Option<ValuationFactors>,
+    pub timestamp_seconds: Option<u64>,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct TransferSnsTreasuryFundsActionAuxiliary {
+    pub valuation: Option<Valuation>,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub enum ActionAuxiliary {
+    TransferSnsTreasuryFunds(TransferSnsTreasuryFundsActionAuxiliary),
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Ballot {
     pub vote: i32,
     pub cast_timestamp_seconds: u64,
@@ -187,11 +233,6 @@ pub struct ManageDappCanisterSettings {
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RegisterDappCanisters {
     pub canister_ids: Vec<Principal>,
-}
-
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub struct Subaccount {
-    pub subaccount: serde_bytes::ByteBuf,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -287,6 +328,7 @@ pub struct ProposalData {
     pub payload_text_rendering: Option<String>,
     pub action: u64,
     pub failure_reason: Option<GovernanceError>,
+    pub action_auxiliary: Option<ActionAuxiliary>,
     pub ballots: Vec<(String, Ballot)>,
     pub minimum_yes_proportion_of_total: Option<Percentage>,
     pub reward_event_round: u64,
@@ -316,12 +358,6 @@ pub struct Split {
 pub struct Follow {
     pub function_id: u64,
     pub followees: Vec<NeuronId>,
-}
-
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub struct Account {
-    pub owner: Option<Principal>,
-    pub subaccount: Option<Subaccount>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -677,6 +713,7 @@ pub struct ListProposals {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListProposalsResponse {
+    pub include_ballots_by_caller: Option<bool>,
     pub proposals: Vec<ProposalData>,
 }
 

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_ledger --out ic_sns_ledger.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-07_23-01+feature/rs/rosetta-api/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-28_23-01+p2p-hotfix/rs/rosetta-api/icrc1/ledger/ledger.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_root --out ic_sns_root.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-07_23-01+feature/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-28_23-01+p2p-hotfix/rs/sns/root/canister/root.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_swap --out ic_sns_swap.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-07_23-01+feature/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-28_23-01+p2p-hotfix/rs/sns/swap/canister/swap.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out ic_sns_wasm.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-07_23-01+feature/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-02-28_23-01+p2p-hotfix/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]


### PR DESCRIPTION
# Motivation
We would like to parse all the latest SNS data. To do so, we update the candid interfaces for the SNS aggregator.
Even with no changes, just updating the reference is good practice.

# Changes
* Updated the Rust code derived from `.did` files in the aggregator.
  * Note: The candid files under `declarations/nns-$CANISTER` are used as inputs.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  Breaking changes are:
    * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants