### PR TITLE
fix: Store using the correct schema when migrating from stable memory to map

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,6 +206,8 @@ jobs:
         run: dfx start --clean --background &>test-upgrade-stable-dfx.log
       - name: Upgrade nns-dapp from Map to AccountsInStableMemory and back again
         run: ./scripts/nns-dapp/migration-test --schema1 Map --schema2 AccountsInStableMemory --accounts 20 --chunk 20
+      - name: Repeat with more accounts
+        run: ./scripts/nns-dapp/migration-test --schema1 Map --schema2 AccountsInStableMemory --accounts 40 --chunk 20
       - name: Upload dfx logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -256,7 +256,10 @@ impl StableState for State {
 impl State {
     /// Saves any unsaved state to stable memory.
     pub fn save(&self) {
-        let schema = self.schema_label();
+        // When saving data to stable memory, ask the accountsdb.  If we migrated from
+        // `AccountsInStableMemory` to `Map`, the stable memory will still have the `AccountsInStableMemory` layout
+        // but we want to save as `Map`.  There is no such issue when migrating from `Map` to `AccountsInStableMemory`.
+        let schema = self.accounts_store.borrow().schema_label();
         println!(
             "START State save: {:?} (accounts: {:?})",
             &schema,


### PR DESCRIPTION
# Motivation
There is a bug:
- In the pre-upgrade hook, we check the current schema and save state accordingly.  That is fine.
- But we determine the schema by looking at the stable memory, not by checking which schema is currently in use.
- When migrating from the heap to stable structures, the stable structures are written to stable memory, so this gives the correct result IF migration has completed.
- But when migrating from stable structures to map, the migration completes correctly, but then in the `pre_upgrade` hook we look at the stable memory, which is still set up for stable structures, and say "oh, save to stable structures".  This not only un-does the migration but also loses any data added after the migration was completed.
- It also gives the incorrect result part way through a migration from map to stable structures.

# Changes
- Use the correct schema when saving data in the pre-upgrade hook.

# Tests
- The bug can be exercised by running the existing migration test twice, with more accounts in the second run.
  - If we test that on main, [the test fails](https://github.com/dfinity/nns-dapp/actions/runs/8324594115).
  - But in this PR, the same test succeeds.

# Todos

- [ ] Add entry to changelog (if necessary).
