### PR TITLE
Load ckBTC info in CkBTCTransactionModal

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,6 +30,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Min ckBTC withdrawal amount was unknown when withdrawing directly from My Tokens.
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
+++ b/frontend/src/lib/modals/accounts/CkBTCTransactionModal.svelte
@@ -11,6 +11,7 @@
   import type { Account } from "$lib/types/account";
   import type { WizardStep } from "@dfinity/gix-components";
   import { transferTokens as transferIcrcTokens } from "$lib/services/icrc-accounts.services";
+  import { loadCkBTCInfo } from "$lib/services/ckbtc-info.services";
   import type { TokenAmountV2, Token } from "@dfinity/utils";
   import type { UniverseCanisterId } from "$lib/types/universe";
   import type { CkBTCAdditionalCanisters } from "$lib/types/ckbtc-canisters";
@@ -151,6 +152,11 @@
 
     return undefined;
   };
+
+  $: loadCkBTCInfo({
+    universeId: universeId,
+    minterCanisterId: canisters.minterCanisterId,
+  });
 </script>
 
 <TransactionModal

--- a/frontend/src/tests/lib/components/accounts/CkBTCWalletFooter.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCWalletFooter.spec.ts
@@ -1,3 +1,4 @@
+import * as ckbtcMinterApi from "$lib/api/ckbtc-minter.api";
 import CkBTCWalletFooter from "$lib/components/accounts/CkBTCWalletFooter.svelte";
 import { CKTESTBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
@@ -9,6 +10,7 @@ import {
   mockBTCAddressTestnet,
   mockCkBTCMainAccount,
 } from "$tests/mocks/ckbtc-accounts.mock";
+import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import {
   mockTokensSubscribe,
   mockUniversesTokens,
@@ -17,15 +19,15 @@ import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
 import CkBTCWalletContextTest from "./CkBTCWalletContextTest.svelte";
 
-vi.mock("$lib/api/ckbtc-minter.api", () => {
-  return {
-    getBTCAddress: vi.fn().mockImplementation(() => mockBTCAddressTestnet),
-  };
-});
+vi.mock("$lib/api/ckbtc-minter.api");
 
 describe("CkBTCWalletFooter", () => {
   beforeEach(() => {
     resetIdentity();
+    vi.mocked(ckbtcMinterApi.getBTCAddress).mockResolvedValue(
+      mockBTCAddressTestnet
+    );
+    vi.mocked(ckbtcMinterApi.minterInfo).mockResolvedValue(mockCkBTCMinterInfo);
     vi.spyOn(tokensStore, "subscribe").mockImplementation(
       mockTokensSubscribe(mockUniversesTokens)
     );

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -1,4 +1,3 @@
-import * as ckbtcMinterApi from "$lib/api/ckbtc-minter.api";
 import * as minterApi from "$lib/api/ckbtc-minter.api";
 import {
   CKTESTBTC_LEDGER_CANISTER_ID,
@@ -330,14 +329,14 @@ describe("CkBTCTransactionModal", () => {
       "The amount falls below the minimum of 0.00085 ckBTC required for converting to BTC."
     );
 
-    expect(ckbtcMinterApi.minterInfo).not.toBeCalled();
+    expect(minterApi.minterInfo).not.toBeCalled();
   });
 
   it("should load ckBTC info if not available", async () => {
     const retreiveBtcMinAmount = 85_000n;
 
     ckBTCInfoStore.reset();
-    vi.mocked(ckbtcMinterApi.minterInfo).mockResolvedValue({
+    vi.mocked(minterApi.minterInfo).mockResolvedValue({
       retrieve_btc_min_amount: retreiveBtcMinAmount,
       min_confirmations: 12,
       kyt_fee: 1234n,
@@ -357,16 +356,16 @@ describe("CkBTCTransactionModal", () => {
       "The amount falls below the minimum of 0.00085 ckBTC required for converting to BTC."
     );
 
-    expect(ckbtcMinterApi.minterInfo).toBeCalledTimes(2);
+    expect(minterApi.minterInfo).toBeCalledTimes(2);
     const expectedParams = {
       canisterId: mockCkBTCAdditionalCanisters.minterCanisterId,
       identity: mockIdentity,
     };
-    expect(ckbtcMinterApi.minterInfo).toBeCalledWith({
+    expect(minterApi.minterInfo).toBeCalledWith({
       ...expectedParams,
       certified: true,
     });
-    expect(ckbtcMinterApi.minterInfo).toBeCalledWith({
+    expect(minterApi.minterInfo).toBeCalledWith({
       ...expectedParams,
       certified: false,
     });

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -23,6 +23,7 @@ import {
   mockCkBTCToken,
   mockCkTESTBTCToken,
 } from "$tests/mocks/ckbtc-accounts.mock";
+import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
 import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
@@ -137,6 +138,9 @@ describe("Tokens route", () => {
       vi.spyOn(icrcLedgerApi, "icrcTransfer").mockResolvedValue(1234n);
       vi.spyOn(ckBTCMinterApi, "updateBalance").mockRejectedValue(
         noPendingUtxos
+      );
+      vi.mocked(ckBTCMinterApi.minterInfo).mockResolvedValue(
+        mockCkBTCMinterInfo
       );
 
       setSnsProjects([


### PR DESCRIPTION
# Motivation

When sending BTC directly from the "My Tokens" table, the amount input field shows an error (unless you've previously visited the ckBTC wallet page):
<img width="578" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/241c3961-1ac9-4b15-88b3-a53a55922e1c">

This is because the `CkBTCTransactionModal` assumes that the minter info is already loaded, but this only happens on the ckBTC wallet page.

# Changes

Load the minter info in the CkBTCTransactionModal if it isn't already loaded.

# Tests

1. Extend the existing unit test that tests that the amount can't be lower than the minimum amount to verify that the minimum amount corresponds to what's already in the minter info store.
2. Add an additional unit test that tests that the minter info is loaded from the API if not present in the store.

# Todos

- [x] Add entry to changelog (if necessary).
