### PR TITLE
NNS1-2918: Add hideZeroBalancesStore

### DIFF
--- a/frontend/src/lib/constants/stores.constants.ts
+++ b/frontend/src/lib/constants/stores.constants.ts
@@ -5,6 +5,7 @@ export enum StoreLocalStorageKey {
   BitcoinConvertBlockIndexes = "nnsBitcoinConvertBlockIndexes",
   SnsProposalFilters = "nnsSnsProposalFilters",
   JsonRepresentation = "jsonRepresentation",
+  HideZeroBalances = "nnsHideZeroBalances",
 }
 
 export const NOT_LOADED = Symbol("NOT_LOADED");

--- a/frontend/src/lib/constants/stores.constants.ts
+++ b/frontend/src/lib/constants/stores.constants.ts
@@ -5,7 +5,7 @@ export enum StoreLocalStorageKey {
   BitcoinConvertBlockIndexes = "nnsBitcoinConvertBlockIndexes",
   SnsProposalFilters = "nnsSnsProposalFilters",
   JsonRepresentation = "jsonRepresentation",
-  HideZeroBalances = "nnsHideZeroBalances",
+  HideZeroBalances = "nnsHideZeroBalanceTokens",
 }
 
 export const NOT_LOADED = Symbol("NOT_LOADED");

--- a/frontend/src/lib/stores/hide-zero-balances.store.ts
+++ b/frontend/src/lib/stores/hide-zero-balances.store.ts
@@ -1,0 +1,12 @@
+import { StoreLocalStorageKey } from "$lib/constants/stores.constants";
+import type { Writable } from "svelte/store";
+import { writableStored } from "./writable-stored";
+
+export type HideZeroBalancesMode = "show" | "hide";
+
+export type HideZeroBalancesStore = Writable<HideZeroBalancesMode>;
+
+export const hideZeroBalancesStore = writableStored<HideZeroBalancesMode>({
+  key: StoreLocalStorageKey.HideZeroBalances,
+  defaultValue: "show",
+});

--- a/frontend/src/lib/stores/writable-stored.ts
+++ b/frontend/src/lib/stores/writable-stored.ts
@@ -5,6 +5,7 @@ import { writable, type Unsubscriber, type Writable } from "svelte/store";
 
 type WritableStored<T> = Writable<T> & {
   unsubscribeStorage: Unsubscriber;
+  resetForTesting: () => void;
 };
 
 type VersionedData<T> = { data: T | undefined; version: number | undefined };
@@ -124,5 +125,8 @@ export const writableStored = <T>({
   return {
     ...store,
     unsubscribeStorage,
+    resetForTesting: () => {
+      store.set(defaultValue);
+    },
   };
 };

--- a/frontend/src/tests/lib/stores/hide-zero-balances.store.spec.ts
+++ b/frontend/src/tests/lib/stores/hide-zero-balances.store.spec.ts
@@ -1,0 +1,29 @@
+import { StoreLocalStorageKey } from "$lib/constants/stores.constants";
+import { hideZeroBalancesStore } from "$lib/stores/hide-zero-balances.store";
+import { get } from "svelte/store";
+
+describe("hideZeroBalancesStore", () => {
+  beforeEach(() => {
+    hideZeroBalancesStore.resetForTesting();
+  });
+
+  it("should be initialized with the default value", () => {
+    expect(get(hideZeroBalancesStore)).toBe("show");
+  });
+
+  it("should update value", () => {
+    hideZeroBalancesStore.set("hide");
+    expect(get(hideZeroBalancesStore)).toBe("hide");
+
+    hideZeroBalancesStore.set("show");
+    expect(get(hideZeroBalancesStore)).toBe("show");
+  });
+
+  it("should write to local storage", () => {
+    hideZeroBalancesStore.set("hide");
+
+    expect(
+      window.localStorage.getItem(StoreLocalStorageKey.HideZeroBalances)
+    ).toEqual('"hide"');
+  });
+});

--- a/frontend/src/tests/lib/stores/writable-stored.spec.ts
+++ b/frontend/src/tests/lib/stores/writable-stored.spec.ts
@@ -173,4 +173,23 @@ describe("writableStored", () => {
       ).toEqual(JSON.stringify(newState));
     });
   });
+
+  it("should resetForTesting", () => {
+    const defaultState = { filter: "new" };
+
+    const store = writableStored({
+      key: StoreLocalStorageKey.ProposalFilters,
+      defaultValue: defaultState,
+    });
+
+    const newState = { filter: "old" };
+
+    expect(get(store)).toEqual(defaultState);
+
+    store.set(newState);
+    expect(get(store)).toEqual(newState);
+
+    store.resetForTesting();
+    expect(get(store)).toEqual(defaultState);
+  });
 });


### PR DESCRIPTION
# Motivation

We want to add a setting to hide tokens with zero balance.
We want this setting to persist. For now we will persist it locally in the browser.

# Changes

1. Add a store `hideZeroBalancesStore` to store the setting to hide tokens with zero balance.
2. Add `resetForTesting` functionality to `writableStored`.

# Tests

1. Unit tests for `hideZeroBalancesStore`.
2. Unit test for `resetForTesting`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary