### PR TITLE
Actionable nns proposal banners

### DIFF
--- a/frontend/src/lib/components/proposals/ActionableProposalsEmpty.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalsEmpty.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { IconProposalsPage, PageBanner } from "@dfinity/gix-components";
+</script>
+
+<PageBanner testId="actionable-proposals-empty">
+  <IconProposalsPage slot="image" />
+  <svelte:fragment slot="title"
+    >{$i18n.actionable_proposals_empty.title}</svelte:fragment
+  >
+  <p class="description" slot="description">
+    {$i18n.actionable_proposals_empty.text}
+  </p>
+</PageBanner>

--- a/frontend/src/lib/components/proposals/ActionableProposalsSignIn.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalsSignIn.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import SignIn from "$lib/components/common/SignIn.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { PageBanner, IconProposalsPage } from "@dfinity/gix-components";
+</script>
+
+<PageBanner testId="actionable-proposals-sign-in">
+  <IconProposalsPage slot="image" />
+  <svelte:fragment slot="title"
+    >{$i18n.actionable_proposals_sign_in.title}</svelte:fragment
+  >
+  <p class="description" slot="description">
+    {$i18n.actionable_proposals_sign_in.text}
+  </p>
+  <SignIn slot="actions" />
+</PageBanner>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -376,8 +376,7 @@
   },
   "actionable_proposals_sign_in": {
     "title": "You are not signed in.",
-    "text": "Sign in to see actionable proposals",
-    "sign_in": "Sign in with Internet Identity"
+    "text": "Sign in to see actionable proposals"
   },
   "actionable_proposals_empty": {
     "title": "There are no actionable proposals you can vote for.",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -374,6 +374,15 @@
     "all_proposals": "All Proposals",
     "actionable_proposals": "Actionable Proposals"
   },
+  "actionable_proposals_sign_in": {
+    "title": "You are not signed in.",
+    "text": "Sign in to see actionable proposals",
+    "sign_in": "Sign in with Internet Identity"
+  },
+  "actionable_proposals_empty": {
+    "title": "There are no actionable proposals you can vote for.",
+    "text": "Check back later!"
+  },
   "canisters": {
     "aria_label_canister_card": "Go to canister details",
     "text": "Developers can create and manage their canisters (a form of smart contracts) and cycles consumption here.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -389,6 +389,17 @@ interface I18nVoting {
   actionable_proposals: string;
 }
 
+interface I18nActionable_proposals_sign_in {
+  title: string;
+  text: string;
+  sign_in: string;
+}
+
+interface I18nActionable_proposals_empty {
+  title: string;
+  text: string;
+}
+
 interface I18nCanisters {
   aria_label_canister_card: string;
   text: string;
@@ -1275,6 +1286,8 @@ interface I18n {
   new_followee: I18nNew_followee;
   follow_neurons: I18nFollow_neurons;
   voting: I18nVoting;
+  actionable_proposals_sign_in: I18nActionable_proposals_sign_in;
+  actionable_proposals_empty: I18nActionable_proposals_empty;
   canisters: I18nCanisters;
   canister_detail: I18nCanister_detail;
   transaction_names: I18nTransaction_names;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -392,7 +392,6 @@ interface I18nVoting {
 interface I18nActionable_proposals_sign_in {
   title: string;
   text: string;
-  sign_in: string;
 }
 
 interface I18nActionable_proposals_empty {

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -382,6 +382,8 @@ describe("NnsProposals", () => {
 
     it("should render skeletons while loading actionable", async () => {
       const po = await renderComponent();
+      expect(await po.getSkeletonCardPo().isPresent()).toEqual(false);
+
       await selectActionableProposals(po);
       expect(await po.getSkeletonCardPo().isPresent()).toEqual(true);
 

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -402,6 +402,15 @@ describe("NnsProposals", () => {
       const po = await renderComponent();
       await selectActionableProposals(po);
       expect(await po.getActionableSignInBanner().isPresent()).toEqual(true);
+      expect(await po.getActionableSignInBanner().getTitleText()).toEqual(
+        "You are not signed in."
+      );
+      expect(await po.getActionableSignInBanner().getDescriptionText()).toEqual(
+        "Sign in to see actionable proposals"
+      );
+      expect(
+        await po.getActionableSignInBanner().getBannerActionsText()
+      ).toEqual("Sign in with Internet Identity");
     });
 
     it('should display "no actionable proposals" banner', async () => {
@@ -410,6 +419,12 @@ describe("NnsProposals", () => {
 
       await selectActionableProposals(po);
       expect(await po.getActionableEmptyBanner().isPresent()).toEqual(true);
+      expect(await po.getActionableEmptyBanner().getTitleText()).toEqual(
+        "There are no actionable proposals you can vote for."
+      );
+      expect(await po.getActionableEmptyBanner().getDescriptionText()).toEqual(
+        "Check back later!"
+      );
     });
 
     it("should display actionable proposals", async () => {

--- a/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
@@ -1,4 +1,5 @@
 import { NnsProposalFiltersPo } from "$tests/page-objects/NnsProposalFilters.page-object";
+import { PageBannerPo } from "$tests/page-objects/PageBanner.page-object";
 import { ProposalCardPo } from "$tests/page-objects/ProposalCard.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
@@ -33,6 +34,20 @@ export class NnsProposalListPo extends BasePageObject {
 
   getProposalCardPos(): Promise<ProposalCardPo[]> {
     return ProposalCardPo.allUnder(this.root);
+  }
+
+  getActionableSignInBanner(): PageBannerPo {
+    return PageBannerPo.under({
+      element: this.root,
+      testId: "actionable-proposals-sign-in",
+    });
+  }
+
+  getActionableEmptyBanner(): PageBannerPo {
+    return PageBannerPo.under({
+      element: this.root,
+      testId: "actionable-proposals-empty",
+    });
   }
 
   hasSpinner(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/PageBanner.page-object.ts
+++ b/frontend/src/tests/page-objects/PageBanner.page-object.ts
@@ -1,0 +1,40 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class PageBannerPo extends BasePageObject {
+  private static readonly TID = "participate-button-component";
+
+  static under({
+    element,
+    testId,
+  }: {
+    element: PageObjectElement;
+    testId: string;
+  }): PageBannerPo {
+    return new PageBannerPo(element.byTestId(testId));
+  }
+
+  getTitle(): PageObjectElement {
+    return this.root.querySelector("h1");
+  }
+
+  getDescription(): PageObjectElement {
+    return this.root.querySelector("[slot='description']");
+  }
+
+  getBannerActions(): PageObjectElement {
+    return this.root.querySelector(".banner-actions");
+  }
+
+  getTitleText(): Promise<string> {
+    return this.getTitle().getText();
+  }
+
+  getDescriptionText(): Promise<string> {
+    return this.getDescription().getText();
+  }
+
+  async getBannerActionsText(): Promise<string> {
+    return (await this.getBannerActions().getText()).trim();
+  }
+}


### PR DESCRIPTION
# Motivation

Display more information when a user attempts to view actionable proposals without being logged (Screenshot 1.) in or when no actionable proposals are available for voting (Screenshot 2.).

# Changes

- [move "all proposals" related blocks](https://github.com/dfinity/nns-dapp/pull/4632/files#diff-1fb3bd8ea562ad07e519536414b00eec641a7271994ed0f75c546432e08cd8dcL63) (loading and no-proposals) under `all-proposal-list` to have the same structure.
- replace ListLoader with LoadingProposals for actionable
- new banner components (`ActionableProposalsEmpty` and `ActionableProposalsSignIn`)
- 

# Tests

- create PageBannerPo
- extend NnsProposalListPo with banners
- move actionable selection in a separate function to avoid code duplication [`selectActionableProposals`](https://github.com/dfinity/nns-dapp/pull/4632/files#diff-5312cc21ef61d3d1c1222fae72550e9f83c6a8b876c8c17327ccdececc49e8f7R340)
- should display banners
- should display actionable proposals

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.

# Screenshots

<img width="613" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/60d71d6c-2a42-4b98-9e7a-96425d36c044">

<img width="617" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/0344d81c-807f-40ef-84b1-340a5499bb5a">

