### PR TITLE
NNS1-2918: Add HideZeroBalancesToggle component

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/HideZeroBalancesToggle.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/HideZeroBalancesToggle.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { Toggle } from "@dfinity/gix-components";
+  import { i18n } from "$lib/stores/i18n";
+  import { hideZeroBalancesStore } from "$lib/stores/hide-zero-balances.store";
+
+  let checked = false;
+  $: checked = $hideZeroBalancesStore === "hide";
+
+  const toggle = () => {
+    hideZeroBalancesStore.set(checked ? "show" : "hide");
+  };
+</script>
+
+<div class="popup-content" data-tid="hide-zero-balances-toggle-component">
+  <div class="popup-header">
+    {$i18n.tokens.balance_header}
+  </div>
+  <div class="toggle-label">
+    {$i18n.tokens.hide_zero_balances}
+    <Toggle
+      {checked}
+      on:nnsToggle={toggle}
+      ariaLabel={$i18n.tokens.hide_zero_balances_toggle_label}
+    />
+  </div>
+</div>
+
+<style lang="scss">
+  .popup-content {
+    display: flex;
+    flex-direction: column;
+    width: 240px;
+    gap: var(--padding-0_5x);
+  }
+
+  .popup-header {
+    font-size: var(--font-size-small);
+    color: var(--text-description);
+  }
+
+  .toggle-label {
+    display: flex;
+    justify-content: space-between;
+    font-size: var(--font-size-standard);
+  }
+</style>

--- a/frontend/src/lib/components/tokens/TokensTable/HideZeroBalancesToggle.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/HideZeroBalancesToggle.svelte
@@ -29,7 +29,7 @@
   .popup-content {
     display: flex;
     flex-direction: column;
-    width: 240px;
+    width: calc(30 * var(--padding));
     gap: var(--padding-0_5x);
   }
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -999,6 +999,8 @@
     "projects_header": "Projects",
     "balance_header": "Balance",
     "accounts_header": "Accounts",
-    "settings_button": "Open tokens settings"
+    "settings_button": "Open tokens settings",
+    "hide_zero_balances": "Hide zero balances",
+    "hide_zero_balances_toggle_label": "Switch between showing and hiding tokens with a balance of zero"
   }
 }

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1053,6 +1053,8 @@ interface I18nTokens {
   balance_header: string;
   accounts_header: string;
   settings_button: string;
+  hide_zero_balances: string;
+  hide_zero_balances_toggle_label: string;
 }
 
 interface I18nNeuron_state {

--- a/frontend/src/tests/lib/components/tokens/TokensTable/HideZeroBalancesToggle.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable/HideZeroBalancesToggle.spec.ts
@@ -2,6 +2,7 @@ import HideZeroBalancesToggle from "$lib/components/tokens/TokensTable/HideZeroB
 import { hideZeroBalancesStore } from "$lib/stores/hide-zero-balances.store";
 import { HideZeroBalancesTogglePo } from "$tests/page-objects/HideZeroBalancesToggle.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
@@ -41,11 +42,13 @@ describe("HideZeroBalancesToggle", () => {
     expect(await toggle.isEnabled()).toBe(false);
 
     hideZeroBalancesStore.set("hide");
+    await runResolvedPromises();
 
     expect(get(hideZeroBalancesStore)).toBe("hide");
     expect(await toggle.isEnabled()).toBe(true);
 
     hideZeroBalancesStore.set("show");
+    await runResolvedPromises();
 
     expect(get(hideZeroBalancesStore)).toBe("show");
     expect(await toggle.isEnabled()).toBe(false);

--- a/frontend/src/tests/lib/components/tokens/TokensTable/HideZeroBalancesToggle.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable/HideZeroBalancesToggle.spec.ts
@@ -1,0 +1,53 @@
+import HideZeroBalancesToggle from "$lib/components/tokens/TokensTable/HideZeroBalancesToggle.svelte";
+import { hideZeroBalancesStore } from "$lib/stores/hide-zero-balances.store";
+import { HideZeroBalancesTogglePo } from "$tests/page-objects/HideZeroBalancesToggle.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+import { get } from "svelte/store";
+
+describe("HideZeroBalancesToggle", () => {
+  beforeEach(() => {
+    hideZeroBalancesStore.resetForTesting();
+  });
+
+  const renderComponent = () => {
+    const { container } = render(HideZeroBalancesToggle);
+    return HideZeroBalancesTogglePo.under(new JestPageObjectElement(container));
+  };
+
+  it("should update the store when toggled", async () => {
+    const po = renderComponent();
+    const toggle = po.getTogglePo();
+
+    expect(get(hideZeroBalancesStore)).toBe("show");
+    expect(await toggle.isEnabled()).toBe(false);
+
+    await toggle.toggle();
+
+    expect(get(hideZeroBalancesStore)).toBe("hide");
+    expect(await toggle.isEnabled()).toBe(true);
+
+    await toggle.toggle();
+
+    expect(get(hideZeroBalancesStore)).toBe("show");
+    expect(await toggle.isEnabled()).toBe(false);
+  });
+
+  it("should update toggle when store is set", async () => {
+    const po = renderComponent();
+    const toggle = po.getTogglePo();
+
+    expect(get(hideZeroBalancesStore)).toBe("show");
+    expect(await toggle.isEnabled()).toBe(false);
+
+    hideZeroBalancesStore.set("hide");
+
+    expect(get(hideZeroBalancesStore)).toBe("hide");
+    expect(await toggle.isEnabled()).toBe(true);
+
+    hideZeroBalancesStore.set("show");
+
+    expect(get(hideZeroBalancesStore)).toBe("show");
+    expect(await toggle.isEnabled()).toBe(false);
+  });
+});

--- a/frontend/src/tests/page-objects/HideZeroBalancesToggle.page-object.ts
+++ b/frontend/src/tests/page-objects/HideZeroBalancesToggle.page-object.ts
@@ -1,0 +1,17 @@
+import { TogglePo } from "$tests/page-objects/Toggle.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class HideZeroBalancesTogglePo extends BasePageObject {
+  private static readonly TID = "hide-zero-balances-toggle-component";
+
+  static under(element: PageObjectElement): HideZeroBalancesTogglePo {
+    return new HideZeroBalancesTogglePo(
+      element.byTestId(HideZeroBalancesTogglePo.TID)
+    );
+  }
+
+  getTogglePo(): TogglePo {
+    return TogglePo.under(this.root);
+  }
+}


### PR DESCRIPTION
# Motivation

We want to add a setting to hide tokens with a zero balance.
We're adding a settings button in the top right of the tokens table.
This button will open a popup with a toggle.
This PR adds the component that will be used as the content inside this popup.

# Changes

Add `HideZeroBalancesToggle` component to be used inside the settings popup.

# Tests

Added unit test for the component.
Here's what the component will look like in context:

<img width="381" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/54df1e25-5b03-4139-b001-e5777e95fc04">

# Todos

- [ ] Add entry to changelog (if necessary).
not yet