### PR TITLE
NNS1-2918: Show setting popup when settings button is clicked

### DIFF
--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import HideZeroBalancesToggle from "$lib/components/tokens/TokensTable/HideZeroBalancesToggle.svelte";
   import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
   import { i18n } from "$lib/stores/i18n";
   import type { UserToken } from "$lib/types/tokens-page";
   import { ENABLE_HIDE_ZERO_BALANCE } from "$lib/stores/feature-flags.store";
   import { IconSettings } from "@dfinity/gix-components";
+  import { Popover } from "@dfinity/gix-components";
 
   export let userTokensData: UserToken[];
+
+  let settingsButton: HTMLButtonElement | undefined;
+  let settingsPopupVisible = false;
+
+  const openSettings = () => {
+    settingsPopupVisible = true;
+  };
 </script>
 
 <TestIdWrapper testId="tokens-page-component">
@@ -20,11 +29,21 @@
         <button
           data-tid="settings-button"
           class="settings-button icon-only"
-          aria-label={$i18n.tokens.settings_button}><IconSettings /></button
+          aria-label={$i18n.tokens.settings_button}
+          bind:this={settingsButton}
+          on:click={openSettings}><IconSettings /></button
         >
       {/if}
     </div>
   </TokensTable>
+  <Popover
+    bind:visible={settingsPopupVisible}
+    anchor={settingsButton}
+    direction="rtl"
+    invisibleBackdrop
+  >
+    <HideZeroBalancesToggle />
+  </Popover>
 </TestIdWrapper>
 
 <style lang="scss">
@@ -34,5 +53,6 @@
     --content-color: var(--text-description);
 
     @include header.button(--primary-tint);
+    margin: 0;
   }
 </style>

--- a/frontend/src/tests/page-objects/TokensPage.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensPage.page-object.ts
@@ -1,6 +1,8 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { BackdropPo } from "./Backdrop.page-object";
 import type { ButtonPo } from "./Button.page-object";
+import { HideZeroBalancesTogglePo } from "./HideZeroBalancesToggle.page-object";
 import { TokensTablePo } from "./TokensTable.page-object";
 import type { TokensTableRowData } from "./TokensTableRow.page-object";
 
@@ -17,6 +19,14 @@ export class TokensPagePo extends BasePageObject {
 
   getSettingsButtonPo(): ButtonPo {
     return this.getButton("settings-button");
+  }
+
+  getHideZeroBalancesTogglePo(): HideZeroBalancesTogglePo {
+    return HideZeroBalancesTogglePo.under(this.root);
+  }
+
+  getBackdropPo(): BackdropPo {
+    return BackdropPo.under(this.root);
   }
 
   hasTokensTable(): Promise<boolean> {


### PR DESCRIPTION
# Motivation

We want to add a settings to hide tokens with a zero balance.
In this PR we open the popup with the toggle when the settings button is clicked.

# Changes

1. And the `Popover` component to the `Tokens` page.
2. Open the `Popover` when the settings button is clicked.

# Tests

Add unit tests for opening and closing the popup.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet, still not functional and behind the feature flag