### PR TITLE
Actionable sns proposal banners

### DIFF
--- a/frontend/src/lib/components/proposals/ActionableProposalsNotSupported.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalsNotSupported.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { PageBanner, IconNotificationPage } from "@dfinity/gix-components";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils.js";
+
+  export let snsName: string;
+</script>
+
+<PageBanner testId="actionable-proposals-not-supported">
+  <IconNotificationPage slot="image" />
+  <svelte:fragment slot="title"
+    >{replacePlaceholders($i18n.actionable_proposals_not_supported.title, {
+      $snsName: snsName,
+    })}</svelte:fragment
+  >
+  <p class="description" slot="description">
+    {$i18n.actionable_proposals_not_supported.text}
+  </p>
+</PageBanner>

--- a/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
@@ -16,7 +16,7 @@
   import ActionableProposalsNotSupported from "$lib/components/proposals/ActionableProposalsNotSupported.svelte";
   import ActionableProposalsEmpty from "$lib/components/proposals/ActionableProposalsEmpty.svelte";
 
-  export let snsName: string | undefined;
+  export let snsName: string;
   export let proposals: SnsProposalData[] | undefined;
   export let includeBallots: boolean;
   export let actionableSelected: boolean;
@@ -57,7 +57,7 @@
       {:else if isNullish(proposals)}
         <LoadingProposals />
       {:else if includeBallots === false}
-        <ActionableProposalsNotSupported snsName={snsName ?? ""} />
+        <ActionableProposalsNotSupported {snsName} />
       {:else if proposals.length === 0}
         <ActionableProposalsEmpty />
       {:else}

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -382,6 +382,10 @@
     "title": "There are no actionable proposals you can vote for.",
     "text": "Check back later!"
   },
+  "actionable_proposals_not_supported": {
+    "title": "$snsName doesn't yet support actionable proposals.",
+    "text": "Because it is running an older version of the SNS governance canister."
+  },
   "canisters": {
     "aria_label_canister_card": "Go to canister details",
     "text": "Developers can create and manage their canisters (a form of smart contracts) and cycles consumption here.",

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -22,11 +22,17 @@
   import type { Principal } from "@dfinity/principal";
   import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
   import type { Readable } from "svelte/store";
-  import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
+  import {
+    actionableSnsProposalsStore,
+    type ActionableSnsProposalsData,
+  } from "$lib/stores/actionable-sns-proposals.store";
   import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
 
   let nsFunctionsStore: Readable<SnsNervousSystemFunction[] | undefined>;
   $: nsFunctionsStore = createSnsNsFunctionsProjectStore($snsOnlyProjectStore);
+
+  let snsName: string | undefined;
+  $: snsName = $snsProjectSelectedStore?.summary?.metadata?.name;
 
   let currentProjectCanisterId: Principal | undefined = undefined;
   const onSnsProjectChanged = async ({
@@ -36,10 +42,7 @@
     rootCanisterId: Principal | undefined;
     snsName: string;
   }) => {
-    if (
-      isNullish(rootCanisterId) ||
-      isNullish($snsProjectSelectedStore?.summary?.metadata?.name)
-    ) {
+    if (isNullish(rootCanisterId) || isNullish(snsName)) {
       return;
     }
 
@@ -59,7 +62,7 @@
 
   $: onSnsProjectChanged({
     rootCanisterId: $snsOnlyProjectStore,
-    snsName: $snsProjectSelectedStore?.summary.metadata.name ?? "",
+    snsName: snsName ?? "",
   });
 
   const fetchProposals = async (filters: SnsFiltersStoreData) => {
@@ -109,31 +112,40 @@
     }
   };
 
+  let actionableProposalsData: ActionableSnsProposalsData | undefined;
+  $: actionableProposalsData = nonNullish(currentProjectCanisterId)
+    ? $actionableSnsProposalsStore[currentProjectCanisterId.toText()]
+    : undefined;
+
+  let actionableSelected: boolean;
+  $: actionableSelected =
+    $actionableProposalsSegmentStore.selected === "actionable";
+
+  let includeBallots: boolean;
+  $: includeBallots = actionableProposalsData?.includeBallotsByCaller ?? false;
+
   // `undefined` means that we haven't loaded the proposals yet.
   let proposals: SnsProposalData[] | undefined;
   $: proposals = nonNullish(currentProjectCanisterId)
     ? sortSnsProposalsById(
-        $snsFilteredProposalsStore[currentProjectCanisterId.toText()]?.proposals
+        actionableSelected
+          ? actionableProposalsData?.proposals
+          : $snsFilteredProposalsStore[currentProjectCanisterId.toText()]
+              ?.proposals
       )
-    : undefined;
-
-  let actionableProposals: SnsProposalData[] | undefined;
-  $: actionableProposals = nonNullish(currentProjectCanisterId)
-    ? $actionableSnsProposalsStore[currentProjectCanisterId.toText()]?.proposals
     : undefined;
 
   let disableInfiniteScroll: boolean;
   $: disableInfiniteScroll = nonNullish(currentProjectCanisterId)
     ? $snsProposalsStore[currentProjectCanisterId.toText()]?.completed ?? false
     : false;
-
-  let isActionable: boolean;
-  $: isActionable = $actionableProposalsSegmentStore.selected === "actionable";
 </script>
 
 <SnsProposalsList
-  proposals={isActionable ? actionableProposals : proposals}
-  {isActionable}
+  {snsName}
+  {proposals}
+  {actionableSelected}
+  {includeBallots}
   nsFunctions={$nsFunctionsStore}
   on:nnsIntersect={loadNextPage}
   {disableInfiniteScroll}

--- a/frontend/src/lib/pages/SnsProposals.svelte
+++ b/frontend/src/lib/pages/SnsProposals.svelte
@@ -141,13 +141,15 @@
     : false;
 </script>
 
-<SnsProposalsList
-  {snsName}
-  {proposals}
-  {actionableSelected}
-  {includeBallots}
-  nsFunctions={$nsFunctionsStore}
-  on:nnsIntersect={loadNextPage}
-  {disableInfiniteScroll}
-  {loadingNextPage}
-/>
+{#if nonNullish(snsName)}
+  <SnsProposalsList
+    {snsName}
+    {proposals}
+    {actionableSelected}
+    {includeBallots}
+    nsFunctions={$nsFunctionsStore}
+    on:nnsIntersect={loadNextPage}
+    {disableInfiniteScroll}
+    {loadingNextPage}
+  />
+{/if}

--- a/frontend/src/lib/stores/actionable-sns-proposals.store.ts
+++ b/frontend/src/lib/stores/actionable-sns-proposals.store.ts
@@ -3,13 +3,14 @@ import type { Principal } from "@dfinity/principal";
 import type { SnsProposalData } from "@dfinity/sns";
 import { writable, type Readable } from "svelte/store";
 
+export interface ActionableSnsProposalsData {
+  proposals: SnsProposalData[];
+  includeBallotsByCaller: boolean;
+}
 export interface ActionableSnsProposalsStoreData {
   // Each SNS Project is an entry in this Store.
   // We use the root canister id as the key to identify the proposals for a specific project.
-  [rootCanisterId: string]: {
-    proposals: SnsProposalData[];
-    includeBallotsByCaller: boolean;
-  };
+  [rootCanisterId: string]: ActionableSnsProposalsData;
 }
 
 export interface ActionableSnsProposalsStore

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -399,6 +399,11 @@ interface I18nActionable_proposals_empty {
   text: string;
 }
 
+interface I18nActionable_proposals_not_supported {
+  title: string;
+  text: string;
+}
+
 interface I18nCanisters {
   aria_label_canister_card: string;
   text: string;
@@ -1289,6 +1294,7 @@ interface I18n {
   voting: I18nVoting;
   actionable_proposals_sign_in: I18nActionable_proposals_sign_in;
   actionable_proposals_empty: I18nActionable_proposals_empty;
+  actionable_proposals_not_supported: I18nActionable_proposals_not_supported;
   canisters: I18nCanisters;
   canister_detail: I18nCanister_detail;
   transaction_names: I18nTransaction_names;

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalsList.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalsList.spec.ts
@@ -81,18 +81,4 @@ describe("SnsProposalsList", () => {
 
     expect(queryByTestId("no-proposals-msg")).toBeInTheDocument();
   });
-
-  describe("actionable proposals", () => {
-    it("should render skeletons while proposals are loading", async () => {
-      const { queryByTestId } = render(SnsProposalsList, {
-        props: {
-          proposals: undefined,
-          isActionable: true,
-          nsFunctions: [],
-        },
-      });
-
-      expect(queryByTestId("proposals-loading")).toBeInTheDocument();
-    });
-  });
 });

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalsList.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalsList.spec.ts
@@ -3,7 +3,6 @@ import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposal
 import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import type { SnsProposalData } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
-import { beforeEach, describe } from "vitest";
 
 describe("SnsProposalsList", () => {
   const proposal1: SnsProposalData = {
@@ -28,7 +27,9 @@ describe("SnsProposalsList", () => {
     const { queryAllByTestId } = render(SnsProposalsList, {
       props: {
         proposals,
-        isActionable: false,
+        includeBallots: false,
+        snsName: undefined,
+        actionableSelected: false,
         nsFunctions: [],
       },
     });
@@ -40,7 +41,9 @@ describe("SnsProposalsList", () => {
     const { queryByTestId } = render(SnsProposalsList, {
       props: {
         proposals,
-        isActionable: false,
+        includeBallots: false,
+        snsName: undefined,
+        actionableSelected: false,
         nsFunctions: [],
         loadingNextPage: true,
       },
@@ -55,7 +58,9 @@ describe("SnsProposalsList", () => {
     const { queryByTestId } = render(SnsProposalsList, {
       props: {
         proposals: undefined,
-        isActionable: false,
+        includeBallots: false,
+        snsName: undefined,
+        actionableSelected: false,
         nsFunctions: [],
       },
     });
@@ -67,7 +72,9 @@ describe("SnsProposalsList", () => {
     const { queryByTestId } = render(SnsProposalsList, {
       props: {
         proposals: [],
-        isActionable: false,
+        includeBallots: false,
+        snsName: undefined,
+        actionableSelected: false,
         nsFunctions: [],
       },
     });

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalsList.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalsList.spec.ts
@@ -1,10 +1,24 @@
 import SnsProposalsList from "$lib/components/sns-proposals/SnsProposalsList.svelte";
 import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
-import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
+import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
+import {
+  createSnsProposal,
+  mockSnsProposal,
+} from "$tests/mocks/sns-proposals.mock";
+import { SnsProposalListPo } from "$tests/page-objects/SnsProposalList.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { SnsProposalData } from "@dfinity/sns";
-import { render } from "@testing-library/svelte";
+import { SnsProposalDecisionStatus } from "@dfinity/sns";
+import { cleanup, render } from "@testing-library/svelte";
 
 describe("SnsProposalsList", () => {
+  const renderComponent = async (props) => {
+    cleanup();
+    const { container } = render(SnsProposalsList, { props });
+    await runResolvedPromises();
+    return SnsProposalListPo.under(new JestPageObjectElement(container));
+  };
   const proposal1: SnsProposalData = {
     ...mockSnsProposal,
     id: [{ id: 1n }],
@@ -83,16 +97,112 @@ describe("SnsProposalsList", () => {
   });
 
   describe("actionable proposals", () => {
+    const actionableProposalA = createSnsProposal({
+      proposalId: 123n,
+      status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+    });
+    const actionableProposalB = createSnsProposal({
+      proposalId: 321n,
+      status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+    });
+    beforeEach(() => {
+      resetIdentity();
+    });
+
     it("should render skeletons while proposals are loading", async () => {
-      const { queryByTestId } = render(SnsProposalsList, {
-        props: {
-          proposals: undefined,
-          isActionable: true,
-          nsFunctions: [],
-        },
+      const po = await renderComponent({
+        proposals: undefined,
+        includeBallots: true,
+        snsName: "sns-name",
+        actionableSelected: true,
+        nsFunctions: [],
       });
 
-      expect(queryByTestId("proposals-loading")).toBeInTheDocument();
+      expect(await po.getSkeletonCardPo().isPresent()).toBe(true);
+    });
+
+    it('should display "Not signIn" banner', async () => {
+      setNoIdentity();
+      const po = await renderComponent({
+        proposals: undefined,
+        includeBallots: false,
+        snsName: "sns-name",
+        actionableSelected: true,
+        nsFunctions: [],
+      });
+      expect(await po.getActionableSignInBanner().isPresent()).toBe(true);
+
+      resetIdentity();
+      const po2 = await renderComponent({
+        proposals: undefined,
+        includeBallots: false,
+        snsName: "sns-name",
+        actionableSelected: true,
+        nsFunctions: [],
+      });
+      expect(await po2.getActionableSignInBanner().isPresent()).toBe(false);
+    });
+
+    it('should display "No actionable proposals" banner', async () => {
+      const po = await renderComponent({
+        proposals: [],
+        includeBallots: true,
+        snsName: "sns-name",
+        actionableSelected: true,
+        nsFunctions: [],
+      });
+      expect(await po.getActionableEmptyBanner().isPresent()).toBe(true);
+
+      const po2 = await renderComponent({
+        proposals: [actionableProposalA],
+        includeBallots: true,
+        snsName: "sns-name",
+        actionableSelected: true,
+        nsFunctions: [],
+      });
+      expect(await po2.getActionableEmptyBanner().isPresent()).toBe(false);
+    });
+
+    it('should display "Actionable not supported" banner', async () => {
+      const po = await renderComponent({
+        proposals: [],
+        includeBallots: false,
+        snsName: "sns-name",
+        actionableSelected: true,
+        nsFunctions: [],
+      });
+      expect(await po.getActionableNotSupportedBanner().isPresent()).toBe(true);
+      expect(await po.getActionableNotSupportedBanner().getTitleText()).toBe(
+        "sns-name doesn't yet support actionable proposals."
+      );
+
+      const poTwo = await renderComponent({
+        proposals: [],
+        includeBallots: true,
+        snsName: "sns-name",
+        actionableSelected: true,
+        nsFunctions: [],
+      });
+      expect(await poTwo.getActionableNotSupportedBanner().isPresent()).toBe(
+        false
+      );
+    });
+
+    it("should display actionable proposals", async () => {
+      const po = await renderComponent({
+        proposals: [actionableProposalA, actionableProposalB],
+        includeBallots: true,
+        snsName: "sns-name",
+        actionableSelected: true,
+        nsFunctions: [],
+      });
+      expect((await po.getProposalCardPos()).length).toEqual(2);
+      expect(await (await po.getProposalCardPos())[0].getProposalId()).toEqual(
+        "ID: 123"
+      );
+      expect(await (await po.getProposalCardPos())[1].getProposalId()).toEqual(
+        "ID: 321"
+      );
     });
   });
 });

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalsList.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalsList.spec.ts
@@ -81,4 +81,18 @@ describe("SnsProposalsList", () => {
 
     expect(queryByTestId("no-proposals-msg")).toBeInTheDocument();
   });
+
+  describe("actionable proposals", () => {
+    it("should render skeletons while proposals are loading", async () => {
+      const { queryByTestId } = render(SnsProposalsList, {
+        props: {
+          proposals: undefined,
+          isActionable: true,
+          nsFunctions: [],
+        },
+      });
+
+      expect(queryByTestId("proposals-loading")).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -44,6 +44,7 @@ describe("SnsProposals", () => {
   const rootCanisterId = mockPrincipal;
   const functionName = "test_function";
   const functionId = 3n;
+  const projectName = "🪙";
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -55,6 +56,7 @@ describe("SnsProposals", () => {
     setSnsProjects([
       {
         rootCanisterId,
+        projectName,
         lifecycle: SnsSwapLifecycle.Committed,
         nervousFunctions: [
           {
@@ -542,7 +544,7 @@ describe("SnsProposals", () => {
         );
         expect(
           await po.getActionableNotSupportedBanner().getTitleText()
-        ).toEqual("Catalyze doesn't yet support actionable proposals.");
+        ).toEqual(`${projectName} doesn't yet support actionable proposals.`);
 
         // select to all proposals
         await po

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -1,7 +1,6 @@
 import SnsProposals from "$lib/pages/SnsProposals.svelte";
 import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
-import { authStore } from "$lib/stores/auth.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { snsFiltersStore } from "$lib/stores/sns-filters.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
@@ -9,7 +8,6 @@ import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
 import { page } from "$mocks/$app/stores";
 import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
 import {
-  mockIdentity,
   mockPrincipal,
   resetIdentity,
   setNoIdentity,
@@ -472,15 +470,25 @@ describe("SnsProposals", () => {
 
       it('should display "Not signIn" banner', async () => {
         setNoIdentity();
-
         const po = await renderComponent();
         await selectActionableProposals(po);
-
         expect(await po.getActionableSignInBanner().isPresent()).toBe(true);
 
-        authStore.setForTesting(mockIdentity);
+        // login
+        resetIdentity();
         await runResolvedPromises();
+        expect(await po.getActionableSignInBanner().isPresent()).toBe(false);
 
+        // logout
+        setNoIdentity();
+        await runResolvedPromises();
+        expect(await po.getActionableSignInBanner().isPresent()).toBe(true);
+
+        // switch to all proposals
+        await po
+          .getSnsProposalFiltersPo()
+          .getActionableProposalsSegmentPo()
+          .clickAllProposals();
         expect(await po.getActionableSignInBanner().isPresent()).toBe(false);
       });
 

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -488,15 +488,6 @@ describe("SnsProposals", () => {
         await selectActionableProposals(po);
 
         expect(await po.getActionableSignInBanner().isPresent()).toBe(true);
-        expect(await po.getActionableSignInBanner().getTitleText()).toEqual(
-          "You are not signed in."
-        );
-        expect(
-          await po.getActionableSignInBanner().getDescriptionText()
-        ).toEqual("Sign in to see actionable proposals");
-        expect(
-          await po.getActionableSignInBanner().getBannerActionsText()
-        ).toEqual("Sign in with Internet Identity");
       });
 
       it("should display loading skeletons", async () => {
@@ -522,12 +513,6 @@ describe("SnsProposals", () => {
 
         await selectActionableProposals(po);
         expect(await po.getActionableEmptyBanner().isPresent()).toBe(true);
-        expect(await po.getActionableEmptyBanner().getTitleText()).toEqual(
-          "There are no actionable proposals you can vote for."
-        );
-        expect(
-          await po.getActionableEmptyBanner().getDescriptionText()
-        ).toEqual("Check back later!");
       });
 
       it('should display "Actionable not supported" banner', async () => {
@@ -545,11 +530,6 @@ describe("SnsProposals", () => {
         expect(
           await po.getActionableNotSupportedBanner().getTitleText()
         ).toEqual("Catalyze doesn't yet support actionable proposals.");
-        expect(
-          await po.getActionableNotSupportedBanner().getDescriptionText()
-        ).toEqual(
-          "Because it is running an older version of the SNS governance canister."
-        );
       });
 
       it("should display actionable proposals", async () => {

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -553,9 +553,6 @@ describe("SnsProposals", () => {
       });
 
       it("should display actionable proposals", async () => {
-        vi.spyOn(authStore, "subscribe").mockImplementation(
-          mockAuthStoreSubscribe
-        );
         const po = await renderComponent();
 
         expect((await po.getProposalCardPos()).length).toEqual(0);

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -26,7 +26,7 @@ import {
   SnsSwapLifecycle,
   type SnsProposalData,
 } from "@dfinity/sns";
-import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 vi.mock("$lib/api/sns-governance.api");
@@ -359,6 +359,7 @@ describe("SnsProposals", () => {
       status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
     });
     const renderComponent = async () => {
+      cleanup();
       const { container } = render(SnsProposals);
       await runResolvedPromises();
       return SnsProposalListPo.under(new JestPageObjectElement(container));

--- a/frontend/src/tests/page-objects/SnsProposalList.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsProposalList.page-object.ts
@@ -1,3 +1,4 @@
+import { PageBannerPo } from "$tests/page-objects/PageBanner.page-object";
 import { ProposalCardPo } from "$tests/page-objects/ProposalCard.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { SnsProposalFiltersPo } from "$tests/page-objects/SnsProposalFilters.page-object";
@@ -27,6 +28,31 @@ export class SnsProposalListPo extends BasePageObject {
     return SnsProposalFiltersPo.under(this.root);
   }
 
+  getActionableSignInBanner(): PageBannerPo {
+    return PageBannerPo.under({
+      element: this.root,
+      testId: "actionable-proposals-sign-in",
+    });
+  }
+
+  getActionableNotSupportedBanner(): PageBannerPo {
+    return PageBannerPo.under({
+      element: this.root,
+      testId: "actionable-proposals-not-supported",
+    });
+  }
+
+  getActionableEmptyBanner(): PageBannerPo {
+    return PageBannerPo.under({
+      element: this.root,
+      testId: "actionable-proposals-empty",
+    });
+  }
+
+  getProposalCardPos(): Promise<ProposalCardPo[]> {
+    return ProposalCardPo.allUnder(this.root);
+  }
+
   hasSpinner(): Promise<boolean> {
     return this.isPresent("spinner");
   }
@@ -35,9 +61,5 @@ export class SnsProposalListPo extends BasePageObject {
     return (
       (await this.isPresent()) && !(await this.getSkeletonCardPo().isPresent())
     );
-  }
-
-  getProposalCardPos(): Promise<ProposalCardPo[]> {
-    return ProposalCardPo.allUnder(this.root);
   }
 }


### PR DESCRIPTION
# Motivation

We want to display different state banners to provide more information when:
- user is not logged in
- Sns has no ballots support by governance canister
- there is nothing to vote for in selected Sns.

# Changes

- New banner `ActionableProposalsNotSupported`
- Update SnsProposalList
  - rename `isActionable` to `actionableSelected`
  - new prop `includeBallots` to control not-supported banner visibility
  - remove `ListLoader` because skeletons are enough and there is no pagination
  - display banners
- reorganised parameters in `SnsProposals` component (`proposals` is generated sooner to not avoid sorting for actionable)

# Tests

- updated props in `SnsProposalList` and remove skeleton test (already available in `SnsProposals`)
- banners visibility in `SnsProposals`

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet

# Screenshots

## Not supported
<img width="1532" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/c70f9ac3-5866-47f5-9223-10525be81613">

## Not sign-in
<img width="1539" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/b051b85a-5515-4343-a78d-eff244c92207">

## No proposals (mocked)
<img width="1536" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/d1f589f7-822a-477d-9941-080eab3ed2dc">

