### PR TITLE
NNS1-2918: Hide tokens with zero balance

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -34,6 +34,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Not Published
 
+* Hide tokens with zero balance based on setting behind feature flag.
+
 ### Operations
 
 #### Added

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+  import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import HideZeroBalancesToggle from "$lib/components/tokens/TokensTable/HideZeroBalancesToggle.svelte";
   import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
   import { i18n } from "$lib/stores/i18n";
   import type { UserToken } from "$lib/types/tokens-page";
   import { ENABLE_HIDE_ZERO_BALANCE } from "$lib/stores/feature-flags.store";
+  import { hideZeroBalancesStore } from "$lib/stores/hide-zero-balances.store";
   import { IconSettings } from "@dfinity/gix-components";
   import { Popover } from "@dfinity/gix-components";
+  import { TokenAmountV2 } from "@dfinity/utils";
 
   export let userTokensData: UserToken[];
 
@@ -16,11 +19,28 @@
   const openSettings = () => {
     settingsPopupVisible = true;
   };
+
+  let shouldHideZeroBalances: boolean;
+  $: shouldHideZeroBalances = $hideZeroBalancesStore === "hide";
+
+  let nonZeroBalanceTokensData: UserToken[] = [];
+  $: nonZeroBalanceTokensData = userTokensData.filter((token) => {
+    return (
+      // Internet Computer is shown, even with zero balance.
+      token.universeId.toText() === OWN_CANISTER_ID_TEXT ||
+      (token.balance instanceof TokenAmountV2 && token.balance.toUlps() > 0n)
+    );
+  });
+
+  let shownTokensData: UserToken[] = [];
+  $: shownTokensData = shouldHideZeroBalances
+    ? nonZeroBalanceTokensData
+    : userTokensData;
 </script>
 
 <TestIdWrapper testId="tokens-page-component">
   <TokensTable
-    {userTokensData}
+    userTokensData={shownTokensData}
     on:nnsAction
     firstColumnHeader={$i18n.tokens.projects_header}
   >

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -24,13 +24,12 @@
   $: shouldHideZeroBalances = $hideZeroBalancesStore === "hide";
 
   let nonZeroBalanceTokensData: UserToken[] = [];
-  $: nonZeroBalanceTokensData = userTokensData.filter((token) => {
-    return (
+  $: nonZeroBalanceTokensData = userTokensData.filter(
+    (token) =>
       // Internet Computer is shown, even with zero balance.
       token.universeId.toText() === OWN_CANISTER_ID_TEXT ||
       (token.balance instanceof TokenAmountV2 && token.balance.toUlps() > 0n)
-    );
-  });
+  );
 
   let shownTokensData: UserToken[] = [];
   $: shownTokensData = shouldHideZeroBalances

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -54,7 +54,7 @@ describe("Tokens page", () => {
   const token1 = zeroBalance;
   const token2 = positiveBalance;
 
-  const renderPage = (userTokensData?: UserTokenData[]) => {
+  const renderPage = (userTokensData: UserTokenData[]) => {
     const { container } = render(TokensPage, {
       props: { userTokensData },
     });

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -1,26 +1,60 @@
-import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import TokensPage from "$lib/pages/Tokens.svelte";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import { hideZeroBalancesStore } from "$lib/stores/hide-zero-balances.store";
 import type { UserTokenData } from "$lib/types/tokens-page";
-import { principal } from "$tests/mocks/sns-projects.mock";
+import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
 import {
+  createIcpUserToken,
   createUserToken,
   userTokensPageMock,
 } from "$tests/mocks/tokens-page.mock";
 import { TokensPagePo } from "$tests/page-objects/TokensPage.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
 describe("Tokens page", () => {
-  const token1 = createUserToken({
-    universeId: OWN_CANISTER_ID,
+  const positiveBalance = createUserToken({
+    universeId: principal(1),
+    title: "Positive balance",
+    balance: TokenAmountV2.fromUlps({
+      amount: 123_000_000n,
+      token: {
+        ...mockSnsToken,
+        symbol: "T1",
+      },
+    }),
   });
-  const token2 = createUserToken({
-    universeId: principal(0),
+  const zeroBalance = createUserToken({
+    universeId: principal(2),
+    title: "Zero balance",
+    balance: TokenAmountV2.fromUlps({
+      amount: 0n,
+      token: {
+        ...mockSnsToken,
+        symbol: "T0",
+      },
+    }),
+  });
+  const icpZeroBalance = createIcpUserToken({
+    balance: TokenAmountV2.fromUlps({
+      amount: 0n,
+      token: NNS_TOKEN_DATA,
+    }),
+  });
+  const unavailableBalance = createUserToken({
+    title: "Unavailable balance",
+    universeId: principal(3),
+    balance: new UnavailableTokenAmount(mockSnsToken),
   });
 
-  const renderPage = (userTokensData: UserTokenData[]) => {
+  const token1 = zeroBalance;
+  const token2 = positiveBalance;
+
+  const renderPage = (userTokensData?: UserTokenData[]) => {
     const { container } = render(TokensPage, {
       props: { userTokensData },
     });
@@ -29,6 +63,7 @@ describe("Tokens page", () => {
 
   beforeEach(() => {
     overrideFeatureFlagsStore.reset();
+    hideZeroBalancesStore.resetForTesting();
   });
 
   it("should render the tokens table", async () => {
@@ -74,6 +109,55 @@ describe("Tokens page", () => {
       await runResolvedPromises();
       expect(await po.getHideZeroBalancesTogglePo().isPresent()).toBe(false);
       expect(await po.getBackdropPo().isPresent()).toBe(false);
+    });
+
+    it("should hide tokens with zero balance", async () => {
+      const po = renderPage([positiveBalance, zeroBalance]);
+
+      expect(await po.getTokensTable().getTokenNames()).toEqual([
+        "Positive balance",
+        "Zero balance",
+      ]);
+
+      await po.getSettingsButtonPo().click();
+      await po.getHideZeroBalancesTogglePo().getTogglePo().toggle();
+
+      expect(await po.getTokensTable().getTokenNames()).toEqual([
+        "Positive balance",
+      ]);
+    });
+
+    it("should hide tokens without balance", async () => {
+      const po = renderPage([unavailableBalance, positiveBalance]);
+
+      expect(await po.getTokensTable().getTokenNames()).toEqual([
+        "Unavailable balance",
+        "Positive balance",
+      ]);
+
+      await po.getSettingsButtonPo().click();
+      await po.getHideZeroBalancesTogglePo().getTogglePo().toggle();
+
+      expect(await po.getTokensTable().getTokenNames()).toEqual([
+        "Positive balance",
+      ]);
+    });
+
+    it("should not hide ICP even with zero balance", async () => {
+      const po = renderPage([icpZeroBalance, positiveBalance]);
+
+      expect(await po.getTokensTable().getTokenNames()).toEqual([
+        "Internet Computer",
+        "Positive balance",
+      ]);
+
+      await po.getSettingsButtonPo().click();
+      await po.getHideZeroBalancesTogglePo().getTogglePo().toggle();
+
+      expect(await po.getTokensTable().getTokenNames()).toEqual([
+        "Internet Computer",
+        "Positive balance",
+      ]);
     });
   });
 


### PR DESCRIPTION
# Motivation

This PR actually hides the tokens with zero balance based on the setting added in previous PRs.

# Changes

If the toggle to hide tokens with zero balance is selected, filter tokens based on balance (and always show ICP).

# Tests

Unit tests were added.

# Todos

- [x] Add entry to changelog (if necessary).
