### PR TITLE
Mock queryFinalizationStatus in ProdLaunchpad.spec.ts

### DIFF
--- a/frontend/src/tests/workflows/Launchpad/ProdLaunchpad.spec.ts
+++ b/frontend/src/tests/workflows/Launchpad/ProdLaunchpad.spec.ts
@@ -1,5 +1,6 @@
 import * as agent from "$lib/api/agent.api";
 import * as proposalsApi from "$lib/api/proposals.api";
+import { queryFinalizationStatus } from "$lib/api/sns-sale.api";
 import { authStore } from "$lib/stores/auth.store";
 import { LaunchpadPo } from "$tests/page-objects/Launchpad.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -12,6 +13,7 @@ import { get } from "svelte/store";
 import { mock } from "vitest-mock-extended";
 
 vi.mock("$lib/api/proposals.api");
+vi.mock("$lib/api/sns-sale.api");
 
 describe("Launchpad", () => {
   beforeEach(() => {
@@ -21,6 +23,12 @@ describe("Launchpad", () => {
     vi.spyOn(proposalsApi, "queryProposals").mockImplementation(() =>
       Promise.resolve([])
     );
+
+    vi.mocked(queryFinalizationStatus).mockResolvedValue({
+      auto_finalize_swap_response: [],
+      has_auto_finalize_been_attempted: [],
+      is_auto_finalize_enabled: [],
+    });
 
     // TODO: agent mocked because some calls to global.fetch were exposed when we migrated to agent-js v0.20.2
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());


### PR DESCRIPTION
# Motivation

We have a copy of (the 3 pages of) the prod sns aggregator data here: https://github.com/dfinity/nns-dapp/tree/main/frontend/src/tests/workflows/Launchpad
We use this in `ProdLaunchpad.spec.ts` to test that we can correctly parse the prod SNS data.

We also have a weekly job to keep this data up-to-date.
The [most recent update PR](https://github.com/dfinity/nns-dapp/pull/4641) caused `ProdLaunchpad.spec.ts` [to fail](https://github.com/dfinity/nns-dapp/actions/runs/8369291084/job/22914793727?pr=4641).

This is because if an SNS was closed less than a week ago, we try to fetch its finalization status and this call was not mocked. And this is the first time since the automatic update job was added that SNSes (ICLighthouse DAO and ELNA AI) were completed.

# Changes

Mock `queryFinalizationStatus` in `ProdLaunchpad.spec.ts`.

# Tests

Tested on branch `bot-aggregator-response-update-1710991986` of https://github.com/dfinity/nns-dapp/pull/4641 that this makes the test pass again.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary