### PR TITLE
NNS1-2918: Button to show all tokens when zero balances are hidden

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1009,6 +1009,8 @@
     "accounts_header": "Accounts",
     "settings_button": "Open tokens settings",
     "hide_zero_balances": "Hide zero balances",
-    "hide_zero_balances_toggle_label": "Switch between showing and hiding tokens with a balance of zero"
+    "hide_zero_balances_toggle_label": "Switch between showing and hiding tokens with a balance of zero",
+    "zero_balance_hidden": "Tokens with 0 balances are hidden.",
+    "show_all": "Show all"
   }
 }

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -35,6 +35,10 @@
   $: shownTokensData = shouldHideZeroBalances
     ? nonZeroBalanceTokensData
     : userTokensData;
+
+  const showAll = () => {
+    hideZeroBalancesStore.set("show");
+  };
 </script>
 
 <TestIdWrapper testId="tokens-page-component">
@@ -52,6 +56,20 @@
           bind:this={settingsButton}
           on:click={openSettings}><IconSettings /></button
         >
+      {/if}
+    </div>
+    <div slot="last-row">
+      {#if shouldHideZeroBalances}
+        <div class="show-all-row">
+          {$i18n.tokens.zero_balance_hidden}
+          <button
+            data-tid="show-all-button"
+            class="ghost show-all"
+            on:click={showAll}
+          >
+            {$i18n.tokens.show_all}</button
+          >
+        </div>
       {/if}
     </div>
   </TokensTable>
@@ -73,5 +91,19 @@
 
     @include header.button(--primary-tint);
     margin: 0;
+  }
+
+  [slot="last-row"] {
+    grid-column: 1 / -1;
+  }
+
+  .show-all-row {
+    color: var(--text-description);
+    padding: var(--padding-2x);
+    background: var(--table-row-background);
+
+    button.show-all {
+      text-decoration: underline;
+    }
   }
 </style>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1065,6 +1065,8 @@ interface I18nTokens {
   settings_button: string;
   hide_zero_balances: string;
   hide_zero_balances_toggle_label: string;
+  zero_balance_hidden: string;
+  show_all: string;
 }
 
 interface I18nNeuron_state {

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -159,6 +159,28 @@ describe("Tokens page", () => {
         "Positive balance",
       ]);
     });
+
+    it("show-all button should show all tokens", async () => {
+      const po = renderPage([positiveBalance, zeroBalance]);
+
+      expect(await po.getShowAllButtonPo().isPresent()).toBe(false);
+
+      await po.getSettingsButtonPo().click();
+      await po.getHideZeroBalancesTogglePo().getTogglePo().toggle();
+
+      expect(await po.getTokensTable().getTokenNames()).toEqual([
+        "Positive balance",
+      ]);
+
+      expect(await po.getShowAllButtonPo().isPresent()).toBe(true);
+      await po.getShowAllButtonPo().click();
+
+      expect(await po.getShowAllButtonPo().isPresent()).toBe(false);
+      expect(await po.getTokensTable().getTokenNames()).toEqual([
+        "Positive balance",
+        "Zero balance",
+      ]);
+    });
   });
 
   it("should not show settings button with feature flag disabled", async () => {

--- a/frontend/src/tests/page-objects/TokensPage.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensPage.page-object.ts
@@ -29,6 +29,10 @@ export class TokensPagePo extends BasePageObject {
     return BackdropPo.under(this.root);
   }
 
+  getShowAllButtonPo(): ButtonPo {
+    return this.getButton("show-all-button");
+  }
+
   hasTokensTable(): Promise<boolean> {
     return this.getTokensTable().isPresent();
   }


### PR DESCRIPTION
# Motivation

We have a setting to hide tokens with a zero balance.
To avoid confusion we want to show a button to show all tokens if the setting is enabled:

<img width="787" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/dd66fc13-9635-4c3f-8edf-f6a790e5f1bb">

# Changes

When zero balance tokens are hidden, show a bottom row with message and button to show all tokens again.

# Tests

Unit tests added.

# Todos

- [ ] Add entry to changelog (if necessary).
covered by existing entry