### PR TITLE
Actionable proposal navigation

### DIFF
--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -22,6 +22,8 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import { SplitBlock } from "@dfinity/gix-components";
   import { nonNullish } from "@dfinity/utils";
+  import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
+  import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 
   const { store } = getContext<SelectedProposalContext>(
     SELECTED_PROPOSAL_CONTEXT_KEY
@@ -33,7 +35,10 @@
     : undefined;
 
   let proposalIds: bigint[] | undefined;
-  $: proposalIds = $filteredProposals.proposals?.map(({ id }) => id as bigint);
+  $: proposalIds =
+    $actionableProposalsSegmentStore.selected === "actionable"
+      ? $actionableNnsProposalsStore.proposals?.map(({ id }) => id as bigint)
+      : $filteredProposals.proposals?.map(({ id }) => id as bigint);
 </script>
 
 <TestIdWrapper testId="nns-proposal-component">

--- a/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
@@ -61,6 +61,7 @@
     on:click={selectNewer}
     class:hidden={isNullish(newerId)}
     data-tid="proposal-nav-newer"
+    data-test-proposal-id={newerId?.toString() ?? ""}
   >
     <IconLeft />
     {$i18n.proposal_detail.newer_short}</button
@@ -72,6 +73,7 @@
     on:click={selectOlder}
     class:hidden={isNullish(olderId)}
     data-tid="proposal-nav-older"
+    data-test-proposal-id={olderId?.toString() ?? ""}
   >
     {$i18n.proposal_detail.older_short}
     <IconRight />

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -40,6 +40,8 @@
   import type { SnsNervousSystemFunction } from "@dfinity/sns";
   import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
   import { tick } from "svelte";
+  import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
+  import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
 
   export let proposalIdText: string | undefined | null = undefined;
 
@@ -206,7 +208,9 @@
   let proposalIds: bigint[];
   $: proposalIds = nonNullish(universeIdText)
     ? sortSnsProposalsById(
-        $snsFilteredProposalsStore[universeIdText]?.proposals
+        $actionableProposalsSegmentStore.selected === "actionable"
+          ? $actionableSnsProposalsStore[universeIdText]?.proposals
+          : $snsFilteredProposalsStore[universeIdText]?.proposals
       )?.map(snsProposalId) ?? []
     : [];
 

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
@@ -1,6 +1,8 @@
 import * as proposalsApi from "$lib/api/proposals.api";
 import { AppPath } from "$lib/constants/routes.constants";
 import { filteredProposals } from "$lib/derived/proposals.derived";
+import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
+import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
 import { referrerPathStore } from "$lib/stores/routes.store";
 import {
   generateMockProposals,
@@ -42,6 +44,7 @@ describe("Proposal", () => {
     });
 
   beforeEach(() => {
+    actionableProposalsSegmentStore.resetForTesting();
     vi.spyOn(proposalsApi, "queryProposalPayload").mockResolvedValue({});
   });
 
@@ -93,7 +96,27 @@ describe("Proposal", () => {
     const po = ProposalNavigationPo.under(new JestPageObjectElement(container));
 
     expect(await po.getOlderButtonPo().isPresent()).toBe(true);
+    expect(await po.getOlderButtonProposalId()).toEqual("4");
     expect(await po.getNewerButtonPo().isPresent()).toBe(true);
+    expect(await po.getNewerButtonProposalId()).toEqual("6");
+  });
+
+  it("should use actionable proposals for navigation when actionable selected", async () => {
+    actionableProposalsSegmentStore.set("actionable");
+
+    // set no nns proposals to ensure that actionable proposals are used
+    vi.spyOn(filteredProposals, "subscribe").mockImplementation(
+      createMockProposalsStoreSubscribe([])
+    );
+    actionableNnsProposalsStore.setProposals(generateMockProposals(10));
+
+    const { container } = renderProposalModern(7n);
+    const po = ProposalNavigationPo.under(new JestPageObjectElement(container));
+
+    expect(await po.getOlderButtonPo().isPresent()).toBe(true);
+    expect(await po.getOlderButtonProposalId()).toEqual("6");
+    expect(await po.getNewerButtonPo().isPresent()).toBe(true);
+    expect(await po.getNewerButtonProposalId()).toEqual("8");
   });
 
   it("should not render proposal navigation when on launchpad", async () => {

--- a/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/ProposalNavigation.spec.ts
@@ -84,6 +84,19 @@ describe("ProposalNavigation", () => {
         expect(await po.getOlderButtonPo().isPresent()).toBe(true);
       });
 
+      it("should render test ids", async () => {
+        const po = renderComponent({
+          title: "Title",
+          currentProposalId: 1n,
+          currentProposalStatus: "open",
+          proposalIds: [2n, 1n, 0n],
+          selectProposal: vi.fn(),
+        });
+
+        expect(await po.getNewerButtonProposalId()).toEqual("2");
+        expect(await po.getOlderButtonProposalId()).toEqual("0");
+      });
+
       it("should enable both buttons", async () => {
         const po = renderComponent({
           title: "Title",

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -3,6 +3,8 @@ import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import { snsFilteredProposalsStore } from "$lib/derived/sns/sns-filtered-proposals.derived";
 import SnsProposalDetail from "$lib/pages/SnsProposalDetail.svelte";
+import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
+import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
 import { authStore } from "$lib/stores/auth.store";
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
@@ -54,6 +56,8 @@ describe("SnsProposalDetail", () => {
   describe("not logged in", () => {
     beforeEach(() => {
       vi.clearAllMocks();
+      actionableProposalsSegmentStore.resetForTesting();
+      actionableSnsProposalsStore.resetForTesting();
       vi.spyOn(console, "error").mockImplementation(() => undefined);
       authStore.setForTesting(undefined);
       snsFunctionsStore.reset();
@@ -276,9 +280,79 @@ describe("SnsProposalDetail", () => {
       expect(await navigationPo.isPresent()).toBe(true);
       expect(await navigationPo.getOlderButtonPo().isPresent()).toBe(true);
       expect(await navigationPo.getNewerButtonPo().isPresent()).toBe(true);
+      expect(await navigationPo.getNewerButtonProposalId()).toBe("3");
+      expect(await navigationPo.getOlderButtonProposalId()).toBe("1");
       // all buttons should be enabled
       expect(await navigationPo.getOlderButtonPo().isDisabled()).toBe(false);
       expect(await navigationPo.getNewerButtonPo().isDisabled()).toBe(false);
+    });
+
+    it("should display proposal navigation for actionable proposal", async () => {
+      const proposals = [
+        createSnsProposal({
+          proposalId: 1n,
+          status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+        }),
+        createSnsProposal({
+          proposalId: 2n,
+          status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+        }),
+        createSnsProposal({
+          proposalId: 3n,
+          status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+        }),
+        createSnsProposal({
+          proposalId: 4n,
+          status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+        }),
+      ];
+      // mock the store to have no proposals to fail when used
+      vi.spyOn(snsFilteredProposalsStore, "subscribe").mockImplementation(
+        buildMockSnsProposalsStoreSubscribe({
+          universeIdText: rootCanisterId.toText(),
+          proposals,
+        })
+      );
+      actionableSnsProposalsStore.set({
+        rootCanisterId,
+        includeBallotsByCaller: true,
+        // set the proposal id=2 to be not actionable
+        proposals: proposals.filter((_, index) => index !== 2),
+      });
+
+      fakeSnsGovernanceApi.addProposalWith({
+        identity: new AnonymousIdentity(),
+        rootCanisterId,
+        id: [{ id: 3n }],
+      });
+
+      const { container } = render(SnsProposalDetail, {
+        props: {
+          // set the proposal with id=2 to be in the middle of the list
+          proposalIdText: "2",
+        },
+      });
+      const po = SnsProposalDetailPo.under(
+        new JestPageObjectElement(container)
+      );
+      await waitFor(async () => expect(await po.isContentLoaded()).toBe(true));
+
+      const navigationPo = po.getProposalNavigationPo();
+      expect(await navigationPo.isPresent()).toBe(true);
+      expect(await navigationPo.getOlderButtonPo().isPresent()).toBe(true);
+      expect(await navigationPo.getNewerButtonPo().isPresent()).toBe(true);
+      // 4 <newer 2 older> 1
+      expect(await navigationPo.getNewerButtonProposalId()).toBe("4");
+      expect(await navigationPo.getOlderButtonProposalId()).toBe("1");
+      // all buttons should be enabled
+      expect(await navigationPo.getOlderButtonPo().isDisabled()).toBe(false);
+      expect(await navigationPo.getNewerButtonPo().isDisabled()).toBe(false);
+
+      actionableProposalsSegmentStore.set("all");
+      await runResolvedPromises();
+      // 3 <newer 2 older> 1
+      expect(await navigationPo.getNewerButtonProposalId()).toBe("3");
+      expect(await navigationPo.getOlderButtonProposalId()).toBe("1");
     });
   });
 

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -288,6 +288,7 @@ describe("SnsProposalDetail", () => {
     });
 
     it("should display proposal navigation for actionable proposal", async () => {
+      actionableProposalsSegmentStore.set("actionable");
       const proposals = [
         createSnsProposal({
           proposalId: 1n,
@@ -306,6 +307,8 @@ describe("SnsProposalDetail", () => {
           status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
         }),
       ];
+      // remove the proposal with id=2 to be not actionable
+      const actionableProposals = proposals.filter((_, index) => index !== 1);
       // mock the store to have no proposals to fail when used
       vi.spyOn(snsFilteredProposalsStore, "subscribe").mockImplementation(
         buildMockSnsProposalsStoreSubscribe({
@@ -316,8 +319,7 @@ describe("SnsProposalDetail", () => {
       actionableSnsProposalsStore.set({
         rootCanisterId,
         includeBallotsByCaller: true,
-        // set the proposal id=2 to be not actionable
-        proposals: proposals.filter((_, index) => index !== 2),
+        proposals: actionableProposals,
       });
 
       fakeSnsGovernanceApi.addProposalWith({
@@ -328,8 +330,7 @@ describe("SnsProposalDetail", () => {
 
       const { container } = render(SnsProposalDetail, {
         props: {
-          // set the proposal with id=2 to be in the middle of the list
-          proposalIdText: "2",
+          proposalIdText: "3",
         },
       });
       const po = SnsProposalDetailPo.under(
@@ -341,7 +342,7 @@ describe("SnsProposalDetail", () => {
       expect(await navigationPo.isPresent()).toBe(true);
       expect(await navigationPo.getOlderButtonPo().isPresent()).toBe(true);
       expect(await navigationPo.getNewerButtonPo().isPresent()).toBe(true);
-      // 4 <newer 2 older> 1
+      // 4 <newer 3 older> 1
       expect(await navigationPo.getNewerButtonProposalId()).toBe("4");
       expect(await navigationPo.getOlderButtonProposalId()).toBe("1");
       // all buttons should be enabled
@@ -350,9 +351,9 @@ describe("SnsProposalDetail", () => {
 
       actionableProposalsSegmentStore.set("all");
       await runResolvedPromises();
-      // 3 <newer 2 older> 1
-      expect(await navigationPo.getNewerButtonProposalId()).toBe("3");
-      expect(await navigationPo.getOlderButtonProposalId()).toBe("1");
+      // 4 <newer 3 older> 2
+      expect(await navigationPo.getNewerButtonProposalId()).toBe("4");
+      expect(await navigationPo.getOlderButtonProposalId()).toBe("2");
     });
   });
 

--- a/frontend/src/tests/page-objects/ProposalNavigation.page-object.ts
+++ b/frontend/src/tests/page-objects/ProposalNavigation.page-object.ts
@@ -43,6 +43,18 @@ export class ProposalNavigationPo extends BasePageObject {
     return this.root.byTestId("title").getText();
   }
 
+  async getNewerButtonProposalId(): Promise<string> {
+    return (await this.getNewerButtonPo().getElement()).getAttribute(
+      "data-test-proposal-id"
+    );
+  }
+
+  async getOlderButtonProposalId(): Promise<string> {
+    return (await this.getOlderButtonPo().getElement()).getAttribute(
+      "data-test-proposal-id"
+    );
+  }
+
   async isNewerButtonHidden(): Promise<boolean> {
     return ProposalNavigationPo.isButtonHidden(this.getNewerButtonPo());
   }


### PR DESCRIPTION
# Motivation

Fix the navigation from actionable proposal detail page. We should use actionable id list instead of all proposal list for the "newer"|"older" buttons.

# Changes

- use `actionableNnsProposalsStore` for actionable Nns proposal
- use `actionableSnsProposalsStore ` for actionable Sns proposal

# Tests

- render `data-test-proposal-navigation` attribute for testing
- extend 'ProposalNavigationPo` with getButtonProposalIds
- "should display proposal navigation for actionable proposal"

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary