### PR TITLE
Make rowHref on token data non-optional

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -29,6 +29,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Min ckBTC withdrawal amount was unknown when withdrawing directly from My Tokens.
 * Fix menu width in collapsed state.
+* Make token table rows always clickable. A few edge cases were missing.
 
 #### Security
 

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
@@ -57,8 +57,7 @@
   };
 </script>
 
-<svelte:element
-  this={nonNullish(userTokenData.rowHref) ? "a" : "div"}
+<a
   href={userTokenData.rowHref}
   role="row"
   tabindex="0"
@@ -111,7 +110,7 @@
       {/each}
     {/if}
   </div>
-</svelte:element>
+</a>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/interaction";

--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -22,6 +22,10 @@ const convertAccountToUserTokenData = ({
   i18nObj: I18n;
   account?: Account;
 }): UserToken => {
+  const rowHref = buildWalletUrl({
+    universe: nnsUniverse.canisterId.toString(),
+    account: account?.identifier,
+  });
   if (isNullish(account)) {
     return {
       universeId: Principal.fromText(nnsUniverse.canisterId),
@@ -29,6 +33,7 @@ const convertAccountToUserTokenData = ({
       balance: "loading",
       logo: nnsUniverse.logo,
       actions: [],
+      rowHref,
     };
   }
 
@@ -55,10 +60,7 @@ const convertAccountToUserTokenData = ({
       amount: NNS_TOKEN_DATA.fee,
       token: NNS_TOKEN_DATA,
     }),
-    rowHref: buildWalletUrl({
-      universe: nnsUniverse.canisterId.toString(),
-      account: account?.identifier,
-    }),
+    rowHref,
     accountIdentifier: account.identifier,
     actions: [UserTokenAction.Receive, UserTokenAction.Send],
   };

--- a/frontend/src/lib/derived/tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-user.derived.ts
@@ -33,15 +33,15 @@ const convertToUserTokenData = ({
   authData: AuthStoreData;
 }): UserToken => {
   const token = tokensByUniverse[baseTokenData.universeId.toText()];
-  const rowHref = isNullish(authData.identity)
-    ? undefined
-    : isUniverseNns(baseTokenData.universeId)
+  const rowHref = isUniverseNns(baseTokenData.universeId)
     ? buildAccountsUrl({ universe: baseTokenData.universeId.toText() })
     : buildWalletUrl({
         universe: baseTokenData.universeId.toText(),
-        account: encodeIcrcAccount({
-          owner: authData.identity.getPrincipal(),
-        }),
+        account: isNullish(authData.identity)
+          ? undefined
+          : encodeIcrcAccount({
+              owner: authData.identity.getPrincipal(),
+            }),
       });
   const accountsList = accounts[baseTokenData.universeId.toText()];
   const mainAccount = accountsList?.find(({ type }) => type === "main");
@@ -50,6 +50,7 @@ const convertToUserTokenData = ({
       ...baseTokenData,
       balance: "loading",
       actions: [],
+      rowHref,
     };
   }
   const fee = TokenAmountV2.fromUlps({ amount: token.fee, token });

--- a/frontend/src/lib/derived/tokens-list-visitors.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-visitors.derived.ts
@@ -20,11 +20,17 @@ const convertToUserToken = ({
   tokensByUniverse: Record<string, IcrcTokenMetadata>;
 }): UserToken => {
   const token = tokensByUniverse[tokenBaseData.universeId.toText()];
+  const rowHref = isUniverseNns(tokenBaseData.universeId)
+    ? buildAccountsUrl({ universe: tokenBaseData.universeId.toText() })
+    : buildWalletUrl({
+        universe: tokenBaseData.universeId.toText(),
+      });
   if (isNullish(token)) {
     return {
       ...tokenBaseData,
       balance: "loading",
       actions: [],
+      rowHref,
     };
   }
   return {
@@ -33,11 +39,7 @@ const convertToUserToken = ({
     token,
     fee: TokenAmountV2.fromUlps({ amount: token.fee, token }),
     actions: [UserTokenAction.GoToDetail],
-    rowHref: isUniverseNns(tokenBaseData.universeId)
-      ? buildAccountsUrl({ universe: tokenBaseData.universeId.toText() })
-      : buildWalletUrl({
-          universe: tokenBaseData.universeId.toText(),
-        }),
+    rowHref,
   };
 };
 

--- a/frontend/src/lib/types/tokens-page.ts
+++ b/frontend/src/lib/types/tokens-page.ts
@@ -23,7 +23,6 @@ export type UserTokenBase = {
   subtitle?: string;
   logo: string;
   actions: UserTokenAction[];
-  rowHref?: string;
 };
 
 /**
@@ -36,6 +35,7 @@ export type UserTokenBase = {
 export type UserTokenLoading = UserTokenBase & {
   balance: "loading";
   actions: [];
+  rowHref: string;
 };
 
 export type UserTokenData = UserTokenBase & {
@@ -45,6 +45,7 @@ export type UserTokenData = UserTokenBase & {
   token: Token;
   // Fees are included in the metadata of ICRC tokens, but this is not a list of only ICRC tokens
   fee: TokenAmountV2;
+  rowHref: string;
 };
 
 export type UserToken = UserTokenLoading | UserTokenData;

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -32,6 +32,9 @@ describe("icp-tokens-list-user.derived", () => {
     title: "Main",
     balance: "loading",
     actions: [],
+    rowHref: buildWalletUrl({
+      universe: OWN_CANISTER_ID_TEXT,
+    }),
   };
   const mainUserTokenData: UserTokenData = {
     ...icpTokenUser,

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -65,6 +65,7 @@ describe("tokens-list-user.derived", () => {
     ...icpTokenBase,
     balance: "loading",
     actions: [],
+    rowHref: buildAccountsUrl({ universe: OWN_CANISTER_ID_TEXT }),
   };
   const snsTetrisToken = mockSnsToken;
   const tetrisRootCanisterId = rootCanisterIdMock;
@@ -89,12 +90,17 @@ describe("tokens-list-user.derived", () => {
     lifecycle: SnsSwapLifecycle.Committed,
     tokenMetadata: snsPackmanToken,
   };
+  const tetrisHref = buildWalletUrl({
+    universe: snsTetris.rootCanisterId.toText(),
+    account: identityMainAccountIdentifier,
+  });
   const tetrisTokenLoading: UserTokenLoading = {
     universeId: snsTetris.rootCanisterId,
     title: snsTetris.projectName,
     logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/g3pce-2iaae/logo.png",
     balance: "loading",
     actions: [],
+    rowHref: tetrisHref,
   };
   const tetrisUserToken: UserTokenData = {
     ...tetrisTokenLoading,
@@ -108,18 +114,20 @@ describe("tokens-list-user.derived", () => {
       amount: snsTetris.tokenMetadata.fee,
       token: snsTetris.tokenMetadata,
     }),
-    rowHref: buildWalletUrl({
-      universe: snsTetris.rootCanisterId.toText(),
-      account: identityMainAccountIdentifier,
-    }),
+    rowHref: tetrisHref,
     accountIdentifier: mockSnsMainAccount.identifier,
   };
+  const pacmanHref = buildWalletUrl({
+    universe: snsPacman.rootCanisterId.toText(),
+    account: identityMainAccountIdentifier,
+  });
   const pacmanTokenLoading: UserTokenLoading = {
     universeId: snsPacman.rootCanisterId,
     title: snsPacman.projectName,
     logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/f7crg-kabae/logo.png",
     balance: "loading",
     actions: [],
+    rowHref: pacmanHref,
   };
   const pacmanUserToken: UserTokenData = {
     ...pacmanTokenLoading,
@@ -133,21 +141,28 @@ describe("tokens-list-user.derived", () => {
       amount: snsPacman.tokenMetadata.fee,
       token: snsPacman.tokenMetadata,
     }),
-    rowHref: buildWalletUrl({
-      universe: snsPacman.rootCanisterId.toText(),
-      account: identityMainAccountIdentifier,
-    }),
+    rowHref: pacmanHref,
     accountIdentifier: mockSnsMainAccount.identifier,
   };
+  const ckBTCHref = buildWalletUrl({
+    universe: ckBTCTokenBase.universeId.toText(),
+    account: identityMainAccountIdentifier,
+  });
   const ckBTCTokenLoading: UserTokenLoading = {
     ...ckBTCTokenBase,
     balance: "loading",
     actions: [],
+    rowHref: ckBTCHref,
   };
+  const ckTESTBTCHref = buildWalletUrl({
+    universe: ckTESTBTCTokenBase.universeId.toText(),
+    account: identityMainAccountIdentifier,
+  });
   const ckTESTBTCTokenLoading: UserTokenLoading = {
     ...ckTESTBTCTokenBase,
     balance: "loading",
     actions: [],
+    rowHref: ckTESTBTCHref,
   };
   const ckBTCUserToken: UserTokenData = {
     ...ckBTCTokenBase,
@@ -161,16 +176,18 @@ describe("tokens-list-user.derived", () => {
       amount: mockCkBTCToken.fee,
       token: mockCkBTCToken,
     }),
-    rowHref: buildWalletUrl({
-      universe: ckBTCTokenBase.universeId.toText(),
-      account: identityMainAccountIdentifier,
-    }),
+    rowHref: ckBTCHref,
     accountIdentifier: mockCkBTCMainAccount.identifier,
   };
+  const ckETHHref = buildWalletUrl({
+    universe: ckETHTokenBase.universeId.toText(),
+    account: identityMainAccountIdentifier,
+  });
   const ckETHTokenLoading: UserTokenLoading = {
     ...ckETHTokenBase,
     balance: "loading",
     actions: [],
+    rowHref: ckETHHref,
   };
   const ckETHUserToken: UserTokenData = {
     ...ckETHTokenBase,
@@ -183,10 +200,7 @@ describe("tokens-list-user.derived", () => {
       amount: mockCkETHToken.fee,
       token: mockCkETHToken,
     }),
-    rowHref: buildWalletUrl({
-      universe: ckETHTokenBase.universeId.toText(),
-      account: identityMainAccountIdentifier,
-    }),
+    rowHref: ckETHHref,
     actions: [UserTokenAction.Receive, UserTokenAction.Send],
     accountIdentifier: mockCkETHMainAccount.identifier,
   };

--- a/frontend/src/tests/lib/derived/tokens-list-visitors.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-visitors.derived.spec.ts
@@ -57,12 +57,14 @@ describe("tokens-list-base.derived", () => {
     actions: [UserTokenAction.GoToDetail],
     rowHref: `/accounts/?u=${OWN_CANISTER_ID_TEXT}`,
   });
+  const tetrisHref = `/wallet/?u=${snsTetris.rootCanisterId.toText()}`;
   const tetrisTokenLoading: UserTokenLoading = {
     universeId: snsTetris.rootCanisterId,
     title: snsTetris.projectName,
     logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/g3pce-2iaae/logo.png",
     balance: "loading",
     actions: [],
+    rowHref: tetrisHref,
   };
   const tetrisVisitorToken: UserTokenData = {
     ...tetrisTokenLoading,
@@ -73,14 +75,16 @@ describe("tokens-list-base.derived", () => {
       amount: snsTetris.tokenMetadata.fee,
       token: snsTetris.tokenMetadata,
     }),
-    rowHref: `/wallet/?u=${snsTetris.rootCanisterId.toText()}`,
+    rowHref: tetrisHref,
   };
+  const pacmanHref = `/wallet/?u=${snsPacman.rootCanisterId.toText()}`;
   const pacmanTokenLoading: UserTokenLoading = {
     universeId: snsPacman.rootCanisterId,
     title: snsPacman.projectName,
     logo: "https://5v72r-4aaaa-aaaaa-aabnq-cai.small12.testnet.dfinity.network/v1/sns/root/f7crg-kabae/logo.png",
     balance: "loading",
     actions: [],
+    rowHref: pacmanHref,
   };
   const pacmanVisitorToken: UserTokenData = {
     ...pacmanTokenLoading,
@@ -91,17 +95,21 @@ describe("tokens-list-base.derived", () => {
       amount: snsPacman.tokenMetadata.fee,
       token: snsPacman.tokenMetadata,
     }),
-    rowHref: `/wallet/?u=${snsPacman.rootCanisterId.toText()}`,
+    rowHref: pacmanHref,
   };
+  const ckBTCHref = `/wallet/?u=${CKBTC_UNIVERSE_CANISTER_ID.toText()}`;
   const ckBTCTokenLoading: UserTokenLoading = {
     ...ckBTCTokenBase,
     balance: "loading",
     actions: [],
+    rowHref: ckBTCHref,
   };
+  const ckTESTBTCHref = `/wallet/?u=${CKTESTBTC_UNIVERSE_CANISTER_ID.toText()}`;
   const ckTESTBTCTokenLoading: UserTokenLoading = {
     ...ckTESTBTCTokenBase,
     balance: "loading",
     actions: [],
+    rowHref: ckTESTBTCHref,
   };
   const ckTESTBTCVisitorToken: UserTokenData = {
     ...ckTESTBTCTokenBase,
@@ -112,7 +120,7 @@ describe("tokens-list-base.derived", () => {
       amount: mockCkTESTBTCToken.fee,
       token: mockCkTESTBTCToken,
     }),
-    rowHref: `/wallet/?u=${CKTESTBTC_UNIVERSE_CANISTER_ID.toText()}`,
+    rowHref: ckTESTBTCHref,
   };
   const ckBTCVisitorToken: UserTokenData = {
     ...ckBTCTokenBase,
@@ -123,7 +131,7 @@ describe("tokens-list-base.derived", () => {
       amount: mockCkBTCToken.fee,
       token: mockCkBTCToken,
     }),
-    rowHref: `/wallet/?u=${CKBTC_UNIVERSE_CANISTER_ID.toText()}`,
+    rowHref: ckBTCHref,
   };
   const ckETHVisitorToken: UserTokenData = {
     ...ckETHTokenBase,

--- a/frontend/src/tests/mocks/tokens-page.mock.ts
+++ b/frontend/src/tests/mocks/tokens-page.mock.ts
@@ -2,7 +2,10 @@ import CKBTC_LOGO from "$lib/assets/ckBTC.svg";
 import CKETH_LOGO from "$lib/assets/ckETH.svg";
 import CKTESTBTC_LOGO from "$lib/assets/ckTESTBTC.svg";
 import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
-import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import {
+  OWN_CANISTER_ID,
+  OWN_CANISTER_ID_TEXT,
+} from "$lib/constants/canister-ids.constants";
 import {
   CKBTC_UNIVERSE_CANISTER_ID,
   CKTESTBTC_UNIVERSE_CANISTER_ID,
@@ -34,6 +37,7 @@ const icpTokenNoBalance: UserTokenData = {
     amount: NNS_TOKEN_DATA.fee,
     token: NNS_TOKEN_DATA,
   }),
+  rowHref: `/accounts/?u=${OWN_CANISTER_ID_TEXT}`,
 };
 const snsTetrisToken = mockSnsToken;
 const snsPackmanToken = {
@@ -73,6 +77,7 @@ export const userTokenPageMock: UserTokenData = {
     token: mockCkBTCToken,
   }),
   actions: [UserTokenAction.Send, UserTokenAction.Receive],
+  rowHref: `/wallet/?u=${principal(0).toText()}`,
 };
 
 export const userTokensPageMock: UserTokenData[] = [
@@ -89,6 +94,7 @@ export const userTokensPageMock: UserTokenData[] = [
       token: mockCkBTCToken,
     }),
     actions: [UserTokenAction.Send, UserTokenAction.Receive],
+    rowHref: `/wallet/?u=${CKBTC_UNIVERSE_CANISTER_ID.toText()}`,
   },
   {
     universeId: principal(0),
@@ -104,6 +110,7 @@ export const userTokensPageMock: UserTokenData[] = [
     }),
     logo: "sns-logo.svg",
     actions: [UserTokenAction.Send, UserTokenAction.Receive],
+    rowHref: `/wallet/?u=${principal(0).toText()}`,
   },
   {
     universeId: principal(1),
@@ -119,6 +126,7 @@ export const userTokensPageMock: UserTokenData[] = [
     }),
     logo: "sns-logo-2.svg",
     actions: [UserTokenAction.Send, UserTokenAction.Receive],
+    rowHref: `/wallet/?u=${principal(1).toText()}`,
   },
 ];
 
@@ -138,6 +146,7 @@ export const defaultUserTokenLoading: UserTokenLoading = {
   balance: "loading",
   logo: "sns-logo.svg",
   actions: [],
+  rowHref: `/wallet/?u=${principal(0).toText()}`,
 };
 
 export const createUserTokenLoading = (


### PR DESCRIPTION
# Motivation

Token table rows are `<a>` tags most of the time but in some cases (when token data or account details are still loading) we don't provide an `href` and make the element a `<div>`.
But there is no reason we can't provide an `href` in those cases as well.
And if we do the code is simpler and the rows are always clickable.

An additional benefit is that if every row has a unique `href` we could use this as key in the `{#each}` which would be necessary to provide smooth transitions when hiding zero balance tokens.

# Changes

1. Make `rowHref` mandatory on `UserTokenLoading` and `UserTokenData`.
2. Make sure `rowHref` is always provided.
3. Make the row always an `<a>` tag.

# Tests

First I provided `rowHref` in all the tests as required by the compliler.
Then I replaced the newly provided `rowHref` value with empty strings and verified that the tests now fail because of the newly expected values.

For manual testing I added a delay in loading token data and account details and verified that while loading the row is now clickable while previously it wasn't.

# Todos

- [x] Add entry to changelog (if necessary).
