### PR TITLE
NNS1-2918: Add a transition when hiding zero balance tokens

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import type { UserToken } from "$lib/types/tokens-page";
+  import { heightTransition } from "$lib/utils/transition.utils";
   import { nonNullish } from "@dfinity/utils";
   import TokensTableRow from "./TokensTableRow.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
@@ -35,8 +36,8 @@
     </div>
   </div>
   <div role="rowgroup">
-    {#each userTokensData as userTokenData}
-      <div class="row-wrapper">
+    {#each userTokensData as userTokenData (userTokenData.rowHref)}
+      <div class="row-wrapper" transition:heightTransition={{ duration: 250 }}>
         <TokensTableRow on:nnsAction {userTokenData} />
       </div>
     {/each}

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -7,6 +7,7 @@
   import type { UserToken } from "$lib/types/tokens-page";
   import { ENABLE_HIDE_ZERO_BALANCE } from "$lib/stores/feature-flags.store";
   import { hideZeroBalancesStore } from "$lib/stores/hide-zero-balances.store";
+  import { heightTransition } from "$lib/utils/transition.utils";
   import { IconSettings } from "@dfinity/gix-components";
   import { Popover } from "@dfinity/gix-components";
   import { TokenAmountV2 } from "@dfinity/utils";
@@ -60,7 +61,10 @@
     </div>
     <div slot="last-row">
       {#if shouldHideZeroBalances}
-        <div class="show-all-row">
+        <div
+          class="show-all-row"
+          transition:heightTransition={{ duration: 250 }}
+        >
           {$i18n.tokens.zero_balance_hidden}
           <button
             data-tid="show-all-button"

--- a/frontend/src/lib/utils/transition.utils.ts
+++ b/frontend/src/lib/utils/transition.utils.ts
@@ -1,0 +1,20 @@
+export const heightTransition = (
+  element: HTMLElement,
+  {
+    delay,
+    duration,
+  }: {
+    delay?: number;
+    duration?: number;
+  }
+) => {
+  const height = element.offsetHeight;
+  return {
+    delay,
+    duration,
+    css: (t: number) =>
+      `height: ${
+        t * height
+      }px; transform: scale(1, ${t}); transform-origin: top`,
+  };
+};

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -127,29 +127,19 @@ describe("TokensTable", () => {
     expect(await row2Po.getSubtitle()).toBeNull();
   });
 
-  it("should render href link if rowHref is present", async () => {
+  it("should render href link", async () => {
     const href = "/accounts";
     const token1 = createUserToken({
       universeId: OWN_CANISTER_ID,
       balance: TokenAmount.fromE8s({ amount: 314000000n, token: ICPToken }),
       rowHref: href,
     });
-    const token2 = createUserToken({
-      universeId: principal(0),
-      balance: TokenAmount.fromE8s({
-        amount: 114000000n,
-        token: { name: "Tetris", symbol: "TETRIS", decimals: 8 },
-      }),
-      rowHref: undefined,
-    });
-    const po = renderTable({ userTokensData: [token1, token2] });
+    const po = renderTable({ userTokensData: [token1] });
 
     const rows = await po.getRows();
     const row1Po = rows[0];
-    const row2Po = rows[1];
 
     expect(await row1Po.getHref()).toBe(href);
-    expect(await row2Po.getHref()).toBeNull();
   });
 
   it("should render specific text if balance not available", async () => {

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -53,6 +53,7 @@ describe("NnsAccounts", () => {
           amount: 314000000n,
           token: NNS_TOKEN_DATA,
         }),
+        rowHref: "/main",
       });
       const subaccountTokenData = createUserToken({
         title: "Subaccount test",
@@ -60,6 +61,7 @@ describe("NnsAccounts", () => {
           amount: 222000000n,
           token: NNS_TOKEN_DATA,
         }),
+        rowHref: "/subaccount",
       });
       const po = renderComponent([mainTokenData, subaccountTokenData]);
       expect(await po.getTokensTablePo().getRowsData()).toEqual([
@@ -81,6 +83,7 @@ describe("NnsAccounts", () => {
           amount: 314000000n,
           token: NNS_TOKEN_DATA,
         }),
+        rowHref: "/main",
       });
       const subaccountTokenData = createUserToken({
         title: "Subaccount test",
@@ -88,6 +91,7 @@ describe("NnsAccounts", () => {
           amount: 222000000n,
           token: NNS_TOKEN_DATA,
         }),
+        rowHref: "/subaccount",
       });
       const po = renderComponent([mainTokenData, subaccountTokenData]);
       expect(await po.getAddAccountRowTabindex()).toBe("0");

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -12,7 +12,7 @@ import {
 } from "$tests/mocks/tokens-page.mock";
 import { TokensPagePo } from "$tests/page-objects/TokensPage.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { advanceTime } from "$tests/utils/timers.test-utils";
 import { TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
@@ -64,6 +64,7 @@ describe("Tokens page", () => {
   beforeEach(() => {
     overrideFeatureFlagsStore.reset();
     hideZeroBalancesStore.resetForTesting();
+    vi.useFakeTimers();
   });
 
   it("should render the tokens table", async () => {
@@ -106,7 +107,10 @@ describe("Tokens page", () => {
       expect(await po.getBackdropPo().isPresent()).toBe(true);
 
       await po.getBackdropPo().click();
-      await runResolvedPromises();
+
+      // Finish transitions
+      await advanceTime();
+
       expect(await po.getHideZeroBalancesTogglePo().isPresent()).toBe(false);
       expect(await po.getBackdropPo().isPresent()).toBe(false);
     });
@@ -121,6 +125,9 @@ describe("Tokens page", () => {
 
       await po.getSettingsButtonPo().click();
       await po.getHideZeroBalancesTogglePo().getTogglePo().toggle();
+
+      // Finish transitions
+      await advanceTime();
 
       expect(await po.getTokensTable().getTokenNames()).toEqual([
         "Positive balance",
@@ -137,6 +144,9 @@ describe("Tokens page", () => {
 
       await po.getSettingsButtonPo().click();
       await po.getHideZeroBalancesTogglePo().getTogglePo().toggle();
+
+      // Finish transitions
+      await advanceTime();
 
       expect(await po.getTokensTable().getTokenNames()).toEqual([
         "Positive balance",
@@ -168,12 +178,18 @@ describe("Tokens page", () => {
       await po.getSettingsButtonPo().click();
       await po.getHideZeroBalancesTogglePo().getTogglePo().toggle();
 
+      // Finish transitions
+      await advanceTime();
+
       expect(await po.getTokensTable().getTokenNames()).toEqual([
         "Positive balance",
       ]);
 
       expect(await po.getShowAllButtonPo().isPresent()).toBe(true);
       await po.getShowAllButtonPo().click();
+
+      // Finish transitions
+      await advanceTime();
 
       expect(await po.getShowAllButtonPo().isPresent()).toBe(false);
       expect(await po.getTokensTable().getTokenNames()).toEqual([

--- a/frontend/src/tests/lib/utils/transition.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transition.utils.spec.ts
@@ -1,0 +1,64 @@
+import { heightTransition } from "$lib/utils/transition.utils";
+
+describe("transition.utils", () => {
+  const element = {
+    offsetHeight: 50,
+  } as HTMLElement;
+
+  describe("heightTransition", () => {
+    it("should pass delay and duration unchanged", () => {
+      expect(
+        heightTransition(element, {
+          delay: 100,
+          duration: 200,
+        })
+      ).toMatchObject({
+        delay: 100,
+        duration: 200,
+      });
+
+      expect(
+        heightTransition(element, {
+          duration: 400,
+        })
+      ).toMatchObject({
+        delay: undefined,
+        duration: 400,
+      });
+
+      expect(heightTransition(element, {})).toMatchObject({
+        delay: undefined,
+        duration: undefined,
+      });
+
+      // Expecting undefined does actually fail if the property is not undefined
+      expect(() => {
+        expect(
+          heightTransition(element, {
+            delay: 100,
+            duration: 200,
+          })
+        ).toMatchObject({
+          delay: undefined,
+          duration: undefined,
+        });
+      }).toThrow();
+    });
+
+    it("should return css function", () => {
+      const { css } = heightTransition(element, {});
+      expect(css(0)).toBe(
+        "height: 0px; transform: scale(1, 0); transform-origin: top"
+      );
+      expect(css(0.2)).toBe(
+        "height: 10px; transform: scale(1, 0.2); transform-origin: top"
+      );
+      expect(css(0.5)).toBe(
+        "height: 25px; transform: scale(1, 0.5); transform-origin: top"
+      );
+      expect(css(1)).toBe(
+        "height: 50px; transform: scale(1, 1); transform-origin: top"
+      );
+    });
+  });
+});

--- a/frontend/src/tests/mocks/tokens-page.mock.ts
+++ b/frontend/src/tests/mocks/tokens-page.mock.ts
@@ -19,7 +19,7 @@ import {
   type UserTokenLoading,
 } from "$lib/types/tokens-page";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
-import { TokenAmountV2 } from "@dfinity/utils";
+import { TokenAmountV2, isNullish, nonNullish } from "@dfinity/utils";
 import { mockCkBTCToken } from "./ckbtc-accounts.mock";
 import { mockSnsToken, principal } from "./sns-projects.mock";
 
@@ -133,6 +133,9 @@ export const userTokensPageMock: UserTokenData[] = [
 export const createUserToken = (params: Partial<UserTokenData> = {}) => ({
   ...userTokenPageMock,
   ...params,
+  ...(isNullish(params.rowHref) && nonNullish(params.universeId)
+    ? { rowHref: `/wallet/?u=${params.universeId.toText()}` }
+    : {}),
 });
 
 export const createIcpUserToken = (params: Partial<UserTokenData> = {}) => ({


### PR DESCRIPTION
# Motivation

When hiding zero balance tokens without transition, the change is very jumpy and it can be disorienting.
Adding a transition makes it obvious what's happening.
Unfortunately the existing transition such as `fade` and `scale` don't look nice.

PS. It turns out that `slide` is close to what I was looking for and I could probably have used that. But it doesn't do the additional scaling, which I think makes it look nicer.

# Changes

1. Add a new custom transition `heightTransition` which squeezes the element vertically.
2. Use the transition on token table rows and on the row with the "Show all" button.
3. Use `rowHref` as a uniq string key for row in the `{#each}`. A uniq key per element is required when using transitions.
4. Automatically add `rowHref` (based in `universeId`) in `createUserToken` for convenience when writing tests.

# Tests

1. Added unit tests for `heightTransition`.
2. Use fake timers to avoid having to wait for transitions in tests.
3. Test manually:

https://github.com/dfinity/nns-dapp/assets/122978264/2f9df545-db4a-4f06-a4f5-bf5fd5038781

# Todos

- [ ] Add entry to changelog (if necessary).
covered by existing entry