### PR TITLE
Consistently exclude account param from URL for main accounts

### DIFF
--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -24,7 +24,7 @@ const convertAccountToUserTokenData = ({
 }): UserToken => {
   const rowHref = buildWalletUrl({
     universe: nnsUniverse.canisterId.toString(),
-    account: account?.identifier,
+    account: account?.type !== "main" ? account?.identifier : undefined,
   });
   if (isNullish(account)) {
     return {

--- a/frontend/src/lib/derived/tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-user.derived.ts
@@ -13,7 +13,6 @@ import {
 import { sumAccounts } from "$lib/utils/accounts.utils";
 import { buildAccountsUrl, buildWalletUrl } from "$lib/utils/navigation.utils";
 import { isUniverseNns } from "$lib/utils/universe.utils";
-import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { isNullish, TokenAmountV2 } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 import type { UniversesAccounts } from "./accounts-list.derived";
@@ -37,11 +36,6 @@ const convertToUserTokenData = ({
     ? buildAccountsUrl({ universe: baseTokenData.universeId.toText() })
     : buildWalletUrl({
         universe: baseTokenData.universeId.toText(),
-        account: isNullish(authData.identity)
-          ? undefined
-          : encodeIcrcAccount({
-              owner: authData.identity.getPrincipal(),
-            }),
       });
   const accountsList = accounts[baseTokenData.universeId.toText()];
   const mainAccount = accountsList?.find(({ type }) => type === "main");

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -46,7 +46,6 @@ describe("icp-tokens-list-user.derived", () => {
     subtitle: undefined,
     rowHref: buildWalletUrl({
       universe: OWN_CANISTER_ID_TEXT,
-      account: mockMainAccount.identifier,
     }),
     accountIdentifier: mockMainAccount.identifier,
   };

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -92,7 +92,6 @@ describe("tokens-list-user.derived", () => {
   };
   const tetrisHref = buildWalletUrl({
     universe: snsTetris.rootCanisterId.toText(),
-    account: identityMainAccountIdentifier,
   });
   const tetrisTokenLoading: UserTokenLoading = {
     universeId: snsTetris.rootCanisterId,
@@ -119,7 +118,6 @@ describe("tokens-list-user.derived", () => {
   };
   const pacmanHref = buildWalletUrl({
     universe: snsPacman.rootCanisterId.toText(),
-    account: identityMainAccountIdentifier,
   });
   const pacmanTokenLoading: UserTokenLoading = {
     universeId: snsPacman.rootCanisterId,
@@ -146,7 +144,6 @@ describe("tokens-list-user.derived", () => {
   };
   const ckBTCHref = buildWalletUrl({
     universe: ckBTCTokenBase.universeId.toText(),
-    account: identityMainAccountIdentifier,
   });
   const ckBTCTokenLoading: UserTokenLoading = {
     ...ckBTCTokenBase,
@@ -156,7 +153,6 @@ describe("tokens-list-user.derived", () => {
   };
   const ckTESTBTCHref = buildWalletUrl({
     universe: ckTESTBTCTokenBase.universeId.toText(),
-    account: identityMainAccountIdentifier,
   });
   const ckTESTBTCTokenLoading: UserTokenLoading = {
     ...ckTESTBTCTokenBase,
@@ -181,7 +177,6 @@ describe("tokens-list-user.derived", () => {
   };
   const ckETHHref = buildWalletUrl({
     universe: ckETHTokenBase.universeId.toText(),
-    account: identityMainAccountIdentifier,
   });
   const ckETHTokenLoading: UserTokenLoading = {
     ...ckETHTokenBase,


### PR DESCRIPTION
# Motivation

We allow navigating to token wallets when not signed in.
When the user is not signed in, we don't know the account identifier so we don't include it in the URL.
When the user signs in, if there is no account identifier in the URL, we show the main account for that token by default.
This means that the URL you get when navigating to a main account is different depending on whether you were signed in when you navigated.
This is not necessary.

This PR makes the experience more consistent and URLs cleaner by always omitting the `account` param when navigating to a main account.

Additionally, when using the `rowHref` as the Svelte `{#each}` key, it means that the row for the ICP main account is considered the same before and after signing in, while previously it would have been considered a new row.

# Changes

When creating a wallet URL, omit the `account` param if it would have been for the main account.

# Tests

1. Updated unit tests to not expect account parameter for main account.
2. Tested manually to see that the account identifier is only present in URL for sub/hardware wallet accounts.
3. Also tested manually in another branch to see that the animation doesn't replace one Main row with another as it did before.

# Todos

- [ ] Add entry to changelog (if necessary).
