### PR TITLE
NNS1-2918: Fix alignment of settings button

### DIFF
--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -84,13 +84,17 @@
 </TestIdWrapper>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/dist/styles/mixins/header";
+  @use "@dfinity/gix-components/dist/styles/mixins/effect";
 
   .settings-button {
     --content-color: var(--text-description);
 
-    @include header.button(--primary-tint);
-    margin: 0;
+    @include effect.ripple-effect(--primary-tint);
+
+    &:focus {
+      background: var(--primary-tint);
+      @include effect.ripple-effect(--primary-tint);
+    }
   }
 
   [slot="last-row"] {


### PR DESCRIPTION
# Motivation

For the tokens settings button I used `@include header.button` to make sure there is some indication when you tab to or click on the button.
But this also adds some padding and margin which makes it look misaligned with the rest of the table.

# Changes

Use some styles from [@include header.button](https://github.com/dfinity/gix-components/blob/fed837c2fd163048c397e8214b39f477589c3a15/src/lib/styles/mixins/_header.scss#L5) directly without using the margin and padding.

# Tests

Before:
<img width="149" alt="Screenshot 2024-03-22 at 13 50 39" src="https://github.com/dfinity/nns-dapp/assets/122978264/5d240b87-5afd-4997-bb5d-9968293b7ac4">

After:
<img width="165" alt="Screenshot 2024-03-22 at 13 50 14" src="https://github.com/dfinity/nns-dapp/assets/122978264/0ff50998-add0-43d2-affe-c935a125b4eb">

# Todos

- [ ] Add entry to changelog (if necessary).
covered by existing entry