### PR TITLE
Remove unused GoToTokenDetail action type

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
@@ -4,16 +4,11 @@
     type UserTokenData,
     type UserTokenLoading,
   } from "$lib/types/tokens-page";
-  import {
-    SvelteComponent,
-    createEventDispatcher,
-    type ComponentType,
-  } from "svelte";
+  import type { SvelteComponent, ComponentType } from "svelte";
   import Logo from "../../ui/Logo.svelte";
   import GoToDetailIcon from "./actions/GoToDetailIcon.svelte";
   import ReceiveButton from "./actions/ReceiveButton.svelte";
   import SendButton from "./actions/SendButton.svelte";
-  import { ActionType } from "$lib/types/actions";
   import { UnavailableTokenAmount } from "$lib/utils/token.utils";
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import { nonNullish } from "@dfinity/utils";
@@ -22,8 +17,6 @@
   import { isUserTokenData } from "$lib/utils/user-token.utils";
 
   export let userTokenData: UserTokenData | UserTokenLoading;
-
-  const dispatcher = createEventDispatcher();
 
   const actionMapper: Record<
     UserTokenAction,
@@ -36,16 +29,6 @@
 
   let userToken: UserTokenData | undefined;
   $: userToken = isUserTokenData(userTokenData) ? userTokenData : undefined;
-
-  const handleClick = () => {
-    if (nonNullish(userToken)) {
-      // Actions can only be dispatched with `UserTokenData`
-      dispatcher("nnsAction", {
-        type: ActionType.GoToTokenDetail,
-        data: userToken,
-      });
-    }
-  };
 
   // Should be the same as the area in the classes `rows-count-X`.
   const cellAreaName = (index: number) => `cell-${index}`;
@@ -61,8 +44,6 @@
   href={userTokenData.rowHref}
   role="row"
   tabindex="0"
-  on:keypress={handleClick}
-  on:click={handleClick}
   data-tid="tokens-table-row-component"
   class={mobileTemplateClass(2)}
   data-title={userTokenData.title}

--- a/frontend/src/lib/types/actions.ts
+++ b/frontend/src/lib/types/actions.ts
@@ -2,7 +2,6 @@ import type { UserTokenData } from "./tokens-page";
 
 export enum ActionType {
   Send = "send",
-  GoToTokenDetail = "goToTokenDetail",
   Receive = "receive",
 }
 

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -12,7 +12,6 @@ import { principal } from "$tests/mocks/sns-projects.mock";
 import {
   createUserToken,
   createUserTokenLoading,
-  userTokenPageMock,
 } from "$tests/mocks/tokens-page.mock";
 import { TokensTablePo } from "$tests/page-objects/TokensTable.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -229,25 +228,6 @@ describe("TokensTable", () => {
     expect(await rowPo.hasGoToDetailIcon()).toBe(true);
     expect(await rowPo.hasReceiveButton()).toBe(false);
     expect(await rowPo.hasSendButton()).toBe(false);
-  });
-
-  it("should trigger event when clicking in the row", async () => {
-    const handleAction = vi.fn();
-    const po = renderTable({
-      userTokensData: [userTokenPageMock],
-      onAction: handleAction,
-    });
-
-    const rows = await po.getRows();
-    await rows[0].click();
-
-    expect(handleAction).toHaveBeenCalledTimes(1);
-    expect(handleAction).toHaveBeenCalledWith(
-      createActionEvent({
-        type: ActionType.GoToTokenDetail,
-        data: userTokenPageMock,
-      })
-    );
   });
 
   it("should trigger event when clicking in Send action", async () => {


### PR DESCRIPTION
# Motivation

When the user clicks on a token row, we dispatch an event with type `ActionType.GoToTokenDetail`.
But there is nothing that responds to this event.
This is not a problem because the token row is a link and the intended navigation happens through the link `href` without the need to dispatch an event.

# Changes

1. Remove the click handler and code to dispatch this event.
2. Remove the event type.

# Tests

1. Remove the corresponding test.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary