### PR TITLE
build: bump ic-js after release

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.2.1-next-2024-03-05.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.2.1-next-2024-03-05.2.tgz",
-      "integrity": "sha512-uCHwge25jrSgJoIcf6kr7iHpBfvKQVcHSzSAje2kcmMHpeYZ84uxH46WeUUDzY8MurQmOqu8AqBFBOwLEv4Pcw==",
+      "version": "2.3.1-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-25.tgz",
+      "integrity": "sha512-IbuP/SUzU6eDVPp9nLxOzZ5J+yF47M/AGwFPVgjPeTnRxjvdZbSqTbbtXMyO1gS+3QiOjQ27BrdBTOyO7BBczA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.0.2-next-2024-03-05.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.2-next-2024-03-05.3.tgz",
-      "integrity": "sha512-yGyTUpBFOpQUe1gtxdpslfBxnAj78fUz66GD01zm+RaAx/Mrl74LpzAumu5bbjLIxrsXFdaM+xucWKR1aW7s8w==",
+      "version": "3.0.3-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-25.tgz",
+      "integrity": "sha512-yHpZMhkV3wTP+vNa4bQfGOltmmyeVfR0d0dGnoWyvJWq4Y0LjBCez3FzcTmOx3ZdsMs5EDoXLZx0tjURWFZMwg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "3.0.0-next-2024-03-05",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.0.0-next-2024-03-05.tgz",
-      "integrity": "sha512-KB1MH2XfFoPDaqTN4U6tiNGWf5cFjSbUlrLBmmMgMQNbRIXS5LZ8SX0KawGS+Oco/sXucS3ZK0sBzU25hBBuQw==",
+      "version": "3.1.0-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.0-next-2024-03-25.tgz",
+      "integrity": "sha512-Qzk6615bh9/qODnOfHi9hXGJtUndZyJOXo5YTLhknJUuNijyoQKbqYJuO7i1n7yprdfP1ykBs1GsundRfO2f0A==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.2.1-next-2024-03-05.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.1-next-2024-03-05.3.tgz",
-      "integrity": "sha512-TKHcUQ/cpbglnN2mXTu+dZ+6LSGaZjDVotNmkjp9fyj0ZaCJBLEwFizAJYUgAg80dTNHjMRr653kq2AXgb4TIw==",
+      "version": "2.2.2-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-25.tgz",
+      "integrity": "sha512-ZMBKrriwA2E1smrwJvODjx3oha5dNKsRKlDbms0k7PG0MWj9LvGFKSXHyqfMJnlsOvLQUeiP6d/LUGdY2PBOOg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.2.0-next-2024-03-05",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.0-next-2024-03-05.tgz",
-      "integrity": "sha512-i0rOHLtBpqvstJdcl7Fa5khxDKr4d5Fskp/3B6E8k0sfIHydFLJOEl5E18LRT8IRP9GN43v3a2euBJCDtDK5bQ==",
+      "version": "2.2.1-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-25.tgz",
+      "integrity": "sha512-+p8ShXSFKqCFMGn6eaabe98fvzG+If5o9cB30RVH4IHX7IewsO1d14b9fkB5MfRHYnP3L251rmB1TW/wcccsBA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "4.0.1-next-2024-03-05.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.1-next-2024-03-05.3.tgz",
-      "integrity": "sha512-332Dw9ExcNyyNDe9jRnZipBsFl4AmTam+63jTt2B6yv4CQNFfyTm+yl6Z3r6W9RLasqvpPYPImHLoCG9B1smFg==",
+      "version": "4.0.2-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-25.tgz",
+      "integrity": "sha512-8Zm1InVqR5zeFSwXei9imK6nkTjV7BF20tWRZ8Rqhba9RqMOOFUNHKd9DQj9WqVn1XvgFGhoL+9r6SOgmHTGJw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -358,9 +358,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.1-next-2024-03-05.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-03-05.3.tgz",
-      "integrity": "sha512-ONpomyj5wom2nHsa46qB5NrnPyOa22z4p4/R8HtbB8xiD1FBkeKFG5uMjlh35KDhP7cj2mR/dClxuJylyxPb/Q==",
+      "version": "1.0.2-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-25.tgz",
+      "integrity": "sha512-coqP3SS1m7lFOfPRh1uVgRIzRqBJ4x0YLW6IfyUxUWn4a00KlMGcmETo5ydcZISXEthzZseA48JnQlU1wRLZ5A==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.0.1-next-2024-03-05",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.1-next-2024-03-05.tgz",
-      "integrity": "sha512-/wpV6XA2g0ZBGOFxjllftU16krkbsgVANKJgve8k999p9B9bXvRN4sC0hBnZzh1XP3zv6dP4ACPq5SpEJcKZJw==",
+      "version": "3.0.2-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-25.tgz",
+      "integrity": "sha512-vQnMlYD49Tu2TtOYPJboQQWzXbDRUi+QSPoxl0c7mIqCeziSdXDrLtXx7DGGnF1eKO6vw7vMEHEV8M5930dDgw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.1.2-next-2024-03-05.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.2-next-2024-03-05.3.tgz",
-      "integrity": "sha512-ZFnAGsckgepLrRyLncwfL5qkjAnzXFkksm6dgGQ/EqBoESMHnQsyIrySxiEVI+tir7RsB7JIEF/JGddbHaUjPA==",
+      "version": "2.1.3-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-25.tgz",
+      "integrity": "sha512-aLmoT6D020nf8356NrqCIdn9AzNVRp32FQuDDZSe+QUoxD+XIwFIMbl1BtzjqQ3wHddxg2+GfNm9Tz6T1SjQLw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7047,9 +7047,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.2.1-next-2024-03-05.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.2.1-next-2024-03-05.2.tgz",
-      "integrity": "sha512-uCHwge25jrSgJoIcf6kr7iHpBfvKQVcHSzSAje2kcmMHpeYZ84uxH46WeUUDzY8MurQmOqu8AqBFBOwLEv4Pcw==",
+      "version": "2.3.1-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-25.tgz",
+      "integrity": "sha512-IbuP/SUzU6eDVPp9nLxOzZ5J+yF47M/AGwFPVgjPeTnRxjvdZbSqTbbtXMyO1gS+3QiOjQ27BrdBTOyO7BBczA==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7057,9 +7057,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.0.2-next-2024-03-05.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.2-next-2024-03-05.3.tgz",
-      "integrity": "sha512-yGyTUpBFOpQUe1gtxdpslfBxnAj78fUz66GD01zm+RaAx/Mrl74LpzAumu5bbjLIxrsXFdaM+xucWKR1aW7s8w==",
+      "version": "3.0.3-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-25.tgz",
+      "integrity": "sha512-yHpZMhkV3wTP+vNa4bQfGOltmmyeVfR0d0dGnoWyvJWq4Y0LjBCez3FzcTmOx3ZdsMs5EDoXLZx0tjURWFZMwg==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7073,9 +7073,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "3.0.0-next-2024-03-05",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.0.0-next-2024-03-05.tgz",
-      "integrity": "sha512-KB1MH2XfFoPDaqTN4U6tiNGWf5cFjSbUlrLBmmMgMQNbRIXS5LZ8SX0KawGS+Oco/sXucS3ZK0sBzU25hBBuQw==",
+      "version": "3.1.0-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.0-next-2024-03-25.tgz",
+      "integrity": "sha512-Qzk6615bh9/qODnOfHi9hXGJtUndZyJOXo5YTLhknJUuNijyoQKbqYJuO7i1n7yprdfP1ykBs1GsundRfO2f0A==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7089,30 +7089,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.2.1-next-2024-03-05.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.1-next-2024-03-05.3.tgz",
-      "integrity": "sha512-TKHcUQ/cpbglnN2mXTu+dZ+6LSGaZjDVotNmkjp9fyj0ZaCJBLEwFizAJYUgAg80dTNHjMRr653kq2AXgb4TIw==",
+      "version": "2.2.2-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-25.tgz",
+      "integrity": "sha512-ZMBKrriwA2E1smrwJvODjx3oha5dNKsRKlDbms0k7PG0MWj9LvGFKSXHyqfMJnlsOvLQUeiP6d/LUGdY2PBOOg==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.2.0-next-2024-03-05",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.0-next-2024-03-05.tgz",
-      "integrity": "sha512-i0rOHLtBpqvstJdcl7Fa5khxDKr4d5Fskp/3B6E8k0sfIHydFLJOEl5E18LRT8IRP9GN43v3a2euBJCDtDK5bQ==",
+      "version": "2.2.1-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-25.tgz",
+      "integrity": "sha512-+p8ShXSFKqCFMGn6eaabe98fvzG+If5o9cB30RVH4IHX7IewsO1d14b9fkB5MfRHYnP3L251rmB1TW/wcccsBA==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "4.0.1-next-2024-03-05.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.1-next-2024-03-05.3.tgz",
-      "integrity": "sha512-332Dw9ExcNyyNDe9jRnZipBsFl4AmTam+63jTt2B6yv4CQNFfyTm+yl6Z3r6W9RLasqvpPYPImHLoCG9B1smFg==",
+      "version": "4.0.2-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-25.tgz",
+      "integrity": "sha512-8Zm1InVqR5zeFSwXei9imK6nkTjV7BF20tWRZ8Rqhba9RqMOOFUNHKd9DQj9WqVn1XvgFGhoL+9r6SOgmHTGJw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.1-next-2024-03-05.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.1-next-2024-03-05.3.tgz",
-      "integrity": "sha512-ONpomyj5wom2nHsa46qB5NrnPyOa22z4p4/R8HtbB8xiD1FBkeKFG5uMjlh35KDhP7cj2mR/dClxuJylyxPb/Q==",
+      "version": "1.0.2-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-25.tgz",
+      "integrity": "sha512-coqP3SS1m7lFOfPRh1uVgRIzRqBJ4x0YLW6IfyUxUWn4a00KlMGcmETo5ydcZISXEthzZseA48JnQlU1wRLZ5A==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7126,17 +7126,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.0.1-next-2024-03-05",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.1-next-2024-03-05.tgz",
-      "integrity": "sha512-/wpV6XA2g0ZBGOFxjllftU16krkbsgVANKJgve8k999p9B9bXvRN4sC0hBnZzh1XP3zv6dP4ACPq5SpEJcKZJw==",
+      "version": "3.0.2-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-25.tgz",
+      "integrity": "sha512-vQnMlYD49Tu2TtOYPJboQQWzXbDRUi+QSPoxl0c7mIqCeziSdXDrLtXx7DGGnF1eKO6vw7vMEHEV8M5930dDgw==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.1.2-next-2024-03-05.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.2-next-2024-03-05.3.tgz",
-      "integrity": "sha512-ZFnAGsckgepLrRyLncwfL5qkjAnzXFkksm6dgGQ/EqBoESMHnQsyIrySxiEVI+tir7RsB7JIEF/JGddbHaUjPA==",
+      "version": "2.1.3-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-25.tgz",
+      "integrity": "sha512-aLmoT6D020nf8356NrqCIdn9AzNVRp32FQuDDZSe+QUoxD+XIwFIMbl1BtzjqQ3wHddxg2+GfNm9Tz6T1SjQLw==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.3.1-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-25.tgz",
-      "integrity": "sha512-IbuP/SUzU6eDVPp9nLxOzZ5J+yF47M/AGwFPVgjPeTnRxjvdZbSqTbbtXMyO1gS+3QiOjQ27BrdBTOyO7BBczA==",
+      "version": "2.3.1-next-2024-03-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-25.1.tgz",
+      "integrity": "sha512-5qh0DViERwCuaYpFyJYFoFjMAMWU/wdTu3eHF94HWH3Uyc8V7wOJpQTFO7LxBeKNMhBqweQFG0pAAlb6EPPsVA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.0.3-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-25.tgz",
-      "integrity": "sha512-yHpZMhkV3wTP+vNa4bQfGOltmmyeVfR0d0dGnoWyvJWq4Y0LjBCez3FzcTmOx3ZdsMs5EDoXLZx0tjURWFZMwg==",
+      "version": "3.0.3-next-2024-03-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-25.1.tgz",
+      "integrity": "sha512-KC0Y/cn49cs+Nm4s3OpQJtfmfdUOkvRNApj41I+KseVvVnpp6E8ZTcMFtezhD4gMqm8kyKEm7T6fywFHacDL6Q==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "3.1.0-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.0-next-2024-03-25.tgz",
-      "integrity": "sha512-Qzk6615bh9/qODnOfHi9hXGJtUndZyJOXo5YTLhknJUuNijyoQKbqYJuO7i1n7yprdfP1ykBs1GsundRfO2f0A==",
+      "version": "3.1.1-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-03-25.tgz",
+      "integrity": "sha512-SX7k/h5j01RQUVUVtU1WYu528gftc48EoswOCwENxDLIV1DyjfAn4/qkY9/gxTKB/OitBMBpqkYdeCHLC2r9qQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.2.2-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-25.tgz",
-      "integrity": "sha512-ZMBKrriwA2E1smrwJvODjx3oha5dNKsRKlDbms0k7PG0MWj9LvGFKSXHyqfMJnlsOvLQUeiP6d/LUGdY2PBOOg==",
+      "version": "2.2.2-next-2024-03-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-25.1.tgz",
+      "integrity": "sha512-0TxMKLueO4gyHNMbaJDzphFndUZ1tdQRf4meOu/Db1FgzQs3HXX4Ti/zqP9hDhMWwp/nbnuBkl1bUImVIe9KWA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.2.1-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-25.tgz",
-      "integrity": "sha512-+p8ShXSFKqCFMGn6eaabe98fvzG+If5o9cB30RVH4IHX7IewsO1d14b9fkB5MfRHYnP3L251rmB1TW/wcccsBA==",
+      "version": "2.2.1-next-2024-03-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-25.1.tgz",
+      "integrity": "sha512-AsAzjy0C/mumA3mi0GlJu2HmT7LyZ5MN24oh9oVclqHVBrHi63tO/E0UgfkMBiRmJfZZpHwXW4Hik1L1AEbvqQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "4.0.2-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-25.tgz",
-      "integrity": "sha512-8Zm1InVqR5zeFSwXei9imK6nkTjV7BF20tWRZ8Rqhba9RqMOOFUNHKd9DQj9WqVn1XvgFGhoL+9r6SOgmHTGJw==",
+      "version": "4.0.2-next-2024-03-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-25.1.tgz",
+      "integrity": "sha512-44d5H983YynMT5WYOkPSjpcI93tuQHY7N5XQt0QI45ZxS28Upl8X0hyQRbk1Zrls4UeM9ezgOCOCdgi74YUD0w==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -358,9 +358,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.2-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-25.tgz",
-      "integrity": "sha512-coqP3SS1m7lFOfPRh1uVgRIzRqBJ4x0YLW6IfyUxUWn4a00KlMGcmETo5ydcZISXEthzZseA48JnQlU1wRLZ5A==",
+      "version": "1.0.2-next-2024-03-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-25.1.tgz",
+      "integrity": "sha512-Qnb5mIEANzEtqVtbcAEawGPOamuafUc+OwfqqxXXf58Oz9QfEc7c716nn1xbSguqEW3z4lGV6FQm/FvG6Ka4cw==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.0.2-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-25.tgz",
-      "integrity": "sha512-vQnMlYD49Tu2TtOYPJboQQWzXbDRUi+QSPoxl0c7mIqCeziSdXDrLtXx7DGGnF1eKO6vw7vMEHEV8M5930dDgw==",
+      "version": "3.0.2-next-2024-03-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-25.1.tgz",
+      "integrity": "sha512-mljahoI6whwQXm4PacC6fzYP3/9OYAccF9W9x5BffxvRnNdZBT94AQCA3vKsrcUUcRmb+AbCHEVHnz0AI/QaMQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.1.3-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-25.tgz",
-      "integrity": "sha512-aLmoT6D020nf8356NrqCIdn9AzNVRp32FQuDDZSe+QUoxD+XIwFIMbl1BtzjqQ3wHddxg2+GfNm9Tz6T1SjQLw==",
+      "version": "2.1.3-next-2024-03-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-25.1.tgz",
+      "integrity": "sha512-Brv61FMlvI05alMS6c85dTFcwrb9ORWSiHh49+FfoD0mxeKaDM8LjzC/wO5Xyd58+ORtSRnmypMnt/803Bd1Jw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7047,9 +7047,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.3.1-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-25.tgz",
-      "integrity": "sha512-IbuP/SUzU6eDVPp9nLxOzZ5J+yF47M/AGwFPVgjPeTnRxjvdZbSqTbbtXMyO1gS+3QiOjQ27BrdBTOyO7BBczA==",
+      "version": "2.3.1-next-2024-03-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-25.1.tgz",
+      "integrity": "sha512-5qh0DViERwCuaYpFyJYFoFjMAMWU/wdTu3eHF94HWH3Uyc8V7wOJpQTFO7LxBeKNMhBqweQFG0pAAlb6EPPsVA==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7057,9 +7057,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.0.3-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-25.tgz",
-      "integrity": "sha512-yHpZMhkV3wTP+vNa4bQfGOltmmyeVfR0d0dGnoWyvJWq4Y0LjBCez3FzcTmOx3ZdsMs5EDoXLZx0tjURWFZMwg==",
+      "version": "3.0.3-next-2024-03-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-25.1.tgz",
+      "integrity": "sha512-KC0Y/cn49cs+Nm4s3OpQJtfmfdUOkvRNApj41I+KseVvVnpp6E8ZTcMFtezhD4gMqm8kyKEm7T6fywFHacDL6Q==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7073,9 +7073,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "3.1.0-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.0-next-2024-03-25.tgz",
-      "integrity": "sha512-Qzk6615bh9/qODnOfHi9hXGJtUndZyJOXo5YTLhknJUuNijyoQKbqYJuO7i1n7yprdfP1ykBs1GsundRfO2f0A==",
+      "version": "3.1.1-next-2024-03-25",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-03-25.tgz",
+      "integrity": "sha512-SX7k/h5j01RQUVUVtU1WYu528gftc48EoswOCwENxDLIV1DyjfAn4/qkY9/gxTKB/OitBMBpqkYdeCHLC2r9qQ==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7089,30 +7089,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.2.2-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-25.tgz",
-      "integrity": "sha512-ZMBKrriwA2E1smrwJvODjx3oha5dNKsRKlDbms0k7PG0MWj9LvGFKSXHyqfMJnlsOvLQUeiP6d/LUGdY2PBOOg==",
+      "version": "2.2.2-next-2024-03-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-25.1.tgz",
+      "integrity": "sha512-0TxMKLueO4gyHNMbaJDzphFndUZ1tdQRf4meOu/Db1FgzQs3HXX4Ti/zqP9hDhMWwp/nbnuBkl1bUImVIe9KWA==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.2.1-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-25.tgz",
-      "integrity": "sha512-+p8ShXSFKqCFMGn6eaabe98fvzG+If5o9cB30RVH4IHX7IewsO1d14b9fkB5MfRHYnP3L251rmB1TW/wcccsBA==",
+      "version": "2.2.1-next-2024-03-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-25.1.tgz",
+      "integrity": "sha512-AsAzjy0C/mumA3mi0GlJu2HmT7LyZ5MN24oh9oVclqHVBrHi63tO/E0UgfkMBiRmJfZZpHwXW4Hik1L1AEbvqQ==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "4.0.2-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-25.tgz",
-      "integrity": "sha512-8Zm1InVqR5zeFSwXei9imK6nkTjV7BF20tWRZ8Rqhba9RqMOOFUNHKd9DQj9WqVn1XvgFGhoL+9r6SOgmHTGJw==",
+      "version": "4.0.2-next-2024-03-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-25.1.tgz",
+      "integrity": "sha512-44d5H983YynMT5WYOkPSjpcI93tuQHY7N5XQt0QI45ZxS28Upl8X0hyQRbk1Zrls4UeM9ezgOCOCdgi74YUD0w==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.2-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-25.tgz",
-      "integrity": "sha512-coqP3SS1m7lFOfPRh1uVgRIzRqBJ4x0YLW6IfyUxUWn4a00KlMGcmETo5ydcZISXEthzZseA48JnQlU1wRLZ5A==",
+      "version": "1.0.2-next-2024-03-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-25.1.tgz",
+      "integrity": "sha512-Qnb5mIEANzEtqVtbcAEawGPOamuafUc+OwfqqxXXf58Oz9QfEc7c716nn1xbSguqEW3z4lGV6FQm/FvG6Ka4cw==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7126,17 +7126,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.0.2-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-25.tgz",
-      "integrity": "sha512-vQnMlYD49Tu2TtOYPJboQQWzXbDRUi+QSPoxl0c7mIqCeziSdXDrLtXx7DGGnF1eKO6vw7vMEHEV8M5930dDgw==",
+      "version": "3.0.2-next-2024-03-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-25.1.tgz",
+      "integrity": "sha512-mljahoI6whwQXm4PacC6fzYP3/9OYAccF9W9x5BffxvRnNdZBT94AQCA3vKsrcUUcRmb+AbCHEVHnz0AI/QaMQ==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.1.3-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-25.tgz",
-      "integrity": "sha512-aLmoT6D020nf8356NrqCIdn9AzNVRp32FQuDDZSe+QUoxD+XIwFIMbl1BtzjqQ3wHddxg2+GfNm9Tz6T1SjQLw==",
+      "version": "2.1.3-next-2024-03-25.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-25.1.tgz",
+      "integrity": "sha512-Brv61FMlvI05alMS6c85dTFcwrb9ORWSiHh49+FfoD0mxeKaDM8LjzC/wO5Xyd58+ORtSRnmypMnt/803Bd1Jw==",
       "requires": {}
     },
     "@esbuild/android-arm": {


### PR DESCRIPTION
# Motivation

ic-js [2024.03.25-1345Z](https://github.com/dfinity/ic-js/releases/tag/2024.03.25-1345Z) and patch [2024.03.25-1430Z](https://github.com/dfinity/ic-js/releases/tag/2024.03.25-1430Z) were released. This PR bumps the libraries to follow their next version numbers.

# Changes

- `npm run upgrade:next` executed
