### PR TITLE
Increase the number of acounts used in randomized tests

### DIFF
--- a/rs/backend/src/accounts_store/schema/proxy/tests.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/tests.rs
@@ -191,7 +191,7 @@ where
     // Check that the default storage is indeed a map.
     assert!(accounts_db.schema_label() == SchemaLabel::Map);
     // Insert some accounts
-    let number_of_accounts_to_migrate: u32 = rng.gen_range(0..40);
+    let number_of_accounts_to_migrate: u32 = rng.gen_range(0..100);
     for _ in 0..number_of_accounts_to_migrate {
         Operation::Insert.perform(&mut accounts_db, &mut reference_db, rng);
     }
@@ -211,7 +211,7 @@ where
         memory_manager.get(PartitionType::Accounts.memory_id()),
     ));
     // Insert some accounts
-    let number_of_accounts_to_migrate: u32 = rng.gen_range(0..40);
+    let number_of_accounts_to_migrate: u32 = rng.gen_range(0..100);
     for _ in 0..number_of_accounts_to_migrate {
         Operation::Insert.perform(&mut accounts_db, &mut reference_db, rng);
     }
@@ -230,7 +230,7 @@ where
     let mut reference_db = AccountsDbAsProxy::default();
     let new_accounts_db = AccountsDb::Map(AccountsDbAsMap::default());
     // Insert some accounts
-    let number_of_accounts_to_migrate: u32 = rng.gen_range(0..40);
+    let number_of_accounts_to_migrate: u32 = rng.gen_range(0..100);
     for _ in 0..number_of_accounts_to_migrate {
         Operation::Insert.perform(&mut accounts_db, &mut reference_db, rng);
     }


### PR DESCRIPTION
# Motivation
As part of the security review with @roelstorms, it was considered that we probably want to increase the number of accounts used in randomized migration testing.

The number of accounts is a random number in the range 0..40.  If we migrate 20 accounts per step (increased from 10), half the time the entire migration is completed in one step.  (Plus a second step to point the switch at the new database.)  This gives insufficient opportunity for the test to find any bugs.

# Changes
- Increase the number of accounts in randomized migration tests to a random number in the range 0..100.

# Tests
- See CI

# Todos

- [ ] Add entry to changelog (if necessary).
