### PR TITLE
Bump ic-js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.3.1-next-2024-03-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-25.1.tgz",
-      "integrity": "sha512-5qh0DViERwCuaYpFyJYFoFjMAMWU/wdTu3eHF94HWH3Uyc8V7wOJpQTFO7LxBeKNMhBqweQFG0pAAlb6EPPsVA==",
+      "version": "2.3.1-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-26.tgz",
+      "integrity": "sha512-D65y+BGiFcBRCYVJkujGXC/U0xhjcYXHHJSQJ242RZHPhaQYBvoUhDLlGIV/q4jLv3FMcBg7p6JLJcuDc5NVlg==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.0.3-next-2024-03-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-25.1.tgz",
-      "integrity": "sha512-KC0Y/cn49cs+Nm4s3OpQJtfmfdUOkvRNApj41I+KseVvVnpp6E8ZTcMFtezhD4gMqm8kyKEm7T6fywFHacDL6Q==",
+      "version": "3.0.3-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-26.tgz",
+      "integrity": "sha512-i7tbQSz1JpLz2aliUPhBvyJcmSCHomJkDKokkLI2rDSX4rO9tbrlXNSq/Uy7xh+PItTTXvv4i3NUiQ5cxQ12rg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "3.1.1-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-03-25.tgz",
-      "integrity": "sha512-SX7k/h5j01RQUVUVtU1WYu528gftc48EoswOCwENxDLIV1DyjfAn4/qkY9/gxTKB/OitBMBpqkYdeCHLC2r9qQ==",
+      "version": "3.1.1-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-03-26.tgz",
+      "integrity": "sha512-qf37JZebmJUo5/CR11P611dl9eYG5WQRF01Y2gEKfHgt4d09oxNbYBAIyJ+btmwTn8KW/E7sSRbM4XHrqKNwdw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.2.2-next-2024-03-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-25.1.tgz",
-      "integrity": "sha512-0TxMKLueO4gyHNMbaJDzphFndUZ1tdQRf4meOu/Db1FgzQs3HXX4Ti/zqP9hDhMWwp/nbnuBkl1bUImVIe9KWA==",
+      "version": "2.2.2-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-26.tgz",
+      "integrity": "sha512-Vxs36efeuZW7WB1mOX8T933S1DfSrGKIhVf6u970dFBRpZLomZQibUcTsddgTCUL44pYRrpypLnOweVPC9fcrA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.2.1-next-2024-03-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-25.1.tgz",
-      "integrity": "sha512-AsAzjy0C/mumA3mi0GlJu2HmT7LyZ5MN24oh9oVclqHVBrHi63tO/E0UgfkMBiRmJfZZpHwXW4Hik1L1AEbvqQ==",
+      "version": "2.2.1-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-26.tgz",
+      "integrity": "sha512-kCcAoSh8Z52JWiKp5nqRZgEUC3Vej3muLzgTqUupARno1qhGieXmcVnJXbeWZMd99zzHBBJGbmEo6SA5ugsOEg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "4.0.2-next-2024-03-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-25.1.tgz",
-      "integrity": "sha512-44d5H983YynMT5WYOkPSjpcI93tuQHY7N5XQt0QI45ZxS28Upl8X0hyQRbk1Zrls4UeM9ezgOCOCdgi74YUD0w==",
+      "version": "4.0.2-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-26.tgz",
+      "integrity": "sha512-SD+W6xGHh0qyZCQZ1oeGrMMm9t/fwTczrf0LQNf1sU2UEtunHkS45nik2itCU0R5l6GVTPBfMslWQkMycAaCmQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -358,9 +358,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.2-next-2024-03-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-25.1.tgz",
-      "integrity": "sha512-Qnb5mIEANzEtqVtbcAEawGPOamuafUc+OwfqqxXXf58Oz9QfEc7c716nn1xbSguqEW3z4lGV6FQm/FvG6Ka4cw==",
+      "version": "1.0.2-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-26.tgz",
+      "integrity": "sha512-37AsycQWZwxURJr32Nvzji0WQgo9G5HxL34n6LguxBbPcd0Y4GavwocXMZT0yv0tk3tacFwWWEwo3e/TnTlfbQ==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.0.2-next-2024-03-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-25.1.tgz",
-      "integrity": "sha512-mljahoI6whwQXm4PacC6fzYP3/9OYAccF9W9x5BffxvRnNdZBT94AQCA3vKsrcUUcRmb+AbCHEVHnz0AI/QaMQ==",
+      "version": "3.0.2-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-26.tgz",
+      "integrity": "sha512-NwOqMhTxK3jZqGGQUXd4n0708S9LGBukT+2l/iODpAHHFJrcU2hwpRN6+1sH5ml8aKCSarEVjdqF2jTG1d3OgQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.1.3-next-2024-03-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-25.1.tgz",
-      "integrity": "sha512-Brv61FMlvI05alMS6c85dTFcwrb9ORWSiHh49+FfoD0mxeKaDM8LjzC/wO5Xyd58+ORtSRnmypMnt/803Bd1Jw==",
+      "version": "2.1.3-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-26.tgz",
+      "integrity": "sha512-Xw1kKmXmWthtC/+ruPkow54QVNpS+6aZlbShf+orbwfM8YcvxYA8LdZRF9zMFqmoKHlhL4hwS36f+NYmg/L5RQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7047,9 +7047,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.3.1-next-2024-03-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-25.1.tgz",
-      "integrity": "sha512-5qh0DViERwCuaYpFyJYFoFjMAMWU/wdTu3eHF94HWH3Uyc8V7wOJpQTFO7LxBeKNMhBqweQFG0pAAlb6EPPsVA==",
+      "version": "2.3.1-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-26.tgz",
+      "integrity": "sha512-D65y+BGiFcBRCYVJkujGXC/U0xhjcYXHHJSQJ242RZHPhaQYBvoUhDLlGIV/q4jLv3FMcBg7p6JLJcuDc5NVlg==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7057,9 +7057,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.0.3-next-2024-03-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-25.1.tgz",
-      "integrity": "sha512-KC0Y/cn49cs+Nm4s3OpQJtfmfdUOkvRNApj41I+KseVvVnpp6E8ZTcMFtezhD4gMqm8kyKEm7T6fywFHacDL6Q==",
+      "version": "3.0.3-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-26.tgz",
+      "integrity": "sha512-i7tbQSz1JpLz2aliUPhBvyJcmSCHomJkDKokkLI2rDSX4rO9tbrlXNSq/Uy7xh+PItTTXvv4i3NUiQ5cxQ12rg==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7073,9 +7073,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "3.1.1-next-2024-03-25",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-03-25.tgz",
-      "integrity": "sha512-SX7k/h5j01RQUVUVtU1WYu528gftc48EoswOCwENxDLIV1DyjfAn4/qkY9/gxTKB/OitBMBpqkYdeCHLC2r9qQ==",
+      "version": "3.1.1-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-03-26.tgz",
+      "integrity": "sha512-qf37JZebmJUo5/CR11P611dl9eYG5WQRF01Y2gEKfHgt4d09oxNbYBAIyJ+btmwTn8KW/E7sSRbM4XHrqKNwdw==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7089,30 +7089,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.2.2-next-2024-03-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-25.1.tgz",
-      "integrity": "sha512-0TxMKLueO4gyHNMbaJDzphFndUZ1tdQRf4meOu/Db1FgzQs3HXX4Ti/zqP9hDhMWwp/nbnuBkl1bUImVIe9KWA==",
+      "version": "2.2.2-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-26.tgz",
+      "integrity": "sha512-Vxs36efeuZW7WB1mOX8T933S1DfSrGKIhVf6u970dFBRpZLomZQibUcTsddgTCUL44pYRrpypLnOweVPC9fcrA==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.2.1-next-2024-03-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-25.1.tgz",
-      "integrity": "sha512-AsAzjy0C/mumA3mi0GlJu2HmT7LyZ5MN24oh9oVclqHVBrHi63tO/E0UgfkMBiRmJfZZpHwXW4Hik1L1AEbvqQ==",
+      "version": "2.2.1-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-26.tgz",
+      "integrity": "sha512-kCcAoSh8Z52JWiKp5nqRZgEUC3Vej3muLzgTqUupARno1qhGieXmcVnJXbeWZMd99zzHBBJGbmEo6SA5ugsOEg==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "4.0.2-next-2024-03-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-25.1.tgz",
-      "integrity": "sha512-44d5H983YynMT5WYOkPSjpcI93tuQHY7N5XQt0QI45ZxS28Upl8X0hyQRbk1Zrls4UeM9ezgOCOCdgi74YUD0w==",
+      "version": "4.0.2-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-26.tgz",
+      "integrity": "sha512-SD+W6xGHh0qyZCQZ1oeGrMMm9t/fwTczrf0LQNf1sU2UEtunHkS45nik2itCU0R5l6GVTPBfMslWQkMycAaCmQ==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.2-next-2024-03-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-25.1.tgz",
-      "integrity": "sha512-Qnb5mIEANzEtqVtbcAEawGPOamuafUc+OwfqqxXXf58Oz9QfEc7c716nn1xbSguqEW3z4lGV6FQm/FvG6Ka4cw==",
+      "version": "1.0.2-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-26.tgz",
+      "integrity": "sha512-37AsycQWZwxURJr32Nvzji0WQgo9G5HxL34n6LguxBbPcd0Y4GavwocXMZT0yv0tk3tacFwWWEwo3e/TnTlfbQ==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7126,17 +7126,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.0.2-next-2024-03-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-25.1.tgz",
-      "integrity": "sha512-mljahoI6whwQXm4PacC6fzYP3/9OYAccF9W9x5BffxvRnNdZBT94AQCA3vKsrcUUcRmb+AbCHEVHnz0AI/QaMQ==",
+      "version": "3.0.2-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-26.tgz",
+      "integrity": "sha512-NwOqMhTxK3jZqGGQUXd4n0708S9LGBukT+2l/iODpAHHFJrcU2hwpRN6+1sH5ml8aKCSarEVjdqF2jTG1d3OgQ==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.1.3-next-2024-03-25.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-25.1.tgz",
-      "integrity": "sha512-Brv61FMlvI05alMS6c85dTFcwrb9ORWSiHh49+FfoD0mxeKaDM8LjzC/wO5Xyd58+ORtSRnmypMnt/803Bd1Jw==",
+      "version": "2.1.3-next-2024-03-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-26.tgz",
+      "integrity": "sha512-Xw1kKmXmWthtC/+ruPkow54QVNpS+6aZlbShf+orbwfM8YcvxYA8LdZRF9zMFqmoKHlhL4hwS36f+NYmg/L5RQ==",
       "requires": {}
     },
     "@esbuild/android-arm": {


### PR DESCRIPTION
# Motivation

Keep our ic-js dependency up to date.

In particular, we want to use the `timestamp` field that was added to the `Transaction` type of the index canister.

# Changes

Ran `npm run upgrade:next`.

# Tests

Still pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary