### PR TITLE
Bump ic-js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.3.1-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-26.tgz",
-      "integrity": "sha512-D65y+BGiFcBRCYVJkujGXC/U0xhjcYXHHJSQJ242RZHPhaQYBvoUhDLlGIV/q4jLv3FMcBg7p6JLJcuDc5NVlg==",
+      "version": "2.3.1-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-26.1.tgz",
+      "integrity": "sha512-24cEfHKdWPOF4IwUWPt//2oRHthQXkvBgffmczISj1L8tgw70mZhcL0xGIfeTbH6yNC3In/FOtZJeNhkRaQahw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.0.3-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-26.tgz",
-      "integrity": "sha512-i7tbQSz1JpLz2aliUPhBvyJcmSCHomJkDKokkLI2rDSX4rO9tbrlXNSq/Uy7xh+PItTTXvv4i3NUiQ5cxQ12rg==",
+      "version": "3.0.3-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-26.1.tgz",
+      "integrity": "sha512-eiERTyIGcofWJZtr7Gmy8pPBV2GjNMIy4JWYAJu7l+dNw8Vv9MGPgPWpvipPZO2Y7CclFsO/saGFbpuLlChSpQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "3.1.1-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-03-26.tgz",
-      "integrity": "sha512-qf37JZebmJUo5/CR11P611dl9eYG5WQRF01Y2gEKfHgt4d09oxNbYBAIyJ+btmwTn8KW/E7sSRbM4XHrqKNwdw==",
+      "version": "3.1.1-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-03-26.1.tgz",
+      "integrity": "sha512-XL9NLn7yj3UxaDKAl8p8WXyezSyB5z9DVicYM9WNVtEFD7MIH07lkaeU3hCJK7FfEiaKA6v8Xs1h+xKskHPpUQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.2.2-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-26.tgz",
-      "integrity": "sha512-Vxs36efeuZW7WB1mOX8T933S1DfSrGKIhVf6u970dFBRpZLomZQibUcTsddgTCUL44pYRrpypLnOweVPC9fcrA==",
+      "version": "2.2.2-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-26.1.tgz",
+      "integrity": "sha512-1zaYqG6jog2C0Yy/hAKgWr7PRoRhBNApa1KTqWDLVBDpzlomGYIU0+bla6+toFV/r++NFcD2a9eFTja3fzTN2A==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.2.1-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-26.tgz",
-      "integrity": "sha512-kCcAoSh8Z52JWiKp5nqRZgEUC3Vej3muLzgTqUupARno1qhGieXmcVnJXbeWZMd99zzHBBJGbmEo6SA5ugsOEg==",
+      "version": "2.2.1-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-26.1.tgz",
+      "integrity": "sha512-AyCiGPTaaQBqRrebXzgIKAkxlGiqYMohGS5M7db6FOw9vhfbqrgLBcqnGos+eCEBNegVjcEZyd8Q/gloIHz+lA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "4.0.2-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-26.tgz",
-      "integrity": "sha512-SD+W6xGHh0qyZCQZ1oeGrMMm9t/fwTczrf0LQNf1sU2UEtunHkS45nik2itCU0R5l6GVTPBfMslWQkMycAaCmQ==",
+      "version": "4.0.2-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-26.1.tgz",
+      "integrity": "sha512-XF/pXWNM02p0nh64siSo7YNf60OlOtncwUg3XDGyPG8S7/L+vzBjNxf5/91pC84WCoGDWISWiTX4gQQL4QTP7w==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -358,9 +358,9 @@
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.2-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-26.tgz",
-      "integrity": "sha512-37AsycQWZwxURJr32Nvzji0WQgo9G5HxL34n6LguxBbPcd0Y4GavwocXMZT0yv0tk3tacFwWWEwo3e/TnTlfbQ==",
+      "version": "1.0.2-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-26.1.tgz",
+      "integrity": "sha512-U5xNYK1LjSMNp2VPOVH5KvKrwZ1w1/zmCqacju865owsYziqVbgPMONX143zK2NPI7ZdfIAD2XCrgNcuHWuIJA==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.0.2-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-26.tgz",
-      "integrity": "sha512-NwOqMhTxK3jZqGGQUXd4n0708S9LGBukT+2l/iODpAHHFJrcU2hwpRN6+1sH5ml8aKCSarEVjdqF2jTG1d3OgQ==",
+      "version": "3.0.2-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-26.1.tgz",
+      "integrity": "sha512-6zlXG1KyLZSh3AnqNa4gSRVYIkpmcU1ALkVFk4LctnYKTK/8dXZ4r8qJc/SYAwweDD//hBH1XpIT/RjP+16WdA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.1.3-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-26.tgz",
-      "integrity": "sha512-Xw1kKmXmWthtC/+ruPkow54QVNpS+6aZlbShf+orbwfM8YcvxYA8LdZRF9zMFqmoKHlhL4hwS36f+NYmg/L5RQ==",
+      "version": "2.1.3-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-26.1.tgz",
+      "integrity": "sha512-bw4BRLTbXB3Aw4PJ5iCI7KyeRP6nZQ+X9MuSlxs2IF37sH6/TTsKMtWF/hQf6L0JtGrwkf7hohtsWNanaFcJMQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7047,9 +7047,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.3.1-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-26.tgz",
-      "integrity": "sha512-D65y+BGiFcBRCYVJkujGXC/U0xhjcYXHHJSQJ242RZHPhaQYBvoUhDLlGIV/q4jLv3FMcBg7p6JLJcuDc5NVlg==",
+      "version": "2.3.1-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-26.1.tgz",
+      "integrity": "sha512-24cEfHKdWPOF4IwUWPt//2oRHthQXkvBgffmczISj1L8tgw70mZhcL0xGIfeTbH6yNC3In/FOtZJeNhkRaQahw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7057,9 +7057,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.0.3-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-26.tgz",
-      "integrity": "sha512-i7tbQSz1JpLz2aliUPhBvyJcmSCHomJkDKokkLI2rDSX4rO9tbrlXNSq/Uy7xh+PItTTXvv4i3NUiQ5cxQ12rg==",
+      "version": "3.0.3-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-26.1.tgz",
+      "integrity": "sha512-eiERTyIGcofWJZtr7Gmy8pPBV2GjNMIy4JWYAJu7l+dNw8Vv9MGPgPWpvipPZO2Y7CclFsO/saGFbpuLlChSpQ==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7073,9 +7073,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "3.1.1-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-03-26.tgz",
-      "integrity": "sha512-qf37JZebmJUo5/CR11P611dl9eYG5WQRF01Y2gEKfHgt4d09oxNbYBAIyJ+btmwTn8KW/E7sSRbM4XHrqKNwdw==",
+      "version": "3.1.1-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-03-26.1.tgz",
+      "integrity": "sha512-XL9NLn7yj3UxaDKAl8p8WXyezSyB5z9DVicYM9WNVtEFD7MIH07lkaeU3hCJK7FfEiaKA6v8Xs1h+xKskHPpUQ==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7089,30 +7089,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.2.2-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-26.tgz",
-      "integrity": "sha512-Vxs36efeuZW7WB1mOX8T933S1DfSrGKIhVf6u970dFBRpZLomZQibUcTsddgTCUL44pYRrpypLnOweVPC9fcrA==",
+      "version": "2.2.2-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-26.1.tgz",
+      "integrity": "sha512-1zaYqG6jog2C0Yy/hAKgWr7PRoRhBNApa1KTqWDLVBDpzlomGYIU0+bla6+toFV/r++NFcD2a9eFTja3fzTN2A==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.2.1-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-26.tgz",
-      "integrity": "sha512-kCcAoSh8Z52JWiKp5nqRZgEUC3Vej3muLzgTqUupARno1qhGieXmcVnJXbeWZMd99zzHBBJGbmEo6SA5ugsOEg==",
+      "version": "2.2.1-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-26.1.tgz",
+      "integrity": "sha512-AyCiGPTaaQBqRrebXzgIKAkxlGiqYMohGS5M7db6FOw9vhfbqrgLBcqnGos+eCEBNegVjcEZyd8Q/gloIHz+lA==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "4.0.2-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-26.tgz",
-      "integrity": "sha512-SD+W6xGHh0qyZCQZ1oeGrMMm9t/fwTczrf0LQNf1sU2UEtunHkS45nik2itCU0R5l6GVTPBfMslWQkMycAaCmQ==",
+      "version": "4.0.2-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-26.1.tgz",
+      "integrity": "sha512-XF/pXWNM02p0nh64siSo7YNf60OlOtncwUg3XDGyPG8S7/L+vzBjNxf5/91pC84WCoGDWISWiTX4gQQL4QTP7w==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.2-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-26.tgz",
-      "integrity": "sha512-37AsycQWZwxURJr32Nvzji0WQgo9G5HxL34n6LguxBbPcd0Y4GavwocXMZT0yv0tk3tacFwWWEwo3e/TnTlfbQ==",
+      "version": "1.0.2-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-26.1.tgz",
+      "integrity": "sha512-U5xNYK1LjSMNp2VPOVH5KvKrwZ1w1/zmCqacju865owsYziqVbgPMONX143zK2NPI7ZdfIAD2XCrgNcuHWuIJA==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7126,17 +7126,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.0.2-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-26.tgz",
-      "integrity": "sha512-NwOqMhTxK3jZqGGQUXd4n0708S9LGBukT+2l/iODpAHHFJrcU2hwpRN6+1sH5ml8aKCSarEVjdqF2jTG1d3OgQ==",
+      "version": "3.0.2-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-26.1.tgz",
+      "integrity": "sha512-6zlXG1KyLZSh3AnqNa4gSRVYIkpmcU1ALkVFk4LctnYKTK/8dXZ4r8qJc/SYAwweDD//hBH1XpIT/RjP+16WdA==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.1.3-next-2024-03-26",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-26.tgz",
-      "integrity": "sha512-Xw1kKmXmWthtC/+ruPkow54QVNpS+6aZlbShf+orbwfM8YcvxYA8LdZRF9zMFqmoKHlhL4hwS36f+NYmg/L5RQ==",
+      "version": "2.1.3-next-2024-03-26.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-26.1.tgz",
+      "integrity": "sha512-bw4BRLTbXB3Aw4PJ5iCI7KyeRP6nZQ+X9MuSlxs2IF37sH6/TTsKMtWF/hQf6L0JtGrwkf7hohtsWNanaFcJMQ==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -465,6 +465,7 @@ describe("NnsWallet", () => {
           memo: 123456n,
           icrc1_memo: [],
           created_at_time: [{ timestamp_nanos: 1234n }],
+          timestamp: [{ timestamp_nanos: 1235n }],
           operation: {
             Transfer: {
               from: mockMainAccount.identifier,
@@ -511,6 +512,7 @@ describe("NnsWallet", () => {
           memo: 123456n,
           icrc1_memo: [],
           created_at_time: [{ timestamp_nanos: 1234n }],
+          timestamp: [{ timestamp_nanos: 1235n }],
           operation: {
             Transfer: {
               from: mockMainAccount.identifier,

--- a/frontend/src/tests/mocks/icp-transactions.mock.ts
+++ b/frontend/src/tests/mocks/icp-transactions.mock.ts
@@ -19,6 +19,7 @@ export const mockTransactionTransfer: Transaction = {
     },
   },
   created_at_time: [{ timestamp_nanos: 234n }],
+  timestamp: [{ timestamp_nanos: 235n }],
 };
 
 const defaultTimestamp = new Date("2023-01-01T00:00:00.000Z");
@@ -32,20 +33,22 @@ export const createTransactionWithId = ({
   memo?: bigint;
   timestamp?: Date;
   id?: bigint;
-}): TransactionWithId => ({
-  id,
-  transaction: {
-    memo: memo ?? 0n,
-    icrc1_memo: [],
-    operation,
-    created_at_time: [
-      {
-        timestamp_nanos:
-          BigInt(timestamp.getTime()) * BigInt(NANO_SECONDS_IN_MILLISECOND),
-      },
-    ],
-  },
-});
+}): TransactionWithId => {
+  const timestampNanos = {
+    timestamp_nanos:
+      BigInt(timestamp.getTime()) * BigInt(NANO_SECONDS_IN_MILLISECOND),
+  };
+  return {
+    id,
+    transaction: {
+      memo: memo ?? 0n,
+      icrc1_memo: [],
+      operation,
+      created_at_time: [timestampNanos],
+      timestamp: [timestampNanos],
+    },
+  };
+};
 
 export const mockTransactionWithId: TransactionWithId = {
   id: 234n,

--- a/frontend/src/tests/mocks/transaction.mock.ts
+++ b/frontend/src/tests/mocks/transaction.mock.ts
@@ -115,5 +115,6 @@ export const mockTransactionWithId: TransactionWithId = {
       },
     },
     created_at_time: [],
+    timestamp: [],
   },
 };


### PR DESCRIPTION
# Motivation

Keep our ic-js dependency up to date.

In particular, we want to use the `timestamp` field that was added to the `Transaction` type of the index canister.

I attempted this with https://github.com/dfinity/nns-dapp/pull/4663 but had forgotten to publish the changes first.

# Changes

1. Ran `npm run upgrade:next`.
2. Set the `timestamp` field on test values where it's required.

# Tests

Still pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary