### PR TITLE
NNS1-2987: Display block timestamp in transaction history

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -20,6 +20,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Always omit the account parameter in the URL when navigating to a main account.
+* Display the block timestamp instead of created timestamp on ICP transaction.
 
 #### Deprecated
 

--- a/frontend/src/lib/utils/icp-transactions.utils.ts
+++ b/frontend/src/lib/utils/icp-transactions.utils.ts
@@ -172,11 +172,14 @@ export const mapIcpTransaction = ({
     });
     const otherParty = isReceive ? txInfo.from : txInfo.to;
 
+    const blockTimestampNanos = fromNullable(transaction.transaction.timestamp)
+      ?.timestamp_nanos;
     const createdTimestampNanos = fromNullable(
       transaction.transaction.created_at_time
     )?.timestamp_nanos;
-    const timestampMilliseconds = nonNullish(createdTimestampNanos)
-      ? Number(createdTimestampNanos) / NANO_SECONDS_IN_MILLISECOND
+    const timestampNanos = blockTimestampNanos ?? createdTimestampNanos;
+    const timestampMilliseconds = nonNullish(timestampNanos)
+      ? Number(timestampNanos) / NANO_SECONDS_IN_MILLISECOND
       : undefined;
     const timestamp = nonNullish(timestampMilliseconds)
       ? new Date(timestampMilliseconds)


### PR DESCRIPTION
# Motivation

In order to have timestamps consistent with the dashboard, we need to use [this](https://github.com/dfinity/ic/blob/03de843e2a01f57a8fb5c2ef928e91574396f6c5/rs/rosetta-api/icp_ledger/index/index.did#L61) instead of [this](https://github.com/dfinity/ic/blob/03de843e2a01f57a8fb5c2ef928e91574396f6c5/rs/rosetta-api/icp_ledger/index/index.did#L60).

# Changes

Use the `timestamp` field if available and fall back on the `created_at_time` field otherwise.

# Tests

Unit test added and tested manually.
Also tested that it doesn't break with an older version of the index canister that doesn't have the `timestamp` field.

# Todos

- [x] Add entry to changelog (if necessary).
