### PR TITLE
style: dropdown changes

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -21,7 +21,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Always omit the account parameter in the URL when navigating to a main account.
 * Display the block timestamp instead of created timestamp on ICP transaction.
-* Styles of project selector on mobile.
+* Minor style changes for mobile project selector.
 
 #### Deprecated
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -21,6 +21,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Always omit the account parameter in the URL when navigating to a main account.
 * Display the block timestamp instead of created timestamp on ICP transaction.
+* Styles of project selector on mobile.
 
 #### Deprecated
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "4.1.0-next-2024-03-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.1.0-next-2024-03-22.1.tgz",
-      "integrity": "sha512-q5LBM0xjE7sBag7WcffwPY595QlO+nT6HAjvDtVmzERLErQw4iq+DcGjNMXYmgPNijb1gLwovYv293k3iL/e+g==",
+      "version": "4.1.0-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.1.0-next-2024-03-28.1.tgz",
+      "integrity": "sha512-PqT7vD0SNkYUb9UW+7hCZ+Pcf20BYeePLPNW+haQZ9cDyA3LRbys7NPdyaTW0ajnhnnVRxapIoi5Wfuppep3Qg==",
       "dependencies": {
         "dompurify": "^3.0.8",
         "html5-qrcode": "^2.3.8",
@@ -7063,9 +7063,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "4.1.0-next-2024-03-22.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.1.0-next-2024-03-22.1.tgz",
-      "integrity": "sha512-q5LBM0xjE7sBag7WcffwPY595QlO+nT6HAjvDtVmzERLErQw4iq+DcGjNMXYmgPNijb1gLwovYv293k3iL/e+g==",
+      "version": "4.1.0-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.1.0-next-2024-03-28.1.tgz",
+      "integrity": "sha512-PqT7vD0SNkYUb9UW+7hCZ+Pcf20BYeePLPNW+haQZ9cDyA3LRbys7NPdyaTW0ajnhnnVRxapIoi5Wfuppep3Qg==",
       "requires": {
         "dompurify": "^3.0.8",
         "html5-qrcode": "^2.3.8",

--- a/frontend/src/lib/components/layout/UniverseSplitContent.svelte
+++ b/frontend/src/lib/components/layout/UniverseSplitContent.svelte
@@ -5,9 +5,11 @@
   import HeaderToolbar from "$lib/components/header/HeaderToolbar.svelte";
 </script>
 
-<div>
+<div class="container">
   <SplitContent>
-    <SelectUniverseNav slot="start" />
+    <div class="nav" slot="start">
+      <SelectUniverseNav />
+    </div>
 
     <Title slot="title" />
 
@@ -21,15 +23,17 @@
   @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   // Temporarily redefine default values of the SplitContent until the proper redesign is implemented.
-  div {
+  .container {
     display: contents;
     --content-start-height: calc(92px + var(--padding-2x));
+    --nav-component-title-display: none;
 
-    :global(.nav-title) {
-      display: none;
-      @include media.min-width(large) {
-        display: block;
-      }
+    @include media.min-width(large) {
+      --nav-component-title-display: block;
     }
+  }
+
+  .nav {
+    margin-top: var(--padding-2x);
   }
 </style>

--- a/frontend/src/lib/components/layout/UniverseSplitContent.svelte
+++ b/frontend/src/lib/components/layout/UniverseSplitContent.svelte
@@ -3,10 +3,9 @@
   import Title from "$lib/components/header/Title.svelte";
   import SelectUniverseNav from "$lib/components/universe/SelectUniverseNav.svelte";
   import HeaderToolbar from "$lib/components/header/HeaderToolbar.svelte";
-  import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
 </script>
 
-<SplitContent perceivedOnMobile={!$ENABLE_VOTING_INDICATION}>
+<SplitContent>
   <SelectUniverseNav slot="start" />
 
   <Title slot="title" />

--- a/frontend/src/lib/components/layout/UniverseSplitContent.svelte
+++ b/frontend/src/lib/components/layout/UniverseSplitContent.svelte
@@ -5,12 +5,31 @@
   import HeaderToolbar from "$lib/components/header/HeaderToolbar.svelte";
 </script>
 
-<SplitContent>
-  <SelectUniverseNav slot="start" />
+<div>
+  <SplitContent>
+    <SelectUniverseNav slot="start" />
 
-  <Title slot="title" />
+    <Title slot="title" />
 
-  <HeaderToolbar slot="toolbar-end" />
+    <HeaderToolbar slot="toolbar-end" />
 
-  <slot slot="end" />
-</SplitContent>
+    <slot slot="end" />
+  </SplitContent>
+</div>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+
+  // Temporarily redefine default values of the SplitContent until the proper redesign is implemented.
+  div {
+    display: contents;
+    --content-start-height: calc(92px + var(--padding-2x));
+
+    :global(.nav-title) {
+      display: none;
+      @include media.min-width(large) {
+        display: block;
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/components/layout/UniverseSplitContent.svelte
+++ b/frontend/src/lib/components/layout/UniverseSplitContent.svelte
@@ -3,9 +3,10 @@
   import Title from "$lib/components/header/Title.svelte";
   import SelectUniverseNav from "$lib/components/universe/SelectUniverseNav.svelte";
   import HeaderToolbar from "$lib/components/header/HeaderToolbar.svelte";
+  import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
 </script>
 
-<SplitContent>
+<SplitContent perceivedOnMobile={!$ENABLE_VOTING_INDICATION}>
   <SelectUniverseNav slot="start" />
 
   <Title slot="title" />

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -50,9 +50,6 @@
   $: actionableProposalSupported = $ENABLE_VOTING_INDICATION
     ? $actionableProposalSupportedStore[universe.canisterId]
     : undefined;
-
-  let compactView = false;
-  $: compactView = $ENABLE_VOTING_INDICATION;
 </script>
 
 <Card
@@ -65,7 +62,7 @@
   noPadding
   noMarginBottom
 >
-  <div class="container" class:selected class:compactView>
+  <div class="container" class:selected>
     <UniverseLogo size="big" {universe} framed={true} />
 
     <div
@@ -98,15 +95,12 @@
     display: flex;
     align-items: center;
     gap: var(--padding-2x);
-    // Same as Card padding
-    // We want to padding in the container to use the hover effect on ALL the card surface.
-    padding: calc(var(--padding-2x) - var(--card-border-size));
-    &.compactView {
-      padding: calc(var(--padding) - var(--card-border-size));
 
-      @include media.min-width(large) {
-        padding: calc(var(--padding-2x) - var(--card-border-size));
-      }
+    padding: calc(var(--padding) - var(--card-border-size));
+    @include media.min-width(large) {
+      // Same as Card padding
+      // We want to padding in the container to use the hover effect on ALL the card surface.
+      padding: calc(var(--padding-2x) - var(--card-border-size));
     }
 
     --value-color: var(--text-color);

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -60,7 +60,7 @@
   {icon}
   testId="select-universe-card"
   noPadding
-  noMarginBottom
+  noMargin
 >
   <div class="container" class:selected>
     <UniverseLogo size="big" {universe} framed={true} />

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -50,6 +50,9 @@
   $: actionableProposalSupported = $ENABLE_VOTING_INDICATION
     ? $actionableProposalSupportedStore[universe.canisterId]
     : undefined;
+
+  let compactView = false;
+  $: compactView = $ENABLE_VOTING_INDICATION;
 </script>
 
 <Card
@@ -60,8 +63,9 @@
   {icon}
   testId="select-universe-card"
   noPadding
+  noMarginBottom
 >
-  <div class="container" class:selected>
+  <div class="container" class:selected class:compactView>
     <UniverseLogo size="big" {universe} framed={true} />
 
     <div
@@ -97,6 +101,13 @@
     // Same as Card padding
     // We want to padding in the container to use the hover effect on ALL the card surface.
     padding: calc(var(--padding-2x) - var(--card-border-size));
+    &.compactView {
+      padding: calc(var(--padding) - var(--card-border-size));
+
+      @include media.min-width(large) {
+        padding: calc(var(--padding-2x) - var(--card-border-size));
+      }
+    }
 
     --value-color: var(--text-color);
 

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -95,13 +95,9 @@
     display: flex;
     align-items: center;
     gap: var(--padding-2x);
-
-    padding: calc(var(--padding) - var(--card-border-size));
-    @include media.min-width(large) {
-      // Same as Card padding
-      // We want to padding in the container to use the hover effect on ALL the card surface.
-      padding: calc(var(--padding-2x) - var(--card-border-size));
-    }
+    // Same as Card padding
+    // We want to padding in the container to use the hover effect on ALL the card surface.
+    padding: calc(var(--padding-2x) - var(--card-border-size));
 
     --value-color: var(--text-color);
 

--- a/frontend/src/lib/components/universe/SelectUniverseNav.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNav.svelte
@@ -12,9 +12,7 @@
   let innerWidth = 0;
   let list = false;
 
-  let largeScreen = false;
-  $: largeScreen = innerWidth > BREAKPOINT_LARGE;
-  $: list = largeScreen;
+  $: list = innerWidth > BREAKPOINT_LARGE;
   $: if (
     $ENABLE_VOTING_INDICATION &&
     $actionableProposalIndicationEnabledStore
@@ -29,14 +27,11 @@
   ) {
     loadActionableSnsProposals();
   }
-
-  let hideTitle = false;
-  $: hideTitle = $ENABLE_VOTING_INDICATION && !largeScreen;
 </script>
 
 <svelte:window bind:innerWidth />
 
-<Nav {hideTitle}>
+<Nav>
   <p class="title" slot="title" data-tid="select-universe-nav-title">
     {$titleTokenSelectorStore}
   </p>

--- a/frontend/src/lib/components/universe/SelectUniverseNav.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNav.svelte
@@ -12,7 +12,9 @@
   let innerWidth = 0;
   let list = false;
 
-  $: list = innerWidth > BREAKPOINT_LARGE;
+  let largeScreen = false;
+  $: largeScreen = innerWidth > BREAKPOINT_LARGE;
+  $: list = largeScreen;
   $: if (
     $ENABLE_VOTING_INDICATION &&
     $actionableProposalIndicationEnabledStore
@@ -27,11 +29,14 @@
   ) {
     loadActionableSnsProposals();
   }
+
+  let hideTitle = false;
+  $: hideTitle = $ENABLE_VOTING_INDICATION && !largeScreen;
 </script>
 
 <svelte:window bind:innerWidth />
 
-<Nav>
+<Nav {hideTitle}>
   <p class="title" slot="title" data-tid="select-universe-nav-title">
     {$titleTokenSelectorStore}
   </p>


### PR DESCRIPTION
# Motivation

Update style for project selector on mobile to provide more space for the content. A first step to the new split content design. Uses changes of `gix-component` pr - https://github.com/dfinity/gix-components/pull/403

# Changes

- `npm run update:gix`
- add `noMarginBottom` to remove bottom margins. To avoid stretching of a SplitContent start block on mobile.
- redefine some `SplitContent` css values.

# Tests

Manually.

# Todos

- [x] Add entry to changelog (if necessary).

# Screenshots

| Before | After |
|--------|--------|
| <img width="326" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/bf644db9-ae48-4ab1-a429-500ac6fa2f96"> | <img width="310" alt="image" src="https://github.com/dfinity/gix-components/assets/98811342/46c6e7ef-d428-46de-ac4a-3b932f8a3819"> |
 | 