### PR TITLE
NNS1-2887: Bump: ic-js (proto dependency removal)

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,6 +26,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Removed
 
+* Remove `protobuf` dependency for Ledger hardware wallet.
+
 #### Fixed
 
 * Make token table rows always clickable. A few edge cases were missing.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.3.1-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-26.1.tgz",
-      "integrity": "sha512-24cEfHKdWPOF4IwUWPt//2oRHthQXkvBgffmczISj1L8tgw70mZhcL0xGIfeTbH6yNC3In/FOtZJeNhkRaQahw==",
+      "version": "2.3.1-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-28.1.tgz",
+      "integrity": "sha512-CNqOVceIVk3CZzm+2e7jGIRTPbE4hS6Yt3sUAgecjV8rtXDFQOWFwQ4gm6ScYnF5UKWR4xF/gxdrY0nbWVJkaA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.0.3-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-26.1.tgz",
-      "integrity": "sha512-eiERTyIGcofWJZtr7Gmy8pPBV2GjNMIy4JWYAJu7l+dNw8Vv9MGPgPWpvipPZO2Y7CclFsO/saGFbpuLlChSpQ==",
+      "version": "3.0.3-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-28.1.tgz",
+      "integrity": "sha512-HRNL46TCIE6v1trBe0Dz3Tlaq24RPm5HgjiBXXcEXvBSV5mLkExdRfvbsq8F+BQj4F/vR4nsJbxqhnS6ypdIhg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -292,9 +292,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "3.1.1-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-03-26.1.tgz",
-      "integrity": "sha512-XL9NLn7yj3UxaDKAl8p8WXyezSyB5z9DVicYM9WNVtEFD7MIH07lkaeU3hCJK7FfEiaKA6v8Xs1h+xKskHPpUQ==",
+      "version": "3.1.1-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-03-28.1.tgz",
+      "integrity": "sha512-Mkq2thjJhY7TG+2qSBy+An0bSfeUr4kgSQf+2MpXHznHxKCBpaeiO3sGGTJmQkTFXBRphrh+A/MzbR3i8ukTqw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -318,21 +318,20 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.2.2-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-26.1.tgz",
-      "integrity": "sha512-1zaYqG6jog2C0Yy/hAKgWr7PRoRhBNApa1KTqWDLVBDpzlomGYIU0+bla6+toFV/r++NFcD2a9eFTja3fzTN2A==",
+      "version": "2.2.2-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-28.1.tgz",
+      "integrity": "sha512-eA9OInBuG5U3f3v2MuphesPqNSHauIzU3jqupgj5gVSfrhQgQ0aZvA7+aAPuJNrlNa3UhdlMoyBLnTu9NRppQQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
-        "@dfinity/nns-proto": "*",
         "@dfinity/principal": "*",
         "@dfinity/utils": "*"
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.2.1-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-26.1.tgz",
-      "integrity": "sha512-AyCiGPTaaQBqRrebXzgIKAkxlGiqYMohGS5M7db6FOw9vhfbqrgLBcqnGos+eCEBNegVjcEZyd8Q/gloIHz+lA==",
+      "version": "2.2.1-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-28.1.tgz",
+      "integrity": "sha512-HUks4+wmWdNUGt4SUQwwBYbnT7mJgVwZIh4NxI8jeIxQyc1Nllx3/a8dJfoSDtkpEdVPX6O+J3eHaaKtqgn48g==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -341,9 +340,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "4.0.2-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-26.1.tgz",
-      "integrity": "sha512-XF/pXWNM02p0nh64siSo7YNf60OlOtncwUg3XDGyPG8S7/L+vzBjNxf5/91pC84WCoGDWISWiTX4gQQL4QTP7w==",
+      "version": "4.0.2-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-28.1.tgz",
+      "integrity": "sha512-qQROQvP6j763V2QSCOfMDFBRPKmCagwleFUZcUkvHFoPx0YMpR/kosTBPLK4QCcPZUIsod+6Oe2L+Rkq/wBUeQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -352,15 +351,14 @@
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
         "@dfinity/ledger-icp": "*",
-        "@dfinity/nns-proto": "*",
         "@dfinity/principal": "*",
         "@dfinity/utils": "*"
       }
     },
     "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.2-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-26.1.tgz",
-      "integrity": "sha512-U5xNYK1LjSMNp2VPOVH5KvKrwZ1w1/zmCqacju865owsYziqVbgPMONX143zK2NPI7ZdfIAD2XCrgNcuHWuIJA==",
+      "version": "1.0.2-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-28.1.tgz",
+      "integrity": "sha512-21qjOuAXyj3Ub3FsZq9fPck6Uw47BIMtGCVtehhnXb4m1FZ8+wD4z5PbrYjBGRhz/IwMPhjKDCZr96PMm4hYtg==",
       "dependencies": {
         "google-protobuf": "^3.21.2"
       }
@@ -374,9 +372,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.0.2-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-26.1.tgz",
-      "integrity": "sha512-6zlXG1KyLZSh3AnqNa4gSRVYIkpmcU1ALkVFk4LctnYKTK/8dXZ4r8qJc/SYAwweDD//hBH1XpIT/RjP+16WdA==",
+      "version": "3.0.2-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-28.1.tgz",
+      "integrity": "sha512-wIrZRvu80Nj47T6Wbsk2AUqMu2XJxPoB7gY8WzqJ90UeeOg6wEFHC2XjHI7/dOF6secdhMJEr99pxuXrWWdNQw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -389,9 +387,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.1.3-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-26.1.tgz",
-      "integrity": "sha512-bw4BRLTbXB3Aw4PJ5iCI7KyeRP6nZQ+X9MuSlxs2IF37sH6/TTsKMtWF/hQf6L0JtGrwkf7hohtsWNanaFcJMQ==",
+      "version": "2.1.3-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-28.1.tgz",
+      "integrity": "sha512-m2ZzgA1+B0zxJErYmkqxqFz5wwOtYLaaE0kP3/Rd1d8u+PPqSR2/DPp2jOtB6lVkbHsCoVSYoSbS/19hQhTccg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7047,9 +7045,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.3.1-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-26.1.tgz",
-      "integrity": "sha512-24cEfHKdWPOF4IwUWPt//2oRHthQXkvBgffmczISj1L8tgw70mZhcL0xGIfeTbH6yNC3In/FOtZJeNhkRaQahw==",
+      "version": "2.3.1-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-28.1.tgz",
+      "integrity": "sha512-CNqOVceIVk3CZzm+2e7jGIRTPbE4hS6Yt3sUAgecjV8rtXDFQOWFwQ4gm6ScYnF5UKWR4xF/gxdrY0nbWVJkaA==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7057,9 +7055,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.0.3-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-26.1.tgz",
-      "integrity": "sha512-eiERTyIGcofWJZtr7Gmy8pPBV2GjNMIy4JWYAJu7l+dNw8Vv9MGPgPWpvipPZO2Y7CclFsO/saGFbpuLlChSpQ==",
+      "version": "3.0.3-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-28.1.tgz",
+      "integrity": "sha512-HRNL46TCIE6v1trBe0Dz3Tlaq24RPm5HgjiBXXcEXvBSV5mLkExdRfvbsq8F+BQj4F/vR4nsJbxqhnS6ypdIhg==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7073,9 +7071,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "3.1.1-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-03-26.1.tgz",
-      "integrity": "sha512-XL9NLn7yj3UxaDKAl8p8WXyezSyB5z9DVicYM9WNVtEFD7MIH07lkaeU3hCJK7FfEiaKA6v8Xs1h+xKskHPpUQ==",
+      "version": "3.1.1-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-03-28.1.tgz",
+      "integrity": "sha512-Mkq2thjJhY7TG+2qSBy+An0bSfeUr4kgSQf+2MpXHznHxKCBpaeiO3sGGTJmQkTFXBRphrh+A/MzbR3i8ukTqw==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7089,30 +7087,30 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.2.2-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-26.1.tgz",
-      "integrity": "sha512-1zaYqG6jog2C0Yy/hAKgWr7PRoRhBNApa1KTqWDLVBDpzlomGYIU0+bla6+toFV/r++NFcD2a9eFTja3fzTN2A==",
+      "version": "2.2.2-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-28.1.tgz",
+      "integrity": "sha512-eA9OInBuG5U3f3v2MuphesPqNSHauIzU3jqupgj5gVSfrhQgQ0aZvA7+aAPuJNrlNa3UhdlMoyBLnTu9NRppQQ==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.2.1-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-26.1.tgz",
-      "integrity": "sha512-AyCiGPTaaQBqRrebXzgIKAkxlGiqYMohGS5M7db6FOw9vhfbqrgLBcqnGos+eCEBNegVjcEZyd8Q/gloIHz+lA==",
+      "version": "2.2.1-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-28.1.tgz",
+      "integrity": "sha512-HUks4+wmWdNUGt4SUQwwBYbnT7mJgVwZIh4NxI8jeIxQyc1Nllx3/a8dJfoSDtkpEdVPX6O+J3eHaaKtqgn48g==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "4.0.2-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-26.1.tgz",
-      "integrity": "sha512-XF/pXWNM02p0nh64siSo7YNf60OlOtncwUg3XDGyPG8S7/L+vzBjNxf5/91pC84WCoGDWISWiTX4gQQL4QTP7w==",
+      "version": "4.0.2-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-28.1.tgz",
+      "integrity": "sha512-qQROQvP6j763V2QSCOfMDFBRPKmCagwleFUZcUkvHFoPx0YMpR/kosTBPLK4QCcPZUIsod+6Oe2L+Rkq/wBUeQ==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
       }
     },
     "@dfinity/nns-proto": {
-      "version": "1.0.2-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-26.1.tgz",
-      "integrity": "sha512-U5xNYK1LjSMNp2VPOVH5KvKrwZ1w1/zmCqacju865owsYziqVbgPMONX143zK2NPI7ZdfIAD2XCrgNcuHWuIJA==",
+      "version": "1.0.2-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-28.1.tgz",
+      "integrity": "sha512-21qjOuAXyj3Ub3FsZq9fPck6Uw47BIMtGCVtehhnXb4m1FZ8+wD4z5PbrYjBGRhz/IwMPhjKDCZr96PMm4hYtg==",
       "requires": {
         "google-protobuf": "^3.21.2"
       }
@@ -7126,17 +7124,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.0.2-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-26.1.tgz",
-      "integrity": "sha512-6zlXG1KyLZSh3AnqNa4gSRVYIkpmcU1ALkVFk4LctnYKTK/8dXZ4r8qJc/SYAwweDD//hBH1XpIT/RjP+16WdA==",
+      "version": "3.0.2-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-28.1.tgz",
+      "integrity": "sha512-wIrZRvu80Nj47T6Wbsk2AUqMu2XJxPoB7gY8WzqJ90UeeOg6wEFHC2XjHI7/dOF6secdhMJEr99pxuXrWWdNQw==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.1.3-next-2024-03-26.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-26.1.tgz",
-      "integrity": "sha512-bw4BRLTbXB3Aw4PJ5iCI7KyeRP6nZQ+X9MuSlxs2IF37sH6/TTsKMtWF/hQf6L0JtGrwkf7hohtsWNanaFcJMQ==",
+      "version": "2.1.3-next-2024-03-28.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-28.1.tgz",
+      "integrity": "sha512-m2ZzgA1+B0zxJErYmkqxqFz5wwOtYLaaE0kP3/Rd1d8u+PPqSR2/DPp2jOtB6lVkbHsCoVSYoSbS/19hQhTccg==",
       "requires": {}
     },
     "@esbuild/android-arm": {


### PR DESCRIPTION
# Motivation

We removed the requirement to depend on protocol buffers for hardware wallet transactions from ic-js.

The actual removal of the nns-proto dependency will be done in a separate PR to keep this PR clean.
But the effect is present with this PR as it reduces the compressed WASM size by ~80KB.

# Changes

Run `npm upgrade:next`

# Tests

Manually tested that the following still work with hardware wallet:
* transfer
* listNeurons
* increaseDissolveDelay
* startDissolving
* stopDissolving
* disburse
* spawnNeuron
* addHotkey
* removeHotkey

The following don't seem to be available in the NNS dapp UI so I didn't test them manually:
* joinCommunityFund
* mergeMaturity

# Todos

- [x] Add entry to changelog (if necessary).
