### PR TITLE
NNS1-2887: Remove dependency on @dfinity/nns-proto

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,6 @@
         "@dfinity/ledger-icp": "next",
         "@dfinity/ledger-icrc": "next",
         "@dfinity/nns": "next",
-        "@dfinity/nns-proto": "next",
         "@dfinity/principal": "^1.0.1",
         "@dfinity/sns": "next",
         "@dfinity/utils": "next",
@@ -353,14 +352,6 @@
         "@dfinity/ledger-icp": "*",
         "@dfinity/principal": "*",
         "@dfinity/utils": "*"
-      }
-    },
-    "node_modules/@dfinity/nns-proto": {
-      "version": "1.0.2-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-28.1.tgz",
-      "integrity": "sha512-21qjOuAXyj3Ub3FsZq9fPck6Uw47BIMtGCVtehhnXb4m1FZ8+wD4z5PbrYjBGRhz/IwMPhjKDCZr96PMm4hYtg==",
-      "dependencies": {
-        "google-protobuf": "^3.21.2"
       }
     },
     "node_modules/@dfinity/principal": {
@@ -3677,11 +3668,6 @@
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
       "dev": true
-    },
-    "node_modules/google-protobuf": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -7107,14 +7093,6 @@
         "randombytes": "^2.1.0"
       }
     },
-    "@dfinity/nns-proto": {
-      "version": "1.0.2-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns-proto/-/nns-proto-1.0.2-next-2024-03-28.1.tgz",
-      "integrity": "sha512-21qjOuAXyj3Ub3FsZq9fPck6Uw47BIMtGCVtehhnXb4m1FZ8+wD4z5PbrYjBGRhz/IwMPhjKDCZr96PMm4hYtg==",
-      "requires": {
-        "google-protobuf": "^3.21.2"
-      }
-    },
     "@dfinity/principal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.0.1.tgz",
@@ -9414,11 +9392,6 @@
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
       "dev": true
-    },
-    "google-protobuf": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
     },
     "gopd": {
       "version": "1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,9 +19,9 @@
     "test": "tsc --noEmit -p ./tsconfig.spec.json && npm run vitest",
     "vitest": "TZ=UTC vitest --config ./vitest.config.ts",
     "test-e2e": "tsc --noEmit -p src/tests/e2e/tsconfig.json && playwright test",
-    "update:agent": "npm rm @dfinity/agent @dfinity/auth-client @dfinity/candid @dfinity/identity @dfinity/principal @dfinity/nns @dfinity/nns-proto @dfinity/cmc @dfinity/sns @dfinity/utils @dfinity/ledger-icrc @dfinity/ledger-icp @dfinity/ckbtc @dfinity/ic-management && npm i @dfinity/agent @dfinity/auth-client @dfinity/candid @dfinity/identity @dfinity/principal @dfinity/utils@next @dfinity/ledger-icrc@next @dfinity/ledger-icp@next @dfinity/nns@next @dfinity/nns-proto@next @dfinity/cmc@next @dfinity/sns@next @dfinity/ckbtc@next @dfinity/ic-management@next && ../scripts/revert-next.sh",
+    "update:agent": "npm rm @dfinity/agent @dfinity/auth-client @dfinity/candid @dfinity/identity @dfinity/principal @dfinity/nns @dfinity/cmc @dfinity/sns @dfinity/utils @dfinity/ledger-icrc @dfinity/ledger-icp @dfinity/ckbtc @dfinity/ic-management && npm i @dfinity/agent @dfinity/auth-client @dfinity/candid @dfinity/identity @dfinity/principal @dfinity/utils@next @dfinity/ledger-icrc@next @dfinity/ledger-icp@next @dfinity/nns@next @dfinity/cmc@next @dfinity/sns@next @dfinity/ckbtc@next @dfinity/ic-management@next && ../scripts/revert-next.sh",
     "update:gix": "npm update @dfinity/gix-components",
-    "upgrade:next": "npm rm @dfinity/nns @dfinity/nns-proto @dfinity/cmc @dfinity/sns @dfinity/utils @dfinity/ledger-icrc @dfinity/ledger-icp @dfinity/ckbtc @dfinity/ic-management && npm i @dfinity/nns@next @dfinity/nns-proto@next @dfinity/cmc@next @dfinity/sns@next @dfinity/utils@next @dfinity/ledger-icrc@next @dfinity/ledger-icp@next @dfinity/ckbtc@next @dfinity/ic-management@next && ../scripts/revert-next.sh",
+    "upgrade:next": "npm rm @dfinity/nns @dfinity/cmc @dfinity/sns @dfinity/utils @dfinity/ledger-icrc @dfinity/ledger-icp @dfinity/ckbtc @dfinity/ic-management && npm i @dfinity/nns@next @dfinity/cmc@next @dfinity/sns@next @dfinity/utils@next @dfinity/ledger-icrc@next @dfinity/ledger-icp@next @dfinity/ckbtc@next @dfinity/ic-management@next && ../scripts/revert-next.sh",
     "start:snapshot": "../scripts/dfx-snapshot-start --snapshot ~/snapshot.tar.xz "
   },
   "engines": {
@@ -73,7 +73,6 @@
     "@dfinity/ledger-icp": "next",
     "@dfinity/ledger-icrc": "next",
     "@dfinity/nns": "next",
-    "@dfinity/nns-proto": "next",
     "@dfinity/principal": "^1.0.1",
     "@dfinity/sns": "next",
     "@dfinity/utils": "next",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,7 +20,6 @@ const config: UserConfig = {
           const folder = dirname(id);
 
           const lazy = [
-            "@dfinity/nns-proto",
             "html5-qrcode",
             "qr-creator",
             "@ledgerhq",


### PR DESCRIPTION
# Motivation

`@dfinity/nns-proto` is no longer required as a peer dependency for `@dfinity/ledger-icp` and `@dfinity/nns`.

# Changes

Remove all remaining references to `nns-proto` from `nns-dapp`.
1. Ran `npm uninstall @dfinity/nns-proto`
2. Removed `@dfinity/nns-proto` from npm `update:agent` and `upgrade:next` commands.
3. Removed handling of `@dfinity/nns-proto` from chunking configuration.

# Tests

Tested manually that hardware wallet operations still work.

# Todos

- [ ] Add entry to changelog (if necessary).
covered