### PR TITLE
Don't sign read-state separately for HW neuron staking

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -31,6 +31,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Make token table rows always clickable. A few edge cases were missing.
+* Don't require double hardware approval on neuron staking.
 
 #### Security
 

--- a/frontend/src/lib/identities/ledger.identity.ts
+++ b/frontend/src/lib/identities/ledger.identity.ts
@@ -404,9 +404,7 @@ export class LedgerIdentity extends SignIdentity {
       }
     }
 
-    // There is an issue with the Ledger App when the neuron flag is set to true and `signWithReadState`.
-    // TODO: Check app version and use `signWithReadState` only if the app version has the issue fixed.
-    if (request.endpoint === "call" && !this.neuronStakeFlag) {
+    if (request.endpoint === "call") {
       return this.createSignAndStoreCallRequests(request);
     }
 

--- a/frontend/src/tests/lib/identities/ledger.identity.spec.ts
+++ b/frontend/src/tests/lib/identities/ledger.identity.spec.ts
@@ -116,18 +116,18 @@ describe("LedgerIdentity", () => {
     expect(readRequest.endpoint).toBe("read_state");
   });
 
-  it("should call to sign read state request after signing call request if neuron flag is set", async () => {
+  it("should not call to sign read state request after signing call request if neuron flag is set", async () => {
     const identity = await LedgerIdentity.create();
 
     identity.flagUpcomingStakeNeuron();
     const request = await identity.transformRequest(mockHttpRequest1);
-    expect(mockLedgerApp.signUpdateCall).toHaveBeenCalledTimes(0);
-    expect(mockLedgerApp.sign).toHaveBeenCalledTimes(1);
+    expect(mockLedgerApp.signUpdateCall).toHaveBeenCalledTimes(1);
+    expect(mockLedgerApp.sign).toHaveBeenCalledTimes(0);
     expect(request.endpoint).toBe("call");
 
     const readRequest = await identity.transformRequest(mockReadStateRequest1);
-    expect(mockLedgerApp.signUpdateCall).toHaveBeenCalledTimes(0);
-    expect(mockLedgerApp.sign).toHaveBeenCalledTimes(2);
+    expect(mockLedgerApp.signUpdateCall).toHaveBeenCalledTimes(1);
+    expect(mockLedgerApp.sign).toHaveBeenCalledTimes(0);
     expect(readRequest.endpoint).toBe("read_state");
   });
 


### PR DESCRIPTION
# Motivation

In the past, when using a Ledger hardware wallet, you always had approve twice because the read_state call had to be signed separately.
Then functionality was added such that both requests could be signed with a single approval.
But there was a bug in the neuron staking flow so just neuron staking still required 2 approvals.
This was fixed in the Ledger app at some point.
So now that we always require version 2.4.9 of higher, we don't need to ask for double approval anymore and also don't need to have this depend on the Ledger app version.

# Changes

Remove the special case for neuron staking and just always sign the read_state request together with the call request.

# Tests

Unit test was adjusted.
Also tested manually.

# Todos

- [x] Add entry to changelog (if necessary).
