### PR TITLE
Update snsdemo to release-2024-03-27

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -355,7 +355,7 @@
         "BINSTALL_VERSION": "1.3.0",
         "DIDC_VERSION": "2024-02-27",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2024-03-20",
+        "SNSDEMO_RELEASE": "release-2024-03-27",
         "IC_COMMIT": "release-2024-03-14_23-01-p2p"
       },
       "packtool": ""


### PR DESCRIPTION
# Motivation
We would like to keep the testing environment, provided by snsdemo, up to date.

# Changes
* Updated `snsdemo` version in `dfx.json`.

# Tests
CI should pass.