### PR TITLE
NNS1-2992: Install xz in reproducible-assets.yaml

### DIFF
--- a/.github/workflows/reproducible-assets.yaml
+++ b/.github/workflows/reproducible-assets.yaml
@@ -18,8 +18,7 @@ jobs:
             brew install jq
             brew install coreutils
             brew install gzip
-            brew install xz@5.4.5
-            brew link --overwrite --force xz@5.4.5
+            brew install xz
             echo "/usr/local/bin" >> $GITHUB_PATH
             echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
           fi

--- a/.github/workflows/reproducible-assets.yaml
+++ b/.github/workflows/reproducible-assets.yaml
@@ -18,6 +18,8 @@ jobs:
             brew install jq
             brew install coreutils
             brew install gzip
+            brew install xz@5.4.5
+            brew link --overwrite --force xz@5.4.5
             echo "/usr/local/bin" >> $GITHUB_PATH
             echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
           fi

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -52,4 +52,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Reinstall xz in reproducible assets workflow to get consistent archives.
+
 #### Security


### PR DESCRIPTION
# Motivation

Our asset builds on MacOS 13 started to result in different hashes from the same build on other OSes.
It turned out that while the `.tar.xz` files were different, the `.tar` files were identical.
Looking at the versions, I discovered that on MacOS 13, GitHub gives us version 5.6.1 of xz by default.
This version is actually compromised. See https://nvd.nist.gov/vuln/detail/CVE-2024-3094
By running `brew install xz` we actually downgrade to version 5.4.6, which produces the same hash as version 5.4.5 which we get by default on MacOS 12.

# Changes

Run `brew install xz` when running on MacOS before building the frontend in `reproducible-assets.yaml`.

# Tests

The reproducible assets workflow passes again: https://github.com/dfinity/nns-dapp/actions/runs/8519799063/job/23334582917

# Todos

- [x] Add entry to changelog (if necessary).
