### PR TITLE
Bump ic-js next

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -250,9 +250,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.3.1-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-28.1.tgz",
-      "integrity": "sha512-CNqOVceIVk3CZzm+2e7jGIRTPbE4hS6Yt3sUAgecjV8rtXDFQOWFwQ4gm6ScYnF5UKWR4xF/gxdrY0nbWVJkaA==",
+      "version": "2.3.1-next-2024-04-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-04-03.1.tgz",
+      "integrity": "sha512-CEFa9/9b6otpsxPONm4mozEpl5bP9FsP9pKSYrsECYnk+SVJjl4aSc4prxUPCZrr0IGuXhW50J4slquafbUv3Q==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -266,9 +266,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.0.3-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-28.1.tgz",
-      "integrity": "sha512-HRNL46TCIE6v1trBe0Dz3Tlaq24RPm5HgjiBXXcEXvBSV5mLkExdRfvbsq8F+BQj4F/vR4nsJbxqhnS6ypdIhg==",
+      "version": "3.0.3-next-2024-04-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-04-03.1.tgz",
+      "integrity": "sha512-ihugp0Bt8iMdVNkt29tNn2ODCONl1u7hM2uNCmUJJUSFzZ2An9whjuO/glfwJUXMlQQqM7l/jwuw9GziTkzYQQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -291,9 +291,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "3.1.1-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-03-28.1.tgz",
-      "integrity": "sha512-Mkq2thjJhY7TG+2qSBy+An0bSfeUr4kgSQf+2MpXHznHxKCBpaeiO3sGGTJmQkTFXBRphrh+A/MzbR3i8ukTqw==",
+      "version": "3.1.1-next-2024-04-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-04-03.1.tgz",
+      "integrity": "sha512-AW9+/8cu9jsx/+FxN8RsH1kyEdYBRRQYhTf+fwsk23vHP/Ij9AFtwdfr8KqMtaZxYwdjURtFZjGBTNngpmfPYA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -317,9 +317,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.2.2-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-28.1.tgz",
-      "integrity": "sha512-eA9OInBuG5U3f3v2MuphesPqNSHauIzU3jqupgj5gVSfrhQgQ0aZvA7+aAPuJNrlNa3UhdlMoyBLnTu9NRppQQ==",
+      "version": "2.2.2-next-2024-04-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-04-03.1.tgz",
+      "integrity": "sha512-CE5XEXx8lwpYSoK+dTQyAWtra+2IK3+obpYfhxMrMKhiw2dNSL+/h5hilzfBccm3Kx4xMjzMUUaMcZ9moA58Qw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -328,9 +328,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.2.1-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-28.1.tgz",
-      "integrity": "sha512-HUks4+wmWdNUGt4SUQwwBYbnT7mJgVwZIh4NxI8jeIxQyc1Nllx3/a8dJfoSDtkpEdVPX6O+J3eHaaKtqgn48g==",
+      "version": "2.2.1-next-2024-04-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-04-03.1.tgz",
+      "integrity": "sha512-mLGYhZLsZReJVHYL31g1IJp49oqCiNePpKvgjCJRDaQ7sN9ry7B/L26bDdmQz0CsI05EGzejyLiaHzIDV94QUg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -339,9 +339,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "4.0.2-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-28.1.tgz",
-      "integrity": "sha512-qQROQvP6j763V2QSCOfMDFBRPKmCagwleFUZcUkvHFoPx0YMpR/kosTBPLK4QCcPZUIsod+6Oe2L+Rkq/wBUeQ==",
+      "version": "4.0.2-next-2024-04-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-04-03.1.tgz",
+      "integrity": "sha512-2L7KMeJcCLopIibbYDDHHDqOlf0Mcj+6e/eQbjTVRxbepWziWwHO5mFplBT9VpK9D3TbqN1V0UGnxTMOlbdqCw==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -363,9 +363,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.0.2-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-28.1.tgz",
-      "integrity": "sha512-wIrZRvu80Nj47T6Wbsk2AUqMu2XJxPoB7gY8WzqJ90UeeOg6wEFHC2XjHI7/dOF6secdhMJEr99pxuXrWWdNQw==",
+      "version": "3.0.2-next-2024-04-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-04-03.1.tgz",
+      "integrity": "sha512-oNrEFUylWCuBVxvBSMXeJCs2t8vODFuJ6oGscvXtMqwjU92l+FMh9ET9fqzMi5nVH2+Sm0hsSP3O9Hjl1wyOVQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -378,9 +378,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.1.3-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-28.1.tgz",
-      "integrity": "sha512-m2ZzgA1+B0zxJErYmkqxqFz5wwOtYLaaE0kP3/Rd1d8u+PPqSR2/DPp2jOtB6lVkbHsCoVSYoSbS/19hQhTccg==",
+      "version": "2.1.3-next-2024-04-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-04-03.1.tgz",
+      "integrity": "sha512-8eWvi1MVg8BuT3OozLRLiM+eLc6DRHJSt67iO9U94sb/0zTXrqrmxuFtldpRfnCrfgm05OsPu67vfON4skeoHA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7031,9 +7031,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.3.1-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-03-28.1.tgz",
-      "integrity": "sha512-CNqOVceIVk3CZzm+2e7jGIRTPbE4hS6Yt3sUAgecjV8rtXDFQOWFwQ4gm6ScYnF5UKWR4xF/gxdrY0nbWVJkaA==",
+      "version": "2.3.1-next-2024-04-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-04-03.1.tgz",
+      "integrity": "sha512-CEFa9/9b6otpsxPONm4mozEpl5bP9FsP9pKSYrsECYnk+SVJjl4aSc4prxUPCZrr0IGuXhW50J4slquafbUv3Q==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7041,9 +7041,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.0.3-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-03-28.1.tgz",
-      "integrity": "sha512-HRNL46TCIE6v1trBe0Dz3Tlaq24RPm5HgjiBXXcEXvBSV5mLkExdRfvbsq8F+BQj4F/vR4nsJbxqhnS6ypdIhg==",
+      "version": "3.0.3-next-2024-04-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-04-03.1.tgz",
+      "integrity": "sha512-ihugp0Bt8iMdVNkt29tNn2ODCONl1u7hM2uNCmUJJUSFzZ2An9whjuO/glfwJUXMlQQqM7l/jwuw9GziTkzYQQ==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7057,9 +7057,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "3.1.1-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-03-28.1.tgz",
-      "integrity": "sha512-Mkq2thjJhY7TG+2qSBy+An0bSfeUr4kgSQf+2MpXHznHxKCBpaeiO3sGGTJmQkTFXBRphrh+A/MzbR3i8ukTqw==",
+      "version": "3.1.1-next-2024-04-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-04-03.1.tgz",
+      "integrity": "sha512-AW9+/8cu9jsx/+FxN8RsH1kyEdYBRRQYhTf+fwsk23vHP/Ij9AFtwdfr8KqMtaZxYwdjURtFZjGBTNngpmfPYA==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7073,21 +7073,21 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.2.2-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-03-28.1.tgz",
-      "integrity": "sha512-eA9OInBuG5U3f3v2MuphesPqNSHauIzU3jqupgj5gVSfrhQgQ0aZvA7+aAPuJNrlNa3UhdlMoyBLnTu9NRppQQ==",
+      "version": "2.2.2-next-2024-04-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-04-03.1.tgz",
+      "integrity": "sha512-CE5XEXx8lwpYSoK+dTQyAWtra+2IK3+obpYfhxMrMKhiw2dNSL+/h5hilzfBccm3Kx4xMjzMUUaMcZ9moA58Qw==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.2.1-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-03-28.1.tgz",
-      "integrity": "sha512-HUks4+wmWdNUGt4SUQwwBYbnT7mJgVwZIh4NxI8jeIxQyc1Nllx3/a8dJfoSDtkpEdVPX6O+J3eHaaKtqgn48g==",
+      "version": "2.2.1-next-2024-04-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-04-03.1.tgz",
+      "integrity": "sha512-mLGYhZLsZReJVHYL31g1IJp49oqCiNePpKvgjCJRDaQ7sN9ry7B/L26bDdmQz0CsI05EGzejyLiaHzIDV94QUg==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "4.0.2-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-03-28.1.tgz",
-      "integrity": "sha512-qQROQvP6j763V2QSCOfMDFBRPKmCagwleFUZcUkvHFoPx0YMpR/kosTBPLK4QCcPZUIsod+6Oe2L+Rkq/wBUeQ==",
+      "version": "4.0.2-next-2024-04-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-04-03.1.tgz",
+      "integrity": "sha512-2L7KMeJcCLopIibbYDDHHDqOlf0Mcj+6e/eQbjTVRxbepWziWwHO5mFplBT9VpK9D3TbqN1V0UGnxTMOlbdqCw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -7102,17 +7102,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.0.2-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-03-28.1.tgz",
-      "integrity": "sha512-wIrZRvu80Nj47T6Wbsk2AUqMu2XJxPoB7gY8WzqJ90UeeOg6wEFHC2XjHI7/dOF6secdhMJEr99pxuXrWWdNQw==",
+      "version": "3.0.2-next-2024-04-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-04-03.1.tgz",
+      "integrity": "sha512-oNrEFUylWCuBVxvBSMXeJCs2t8vODFuJ6oGscvXtMqwjU92l+FMh9ET9fqzMi5nVH2+Sm0hsSP3O9Hjl1wyOVQ==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.1.3-next-2024-03-28.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-03-28.1.tgz",
-      "integrity": "sha512-m2ZzgA1+B0zxJErYmkqxqFz5wwOtYLaaE0kP3/Rd1d8u+PPqSR2/DPp2jOtB6lVkbHsCoVSYoSbS/19hQhTccg==",
+      "version": "2.1.3-next-2024-04-03.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-04-03.1.tgz",
+      "integrity": "sha512-8eWvi1MVg8BuT3OozLRLiM+eLc6DRHJSt67iO9U94sb/0zTXrqrmxuFtldpRfnCrfgm05OsPu67vfON4skeoHA==",
       "requires": {}
     },
     "@esbuild/android-arm": {


### PR DESCRIPTION
# Motivation

Bump ic-js next which contains the [PR](https://github.com/dfinity/ic-js/pull/585) that bumps did files and the xdr_conversion_rate and neurons fund economics for NNS governance in nns-js.

# Changes

- `npm run upgrade:next`
