### PR TITLE
Update IC candid files to release-2024-03-27_23-01-p2p

### DIFF
--- a/declarations/nns_governance/nns_governance.did
+++ b/declarations/nns_governance/nns_governance.did
@@ -1,5 +1,5 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-14_23-01-p2p/rs/nns/governance/canister/governance.did>
-type AccountIdentifier = record { hash : vec nat8 };
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-27_23-01-p2p/rs/nns/governance/canister/governance.did>
+type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
   ManageNeuron : ManageNeuron;
@@ -34,7 +34,7 @@ type CanisterStatusResultV2 = record {
   memory_size : opt nat64;
   cycles : opt nat64;
   idle_cycles_burned_per_day : opt nat64;
-  module_hash : vec nat8;
+  module_hash : blob;
 };
 type CanisterSummary = record {
   status : opt CanisterStatusResultV2;
@@ -148,7 +148,7 @@ type DissolveState = variant {
   WhenDissolvedTimestampSeconds : nat64;
 };
 type Duration = record { seconds : opt nat64 };
-type ExecuteNnsFunction = record { nns_function : int32; payload : vec nat8 };
+type ExecuteNnsFunction = record { nns_function : int32; payload : blob };
 type Follow = record { topic : int32; followees : vec NeuronId };
 type Followees = record { followees : vec NeuronId };
 type Followers = record { followers : vec NeuronId };
@@ -344,7 +344,7 @@ type Neuron = record {
   auto_stake_maturity : opt bool;
   aging_since_timestamp_seconds : nat64;
   hot_keys : vec principal;
-  account : vec nat8;
+  account : blob;
   joined_community_fund_timestamp_seconds : opt nat64;
   dissolve_state : opt DissolveState;
   followees : vec record { int32; Followees };
@@ -369,10 +369,7 @@ type NeuronDistribution = record {
   stake : opt Tokens;
 };
 type NeuronId = record { id : nat64 };
-type NeuronIdOrSubaccount = variant {
-  Subaccount : vec nat8;
-  NeuronId : NeuronId;
-};
+type NeuronIdOrSubaccount = variant { Subaccount : blob; NeuronId : NeuronId };
 type NeuronInFlightCommand = record {
   command : opt Command_2;
   timestamp : nat64;
@@ -391,11 +388,11 @@ type NeuronInfo = record {
   age_seconds : nat64;
 };
 type NeuronStakeTransfer = record {
-  to_subaccount : vec nat8;
+  to_subaccount : blob;
   neuron_stake_e8s : nat64;
   from : opt principal;
   memo : nat64;
-  from_subaccount : vec nat8;
+  from_subaccount : blob;
   transfer_timestamp : nat64;
   block_height : nat64;
 };

--- a/declarations/nns_ledger/nns_ledger.did
+++ b/declarations/nns_ledger/nns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-14_23-01-p2p/rs/rosetta-api/icp_ledger/ledger.did>
+//! Candid for canister `nns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-27_23-01-p2p/rs/rosetta-api/icp_ledger/ledger.did>
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.

--- a/declarations/nns_registry/nns_registry.did
+++ b/declarations/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-14_23-01-p2p/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-27_23-01-p2p/rs/registry/canister/canister/registry.did>
 type AddApiBoundaryNodePayload = record { node_id : principal; version : text };
 type AddFirewallRulesPayload = record {
   expected_hash : text;
@@ -17,15 +17,15 @@ type AddNodeOperatorPayload = record {
 type AddNodePayload = record {
   prometheus_metrics_endpoint : text;
   http_endpoint : text;
-  idkg_dealing_encryption_pk : opt vec nat8;
+  idkg_dealing_encryption_pk : opt blob;
   domain : opt text;
   public_ipv4_config : opt IPv4Config;
   xnet_endpoint : text;
-  chip_id : opt vec nat8;
-  committee_signing_pk : vec nat8;
-  node_signing_pk : vec nat8;
-  transport_tls_cert : vec nat8;
-  ni_dkg_dealing_encryption_pk : vec nat8;
+  chip_id : opt blob;
+  committee_signing_pk : blob;
+  node_signing_pk : blob;
+  transport_tls_cert : blob;
+  ni_dkg_dealing_encryption_pk : blob;
   p2p_flow_endpoints : vec text;
 };
 type AddNodesToSubnetPayload = record {
@@ -141,10 +141,10 @@ type IPv4Config = record {
 };
 type NodeOperatorRecord = record {
   ipv6 : opt text;
-  node_operator_principal_id : vec nat8;
+  node_operator_principal_id : blob;
   node_allowance : nat64;
   rewardable_nodes : vec record { text; nat32 };
-  node_provider_principal_id : vec nat8;
+  node_provider_principal_id : blob;
   dc_id : text;
 };
 type NodeProvidersMonthlyXdrRewards = record {
@@ -166,7 +166,7 @@ type RecoverSubnetPayload = record {
   subnet_id : principal;
   registry_store_uri : opt record { text; text; nat64 };
   ecdsa_config : opt EcdsaInitialConfig;
-  state_hash : vec nat8;
+  state_hash : blob;
   time_ns : nat64;
 };
 type RemoveApiBoundaryNodesPayload = record { node_ids : vec principal };
@@ -177,7 +177,7 @@ type RemoveFirewallRulesPayload = record {
 };
 type RemoveNodeDirectlyPayload = record { node_id : principal };
 type RemoveNodeOperatorsPayload = record {
-  node_operators_to_remove : vec vec nat8;
+  node_operators_to_remove : vec blob;
 };
 type RemoveNodesPayload = record { node_ids : vec principal };
 type RerouteCanisterRangesPayload = record {
@@ -185,14 +185,13 @@ type RerouteCanisterRangesPayload = record {
   reassigned_canister_ranges : vec CanisterIdRange;
   destination_subnet : principal;
 };
-type Result = variant { Ok : principal; Err : text };
-type Result_1 = variant { Ok; Err : text };
-type Result_2 = variant {
+type Result = variant {
   Ok : vec record { DataCenterRecord; NodeOperatorRecord };
   Err : text;
 };
-type Result_3 = variant { Ok : NodeProvidersMonthlyXdrRewards; Err : text };
-type Result_4 = variant { Ok : GetSubnetForCanisterResponse; Err : text };
+type Result_1 = variant { Ok : NodeProvidersMonthlyXdrRewards; Err : text };
+type Result_2 = variant { Ok : GetSubnetForCanisterResponse; Err : text };
+type Result_3 = variant { Ok; Err : text };
 type RetireReplicaVersionPayload = record { replica_version_ids : vec text };
 type SetFirewallConfigPayload = record {
   ipv4_prefixes : vec text;
@@ -223,7 +222,7 @@ type UpdateElectedReplicaVersionsPayload = record {
   release_package_sha256_hex : opt text;
 };
 type UpdateNodeDirectlyPayload = record {
-  idkg_dealing_encryption_pk : opt vec nat8;
+  idkg_dealing_encryption_pk : opt blob;
 };
 type UpdateNodeDomainDirectlyPayload = record {
   node_id : principal;
@@ -297,23 +296,21 @@ type UpdateUnassignedNodesConfigPayload = record {
 service : {
   add_api_boundary_node : (AddApiBoundaryNodePayload) -> ();
   add_firewall_rules : (AddFirewallRulesPayload) -> ();
-  add_node : (AddNodePayload) -> (Result);
+  add_node : (AddNodePayload) -> (principal);
   add_node_operator : (AddNodeOperatorPayload) -> ();
   add_nodes_to_subnet : (AddNodesToSubnetPayload) -> ();
   add_or_remove_data_centers : (AddOrRemoveDataCentersProposalPayload) -> ();
   bless_replica_version : (BlessReplicaVersionPayload) -> ();
   change_subnet_membership : (ChangeSubnetMembershipPayload) -> ();
   clear_provisional_whitelist : () -> ();
-  complete_canister_migration : (CompleteCanisterMigrationPayload) -> (
-      Result_1,
-    );
+  complete_canister_migration : (CompleteCanisterMigrationPayload) -> ();
   create_subnet : (CreateSubnetPayload) -> ();
   delete_subnet : (DeleteSubnetPayload) -> ();
   get_build_metadata : () -> (text) query;
-  get_node_operators_and_dcs_of_node_provider : (principal) -> (Result_2) query;
-  get_node_providers_monthly_xdr_rewards : () -> (Result_3) query;
-  get_subnet_for_canister : (GetSubnetForCanisterRequest) -> (Result_4) query;
-  prepare_canister_migration : (PrepareCanisterMigrationPayload) -> (Result_1);
+  get_node_operators_and_dcs_of_node_provider : (principal) -> (Result) query;
+  get_node_providers_monthly_xdr_rewards : () -> (Result_1) query;
+  get_subnet_for_canister : (GetSubnetForCanisterRequest) -> (Result_2) query;
+  prepare_canister_migration : (PrepareCanisterMigrationPayload) -> ();
   recover_subnet : (RecoverSubnetPayload) -> ();
   remove_api_boundary_nodes : (RemoveApiBoundaryNodesPayload) -> ();
   remove_firewall_rules : (RemoveFirewallRulesPayload) -> ();
@@ -321,7 +318,7 @@ service : {
   remove_node_operators : (RemoveNodeOperatorsPayload) -> ();
   remove_nodes : (RemoveNodesPayload) -> ();
   remove_nodes_from_subnet : (RemoveNodesPayload) -> ();
-  reroute_canister_ranges : (RerouteCanisterRangesPayload) -> (Result_1);
+  reroute_canister_ranges : (RerouteCanisterRangesPayload) -> ();
   retire_replica_version : (RetireReplicaVersionPayload) -> ();
   set_firewall_config : (SetFirewallConfigPayload) -> ();
   update_api_boundary_nodes_version : (
@@ -330,10 +327,10 @@ service : {
   update_elected_hostos_versions : (UpdateElectedHostosVersionsPayload) -> ();
   update_elected_replica_versions : (UpdateElectedReplicaVersionsPayload) -> ();
   update_firewall_rules : (AddFirewallRulesPayload) -> ();
-  update_node_directly : (UpdateNodeDirectlyPayload) -> (Result_1);
-  update_node_domain_directly : (UpdateNodeDomainDirectlyPayload) -> (Result_1);
+  update_node_directly : (UpdateNodeDirectlyPayload) -> ();
+  update_node_domain_directly : (UpdateNodeDomainDirectlyPayload) -> (Result_3);
   update_node_ipv4_config_directly : (UpdateNodeIPv4ConfigDirectlyPayload) -> (
-      Result_1,
+      Result_3,
     );
   update_node_operator_config : (UpdateNodeOperatorConfigPayload) -> ();
   update_node_operator_config_directly : (

--- a/declarations/sns_governance/sns_governance.did
+++ b/declarations/sns_governance/sns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-14_23-01-p2p/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-27_23-01-p2p/rs/sns/governance/canister/governance.did>
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
@@ -18,7 +18,8 @@ type Action = variant {
   Motion : Motion;
 };
 type ActionAuxiliary = variant {
-  TransferSnsTreasuryFunds : TransferSnsTreasuryFundsActionAuxiliary;
+  TransferSnsTreasuryFunds : MintSnsTokensActionAuxiliary;
+  MintSnsTokens : MintSnsTokensActionAuxiliary;
 };
 type AddNeuronPermissions = record {
   permissions_to_add : opt NeuronPermissionList;
@@ -40,7 +41,7 @@ type CanisterStatusResultV2 = record {
   cycles : nat;
   settings : DefiniteCanisterSettingsArgs;
   idle_cycles_burned_per_day : nat;
-  module_hash : opt vec nat8;
+  module_hash : opt blob;
 };
 type CanisterStatusType = variant { stopped; stopping; running };
 type ChangeAutoStakeMaturity = record {
@@ -135,7 +136,7 @@ type DissolveState = variant {
 };
 type ExecuteGenericNervousSystemFunction = record {
   function_id : nat64;
-  payload : vec nat8;
+  payload : blob;
 };
 type FinalizeDisburseMaturity = record {
   amount_to_be_disbursed_e8s : nat64;
@@ -245,7 +246,7 @@ type ManageDappCanisterSettings = record {
   compute_allocation : opt nat64;
 };
 type ManageLedgerParameters = record { transfer_fee : opt nat64 };
-type ManageNeuron = record { subaccount : vec nat8; command : opt Command };
+type ManageNeuron = record { subaccount : blob; command : opt Command };
 type ManageNeuronResponse = record { command : opt Command_1 };
 type ManageSnsMetadata = record {
   url : opt text;
@@ -269,6 +270,7 @@ type MintSnsTokens = record {
   memo : opt nat64;
   amount_e8s : opt nat64;
 };
+type MintSnsTokensActionAuxiliary = record { valuation : opt Valuation };
 type Motion = record { motion_text : text };
 type NervousSystemFunction = record {
   id : nat64;
@@ -315,7 +317,7 @@ type Neuron = record {
   followees : vec record { nat64; Followees };
   neuron_fees_e8s : nat64;
 };
-type NeuronId = record { id : vec nat8 };
+type NeuronId = record { id : blob };
 type NeuronInFlightCommand = record {
   command : opt Command_2;
   timestamp : nat64;
@@ -398,7 +400,7 @@ type StakeMaturityResponse = record {
   maturity_e8s : nat64;
   staked_maturity_e8s : nat64;
 };
-type Subaccount = record { subaccount : vec nat8 };
+type Subaccount = record { subaccount : blob };
 type SwapNeuron = record { id : opt NeuronId; status : int32 };
 type Tally = record {
   no : nat64;
@@ -414,9 +416,6 @@ type TransferSnsTreasuryFunds = record {
   memo : opt nat64;
   amount_e8s : nat64;
 };
-type TransferSnsTreasuryFundsActionAuxiliary = record {
-  valuation : opt Valuation;
-};
 type UpgradeInProgress = record {
   mark_failed_at_seconds : nat64;
   checking_upgrade_lock : nat64;
@@ -424,10 +423,10 @@ type UpgradeInProgress = record {
   target_version : opt Version;
 };
 type UpgradeSnsControlledCanister = record {
-  new_canister_wasm : vec nat8;
+  new_canister_wasm : blob;
   mode : opt int32;
   canister_id : opt principal;
-  canister_upgrade_arg : opt vec nat8;
+  canister_upgrade_arg : opt blob;
 };
 type Valuation = record {
   token : opt int32;
@@ -441,12 +440,12 @@ type ValuationFactors = record {
   tokens : opt Tokens;
 };
 type Version = record {
-  archive_wasm_hash : vec nat8;
-  root_wasm_hash : vec nat8;
-  swap_wasm_hash : vec nat8;
-  ledger_wasm_hash : vec nat8;
-  governance_wasm_hash : vec nat8;
-  index_wasm_hash : vec nat8;
+  archive_wasm_hash : blob;
+  root_wasm_hash : blob;
+  swap_wasm_hash : blob;
+  ledger_wasm_hash : blob;
+  governance_wasm_hash : blob;
+  index_wasm_hash : blob;
 };
 type VotingRewardsParameters = record {
   final_reward_rate_basis_points : opt nat64;

--- a/declarations/sns_ledger/sns_ledger.did
+++ b/declarations/sns_ledger/sns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-14_23-01-p2p/rs/rosetta-api/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-27_23-01-p2p/rs/rosetta-api/icrc1/ledger/ledger.did>
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.

--- a/declarations/sns_root/sns_root.did
+++ b/declarations/sns_root/sns_root.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-14_23-01-p2p/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-27_23-01-p2p/rs/sns/root/canister/root.did>
 type CanisterCallError = record { code : opt int32; description : text };
 type CanisterIdRecord = record { canister_id : principal };
 type CanisterInstallMode = variant { reinstall; upgrade; install };
@@ -7,7 +7,7 @@ type CanisterStatusResult = record {
   memory_size : nat;
   cycles : nat;
   settings : DefiniteCanisterSettings;
-  module_hash : opt vec nat8;
+  module_hash : opt blob;
 };
 type CanisterStatusResultV2 = record {
   status : CanisterStatusType;
@@ -15,7 +15,7 @@ type CanisterStatusResultV2 = record {
   cycles : nat;
   settings : DefiniteCanisterSettingsArgs;
   idle_cycles_burned_per_day : nat;
-  module_hash : opt vec nat8;
+  module_hash : opt blob;
 };
 type CanisterStatusType = variant { stopped; stopping; running };
 type CanisterSummary = record {
@@ -23,12 +23,11 @@ type CanisterSummary = record {
   canister_id : opt principal;
 };
 type ChangeCanisterRequest = record {
-  arg : vec nat8;
-  wasm_module : vec nat8;
+  arg : blob;
+  wasm_module : blob;
   stop_before_installing : bool;
   mode : CanisterInstallMode;
   canister_id : principal;
-  query_allocation : opt nat;
   memory_allocation : opt nat;
   compute_allocation : opt nat;
 };

--- a/declarations/sns_swap/sns_swap.did
+++ b/declarations/sns_swap/sns_swap.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-14_23-01-p2p/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-27_23-01-p2p/rs/sns/swap/canister/swap.did>
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;
@@ -10,7 +10,7 @@ type CanisterStatusResultV2 = record {
   cycles : nat;
   settings : DefiniteCanisterSettingsArgs;
   idle_cycles_burned_per_day : nat;
-  module_hash : opt vec nat8;
+  module_hash : opt blob;
 };
 type CanisterStatusType = variant { stopped; stopping; running };
 type CfInvestment = record { hotkey_principal : text; nns_neuron_id : nat64 };
@@ -92,7 +92,7 @@ type GetOpenTicketResponse = record { result : opt Result_1 };
 type GetSaleParametersResponse = record { params : opt Params };
 type GetStateResponse = record { swap : opt Swap; derived : opt DerivedState };
 type GovernanceError = record { error_message : text; error_type : int32 };
-type Icrc1Account = record { owner : opt principal; subaccount : opt vec nat8 };
+type Icrc1Account = record { owner : opt principal; subaccount : opt blob };
 type IdealMatchedParticipationFunction = record {
   serialized_representation : opt text;
 };
@@ -164,7 +164,7 @@ type NeuronBasketConstructionParameters = record {
   dissolve_delay_interval_seconds : nat64;
   count : nat64;
 };
-type NeuronId = record { id : vec nat8 };
+type NeuronId = record { id : blob };
 type NeuronsFundParticipants = record { cf_participants : vec CfParticipant };
 type NeuronsFundParticipationConstraints = record {
   coefficient_intervals : vec LinearScalingCoefficient;
@@ -173,7 +173,7 @@ type NeuronsFundParticipationConstraints = record {
   ideal_matched_participation_function : opt IdealMatchedParticipationFunction;
 };
 type NewSaleTicketRequest = record {
-  subaccount : opt vec nat8;
+  subaccount : opt blob;
   amount_icp_e8s : nat64;
 };
 type NewSaleTicketResponse = record { result : opt Result_2 };
@@ -252,7 +252,7 @@ type Swap = record {
   purge_old_tickets_last_completion_timestamp_nanoseconds : opt nat64;
   direct_participation_icp_e8s : opt nat64;
   lifecycle : int32;
-  purge_old_tickets_next_principal : opt vec nat8;
+  purge_old_tickets_next_principal : opt blob;
   decentralization_swap_termination_timestamp_seconds : opt nat64;
   buyers : vec record { text; BuyerState };
   params : opt Params;

--- a/declarations/sns_wasm/sns_wasm.did
+++ b/declarations/sns_wasm/sns_wasm.did
@@ -1,5 +1,5 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-14_23-01-p2p/rs/nns/sns-wasm/canister/sns-wasm.did>
-type AddWasmRequest = record { hash : vec nat8; wasm : opt SnsWasm };
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-27_23-01-p2p/rs/nns/sns-wasm/canister/sns-wasm.did>
+type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
 type Canister = record { id : opt principal };
@@ -59,7 +59,7 @@ type GetNextSnsVersionRequest = record {
 };
 type GetNextSnsVersionResponse = record { next_version : opt SnsVersion };
 type GetSnsSubnetIdsResponse = record { sns_subnet_ids : vec principal };
-type GetWasmRequest = record { hash : vec nat8 };
+type GetWasmRequest = record { hash : blob };
 type GetWasmResponse = record { wasm : opt SnsWasm };
 type IdealMatchedParticipationFunction = record {
   serialized_representation : opt text;
@@ -116,7 +116,7 @@ type PrettySnsVersion = record {
   governance_wasm_hash : text;
   index_wasm_hash : text;
 };
-type Result = variant { Error : SnsWasmError; Hash : vec nat8 };
+type Result = variant { Error : SnsWasmError; Hash : blob };
 type SnsCanisterIds = record {
   root : opt principal;
   swap : opt principal;
@@ -170,14 +170,14 @@ type SnsUpgrade = record {
   current_version : opt SnsVersion;
 };
 type SnsVersion = record {
-  archive_wasm_hash : vec nat8;
-  root_wasm_hash : vec nat8;
-  swap_wasm_hash : vec nat8;
-  ledger_wasm_hash : vec nat8;
-  governance_wasm_hash : vec nat8;
-  index_wasm_hash : vec nat8;
+  archive_wasm_hash : blob;
+  root_wasm_hash : blob;
+  swap_wasm_hash : blob;
+  ledger_wasm_hash : blob;
+  governance_wasm_hash : blob;
+  index_wasm_hash : blob;
 };
-type SnsWasm = record { wasm : vec nat8; canister_type : int32 };
+type SnsWasm = record { wasm : blob; canister_type : int32 };
 type SnsWasmCanisterInitPayload = record {
   allowed_principals : vec principal;
   access_controls_enabled : bool;

--- a/dfx.json
+++ b/dfx.json
@@ -356,7 +356,7 @@
         "DIDC_VERSION": "2024-02-27",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-03-27",
-        "IC_COMMIT": "release-2024-03-14_23-01-p2p"
+        "IC_COMMIT": "release-2024-03-27_23-01-p2p"
       },
       "packtool": ""
     }


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
Even with no changes, just updating the reference is good practice.

# Changes
## Changes made by a bot triggered by github-merge-queue
- Update the version of `ic` specified in `dfx.json`.
- Update the NNS candid files to the versions in that commit.

# Tests
- See CI
- [ ] Check for breaking changes in the APIs and schedule any required follow-on work.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants