### PR TITLE
Remove duplicate changelog entry

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -38,8 +38,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Not Published
 
-* Hide tokens with zero balance based on setting behind feature flag.
-
 ### Operations
 
 #### Added


### PR DESCRIPTION
# Motivation

The feature flag for "hide tokens with zero balance" was added and enabled in the same release.
Having a change log entry for both is misleading.

# Changes

Remove the changelog entry for the feature flag and just keep the entry (on line 18) for the feature itself.

# Tests

n/a

# Todos

- [x] Add entry to changelog (if necessary).
