### PR TITLE
Pre completion check

### DIFF
--- a/rs/backend/Cargo.toml
+++ b/rs/backend/Cargo.toml
@@ -13,7 +13,6 @@ hex = "0.4.3"
 itertools = "0.12.0"
 lazy_static = "1.4.0"
 lzma-rs = "0.3.0"
-pretty_assertions = "1.4.0"
 regex = "1.10.2"
 serde = "1.0.193"
 serde_bytes = "0.11.12"
@@ -52,6 +51,7 @@ proposals = { path = "../proposals" }
 [dev-dependencies]
 anyhow = "1.0.75"
 maplit = "1.0.2"
+pretty_assertions = "1.4.0"
 proptest = "1.0.0"
 rand = "0.8.5"
 

--- a/rs/backend/Cargo.toml
+++ b/rs/backend/Cargo.toml
@@ -13,6 +13,7 @@ hex = "0.4.3"
 itertools = "0.12.0"
 lazy_static = "1.4.0"
 lzma-rs = "0.3.0"
+pretty_assertions = "1.4.0"
 regex = "1.10.2"
 serde = "1.0.193"
 serde_bytes = "0.11.12"
@@ -51,7 +52,6 @@ proposals = { path = "../proposals" }
 [dev-dependencies]
 anyhow = "1.0.75"
 maplit = "1.0.2"
-pretty_assertions = "1.4.0"
 proptest = "1.0.0"
 rand = "0.8.5"
 

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -100,6 +100,12 @@ impl AccountsDbTrait for AccountsStore {
     fn iter(&self) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_> {
         self.accounts_db.iter()
     }
+    fn first_key_value(&self) -> Option<(Vec<u8>, Account)> {
+        self.accounts_db.first_key_value()
+    }
+    fn last_key_value(&self) -> Option<(Vec<u8>, Account)> {
+        self.accounts_db.last_key_value()
+    }
     fn values(&self) -> Box<dyn Iterator<Item = Account> + '_> {
         self.accounts_db.values()
     }

--- a/rs/backend/src/accounts_store/schema.rs
+++ b/rs/backend/src/accounts_store/schema.rs
@@ -97,6 +97,12 @@ pub trait AccountsDbTrait {
     /// Iterates over entries in the data store.
     fn iter(&self) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_>;
 
+    /// Returns the first key-value pair in the map. The key in this pair is the maximum key in the map.
+    fn first_key_value(&self) -> Option<(Vec<u8>, Account)>;
+
+    /// Returns the last key-value pair in the map. The key in this pair is the maximum key in the map.
+    fn last_key_value(&self) -> Option<(Vec<u8>, Account)>;
+
     /// Iterates over accounts in the data store.
     fn values(&self) -> Box<dyn Iterator<Item = Account> + '_> {
         let iterator = self.iter().map(|(_key, value)| value);

--- a/rs/backend/src/accounts_store/schema/accounts_in_unbounded_stable_btree_map.rs
+++ b/rs/backend/src/accounts_store/schema/accounts_in_unbounded_stable_btree_map.rs
@@ -72,14 +72,10 @@ where
         Box::new(iterator)
     }
     fn first_key_value(&self) -> Option<(Vec<u8>, Account)> {
-        self.accounts
-            .first_key_value()
-            .map(|(key, value)| (key.clone(), value.clone()))
+        self.accounts.first_key_value()
     }
     fn last_key_value(&self) -> Option<(Vec<u8>, Account)> {
-        self.accounts
-            .last_key_value()
-            .map(|(key, value)| (key.clone(), value.clone()))
+        self.accounts.last_key_value()
     }
     fn values(&self) -> Box<dyn Iterator<Item = Account> + '_> {
         let iterator = self.accounts.iter().map(|(_key, value)| value);

--- a/rs/backend/src/accounts_store/schema/accounts_in_unbounded_stable_btree_map.rs
+++ b/rs/backend/src/accounts_store/schema/accounts_in_unbounded_stable_btree_map.rs
@@ -71,6 +71,16 @@ where
         let iterator = self.accounts.iter();
         Box::new(iterator)
     }
+    fn first_key_value(&self) -> Option<(Vec<u8>, Account)> {
+        self.accounts
+            .first_key_value()
+            .map(|(key, value)| (key.clone(), value.clone()))
+    }
+    fn last_key_value(&self) -> Option<(Vec<u8>, Account)> {
+        self.accounts
+            .last_key_value()
+            .map(|(key, value)| (key.clone(), value.clone()))
+    }
     fn values(&self) -> Box<dyn Iterator<Item = Account> + '_> {
         let iterator = self.accounts.iter().map(|(_key, value)| value);
         Box::new(iterator)

--- a/rs/backend/src/accounts_store/schema/map.rs
+++ b/rs/backend/src/accounts_store/schema/map.rs
@@ -31,6 +31,16 @@ impl AccountsDbTrait for AccountsDbAsMap {
         let iterator = self.accounts.iter().map(|(key, val)| (key.clone(), val.clone()));
         Box::new(iterator)
     }
+    fn first_key_value(&self) -> Option<(Vec<u8>, Account)> {
+        self.accounts
+            .first_key_value()
+            .map(|(key, val)| (key.clone(), val.clone()))
+    }
+    fn last_key_value(&self) -> Option<(Vec<u8>, Account)> {
+        self.accounts
+            .last_key_value()
+            .map(|(key, val)| (key.clone(), val.clone()))
+    }
     fn values(&self) -> Box<dyn Iterator<Item = Account> + '_> {
         let iterator = self.accounts.values().cloned();
         Box::new(iterator)

--- a/rs/backend/src/accounts_store/schema/proxy.rs
+++ b/rs/backend/src/accounts_store/schema/proxy.rs
@@ -111,6 +111,14 @@ impl AccountsDbTrait for AccountsDbAsProxy {
     fn iter(&self) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_> {
         self.authoritative_db.iter()
     }
+    /// Gets the first key-value pair in the authoritative database.
+    fn first_key_value(&self) -> Option<(Vec<u8>, Account)> {
+        self.authoritative_db.first_key_value()
+    }
+    /// Gets the last key-value pair in the authoritative database.
+    fn last_key_value(&self) -> Option<(Vec<u8>, Account)> {
+        self.authoritative_db.last_key_value()
+    }
     /// Iterates over the values of the authoritative database.
     fn values(&self) -> Box<dyn Iterator<Item = Account> + '_> {
         self.authoritative_db.values()

--- a/rs/backend/src/accounts_store/schema/proxy/enum_boilerplate.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/enum_boilerplate.rs
@@ -59,6 +59,22 @@ impl AccountsDbTrait for AccountsDb {
             AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => unbounded_stable_btree_map_db.iter(),
         }
     }
+    fn first_key_value(&self) -> Option<(Vec<u8>, Account)> {
+        match self {
+            AccountsDb::Map(map_db) => map_db.first_key_value(),
+            AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => {
+                unbounded_stable_btree_map_db.first_key_value()
+            }
+        }
+    }
+    fn last_key_value(&self) -> Option<(Vec<u8>, Account)> {
+        match self {
+            AccountsDb::Map(map_db) => map_db.last_key_value(),
+            AccountsDb::UnboundedStableBTreeMap(unbounded_stable_btree_map_db) => {
+                unbounded_stable_btree_map_db.last_key_value()
+            }
+        }
+    }
     fn range(&self, key_range: impl RangeBounds<Vec<u8>>) -> Box<dyn Iterator<Item = (Vec<u8>, Account)> + '_> {
         match self {
             AccountsDb::Map(map_db) => map_db.range(key_range),

--- a/rs/backend/src/accounts_store/schema/proxy/migration.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/migration.rs
@@ -93,31 +93,31 @@ impl AccountsDbAsProxy {
                 let old = self.authoritative_db.db_accounts_len();
                 let new = migration.db.db_accounts_len();
                 if old != new {
-                    eprintln!(
-                    "ERROR ERROR ERROR: Account migration failed: Old and new account databases have different lengths: {old} -> {new}\n Migration will be aborted.",
-                );
+                    eprintln!("MIGRATION ERROR: Account migration failed: Old and new account databases have different lengths: {old} -> {new}\n Migration will be aborted.");
                     return;
                 }
             }
             {
                 // The first account in the BTreeMap should be the same.
                 // Given that keys are random this effectively a random account.
+                //
+                // Note: IF the migration intentionally modifies accounts, this check will have to be adjusted to compare just the invariant aspects of the account.
                 let old = self.authoritative_db.first_key_value();
                 let new = migration.db.first_key_value();
                 if old != new {
-                    eprintln!(
-                    "Old and new account databases have different first entries: {old:?} -> {new:?}\n Migration will be aborted.");
+                    eprintln!("MIGRATION ERROR: Old and new account databases have different first entries: {old:?} -> {new:?}\n Migration will be aborted.");
                     return;
                 }
             }
             {
                 // The last account in the BTreeMap should be the same.
                 // Given that keys are random this effectively a random account.
+                //
+                // Note: IF the migration intentionally modifies accounts, this check will have to be adjusted to compare just the invariant aspects of the account.
                 let old = self.authoritative_db.last_key_value();
                 let new = migration.db.last_key_value();
                 if old != new {
-                    eprintln!(
-                        "Old and new account databases have different last entries: {old:?} -> {new:?}\n Migration will be aborted.");
+                    eprintln!("MIGRATION ERROR: Old and new account databases have different last entries: {old:?} -> {new:?}\n Migration will be aborted.");
                     return;
                 }
             }

--- a/rs/backend/src/accounts_store/schema/proxy/migration.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/migration.rs
@@ -1,6 +1,7 @@
 //! Code for migration from the authoritative database to a new database.
 use super::{AccountsDb, AccountsDbAsProxy, AccountsDbTrait, Migration};
 use ic_cdk::println;
+use pretty_assertions::assert_eq;
 
 impl AccountsDbAsProxy {
     /// The default number of accounts to move in a migration step.

--- a/rs/backend/src/accounts_store/schema/proxy/migration.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/migration.rs
@@ -83,6 +83,22 @@ impl AccountsDbAsProxy {
     /// Completes any migration in progress.
     pub fn complete_migration(&mut self) {
         if let Some(migration) = self.migration.take() {
+            // Sanity check before calling migration complete:  Has all the data been migrated?
+            assert_eq!(
+                self.authoritative_db.db_accounts_len(),
+                migration.db.db_accounts_len(),
+                "Old and new account databases have different lengths"
+            );
+            assert_eq!(
+                self.authoritative_db.first_key_value(), // Given that keys are random this efefctively a random account.
+                migration.db.first_key_value(),
+                "Old and new account databases have different first entries"
+            );
+            assert_eq!(
+                self.authoritative_db.last_key_value(), // Given that keys are random this efefctively a random account.
+                migration.db.last_key_value(),
+                "Old and new account databases have different last entries"
+            );
             println!(
                 "Account migration complete: {:?} -> {:?}",
                 self.authoritative_db, migration.db

--- a/rs/backend/src/accounts_store/schema/proxy/tests.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/tests.rs
@@ -372,19 +372,19 @@ fn migration_should_be_aborted_if_the_new_db_has_a_different_first_account() {
     accounts_db.start_migrating_accounts_to(new_accounts_db);
     // Migrate account 0:
     accounts_db.step_migration(AccountsDbAsProxy::MIGRATION_STEP_SIZE);
-    let key_to_remove = [0u8; 32];
+    let key_to_change = [0u8; 32];
     assert!(
         accounts_db
             .migration
             .as_ref()
             .unwrap()
             .db
-            .db_get_account(&key_to_remove)
+            .db_get_account(&key_to_change)
             .is_some(),
         "Expected the first account to have been migrated"
     );
     // Breaks the invariant by altering the first account in the authoritative db but not the new db.
-    let original_account = accounts_db.authoritative_db.db_get_account(&key_to_remove).unwrap();
+    let original_account = accounts_db.authoritative_db.db_get_account(&key_to_change).unwrap();
     let altered_account = toy_account(0, 1);
     assert_ne!(
         original_account, altered_account,
@@ -392,7 +392,7 @@ fn migration_should_be_aborted_if_the_new_db_has_a_different_first_account() {
     );
     accounts_db
         .authoritative_db
-        .db_insert_account(&key_to_remove, altered_account.clone());
+        .db_insert_account(&key_to_change, altered_account.clone());
     // Finish the migration.
     // ... Limit the number of steps, just so that we don't get an infinite loop if there is a bug and migration never finishes.
     let plenty_of_steps = u32::from(number_of_accounts_to_migrate) + AccountsDbAsProxy::MIGRATION_FINALIZATION_BLOCKS;
@@ -403,13 +403,13 @@ fn migration_should_be_aborted_if_the_new_db_has_a_different_first_account() {
         } else {
             // Note: This is called at least once as the number of accounts is greater than the step size.
             assert_ne!(
-                accounts_db.authoritative_db.db_get_account(&key_to_remove),
+                accounts_db.authoritative_db.db_get_account(&key_to_change),
                 accounts_db
                     .migration
                     .as_ref()
                     .unwrap()
                     .db
-                    .db_get_account(&key_to_remove),
+                    .db_get_account(&key_to_change),
                 "Expected the first account still to be different in the migration db."
             );
         }
@@ -421,7 +421,7 @@ fn migration_should_be_aborted_if_the_new_db_has_a_different_first_account() {
     );
     // The first account should be as for the old database.
     assert_eq!(
-        accounts_db.authoritative_db.db_get_account(&key_to_remove),
+        accounts_db.authoritative_db.db_get_account(&key_to_change),
         Some(altered_account),
         "The first account should be as for the old database"
     );


### PR DESCRIPTION
# Motivation
The security review recommended sanity checks before finalizing the migration.

# Changes
- Verify that the following data is the same in the old and new databases before finalizing:
  - The number of accounts
  - The first and last accounts, ordered by key.

# Tests
- Existing tests already perform migration, so exercise the happy path of these checks.
- The unhappy path is exercised by changing or removing an account that has already been migrated in one database but not another.

# Todos

- [ ] Add entry to changelog (if necessary).
   Please let me know if this is wanted.  So far the NNS team has seemed to prefer changelog entries only for user-visible changes.
