### PR TITLE
Mock queryAccountBalance in routes/app/wallet/page.spec.ts

### DIFF
--- a/frontend/src/tests/routes/app/wallet/page.spec.ts
+++ b/frontend/src/tests/routes/app/wallet/page.spec.ts
@@ -1,4 +1,5 @@
 import * as accountsApi from "$lib/api/accounts.api";
+import * as icpLedgerApi from "$lib/api/icp-ledger.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { page } from "$mocks/$app/stores";
@@ -18,6 +19,7 @@ describe("Wallet page", () => {
     resetIdentity();
 
     vi.spyOn(accountsApi, "getTransactions").mockResolvedValue([]);
+    vi.spyOn(icpLedgerApi, "queryAccountBalance").mockResolvedValue(0n);
 
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT },


### PR DESCRIPTION
# Motivation

When running test `routes/app/wallet/page.spec.ts`, the following appears in the output:
```
TypeError: id.transformRequest is not a function
    at HttpAgent.call (/Users/dskloet/dev/nns-dapp/tree4/frontend/node_modules/@dfinity/agent/src/agent/http/index.ts:424:33)
    at caller (/Users/dskloet/dev/nns-dapp/tree4/frontend/node_modules/@dfinity/agent/src/actor.ts:484:28)
    at e.accountBalance (/Users/dskloet/dev/nns-dapp/tree4/frontend/node_modules/@dfinity/ledger-icp/dist/esm/chunk-OUNV42BS.js:4:13050)
    at Module.queryAccountBalance (/Users/dskloet/dev/nns-dapp/tree4/frontend/src/lib/api/icp-ledger.api.ts:144:22)
    at Module.queryAndUpdate (/Users/dskloet/dev/nns-dapp/tree4/frontend/src/lib/services/utils.services.ts:106:3)
```
However since this only happens after the test already passed, it's not caught by the test.
Never the less, it's jarring.

This happens because the component tries to call `queryAccountBalance`, which should be mocked but because it isn't, it tries to actually call the canister and it realizes that our mock identity is not a real identity and doesn't have `transformRequest`.

# Changes

Mock `queryAccountBalance` in `routes/app/wallet/page.spec.ts`

# Tests

Ran the test and it no longer produces the confusing output.
I also tried adding a delay in the test and that caused the test to actually fail because of the output.
But I don't think we want to actually delay every test to catch this in the future so I removed the delay again.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary