### PR TITLE
Fix copied tooltip IDs

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -33,6 +33,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Make token table rows always clickable. A few edge cases were missing.
 * Don't require double hardware approval on neuron staking.
+* Fixed duplicate tooltip IDs to be unique.
 
 #### Security
 

--- a/frontend/src/lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte
@@ -32,7 +32,7 @@
     >{$i18n.neuron_detail.available_description}
     <TooltipIcon
       text={$i18n.neuron_detail.nns_available_maturity_tooltip}
-      tooltipId="sns-staked-maturity-tooltip"
+      tooltipId="available-maturity-tooltip"
     /></svelte:fragment
   >
   {#if isControllable}

--- a/frontend/src/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.svelte
@@ -45,7 +45,7 @@
           $token: token.symbol,
         }
       )}
-      tooltipId="sns-staked-maturity-tooltip"
+      tooltipId="sns-available-maturity-tooltip"
     /></svelte:fragment
   >
   {#if allowedToStakeMaturity}

--- a/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
@@ -96,4 +96,12 @@ describe("NnsAvailableMaturityItemAction", () => {
     expect(await po.hasSpawnButton()).toBe(false);
     expect(await po.hasStakeButton()).toBe(false);
   });
+
+  it("should have an appropriate tooltip ID", async () => {
+    const po = renderComponent(mockNeuron);
+
+    expect(await po.getTooltipIconPo().getTooltipPo().getTooltipId()).toBe(
+      "available-maturity-tooltip"
+    );
+  });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.spec.ts
@@ -128,4 +128,12 @@ describe("SnsAvailableMaturityItemAction", () => {
       "Available maturity can be staked, or burned to disburse an amount of REAL that is subject to a non-deterministic process, called maturity modulation."
     );
   });
+
+  it("should have an appropriate tooltip ID", async () => {
+    const po = renderComponent(controlledNeuron);
+
+    expect(await po.getTooltipIconPo().getTooltipPo().getTooltipId()).toBe(
+      "sns-available-maturity-tooltip"
+    );
+  });
 });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakedMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsStakedMaturityItemAction.spec.ts
@@ -32,4 +32,15 @@ describe("SnsStakedMaturityItemAction", () => {
 
     expect(await po.getStakedMaturity()).toBe("3.14");
   });
+
+  it("should have an appropriate tooltip ID", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1],
+    });
+    const po = renderComponent(neuron);
+
+    expect(await po.getTooltipIconPo().getTooltipPo().getTooltipId()).toBe(
+      "sns-staked-maturity-tooltip"
+    );
+  });
 });

--- a/frontend/src/tests/page-objects/NnsAvailableMaturityItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsAvailableMaturityItemAction.page-object.ts
@@ -1,3 +1,4 @@
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -8,6 +9,10 @@ export class NnsAvailableMaturityItemActionPo extends BasePageObject {
     return new NnsAvailableMaturityItemActionPo(
       element.byTestId(NnsAvailableMaturityItemActionPo.TID)
     );
+  }
+
+  getTooltipIconPo(): TooltipIconPo {
+    return TooltipIconPo.under(this.root);
   }
 
   getMaturity(): Promise<string> {

--- a/frontend/src/tests/page-objects/SnsStakedMaturityItemAction.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsStakedMaturityItemAction.page-object.ts
@@ -1,3 +1,4 @@
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -8,6 +9,10 @@ export class SnsStakedMaturityItemActionPo extends BasePageObject {
     return new SnsStakedMaturityItemActionPo(
       element.byTestId(SnsStakedMaturityItemActionPo.TID)
     );
+  }
+
+  getTooltipIconPo(): TooltipIconPo {
+    return TooltipIconPo.under(this.root);
   }
 
   getStakedMaturity(): Promise<string> {


### PR DESCRIPTION
# Motivation

A tooltip appears when you hover over a tooltip target.
The tooltip target should have an `aria-describedby` attribute that matches the `id` attribute on the tooltip such that screen readers can associate the two.
And for this for work correctly, the `id` attribute has to be unique.

But I found some tooltip ID which were copied and not unique.

# Changes

1. Fix the incorrectly copied tooltip IDs to match their context.
2. Add unit tests for the affected tooltip IDs.
3. Add getters on page objects where necessary.

# Tests

Unit tests added.

Also, this was caught by another change where the page object getter actually depends on this ID and that caused some tests to fail and this fixed them.

# Todos

- [x] Add entry to changelog (if necessary).
