### PR TITLE
security: Make it hard to create partitions without a schema label

### DIFF
--- a/rs/backend/src/state/partitions.rs
+++ b/rs/backend/src/state/partitions.rs
@@ -29,7 +29,7 @@ pub struct Partitions {
     /// provide when we convert back.
     ///
     /// Update: `into_memory()` [has now been implemented in stable structures](https://github.com/dfinity/stable-structures/pull/188), so
-    /// after the next release of stable_structures we should be able to delete this field.  The current version of stable structurws is
+    /// after the next release of `stable_structures` we should be able to delete this field.  The current version of stable structures is
     /// 0.6.3 so anything strictly after that is probably fine.
     #[cfg(test)]
     memory: DefaultMemoryImpl,

--- a/rs/backend/src/state/partitions.rs
+++ b/rs/backend/src/state/partitions.rs
@@ -240,9 +240,6 @@ impl Partitions {
 ///
 /// Note: Would prefer to use `TryFrom`, but that causes a conflict.  `DefaultMemoryImpl` a type alias which
 /// may refer to a type that has a generic implementation of `TryFrom`.  This is frustrating.
-///
-/// # Panics
-/// - If the memory is managed but does not have a schema label.
 impl Partitions {
     pub fn try_from_memory(memory: DefaultMemoryImpl) -> Result<Self, DefaultMemoryImpl> {
         if Self::is_managed(&memory) {
@@ -252,7 +249,9 @@ impl Partitions {
                 #[cfg(test)]
                 memory,
             };
-            let _ = partitions.schema_label(); // Panics if the schema label is missing.
+            // TODO: Assert that the schema label is defined.
+            //       Motivation: Partitions SHOULD always have a defined schema.
+            //       Note: Some tests that create artificial scenarios will have to be adapted.
             Ok(partitions)
         } else {
             Err(memory)

--- a/rs/backend/src/state/partitions/schemas.rs
+++ b/rs/backend/src/state/partitions/schemas.rs
@@ -4,6 +4,7 @@ use super::{PartitionType, Partitions};
 use crate::accounts_store::schema::SchemaLabelBytes;
 use crate::state::SchemaLabel;
 use ic_cdk::println;
+use ic_stable_structures::memory_manager::MemoryManager;
 #[cfg(test)]
 mod tests;
 
@@ -44,7 +45,12 @@ impl Partitions {
         match schema {
             SchemaLabel::Map => panic!("Map schema does not use partitions"),
             SchemaLabel::AccountsInStableMemory => {
-                let partitions = Partitions::from(memory);
+                let memory_manager = MemoryManager::init(Self::copy_memory_reference(&memory));
+                let partitions = Partitions {
+                    memory_manager,
+                    #[cfg(test)]
+                    memory,
+                };
                 partitions.set_schema_label(schema);
                 partitions
             }


### PR DESCRIPTION
# Motivation
Partitions SHOULD always have the `schema_label` populated in virtual stable memory.  `Partitions::from(..)` does not write such a  label, relying instead on later code to populate it.  This is an unnecessary risk.

## Options
- If `Partiitions::from(..)` creates a memory manager, it should also populate a schema.  Presumably the default schema.  Given that neither of the two places that call `Partitions::from()` would benefit from this code, this seems not the best way to proceed.

- Given that `Partitions::from()` is a tiny function, a simple two-liner, and used only internally in two places it seems best to simply delete it.  Furthermore the two lines are likely to be reduced to one line once we move to the next version of the stable structures library.

# Changes
- Delete `Partitions::from(memory)`

# Tests
- None.  Existing tests should suffice.

# Todos

- [ ] Add entry to changelog (if necessary).
- When loading existing partitions from stable memory, verify that the schema label is defined.  Four unit tests that use over-simplistic toy memory will have to be updated.  This can be done in a later PR.