### PR TITLE
Use page object in IdentifierHash test

### DIFF
--- a/frontend/src/tests/lib/components/ui/IdentifierHash.spec.ts
+++ b/frontend/src/tests/lib/components/ui/IdentifierHash.spec.ts
@@ -1,27 +1,28 @@
 import IdentifierHash from "$lib/components/ui/IdentifierHash.svelte";
-import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
+import { IdentifierHashPo } from "$tests/page-objects/IdentifierHash.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 
 describe("IdentifierHash", () => {
   const identifier = "12345678901234567890";
 
-  it("should render a hashed identifier", () => {
-    const { getByTestId } = render(IdentifierHash, {
-      props: { identifier },
-    });
+  const renderComponent = (props) => {
+    const { container } = render(IdentifierHash, props);
+    return IdentifierHashPo.under(new JestPageObjectElement(container));
+  };
 
-    const small = getByTestId("identifier");
-    expect(small?.textContent).toEqual(shortenWithMiddleEllipsis(identifier));
+  it("should render a hashed identifier", async () => {
+    const po = renderComponent({ identifier: "12345678901234567890" });
+
+    expect(await po.getDisplayedText()).toBe("1234567...4567890");
+    expect(await po.getFullText()).toBe("12345678901234567890");
   });
 
-  it("should render the identifier as aria-label", () => {
-    const { container } = render(IdentifierHash, {
-      props: { identifier },
-    });
+  it("should render the identifier as aria-label", async () => {
+    const po = renderComponent({ identifier });
 
-    const button = container.querySelector("button");
-    expect(
-      button?.getAttribute("aria-label").includes(identifier)
-    ).toBeTruthy();
+    expect(await po.getCopyButtonPo().getAriaLabel()).toBe(
+      `Copy to clipboard: ${identifier}`
+    );
   });
 });

--- a/frontend/src/tests/page-objects/Button.page-object.ts
+++ b/frontend/src/tests/page-objects/Button.page-object.ts
@@ -27,4 +27,8 @@ export class ButtonPo extends SimpleBasePageObject {
   getClasses(): Promise<string[]> {
     return this.root.getClasses();
   }
+
+  getAriaLabel(): Promise<string> {
+    return this.root.getAttribute("aria-label");
+  }
 }

--- a/frontend/src/tests/page-objects/Hash.page-object.ts
+++ b/frontend/src/tests/page-objects/Hash.page-object.ts
@@ -4,7 +4,7 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class HashPo extends BasePageObject {
-  private static readonly TID = "hash-component";
+  static readonly TID = "hash-component";
 
   static under(element: PageObjectElement): HashPo {
     return new HashPo(element.byTestId(HashPo.TID));

--- a/frontend/src/tests/page-objects/IdentifierHash.page-object.ts
+++ b/frontend/src/tests/page-objects/IdentifierHash.page-object.ts
@@ -1,0 +1,12 @@
+import { HashPo } from "$tests/page-objects/Hash.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class IdentifierHashPo extends HashPo {
+  static under(element: PageObjectElement): IdentifierHashPo {
+    return new IdentifierHashPo(element.byTestId(HashPo.TID));
+  }
+
+  getDisplayedText(): Promise<string> {
+    return super.getText("identifier");
+  }
+}

--- a/frontend/src/tests/page-objects/IdentifierHash.page-object.ts
+++ b/frontend/src/tests/page-objects/IdentifierHash.page-object.ts
@@ -7,6 +7,6 @@ export class IdentifierHashPo extends HashPo {
   }
 
   getDisplayedText(): Promise<string> {
-    return super.getText("identifier");
+    return this.getText("identifier");
   }
 }


### PR DESCRIPTION
# Motivation

To make the test easier to read and maintain.

# Changes

1. Introduce `IdentifierHashPo`, extended from `HashPo` because the `IdentifierHash` component only consists of an instance of `Hash`.
2. Make `HashPo.TID` not private to reuse in `IdentifierHashPo`.
3. Use `IdentifierHashPo` in `IdentifierHash.spec.ts`.
4. Make expectations in the test more explicit so it's easier to understand what is really expected.

# Tests

only test changes

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary