### PR TITLE
vi.unstubAllGlobals in NnsWallet.spec.ts

### DIFF
--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -80,6 +80,7 @@ describe("NnsWallet", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.clearAllTimers();
+    vi.unstubAllGlobals();
     cancelPollAccounts();
     resetAccountsForTesting();
     neuronsStore.reset();

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -110,6 +110,8 @@ vi.mock("$app/stores", () => ({
 }));
 
 // Issue: https://github.com/testing-library/svelte-testing-library/issues/206
-vi.stubGlobal("requestAnimationFrame", (fn) => {
-  return window.setTimeout(() => fn(Date.now()), 0);
+Object.defineProperty(global, "requestAnimationFrame", {
+  value: (fn) => {
+    return window.setTimeout(() => fn(Date.now()), 0);
+  },
 });


### PR DESCRIPTION
# Motivation

In `NnsWallet.spec.ts` in `"should render second page of transactions from ICP Index canister"` we set the global value of `IntersectionObserver` to `IntersectionObserverActive`. This is not being cleaned up so it is unintentionally affecting other tests.

The best way to clean up global value replacements is by always calling `vi.unstubAllGlobals` before each test.

However, currently another work-around in `frontend/vitest.setup.ts` is also set with `stubGlobal` and reverted by calling `vi.unstubAllGlobals`.

# Changes

1. In `frontend/vitest.setup.ts` use `Object.defineProperty` instead of `vi.stubGlobal` to overwrite `requestAnimationFrame` so that we can safely use `vi.unstubAllGlobals` in tested.
2. In `frontend/src/tests/lib/pages/NnsWallet.spec.ts` use `vi.unstubAllGlobals` to make sure other tests aren't being affected by an individual test stubbing `IntersectionObserver`.

# Tests

test only change

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary