### PR TITLE
Use unique tooltip IDs in IdentifierHash

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -35,6 +35,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Don't require double hardware approval on neuron staking.
 * Fixed duplicate tooltip IDs to be unique.
 * Redirect to accounts page after signing in on wallet page with incorrect account identifier.
+* Make sure `IdentifierHash` uses a unique `id` and `aria-describedby` attribute.
 
 #### Security
 

--- a/frontend/src/lib/components/ui/IdentifierHash.svelte
+++ b/frontend/src/lib/components/ui/IdentifierHash.svelte
@@ -8,7 +8,8 @@
   export let identifier: string;
   export let splitLength: number | undefined = undefined;
 
-  let elementId = `identifier-${nextElementIdNumber++}`;
+  let elementId = `identifier-${nextElementIdNumber}`;
+  ++nextElementIdNumber;
 </script>
 
 <Hash

--- a/frontend/src/lib/components/ui/IdentifierHash.svelte
+++ b/frontend/src/lib/components/ui/IdentifierHash.svelte
@@ -1,12 +1,18 @@
+<script lang="ts" context="module">
+  let nextElementIdNumber = 0;
+</script>
+
 <script lang="ts">
   import Hash from "$lib/components/ui/Hash.svelte";
 
   export let identifier: string;
   export let splitLength: number | undefined = undefined;
+
+  let elementId = `identifier-${nextElementIdNumber++}`;
 </script>
 
 <Hash
-  id="identifier"
+  id={elementId}
   tagName="p"
   testId="identifier"
   text={identifier}

--- a/frontend/src/tests/lib/components/ui/IdentifierHash.spec.ts
+++ b/frontend/src/tests/lib/components/ui/IdentifierHash.spec.ts
@@ -7,7 +7,10 @@ describe("IdentifierHash", () => {
   const identifier = "12345678901234567890";
 
   const renderComponent = (props) => {
-    const { container } = render(IdentifierHash, props);
+    // By default, render() reuses the container element between different calls
+    // from the same test.
+    const container = document.createElement("div");
+    render(IdentifierHash, props, { container });
     return IdentifierHashPo.under(new JestPageObjectElement(container));
   };
 
@@ -24,5 +27,18 @@ describe("IdentifierHash", () => {
     expect(await po.getCopyButtonPo().getAriaLabel()).toBe(
       `Copy to clipboard: ${identifier}`
     );
+  });
+
+  it("should use a unique tooltip ID each time", async () => {
+    const po1 = renderComponent({ identifier });
+    const po2 = renderComponent({ identifier });
+
+    const id1 = await po1.getTooltipPo().getTooltipId();
+    const id2 = await po2.getTooltipPo().getTooltipId();
+
+    expect(id1).toMatch(/^identifier-\d+$/);
+    expect(id2).toMatch(/^identifier-\d+$/);
+
+    expect(id1).not.toBe(id2);
   });
 });


### PR DESCRIPTION
# Motivation

Whenever we have a tooltip, the tooltip element must have a unique `id` attribute and the tooltip target must have a matching `aria-describedby` attribute to help screen readers associate the tooltip to the target.
Currently, the `IdentifierHash` component uses `identifier` as the `id` which is used for the corresponding tooltip.
When multiple `IdentifierHash` components are on the page (for example, the account identifier and the user principal), this `id` is not unique.

# Changes

Attach a sequence number to the `id` in `IdentifierHash` to make it unique.

# Tests

1. Add a unit test which instantiates `IdentifierHash` twice and checks that the tooltip IDs are different.
2. Don't reuse the same container in `render` so that we can have multiple components instances and corresponding page objects in a single test. 

# Todos

- [x] Add entry to changelog (if necessary).
