### PR TITLE
Rename getText on TooltipPo to getTooltipText

### DIFF
--- a/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ParticipateButton.spec.ts
@@ -300,7 +300,9 @@ describe("ParticipateButton", () => {
       expect(button.getAttribute("disabled")).not.toBeNull();
 
       const tooltipPo = new TooltipPo(new JestPageObjectElement(container));
-      expect(await tooltipPo.getText()).toBe("Maximum commitment reached");
+      expect(await tooltipPo.getTooltipText()).toBe(
+        "Maximum commitment reached"
+      );
     });
 
     it("should disable button if user is from a restricted country", async () => {
@@ -328,7 +330,7 @@ describe("ParticipateButton", () => {
       expect(button.getAttribute("disabled")).not.toBeNull();
 
       const tooltipPo = new TooltipPo(new JestPageObjectElement(container));
-      expect(await tooltipPo.getText()).toBe(
+      expect(await tooltipPo.getTooltipText()).toBe(
         "You are not eligible to participate in this swap."
       );
     });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/VestingTooltipWrapper.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/VestingTooltipWrapper.spec.ts
@@ -35,7 +35,7 @@ describe("VestingTooltipWrapper", () => {
     const po = renderComponent(vestingNeuron);
 
     expect(await po.getTooltipPo().isPresent()).toBe(true);
-    expect(await po.getTooltipPo().getText()).toBe(
+    expect(await po.getTooltipPo().getTooltipText()).toBe(
       "This function is not available during your vesting period. Vesting will last another 29 days, 10 hours"
     );
   });

--- a/frontend/src/tests/page-objects/DisburseMaturityButton.page-object.ts
+++ b/frontend/src/tests/page-objects/DisburseMaturityButton.page-object.ts
@@ -21,6 +21,6 @@ export class DisburseMaturityButtonPo extends BasePageObject {
   }
 
   getTooltipText(): Promise<string> {
-    return TooltipPo.under(this.root).getText();
+    return TooltipPo.under(this.root).getTooltipText();
   }
 }

--- a/frontend/src/tests/page-objects/Hash.page-object.ts
+++ b/frontend/src/tests/page-objects/Hash.page-object.ts
@@ -19,7 +19,7 @@ export class HashPo extends BasePageObject {
   }
 
   getFullText(): Promise<string> {
-    return this.getTooltipPo().getText();
+    return this.getTooltipPo().getTooltipText();
   }
 
   hasCopyButton(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/Tooltip.page-object.ts
+++ b/frontend/src/tests/page-objects/Tooltip.page-object.ts
@@ -9,7 +9,7 @@ export class TooltipPo extends BasePageObject {
     return new TooltipPo(element.byTestId(TooltipPo.TID));
   }
 
-  getText(): Promise<string> {
+  getTooltipText(): Promise<string> {
     return assertNonNullish(this.root.querySelector(".tooltip")).getText();
   }
 

--- a/frontend/src/tests/page-objects/TooltipIcon.page-object.ts
+++ b/frontend/src/tests/page-objects/TooltipIcon.page-object.ts
@@ -14,6 +14,6 @@ export class TooltipIconPo extends BasePageObject {
   }
 
   getText(): Promise<string> {
-    return this.getTooltipPo().getText();
+    return this.getTooltipPo().getTooltipText();
   }
 }

--- a/frontend/src/tests/page-objects/WalletPageHeading.page-object.ts
+++ b/frontend/src/tests/page-objects/WalletPageHeading.page-object.ts
@@ -19,7 +19,7 @@ export class WalletPageHeadingPo extends BasePageObject {
   }
 
   getTooltipText(): Promise<string> {
-    return TooltipPo.under(this.root).getText();
+    return TooltipPo.under(this.root).getTooltipText();
   }
 
   hasBalancePlaceholder(): Promise<boolean> {


### PR DESCRIPTION
# Motivation

Currently `getText` on `TooltipPo` is masking the `getText` method from the base class.

# Changes

Rename `getText` on `TooltipPo` to `getTooltipText`.

# Tests

Still pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary