### PR TITLE
Enable ENABLE_ICP_INDEX in unit tests

### DIFF
--- a/frontend/src/tests/mocks/transaction.mock.ts
+++ b/frontend/src/tests/mocks/transaction.mock.ts
@@ -1,3 +1,4 @@
+import type { GetTransactionsResponse } from "$lib/api/icp-index.api";
 import type { Transaction as NnsTransaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import type { Transaction, UiTransaction } from "$lib/types/transaction";
 import { AccountTransactionType } from "$lib/types/transaction";
@@ -117,4 +118,33 @@ export const mockTransactionWithId: TransactionWithId = {
     created_at_time: [],
     timestamp: [],
   },
+};
+
+export const createMockSendTransactionWithId = ({
+  amount = 110_000_023n,
+  fee = 10_000n,
+  to = mockSubAccount.identifier,
+}: {
+  amount?: bigint;
+  fee?: bigint;
+  to?: string;
+}): TransactionWithId => ({
+  ...mockTransactionWithId,
+  transaction: {
+    ...mockTransactionWithId.transaction,
+    operation: {
+      Transfer: {
+        ...mockTransactionWithId.transaction.operation["Transfer"],
+        to,
+        fee: { e8s: fee },
+        amount: { e8s: amount },
+      },
+    },
+  },
+});
+
+export const mockEmptyGetTransactionsResponse: GetTransactionsResponse = {
+  transactions: [],
+  oldestTxId: 0n,
+  balance: 0n,
 };

--- a/frontend/src/tests/mocks/transaction.mock.ts
+++ b/frontend/src/tests/mocks/transaction.mock.ts
@@ -128,20 +128,25 @@ export const createMockSendTransactionWithId = ({
   amount?: bigint;
   fee?: bigint;
   to?: string;
-}): TransactionWithId => ({
-  ...mockTransactionWithId,
-  transaction: {
+}): TransactionWithId => {
+  const transfer = {
+    ...mockTransactionWithId.transaction["Transfer"],
+    to,
+    fee: { e8s: fee },
+    amount: { e8s: amount },
+  };
+  const operation = {
+    Transfer: transfer,
+  };
+  const transaction = {
     ...mockTransactionWithId.transaction,
-    operation: {
-      Transfer: {
-        ...mockTransactionWithId.transaction.operation["Transfer"],
-        to,
-        fee: { e8s: fee },
-        amount: { e8s: amount },
-      },
-    },
-  },
-});
+    operation,
+  };
+  return {
+    ...mockTransactionWithId,
+    transaction,
+  };
+};
 
 export const mockEmptyGetTransactionsResponse: GetTransactionsResponse = {
   transactions: [],

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -40,7 +40,7 @@ vi.mock("./src/lib/utils/env-vars.utils.ts", () => ({
     featureFlags: JSON.stringify({
       ENABLE_CKBTC: true,
       ENABLE_CKTESTBTC: true,
-      ENABLE_ICP_INDEX: false,
+      ENABLE_ICP_INDEX: true,
       ENABLE_VOTING_INDICATION: true,
       ENABLE_HIDE_ZERO_BALANCE: true,
       TEST_FLAG_EDITABLE: true,


### PR DESCRIPTION
# Motivation

`ENABLE_ICP_INDEX` has been enabled on mainnet for some time.
Before we can clean up the code, some tests need to be updated.

This is the feature flag to enable reading ICP transactions from the ICP index canister instead of from the NNS dapp canister.

# Changes

1. Enable `ENABLE_ICP_INDEX` in unit tests.
2. Update unit tests that were still using the old functionality to use the new functionality instead.

# Tests

Updated

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary