### PR TITLE
Disallow build warnings for Rust

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[future-incompat-report]
+frequency = "never"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run Unit Tests
         shell: bash
         run: |
-          cargo test --lib --bins --benches --examples --all-features
+          RUSTFLAGS="-D warnings" cargo test --lib --bins --benches --examples --all-features
         env:
           RUST_BACKTRACE: 1
       - name: Lint rustdoc

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -46,6 +46,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Disallow build warnings for Rust.
+
 #### Deprecated
 
 #### Removed

--- a/rs/backend/src/accounts_store/schema/proxy/tests.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/tests.rs
@@ -1,4 +1,3 @@
-use candid::types::number;
 use ic_stable_structures::memory_manager;
 use pretty_assertions::assert_eq;
 use proptest::proptest;

--- a/rs/backend/src/state/partitions.rs
+++ b/rs/backend/src/state/partitions.rs
@@ -60,15 +60,6 @@ pub enum PartitionsMaybe {
 }
 
 impl PartitionsMaybe {
-    /// Gets the schema label.
-    #[cfg(test)]
-    pub fn schema_label(&self) -> SchemaLabel {
-        match self {
-            #[cfg(test)]
-            PartitionsMaybe::Partitions(partitions) => partitions.schema_label(),
-            PartitionsMaybe::None(_) => SchemaLabel::Map,
-        }
-    }
     /// Gets or creates partitions.
     ///
     /// WARNING: Partitioning overwrites the memory.  Please be sure that you have extracted all useful data from raw memory before calling this.


### PR DESCRIPTION
# Motivation

Build warnings are distracting and confusing.

There is one type of build warning that can start appearing without any changes in the code: future incompatibility.
When there is a breaking change in a future version of a dependency, this will start causing build warnings without changes in the repository. We need to disable these warning in order to safely disallow any build warnings in Rust and prevent the introduction of new warnings.

# Changes

1. Add `RUSTFLAGS="-D warnings"` in front of `cargo test` in CI to disallow build warning.
2. Disable the "future incompatibility" warning by adding a `config.toml` file.
3. Fix a warning by removing unused `use candid::types::number;` from `rs/backend/src/accounts_store/schema/proxy/tests.rs`.
4. Fix a warning by removing unused `schema_label` from `rs/backend/src/state/partitions.rs`

# Tests

CI passes

# Todos

- [x] Add entry to changelog (if necessary).
