### PR TITLE
Sort neurons by decreasing dissolve delay when stake is equal

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Sort neurons by decreasing dissolve delay when stakes are equal.
+
 #### Deprecated
 
 #### Removed

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -294,8 +294,31 @@ export const formatMaturity = (value?: bigint): string =>
     value: isNullish(value) ? 0n : value,
   });
 
+// Used to sort neurons by:
+// * decreasing stake, or when stake is equal by
+// * decreasing dissolve delay
+const compareNeurons = (a: NeuronInfo, b: NeuronInfo): number => {
+  const stakeA = neuronStake(a);
+  const stakeB = neuronStake(b);
+  if (stakeA > stakeB) {
+    return -1;
+  }
+  if (stakeA < stakeB) {
+    return 1;
+  }
+  const dissolveDelayA = a.dissolveDelaySeconds;
+  const dissolveDelayB = b.dissolveDelaySeconds;
+  if (dissolveDelayA > dissolveDelayB) {
+    return -1;
+  }
+  if (dissolveDelayA < dissolveDelayB) {
+    return 1;
+  }
+  return 0;
+};
+
 export const sortNeuronsByStake = (neurons: NeuronInfo[]): NeuronInfo[] =>
-  [...neurons].sort((a, b) => Number(neuronStake(b) - neuronStake(a)));
+  [...neurons].sort(compareNeurons);
 
 /*
  * Returns true if the neuron can be controlled by current user

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -664,6 +664,36 @@ describe("neuron-utils", () => {
         neuron1,
       ]);
     });
+
+    it("should sort neurons by dissolve delay for equal stake", () => {
+      const neuron1 = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          dissolveDelaySeconds: 100_000_000n,
+        },
+      };
+      const neuron2 = {
+        ...mockNeuron,
+        dissolveDelaySeconds: 200_000_000n,
+      };
+      const neuron3 = {
+        ...mockNeuron,
+        dissolveDelaySeconds: 300_000_000n,
+      };
+      expect(sortNeuronsByStake([])).toEqual([]);
+      expect(sortNeuronsByStake([neuron1])).toEqual([neuron1]);
+      expect(sortNeuronsByStake([neuron3, neuron2, neuron1])).toEqual([
+        neuron3,
+        neuron2,
+        neuron1,
+      ]);
+      expect(sortNeuronsByStake([neuron2, neuron1, neuron3])).toEqual([
+        neuron3,
+        neuron2,
+        neuron1,
+      ]);
+    });
   });
 
   describe("isNeuronControllable", () => {

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -668,10 +668,7 @@ describe("neuron-utils", () => {
     it("should sort neurons by dissolve delay for equal stake", () => {
       const neuron1 = {
         ...mockNeuron,
-        fullNeuron: {
-          ...mockNeuron.fullNeuron,
-          dissolveDelaySeconds: 100_000_000n,
-        },
+        dissolveDelaySeconds: 100_000_000n,
       };
       const neuron2 = {
         ...mockNeuron,
@@ -689,6 +686,53 @@ describe("neuron-utils", () => {
         neuron1,
       ]);
       expect(sortNeuronsByStake([neuron2, neuron1, neuron3])).toEqual([
+        neuron3,
+        neuron2,
+        neuron1,
+      ]);
+    });
+
+    it("should sort neurons by stake first and then dissolve delay", () => {
+      const neuron1 = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          cachedNeuronStake: 500_000_000n,
+        },
+        dissolveDelaySeconds: 100_000_000n,
+      };
+      const neuron2 = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          cachedNeuronStake: 500_000_000n,
+        },
+        dissolveDelaySeconds: 200_000_000n,
+      };
+      const neuron3 = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          cachedNeuronStake: 700_000_000n,
+        },
+        dissolveDelaySeconds: 100_000_000n,
+      };
+      const neuron4 = {
+        ...mockNeuron,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          cachedNeuronStake: 700_000_000n,
+        },
+        dissolveDelaySeconds: 200_000_000n,
+      };
+      expect(sortNeuronsByStake([neuron3, neuron4, neuron2, neuron1])).toEqual([
+        neuron4,
+        neuron3,
+        neuron2,
+        neuron1,
+      ]);
+      expect(sortNeuronsByStake([neuron1, neuron2, neuron3, neuron4])).toEqual([
+        neuron4,
         neuron3,
         neuron2,
         neuron1,


### PR DESCRIPTION
# Motivation

In the neurons view, we sort neurons by decreasing stake.
If they stakes are equal we want to sort by decreasing dissolve delay.

# Changes

Change `sortNeuronsByStake` to take dissolve delay into account as a tie breaker.

# Tests

* Unit tests added.
* Tested manually:

<img width="927" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/f6fe0fdb-5310-4cfe-9a18-e7b5fb69ab86">

# Todos

- [x] Add entry to changelog (if necessary).
