### PR TITLE
Remove top margin in UniverseSplitContent

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -27,6 +27,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Redirect to accounts page after signing in on wallet page with incorrect account identifier.
 * Make sure `IdentifierHash` uses a unique `id` and `aria-describedby` attribute.
 * Place tooltip in document body to avoid overflow issues.
+* Align "Nervous System" and universe title on the neurons tab.
 
 #### Security
 

--- a/frontend/src/lib/components/layout/UniverseSplitContent.svelte
+++ b/frontend/src/lib/components/layout/UniverseSplitContent.svelte
@@ -32,8 +32,4 @@
       --nav-component-title-display: block;
     }
   }
-
-  .nav {
-    margin-top: var(--padding-2x);
-  }
 </style>


### PR DESCRIPTION
# Motivation

Titles currently aren't aligned because of this unnecessary margin.

# Changes

Remove the top margin in `UniverseSplitContent`.

# Tests

Tested manually:
Before:
<img width="765" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/79e6f1e5-3f25-4528-8452-4ade0a80c9a3">

After:
<img width="775" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/25c3373d-f3db-45a9-8e1b-97cd4d49e6b7">


# Todos

- [x] Add entry to changelog (if necessary).
