### PR TITLE
Bump: gix-components

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Sort neurons by decreasing dissolve delay when stakes are equal.
+* Make the progress bar on the swap page straight instead of rounded.
 
 #### Deprecated
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -277,9 +277,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "4.1.0-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.1.0-next-2024-04-03.1.tgz",
-      "integrity": "sha512-WakyOkilOmrVI+aKZSzyLpDOr0Ic7W4zJPJoNLnck0BFmZlVMFraEX1jZGIcdI6g5fuX3hTNG8WK7WjkgqYbfg==",
+      "version": "4.1.0-next-2024-04-09",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.1.0-next-2024-04-09.tgz",
+      "integrity": "sha512-+LAj4BItSlA9+UVrXOmaq3jsx7hycBcJQzslxALHHNnebKHFaQGdAE66IFXGHUbmQIiIz5c4Faz3ZuLvsNZBoQ==",
       "dependencies": {
         "dompurify": "^3.0.8",
         "html5-qrcode": "^2.3.8",
@@ -7047,9 +7047,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "4.1.0-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.1.0-next-2024-04-03.1.tgz",
-      "integrity": "sha512-WakyOkilOmrVI+aKZSzyLpDOr0Ic7W4zJPJoNLnck0BFmZlVMFraEX1jZGIcdI6g5fuX3hTNG8WK7WjkgqYbfg==",
+      "version": "4.1.0-next-2024-04-09",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.1.0-next-2024-04-09.tgz",
+      "integrity": "sha512-+LAj4BItSlA9+UVrXOmaq3jsx7hycBcJQzslxALHHNnebKHFaQGdAE66IFXGHUbmQIiIz5c4Faz3ZuLvsNZBoQ==",
       "requires": {
         "dompurify": "^3.0.8",
         "html5-qrcode": "^2.3.8",


### PR DESCRIPTION
# Motivation

Pull in the progress bar style changes from https://github.com/dfinity/gix-components/pull/409 to make the value of the progress bar straight instead of rounded.

# Changes

Ran `npm run update:gix`.

# Tests

Manual inspection.
Before:
<img width="552" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/7ac869da-99b6-4b64-8756-211d3dccde90">

After:
<img width="551" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/e1fd8874-c785-4759-a4e5-9c40d9db6b7a">


# Todos

- [ ] Add entry to changelog (if necessary).
