### PR TITLE
Split VotingNeuronListItem from VotingNeuronSelectList

### DIFF
--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { SNS_NEURON_ID_DISPLAY_LENGTH } from "$lib/constants/sns-neurons.constants";
+  import { i18n } from "$lib/stores/i18n";
+  import { votingNeuronSelectStore } from "$lib/stores/vote-registration.store";
+  import type { VotingNeuron } from "$lib/types/proposals";
+  import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { formatVotingPower } from "$lib/utils/neuron.utils";
+  import { Checkbox, KeyValuePair } from "@dfinity/gix-components";
+  import { fade } from "svelte/transition";
+
+  export let neuron: VotingNeuron;
+  export let disabled: boolean;
+  export let toggleSelection: (neuronId: string) => void;
+</script>
+
+<li in:fade data-tid="voting-neuron-list-item-component">
+  <KeyValuePair>
+    <span slot="key" class="label">
+      <span
+        data-tid="neuron-id"
+        aria-label={replacePlaceholders(
+          $i18n.proposal_detail__vote.cast_vote_neuronId,
+          {
+            $neuronId: neuron.neuronIdString,
+          }
+        )}
+        title={neuron.neuronIdString}
+        >{shortenWithMiddleEllipsis(
+          neuron.neuronIdString,
+          SNS_NEURON_ID_DISPLAY_LENGTH
+        )}</span
+      >
+    </span>
+    <span slot="value" class="value">
+      <Checkbox
+        inputId={neuron.neuronIdString}
+        checked={$votingNeuronSelectStore.selectedIds.includes(
+          neuron.neuronIdString
+        )}
+        on:nnsChange={() => toggleSelection(neuron.neuronIdString)}
+        {disabled}
+      >
+        <span
+          class="value"
+          data-tid="voting-neuron-select-voting-power"
+          aria-label={replacePlaceholders(
+            $i18n.proposal_detail__vote.cast_vote_votingPower,
+            {
+              $votingPower: formatVotingPower(neuron.votingPower),
+            }
+          )}>{formatVotingPower(neuron.votingPower)}</span
+        >
+      </Checkbox>
+    </span>
+  </KeyValuePair>
+</li>

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.svelte
@@ -1,13 +1,7 @@
 <script lang="ts">
-  import { i18n } from "$lib/stores/i18n";
-  import { Checkbox, KeyValuePair } from "@dfinity/gix-components";
-  import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { formatVotingPower } from "$lib/utils/neuron.utils";
   import { votingNeuronSelectStore } from "$lib/stores/vote-registration.store";
-  import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
-  import { SNS_NEURON_ID_DISPLAY_LENGTH } from "$lib/constants/sns-neurons.constants";
   import VotingCardNeuronList from "$lib/components/proposal-detail/VotingCard/VotingCardNeuronList.svelte";
-  import { fade } from "svelte/transition";
+  import VotingNeuronListItem from "$lib/components/proposal-detail/VotingCard/VotingNeuronListItem.svelte";
 
   export let disabled: boolean;
 
@@ -18,46 +12,7 @@
 {#if $votingNeuronSelectStore.neurons.length > 0}
   <VotingCardNeuronList>
     {#each $votingNeuronSelectStore.neurons as neuron}
-      <li in:fade>
-        <KeyValuePair>
-          <span slot="key" class="label">
-            <span
-              aria-label={replacePlaceholders(
-                $i18n.proposal_detail__vote.cast_vote_neuronId,
-                {
-                  $neuronId: neuron.neuronIdString,
-                }
-              )}
-              title={neuron.neuronIdString}
-              >{shortenWithMiddleEllipsis(
-                neuron.neuronIdString,
-                SNS_NEURON_ID_DISPLAY_LENGTH
-              )}</span
-            >
-          </span>
-          <span slot="value" class="value">
-            <Checkbox
-              inputId={neuron.neuronIdString}
-              checked={$votingNeuronSelectStore.selectedIds.includes(
-                neuron.neuronIdString
-              )}
-              on:nnsChange={() => toggleSelection(neuron.neuronIdString)}
-              {disabled}
-            >
-              <span
-                class="value"
-                data-tid="voting-neuron-select-voting-power"
-                aria-label={replacePlaceholders(
-                  $i18n.proposal_detail__vote.cast_vote_votingPower,
-                  {
-                    $votingPower: formatVotingPower(neuron.votingPower),
-                  }
-                )}>{formatVotingPower(neuron.votingPower)}</span
-              >
-            </Checkbox>
-          </span>
-        </KeyValuePair>
-      </li>
+      <VotingNeuronListItem {neuron} {disabled} {toggleSelection} />
     {/each}
   </VotingCardNeuronList>
 {/if}

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.spec.ts
@@ -86,7 +86,7 @@ describe("VotingNeuronListItem", () => {
     expect(toggleSelection).toBeCalledTimes(1);
   });
 
-  it("should call dissable checkbox", async () => {
+  it("should disable checkbox", async () => {
     const votingNeuron = createVotingNeuron({});
 
     const po = renderComponent({

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.spec.ts
@@ -1,0 +1,111 @@
+import VotingNeuronListItem from "$lib/components/proposal-detail/VotingCard/VotingNeuronListItem.svelte";
+import type { VotingNeuron } from "$lib/types/proposals";
+import { nnsNeuronToVotingNeuron } from "$lib/utils/proposals.utils";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { mockProposalInfo } from "$tests/mocks/proposal.mock";
+import { VotingNeuronListItemPo } from "$tests/page-objects/VotingNeuronListItem.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("VotingNeuronListItem", () => {
+  const createVotingNeuron = ({
+    neuronId = 1n,
+    votingPower = 100_000_000n,
+  }: {
+    neuronId?: bigint;
+    votingPower?: bigint;
+  }): VotingNeuron => {
+    return nnsNeuronToVotingNeuron({
+      neuron: {
+        ...mockNeuron,
+        neuronId,
+        votingPower,
+      },
+      proposal: mockProposalInfo,
+    });
+  };
+
+  const renderComponent = ({
+    votingNeuron,
+    disabled = false,
+    toggleSelection = () => undefined,
+  }: {
+    votingNeuron: VotingNeuron;
+    disabled?: boolean;
+    toggleSelection?: (neuronId: string) => void;
+  }) => {
+    const { container } = render(VotingNeuronListItem, {
+      neuron: votingNeuron,
+      disabled,
+      toggleSelection,
+    });
+    return VotingNeuronListItemPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should render neuron ID", async () => {
+    const neuronId = 1133n;
+
+    const votingNeuron = createVotingNeuron({ neuronId });
+
+    const po = renderComponent({
+      votingNeuron,
+    });
+
+    expect(await po.getNeuronId()).toBe("1133");
+  });
+
+  it("should shorten neuron ID with ellipses", async () => {
+    const neuronId = 1234567890123456789012345678901234567890n;
+
+    const votingNeuron = createVotingNeuron({ neuronId });
+
+    const po = renderComponent({
+      votingNeuron,
+    });
+
+    expect(await po.getNeuronId()).toBe("12345678901234...78901234567890");
+  });
+
+  it("should call toggleSelection when checkbox is clicked", async () => {
+    const neuronId = 1133n;
+
+    const votingNeuron = createVotingNeuron({ neuronId });
+    const toggleSelection = vi.fn();
+
+    const po = renderComponent({
+      votingNeuron,
+      toggleSelection,
+    });
+
+    expect(toggleSelection).not.toBeCalled();
+
+    await po.getCheckboxPo().click();
+
+    expect(toggleSelection).toBeCalledWith("1133");
+    expect(toggleSelection).toBeCalledTimes(1);
+  });
+
+  it("should render voting power", async () => {
+    const votingPower = 123_000_000n;
+
+    const votingNeuron = createVotingNeuron({ votingPower });
+
+    const po = renderComponent({
+      votingNeuron,
+    });
+
+    expect(await po.getDisplayedVotingPower()).toBe("1.23");
+  });
+
+  it("should round voting power", async () => {
+    const votingPower = 123_456_000n;
+
+    const votingNeuron = createVotingNeuron({ votingPower });
+
+    const po = renderComponent({
+      votingNeuron,
+    });
+
+    expect(await po.getDisplayedVotingPower()).toBe("1.23");
+  });
+});

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.spec.ts
@@ -79,10 +79,22 @@ describe("VotingNeuronListItem", () => {
 
     expect(toggleSelection).not.toBeCalled();
 
+    expect(await po.getCheckboxPo().isDisabled()).toBe(false);
     await po.getCheckboxPo().click();
 
     expect(toggleSelection).toBeCalledWith("1133");
     expect(toggleSelection).toBeCalledTimes(1);
+  });
+
+  it("should call dissable checkbox", async () => {
+    const votingNeuron = createVotingNeuron({});
+
+    const po = renderComponent({
+      votingNeuron,
+      disabled: true,
+    });
+
+    expect(await po.getCheckboxPo().isDisabled()).toBe(true);
   });
 
   it("should render voting power", async () => {

--- a/frontend/src/tests/page-objects/VotingNeuronListItem.page-object.ts
+++ b/frontend/src/tests/page-objects/VotingNeuronListItem.page-object.ts
@@ -1,0 +1,25 @@
+import { CheckboxPo } from "$tests/page-objects/Checkbox.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class VotingNeuronListItemPo extends BasePageObject {
+  private static readonly TID = "voting-neuron-list-item-component";
+
+  static under(element: PageObjectElement): VotingNeuronListItemPo {
+    return new VotingNeuronListItemPo(
+      element.byTestId(VotingNeuronListItemPo.TID)
+    );
+  }
+
+  getCheckboxPo(): CheckboxPo {
+    return CheckboxPo.under({ element: this.root });
+  }
+
+  getNeuronId(): Promise<string> {
+    return this.getText("neuron-id");
+  }
+
+  getDisplayedVotingPower(): Promise<string> {
+    return this.getText("voting-neuron-select-voting-power");
+  }
+}


### PR DESCRIPTION
# Motivation

The `VotingNeuronSelectList` has a list of items, one for each neuron.

<img width="789" alt="Screenshot 2024-04-10 at 11 39 00" src="https://github.com/dfinity/nns-dapp/assets/122978264/531532aa-4113-4d58-a1a1-1afa2c00f8dc">

To make it easier to test these items in isolation, we make a separate component for the item.

# Changes

Create a new `VotingNeuronListItem` component and use it in `VotingNeuronSelectList` instead of rendering the items directly in the list.

# Tests

Unit test added for the new `VotingNeuronListItem` component.
Unit test for `VotingNeuronSelectList` continue to pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary