### PR TITLE
Use page objects in VotingNeuronSelectList

### DIFF
--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.svelte
@@ -2,6 +2,7 @@
   import { votingNeuronSelectStore } from "$lib/stores/vote-registration.store";
   import VotingCardNeuronList from "$lib/components/proposal-detail/VotingCard/VotingCardNeuronList.svelte";
   import VotingNeuronListItem from "$lib/components/proposal-detail/VotingCard/VotingNeuronListItem.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let disabled: boolean;
 
@@ -9,10 +10,12 @@
     votingNeuronSelectStore.toggleSelection(neuronId);
 </script>
 
-{#if $votingNeuronSelectStore.neurons.length > 0}
-  <VotingCardNeuronList>
-    {#each $votingNeuronSelectStore.neurons as neuron}
-      <VotingNeuronListItem {neuron} {disabled} {toggleSelection} />
-    {/each}
-  </VotingCardNeuronList>
-{/if}
+<TestIdWrapper testId="voting-neuron-select-list-component">
+  {#if $votingNeuronSelectStore.neurons.length > 0}
+    <VotingCardNeuronList>
+      {#each $votingNeuronSelectStore.neurons as neuron}
+        <VotingNeuronListItem {neuron} {disabled} {toggleSelection} />
+      {/each}
+    </VotingCardNeuronList>
+  {/if}
+</TestIdWrapper>

--- a/frontend/src/tests/page-objects/VotingNeuronListItem.page-object.ts
+++ b/frontend/src/tests/page-objects/VotingNeuronListItem.page-object.ts
@@ -5,6 +5,14 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class VotingNeuronListItemPo extends BasePageObject {
   private static readonly TID = "voting-neuron-list-item-component";
 
+  static async allUnder(
+    element: PageObjectElement
+  ): Promise<VotingNeuronListItemPo[]> {
+    return Array.from(
+      await element.allByTestId(VotingNeuronListItemPo.TID)
+    ).map((el) => new VotingNeuronListItemPo(el));
+  }
+
   static under(element: PageObjectElement): VotingNeuronListItemPo {
     return new VotingNeuronListItemPo(
       element.byTestId(VotingNeuronListItemPo.TID)

--- a/frontend/src/tests/page-objects/VotingNeuronSelectList.page-object.ts
+++ b/frontend/src/tests/page-objects/VotingNeuronSelectList.page-object.ts
@@ -1,0 +1,19 @@
+import { VotingNeuronListItemPo } from "$tests/page-objects/VotingNeuronListItem.page-object";
+import { NnsProposalFiltersPo } from "$tests/page-objects/NnsProposalFilters.page-object";
+import { PageBannerPo } from "$tests/page-objects/PageBanner.page-object";
+import { ProposalCardPo } from "$tests/page-objects/ProposalCard.page-object";
+import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class VotingNeuronSelectListPo extends BasePageObject {
+  private static readonly TID = "voting-neuron-select-list-component";
+
+  static under(element: PageObjectElement): VotingNeuronSelectListPo {
+    return new VotingNeuronSelectListPo(element.byTestId(VotingNeuronSelectListPo.TID));
+  }
+
+  getVotingNeuronListItemPos(): Promise<VotingNeuronListItemPo[]> {
+    return VotingNeuronListItemPo.allUnder(this.root);
+  }
+}

--- a/frontend/src/tests/page-objects/VotingNeuronSelectList.page-object.ts
+++ b/frontend/src/tests/page-objects/VotingNeuronSelectList.page-object.ts
@@ -1,8 +1,4 @@
 import { VotingNeuronListItemPo } from "$tests/page-objects/VotingNeuronListItem.page-object";
-import { NnsProposalFiltersPo } from "$tests/page-objects/NnsProposalFilters.page-object";
-import { PageBannerPo } from "$tests/page-objects/PageBanner.page-object";
-import { ProposalCardPo } from "$tests/page-objects/ProposalCard.page-object";
-import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -10,7 +6,9 @@ export class VotingNeuronSelectListPo extends BasePageObject {
   private static readonly TID = "voting-neuron-select-list-component";
 
   static under(element: PageObjectElement): VotingNeuronSelectListPo {
-    return new VotingNeuronSelectListPo(element.byTestId(VotingNeuronSelectListPo.TID));
+    return new VotingNeuronSelectListPo(
+      element.byTestId(VotingNeuronSelectListPo.TID)
+    );
   }
 
   getVotingNeuronListItemPos(): Promise<VotingNeuronListItemPo[]> {


### PR DESCRIPTION
# Motivation

Making the test easier to read and maintain.

Also 2 tests are nonsense and are deleted. These tests assume that the component shows a sum of voting powers but `VotingNeuronSelectList` doesn't do that at all. The sum of selected voting powers is rendered in `VotableNeuronList` instead.

`"should not display total voting power of neurons"` tests that the total voting power of neurons (as opposed to the total voting power of ballots) is not displayed. But neither is displayed so obviously this passes but it's meaningless.
`"should recalculate total voting power after selection"` doesn't test anything because the only expectation in the test is an async expectation that's not awaited. If `await` is added to the test, the test fails because the component doesn't render any sum of voting powers.

# Changes

1. Add `VotingNeuronSelectListPo` to use in the test.
2. Add `allUnder` to `VotingNeuronListItemPo` to get a list of page objects, used in `VotingNeuronSelectListPo`.
3. Use `VotingNeuronSelectListPo` in `VotingNeuronSelectList.svelte`.

# Tests

only tests

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary