### PR TITLE
Show tooltip with exact voting power in voting card

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -15,6 +15,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+* Tooltip with exact voting power in voting card.
+
 #### Changed
 
 * Sort neurons by decreasing dissolve delay when stakes are equal.

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotableNeuronList.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotableNeuronList.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { selectedNeuronsVotingPower } from "$lib/utils/proposals.utils";
   import { i18n } from "$lib/stores/i18n";
-  import { Value } from "@dfinity/gix-components";
-  import { formatVotingPower } from "$lib/utils/neuron.utils";
+  import { Tooltip, Value } from "@dfinity/gix-components";
+  import {
+    formatVotingPower,
+    formatVotingPowerDetailed,
+  } from "$lib/utils/neuron.utils";
   import {
     type VoteRegistrationStoreEntry,
     votingNeuronSelectStore,
@@ -42,11 +45,18 @@
     <svelte:fragment slot="end">
       <span class="label">{$i18n.proposal_detail__vote.voting_power_label}</span
       >
-      <Value testId="voting-collapsible-toolbar-voting-power"
-        >{formatVotingPower(
+      <Tooltip
+        id="voting-power-tooltip"
+        text={formatVotingPowerDetailed(
           totalNeuronsVotingPower === undefined ? 0n : totalNeuronsVotingPower
-        )}</Value
+        )}
       >
+        <Value testId="voting-collapsible-toolbar-voting-power"
+          >{formatVotingPower(
+            totalNeuronsVotingPower === undefined ? 0n : totalNeuronsVotingPower
+          )}</Value
+        >
+      </Tooltip>
     </svelte:fragment>
     <VotingNeuronSelectList disabled={voteRegistration !== undefined} />
   </ExpandableProposalNeurons>

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.svelte
@@ -5,8 +5,11 @@
   import type { VotingNeuron } from "$lib/types/proposals";
   import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { formatVotingPower } from "$lib/utils/neuron.utils";
-  import { Checkbox, KeyValuePair } from "@dfinity/gix-components";
+  import {
+    formatVotingPower,
+    formatVotingPowerDetailed,
+  } from "$lib/utils/neuron.utils";
+  import { Checkbox, KeyValuePair, Tooltip } from "@dfinity/gix-components";
   import { fade } from "svelte/transition";
 
   export let neuron: VotingNeuron;
@@ -41,16 +44,21 @@
         on:nnsChange={() => toggleSelection(neuron.neuronIdString)}
         {disabled}
       >
-        <span
-          class="value"
-          data-tid="voting-neuron-select-voting-power"
-          aria-label={replacePlaceholders(
-            $i18n.proposal_detail__vote.cast_vote_votingPower,
-            {
-              $votingPower: formatVotingPower(neuron.votingPower),
-            }
-          )}>{formatVotingPower(neuron.votingPower)}</span
+        <Tooltip
+          id="voting-power-tooltip"
+          text={formatVotingPowerDetailed(neuron.votingPower)}
         >
+          <span
+            class="value"
+            data-tid="voting-neuron-select-voting-power"
+            aria-label={replacePlaceholders(
+              $i18n.proposal_detail__vote.cast_vote_votingPower,
+              {
+                $votingPower: formatVotingPower(neuron.votingPower),
+              }
+            )}>{formatVotingPower(neuron.votingPower)}</span
+          >
+        </Tooltip>
       </Checkbox>
     </span>
   </KeyValuePair>

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -249,6 +249,9 @@ export const getSpawningTimeInSeconds = (
 export const formatVotingPower = (value: bigint | number): string =>
   formatNumber(Number(value) / E8S_PER_ICP);
 
+export const formatVotingPowerDetailed = (value: bigint | number): string =>
+  formatNumber(Number(value) / E8S_PER_ICP, { minFraction: 8, maxFraction: 8 });
+
 export const isSeedNeuron = (neuron: NeuronInfo): boolean =>
   neuron.neuronType === NeuronType.Seed;
 

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotableNeuronList.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotableNeuronList.spec.ts
@@ -14,7 +14,7 @@ describe("VotableNeuronList", () => {
   const neuron1 = {
     ...mockNeuron,
     neuronId: 111n,
-    votingPower: 10_000_000_000n,
+    votingPower: 10_000_000_123n,
   };
   const neuron2 = {
     ...mockNeuron,
@@ -58,6 +58,11 @@ describe("VotableNeuronList", () => {
   it("should display total voting power of ballots not of neurons", async () => {
     const po = renderComponent();
     expect(await po.getDisplayedTotalSelectedVotingPower()).toBe("897.00");
+  });
+
+  it("should have a tooltip with exact voting power", async () => {
+    const po = renderComponent();
+    expect(await po.getTooltipPo().getTooltipText()).toBe("897.00000123");
   });
 
   it("should not display total voting power of neurons", async () => {

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.spec.ts
@@ -120,4 +120,16 @@ describe("VotingNeuronListItem", () => {
 
     expect(await po.getDisplayedVotingPower()).toBe("1.23");
   });
+
+  it("should have tooltip with exact voting power", async () => {
+    const votingPower = 123_456_000n;
+
+    const votingNeuron = createVotingNeuron({ votingPower });
+
+    const po = renderComponent({
+      votingNeuron,
+    });
+
+    expect(await po.getTooltipPo().getTooltipText()).toBe("1.23456000");
+  });
 });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -30,6 +30,7 @@ import {
   followeesByTopic,
   followeesNeurons,
   formatVotingPower,
+  formatVotingPowerDetailed,
   formattedMaturity,
   formattedStakedMaturity,
   formattedTotalMaturity,
@@ -213,6 +214,18 @@ describe("neuron-utils", () => {
       expect(formatVotingPower(0n)).toBe("0.00");
       expect(formatVotingPower(100_000_000n)).toBe("1.00");
       expect(formatVotingPower(9_999_900_000n)).toBe("100.00");
+    });
+  });
+
+  describe("formatVotingPowerDetailed", () => {
+    it("should format", () => {
+      expect(formatVotingPowerDetailed(0n)).toBe("0.00000000");
+      expect(formatVotingPowerDetailed(1n)).toBe("0.00000001");
+      expect(formatVotingPowerDetailed(100_000_000n)).toBe("1.00000000");
+      expect(formatVotingPowerDetailed(100_000_001n)).toBe("1.00000001");
+      expect(formatVotingPowerDetailed(999_999_999_999_999n)).toBe(
+        "9’999’999.99999999"
+      );
     });
   });
 

--- a/frontend/src/tests/page-objects/VotableNeuronList.page-object.ts
+++ b/frontend/src/tests/page-objects/VotableNeuronList.page-object.ts
@@ -1,3 +1,4 @@
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import { VotingNeuronSelectListPo } from "$tests/page-objects/VotingNeuronSelectList.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -11,6 +12,10 @@ export class VotableNeuronListPo extends BasePageObject {
 
   getVotingNeuronSelectListPo(): VotingNeuronSelectListPo {
     return VotingNeuronSelectListPo.under(this.root);
+  }
+
+  getTooltipPo(): TooltipPo {
+    return TooltipPo.under(this.root);
   }
 
   getTitle() {

--- a/frontend/src/tests/page-objects/VotingNeuronListItem.page-object.ts
+++ b/frontend/src/tests/page-objects/VotingNeuronListItem.page-object.ts
@@ -1,4 +1,5 @@
 import { CheckboxPo } from "$tests/page-objects/Checkbox.page-object";
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -21,6 +22,10 @@ export class VotingNeuronListItemPo extends BasePageObject {
 
   getCheckboxPo(): CheckboxPo {
     return CheckboxPo.under({ element: this.root });
+  }
+
+  getTooltipPo(): TooltipPo {
+    return TooltipPo.under(this.root);
   }
 
   getNeuronId(): Promise<string> {


### PR DESCRIPTION
# Motivation

We show rounded voting power on individual neurons and total selected voting power on the voting card.

<img width="789" alt="Screenshot 2024-04-10 at 11 39 00" src="https://github.com/dfinity/nns-dapp/assets/122978264/531532aa-4113-4d58-a1a1-1afa2c00f8dc">

Sometimes this means that the numbers you see don't add up.
We want to add a tooltip to show the exact voting power so people can verify that the actual numbers do add up.


# Changes

1. Add a function to format the detailed voting power.
2. Add a tooltip on individual neuron voting power.
3. Add a tooltip on the voting power sum.

# Tests

Unit test were added.
Tested manually here: https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [x] Add entry to changelog (if necessary).
