### PR TITLE
NNS1-2906: Remove the code path for when ENABLE_ICP_INDEX is disabled

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,7 +26,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Removed
 
-* Remove the possibility to disable `ENABLE_ICP_INDEX`.
+* Deprecate the feature flag `ENABLE_ICP_INDEX`.
 
 #### Fixed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,6 +26,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Removed
 
+* Remove the possibility to dissable `ENABLE_ICP_INDEX`.
+
 #### Fixed
 
 * Fixed duplicate tooltip IDs to be unique.

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,7 +26,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Removed
 
-* Remove the possibility to dissable `ENABLE_ICP_INDEX`.
+* Remove the possibility to disable `ENABLE_ICP_INDEX`.
 
 #### Fixed
 


### PR DESCRIPTION
# Motivation

`ENABLE_ICP_INDEX` is enabled on mainnet and in tests so the negative code path is not used anymore.

# Changes

Remove the conditionals on `ENABLE_ICP_INDEX` and only keep the branch where `ENABLE_ICP_INDEX` is true.

All the code that becomes unused as a result will be cleaned up in future PRs.

# Tests

Still pass

# Todos

- [x] Add entry to changelog (if necessary).
