### PR TITLE
Use page objects in NnsNeurons.spec.ts

### DIFF
--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -46,4 +46,8 @@ export class NnsNeuronsPo extends BasePageObject {
 
     throw new Error(`Neuron card with id ${neuronId} not found`);
   }
+
+  hasEmptyMessage(): Promise<boolean> {
+    return this.isPresent("empty-message-component");
+  }
 }


### PR DESCRIPTION
# Motivation

Make the test easier to read and maintain.

# Changes

1. Use `NnsNeuronsPo` in `NnsNeurons.spec.ts`.
2. Add a missing test that it's also possible for the "empty" message not to be displayed.

# Tests

only tests

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary