### PR TITLE
Custom render function for testing, which doesn't reuse the container

### DIFF
--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalsList.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalsList.spec.ts
@@ -8,13 +8,12 @@ import {
 import { mockSnsCanisterIdText } from "$tests/mocks/sns.api.mock";
 import { SnsProposalListPo } from "$tests/page-objects/SnsProposalList.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { SnsProposalDecisionStatus, type SnsProposalData } from "@dfinity/sns";
-import { cleanup, render } from "@testing-library/svelte";
 
 describe("SnsProposalsList", () => {
   const renderComponent = async (props) => {
-    cleanup();
     const { container } = render(SnsProposalsList, { props });
     await runResolvedPromises();
     return SnsProposalListPo.under(new JestPageObjectElement(container));

--- a/frontend/src/tests/lib/components/ui/IdentifierHash.spec.ts
+++ b/frontend/src/tests/lib/components/ui/IdentifierHash.spec.ts
@@ -1,17 +1,13 @@
 import IdentifierHash from "$lib/components/ui/IdentifierHash.svelte";
 import { IdentifierHashPo } from "$tests/page-objects/IdentifierHash.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { render } from "@testing-library/svelte";
+import { render } from "$tests/utils/svelte.test-utils";
 
 describe("IdentifierHash", () => {
   const identifier = "12345678901234567890";
 
   const renderComponent = (props) => {
-    // By default, render() reuses the container element between different calls
-    // from the same test.
-    const container = document.createElement("div");
-    document.body.appendChild(container);
-    render(IdentifierHash, props, { container });
+    const { container } = render(IdentifierHash, props);
     return IdentifierHashPo.under(new JestPageObjectElement(container));
   };
 

--- a/frontend/src/tests/lib/components/ui/ProposalStatusTag.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ProposalStatusTag.spec.ts
@@ -1,11 +1,10 @@
 import ProposalStatusTag from "$lib/components/ui/ProposalStatusTag.svelte";
 import { ProposalStatusTagPo } from "$tests/page-objects/ProposalStatusTag.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { cleanup, render } from "@testing-library/svelte";
+import { render } from "$tests/utils/svelte.test-utils";
 
 describe("ProposalStatusTag", () => {
   const renderComponent = (props) => {
-    cleanup();
     const { container } = render(ProposalStatusTag, {
       props,
     });

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -24,7 +24,7 @@ import {
 } from "$tests/utils/accounts.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { Principal } from "@dfinity/principal";
-import { cleanup, render } from "@testing-library/svelte";
+import { render } from "@testing-library/svelte";
 import { describe } from "vitest";
 
 describe("SelectUniverseCard", () => {
@@ -32,7 +32,6 @@ describe("SelectUniverseCard", () => {
   const mockSnsUniverse: Universe = createUniverse(mockSummary);
 
   const renderComponent = async (props) => {
-    cleanup();
     const { container } = render(SelectUniverseCard, props);
     await runResolvedPromises();
     return SelectUniverseCardPo.under(new JestPageObjectElement(container));

--- a/frontend/src/tests/lib/pages/SnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposals.spec.ts
@@ -18,6 +18,7 @@ import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { SnsProposalListPo } from "$tests/page-objects/SnsProposalList.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { render } from "$tests/utils/svelte.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { AnonymousIdentity } from "@dfinity/agent";
 import {
@@ -26,7 +27,7 @@ import {
   SnsSwapLifecycle,
   type SnsProposalData,
 } from "@dfinity/sns";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
+import { fireEvent, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 vi.mock("$lib/api/sns-governance.api");
@@ -359,7 +360,6 @@ describe("SnsProposals", () => {
       status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
     });
     const renderComponent = async () => {
-      cleanup();
       const { container } = render(SnsProposals);
       await runResolvedPromises();
       return SnsProposalListPo.under(new JestPageObjectElement(container));

--- a/frontend/src/tests/utils/svelte.test-utils.ts
+++ b/frontend/src/tests/utils/svelte.test-utils.ts
@@ -1,0 +1,16 @@
+import { render as svelteRender } from "@testing-library/svelte";
+
+// Adapted from Svelte render to work around the surprising behavior that render
+// reuses the same container element between different calls from the same test.
+export const render = (
+  component,
+  componentOptions = {},
+  renderOptions = {}
+) => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  return svelteRender(component, componentOptions, {
+    ...renderOptions,
+    container,
+  });
+};


### PR DESCRIPTION
# Motivation

When you call Svelte `render` multiple times within the same test, it renders both components into the same container.
We recently discovered this through some very surprising test behavior.
Our first solution was to always call `cleanup` before rendering.
This empties the container first, which makes sure that the previous render does not interfere with the new one.
But it doesn't allow you to access both components at the same time.
A better solution is to render each component into a separate container.

# Changes

Add a custom render function which creates a new container for each invocation.

# Tests

Use the custom render function in places that were working around the issue.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary