### PR TITLE
NNS1-3004: Message informing about topic renames

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Tooltip with exact voting power in voting card.
+* Message informing about proposal topic changes.
 
 #### Changed
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -241,7 +241,7 @@
     "title": "Neurons",
     "text": "Earn voting rewards by staking your ICP in neurons. Neurons allow you to participate in governance on the Internet Computer by submitting and voting on Network Nervous System (NNS) proposals.",
     "rename_topic_message": "There were changes made to proposal topics. Review your neuron following to confirm it is set up according to your preferences.",
-    "rename_topic_learn_more_label": "Learn more about the changes made to proposals topics.",
+    "rename_topic_learn_more_label": "Learn more about the changes made to proposal topics.",
     "stake_token": "Stake $token",
     "merge_neurons": "Merge Neurons",
     "merge_neurons_modal_title": "Select two neurons to merge",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -31,7 +31,8 @@
     "receive_with_token": "Receive $token",
     "receive": "Receive",
     "send_with_token": "Send $token",
-    "collapse_all": "Collapse All"
+    "collapse_all": "Collapse All",
+    "learn_more": "Learn more"
   },
   "error": {
     "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser.",
@@ -239,6 +240,8 @@
   "neurons": {
     "title": "Neurons",
     "text": "Earn voting rewards by staking your ICP in neurons. Neurons allow you to participate in governance on the Internet Computer by submitting and voting on Network Nervous System (NNS) proposals.",
+    "rename_topic_message": "There were changes made to proposal topics. Review your neuron following to confirm it is set up according to your preferences.",
+    "rename_topic_learn_more_label": "Learn more about the changes made to proposals topics.",
     "stake_token": "Stake $token",
     "merge_neurons": "Merge Neurons",
     "merge_neurons_modal_title": "Select two neurons to merge",

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -4,7 +4,7 @@
   import NnsNeuronCard from "$lib/components/neurons/NnsNeuronCard.svelte";
   import { neuronsStore, sortedNeuronStore } from "$lib/stores/neurons.store";
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
-  import { Tooltip } from "@dfinity/gix-components";
+  import { IconInfo, Tooltip } from "@dfinity/gix-components";
   import { isSpawning } from "$lib/utils/neuron.utils";
   import { pageStore } from "$lib/derived/page.derived";
   import { buildNeuronUrl } from "$lib/utils/navigation.utils";
@@ -21,6 +21,22 @@
 </script>
 
 <TestIdWrapper testId="nns-neurons-component">
+  {#if !isLoading && $sortedNeuronStore.length > 0}
+    <div class="topic-rename-message" data-tid="topic-rename-message">
+      <div class="icon-info">
+        <IconInfo />
+      </div>
+      <span>
+        {$i18n.neurons.rename_topic_message}
+        <a
+          href=""
+          rel="noopener noreferrer"
+          aria-label={$i18n.neurons.rename_topic_learn_more_label}
+          target="_blank">{$i18n.core.learn_more}</a
+        >
+      </span>
+    </div>
+  {/if}
   <div class="card-grid" data-tid="neurons-body">
     {#if isLoading}
       <SkeletonCard />
@@ -56,3 +72,22 @@
     <EmptyMessage>{$i18n.neurons.text}</EmptyMessage>
   {/if}
 </TestIdWrapper>
+
+<style lang="scss">
+  .topic-rename-message {
+    display: flex;
+    gap: var(--padding);
+    align-items: center;
+
+    background-color: var(--card-background);
+    border-radius: var(--border-radius);
+    margin-bottom: var(--padding-2x);
+    padding: var(--padding-2x);
+
+    .icon-info {
+      padding: var(--padding);
+      background-color: var(--tooltip-border-color);
+      border-radius: 50%;
+    }
+  }
+</style>

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -29,7 +29,7 @@
       <span>
         {$i18n.neurons.rename_topic_message}
         <a
-          href=""
+          href="https://forum.dfinity.org/t/bringing-clarity-to-icp-upgrade-proposals/29626"
           rel="noopener noreferrer"
           aria-label={$i18n.neurons.rename_topic_learn_more_label}
           target="_blank">{$i18n.core.learn_more}</a

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -35,6 +35,7 @@ interface I18nCore {
   receive: string;
   send_with_token: string;
   collapse_all: string;
+  learn_more: string;
 }
 
 interface I18nError {
@@ -250,6 +251,8 @@ interface I18nNeuron_types {
 interface I18nNeurons {
   title: string;
   text: string;
+  rename_topic_message: string;
+  rename_topic_learn_more_label: string;
   stake_token: string;
   merge_neurons: string;
   merge_neurons_modal_title: string;

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -73,6 +73,12 @@ describe("NnsNeurons", () => {
 
       expect(await po.hasEmptyMessage()).toBe(false);
     });
+
+    it("should render topic rename message", async () => {
+      const po = await renderComponent();
+
+      expect(await po.hasTopicRenameMessage()).toBe(true);
+    });
   });
 
   describe("no neurons", () => {
@@ -87,6 +93,37 @@ describe("NnsNeurons", () => {
       const po = await renderComponent();
 
       expect(await po.hasEmptyMessage()).toBe(true);
+    });
+
+    it("should not render topic rename message", async () => {
+      const po = await renderComponent();
+
+      expect(await po.hasTopicRenameMessage()).toBe(false);
+    });
+  });
+
+  describe("while loading", () => {
+    beforeEach(() => {
+      vi.spyOn(authServices, "getAuthenticatedIdentity").mockResolvedValue(
+        mockIdentity
+      );
+      vi.spyOn(api, "queryNeurons").mockReturnValue(
+        new Promise(() => {
+          // Don't resolve the promise to keep the component in loading state.
+        })
+      );
+    });
+
+    it("should not render an empty message", async () => {
+      const po = await renderComponent();
+
+      expect(await po.hasEmptyMessage()).toBe(false);
+    });
+
+    it("should not render topic rename message", async () => {
+      const po = await renderComponent();
+
+      expect(await po.hasTopicRenameMessage()).toBe(false);
     });
   });
 

--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -50,4 +50,8 @@ export class NnsNeuronsPo extends BasePageObject {
   hasEmptyMessage(): Promise<boolean> {
     return this.isPresent("empty-message-component");
   }
+
+  async hasTopicRenameMessage(): Promise<boolean> {
+    return this.isPresent("topic-rename-message");
+  }
 }


### PR DESCRIPTION
# Motivation

We are going to change some topics and proposal types and want to make sure the users are informed.

# Changes

Add a message linking to the forum post on top of the neurons page for users who have neurons.

# Tests

Unit tests added.

Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [x] Add entry to changelog (if necessary).
