### PR TITLE
Component to display voting power with tooltip

### DIFF
--- a/frontend/src/lib/components/ic/VotingPowerDisplay.svelte
+++ b/frontend/src/lib/components/ic/VotingPowerDisplay.svelte
@@ -1,0 +1,28 @@
+<script lang="ts" context="module">
+  let nextTooltipIdNumber = 0;
+</script>
+
+<script lang="ts">
+  import { Tooltip } from "@dfinity/gix-components";
+  import {
+    formatVotingPower,
+    formatVotingPowerDetailed,
+  } from "$lib/utils/neuron.utils";
+
+  export let valueTestId: string;
+  export let valueAriaLabel: string | undefined = undefined;
+  export let votingPowerE8s: bigint;
+
+  let tooltipId = `voting-power-tooltip-${nextTooltipIdNumber}`;
+  ++nextTooltipIdNumber;
+</script>
+
+<Tooltip
+  testId="voting-power-display-component"
+  id={tooltipId}
+  text={formatVotingPowerDetailed(votingPowerE8s)}
+>
+  <span data-tid={valueTestId} aria-label={valueAriaLabel}
+    >{formatVotingPower(votingPowerE8s)}</span
+  >
+</Tooltip>

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotableNeuronList.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotableNeuronList.svelte
@@ -1,16 +1,12 @@
 <script lang="ts">
   import { selectedNeuronsVotingPower } from "$lib/utils/proposals.utils";
   import { i18n } from "$lib/stores/i18n";
-  import { Tooltip, Value } from "@dfinity/gix-components";
-  import {
-    formatVotingPower,
-    formatVotingPowerDetailed,
-  } from "$lib/utils/neuron.utils";
   import {
     type VoteRegistrationStoreEntry,
     votingNeuronSelectStore,
   } from "$lib/stores/vote-registration.store";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import VotingPowerDisplay from "$lib/components/ic/VotingPowerDisplay.svelte";
   import ExpandableProposalNeurons from "$lib/components/proposal-detail/VotingCard/ExpandableProposalNeurons.svelte";
   import VotingNeuronSelectList from "$lib/components/proposal-detail/VotingCard/VotingNeuronSelectList.svelte";
 
@@ -45,18 +41,10 @@
     <svelte:fragment slot="end">
       <span class="label">{$i18n.proposal_detail__vote.voting_power_label}</span
       >
-      <Tooltip
-        id="voting-power-tooltip"
-        text={formatVotingPowerDetailed(
-          totalNeuronsVotingPower === undefined ? 0n : totalNeuronsVotingPower
-        )}
-      >
-        <Value testId="voting-collapsible-toolbar-voting-power"
-          >{formatVotingPower(
-            totalNeuronsVotingPower === undefined ? 0n : totalNeuronsVotingPower
-          )}</Value
-        >
-      </Tooltip>
+      <VotingPowerDisplay
+        valueTestId="voting-collapsible-toolbar-voting-power"
+        votingPowerE8s={totalNeuronsVotingPower}
+      />
     </svelte:fragment>
     <VotingNeuronSelectList disabled={voteRegistration !== undefined} />
   </ExpandableProposalNeurons>

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
   import { SNS_NEURON_ID_DISPLAY_LENGTH } from "$lib/constants/sns-neurons.constants";
+  import VotingPowerDisplay from "$lib/components/ic/VotingPowerDisplay.svelte";
   import { i18n } from "$lib/stores/i18n";
   import { votingNeuronSelectStore } from "$lib/stores/vote-registration.store";
   import type { VotingNeuron } from "$lib/types/proposals";
   import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import {
-    formatVotingPower,
-    formatVotingPowerDetailed,
-  } from "$lib/utils/neuron.utils";
-  import { Checkbox, KeyValuePair, Tooltip } from "@dfinity/gix-components";
+  import { formatVotingPower } from "$lib/utils/neuron.utils";
+  import { Checkbox, KeyValuePair } from "@dfinity/gix-components";
   import { fade } from "svelte/transition";
 
   export let neuron: VotingNeuron;
@@ -44,21 +42,16 @@
         on:nnsChange={() => toggleSelection(neuron.neuronIdString)}
         {disabled}
       >
-        <Tooltip
-          id="voting-power-tooltip"
-          text={formatVotingPowerDetailed(neuron.votingPower)}
-        >
-          <span
-            class="value"
-            data-tid="voting-neuron-select-voting-power"
-            aria-label={replacePlaceholders(
-              $i18n.proposal_detail__vote.cast_vote_votingPower,
-              {
-                $votingPower: formatVotingPower(neuron.votingPower),
-              }
-            )}>{formatVotingPower(neuron.votingPower)}</span
-          >
-        </Tooltip>
+        <VotingPowerDisplay
+          valueTestId="voting-neuron-select-voting-power"
+          valueAriaLabel={replacePlaceholders(
+            $i18n.proposal_detail__vote.cast_vote_votingPower,
+            {
+              $votingPower: formatVotingPower(neuron.votingPower),
+            }
+          )}
+          votingPowerE8s={neuron.votingPower}
+        />
       </Checkbox>
     </span>
   </KeyValuePair>

--- a/frontend/src/tests/lib/components/ic/VotingPowerDisplay.spec.ts
+++ b/frontend/src/tests/lib/components/ic/VotingPowerDisplay.spec.ts
@@ -1,0 +1,54 @@
+import VotingPowerDisplay from "$lib/components/ic/VotingPowerDisplay.svelte";
+import { VotingPowerDisplayPo } from "$tests/page-objects/VotingPowerDisplay.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+
+describe("VotingPowerDisplay", () => {
+  const renderComponent = ({
+    votingPowerE8s = 100_000_000n,
+    valueTestId = "test-id",
+    valueAriaLabel,
+  }: {
+    votingPowerE8s?: bigint;
+    valueTestId?: string;
+    valueAriaLabel?: string;
+  }) => {
+    const { container } = render(VotingPowerDisplay, {
+      valueTestId,
+      votingPowerE8s,
+      valueAriaLabel,
+    });
+    return VotingPowerDisplayPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should render voting power", async () => {
+    const po = renderComponent({ votingPowerE8s: 123_456_000n });
+    expect(await po.getDisplayedVotingPower()).toEqual("1.23");
+    expect(await po.getExactVotingPower()).toEqual("1.23456000");
+  });
+
+  it("should have the specified test ID on the displayed voting power", async () => {
+    const valueTestId = "test-id-for-testing";
+    const po = renderComponent({ votingPowerE8s: 789_000_000n, valueTestId });
+    expect(await po.getText(valueTestId)).toBe("7.89");
+  });
+
+  it("should render the aria-label on the displayed element", async () => {
+    const valueTestId = "test-id-for-testing";
+    const valueAriaLabel = "Test aria label description";
+    const po = renderComponent({ valueTestId, valueAriaLabel });
+    expect(await po.root.byTestId(valueTestId).getAttribute("aria-label")).toBe(
+      valueAriaLabel
+    );
+  });
+
+  it("should created a new tooltip ID each time", async () => {
+    const po1 = renderComponent({});
+    const po2 = renderComponent({});
+
+    expect(await po1.getTooltipId()).toMatch(/voting-power-tooltip-\d+/);
+    expect(await po2.getTooltipId()).toMatch(/voting-power-tooltip-\d+/);
+
+    expect(await po1.getTooltipId()).not.toEqual(await po2.getTooltipId());
+  });
+});

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotableNeuronList.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotableNeuronList.spec.ts
@@ -62,7 +62,9 @@ describe("VotableNeuronList", () => {
 
   it("should have a tooltip with exact voting power", async () => {
     const po = renderComponent();
-    expect(await po.getTooltipPo().getTooltipText()).toBe("897.00000123");
+    expect(await po.getVotingPowerDisplayPo().getTooltipText()).toBe(
+      "897.00000123"
+    );
   });
 
   it("should not display total voting power of neurons", async () => {

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingNeuronListItem.spec.ts
@@ -130,6 +130,8 @@ describe("VotingNeuronListItem", () => {
       votingNeuron,
     });
 
-    expect(await po.getTooltipPo().getTooltipText()).toBe("1.23456000");
+    expect(await po.getVotingPowerDisplayPo().getTooltipText()).toBe(
+      "1.23456000"
+    );
   });
 });

--- a/frontend/src/tests/page-objects/Tooltip.page-object.ts
+++ b/frontend/src/tests/page-objects/Tooltip.page-object.ts
@@ -29,4 +29,8 @@ export class TooltipPo extends BasePageObject {
     const tooltipElemenet = body.querySelector(`#${id}`);
     return tooltipElemenet;
   }
+
+  async getDisplayedText(): Promise<string> {
+    return this.root.querySelector(".tooltip-target").getText();
+  }
 }

--- a/frontend/src/tests/page-objects/VotableNeuronList.page-object.ts
+++ b/frontend/src/tests/page-objects/VotableNeuronList.page-object.ts
@@ -1,5 +1,5 @@
-import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import { VotingNeuronSelectListPo } from "$tests/page-objects/VotingNeuronSelectList.page-object";
+import { VotingPowerDisplayPo } from "$tests/page-objects/VotingPowerDisplay.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -14,8 +14,8 @@ export class VotableNeuronListPo extends BasePageObject {
     return VotingNeuronSelectListPo.under(this.root);
   }
 
-  getTooltipPo(): TooltipPo {
-    return TooltipPo.under(this.root);
+  getVotingPowerDisplayPo(): VotingPowerDisplayPo {
+    return VotingPowerDisplayPo.under(this.root);
   }
 
   getTitle() {

--- a/frontend/src/tests/page-objects/VotingNeuronListItem.page-object.ts
+++ b/frontend/src/tests/page-objects/VotingNeuronListItem.page-object.ts
@@ -1,5 +1,5 @@
 import { CheckboxPo } from "$tests/page-objects/Checkbox.page-object";
-import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
+import { VotingPowerDisplayPo } from "$tests/page-objects/VotingPowerDisplay.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -24,8 +24,8 @@ export class VotingNeuronListItemPo extends BasePageObject {
     return CheckboxPo.under({ element: this.root });
   }
 
-  getTooltipPo(): TooltipPo {
-    return TooltipPo.under(this.root);
+  getVotingPowerDisplayPo(): VotingPowerDisplayPo {
+    return VotingPowerDisplayPo.under(this.root);
   }
 
   getNeuronId(): Promise<string> {

--- a/frontend/src/tests/page-objects/VotingPowerDisplay.page-object.ts
+++ b/frontend/src/tests/page-objects/VotingPowerDisplay.page-object.ts
@@ -1,0 +1,21 @@
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class VotingPowerDisplayPo extends TooltipPo {
+  private static readonly VOTING_POWER_DISPLAY_TID =
+    "voting-power-display-component";
+
+  static under(element: PageObjectElement): VotingPowerDisplayPo {
+    return new VotingPowerDisplayPo(
+      element.byTestId(VotingPowerDisplayPo.VOTING_POWER_DISPLAY_TID)
+    );
+  }
+
+  getDisplayedVotingPower(): Promise<string> {
+    return this.getDisplayedText();
+  }
+
+  getExactVotingPower(): Promise<string> {
+    return this.getTooltipText();
+  }
+}


### PR DESCRIPTION
# Motivation

In 2 different places we display rounded voting power with a tooltip for the exact amount.
We want to do this in even more places.
So in this PR I factored out a component for this to reuse.

# Changes

1. Add `VotingPowerDisplay` component which displays rounded voting power and has a tooltip with exact voting power.
2. Use this in `VotableNeuronList` and `VotingNeuronListItem` instead of duplicating the code.

# Tests

Added unit tests for `VotingPowerDisplay` and adapted existing unit test for the new structure.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary