### PR TITLE
NNS1-2905: Remove get_transactions method from nns-dapp canister

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -27,6 +27,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Removed
 
 * Deprecate the feature flag `ENABLE_ICP_INDEX`.
+* Removed `get_transactions` method from nns-dapp canister.
 
 #### Fixed
 

--- a/rs/backend/nns-dapp-exports-production.txt
+++ b/rs/backend/nns-dapp-exports-production.txt
@@ -8,7 +8,6 @@ canister_query get_canisters
 canister_query get_exceptional_transactions
 canister_query get_histogram
 canister_query get_stats
-canister_query get_transactions
 canister_query http_request
 canister_update <ic-cdk internal> timer_executor
 canister_update add_account

--- a/rs/backend/nns-dapp-exports-test.txt
+++ b/rs/backend/nns-dapp-exports-test.txt
@@ -9,7 +9,6 @@ canister_query get_exceptional_transactions
 canister_query get_histogram
 canister_query get_stats
 canister_query get_toy_account
-canister_query get_transactions
 canister_query http_request
 canister_update <ic-cdk internal> timer_executor
 canister_update add_account

--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -1,6 +1,5 @@
 type AccountIdentifier = text;
 type BlockHeight = nat64;
-type CanisterId = principal;
 type ICPTs = record { e8s: nat64; };
 type Memo = nat64;
 type NeuronId = nat64;

--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -34,68 +34,6 @@ type GetAccountResponse =
         AccountNotFound;
     };
 
-type Timestamp =
-    record {
-        timestamp_nanos: nat64;
-    };
-
-type GetTransactionsRequest =
-    record {
-        account_identifier: AccountIdentifier;
-        offset: nat32;
-        page_size: nat8;
-    };
-
-type GetTransactionsResponse =
-    record {
-        transactions: vec Transaction;
-        total: nat32;
-    };
-
-type Send =
-    record {
-        to: AccountIdentifier;
-        amount: ICPTs;
-        fee: ICPTs;
-    };
-
-type Receive =
-    record {
-        from: AccountIdentifier;
-        amount: ICPTs;
-        fee: ICPTs;
-    };
-
-type Transfer =
-    variant {
-        Burn: record { amount: ICPTs; };
-        Mint: record { amount: ICPTs; };
-        Send: Send;
-        Receive: Receive;
-    };
-
-type Transaction =
-    record {
-        block_height: BlockHeight;
-        timestamp: Timestamp;
-        memo: nat64;
-        transfer: Transfer;
-        transaction_type: opt TransactionType;
-    };
-
-type TransactionType =
-    variant {
-        Burn;
-        Mint;
-        Transfer;
-        StakeNeuron;
-        StakeNeuronNotification;
-        TopUpNeuron;
-        CreateCanister;
-        TopUpCanister: CanisterId;
-        ParticipateSwap: CanisterId;
-    };
-
 type CreateSubAccountResponse =
     variant {
         Ok: SubAccountDetails;
@@ -264,7 +202,6 @@ type SchemaLabel = variant {
 service: (opt Config) -> {
     get_account: () -> (GetAccountResponse) query;
     add_account: () -> (AccountIdentifier);
-    get_transactions: (GetTransactionsRequest) -> (GetTransactionsResponse) query;
     create_sub_account: (text) -> (CreateSubAccountResponse);
     rename_sub_account: (RenameSubAccountRequest) -> (RenameSubAccountResponse);
     register_hardware_wallet: (RegisterHardwareWalletRequest) -> (RegisterHardwareWalletResponse);

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -781,6 +781,7 @@ impl AccountsStore {
     }
 
     /// Gets all the transactions to or from the caller.
+    /// TODO: Delete this.
     #[must_use]
     #[allow(clippy::needless_pass_by_value)] // The pattern is to pass a request by value.
     #[allow(dead_code)]
@@ -1811,6 +1812,7 @@ pub struct TransactionResult {
     transaction_type: Option<TransactionType>,
 }
 
+/// TODO: Delete this.
 #[derive(CandidType, Debug, PartialEq)]
 #[allow(dead_code)]
 pub enum TransferResult {

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -783,6 +783,7 @@ impl AccountsStore {
     /// Gets all the transactions to or from the caller.
     #[must_use]
     #[allow(clippy::needless_pass_by_value)] // The pattern is to pass a request by value.
+    #[allow(dead_code)]
     pub fn get_transactions(&self, caller: PrincipalId, request: GetTransactionsRequest) -> GetTransactionsResponse {
         let account_identifier = AccountIdentifier::from(caller);
         let empty_transaction_response = GetTransactionsResponse {
@@ -1811,6 +1812,7 @@ pub struct TransactionResult {
 }
 
 #[derive(CandidType, Debug, PartialEq)]
+#[allow(dead_code)]
 pub enum TransferResult {
     Burn {
         amount: Tokens,

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -781,7 +781,7 @@ impl AccountsStore {
     }
 
     /// Gets all the transactions to or from the caller.
-    /// TODO: Delete this.
+    /// TODO(NNS1-2905): Delete this.
     #[must_use]
     #[allow(clippy::needless_pass_by_value)] // The pattern is to pass a request by value.
     #[allow(dead_code)]
@@ -1812,7 +1812,7 @@ pub struct TransactionResult {
     transaction_type: Option<TransactionType>,
 }
 
-/// TODO: Delete this.
+/// TODO(NNS1-2905): Delete this.
 #[derive(CandidType, Debug, PartialEq)]
 #[allow(dead_code)]
 pub enum TransferResult {

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -1,9 +1,8 @@
 use crate::accounts_store::histogram::AccountsStoreHistogram;
 use crate::accounts_store::{
     AccountDetails, AttachCanisterRequest, AttachCanisterResponse, CreateSubAccountResponse, DetachCanisterRequest,
-    DetachCanisterResponse, GetTransactionsRequest, GetTransactionsResponse, NamedCanister,
-    RegisterHardwareWalletRequest, RegisterHardwareWalletResponse, RenameCanisterRequest, RenameCanisterResponse,
-    RenameSubAccountRequest, RenameSubAccountResponse,
+    DetachCanisterResponse, NamedCanister, RegisterHardwareWalletRequest, RegisterHardwareWalletResponse,
+    RenameCanisterRequest, RenameCanisterResponse, RenameSubAccountRequest, RenameSubAccountResponse,
 };
 use crate::arguments::{set_canister_arguments, CanisterArguments, CANISTER_ARGUMENTS};
 use crate::assets::{hash_bytes, insert_asset, insert_tar_xz, Asset};
@@ -142,20 +141,6 @@ fn add_account_impl() -> AccountIdentifier {
     let principal = dfn_core::api::caller();
     STATE.with(|s| s.accounts_store.borrow_mut().add_account(principal));
     AccountIdentifier::from(principal)
-}
-
-/// Returns a page of transactions for a given `AccountIdentifier`.
-///
-/// The `AccountIdentifier` must be linked to the caller's account, else an empty `Vec` will be
-/// returned.
-#[export_name = "canister_query get_transactions"]
-pub fn get_transactions() {
-    over(candid_one, get_transactions_impl);
-}
-
-fn get_transactions_impl(request: GetTransactionsRequest) -> GetTransactionsResponse {
-    let principal = dfn_core::api::caller();
-    STATE.with(|s| s.accounts_store.borrow().get_transactions(principal, request))
 }
 
 /// Creates a new ledger sub account and links it to the user's account.


### PR DESCRIPTION
# Motivation

The nns-dapp frontend now reads ICP transactions from the ICP index canister.
It no longer needs to read transactions from the nns-dapp canister and we want to clean up the canister code.

In this PR we only remove the possibility to get transactions from the nns-dapp canister. We don't remove the data yet so that it's easy to revert if for whatever reason this causes problems.

# Changes

Remove the `get_transactions` method from the nns-dapp canister.

# Tests

Existing unit tests, test the method on the account store, which still exists.

# Todos

- [x] Add entry to changelog (if necessary).
