### PR TITLE
Fix confusing test output caused by missing mocks

### DIFF
--- a/frontend/src/tests/lib/components/neurons/EditFollowNeurons.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/EditFollowNeurons.spec.ts
@@ -31,9 +31,7 @@ describe("EditFollowNeurons", () => {
   beforeEach(() => {
     neuronsStore.reset();
     resetIdentity();
-    const spyQueryKnownNeurons = vi
-      .spyOn(governanceApi, "queryKnownNeurons")
-      .mockResolvedValue([]);
+    vi.spyOn(governanceApi, "queryKnownNeurons").mockResolvedValue([]);
     fillNeuronStore();
   });
 

--- a/frontend/src/tests/lib/components/neurons/EditFollowNeurons.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/EditFollowNeurons.spec.ts
@@ -1,5 +1,7 @@
+import * as governanceApi from "$lib/api/governance.api";
 import EditFollowNeurons from "$lib/components/neurons/EditFollowNeurons.svelte";
 import { neuronsStore } from "$lib/stores/neurons.store";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { EditFollowNeuronsPo } from "$tests/page-objects/EditFollowNeurons.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -28,6 +30,10 @@ describe("EditFollowNeurons", () => {
 
   beforeEach(() => {
     neuronsStore.reset();
+    resetIdentity();
+    const spyQueryKnownNeurons = vi
+      .spyOn(governanceApi, "queryKnownNeurons")
+      .mockResolvedValue([]);
     fillNeuronStore();
   });
 

--- a/frontend/src/tests/lib/modals/neurons/FollowNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/FollowNeuronsModal.spec.ts
@@ -31,9 +31,7 @@ describe("FollowNeuronsModal", () => {
   beforeEach(() => {
     neuronsStore.reset();
     resetIdentity();
-    const spyQueryKnownNeurons = vi
-      .spyOn(governanceApi, "queryKnownNeurons")
-      .mockResolvedValue([]);
+    vi.spyOn(governanceApi, "queryKnownNeurons").mockResolvedValue([]);
     fillNeuronStore();
   });
 

--- a/frontend/src/tests/lib/modals/neurons/FollowNeuronsModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/FollowNeuronsModal.spec.ts
@@ -1,5 +1,7 @@
+import * as governanceApi from "$lib/api/governance.api";
 import FollowNeuronsModal from "$lib/modals/neurons/FollowNeuronsModal.svelte";
 import { neuronsStore } from "$lib/stores/neurons.store";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { FollowNeuronsModalPo } from "$tests/page-objects/FollowNeuronsModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -28,6 +30,10 @@ describe("FollowNeuronsModal", () => {
 
   beforeEach(() => {
     neuronsStore.reset();
+    resetIdentity();
+    const spyQueryKnownNeurons = vi
+      .spyOn(governanceApi, "queryKnownNeurons")
+      .mockResolvedValue([]);
     fillNeuronStore();
   });
 

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -1,4 +1,5 @@
 import * as ckbtcMinterApi from "$lib/api/ckbtc-minter.api";
+import * as governanceApi from "$lib/api/governance.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
@@ -126,6 +127,7 @@ describe("Wallet", () => {
         throw new Error(`Unexpected canisterId: ${canisterId.toText()}`);
       }
     );
+    vi.spyOn(governanceApi, "queryNeurons").mockResolvedValue([]);
   });
 
   beforeAll(() => {

--- a/frontend/src/tests/routes/app/wallet/page.spec.ts
+++ b/frontend/src/tests/routes/app/wallet/page.spec.ts
@@ -1,4 +1,5 @@
-import * as accountsApi from "$lib/api/accounts.api";
+import * as governanceApi from "$lib/api/governance.api";
+import * as indexApi from "$lib/api/icp-index.api";
 import * as icpLedgerApi from "$lib/api/icp-ledger.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
@@ -9,6 +10,7 @@ import {
   mockAccountsStoreData,
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
+import { mockEmptyGetTransactionsResponse } from "$tests/mocks/transaction.mock";
 import { WalletPo } from "$tests/page-objects/Wallet.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
@@ -18,8 +20,11 @@ describe("Wallet page", () => {
   beforeEach(() => {
     resetIdentity();
 
-    vi.spyOn(accountsApi, "getTransactions").mockResolvedValue([]);
+    vi.spyOn(indexApi, "getTransactions").mockResolvedValue(
+      mockEmptyGetTransactionsResponse
+    );
     vi.spyOn(icpLedgerApi, "queryAccountBalance").mockResolvedValue(0n);
+    vi.spyOn(governanceApi, "queryNeurons").mockResolvedValue([]);
 
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT },


### PR DESCRIPTION
# Motivation

Some of our tests produce output like this:
```
TypeError: id.transformRequest is not a function
    at HttpAgent.call (/Users/dskloet/dev/nns-dapp/tree9/frontend/node_modules/@dfinity/agent/src/agent/http/index.ts:424:33)
    at caller (/Users/dskloet/dev/nns-dapp/tree9/frontend/node_modules/@dfinity/agent/src/actor.ts:484:28)
    at getTransactions (/Users/dskloet/dev/nns-dapp/tree9/frontend/node_modules/@dfinity/ledger-icp/dist/esm/chunk-SUVDEL6N.js:3:3602)
    at Module.getTransactions (/Users/dskloet/dev/nns-dapp/tree9/frontend/src/lib/api/icp-index.api.ts:35:37)
    at Module.loadIcpAccountTransactions (/Users/dskloet/dev/nns-dapp/tree9/frontend/src/lib/services/icp-transactions.services.ts:23:42)
    at reloadTransactions (/Users/dskloet/dev/nns-dapp/tree9/frontend/src/lib/pages/NnsWallet.svelte:1245:3)
    at accountDidUpdate (/Users/dskloet/dev/nns-dapp/tree9/frontend/src/lib/pages/NnsWallet.svelte:1272:3)
```
Because a function (in this case `getTransactions`) is called that should have been mocked out but wasn't.
This doesn't cause the test to fail because the test tests something that doesn't depend on this call, and the test passes even before these errors are logged.
If we introduce an artificial delay, these tests fail because tests that log anything are made to fail.
So I temporarily added a delay after every test to find all these tests and fix them.

# Changes

Add missing mock behavior to get rid of the confusing test logs.

# Tests

Pass, even with the artificial delay.
But I've removed the artificial delay again because we don't want tests to be slow.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary