### PR TITLE
Sns selector style adjustments for mobile

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,7 +30,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
-* Sns selector gaps.
+* SNS selector gaps.
 
 #### Security
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,6 +30,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Sns selector gaps.
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/components/layout/UniverseSplitContent.svelte
+++ b/frontend/src/lib/components/layout/UniverseSplitContent.svelte
@@ -26,10 +26,5 @@
   .container {
     display: contents;
     --content-start-height: calc(92px + var(--padding-2x));
-    --nav-component-title-display: none;
-
-    @include media.min-width(large) {
-      --nav-component-title-display: block;
-    }
   }
 </style>

--- a/frontend/src/lib/components/proposals/NnsProposalsFilters.svelte
+++ b/frontend/src/lib/components/proposals/NnsProposalsFilters.svelte
@@ -123,7 +123,7 @@
   .proposal-filters {
     display: flex;
     flex-direction: column;
-    gap: var(--padding);
+    gap: var(--padding-2x);
     margin-bottom: var(--padding-3x);
 
     @include media.min-width(medium) {

--- a/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsFilters.svelte
@@ -102,7 +102,7 @@
   .proposal-filters {
     display: flex;
     flex-direction: column;
-    gap: var(--padding);
+    gap: var(--padding-2x);
     margin-bottom: var(--padding-3x);
 
     @include media.min-width(medium) {

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -26,12 +26,7 @@
     role === "button" ? "framed" : role === "link" ? "transparent" : undefined;
 
   let icon: "expand" | "check" | undefined = undefined;
-  $: icon =
-    role === "button" && selected
-      ? "check"
-      : role === "dropdown"
-      ? "expand"
-      : undefined;
+  $: icon = role === "dropdown" ? "expand" : undefined;
 
   let displayProjectAccountsBalance = false;
   $: displayProjectAccountsBalance =

--- a/frontend/src/lib/components/universe/SelectUniverseNav.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNav.svelte
@@ -31,19 +31,21 @@
 
 <svelte:window bind:innerWidth />
 
-<Nav>
-  <p class="title" slot="title" data-tid="select-universe-nav-title">
-    {$titleTokenSelectorStore}
-  </p>
+<div class="container">
+  <Nav>
+    <p class="title" slot="title" data-tid="select-universe-nav-title">
+      {$titleTokenSelectorStore}
+    </p>
 
-  {#if list}
-    <SelectUniverseNavList />
-  {:else}
-    <div>
-      <SelectUniverseDropdown />
-    </div>
-  {/if}
-</Nav>
+    {#if list}
+      <SelectUniverseNavList />
+    {:else}
+      <div class="select-universe">
+        <SelectUniverseDropdown />
+      </div>
+    {/if}
+  </Nav>
+</div>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/fonts";
@@ -57,8 +59,15 @@
     }
   }
 
-  div {
-    // Add some gap, because the title is hidden on mobile
+  // 1. hide Nav title on mobile
+  .container {
+    --nav-component-title-display: none;
+    @include media.min-width(large) {
+      --nav-component-title-display: block;
+    }
+  }
+  // 2. add some gap, because the Nav title is hidden on mobile
+  .select-universe {
     margin-top: var(--padding-1_5x);
   }
 </style>

--- a/frontend/src/lib/components/universe/SelectUniverseNav.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNav.svelte
@@ -39,7 +39,9 @@
   {#if list}
     <SelectUniverseNavList />
   {:else}
-    <SelectUniverseDropdown />
+    <div>
+      <SelectUniverseDropdown />
+    </div>
   {/if}
 </Nav>
 
@@ -53,5 +55,10 @@
     @include media.min-width(large) {
       @include fonts.h3(true);
     }
+  }
+
+  div {
+    // Add some gap, because the title is hidden on mobile
+    margin-top: var(--padding-1_5x);
   }
 </style>

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -85,13 +85,6 @@ describe("SelectUniverseCard", () => {
   });
 
   describe("icon", () => {
-    it("display an icon if role button and selected", async () => {
-      const po = await renderComponent({
-        props: { ...props, role: "button", selected: true },
-      });
-      expect(await po.hasIcon()).toBe(true);
-    });
-
     it("display no icon if role button but not selected", async () => {
       const po = await renderComponent({
         props: { ...props, role: "button", selected: false },


### PR DESCRIPTION
# Motivation

Improve mobile styles of sns selector.

# Changes

- Move `--nav-component-title-display` to have both hide-title-on-mobile and add a gap when not title in one place.
  - Add extra gap before Sns mobile selector.
- Increase the gap between actionable segment and filter buttons.
- Remove selected icon from Sns dropdown (there is still a border shown for the selection) (second screenshot).

# Tests

- Tested manually.

| Before | After |
|--------|--------|
| <img width="382" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/86276cdd-10f9-4d99-a19d-d53cfc7e601d"> | <img width="380" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/6223a07d-171e-488c-97c9-b0e063ce8ddd"> | 
| <img width="379" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/5c77f955-8f5a-447b-9c96-5a664737fabf"> | <img width="381" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/59183f07-2a98-48bf-8040-dbd87780aba2"> |

# Todos

- [x] Add entry to changelog (if necessary).
