### PR TITLE
Actionable proposals tooltips

### DIFF
--- a/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
@@ -8,6 +8,7 @@
   import { isUniverseNns } from "$lib/utils/universe.utils";
   import type { Universe } from "$lib/types/universe";
   import { Principal } from "@dfinity/principal";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let count: number;
   export let universe: Universe;
@@ -23,23 +24,24 @@
 </script>
 
 {#if mounted}
-  <Tooltip
-    id="actionable-count-tooltip"
-    text={replacePlaceholders(tooltipText, {
-      $count: count,
-      $snsName: universe.title,
-    })}
-    top={true}
-  >
-    <span
-      transition:scale={{
-        duration: 250,
-        easing: cubicOut,
-      }}
-      data-tid="actionable-proposal-count-badge-component"
-      class="tag">{count}</span
+  <TestIdWrapper testId="actionable-proposal-count-badge-component">
+    <Tooltip
+      id="actionable-count-tooltip"
+      text={replacePlaceholders(tooltipText, {
+        $count: count,
+        $snsName: universe.title,
+      })}
+      top={true}
     >
-  </Tooltip>
+      <span
+        transition:scale={{
+          duration: 250,
+          easing: cubicOut,
+        }}
+        class="tag">{count}</span
+      >
+    </Tooltip>
+  </TestIdWrapper>
 {/if}
 
 <style lang="scss">

--- a/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
@@ -2,8 +2,20 @@
   import { scale } from "svelte/transition";
   import { cubicOut } from "svelte/easing";
   import { onMount } from "svelte";
+  import { Tooltip } from "@dfinity/gix-components";
+  import { i18n } from "$lib/stores/i18n";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { isUniverseNns } from "$lib/utils/universe.utils";
+  import type { Universe } from "$lib/types/universe";
+  import { Principal } from "@dfinity/principal";
 
   export let count: number;
+  export let universe: Universe;
+
+  let tooltipText = "";
+  $: tooltipText = isUniverseNns(Principal.fromText(universe.canisterId))
+    ? $i18n.voting.nns_actionable_proposal_tooltip
+    : $i18n.voting.sns_actionable_proposal_tooltip;
 
   // Always rerender to trigger animation start
   let mounted = false;
@@ -11,14 +23,23 @@
 </script>
 
 {#if mounted}
-  <span
-    transition:scale={{
-      duration: 250,
-      easing: cubicOut,
-    }}
-    data-tid="actionable-proposal-count-badge-component"
-    class="tag">{count}</span
+  <Tooltip
+    id="actionable-count-tooltip"
+    text={replacePlaceholders(tooltipText, {
+      $count: count,
+      $snsName: universe.title,
+    })}
+    top={true}
   >
+    <span
+      transition:scale={{
+        duration: 250,
+        easing: cubicOut,
+      }}
+      data-tid="actionable-proposal-count-badge-component"
+      class="tag">{count}</span
+    >
+  </Tooltip>
 {/if}
 
 <style lang="scss">

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Card } from "@dfinity/gix-components";
+  import { Card, Tooltip } from "@dfinity/gix-components";
   import UniverseLogo from "$lib/components/universe/UniverseLogo.svelte";
   import UniverseAccountsBalance from "$lib/components/universe/UniverseAccountsBalance.svelte";
   import { pageStore } from "$lib/derived/page.derived";
@@ -15,6 +15,7 @@
   import ActionableProposalCountBadge from "$lib/components/proposals/ActionableProposalCountBadge.svelte";
   import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
   import { nonNullish } from "@dfinity/utils";
+  import { i18n } from "$lib/stores/i18n";
 
   export let selected: boolean;
   export let role: "link" | "button" | "dropdown" = "link";
@@ -78,7 +79,13 @@
               {universe}
             />
           {:else if actionableProposalSupported === false}
-            <span class="not-supported-badge" data-tid="not-supported-badge" />
+            <Tooltip
+              id="actionable-not-supported-tooltip"
+              text={$i18n.actionable_proposals_not_supported.dot_tooltip}
+              top={true}
+            >
+              <div class="not-supported-badge" data-tid="not-supported-badge" />
+            </Tooltip>
           {/if}
         {/if}
       </span>

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -73,7 +73,10 @@
         {universe.title}
         {#if $ENABLE_VOTING_INDICATION && $actionableProposalIndicationEnabledStore}
           {#if nonNullish(actionableProposalCount) && actionableProposalCount > 0}
-            <ActionableProposalCountBadge count={actionableProposalCount} />
+            <ActionableProposalCountBadge
+              count={actionableProposalCount}
+              {universe}
+            />
           {:else if actionableProposalSupported === false}
             <span class="not-supported-badge" data-tid="not-supported-badge" />
           {/if}

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -16,6 +16,7 @@
   import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
   import { nonNullish } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let selected: boolean;
   export let role: "link" | "button" | "dropdown" = "link";
@@ -79,13 +80,15 @@
               {universe}
             />
           {:else if actionableProposalSupported === false}
-            <Tooltip
-              id="actionable-not-supported-tooltip"
-              text={$i18n.actionable_proposals_not_supported.dot_tooltip}
-              top={true}
-            >
-              <div class="not-supported-badge" data-tid="not-supported-badge" />
-            </Tooltip>
+            <TestIdWrapper testId="not-supported-badge">
+              <Tooltip
+                id="actionable-not-supported-tooltip"
+                text={$i18n.actionable_proposals_not_supported.dot_tooltip}
+                top={true}
+              >
+                <div class="not-supported-badge" />
+              </Tooltip>
+            </TestIdWrapper>
           {/if}
         {/if}
       </span>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -375,7 +375,9 @@
     "uncheck_all": "Clear",
     "nothing_found": "No proposals found for the filters.",
     "all_proposals": "All Proposals",
-    "actionable_proposals": "Actionable Proposals"
+    "actionable_proposals": "Actionable Proposals",
+    "nns_actionable_proposal_tooltip": "There are $count NNS proposals you can vote on.",
+    "sns_actionable_proposal_tooltip": "There are $count $snsName proposals you can vote on."
   },
   "actionable_proposals_sign_in": {
     "title": "You are not signed in.",
@@ -387,7 +389,8 @@
   },
   "actionable_proposals_not_supported": {
     "title": "$snsName doesn't yet support actionable proposals.",
-    "text": "Because it is running an older version of the SNS governance canister."
+    "text": "Because it is running an older version of the SNS governance canister.",
+    "dot_tooltip": "This SNS doesn't yet support actionable proposals."
   },
   "canisters": {
     "aria_label_canister_card": "Go to canister details",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -390,6 +390,8 @@ interface I18nVoting {
   nothing_found: string;
   all_proposals: string;
   actionable_proposals: string;
+  nns_actionable_proposal_tooltip: string;
+  sns_actionable_proposal_tooltip: string;
 }
 
 interface I18nActionable_proposals_sign_in {
@@ -405,6 +407,7 @@ interface I18nActionable_proposals_empty {
 interface I18nActionable_proposals_not_supported {
   title: string;
   text: string;
+  dot_tooltip: string;
 }
 
 interface I18nCanisters {

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -1,6 +1,7 @@
 import SelectUniverseCard from "$lib/components/universe/SelectUniverseCard.svelte";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
+import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import type { Universe } from "$lib/types/universe";
@@ -13,6 +14,7 @@ import {
   mockMainAccount,
   mockSubAccount,
 } from "$tests/mocks/icp-accounts.store.mock";
+import { mockProposals } from "$tests/mocks/proposals.store.mock";
 import { mockSummary } from "$tests/mocks/sns-projects.mock";
 import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { nnsUniverseMock } from "$tests/mocks/universe.mock";
@@ -242,7 +244,37 @@ describe("SelectUniverseCard", () => {
           expect(await po.getActionableProposalCountBadgePo().isPresent()).toBe(
             true
           );
-          expect(await po.getActionableProposalCount()).toBe("2");
+          expect((await po.getActionableProposalCount()).trim()).toBe("2");
+          expect(
+            await po
+              .getActionableProposalCountBadgePo()
+              .getTooltipPo()
+              .getTooltipText()
+          ).toBe("There are 2 Tetris proposals you can vote on.");
+        });
+
+        it("should display actionable proposal count tooltip for NNS", async () => {
+          page.mock({
+            data: { universe: OWN_CANISTER_ID_TEXT },
+            routeId: AppPath.Proposals,
+          });
+
+          actionableNnsProposalsStore.setProposals([...mockProposals]);
+
+          const po = await renderComponent({
+            props: { universe: nnsUniverseMock, selected: false },
+          });
+
+          expect(await po.getActionableProposalCountBadgePo().isPresent()).toBe(
+            true
+          );
+          expect((await po.getActionableProposalCount()).trim()).toBe("2");
+          expect(
+            await po
+              .getActionableProposalCountBadgePo()
+              .getTooltipPo()
+              .getTooltipText()
+          ).toBe("There are 2 NNS proposals you can vote on.");
         });
 
         it("should not display actionable proposal count when the feature flag is disabled", async () => {
@@ -355,6 +387,11 @@ describe("SelectUniverseCard", () => {
           expect(
             await po.getActionableProposalNotSupportedBadge().isPresent()
           ).toBe(true);
+          expect(
+            await po
+              .getActionableProposalNotSupportedTooltipPo()
+              .getTooltipText()
+          ).toBe("This SNS doesn't yet support actionable proposals.");
         });
       });
     });

--- a/frontend/src/tests/page-objects/ActionableProposalCountBadge.page-object.ts
+++ b/frontend/src/tests/page-objects/ActionableProposalCountBadge.page-object.ts
@@ -1,3 +1,4 @@
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -8,5 +9,9 @@ export class ActionableProposalCountBadgePo extends BasePageObject {
     return new ActionableProposalCountBadgePo(
       element.byTestId(ActionableProposalCountBadgePo.TID)
     );
+  }
+
+  getTooltipPo(): TooltipPo {
+    return TooltipPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
@@ -1,5 +1,6 @@
 import { ActionableProposalCountBadgePo } from "$tests/page-objects/ActionableProposalCountBadge.page-object";
 import { CardPo } from "$tests/page-objects/Card.page-object";
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import { UniverseAccountsBalancePo } from "$tests/page-objects/UniverseAccountsBalance.page-object";
 import { UniverseLogoPo } from "$tests/page-objects/UniverseLogo.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -68,6 +69,10 @@ export class SelectUniverseCardPo extends CardPo {
 
   getActionableProposalNotSupportedBadge(): PageObjectElement {
     return this.root.byTestId("not-supported-badge");
+  }
+
+  getActionableProposalNotSupportedTooltipPo(): TooltipPo {
+    return TooltipPo.under(this.getActionableProposalNotSupportedBadge());
   }
 
   getActionableProposalCount(): Promise<string> {


### PR DESCRIPTION
# Motivation

Display tooltips for actionable count and not-supported badges.

# Changes

- Wrap badges with `TestIdWrapper` to be able to reach tooltip by element.
- Actionable count tooltip.
- Actionable not supported dot tooltip.

# Tests

- tooltips should have appropriate texts.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet

# Screenshots

## NNS
![image](https://github.com/dfinity/nns-dapp/assets/98811342/72321cb2-5bf4-44ab-ac76-82b353e64e30)

## SNS
![image](https://github.com/dfinity/nns-dapp/assets/98811342/8e794267-e938-41db-9730-3bf3eddf9f43)

## Not supported
![image](https://github.com/dfinity/nns-dapp/assets/98811342/898ef964-6547-4628-b54d-2f8a11f784ee)
