### PR TITLE
Reorder launchpad sections

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -20,6 +20,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Rename some topics and proposal types.
+* Reorder launchpad sections.
 
 #### Deprecated
 

--- a/frontend/src/lib/pages/Launchpad.svelte
+++ b/frontend/src/lib/pages/Launchpad.svelte
@@ -27,9 +27,9 @@
 </script>
 
 <main data-tid="launchpad-component">
-  <div class="open-projects">
-    <h2>{$i18n.sns_launchpad.open_projects}</h2>
-    <Projects testId="open-projects" status={SnsSwapLifecycle.Open} />
+  <div class="proposals">
+    <h2>{$i18n.sns_launchpad.proposals}</h2>
+    <Proposals />
   </div>
 
   {#if showAdopted}
@@ -38,6 +38,11 @@
       <Projects testId="upcoming-projects" status={SnsSwapLifecycle.Adopted} />
     </div>
   {/if}
+
+  <div class="open-projects">
+    <h2>{$i18n.sns_launchpad.open_projects}</h2>
+    <Projects testId="open-projects" status={SnsSwapLifecycle.Open} />
+  </div>
 
   {#if showCommitted}
     <div class="committed-projects">
@@ -48,33 +53,12 @@
       />
     </div>
   {/if}
-
-  <div class="proposals">
-    <h2>{$i18n.sns_launchpad.proposals}</h2>
-    <Proposals />
-  </div>
 </main>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/dist/styles/mixins/media";
-
   main {
     display: grid;
     gap: var(--padding-4x);
-
-    // display "proposals" before "committed-projects" on mobile
-    .committed-projects {
-      order: 2;
-      @include media.min-width(medium) {
-        order: 1;
-      }
-    }
-    .proposals {
-      order: 1;
-      @include media.min-width(medium) {
-        order: 2;
-      }
-    }
   }
 
   h2 {


### PR DESCRIPTION
# Motivation

Reorder launchpad sections to be the same on mobile and desktop:

1. Proposals
2. Upcoming (hidden if no upcoming)
3. Current launches
4. Launched

# Changes

- change section order
- remove obsolete styles

# Tests

- (Manu|Loc)ally

# Todos

- [x] Add entry to changelog (if necessary).

# Screenshots

| Mobile | Desktop |
|--------|--------|
| <img width="390" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/05092df4-ce06-4f3d-afdb-4b8536948b26"> | <img width="1261" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/33faca84-df29-4c8d-89c6-c8f6f9be2562"> | 