### PR TITLE
style: align launchpad card text

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -20,6 +20,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Rename some topics and proposal types.
+* Improve launchpad card text alignment.
 
 #### Deprecated
 

--- a/frontend/src/lib/components/launchpad/ProjectCard.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCard.svelte
@@ -89,6 +89,8 @@
 
   p {
     margin: 0 0 var(--padding-1_5x);
+    // Occupy all available space to shift blocks after the description down
+    flex-grow: 1;
   }
 
   .spinner {


### PR DESCRIPTION
# Motivation

Align launchpad card content to shift blocks after the description down.

# Changes

- css

# Tests

Manually.

# Todos

- [x] Add entry to changelog (if necessary).

# Screenshots

<img width="1024" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/62a77a2f-8f5b-4728-9530-b7469c3f6f00">
