### PR TITLE
Order icp subaccounts

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -20,6 +20,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Rename some topics and proposal types.
+* Reorder launchpad sections.
 * Improve launchpad card text alignment.
 
 #### Deprecated

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,7 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Message informing about proposal topic changes.
-* Order ICP subaccounts based on balance.
+* Order ICP sub-accounts based on balance.
 
 #### Changed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Message informing about proposal topic changes.
+* Order ICP subaccounts based on balance.
 
 #### Changed
 

--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -8,6 +8,7 @@ import type { Account, AccountType } from "$lib/types/account";
 import { UserTokenAction, type UserToken } from "$lib/types/tokens-page";
 import type { Universe } from "$lib/types/universe";
 import { buildWalletUrl } from "$lib/utils/navigation.utils";
+import { sortUserTokens } from "$lib/utils/token.utils";
 import { Principal } from "@dfinity/principal";
 import { isNullish, TokenAmountV2 } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
@@ -77,11 +78,15 @@ export const icpTokensListUser = derived<
       i18nObj,
       account: icpAccounts.main,
     }),
-    ...(icpAccounts.subAccounts ?? []).map((account) =>
-      convertAccountToUserTokenData({ nnsUniverse, i18nObj, account })
+    ...sortUserTokens(
+      (icpAccounts.subAccounts ?? []).map((account) =>
+        convertAccountToUserTokenData({ nnsUniverse, i18nObj, account })
+      )
     ),
-    ...(icpAccounts.hardwareWallets ?? []).map((account) =>
-      convertAccountToUserTokenData({ nnsUniverse, i18nObj, account })
+    ...sortUserTokens(
+      (icpAccounts.hardwareWallets ?? []).map((account) =>
+        convertAccountToUserTokenData({ nnsUniverse, i18nObj, account })
+      )
     ),
   ]
 );

--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -78,15 +78,13 @@ export const icpTokensListUser = derived<
       i18nObj,
       account: icpAccounts.main,
     }),
-    ...sortUserTokens(
-      (icpAccounts.subAccounts ?? []).map((account) =>
+    ...sortUserTokens([
+      ...(icpAccounts.subAccounts ?? []).map((account) =>
         convertAccountToUserTokenData({ nnsUniverse, i18nObj, account })
-      )
-    ),
-    ...sortUserTokens(
-      (icpAccounts.hardwareWallets ?? []).map((account) =>
+      ),
+      ...(icpAccounts.hardwareWallets ?? []).map((account) =>
         convertAccountToUserTokenData({ nnsUniverse, i18nObj, account })
-      )
-    ),
+      ),
+    ]),
   ]
 );

--- a/frontend/src/lib/pages/Launchpad.svelte
+++ b/frontend/src/lib/pages/Launchpad.svelte
@@ -27,9 +27,9 @@
 </script>
 
 <main data-tid="launchpad-component">
-  <div class="open-projects">
-    <h2>{$i18n.sns_launchpad.open_projects}</h2>
-    <Projects testId="open-projects" status={SnsSwapLifecycle.Open} />
+  <div class="proposals">
+    <h2>{$i18n.sns_launchpad.proposals}</h2>
+    <Proposals />
   </div>
 
   {#if showAdopted}
@@ -38,6 +38,11 @@
       <Projects testId="upcoming-projects" status={SnsSwapLifecycle.Adopted} />
     </div>
   {/if}
+
+  <div class="open-projects">
+    <h2>{$i18n.sns_launchpad.open_projects}</h2>
+    <Projects testId="open-projects" status={SnsSwapLifecycle.Open} />
+  </div>
 
   {#if showCommitted}
     <div class="committed-projects">
@@ -48,33 +53,12 @@
       />
     </div>
   {/if}
-
-  <div class="proposals">
-    <h2>{$i18n.sns_launchpad.proposals}</h2>
-    <Proposals />
-  </div>
 </main>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/dist/styles/mixins/media";
-
   main {
     display: grid;
     gap: var(--padding-4x);
-
-    // display "proposals" before "committed-projects" on mobile
-    .committed-projects {
-      order: 2;
-      @include media.min-width(medium) {
-        order: 1;
-      }
-    }
-    .proposals {
-      order: 1;
-      @include media.min-width(medium) {
-        order: 2;
-      }
-    }
   }
 
   h2 {

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -4,6 +4,7 @@ import {
   ICP_DISPLAYED_DECIMALS_DETAILED,
   ICP_DISPLAYED_HEIGHT_DECIMALS,
 } from "$lib/constants/icp.constants";
+import type { UserToken } from "$lib/types/tokens-page";
 import {
   ICPToken,
   TokenAmount,
@@ -272,3 +273,17 @@ export class UnavailableTokenAmount {
     this.token = token;
   }
 }
+
+export const sortUserTokens = (tokens: UserToken[]): UserToken[] => [
+  // sort only tokens with valid balance
+  ...tokens
+    .filter(({ balance }) => balance instanceof TokenAmountV2)
+    .sort(({ balance: balanceA }, { balance: balanceB }) =>
+      (balanceA as TokenAmountV2).toUlps() >
+      (balanceB as TokenAmountV2).toUlps()
+        ? -1
+        : 1
+    ),
+  // tokens without balance
+  ...tokens.filter(({ balance }) => !(balance instanceof TokenAmountV2)),
+];

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -49,33 +49,49 @@ describe("icp-tokens-list-user.derived", () => {
     }),
     accountIdentifier: mockMainAccount.identifier,
   };
-  const subaccountUserTokenData: UserTokenData = {
-    ...icpTokenUser,
-    balance: TokenAmountV2.fromUlps({
-      amount: mockSubAccount.balanceUlps,
-      token: NNS_TOKEN_DATA,
-    }),
-    title: mockSubAccount.name,
-    subtitle: undefined,
-    rowHref: buildWalletUrl({
-      universe: OWN_CANISTER_ID_TEXT,
-      account: mockSubAccount.identifier,
-    }),
-    accountIdentifier: mockSubAccount.identifier,
+  const subaccountUserTokenData = (
+    balanceUlps: bigint = mockSubAccount.balanceUlps
+  ): UserTokenData => {
+    const accountIdentifier =
+      balanceUlps === mockSubAccount.balanceUlps
+        ? mockSubAccount.identifier
+        : `${balanceUlps}`;
+    return {
+      ...icpTokenUser,
+      balance: TokenAmountV2.fromUlps({
+        amount: balanceUlps,
+        token: NNS_TOKEN_DATA,
+      }),
+      title: mockSubAccount.name,
+      subtitle: undefined,
+      rowHref: buildWalletUrl({
+        universe: OWN_CANISTER_ID_TEXT,
+        account: accountIdentifier,
+      }),
+      accountIdentifier,
+    };
   };
-  const hardwareWalletUserTokenData: UserTokenData = {
-    ...icpTokenUser,
-    balance: TokenAmountV2.fromUlps({
-      amount: mockHardwareWalletAccount.balanceUlps,
-      token: NNS_TOKEN_DATA,
-    }),
-    title: mockHardwareWalletAccount.name,
-    subtitle: "Hardware Wallet Controlled",
-    rowHref: buildWalletUrl({
-      universe: OWN_CANISTER_ID_TEXT,
-      account: mockHardwareWalletAccount.identifier,
-    }),
-    accountIdentifier: mockHardwareWalletAccount.identifier,
+  const hardwareWalletUserTokenData = (
+    balanceUlps: bigint = mockHardwareWalletAccount.balanceUlps
+  ): UserTokenData => {
+    const accountIdentifier =
+      balanceUlps === mockHardwareWalletAccount.balanceUlps
+        ? mockHardwareWalletAccount.identifier
+        : `${balanceUlps}`;
+    return {
+      ...icpTokenUser,
+      balance: TokenAmountV2.fromUlps({
+        amount: balanceUlps,
+        token: NNS_TOKEN_DATA,
+      }),
+      title: mockHardwareWalletAccount.name,
+      subtitle: "Hardware Wallet Controlled",
+      rowHref: buildWalletUrl({
+        universe: OWN_CANISTER_ID_TEXT,
+        account: accountIdentifier,
+      }),
+      accountIdentifier,
+    };
   };
 
   describe("icpTokensListVisitors", () => {
@@ -101,7 +117,7 @@ describe("icp-tokens-list-user.derived", () => {
       });
       expect(get(icpTokensListUser)).toEqual([
         mainUserTokenData,
-        subaccountUserTokenData,
+        subaccountUserTokenData(),
       ]);
     });
 
@@ -113,8 +129,44 @@ describe("icp-tokens-list-user.derived", () => {
       });
       expect(get(icpTokensListUser)).toEqual([
         mainUserTokenData,
-        subaccountUserTokenData,
-        hardwareWalletUserTokenData,
+        subaccountUserTokenData(),
+        hardwareWalletUserTokenData(),
+      ]);
+    });
+
+    it.only("should sort user tokens", () => {
+      const subAccount1 = {
+        ...mockSubAccount,
+        identifier: "1",
+        balanceUlps: 1n,
+      };
+      const subAccount5 = {
+        ...mockSubAccount,
+        identifier: "5",
+        balanceUlps: 5n,
+      };
+      const hwAccount3 = {
+        ...mockHardwareWalletAccount,
+        identifier: "3",
+        balanceUlps: 3n,
+      };
+      const hwAccount7 = {
+        ...mockHardwareWalletAccount,
+        identifier: "7",
+        balanceUlps: 7n,
+      };
+      setAccountsForTesting({
+        main: mockMainAccount,
+        subAccounts: [subAccount5, subAccount1],
+        hardwareWallets: [hwAccount3, hwAccount7],
+      });
+
+      expect(get(icpTokensListUser)).toEqual([
+        mainUserTokenData,
+        hardwareWalletUserTokenData(7n),
+        subaccountUserTokenData(5n),
+        hardwareWalletUserTokenData(3n),
+        subaccountUserTokenData(1n),
       ]);
     });
   });

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -134,7 +134,7 @@ describe("icp-tokens-list-user.derived", () => {
       ]);
     });
 
-    it.only("should sort user tokens", () => {
+    it("should sort user tokens", () => {
       const subAccount1 = {
         ...mockSubAccount,
         identifier: "1",

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -52,6 +52,7 @@ describe("icp-tokens-list-user.derived", () => {
   const subaccountUserTokenData = (
     balanceUlps: bigint = mockSubAccount.balanceUlps
   ): UserTokenData => {
+    // Use balance (when explicitly provided) as identifier to have unique sub-accounts
     const accountIdentifier =
       balanceUlps === mockSubAccount.balanceUlps
         ? mockSubAccount.identifier
@@ -74,6 +75,7 @@ describe("icp-tokens-list-user.derived", () => {
   const hardwareWalletUserTokenData = (
     balanceUlps: bigint = mockHardwareWalletAccount.balanceUlps
   ): UserTokenData => {
+    // Use balance (when explicitly provided) as identifier to have unique sub-accounts
     const accountIdentifier =
       balanceUlps === mockHardwareWalletAccount.balanceUlps
         ? mockHardwareWalletAccount.identifier


### PR DESCRIPTION
# Motivation

Order ICP subaccounts based on balance from high to low. Always have “Main” on top.

# Changes

- new util `sortUserTokens`
- sort subaccounts in `icpTokensListUser` derived store (the store is used only in one place - icp accounts page)

# Tests

- `sortUserTokens`
- `icpTokensListUser` store should sort user tokens

# Todos

- [x] Add entry to changelog (if necessary).

# Screenshots

<img width="817" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/90808e47-6c0c-448b-bb52-9e85a36b6537">
