### PR TITLE
Fix actionable navigation between voting and getting new proposals

### DIFF
--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -42,7 +42,7 @@
 </script>
 
 <TestIdWrapper testId="nns-proposal-component">
-  {#if $store?.proposal?.id !== undefined}
+  {#if $store?.proposal?.id !== undefined && nonNullish(proposalIds)}
     {#if $referrerPathStore !== AppPath.Launchpad}
       <ProposalNavigation
         title={proposalType}


### PR DESCRIPTION
# Motivation

When the user clicks 'next' or 'prev' to navigate through proposals while voting, there is a chance (especially on slow network) that the dapp may break, because after successful voting the actionables are removed and the new data could be not retrieved yet.

# Changes

- check that `proposalIds` exists before rendering the `ProposalNavigation`

# Tests

It's possible to reproduce the issue locally, so the fix was also tested locally.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary since the feature is not publicly available