### PR TITLE
Update aggregator candid bindings

### DIFF
--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_governance --out ic_sns_governance.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-14_23-01-p2p/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/sns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
@@ -191,13 +191,14 @@ pub struct Valuation {
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub struct TransferSnsTreasuryFundsActionAuxiliary {
+pub struct MintSnsTokensActionAuxiliary {
     pub valuation: Option<Valuation>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum ActionAuxiliary {
-    TransferSnsTreasuryFunds(TransferSnsTreasuryFundsActionAuxiliary),
+    TransferSnsTreasuryFunds(MintSnsTokensActionAuxiliary),
+    MintSnsTokens(MintSnsTokensActionAuxiliary),
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_ledger --out ic_sns_ledger.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-14_23-01-p2p/rs/rosetta-api/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/rosetta-api/icrc1/ledger/ledger.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
@@ -332,6 +332,31 @@ pub enum TransferFromResult {
     Err(TransferFromError),
 }
 
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct GetArchivesArgs {
+    pub from: Option<Principal>,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct GetArchivesResultItem {
+    pub end: candid::Nat,
+    pub canister_id: Principal,
+    pub start: candid::Nat,
+}
+
+pub type GetArchivesResult = Vec<GetArchivesResultItem>;
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Icrc3DataCertificate {
+    pub certificate: serde_bytes::ByteBuf,
+    pub hash_tree: serde_bytes::ByteBuf,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Icrc3SupportedBlockTypesRetItem {
+    pub url: String,
+    pub block_type: String,
+}
+
 pub struct Service(pub Principal);
 impl Service {
     pub async fn archives(&self) -> CallResult<(Vec<ArchiveInfo>,)> {
@@ -384,5 +409,14 @@ impl Service {
     }
     pub async fn icrc_2_transfer_from(&self, arg0: TransferFromArgs) -> CallResult<(TransferFromResult,)> {
         ic_cdk::call(self.0, "icrc2_transfer_from", (arg0,)).await
+    }
+    pub async fn icrc_3_get_archives(&self, arg0: GetArchivesArgs) -> CallResult<(GetArchivesResult,)> {
+        ic_cdk::call(self.0, "icrc3_get_archives", (arg0,)).await
+    }
+    pub async fn icrc_3_get_tip_certificate(&self) -> CallResult<(Option<Icrc3DataCertificate>,)> {
+        ic_cdk::call(self.0, "icrc3_get_tip_certificate", ()).await
+    }
+    pub async fn icrc_3_supported_block_types(&self) -> CallResult<(Vec<Icrc3SupportedBlockTypesRetItem>,)> {
+        ic_cdk::call(self.0, "icrc3_supported_block_types", ()).await
     }
 }

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_root --out ic_sns_root.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-14_23-01-p2p/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/sns/root/canister/root.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
@@ -74,7 +74,6 @@ pub struct ChangeCanisterRequest {
     pub stop_before_installing: bool,
     pub mode: CanisterInstallMode,
     pub canister_id: Principal,
-    pub query_allocation: Option<candid::Nat>,
     pub memory_allocation: Option<candid::Nat>,
     pub compute_allocation: Option<candid::Nat>,
 }

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_swap --out ic_sns_swap.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-14_23-01-p2p/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/sns/swap/canister/swap.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out ic_sns_wasm.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-03-14_23-01-p2p/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]


### PR DESCRIPTION
# Motivation
We would like to parse all the latest SNS data. To do so, we update the candid interfaces for the SNS aggregator.
Even with no changes, just updating the reference is good practice.

# Changes
* Updated the Rust code derived from `.did` files in the aggregator.
  * Note: The candid files under `declarations/nns-$CANISTER` are used as inputs.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  Breaking changes are:
    * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants