### PR TITLE
Ignore exclude voted proposals filter

### DIFF
--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -1,5 +1,6 @@
 import { goto } from "$app/navigation";
 import { pageStore } from "$lib/derived/page.derived";
+import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
 import { i18n } from "$lib/stores/i18n";
 import type { ProposalsFiltersStore } from "$lib/stores/proposals.store";
 import type { VoteRegistrationStoreEntry } from "$lib/stores/vote-registration.store";
@@ -92,7 +93,8 @@ export const hideProposal = ({
   identity: Identity | undefined | null;
 }): boolean =>
   !matchFilters({ proposalInfo, filters }) ||
-  (nonNullish(identity) &&
+  (!get(ENABLE_VOTING_INDICATION) &&
+    nonNullish(identity) &&
     !identity.getPrincipal().isAnonymous() &&
     isExcludedVotedProposal({ proposalInfo, filters, neurons }));
 

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -180,7 +180,7 @@ describe("NnsProposals", () => {
         ).toEqual(true);
       });
 
-      it("should hide proposal card if already voted", async () => {
+      it("should not hide proposal card if already voted", async () => {
         neuronsStore.setNeurons({ neurons: [mockNeuron], certified: true });
 
         const { queryAllByTestId } = render(NnsProposals);
@@ -189,7 +189,7 @@ describe("NnsProposals", () => {
 
         await waitFor(() =>
           expect(queryAllByTestId("proposal-card").length).toBe(
-            mockProposals.length - 1
+            mockProposals.length
           )
         );
       });

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -727,6 +727,7 @@ describe("proposals-utils", () => {
       ).toBe(true);
     });
 
+    // TODO: remove the whole block when ENABLE_VOTING_INDICATION is removed
     describe("with ENABLE_VOTING_INDICATION disabled", () => {
       beforeEach(() => {
         overrideFeatureFlagsStore.setFlag("ENABLE_VOTING_INDICATION", false);

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import {
   concatenateUniqueProposals,
@@ -114,6 +115,10 @@ describe("proposals-utils", () => {
         neuronId: 0n,
       } as NeuronInfo,
     ];
+
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_VOTING_INDICATION", false);
+    });
 
     it("hideProposal", () => {
       expect(
@@ -432,6 +437,81 @@ describe("proposals-utils", () => {
         })
       ).toBeTruthy();
     });
+
+    describe("with ENABLE_VOTING_INDICATION enabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_VOTING_INDICATION", true);
+      });
+
+      it("should show proposals with or without ballots when excludeVotedProposals enabled", () => {
+        expect(
+          hideProposal({
+            proposalInfo: {
+              ...mockProposals[0],
+              ballots: [],
+            },
+            filters: {
+              ...DEFAULT_PROPOSALS_FILTERS,
+              excludeVotedProposals: true,
+            },
+            neurons,
+            identity: mockIdentity,
+          })
+        ).toBe(false);
+
+        expect(
+          hideProposal({
+            proposalInfo: {
+              ...mockProposals[0],
+              ballots: [
+                {
+                  neuronId: 0n,
+                  vote: Vote.Unspecified,
+                } as Ballot,
+              ],
+            },
+            filters: {
+              ...DEFAULT_PROPOSALS_FILTERS,
+              excludeVotedProposals: true,
+            },
+            neurons,
+            identity: mockIdentity,
+          })
+        ).toBe(false);
+      });
+
+      it("should check for matched filter", () => {
+        expect(
+          hideProposal({
+            proposalInfo: proposalWithBallot({
+              proposal: mockProposals[0],
+            }),
+            filters: {
+              ...DEFAULT_PROPOSALS_FILTERS,
+              topics: [Topic.Kyc],
+              excludeVotedProposals: true,
+            },
+            neurons,
+            identity: mockIdentity,
+          })
+        ).toBe(true);
+
+        expect(
+          hideProposal({
+            proposalInfo: proposalWithBallot({
+              proposal: mockProposals[0],
+            }),
+            filters: {
+              ...DEFAULT_PROPOSALS_FILTERS,
+              topics: [Topic.Governance],
+              excludeVotedProposals: true,
+            },
+            neurons,
+            identity: mockIdentity,
+          })
+        ).toBe(false);
+      });
+    });
   });
 
   describe("hasMatchingProposals", () => {
@@ -622,7 +702,7 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBe(false);
+      ).toBe(true);
 
       expect(
         hasMatchingProposals({
@@ -644,7 +724,219 @@ describe("proposals-utils", () => {
           neurons,
           identity: mockIdentity,
         })
-      ).toBe(false);
+      ).toBe(true);
+    });
+
+    describe("with ENABLE_VOTING_INDICATION disabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_VOTING_INDICATION", false);
+      });
+
+      it("should have matching proposals", () => {
+        expect(
+          hasMatchingProposals({
+            proposals: mockProposals,
+            filters: {
+              ...DEFAULT_PROPOSALS_FILTERS,
+              excludeVotedProposals: false,
+            },
+            neurons,
+            identity: mockIdentity,
+          })
+        ).toBeTruthy();
+
+        expect(
+          hasMatchingProposals({
+            proposals: mockProposals.map((proposal) => ({
+              ...proposal,
+              ballots: [
+                {
+                  neuronId: 0n,
+                  vote: Vote.Unspecified,
+                } as Ballot,
+              ],
+            })),
+            filters: {
+              ...DEFAULT_PROPOSALS_FILTERS,
+              excludeVotedProposals: true,
+            },
+            neurons,
+            identity: mockIdentity,
+          })
+        ).toBeTruthy();
+
+        expect(
+          hasMatchingProposals({
+            proposals: [
+              ...mockProposals,
+              {
+                ...mockProposals[0],
+                ballots: [
+                  {
+                    neuronId: 0n,
+                    vote: Vote.Unspecified,
+                  } as Ballot,
+                ],
+              },
+            ],
+            filters: {
+              ...DEFAULT_PROPOSALS_FILTERS,
+              excludeVotedProposals: false,
+            },
+            neurons,
+            identity: mockIdentity,
+          })
+        ).toBeTruthy();
+
+        expect(
+          hasMatchingProposals({
+            proposals: [
+              ...mockProposals,
+              {
+                ...mockProposals[1],
+                ballots: [
+                  {
+                    neuronId: 0n,
+                    vote: Vote.Unspecified,
+                  } as Ballot,
+                ],
+              },
+            ],
+            filters: {
+              ...DEFAULT_PROPOSALS_FILTERS,
+              excludeVotedProposals: false,
+            },
+            neurons,
+            identity: mockIdentity,
+          })
+        ).toBeTruthy();
+
+        expect(
+          hasMatchingProposals({
+            proposals: [
+              ...mockProposals,
+              {
+                ...mockProposals[0],
+                ballots: [
+                  {
+                    neuronId: 0n,
+                    vote: Vote.Unspecified,
+                  } as Ballot,
+                ],
+              },
+            ],
+            filters: {
+              ...DEFAULT_PROPOSALS_FILTERS,
+              excludeVotedProposals: true,
+            },
+            neurons,
+            identity: mockIdentity,
+          })
+        ).toBeTruthy();
+
+        expect(
+          hasMatchingProposals({
+            proposals: [
+              ...mockProposals,
+              {
+                ...mockProposals[1],
+                ballots: [
+                  {
+                    neuronId: 0n,
+                    vote: Vote.Unspecified,
+                  } as Ballot,
+                ],
+              },
+            ],
+            filters: {
+              ...DEFAULT_PROPOSALS_FILTERS,
+              excludeVotedProposals: true,
+            },
+            neurons,
+            identity: mockIdentity,
+          })
+        ).toBeTruthy();
+
+        expect(
+          hasMatchingProposals({
+            proposals: [
+              {
+                ...mockProposals[0],
+                ballots: [
+                  {
+                    neuronId: 0n,
+                    vote: Vote.Yes,
+                  } as Ballot,
+                ],
+              },
+            ],
+            filters: {
+              ...DEFAULT_PROPOSALS_FILTERS,
+              excludeVotedProposals: true,
+            },
+            neurons,
+            identity: null,
+          })
+        ).toBeTruthy();
+      });
+
+      it("should not have matching proposals", () => {
+        expect(
+          hasMatchingProposals({
+            proposals: [],
+            filters: {
+              ...DEFAULT_PROPOSALS_FILTERS,
+              excludeVotedProposals: false,
+            },
+            neurons,
+            identity: mockIdentity,
+          })
+        ).toBe(false);
+
+        expect(
+          hasMatchingProposals({
+            proposals: [
+              {
+                ...mockProposals[0],
+                ballots: [
+                  {
+                    neuronId: 0n,
+                    vote: Vote.Yes,
+                  } as Ballot,
+                ],
+              },
+            ],
+            filters: {
+              ...DEFAULT_PROPOSALS_FILTERS,
+              excludeVotedProposals: true,
+            },
+            neurons,
+            identity: mockIdentity,
+          })
+        ).toBe(false);
+
+        expect(
+          hasMatchingProposals({
+            proposals: [
+              {
+                ...mockProposals[0],
+                ballots: [
+                  {
+                    neuronId: 0n,
+                    vote: Vote.No,
+                  } as Ballot,
+                ],
+              },
+            ],
+            filters: {
+              ...DEFAULT_PROPOSALS_FILTERS,
+              excludeVotedProposals: true,
+            },
+            neurons,
+            identity: mockIdentity,
+          })
+        ).toBe(false);
+      });
     });
   });
 


### PR DESCRIPTION
# Motivation

Ignore the "show only votable" flag when "actionable proposals" enabled (because the checkbox is hidden).
<img width="279" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/fed0086d-f25d-46da-a41b-9e5d02457e85">


# Changes

- update the filtering util function to ignore the filter selection when actionable proposals feature is enabled.

# Tests

- updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary