### PR TITLE
Remove explicit chrono dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4293,7 +4293,6 @@ dependencies = [
  "anyhow",
  "base64 0.21.5",
  "candid 0.8.4",
- "chrono",
  "cycles-minting-canister 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",
  "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=89129b8212791d7e05cab62ff08eece2888a86e0)",

--- a/rs/backend/Cargo.toml
+++ b/rs/backend/Cargo.toml
@@ -22,12 +22,6 @@ strum = "0.25.0"
 strum_macros = "0.25.3"
 tar = "0.4.40"
 
-# chrono 0.4.19 has vulnerabilities fixed in 0.4.20
-# but, 0.4.20 doesn't satisfy ic. We get the followig error when deploying the canister:
-# The Replica returned an error: code 5, message: "Wasm module of canister vo5te-2aaaa-aaaaa-aaazq-cai is not valid: Wasm module has an invalid import section. Module imports function '__wbindgen_describe' from '__wbindgen_placeholder__' that is not exported by the runtime."
-# 0.4.19 works and satisfies ic.
-chrono = "=0.4.19"
-
 cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "89129b8212791d7e05cab62ff08eece2888a86e0" }
 dfn_candid = { git = "https://github.com/dfinity/ic", rev = "89129b8212791d7e05cab62ff08eece2888a86e0" }
 dfn_core = { git = "https://github.com/dfinity/ic", rev = "89129b8212791d7e05cab62ff08eece2888a86e0" }


### PR DESCRIPTION
# Motivation

`rs/backend/Cargo.toml` has an explicit dependency on `chrono` version 0.4.19.
But no code in nns-dapp depends directly on `chrono` (nor did it when the dependency was added).
Removing the explicit dependency does not seem to break anything.
If I increase the explicit dependency to 0.4.20 (or higher), I do get the error from the comment but not if I just remove it.
And having the dependency prevents us from updating other dependencies which require different versions of `chrono`.

# Changes

1. Remove the `chrono` dependency from `rs/backend/Cargo.toml`.

# Tests

CI passes

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary