### PR TITLE
Update didc release to 2024-04-11

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -353,7 +353,7 @@
         "IDL2JSON_VERSION": "0.8.8",
         "OPTIMIZER_VERSION": "0.3.6",
         "BINSTALL_VERSION": "1.3.0",
-        "DIDC_VERSION": "2024-02-27",
+        "DIDC_VERSION": "2024-04-11",
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-04-17",


### PR DESCRIPTION
# Motivation
A newer version of `didc` is available.
Even with no changes, just updating the reference is good practice.

# Changes
## Changes made by a bot triggered by github-merge-queue
- Update the version of `didc` specified in `dfx.json`.

## Changes made by a human (delete if inapplicable)

# Tests
- CI contains tests that detect most breaking changes in `didc`.
- [ ] Please check [the didc release notes](https://github.com/dfinity/candid/releases) (if any).
- [ ] Please check [the didc git history](https://github.com/dfinity/candid/commits/master/tools/didc) (if reasonably short and understandable).