### PR TITLE
NNS1-2905: Remove transactions from histogram

### DIFF
--- a/rs/backend/src/accounts_store/histogram.rs
+++ b/rs/backend/src/accounts_store/histogram.rs
@@ -10,86 +10,35 @@ mod tests;
 pub struct AccountsStoreHistogram {
     /// The number of accounts in the store.
     pub accounts_count: u64,
-    /// A histogram of the number of transactions per account.
-    /// Note: The buckets are logarithmic, so the buckets are:
-    ///
-    /// - bucket key 0: 0 transactions
-    /// - bucket key 1: 1 transaction
-    /// - bucket key 3: 2-3 transactions
-    /// - bucket key 7: 4-7 transactions
-    /// - etc
-    ///
-    /// This is because otherwise accounts with a large number of transactions would be insufficiently anonymised.
-    /// There are block explorers so technically this data is already public but we don't need that level of
-    /// precision and would rather not leak information.
-    default_account_transactions: BTreeMap<u32, u64>,
     /// A histogram of the number of sub-accounts per account.
     ///
-    /// Note: The buckets are logarithmic, as with `default_account_transactions`.
-    sub_accounts: BTreeMap<u32, u64>,
-    /// A histogram of the number of transactions per sub account.
+    /// Note: The buckets are logarithmic, so the buckets are:
     ///
-    /// Note: The buckets are logarithmic, as with `default_account_transactions`.
-    sub_account_transactions: BTreeMap<u32, u64>,
-    /// The total number of subaccount transactions for a given main account.
-    total_sub_account_transactions: BTreeMap<u32, u64>,
+    /// - bucket key 0: 0 sub-accounts
+    /// - bucket key 1: 1 sub-account
+    /// - bucket key 3: 2-3 sub-accounts
+    /// - bucket key 7: 4-7 sub-accounts
+    /// - etc
+    sub_accounts: BTreeMap<u32, u64>,
     /// A histogram of the number of hardware wallets per account.
     ///
-    /// Note: The buckets are logarithmic, as with `default_account_transactions`.
+    /// Note: The buckets are logarithmic, as with `sub_accounts`.
     hardware_wallet_accounts: BTreeMap<u32, u64>,
-    /// The number of transactions per hardware wallet.
-    hardware_wallet_transactions: BTreeMap<u32, u64>,
-    /// The total number of hardware wallet transactions for a given main account.
-    total_hardware_wallet_transactions: BTreeMap<u32, u64>,
     /// A histogram of the number of canisters per account.
     ///
-    /// Note: The buckets are logarithmic, as with `default_account_transactions`.
+    /// Note: The buckets are logarithmic, as with `sub_accounts`.
     canisters: BTreeMap<u32, u64>,
 }
 
 // Getters and setters for the histogram fields that ensure that data is placed in the right columns.
 impl AccountsStoreHistogram {
-    /// The bucket for a given number of default account transactions.
-    ///
-    /// Note: The bucket is logarithmic base 2.
-    pub fn default_account_transactions(&mut self, count: usize) -> &mut u64 {
-        self.default_account_transactions.entry(log2_bucket(count)).or_insert(0)
-    }
     /// The bucket for a given number of sub-accounts.
     pub fn sub_accounts(&mut self, count: usize) -> &mut u64 {
         self.sub_accounts.entry(log2_bucket(count)).or_insert(0)
     }
-    /// The bucket for a given number of sub-account transactions.
-    ///
-    /// Note: The bucket is logarithmic base 2.
-    pub fn sub_account_transactions(&mut self, count: usize) -> &mut u64 {
-        self.sub_account_transactions.entry(log2_bucket(count)).or_insert(0)
-    }
-    /// The bucket for a the total number of sub-account transactions in a given main account.
-    ///
-    /// Note: The bucket is logarithmic base 2.
-    pub fn total_sub_account_transactions(&mut self, count: usize) -> &mut u64 {
-        self.total_sub_account_transactions
-            .entry(log2_bucket(count))
-            .or_insert(0)
-    }
     /// The bucket for a given number of hardware wallets.
     pub fn hardware_wallet_accounts(&mut self, count: usize) -> &mut u64 {
         self.hardware_wallet_accounts.entry(log2_bucket(count)).or_insert(0)
-    }
-    /// The bucket for a given number of hardware wallet transactions.
-    ///
-    /// Note: The bucket is logarithmic base 2.
-    pub fn hardware_wallet_transactions(&mut self, count: usize) -> &mut u64 {
-        self.hardware_wallet_transactions.entry(log2_bucket(count)).or_insert(0)
-    }
-    /// The bucket for a the total number of sub-account transactions in a given main account.
-    ///
-    /// Note: The bucket is logarithmic base 2.
-    pub fn total_hardware_wallet_transactions(&mut self, count: usize) -> &mut u64 {
-        self.total_hardware_wallet_transactions
-            .entry(log2_bucket(count))
-            .or_insert(0)
     }
     /// The bucket for a given number of canisters.
     ///
@@ -99,9 +48,7 @@ impl AccountsStoreHistogram {
     }
     /// Remove empty buckets from the histogram.
     pub fn remove_empty_buckets(&mut self) {
-        self.default_account_transactions.retain(|_, count| *count != 0);
         self.sub_accounts.retain(|_, count| *count != 0);
-        self.sub_account_transactions.retain(|_, count| *count != 0);
         self.hardware_wallet_accounts.retain(|_, count| *count != 0);
         self.canisters.retain(|_, count| *count != 0);
     }
@@ -112,20 +59,8 @@ impl Add<&Account> for AccountsStoreHistogram {
 
     fn add(mut self, rhs: &Account) -> AccountsStoreHistogram {
         self.accounts_count += 1;
-        *self.default_account_transactions(rhs.default_account_transactions.len()) += 1;
         *self.sub_accounts(rhs.sub_accounts.len()) += 1;
-        let total_sub_account_transactions = rhs.sub_accounts.values().fold(0, |total, sub_account| {
-            *self.sub_account_transactions(sub_account.transactions.len()) += 1;
-            total + sub_account.transactions.len()
-        });
-        *self.total_sub_account_transactions(total_sub_account_transactions) += 1;
         *self.hardware_wallet_accounts(rhs.hardware_wallet_accounts.len()) += 1;
-        let total_hardware_wallet_transactions =
-            rhs.hardware_wallet_accounts.iter().fold(0, |total, hardware_wallet| {
-                *self.hardware_wallet_transactions(hardware_wallet.transactions.len()) += 1;
-                total + hardware_wallet.transactions.len()
-            });
-        *self.total_hardware_wallet_transactions(total_hardware_wallet_transactions) += 1;
         *self.canisters(rhs.canisters.len()) += 1;
         self
     }

--- a/rs/backend/src/accounts_store/histogram/tests.rs
+++ b/rs/backend/src/accounts_store/histogram/tests.rs
@@ -74,15 +74,7 @@ mod should_increment_correct_bucket {
         };
     }
 
-    should_increment_correct_bucket!(default_account_transactions);
-
     should_increment_correct_bucket!(sub_accounts);
-    should_increment_correct_bucket!(sub_account_transactions);
-    should_increment_correct_bucket!(total_sub_account_transactions);
-
     should_increment_correct_bucket!(hardware_wallet_accounts);
-    should_increment_correct_bucket!(hardware_wallet_transactions);
-    should_increment_correct_bucket!(total_hardware_wallet_transactions);
-
     should_increment_correct_bucket!(canisters);
 }

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -1089,11 +1089,8 @@ fn get_histogram() {
 
         // These new accounts are empty, so the 0 bucket should be incremented in each histogram:
         expected_histogram.accounts_count += 2;
-        *expected_histogram.default_account_transactions(0) += 2;
         *expected_histogram.sub_accounts(0) += 2;
-        *expected_histogram.total_sub_account_transactions(0) += 2;
         *expected_histogram.hardware_wallet_accounts(0) += 2;
-        *expected_histogram.total_hardware_wallet_transactions(0) += 2;
         *expected_histogram.canisters(0) += 2;
 
         let actual_histogram = store.get_histogram();
@@ -1110,8 +1107,6 @@ fn get_histogram() {
         // The histogram entry for the number of sub-accounts will have changed from 0 to 1, 2 etc for one account:
         *expected_histogram.sub_accounts(i) -= 1;
         *expected_histogram.sub_accounts(i + 1) += 1;
-        // Also, all these sub-accounts have no transactions:
-        *expected_histogram.sub_account_transactions(0) += 1;
         // Check:
         let actual_histogram = store.get_histogram();
         expected_histogram.remove_empty_buckets();
@@ -1143,7 +1138,6 @@ fn get_histogram() {
         // The two accounts (principal3 and principal4) have 1 hardware wallet each, so the 1 bucket should be incremented in each histogram:
         *expected_histogram.hardware_wallet_accounts(0) -= 2;
         *expected_histogram.hardware_wallet_accounts(1) += 2;
-        *expected_histogram.hardware_wallet_transactions(0) += 2;
 
         let actual_histogram = store.get_histogram();
         assert_eq!(
@@ -1220,12 +1214,8 @@ pub(crate) fn setup_test_store() -> AccountsStore {
 pub fn test_store_histogram() -> AccountsStoreHistogram {
     let mut ans = AccountsStoreHistogram::default();
     ans.accounts_count = 2;
-    *ans.default_account_transactions(4) += 1; // Account ID 1 makes 4 transactions.
-    *ans.default_account_transactions(1) += 1; // Account ID 2 makes 1 transaction.
     *ans.sub_accounts(0) += 2; // Neither test account has sub-accounts.
-    *ans.total_sub_account_transactions(0) += 2; // Both accounts therefore also have no sub-account transactions.
     *ans.hardware_wallet_accounts(0) += 2; // Neither test account has hardware wallets.
-    *ans.total_hardware_wallet_transactions(0) += 2; // Therefore neither has any hardware wallet transactions.
     *ans.canisters(0) += 2; // Neither test account has canisters.
     ans
 }


### PR DESCRIPTION
# Motivation

We no longer read transactions from the nns-dapp canister, but from the index canister instead.
We want to remove the transactions from nns-dapp canister so we need to remove all the code that is still using the transactions.

https://github.com/dfinity/nns-dapp/pull/3273 added a method to get histogram stats about the accounts stored in nns-dapp. Some of the histograms are about transactions. When we remove the transactions, we no longer can or need to include transaction stats in the histogram.

# Changes

Remove transaction stats from the histogram.

# Tests

Removed tests specific to transactions in histograms.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary