### PR TITLE
NNS1-2905: Stop detecting StakeNeuronNotification transactions

### DIFF
--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -164,25 +164,6 @@ fn append_transaction_detects_neuron_transactions() {
         TransactionType::StakeNeuron
     ));
 
-    let notification = Transfer {
-        from: AccountIdentifier::new(neuron_principal, None),
-        to: neuron_account,
-        amount: Tokens::from_tokens(0).unwrap(),
-        fee: Tokens::from_e8s(10000),
-    };
-    store
-        .append_transaction(
-            notification,
-            Memo(block_height),
-            block_height + 1,
-            TimeStamp::from_nanos_since_unix_epoch(100),
-        )
-        .unwrap();
-    assert!(matches!(
-        store.transactions.back().unwrap().transaction_type.unwrap(),
-        TransactionType::StakeNeuronNotification
-    ));
-
     let topup1 = Transfer {
         from: AccountIdentifier::new(neuron_principal, None),
         to: neuron_account,

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -174,7 +174,7 @@ fn append_transaction_detects_neuron_transactions() {
         .append_transaction(
             topup1,
             Memo(0),
-            block_height + 2,
+            block_height + 1,
             TimeStamp::from_nanos_since_unix_epoch(100),
         )
         .unwrap();
@@ -193,7 +193,7 @@ fn append_transaction_detects_neuron_transactions() {
         .append_transaction(
             topup2,
             Memo(0),
-            block_height + 3,
+            block_height + 2,
             TimeStamp::from_nanos_since_unix_epoch(100),
         )
         .unwrap();


### PR DESCRIPTION
# Motivation

We no longer read transactions from the nns-dapp canister, but from the index canister instead.
We want to remove the transactions from nns-dapp canister so we need to remove all the code that is still using the transactions.

Staking a neuron used to involve 2 ledger transactions:
1. Transferring the stake to the neuron account.
2. Transferring 0 ICP to the neuron account with a memo pointing to the previous transaction.

The second transaction would prompt the nns-dapp to claim the neuron.
But this is no longer how neurons are staked.
The second transaction would have transaction type `StakeNeuronNotification`.
Detecting this transaction type requires looking at previous transactions.
Because we want to remove the transactions from the nns-dapp canister, we can no longer do this.

# Changes

1. Treat every transaction to an existing neuron account as a top-up.
2. Remove `is_stake_neuron_notification` and `get_transaction_index` which are no longer necessary.

# Tests

Remove the test for detecting `StakeNeuronNotification` transactions.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary