### PR TITLE
NNS1-2905: Stop fixing old transactions

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -1040,6 +1040,7 @@ impl AccountsStore {
         }
     }
 
+    #[cfg(test)]
     fn get_transaction(&self, transaction_index: TransactionIndex) -> Option<&Transaction> {
         match self.transactions.front() {
             Some(t) => {

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -1057,24 +1057,6 @@ impl AccountsStore {
         }
     }
 
-    fn get_transaction_mut(&mut self, transaction_index: TransactionIndex) -> Option<&mut Transaction> {
-        match self.transactions.front() {
-            Some(t) => {
-                if t.transaction_index > transaction_index {
-                    None
-                } else {
-                    let offset = t.transaction_index;
-                    self.transactions.get_mut(
-                        usize::try_from(transaction_index - offset).unwrap_or_else(|_| {
-                            unreachable!("The number of transactions is far below the size of memory")
-                        }),
-                    )
-                }
-            }
-            None => None,
-        }
-    }
-
     fn link_hardware_wallet_to_account(
         &mut self,
         account_identifier: AccountIdentifier,


### PR DESCRIPTION
# Motivation

We no longer read transactions from the nns-dapp canister, but from the index canister instead.
We want to remove the transactions from nns-dapp canister so we need to remove all the code that is still using the transactions.

At some point in the past, transactions didn't have a transaction type.
New transactions were assigned a type and there was also code in place to fix old transactions for old users once they logged in.
We want to stop storing the transactions so we no longer need to care about fixing the type of a few very old transaction.s

# Changes

1. Stop calling `fix_transactions_for_early_user` and remove resulting unused code.
2. Mark `get_transaction` which is no longer used, but is still used in a test (that will be deleted in another PR) as test-only.

# Tests

Still pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary