### PR TITLE
NNS1-2905: Remove transactions field from AccountsStore

### DIFF
--- a/rs/backend/src/accounts_store/toy_data.rs
+++ b/rs/backend/src/accounts_store/toy_data.rs
@@ -2,8 +2,7 @@
 
 use crate::accounts_store::{
     schema::AccountsDbTrait, Account, AccountIdentifier, AccountsStore, AttachCanisterRequest, CanisterId, Memo,
-    NeuronDetails, NeuronId, Operation, PrincipalId, RegisterHardwareWalletRequest, TimeStamp, Tokens, Transaction,
-    TransactionType,
+    NeuronDetails, NeuronId, PrincipalId, RegisterHardwareWalletRequest,
 };
 
 #[cfg(test)]
@@ -16,7 +15,6 @@ const MAX_SUB_ACCOUNTS_PER_ACCOUNT: u64 = 3; // Toy accounts have between 0 and 
 const MAX_HARDWARE_WALLETS_PER_ACCOUNT: u64 = 1; // Toy accounts have between 0 and this many hardware wallets.
 const MAX_CANISTERS_PER_ACCOUNT: u64 = 2; // Toy accounts have between 0 and this many canisters.
 const NEURONS_PER_ACCOUNT: f32 = 0.3;
-const TRANSACTIONS_PER_ACCOUNT: f32 = 3.0;
 
 /// A specification for how large a toy account should be.
 ///
@@ -158,8 +156,6 @@ impl AccountsStore {
         let (index_range_start, index_range_end) = (num_existing_accounts, (num_existing_accounts + num_accounts));
         let mut neurons_needed: f32 = 0.0;
         let mut neurons_created: f32 = 0.0;
-        let mut transactions_needed: f32 = 0.0;
-        let mut transactions_created: f32 = 0.0;
         // Creates accounts:
         for toy_account_index in index_range_start..index_range_end {
             let account = PrincipalId::new_user_test_id(toy_account_index);
@@ -205,25 +201,6 @@ impl AccountsStore {
                     AccountIdentifier::from(PrincipalId::new_user_test_id(toy_account_index)),
                     neuron,
                 );
-            }
-            // Creates transactions
-            transactions_needed += TRANSACTIONS_PER_ACCOUNT;
-            while transactions_created < transactions_needed {
-                transactions_created += 1.0;
-                // Warning: This is in no way semantically meaningful or correct.  It is just data to fill up memory and exercise upgrades.
-                self.transactions.push_back(Transaction {
-                    transaction_index: 9,
-                    block_height: 10,
-                    timestamp: TimeStamp::from_nanos_since_unix_epoch(341),
-                    memo: Memo(11),
-                    transfer: Operation::Transfer {
-                        to: AccountIdentifier::from(PrincipalId::new_user_test_id(12)),
-                        amount: Tokens::from_e8s(10_000),
-                        from: AccountIdentifier::from(PrincipalId::new_user_test_id(14)),
-                        fee: Tokens::from_e8s(10_001),
-                    },
-                    transaction_type: Some(TransactionType::Transfer),
-                });
             }
         }
         index_range_start

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -100,20 +100,19 @@ populate() {
   done
   verify_healthy
   check_state_size
-  check_num_transactions
   test -z "${SCHEMA1:-}" || assert_schema_is "${SCHEMA1}"
 }
 upgrade_to_wasm2() {
   echo "Upgrading to $(working_wasm 2)..."
   upgrade_nnsdapp "$(working_wasm 2)" "$(working_arguments 2)"
-  check_num_transactions
+  check_state_size
   test -z "${SCHEMA2:-}" || assert_schema_is "${SCHEMA2}"
 }
 downgrade_to_wasm1() {
   echo "Reverting to $(working_wasm 1)..."
   upgrade_nnsdapp "$(working_wasm 1)" "$(working_arguments 1)"
   verify_healthy
-  check_num_transactions
+  check_state_size
   test -z "${SCHEMA1:-}" || assert_schema_is "${SCHEMA1}"
 }
 

--- a/scripts/nns-dapp/migration-test.canister
+++ b/scripts/nns-dapp/migration-test.canister
@@ -81,29 +81,6 @@ check_state_size() {
   fi
 }
 
-# Verifies that the number of transactions is reasonable.  Some may be pruned, but not a lot.
-# TODO: Unit Test
-check_num_transactions() {
-  # The toy state creates 3 transactions per account; see TRANSACTIONS_PER_ACCOUNT
-  # in: rs/backend/src/accounts_store/toy_data.rs
-  toy_transactions="$((NUM_TOY_ACCOUNTS * 3))"
-  # Note: Transactions MAY be pruned if the state is large enough, however in tests
-  # we should not make the state so large that, say, half the transactions are pruned.
-  # If that many are pruned, either the test is unrealistic or we should increase the
-  # amount of storage available.
-  expected_min_transactions="$((toy_transactions / 2))"
-  transactions_count="$(get_transactions_count)"
-  if ((transactions_count < expected_min_transactions)); then
-    {
-      echo "ERROR: 'transactions_count' is smaller than expected."
-      printf "  Expected at least: %10d\n" "$expected_min_transactions"
-      printf "  Actual:            %10d\n" "$transactions_count"
-      printf "  Note: Transactions MAY be pruned but if a lot are being pruned, there is insufficient memory."
-      exit 1
-    } >&2
-  fi
-}
-
 # Wait for the migration countdown to complete.
 wait_for_migration() {
   local migration_countdown


### PR DESCRIPTION
# Motivation

The NNS dapp FE no longer reads transactions from the nns-dapp canister, but instead from the index canister.

In this PR we remove the `transactions` field on the `AccountsStore`. To be able to do this we also need to remove a few remaining usages (most usages were already removed in https://github.com/dfinity/nns-dapp/pull/4756, https://github.com/dfinity/nns-dapp/pull/4757, https://github.com/dfinity/nns-dapp/pull/4758, https://github.com/dfinity/nns-dapp/pull/4759, https://github.com/dfinity/nns-dapp/pull/4760) for stats and metrics and encode/decode something in its place for compatibility in the stable memory format between upgrades.

This PR does not remove the transactions related stats fields and also doesn't remove the transaction index vectors from accounts. Those will be cleaned up in later PRs.

# Changes

1. Remove the `transactions` field from `AccountsStore`.
2. Remove the transaction count from the debug representation.
3. Stop setting stats dependent on `transactions`.
4. When encoding state to stable memory, encode an empty transactions array instead.
5. When decoding state from stable memory, ignore the transactions slot by decoding into `Reserved`.
6. Stop populating `transactions` in toy accounts.
7. Stop checking transaction counts in the migrations test. Instead use `check_state_size` in places where it wasn't already to still have some coverage.

# Tests

The downgrade-upgrade test passes.
I also manually did an upgrade and made sure I could still top up a neuron with an external transaction. This means the neuron accounts are still decoded correctly.
I also checked the stats and metrics.
Then I did a downgrade and made sure the transactions count could once again be increased.

# Todos

- [ ] Add entry to changelog (if necessary).
is covered by existing entry "Stop storing transactions in the nns-dapp canister."