### PR TITLE
Update ic-stable-structure dep from 0.6.0 to 0.6.4

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -21,6 +21,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Update main navigation style on mobile. 
 * Update IC dependencies in nns-dapp crates.
+* Update `ic-stable-structures` dependency to 0.6.4.
 
 #### Deprecated
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3190,9 +3190,12 @@ checksum = "95dce29e3ceb0e6da3e78b305d95365530f2efd2146ca18590c0ef3aa6038568"
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4867a1d9f232e99ca68682161d1fc67dff9501f4f1bf42d69a9358289ad0f8"
+checksum = "07e2282054c8ddf0cb2a7abf5c174c373917b4345c9a096ae4aa7f7185cdcdc7"
+dependencies = [
+ "ic_principal",
+]
 
 [[package]]
 name = "ic-sys"
@@ -3339,15 +3342,13 @@ dependencies = [
 
 [[package]]
 name = "ic_principal"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899a4e8ddada85b91a2fe32b4dc6c0d475ef7bfef3f51cf2aecb26ee4ac4724f"
+checksum = "1762deb6f7c8d8c2bdee4b6c5a47b60195b74e9b5280faa5ba29692f8e17429c"
 dependencies = [
  "crc32fast",
  "data-encoding",
- "hex",
  "serde",
- "serde_bytes",
  "sha2 0.10.8",
  "thiserror",
 ]
@@ -3860,7 +3861,7 @@ dependencies = [
  "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-nns-governance",
  "ic-sns-swap",
- "ic-stable-structures 0.6.0",
+ "ic-stable-structures 0.6.4",
  "ic_principal",
  "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "itertools 0.12.0",

--- a/rs/backend/Cargo.toml
+++ b/rs/backend/Cargo.toml
@@ -36,7 +36,7 @@ ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70e
 ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
 ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
 ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-ic-stable-structures = "0.6.0"
+ic-stable-structures = "0.6.4"
 icp-ledger = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
 on_wire = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
 


### PR DESCRIPTION
# Motivation

Use the newest version of stable structures.

# Changes

Update the dependency of `ic-stable-structure` in `rs/backend/Cargo.toml`.

# Tests

CI

# Todos

- [x] Add entry to changelog (if necessary).
