### PR TITLE
Update IC candid files to release-2024-04-17_23-01-hotfix-bitcoin-query-stats

### DIFF
--- a/declarations/nns_governance/nns_governance.did
+++ b/declarations/nns_governance/nns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;

--- a/declarations/nns_ledger/nns_ledger.did
+++ b/declarations/nns_ledger/nns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/rosetta-api/icp_ledger/ledger.did>
+//! Candid for canister `nns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/rosetta-api/icp_ledger/ledger.did>
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.

--- a/declarations/nns_registry/nns_registry.did
+++ b/declarations/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/registry/canister/canister/registry.did>
 type AddApiBoundaryNodePayload = record { node_id : principal; version : text };
 type AddFirewallRulesPayload = record {
   expected_hash : text;
@@ -96,6 +96,9 @@ type DataCenterRecord = record {
   owner : text;
 };
 type DeleteSubnetPayload = record { subnet_id : opt principal };
+type DeployGuestosToAllUnassignedNodesPayload = record {
+  elected_replica_version : text;
+};
 type EcdsaConfig = record {
   quadruples_to_create_in_advance : nat32;
   max_queue_size : opt nat32;
@@ -253,6 +256,9 @@ type UpdateNodesHostosVersionPayload = record {
   hostos_version_id : opt text;
   node_ids : vec principal;
 };
+type UpdateSshReadOnlyAccessForAllUnassignedNodesPayload = record {
+  ssh_readonly_keys : vec text;
+};
 type UpdateSubnetPayload = record {
   unit_delay_millis : opt nat64;
   max_duplicity : opt nat32;
@@ -309,6 +315,9 @@ service : {
     );
   create_subnet : (CreateSubnetPayload) -> ();
   delete_subnet : (DeleteSubnetPayload) -> ();
+  deploy_guestos_to_all_unassigned_nodes : (
+      DeployGuestosToAllUnassignedNodesPayload,
+    ) -> ();
   get_build_metadata : () -> (text) query;
   get_node_operators_and_dcs_of_node_provider : (principal) -> (Result_2) query;
   get_node_providers_monthly_xdr_rewards : () -> (Result_3) query;
@@ -341,6 +350,9 @@ service : {
     ) -> ();
   update_node_rewards_table : (UpdateNodeRewardsTableProposalPayload) -> ();
   update_nodes_hostos_version : (UpdateNodesHostosVersionPayload) -> ();
+  update_ssh_readonly_access_for_all_unassigned_nodes : (
+      UpdateSshReadOnlyAccessForAllUnassignedNodesPayload,
+    ) -> ();
   update_subnet : (UpdateSubnetPayload) -> ();
   update_subnet_replica_version : (UpdateSubnetReplicaVersionPayload) -> ();
   update_unassigned_nodes_config : (UpdateUnassignedNodesConfigPayload) -> ();

--- a/declarations/sns_governance/sns_governance.did
+++ b/declarations/sns_governance/sns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/sns/governance/canister/governance.did>
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
@@ -387,6 +387,7 @@ type RewardEvent = record {
   rounds_since_last_distribution : opt nat64;
   actual_timestamp_seconds : nat64;
   end_timestamp_seconds : opt nat64;
+  total_available_e8s_equivalent : opt nat64;
   distributed_e8s_equivalent : nat64;
   round : nat64;
   settled_proposals : vec ProposalId;

--- a/declarations/sns_ledger/sns_ledger.did
+++ b/declarations/sns_ledger/sns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/rosetta-api/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/rosetta-api/icrc1/ledger/ledger.did>
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.
@@ -126,6 +126,17 @@ type ChangeFeeCollector = variant {
     Unset; SetTo: Account;
 };
 
+type ChangeArchiveOptions = record {
+    num_blocks_to_archive : opt nat64;
+    max_transactions_per_response : opt nat64;
+    trigger_threshold : opt nat64;
+    max_message_size_bytes : opt nat64;
+    cycles_for_archive_creation : opt nat64;
+    node_max_memory_size_bytes : opt nat64;
+    controller_id : opt principal;
+    more_controller_ids : opt vec principal;
+};
+
 type UpgradeArgs = record {
     metadata : opt vec record { text; MetadataValue };
     token_symbol : opt text;
@@ -136,6 +147,7 @@ type UpgradeArgs = record {
     feature_flags : opt FeatureFlags;
     maximum_number_of_accounts: opt nat64;
     accounts_overflow_trim_quantity: opt nat64;
+    change_archive_options : opt ChangeArchiveOptions;
 };
 
 type LedgerArg = variant {
@@ -244,14 +256,14 @@ type Transfer = record {
   spender : opt Account;
 };
 
-type Value = variant { 
-    Blob : blob; 
-    Text : text; 
+type Value = variant {
+    Blob : blob;
+    Text : text;
     Nat : nat;
-    Nat64: nat64; 
+    Nat64: nat64;
     Int : int;
-    Array : vec Value; 
-    Map : Map; 
+    Array : vec Value;
+    Map : Map;
 };
 
 type Map = vec record { text; Value };
@@ -365,6 +377,15 @@ type ArchiveInfo = record {
     block_range_end: BlockIndex;
 };
 
+type ICRC3Value = variant {
+    Blob : blob;
+    Text : text;
+    Nat : nat;
+    Int : int;
+    Array : vec ICRC3Value;
+    Map : vec record { text; ICRC3Value };
+};
+
 type GetArchivesArgs = record {
     // The last archive seen by the client.
     // The Ledger will return archives coming
@@ -384,6 +405,19 @@ type GetArchivesResult = vec record {
     end : nat;
 };
 
+type GetBlocksResult = record {
+    // Total number of blocks in the
+    // block log
+    log_length : nat;
+
+    blocks : vec record { id : nat; block: ICRC3Value };
+
+    archived_blocks : vec record {
+        args : vec GetBlocksArgs;
+        callback : func (vec GetBlocksArgs) -> (GetBlocksResult) query;
+    };
+};
+
 type ICRC3DataCertificate = record {
   // See https://internetcomputer.org/docs/current/references/ic-interface-spec#certification
   certificate : blob;
@@ -395,8 +429,8 @@ type ICRC3DataCertificate = record {
 service : (ledger_arg : LedgerArg) -> {
     archives : () -> (vec ArchiveInfo) query;
     get_transactions : (GetTransactionsRequest) -> (GetTransactionsResponse) query;
-    get_blocks : (GetBlocksArgs) -> (GetBlocksResponse) query;  
-    get_data_certificate : () -> (DataCertificate) query; 
+    get_blocks : (GetBlocksArgs) -> (GetBlocksResponse) query;
+    get_data_certificate : () -> (DataCertificate) query;
 
     icrc1_name : () -> (text) query;
     icrc1_symbol : () -> (text) query;
@@ -408,12 +442,13 @@ service : (ledger_arg : LedgerArg) -> {
     icrc1_balance_of : (Account) -> (Tokens) query;
     icrc1_transfer : (TransferArg) -> (TransferResult);
     icrc1_supported_standards : () -> (vec StandardRecord) query;
-  
+
     icrc2_approve : (ApproveArgs) -> (ApproveResult);
     icrc2_allowance : (AllowanceArgs) -> (Allowance) query;
     icrc2_transfer_from : (TransferFromArgs) -> (TransferFromResult);
 
     icrc3_get_archives : (GetArchivesArgs) -> (GetArchivesResult) query;
     icrc3_get_tip_certificate : () -> (opt ICRC3DataCertificate) query;
+    icrc3_get_blocks : (vec GetBlocksArgs) -> (GetBlocksResult) query;
     icrc3_supported_block_types : () -> (vec record { block_type : text; url : text }) query;
 }

--- a/declarations/sns_root/sns_root.did
+++ b/declarations/sns_root/sns_root.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/sns/root/canister/root.did>
 type CanisterCallError = record { code : opt int32; description : text };
 type CanisterIdRecord = record { canister_id : principal };
 type CanisterInstallMode = variant { reinstall; upgrade; install };
@@ -7,7 +7,9 @@ type CanisterStatusResult = record {
   memory_size : nat;
   cycles : nat;
   settings : DefiniteCanisterSettings;
+  idle_cycles_burned_per_day : opt nat;
   module_hash : opt blob;
+  reserved_cycles : opt nat;
 };
 type CanisterStatusResultV2 = record {
   status : CanisterStatusType;
@@ -31,7 +33,13 @@ type ChangeCanisterRequest = record {
   memory_allocation : opt nat;
   compute_allocation : opt nat;
 };
-type DefiniteCanisterSettings = record { controllers : vec principal };
+type DefiniteCanisterSettings = record {
+  freezing_threshold : opt nat;
+  controllers : vec principal;
+  reserved_cycles_limit : opt nat;
+  memory_allocation : opt nat;
+  compute_allocation : opt nat;
+};
 type DefiniteCanisterSettingsArgs = record {
   freezing_threshold : nat;
   controllers : vec principal;

--- a/declarations/sns_swap/sns_swap.did
+++ b/declarations/sns_swap/sns_swap.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/sns/swap/canister/swap.did>
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;

--- a/declarations/sns_wasm/sns_wasm.did
+++ b/declarations/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
@@ -59,6 +59,8 @@ type GetNextSnsVersionRequest = record {
 };
 type GetNextSnsVersionResponse = record { next_version : opt SnsVersion };
 type GetSnsSubnetIdsResponse = record { sns_subnet_ids : vec principal };
+type GetWasmMetadataRequest = record { hash : opt blob };
+type GetWasmMetadataResponse = record { result : opt Result_1 };
 type GetWasmRequest = record { hash : blob };
 type GetWasmResponse = record { wasm : opt SnsWasm };
 type IdealMatchedParticipationFunction = record {
@@ -90,6 +92,11 @@ type ListUpgradeStepsRequest = record {
   sns_governance_canister_id : opt principal;
 };
 type ListUpgradeStepsResponse = record { steps : vec ListUpgradeStep };
+type MetadataSection = record {
+  contents : opt blob;
+  name : opt text;
+  visibility : opt text;
+};
 type NeuronBasketConstructionParameters = record {
   dissolve_delay_interval_seconds : nat64;
   count : nat64;
@@ -108,6 +115,7 @@ type NeuronsFundParticipationConstraints = record {
   min_direct_participation_threshold_icp_e8s : opt nat64;
   ideal_matched_participation_function : opt IdealMatchedParticipationFunction;
 };
+type Ok = record { sections : vec MetadataSection };
 type PrettySnsVersion = record {
   archive_wasm_hash : text;
   root_wasm_hash : text;
@@ -117,6 +125,7 @@ type PrettySnsVersion = record {
   index_wasm_hash : text;
 };
 type Result = variant { Error : SnsWasmError; Hash : blob };
+type Result_1 = variant { Ok : Ok; Error : SnsWasmError };
 type SnsCanisterIds = record {
   root : opt principal;
   swap : opt principal;
@@ -218,6 +227,9 @@ service : (SnsWasmCanisterInitPayload) -> {
     ) query;
   get_sns_subnet_ids : (record {}) -> (GetSnsSubnetIdsResponse) query;
   get_wasm : (GetWasmRequest) -> (GetWasmResponse) query;
+  get_wasm_metadata : (GetWasmMetadataRequest) -> (
+      GetWasmMetadataResponse,
+    ) query;
   insert_upgrade_path_entries : (InsertUpgradePathEntriesRequest) -> (
       InsertUpgradePathEntriesResponse,
     );

--- a/dfx.json
+++ b/dfx.json
@@ -357,7 +357,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-04-17",
-        "IC_COMMIT": "release-2024-04-03_23-01-base"
+        "IC_COMMIT": "release-2024-04-17_23-01-hotfix-bitcoin-query-stats"
       },
       "packtool": ""
     }


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
Even with no changes, just updating the reference is good practice.

# Changes
## Changes made by a bot triggered by github-merge-queue
- Update the version of `ic` specified in `dfx.json`.
- Update the NNS candid files to the versions in that commit.

# Tests
- See CI
- [ ] Check for breaking changes in the APIs and schedule any required follow-on work.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants