### PR TITLE
NNS1-2905: Encode unused transactions as VecDeque<candid::Empty>

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -9,7 +9,6 @@ use histogram::AccountsStoreHistogram;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_cdk::println;
 use ic_crypto_sha::Sha256;
-use ic_ledger_core::timestamp::TimeStamp;
 use ic_nns_common::types::NeuronId;
 use ic_nns_constants::{CYCLES_MINTING_CANISTER_ID, GOVERNANCE_CANISTER_ID};
 use ic_stable_structures::{storable::Bound, Storable};
@@ -219,16 +218,6 @@ impl PartialOrd for NamedCanister {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
-}
-
-#[derive(CandidType, Deserialize, Debug, Eq, PartialEq)]
-struct Transaction {
-    transaction_index: TransactionIndex,
-    block_height: BlockIndex,
-    timestamp: TimeStamp,
-    memo: Memo,
-    transfer: Operation,
-    transaction_type: Option<TransactionType>,
 }
 
 #[derive(Copy, Clone, CandidType, Deserialize, Debug, Eq, PartialEq)]
@@ -1142,7 +1131,7 @@ impl StableState for AccountsStore {
             HashMap::<(AccountIdentifier, AccountIdentifier), (TransactionType, u64)>::new(),
             // Transactions are unused but we need to encode them for backwards
             // compatibility.
-            VecDeque::<Transaction>::new(),
+            VecDeque::<candid::Empty>::new(),
             &self.neuron_accounts,
             &self.block_height_synced_up_to,
             &self.multi_part_transactions_processor,


### PR DESCRIPTION
# Motivation

We want to update our dependency on `ic-ledger-core`.
Between the version we currently depend on and the latest version, [this MR](https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/12530) made an incompatible change to the `Approve` type, which is used in the `Operation` type which we use in the `Transaction` type to store transactions in stable memory.

We no longer want to store transactions in stable memory, but if we need to roll back after the next release, the current version will try to read from stable memory into the old (incompatible) transaction type. Even though it will read an empty array, this will cause an error if the array element types don't match.

Fortunately, Candid has a type `Empty` which is a subtype of every type so an empty array with this element type can be read into any array type, including an array of the old incompatible Transaction type.

It's not possible to create instances of the `Empty` type but since we write an empty array we don't need any instances.

# Changes

1. When encoding an empty transactions array in the pre-upgrade hook, make the array have element type `candid::Empty` instead of `Transaction` (which would be incompatible after updating our `ic-ledger-core` dependency.
2. Remove the `Transaction` type which is no longer used.

# Tests

Current tests pass.
I also tested it in another branch which updates the `ic-ledger-core` dependency. Without this change, the downgrade-upgrade test fails and with this change it passes.

# Todos

- [ ] Add entry to changelog (if necessary).
covered by existing entry