### PR TITLE
Change playwright runs-on 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           retention-days: 3
   test-playwright-e2e-shard-1-of-2:
     needs: build
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
       - name: Checkout nns-dapp
@@ -88,7 +88,7 @@ jobs:
           shard_count: 2
   test-playwright-e2e-shard-2-of-2:
     needs: build
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
       - name: Checkout nns-dapp


### PR DESCRIPTION
# Motivation

Our Playwright tests started failing when trying to install browsers with the following error:
```
E: Failed to fetch https://packages.microsoft.com/ubuntu/22.04/prod/dists/jammy/InRelease  Clearsigned file isn't valid, got 'NOSPLIT' (does the network require authentication?)
E: The repository 'https://packages.microsoft.com/ubuntu/22.04/prod jammy InRelease' is no longer signed.
```
For example: https://github.com/dfinity/nns-dapp/actions/runs/8813756690/job/24193274978?pr=4762

I guess either the GitHub runner or the Microsoft server got a bad configuration. 

If we switch `runs-on:` from the high performance Ubuntu 22.04 environment named `ubuntu-latest-m` to `ubuntu-20.04`, the tests are a bit slower but at least they pass.

We used `ubuntu-latest-m` when the e2e tests were the slowest tests but that might not even be the case anymore. Anyway we can try switching back later if the tests are a bottleneck, but it's not important enough to leave a TODO.

# Changes

Change `runs-on:` for `test-playwright-e2e-shard-1-of-2` and `test-playwright-e2e-shard-2-of-2` from `ubuntu-latest-m` to `ubuntu-20.04`.

# Tests

CI passes again.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary