### PR TITLE
Update IC deps rev and remove TransferFrom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,33 +862,33 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
  "build-info",
  "build-info-build",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-certified-map 0.3.4",
  "ic-crypto-getrandom-for-wasm",
  "ic-crypto-tree-hash",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-metrics-encoder",
  "ic-nervous-system-common-build-metadata",
  "ic-nns-common",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-types",
  "ic-xrc-types",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "lazy_static",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "prost",
  "rand",
  "serde",
@@ -1024,12 +1024,12 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "serde",
 ]
 
@@ -1048,10 +1048,10 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
 ]
 
 [[package]]
@@ -1066,11 +1066,11 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "serde",
  "serde_bytes",
 ]
@@ -1090,11 +1090,11 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_http 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_http 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-metrics-encoder",
  "serde_bytes",
 ]
@@ -1114,11 +1114,11 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "prost",
 ]
 
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "fe-derive"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1765,7 +1765,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "base32",
  "byte-unit",
@@ -1774,9 +1774,9 @@ dependencies = [
  "comparable",
  "crc32fast",
  "ic-crypto-sha2",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-stable-structures 0.5.6",
- "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "prost",
  "serde",
  "strum 0.23.0",
@@ -1827,11 +1827,11 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
  "ic-btc-interface 0.1.0 (git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "serde",
  "serde_bytes",
 ]
@@ -1851,10 +1851,10 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "ed25519-consensus",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-crypto-ecdsa-secp256k1",
  "ic-crypto-internal-types",
  "ic-crypto-secrets-containers",
@@ -1874,7 +1874,7 @@ source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad6
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "serde",
 ]
@@ -1882,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.10",
@@ -1891,7 +1891,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
  "serde",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "ic-constants"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 
 [[package]]
 name = "ic-constants"
@@ -2037,7 +2037,7 @@ source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad6
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "k256",
  "lazy_static",
@@ -2051,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "getrandom 0.2.10",
 ]
@@ -2059,7 +2059,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "hex",
  "ic-types",
@@ -2070,7 +2070,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "base64 0.11.0",
  "curve25519-dalek",
@@ -2080,7 +2080,7 @@ dependencies = [
  "ic-crypto-internal-seed",
  "ic-crypto-internal-types",
  "ic-crypto-secrets-containers",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-types",
  "rand",
  "rand_chacha",
@@ -2092,7 +2092,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "hex",
  "ic-crypto-getrandom-for-wasm",
@@ -2111,15 +2111,15 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "ic-crypto-internal-sha2 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-crypto-internal-sha2 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
 ]
 
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "base64 0.11.0",
  "hex",
@@ -2127,7 +2127,7 @@ dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-secrets-containers",
  "ic-crypto-sha2",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-types",
  "rand",
  "rand_chacha",
@@ -2138,7 +2138,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "openssl",
  "sha2 0.9.9",
@@ -2170,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "base64 0.11.0",
  "cached",
@@ -2197,7 +2197,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381-der"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "simple_asn1",
 ]
@@ -2205,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "fe-derive",
  "hex",
@@ -2232,13 +2232,13 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "arrayvec 0.5.2",
  "base64 0.11.0",
  "hex",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "serde",
  "serde_cbor",
  "strum 0.23.0",
@@ -2250,17 +2250,17 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-crypto-internal-basic-sig-ed25519",
  "ic-crypto-internal-multi-sig-bls12381",
  "ic-crypto-internal-threshold-sig-bls12381",
  "ic-crypto-internal-threshold-sig-ecdsa",
  "ic-crypto-internal-types",
  "ic-crypto-tls-cert-validation",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-types",
  "serde",
  "x509-parser 0.12.0",
@@ -2269,7 +2269,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "serde",
  "zeroize",
@@ -2286,23 +2286,23 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "ic-crypto-internal-sha2 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-crypto-internal-sha2 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
 ]
 
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "chrono",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-crypto-internal-basic-sig-ed25519",
  "ic-crypto-internal-types",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-types",
  "serde",
  "x509-parser 0.9.2",
@@ -2311,12 +2311,12 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "assert_matches",
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "serde",
  "serde_bytes",
  "thiserror",
@@ -2325,22 +2325,22 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "base64 0.11.0",
  "ed25519-consensus",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-crypto-internal-basic-sig-der-utils",
  "ic-crypto-internal-basic-sig-ed25519",
  "ic-crypto-internal-types",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "simple_asn1",
 ]
 
 [[package]]
 name = "ic-error-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "serde",
  "strum 0.23.0",
@@ -2360,15 +2360,15 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
  "float-cmp",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-btc-interface 0.1.0 (git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7)",
- "ic-btc-types-internal 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-error-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-btc-types-internal 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-error-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "num-traits",
  "serde",
  "serde_bytes",
@@ -2400,17 +2400,17 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
  "ciborium",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-crypto-sha2",
- "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-ledger-hash-of",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "num-bigint",
  "num-traits",
  "serde",
@@ -2441,14 +2441,14 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-client"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "num-traits",
  "serde",
 ]
@@ -2456,23 +2456,23 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
  "ciborium",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-canister-profiler",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-cdk 0.7.4",
  "ic-cdk-macros 0.6.10",
  "ic-cdk-timers 0.1.2",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-icrc1-ledger",
  "ic-icrc1-tokens-u64",
  "ic-ledger-hash-of",
  "ic-metrics-encoder",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "num-traits",
  "scopeguard",
  "serde",
@@ -2481,26 +2481,26 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
  "ciborium",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-canister-log 0.2.0",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-cdk 0.7.4",
  "ic-cdk-macros 0.6.10",
  "ic-crypto-tree-hash",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-icrc1-client",
  "ic-icrc1-tokens-u64",
- "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-ledger-hash-of",
  "ic-metrics-encoder",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "num-traits",
  "serde",
  "serde_bytes",
@@ -2509,10 +2509,10 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-stable-structures 0.5.6",
  "num-traits",
  "serde",
@@ -2521,17 +2521,17 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-canister-log 0.2.0",
- "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-ledger-hash-of",
- "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "num-traits",
  "serde",
 ]
@@ -2555,19 +2555,19 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
  "ciborium",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-ledger-hash-of",
- "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "num-traits",
  "serde",
  "serde_bytes",
@@ -2596,7 +2596,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
  "ciborium",
@@ -2613,14 +2613,14 @@ checksum = "7cb321e571828d64d62319deeaaec4c8e68cdf93144dd6fe248e7a51ab2d3b5d"
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-nervous-system-proxied-canister-calls-tracker",
  "ic-nervous-system-runtime",
  "num-traits",
@@ -2631,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2640,22 +2640,22 @@ dependencies = [
  "by_address",
  "bytes",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-canister-log 0.2.0",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-metrics-encoder",
  "ic-nervous-system-runtime",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-stable-structures 0.5.6",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "json5",
  "maplit",
  "priority-queue",
@@ -2702,14 +2702,14 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-canister-client-sender",
  "ic-types",
  "lazy_static",
@@ -2721,9 +2721,9 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-stable-structures 0.5.6",
  "maplit",
  "num-traits",
@@ -2732,11 +2732,11 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
  "comparable",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "prost",
  "serde",
 ]
@@ -2744,29 +2744,29 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
 ]
 
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-cdk 0.7.4",
  "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-nervous-system-proxied-canister-calls-tracker",
  "ic-nervous-system-runtime",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "lazy_static",
  "num-traits",
  "serde",
@@ -2776,34 +2776,34 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-cdk 0.7.4",
 ]
 
 [[package]]
 name = "ic-nns-common"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
  "comparable",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-crypto-sha2",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-registry-keys",
  "ic-registry-transport",
  "ic-types",
  "lazy_static",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "prost",
  "serde",
  "sha2 0.9.9",
@@ -2812,9 +2812,9 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "lazy_static",
 ]
 
@@ -2830,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2839,17 +2839,17 @@ dependencies = [
  "comparable",
  "csv",
  "cycles-minting-canister",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-crypto-getrandom-for-wasm",
  "ic-crypto-sha2",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-common-test-keys",
  "ic-nervous-system-governance",
@@ -2857,19 +2857,19 @@ dependencies = [
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
  "ic-nns-common",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-sns-init",
  "ic-sns-root",
  "ic-sns-swap",
  "ic-sns-wasm",
  "ic-stable-structures 0.5.6",
  "ic-types",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "itertools 0.10.5",
  "lazy_static",
  "maplit",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "prost",
  "rand",
  "rand_chacha",
@@ -2882,22 +2882,22 @@ dependencies = [
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-nervous-system-clients",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "serde",
 ]
 
 [[package]]
 name = "ic-protobuf"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "bincode",
  "candid 0.8.4",
@@ -2927,11 +2927,11 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-types",
  "serde",
 ]
@@ -2939,32 +2939,32 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "serde",
 ]
 
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "serde",
 ]
 
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "serde",
  "strum 0.23.0",
  "strum_macros 0.23.1",
@@ -2973,12 +2973,12 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "bytes",
  "candid 0.8.4",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "prost",
  "serde",
 ]
@@ -2986,7 +2986,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2997,33 +2997,33 @@ dependencies = [
  "clap",
  "comparable",
  "csv",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-canister-log 0.2.0",
  "ic-canister-profiler",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-icrc1-client",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "lazy_static",
  "maplit",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "prost",
  "prost-build",
  "rand",
@@ -3039,26 +3039,26 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.11.0",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-crypto-sha2",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-icrc1-index",
  "ic-icrc1-ledger",
- "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-nervous-system-proto",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-sns-governance",
  "ic-sns-root",
  "ic-sns-swap",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "isocountry",
  "lazy_static",
  "maplit",
@@ -3073,30 +3073,30 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "async-trait",
  "build-info",
  "build-info-build",
  "candid 0.8.4",
  "comparable",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "futures",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-canister-log 0.2.0",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-cdk 0.7.4",
  "ic-cdk-macros 0.6.10",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
  "ic-sns-swap",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "num-traits",
  "prost",
  "serde",
@@ -3105,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3113,31 +3113,31 @@ dependencies = [
  "bytes",
  "candid 0.8.4",
  "comparable",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-canister-log 0.2.0",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-crypto-sha2",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-nervous-system-proto",
  "ic-nervous-system-runtime",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-sns-governance",
  "ic-stable-structures 0.5.6",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "itertools 0.10.5",
  "lazy_static",
  "maplit",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "prost",
  "prost-build",
  "registry-canister",
@@ -3150,32 +3150,32 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "async-trait",
  "build-info",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "futures",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-cdk 0.7.4",
  "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-nervous-system-proto",
  "ic-nervous-system-runtime",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-nns-handler-root-interface",
  "ic-sns-governance",
  "ic-sns-init",
  "ic-sns-root",
  "ic-types",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "maplit",
  "prost",
  "serde",
@@ -3197,14 +3197,14 @@ checksum = "be4867a1d9f232e99ca68682161d1fc67dff9501f4f1bf42d69a9358289ad0f8"
 [[package]]
 name = "ic-sys"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
  "lazy_static",
  "libc",
  "nix",
- "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "wsl",
 ]
 
@@ -3225,7 +3225,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "base32",
  "base64 0.11.0",
@@ -3235,20 +3235,20 @@ dependencies = [
  "derive_more 0.99.8-alpha.0",
  "hex",
  "http",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-btc-types-internal 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-btc-types-internal 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
  "ic-crypto-tree-hash",
- "ic-error-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-error-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "maplit",
  "num-traits",
  "once_cell",
- "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "prost",
  "serde",
  "serde_bytes",
@@ -3265,13 +3265,13 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "bitflags 1.3.2",
  "cvt",
  "features",
  "hex",
- "ic-sys 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-sys 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "libc",
  "nix",
  "prost",
@@ -3355,28 +3355,28 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
  "comparable",
  "crc32fast",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_http 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_http 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-crypto-sha2",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-ledger-hash-of",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "lazy_static",
  "num-traits",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "prost",
  "prost-derive",
  "serde",
@@ -3421,10 +3421,9 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "ciborium",
  "hex",
  "num-traits",
  "serde",
@@ -3845,30 +3844,30 @@ dependencies = [
  "base64 0.21.5",
  "candid 0.8.4",
  "cycles-minting-canister",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "flate2",
  "futures",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-cdk 0.9.2",
  "ic-cdk-macros 0.6.10",
  "ic-certified-map 0.3.4",
  "ic-crypto-sha2",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-nns-common",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-nns-governance",
  "ic-sns-swap",
  "ic-stable-structures 0.6.0",
  "ic_principal",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "itertools 0.12.0",
  "lazy_static",
  "lzma-rs",
  "maplit",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "pocket-ic",
  "pretty_assertions",
  "proposals",
@@ -4063,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 
 [[package]]
 name = "on_wire"
@@ -4263,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
  "serde",
@@ -4475,19 +4474,19 @@ dependencies = [
  "anyhow",
  "candid 0.8.4",
  "cycles-minting-canister",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-btc-interface 0.1.0 (git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7)",
  "ic-cdk 0.9.2",
  "ic-cdk-macros 0.6.10",
  "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-nervous-system-root",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "idl2json",
  "pretty_assertions",
  "serde",
@@ -4749,29 +4748,29 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "registry-canister"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "build-info",
  "build-info-build",
  "candid 0.8.4",
  "cycles-minting-canister",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "futures",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-cdk 0.7.4",
  "ic-certified-map 0.3.4",
  "ic-crypto-node-key-validation",
  "ic-crypto-sha2",
  "ic-crypto-utils-basic-sig",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-metrics-encoder",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-nervous-system-common-build-metadata",
  "ic-nns-common",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "ic-registry-keys",
  "ic-registry-routing-table",
  "ic-registry-subnet-features",
@@ -4780,7 +4779,7 @@ dependencies = [
  "ic-types",
  "ipnet",
  "leb128",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
  "prost",
  "serde",
  "serde_cbor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,33 +862,33 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
  "build-info",
  "build-info-build",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-certified-map 0.3.4",
  "ic-crypto-getrandom-for-wasm",
  "ic-crypto-tree-hash",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-metrics-encoder",
  "ic-nervous-system-common-build-metadata",
  "ic-nns-common",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-types",
  "ic-xrc-types",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "lazy_static",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "prost",
  "rand",
  "serde",
@@ -1024,6 +1024,18 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+dependencies = [
+ "candid 0.8.4",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "serde",
+]
+
+[[package]]
+name = "dfn_candid"
+version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 dependencies = [
  "candid 0.8.4",
@@ -1034,15 +1046,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "dfn_candid"
+name = "dfn_core"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
- "candid 0.8.4",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "serde",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
 ]
 
 [[package]]
@@ -1055,12 +1064,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "dfn_core"
+name = "dfn_http"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "candid 0.8.4",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "serde",
+ "serde_bytes",
 ]
 
 [[package]]
@@ -1076,14 +1088,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "dfn_http"
+name = "dfn_http_metrics"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
- "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "serde",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_http 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-metrics-encoder",
  "serde_bytes",
 ]
 
@@ -1100,15 +1112,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "dfn_http_metrics"
+name = "dfn_protobuf"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_http 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-metrics-encoder",
- "serde_bytes",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "prost",
 ]
 
 [[package]]
@@ -1119,17 +1130,6 @@ dependencies = [
  "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
  "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
  "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "prost",
-]
-
-[[package]]
-name = "dfn_protobuf"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
  "prost",
 ]
 
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "fe-derive"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1765,6 +1765,27 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+dependencies = [
+ "base32",
+ "byte-unit",
+ "bytes",
+ "candid 0.8.4",
+ "comparable",
+ "crc32fast",
+ "ic-crypto-sha2",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-stable-structures 0.5.6",
+ "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "prost",
+ "serde",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
+]
+
+[[package]]
+name = "ic-base-types"
+version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 dependencies = [
  "base32",
@@ -1777,27 +1798,6 @@ dependencies = [
  "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
  "ic-stable-structures 0.5.6",
  "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "prost",
- "serde",
- "strum 0.23.0",
- "strum_macros 0.23.1",
-]
-
-[[package]]
-name = "ic-base-types"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "base32",
- "byte-unit",
- "bytes",
- "candid 0.8.4",
- "comparable",
- "crc32fast",
- "ic-crypto-sha2",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-stable-structures 0.5.6",
- "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
  "prost",
  "serde",
  "strum 0.23.0",
@@ -1827,6 +1827,18 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+dependencies = [
+ "candid 0.8.4",
+ "ic-btc-interface 0.1.0 (git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "ic-btc-types-internal"
+version = "0.1.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 dependencies = [
  "candid 0.8.4",
@@ -1837,24 +1849,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-btc-types-internal"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "candid 0.8.4",
- "ic-btc-interface 0.1.0 (git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
 name = "ic-canister-client-sender"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "ed25519-consensus",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-crypto-ecdsa-secp256k1",
  "ic-crypto-internal-types",
  "ic-crypto-secrets-containers",
@@ -1874,7 +1874,7 @@ source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad6
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "serde",
 ]
@@ -1882,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.10",
@@ -1891,7 +1891,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "candid 0.8.4",
  "serde",
@@ -1901,7 +1901,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 dependencies = [
  "candid 0.8.4",
  "serde",
@@ -2027,17 +2027,17 @@ dependencies = [
 [[package]]
 name = "ic-constants"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 
 [[package]]
 name = "ic-constants"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "k256",
  "lazy_static",
@@ -2051,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "getrandom 0.2.10",
 ]
@@ -2059,7 +2059,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "hex",
  "ic-types",
@@ -2070,7 +2070,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "base64 0.11.0",
  "curve25519-dalek",
@@ -2080,7 +2080,7 @@ dependencies = [
  "ic-crypto-internal-seed",
  "ic-crypto-internal-types",
  "ic-crypto-secrets-containers",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-types",
  "rand",
  "rand_chacha",
@@ -2092,7 +2092,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "hex",
  "ic-crypto-getrandom-for-wasm",
@@ -2111,15 +2111,15 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
- "ic-crypto-internal-sha2 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-crypto-internal-sha2 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
 ]
 
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "base64 0.11.0",
  "hex",
@@ -2127,7 +2127,7 @@ dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-secrets-containers",
  "ic-crypto-sha2",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-types",
  "rand",
  "rand_chacha",
@@ -2138,7 +2138,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2147,6 +2147,15 @@ dependencies = [
  "rand_chacha",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "ic-crypto-internal-sha2"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+dependencies = [
+ "openssl",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -2159,18 +2168,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-crypto-internal-sha2"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "openssl",
- "sha2 0.9.9",
-]
-
-[[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "base64 0.11.0",
  "cached",
@@ -2197,7 +2197,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381-der"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "simple_asn1",
 ]
@@ -2205,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "fe-derive",
  "hex",
@@ -2232,13 +2232,13 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "arrayvec 0.5.2",
  "base64 0.11.0",
  "hex",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "serde",
  "serde_cbor",
  "strum 0.23.0",
@@ -2250,17 +2250,17 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-crypto-internal-basic-sig-ed25519",
  "ic-crypto-internal-multi-sig-bls12381",
  "ic-crypto-internal-threshold-sig-bls12381",
  "ic-crypto-internal-threshold-sig-ecdsa",
  "ic-crypto-internal-types",
  "ic-crypto-tls-cert-validation",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-types",
  "serde",
  "x509-parser 0.12.0",
@@ -2269,7 +2269,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "serde",
  "zeroize",
@@ -2286,23 +2286,23 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
- "ic-crypto-internal-sha2 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-crypto-internal-sha2 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
 ]
 
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "chrono",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-crypto-internal-basic-sig-ed25519",
  "ic-crypto-internal-types",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-types",
  "serde",
  "x509-parser 0.9.2",
@@ -2311,12 +2311,12 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "assert_matches",
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "serde",
  "serde_bytes",
  "thiserror",
@@ -2325,16 +2325,26 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "base64 0.11.0",
  "ed25519-consensus",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-crypto-internal-basic-sig-der-utils",
  "ic-crypto-internal-basic-sig-ed25519",
  "ic-crypto-internal-types",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "simple_asn1",
+]
+
+[[package]]
+name = "ic-error-types"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+dependencies = [
+ "serde",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
 ]
 
 [[package]]
@@ -2348,11 +2358,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-error-types"
+name = "ic-ic00-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
+ "candid 0.8.4",
+ "float-cmp",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-btc-interface 0.1.0 (git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7)",
+ "ic-btc-types-internal 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-error-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "num-traits",
  "serde",
+ "serde_bytes",
+ "serde_cbor",
  "strum 0.23.0",
  "strum_macros 0.23.1",
 ]
@@ -2378,23 +2398,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-ic00-types"
+name = "ic-icrc1"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "candid 0.8.4",
- "float-cmp",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-btc-interface 0.1.0 (git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7)",
- "ic-btc-types-internal 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-error-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ciborium",
+ "hex",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-crypto-sha2",
+ "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-hash-of",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "num-bigint",
  "num-traits",
  "serde",
  "serde_bytes",
- "serde_cbor",
- "strum 0.23.0",
- "strum_macros 0.23.1",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -2417,38 +2439,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-icrc1"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "candid 0.8.4",
- "ciborium",
- "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-crypto-sha2",
- "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-hash-of",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "num-bigint",
- "num-traits",
- "serde",
- "serde_bytes",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
 name = "ic-icrc1-client"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "num-traits",
  "serde",
 ]
@@ -2456,23 +2456,23 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
  "ciborium",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-canister-profiler",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-cdk 0.7.4",
  "ic-cdk-macros 0.6.10",
  "ic-cdk-timers 0.1.2",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-icrc1-ledger",
  "ic-icrc1-tokens-u64",
  "ic-ledger-hash-of",
  "ic-metrics-encoder",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "num-traits",
  "scopeguard",
  "serde",
@@ -2481,26 +2481,26 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
  "ciborium",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-canister-log 0.2.0",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-cdk 0.7.4",
  "ic-cdk-macros 0.6.10",
  "ic-crypto-tree-hash",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-icrc1-client",
  "ic-icrc1-tokens-u64",
- "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-ledger-hash-of",
  "ic-metrics-encoder",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "num-traits",
  "serde",
  "serde_bytes",
@@ -2509,11 +2509,29 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "candid 0.8.4",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-stable-structures 0.5.6",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "ic-ledger-canister-core"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+dependencies = [
+ "async-trait",
+ "candid 0.8.4",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-canister-log 0.2.0",
+ "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-hash-of",
+ "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "num-traits",
  "serde",
 ]
@@ -2535,21 +2553,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-ledger-canister-core"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+name = "ic-ledger-core"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-canister-log 0.2.0",
- "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ciborium",
+ "hex",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-crypto-sha2",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-ledger-hash-of",
- "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "num-traits",
  "serde",
+ "serde_bytes",
 ]
 
 [[package]]
@@ -2573,30 +2594,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-ledger-core"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "async-trait",
- "candid 0.8.4",
- "ciborium",
- "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-hash-of",
- "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "num-traits",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "candid 0.8.4",
  "ciborium",
@@ -2613,19 +2613,56 @@ checksum = "7cb321e571828d64d62319deeaaec4c8e68cdf93144dd6fe248e7a51ab2d3b5d"
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-nervous-system-proxied-canister-calls-tracker",
  "ic-nervous-system-runtime",
  "num-traits",
  "serde",
  "serde_bytes",
+]
+
+[[package]]
+name = "ic-nervous-system-common"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "build-info",
+ "build-info-build",
+ "by_address",
+ "bytes",
+ "candid 0.8.4",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-canister-log 0.2.0",
+ "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-crypto-sha2",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-metrics-encoder",
+ "ic-nervous-system-runtime",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-stable-structures 0.5.6",
+ "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "json5",
+ "maplit",
+ "priority-queue",
+ "prost",
+ "rust_decimal",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2663,53 +2700,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-nervous-system-common"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "anyhow",
- "async-trait",
- "build-info",
- "build-info-build",
- "by_address",
- "bytes",
- "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-canister-log 0.2.0",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-metrics-encoder",
- "ic-nervous-system-runtime",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-stable-structures 0.5.6",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "json5",
- "maplit",
- "priority-queue",
- "prost",
- "rust_decimal",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-canister-client-sender",
  "ic-types",
  "lazy_static",
@@ -2721,9 +2721,9 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-stable-structures 0.5.6",
  "maplit",
  "num-traits",
@@ -2732,11 +2732,11 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "candid 0.8.4",
  "comparable",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "prost",
  "serde",
 ]
@@ -2744,29 +2744,29 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
 ]
 
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-cdk 0.7.4",
  "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-nervous-system-proxied-canister-calls-tracker",
  "ic-nervous-system-runtime",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "lazy_static",
  "num-traits",
  "serde",
@@ -2776,37 +2776,46 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-cdk 0.7.4",
 ]
 
 [[package]]
 name = "ic-nns-common"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "candid 0.8.4",
  "comparable",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-crypto-sha2",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-registry-keys",
  "ic-registry-transport",
  "ic-types",
  "lazy_static",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "prost",
  "serde",
  "sha2 0.9.9",
+]
+
+[[package]]
+name = "ic-nns-constants"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+dependencies = [
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "lazy_static",
 ]
 
 [[package]]
@@ -2819,18 +2828,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-nns-constants"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "lazy_static",
-]
-
-[[package]]
 name = "ic-nns-governance"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2839,17 +2839,17 @@ dependencies = [
  "comparable",
  "csv",
  "cycles-minting-canister",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-crypto-getrandom-for-wasm",
  "ic-crypto-sha2",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-common-test-keys",
  "ic-nervous-system-governance",
@@ -2857,19 +2857,19 @@ dependencies = [
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
  "ic-nns-common",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-sns-init",
  "ic-sns-root",
  "ic-sns-swap",
  "ic-sns-wasm",
  "ic-stable-structures 0.5.6",
  "ic-types",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "itertools 0.10.5",
  "lazy_static",
  "maplit",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "prost",
  "rand",
  "rand_chacha",
@@ -2882,22 +2882,22 @@ dependencies = [
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-nervous-system-clients",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "serde",
 ]
 
 [[package]]
 name = "ic-protobuf"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "bincode",
  "candid 0.8.4",
@@ -2912,7 +2912,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 dependencies = [
  "bincode",
  "candid 0.8.4",
@@ -2927,11 +2927,11 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "candid 0.8.4",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-types",
  "serde",
 ]
@@ -2939,32 +2939,32 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "candid 0.8.4",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "serde",
 ]
 
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "candid 0.8.4",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "serde",
 ]
 
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "candid 0.8.4",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "serde",
  "strum 0.23.0",
  "strum_macros 0.23.1",
@@ -2973,12 +2973,12 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "bytes",
  "candid 0.8.4",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "prost",
  "serde",
 ]
@@ -2986,7 +2986,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2997,33 +2997,33 @@ dependencies = [
  "clap",
  "comparable",
  "csv",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-canister-log 0.2.0",
  "ic-canister-profiler",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-icrc1-client",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "lazy_static",
  "maplit",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "prost",
  "prost-build",
  "rand",
@@ -3039,26 +3039,26 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "base64 0.13.1",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-crypto-sha2",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-icrc1-index",
  "ic-icrc1-ledger",
- "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-nervous-system-proto",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-sns-governance",
  "ic-sns-root",
  "ic-sns-swap",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "isocountry",
  "lazy_static",
  "maplit",
@@ -3073,30 +3073,30 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "async-trait",
  "build-info",
  "build-info-build",
  "candid 0.8.4",
  "comparable",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "futures",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-canister-log 0.2.0",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-cdk 0.7.4",
  "ic-cdk-macros 0.6.10",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
  "ic-sns-swap",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "num-traits",
  "prost",
  "serde",
@@ -3105,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3113,31 +3113,31 @@ dependencies = [
  "bytes",
  "candid 0.8.4",
  "comparable",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-canister-log 0.2.0",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-crypto-sha2",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-nervous-system-proto",
  "ic-nervous-system-runtime",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-sns-governance",
  "ic-stable-structures 0.5.6",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "itertools 0.10.5",
  "lazy_static",
  "maplit",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "prost",
  "prost-build",
  "registry-canister",
@@ -3150,32 +3150,32 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "async-trait",
  "build-info",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "futures",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-cdk 0.7.4",
  "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-nervous-system-proto",
  "ic-nervous-system-runtime",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-nns-handler-root-interface",
  "ic-sns-governance",
  "ic-sns-init",
  "ic-sns-root",
  "ic-types",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "maplit",
  "prost",
  "serde",
@@ -3197,6 +3197,20 @@ checksum = "be4867a1d9f232e99ca68682161d1fc67dff9501f4f1bf42d69a9358289ad0f8"
 [[package]]
 name = "ic-sys"
 version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+dependencies = [
+ "hex",
+ "ic-crypto-sha2",
+ "lazy_static",
+ "libc",
+ "nix",
+ "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "wsl",
+]
+
+[[package]]
+name = "ic-sys"
+version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 dependencies = [
  "hex",
@@ -3209,23 +3223,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-sys"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "hex",
- "ic-crypto-sha2",
- "lazy_static",
- "libc",
- "nix",
- "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "wsl",
-]
-
-[[package]]
 name = "ic-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "base32",
  "base64 0.11.0",
@@ -3235,20 +3235,20 @@ dependencies = [
  "derive_more 0.99.8-alpha.0",
  "hex",
  "http",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-btc-types-internal 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-btc-types-internal 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
  "ic-crypto-tree-hash",
- "ic-error-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-error-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "maplit",
  "num-traits",
  "once_cell",
- "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "prost",
  "serde",
  "serde_bytes",
@@ -3265,13 +3265,13 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "bitflags 1.3.2",
  "cvt",
  "features",
  "hex",
- "ic-sys 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
+ "ic-sys 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "libc",
  "nix",
  "prost",
@@ -3284,13 +3284,13 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 dependencies = [
  "bitflags 1.3.2",
  "cvt",
  "features",
  "hex",
- "ic-sys 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-sys 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
  "libc",
  "nix",
  "prost",
@@ -3355,6 +3355,40 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
+dependencies = [
+ "candid 0.8.4",
+ "comparable",
+ "crc32fast",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_http 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "hex",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-crypto-sha2",
+ "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-ledger-hash-of",
+ "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "lazy_static",
+ "num-traits",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "prost",
+ "prost-derive",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
+]
+
+[[package]]
+name = "icp-ledger"
+version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 dependencies = [
  "candid 0.8.4",
@@ -3385,43 +3419,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "icp-ledger"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
-dependencies = [
- "candid 0.8.4",
- "comparable",
- "crc32fast",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_http 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-crypto-sha2",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-ledger-hash-of",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "lazy_static",
- "num-traits",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "prost",
- "prost-derive",
- "serde",
- "serde_bytes",
- "serde_cbor",
- "strum 0.24.1",
- "strum_macros 0.24.3",
-]
-
-[[package]]
 name = "icrc-ledger-types"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "candid 0.8.4",
  "ciborium",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 dependencies = [
  "candid 0.8.4",
  "ciborium",
@@ -3845,30 +3845,30 @@ dependencies = [
  "base64 0.21.5",
  "candid 0.8.4",
  "cycles-minting-canister",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "flate2",
  "futures",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-cdk 0.9.2",
  "ic-cdk-macros 0.6.10",
  "ic-certified-map 0.3.4",
  "ic-crypto-sha2",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-nns-common",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-nns-governance",
  "ic-sns-swap",
  "ic-stable-structures 0.6.0",
  "ic_principal",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "itertools 0.12.0",
  "lazy_static",
  "lzma-rs",
  "maplit",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "pocket-ic",
  "pretty_assertions",
  "proposals",
@@ -4063,12 +4063,12 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 
 [[package]]
 name = "on_wire"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 
 [[package]]
 name = "once_cell"
@@ -4263,7 +4263,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "candid 0.8.4",
  "serde",
@@ -4273,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 dependencies = [
  "candid 0.8.4",
  "serde",
@@ -4475,19 +4475,19 @@ dependencies = [
  "anyhow",
  "candid 0.8.4",
  "cycles-minting-canister",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-btc-interface 0.1.0 (git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7)",
  "ic-cdk 0.9.2",
  "ic-cdk-macros 0.6.10",
  "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-nervous-system-root",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "idl2json",
  "pretty_assertions",
  "serde",
@@ -4749,29 +4749,29 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "registry-canister"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01#f8f59f896499f2fef394d8321116f83351c59aa8"
+source = "git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063#2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063"
 dependencies = [
  "build-info",
  "build-info-build",
  "candid 0.8.4",
  "cycles-minting-canister",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "futures",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-cdk 0.7.4",
  "ic-certified-map 0.3.4",
  "ic-crypto-node-key-validation",
  "ic-crypto-sha2",
  "ic-crypto-utils-basic-sig",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-metrics-encoder",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-nervous-system-common-build-metadata",
  "ic-nns-common",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
+ "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "ic-registry-keys",
  "ic-registry-routing-table",
  "ic-registry-subnet-features",
@@ -4780,7 +4780,7 @@ dependencies = [
  "ic-types",
  "ipnet",
  "leb128",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-08-01_23-01)",
+ "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063)",
  "prost",
  "serde",
  "serde_cbor",

--- a/rs/backend/Cargo.toml
+++ b/rs/backend/Cargo.toml
@@ -22,23 +22,23 @@ strum = "0.25.0"
 strum_macros = "0.25.3"
 tar = "0.4.40"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-certified-map = "0.3.4" # == https://github.com/dfinity/cdk-rs 6a15aa1616bcfdfdc4c120d17d37a089f5700c36
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
 ic-stable-structures = "0.6.0"
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
 
 proposals = { path = "../proposals" }
 

--- a/rs/backend/Cargo.toml
+++ b/rs/backend/Cargo.toml
@@ -22,23 +22,23 @@ strum = "0.25.0"
 strum_macros = "0.25.3"
 tar = "0.4.40"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-certified-map = "0.3.4" # == https://github.com/dfinity/cdk-rs 6a15aa1616bcfdfdc4c120d17d37a089f5700c36
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
 ic-stable-structures = "0.6.0"
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
 
 proposals = { path = "../proposals" }
 

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -12,7 +12,7 @@ use ic_crypto_sha2::Sha256;
 use ic_nns_common::types::NeuronId;
 use ic_nns_constants::{CYCLES_MINTING_CANISTER_ID, GOVERNANCE_CANISTER_ID};
 use ic_stable_structures::{storable::Bound, Storable};
-use icp_ledger::Operation::{self, Approve, Burn, Mint, Transfer, TransferFrom};
+use icp_ledger::Operation::{self, Approve, Burn, Mint, Transfer};
 use icp_ledger::{AccountIdentifier, BlockIndex, Memo, Subaccount, Tokens};
 use itertools::Itertools;
 use on_wire::{FromWire, IntoWire};
@@ -581,12 +581,6 @@ impl AccountsStore {
         match *transfer {
             Burn { from: _, amount: _ } | Mint { to: _, amount: _ } | Approve { .. } => {}
             Transfer {
-                from,
-                to,
-                amount,
-                fee: _,
-            }
-            | TransferFrom {
                 from,
                 to,
                 spender: _,

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -148,6 +148,7 @@ fn maybe_process_transaction_detects_neuron_transactions() {
     let transfer = Transfer {
         from: AccountIdentifier::new(neuron_principal, None),
         to: neuron_account,
+        spender: None,
         amount: Tokens::from_tokens(1).unwrap(),
         fee: Tokens::from_e8s(10000),
     };
@@ -167,6 +168,7 @@ fn maybe_process_transaction_detects_neuron_transactions() {
     let topup1 = Transfer {
         from: AccountIdentifier::new(neuron_principal, None),
         to: neuron_account,
+        spender: None,
         amount: Tokens::from_tokens(2).unwrap(),
         fee: Tokens::from_e8s(10000),
     };
@@ -187,6 +189,7 @@ fn maybe_process_transaction_detects_neuron_transactions() {
     let topup2 = Transfer {
         from: AccountIdentifier::new(neuron_principal, None),
         to: neuron_account,
+        spender: None,
         amount: Tokens::from_tokens(3).unwrap(),
         fee: Tokens::from_e8s(10000),
     };
@@ -217,6 +220,7 @@ fn maybe_process_transaction_detects_neuron_transactions_from_external_accounts(
     let transfer = Transfer {
         from: AccountIdentifier::new(neuron_principal, None),
         to: neuron_account,
+        spender: None,
         amount: Tokens::from_tokens(1).unwrap(),
         fee: Tokens::from_e8s(10000),
     };
@@ -227,6 +231,7 @@ fn maybe_process_transaction_detects_neuron_transactions_from_external_accounts(
     let topup = Transfer {
         from: AccountIdentifier::new(PrincipalId::from_str(TEST_ACCOUNT_4).unwrap(), None),
         to: neuron_account,
+        spender: None,
         amount: Tokens::from_tokens(2).unwrap(),
         fee: Tokens::from_e8s(10000),
     };
@@ -267,6 +272,7 @@ fn topup_neuron_owned_by_other_principal_refreshes_balance_using_neurons_princip
     let stake_neuron_transfer = Transfer {
         from: AccountIdentifier::new(neuron_principal, None),
         to: neuron_account,
+        spender: None,
         amount: Tokens::from_tokens(1).unwrap(),
         fee: Tokens::from_e8s(10000),
     };
@@ -277,6 +283,7 @@ fn topup_neuron_owned_by_other_principal_refreshes_balance_using_neurons_princip
     let topup = Transfer {
         from: AccountIdentifier::new(other_principal, None),
         to: neuron_account,
+        spender: None,
         amount: Tokens::from_tokens(2).unwrap(),
         fee: Tokens::from_e8s(10000),
     };
@@ -1028,6 +1035,7 @@ pub(crate) fn setup_test_store() -> AccountsStore {
         let transfer = Transfer {
             amount: Tokens::from_e8s(300_000_000),
             fee: Tokens::from_e8s(1_000),
+            spender: None,
             from: account_identifier1,
             to: account_identifier2,
         };

--- a/rs/proposals/Cargo.toml
+++ b/rs/proposals/Cargo.toml
@@ -11,17 +11,17 @@ serde = "1.0.193"
 serde_bytes = "0.11.12"
 serde_json = "1.0.108"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
 ic-btc-interface = { git = "https://github.com/dfinity/bitcoin-canister", rev = "b1693619e3d4dbc00d8c79e9b6886e1db48b21f7" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2023-08-01_23-01" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
 
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }

--- a/rs/proposals/Cargo.toml
+++ b/rs/proposals/Cargo.toml
@@ -11,17 +11,17 @@ serde = "1.0.193"
 serde_bytes = "0.11.12"
 serde_json = "1.0.108"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
 ic-btc-interface = { git = "https://github.com/dfinity/bitcoin-canister", rev = "b1693619e3d4dbc00d8c79e9b6886e1db48b21f7" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
 
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }


### PR DESCRIPTION
# Motivation

If I update the IC deps rev from release-2023-08-01_23-01 to release-2023-08-09_23-01 (which is the next release after it), I get multiple build problems.
If I only update to [2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063](https://github.com/dfinity/ic/commit/2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063) which is a commit in between those releases, I get only one build problem, caused by `TransferFrom having been merged with `Transfer`.

# Changes

1. Update the IC deps rev to `2bc1a2bef3c9e5ec5e15da11e1f46531b3daa063`.
2. Merge our usage of `TransferFrom` with that of `Transfer`. We already did the same for both cases.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary