### PR TITLE
Update proposal rendering dependencies

### DIFF
--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -237,6 +237,11 @@ pub struct DeleteSubnetPayload {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct DeployGuestosToAllUnassignedNodesPayload {
+    pub elected_replica_version: String,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct NodeOperatorRecord {
     pub ipv6: Option<String>,
     pub node_operator_principal_id: serde_bytes::ByteBuf,
@@ -423,6 +428,11 @@ pub struct UpdateNodesHostosVersionPayload {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct UpdateSshReadOnlyAccessForAllUnassignedNodesPayload {
+    pub ssh_readonly_keys: Vec<String>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct EcdsaConfig {
     pub quadruples_to_create_in_advance: u32,
     pub max_queue_size: Option<u32>,
@@ -516,6 +526,12 @@ impl Service {
     pub async fn delete_subnet(&self, arg0: DeleteSubnetPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "delete_subnet", (arg0,)).await
     }
+    pub async fn deploy_guestos_to_all_unassigned_nodes(
+        &self,
+        arg0: DeployGuestosToAllUnassignedNodesPayload,
+    ) -> CallResult<()> {
+        ic_cdk::call(self.0, "deploy_guestos_to_all_unassigned_nodes", (arg0,)).await
+    }
     pub async fn get_build_metadata(&self) -> CallResult<(String,)> {
         ic_cdk::call(self.0, "get_build_metadata", ()).await
     }
@@ -602,6 +618,12 @@ impl Service {
     }
     pub async fn update_nodes_hostos_version(&self, arg0: UpdateNodesHostosVersionPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "update_nodes_hostos_version", (arg0,)).await
+    }
+    pub async fn update_ssh_readonly_access_for_all_unassigned_nodes(
+        &self,
+        arg0: UpdateSshReadOnlyAccessForAllUnassignedNodesPayload,
+    ) -> CallResult<()> {
+        ic_cdk::call(self.0, "update_ssh_readonly_access_for_all_unassigned_nodes", (arg0,)).await
     }
     pub async fn update_subnet(&self, arg0: UpdateSubnetPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "update_subnet", (arg0,)).await

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -301,6 +301,34 @@ pub struct GetWasmResponse {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct GetWasmMetadataRequest {
+    pub hash: Option<serde_bytes::ByteBuf>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct MetadataSection {
+    pub contents: Option<serde_bytes::ByteBuf>,
+    pub name: Option<String>,
+    pub visibility: Option<String>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct Ok {
+    pub sections: Vec<MetadataSection>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub enum Result1 {
+    Ok(Ok),
+    Error(SnsWasmError),
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct GetWasmMetadataResponse {
+    pub result: Option<Result1>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct SnsUpgrade {
     pub next_version: Option<SnsVersion>,
     pub current_version: Option<SnsVersion>,
@@ -415,6 +443,9 @@ impl Service {
     }
     pub async fn get_wasm(&self, arg0: GetWasmRequest) -> CallResult<(GetWasmResponse,)> {
         ic_cdk::call(self.0, "get_wasm", (arg0,)).await
+    }
+    pub async fn get_wasm_metadata(&self, arg0: GetWasmMetadataRequest) -> CallResult<(GetWasmMetadataResponse,)> {
+        ic_cdk::call(self.0, "get_wasm_metadata", (arg0,)).await
     }
     pub async fn insert_upgrade_path_entries(
         &self,


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.
Even with no changes, just updating the reference is good practice.

# Changes
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.
  * Note: The candid files under `declarations/nns-$CANISTER` are used as inputs.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants