### PR TITLE
NNS1-2906: Remove unused transactions from debug store

### DIFF
--- a/frontend/src/lib/components/accounts/TransactionList.svelte
+++ b/frontend/src/lib/components/accounts/TransactionList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  // TODO(NNS1-2906): Delete this file.
   import type { Transaction as NnsTransaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
   import type { Account } from "$lib/types/account";
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";

--- a/frontend/src/lib/derived/debug.derived.ts
+++ b/frontend/src/lib/derived/debug.derived.ts
@@ -1,4 +1,3 @@
-import type { Transaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
 import { canistersStore } from "$lib/stores/canisters.store";
@@ -79,10 +78,6 @@ let selectedSnsNeuronStore: Readable<SelectedSnsNeuronStore> = readable({
 export const debugSelectedSnsNeuronStore = (
   store: Readable<SelectedSnsNeuronStore>
 ) => (selectedSnsNeuronStore = createDerivedStore(store));
-const transactionsStore = writable<Transaction[] | undefined>(undefined);
-export const debugTransactions = (transactions: Transaction[] | undefined) => {
-  transactionsStore.set(transactions);
-};
 const snsProposalStore = writable<SnsProposalData | undefined>(undefined);
 export const debugSnsProposalStore = (
   proposal: SnsProposalData | undefined
@@ -116,7 +111,6 @@ export const initDebugStore = () =>
       snsNeuronsStore,
       icrcTransactionsStore,
       selectedSnsNeuronStore,
-      transactionsStore,
       snsProjectsStore,
       snsFunctionsStore,
       snsProposalStore,
@@ -145,7 +139,6 @@ export const initDebugStore = () =>
       $snsNeuronsStore,
       $snsTransactionsStore,
       $selectedSnsNeuronStore,
-      $transactionsStore,
       $projectsStore,
       $snsFunctionsStore,
       $snsProposalStore,
@@ -173,7 +166,6 @@ export const initDebugStore = () =>
       snsNeurons: $snsNeuronsStore,
       snsTransactions: $snsTransactionsStore,
       selectedSnsNeuron: $selectedSnsNeuronStore,
-      transactions: $transactionsStore,
       snsProposal: $snsProposalStore,
       projects: $projectsStore,
       snsFunctions: $snsFunctionsStore,

--- a/frontend/src/lib/directives/debug.directives.ts
+++ b/frontend/src/lib/directives/debug.directives.ts
@@ -19,7 +19,6 @@ import {
   anonymizeSnsSummary,
   anonymizeSnsSwapCommitment,
   anonymizeSnsTypeStore,
-  anonymizeTransaction,
   anonymizeTransactionStore,
   anonymizeVotingNeuron,
   cutAndAnonymize,
@@ -221,7 +220,6 @@ const anonymiseStoreState = async () => {
     selectedSnsNeuron,
     snsFunctions,
     snsTransactions,
-    transactions,
     aggregatorStore,
     tokensStore,
     icrcAccountsStore,
@@ -286,9 +284,6 @@ const anonymiseStoreState = async () => {
       selected: selectedSnsNeuron.selected,
       neuron: await anonymizeSnsNeuron(selectedSnsNeuron.neuron),
     },
-    transactions: await mapPromises(transactions, (transaction) =>
-      anonymizeTransaction({ transaction, account: accounts?.main })
-    ),
     snsFunctions,
     snsTransactions: await anonymizeSnsTypeStore(
       snsTransactions,

--- a/frontend/src/lib/services/icp-accounts.services.ts
+++ b/frontend/src/lib/services/icp-accounts.services.ts
@@ -354,6 +354,7 @@ const transferError = ({
   return { success: false, err: labelKey };
 };
 
+// TODO(NNS1-2906): Delete this.
 export const getAccountTransactions = async ({
   accountIdentifier,
   onLoad,

--- a/frontend/src/lib/utils/anonymize.utils.ts
+++ b/frontend/src/lib/utils/anonymize.utils.ts
@@ -387,6 +387,7 @@ export const anonymizeCanister = async (
   };
 };
 
+// TODO(NNS1-2906): Delete this file.
 export const anonymizeTransaction = async ({
   transaction,
   account,


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/4714 created a lot of dead code.
If we try to clean if up all at once, it will be hard to make sure it's really all deleted.
So I went over the removed imports from that PR and marked the ones that aren't used anywhere else to be deleted.
And then only actually deleted dead code from the debug store.
The other dead code will be removed in future PRs because it will generate further dead code and by making sure we always mark newly dead code it will be easy to see that nothing is missed.

# Changes

1. Remove unused `debugTransactions` and related code.
2. Mark other dead code for deletion.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary