### PR TITLE
NNS1-2906: Delete more dead code

### DIFF
--- a/frontend/src/lib/api/accounts.api.ts
+++ b/frontend/src/lib/api/accounts.api.ts
@@ -1,7 +1,4 @@
-import type {
-  AccountIdentifierString,
-  Transaction,
-} from "$lib/canisters/nns-dapp/nns-dapp.types";
+import type { AccountIdentifierString } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { hashCode, logWithTimestamp } from "$lib/utils/dev.utils";
 import type { Identity } from "@dfinity/agent";
 import { nnsDappCanister } from "./nns-dapp.api";
@@ -22,40 +19,6 @@ export const createSubAccount = async ({
   });
 
   logWithTimestamp(`Creating SubAccount ${hashCode(name)} complete.`);
-};
-
-// TODO(NNS1-2906): Delete this.
-export const getTransactions = async ({
-  identity,
-  icpAccountIdentifier,
-  pageSize,
-  offset,
-  certified,
-}: {
-  identity: Identity;
-  icpAccountIdentifier: AccountIdentifierString;
-  pageSize: number;
-  offset: number;
-  certified: boolean;
-}): Promise<Transaction[]> => {
-  logWithTimestamp(
-    `Loading Transactions ${hashCode(icpAccountIdentifier)} call...`
-  );
-
-  const { canister } = await nnsDappCanister({ identity });
-
-  const { transactions } = await canister.getTransactions({
-    accountIdentifier: icpAccountIdentifier,
-    pageSize,
-    offset,
-    certified,
-  });
-
-  logWithTimestamp(
-    `Loading Transactions ${hashCode(icpAccountIdentifier)} complete.`
-  );
-
-  return transactions;
 };
 
 export const renameSubAccount = async ({

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.canister.ts
@@ -302,6 +302,7 @@ export class NNSDappCanister {
     throw new Error(`Error detaching canister ${JSON.stringify(response)}`);
   };
 
+  // TODO(NNS1-2906): Delete this.
   public async getTransactions({
     accountIdentifier,
     pageSize,

--- a/frontend/src/tests/lib/api/accounts.api.spec.ts
+++ b/frontend/src/tests/lib/api/accounts.api.spec.ts
@@ -1,14 +1,8 @@
-import {
-  createSubAccount,
-  getTransactions,
-  renameSubAccount,
-} from "$lib/api/accounts.api";
+import { createSubAccount, renameSubAccount } from "$lib/api/accounts.api";
 import * as agent from "$lib/api/agent.api";
 import { NNSDappCanister } from "$lib/canisters/nns-dapp/nns-dapp.canister";
-import type { GetTransactionsResponse } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockSubAccount } from "$tests/mocks/icp-accounts.store.mock";
-import { mockSentToSubAccountTransaction } from "$tests/mocks/transaction.mock";
 import type { HttpAgent } from "@dfinity/agent";
 import { mock } from "vitest-mock-extended";
 
@@ -41,28 +35,5 @@ describe("accounts-api", () => {
     });
 
     expect(nnsDappMock.renameSubAccount).toBeCalled();
-  });
-
-  it("should call ledger and nnsdapp to get account and balance", async () => {
-    // NNSDapp mock
-    const mockResponse: GetTransactionsResponse = {
-      total: 1,
-      transactions: [mockSentToSubAccountTransaction],
-    };
-    const nnsDappMock = mock<NNSDappCanister>();
-    nnsDappMock.getTransactions.mockResolvedValue(mockResponse);
-    vi.spyOn(NNSDappCanister, "create").mockReturnValue(nnsDappMock);
-
-    const response = await getTransactions({
-      identity: mockIdentity,
-      certified: true,
-      icpAccountIdentifier: "",
-      pageSize: 1,
-      offset: 0,
-    });
-
-    expect(nnsDappMock.getTransactions).toBeCalled();
-    expect(nnsDappMock.getTransactions).toBeCalledTimes(1);
-    expect(response).toEqual([mockSentToSubAccountTransaction]);
   });
 });


### PR DESCRIPTION
# Motivation

Delete more dead code. Follow-up from https://github.com/dfinity/nns-dapp/pull/4771

# Changes

1. Removed `getTransactions` from `frontend/src/lib/api/accounts.api.ts`.
2. Marked resulting dead code.

# Tests

Removed.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary