### PR TITLE
Update snsdemo to release-2024-04-24

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -356,7 +356,7 @@
         "DIDC_VERSION": "2024-04-11",
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2024-04-17",
+        "SNSDEMO_RELEASE": "release-2024-04-24",
         "IC_COMMIT": "release-2024-04-17_23-01-hotfix-bitcoin-query-stats"
       },
       "packtool": ""


### PR DESCRIPTION
# Motivation
We would like to keep the testing environment, provided by snsdemo, up to date.

# Changes
* Updated `snsdemo` version in `dfx.json`.

# Tests
CI should pass.