### PR TITLE
Use same IC deps for sns_aggregator as for proposals and backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4949,6 +4949,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.5",
  "candid 0.8.4",
+ "dfn_candid",
  "dfn_core",
  "ic-cdk 0.9.2",
  "ic-cdk-macros 0.6.10",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,26 +869,26 @@ dependencies = [
  "build-info",
  "build-info-build",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_candid",
+ "dfn_core",
+ "dfn_http_metrics",
+ "dfn_protobuf",
+ "ic-base-types",
  "ic-certified-map 0.3.4",
  "ic-crypto-getrandom-for-wasm",
  "ic-crypto-tree-hash",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ic00-types",
+ "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-nervous-system-common-build-metadata",
  "ic-nns-common",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nns-constants",
+ "ic-protobuf",
  "ic-types",
  "ic-xrc-types",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icp-ledger",
  "lazy_static",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "on_wire",
  "prost",
  "rand",
  "serde",
@@ -1027,21 +1027,9 @@ version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "serde",
-]
-
-[[package]]
-name = "dfn_candid"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "candid 0.8.4",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
+ "dfn_core",
+ "ic-base-types",
+ "on_wire",
  "serde",
 ]
 
@@ -1050,17 +1038,8 @@ name = "dfn_core"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
-]
-
-[[package]]
-name = "dfn_core"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
+ "ic-base-types",
+ "on_wire",
 ]
 
 [[package]]
@@ -1069,20 +1048,8 @@ version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "dfn_http"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
+ "dfn_candid",
+ "dfn_core",
  "serde",
  "serde_bytes",
 ]
@@ -1092,21 +1059,9 @@ name = "dfn_http_metrics"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_http 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-metrics-encoder",
- "serde_bytes",
-]
-
-[[package]]
-name = "dfn_http_metrics"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "dfn_http 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
+ "dfn_candid",
+ "dfn_core",
+ "dfn_http",
  "ic-metrics-encoder",
  "serde_bytes",
 ]
@@ -1116,20 +1071,9 @@ name = "dfn_protobuf"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "prost",
-]
-
-[[package]]
-name = "dfn_protobuf"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
+ "dfn_core",
+ "ic-base-types",
+ "on_wire",
  "prost",
 ]
 
@@ -1774,30 +1718,9 @@ dependencies = [
  "comparable",
  "crc32fast",
  "ic-crypto-sha2",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf",
  "ic-stable-structures 0.5.6",
- "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "prost",
- "serde",
- "strum 0.23.0",
- "strum_macros 0.23.1",
-]
-
-[[package]]
-name = "ic-base-types"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "base32",
- "byte-unit",
- "bytes",
- "candid 0.8.4",
- "comparable",
- "crc32fast",
- "ic-crypto-sha",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-stable-structures 0.5.6",
- "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
+ "phantom_newtype",
  "prost",
  "serde",
  "strum 0.23.0",
@@ -1815,35 +1738,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-btc-interface"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/bitcoin-canister?rev=e4e89f2caedffbe0cfdec6f9d4a77f66dcb9119e#e4e89f2caedffbe0cfdec6f9d4a77f66dcb9119e"
-dependencies = [
- "candid 0.8.4",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
 name = "ic-btc-types-internal"
 version = "0.1.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "ic-btc-interface 0.1.0 (git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "ic-btc-types-internal"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "candid 0.8.4",
- "ic-btc-interface 0.1.0 (git+https://github.com/dfinity/bitcoin-canister?rev=e4e89f2caedffbe0cfdec6f9d4a77f66dcb9119e)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
+ "ic-btc-interface",
+ "ic-protobuf",
  "serde",
  "serde_bytes",
 ]
@@ -1854,7 +1755,7 @@ version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "ed25519-consensus",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
  "ic-crypto-ecdsa-secp256k1",
  "ic-crypto-internal-types",
  "ic-crypto-secrets-containers",
@@ -1865,11 +1766,6 @@ dependencies = [
  "rand_chacha",
  "simple_asn1",
 ]
-
-[[package]]
-name = "ic-canister-log"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 
 [[package]]
 name = "ic-canister-log"
@@ -1892,16 +1788,6 @@ dependencies = [
 name = "ic-canisters-http-types"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
-dependencies = [
- "candid 0.8.4",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "ic-canisters-http-types"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 dependencies = [
  "candid 0.8.4",
  "serde",
@@ -2030,11 +1916,6 @@ version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 
 [[package]]
-name = "ic-constants"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-
-[[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.1.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
@@ -2080,7 +1961,7 @@ dependencies = [
  "ic-crypto-internal-seed",
  "ic-crypto-internal-types",
  "ic-crypto-secrets-containers",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf",
  "ic-types",
  "rand",
  "rand_chacha",
@@ -2113,7 +1994,7 @@ name = "ic-crypto-internal-hmac"
 version = "0.1.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "ic-crypto-internal-sha2 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-crypto-internal-sha2",
 ]
 
 [[package]]
@@ -2127,7 +2008,7 @@ dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-secrets-containers",
  "ic-crypto-sha2",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf",
  "ic-types",
  "rand",
  "rand_chacha",
@@ -2153,15 +2034,6 @@ dependencies = [
 name = "ic-crypto-internal-sha2"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
-dependencies = [
- "openssl",
- "sha2 0.9.9",
-]
-
-[[package]]
-name = "ic-crypto-internal-sha2"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 dependencies = [
  "openssl",
  "sha2 0.9.9",
@@ -2237,8 +2109,8 @@ dependencies = [
  "arrayvec 0.5.2",
  "base64 0.11.0",
  "hex",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf",
+ "phantom_newtype",
  "serde",
  "serde_cbor",
  "strum 0.23.0",
@@ -2253,14 +2125,14 @@ version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
  "ic-crypto-internal-basic-sig-ed25519",
  "ic-crypto-internal-multi-sig-bls12381",
  "ic-crypto-internal-threshold-sig-bls12381",
  "ic-crypto-internal-threshold-sig-ecdsa",
  "ic-crypto-internal-types",
  "ic-crypto-tls-cert-validation",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf",
  "ic-types",
  "serde",
  "x509-parser 0.12.0",
@@ -2276,19 +2148,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-crypto-sha"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "ic-crypto-internal-sha2 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
-]
-
-[[package]]
 name = "ic-crypto-sha2"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "ic-crypto-internal-sha2 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-crypto-internal-sha2",
 ]
 
 [[package]]
@@ -2297,12 +2161,12 @@ version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "chrono",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
  "ic-crypto-internal-basic-sig-ed25519",
  "ic-crypto-internal-types",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf",
  "ic-types",
  "serde",
  "x509-parser 0.9.2",
@@ -2316,7 +2180,7 @@ dependencies = [
  "assert_matches",
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf",
  "serde",
  "serde_bytes",
  "thiserror",
@@ -2329,11 +2193,11 @@ source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d
 dependencies = [
  "base64 0.11.0",
  "ed25519-consensus",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
  "ic-crypto-internal-basic-sig-der-utils",
  "ic-crypto-internal-basic-sig-ed25519",
  "ic-crypto-internal-types",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf",
  "simple_asn1",
 ]
 
@@ -2348,47 +2212,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-error-types"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "serde",
- "strum 0.23.0",
- "strum_macros 0.23.1",
-]
-
-[[package]]
 name = "ic-ic00-types"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
  "float-cmp",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-btc-interface 0.1.0 (git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7)",
- "ic-btc-types-internal 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-error-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "num-traits",
- "serde",
- "serde_bytes",
- "serde_cbor",
- "strum 0.23.0",
- "strum_macros 0.23.1",
-]
-
-[[package]]
-name = "ic-ic00-types"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "candid 0.8.4",
- "float-cmp",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-btc-interface 0.1.0 (git+https://github.com/dfinity/bitcoin-canister?rev=e4e89f2caedffbe0cfdec6f9d4a77f66dcb9119e)",
- "ic-btc-types-internal 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-error-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
+ "ic-base-types",
+ "ic-btc-interface",
+ "ic-btc-types-internal",
+ "ic-error-types",
+ "ic-protobuf",
  "num-traits",
  "serde",
  "serde_bytes",
@@ -2405,12 +2239,12 @@ dependencies = [
  "candid 0.8.4",
  "ciborium",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
  "ic-crypto-sha2",
- "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-canister-core",
+ "ic-ledger-core",
  "ic-ledger-hash-of",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icrc-ledger-types",
  "num-bigint",
  "num-traits",
  "serde",
@@ -2420,35 +2254,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-icrc1"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "candid 0.8.4",
- "ciborium",
- "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-crypto-sha",
- "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "num-traits",
- "serde",
- "serde_bytes",
- "tempfile",
-]
-
-[[package]]
 name = "ic-icrc1-client"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
+ "ic-icrc1",
+ "ic-ledger-core",
+ "icrc-ledger-types",
  "num-traits",
  "serde",
 ]
@@ -2461,18 +2276,18 @@ dependencies = [
  "async-trait",
  "candid 0.8.4",
  "ciborium",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
  "ic-canister-profiler",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-canisters-http-types",
  "ic-cdk 0.7.4",
  "ic-cdk-macros 0.6.10",
  "ic-cdk-timers 0.1.2",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-icrc1",
  "ic-icrc1-ledger",
  "ic-icrc1-tokens-u64",
  "ic-ledger-hash-of",
  "ic-metrics-encoder",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icrc-ledger-types",
  "num-traits",
  "scopeguard",
  "serde",
@@ -2487,20 +2302,20 @@ dependencies = [
  "candid 0.8.4",
  "ciborium",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-canister-log 0.2.0",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
+ "ic-canister-log",
+ "ic-canisters-http-types",
  "ic-cdk 0.7.4",
  "ic-cdk-macros 0.6.10",
  "ic-crypto-tree-hash",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-icrc1",
  "ic-icrc1-client",
  "ic-icrc1-tokens-u64",
- "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-canister-core",
+ "ic-ledger-core",
  "ic-ledger-hash-of",
  "ic-metrics-encoder",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icrc-ledger-types",
  "num-traits",
  "serde",
  "serde_bytes",
@@ -2512,7 +2327,7 @@ version = "0.1.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-core",
  "ic-stable-structures 0.5.6",
  "num-traits",
  "serde",
@@ -2525,30 +2340,14 @@ source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-canister-log 0.2.0",
- "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
+ "ic-canister-log",
+ "ic-constants",
+ "ic-ic00-types",
+ "ic-ledger-core",
  "ic-ledger-hash-of",
- "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-utils",
  "num-traits",
- "serde",
-]
-
-[[package]]
-name = "ic-ledger-canister-core"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "async-trait",
- "candid 0.8.4",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-canister-log 0.1.0",
- "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
  "serde",
 ]
 
@@ -2561,33 +2360,13 @@ dependencies = [
  "candid 0.8.4",
  "ciborium",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
+ "ic-constants",
  "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ic00-types",
  "ic-ledger-hash-of",
- "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "num-traits",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "ic-ledger-core"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "async-trait",
- "candid 0.8.4",
- "ciborium",
- "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-crypto-sha",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
+ "ic-utils",
+ "icrc-ledger-types",
  "num-traits",
  "serde",
  "serde_bytes",
@@ -2617,10 +2396,10 @@ source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_candid",
+ "dfn_core",
+ "ic-base-types",
+ "ic-ic00-types",
  "ic-nervous-system-proxied-canister-calls-tracker",
  "ic-nervous-system-runtime",
  "num-traits",
@@ -2640,60 +2419,26 @@ dependencies = [
  "by_address",
  "bytes",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-canister-log 0.2.0",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_candid",
+ "dfn_core",
+ "dfn_protobuf",
+ "ic-base-types",
+ "ic-canister-log",
+ "ic-canisters-http-types",
  "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ic00-types",
+ "ic-icrc1",
+ "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-nervous-system-runtime",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nns-constants",
  "ic-stable-structures 0.5.6",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icp-ledger",
+ "icrc-ledger-types",
  "json5",
  "maplit",
  "priority-queue",
  "prost",
- "rust_decimal",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "ic-nervous-system-common"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "anyhow",
- "async-trait",
- "build-info",
- "build-info-build",
- "by_address",
- "bytes",
- "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-canister-log 0.1.0",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-crypto-sha",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-metrics-encoder",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "json5",
- "maplit",
- "priority-queue",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -2709,7 +2454,7 @@ name = "ic-nervous-system-common-test-keys"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
  "ic-canister-client-sender",
  "ic-types",
  "lazy_static",
@@ -2723,7 +2468,7 @@ name = "ic-nervous-system-governance"
 version = "0.0.1"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
  "ic-stable-structures 0.5.6",
  "maplit",
  "num-traits",
@@ -2736,7 +2481,7 @@ source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d
 dependencies = [
  "candid 0.8.4",
  "comparable",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
  "prost",
  "serde",
 ]
@@ -2746,7 +2491,7 @@ name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.0.1"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
 ]
 
 [[package]]
@@ -2756,17 +2501,17 @@ source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_candid",
+ "dfn_core",
+ "ic-base-types",
  "ic-cdk 0.7.4",
  "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ic00-types",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nervous-system-common",
  "ic-nervous-system-proxied-canister-calls-tracker",
  "ic-nervous-system-runtime",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nns-constants",
  "lazy_static",
  "num-traits",
  "serde",
@@ -2780,9 +2525,9 @@ source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_candid",
+ "dfn_core",
+ "ic-base-types",
  "ic-cdk 0.7.4",
 ]
 
@@ -2793,17 +2538,17 @@ source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d
 dependencies = [
  "candid 0.8.4",
  "comparable",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_core",
+ "ic-base-types",
  "ic-crypto-sha2",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nervous-system-common",
+ "ic-nns-constants",
+ "ic-protobuf",
  "ic-registry-keys",
  "ic-registry-transport",
  "ic-types",
  "lazy_static",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "on_wire",
  "prost",
  "serde",
  "sha2 0.9.9",
@@ -2814,16 +2559,7 @@ name = "ic-nns-constants"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "lazy_static",
-]
-
-[[package]]
-name = "ic-nns-constants"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
+ "ic-base-types",
  "lazy_static",
 ]
 
@@ -2839,17 +2575,17 @@ dependencies = [
  "comparable",
  "csv",
  "cycles-minting-canister",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_candid",
+ "dfn_core",
+ "dfn_http_metrics",
+ "dfn_protobuf",
+ "ic-base-types",
  "ic-crypto-getrandom-for-wasm",
  "ic-crypto-sha2",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nervous-system-common",
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-common-test-keys",
  "ic-nervous-system-governance",
@@ -2857,19 +2593,19 @@ dependencies = [
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
  "ic-nns-common",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nns-constants",
+ "ic-protobuf",
  "ic-sns-init",
  "ic-sns-root",
  "ic-sns-swap",
  "ic-sns-wasm",
  "ic-stable-structures 0.5.6",
  "ic-types",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icp-ledger",
  "itertools 0.10.5",
  "lazy_static",
  "maplit",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "on_wire",
  "prost",
  "rand",
  "rand_chacha",
@@ -2886,11 +2622,11 @@ source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d
 dependencies = [
  "async-trait",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_candid",
+ "dfn_core",
+ "ic-base-types",
  "ic-nervous-system-clients",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nns-constants",
  "serde",
 ]
 
@@ -2898,21 +2634,6 @@ dependencies = [
 name = "ic-protobuf"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
-dependencies = [
- "bincode",
- "candid 0.8.4",
- "erased-serde",
- "maplit",
- "prost",
- "serde",
- "serde_json",
- "slog",
-]
-
-[[package]]
-name = "ic-protobuf"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 dependencies = [
  "bincode",
  "candid 0.8.4",
@@ -2930,8 +2651,8 @@ version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
+ "ic-ic00-types",
  "ic-types",
  "serde",
 ]
@@ -2942,8 +2663,8 @@ version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
+ "ic-protobuf",
  "serde",
 ]
 
@@ -2953,8 +2674,8 @@ version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ic00-types",
+ "ic-protobuf",
  "serde",
 ]
 
@@ -2964,7 +2685,7 @@ version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf",
  "serde",
  "strum 0.23.0",
  "strum_macros 0.23.1",
@@ -2977,8 +2698,8 @@ source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d
 dependencies = [
  "bytes",
  "candid 0.8.4",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
+ "ic-protobuf",
  "prost",
  "serde",
 ]
@@ -2997,33 +2718,33 @@ dependencies = [
  "clap",
  "comparable",
  "csv",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_candid",
+ "dfn_core",
+ "dfn_http_metrics",
+ "dfn_protobuf",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-canister-log 0.2.0",
+ "ic-base-types",
+ "ic-canister-log",
  "ic-canister-profiler",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-canisters-http-types",
  "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ic00-types",
+ "ic-icrc1",
  "ic-icrc1-client",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nervous-system-common",
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nns-constants",
+ "ic-protobuf",
+ "icp-ledger",
+ "icrc-ledger-types",
  "lazy_static",
  "maplit",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "on_wire",
  "prost",
  "prost-build",
  "rand",
@@ -3043,22 +2764,22 @@ source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d
 dependencies = [
  "base64 0.11.0",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_candid",
+ "dfn_core",
+ "ic-base-types",
  "ic-crypto-sha2",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-icrc1",
  "ic-icrc1-index",
  "ic-icrc1-ledger",
- "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-canister-core",
+ "ic-ledger-core",
+ "ic-nervous-system-common",
  "ic-nervous-system-proto",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nns-constants",
  "ic-sns-governance",
  "ic-sns-root",
  "ic-sns-swap",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icrc-ledger-types",
  "isocountry",
  "lazy_static",
  "maplit",
@@ -3080,23 +2801,23 @@ dependencies = [
  "build-info-build",
  "candid 0.8.4",
  "comparable",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_candid",
  "futures",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-canister-log 0.2.0",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
+ "ic-canister-log",
+ "ic-canisters-http-types",
  "ic-cdk 0.7.4",
  "ic-cdk-macros 0.6.10",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ic00-types",
+ "ic-icrc1",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nervous-system-common",
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
  "ic-sns-swap",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icrc-ledger-types",
  "num-traits",
  "prost",
  "serde",
@@ -3113,31 +2834,31 @@ dependencies = [
  "bytes",
  "candid 0.8.4",
  "comparable",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_candid",
+ "dfn_core",
+ "dfn_http_metrics",
+ "dfn_protobuf",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-canister-log 0.2.0",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
+ "ic-canister-log",
+ "ic-canisters-http-types",
  "ic-crypto-sha2",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-icrc1",
+ "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nervous-system-common",
  "ic-nervous-system-proto",
  "ic-nervous-system-runtime",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-protobuf",
  "ic-sns-governance",
  "ic-stable-structures 0.5.6",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icp-ledger",
+ "icrc-ledger-types",
  "itertools 0.10.5",
  "lazy_static",
  "maplit",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "on_wire",
  "prost",
  "prost-build",
  "registry-canister",
@@ -3155,27 +2876,27 @@ dependencies = [
  "async-trait",
  "build-info",
  "candid 0.8.4",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_candid",
+ "dfn_core",
+ "dfn_http_metrics",
  "futures",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
  "ic-cdk 0.7.4",
  "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ic00-types",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nervous-system-common",
  "ic-nervous-system-proto",
  "ic-nervous-system-runtime",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nns-constants",
  "ic-nns-handler-root-interface",
  "ic-sns-governance",
  "ic-sns-init",
  "ic-sns-root",
  "ic-types",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icrc-ledger-types",
  "maplit",
  "prost",
  "serde",
@@ -3207,21 +2928,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "nix",
- "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "wsl",
-]
-
-[[package]]
-name = "ic-sys"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "hex",
- "ic-crypto-sha",
- "lazy_static",
- "libc",
- "nix",
- "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
+ "phantom_newtype",
  "wsl",
 ]
 
@@ -3238,20 +2945,20 @@ dependencies = [
  "derive_more 0.99.8-alpha.0",
  "hex",
  "http",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-btc-types-internal 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
+ "ic-btc-types-internal",
+ "ic-constants",
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
  "ic-crypto-tree-hash",
- "ic-error-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-utils 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-error-types",
+ "ic-ic00-types",
+ "ic-protobuf",
+ "ic-utils",
  "maplit",
  "num-traits",
  "once_cell",
- "phantom_newtype 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "phantom_newtype",
  "prost",
  "serde",
  "serde_bytes",
@@ -3274,26 +2981,7 @@ dependencies = [
  "cvt",
  "features",
  "hex",
- "ic-sys 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "libc",
- "nix",
- "prost",
- "rand",
- "scoped_threadpool",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "ic-utils"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "bitflags 1.3.2",
- "cvt",
- "features",
- "hex",
- "ic-sys 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
+ "ic-sys",
  "libc",
  "nix",
  "prost",
@@ -3361,55 +3049,23 @@ dependencies = [
  "candid 0.8.4",
  "comparable",
  "crc32fast",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_http 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_candid",
+ "dfn_core",
+ "dfn_http",
+ "dfn_http_metrics",
+ "dfn_protobuf",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
+ "ic-canisters-http-types",
  "ic-crypto-sha2",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-icrc1",
+ "ic-ledger-canister-core",
+ "ic-ledger-core",
  "ic-ledger-hash-of",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icrc-ledger-types",
  "lazy_static",
  "num-traits",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "prost",
- "prost-derive",
- "serde",
- "serde_bytes",
- "serde_cbor",
- "strum 0.24.1",
- "strum_macros 0.24.3",
-]
-
-[[package]]
-name = "icp-ledger"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "candid 0.8.4",
- "comparable",
- "crc32fast",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "dfn_http 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-canisters-http-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-crypto-sha",
- "ic-icrc1 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-ledger-canister-core 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "icrc-ledger-types 0.1.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "lazy_static",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
+ "on_wire",
  "prost",
  "prost-derive",
  "serde",
@@ -3425,20 +3081,6 @@ version = "0.1.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
 dependencies = [
  "candid 0.8.4",
- "hex",
- "num-traits",
- "serde",
- "serde_bytes",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "icrc-ledger-types"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "candid 0.8.4",
- "ciborium",
  "hex",
  "num-traits",
  "serde",
@@ -3845,30 +3487,30 @@ dependencies = [
  "base64 0.21.5",
  "candid 0.8.4",
  "cycles-minting-canister",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_candid",
+ "dfn_core",
+ "dfn_protobuf",
  "flate2",
  "futures",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
  "ic-cdk 0.9.2",
  "ic-cdk-macros 0.6.10",
  "ic-certified-map 0.3.4",
  "ic-crypto-sha2",
- "ic-ledger-core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ledger-core",
  "ic-nns-common",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nns-constants",
  "ic-nns-governance",
  "ic-sns-swap",
  "ic-stable-structures 0.6.4",
  "ic_principal",
- "icp-ledger 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "icp-ledger",
  "itertools 0.12.0",
  "lazy_static",
  "lzma-rs",
  "maplit",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "on_wire",
  "pocket-ic",
  "pretty_assertions",
  "proposals",
@@ -4064,11 +3706,6 @@ dependencies = [
 name = "on_wire"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0#3ae40dbfd32be70eff0941d7d793856d45c28fc0"
-
-[[package]]
-name = "on_wire"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
 
 [[package]]
 name = "once_cell"
@@ -4271,16 +3908,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phantom_newtype"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01#e0c5ad62a151d1bd0b2f59822c127f4ae7a4ce28"
-dependencies = [
- "candid 0.8.4",
- "serde",
- "slog",
-]
-
-[[package]]
 name = "phf_shared"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4475,19 +4102,19 @@ dependencies = [
  "anyhow",
  "candid 0.8.4",
  "cycles-minting-canister",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_candid",
+ "dfn_core",
  "hex",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-btc-interface 0.1.0 (git+https://github.com/dfinity/bitcoin-canister?rev=b1693619e3d4dbc00d8c79e9b6886e1db48b21f7)",
+ "ic-base-types",
+ "ic-btc-interface",
  "ic-cdk 0.9.2",
  "ic-cdk-macros 0.6.10",
  "ic-crypto-sha2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ic00-types",
+ "ic-nervous-system-common",
  "ic-nervous-system-root",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nns-constants",
+ "ic-protobuf",
  "idl2json",
  "pretty_assertions",
  "serde",
@@ -4755,23 +4382,23 @@ dependencies = [
  "build-info-build",
  "candid 0.8.4",
  "cycles-minting-canister",
- "dfn_candid 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "dfn_http_metrics 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "dfn_candid",
+ "dfn_core",
+ "dfn_http_metrics",
  "futures",
- "ic-base-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-base-types",
  "ic-cdk 0.7.4",
  "ic-certified-map 0.3.4",
  "ic-crypto-node-key-validation",
  "ic-crypto-sha2",
  "ic-crypto-utils-basic-sig",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-ic00-types",
  "ic-metrics-encoder",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nervous-system-common",
  "ic-nervous-system-common-build-metadata",
  "ic-nns-common",
- "ic-nns-constants 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
- "ic-protobuf 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "ic-nns-constants",
+ "ic-protobuf",
  "ic-registry-keys",
  "ic-registry-routing-table",
  "ic-registry-subnet-features",
@@ -4780,7 +4407,7 @@ dependencies = [
  "ic-types",
  "ipnet",
  "leb128",
- "on_wire 0.8.0 (git+https://github.com/dfinity/ic?rev=3ae40dbfd32be70eff0941d7d793856d45c28fc0)",
+ "on_wire",
  "prost",
  "serde",
  "serde_cbor",
@@ -5322,13 +4949,13 @@ dependencies = [
  "anyhow",
  "base64 0.21.5",
  "candid 0.8.4",
- "dfn_core 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
+ "dfn_core",
  "ic-cdk 0.9.2",
  "ic-cdk-macros 0.6.10",
  "ic-cdk-timers 0.6.0",
  "ic-certified-map 0.3.2",
- "ic-ic00-types 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
- "ic-nervous-system-common 0.8.0 (git+https://github.com/dfinity/ic?rev=release-2023-06-07_23-01)",
+ "ic-ic00-types",
+ "ic-nervous-system-common",
  "lazy_static",
  "num-traits",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,24 @@ version = "2.0.74"
 ic-cdk = "0.9.2"
 ic-cdk-macros = "0.6.10"
 
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+
 [profile.release]
 lto = false
 opt-level = "z"

--- a/rs/backend/Cargo.toml
+++ b/rs/backend/Cargo.toml
@@ -22,23 +22,23 @@ strum = "0.25.0"
 strum_macros = "0.25.3"
 tar = "0.4.40"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+cycles-minting-canister = { workspace = true }
+dfn_candid = { workspace = true }
+dfn_core = { workspace = true }
+dfn_protobuf = { workspace = true }
+ic-base-types = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-certified-map = "0.3.4" # == https://github.com/dfinity/cdk-rs 6a15aa1616bcfdfdc4c120d17d37a089f5700c36
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-crypto-sha2 = { workspace = true }
+ic-ledger-core = { workspace = true }
+ic-nns-common = { workspace = true }
+ic-nns-constants = { workspace = true }
+ic-nns-governance = { workspace = true }
+ic-sns-swap = { workspace = true }
 ic-stable-structures = "0.6.4"
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+icp-ledger = { workspace = true }
+on_wire = { workspace = true }
 
 proposals = { path = "../proposals" }
 

--- a/rs/proposals/Cargo.toml
+++ b/rs/proposals/Cargo.toml
@@ -11,17 +11,17 @@ serde = "1.0.193"
 serde_bytes = "0.11.12"
 serde_json = "1.0.108"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+cycles-minting-canister = { workspace = true }
+dfn_candid = { workspace = true }
+dfn_core = { workspace = true }
+ic-base-types = { workspace = true }
 ic-btc-interface = { git = "https://github.com/dfinity/bitcoin-canister", rev = "b1693619e3d4dbc00d8c79e9b6886e1db48b21f7" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "3ae40dbfd32be70eff0941d7d793856d45c28fc0" }
+ic-crypto-sha2 = { workspace = true }
+ic-ic00-types = { workspace = true }
+ic-nervous-system-common = { workspace = true }
+ic-nervous-system-root = { workspace = true }
+ic-nns-constants = { workspace = true }
+ic-protobuf = { workspace = true }
 
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }

--- a/rs/sns_aggregator/Cargo.toml
+++ b/rs/sns_aggregator/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 anyhow = "1.0.75"
 base64 = "0.21.5"
 candid = "0.8.2"
+dfn_candid = { workspace = true }
 dfn_core = { workspace = true }
 # This next candid is 0.9.0_beta code that fixes serde Nat but has other issues.  Keep checking until the issues are fixed.
 #candid = { git = "https://github.com/dfinity/candid" , rev = "42ffed660ded37585c4b9f97e3ce90919e24c518" }

--- a/rs/sns_aggregator/Cargo.toml
+++ b/rs/sns_aggregator/Cargo.toml
@@ -11,15 +11,15 @@ crate-type = ["cdylib"]
 anyhow = "1.0.75"
 base64 = "0.21.5"
 candid = "0.8.2"
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2023-06-07_23-01" }
+dfn_core = { workspace = true }
 # This next candid is 0.9.0_beta code that fixes serde Nat but has other issues.  Keep checking until the issues are fixed.
 #candid = { git = "https://github.com/dfinity/candid" , rev = "42ffed660ded37585c4b9f97e3ce90919e24c518" }
 ic-cdk = { version = "0.9.2" }
 ic-cdk-macros = { version = "0.6.10" }
 ic-cdk-timers = "0.6.0"
 ic-certified-map = { git = "https://github.com/dfinity/cdk-rs", rev = "58791941b72471e09e3d9e733f2a3d4d54e52b5a" }
-ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-06-07_23-01" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2023-06-07_23-01" }
+ic-ic00-types = { workspace = true }
+ic-nervous-system-common = { workspace = true }
 lazy_static = "1.4.0"
 num-traits = "0.2.15"
 serde = "1.0.193"


### PR DESCRIPTION
# Motivation

Since https://github.com/dfinity/nns-dapp/pull/4751 the `backend` and `proposals` crates use the same `rev` for the IC repo dependencies.
But `sns_aggregator` still uses an older `rev`.
Using the same `rev` for all crates makes it less likely that dependencies will interfere.
And `sns_aggregator` builds fine with the same `rev` as `backend` and `proposals`, except for 1 issue.
The issue is that `sns_aggregator` uses `ic_nervous_system_common::get_canister_status` which was removed in https://gitlab.com/dfinity-lab/public/ic/-/commit/bac55cb48c342112f8f20756e67e813eb3f2be2d
The function is small so I inlined it in `sns_aggregator` instead.

Defining the dependencies in the workspace makes it easier to keep them in sync.

# Changes

1. Define IC repo dependencies in `/Cargo.toml`.
2. Use workspace dependencies in `backend`, `proposals` and `sns_aggregator` crates.
3. Replace calling `ic_nervous_system_common::get_canister_status` (which no longer exists) with the code that used to be inside that function.

Also note that `Cargo.lock` got updated and has a lot more red than green, which I assume is a good thing.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
covered by existing entry `Update IC dependencies in nns-dapp crates.`