### PR TITLE
NNS1-2906: Remove unused mapToSelfTransaction

### DIFF
--- a/frontend/src/lib/utils/transactions.utils.ts
+++ b/frontend/src/lib/utils/transactions.utils.ts
@@ -1,4 +1,3 @@
-import type { Transaction as NnsTransaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import {
   AccountTransactionType,
   TransactionNetwork,

--- a/frontend/src/lib/utils/transactions.utils.ts
+++ b/frontend/src/lib/utils/transactions.utils.ts
@@ -4,7 +4,6 @@ import {
   TransactionNetwork,
 } from "$lib/types/transaction";
 import { isNullish } from "@dfinity/utils";
-import { stringifyJson } from "./utils";
 
 export const transactionDisplayAmount = ({
   useFee,
@@ -64,30 +63,6 @@ export const transactionName = ({
       return i18n.transaction_names.refundSwap;
   }
   return type;
-};
-
-/** (from==to workaround) Set `mapToSelfNnsTransaction: true` when sender and receiver are the same account (e.g. transmitting from `main` to `main` account) */
-export const mapToSelfTransaction = (
-  transactions: NnsTransaction[]
-): { transaction: NnsTransaction; toSelfTransaction: boolean }[] => {
-  const resultTransactions = transactions.map((transaction) => ({
-    transaction: { ...transaction },
-    toSelfTransaction: false,
-  }));
-
-  // We rely on self transactions to be one next to each other.
-  // We only set the first transaction to `toSelfTransaction: true`
-  // because the second one will be `toSelfTransaction: false` and it will be displayed as `Sent` transaction.
-  for (let i = 0; i < resultTransactions.length - 1; i++) {
-    const { transaction } = resultTransactions[i];
-    const { transaction: nextTransaction } = resultTransactions[i + 1];
-
-    if (stringifyJson(transaction) === stringifyJson(nextTransaction)) {
-      resultTransactions[i].toSelfTransaction = true;
-    }
-  }
-
-  return resultTransactions;
 };
 
 export const isTransactionNetworkBtc = (

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -6,7 +6,6 @@ import { enumKeys } from "$lib/utils/enum.utils";
 import {
   getUniqueTransactions,
   isTransactionNetworkBtc,
-  mapToSelfTransaction,
   transactionDisplayAmount,
   transactionName,
 } from "$lib/utils/transactions.utils";
@@ -19,43 +18,6 @@ import {
 } from "$tests/mocks/transaction.mock";
 
 describe("transactions-utils", () => {
-  describe("mapToSelfTransaction", () => {
-    it("should map to self transactions", () => {
-      const transactions = mapToSelfTransaction([
-        {
-          ...mockSentToSubAccountTransaction,
-          timestamp: { timestamp_nanos: 111n },
-        },
-        mockReceivedFromMainAccountTransaction,
-        mockReceivedFromMainAccountTransaction,
-        {
-          ...mockSentToSubAccountTransaction,
-          timestamp: { timestamp_nanos: 222n },
-        },
-        {
-          ...mockSentToSubAccountTransaction,
-          timestamp: { timestamp_nanos: 333n },
-        },
-        mockSentToSubAccountTransaction,
-        mockSentToSubAccountTransaction,
-      ]);
-
-      const toSelfTransactions = transactions.map(
-        ({ toSelfTransaction }) => toSelfTransaction
-      );
-
-      expect(toSelfTransactions).toEqual([
-        false,
-        true,
-        false,
-        false,
-        false,
-        true,
-        false,
-      ]);
-    });
-  });
-
   describe("transactionDisplayAmount", () => {
     it("should calculate with fee", () => {
       expect(

--- a/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -12,10 +12,6 @@ import {
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { createIcrcTransactionWithId } from "$tests/mocks/icrc-transactions.mock";
-import {
-  mockReceivedFromMainAccountTransaction,
-  mockSentToSubAccountTransaction,
-} from "$tests/mocks/transaction.mock";
 
 describe("transactions-utils", () => {
   describe("transactionDisplayAmount", () => {

--- a/frontend/src/tests/mocks/transaction.mock.ts
+++ b/frontend/src/tests/mocks/transaction.mock.ts
@@ -1,62 +1,10 @@
 import type { GetTransactionsResponse } from "$lib/api/icp-index.api";
-import type { Transaction as NnsTransaction } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import type { Transaction, UiTransaction } from "$lib/types/transaction";
 import { AccountTransactionType } from "$lib/types/transaction";
 import type { TransactionWithId } from "@dfinity/ledger-icp";
 import { TokenAmount } from "@dfinity/utils";
-import { mockMainAccount, mockSubAccount } from "./icp-accounts.store.mock";
+import { mockSubAccount } from "./icp-accounts.store.mock";
 import { mockSnsToken } from "./sns-projects.mock";
-
-export const createMockSendTransaction = ({
-  amount = 110_000_023n,
-  fee = 10_000n,
-  to = mockSubAccount.identifier,
-}: {
-  amount?: bigint;
-  fee?: bigint;
-  to?: string;
-}): NnsTransaction => ({
-  transaction_type: [{ Transfer: null }],
-  memo: 0n,
-  timestamp: { timestamp_nanos: 0n },
-  block_height: 208n,
-  transfer: {
-    Send: {
-      to,
-      fee: { e8s: fee },
-      amount: { e8s: amount },
-    },
-  },
-});
-
-export const mockSentToSubAccountTransaction = createMockSendTransaction({
-  to: mockSubAccount.identifier,
-});
-
-export const createMockReceiveTransaction = ({
-  amount = 110_000_000n,
-  fee = 10_000n,
-  from = mockMainAccount.identifier,
-}: {
-  amount?: bigint;
-  fee?: bigint;
-  from?: string;
-}): NnsTransaction => ({
-  transaction_type: [{ Transfer: null }],
-  memo: 0n,
-  timestamp: { timestamp_nanos: 1_652_121_288_218_078_256n },
-  block_height: 208n,
-  transfer: {
-    Receive: {
-      fee: { e8s: fee },
-      from,
-      amount: { e8s: amount },
-    },
-  },
-});
-
-export const mockReceivedFromMainAccountTransaction =
-  createMockReceiveTransaction({ from: mockMainAccount.identifier });
 
 const displayAmount = 11_000_000_000_000_000n;
 


### PR DESCRIPTION
# Motivation

`mapToSelfTransaction` from `frontend/src/lib/utils/transactions.utils.ts` is unused.
It became unused in https://github.com/dfinity/nns-dapp/pull/4775 but I missed it because there is still another `mapToSelfTransaction` in `frontend/src/lib/utils/icp-transactions.utils.ts` which is used.

# Changes

1. Remove `mapToSelfTransaction` from `frontend/src/lib/utils/transactions.utils.ts`.

# Tests

Removed

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary