### PR TITLE
NNS1-2906: Remove get_transactions from nns-dapp candid

### DIFF
--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.certified.idl.js
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.certified.idl.js
@@ -49,7 +49,6 @@ export const idlFactory = ({ IDL }) => {
     canister_id: IDL.Principal,
   });
   const BlockHeight = IDL.Nat64;
-  const CanisterId = IDL.Principal;
   const NeuronId = IDL.Nat64;
   const GetProposalPayloadResponse = IDL.Variant({
     Ok: IDL.Text,
@@ -69,51 +68,6 @@ export const idlFactory = ({ IDL }) => {
     block_height_synced_up_to: IDL.Opt(IDL.Nat64),
     latest_transaction_timestamp_nanos: IDL.Nat64,
     earliest_transaction_timestamp_nanos: IDL.Nat64,
-  });
-  const GetTransactionsRequest = IDL.Record({
-    page_size: IDL.Nat8,
-    offset: IDL.Nat32,
-    account_identifier: AccountIdentifier,
-  });
-  const TransactionType = IDL.Variant({
-    Burn: IDL.Null,
-    Mint: IDL.Null,
-    StakeNeuronNotification: IDL.Null,
-    TopUpCanister: CanisterId,
-    ParticipateSwap: CanisterId,
-    CreateCanister: IDL.Null,
-    Transfer: IDL.Null,
-    TopUpNeuron: IDL.Null,
-    StakeNeuron: IDL.Null,
-  });
-  const Timestamp = IDL.Record({ timestamp_nanos: IDL.Nat64 });
-  const ICPTs = IDL.Record({ e8s: IDL.Nat64 });
-  const Send = IDL.Record({
-    to: AccountIdentifier,
-    fee: ICPTs,
-    amount: ICPTs,
-  });
-  const Receive = IDL.Record({
-    fee: ICPTs,
-    from: AccountIdentifier,
-    amount: ICPTs,
-  });
-  const Transfer = IDL.Variant({
-    Burn: IDL.Record({ amount: ICPTs }),
-    Mint: IDL.Record({ amount: ICPTs }),
-    Send: Send,
-    Receive: Receive,
-  });
-  const Transaction = IDL.Record({
-    transaction_type: IDL.Opt(TransactionType),
-    memo: IDL.Nat64,
-    timestamp: Timestamp,
-    block_height: BlockHeight,
-    transfer: Transfer,
-  });
-  const GetTransactionsResponse = IDL.Record({
-    total: IDL.Nat32,
-    transactions: IDL.Vec(Transaction),
   });
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
   const HttpRequest = IDL.Record({
@@ -186,11 +140,6 @@ export const idlFactory = ({ IDL }) => {
       []
     ),
     get_stats: IDL.Func([], [Stats], []),
-    get_transactions: IDL.Func(
-      [GetTransactionsRequest],
-      [GetTransactionsResponse],
-      []
-    ),
     http_request: IDL.Func([HttpRequest], [HttpResponse], []),
     register_hardware_wallet: IDL.Func(
       [RegisterHardwareWalletRequest],

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.did
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.did
@@ -1,8 +1,6 @@
 // TODO: Synchronize with `rs/nns-dapp.did`. Check how scripts/nns-dapp.update.sh works.
 type AccountIdentifier = text;
 type BlockHeight = nat64;
-type CanisterId = principal;
-type ICPTs = record { e8s: nat64; };
 type Memo = nat64;
 type NeuronId = nat64;
 type SubAccount = vec nat8;
@@ -33,68 +31,6 @@ type GetAccountResponse =
     variant {
         Ok: AccountDetails;
         AccountNotFound;
-    };
-
-type Timestamp =
-    record {
-        timestamp_nanos: nat64;
-    };
-
-type GetTransactionsRequest =
-    record {
-        account_identifier: AccountIdentifier;
-        offset: nat32;
-        page_size: nat8;
-    };
-
-type GetTransactionsResponse =
-    record {
-        transactions: vec Transaction;
-        total: nat32;
-    };
-
-type Send =
-    record {
-        to: AccountIdentifier;
-        amount: ICPTs;
-        fee: ICPTs;
-    };
-
-type Receive =
-    record {
-        from: AccountIdentifier;
-        amount: ICPTs;
-        fee: ICPTs;
-    };
-
-type Transfer =
-    variant {
-        Burn: record { amount: ICPTs; };
-        Mint: record { amount: ICPTs; };
-        Send: Send;
-        Receive: Receive;
-    };
-
-type Transaction =
-    record {
-        block_height: BlockHeight;
-        timestamp: Timestamp;
-        memo: nat64;
-        transfer: Transfer;
-        transaction_type: opt TransactionType;
-    };
-
-type TransactionType =
-    variant {
-        Burn;
-        Mint;
-        Transfer;
-        StakeNeuron;
-        StakeNeuronNotification;
-        TopUpNeuron;
-        CreateCanister;
-        TopUpCanister: CanisterId;
-        ParticipateSwap: CanisterId;
     };
 
 type CreateSubAccountResponse =
@@ -227,7 +163,6 @@ type HttpResponse =
 service : {
     get_account: () -> (GetAccountResponse) query;
     add_account: () -> (AccountIdentifier);
-    get_transactions: (GetTransactionsRequest) -> (GetTransactionsResponse) query;
     create_sub_account: (text) -> (CreateSubAccountResponse);
     rename_sub_account: (RenameSubAccountRequest) -> (RenameSubAccountResponse);
     register_hardware_wallet: (RegisterHardwareWalletRequest) -> (RegisterHardwareWalletResponse);

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js
@@ -49,7 +49,6 @@ export const idlFactory = ({ IDL }) => {
     canister_id: IDL.Principal,
   });
   const BlockHeight = IDL.Nat64;
-  const CanisterId = IDL.Principal;
   const NeuronId = IDL.Nat64;
   const GetProposalPayloadResponse = IDL.Variant({
     Ok: IDL.Text,
@@ -69,51 +68,6 @@ export const idlFactory = ({ IDL }) => {
     block_height_synced_up_to: IDL.Opt(IDL.Nat64),
     latest_transaction_timestamp_nanos: IDL.Nat64,
     earliest_transaction_timestamp_nanos: IDL.Nat64,
-  });
-  const GetTransactionsRequest = IDL.Record({
-    page_size: IDL.Nat8,
-    offset: IDL.Nat32,
-    account_identifier: AccountIdentifier,
-  });
-  const TransactionType = IDL.Variant({
-    Burn: IDL.Null,
-    Mint: IDL.Null,
-    StakeNeuronNotification: IDL.Null,
-    TopUpCanister: CanisterId,
-    ParticipateSwap: CanisterId,
-    CreateCanister: IDL.Null,
-    Transfer: IDL.Null,
-    TopUpNeuron: IDL.Null,
-    StakeNeuron: IDL.Null,
-  });
-  const Timestamp = IDL.Record({ timestamp_nanos: IDL.Nat64 });
-  const ICPTs = IDL.Record({ e8s: IDL.Nat64 });
-  const Send = IDL.Record({
-    to: AccountIdentifier,
-    fee: ICPTs,
-    amount: ICPTs,
-  });
-  const Receive = IDL.Record({
-    fee: ICPTs,
-    from: AccountIdentifier,
-    amount: ICPTs,
-  });
-  const Transfer = IDL.Variant({
-    Burn: IDL.Record({ amount: ICPTs }),
-    Mint: IDL.Record({ amount: ICPTs }),
-    Send: Send,
-    Receive: Receive,
-  });
-  const Transaction = IDL.Record({
-    transaction_type: IDL.Opt(TransactionType),
-    memo: IDL.Nat64,
-    timestamp: Timestamp,
-    block_height: BlockHeight,
-    transfer: Transfer,
-  });
-  const GetTransactionsResponse = IDL.Record({
-    total: IDL.Nat32,
-    transactions: IDL.Vec(Transaction),
   });
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
   const HttpRequest = IDL.Record({
@@ -186,11 +140,6 @@ export const idlFactory = ({ IDL }) => {
       []
     ),
     get_stats: IDL.Func([], [Stats], ["query"]),
-    get_transactions: IDL.Func(
-      [GetTransactionsRequest],
-      [GetTransactionsResponse],
-      ["query"]
-    ),
     http_request: IDL.Func([HttpRequest], [HttpResponse], ["query"]),
     register_hardware_wallet: IDL.Func(
       [RegisterHardwareWalletRequest],

--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.types.ts
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.types.ts
@@ -1,5 +1,4 @@
 import type { BlockHeight } from "@dfinity/ledger-icp";
-import type { E8s } from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 export interface AccountDetails {
   principal: Principal;
@@ -38,15 +37,6 @@ export type GetAccountResponse =
   | { Ok: AccountDetails }
   | { AccountNotFound: null };
 export type GetProposalPayloadResponse = { Ok: string } | { Err: string };
-export interface GetTransactionsRequest {
-  page_size: number;
-  offset: number;
-  account_identifier: AccountIdentifierString;
-}
-export interface GetTransactionsResponse {
-  total: number;
-  transactions: Array<Transaction>;
-}
 export interface HardwareWalletAccountDetails {
   principal: Principal;
   name: string;
@@ -63,14 +53,6 @@ export interface HttpResponse {
   body: Array<number>;
   headers: Array<HeaderField>;
   status_code: number;
-}
-export interface ICPTs {
-  e8s: E8s;
-}
-export interface Receive {
-  fee: ICPTs;
-  from: AccountIdentifierString;
-  amount: ICPTs;
 }
 export interface RegisterHardwareWalletRequest {
   principal: Principal;
@@ -101,11 +83,6 @@ export type RenameSubAccountResponse =
   | { AccountNotFound: null }
   | { SubAccountNotFound: null }
   | { NameTooLong: null };
-export interface Send {
-  to: AccountIdentifierString;
-  fee: ICPTs;
-  amount: ICPTs;
-}
 export interface Stats {
   latest_transaction_block_height: BlockHeight;
   seconds_since_last_ledger_sync: bigint;
@@ -129,31 +106,6 @@ export interface SubAccountDetails {
   sub_account: SubAccountArray;
   account_identifier: AccountIdentifierString;
 }
-export interface Timestamp {
-  timestamp_nanos: bigint;
-}
-export interface Transaction {
-  transaction_type: [] | [TransactionType];
-  memo: bigint;
-  timestamp: Timestamp;
-  block_height: BlockHeight;
-  transfer: Transfer;
-}
-export type TransactionType =
-  | { Burn: null }
-  | { Mint: null }
-  | { StakeNeuronNotification: null }
-  | { TopUpCanister: CanisterId }
-  | { ParticipateSwap: CanisterId }
-  | { CreateCanister: null }
-  | { Transfer: null }
-  | { TopUpNeuron: null }
-  | { StakeNeuron: null };
-export type Transfer =
-  | { Burn: { amount: ICPTs } }
-  | { Mint: { amount: ICPTs } }
-  | { Send: Send }
-  | { Receive: Receive };
 export default interface _SERVICE {
   add_account: () => Promise<AccountIdentifierString>;
   add_stable_asset: (arg_0: Array<number>) => Promise<undefined>;
@@ -171,9 +123,6 @@ export default interface _SERVICE {
   get_canisters: () => Promise<Array<CanisterDetails>>;
   get_proposal_payload: (arg_0: bigint) => Promise<GetProposalPayloadResponse>;
   get_stats: () => Promise<Stats>;
-  get_transactions: (
-    arg_0: GetTransactionsRequest
-  ) => Promise<GetTransactionsResponse>;
   http_request: (arg_0: HttpRequest) => Promise<HttpResponse>;
   register_hardware_wallet: (
     arg_0: RegisterHardwareWalletRequest


### PR DESCRIPTION
# Motivation

The `nns-dapp` canister no longer has the `get_transactions` method and we removed all the code that used it from the FE.

# Changes

Remove `get_transactions` and all the types used by (only) it from 
* `frontend/src/lib/canisters/nns-dapp/nns-dapp.certified.idl.js`
* `frontend/src/lib/canisters/nns-dapp/nns-dapp.did`
* `frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js`
* `frontend/src/lib/canisters/nns-dapp/nns-dapp.types.ts`

# Tests

Still pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary, it was already removed from https://github.com/dfinity/nns-dapp/blob/main/rs/backend/nns-dapp.did and this candid was only internal to the FE code.