### PR TITLE
Remove unused mock data

### DIFF
--- a/frontend/src/lib/types/transaction.ts
+++ b/frontend/src/lib/types/transaction.ts
@@ -68,18 +68,6 @@ export enum AccountTransactionType {
   RefundSwap = "refundSwap",
 }
 
-export interface Transaction {
-  type: AccountTransactionType;
-  isReceive: boolean;
-  isSend: boolean;
-  // Account string representation
-  from: string | undefined;
-  // Account string representation
-  to: string | undefined;
-  displayAmount: bigint;
-  date: Date;
-}
-
 export type TransactionIconType = "sent" | "received" | "failed" | "reimbursed";
 
 export interface UiTransaction {

--- a/frontend/src/tests/mocks/transaction.mock.ts
+++ b/frontend/src/tests/mocks/transaction.mock.ts
@@ -1,32 +1,11 @@
 import type { GetTransactionsResponse } from "$lib/api/icp-index.api";
-import type { Transaction, UiTransaction } from "$lib/types/transaction";
-import { AccountTransactionType } from "$lib/types/transaction";
+import type { UiTransaction } from "$lib/types/transaction";
 import type { TransactionWithId } from "@dfinity/ledger-icp";
 import { TokenAmount } from "@dfinity/utils";
 import { mockSubAccount } from "./icp-accounts.store.mock";
 import { mockSnsToken } from "./sns-projects.mock";
 
 const displayAmount = 11_000_000_000_000_000n;
-
-export const mockTransactionReceiveDataFromMain: Transaction = {
-  type: AccountTransactionType.Send,
-  isReceive: true,
-  isSend: false,
-  from: "aaaaa-aa",
-  to: "bbbbb-bb",
-  displayAmount,
-  date: new Date("03-14-2021"),
-};
-
-export const mockTransactionSendDataFromMain: Transaction = {
-  type: AccountTransactionType.Send,
-  isReceive: false,
-  isSend: true,
-  from: "aaaaa-aa",
-  to: "bbbbb-bb",
-  displayAmount,
-  date: new Date("03-14-2021"),
-};
 
 export const createMockUiTransaction = ({
   domKey = "123-1",

--- a/frontend/src/tests/mocks/transaction.mock.ts
+++ b/frontend/src/tests/mocks/transaction.mock.ts
@@ -5,8 +5,6 @@ import { TokenAmount } from "@dfinity/utils";
 import { mockSubAccount } from "./icp-accounts.store.mock";
 import { mockSnsToken } from "./sns-projects.mock";
 
-const displayAmount = 11_000_000_000_000_000n;
-
 export const createMockUiTransaction = ({
   domKey = "123-1",
   isIncoming = false,


### PR DESCRIPTION
# Motivation

These variables are not used.

# Changes

1. Remove `mockTransactionReceiveDataFromMain` and `mockTransactionSendDataFromMain` from `frontend/src/tests/mocks/transaction.mock.ts`.
2. Remove the now unused type `Transaction` from `frontend/src/lib/types/transaction.ts`.

# Tests

Still pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary