### PR TITLE
upgrade-downgrade test script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           shard_number: 2
           shard_count: 2
-  test-downgrade-upgrade:
+  test-upgrade-downgrade:
     needs: build
     runs-on: ubuntu-20.04
     timeout-minutes: 40
@@ -119,19 +119,8 @@ jobs:
         run: |
           sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
           cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)" && idl2json --version
-      - name: Start dfx
-        run: dfx start --clean --background &>test-downgrade-upgrade.log
-      - name: Get the production Wasm and args for deploying it locally.
-        run: |
-          mkdir prod
-          curl -sL https://github.com/dfinity/nns-dapp/releases/download/prod/nns-dapp_test.wasm.gz > prod/nns-dapp_test.wasm.gz
-          curl -sL https://github.com/dfinity/nns-dapp/releases/download/prod/nns-dapp-arg-local.did > prod/nns-dapp-arg-local.did
-      - name: Downgrade nns-dapp to prod and upgrade back again
-        run: scripts/nns-dapp/migration-test --wasm1 out/nns-dapp_test.wasm.gz --args1 out/nns-dapp-arg-local.did --wasm2 prod/nns-dapp_test.wasm.gz --args2 prod/nns-dapp-arg-local.did --accounts 94 --chunk 30
-      - name: Repeat with more data
-        run: scripts/nns-dapp/migration-test --wasm1 out/nns-dapp_test.wasm.gz --args1 out/nns-dapp-arg-local.did --wasm2 prod/nns-dapp_test.wasm.gz --args2 prod/nns-dapp-arg-local.did --accounts 201 --chunk 20
-      - name: Count upgrade cycles
-        run: scripts/nns-dapp/estimate-upgrade-cycles | tee -a $GITHUB_STEP_SUMMARY
+      - name: Run uprade-downgrade test
+        run: ./scripts/nns-dapp/upgrade-downgrade-test --github_step_summary "$GITHUB_STEP_SUMMARY"
   test-upgrade-map:
     needs: build
     runs-on: ubuntu-20.04

--- a/scripts/nns-dapp/upgrade-downgrade-test
+++ b/scripts/nns-dapp/upgrade-downgrade-test
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+DEFAULT_WASM_FILENAME="nns-dapp_test.wasm.gz"
+
+print_help() {
+  cat <<-EOF
+
+	Installs the production NNS dapp WASM, upgrades to the given WASM, and then
+	downgrades back to the production WASM.
+
+	EOF
+}
+
+TOP_DIR=$(git rev-parse --show-toplevel)
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/../clap.bash"
+# Define options
+clap.define short=w long=wasm desc="WASM to test" variable=WASM default="nns-dapp_test.wasm.gz"
+clap.define short=a long=args desc="Args file for WASM installation" variable=ARGS_FILE default="nns-dapp-arg-local.did"
+clap.define long=github_step_summary desc="File to append stats to" variable=GITHUB_STEP_SUMMARY default=""
+
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+# Check if the WASM file exists:
+if ! [ -f "$WASM" ]; then
+  echo "WASM file $WASM does not exist" >&2
+  exit 1
+fi
+
+# Check if the ARGS_FILE file exists:
+if ! [ -f "$ARGS_FILE" ]; then
+  echo "Args file $ARGS_FILE does not exist" >&2
+  exit 1
+fi
+
+# Check if a replica is running:
+if pgrep replica; then
+  echo "A replica is already running. Shut it down first." >&2
+  exit 1
+fi
+
+dfx start --clean --background
+
+prod_dir="$(mktemp -d prod-XXXXXX)"
+
+cleanup() {
+  dfx stop
+  rm -rf "$prod_dir"
+}
+
+trap cleanup EXIT
+
+echo "Downloading production WASM and args file to temporary directory $prod_dir"
+
+curl -sL https://github.com/dfinity/nns-dapp/releases/download/prod/nns-dapp_test.wasm.gz >"$prod_dir/nns-dapp_test.wasm.gz"
+curl -sL https://github.com/dfinity/nns-dapp/releases/download/prod/nns-dapp-arg-local.did >"$prod_dir/nns-dapp-arg-local.did"
+
+PROD_WASM="$prod_dir/nns-dapp_test.wasm.gz"
+PROD_ARGS_FILE="$prod_dir/nns-dapp-arg-local.did"
+
+"$SOURCE_DIR/migration-test" --wasm1 "$PROD_WASM" --args1 "$PROD_ARGS_FILE" --wasm2 "$WASM" --args2 "$ARGS_FILE" --accounts 94 --chunk 30
+"$SOURCE_DIR/migration-test" --wasm1 "$PROD_WASM" --args1 "$PROD_ARGS_FILE" --wasm2 "$WASM" --args2 "$ARGS_FILE" --accounts 201 --chunk 20
+
+# If GITHUB_STEP_SUMMARY is non-empty, append the summary to the file:
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  "$SOURCE_DIR/estimate-upgrade-cycles" | tee -a "$GITHUB_STEP_SUMMARY"
+fi


### PR DESCRIPTION
# Motivation

We test that we can upgrade and downgrade between the prod canister and the next version of the canister.
This test first downgrades from the new version to the prod version and then upgrades from the prod version to the new version. This was done because we assumed the new version was already running but this is no longer the case.

So to be more realistic, let's upgrade first and then downgrade.

This test is performed on CI. To make it more convenient, I've added a script to do it and call the script from CI.

# Changes

1. Add a `scripts/nns-dapp/upgrade-downgrade-test` script to perform the upgrade-downgrade test.
2. Call the script from `.github/workflows/build.yml` instead of the original steps.
3. Swap the `--wasm1`/`--args1` and `--wasm2`/`--args2` parameters to make the test more realistic.
4. Rename the job from `test-downgrade-upgrade` to `test-upgrade-downgrade` to reflect the swap.

# Tests

I changed the name of a struct that's stored in stable memory and made sure it was caught by the test.

# Todos

- [x] Add entry to changelog (if necessary).
