### PR TITLE
NNS1-2905: Remove metrics/stats that depend on transactions

### DIFF
--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -826,7 +826,6 @@ pub(crate) fn assert_initial_test_store_stats_are_correct(stats: &Stats) {
     assert_eq!(0, stats.sub_accounts_count);
     assert_eq!(0, stats.hardware_wallet_accounts_count);
     assert_eq!(3, stats.block_height_synced_up_to.unwrap());
-    assert_eq!(0, stats.earliest_transaction_block_height);
     assert!(stats.seconds_since_last_ledger_sync > 1_000_000_000);
 }
 

--- a/rs/backend/src/stats.rs
+++ b/rs/backend/src/stats.rs
@@ -3,7 +3,6 @@ use crate::perf::PerformanceCount;
 use crate::state::State;
 use crate::STATE;
 use candid::CandidType;
-use icp_ledger::BlockIndex;
 use serde::Deserialize;
 #[cfg(test)]
 mod tests;
@@ -32,12 +31,7 @@ pub struct Stats {
     pub accounts_count: u64,
     pub sub_accounts_count: u64,
     pub hardware_wallet_accounts_count: u64,
-    pub transactions_count: u64,
     pub block_height_synced_up_to: Option<u64>,
-    pub earliest_transaction_timestamp_nanos: u64,
-    pub earliest_transaction_block_height: BlockIndex,
-    pub latest_transaction_timestamp_nanos: u64,
-    pub latest_transaction_block_height: BlockIndex,
     pub seconds_since_last_ledger_sync: u64,
     pub neurons_created_count: u64,
     pub neurons_topped_up_count: u64,
@@ -73,11 +67,6 @@ pub fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         "neurons_topped_up_count",
         stats.neurons_topped_up_count as f64,
         "Number of neurons topped up by the canister.",
-    )?;
-    w.encode_gauge(
-        "transactions_count",
-        stats.transactions_count as f64,
-        "Number of transactions processed by the canister.",
     )?;
     w.encode_gauge(
         "accounts_count",


### PR DESCRIPTION
# Motivation

We no longer store transactions in the nns-dapp canister.
So metrics/stats derived from them are now meaningless.

# Changes

1. Remove `transactions_count` from metrics.
2. Remove `transactions_count`, `earliest_transaction_timestamp_nanos`, `earliest_transaction_block_height`, `latest_transaction_timestamp_nanos`, and `latest_transaction_block_height` from `get_stats` response.

# Tests

Checked manually that the metric is no longer there on http://qsgjb-riaaa-aaaaa-aaaga-cai.localhost:8080/metrics

# Todos

- [ ] Add entry to changelog (if necessary).
