### PR TITLE
Upgrade ic js 2024 04 26

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -250,9 +250,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.3.1-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-04-03.1.tgz",
-      "integrity": "sha512-CEFa9/9b6otpsxPONm4mozEpl5bP9FsP9pKSYrsECYnk+SVJjl4aSc4prxUPCZrr0IGuXhW50J4slquafbUv3Q==",
+      "version": "2.3.1-next-2024-04-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-04-26.tgz",
+      "integrity": "sha512-N1kX7oJJiHjumN1266jcxL7i8nYTAa47zislRq1aSbLwRU8FqsPNIQXhiVMyqfplCS/MswNea0MGFlwrW8MlVg==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -266,9 +266,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.0.3-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-04-03.1.tgz",
-      "integrity": "sha512-ihugp0Bt8iMdVNkt29tNn2ODCONl1u7hM2uNCmUJJUSFzZ2An9whjuO/glfwJUXMlQQqM7l/jwuw9GziTkzYQQ==",
+      "version": "3.0.3-next-2024-04-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-04-26.tgz",
+      "integrity": "sha512-FPu3N3lXCUTmh0L6OeRJIBq25VZLihCydNGjH0gBpElS4z1VC7x60LhXsrpBlh3ZcNAoASdfmt5evLyB6Ws0gg==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -291,9 +291,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "3.1.1-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-04-03.1.tgz",
-      "integrity": "sha512-AW9+/8cu9jsx/+FxN8RsH1kyEdYBRRQYhTf+fwsk23vHP/Ij9AFtwdfr8KqMtaZxYwdjURtFZjGBTNngpmfPYA==",
+      "version": "3.1.1-next-2024-04-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-04-26.tgz",
+      "integrity": "sha512-lcVBDEq0iLeWfTQ6UV8AEvbf9Iqzshhv/aKgpJVz8iG/qZZjmvVmIvK95uEciME5D3//KYgwzSnz3OL1LEybcQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -317,9 +317,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.2.2-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-04-03.1.tgz",
-      "integrity": "sha512-CE5XEXx8lwpYSoK+dTQyAWtra+2IK3+obpYfhxMrMKhiw2dNSL+/h5hilzfBccm3Kx4xMjzMUUaMcZ9moA58Qw==",
+      "version": "2.2.2-next-2024-04-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-04-26.tgz",
+      "integrity": "sha512-3sPyBUuKYjKXSBQ+o/CtE9eDqjjK3YeSG/ujUcfV3NrjRrG+0Tu2eRnCp2OdCXV2cfMEwN6RRZKnSPvyHOu6WQ==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -328,9 +328,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.2.1-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-04-03.1.tgz",
-      "integrity": "sha512-mLGYhZLsZReJVHYL31g1IJp49oqCiNePpKvgjCJRDaQ7sN9ry7B/L26bDdmQz0CsI05EGzejyLiaHzIDV94QUg==",
+      "version": "2.2.1-next-2024-04-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-04-26.tgz",
+      "integrity": "sha512-t1kG1pv9rSr1Y9lIVOrlvuRbakVKjTFKOCgYxMbM6GQpcpfiQE1EEHiLRPJ3VeTL18xe57ocUPqLDxXWkjo+Vw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -339,9 +339,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "4.0.2-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-04-03.1.tgz",
-      "integrity": "sha512-2L7KMeJcCLopIibbYDDHHDqOlf0Mcj+6e/eQbjTVRxbepWziWwHO5mFplBT9VpK9D3TbqN1V0UGnxTMOlbdqCw==",
+      "version": "4.0.2-next-2024-04-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-04-26.tgz",
+      "integrity": "sha512-Wnj7hU94P3lnsCJ37BKbb1mfPZ1Cx9+z98O8lpeeLmG+hTgvqsAOqaYad4w89BhvQ1DG0GY13gDtpfV6xxJjag==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -363,9 +363,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.0.2-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-04-03.1.tgz",
-      "integrity": "sha512-oNrEFUylWCuBVxvBSMXeJCs2t8vODFuJ6oGscvXtMqwjU92l+FMh9ET9fqzMi5nVH2+Sm0hsSP3O9Hjl1wyOVQ==",
+      "version": "3.0.2-next-2024-04-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-04-26.tgz",
+      "integrity": "sha512-07DYIlikCMlf2iX8bITYvbb+mXliLidXU09atH1VLpyWx4N5ZCVmaSfb/o9i/zs2ntJWUXulG8dA8irC9Nx3ZQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -378,9 +378,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.1.3-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-04-03.1.tgz",
-      "integrity": "sha512-8eWvi1MVg8BuT3OozLRLiM+eLc6DRHJSt67iO9U94sb/0zTXrqrmxuFtldpRfnCrfgm05OsPu67vfON4skeoHA==",
+      "version": "2.1.3-next-2024-04-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-04-26.tgz",
+      "integrity": "sha512-xQlzm0qB7fn3HyPLrMN82WS3tTyMzQ+H3U42RGVDcLNwqBFMo7AUK0afaGYRb/YLDYxXa89Zo593X8xYiKrI3w==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -7031,9 +7031,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.3.1-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-04-03.1.tgz",
-      "integrity": "sha512-CEFa9/9b6otpsxPONm4mozEpl5bP9FsP9pKSYrsECYnk+SVJjl4aSc4prxUPCZrr0IGuXhW50J4slquafbUv3Q==",
+      "version": "2.3.1-next-2024-04-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.1-next-2024-04-26.tgz",
+      "integrity": "sha512-N1kX7oJJiHjumN1266jcxL7i8nYTAa47zislRq1aSbLwRU8FqsPNIQXhiVMyqfplCS/MswNea0MGFlwrW8MlVg==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7041,9 +7041,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.0.3-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-04-03.1.tgz",
-      "integrity": "sha512-ihugp0Bt8iMdVNkt29tNn2ODCONl1u7hM2uNCmUJJUSFzZ2An9whjuO/glfwJUXMlQQqM7l/jwuw9GziTkzYQQ==",
+      "version": "3.0.3-next-2024-04-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.3-next-2024-04-26.tgz",
+      "integrity": "sha512-FPu3N3lXCUTmh0L6OeRJIBq25VZLihCydNGjH0gBpElS4z1VC7x60LhXsrpBlh3ZcNAoASdfmt5evLyB6Ws0gg==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7057,9 +7057,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "3.1.1-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-04-03.1.tgz",
-      "integrity": "sha512-AW9+/8cu9jsx/+FxN8RsH1kyEdYBRRQYhTf+fwsk23vHP/Ij9AFtwdfr8KqMtaZxYwdjURtFZjGBTNngpmfPYA==",
+      "version": "3.1.1-next-2024-04-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-3.1.1-next-2024-04-26.tgz",
+      "integrity": "sha512-lcVBDEq0iLeWfTQ6UV8AEvbf9Iqzshhv/aKgpJVz8iG/qZZjmvVmIvK95uEciME5D3//KYgwzSnz3OL1LEybcQ==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7073,21 +7073,21 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.2.2-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-04-03.1.tgz",
-      "integrity": "sha512-CE5XEXx8lwpYSoK+dTQyAWtra+2IK3+obpYfhxMrMKhiw2dNSL+/h5hilzfBccm3Kx4xMjzMUUaMcZ9moA58Qw==",
+      "version": "2.2.2-next-2024-04-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.2-next-2024-04-26.tgz",
+      "integrity": "sha512-3sPyBUuKYjKXSBQ+o/CtE9eDqjjK3YeSG/ujUcfV3NrjRrG+0Tu2eRnCp2OdCXV2cfMEwN6RRZKnSPvyHOu6WQ==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.2.1-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-04-03.1.tgz",
-      "integrity": "sha512-mLGYhZLsZReJVHYL31g1IJp49oqCiNePpKvgjCJRDaQ7sN9ry7B/L26bDdmQz0CsI05EGzejyLiaHzIDV94QUg==",
+      "version": "2.2.1-next-2024-04-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.2.1-next-2024-04-26.tgz",
+      "integrity": "sha512-t1kG1pv9rSr1Y9lIVOrlvuRbakVKjTFKOCgYxMbM6GQpcpfiQE1EEHiLRPJ3VeTL18xe57ocUPqLDxXWkjo+Vw==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "4.0.2-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-04-03.1.tgz",
-      "integrity": "sha512-2L7KMeJcCLopIibbYDDHHDqOlf0Mcj+6e/eQbjTVRxbepWziWwHO5mFplBT9VpK9D3TbqN1V0UGnxTMOlbdqCw==",
+      "version": "4.0.2-next-2024-04-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-4.0.2-next-2024-04-26.tgz",
+      "integrity": "sha512-Wnj7hU94P3lnsCJ37BKbb1mfPZ1Cx9+z98O8lpeeLmG+hTgvqsAOqaYad4w89BhvQ1DG0GY13gDtpfV6xxJjag==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -7102,17 +7102,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.0.2-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-04-03.1.tgz",
-      "integrity": "sha512-oNrEFUylWCuBVxvBSMXeJCs2t8vODFuJ6oGscvXtMqwjU92l+FMh9ET9fqzMi5nVH2+Sm0hsSP3O9Hjl1wyOVQ==",
+      "version": "3.0.2-next-2024-04-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.2-next-2024-04-26.tgz",
+      "integrity": "sha512-07DYIlikCMlf2iX8bITYvbb+mXliLidXU09atH1VLpyWx4N5ZCVmaSfb/o9i/zs2ntJWUXulG8dA8irC9Nx3ZQ==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.1.3-next-2024-04-03.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-04-03.1.tgz",
-      "integrity": "sha512-8eWvi1MVg8BuT3OozLRLiM+eLc6DRHJSt67iO9U94sb/0zTXrqrmxuFtldpRfnCrfgm05OsPu67vfON4skeoHA==",
+      "version": "2.1.3-next-2024-04-26",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.1.3-next-2024-04-26.tgz",
+      "integrity": "sha512-xQlzm0qB7fn3HyPLrMN82WS3tTyMzQ+H3U42RGVDcLNwqBFMo7AUK0afaGYRb/YLDYxXa89Zo593X8xYiKrI3w==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/tests/mocks/sns-proposals.mock.ts
+++ b/frontend/src/tests/mocks/sns-proposals.mock.ts
@@ -55,6 +55,7 @@ export const mockSnsProposal: SnsProposalData = {
   reward_event_end_timestamp_seconds: [],
   minimum_yes_proportion_of_exercised: [],
   minimum_yes_proportion_of_total: [],
+  action_auxiliary: [],
 };
 
 const acceptedTally: SnsTally = {


### PR DESCRIPTION
# Motivation

Upgrade `ic-js` to get new proposal types mapping.

# Changes

- `npm run upgrade:next`
- Add new `action_auxiliary` property to mock data.

# Tests

Pass.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.