### PR TITLE
Add proposal types 47-51 support

### DIFF
--- a/frontend/src/lib/i18n/en.governance.json
+++ b/frontend/src/lib/i18n/en.governance.json
@@ -145,7 +145,12 @@
     "UpdateNodesHostosVersion": "Update Nodes HostOS Version",
     "AddApiBoundaryNode": "Add API Boundary Node",
     "RemoveApiBoundaryNodes": "Remove API Boundary Node",
-    "UpdateApiBoundaryNodesVersion": "Update API Boundary Nodes Version"
+    "UpdateApiBoundaryNodesVersion": "Update API Boundary Nodes Version",
+    "DeployGuestosToSomeApiBoundaryNodes": "Deploy GuestOS To Some API Boundary Nodes",
+    "DeployGuestosToAllUnassignedNodes": "Deploy GuestOS To All Unassigned Nodes",
+    "UpdateSshReadOnlyAccessForAllUnassignedNodes": "Update SSH Read Only Access For All Unassigned Nodes",
+    "ReviseElectedHostosVersions": "Revise Elected HostOS Versions",
+    "DeployHostosToSomeNodes": "Deploy HostOS To Some Nodes"
   },
   "nns_functions_description": {
     "Unspecified": "",
@@ -192,6 +197,11 @@
     "UpdateNodesHostosVersion": "Update the HostOS version running on a given list of nodes. The proposal changes the HostOS version that is used on the specified nodes. The version must be contained in the list of HostOS versions.",
     "AddApiBoundaryNode": "A proposal to add a new API Boundary Node using an assigned node",
     "RemoveApiBoundaryNodes": "A proposal to remove a set of API Boundary Nodes, which will designate them as unassigned nodes",
-    "UpdateApiBoundaryNodesVersion": "A proposal to update the version of a set of API Boundary Nodes"
+    "UpdateApiBoundaryNodesVersion": "A proposal to update the version of a set of API Boundary Nodes",
+    "DeployGuestosToSomeApiBoundaryNodes": "A proposal to update the version of a set of API Boundary Nodes",
+    "DeployGuestosToAllUnassignedNodes": "A proposal to update the version of all unassigned nodes",
+    "UpdateSshReadOnlyAccessForAllUnassignedNodes": "A proposal to update SSH readonly access for all unassigned nodes",
+    "ReviseElectedHostosVersions": "A proposal to change the set of currently elected HostOS versions, by electing a new version, and/or unelecting some priorly elected versions.<br/><br/>HostOS versions are identified by the hash of the installation image.<br/><br/>The version to elect is added to the Registry, and the versions to unelect are removed from the Registry, ensuring that HostOS cannot upgrade to these versions anymore.<br/><br/>This proposal does not actually perform the upgrade; for deployment of an elected version, please refer to `NNS_FUNCTION_DEPLOY_HOSTOS_TO_SOME_NODES`",
+    "DeployHostosToSomeNodes": "Deploy a HostOS version to a given set of nodes. The proposal changes the HostOS version that is used on the specified nodes."
   }
 }

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1233,6 +1233,11 @@ interface I18nNns_functions {
   AddApiBoundaryNode: string;
   RemoveApiBoundaryNodes: string;
   UpdateApiBoundaryNodesVersion: string;
+  DeployGuestosToSomeApiBoundaryNodes: string;
+  DeployGuestosToAllUnassignedNodes: string;
+  UpdateSshReadOnlyAccessForAllUnassignedNodes: string;
+  ReviseElectedHostosVersions: string;
+  DeployHostosToSomeNodes: string;
 }
 
 interface I18nNns_functions_description {
@@ -1281,6 +1286,11 @@ interface I18nNns_functions_description {
   AddApiBoundaryNode: string;
   RemoveApiBoundaryNodes: string;
   UpdateApiBoundaryNodesVersion: string;
+  DeployGuestosToSomeApiBoundaryNodes: string;
+  DeployGuestosToAllUnassignedNodes: string;
+  UpdateSshReadOnlyAccessForAllUnassignedNodes: string;
+  ReviseElectedHostosVersions: string;
+  DeployHostosToSomeNodes: string;
 }
 
 interface I18n {

--- a/rs/proposals/src/def.rs
+++ b/rs/proposals/src/def.rs
@@ -470,3 +470,26 @@ pub type RemoveApiBoundaryNodesPayload = crate::canisters::nns_registry::api::Re
 // https://github.com/dfinity/ic/blob/04c9c04c7a1f52ab5529531691a7c1bcf289c30d/rs/registry/canister/src/mutations/do_update_api_boundary_nodes_version.rs#L14
 pub type UpdateApiBoundaryNodesVersionPayload =
     crate::canisters::nns_registry::api::UpdateApiBoundaryNodesVersionPayload;
+
+// NNS function 47 - UpdateApiBoundaryNodesVersion
+// https://github.com/dfinity/ic/blob/04c9c04c7a1f52ab5529531691a7c1bcf289c30d/rs/registry/canister/src/mutations/do_update_api_boundary_nodes_version.rs#L14
+pub type DeployGuestosToSomeApiBoundaryNodesPayload =
+    crate::canisters::nns_registry::api::UpdateApiBoundaryNodesVersionPayload;
+
+// NNS function 48 - DeployGuestosToAllUnassignedNodes
+// https://github.com/dfinity/ic/blob/3343a9ec1ea3170dcfd0cc4f4298d5ce09abb036/rs/registry/canister/src/mutations/do_deploy_guestos_to_all_unassigned_nodes.rs#L36
+pub type DeployGuestosToAllUnassignedNodesPayload =
+    crate::canisters::nns_registry::api::DeployGuestosToAllUnassignedNodesPayload;
+
+// NNS function 49 - UpdateSshReadonlyAccessForAllUnassignedNodes
+// https://github.com/dfinity/ic/blob/3343a9ec1ea3170dcfd0cc4f4298d5ce09abb036/rs/registry/canister/src/mutations/do_deploy_guestos_to_all_unassigned_nodes.rs#L36
+pub type UpdateSshReadOnlyAccessForAllUnassignedNodesPayload =
+    crate::canisters::nns_registry::api::UpdateSshReadOnlyAccessForAllUnassignedNodesPayload;
+
+// NNS function 50 - ReviseElectedHostosVersions
+// https://github.com/dfinity/ic/blob/26098e18ddd64ab50d3f3725f50c7f369cd3f90e/rs/registry/canister/src/mutations/do_update_elected_hostos_versions.rs#L88
+pub type ReviseElectedHostosVersionsPayload = crate::canisters::nns_registry::api::UpdateElectedHostosVersionsPayload;
+
+// NNS function 51 - DeployHostosToSomeNodes
+// https://github.com/dfinity/ic/blob/26098e18ddd64ab50d3f3725f50c7f369cd3f90e/rs/registry/canister/src/mutations/do_update_nodes_hostos_version.rs#L38C12-L38C43
+pub type DeployHostosToSomeNodesPayload = crate::canisters::nns_registry::api::UpdateNodesHostosVersionPayload;

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -7,15 +7,17 @@ use crate::def::{
     AddWasmRequestTrimmed, BitcoinSetConfigProposal, BitcoinSetConfigProposalHumanReadable, BlessReplicaVersionPayload,
     ChangeNnsCanisterProposal, ChangeNnsCanisterProposalTrimmed, ChangeSubnetMembershipPayload,
     ChangeSubnetTypeAssignmentArgs, CompleteCanisterMigrationPayload, CreateSubnetPayload,
-    InsertUpgradePathEntriesRequest, InsertUpgradePathEntriesRequestHumanReadable, PrepareCanisterMigrationPayload,
-    RecoverSubnetPayload, RemoveApiBoundaryNodesPayload, RemoveFirewallRulesPayload, RemoveNodeOperatorsPayload,
-    RemoveNodeOperatorsPayloadHumanReadable, RemoveNodesFromSubnetPayload, RemoveNodesPayload,
-    RerouteCanisterRangesPayload, RetireReplicaVersionPayload, SetAuthorizedSubnetworkListArgs,
-    SetFirewallConfigPayload, StopOrStartNnsCanisterProposal, UpdateAllowedPrincipalsRequest,
-    UpdateApiBoundaryNodesVersionPayload, UpdateElectedHostosVersionsPayload, UpdateElectedReplicaVersionsPayload,
-    UpdateFirewallRulesPayload, UpdateIcpXdrConversionRatePayload, UpdateNodeOperatorConfigPayload,
-    UpdateNodeRewardsTableProposalPayload, UpdateNodesHostosVersionPayload, UpdateSnsSubnetListRequest,
-    UpdateSubnetPayload, UpdateSubnetReplicaVersionPayload, UpdateSubnetTypeArgs, UpdateUnassignedNodesConfigPayload,
+    DeployGuestosToAllUnassignedNodesPayload, DeployGuestosToSomeApiBoundaryNodesPayload,
+    DeployHostosToSomeNodesPayload, InsertUpgradePathEntriesRequest, InsertUpgradePathEntriesRequestHumanReadable,
+    PrepareCanisterMigrationPayload, RecoverSubnetPayload, RemoveApiBoundaryNodesPayload, RemoveFirewallRulesPayload,
+    RemoveNodeOperatorsPayload, RemoveNodeOperatorsPayloadHumanReadable, RemoveNodesFromSubnetPayload,
+    RemoveNodesPayload, RerouteCanisterRangesPayload, RetireReplicaVersionPayload, ReviseElectedHostosVersionsPayload,
+    SetAuthorizedSubnetworkListArgs, SetFirewallConfigPayload, StopOrStartNnsCanisterProposal,
+    UpdateAllowedPrincipalsRequest, UpdateApiBoundaryNodesVersionPayload, UpdateElectedHostosVersionsPayload,
+    UpdateElectedReplicaVersionsPayload, UpdateFirewallRulesPayload, UpdateIcpXdrConversionRatePayload,
+    UpdateNodeOperatorConfigPayload, UpdateNodeRewardsTableProposalPayload, UpdateNodesHostosVersionPayload,
+    UpdateSnsSubnetListRequest, UpdateSshReadOnlyAccessForAllUnassignedNodesPayload, UpdateSubnetPayload,
+    UpdateSubnetReplicaVersionPayload, UpdateSubnetTypeArgs, UpdateUnassignedNodesConfigPayload,
     UpgradeRootProposalPayload, UpgradeRootProposalPayloadTrimmed,
 };
 use candid::parser::types::{self as parser_types, IDLType, IDLTypes};
@@ -318,6 +320,11 @@ fn transform_payload_to_json(nns_function: i32, payload_bytes: &[u8]) -> Result<
         44 => identity::<RemoveApiBoundaryNodesPayload>(payload_bytes),
         // 45 reserved ("NNS_FUNCTION_UPDATE_API_BOUNDARY_NODE_DOMAIN") - https://github.com/dfinity/ic/blob/cd8ad64ed63e38db0d40386ba226df25767d4cd6/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto#L616
         46 => identity::<UpdateApiBoundaryNodesVersionPayload>(payload_bytes),
+        47 => identity::<DeployGuestosToSomeApiBoundaryNodesPayload>(payload_bytes),
+        48 => identity::<DeployGuestosToAllUnassignedNodesPayload>(payload_bytes),
+        49 => identity::<UpdateSshReadOnlyAccessForAllUnassignedNodesPayload>(payload_bytes),
+        50 => identity::<ReviseElectedHostosVersionsPayload>(payload_bytes),
+        51 => identity::<DeployHostosToSomeNodesPayload>(payload_bytes),
         _ => Err("Unrecognised NNS function".to_string()),
     }
 }


### PR DESCRIPTION
# Motivation

Add proposal types 47-51 support.

- 47 `DeployGuestosToSomeApiBoundaryNodes` - [test link](https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/proposal/?u=qsgjb-riaaa-aaaaa-aaaga-cai&proposal=15)
- 48 `DeployGuestosToAllUnassignedNodes` - [test link](https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/proposal/?u=qsgjb-riaaa-aaaaa-aaaga-cai&proposal=16)
- 49 `UpdateSshReadOnlyAccessForAllUnassignedNodes` - [test link](https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/proposal/?u=qsgjb-riaaa-aaaaa-aaaga-cai&proposal=17)
- 50 `ReviseElectedHostosVersions` - TBD
- 51 `DeployHostosToSomeNodes` - TBD

# Changes

- Add and map new proposal payload types.
- Update labels needed for new proposals.

# Tests

- Manually on devenv

# Todos

- [ ] Add entry to changelog (if necessary).
