### PR TITLE
Load actionables at app startup

### DIFF
--- a/frontend/src/lib/components/universe/SelectUniverseNav.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNav.svelte
@@ -3,30 +3,11 @@
   import SelectUniverseNavList from "$lib/components/universe/SelectUniverseNavList.svelte";
   import SelectUniverseDropdown from "$lib/components/universe/SelectUniverseDropdown.svelte";
   import { titleTokenSelectorStore } from "$lib/derived/title-token-selector.derived";
-  import { actionableProposalIndicationEnabledStore } from "$lib/derived/actionable-proposals.derived";
-  import { loadActionableProposals } from "$lib/services/actionable-proposals.services";
-  import { loadActionableSnsProposals } from "$lib/services/actionable-sns-proposals.services";
-  import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
-  import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
 
   let innerWidth = 0;
   let list = false;
 
   $: list = innerWidth > BREAKPOINT_LARGE;
-  $: if (
-    $ENABLE_VOTING_INDICATION &&
-    $actionableProposalIndicationEnabledStore
-  ) {
-    loadActionableProposals();
-  }
-  $: if (
-    $ENABLE_VOTING_INDICATION &&
-    $actionableProposalIndicationEnabledStore &&
-    // Check for the length in case the sns list is not yet loaded
-    $snsProjectsCommittedStore.length > 0
-  ) {
-    loadActionableSnsProposals();
-  }
 </script>
 
 <svelte:window bind:innerWidth />

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -8,6 +8,10 @@
   } from "$lib/services/worker-auth.services";
   import { initAppPrivateDataProxy } from "$lib/proxy/app.services.proxy";
   import { toastsClean } from "$lib/stores/toasts.store";
+  import { loadActionableProposals } from "$lib/services/actionable-proposals.services";
+  import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
+  import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { loadActionableSnsProposals } from "$lib/services/actionable-sns-proposals.services";
 
   let ready = false;
 
@@ -44,6 +48,12 @@
   });
 
   $: syncAuth($authStore);
+
+  $: $authSignedInStore && loadActionableProposals();
+  // Check for the committed projects length in case the sns list is not yet loaded
+  $: $authSignedInStore &&
+    $snsProjectsCommittedStore.length > 0 &&
+    loadActionableSnsProposals();
 </script>
 
 <slot />

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
@@ -1,120 +1,27 @@
-import * as governanceApi from "$lib/api/governance.api";
-import * as api from "$lib/api/proposals.api";
-import * as snsGovernanceApi from "$lib/api/sns-governance.api";
 import SelectUniverseNav from "$lib/components/universe/SelectUniverseNav.svelte";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
-import * as actionableProposalsServices from "$lib/services/actionable-proposals.services";
-import * as actionableSnsProposalsServices from "$lib/services/actionable-sns-proposals.services";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
-import { neuronsStore } from "$lib/stores/neurons.store";
-import { enumValues } from "$lib/utils/enum.utils";
-import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
+import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
 import { page } from "$mocks/$app/stores";
-import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
-import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
-import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
+import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
 import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { SelectUniverseDropdownPo } from "$tests/page-objects/SelectUniverseDropdown.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import type { NeuronInfo, ProposalInfo } from "@dfinity/nns";
+import type { ProposalInfo } from "@dfinity/nns";
 import {
-  SnsNeuronPermissionType,
   SnsProposalDecisionStatus,
   SnsProposalRewardStatus,
   SnsSwapLifecycle,
-  SnsVote,
-  neuronSubaccount,
-  type SnsBallot,
-  type SnsListProposalsResponse,
-  type SnsNeuron,
-  type SnsNeuronId,
   type SnsProposalData,
 } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
 describe("SelectUniverseNav", () => {
-  const neuron: NeuronInfo = {
-    ...mockNeuron,
-    neuronId: 0n,
-    recentBallots: [],
-  };
-  const votableProposal: ProposalInfo = {
-    ...mockProposalInfo,
-
-    id: 0n,
-  };
-  let spyQueryProposals = vi
-    .spyOn(api, "queryProposals")
-    .mockResolvedValue([votableProposal]);
-  let spyQueryNeurons = vi
-    .spyOn(governanceApi, "queryNeurons")
-    .mockResolvedValue([neuron]);
-  const subaccount = neuronSubaccount({
-    controller: mockIdentity.getPrincipal(),
-    index: 0,
-  });
-  const snsNeuronId: SnsNeuronId = { id: subaccount };
-  const allPermissions = Int32Array.from(enumValues(SnsNeuronPermissionType));
-  const snsNeuron: SnsNeuron = {
-    ...mockSnsNeuron,
-    created_timestamp_seconds: 0n,
-    id: [snsNeuronId] as [SnsNeuronId],
-    permissions: [
-      {
-        principal: [mockIdentity.getPrincipal()],
-        permission_type: allPermissions,
-      },
-    ],
-  };
-  const snsNeuronIdHex = getSnsNeuronIdAsHexString(snsNeuron);
-  const votableSnsProposalProps = {
-    proposalId: 0n,
-    createdAt: 1n,
-    status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
-    rewardStatus: SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
-    ballots: [
-      [
-        snsNeuronIdHex,
-        {
-          vote: SnsVote.Unspecified,
-          cast_timestamp_seconds: 123n,
-          voting_power: 10000n,
-        },
-      ],
-    ] as [string, SnsBallot][],
-  };
-  const votableSnsProposal1: SnsProposalData = createSnsProposal({
-    ...votableSnsProposalProps,
-    proposalId: 0n,
-  });
-  const votableSnsProposal2: SnsProposalData = createSnsProposal({
-    ...votableSnsProposalProps,
-    proposalId: 1n,
-  });
-  const spyQuerySnsNeurons = vi
-    .spyOn(snsGovernanceApi, "querySnsNeurons")
-    .mockResolvedValue([snsNeuron]);
-  const spyQuerySnsProposals = vi
-    .spyOn(snsGovernanceApi, "queryProposals")
-    .mockImplementation(
-      async () =>
-        ({
-          proposals: [votableSnsProposal1, votableSnsProposal2],
-          include_ballots_by_caller: [true],
-        }) as SnsListProposalsResponse
-    );
-  const spyLoadActionableProposals = vi.spyOn(
-    actionableProposalsServices,
-    "loadActionableProposals"
-  );
-  const spyLoadActionableSnsProposals = vi.spyOn(
-    actionableSnsProposalsServices,
-    "loadActionableSnsProposals"
-  );
   const renderComponent = () => {
     const { container } = render(SelectUniverseNav);
     return SelectUniverseDropdownPo.under(new JestPageObjectElement(container));
@@ -123,20 +30,8 @@ describe("SelectUniverseNav", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetSnsProjects();
-    neuronsStore.reset();
     actionableNnsProposalsStore.reset();
-
-    spyQueryNeurons.mockClear();
-    spyQueryProposals.mockClear();
-    spyQuerySnsNeurons.mockClear();
-    spyQuerySnsProposals.mockClear();
-
-    spyQueryProposals = vi
-      .spyOn(api, "queryProposals")
-      .mockResolvedValue([votableProposal]);
-    spyQueryNeurons = vi
-      .spyOn(governanceApi, "queryNeurons")
-      .mockResolvedValue([neuron]);
+    actionableSnsProposalsStore.resetForTesting();
 
     resetIdentity();
     page.mock({
@@ -154,33 +49,36 @@ describe("SelectUniverseNav", () => {
     expect(await po.getSelectUniverseCardPo().isPresent()).toEqual(true);
   });
 
-  it("should load Nns neurons and proposals", async () => {
-    expect(spyLoadActionableProposals).toHaveBeenCalledTimes(0);
-    await renderComponent();
-    await runResolvedPromises();
-    expect(spyLoadActionableProposals).toHaveBeenCalledTimes(1);
-  });
-
-  it("should load actionable Sns proposals", async () => {
-    expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(0);
-    setSnsProjects([{ lifecycle: SnsSwapLifecycle.Committed }]);
-    await renderComponent();
-    await runResolvedPromises();
-    expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(1);
-  });
-
-  it("should load actionable Sns proposals after sns list update", async () => {
-    expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(0);
-    await renderComponent();
-    await runResolvedPromises();
-    expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(0);
-
-    setSnsProjects([{ lifecycle: SnsSwapLifecycle.Committed }]);
-    await runResolvedPromises();
-    expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(1);
-  });
-
   it("should display actionable proposal count", async () => {
+    const votableProposal: ProposalInfo = {
+      ...mockProposalInfo,
+      id: 0n,
+    };
+    const votableSnsProposalProps = {
+      createdAt: 1n,
+      status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+      rewardStatus: SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
+    };
+    const votableSnsProposal1: SnsProposalData = createSnsProposal({
+      ...votableSnsProposalProps,
+      proposalId: 0n,
+    });
+    const votableSnsProposal2: SnsProposalData = createSnsProposal({
+      ...votableSnsProposalProps,
+      proposalId: 1n,
+    });
+
+    actionableNnsProposalsStore.setProposals([
+      {
+        ...votableProposal,
+      },
+    ]);
+    actionableSnsProposalsStore.set({
+      rootCanisterId: mockSnsFullProject.rootCanisterId,
+      proposals: [votableSnsProposal1, votableSnsProposal2],
+      includeBallotsByCaller: true,
+    });
+
     setSnsProjects([{ lifecycle: SnsSwapLifecycle.Committed }]);
     const po = await renderComponent();
     await runResolvedPromises();

--- a/frontend/src/tests/routes/layout.spec.ts
+++ b/frontend/src/tests/routes/layout.spec.ts
@@ -84,18 +84,34 @@ describe("Layout", () => {
         .mockResolvedValue();
     });
 
-    it("should call loadActionableProposals", async () => {
+    it("should call loadActionableProposals on startup", async () => {
+      expect(spyLoadActionableProposals).toHaveBeenCalledTimes(0);
+      resetIdentity();
+      render(App);
+      await runResolvedPromises();
+      expect(spyLoadActionableProposals).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call loadActionableProposals after sign-in", async () => {
       expect(spyLoadActionableProposals).toHaveBeenCalledTimes(0);
       render(App);
       await runResolvedPromises();
       expect(spyLoadActionableProposals).toHaveBeenCalledTimes(0);
-      // mockSignIn();
       resetIdentity();
       await runResolvedPromises();
       expect(spyLoadActionableProposals).toHaveBeenCalledTimes(1);
     });
 
-    it("should call loadActionableSnsProposals", async () => {
+    it("should call loadActionableSnsProposals on startup", async () => {
+      expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(0);
+      resetIdentity();
+      setSnsProjects([{ lifecycle: SnsSwapLifecycle.Committed }]);
+      render(App);
+      await runResolvedPromises();
+      expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call loadActionableSnsProposals after sign-in and sns availability", async () => {
       expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(0);
       render(App);
       await runResolvedPromises();


### PR DESCRIPTION
# Motivation

To display total actionable proposal count in the main navigation, we need to load them at the dapp startup.

# Changes

- Move actionable loading into +layout file, where the other initializations are done.

# Tests

- Tests were moved and adjusted.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet