### PR TITLE
NNS1-2966: Tooltip on voted neuron voting power

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Add new proposal types support (47-51)
 * Message informing about proposal topic changes.
+* Tooltips with exact voting power on voted neurons.
 
 #### Changed
 

--- a/frontend/src/lib/components/proposal-detail/MyVotes.svelte
+++ b/frontend/src/lib/components/proposal-detail/MyVotes.svelte
@@ -3,13 +3,11 @@
   import { i18n } from "$lib/stores/i18n";
   import { KeyValuePair } from "@dfinity/gix-components";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import {
-    formatVotingPower,
-    type CompactNeuronInfo,
-  } from "$lib/utils/neuron.utils";
+  import type { CompactNeuronInfo } from "$lib/utils/neuron.utils";
   import { getVoteDisplay } from "$lib/utils/proposals.utils";
   import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
   import { SNS_NEURON_ID_DISPLAY_LENGTH } from "$lib/constants/sns-neurons.constants";
+  import VotingPowerDisplay from "$lib/components/ic/VotingPowerDisplay.svelte";
   import VotingCardNeuronList from "$lib/components/proposal-detail/VotingCard/VotingCardNeuronList.svelte";
   import { fade } from "svelte/transition";
   import VoteResultIcon from "$lib/components/proposal-detail/VotingCard/VoteResultIcon.svelte";
@@ -55,9 +53,10 @@
               class="vote-details"
               class:rejected={neuron.vote === Vote.No}
             >
-              <span data-tid="my-votes-voting-power"
-                >{formatVotingPower(neuron.votingPower)}</span
-              >
+              <VotingPowerDisplay
+                valueTestId="my-votes-voting-power"
+                votingPowerE8s={neuron.votingPower}
+              />
               <VoteResultIcon vote={neuron.vote} />
             </span>
           </KeyValuePair>

--- a/frontend/src/lib/components/proposal-detail/VotingCard/VotedNeuronList.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/VotedNeuronList.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import { Value } from "@dfinity/gix-components";
   import {
     type CompactNeuronInfo,
-    formatVotingPower,
     neuronsVotingPower,
   } from "$lib/utils/neuron.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import VotingPowerDisplay from "$lib/components/ic/VotingPowerDisplay.svelte";
   import ExpandableProposalNeurons from "$lib/components/proposal-detail/VotingCard/ExpandableProposalNeurons.svelte";
   import MyVotes from "$lib/components/proposal-detail/MyVotes.svelte";
   import { Vote } from "@dfinity/nns";
@@ -52,9 +51,10 @@
     <svelte:fragment slot="end">
       <span class="label">{$i18n.proposal_detail__vote.voting_power_label}</span
       >
-      <Value testId="voted-voting-power"
-        >{formatVotingPower(votedVotingPower)}</Value
-      >
+      <VotingPowerDisplay
+        valueTestId="voted-voting-power"
+        votingPowerE8s={votedVotingPower}
+      />
     </svelte:fragment>
     <MyVotes {neuronsVotedForProposal} />
   </ExpandableProposalNeurons>

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotedNeuronList.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotedNeuronList.spec.ts
@@ -36,6 +36,11 @@ describe("VotedNeuronList", () => {
     expect(await po.getDisplayedTotalVotingPower()).toBe("300.00");
   });
 
+  it("should have tooltip with exact total voting power of neurons", async () => {
+    const po = renderComponent([neuron1, neuron2]);
+    expect(await po.getExactTotalVotingPower()).toBe("300.00000123");
+  });
+
   it("should display neuron ID of individual neurons", async () => {
     const po = renderComponent([neuron1, neuron2]);
     expect(await po.getMyVotesPo().getNeuronIds()).toEqual(["111", "222"]);
@@ -46,6 +51,14 @@ describe("VotedNeuronList", () => {
     expect(await po.getMyVotesPo().getDisplayedVotingPowers()).toEqual([
       "100.00",
       "200.00",
+    ]);
+  });
+
+  it("should have tooltips with exact voting power of neurons", async () => {
+    const po = renderComponent([neuron1, neuron2]);
+    expect(await po.getMyVotesPo().getExactVotingPowers()).toEqual([
+      "100.00000123",
+      "200.00000000",
     ]);
   });
 });

--- a/frontend/src/tests/page-objects/MyVotes.page-object.ts
+++ b/frontend/src/tests/page-objects/MyVotes.page-object.ts
@@ -9,7 +9,7 @@ export class MyVotesPo extends BasePageObject {
     return new MyVotesPo(element.byTestId(MyVotesPo.TID));
   }
 
-  getVotingPowerDisplayPosition(): Promise<VotingPowerDisplayPo[]> {
+  getVotingPowerDisplayPos(): Promise<VotingPowerDisplayPo[]> {
     return VotingPowerDisplayPo.allUnder(this.root);
   }
 
@@ -19,14 +19,14 @@ export class MyVotesPo extends BasePageObject {
   }
 
   async getDisplayedVotingPowers(): Promise<string[]> {
-    const votingPowerDisplaydPos = await this.getVotingPowerDisplayPosition();
+    const votingPowerDisplaydPos = await this.getVotingPowerDisplayPos();
     return Promise.all(
       votingPowerDisplaydPos.map((po) => po.getDisplayedVotingPower())
     );
   }
 
   async getExactVotingPowers(): Promise<string[]> {
-    const votingPowerDisplaydPos = await this.getVotingPowerDisplayPosition();
+    const votingPowerDisplaydPos = await this.getVotingPowerDisplayPos();
     return Promise.all(
       votingPowerDisplaydPos.map((po) => po.getExactVotingPower())
     );

--- a/frontend/src/tests/page-objects/MyVotes.page-object.ts
+++ b/frontend/src/tests/page-objects/MyVotes.page-object.ts
@@ -1,3 +1,4 @@
+import { VotingPowerDisplayPo } from "$tests/page-objects/VotingPowerDisplay.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -8,13 +9,26 @@ export class MyVotesPo extends BasePageObject {
     return new MyVotesPo(element.byTestId(MyVotesPo.TID));
   }
 
+  getVotingPowerDisplayPosition(): Promise<VotingPowerDisplayPo[]> {
+    return VotingPowerDisplayPo.allUnder(this.root);
+  }
+
   async getNeuronIds(): Promise<string[]> {
     const elements = await this.root.allByTestId("neuron-id");
     return Promise.all(elements.map((el) => el.getText()));
   }
 
   async getDisplayedVotingPowers(): Promise<string[]> {
-    const elements = await this.root.allByTestId("my-votes-voting-power");
-    return Promise.all(elements.map((el) => el.getText()));
+    const votingPowerDisplaydPos = await this.getVotingPowerDisplayPosition();
+    return Promise.all(
+      votingPowerDisplaydPos.map((po) => po.getDisplayedVotingPower())
+    );
+  }
+
+  async getExactVotingPowers(): Promise<string[]> {
+    const votingPowerDisplaydPos = await this.getVotingPowerDisplayPosition();
+    return Promise.all(
+      votingPowerDisplaydPos.map((po) => po.getExactVotingPower())
+    );
   }
 }

--- a/frontend/src/tests/page-objects/VotedNeuronList.page-object.ts
+++ b/frontend/src/tests/page-objects/VotedNeuronList.page-object.ts
@@ -1,5 +1,6 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { MyVotesPo } from "$tests/page-objects/MyVotes.page-object";
+import { VotingPowerDisplayPo } from "$tests/page-objects/VotingPowerDisplay.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class VotedNeuronListPo extends BasePageObject {
@@ -7,6 +8,12 @@ export class VotedNeuronListPo extends BasePageObject {
 
   static under(element: PageObjectElement): VotedNeuronListPo {
     return new VotedNeuronListPo(element.byTestId(VotedNeuronListPo.TID));
+  }
+
+  // There are multiple VotingPowerDisplays in the component but the first one
+  // has the total voted voting power.
+  getTotalVotingPowerDisplayPo(): VotingPowerDisplayPo {
+    return VotingPowerDisplayPo.under(this.root);
   }
 
   getMyVotesPo(): MyVotesPo {
@@ -18,6 +25,10 @@ export class VotedNeuronListPo extends BasePageObject {
   }
 
   getDisplayedTotalVotingPower(): Promise<string> {
-    return this.getText("voted-voting-power");
+    return this.getTotalVotingPowerDisplayPo().getDisplayedVotingPower();
+  }
+
+  getExactTotalVotingPower(): Promise<string> {
+    return this.getTotalVotingPowerDisplayPo().getExactVotingPower();
   }
 }

--- a/frontend/src/tests/page-objects/VotingPowerDisplay.page-object.ts
+++ b/frontend/src/tests/page-objects/VotingPowerDisplay.page-object.ts
@@ -11,6 +11,14 @@ export class VotingPowerDisplayPo extends TooltipPo {
     );
   }
 
+  static async allUnder(
+    element: PageObjectElement
+  ): Promise<VotingPowerDisplayPo[]> {
+    return Array.from(
+      await element.allByTestId(VotingPowerDisplayPo.VOTING_POWER_DISPLAY_TID)
+    ).map((el) => new VotingPowerDisplayPo(el));
+  }
+
   getDisplayedVotingPower(): Promise<string> {
     return this.getDisplayedText();
   }


### PR DESCRIPTION
# Motivation

Voting power of neurons is displayed as rounded numbers. We want to give people access to the exact numbers.
This PR adds a tooltip on voting power of voted neurons, similar to what https://github.com/dfinity/nns-dapp/pull/4713 did for votable neurons.

# Changes

1. Use `VotingPowerDisplay` component for the total voted neuron voting power in `VotedNeuronList` and the individual voted neurons in `MyVotes`.


# Tests

1. Unit tests for both tooltips were added in `frontend/src/tests/lib/components/proposal-detail/VotingCard/VotedNeuronList.spec.ts`.
2. Page objects were updated.

# Todos

- [x] Add entry to changelog (if necessary).
