### PR TITLE
NNS1-2905: Remove transactions fields from accounts (step 1)

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -29,6 +29,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Stop encoding the accounts map in the `AccountsStore`.
 * Removed `ENABLE_HIDE_ZERO_BALANCE` feature flag.
 * Proposal filtering by reward status.
+* Removed transactions from accounts stored in nns-dapp.
 
 #### Fixed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -29,7 +29,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Stop encoding the accounts map in the `AccountsStore`.
 * Removed `ENABLE_HIDE_ZERO_BALANCE` feature flag.
 * Proposal filtering by reward status.
-* Removed transactions from accounts stored in nns-dapp.
+* Intermediate step to remove transactions from accounts stored in nns-dapp.
 
 #### Fixed
 

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -212,7 +212,7 @@ impl From<Account> for OldAccount {
 struct NamedSubAccount {
     name: String,
     account_identifier: AccountIdentifier,
-    // transactions: Do not reuse this field. There are still accounts in stable memor with this unused field.
+    // transactions: Do not reuse this field. There are still accounts in stable memory with this unused field.
 }
 
 // TODO(NNS1-2905): Delete this after it has been on mainnet for at least 1 release.

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -153,19 +153,58 @@ pub struct Account {
     /// Note: The principal was not stored for early users.  When early users log in, we discover their principal and set this field.
     principal: Option<PrincipalId>,
     account_identifier: AccountIdentifier,
-    default_account_transactions: Vec<TransactionIndex>,
     sub_accounts: HashMap<u8, NamedSubAccount>,
     hardware_wallet_accounts: Vec<NamedHardwareWalletAccount>,
     canisters: Vec<NamedCanister>,
+    // default_account_transactions: Do not reuse this field. There are still accounts in stable memor with this unused field.
 }
 
 impl Storable for Account {
     const BOUND: Bound = Bound::Unbounded;
     fn to_bytes(&self) -> Cow<'_, [u8]> {
-        candid::encode_one(self).expect("Failed to serialize account").into()
+        // Encode Account in a way that can still be restored if we need to
+        // roll back the release.
+        let old_account = OldAccount::from(self.clone());
+        candid::encode_one(old_account)
+            .expect("Failed to serialize account")
+            .into()
+        // TODO(NNS1-2905): Restore direct encoding once OldAccount is deleted.
+        // candid::encode_one(self).expect("Failed to serialize account").into()
     }
     fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
         candid::decode_one(&bytes).expect("Failed to parse account from store.")
+    }
+}
+
+// TODO(NNS1-2905): Delete this after it has been on mainnet for at least 1 release.
+#[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
+struct OldAccount {
+    principal: Option<PrincipalId>,
+    account_identifier: AccountIdentifier,
+    default_account_transactions: Vec<TransactionIndex>,
+    sub_accounts: HashMap<u8, OldNamedSubAccount>,
+    hardware_wallet_accounts: Vec<OldNamedHardwareWalletAccount>,
+    canisters: Vec<NamedCanister>,
+}
+
+impl From<Account> for OldAccount {
+    fn from(account: Account) -> Self {
+        OldAccount {
+            principal: account.principal,
+            account_identifier: account.account_identifier,
+            default_account_transactions: Vec::new(),
+            sub_accounts: account
+                .sub_accounts
+                .into_iter()
+                .map(|(id, sa)| (id, sa.into()))
+                .collect(),
+            hardware_wallet_accounts: account
+                .hardware_wallet_accounts
+                .into_iter()
+                .map(NamedHardwareWalletAccount::into)
+                .collect(),
+            canisters: account.canisters,
+        }
     }
 }
 
@@ -173,14 +212,50 @@ impl Storable for Account {
 struct NamedSubAccount {
     name: String,
     account_identifier: AccountIdentifier,
+    // transactions: Do not reuse this field. There are still accounts in stable memor with this unused field.
+}
+
+// TODO(NNS1-2905): Delete this after it has been on mainnet for at least 1 release.
+#[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
+struct OldNamedSubAccount {
+    name: String,
+    account_identifier: AccountIdentifier,
     transactions: Vec<TransactionIndex>,
+}
+
+impl From<NamedSubAccount> for OldNamedSubAccount {
+    fn from(sub_account: NamedSubAccount) -> Self {
+        OldNamedSubAccount {
+            name: sub_account.name,
+            account_identifier: sub_account.account_identifier,
+            transactions: Vec::new(),
+        }
+    }
 }
 
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
 struct NamedHardwareWalletAccount {
     name: String,
     principal: PrincipalId,
+    // transactions: Do not reuse this field. There are still accounts in stable memor with this unused field.
+}
+
+// TODO(NNS1-2905): Delete this after it has been on mainnet for at least 1 release.
+#[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
+struct OldNamedHardwareWalletAccount {
+    name: String,
+    principal: PrincipalId,
     transactions: Vec<TransactionIndex>,
+}
+
+impl From<NamedHardwareWalletAccount> for OldNamedHardwareWalletAccount {
+    fn from(hw_account: NamedHardwareWalletAccount) -> Self {
+        OldNamedHardwareWalletAccount {
+            name: hw_account.name,
+            principal: hw_account.principal,
+            transactions: Vec::new(),
+        }
+    }
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -544,7 +619,6 @@ impl AccountsStore {
                 account.hardware_wallet_accounts.push(NamedHardwareWalletAccount {
                     name: request.name,
                     principal: request.principal,
-                    transactions: Vec::new(),
                 });
                 account
                     .hardware_wallet_accounts
@@ -1204,7 +1278,6 @@ impl Account {
         Account {
             principal: Some(principal),
             account_identifier,
-            default_account_transactions: Vec::new(),
             sub_accounts: HashMap::new(),
             hardware_wallet_accounts: Vec::new(),
             canisters: Vec::new(),
@@ -1217,7 +1290,6 @@ impl NamedSubAccount {
         NamedSubAccount {
             name,
             account_identifier,
-            transactions: Vec::new(),
         }
     }
 }

--- a/rs/backend/src/accounts_store/schema/tests.rs
+++ b/rs/backend/src/accounts_store/schema/tests.rs
@@ -21,7 +21,6 @@ pub fn toy_account(account_index: u64, num_canisters: u64) -> Account {
     let mut account = Account {
         principal: Some(principal),
         account_identifier,
-        default_account_transactions: Vec::new(),
         sub_accounts: HashMap::new(),
         hardware_wallet_accounts: Vec::new(),
         canisters: Vec::new(),

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -1113,7 +1113,7 @@ fn old_account_can_be_decoded_to_new_account() {
     let expected_new_account = create_new_test_account_for_encoding();
     let old_account = OldAccount::from(expected_new_account.clone());
 
-    let bytes = Candid((old_account,)).into_bytes().unwrap();
+    let bytes = candid::encode_one(old_account).unwrap();
     let decoded_new_account = Account::from_bytes(Cow::Owned(bytes));
 
     assert_eq!(decoded_new_account, expected_new_account);
@@ -1139,7 +1139,7 @@ fn new_account_can_be_decoded_to_old_account() {
     let expected_old_account = OldAccount::from(new_account.clone());
 
     let bytes = new_account.to_bytes();
-    let (decoded_old_account,): (OldAccount,) = Candid::from_bytes(bytes.into_owned()).map(|c| c.0).unwrap();
+    let decoded_old_account: OldAccount = candid::decode_one(&bytes.into_owned()).unwrap();
 
     assert_eq!(decoded_old_account, expected_old_account);
 }

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -1067,14 +1067,81 @@ fn accounts_should_implement_storable() {
         ToyAccountSize {
             sub_accounts: 2,
             canisters: 3,
-            default_account_transactions: 4,
-            sub_account_transactions: 5,
             hardware_wallets: 6,
         },
     );
     let bytes = account.to_bytes();
     let parsed = Account::from_bytes(bytes);
     assert_eq!(account, parsed);
+}
+
+fn create_new_test_account_for_encoding() -> Account {
+    let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
+    let account_identifier = AccountIdentifier::from(principal);
+
+    let sub_principal = PrincipalId::from_str(TEST_ACCOUNT_2).unwrap();
+    let sub_account_identifier = AccountIdentifier::from(sub_principal);
+
+    let hw_principal = PrincipalId::from_str(TEST_ACCOUNT_3).unwrap();
+
+    let new_sub_account = NamedSubAccount {
+        name: "Sub1".to_string(),
+        account_identifier: sub_account_identifier,
+    };
+
+    let mut new_sub_accounts = HashMap::new();
+    new_sub_accounts.insert(1, new_sub_account);
+
+    let new_hw_account = NamedHardwareWalletAccount {
+        name: "HW1".to_string(),
+        principal: hw_principal,
+    };
+
+    Account {
+        principal: Some(principal),
+        account_identifier,
+        sub_accounts: new_sub_accounts,
+        hardware_wallet_accounts: vec![new_hw_account],
+        canisters: vec![],
+    }
+}
+
+#[test]
+fn old_account_can_be_decoded_to_new_account() {
+    // Test that after upgrading to the next release, we are able to decode the
+    // old accounts from stable memory.
+    let expected_new_account = create_new_test_account_for_encoding();
+    let old_account = OldAccount::from(expected_new_account.clone());
+
+    let bytes = Candid((old_account,)).into_bytes().unwrap();
+    let decoded_new_account = Account::from_bytes(Cow::Owned(bytes));
+
+    assert_eq!(decoded_new_account, expected_new_account);
+}
+
+#[test]
+fn new_account_can_be_decoded_to_new_account() {
+    // Test that after upgrading to the next release after the next release, we
+    // are able to decode the new accounts that were encoded as old accounts.
+    let expected_new_account = create_new_test_account_for_encoding();
+
+    let bytes = expected_new_account.to_bytes();
+    let decoded_new_account = Account::from_bytes(bytes);
+
+    assert_eq!(decoded_new_account, expected_new_account);
+}
+
+#[test]
+fn new_account_can_be_decoded_to_old_account() {
+    // Test that, in case we need to roll back after the next release, the
+    // previous version is able to decode accounts written by the next version.
+    let new_account = create_new_test_account_for_encoding();
+    let expected_old_account = OldAccount::from(new_account.clone());
+
+    let bytes = new_account.to_bytes();
+    let (decoded_old_account,): (OldAccount,) = Candid::from_bytes(bytes.into_owned()).map(|c| c.0).unwrap();
+
+    assert_eq!(decoded_old_account, expected_old_account);
 }
 
 crate::accounts_store::schema::tests::test_accounts_db!(AccountsStore::default());


### PR DESCRIPTION
# Motivation

We no longer store transactions in the nns-dapp canister because the frontend now reads transactions from the index canister.
However we still store transaction indexes on individual accounts. These indexes used to point into the vector of transactions which we no longer have and are now completely unused. So we want to clean these up.
Because these accounts are stored in stable memory we have to be careful about removing fields from them or we might get errors when decoding stable memory.
In particular, we should be able to revert to a previous release of nns-dapp in case of an emergency.
So we have to stop reading the fields at least 1 release before we stop writing the fields.
For this purpose we introduce "Old" types for each of the account types which still have the removed fields and use these types when writing to stable memory, while using types with the unused fields removed when reading.

Once we have a release with this code, we can remove the "Old" types and read and write without the unused fields.
There will still be accounts in stable memory with the unused data but it will be ignored on reading and removed on writing.

# Changes

1. Add `OldAccount` which is a copy of `Account` (as before this PR).
2. Add `OldNamedSubAccount` which is a copy of `NamedSubAccount` (as before this PR).
3. Add `OldNamedHardwareWalletAccount` which is a copy of `NamedHardwareWalletAccount` (as before this PR).
4. Remove `default_account_transactions` from `Account`.
5. Remove `transactions` from `NamedSubAccount` and from `NamedHardwareWalletAccount`.
6. In `Storable::to_bytes` for `Account`, convert to `OldAccount` before encoding.
7. Stop populating transactions fields (which no longer exist) when creating toy accounts for testing.

# Tests

1. Unit tests added to convert old to new and new to old accounts and to decode an encoded new account to a new account.
2. `upgrade-downgrade-test` passes.
3. Tested upgrade and downgrade manually.
4. Prepared [branch with future clean](https://github.com/dfinity/nns-dapp/pull/4836) up and tested (manually and with `upgrade-downgrade-test`) upgrade and downgrade between this branch and that one.
5. Also tested upgrading directly to the final branch and noticed that it had the expected problems.

# Todos

- [x] Add entry to changelog (if necessary).
