### PR TITLE
fix: hidden TVL below 1200 px

### DIFF
--- a/frontend/src/lib/components/common/MenuMetrics.svelte
+++ b/frontend/src/lib/components/common/MenuMetrics.svelte
@@ -50,8 +50,8 @@
     }
 
     &.sticky {
-      // On xlarge screen the menu can be always open
-      @include media.min-width(xlarge) {
+      // On large screen the menu can be always open
+      @include media.min-width(large) {
         @include open;
       }
     }


### PR DESCRIPTION
# Motivation

The TVL block is hidden when the viewport is less than 1200px wide.

# Changes

- Open it starting from `large` breakpoint instead of `xlarge`

# Tests

- Manually.

# Todos

- [x] Add entry to changelog (if necessary).

# Screenshots

| Before | After |
|--------|--------|
| https://github.com/dfinity/nns-dapp/assets/98811342/ddc33f92-413a-41f0-bc5e-cb97e9862068 | https://github.com/dfinity/nns-dapp/assets/98811342/e6925892-0f5d-456a-ab73-23f4274e8588 | 









