### PR TITLE
New actionableProposalTotalCount Store

### DIFF
--- a/frontend/src/lib/derived/actionable-proposals.derived.ts
+++ b/frontend/src/lib/derived/actionable-proposals.derived.ts
@@ -40,6 +40,13 @@ export const actionableProposalCountStore: Readable<ActionableProposalCountData>
     })
   );
 
+/** A store that contains a total count of all actionable proposals (nns + snses) */
+export const actionableProposalTotalCountStore: Readable<number> = derived(
+  actionableProposalCountStore,
+  (map) =>
+    Object.values(map).reduce((acc: number, count) => acc + (count ?? 0), 0)
+);
+
 export interface ActionableProposalSupportData {
   // We use the root canister id as the key to identify the actionable proposals support for a specific project.
   [rootCanisterId: string]: boolean | undefined;

--- a/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
@@ -4,6 +4,7 @@ import {
   actionableProposalCountStore,
   actionableProposalIndicationEnabledStore,
   actionableProposalSupportedStore,
+  actionableProposalTotalCountStore,
 } from "$lib/derived/actionable-proposals.derived";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
@@ -145,6 +146,53 @@ describe("actionable proposals derived stores", () => {
         [OWN_CANISTER_ID_TEXT]: true,
         [principal0.toText()]: true,
         [principal1.toText()]: false,
+      });
+    });
+
+    describe("actionableProposalTotalCountStore", () => {
+      const nnsProposals: ProposalInfo[] = [
+        {
+          ...mockProposalInfo,
+          id: 0n,
+        },
+        {
+          ...mockProposalInfo,
+          id: 1n,
+        },
+      ];
+      const snsProposals = [mockSnsProposal];
+      const principal0 = principal(0);
+      const principal1 = principal(1);
+      const principal2 = principal(2);
+
+      beforeEach(() => {
+        actionableNnsProposalsStore.reset();
+        actionableSnsProposalsStore.resetForTesting();
+      });
+
+      it("returns total actionable proposal count", async () => {
+        expect(get(actionableProposalTotalCountStore)).toEqual(0);
+
+        actionableNnsProposalsStore.setProposals(nnsProposals);
+        actionableSnsProposalsStore.set({
+          rootCanisterId: principal0,
+          proposals: snsProposals,
+          includeBallotsByCaller: true,
+        });
+        actionableSnsProposalsStore.set({
+          rootCanisterId: principal1,
+          proposals: snsProposals,
+          includeBallotsByCaller: true,
+        });
+        actionableSnsProposalsStore.set({
+          rootCanisterId: principal2,
+          proposals: [],
+          includeBallotsByCaller: false,
+        });
+
+        expect(get(actionableProposalTotalCountStore)).toEqual(
+          nnsProposals.length + snsProposals.length * 2
+        );
       });
     });
   });

--- a/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
@@ -186,7 +186,8 @@ describe("actionable proposals derived stores", () => {
         });
         actionableSnsProposalsStore.set({
           rootCanisterId: principal2,
-          proposals: [],
+          proposals: snsProposals,
+          // this flag produces undefined count
           includeBallotsByCaller: false,
         });
 


### PR DESCRIPTION
# Motivation

A new store to get a total number of all actionable proposals.

# Changes

- `actionableProposalTotalCountStore`

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not needed.