### PR TITLE
Actionable proposals total badge

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Add new proposal types support (47-51)
 * Message informing about proposal topic changes.
 * Tooltips with exact voting power on voted neurons.
+* Display the total count of actionable proposals.
 
 #### Changed
 

--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -21,6 +21,7 @@
   import { pageStore } from "$lib/derived/page.derived";
   import { isSelectedPath } from "$lib/utils/navigation.utils";
   import MenuMetrics from "$lib/components/common/MenuMetrics.svelte";
+  import ActionableProposalTotalCountBadge from "$lib/components/proposals/ActionableProposalTotalCountBadge.svelte";
 
   let routes: {
     context: string;
@@ -65,6 +66,7 @@
       }),
       title: $i18n.navigation.voting,
       icon: IconVote,
+      statusIcon: ActionableProposalTotalCountBadge,
     },
     {
       context: "launchpad",

--- a/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
@@ -12,6 +12,7 @@
 
   export let count: number;
   export let universe: Universe;
+  export let noAnimation = false;
 
   let tooltipText = "";
   $: tooltipText = isUniverseNns(Principal.fromText(universe.canisterId))
@@ -24,7 +25,7 @@
 </script>
 
 <TestIdWrapper testId="actionable-proposal-count-badge-component">
-  {#if mounted}
+  {#if noAnimation || mounted}
     <Tooltip
       id="actionable-count-tooltip"
       text={replacePlaceholders(tooltipText, {

--- a/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
@@ -14,21 +14,25 @@
   export let universe: Universe | "all";
   export let noAnimation = false;
 
+  let isTotal = false;
+  $: isTotal = universe === "all";
+
   let tooltipText = "";
-  $: tooltipText =
-    universe === "all"
-      ? replacePlaceholders($i18n.voting.total_actionable_proposal_tooltip, {
-          $count: `${count}`,
-        })
-      : replacePlaceholders(
-          isUniverseNns(Principal.fromText(universe.canisterId))
-            ? $i18n.voting.nns_actionable_proposal_tooltip
-            : $i18n.voting.sns_actionable_proposal_tooltip,
-          {
-            $count: `${count}`,
-            $snsName: universe.title,
-          }
-        );
+  $: tooltipText = isTotal
+    ? // Total
+      replacePlaceholders($i18n.voting.total_actionable_proposal_tooltip, {
+        $count: `${count}`,
+      })
+    : isUniverseNns(Principal.fromText(universe.canisterId))
+    ? // NNS
+      replacePlaceholders($i18n.voting.nns_actionable_proposal_tooltip, {
+        $count: `${count}`,
+      })
+    : // SNS
+      replacePlaceholders($i18n.voting.sns_actionable_proposal_tooltip, {
+        $count: `${count}`,
+        $snsName: universe.title,
+      });
 
   // Always rerender to trigger animation start
   let mounted = false;

--- a/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
@@ -20,25 +20,23 @@
 
   let tooltipId = `actionable-count-tooltip-${nextTooltipIdNumber++}`;
 
-  let isTotal = false;
-  $: isTotal = universe === "all";
-
   let tooltipText = "";
-  $: tooltipText = isTotal
-    ? // Total
-      replacePlaceholders($i18n.voting.total_actionable_proposal_tooltip, {
-        $count: `${count}`,
-      })
-    : isUniverseNns(Principal.fromText(universe.canisterId))
-    ? // NNS
-      replacePlaceholders($i18n.voting.nns_actionable_proposal_tooltip, {
-        $count: `${count}`,
-      })
-    : // SNS
-      replacePlaceholders($i18n.voting.sns_actionable_proposal_tooltip, {
-        $count: `${count}`,
-        $snsName: universe.title,
-      });
+  $: tooltipText =
+    universe === "all"
+      ? // Total
+        replacePlaceholders($i18n.voting.total_actionable_proposal_tooltip, {
+          $count: `${count}`,
+        })
+      : isUniverseNns(Principal.fromText(universe.canisterId))
+      ? // NNS
+        replacePlaceholders($i18n.voting.nns_actionable_proposal_tooltip, {
+          $count: `${count}`,
+        })
+      : // SNS
+        replacePlaceholders($i18n.voting.sns_actionable_proposal_tooltip, {
+          $count: `${count}`,
+          $snsName: universe.title,
+        });
 
   // Always rerender to trigger animation start
   let mounted = false;

--- a/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
@@ -5,7 +5,6 @@
 <script lang="ts">
   import { scale } from "svelte/transition";
   import { cubicOut } from "svelte/easing";
-  import { onMount } from "svelte";
   import { Tooltip } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -16,7 +15,6 @@
 
   export let count: number;
   export let universe: Universe | "all";
-  export let noAnimation = false;
 
   let tooltipId = `actionable-count-tooltip-${nextTooltipIdNumber++}`;
 
@@ -37,25 +35,19 @@
           $count: `${count}`,
           $snsName: universe.title,
         });
-
-  // Always rerender to trigger animation start
-  let mounted = false;
-  onMount(() => (mounted = true));
 </script>
 
 <TestIdWrapper testId="actionable-proposal-count-badge-component">
-  {#if noAnimation || mounted}
-    <Tooltip id={tooltipId} text={tooltipText} top={true}
-      ><span
-        transition:scale={{
-          duration: 250,
-          easing: cubicOut,
-        }}
-        class="tag"
-        role="status">{count}</span
-      ></Tooltip
-    >
-  {/if}
+  <Tooltip id={tooltipId} text={tooltipText} top={true}
+    ><span
+      transition:scale={{
+        duration: 250,
+        easing: cubicOut,
+      }}
+      class="tag"
+      role="status">{count}</span
+    ></Tooltip
+  >
 </TestIdWrapper>
 
 <style lang="scss">

--- a/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
@@ -11,13 +11,19 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let count: number;
-  export let universe: Universe;
+  export let universe: Universe | "all";
   export let noAnimation = false;
 
   let tooltipText = "";
-  $: tooltipText = isUniverseNns(Principal.fromText(universe.canisterId))
-    ? $i18n.voting.nns_actionable_proposal_tooltip
-    : $i18n.voting.sns_actionable_proposal_tooltip;
+  $: tooltipText =
+    universe === "all"
+      ? $i18n.voting.total_actionable_proposal_tooltip
+      : isUniverseNns(Principal.fromText(universe.canisterId))
+      ? $i18n.voting.nns_actionable_proposal_tooltip
+      : $i18n.voting.sns_actionable_proposal_tooltip;
+
+  let snsName = "";
+  $: snsName = universe === "all" ? "" : universe.title;
 
   // Always rerender to trigger animation start
   let mounted = false;
@@ -30,7 +36,7 @@
       id="actionable-count-tooltip"
       text={replacePlaceholders(tooltipText, {
         $count: `${count}`,
-        $snsName: universe.title,
+        $snsName: snsName,
       })}
       top={true}
       ><span

--- a/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
@@ -1,7 +1,3 @@
-<script lang="ts" context="module">
-  let nextTooltipIdNumber = 0;
-</script>
-
 <script lang="ts">
   import { scale } from "svelte/transition";
   import { cubicOut } from "svelte/easing";
@@ -15,8 +11,6 @@
 
   export let count: number;
   export let universe: Universe | "all";
-
-  let tooltipId = `actionable-count-tooltip-${nextTooltipIdNumber++}`;
 
   let tooltipText = "";
   $: tooltipText =
@@ -38,7 +32,7 @@
 </script>
 
 <TestIdWrapper testId="actionable-proposal-count-badge-component">
-  <Tooltip id={tooltipId} text={tooltipText} top={true}
+  <Tooltip id="actionable-count-tooltip" text={tooltipText} top={true}
     ><span
       transition:scale={{
         duration: 250,

--- a/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
@@ -17,13 +17,18 @@
   let tooltipText = "";
   $: tooltipText =
     universe === "all"
-      ? $i18n.voting.total_actionable_proposal_tooltip
-      : isUniverseNns(Principal.fromText(universe.canisterId))
-      ? $i18n.voting.nns_actionable_proposal_tooltip
-      : $i18n.voting.sns_actionable_proposal_tooltip;
-
-  let snsName = "";
-  $: snsName = universe === "all" ? "" : universe.title;
+      ? replacePlaceholders($i18n.voting.total_actionable_proposal_tooltip, {
+          $count: `${count}`,
+        })
+      : replacePlaceholders(
+          isUniverseNns(Principal.fromText(universe.canisterId))
+            ? $i18n.voting.nns_actionable_proposal_tooltip
+            : $i18n.voting.sns_actionable_proposal_tooltip,
+          {
+            $count: `${count}`,
+            $snsName: universe.title,
+          }
+        );
 
   // Always rerender to trigger animation start
   let mounted = false;
@@ -32,13 +37,7 @@
 
 <TestIdWrapper testId="actionable-proposal-count-badge-component">
   {#if noAnimation || mounted}
-    <Tooltip
-      id="actionable-count-tooltip"
-      text={replacePlaceholders(tooltipText, {
-        $count: `${count}`,
-        $snsName: snsName,
-      })}
-      top={true}
+    <Tooltip id="actionable-count-tooltip" text={tooltipText} top={true}
       ><span
         transition:scale={{
           duration: 250,

--- a/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
@@ -1,3 +1,7 @@
+<script lang="ts" context="module">
+  let nextTooltipIdNumber = 0;
+</script>
+
 <script lang="ts">
   import { scale } from "svelte/transition";
   import { cubicOut } from "svelte/easing";
@@ -13,6 +17,8 @@
   export let count: number;
   export let universe: Universe | "all";
   export let noAnimation = false;
+
+  let tooltipId = `actionable-count-tooltip-${nextTooltipIdNumber++}`;
 
   let isTotal = false;
   $: isTotal = universe === "all";
@@ -41,7 +47,7 @@
 
 <TestIdWrapper testId="actionable-proposal-count-badge-component">
   {#if noAnimation || mounted}
-    <Tooltip id="actionable-count-tooltip" text={tooltipText} top={true}
+    <Tooltip id={tooltipId} text={tooltipText} top={true}
       ><span
         transition:scale={{
           duration: 250,

--- a/frontend/src/lib/components/proposals/ActionableProposalTotalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalTotalCountBadge.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import ActionableProposalCountBadge from "$lib/components/proposals/ActionableProposalCountBadge.svelte";
+  import { actionableProposalTotalCountStore } from "$lib/derived/actionable-proposals.derived";
+  import { nonNullish } from "@dfinity/utils";
+  import { cubicOut } from "svelte/easing";
+  import { scale } from "svelte/transition";
+
+  let count = 0;
+  $: count = $actionableProposalTotalCountStore;
+</script>
+
+{#if nonNullish(count) && count > 0}
+  <div
+    transition:scale={{
+      duration: 250,
+      easing: cubicOut,
+    }}
+  >
+    <ActionableProposalCountBadge {count} universe="all" noAnimation />
+  </div>
+{/if}

--- a/frontend/src/lib/components/proposals/ActionableProposalTotalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalTotalCountBadge.svelte
@@ -2,20 +2,11 @@
   import ActionableProposalCountBadge from "$lib/components/proposals/ActionableProposalCountBadge.svelte";
   import { actionableProposalTotalCountStore } from "$lib/derived/actionable-proposals.derived";
   import { nonNullish } from "@dfinity/utils";
-  import { cubicOut } from "svelte/easing";
-  import { scale } from "svelte/transition";
 
   let count = 0;
   $: count = $actionableProposalTotalCountStore;
 </script>
 
 {#if nonNullish(count) && count > 0}
-  <div
-    transition:scale={{
-      duration: 250,
-      easing: cubicOut,
-    }}
-  >
-    <ActionableProposalCountBadge {count} universe="all" noAnimation />
-  </div>
+  <ActionableProposalCountBadge {count} universe="all" />
 {/if}

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -17,6 +17,7 @@
   import { nonNullish } from "@dfinity/utils";
   import { i18n } from "$lib/stores/i18n";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import { onMount } from "svelte";
 
   export let selected: boolean;
   // "link" for desktop, "button" for mobile, "dropdown" to open the modal
@@ -43,6 +44,10 @@
   $: actionableProposalSupported = $ENABLE_VOTING_INDICATION
     ? $actionableProposalSupportedStore[universe.canisterId]
     : undefined;
+
+  // Always rerender to trigger animation start
+  let mounted = false;
+  onMount(() => (mounted = true));
 </script>
 
 <Card
@@ -65,7 +70,7 @@
       <span class="name">
         {universe.title}
         {#if $ENABLE_VOTING_INDICATION && $actionableProposalIndicationEnabledStore}
-          {#if nonNullish(actionableProposalCount) && actionableProposalCount > 0}
+          {#if nonNullish(actionableProposalCount) && actionableProposalCount > 0 && mounted}
             <ActionableProposalCountBadge
               count={actionableProposalCount}
               {universe}

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -377,7 +377,7 @@
     "actionable_proposals": "Actionable Proposals",
     "nns_actionable_proposal_tooltip": "There are $count NNS proposals you can vote on.",
     "sns_actionable_proposal_tooltip": "There are $count $snsName proposals you can vote on.",
-    "total_actionable_proposal_tooltip": "There are a total of $count proposals on which you can vote.",
+    "total_actionable_proposal_tooltip": "There are a total of $count proposals you can vote on.",
     "is_actionable_status_badge_tooltip": "You can still vote on this proposal."
   },
   "actionable_proposals_sign_in": {

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -377,6 +377,7 @@
     "actionable_proposals": "Actionable Proposals",
     "nns_actionable_proposal_tooltip": "There are $count NNS proposals you can vote on.",
     "sns_actionable_proposal_tooltip": "There are $count $snsName proposals you can vote on.",
+    "total_actionable_proposal_tooltip": "There are a total of $count proposals on which you can vote.",
     "is_actionable_status_badge_tooltip": "You can still vote on this proposal."
   },
   "actionable_proposals_sign_in": {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -391,6 +391,7 @@ interface I18nVoting {
   actionable_proposals: string;
   nns_actionable_proposal_tooltip: string;
   sns_actionable_proposal_tooltip: string;
+  total_actionable_proposal_tooltip: string;
   is_actionable_status_badge_tooltip: string;
 }
 

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -136,5 +136,18 @@ describe("MenuItems", () => {
           .getTooltipText()
       ).toEqual("There are a total of 3 proposals you can vote on.");
     });
+
+    it("should not display actionable proposal count when no proposal available", async () => {
+      page.mock({
+        data: { universe: OWN_CANISTER_ID_TEXT },
+        routeId: AppPath.Neurons,
+      });
+
+      const po = renderComponent();
+
+      expect(await po.getProposalsActionableCountBadgePo().isPresent()).toBe(
+        false
+      );
+    });
   });
 });

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -129,6 +129,12 @@ describe("MenuItems", () => {
       expect(
         (await po.getProposalsActionableCountBadgePo().getText()).trim()
       ).toEqual("3");
+      expect(
+        await po
+          .getProposalsActionableCountBadgePo()
+          .getTooltipPo()
+          .getTooltipText()
+      ).toEqual("There are a total of 3 proposals you can vote on.");
     });
   });
 });

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -1,9 +1,18 @@
 import MenuItems from "$lib/components/common/MenuItems.svelte";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
+import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
+import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { page } from "$mocks/$app/stores";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockProposalInfo } from "$tests/mocks/proposal.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
+import { MenuItemsPo } from "$tests/page-objects/MenuItems.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import type { ProposalInfo } from "@dfinity/nns";
 import { render } from "@testing-library/svelte";
 
 vi.mock("$lib/services/$public/worker-metrics.services", () => ({
@@ -20,6 +29,10 @@ vi.mock("$lib/services/$public/worker-metrics.services", () => ({
 }));
 
 describe("MenuItems", () => {
+  const renderComponent = (): MenuItemsPo => {
+    const { container } = render(MenuItems);
+    return MenuItemsPo.under(new JestPageObjectElement(container));
+  };
   const shouldRenderMenuItem = ({
     context,
     labelKey,
@@ -73,6 +86,49 @@ describe("MenuItems", () => {
 
       const accountsLink = getByTestId("menuitem-accounts");
       expect(accountsLink.classList.contains("selected")).toBe(true);
+    });
+  });
+
+  describe("actionable proposal count badge", () => {
+    const nnsProposals: ProposalInfo[] = [
+      {
+        ...mockProposalInfo,
+        id: 0n,
+      },
+      {
+        ...mockProposalInfo,
+        id: 1n,
+      },
+    ];
+    const snsProposals = [mockSnsProposal];
+    const snsRootCanisterId = principal(0);
+
+    beforeEach(() => {
+      resetIdentity();
+      actionableNnsProposalsStore.reset();
+      actionableSnsProposalsStore.resetForTesting();
+    });
+
+    it("should display actionable proposal count", async () => {
+      page.mock({
+        data: { universe: OWN_CANISTER_ID_TEXT },
+        routeId: AppPath.Neurons,
+      });
+      actionableNnsProposalsStore.setProposals(nnsProposals);
+      actionableSnsProposalsStore.set({
+        rootCanisterId: snsRootCanisterId,
+        proposals: snsProposals,
+        includeBallotsByCaller: true,
+      });
+
+      const po = renderComponent();
+
+      expect(await po.getProposalsActionableCountBadgePo().isPresent()).toBe(
+        true
+      );
+      expect(
+        (await po.getProposalsActionableCountBadgePo().getText()).trim()
+      ).toEqual("3");
     });
   });
 });

--- a/frontend/src/tests/page-objects/MenuItems.page-object.ts
+++ b/frontend/src/tests/page-objects/MenuItems.page-object.ts
@@ -1,5 +1,6 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { ActionableProposalCountBadgePo } from "$tests/page-objects/ActionableProposalCountBadge.page-object";
 import { GetTokensPo } from "$tests/page-objects/GetTokens.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class MenuItemsPo extends BasePageObject {
@@ -7,6 +8,10 @@ export class MenuItemsPo extends BasePageObject {
 
   static under(element: PageObjectElement): MenuItemsPo {
     return new MenuItemsPo(element.byTestId(MenuItemsPo.TID));
+  }
+
+  getProposalsActionableCountBadgePo(): ActionableProposalCountBadgePo {
+    return ActionableProposalCountBadgePo.under(this.root);
   }
 
   clickAccounts(): Promise<void> {


### PR DESCRIPTION
# Motivation

Display the total count of actionable proposals in main navigation.

# Changes

- Add new total count tooltip support to the count badge.
- Add `noAnimation` prop to skip animation (on navigation).
- New component `ActionableProposalTotalCountBadge`.
- Add the count badge to the main menu.

# Tests

- MainMenu should display `ActionableProposalTotalCountBadge`.

# Todos

- [x] Add entry to changelog (if necessary).

# Screenshot

<img width="515" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/a9fb47f3-9da4-4045-aa71-112778ff9f79">
