### PR TITLE
Improve did2rs and update aggregator candid bindings

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -50,10 +50,14 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Automatically handle `candid::define_function` in `did2rs`.
+
 #### Deprecated
 
 #### Removed
 
 #### Fixed
+
+* Make `did2rs` work on Mac.
 
 #### Security

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_governance --out ic_sns_governance.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/sns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
@@ -135,6 +135,7 @@ pub struct RewardEvent {
     pub rounds_since_last_distribution: Option<u64>,
     pub actual_timestamp_seconds: u64,
     pub end_timestamp_seconds: Option<u64>,
+    pub total_available_e8s_equivalent: Option<u64>,
     pub distributed_e8s_equivalent: u64,
     pub round: u64,
     pub settled_proposals: Vec<ProposalId>,

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,20 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index c68feb87d..e482df83a 100644
+index 6b8559267..fb6f8d68e 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-@@ -113,17 +113,15 @@ pub struct BlockRange {
-     pub blocks: Vec<Block>,
- }
- 
--candid::define_function!(pub QueryBlockArchiveFn : (GetBlocksArgs) -> (
--    BlockRange,
--  ) query);
--#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-+pub type QueryBlockArchiveFn = candid::Func;
-+#[derive(CandidType, Deserialize)]
- pub struct GetBlocksResponseArchivedBlocksItem {
-     pub callback: QueryBlockArchiveFn,
-     pub start: BlockIndex,
+@@ -130,7 +130,7 @@ pub struct GetBlocksResponseArchivedBlocksItem {
      pub length: candid::Nat,
  }
  
@@ -23,19 +11,7 @@ index c68feb87d..e482df83a 100644
  pub struct GetBlocksResponse {
      pub certificate: Option<serde_bytes::ByteBuf>,
      pub first_index: BlockIndex,
-@@ -201,17 +199,15 @@ pub struct TransactionRange {
-     pub transactions: Vec<Transaction>,
- }
- 
--candid::define_function!(pub QueryArchiveFn : (GetTransactionsRequest) -> (
--    TransactionRange,
--  ) query);
--#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-+pub type QueryArchiveFn = candid::Func;
-+#[derive(CandidType, Deserialize)]
- pub struct GetTransactionsResponseArchivedTransactionsItem {
-     pub callback: QueryArchiveFn,
-     pub start: TxIndex,
+@@ -216,7 +216,7 @@ pub struct GetTransactionsResponseArchivedTransactionsItem {
      pub length: candid::Nat,
  }
  

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,8 +1,8 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index 6b8559267..fb6f8d68e 100644
+index 8ffaeb573..182a57e26 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-@@ -130,7 +130,7 @@ pub struct GetBlocksResponseArchivedBlocksItem {
+@@ -143,7 +143,7 @@ pub struct GetBlocksResponseArchivedBlocksItem {
      pub length: candid::Nat,
  }
  
@@ -11,7 +11,7 @@ index 6b8559267..fb6f8d68e 100644
  pub struct GetBlocksResponse {
      pub certificate: Option<serde_bytes::ByteBuf>,
      pub first_index: BlockIndex,
-@@ -216,7 +216,7 @@ pub struct GetTransactionsResponseArchivedTransactionsItem {
+@@ -229,7 +229,7 @@ pub struct GetTransactionsResponseArchivedTransactionsItem {
      pub length: candid::Nat,
  }
  
@@ -20,3 +20,12 @@ index 6b8559267..fb6f8d68e 100644
  pub struct GetTransactionsResponse {
      pub first_index: TxIndex,
      pub log_length: candid::Nat,
+@@ -381,7 +381,7 @@ pub struct GetBlocksResultArchivedBlocksItem {
+     pub callback: GetBlocksResultArchivedBlocksItemCallback,
+ }
+ 
+-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
++#[derive(CandidType, Deserialize)]
+ pub struct GetBlocksResult {
+     pub log_length: candid::Nat,
+     pub blocks: Vec<GetBlocksResultBlocksItem>,

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -381,7 +381,7 @@ pub struct GetBlocksResultArchivedBlocksItem {
     pub callback: GetBlocksResultArchivedBlocksItemCallback,
 }
 
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+#[derive(CandidType, Deserialize)]
 pub struct GetBlocksResult {
     pub log_length: candid::Nat,
     pub blocks: Vec<GetBlocksResultBlocksItem>,

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_root --out ic_sns_root.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/sns/root/canister/root.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
@@ -45,7 +45,11 @@ pub enum CanisterStatusType {
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DefiniteCanisterSettings {
+    pub freezing_threshold: Option<candid::Nat>,
     pub controllers: Vec<Principal>,
+    pub reserved_cycles_limit: Option<candid::Nat>,
+    pub memory_allocation: Option<candid::Nat>,
+    pub compute_allocation: Option<candid::Nat>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -54,7 +58,9 @@ pub struct CanisterStatusResult {
     pub memory_size: candid::Nat,
     pub cycles: candid::Nat,
     pub settings: DefiniteCanisterSettings,
+    pub idle_cycles_burned_per_day: Option<candid::Nat>,
     pub module_hash: Option<serde_bytes::ByteBuf>,
+    pub reserved_cycles: Option<candid::Nat>,
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_swap --out ic_sns_swap.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/sns/swap/canister/swap.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out ic_sns_wasm.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-03_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
@@ -300,6 +300,34 @@ pub struct GetWasmResponse {
 }
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct GetWasmMetadataRequest {
+    pub hash: Option<serde_bytes::ByteBuf>,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct MetadataSection {
+    pub contents: Option<serde_bytes::ByteBuf>,
+    pub name: Option<String>,
+    pub visibility: Option<String>,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Ok {
+    pub sections: Vec<MetadataSection>,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub enum Result1 {
+    Ok(Ok),
+    Error(SnsWasmError),
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct GetWasmMetadataResponse {
+    pub result: Option<Result1>,
+}
+
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SnsUpgrade {
     pub next_version: Option<SnsVersion>,
     pub current_version: Option<SnsVersion>,
@@ -414,6 +442,9 @@ impl Service {
     }
     pub async fn get_wasm(&self, arg0: GetWasmRequest) -> CallResult<(GetWasmResponse,)> {
         ic_cdk::call(self.0, "get_wasm", (arg0,)).await
+    }
+    pub async fn get_wasm_metadata(&self, arg0: GetWasmMetadataRequest) -> CallResult<(GetWasmMetadataResponse,)> {
+        ic_cdk::call(self.0, "get_wasm_metadata", (arg0,)).await
     }
     pub async fn insert_upgrade_path_entries(
         &self,

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -109,6 +109,7 @@ fi
   #     These are changed to legal Rust: `StopDissolving(EmptyRecord),`
   #     where "EmptyRecord" is defined as the name suggests.
   #   - Deprecated: Uses `candid::Principal` instead of `Principal`.
+  #   - Change creating callback types with `candid::define_function!` to `pub type ... = candid::Func;`
   #
   # Final tweaks are defined manually and encoded as patch files.  The changes typically include:
   #   - Replacing the anonymous result{} type in enums with EmptyRecord.  didc produces valid rust code, but

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -52,6 +52,12 @@ DID_PATH="${DID_PATH:-${GIT_ROOT}/declarations/${CANISTER_NAME}/${CANISTER_NAME}
 
 cd "$GIT_ROOT"
 
+if [[ "$(uname)" == "Darwin" ]]; then
+  sed="gsed"
+else
+  sed="sed"
+fi
+
 : "Ensure that tools are installed and working.  Rustfmt in particular can self-upgrade when called and the self-upgrade can fail."
 {
   didc --version
@@ -67,7 +73,7 @@ cd "$GIT_ROOT"
 
   # We preserve lines starting `//!` at the head of the .did file.
   # These are used to provide information about provenance.
-  sed -nE '/\/\/!/{p;b;};q' "${DID_PATH}"
+  "$sed" -nE '/\/\/!/{p;b;};q' "${DID_PATH}"
 
   # Here we write the next few lines of the Rust file.
   #
@@ -113,7 +119,7 @@ cd "$GIT_ROOT"
   # shellcheck disable=SC2016
   didc bind "${DID_PATH}" --target rs |
     rustfmt --edition 2021 |
-    sed -E '
+    "$sed" -E '
             # Comment out the header "use", "//!" and "#!" lines.
 	    s@^(use |//!|#!)@// &@;
 
@@ -130,6 +136,7 @@ cd "$GIT_ROOT"
 	    # Replace invalid "{}" in generated Rust code with "EmptyRecord":
 	    /^pub (struct|enum) /,/^}/{s/ *\{\},$/(EmptyRecord),/g};
 	    ' |
+    "$sed" -z 's/candid::define_function!(pub \([^ ]*\) [^;]*;\n#\[derive([^)]*)\]/pub type \1 = candid::Func;\n#[derive(CandidType, Deserialize)]/g' |
     rustfmt --edition 2021
 } >"${RUST_PATH}"
 if test -f "${EDIT_PATH}"; then

--- a/scripts/sns/aggregator/mk_nns_patch.sh
+++ b/scripts/sns/aggregator/mk_nns_patch.sh
@@ -2,6 +2,12 @@
 set -euo pipefail
 SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../.."
 
+if [[ "$(uname)" == "Darwin" ]]; then
+  sed="gsed"
+else
+  sed="sed"
+fi
+
 # Checks whether we have the .did file for a canister.
 #
 # # Input
@@ -21,7 +27,7 @@ filter_has_canister_did() {
 #
 # E.g. rs/sns_aggregator/src/types/ic_sns_governance.rs -> sns_governance
 canister_name_from_aggregator_type_path() {
-  sed -nr 's@.*/ic_(.*).rs$@\1@g;ta;b;:a;p'
+  "$sed" -nr 's@.*/ic_(.*).rs$@\1@g;ta;b;:a;p'
 }
 
 GIT_ROOT="$(git rev-parse --show-toplevel)"


### PR DESCRIPTION
# Motivation

The latest automatically generated candid bindings update PR had errors on CI: https://github.com/dfinity/nns-dapp/pull/4792
The problem was that the latest [sns_ledger.did](https://github.com/dfinity/nns-dapp/blob/main/declarations/sns_ledger/sns_ledger.did) adds a type `GetBlocksResult` which has a field that is a callback.
This type is not found by Rust after the bindings are generated.

We already had similar issues before and they were solved with an additional [patch file](https://github.com/dfinity/nns-dapp/blob/abf9d48de02a9c4ebd8ed9da897601601395a1aa/rs/sns_aggregator/src/types/ic_sns_ledger.patch#L9).

So the current issue could have been fixed by adding more changes to the patch file. But to make things easier in the future, I decided to make the callback handling automatic.

# Changes

1. Make `did2rs` work on Mac by calling `gsed` instead of `sed` on Mac (might requires installing `gsed` and `gawk`).
2. Add an extra `sed` step which the `candid::define_function` definition to a `candid::Func` and removes additional traits that can't be applied to the callback.
3. Regenerate the patch file with `scripts/sns/aggregator/mk_nns_patch.sh` to see that some of the patches are no longer necessary.
4. Run `scripts/sns/aggregator/mk_nns_types.sh` (as the automated PR would) to see that it no longer causes build issues.
5. Manually remove `Serialize, Clone, Debug,` from `GetBlocksResult` because it also can't be serialized because of the `archived_blocks` field.
6. Regenerate patches again.

# Tests

CI passes.

# Todos

- [x] Add entry to changelog (if necessary).
