### PR TITLE
Actionable count tooltip

### DIFF
--- a/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
@@ -1,3 +1,7 @@
+<script lang="ts" context="module">
+  let nextTooltipIdNumber = 0;
+</script>
+
 <script lang="ts">
   import { scale } from "svelte/transition";
   import { cubicOut } from "svelte/easing";
@@ -11,6 +15,8 @@
 
   export let count: number;
   export let universe: Universe | "all";
+
+  let tooltipId = `actionable-count-tooltip-${nextTooltipIdNumber++}`;
 
   let tooltipText = "";
   $: tooltipText =
@@ -32,7 +38,7 @@
 </script>
 
 <TestIdWrapper testId="actionable-proposal-count-badge-component">
-  <Tooltip id="actionable-count-tooltip" text={tooltipText} top={true}
+  <Tooltip id={tooltipId} text={tooltipText} top={true}
     ><span
       transition:scale={{
         duration: 250,

--- a/frontend/src/tests/lib/components/proposals/ActionableProposalCountBadge.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/ActionableProposalCountBadge.spec.ts
@@ -1,0 +1,64 @@
+import ActionableProposalCountBadge from "$lib/components/proposals/ActionableProposalCountBadge.svelte";
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { mockUniverse } from "$tests/mocks/sns-projects.mock";
+import { ActionableProposalCountBadgePo } from "$tests/page-objects/ActionableProposalCountBadge.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+
+describe("ActionableProposalCountBadge", () => {
+  const renderComponent = (props) => {
+    const { container } = render(ActionableProposalCountBadge, {
+      props,
+    });
+
+    return ActionableProposalCountBadgePo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should render a proposal count", async () => {
+    const po = renderComponent({ count: 5, universe: mockUniverse });
+    expect(await po.isPresent()).toEqual(true);
+    expect((await po.getText()).trim()).toEqual("5");
+  });
+
+  it("should have Sns tooltip", async () => {
+    const po = renderComponent({ count: 5, universe: mockUniverse });
+    expect(await po.getTooltipPo().isPresent()).toEqual(true);
+    expect(await po.getTooltipPo().getTooltipText()).toEqual(
+      "There are 5 Tetris proposals you can vote on."
+    );
+  });
+
+  it("should have Nns tooltip", async () => {
+    const po1 = renderComponent({
+      count: 5,
+      universe: {
+        ...mockUniverse,
+        canisterId: OWN_CANISTER_ID_TEXT,
+      },
+    });
+    expect(await po1.getTooltipPo().getTooltipText()).toEqual(
+      "There are 5 NNS proposals you can vote on."
+    );
+  });
+
+  it("should have total tooltip", async () => {
+    const po2 = renderComponent({
+      count: 5,
+      universe: "all",
+    });
+    expect(await po2.getTooltipPo().getTooltipText()).toEqual(
+      "There are a total of 5 proposals you can vote on."
+    );
+  });
+
+  it("should render different tooltip ids", async () => {
+    const po = renderComponent({ count: 5, universe: mockUniverse });
+    const po1 = renderComponent({ count: 6, universe: mockUniverse });
+
+    expect(await po.getTooltipPo().getTooltipId()).not.toEqual(
+      await po1.getTooltipPo().getTooltipId()
+    );
+  });
+});


### PR DESCRIPTION
# Motivation

Add unique id to actionable count tooltip to let screen readers know which tooltip applies to which badge.

# Changes

- Add global counter and use it for id generation.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.