### PR TITLE
Do not rely on Docker build for SNS aggregator release template

### DIFF
--- a/scripts/sns/aggregator/release
+++ b/scripts/sns/aggregator/release
@@ -18,7 +18,7 @@ fi
 read -rp "HSM Pin: " DFX_HSM_PIN
 
 AGGREGATOR_CANISTER_ID="3r4gx-wqaaa-aaaaq-aaaia-cai"
-WASM="./release/docker/sns_aggregator.wasm.gz"
+WASM="./release/ci/sns_aggregator.wasm.gz"
 SHA="$(sha256sum <"$WASM" | awk '{print $1}')"
 
 ARG_DID="./release/sns_aggregator_arg.did"

--- a/scripts/sns/aggregator/release-template
+++ b/scripts/sns/aggregator/release-template
@@ -2,11 +2,9 @@
 set -euo pipefail
 cd "$(dirname "$0")/../../.."
 
-./scripts/docker-build
+WASM="release/ci/sns_aggregator.wasm.gz"
 mkdir -p release/ci
-mkdir -p release/docker
-WASM="sns_aggregator.wasm.gz"
-cp "$WASM" release/docker/
+./scripts/nns-dapp/download-ci-wasm --commit aggregator-release-candidate --wasm-filename sns_aggregator.wasm.gz
 
 if test -f "$WASM"; then
   SHA="$(sha256sum "$WASM" | awk '{print $1}')"


### PR DESCRIPTION
# Motivation

Our Docker build runs out of memory on M1 Mac.
It would be nice to be able to do most of the SNS aggregator release process on a Mac, even if we need to run the Docker build separately on a DevEnv.

# Changes

To get the SNS aggregator WASM to release, download it from CI instead of building it with Docker.

# Tests

Used for this week's SNS aggregator release.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary