### PR TITLE
NNS1-3047: Local copy of CanisterStatusResultV2

### DIFF
--- a/rs/sns_aggregator/src/lib.rs
+++ b/rs/sns_aggregator/src/lib.rs
@@ -1,5 +1,6 @@
 //! Entry points for the caching canister.
 #![warn(missing_docs)]
+#![allow(clippy::missing_docs_in_private_items)]
 #![deny(clippy::panic)]
 #![deny(clippy::expect_used)]
 #![deny(clippy::unwrap_used)]

--- a/rs/sns_aggregator/src/lib.rs
+++ b/rs/sns_aggregator/src/lib.rs
@@ -1,6 +1,5 @@
 //! Entry points for the caching canister.
 #![warn(missing_docs)]
-#![warn(clippy::missing_docs_in_private_items)]
 #![deny(clippy::panic)]
 #![deny(clippy::expect_used)]
 #![deny(clippy::unwrap_used)]
@@ -16,12 +15,13 @@ use std::collections::VecDeque;
 use std::time::Duration;
 
 use assets::{insert_favicon, insert_home_page, AssetHashes, HttpRequest, HttpResponse};
-use candid::{candid_method, export_service};
+use candid::{candid_method, export_service, CandidType, Principal};
 use dfn_core::api::{call, CanisterId};
 use fast_scheduler::FastScheduler;
 use ic_cdk::api::call::{self};
 use ic_cdk_timers::{clear_timer, set_timer, set_timer_interval};
 use ic_ic00_types::{CanisterIdRecord, IC_00};
+use serde::Deserialize;
 use state::{Config, StableState, STATE};
 use types::Icrc1Value;
 
@@ -44,11 +44,45 @@ fn health_check() -> String {
     })
 }
 
+/// Generated with `didc bind`.
+#[derive(CandidType, Deserialize)]
+enum CanisterStatusType {
+    #[serde(rename = "stopped")]
+    Stopped,
+    #[serde(rename = "stopping")]
+    Stopping,
+    #[serde(rename = "running")]
+    Running,
+}
+
+/// Generated with `didc bind`.
+#[derive(CandidType, Deserialize)]
+struct DefiniteCanisterSettingsArgs {
+    controller: Principal,
+    freezing_threshold: candid::Nat,
+    controllers: Vec<Principal>,
+    memory_allocation: candid::Nat,
+    compute_allocation: candid::Nat,
+}
+
+/// Generated with `didc bind`.
+#[derive(CandidType, Deserialize)]
+struct CanisterStatusResultV2 {
+    controller: Principal,
+    status: CanisterStatusType,
+    freezing_threshold: candid::Nat,
+    balance: Vec<(serde_bytes::ByteBuf, candid::Nat)>,
+    memory_size: candid::Nat,
+    cycles: candid::Nat,
+    settings: DefiniteCanisterSettingsArgs,
+    idle_cycles_burned_per_day: candid::Nat,
+    module_hash: Option<serde_bytes::ByteBuf>,
+}
 /// API method to get cycle balance and burn rate.
 #[candid_method(update)]
 #[ic_cdk_macros::update]
 #[allow(clippy::panic)] // This is a readonly function, only a rather arcane reason prevents it from being a query call.
-async fn get_canister_status() -> ic_ic00_types::CanisterStatusResultV2 {
+async fn get_canister_status() -> CanisterStatusResultV2 {
     let own_canister_id = dfn_core::api::id();
     let canister_id_record: CanisterIdRecord = CanisterId::new(own_canister_id.get())
         .unwrap_or_else(|err| panic!("Couldn't get canister_status of {own_canister_id}.  Err: {err:#?}"))

--- a/rs/sns_aggregator/src/lib.rs
+++ b/rs/sns_aggregator/src/lib.rs
@@ -45,7 +45,7 @@ fn health_check() -> String {
     })
 }
 
-/// Generated with `didc bind`.
+/// Generated with `didc bind` from `sns_aggregator.did`.
 #[derive(CandidType, Deserialize)]
 enum CanisterStatusType {
     #[serde(rename = "stopped")]
@@ -56,7 +56,7 @@ enum CanisterStatusType {
     Running,
 }
 
-/// Generated with `didc bind`.
+/// Generated with `didc bind` from `sns_aggregator.did`.
 #[derive(CandidType, Deserialize)]
 struct DefiniteCanisterSettingsArgs {
     controller: Principal,
@@ -66,7 +66,7 @@ struct DefiniteCanisterSettingsArgs {
     compute_allocation: candid::Nat,
 }
 
-/// Generated with `didc bind`.
+/// Generated with `didc bind` from `sns_aggregator.did`.
 #[derive(CandidType, Deserialize)]
 struct CanisterStatusResultV2 {
     controller: Principal,


### PR DESCRIPTION
# Motivation

SNS aggregator uses the type `ic_ic00_types::CanisterStatusResultV2` to decode the result from calling `canister_status` on the management canister.
This means that if new fields are added to this type, we can't update our IC dependencies unless we wait for a version of the replica that includes these fields in the `canister_status` response.
This coupling makes it harder to keep our dependencies up to date.

Instead we should have our local copy of the type which we can update independently from our dependencies and the replica version.

# Changes

1. I ran `didc bind --target rs rs/sns_aggregator/sns_aggregator.did >temp.rs` then copied the types I needed out of the temporary file into `rs/sns_aggregator/src/lib.rs`.
2. Disabled warning for missing docs on private fields. As we [have in other places](https://github.com/search?q=repo%3Adfinity%2Fnns-dapp+%22%23%21%5Ballow%28clippy%3A%3Amissing_docs_in_private_items%29%5D%22&type=code) as well.

# Tests

Existing tests pass.
And tested in another branch that this allowed me to update our IC repo dependencies.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary