### PR TITLE
NNS1-3047: Ignore Burn and Mint fields

### DIFF
--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -577,7 +577,7 @@ impl AccountsStore {
         }
 
         match *transfer {
-            Burn { from: _, amount: _ } | Mint { to: _, amount: _ } | Approve { .. } => {}
+            Burn { .. } | Mint { .. } | Approve { .. } => {}
             Transfer {
                 from,
                 to,


### PR DESCRIPTION
# Motivation

We process transactions in the NNS dapp, but only `Transfer` transactions.
We ignore `Burn`, `Mint` and `Approve` transactions so we don't care about their fields.
Specifying their fields makes adding optional fields a breaking change and makes it harder to update our dependencies.

# Changes

Stop checking for fields of `Burn` and `Mint` transactions that we don't process anyway.

# Tests

Existing tests pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary