### PR TITLE
Removed dependency on stores from proposals.api.ts

### DIFF
--- a/frontend/src/lib/api/proposals.api.ts
+++ b/frontend/src/lib/api/proposals.api.ts
@@ -1,27 +1,33 @@
 import { createAgent } from "$lib/api/agent.api";
 import { DEFAULT_LIST_PAGINATION_LIMIT } from "$lib/constants/constants";
 import { HOST } from "$lib/constants/environment.constants";
-import type { ProposalsFiltersStore } from "$lib/stores/proposals.store";
 import { hashCode, logWithTimestamp } from "$lib/utils/dev.utils";
 import { enumsExclude } from "$lib/utils/enum.utils";
 import type { Identity } from "@dfinity/agent";
-import type {
-  ListProposalsResponse,
-  ProposalId,
-  ProposalInfo,
+import {
+  GovernanceCanister,
+  ProposalRewardStatus,
+  ProposalStatus,
+  Topic,
+  type ListProposalsResponse,
+  type ProposalId,
+  type ProposalInfo,
 } from "@dfinity/nns";
-import { GovernanceCanister, Topic } from "@dfinity/nns";
 import { nnsDappCanister } from "./nns-dapp.api";
 
 export const queryProposals = async ({
   beforeProposal,
   identity,
-  filters,
+  includeTopics = [],
+  includeRewardStatus = [],
+  includeStatus = [],
   certified,
 }: {
   beforeProposal: ProposalId | undefined;
   identity: Identity;
-  filters: ProposalsFiltersStore;
+  includeTopics?: Topic[];
+  includeRewardStatus?: ProposalRewardStatus[];
+  includeStatus?: ProposalStatus[];
   certified: boolean;
 }): Promise<ProposalInfo[]> => {
   logWithTimestamp(
@@ -34,22 +40,20 @@ export const queryProposals = async ({
     agent: await createAgent({ identity, host: HOST }),
   });
 
-  const { rewards, status, topics }: ProposalsFiltersStore = filters;
-
   const { proposals }: ListProposalsResponse = await governance.listProposals({
     request: {
       limit: DEFAULT_LIST_PAGINATION_LIMIT,
       beforeProposal,
       excludeTopic:
         // We want all topics if the filter is empty
-        topics.length === 0
+        includeTopics.length === 0
           ? []
           : enumsExclude<Topic>({
               obj: Topic as unknown as Topic,
-              values: topics,
+              values: includeTopics,
             }),
-      includeRewardStatus: rewards,
-      includeStatus: status,
+      includeRewardStatus,
+      includeStatus,
       includeAllManageNeuronProposals: false,
     },
     certified,

--- a/frontend/src/lib/services/$public/proposals.services.ts
+++ b/frontend/src/lib/services/$public/proposals.services.ts
@@ -160,7 +160,14 @@ const findProposals = async ({
     strategy: FORCE_CALL_STRATEGY,
     identityType: "current",
     request: ({ certified, identity }) =>
-      queryProposals({ beforeProposal, identity, filters, certified }),
+      queryProposals({
+        beforeProposal,
+        identity,
+        includeTopics: filters.topics,
+        includeStatus: filters.status,
+        includeRewardStatus: filters.rewards,
+        certified,
+      }),
     onLoad: ({ response: proposals, certified }) => {
       if (!certified) {
         uncertifiedProposals = proposals;

--- a/frontend/src/lib/services/$public/sns.services.ts
+++ b/frontend/src/lib/services/$public/sns.services.ts
@@ -87,13 +87,8 @@ export const loadProposalsSnsCF = async (): Promise<void> => {
       queryProposals({
         beforeProposal: undefined,
         identity,
-        filters: {
-          topics: [Topic.SnsAndCommunityFund],
-          rewards: [],
-          status: [ProposalStatus.Open],
-          excludeVotedProposals: false,
-          lastAppliedFilter: undefined,
-        },
+        includeTopics: [Topic.SnsAndCommunityFund],
+        includeStatus: [ProposalStatus.Open],
         certified,
       }),
     onLoad: ({ response: proposals, certified }) =>

--- a/frontend/src/lib/services/actionable-proposals.services.ts
+++ b/frontend/src/lib/services/actionable-proposals.services.ts
@@ -7,7 +7,6 @@ import { getCurrentIdentity } from "$lib/services/auth.services";
 import { listNeurons } from "$lib/services/neurons.services";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { definedNeuronsStore, neuronsStore } from "$lib/stores/neurons.store";
-import type { ProposalsFiltersStore } from "$lib/stores/proposals.store";
 import { lastProposalId } from "$lib/utils/proposals.utils";
 import type { ProposalInfo } from "@dfinity/nns";
 import {
@@ -55,14 +54,6 @@ const queryNeurons = async (): Promise<NeuronInfo[]> => {
 /// Fetch all (500 max) proposals that are accepting votes.
 const queryProposals = async (): Promise<ProposalInfo[]> => {
   const identity = getCurrentIdentity();
-  const filters: ProposalsFiltersStore = {
-    // We just want to fetch proposals that are accepting votes, so we don't need to filter by rest of the filters.
-    rewards: [ProposalRewardStatus.AcceptVotes],
-    topics: [],
-    status: [],
-    excludeVotedProposals: false,
-    lastAppliedFilter: undefined,
-  };
 
   let sortedProposals: ProposalInfo[] = [];
   for (
@@ -74,7 +65,7 @@ const queryProposals = async (): Promise<ProposalInfo[]> => {
     const page = await queryNnsProposals({
       beforeProposal: lastProposalId(sortedProposals),
       identity,
-      filters,
+      includeRewardStatus: [ProposalRewardStatus.AcceptVotes],
       certified: false,
     });
     // Sort proposals by id in descending order to be sure that "lastProposalId" returns correct id.

--- a/frontend/src/tests/lib/api/proposals.api.spec.ts
+++ b/frontend/src/tests/lib/api/proposals.api.spec.ts
@@ -17,6 +17,12 @@ describe("proposals-api", () => {
   const mockGovernanceCanister: MockGovernanceCanister =
     new MockGovernanceCanister(mockProposals);
 
+  const {
+    topics: defaultIncludeTopcis,
+    rewards: defaultIncludeRewardStatus,
+    status: defaultIncludeStatus,
+  } = DEFAULT_PROPOSALS_FILTERS;
+
   let spyListProposals;
 
   beforeEach(() => {
@@ -34,7 +40,9 @@ describe("proposals-api", () => {
     it("should call the canister to list proposals", async () => {
       await queryProposals({
         beforeProposal: undefined,
-        filters: DEFAULT_PROPOSALS_FILTERS,
+        includeTopics: defaultIncludeTopcis,
+        includeStatus: defaultIncludeStatus,
+        includeRewardStatus: defaultIncludeRewardStatus,
         identity: mockIdentity,
         certified: true,
       });
@@ -45,7 +53,9 @@ describe("proposals-api", () => {
     it("should call the canister to list the next proposals", async () => {
       await queryProposals({
         beforeProposal: mockProposals[mockProposals.length - 1].id,
-        filters: DEFAULT_PROPOSALS_FILTERS,
+        includeTopics: defaultIncludeTopcis,
+        includeStatus: defaultIncludeStatus,
+        includeRewardStatus: defaultIncludeRewardStatus,
         identity: mockIdentity,
         certified: true,
       });
@@ -56,10 +66,9 @@ describe("proposals-api", () => {
     it("should call with no excluded topics if topics filter is empty", async () => {
       await queryProposals({
         beforeProposal: mockProposals[mockProposals.length - 1].id,
-        filters: {
-          ...DEFAULT_PROPOSALS_FILTERS,
-          topics: [],
-        },
+        includeTopics: [],
+        includeStatus: defaultIncludeStatus,
+        includeRewardStatus: defaultIncludeRewardStatus,
         identity: mockIdentity,
         certified: true,
       });

--- a/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
+++ b/frontend/src/tests/lib/components/launchpad/Proposals.spec.ts
@@ -29,13 +29,8 @@ describe("Proposals", () => {
       beforeProposal: undefined,
       certified: false,
       identity: new AnonymousIdentity(),
-      filters: {
-        topics: [Topic.SnsAndCommunityFund],
-        rewards: [],
-        status: [ProposalStatus.Open],
-        excludeVotedProposals: false,
-        lastAppliedFilter: undefined,
-      },
+      includeTopics: [Topic.SnsAndCommunityFund],
+      includeStatus: [ProposalStatus.Open],
     });
   });
 

--- a/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
@@ -104,13 +104,7 @@ describe("actionable-proposals.services", () => {
         expect.objectContaining({
           beforeProposal: undefined,
           certified: false,
-          filters: {
-            excludeVotedProposals: false,
-            lastAppliedFilter: undefined,
-            rewards: [ProposalRewardStatus.AcceptVotes],
-            status: [],
-            topics: [],
-          },
+          includeRewardStatus: [ProposalRewardStatus.AcceptVotes],
         })
       );
     });
@@ -132,26 +126,14 @@ describe("actionable-proposals.services", () => {
         identity: mockIdentity,
         beforeProposal: undefined,
         certified: false,
-        filters: {
-          excludeVotedProposals: false,
-          lastAppliedFilter: undefined,
-          rewards: [ProposalRewardStatus.AcceptVotes],
-          status: [],
-          topics: [],
-        },
+        includeRewardStatus: [ProposalRewardStatus.AcceptVotes],
       });
       expect(spyQueryProposals).toHaveBeenCalledWith({
         identity: mockIdentity,
         beforeProposal:
           firstResponseProposals[firstResponseProposals.length - 1].id,
         certified: false,
-        filters: {
-          excludeVotedProposals: false,
-          lastAppliedFilter: undefined,
-          rewards: [ProposalRewardStatus.AcceptVotes],
-          status: [],
-          topics: [],
-        },
+        includeRewardStatus: [ProposalRewardStatus.AcceptVotes],
       });
       expect(get(actionableNnsProposalsStore)?.proposals?.length).toEqual(101);
       expect(get(actionableNnsProposalsStore)?.proposals).toEqual([

--- a/frontend/src/tests/lib/services/vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/vote-registration.services.spec.ts
@@ -301,13 +301,7 @@ describe("vote-registration-services", () => {
         expect(spyQueryProposals).toBeCalledWith({
           beforeProposal: undefined,
           certified: false,
-          filters: {
-            excludeVotedProposals: false,
-            lastAppliedFilter: undefined,
-            rewards: [ProposalRewardStatus.AcceptVotes],
-            status: [],
-            topics: [],
-          },
+          includeRewardStatus: [ProposalRewardStatus.AcceptVotes],
           identity: mockIdentity,
         });
 

--- a/frontend/src/tests/workflows/NnsProposals.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposals.spec.ts
@@ -35,6 +35,12 @@ vi.mock("$lib/api/proposals.api", () => {
 vi.mock("$lib/api/governance.api");
 
 describe("NnsProposals", () => {
+  const {
+    topics: defaultIncludeTopcis,
+    rewards: defaultIncludeRewardStatus,
+    status: defaultIncludeStatus,
+  } = DEFAULT_PROPOSALS_FILTERS;
+
   afterEach(() => {
     vi.clearAllMocks();
     neuronsStore.reset();
@@ -61,13 +67,17 @@ describe("NnsProposals", () => {
       expect(queryProposals).toHaveBeenCalledWith({
         beforeProposal: undefined,
         certified: false,
-        filters: DEFAULT_PROPOSALS_FILTERS,
+        includeTopics: defaultIncludeTopcis,
+        includeStatus: defaultIncludeStatus,
+        includeRewardStatus: defaultIncludeRewardStatus,
         identity: mockIdentity,
       });
       expect(queryProposals).toHaveBeenCalledWith({
         beforeProposal: undefined,
         certified: true,
-        filters: DEFAULT_PROPOSALS_FILTERS,
+        includeTopics: defaultIncludeTopcis,
+        includeStatus: defaultIncludeStatus,
+        includeRewardStatus: defaultIncludeRewardStatus,
         identity: mockIdentity,
       });
     });
@@ -113,7 +123,9 @@ describe("NnsProposals", () => {
       expect(queryProposals).toHaveBeenCalledWith({
         beforeProposal: undefined,
         certified: false,
-        filters: DEFAULT_PROPOSALS_FILTERS,
+        includeTopics: defaultIncludeTopcis,
+        includeStatus: defaultIncludeStatus,
+        includeRewardStatus: defaultIncludeRewardStatus,
         identity: new AnonymousIdentity(),
       });
     });


### PR DESCRIPTION
# Motivation

The API layer shouldn't depend on the stores.

# Changes

Instead of passing the `filters` to `queryProposals`, pass `includeTopics`, `includeRewardStatus` and `includeStatus` individually.

# Tests

Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary