### PR TITLE
Update rust version to 1.78.0 (+ lint fixes)

### DIFF
--- a/rs/backend/src/accounts_store/schema.rs
+++ b/rs/backend/src/accounts_store/schema.rs
@@ -78,6 +78,7 @@ pub trait AccountsDbTrait {
     /// # Returns
     /// - `None`, if the account does not exist.
     /// - `Some(result)`, where `result` is the value returned by `f`, if the account exists.
+    #[cfg(test)]
     fn db_try_with_account<F, RS, RF>(&mut self, account_key: &[u8], f: F) -> Option<Result<RS, RF>>
     where
         // The closure takes an account as an argument.  It may return any type.
@@ -149,9 +150,12 @@ pub enum SchemaLabelError {
 }
 
 /// A trait for data stores that support `BTreeMap` for account storage.
+#[cfg(test)]
 pub trait AccountsDbBTreeMapTrait {
     /// Creates a database from a map of accounts.
+    #[cfg(test)]
     fn from_map(map: std::collections::BTreeMap<Vec<u8>, Account>) -> Self;
     /// Provides the accounts as a map.
+    #[cfg(test)]
     fn as_map(&self) -> &std::collections::BTreeMap<Vec<u8>, Account>;
 }

--- a/rs/backend/src/accounts_store/schema/map.rs
+++ b/rs/backend/src/accounts_store/schema/map.rs
@@ -1,6 +1,8 @@
 //! An accounts DB implemented as a hash map.
 
-use super::{Account, AccountsDbBTreeMapTrait, AccountsDbTrait, SchemaLabel};
+#[cfg(test)]
+use super::AccountsDbBTreeMapTrait;
+use super::{Account, AccountsDbTrait, SchemaLabel};
 use core::fmt;
 use core::ops::RangeBounds;
 use std::collections::BTreeMap;
@@ -57,10 +59,13 @@ impl AccountsDbTrait for AccountsDbAsMap {
     }
 }
 
+#[cfg(test)]
 impl AccountsDbBTreeMapTrait for AccountsDbAsMap {
+    #[cfg(test)]
     fn from_map(map: BTreeMap<Vec<u8>, Account>) -> Self {
         Self { accounts: map }
     }
+    #[cfg(test)]
     fn as_map(&self) -> &BTreeMap<Vec<u8>, Account> {
         &self.accounts
     }

--- a/rs/sns_aggregator/src/upstream.rs
+++ b/rs/sns_aggregator/src/upstream.rs
@@ -68,8 +68,20 @@ async fn set_list_of_sns_to_get() -> anyhow::Result<()> {
             ));
             let instances: Vec<_> = (0..).zip(stuff.instances.into_iter()).collect();
             STATE.with(|state| {
-                state.stable.borrow().sns_cache.borrow_mut().all_sns = instances.clone();
-                state.stable.borrow().sns_cache.borrow_mut().sns_to_get = instances;
+                state
+                    .stable
+                    .borrow()
+                    .sns_cache
+                    .borrow_mut()
+                    .all_sns
+                    .clone_from(&instances);
+                state
+                    .stable
+                    .borrow()
+                    .sns_cache
+                    .borrow_mut()
+                    .sns_to_get
+                    .clone_from(&instances);
             });
             Ok(())
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Please, from time to time, update this to the latest stable version on Rust Forge: https://forge.rust-lang.org/
-channel = "1.77.2"
+channel = "1.78.0"
 components = ["rustfmt", "clippy"]
 targets = [ "wasm32-unknown-unknown"]


### PR DESCRIPTION
# Motivation

We update the Rust version automatically but the new version has a stricter lint so some issues needed to be fixed manually.

# Changes

1. Update `channel` in `rust-toolchain.toml`.
2. Mark some methods and traits only used in tests with `#[cfg(test)]` to satisfy the linter.
3. Use `clone_from` to satisfy the linter.

# Tests

Lint passes.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary