### PR TITLE
css: improve badge with narrow content width

### DIFF
--- a/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
@@ -55,5 +55,7 @@
     background: var(--primary);
     color: var(--primary-contrast);
     border-radius: var(--padding-8x);
+    min-width: var(--padding);
+    justify-content: center;
   }
 </style>

--- a/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
@@ -55,7 +55,7 @@
     background: var(--primary);
     color: var(--primary-contrast);
     border-radius: var(--padding-8x);
-    min-width: var(--padding);
+    min-width: 7px;
     justify-content: center;
   }
 </style>


### PR DESCRIPTION
# Motivation

Improve actionable count badge min width.

# Changes

- Set minimum width and center the content

# Tests

- Manually

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary

# Screenshots

| Before | After |
|--------|--------|
| <img width="480" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/07b490d0-b4eb-48e0-84b3-9a6346ac21e0"> | <img width="485" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/b1121f9d-4f23-4668-a320-bdcb9a6fcd9f"> | 