### PR TITLE
Remove exclude voted proposals feature

### DIFF
--- a/frontend/src/lib/components/proposals/NnsProposalsFilters.svelte
+++ b/frontend/src/lib/components/proposals/NnsProposalsFilters.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
   import type { ProposalsFilterModalProps } from "$lib/types/proposals";
   import NnsProposalsFilterModal from "$lib/modals/proposals/NnsProposalsFilterModal.svelte";
-  import { Checkbox } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
   import { ProposalStatus, Topic } from "@dfinity/nns";
   import { proposalsFiltersStore } from "$lib/stores/proposals.store";
   import { enumsExclude } from "$lib/utils/enum.utils";
   import FiltersButton from "$lib/components/ui/FiltersButton.svelte";
   import { DEPRECATED_TOPICS } from "$lib/constants/proposals.constants";
-  import SignedInOnly from "$lib/components/common/SignedInOnly.svelte";
   import FiltersWrapper from "./FiltersWrapper.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { ENABLE_VOTING_INDICATION } from "$lib/stores/feature-flags.store";
@@ -23,9 +21,8 @@
 
   let topics: Topic[];
   let status: ProposalStatus[];
-  let excludeVotedProposals: boolean;
 
-  $: ({ topics, status, excludeVotedProposals } = $proposalsFiltersStore);
+  $: ({ topics, status } = $proposalsFiltersStore);
 
   let totalFiltersTopic = enumsExclude({
     obj: Topic as unknown as Topic,
@@ -73,22 +70,6 @@
               selectedFilters: status,
             })}>{$i18n.voting.status}</FiltersButton
         >
-
-        {#if !$ENABLE_VOTING_INDICATION}
-          <SignedInOnly>
-            <Checkbox
-              testId="votable-proposals-only"
-              inputId="hide-unavailable-proposals"
-              checked={excludeVotedProposals}
-              on:nnsChange={() =>
-                proposalsFiltersStore.toggleExcludeVotedProposals()}
-              text="block"
-              --checkbox-padding="var(--padding)"
-              --checkbox-label-order="1"
-              >{$i18n.voting.hide_unavailable_proposals}</Checkbox
-            >
-          </SignedInOnly>
-        {/if}
       </FiltersWrapper>
     {/if}
   </div>

--- a/frontend/src/lib/constants/proposals.constants.ts
+++ b/frontend/src/lib/constants/proposals.constants.ts
@@ -14,7 +14,6 @@ export const DEFAULT_PROPOSALS_FILTERS = {
     Topic.SnsAndCommunityFund,
   ],
   status: [ProposalStatus.Open],
-  excludeVotedProposals: false,
   lastAppliedFilter: undefined,
 };
 

--- a/frontend/src/lib/constants/proposals.constants.ts
+++ b/frontend/src/lib/constants/proposals.constants.ts
@@ -14,7 +14,6 @@ export const DEFAULT_PROPOSALS_FILTERS = {
     Topic.SnsAndCommunityFund,
   ],
   status: [ProposalStatus.Open],
-  lastAppliedFilter: undefined,
 };
 
 export const DEPRECATED_TOPICS = [Topic.SnsDecentralizationSale];

--- a/frontend/src/lib/derived/proposals.derived.ts
+++ b/frontend/src/lib/derived/proposals.derived.ts
@@ -1,8 +1,5 @@
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
-import type {
-  ProposalsFiltersStore,
-  ProposalsStore,
-} from "$lib/stores/proposals.store";
+import type { ProposalsStore } from "$lib/stores/proposals.store";
 import {
   proposalsFiltersStore,
   proposalsStore,
@@ -31,26 +28,6 @@ export const sortedProposals: Readable<ProposalsStore> = derived(
   })
 );
 
-// HACK:
-//
-// 1. the governance canister does not implement a filter to hide proposals where all neurons have voted or are ineligible.
-// 2. the app does not simply display nothing when a filter is empty but re-filter the results provided by the backend.
-//
-// In addition, we have implemented an "optimistic voting" feature.
-//
-// That's why we hide and re-process these proposals delivered by the backend on the client side.
-const hide = ({
-  proposalInfo,
-  filters,
-}: {
-  proposalInfo: ProposalInfo;
-  filters: ProposalsFiltersStore;
-}): boolean =>
-  hideProposal({
-    filters,
-    proposalInfo,
-  });
-
 export interface UIProposalsStore {
   proposals: (ProposalInfo & { hidden: boolean })[];
   certified: boolean | undefined;
@@ -61,7 +38,7 @@ export const uiProposals: Readable<UIProposalsStore> = derived(
   ([{ proposals, certified }, filters]) => ({
     proposals: proposals.map((proposalInfo) => ({
       ...proposalInfo,
-      hidden: hide({
+      hidden: hideProposal({
         proposalInfo,
         filters,
       }),

--- a/frontend/src/lib/derived/proposals.derived.ts
+++ b/frontend/src/lib/derived/proposals.derived.ts
@@ -1,6 +1,4 @@
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
-import { authStore } from "$lib/stores/auth.store";
-import { definedNeuronsStore } from "$lib/stores/neurons.store";
 import type {
   ProposalsFiltersStore,
   ProposalsStore,
@@ -10,8 +8,7 @@ import {
   proposalsStore,
 } from "$lib/stores/proposals.store";
 import { hideProposal } from "$lib/utils/proposals.utils";
-import type { Identity } from "@dfinity/agent";
-import type { NeuronInfo, ProposalInfo } from "@dfinity/nns";
+import type { ProposalInfo } from "@dfinity/nns";
 import { derived, type Readable } from "svelte/store";
 
 /**
@@ -45,19 +42,13 @@ export const sortedProposals: Readable<ProposalsStore> = derived(
 const hide = ({
   proposalInfo,
   filters,
-  neurons,
-  identity,
 }: {
   proposalInfo: ProposalInfo;
   filters: ProposalsFiltersStore;
-  neurons: NeuronInfo[];
-  identity: Identity | undefined | null;
 }): boolean =>
   hideProposal({
     filters,
     proposalInfo,
-    neurons,
-    identity,
   });
 
 export interface UIProposalsStore {
@@ -66,15 +57,13 @@ export interface UIProposalsStore {
 }
 
 export const uiProposals: Readable<UIProposalsStore> = derived(
-  [sortedProposals, proposalsFiltersStore, definedNeuronsStore, authStore],
-  ([{ proposals, certified }, filters, neurons, { identity }]) => ({
+  [sortedProposals, proposalsFiltersStore],
+  ([{ proposals, certified }, filters]) => ({
     proposals: proposals.map((proposalInfo) => ({
       ...proposalInfo,
       hidden: hide({
         proposalInfo,
         filters,
-        neurons,
-        identity,
       }),
     })),
     certified,

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -368,7 +368,6 @@
     "topics": "Topics",
     "types": "Types",
     "status": "Proposal Status",
-    "hide_unavailable_proposals": "Show only proposals you can still vote for",
     "check_all": "Select All",
     "uncheck_all": "Clear",
     "nothing_found": "No proposals found for the filters.",

--- a/frontend/src/lib/pages/NnsProposals.svelte
+++ b/frontend/src/lib/pages/NnsProposals.svelte
@@ -105,16 +105,9 @@
     initialized = true;
   });
 
-  const applyFilter = ({ lastAppliedFilter }: ProposalsFiltersStore) => {
+  const applyFilter = () => {
     // We only want to display spinner and reset the proposals store if filters are modified by the user
     if (!initialized) {
-      return;
-    }
-
-    if (lastAppliedFilter === "excludeVotedProposals") {
-      // Make a visual feedback that the filter was applyed
-      hidden = true;
-      setTimeout(() => (hidden = false), 200);
       return;
     }
 
@@ -133,9 +126,9 @@
   // goes back into loading state immediately after proposals are loaded.
   // TODO: Fix NnsProposals to load proposals only once and remove the
   // work-around from NnsProposalList.page-object.ts
-  $: $definedNeuronsStore, applyFilter($proposalsFiltersStore);
 
   $: $authStore.identity, (() => proposalsFiltersStore.reload())();
+  $: $definedNeuronsStore, applyFilter();
 
   const updateNothingFound = () => {
     // Update the "nothing found" UI information only when the results of the certified query has been received to minimize UI glitches

--- a/frontend/src/lib/pages/NnsProposals.svelte
+++ b/frontend/src/lib/pages/NnsProposals.svelte
@@ -124,7 +124,7 @@
   // goes back into loading state immediately after proposals are loaded.
   // TODO: Fix NnsProposals to load proposals only once and remove the
   // work-around from NnsProposalList.page-object.ts
-  $: $definedNeuronsStore, applyFilter();
+  $: $definedNeuronsStore, $proposalsFiltersStore, applyFilter();
 
   const updateNothingFound = () => {
     // Update the "nothing found" UI information only when the results of the certified query has been received to minimize UI glitches

--- a/frontend/src/lib/pages/NnsProposals.svelte
+++ b/frontend/src/lib/pages/NnsProposals.svelte
@@ -5,7 +5,6 @@
     lastProposalId,
   } from "$lib/utils/proposals.utils";
   import {
-    type ProposalsFiltersStore,
     proposalsFiltersStore,
     proposalsStore,
   } from "$lib/stores/proposals.store";
@@ -126,8 +125,6 @@
   // goes back into loading state immediately after proposals are loaded.
   // TODO: Fix NnsProposals to load proposals only once and remove the
   // work-around from NnsProposalList.page-object.ts
-
-  $: $authStore.identity, (() => proposalsFiltersStore.reload())();
   $: $definedNeuronsStore, applyFilter();
 
   const updateNothingFound = () => {

--- a/frontend/src/lib/pages/NnsProposals.svelte
+++ b/frontend/src/lib/pages/NnsProposals.svelte
@@ -22,7 +22,6 @@
     sortedProposals,
     filteredProposals,
   } from "$lib/derived/proposals.derived";
-  import { authStore } from "$lib/stores/auth.store";
   import { listNeurons } from "$lib/services/neurons.services";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { notForceCallStrategy } from "$lib/utils/env.utils";
@@ -140,8 +139,6 @@
       !hasMatchingProposals({
         proposals: $filteredProposals.proposals,
         filters: $proposalsFiltersStore,
-        neurons: $definedNeuronsStore,
-        identity: $authStore.identity,
       });
   };
 

--- a/frontend/src/lib/stores/proposals.store.ts
+++ b/frontend/src/lib/stores/proposals.store.ts
@@ -18,7 +18,6 @@ import { writableStored } from "./writable-stored";
 export interface ProposalsFiltersStore {
   topics: Topic[];
   status: ProposalStatus[];
-  excludeVotedProposals: boolean;
   lastAppliedFilter: undefined | "topics" | "status" | "excludeVotedProposals";
 }
 
@@ -114,8 +113,6 @@ const initProposalsStore = () => {
  *
  * - filterTopics: set the filter topics (enum Topic)
  * - filterStatus: set the filter for the status of the proposals (enum ProposalStatus)
- * - excludeVotedProposals: "Show only proposals you can still vote for"
- *
  */
 const initProposalsFiltersStore = () => {
   const { subscribe, update, set } = writableStored<ProposalsFiltersStore>({
@@ -142,11 +139,6 @@ const initProposalsFiltersStore = () => {
       }));
     },
 
-    toggleExcludeVotedProposals() {
-      update((filters: ProposalsFiltersStore) => ({
-        ...filters,
-        excludeVotedProposals: !filters.excludeVotedProposals,
-        lastAppliedFilter: "excludeVotedProposals",
       }));
     },
 

--- a/frontend/src/lib/stores/proposals.store.ts
+++ b/frontend/src/lib/stores/proposals.store.ts
@@ -18,7 +18,6 @@ import { writableStored } from "./writable-stored";
 export interface ProposalsFiltersStore {
   topics: Topic[];
   status: ProposalStatus[];
-  lastAppliedFilter: undefined | "topics" | "status" | "excludeVotedProposals";
 }
 
 export interface ProposalsStore {
@@ -127,7 +126,6 @@ const initProposalsFiltersStore = () => {
       update((filters: ProposalsFiltersStore) => ({
         ...filters,
         topics,
-        lastAppliedFilter: "topics",
       }));
     },
 
@@ -135,19 +133,12 @@ const initProposalsFiltersStore = () => {
       update((filters: ProposalsFiltersStore) => ({
         ...filters,
         status,
-        lastAppliedFilter: "status",
-      }));
-    },
-
       }));
     },
 
     reset() {
       set(DEFAULT_PROPOSALS_FILTERS);
     },
-
-    reload: () =>
-      update((state) => ({ ...state, lastAppliedFilter: undefined })),
   };
 };
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -382,7 +382,6 @@ interface I18nVoting {
   topics: string;
   types: string;
   status: string;
-  hide_unavailable_proposals: string;
   check_all: string;
   uncheck_all: string;
   nothing_found: string;

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -80,19 +80,10 @@ export const getNnsFunctionKey = (
 export const hideProposal = ({
   proposalInfo,
   filters,
-  neurons,
-  identity,
 }: {
   proposalInfo: ProposalInfo;
   filters: ProposalsFiltersStore;
-  neurons: NeuronInfo[];
-  identity: Identity | undefined | null;
-}): boolean =>
-  !matchFilters({ proposalInfo, filters }) ||
-  (!get(ENABLE_VOTING_INDICATION) &&
-    nonNullish(identity) &&
-    !identity.getPrincipal().isAnonymous() &&
-    isExcludedVotedProposal({ proposalInfo, filters, neurons }));
+}): boolean => !matchFilters({ proposalInfo, filters });
 
 /**
  * Does the proposal returned by the backend really matches the filter selected by the user?
@@ -120,13 +111,9 @@ const matchFilters = ({
 export const hasMatchingProposals = ({
   proposals,
   filters,
-  neurons,
-  identity,
 }: {
   proposals: ProposalInfo[];
   filters: ProposalsFiltersStore;
-  neurons: NeuronInfo[];
-  identity: Identity | undefined | null;
 }): boolean => {
   if (proposals.length === 0) {
     return false;
@@ -134,8 +121,7 @@ export const hasMatchingProposals = ({
 
   return (
     proposals.find(
-      (proposalInfo: ProposalInfo) =>
-        !hideProposal({ proposalInfo, filters, neurons, identity })
+      (proposalInfo: ProposalInfo) => !hideProposal({ proposalInfo, filters })
     ) !== undefined
   );
 };

--- a/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
@@ -228,14 +228,6 @@ describe("NnsProposalsFilters", () => {
           ).toEqual(true);
         });
 
-        it("should hide votable proposals checkbox", async () => {
-          const po = await renderComponent();
-
-          expect(
-            await po.getVotableProposalsOnlyCheckboxPo().isPresent()
-          ).toEqual(false);
-        });
-
         it('should "all" be preselected by default', async () => {
           const po = await renderComponent();
           expect(
@@ -300,13 +292,6 @@ describe("NnsProposalsFilters", () => {
         it("should render proposal filters", async () => {
           const po = await renderComponent();
           expect(await po.getFiltersWrapper().isPresent()).toEqual(true);
-        });
-
-        it("should display votable proposals checkbox", async () => {
-          const po = await renderComponent();
-          expect(
-            await po.getVotableProposalsOnlyCheckboxPo().isPresent()
-          ).toEqual(true);
         });
       });
     });

--- a/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
@@ -72,39 +72,6 @@ describe("NnsProposalsFilters", () => {
         text: en.voting.status,
       });
     });
-
-    describe("signed in", () => {
-      beforeAll(() => {
-        authStoreMock.next({
-          identity: mockIdentity,
-        });
-        overrideFeatureFlagsStore.reset();
-      });
-
-      it("should render a checkbox", () => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_VOTING_INDICATION", false);
-        const { container } = render(NnsProposalsFilters);
-
-        const input: HTMLInputElement | null = container.querySelector("input");
-
-        expect(input?.getAttribute("type")).toEqual("checkbox");
-        expect(input?.getAttribute("id")).toEqual("hide-unavailable-proposals");
-      });
-    });
-
-    describe("not signed in", () => {
-      beforeAll(() => {
-        authStoreMock.next({
-          identity: undefined,
-        });
-      });
-
-      it("should not render a checkbox", () => {
-        const { getByTestId } = render(NnsProposalsFilters);
-
-        expect(() => getByTestId("hide-unavailable-proposals")).toThrow();
-      });
-    });
   });
 
   describe("custom filter selection", () => {

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -15,11 +15,9 @@ import {
   authStoreMock,
   mockAuthStoreSubscribe,
   mockIdentity,
-  mutableMockAuthStoreSubscribe,
 } from "$tests/mocks/auth.store.mock";
 import { MockGovernanceCanister } from "$tests/mocks/governance.canister.mock";
 import en from "$tests/mocks/i18n.mock";
-import { mockNeuron } from "$tests/mocks/neurons.mock";
 import {
   mockEmptyProposalsStoreSubscribe,
   mockProposals,
@@ -118,11 +116,6 @@ describe("NnsProposals", () => {
 
         expect(getByText("Topics")).toBeInTheDocument();
         expect(getByText("Proposal Status")).toBeInTheDocument();
-        expect(
-          getByText("Show only proposals", {
-            exact: false,
-          })
-        ).toBeInTheDocument();
       });
 
       it("should render a spinner while searching proposals", async () => {
@@ -177,20 +170,6 @@ describe("NnsProposals", () => {
             .getProposalStatusTagPo()
             .hasActionableStatusBadge()
         ).toEqual(true);
-      });
-
-      it("should not hide proposal card if already voted", async () => {
-        neuronsStore.setNeurons({ neurons: [mockNeuron], certified: true });
-
-        const { queryAllByTestId } = render(NnsProposals);
-
-        proposalsFiltersStore.toggleExcludeVotedProposals();
-
-        await waitFor(() =>
-          expect(queryAllByTestId("proposal-card").length).toBe(
-            mockProposals.length
-          )
-        );
       });
 
       it("should disable infinite scroll when all proposals loaded", async () => {
@@ -301,68 +280,6 @@ describe("NnsProposals", () => {
           getByText((secondProposal.proposal as Proposal).title as string)
         ).toBeInTheDocument();
       });
-
-      it("should render proposals also when ", () => {
-        mockLoadProposals();
-
-        const { getByText } = render(NnsProposals);
-
-        const firstProposal = mockProposals[0] as ProposalInfo;
-        const secondProposal = mockProposals[1] as ProposalInfo;
-        expect(
-          getByText((firstProposal.proposal as Proposal).title as string)
-        ).toBeInTheDocument();
-        expect(
-          getByText((secondProposal.proposal as Proposal).title as string)
-        ).toBeInTheDocument();
-
-        proposalsFiltersStore.toggleExcludeVotedProposals();
-      });
-    });
-  });
-
-  describe("log in and out", () => {
-    let spyReload;
-
-    beforeEach(() => {
-      spyReload = vi.spyOn(proposalsFiltersStore, "reload");
-      vi.spyOn(authStore, "subscribe").mockImplementation(
-        mutableMockAuthStoreSubscribe
-      );
-
-      vi.spyOn(proposalsStore, "subscribe").mockImplementation(
-        mockProposalsStoreSubscribe
-      );
-    });
-
-    it("should reload filters on sign-in", () => {
-      expect(spyReload).not.toHaveBeenCalled();
-      authStoreMock.next({
-        identity: undefined,
-      });
-
-      render(NnsProposals);
-
-      authStoreMock.next({
-        identity: mockIdentity,
-      });
-
-      expect(spyReload).toHaveBeenCalledTimes(1);
-    });
-
-    it("should reload filters after sign-out", () => {
-      expect(spyReload).not.toHaveBeenCalled();
-      authStoreMock.next({
-        identity: mockIdentity,
-      });
-
-      render(NnsProposals);
-
-      authStoreMock.next({
-        identity: undefined,
-      });
-
-      expect(spyReload).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/frontend/src/tests/lib/stores/proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/proposals.store.spec.ts
@@ -97,8 +97,6 @@ describe("proposals-store", () => {
 
     it("should be initialized with default filters", () => {
       const filters = get(proposalsFiltersStore);
-      // reset because of beforeEach
-      filters.lastAppliedFilter = undefined;
       expect(filters).toEqual(DEFAULT_PROPOSALS_FILTERS);
     });
 
@@ -119,7 +117,6 @@ describe("proposals-store", () => {
       const filters = get(proposalsFiltersStore);
       expect(filters).toEqual({
         ...DEFAULT_PROPOSALS_FILTERS,
-        lastAppliedFilter: "topics",
         topics: filter,
       });
     });
@@ -131,23 +128,8 @@ describe("proposals-store", () => {
       const filters = get(proposalsFiltersStore);
       expect(filters).toEqual({
         ...DEFAULT_PROPOSALS_FILTERS,
-        lastAppliedFilter: "status",
         status: filter,
       });
-    });
-
-    it("should reload filters", () => {
-      const filter = [Topic.NetworkEconomics, Topic.SubnetManagement];
-      proposalsFiltersStore.filterTopics(filter);
-
-      proposalsFiltersStore.reload();
-
-      const filters = get(proposalsFiltersStore);
-      expect(filters).toEqual({
-        ...DEFAULT_PROPOSALS_FILTERS,
-        topics: filter,
-      });
-      expect(filters.lastAppliedFilter).toBeUndefined();
     });
   });
 

--- a/frontend/src/tests/lib/stores/proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/proposals.store.spec.ts
@@ -136,26 +136,6 @@ describe("proposals-store", () => {
       });
     });
 
-    it("should toggle excluded vote proposals back and forth", () => {
-      proposalsFiltersStore.toggleExcludeVotedProposals();
-
-      let filters = get(proposalsFiltersStore);
-      expect(filters).toEqual({
-        ...DEFAULT_PROPOSALS_FILTERS,
-        lastAppliedFilter: "excludeVotedProposals",
-        excludeVotedProposals: true,
-      });
-
-      proposalsFiltersStore.toggleExcludeVotedProposals();
-
-      filters = get(proposalsFiltersStore);
-      expect(filters).toEqual({
-        ...DEFAULT_PROPOSALS_FILTERS,
-        lastAppliedFilter: "excludeVotedProposals",
-        excludeVotedProposals: false,
-      });
-    });
-
     it("should reload filters", () => {
       const filter = [Topic.NetworkEconomics, Topic.SubnetManagement];
       proposalsFiltersStore.filterTopics(filter);

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -24,7 +24,6 @@ import {
   replaceProposals,
   selectedNeuronsVotingPower,
 } from "$lib/utils/proposals.utils";
-import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import {
@@ -95,27 +94,6 @@ describe("proposals-utils", () => {
     ));
 
   describe("hideProposal", () => {
-    const proposalWithBallot = ({
-      proposal,
-      vote,
-    }: {
-      proposal: ProposalInfo;
-      vote?: Vote;
-    }): ProposalInfo => ({
-      ...proposal,
-      ballots: [
-        {
-          neuronId: 0n,
-          vote: vote ?? Vote.Unspecified,
-        } as Ballot,
-      ],
-    });
-    const neurons = [
-      {
-        neuronId: 0n,
-      } as NeuronInfo,
-    ];
-
     beforeEach(() => {
       overrideFeatureFlagsStore.setFlag("ENABLE_VOTING_INDICATION", false);
     });
@@ -126,10 +104,7 @@ describe("proposals-utils", () => {
           proposalInfo: mockProposals[0],
           filters: {
             ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: false,
           },
-          neurons,
-          identity: mockIdentity,
         })
       ).toBe(false);
 
@@ -138,34 +113,25 @@ describe("proposals-utils", () => {
           proposalInfo: mockProposals[1],
           filters: {
             ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: false,
           },
-          neurons,
-          identity: mockIdentity,
         })
       ).toBe(false);
 
       expect(
         hideProposal({
-          proposalInfo: proposalWithBallot({ proposal: mockProposals[0] }),
+          proposalInfo: mockProposals[0],
           filters: {
             ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: true,
           },
-          neurons,
-          identity: mockIdentity,
         })
       ).toBe(false);
 
       expect(
         hideProposal({
-          proposalInfo: proposalWithBallot({ proposal: mockProposals[1] }),
+          proposalInfo: mockProposals[1],
           filters: {
             ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: true,
           },
-          neurons,
-          identity: mockIdentity,
         })
       ).toBe(false);
 
@@ -182,10 +148,7 @@ describe("proposals-utils", () => {
           },
           filters: {
             ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: false,
           },
-          neurons,
-          identity: mockIdentity,
         })
       ).toBe(false);
 
@@ -202,127 +165,38 @@ describe("proposals-utils", () => {
           },
           filters: {
             ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: false,
           },
-          neurons,
-          identity: mockIdentity,
         })
       ).toBe(false);
-
-      expect(
-        hideProposal({
-          proposalInfo: proposalWithBallot({ proposal: mockProposals[0] }),
-          filters: {
-            ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: true,
-          },
-          neurons,
-          identity: mockIdentity,
-        })
-      ).toBe(false);
-
-      expect(
-        hideProposal({
-          proposalInfo: proposalWithBallot({ proposal: mockProposals[1] }),
-          filters: {
-            ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: true,
-          },
-          neurons,
-          identity: mockIdentity,
-        })
-      ).toBe(false);
-
-      expect(
-        hideProposal({
-          proposalInfo: proposalWithBallot({
-            proposal: mockProposals[0],
-            vote: Vote.Yes,
-          }),
-          filters: {
-            ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: true,
-          },
-          neurons,
-          identity: undefined,
-        })
-      ).toBe(false);
-    });
-
-    it("should hide proposal", () => {
-      expect(
-        hideProposal({
-          proposalInfo: proposalWithBallot({
-            proposal: mockProposals[0],
-            vote: Vote.Yes,
-          }),
-          filters: {
-            ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: true,
-          },
-          neurons,
-          identity: mockIdentity,
-        })
-      ).toBeTruthy();
-
-      expect(
-        hideProposal({
-          proposalInfo: proposalWithBallot({
-            proposal: mockProposals[0],
-            vote: Vote.No,
-          }),
-          filters: {
-            ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: true,
-          },
-          neurons,
-          identity: mockIdentity,
-        })
-      ).toBeTruthy();
     });
 
     it("should not hide proposal if a filter is empty", () => {
       expect(
         hideProposal({
-          proposalInfo: proposalWithBallot({
-            proposal: mockProposals[0],
-          }),
+          proposalInfo: mockProposals[0],
           filters: {
             ...DEFAULT_PROPOSALS_FILTERS,
             topics: [],
-            excludeVotedProposals: false,
           },
-          neurons,
-          identity: mockIdentity,
         })
       ).toBe(false);
 
       expect(
         hideProposal({
-          proposalInfo: proposalWithBallot({
-            proposal: mockProposals[0],
-          }),
+          proposalInfo: mockProposals[0],
           filters: {
             ...DEFAULT_PROPOSALS_FILTERS,
             status: [],
-            excludeVotedProposals: false,
           },
-          neurons,
-          identity: mockIdentity,
         })
       ).toBe(false);
 
       expect(
         hideProposal({
-          proposalInfo: proposalWithBallot({
-            proposal: mockProposals[0],
-          }),
+          proposalInfo: mockProposals[0],
           filters: {
             ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: false,
           },
-          neurons,
-          identity: mockIdentity,
         })
       ).toBe(false);
     });
@@ -330,94 +204,21 @@ describe("proposals-utils", () => {
     it("should hide proposal if does not match filter", () => {
       expect(
         hideProposal({
-          proposalInfo: proposalWithBallot({
-            proposal: mockProposals[0],
-          }),
+          proposalInfo: mockProposals[0],
           filters: {
             ...DEFAULT_PROPOSALS_FILTERS,
             topics: [Topic.Kyc],
-            excludeVotedProposals: false,
           },
-          neurons,
-          identity: mockIdentity,
         })
       ).toBeTruthy();
 
       expect(
         hideProposal({
-          proposalInfo: proposalWithBallot({
-            proposal: mockProposals[0],
-          }),
+          proposalInfo: mockProposals[0],
           filters: {
             ...DEFAULT_PROPOSALS_FILTERS,
             status: [ProposalStatus.Executed],
-            excludeVotedProposals: false,
           },
-          neurons,
-          identity: mockIdentity,
-        })
-      ).toBeTruthy();
-    });
-
-    it("should not show proposal without ballots", () => {
-      expect(
-        hideProposal({
-          proposalInfo: {
-            ...mockProposals[0],
-            ballots: [],
-          },
-          filters: {
-            ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: true,
-          },
-          neurons,
-          identity: mockIdentity,
-        })
-      ).toBeTruthy();
-
-      expect(
-        hideProposal({
-          proposalInfo: {
-            ...mockProposals[0],
-            ballots: [
-              {
-                neuronId: 0n,
-                vote: Vote.Unspecified,
-              } as Ballot,
-            ],
-          },
-          filters: {
-            ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: true,
-          },
-          neurons,
-          identity: mockIdentity,
-        })
-      ).toBe(false);
-    });
-
-    it("should ignore ballots neuronIds that are not in neurons", () => {
-      expect(
-        hideProposal({
-          proposalInfo: {
-            ...mockProposals[0],
-            ballots: [
-              {
-                neuronId: 0n,
-                vote: Vote.Unspecified,
-              } as Ballot,
-            ],
-          },
-          filters: {
-            ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: true,
-          },
-          neurons: [
-            {
-              neuronId: 666n,
-            } as NeuronInfo,
-          ],
-          identity: mockIdentity,
         })
       ).toBeTruthy();
     });
@@ -427,71 +228,24 @@ describe("proposals-utils", () => {
         overrideFeatureFlagsStore.setFlag("ENABLE_VOTING_INDICATION", true);
       });
 
-      it("should show proposals with or without ballots when excludeVotedProposals enabled", () => {
-        expect(
-          hideProposal({
-            proposalInfo: {
-              ...mockProposals[0],
-              ballots: [],
-            },
-            filters: {
-              ...DEFAULT_PROPOSALS_FILTERS,
-              excludeVotedProposals: true,
-            },
-            neurons,
-            identity: mockIdentity,
-          })
-        ).toBe(false);
-
-        expect(
-          hideProposal({
-            proposalInfo: {
-              ...mockProposals[0],
-              ballots: [
-                {
-                  neuronId: 0n,
-                  vote: Vote.Unspecified,
-                } as Ballot,
-              ],
-            },
-            filters: {
-              ...DEFAULT_PROPOSALS_FILTERS,
-              excludeVotedProposals: true,
-            },
-            neurons,
-            identity: mockIdentity,
-          })
-        ).toBe(false);
-      });
-
       it("should check for matched filter", () => {
         expect(
           hideProposal({
-            proposalInfo: proposalWithBallot({
-              proposal: mockProposals[0],
-            }),
+            proposalInfo: mockProposals[0],
             filters: {
               ...DEFAULT_PROPOSALS_FILTERS,
               topics: [Topic.Kyc],
-              excludeVotedProposals: true,
             },
-            neurons,
-            identity: mockIdentity,
           })
         ).toBe(true);
 
         expect(
           hideProposal({
-            proposalInfo: proposalWithBallot({
-              proposal: mockProposals[0],
-            }),
+            proposalInfo: mockProposals[0],
             filters: {
               ...DEFAULT_PROPOSALS_FILTERS,
               topics: [Topic.Governance],
-              excludeVotedProposals: true,
             },
-            neurons,
-            identity: mockIdentity,
           })
         ).toBe(false);
       });
@@ -499,42 +253,13 @@ describe("proposals-utils", () => {
   });
 
   describe("hasMatchingProposals", () => {
-    const neurons = [
-      {
-        neuronId: 0n,
-      } as NeuronInfo,
-    ];
-
     it("should have matching proposals", () => {
       expect(
         hasMatchingProposals({
           proposals: mockProposals,
           filters: {
             ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: false,
           },
-          neurons,
-          identity: mockIdentity,
-        })
-      ).toBeTruthy();
-
-      expect(
-        hasMatchingProposals({
-          proposals: mockProposals.map((proposal) => ({
-            ...proposal,
-            ballots: [
-              {
-                neuronId: 0n,
-                vote: Vote.Unspecified,
-              } as Ballot,
-            ],
-          })),
-          filters: {
-            ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: true,
-          },
-          neurons,
-          identity: mockIdentity,
         })
       ).toBeTruthy();
 
@@ -554,10 +279,7 @@ describe("proposals-utils", () => {
           ],
           filters: {
             ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: false,
           },
-          neurons,
-          identity: mockIdentity,
         })
       ).toBeTruthy();
 
@@ -577,78 +299,7 @@ describe("proposals-utils", () => {
           ],
           filters: {
             ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: false,
           },
-          neurons,
-          identity: mockIdentity,
-        })
-      ).toBeTruthy();
-
-      expect(
-        hasMatchingProposals({
-          proposals: [
-            ...mockProposals,
-            {
-              ...mockProposals[0],
-              ballots: [
-                {
-                  neuronId: 0n,
-                  vote: Vote.Unspecified,
-                } as Ballot,
-              ],
-            },
-          ],
-          filters: {
-            ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: true,
-          },
-          neurons,
-          identity: mockIdentity,
-        })
-      ).toBeTruthy();
-
-      expect(
-        hasMatchingProposals({
-          proposals: [
-            ...mockProposals,
-            {
-              ...mockProposals[1],
-              ballots: [
-                {
-                  neuronId: 0n,
-                  vote: Vote.Unspecified,
-                } as Ballot,
-              ],
-            },
-          ],
-          filters: {
-            ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: true,
-          },
-          neurons,
-          identity: mockIdentity,
-        })
-      ).toBeTruthy();
-
-      expect(
-        hasMatchingProposals({
-          proposals: [
-            {
-              ...mockProposals[0],
-              ballots: [
-                {
-                  neuronId: 0n,
-                  vote: Vote.Yes,
-                } as Ballot,
-              ],
-            },
-          ],
-          filters: {
-            ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: true,
-          },
-          neurons,
-          identity: null,
         })
       ).toBeTruthy();
     });
@@ -659,56 +310,9 @@ describe("proposals-utils", () => {
           proposals: [],
           filters: {
             ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: false,
           },
-          neurons,
-          identity: mockIdentity,
         })
       ).toBe(false);
-
-      expect(
-        hasMatchingProposals({
-          proposals: [
-            {
-              ...mockProposals[0],
-              ballots: [
-                {
-                  neuronId: 0n,
-                  vote: Vote.Yes,
-                } as Ballot,
-              ],
-            },
-          ],
-          filters: {
-            ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: true,
-          },
-          neurons,
-          identity: mockIdentity,
-        })
-      ).toBe(true);
-
-      expect(
-        hasMatchingProposals({
-          proposals: [
-            {
-              ...mockProposals[0],
-              ballots: [
-                {
-                  neuronId: 0n,
-                  vote: Vote.No,
-                } as Ballot,
-              ],
-            },
-          ],
-          filters: {
-            ...DEFAULT_PROPOSALS_FILTERS,
-            excludeVotedProposals: true,
-          },
-          neurons,
-          identity: mockIdentity,
-        })
-      ).toBe(true);
     });
 
     // TODO: remove the whole block when ENABLE_VOTING_INDICATION is removed
@@ -723,202 +327,18 @@ describe("proposals-utils", () => {
             proposals: mockProposals,
             filters: {
               ...DEFAULT_PROPOSALS_FILTERS,
-              excludeVotedProposals: false,
             },
-            neurons,
-            identity: mockIdentity,
-          })
-        ).toBeTruthy();
-
-        expect(
-          hasMatchingProposals({
-            proposals: mockProposals.map((proposal) => ({
-              ...proposal,
-              ballots: [
-                {
-                  neuronId: 0n,
-                  vote: Vote.Unspecified,
-                } as Ballot,
-              ],
-            })),
-            filters: {
-              ...DEFAULT_PROPOSALS_FILTERS,
-              excludeVotedProposals: true,
-            },
-            neurons,
-            identity: mockIdentity,
-          })
-        ).toBeTruthy();
-
-        expect(
-          hasMatchingProposals({
-            proposals: [
-              ...mockProposals,
-              {
-                ...mockProposals[0],
-                ballots: [
-                  {
-                    neuronId: 0n,
-                    vote: Vote.Unspecified,
-                  } as Ballot,
-                ],
-              },
-            ],
-            filters: {
-              ...DEFAULT_PROPOSALS_FILTERS,
-              excludeVotedProposals: false,
-            },
-            neurons,
-            identity: mockIdentity,
-          })
-        ).toBeTruthy();
-
-        expect(
-          hasMatchingProposals({
-            proposals: [
-              ...mockProposals,
-              {
-                ...mockProposals[1],
-                ballots: [
-                  {
-                    neuronId: 0n,
-                    vote: Vote.Unspecified,
-                  } as Ballot,
-                ],
-              },
-            ],
-            filters: {
-              ...DEFAULT_PROPOSALS_FILTERS,
-              excludeVotedProposals: false,
-            },
-            neurons,
-            identity: mockIdentity,
-          })
-        ).toBeTruthy();
-
-        expect(
-          hasMatchingProposals({
-            proposals: [
-              ...mockProposals,
-              {
-                ...mockProposals[0],
-                ballots: [
-                  {
-                    neuronId: 0n,
-                    vote: Vote.Unspecified,
-                  } as Ballot,
-                ],
-              },
-            ],
-            filters: {
-              ...DEFAULT_PROPOSALS_FILTERS,
-              excludeVotedProposals: true,
-            },
-            neurons,
-            identity: mockIdentity,
-          })
-        ).toBeTruthy();
-
-        expect(
-          hasMatchingProposals({
-            proposals: [
-              ...mockProposals,
-              {
-                ...mockProposals[1],
-                ballots: [
-                  {
-                    neuronId: 0n,
-                    vote: Vote.Unspecified,
-                  } as Ballot,
-                ],
-              },
-            ],
-            filters: {
-              ...DEFAULT_PROPOSALS_FILTERS,
-              excludeVotedProposals: true,
-            },
-            neurons,
-            identity: mockIdentity,
-          })
-        ).toBeTruthy();
-
-        expect(
-          hasMatchingProposals({
-            proposals: [
-              {
-                ...mockProposals[0],
-                ballots: [
-                  {
-                    neuronId: 0n,
-                    vote: Vote.Yes,
-                  } as Ballot,
-                ],
-              },
-            ],
-            filters: {
-              ...DEFAULT_PROPOSALS_FILTERS,
-              excludeVotedProposals: true,
-            },
-            neurons,
-            identity: null,
           })
         ).toBeTruthy();
       });
 
-      it("should not have matching proposals", () => {
+      it("should not have matching proposals when no proposals", () => {
         expect(
           hasMatchingProposals({
             proposals: [],
             filters: {
               ...DEFAULT_PROPOSALS_FILTERS,
-              excludeVotedProposals: false,
             },
-            neurons,
-            identity: mockIdentity,
-          })
-        ).toBe(false);
-
-        expect(
-          hasMatchingProposals({
-            proposals: [
-              {
-                ...mockProposals[0],
-                ballots: [
-                  {
-                    neuronId: 0n,
-                    vote: Vote.Yes,
-                  } as Ballot,
-                ],
-              },
-            ],
-            filters: {
-              ...DEFAULT_PROPOSALS_FILTERS,
-              excludeVotedProposals: true,
-            },
-            neurons,
-            identity: mockIdentity,
-          })
-        ).toBe(false);
-
-        expect(
-          hasMatchingProposals({
-            proposals: [
-              {
-                ...mockProposals[0],
-                ballots: [
-                  {
-                    neuronId: 0n,
-                    vote: Vote.No,
-                  } as Ballot,
-                ],
-              },
-            ],
-            filters: {
-              ...DEFAULT_PROPOSALS_FILTERS,
-              excludeVotedProposals: true,
-            },
-            neurons,
-            identity: mockIdentity,
           })
         ).toBe(false);
       });

--- a/frontend/src/tests/page-objects/NnsProposalFilters.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsProposalFilters.page-object.ts
@@ -1,5 +1,4 @@
 import { ActionableProposalsSegmentPo } from "$tests/page-objects/ActionableProposalsSegment.page-object";
-import { CheckboxPo } from "$tests/page-objects/Checkbox.page-object";
 import { FilterModalPo } from "$tests/page-objects/FilterModal.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -31,13 +30,6 @@ export class NnsProposalFiltersPo extends BasePageObject {
 
   getFilterModalPo(): FilterModalPo {
     return FilterModalPo.under(this.root);
-  }
-
-  getVotableProposalsOnlyCheckboxPo(): CheckboxPo {
-    return CheckboxPo.under({
-      element: this.root,
-      testId: "votable-proposals-only",
-    });
   }
 
   async selectEntriesInFilterModal(ids: string[]): Promise<void> {


### PR DESCRIPTION
# Motivation

Remove "Show only proposals you can still vote for" checkbox. This is the first step to get rid of `ENABLE_VOTING_INDICATION` feature flag.

# Changes

- Remove the `<Checkbox>`  from `NnsProposalsFilters` component.
- Remove obsolete code from `ProposalsFiltersStore`:
  - Remove `excludeVotedProposals` (reflects the removed checkbox state).
  - Remove `lastAppliedFilter` (it was used only to render a preloader when `excludeVotedProposals` is checked).
  - Removed `reload()` that was there to fix — “The filter to show only the ones you can vote on was being used even though the user was not logged in” (#1562).
- Remove `isExcludedVotedProposal` util.
- Remove unused arguments because neurons and identity were needed only for `isExcludedVotedProposal()`.

# Tests

- Remove `getVotableProposalsOnlyCheckboxPo`.
- Update tests.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.