### PR TITLE
E2e test stake increase recovery process

### DIFF
--- a/frontend/src/lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronAdvancedSection.svelte
@@ -70,7 +70,7 @@
       </KeyValuePair>
     {/if}
     {#if nonNullish(neuron.fullNeuron)}
-      <KeyValuePair>
+      <KeyValuePair testId="neuron-account-row">
         <span slot="key" class="label"
           >{$i18n.neuron_detail.neuron_account}</span
         >

--- a/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
+++ b/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
@@ -27,10 +27,6 @@ test("Test neuron increase stake", async ({ page, context }) => {
   expect(neuronIds).toHaveLength(1);
   const neuronId = neuronIds[0];
 
-  step("Go to the neurons tab");
-  await appPo.goToNeurons();
-  await appPo.getNeuronsPo().getNnsNeuronsPo().waitForContentLoaded();
-
   step("Open neuron details");
   await appPo.goToNeuronDetails(neuronId);
 
@@ -90,7 +86,6 @@ test("Test neuron increase stake", async ({ page, context }) => {
   });
 
   await appPo.goBack({ waitAbsent: false });
-  //await new Promise((r) => setTimeout(r, 5000));
   await appPo.getAccountsPo().waitFor();
   await appPo.goBack();
   await appPo.goToNeuronDetails(neuronId);

--- a/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
+++ b/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
@@ -1,0 +1,106 @@
+import { AppPo } from "$tests/page-objects/App.page-object";
+import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
+import { getNnsNeuronCardsIds } from "$tests/utils/e2e.nns-neuron.test-utils";
+import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import { expect, test } from "@playwright/test";
+
+test("Test neuron increase stake", async ({ page, context }) => {
+  await page.goto("/");
+  await expect(page).toHaveTitle("Tokens / NNS Dapp");
+  await signInWithNewUser({ page, context });
+
+  const pageElement = PlaywrightPageObjectElement.fromPage(page);
+  const appPo = new AppPo(pageElement);
+
+  step("Get some ICP");
+  await appPo.getIcpTokens(20);
+
+  step("Stake neuron");
+  await appPo.goToNeurons();
+  const initialStake = 10;
+  await appPo
+    .getNeuronsPo()
+    .getNnsNeuronsFooterPo()
+    .stakeNeuron({ amount: initialStake, dissolveDelayDays: "max" });
+
+  const neuronIds = await getNnsNeuronCardsIds(appPo);
+  expect(neuronIds).toHaveLength(1);
+  const neuronId = neuronIds[0];
+
+  step("Go to the neurons tab");
+  await appPo.goToNeurons();
+  await appPo.getNeuronsPo().getNnsNeuronsPo().waitForContentLoaded();
+
+  step("Open neuron details");
+  await appPo.goToNeuronDetails(neuronId);
+
+  step("Get neuron voting power");
+  const neuronStake1 = Number(
+    await appPo
+      .getNeuronDetailPo()
+      .getNnsNeuronDetailPo()
+      .getVotingPowerSectionPo()
+      .getStake()
+  );
+
+  expect(neuronStake1).toBe(initialStake);
+
+  step("Increase neuron stake");
+  const increase1 = 5;
+  await appPo
+    .getNeuronDetailPo()
+    .getNnsNeuronDetailPo()
+    .increaseStake({ amount: increase1 });
+
+  const neuronStake2 = Number(
+    await appPo
+      .getNeuronDetailPo()
+      .getNnsNeuronDetailPo()
+      .getVotingPowerSectionPo()
+      .getStake()
+  );
+
+  expect(neuronStake2).toBe(initialStake + increase1);
+
+  // Increasing neuron stake is a 2-step process:
+  // 1. Transfer ICP to the neuron account.
+  // 2. Refresh the neuron.
+  // These steps are normally performed by the frontend code, but it's
+  // possible the process gets interrupted between steps 1 and 2.
+  // To recover from this, the nns-dapp canister watches all
+  // transactions to see if it needs to refresh any neurons.
+  // This is why transferring ICP to the neuron account works to
+  // increase the neuron stake.
+  // When we switch to using ICRC-2 this is no longer necessary and
+  // this test can be removed.
+  step("Increase neuron stake with transfer to neuron account");
+  const increase2 = 3;
+  const neuronAccount = await appPo
+      .getNeuronDetailPo()
+      .getNnsNeuronDetailPo()
+      .getAdvancedSectionPo()
+      .neuronAccount();
+
+  await appPo.goBack();
+  await appPo.goToAccounts();
+  await appPo.goToNnsMainAccountWallet();
+  await appPo.getWalletPo().getNnsWalletPo().transferToAddress({
+    destinationAddress: neuronAccount,
+    amount: increase2,
+  });
+
+  await appPo.goBack({waitAbsent: false});
+  //await new Promise((r) => setTimeout(r, 5000));
+  await appPo.getAccountsPo().waitFor();
+  await appPo.goBack();
+  await appPo.goToNeuronDetails(neuronId);
+  const neuronStake3 = Number(
+    await appPo
+      .getNeuronDetailPo()
+      .getNnsNeuronDetailPo()
+      .getVotingPowerSectionPo()
+      .getStake()
+  );
+  expect(neuronStake3).toBe(initialStake + increase1 + increase2);
+});

--- a/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
+++ b/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
@@ -1,7 +1,6 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { getNnsNeuronCardsIds } from "$tests/utils/e2e.nns-neuron.test-utils";
-import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
 import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
@@ -77,10 +76,10 @@ test("Test neuron increase stake", async ({ page, context }) => {
   step("Increase neuron stake with transfer to neuron account");
   const increase2 = 3;
   const neuronAccount = await appPo
-      .getNeuronDetailPo()
-      .getNnsNeuronDetailPo()
-      .getAdvancedSectionPo()
-      .neuronAccount();
+    .getNeuronDetailPo()
+    .getNnsNeuronDetailPo()
+    .getAdvancedSectionPo()
+    .neuronAccount();
 
   await appPo.goBack();
   await appPo.goToAccounts();
@@ -90,7 +89,7 @@ test("Test neuron increase stake", async ({ page, context }) => {
     amount: increase2,
   });
 
-  await appPo.goBack({waitAbsent: false});
+  await appPo.goBack({ waitAbsent: false });
   //await new Promise((r) => setTimeout(r, 5000));
   await appPo.getAccountsPo().waitFor();
   await appPo.goBack();

--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -6,7 +6,7 @@ import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { ProposalStatus, Topic } from "@dfinity/nns";
 import { expect, test } from "@playwright/test";
 
-test("Test neuron voting", async ({ page, context }) => {
+test("Test proposals", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
   await signInWithNewUser({ page, context });

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -56,6 +56,7 @@ describe("NnsNeuronAdvancedSection", () => {
   });
 
   it("should render neuron data", async () => {
+    const neuronAccountIdentifier = mockSubAccount.identifier;
     const neuron: NeuronInfo = {
       ...mockNeuron,
       neuronId: 12345n,
@@ -64,7 +65,7 @@ describe("NnsNeuronAdvancedSection", () => {
       fullNeuron: {
         ...mockNeuron.fullNeuron,
         agingSinceTimestampSeconds: BigInt(SECONDS_IN_MONTH),
-        accountIdentifier: mockSubAccount.identifier,
+        accountIdentifier: neuronAccountIdentifier,
       },
     };
     const po = renderComponent(neuron);
@@ -74,7 +75,7 @@ describe("NnsNeuronAdvancedSection", () => {
       "Jul 18, 2023 7:44 AM"
     );
     expect(await po.neuronAge()).toBe("30 days, 10 hours");
-    expect(await po.neuronAccount()).toBe("d0654c5...2ff9f32");
+    expect(await po.neuronAccount()).toBe(neuronAccountIdentifier);
   });
 
   it("should render last rewards distribution", async () => {

--- a/frontend/src/tests/page-objects/NnsNeuronAdvancedSection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronAdvancedSection.page-object.ts
@@ -1,5 +1,6 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { HashPo } from "./Hash.page-object";
 import { NnsNeuronAgePo } from "./NnsNeuronAge.page-object";
 
 export class NnsNeuronAdvancedSectionPo extends BasePageObject {
@@ -32,7 +33,7 @@ export class NnsNeuronAdvancedSectionPo extends BasePageObject {
   }
 
   neuronAccount(): Promise<string> {
-    return this.getText("neuron-account");
+    return HashPo.under(this.root.byTestId("neuron-account-row")).getFullText();
   }
 
   lastRewardsDistribution(): Promise<string> {

--- a/frontend/src/tests/page-objects/NnsNeuronVotingPowerSection.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeuronVotingPowerSection.page-object.ts
@@ -29,6 +29,10 @@ export class NnsNeuronVotingPowerSectionPo extends BasePageObject {
     return this.getStakeItemActionPo().isPresent();
   }
 
+  getStake(): Promise<string> {
+    return this.getStakeItemActionPo().getStake();
+  }
+
   getNeuronStateItemActionPo(): NnsNeuronStateItemActionPo {
     return NnsNeuronStateItemActionPo.under(this.root);
   }

--- a/frontend/src/tests/page-objects/NnsWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsWallet.page-object.ts
@@ -96,4 +96,20 @@ export class NnsWalletPo extends BasePageObject {
     });
     await modal.waitForAbsent();
   }
+
+  async transferToAddress({
+    destinationAddress,
+    amount,
+  }: {
+    destinationAddress: string;
+    amount: number;
+  }): Promise<void> {
+    await this.clickSend();
+    const modal = this.getIcpTransactionModalPo();
+    await modal.transferToAddress({
+      destinationAddress,
+      amount,
+    });
+    await modal.waitForAbsent();
+  }
 }

--- a/frontend/src/tests/page-objects/playwright.page-object.ts
+++ b/frontend/src/tests/page-objects/playwright.page-object.ts
@@ -2,27 +2,37 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 import type { Locator, Page } from "@playwright/test";
 
 export class PlaywrightPageObjectElement implements PageObjectElement {
+  readonly page: Page;
   readonly locator: Locator;
 
-  constructor(locator: Locator) {
+  constructor({ locator, page }: { locator: Locator; page: Page }) {
     this.locator = locator;
+    this.page = page;
   }
 
   static fromPage(page: Page): PlaywrightPageObjectElement {
-    return new PlaywrightPageObjectElement(page.locator("body"));
+    return new PlaywrightPageObjectElement({
+      locator: page.locator("body"),
+      page,
+    });
   }
 
   querySelector(selector: string): PlaywrightPageObjectElement {
-    return new PlaywrightPageObjectElement(
-      this.locator.locator(selector).first()
-    );
+    return new PlaywrightPageObjectElement({
+      locator: this.locator.locator(selector).first(),
+      page: this.page,
+    });
   }
 
   async querySelectorAll(
     selector: string
   ): Promise<PlaywrightPageObjectElement[]> {
     return (await this.locator.locator(selector).all()).map(
-      (locator) => new PlaywrightPageObjectElement(locator)
+      (locator) =>
+        new PlaywrightPageObjectElement({
+          locator,
+          page: this.page,
+        })
     );
   }
 
@@ -36,7 +46,10 @@ export class PlaywrightPageObjectElement implements PageObjectElement {
     const elements: PlaywrightPageObjectElement[] = [];
     for (let i = 0; i < count; i++) {
       elements.push(
-        new PlaywrightPageObjectElement(this.locator.locator(selector).nth(i))
+        new PlaywrightPageObjectElement({
+          locator: this.locator.locator(selector).nth(i),
+          page: this.page,
+        })
       );
     }
     return elements;
@@ -140,6 +153,6 @@ export class PlaywrightPageObjectElement implements PageObjectElement {
   }
 
   async getDocumentBody(): Promise<PlaywrightPageObjectElement> {
-    throw new Error("Not implemented");
+    return PlaywrightPageObjectElement.fromPage(this.page);
   }
 }


### PR DESCRIPTION
# Motivation

The nns-dapp canister has a process where it finishes refreshing a neuron if ICP is transferred to a neuron account but the frontend got interrupted before it could refresh the neuron.
Recently I needed to test this several times manually so I decided it would be good to have an e2e test for it.

# Changes

1. Implement `getDocumentBody()` on `PlaywrightPageObjectElement` to allow getting tooltip text in e2e test.
2. Use `HashPo.getFullText()` to get the full neuron account instead of the truncated one.
3. Update unit test that previously expected a truncated neuron account identifier to now expect the full identifier.
4. Add an e2e test that tests that neuron stake can be increased both the normal way and by making a direct transfer to the neuron account.

Drive-by:

5. Fix test description in `frontend/src/tests/e2e/proposals.spec.ts`.

# Tests

* I ran the test 20+ times to make sure it's not very flaky.
* I commented out [this line](https://github.com/dfinity/nns-dapp/blob/9eea661f750b05feb46a9a65e77877db5cbcd929/rs/backend/src/ledger_sync.rs#L58) to see that it makes the test fail.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary