### PR TITLE
Update IC candid files to release-2024-05-01_23-01-storage-layer

### DIFF
--- a/declarations/nns_governance/nns_governance.did
+++ b/declarations/nns_governance/nns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-24_23-01-storage-layer/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;

--- a/declarations/nns_ledger/nns_ledger.did
+++ b/declarations/nns_ledger/nns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-24_23-01-storage-layer/rs/rosetta-api/icp_ledger/ledger.did>
+//! Candid for canister `nns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/rosetta-api/icp_ledger/ledger.did>
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.

--- a/declarations/nns_registry/nns_registry.did
+++ b/declarations/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-24_23-01-storage-layer/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/registry/canister/canister/registry.did>
 type AddApiBoundaryNodePayload = record { node_id : principal; version : text };
 type AddFirewallRulesPayload = record {
   expected_hash : text;
@@ -135,6 +135,7 @@ type FirewallRule = record {
 type FirewallRulesScope = variant {
   Node : principal;
   ReplicaNodes;
+  ApiBoundaryNodes;
   Subnet : principal;
   Global;
 };

--- a/declarations/sns_governance/sns_governance.did
+++ b/declarations/sns_governance/sns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-24_23-01-storage-layer/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/sns/governance/canister/governance.did>
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
@@ -242,10 +242,16 @@ type ManageDappCanisterSettings = record {
   canister_ids : vec principal;
   reserved_cycles_limit : opt nat64;
   log_visibility : opt int32;
+  wasm_memory_limit : opt nat64;
   memory_allocation : opt nat64;
   compute_allocation : opt nat64;
 };
-type ManageLedgerParameters = record { transfer_fee : opt nat64 };
+type ManageLedgerParameters = record {
+  token_symbol : opt text;
+  transfer_fee : opt nat64;
+  token_logo : opt text;
+  token_name : opt text;
+};
 type ManageNeuron = record { subaccount : blob; command : opt Command };
 type ManageNeuronResponse = record { command : opt Command_1 };
 type ManageSnsMetadata = record {

--- a/declarations/sns_ledger/sns_ledger.did
+++ b/declarations/sns_ledger/sns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-24_23-01-storage-layer/rs/rosetta-api/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/rosetta-api/icrc1/ledger/ledger.did>
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.

--- a/declarations/sns_root/sns_root.did
+++ b/declarations/sns_root/sns_root.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-24_23-01-storage-layer/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/sns/root/canister/root.did>
 type CanisterCallError = record { code : opt int32; description : text };
 type CanisterIdRecord = record { canister_id : principal };
 type CanisterInstallMode = variant { reinstall; upgrade; install };
@@ -74,6 +74,7 @@ type ManageDappCanisterSettingsRequest = record {
   canister_ids : vec principal;
   reserved_cycles_limit : opt nat64;
   log_visibility : opt int32;
+  wasm_memory_limit : opt nat64;
   memory_allocation : opt nat64;
   compute_allocation : opt nat64;
 };

--- a/declarations/sns_swap/sns_swap.did
+++ b/declarations/sns_swap/sns_swap.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-24_23-01-storage-layer/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/sns/swap/canister/swap.did>
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;

--- a/declarations/sns_wasm/sns_wasm.did
+++ b/declarations/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-24_23-01-storage-layer/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };

--- a/dfx.json
+++ b/dfx.json
@@ -356,7 +356,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-05-01",
-        "IC_COMMIT": "release-2024-04-24_23-01-storage-layer"
+        "IC_COMMIT": "release-2024-05-01_23-01-storage-layer"
       },
       "packtool": ""
     }


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
Even with no changes, just updating the reference is good practice.

# Changes
## Changes made by a bot triggered by github-merge-queue
- Update the version of `ic` specified in `dfx.json`.
- Update the NNS candid files to the versions in that commit.

# Tests
- See CI
- [ ] Check for breaking changes in the APIs and schedule any required follow-on work.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants