### PR TITLE
NNS1-2905: Improve upgrade-downgrade-test

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -44,6 +44,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* In `migration-test`, also populate some accounts between upgrade and downgrade.
+
 #### Deprecated
 
 #### Removed

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -124,7 +124,7 @@ test_upgrade_downgrade() {
   install_wasm1
   populate $((NUM_TOY_ACCOUNTS / 2))
   upgrade_to_wasm2
-  populate $NUM_TOY_ACCOUNTS
+  populate "$NUM_TOY_ACCOUNTS"
   downgrade_to_wasm1
   echo SUCCESS
 }

--- a/scripts/nns-dapp/migration-test
+++ b/scripts/nns-dapp/migration-test
@@ -95,24 +95,25 @@ install_wasm1() {
 }
 populate() {
   echo "Installing state..."
-  while (("$(dfx canister call nns-dapp get_stats | idl2json | jq -r .accounts_count)" < NUM_TOY_ACCOUNTS)); do
+  target_accounts_count="$1"
+  while (("$(get_accounts_count)" < target_accounts_count)); do
     dfx canister call nns-dapp create_toy_accounts "($TOY_ACCOUNT_CHUNK_SIZE: nat)"
   done
   verify_healthy
-  check_state_size
+  check_state_size "$target_accounts_count"
   test -z "${SCHEMA1:-}" || assert_schema_is "${SCHEMA1}"
 }
 upgrade_to_wasm2() {
   echo "Upgrading to $(working_wasm 2)..."
   upgrade_nnsdapp "$(working_wasm 2)" "$(working_arguments 2)"
-  check_state_size
+  check_state_size "$((NUM_TOY_ACCOUNTS / 2))"
   test -z "${SCHEMA2:-}" || assert_schema_is "${SCHEMA2}"
 }
 downgrade_to_wasm1() {
   echo "Reverting to $(working_wasm 1)..."
   upgrade_nnsdapp "$(working_wasm 1)" "$(working_arguments 1)"
   verify_healthy
-  check_state_size
+  check_state_size "$NUM_TOY_ACCOUNTS"
   test -z "${SCHEMA1:-}" || assert_schema_is "${SCHEMA1}"
 }
 
@@ -121,8 +122,9 @@ test_upgrade_downgrade() {
   get_assets
   find "$WORKDIR"
   install_wasm1
-  populate
+  populate $((NUM_TOY_ACCOUNTS / 2))
   upgrade_to_wasm2
+  populate $NUM_TOY_ACCOUNTS
   downgrade_to_wasm1
   echo SUCCESS
 }

--- a/scripts/nns-dapp/migration-test.canister
+++ b/scripts/nns-dapp/migration-test.canister
@@ -49,9 +49,13 @@ assert_accounts_db_stats_are_not_recomputed_on_upgrade() {
   }
 }
 
+get_accounts_count() {
+  dfx canister call nns-dapp get_stats | idl2json | jq -r .accounts_count
+}
+
 # Gets some sample accounts
 sample_toy_accounts() {
-  seq 0 "$TOY_ACCOUNT_CHUNK_SIZE" "$((NUM_TOY_ACCOUNTS - 1))" | xargs -I{} dfx canister call nns-dapp get_toy_account "({})" --query
+  seq 0 "$TOY_ACCOUNT_CHUNK_SIZE" "$(($(get_accounts_count) - 1))" | xargs -I{} dfx canister call nns-dapp get_toy_account "({})" --query
 }
 
 # Gets data that should be invariant across upgrades
@@ -67,7 +71,7 @@ get_upgrade_invariants() {
 # Verifies that the state is at least as large as expected.
 check_state_size() {
   local invariants accounts_count expected_min_accounts
-  expected_min_accounts="$NUM_TOY_ACCOUNTS"
+  expected_min_accounts="$1"
   invariants="$(get_upgrade_invariant_stats)"
   accounts_count="$(jq -r .accounts_count <<<"$invariants")"
   if ((accounts_count < expected_min_accounts)); then


### PR DESCRIPTION
# Motivation

We no longer store transactions in the nns-dapp canister because the frontend now reads transactions from the index canister.
However we still store transaction indexes on individual accounts. These indexes used to point into the vector of transactions which we no longer have and are now completely unused. So we want to clean these up.
Because these accounts are stored in stable memory we have to be careful about removing fields from them or we might get errors when decoding stable memory.
In particular, we should be able to revert to a previous release of nns-dapp in case of an emergency.
So we have to stop reading the fields at least 1 release before we stop writing the fields and we can't just remove the fields directly.

However when testing the changes necessary for this, I noticed that our `upgrade-downgrade-test` does not break even if we remove the fields directly.

We used to encode all data pre-upgrade and decode all data post-upgrade, but now accounts are stored in stable memory. This means that simply upgrading is not enough to detect a data incompatibility. We have to actually write accounts pre-upgrade and read them post-upgrade **and** write accounts pre-downgrade and read accounts post-downgrade.

# Changes

1. In `scripts/nns-dapp/migration-test`, instead of populating all accounts before upgrading and downgrading, populate half of the accounts before upgrading and the other half between upgrading and downgrading.

# Tests

1. The `upgrade-downgrade-test` still passes on head of `main`.
2. The `upgrade-downgrade-test` now fails when removing transactions fields from account, while previous it did not fail.

# Todos

- [x] Add entry to changelog (if necessary).
