### PR TITLE
test: replace render with po in NnsProposals spec

### DIFF
--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -24,10 +24,11 @@ import {
 } from "$tests/mocks/proposals.store.mock";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { NnsProposalListPo } from "$tests/page-objects/NnsProposalList.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { HttpAgent } from "@dfinity/agent";
 import { GovernanceCanister, type ProposalInfo } from "@dfinity/nns";
-import { render, waitFor } from "@testing-library/svelte";
+import { waitFor } from "@testing-library/svelte";
 import type { Subscriber } from "svelte/store";
 import { mock } from "vitest-mock-extended";
 

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -129,7 +129,7 @@ describe("NnsProposals", () => {
         proposalsFiltersStore.filterTopics(DEFAULT_PROPOSALS_FILTERS.topics);
         await runResolvedPromises();
 
-        expect(await po.getListLoaderSpinnerPo().isPresent()).toEqual(true);
+        expect(await po.hasListLoaderSpinner()).toEqual(true);
       });
 
       it("should render proposals", async () => {
@@ -137,13 +137,14 @@ describe("NnsProposals", () => {
         const firstProposal = mockProposals[0] as ProposalInfo;
         const secondProposal = mockProposals[1] as ProposalInfo;
 
-        expect(await po.getProposalCardPos()).toHaveLength(2);
-        expect(
-          await (await po.getProposalCardPos())[0].getProposalId()
-        ).toEqual(`ID: ${firstProposal.id}`);
-        expect(
-          await (await po.getProposalCardPos())[1].getProposalId()
-        ).toEqual(`ID: ${secondProposal.id}`);
+        const cardPos = await po.getProposalCardPos();
+        expect(cardPos).toHaveLength(2);
+        expect(await cardPos[0].getProposalId()).toEqual(
+          `ID: ${firstProposal.id}`
+        );
+        expect(await cardPos[1].getProposalId()).toEqual(
+          `ID: ${secondProposal.id}`
+        );
       });
 
       it("should display actionable mark on all proposals view", async () => {
@@ -270,16 +271,17 @@ describe("NnsProposals", () => {
         mockLoadProposals();
 
         const po = await renderComponent();
+        const cardPos = await po.getProposalCardPos();
         const firstProposal = mockProposals[0] as ProposalInfo;
         const secondProposal = mockProposals[1] as ProposalInfo;
 
-        expect(await po.getProposalCardPos()).toHaveLength(2);
-        expect(
-          await (await po.getProposalCardPos())[0].getProposalId()
-        ).toEqual(`ID: ${firstProposal.id}`);
-        expect(
-          await (await po.getProposalCardPos())[1].getProposalId()
-        ).toEqual(`ID: ${secondProposal.id}`);
+        expect(cardPos).toHaveLength(2);
+        expect(await cardPos[0].getProposalId()).toEqual(
+          `ID: ${firstProposal.id}`
+        );
+        expect(await cardPos[1].getProposalId()).toEqual(
+          `ID: ${secondProposal.id}`
+        );
       });
     });
   });

--- a/frontend/src/tests/page-objects/NnsProposalFilters.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsProposalFilters.page-object.ts
@@ -11,12 +11,20 @@ export class NnsProposalFiltersPo extends BasePageObject {
     return new NnsProposalFiltersPo(element.byTestId(NnsProposalFiltersPo.TID));
   }
 
+  getFilterByTopicsButtonPo(): PageObjectElement {
+    return this.root.byTestId("filters-by-topics");
+  }
+
+  getFilterByStatusButtonPo(): PageObjectElement {
+    return this.root.byTestId("filters-by-status");
+  }
+
   clickFiltersByTopicsButton(): Promise<void> {
-    return this.click("filters-by-topics");
+    return this.getFilterByTopicsButtonPo().click();
   }
 
   clickFiltersByStatusButton(): Promise<void> {
-    return this.click("filters-by-status");
+    return this.getFilterByStatusButtonPo().click();
   }
 
   getActionableProposalsSegmentPo(): ActionableProposalsSegmentPo {

--- a/frontend/src/tests/page-objects/NnsProposalFilters.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsProposalFilters.page-object.ts
@@ -1,4 +1,5 @@
 import { ActionableProposalsSegmentPo } from "$tests/page-objects/ActionableProposalsSegment.page-object";
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { FilterModalPo } from "$tests/page-objects/FilterModal.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -11,12 +12,12 @@ export class NnsProposalFiltersPo extends BasePageObject {
     return new NnsProposalFiltersPo(element.byTestId(NnsProposalFiltersPo.TID));
   }
 
-  getFilterByTopicsButtonPo(): PageObjectElement {
-    return this.root.byTestId("filters-by-topics");
+  getFilterByTopicsButtonPo(): ButtonPo {
+    return this.getButton("filters-by-topics");
   }
 
-  getFilterByStatusButtonPo(): PageObjectElement {
-    return this.root.byTestId("filters-by-status");
+  getFilterByStatusButtonPo(): ButtonPo {
+    return this.getButton("filters-by-status");
   }
 
   clickFiltersByTopicsButton(): Promise<void> {

--- a/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
@@ -17,8 +17,8 @@ export class NnsProposalListPo extends BasePageObject {
     return SkeletonCardPo.under(this.root);
   }
 
-  getListLoaderSpinnerPo(): PageObjectElement {
-    return this.root.byTestId("next-page-sns-proposals-spinner");
+  hasListLoaderSpinner(): Promise<boolean> {
+    return this.isPresent("next-page-sns-proposals-spinner");
   }
 
   getAllProposalList(): PageObjectElement {

--- a/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
@@ -1,4 +1,5 @@
 import { NnsProposalFiltersPo } from "$tests/page-objects/NnsProposalFilters.page-object";
+import { NoProposalsPo } from "$tests/page-objects/NoProposals.page-object";
 import { PageBannerPo } from "$tests/page-objects/PageBanner.page-object";
 import { ProposalCardPo } from "$tests/page-objects/ProposalCard.page-object";
 import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
@@ -14,6 +15,10 @@ export class NnsProposalListPo extends BasePageObject {
 
   getSkeletonCardPo(): SkeletonCardPo {
     return SkeletonCardPo.under(this.root);
+  }
+
+  getListLoaderSpinnerPo(): PageObjectElement {
+    return this.root.byTestId("next-page-sns-proposals-spinner");
   }
 
   getAllProposalList(): PageObjectElement {
@@ -48,6 +53,10 @@ export class NnsProposalListPo extends BasePageObject {
       element: this.root,
       testId: "actionable-proposals-empty",
     });
+  }
+
+  getNoProposalsPo(): NoProposalsPo {
+    return NoProposalsPo.under(this.root);
   }
 
   hasSpinner(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/NoProposals.page-object.ts
+++ b/frontend/src/tests/page-objects/NoProposals.page-object.ts
@@ -1,0 +1,10 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NoProposalsPo extends BasePageObject {
+  private static readonly TID = "no-proposals-msg";
+
+  static under(element: PageObjectElement): NoProposalsPo {
+    return new NoProposalsPo(element.byTestId(NoProposalsPo.TID));
+  }
+}


### PR DESCRIPTION
# Motivation

In the near future the actionable proposals will be selected by default. To be able to switch between all and actionable proposals in the spec file, they should use page object for rendering.

# Changes

- Add missing PO getters.
- Switch from `render()` to using a page object.

# Tests

- Yes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.