### PR TITLE
Update proposal rendering dependencies

### DIFF
--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,13 +1,12 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code, unused_imports)]
-use candid::{self, CandidType, Decode, Deserialize, Encode};
+use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
 use ic_cdk::api::call::CallResult;
-use ic_principal::Principal;
 use serde::Serialize;
 
 #[derive(Serialize, CandidType, Deserialize)]
@@ -545,6 +544,20 @@ pub struct GovernanceCachedMetrics {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct RestoreAgingNeuronGroup {
+    pub count: Option<u64>,
+    pub previous_total_stake_e8s: Option<u64>,
+    pub current_total_stake_e8s: Option<u64>,
+    pub group_type: i32,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct RestoreAgingSummary {
+    pub groups: Vec<RestoreAgingNeuronGroup>,
+    pub timestamp_seconds: Option<u64>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct RewardEvent {
     pub rounds_since_last_distribution: Option<u64>,
     pub day_after_genesis: u64,
@@ -808,6 +821,7 @@ pub struct Governance {
     pub node_providers: Vec<NodeProvider>,
     pub cached_daily_maturity_modulation_basis_points: Option<i32>,
     pub economics: Option<NetworkEconomics>,
+    pub restore_aging_summary: Option<RestoreAgingSummary>,
     pub spawning_neurons: Option<bool>,
     pub latest_reward_event: Option<RewardEvent>,
     pub to_claim_transfers: Vec<NeuronStakeTransfer>,
@@ -1160,6 +1174,9 @@ impl Service {
     }
     pub async fn get_proposal_info(&self, arg0: u64) -> CallResult<(Option<ProposalInfo>,)> {
         ic_cdk::call(self.0, "get_proposal_info", (arg0,)).await
+    }
+    pub async fn get_restore_aging_summary(&self) -> CallResult<(RestoreAgingSummary,)> {
+        ic_cdk::call(self.0, "get_restore_aging_summary", ()).await
     }
     pub async fn list_known_neurons(&self) -> CallResult<(ListKnownNeuronsResponse,)> {
         ic_cdk::call(self.0, "list_known_neurons", ()).await

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -27,6 +27,7 @@ pub struct AddApiBoundaryNodePayload {
 pub enum FirewallRulesScope {
     Node(Principal),
     ReplicaNodes,
+    ApiBoundaryNodes,
     Subnet(Principal),
     Global,
 }
@@ -237,6 +238,12 @@ pub struct DeleteSubnetPayload {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct DeployGuestosToAllSubnetNodesPayload {
+    pub subnet_id: Principal,
+    pub replica_version_id: String,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct DeployGuestosToAllUnassignedNodesPayload {
     pub elected_replica_version: String,
 }
@@ -342,6 +349,15 @@ pub struct RetireReplicaVersionPayload {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct ReviseElectedGuestosVersionsPayload {
+    pub release_package_urls: Vec<String>,
+    pub replica_versions_to_unelect: Vec<String>,
+    pub replica_version_to_elect: Option<String>,
+    pub guest_launch_measurement_sha256_hex: Option<String>,
+    pub release_package_sha256_hex: Option<String>,
+}
+
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct SetFirewallConfigPayload {
     pub ipv4_prefixes: Vec<String>,
     pub firewall_config: String,
@@ -359,15 +375,6 @@ pub struct UpdateElectedHostosVersionsPayload {
     pub release_package_urls: Vec<String>,
     pub hostos_version_to_elect: Option<String>,
     pub hostos_versions_to_unelect: Vec<String>,
-    pub release_package_sha256_hex: Option<String>,
-}
-
-#[derive(Serialize, CandidType, Deserialize)]
-pub struct UpdateElectedReplicaVersionsPayload {
-    pub release_package_urls: Vec<String>,
-    pub replica_versions_to_unelect: Vec<String>,
-    pub replica_version_to_elect: Option<String>,
-    pub guest_launch_measurement_sha256_hex: Option<String>,
     pub release_package_sha256_hex: Option<String>,
 }
 
@@ -477,12 +484,6 @@ pub struct UpdateSubnetPayload {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
-pub struct UpdateSubnetReplicaVersionPayload {
-    pub subnet_id: Principal,
-    pub replica_version_id: String,
-}
-
-#[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateUnassignedNodesConfigPayload {
     pub replica_version: Option<String>,
     pub ssh_readonly_access: Option<Vec<String>>,
@@ -525,6 +526,12 @@ impl Service {
     }
     pub async fn delete_subnet(&self, arg0: DeleteSubnetPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "delete_subnet", (arg0,)).await
+    }
+    pub async fn deploy_guestos_to_all_subnet_nodes(
+        &self,
+        arg0: DeployGuestosToAllSubnetNodesPayload,
+    ) -> CallResult<()> {
+        ic_cdk::call(self.0, "deploy_guestos_to_all_subnet_nodes", (arg0,)).await
     }
     pub async fn deploy_guestos_to_all_unassigned_nodes(
         &self,
@@ -574,6 +581,9 @@ impl Service {
     pub async fn retire_replica_version(&self, arg0: RetireReplicaVersionPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "retire_replica_version", (arg0,)).await
     }
+    pub async fn revise_elected_replica_versions(&self, arg0: ReviseElectedGuestosVersionsPayload) -> CallResult<()> {
+        ic_cdk::call(self.0, "revise_elected_replica_versions", (arg0,)).await
+    }
     pub async fn set_firewall_config(&self, arg0: SetFirewallConfigPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "set_firewall_config", (arg0,)).await
     }
@@ -586,7 +596,7 @@ impl Service {
     pub async fn update_elected_hostos_versions(&self, arg0: UpdateElectedHostosVersionsPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "update_elected_hostos_versions", (arg0,)).await
     }
-    pub async fn update_elected_replica_versions(&self, arg0: UpdateElectedReplicaVersionsPayload) -> CallResult<()> {
+    pub async fn update_elected_replica_versions(&self, arg0: ReviseElectedGuestosVersionsPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "update_elected_replica_versions", (arg0,)).await
     }
     pub async fn update_firewall_rules(&self, arg0: AddFirewallRulesPayload) -> CallResult<()> {
@@ -628,7 +638,7 @@ impl Service {
     pub async fn update_subnet(&self, arg0: UpdateSubnetPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "update_subnet", (arg0,)).await
     }
-    pub async fn update_subnet_replica_version(&self, arg0: UpdateSubnetReplicaVersionPayload) -> CallResult<()> {
+    pub async fn update_subnet_replica_version(&self, arg0: DeployGuestosToAllSubnetNodesPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "update_subnet_replica_version", (arg0,)).await
     }
     pub async fn update_unassigned_nodes_config(&self, arg0: UpdateUnassignedNodesConfigPayload) -> CallResult<()> {

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-04-17_23-01-hotfix-bitcoin-query-stats/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.
Even with no changes, just updating the reference is good practice.

# Changes
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.
  * Note: The candid files under `declarations/nns-$CANISTER` are used as inputs.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants