### PR TITLE
Fix description of snsdemo update PRs

### DIFF
--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -75,6 +75,7 @@ jobs:
 
             # Changes
             * Updated `snsdemo` version in `dfx.json`.
+            * Ensured that the `dfx` version in `dfx.json` matches `snsdemo`.
 
             # Tests
             CI should pass.


### PR DESCRIPTION
# Motivation

In https://github.com/dfinity/nns-dapp/pull/4058 I removed a line from the automatic PR description of snsdemo updates.
But I should have only removed part of that line.
We still check that the dfx version matches. Only the IC commit is moved to a separate update job.

# Changes

Restore part of the line that was removed in https://github.com/dfinity/nns-dapp/pull/4058

# Tests

no

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary