### PR TITLE
End-to-end test for nns-dapp get_proposal_payload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,10 @@ jobs:
           go install github.com/ericchiang/pup@latest
           pup --version
       - name: Install IC tools
-        run: bin/dfx-sns-demo-install
+        run: |
+          pushd snsdemo
+          bin/dfx-sns-demo-install
+          popd
       - name: Test getting proposal payloads
         run: scripts/nns-dapp/test-proposal-payloads
       - name: Verify that arguments are set in index.html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,6 +204,10 @@ jobs:
         run: |
           go install github.com/ericchiang/pup@latest
           pup --version
+      - name: Install IC tools
+        run: bin/dfx-sns-demo-install
+      - name: Test getting proposal payloads
+        run: scripts/nns-dapp/test-proposal-payloads
       - name: Verify that arguments are set in index.html
         run: |
           for ((i=5; i>0; i--)); do
@@ -413,9 +417,6 @@ jobs:
           fi
       - name: Verify that fast data is updated fast
         run: |
-          # Which tools are we using?
-          type sns
-          type ic-admin
           pushd snsdemo
           # Install tools such as quill
           bin/dfx-sns-demo-install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,14 +30,14 @@ jobs:
       - name: Skip build for testing
         # Set to true and set a recent `run_id` below to reuse an existing build
         # instead of building.
-        if: false
+        if: true
         id: skip_build
         run: |
           echo "skip_build=true" >> "$GITHUB_OUTPUT"
           mkdir out
           # The run ID is the number at the end of a URL like this:
           # https://github.com/dfinity/nns-dapp/actions/runs/5801187848
-          run_id=5801187848
+          run_id=9029510321
           gh run download "$run_id" --dir ./out -n out
       - name: Build nns-dapp repo
         if: steps.skip_build.outputs.skip_build != 'true'
@@ -413,6 +413,9 @@ jobs:
           fi
       - name: Verify that fast data is updated fast
         run: |
+          # Which tools are we using?
+          type sns
+          type ic-admin
           pushd snsdemo
           # Install tools such as quill
           bin/dfx-sns-demo-install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,14 +30,14 @@ jobs:
       - name: Skip build for testing
         # Set to true and set a recent `run_id` below to reuse an existing build
         # instead of building.
-        if: true
+        if: false
         id: skip_build
         run: |
           echo "skip_build=true" >> "$GITHUB_OUTPUT"
           mkdir out
           # The run ID is the number at the end of a URL like this:
           # https://github.com/dfinity/nns-dapp/actions/runs/5801187848
-          run_id=9029510321
+          run_id=5801187848
           gh run download "$run_id" --dir ./out -n out
       - name: Build nns-dapp repo
         if: steps.skip_build.outputs.skip_build != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,7 +210,7 @@ jobs:
           bin/dfx-sns-demo-install
           popd
       - name: Test getting proposal payloads
-        run: scripts/nns-dapp/test-proposal-payloads
+        run: scripts/nns-dapp/test-proposal-payload
       - name: Verify that arguments are set in index.html
         run: |
           for ((i=5; i>0; i--)); do

--- a/scripts/nns-dapp/test-proposal-payload
+++ b/scripts/nns-dapp/test-proposal-payload
@@ -50,7 +50,7 @@ test_nns_function_11() {
     $SUBNET_ID $REPLICA_VERSION_ID)"
 
   ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
-  EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"subnet_id\\\":\\\"$SUBNET_ID\\\",\\\"replica_version_id\\\":\\\"$REPLICA_VERSION_ID\\\"}\"}"
+  EXPECTED_PAYLOAD="{\"subnet_id\":\"$SUBNET_ID\",\"replica_version_id\":\"$REPLICA_VERSION_ID\"}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }
@@ -63,7 +63,7 @@ test_nns_function_38() {
     --replica-versions-to-unelect $REPLICA_VERSION_ID)"
 
   ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
-  EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"release_package_urls\\\":[],\\\"replica_versions_to_unelect\\\":[\\\"$REPLICA_VERSION_ID\\\"],\\\"replica_version_to_elect\\\":null,\\\"guest_launch_measurement_sha256_hex\\\":null,\\\"release_package_sha256_hex\\\":null}\"}"
+  EXPECTED_PAYLOAD="{\"release_package_urls\":[],\"replica_versions_to_unelect\":[\"$REPLICA_VERSION_ID\"],\"replica_version_to_elect\":null,\"guest_launch_measurement_sha256_hex\":null,\"release_package_sha256_hex\":null}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }
@@ -77,7 +77,7 @@ test_nns_function_47() {
     --version $REPLICA_VERSION_ID)"
 
   ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
-  EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"version\\\":\\\"$REPLICA_VERSION_ID\\\",\\\"node_ids\\\":[\\\"$NODE_ID\\\"]}\"}"
+  EXPECTED_PAYLOAD="{\"version\":\"$REPLICA_VERSION_ID\",\"node_ids\":[\"$NODE_ID\"]}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }
@@ -90,7 +90,7 @@ test_nns_function_48() {
     --replica-version-id $REPLICA_VERSION_ID)"
 
   ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
-  EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"elected_replica_version\\\":\\\"$REPLICA_VERSION_ID\\\"}\"}"
+  EXPECTED_PAYLOAD="{\"elected_replica_version\":\"$REPLICA_VERSION_ID\"}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }
@@ -101,7 +101,7 @@ test_nns_function_49() {
   PROPOSAL_ID="$(run_ic_admin "$subcommand")"
 
   ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
-  EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"ssh_readonly_keys\\\":[]}\"}"
+  EXPECTED_PAYLOAD="{\"ssh_readonly_keys\":[]}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }
@@ -114,7 +114,7 @@ test_nns_function_50() {
     --hostos-versions-to-unelect $REPLICA_VERSION_ID)"
 
   ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
-  EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"release_package_urls\\\":[],\\\"hostos_version_to_elect\\\":null,\\\"hostos_versions_to_unelect\\\":[\\\"$REPLICA_VERSION_ID\\\"],\\\"release_package_sha256_hex\\\":null}\"}"
+  EXPECTED_PAYLOAD="{\"release_package_urls\":[],\"hostos_version_to_elect\":null,\"hostos_versions_to_unelect\":[\"$REPLICA_VERSION_ID\"],\"release_package_sha256_hex\":null}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }
@@ -125,7 +125,7 @@ test_nns_function_51() {
   PROPOSAL_ID="$(run_ic_admin "$subcommand" $NODE_ID)"
 
   ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
-  EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"hostos_version_id\\\":null,\\\"node_ids\\\":[\\\"$NODE_ID\\\"]}\"}"
+  EXPECTED_PAYLOAD="{\"hostos_version_id\":null,\"node_ids\":[\"$NODE_ID\"]}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }
@@ -142,7 +142,7 @@ run_ic_admin() {
 
 get_payload() {
   proposal_id="$1"
-  dfx canister call nns-dapp get_proposal_payload "($proposal_id : nat64)" | idl2json | jq -c .
+  dfx canister call nns-dapp get_proposal_payload "($proposal_id : nat64)" | idl2json | jq -r '.Ok'
 }
 
 verify_payload() {
@@ -150,7 +150,7 @@ verify_payload() {
   ACTUAL_PAYLOAD="$2"
   EXPECTED_PAYLOAD="$3"
 
-  if [[ "$ACTUAL_PAYLOAD" != "$EXPECTED_PAYLOAD" ]]; then
+  if ! jq --exit-status -n "$ACTUAL_PAYLOAD | contains($EXPECTED_PAYLOAD)"; then
     {
       echo "Unexpected payload for $subcommand."
       echo "EXPECTED_PAYLOAD='$EXPECTED_PAYLOAD'"

--- a/scripts/nns-dapp/test-proposal-payload
+++ b/scripts/nns-dapp/test-proposal-payload
@@ -49,7 +49,7 @@ test_nns_function_11() {
     "$subcommand" \
     $SUBNET_ID $REPLICA_VERSION_ID)"
 
-  ACTUAL_PAYLOAD="$(dfx canister call nns-dapp get_proposal_payload "($PROPOSAL_ID : nat64)" | idl2json | jq -c .)"
+  ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
   EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"subnet_id\\\":\\\"$SUBNET_ID\\\",\\\"replica_version_id\\\":\\\"$REPLICA_VERSION_ID\\\"}\"}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
@@ -62,7 +62,7 @@ test_nns_function_38() {
     "$subcommand" \
     --replica-versions-to-unelect $REPLICA_VERSION_ID)"
 
-  ACTUAL_PAYLOAD="$(dfx canister call nns-dapp get_proposal_payload "($PROPOSAL_ID : nat64)" | idl2json | jq -c .)"
+  ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
   EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"release_package_urls\\\":[],\\\"replica_versions_to_unelect\\\":[\\\"$REPLICA_VERSION_ID\\\"],\\\"replica_version_to_elect\\\":null,\\\"guest_launch_measurement_sha256_hex\\\":null,\\\"release_package_sha256_hex\\\":null}\"}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
@@ -76,7 +76,7 @@ test_nns_function_47() {
     --nodes $NODE_ID \
     --version $REPLICA_VERSION_ID)"
 
-  ACTUAL_PAYLOAD="$(dfx canister call nns-dapp get_proposal_payload "($PROPOSAL_ID : nat64)" | idl2json | jq -c .)"
+  ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
   EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"version\\\":\\\"$REPLICA_VERSION_ID\\\",\\\"node_ids\\\":[\\\"$NODE_ID\\\"]}\"}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
@@ -89,7 +89,7 @@ test_nns_function_48() {
     "$subcommand" \
     --replica-version-id $REPLICA_VERSION_ID)"
 
-  ACTUAL_PAYLOAD="$(dfx canister call nns-dapp get_proposal_payload "($PROPOSAL_ID : nat64)" | idl2json | jq -c .)"
+  ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
   EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"elected_replica_version\\\":\\\"$REPLICA_VERSION_ID\\\"}\"}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
@@ -100,7 +100,7 @@ test_nns_function_49() {
 
   PROPOSAL_ID="$(run_ic_admin "$subcommand")"
 
-  ACTUAL_PAYLOAD="$(dfx canister call nns-dapp get_proposal_payload "($PROPOSAL_ID : nat64)" | idl2json | jq -c .)"
+  ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
   EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"ssh_readonly_keys\\\":[]}\"}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
@@ -113,7 +113,7 @@ test_nns_function_50() {
     "$subcommand" \
     --hostos-versions-to-unelect $REPLICA_VERSION_ID)"
 
-  ACTUAL_PAYLOAD="$(dfx canister call nns-dapp get_proposal_payload "($PROPOSAL_ID : nat64)" | idl2json | jq -c .)"
+  ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
   EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"release_package_urls\\\":[],\\\"hostos_version_to_elect\\\":null,\\\"hostos_versions_to_unelect\\\":[\\\"$REPLICA_VERSION_ID\\\"],\\\"release_package_sha256_hex\\\":null}\"}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
@@ -124,7 +124,7 @@ test_nns_function_51() {
 
   PROPOSAL_ID="$(run_ic_admin "$subcommand" $NODE_ID)"
 
-  ACTUAL_PAYLOAD="$(dfx canister call nns-dapp get_proposal_payload "($PROPOSAL_ID : nat64)" | idl2json | jq -c .)"
+  ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
   EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"hostos_version_id\\\":null,\\\"node_ids\\\":[\\\"$NODE_ID\\\"]}\"}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
@@ -138,6 +138,11 @@ run_ic_admin() {
     --summary "$SUMMARY" \
     --proposer "$NEURON_ID" |
     grep -E '^proposal [0-9]+$' | sed 's/proposal //'
+}
+
+get_payload() {
+  proposal_id="$1"
+  dfx canister call nns-dapp get_proposal_payload "($proposal_id : nat64)" | idl2json | jq -c .
 }
 
 verify_payload() {

--- a/scripts/nns-dapp/test-proposal-payload
+++ b/scripts/nns-dapp/test-proposal-payload
@@ -137,7 +137,7 @@ run_ic_admin() {
     "$@" \
     --summary "$SUMMARY" \
     --proposer "$NEURON_ID" |
-    grep -o -E '^proposal \d+$' | sed 's/proposal //'
+    grep -E '^proposal [0-9]+$' | sed 's/proposal //'
 }
 
 verify_payload() {

--- a/scripts/nns-dapp/test-proposal-payload
+++ b/scripts/nns-dapp/test-proposal-payload
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.."
+
+print_help() {
+  cat <<-EOF
+
+	Create proposals of different types and test that nns-dapp can get their payloads.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=i long=identity desc="Identity to use to create proposals" variable=DFX_IDENTITY default="snsdemo8"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+# Check if a replica is running:
+if ! pgrep replica; then
+  echo "A replica must be running to submit proposals to." >&2
+  exit 1
+fi
+
+IDENTITY_PATH="$HOME/.config/dfx/identity/${DFX_IDENTITY}"
+
+# Check that the identity exists
+if ! [ -d "$IDENTITY_PATH" ]; then
+  echo "Identity $IDENTITY_PATH does not exist" >&2
+  exit 1
+fi
+
+PEM="${IDENTITY_PATH}/identity.pem"
+NNS_URL="http://localhost:$(
+  cd ~
+  dfx info replica-port
+)"
+NEURON_ID="$(cat "${IDENTITY_PATH}/neurons/local")"
+SUMMARY="Testing proposal payloads"
+
+NODE_ID="ynkov-ujzr4-rgyrv-ou4yf-orw6f-rrslu-w65tu-agnfu-xwdrv-xmayj-qae"
+SUBNET_ID="52o7h-ke47f-b5z7i-ah4wu-qhruc-kfdcl-xzzhl-sjmfh-3ryrf-xxtei-bae"
+REPLICA_VERSION_ID="48da85ee6c03e8c15f3e90b21bf9ccae7b753ee6"
+
+test_nns_function_11() {
+  subcommand="propose-to-deploy-guestos-to-all-subnet-nodes"
+
+  PROPOSAL_ID="$(run_ic_admin \
+    "$subcommand" \
+    $SUBNET_ID $REPLICA_VERSION_ID)"
+
+  ACTUAL_PAYLOAD="$(dfx canister call nns-dapp get_proposal_payload "($PROPOSAL_ID : nat64)" | idl2json | jq -c .)"
+  EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"subnet_id\\\":\\\"$SUBNET_ID\\\",\\\"replica_version_id\\\":\\\"$REPLICA_VERSION_ID\\\"}\"}"
+
+  verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
+}
+
+te_st_nns_function_38() {
+  subcommand="propose-to-revise-elected-guestos-versions"
+
+  PROPOSAL_ID="$(run_ic_admin \
+    "$subcommand" \
+    --replica-versions-to-unelect $REPLICA_VERSION_ID)"
+
+  ACTUAL_PAYLOAD="$(dfx canister call nns-dapp get_proposal_payload "($PROPOSAL_ID : nat64)" | idl2json | jq -c .)"
+  EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"release_package_urls\\\":[],\\\"replica_versions_to_unelect\\\":[\\\"$REPLICA_VERSION_ID\\\"],\\\"replica_version_to_elect\\\":null,\\\"guest_launch_measurement_sha256_hex\\\":null,\\\"release_package_sha256_hex\\\":null}\"}"
+
+  verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
+}
+
+te__st_nns_function_47() {
+  subcommand="propose-to-deploy-guestos-to-some-api-boundary-nodes"
+
+  PROPOSAL_ID="$(run_ic_admin \
+    "$subcommand" \
+    --nodes $NODE_ID \
+    --version $REPLICA_VERSION_ID)"
+
+  ACTUAL_PAYLOAD="$(dfx canister call nns-dapp get_proposal_payload "($PROPOSAL_ID : nat64)" | idl2json | jq -c .)"
+  EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"version\\\":\\\"$REPLICA_VERSION_ID\\\",\\\"node_ids\\\":[\\\"$NODE_ID\\\"]}\"}"
+
+  verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
+}
+
+te___st_nns_function_48() {
+  subcommand="propose-to-deploy-guestos-to-all-unassigned-nodes"
+
+  PROPOSAL_ID="$(run_ic_admin \
+    "$subcommand" \
+    --replica-version-id $REPLICA_VERSION_ID)"
+
+  ACTUAL_PAYLOAD="$(dfx canister call nns-dapp get_proposal_payload "($PROPOSAL_ID : nat64)" | idl2json | jq -c .)"
+  EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"elected_replica_version\\\":\\\"$REPLICA_VERSION_ID\\\"}\"}"
+
+  verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
+}
+
+te___st_nns_function_49() {
+  subcommand="propose-to-update-ssh-readonly-access-for-all-unassigned-nodes"
+
+  PROPOSAL_ID="$(run_ic_admin "$subcommand")"
+
+  ACTUAL_PAYLOAD="$(dfx canister call nns-dapp get_proposal_payload "($PROPOSAL_ID : nat64)" | idl2json | jq -c .)"
+  EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"ssh_readonly_keys\\\":[]}\"}"
+
+  verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
+}
+
+te__st_nns_function_50() {
+  subcommand="propose-to-revise-elected-hostos-versions"
+
+  PROPOSAL_ID="$(run_ic_admin \
+    "$subcommand" \
+    --hostos-versions-to-unelect $REPLICA_VERSION_ID)"
+
+  ACTUAL_PAYLOAD="$(dfx canister call nns-dapp get_proposal_payload "($PROPOSAL_ID : nat64)" | idl2json | jq -c .)"
+  EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"release_package_urls\\\":[],\\\"hostos_version_to_elect\\\":null,\\\"hostos_versions_to_unelect\\\":[\\\"$REPLICA_VERSION_ID\\\"],\\\"release_package_sha256_hex\\\":null}\"}"
+
+  verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
+}
+
+te_st_nns_function_51() {
+  subcommand="propose-to-deploy-hostos-to-some-nodes"
+
+  PROPOSAL_ID="$(run_ic_admin "$subcommand" $NODE_ID)"
+
+  ACTUAL_PAYLOAD="$(dfx canister call nns-dapp get_proposal_payload "($PROPOSAL_ID : nat64)" | idl2json | jq -c .)"
+  EXPECTED_PAYLOAD="{\"Ok\":\"{\\\"hostos_version_id\\\":null,\\\"node_ids\\\":[\\\"$NODE_ID\\\"]}\"}"
+
+  verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
+}
+
+run_ic_admin() {
+  ic-admin \
+    --secret-key-pem "$PEM" \
+    --nns-url "$NNS_URL" \
+    "$@" \
+    --summary "$SUMMARY" \
+    --proposer "$NEURON_ID" |
+    grep -o -E '^proposal \d+$' | sed 's/proposal //'
+}
+
+verify_payload() {
+  subcommand="$1"
+  ACTUAL_PAYLOAD="$2"
+  EXPECTED_PAYLOAD="$3"
+
+  if [[ "$ACTUAL_PAYLOAD" != "$EXPECTED_PAYLOAD" ]]; then
+    {
+      echo "Unexpected payload for $subcommand."
+      echo "EXPECTED_PAYLOAD='$EXPECTED_PAYLOAD'"
+      echo "  ACTUAL_PAYLOAD='$ACTUAL_PAYLOAD'"
+    } >&2
+    exit 1
+  else
+    echo "Payload for $subcommand is as expected."
+  fi
+}
+
+declare -F | grep test_nns_function_ | sed -e 's/declare -f //' | while read -r test; do
+  echo "Running $test"
+  $test
+done
+
+FIRST_UNDEFINED_NNS_FUNCTION=52
+
+for i in $(seq 0 5); do
+  undefined_nns_function=$((FIRST_UNDEFINED_NNS_FUNCTION + i))
+
+  ERROR=$(dfx canister call nns-governance manage_neuron "(record {id=opt record{id=$NEURON_ID : nat64}; command=opt variant{MakeProposal=record{url=\"https://forum.dfinity.org/\"; title=opt \"title\"; summary=\"summary\"; action=opt variant{ExecuteNnsFunction=record{nns_function = $undefined_nns_function : int32; payload=blob \"payload\" } } } } })" | idl2json | jq -c '.command[0].Error.error_message')
+
+  if [[ "$ERROR" != "\"Topic not specified."* ]]; then
+    {
+      echo "NNS function $undefined_nns_function is no longer undefined."
+      echo "Please add a test for it."
+    } >&2
+    exit 1
+  else
+    echo "NNS function $undefined_nns_function is still undefined as expected."
+  fi
+done

--- a/scripts/nns-dapp/test-proposal-payload
+++ b/scripts/nns-dapp/test-proposal-payload
@@ -55,7 +55,7 @@ test_nns_function_11() {
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }
 
-te_st_nns_function_38() {
+test_nns_function_38() {
   subcommand="propose-to-revise-elected-guestos-versions"
 
   PROPOSAL_ID="$(run_ic_admin \
@@ -68,7 +68,7 @@ te_st_nns_function_38() {
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }
 
-te__st_nns_function_47() {
+test_nns_function_47() {
   subcommand="propose-to-deploy-guestos-to-some-api-boundary-nodes"
 
   PROPOSAL_ID="$(run_ic_admin \
@@ -82,7 +82,7 @@ te__st_nns_function_47() {
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }
 
-te___st_nns_function_48() {
+test_nns_function_48() {
   subcommand="propose-to-deploy-guestos-to-all-unassigned-nodes"
 
   PROPOSAL_ID="$(run_ic_admin \
@@ -95,7 +95,7 @@ te___st_nns_function_48() {
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }
 
-te___st_nns_function_49() {
+test_nns_function_49() {
   subcommand="propose-to-update-ssh-readonly-access-for-all-unassigned-nodes"
 
   PROPOSAL_ID="$(run_ic_admin "$subcommand")"
@@ -106,7 +106,7 @@ te___st_nns_function_49() {
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }
 
-te__st_nns_function_50() {
+test_nns_function_50() {
   subcommand="propose-to-revise-elected-hostos-versions"
 
   PROPOSAL_ID="$(run_ic_admin \
@@ -119,7 +119,7 @@ te__st_nns_function_50() {
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }
 
-te_st_nns_function_51() {
+test_nns_function_51() {
   subcommand="propose-to-deploy-hostos-to-some-nodes"
 
   PROPOSAL_ID="$(run_ic_admin "$subcommand" $NODE_ID)"
@@ -162,6 +162,7 @@ declare -F | grep test_nns_function_ | sed -e 's/declare -f //' | while read -r 
   $test
 done
 
+# Make sure that we add tests for new NNS function.
 FIRST_UNDEFINED_NNS_FUNCTION=52
 
 for i in $(seq 0 5); do

--- a/scripts/nns-dapp/test-proposal-payload
+++ b/scripts/nns-dapp/test-proposal-payload
@@ -157,6 +157,7 @@ verify_payload() {
   fi
 }
 
+# Find and run declared test functions.
 declare -F | grep test_nns_function_ | sed -e 's/declare -f //' | while read -r test; do
   echo "Running $test"
   $test


### PR DESCRIPTION
# Motivation

Adding support for new NNS functions is usually quite easy but manually testing a new proposal type can be a lot of work.
This has always lacked testing coverage so I decided to add a testing script for it.

# Changes

1. Add a script which creates proposals of various types and tests getting their payload with the nns-dapp `get_proposal_payload` method. I didn't add coverage for every function but did for some recently relevant ones. We should add more as we add/change more proposal types.
2. Test that no new proposal types were added that we were not aware of.
3. Run the test script on CI.

# Tests

test-only

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary