### PR TITLE
Support proposal type AddApiBoundaryNodesPayload 

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -22,6 +22,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Update IC, Candid, and `ic-cdk` dependencies.
+* Changed support for NNS function 43 from `AddApiBoundaryNodePayload` (singular) to `AddApiBoundaryNodesPayload` (plural).
 
 #### Deprecated
 

--- a/declarations/nns_governance/nns_governance.did
+++ b/declarations/nns_governance/nns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;

--- a/declarations/nns_ledger/nns_ledger.did
+++ b/declarations/nns_ledger/nns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/rosetta-api/icp_ledger/ledger.did>
+//! Candid for canister `nns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/rosetta-api/icp_ledger/ledger.did>
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.

--- a/declarations/nns_registry/nns_registry.did
+++ b/declarations/nns_registry/nns_registry.did
@@ -1,5 +1,8 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/registry/canister/canister/registry.did>
-type AddApiBoundaryNodePayload = record { node_id : principal; version : text };
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/registry/canister/canister/registry.did>
+type AddApiBoundaryNodesPayload = record {
+  version : text;
+  node_ids : vec principal;
+};
 type AddFirewallRulesPayload = record {
   expected_hash : text;
   scope : FirewallRulesScope;
@@ -220,10 +223,6 @@ type SubnetFeatures = record {
   sev_enabled : opt bool;
 };
 type SubnetType = variant { application; verified_application; system };
-type UpdateApiBoundaryNodesVersionPayload = record {
-  version : text;
-  node_ids : vec principal;
-};
 type UpdateElectedHostosVersionsPayload = record {
   release_package_urls : vec text;
   hostos_version_to_elect : opt text;
@@ -302,7 +301,7 @@ type UpdateUnassignedNodesConfigPayload = record {
   ssh_readonly_access : opt vec text;
 };
 service : {
-  add_api_boundary_node : (AddApiBoundaryNodePayload) -> ();
+  add_api_boundary_nodes : (AddApiBoundaryNodesPayload) -> ();
   add_firewall_rules : (AddFirewallRulesPayload) -> ();
   add_node : (AddNodePayload) -> (Result);
   add_node_operator : (AddNodeOperatorPayload) -> ();
@@ -338,9 +337,7 @@ service : {
   retire_replica_version : (RetireReplicaVersionPayload) -> ();
   revise_elected_replica_versions : (ReviseElectedGuestosVersionsPayload) -> ();
   set_firewall_config : (SetFirewallConfigPayload) -> ();
-  update_api_boundary_nodes_version : (
-      UpdateApiBoundaryNodesVersionPayload,
-    ) -> ();
+  update_api_boundary_nodes_version : (AddApiBoundaryNodesPayload) -> ();
   update_elected_hostos_versions : (UpdateElectedHostosVersionsPayload) -> ();
   update_elected_replica_versions : (ReviseElectedGuestosVersionsPayload) -> ();
   update_firewall_rules : (AddFirewallRulesPayload) -> ();

--- a/declarations/sns_governance/sns_governance.did
+++ b/declarations/sns_governance/sns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/sns/governance/canister/governance.did>
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;

--- a/declarations/sns_ledger/sns_ledger.did
+++ b/declarations/sns_ledger/sns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/rosetta-api/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/rosetta-api/icrc1/ledger/ledger.did>
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.

--- a/declarations/sns_root/sns_root.did
+++ b/declarations/sns_root/sns_root.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/sns/root/canister/root.did>
 type CanisterCallError = record { code : opt int32; description : text };
 type CanisterIdRecord = record { canister_id : principal };
 type CanisterInstallMode = variant { reinstall; upgrade; install };

--- a/declarations/sns_swap/sns_swap.did
+++ b/declarations/sns_swap/sns_swap.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/sns/swap/canister/swap.did>
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;

--- a/declarations/sns_wasm/sns_wasm.did
+++ b/declarations/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
@@ -186,7 +186,11 @@ type SnsVersion = record {
   governance_wasm_hash : blob;
   index_wasm_hash : blob;
 };
-type SnsWasm = record { wasm : blob; canister_type : int32 };
+type SnsWasm = record {
+  wasm : blob;
+  proposal_id : opt nat64;
+  canister_type : int32;
+};
 type SnsWasmCanisterInitPayload = record {
   allowed_principals : vec principal;
   access_controls_enabled : bool;

--- a/dfx.json
+++ b/dfx.json
@@ -355,7 +355,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-05-10",
-        "IC_COMMIT": "release-2024-05-01_23-01-storage-layer"
+        "IC_COMMIT": "release-2024-05-09_23-02-storage-layer"
       },
       "packtool": ""
     }

--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -18,9 +18,9 @@ pub struct EmptyRecord {}
 // use ic_cdk::api::call::CallResult as Result;
 
 #[derive(Serialize, CandidType, Deserialize)]
-pub struct AddApiBoundaryNodePayload {
-    pub node_id: Principal,
+pub struct AddApiBoundaryNodesPayload {
     pub version: String,
+    pub node_ids: Vec<Principal>,
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
@@ -365,12 +365,6 @@ pub struct SetFirewallConfigPayload {
 }
 
 #[derive(Serialize, CandidType, Deserialize)]
-pub struct UpdateApiBoundaryNodesVersionPayload {
-    pub version: String,
-    pub node_ids: Vec<Principal>,
-}
-
-#[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateElectedHostosVersionsPayload {
     pub release_package_urls: Vec<String>,
     pub hostos_version_to_elect: Option<String>,
@@ -491,8 +485,8 @@ pub struct UpdateUnassignedNodesConfigPayload {
 
 pub struct Service(pub Principal);
 impl Service {
-    pub async fn add_api_boundary_node(&self, arg0: AddApiBoundaryNodePayload) -> CallResult<()> {
-        ic_cdk::call(self.0, "add_api_boundary_node", (arg0,)).await
+    pub async fn add_api_boundary_nodes(&self, arg0: AddApiBoundaryNodesPayload) -> CallResult<()> {
+        ic_cdk::call(self.0, "add_api_boundary_nodes", (arg0,)).await
     }
     pub async fn add_firewall_rules(&self, arg0: AddFirewallRulesPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "add_firewall_rules", (arg0,)).await
@@ -587,10 +581,7 @@ impl Service {
     pub async fn set_firewall_config(&self, arg0: SetFirewallConfigPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "set_firewall_config", (arg0,)).await
     }
-    pub async fn update_api_boundary_nodes_version(
-        &self,
-        arg0: UpdateApiBoundaryNodesVersionPayload,
-    ) -> CallResult<()> {
+    pub async fn update_api_boundary_nodes_version(&self, arg0: AddApiBoundaryNodesPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "update_api_boundary_nodes_version", (arg0,)).await
     }
     pub async fn update_elected_hostos_versions(&self, arg0: UpdateElectedHostosVersionsPayload) -> CallResult<()> {

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-01_23-01-storage-layer/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -27,6 +27,7 @@ pub struct SnsWasmCanisterInitPayload {
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SnsWasm {
     pub wasm: serde_bytes::ByteBuf,
+    pub proposal_id: Option<u64>,
     pub canister_type: i32,
 }
 

--- a/rs/proposals/src/def.rs
+++ b/rs/proposals/src/def.rs
@@ -469,13 +469,11 @@ pub type RemoveApiBoundaryNodesPayload = crate::canisters::nns_registry::api::Re
 
 // NNS function 46 - UpdateApiBoundaryNodesVersion
 // https://github.com/dfinity/ic/blob/04c9c04c7a1f52ab5529531691a7c1bcf289c30d/rs/registry/canister/src/mutations/do_update_api_boundary_nodes_version.rs#L14
-pub type UpdateApiBoundaryNodesVersionPayload =
-    crate::canisters::nns_registry::api::AddApiBoundaryNodesPayload;
+pub type UpdateApiBoundaryNodesVersionPayload = crate::canisters::nns_registry::api::AddApiBoundaryNodesPayload;
 
 // NNS function 47 - UpdateApiBoundaryNodesVersion
 // https://github.com/dfinity/ic/blob/04c9c04c7a1f52ab5529531691a7c1bcf289c30d/rs/registry/canister/src/mutations/do_update_api_boundary_nodes_version.rs#L14
-pub type DeployGuestosToSomeApiBoundaryNodesPayload =
-    UpdateApiBoundaryNodesVersionPayload;
+pub type DeployGuestosToSomeApiBoundaryNodesPayload = UpdateApiBoundaryNodesVersionPayload;
 
 // NNS function 48 - DeployGuestosToAllUnassignedNodes
 // https://github.com/dfinity/ic/blob/3343a9ec1ea3170dcfd0cc4f4298d5ce09abb036/rs/registry/canister/src/mutations/do_deploy_guestos_to_all_unassigned_nodes.rs#L36

--- a/rs/proposals/src/def.rs
+++ b/rs/proposals/src/def.rs
@@ -461,7 +461,7 @@ pub type UpdateNodesHostosVersionPayload = crate::canisters::nns_registry::api::
 
 // NNS function 43 - AddApiBoundaryNode
 // https://github.com/dfinity/ic/blob/04c9c04c7a1f52ab5529531691a7c1bcf289c30d/rs/registry/canister/src/mutations/do_add_api_boundary_node.rs#L14
-pub type AddApiBoundaryNodePayload = crate::canisters::nns_registry::api::AddApiBoundaryNodePayload;
+pub type AddApiBoundaryNodesPayload = crate::canisters::nns_registry::api::AddApiBoundaryNodesPayload;
 
 // NNS function 44 - RemoveApiBoundaryNodes
 // https://github.com/dfinity/ic/blob/04c9c04c7a1f52ab5529531691a7c1bcf289c30d/rs/registry/canister/src/mutations/do_remove_api_boundary_nodes.rs#L14
@@ -470,12 +470,12 @@ pub type RemoveApiBoundaryNodesPayload = crate::canisters::nns_registry::api::Re
 // NNS function 46 - UpdateApiBoundaryNodesVersion
 // https://github.com/dfinity/ic/blob/04c9c04c7a1f52ab5529531691a7c1bcf289c30d/rs/registry/canister/src/mutations/do_update_api_boundary_nodes_version.rs#L14
 pub type UpdateApiBoundaryNodesVersionPayload =
-    crate::canisters::nns_registry::api::UpdateApiBoundaryNodesVersionPayload;
+    crate::canisters::nns_registry::api::AddApiBoundaryNodesPayload;
 
 // NNS function 47 - UpdateApiBoundaryNodesVersion
 // https://github.com/dfinity/ic/blob/04c9c04c7a1f52ab5529531691a7c1bcf289c30d/rs/registry/canister/src/mutations/do_update_api_boundary_nodes_version.rs#L14
 pub type DeployGuestosToSomeApiBoundaryNodesPayload =
-    crate::canisters::nns_registry::api::UpdateApiBoundaryNodesVersionPayload;
+    UpdateApiBoundaryNodesVersionPayload;
 
 // NNS function 48 - DeployGuestosToAllUnassignedNodes
 // https://github.com/dfinity/ic/blob/3343a9ec1ea3170dcfd0cc4f4298d5ce09abb036/rs/registry/canister/src/mutations/do_deploy_guestos_to_all_unassigned_nodes.rs#L36

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -2,7 +2,7 @@
 use crate::canisters::internet_identity::InternetIdentityInit;
 use crate::canisters::nns_governance::api::{Action, ProposalInfo};
 use crate::def::{
-    AddApiBoundaryNodePayload, AddFirewallRulesPayload, AddNnsCanisterProposal, AddNnsCanisterProposalTrimmed,
+    AddApiBoundaryNodesPayload, AddFirewallRulesPayload, AddNnsCanisterProposal, AddNnsCanisterProposalTrimmed,
     AddNodeOperatorPayload, AddNodesToSubnetPayload, AddOrRemoveDataCentersProposalPayload, AddWasmRequest,
     AddWasmRequestTrimmed, BitcoinSetConfigProposal, BitcoinSetConfigProposalHumanReadable, BlessReplicaVersionPayload,
     ChangeNnsCanisterProposal, ChangeNnsCanisterProposalTrimmed, ChangeSubnetMembershipPayload,
@@ -321,7 +321,7 @@ fn transform_payload_to_json(nns_function: i32, payload_bytes: &[u8]) -> Result<
         40 => identity::<UpdateElectedHostosVersionsPayload>(payload_bytes),
         41 => identity::<UpdateNodesHostosVersionPayload>(payload_bytes),
         // 42 => HARD RESET
-        43 => identity::<AddApiBoundaryNodePayload>(payload_bytes),
+        43 => identity::<AddApiBoundaryNodesPayload>(payload_bytes),
         44 => identity::<RemoveApiBoundaryNodesPayload>(payload_bytes),
         // 45 reserved ("NNS_FUNCTION_UPDATE_API_BOUNDARY_NODE_DOMAIN") - https://github.com/dfinity/ic/blob/cd8ad64ed63e38db0d40386ba226df25767d4cd6/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto#L616
         46 => identity::<UpdateApiBoundaryNodesVersionPayload>(payload_bytes),

--- a/scripts/nns-dapp/test-proposal-payload
+++ b/scripts/nns-dapp/test-proposal-payload
@@ -99,6 +99,20 @@ test_nns_function_38() {
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }
 
+test_nns_function_43() {
+  subcommand="propose-to-add-api-boundary-nodes"
+
+  PROPOSAL_ID="$(run_ic_admin \
+    "$subcommand" \
+    --nodes $NODE_ID \
+    --version $REPLICA_VERSION_ID)"
+
+  ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
+  EXPECTED_PAYLOAD="{\"release_package_urls\":[],\"replica_versions_to_unelect\":[\"$REPLICA_VERSION_ID\"],\"replica_version_to_elect\":null,\"guest_launch_measurement_sha256_hex\":null,\"release_package_sha256_hex\":null}"
+
+  verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
+}
+
 test_nns_function_47() {
   subcommand="propose-to-deploy-guestos-to-some-api-boundary-nodes"
 

--- a/scripts/nns-dapp/test-proposal-payload
+++ b/scripts/nns-dapp/test-proposal-payload
@@ -39,6 +39,7 @@ NEURON_ID="$(cat "${IDENTITY_PATH}/neurons/local")"
 SUMMARY="Testing proposal payloads"
 
 NODE_ID="ynkov-ujzr4-rgyrv-ou4yf-orw6f-rrslu-w65tu-agnfu-xwdrv-xmayj-qae"
+NODE_ID_2="7e6za-cdhql-kvxja-dfse5-jrme3-rwmau-6foiv-fxnwt-h7qos-wqryb-pae"
 SUBNET_ID="52o7h-ke47f-b5z7i-ah4wu-qhruc-kfdcl-xzzhl-sjmfh-3ryrf-xxtei-bae"
 REPLICA_VERSION_ID="48da85ee6c03e8c15f3e90b21bf9ccae7b753ee6"
 
@@ -105,10 +106,11 @@ test_nns_function_43() {
   PROPOSAL_ID="$(run_ic_admin \
     "$subcommand" \
     --nodes $NODE_ID \
+    --nodes $NODE_ID_2 \
     --version $REPLICA_VERSION_ID)"
 
   ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
-  EXPECTED_PAYLOAD="{\"version\":\"$REPLICA_VERSION_ID\",\"node_ids\":[\"$NODE_ID\"]}"
+  EXPECTED_PAYLOAD="{\"version\":\"$REPLICA_VERSION_ID\",\"node_ids\":[\"$NODE_ID\",\"$NODE_ID_2\"]}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }

--- a/scripts/nns-dapp/test-proposal-payload
+++ b/scripts/nns-dapp/test-proposal-payload
@@ -108,7 +108,7 @@ test_nns_function_43() {
     --version $REPLICA_VERSION_ID)"
 
   ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
-  EXPECTED_PAYLOAD="{\"release_package_urls\":[],\"replica_versions_to_unelect\":[\"$REPLICA_VERSION_ID\"],\"replica_version_to_elect\":null,\"guest_launch_measurement_sha256_hex\":null,\"release_package_sha256_hex\":null}"
+  EXPECTED_PAYLOAD="{\"version\":\"$REPLICA_VERSION_ID\",\"node_ids\":[\"$NODE_ID\"]}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }


### PR DESCRIPTION
# Motivation

The proposal type to add API Boundary nodes [now supports](https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/19097) adding multiple nodes in one proposal.
This is a breaking change but it's OK because proposals of this type have never been created and will not be created for a few more weeks.

Also note that the candid in `rs/registry/canister/canister/canister.rs` was regenerated automatically and because of how the tool works, this resulted in `UpdateApiBoundaryNodesVersionPayload` being removed and replaced by `AddApiBoundaryNodesPayload`, which is structurally the same. We work around this in `rs/proposals/src/def.rs` with
```
pub type UpdateApiBoundaryNodesVersionPayload = crate::canisters::nns_registry::api::AddApiBoundaryNodesPayload;
```
Note that we were already in a similar situation with `DeployGuestosToSomeApiBoundaryNodesPayload`.

# Changes

1. Ran `scripts/update_ic_commit --ic_commit release-2024-05-09_23-02-storage-layer` to update candid files.
2. Ran `./scripts/proposals/did2rs` to update Rust types in `api.rs` files.
3. Manually updated `def.rs` to rename the changed type and to work around the type removed by the candid generation tool.
4. Rename the type in `rs/proposals/src/lib.rs`

# Tests

Added a test for `ic-admin propose-to-add-api-boundary-nodes`.

# Todos

- [x] Add entry to changelog (if necessary).
