### PR TITLE
Update IC Cargo Dependencies to release-2024-05-09_23-02-storage-layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,23 +13,23 @@ version = "2.0.76"
 ic-cdk = "0.13.3"
 ic-cdk-macros = "0.13.3"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
 
 [profile.release]
 lto = false


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
We want to keep our Cargo dependencies up to date.

# Changes
* Ran `scripts/update-ic-cargo-deps` to update the Cargo.toml dependencies to the latest IC release.

# Tests
* See CI