### PR TITLE
Update Cargo.lock in deps update PR

### DIFF
--- a/.github/workflows/update-ic-cargo-deps.yaml
+++ b/.github/workflows/update-ic-cargo-deps.yaml
@@ -30,6 +30,7 @@ jobs:
           reviewers: mstrasinskis, dskloetd, nns-team
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
           add-paths: |
+            Cargo.lock
             Cargo.toml
             rs/
           commit-message: Update IC Cargo Dependencies

--- a/scripts/update-ic-cargo-deps
+++ b/scripts/update-ic-cargo-deps
@@ -29,3 +29,5 @@ for cargo_toml_file in "Cargo.toml" $(find "$TOP_DIR/rs" -name "Cargo.toml"); do
     rm "$cargo_toml_file.bak"
   done
 done
+
+cargo update --workspace


### PR DESCRIPTION
# Motivation

We have a job to update IC repo cargo dependencies.
But when dependencies are updated, the `Cargo.lock` file needs to be updated as well.
This normally happens automatically when you run `cargo build`, but on IC we run `cargo build --locked` to ensure the `Cargo.lock` file is not changed.
So we need to update the `Cargo.lock` file in the same script that updates the dependencies, and include it in the bot PR.

# Changes

1. Run `cargo update --workspace` at the end of `scripts/update-ic-cargo-deps`.
2. Include `Cargo.lock` in files added to the bot PR.

# Tests

Manually:
1. Ran `scripts/update-ic-cargo-deps` without the change.
2. Ran `cargo build` to see what updates were needed to the `Cargo.lock` file.
3. Made a copy of the `Cargo.lock` file.
4. Restored `Cargo.lock`.
5. Ran `cargo update --workspace` (which is much faster than `cargo build`).
6. Compared the changes made by `cargo  update --workspace` to the changes made by `cargo build`.

The changes were identical.

Also ran the workflow which created [this PR](https://github.com/dfinity/nns-dapp/pull/4857).

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary