### PR TITLE
Update IC Cargo Dependencies to release-2024-05-09_23-02-storage-layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,7 +1040,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1165,7 +1165,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "dfn_core",
@@ -1177,7 +1177,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1186,7 +1186,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "dfn_candid",
@@ -1198,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1210,7 +1210,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "on_wire",
  "prost",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1914,7 +1914,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -1951,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "ic-btc-interface 0.2.0 (git+https://github.com/dfinity/bitcoin-canister?rev=62a71e47c491fb842ccc257b1c675651501f4b82)",
@@ -1964,7 +1964,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ecdsa-secp256k1",
@@ -1977,7 +1977,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "serde",
 ]
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.10",
@@ -1994,7 +1994,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "serde",
@@ -2121,12 +2121,12 @@ dependencies = [
 [[package]]
 name = "ic-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "k256",
  "lazy_static",
@@ -2140,7 +2140,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "getrandom",
 ]
@@ -2160,7 +2160,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "hex",
  "ic-types",
@@ -2170,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -2192,7 +2192,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -2210,7 +2210,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2218,7 +2218,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2250,7 +2250,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -2258,7 +2258,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "base64 0.13.1",
  "cached",
@@ -2284,7 +2284,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2314,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "arrayvec 0.7.4",
  "hex",
@@ -2331,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2349,7 +2349,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "serde",
  "zeroize",
@@ -2358,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-test-utils-reproducible-rng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "rand",
  "rand_chacha",
@@ -2375,7 +2375,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2389,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "assert_matches",
  "ic-crypto-internal-types",
@@ -2403,7 +2403,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2423,7 +2423,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "ic-protobuf",
  "ic-utils",
@@ -2435,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "ciborium",
@@ -2457,7 +2457,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "ciborium",
@@ -2484,7 +2484,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "async-trait",
  "candid 0.10.8",
@@ -2512,7 +2512,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "ic-ledger-core",
@@ -2524,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "async-trait",
  "candid 0.10.8",
@@ -2542,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "ic-ledger-hash-of",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "hex",
@@ -2564,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "ic-base-types",
@@ -2589,7 +2589,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "async-trait",
  "candid 0.10.8",
@@ -2606,12 +2606,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2647,12 +2647,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -2677,12 +2677,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "comparable",
@@ -2695,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "ic-base-types",
 ]
@@ -2703,7 +2703,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "dfn_core",
@@ -2719,7 +2719,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "async-trait",
  "candid 0.10.8",
@@ -2732,12 +2732,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -2750,7 +2750,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "comparable",
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "ic-base-types",
 ]
@@ -2783,7 +2783,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2846,12 +2846,12 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "async-trait",
  "candid 0.10.8",
@@ -2866,7 +2866,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "bincode",
  "candid 0.10.8",
@@ -2881,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "ic-base-types",
@@ -2893,7 +2893,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "ic-base-types",
@@ -2904,7 +2904,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "ic-management-canister-types",
@@ -2915,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "ic-protobuf",
@@ -2927,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "ic-base-types",
@@ -2939,7 +2939,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2996,7 +2996,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -3004,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -3015,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "async-trait",
  "candid 0.10.8",
@@ -3036,7 +3036,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "base64 0.13.1",
  "candid 0.10.8",
@@ -3063,7 +3063,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3130,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "comparable",
@@ -3145,7 +3145,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "async-trait",
  "candid 0.10.8",
@@ -3192,7 +3192,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3227,7 +3227,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "hex",
  "prost",
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "comparable",
@@ -3343,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "async-trait",
  "candid 0.10.8",
@@ -3354,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.5"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "base32",
  "candid 0.10.8",
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 
 [[package]]
 name = "once_cell"
@@ -4228,7 +4228,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "candid 0.10.8",
  "serde",
@@ -4732,7 +4732,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=823cb40db671f13577940fcd0274ad263c7b6922#823cb40db671f13577940fcd0274ad263c7b6922"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
 dependencies = [
  "build-info",
  "build-info-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,23 +13,23 @@ version = "2.0.76"
 ic-cdk = "0.13.3"
 ic-cdk-macros = "0.13.3"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "823cb40db671f13577940fcd0274ad263c7b6922" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
 
 [profile.release]
 lto = false


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
We want to keep our Cargo dependencies up to date.

# Changes
* Ran `scripts/update-ic-cargo-deps` to update the Cargo.toml dependencies to the latest IC release.

# Tests
* See CI