### PR TITLE
Support SubnetRentalRequest NNS function 52

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Close modal on ESC key press.
 * Add `ENABLE_ACTIONABLE_TAB` feature flag.
 * Support `ApiBoundaryNodes` in `FirewallRulesScope` of `AddFirewallRulesPayload`.
+* Support NNS function 52 for `SubnetRentalRequest`.
 
 #### Changed
 

--- a/dfx.json
+++ b/dfx.json
@@ -354,7 +354,7 @@
         "DIDC_VERSION": "2024-04-11",
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2024-05-10",
+        "SNSDEMO_RELEASE": "release-2024-05-14",
         "IC_COMMIT": "release-2024-05-09_23-02-storage-layer"
       },
       "packtool": ""

--- a/rs/proposals/src/def.rs
+++ b/rs/proposals/src/def.rs
@@ -492,3 +492,16 @@ pub type ReviseElectedHostosVersionsPayload = crate::canisters::nns_registry::ap
 // NNS function 51 - DeployHostosToSomeNodes
 // https://github.com/dfinity/ic/blob/26098e18ddd64ab50d3f3725f50c7f369cd3f90e/rs/registry/canister/src/mutations/do_update_nodes_hostos_version.rs#L38C12-L38C43
 pub type DeployHostosToSomeNodesPayload = crate::canisters::nns_registry::api::UpdateNodesHostosVersionPayload;
+
+// Copied from https://github.com/dfinity/ic/blob/master/rs/nns/governance/src/governance.rs
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, Clone, Debug)]
+pub struct SubnetRentalRequest {
+    pub user: PrincipalId,
+    pub rental_condition_id: RentalConditionId,
+}
+
+// Copied from https://github.com/dfinity/ic/blob/master/rs/nns/governance/src/governance.rs
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, Clone, Copy, Debug)]
+pub enum RentalConditionId {
+    App13CH,
+}

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -14,11 +14,11 @@ use crate::def::{
     RemoveNodeOperatorsPayloadHumanReadable, RemoveNodesFromSubnetPayload, RemoveNodesPayload,
     RerouteCanisterRangesPayload, RetireReplicaVersionPayload, ReviseElectedGuestosVersionsPayload,
     ReviseElectedHostosVersionsPayload, SetAuthorizedSubnetworkListArgs, SetFirewallConfigPayload,
-    StopOrStartNnsCanisterProposal, UpdateAllowedPrincipalsRequest, UpdateApiBoundaryNodesVersionPayload,
-    UpdateElectedHostosVersionsPayload, UpdateFirewallRulesPayload, UpdateIcpXdrConversionRatePayload,
-    UpdateNodeOperatorConfigPayload, UpdateNodeRewardsTableProposalPayload, UpdateNodesHostosVersionPayload,
-    UpdateSnsSubnetListRequest, UpdateSshReadOnlyAccessForAllUnassignedNodesPayload, UpdateSubnetPayload,
-    UpdateSubnetTypeArgs, UpdateUnassignedNodesConfigPayload, UpgradeRootProposalPayload,
+    StopOrStartNnsCanisterProposal, SubnetRentalRequest, UpdateAllowedPrincipalsRequest,
+    UpdateApiBoundaryNodesVersionPayload, UpdateElectedHostosVersionsPayload, UpdateFirewallRulesPayload,
+    UpdateIcpXdrConversionRatePayload, UpdateNodeOperatorConfigPayload, UpdateNodeRewardsTableProposalPayload,
+    UpdateNodesHostosVersionPayload, UpdateSnsSubnetListRequest, UpdateSshReadOnlyAccessForAllUnassignedNodesPayload,
+    UpdateSubnetPayload, UpdateSubnetTypeArgs, UpdateUnassignedNodesConfigPayload, UpgradeRootProposalPayload,
     UpgradeRootProposalPayloadTrimmed,
 };
 use candid::types::{self as candid_types, Type, TypeInner};
@@ -330,6 +330,7 @@ fn transform_payload_to_json(nns_function: i32, payload_bytes: &[u8]) -> Result<
         49 => identity::<UpdateSshReadOnlyAccessForAllUnassignedNodesPayload>(payload_bytes),
         50 => identity::<ReviseElectedHostosVersionsPayload>(payload_bytes),
         51 => identity::<DeployHostosToSomeNodesPayload>(payload_bytes),
+        52 => identity::<SubnetRentalRequest>(payload_bytes),
         _ => Err("Unrecognised NNS function".to_string()),
     }
 }

--- a/scripts/nns-dapp/test-proposal-payload
+++ b/scripts/nns-dapp/test-proposal-payload
@@ -42,6 +42,7 @@ NODE_ID="ynkov-ujzr4-rgyrv-ou4yf-orw6f-rrslu-w65tu-agnfu-xwdrv-xmayj-qae"
 NODE_ID_2="7e6za-cdhql-kvxja-dfse5-jrme3-rwmau-6foiv-fxnwt-h7qos-wqryb-pae"
 SUBNET_ID="52o7h-ke47f-b5z7i-ah4wu-qhruc-kfdcl-xzzhl-sjmfh-3ryrf-xxtei-bae"
 REPLICA_VERSION_ID="48da85ee6c03e8c15f3e90b21bf9ccae7b753ee6"
+USER_PRINCIPAL="fw6gp-yqo6v-iuhjd-pv26u-cn4qv-bzewd-ubz6s-fcssu-pfpct-xrda2-uqe"
 
 test_nns_function_11() {
   subcommand="propose-to-deploy-guestos-to-all-subnet-nodes"
@@ -173,6 +174,20 @@ test_nns_function_51() {
 
   ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
   EXPECTED_PAYLOAD="{\"hostos_version_id\":null,\"node_ids\":[\"$NODE_ID\"]}"
+
+  verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
+}
+
+test_nns_function_52() {
+  subcommand="propose-to-rent-subnet"
+
+  PROPOSAL_ID="$(run_ic_admin \
+    "$subcommand" \
+     --rental-condition-id App13CH \
+     --user "$USER_PRINCIPAL")"
+
+  ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
+  EXPECTED_PAYLOAD="{\"user\":\"$USER_PRINCIPAL\",\"rental_condition_id\":\"App13CH\"}"
 
   verify_payload "$subcommand" "$ACTUAL_PAYLOAD" "$EXPECTED_PAYLOAD"
 }

--- a/scripts/nns-dapp/test-proposal-payload
+++ b/scripts/nns-dapp/test-proposal-payload
@@ -181,7 +181,8 @@ test_nns_function_51() {
 test_nns_function_52() {
   subcommand="propose-to-rent-subnet"
 
-  PROPOSAL_ID="$(run_ic_admin \
+  # TODO: Use `run_ic_admin` instead of `run_ic_admin_with_test_neuron` once `ic-admin` is fixed.
+  PROPOSAL_ID="$(run_ic_admin_with_test_neuron \
     "$subcommand" \
     --rental-condition-id App13CH \
     --user "$USER_PRINCIPAL")"
@@ -199,6 +200,17 @@ run_ic_admin() {
     "$@" \
     --summary "$SUMMARY" \
     --proposer "$NEURON_ID" |
+    grep -E '^proposal [0-9]+$' | sed 's/proposal //'
+}
+
+# Work-around for when `run_ic_admin` gives this error:
+# Specifying a secret key or HSM is only supported for methods that interact with NNS handlers.
+run_ic_admin_with_test_neuron() {
+  ic-admin \
+    --nns-url "$NNS_URL" \
+    "$@" \
+    --summary "$SUMMARY" \
+    --test-neuron-proposer |
     grep -E '^proposal [0-9]+$' | sed 's/proposal //'
 }
 
@@ -231,7 +243,7 @@ declare -F | grep test_nns_function_ | sed -e 's/declare -f //' | while read -r 
 done
 
 # Make sure that we add tests for new NNS function.
-FIRST_UNDEFINED_NNS_FUNCTION=52
+FIRST_UNDEFINED_NNS_FUNCTION=53
 
 for i in $(seq 0 5); do
   undefined_nns_function=$((FIRST_UNDEFINED_NNS_FUNCTION + i))

--- a/scripts/nns-dapp/test-proposal-payload
+++ b/scripts/nns-dapp/test-proposal-payload
@@ -183,8 +183,8 @@ test_nns_function_52() {
 
   PROPOSAL_ID="$(run_ic_admin \
     "$subcommand" \
-     --rental-condition-id App13CH \
-     --user "$USER_PRINCIPAL")"
+    --rental-condition-id App13CH \
+    --user "$USER_PRINCIPAL")"
 
   ACTUAL_PAYLOAD="$(get_payload "$PROPOSAL_ID")"
   EXPECTED_PAYLOAD="{\"user\":\"$USER_PRINCIPAL\",\"rental_condition_id\":\"App13CH\"}"


### PR DESCRIPTION
# Motivation

There is a new proposal type to rent subnets, using NNS function 52.

# Changes

1. Copy Rust types `SubnetRentalRequest` and `RentalConditionId` from the IC repo to `rs/proposals/src/def.rs`.
2. Render the payload as json without transformation.

# Tests

1. Added a test in `scripts/nns-dapp/test-proposal-payload`.
2. Use `--test-neuron-proposer` because `ic-admin` doesn't work for subnet rental with `--secret-key-pem`.
3. Update snsdemo to a release that supports subnet rentals.

# Todos

- [x] Add entry to changelog (if necessary).
