### PR TITLE
Fix sale success message

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -37,6 +37,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Successful swap message should not be shown when participant count is insufficient.
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -40,7 +40,8 @@
 
   let min_icp_e8s: bigint;
   let max_icp_e8s: bigint;
-  $: ({ min_icp_e8s, max_icp_e8s } = params);
+  let min_participants: number;
+  $: ({ min_icp_e8s, max_icp_e8s, min_participants } = params);
 
   let projectCommitments: ProjectCommitmentSplit;
   $: projectCommitments = getProjectCommitmentSplit(summary);
@@ -68,6 +69,9 @@
     ? projectCommitments.directCommitmentE8s >=
       projectCommitments.minDirectCommitmentE8s
     : false;
+  let isMinParticipantsReached: boolean;
+  $: isMinParticipantsReached =
+    nonNullish(saleBuyerCount) && saleBuyerCount >= min_participants;
 
   let maxNfParticipation: bigint | undefined;
   $: maxNfParticipation = getMaxNeuronsFundParticipation(summary);
@@ -84,7 +88,7 @@
       >
     </KeyValuePair>
   {/if}
-  {#if isMinParticipationReached}
+  {#if isMinParticipationReached && isMinParticipantsReached}
     <p
       data-tid="min-participation-reached"
       class="content-cell-island__card min-participation-reached"

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -89,13 +89,15 @@ describe("ProjectCommitment", () => {
       directCommitment,
       minDirectParticipation: 10000000000n,
       maxDirectParticipation: 100000000000n,
+      buyersCount: 100n,
+      minParticipants: 100,
     });
     const po = renderComponent(summary);
 
     expect(await po.getGoalReachedMessage()).toEqual(null);
   });
 
-  it("should render success message when current commitment reaches the min participation goal", async () => {
+  it("should hide success message when current saleBuyerCount is less then min_participants", async () => {
     const directCommitment = 30000000000n;
     const summary = createSummary({
       currentTotalCommitment: directCommitment,
@@ -103,6 +105,24 @@ describe("ProjectCommitment", () => {
       directCommitment,
       minDirectParticipation: 10000000000n,
       maxDirectParticipation: 100000000000n,
+      buyersCount: 99n,
+      minParticipants: 100,
+    });
+    const po = renderComponent(summary);
+
+    expect(await po.getGoalReachedMessage()).toEqual(null);
+  });
+
+  it("should render success message when current commitment reaches the min participation goal and there are enough participants", async () => {
+    const directCommitment = 30000000000n;
+    const summary = createSummary({
+      currentTotalCommitment: directCommitment,
+      neuronsFundCommitment: 0n,
+      directCommitment,
+      minDirectParticipation: 10000000000n,
+      maxDirectParticipation: 100000000000n,
+      buyersCount: 100n,
+      minParticipants: 100,
     });
     const po = renderComponent(summary);
 


### PR DESCRIPTION
# Motivation

The current message `"Minimum participation has been reached, the swap is successful"` erroneously displays even when the number of participants in a swap falls below the configured threshold (`min_participants`). This PR rectifies this issue by enhancing the logic to consider both directly committed ICPs and the total participant count.

# Changes

- Extend the success message visibility logic.

# Tests

- "should hide success message when current saleBuyerCount is less then min_participants"

# Todos

- [x] Add entry to changelog (if necessary).
