### PR TITLE
Add NeuronsTableRow component

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
+  import type { TableNeuron } from "$lib/types/neurons-table";
+  import NeuronsTableRow from "$lib/components/neurons/NeuronsTable/NeuronsTableRow.svelte";
+
+  export let neurons: TableNeuron[];
 </script>
 
-<h1 data-tid="neurons-table-component">
-  The neurons table is not yet implemented.
-</h1>
+<div data-tid="neurons-table-component">
+  <h1>The neurons table is under construction.</h1>
+  {#each neurons as neuron}
+    <NeuronsTableRow {neuron} />
+  {/each}
+</div>

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTableRow.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTableRow.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import type { TableNeuron } from "$lib/types/neurons-table";
+
+  export let neuron: TableNeuron;
+</script>
+
+<div data-tid="neurons-table-row-component">
+  <div data-tid="neuron-id">{neuron.neuronId}</div>
+</div>

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
   import { ENABLE_NEURONS_TABLE } from "$lib/stores/feature-flags.store";
+  import type { TableNeuron } from "$lib/types/neurons-table";
   import { i18n } from "$lib/stores/i18n";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import NnsNeuronCard from "$lib/components/neurons/NnsNeuronCard.svelte";
   import NeuronsTable from "$lib/components/neurons/NeuronsTable/NeuronsTable.svelte";
-  import { neuronsStore, sortedNeuronStore } from "$lib/stores/neurons.store";
+  import {
+    neuronsStore,
+    sortedNeuronStore,
+    definedNeuronsStore,
+  } from "$lib/stores/neurons.store";
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
   import { IconInfo, Tooltip } from "@dfinity/gix-components";
   import { isSpawning } from "$lib/utils/neuron.utils";
@@ -13,6 +18,7 @@
   import EmptyMessage from "$lib/components/ui/EmptyMessage.svelte";
   import { onMount } from "svelte";
   import { listNeurons } from "$lib/services/neurons.services";
+  import { tableNeuronsFromNeuronInfos } from "$lib/utils/neuron.utils";
 
   let isLoading = false;
   $: isLoading = $neuronsStore.neurons === undefined;
@@ -20,6 +26,11 @@
   onMount(() => {
     listNeurons();
   });
+
+  let tableNeurons: TableNeuron[] = [];
+  $: tableNeurons = $ENABLE_NEURONS_TABLE
+    ? tableNeuronsFromNeuronInfos($definedNeuronsStore)
+    : [];
 </script>
 
 <TestIdWrapper testId="nns-neurons-component">
@@ -40,7 +51,7 @@
     </div>
   {/if}
   {#if $ENABLE_NEURONS_TABLE}
-    <NeuronsTable />
+    <NeuronsTable neurons={tableNeurons} />
   {:else}
     <div class="card-grid" data-tid="neurons-body">
       {#if isLoading}

--- a/frontend/src/lib/types/neurons-table.ts
+++ b/frontend/src/lib/types/neurons-table.ts
@@ -1,0 +1,3 @@
+export type TableNeuron = {
+  neuronId: bigint;
+};

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -22,6 +22,7 @@ import type { IcpAccountsStoreData } from "$lib/derived/icp-accounts.derived";
 import type { NeuronsStore } from "$lib/stores/neurons.store";
 import type { VoteRegistrationStoreData } from "$lib/stores/vote-registration.store";
 import type { Account } from "$lib/types/account";
+import type { TableNeuron } from "$lib/types/neurons-table";
 import type { Identity } from "@dfinity/agent";
 import type { WizardStep } from "@dfinity/gix-components";
 import {
@@ -1036,4 +1037,12 @@ export const getTopicSubtitle = ({
     [Topic.SubnetRental]: i18n.follow_neurons.topic_16_subtitle,
   };
   return mapper[topic];
+};
+
+export const tableNeuronsFromNeuronInfos = (
+  neuronInfos: NeuronInfo[]
+): TableNeuron[] => {
+  return neuronInfos.map(({ neuronId }) => ({
+    neuronId,
+  }));
 };

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -1,0 +1,28 @@
+import NeuronsTable from "$lib/components/neurons/NeuronsTable/NeuronsTable.svelte";
+import type { TableNeuron } from "$lib/types/neurons-table";
+import { NeuronsTablePo } from "$tests/page-objects/NeuronsTable.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+
+describe("NeuronsTable", () => {
+  const neuron1: TableNeuron = {
+    neuronId: 10n,
+  };
+  const neuron2: TableNeuron = {
+    neuronId: 99n,
+  };
+  const renderComponent = () => {
+    const { container } = render(NeuronsTable, {
+      neurons: [neuron1, neuron2],
+    });
+    return NeuronsTablePo.under(new JestPageObjectElement(container));
+  };
+
+  it("should render neurons", async () => {
+    const po = renderComponent();
+    const rowPos = await po.getNeuronsTableRowPos();
+    expect(rowPos).toHaveLength(2);
+    expect(await rowPos[0].getNeuronId()).toBe(neuron1.neuronId.toString());
+    expect(await rowPos[1].getNeuronId()).toBe(neuron2.neuronId.toString());
+  });
+});

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTableRow.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTableRow.spec.ts
@@ -1,0 +1,22 @@
+import NeuronsTableRow from "$lib/components/neurons/NeuronsTable/NeuronsTableRow.svelte";
+import type { TableNeuron } from "$lib/types/neurons-table";
+import { NeuronsTableRowPo } from "$tests/page-objects/NeuronsTableRow.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+
+describe("NeuronsTableRow", () => {
+  const neuron: TableNeuron = {
+    neuronId: 10n,
+  };
+  const renderComponent = () => {
+    const { container } = render(NeuronsTableRow, {
+      neuron,
+    });
+    return NeuronsTableRowPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should render table row", async () => {
+    const po = renderComponent();
+    expect(await po.getNeuronId()).toBe(neuron.neuronId.toString());
+  });
+});

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -99,10 +99,17 @@ describe("NnsNeurons", () => {
         overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", true);
       });
 
-      it("should not render the neurons table", async () => {
+      it("should render the neurons table", async () => {
         const po = await renderComponent();
 
         expect(await po.getNeuronsTablePo().isPresent()).toBe(true);
+      });
+
+      it("should render neurons table rows", async () => {
+        const po = await renderComponent();
+
+        const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
+        expect(rows).toHaveLength(3);
       });
 
       it("should not render the NeuronCards", async () => {

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -63,6 +63,7 @@ import {
   neuronVotingPower,
   neuronsVotingPower,
   sortNeuronsByStake,
+  tableNeuronsFromNeuronInfos,
   topicsToFollow,
   userAuthorizedNeuron,
   validTopUpAmount,
@@ -2831,6 +2832,31 @@ describe("neuron-utils", () => {
       expect(getTopicSubtitle({ topic: Topic.SubnetRental, i18n: en })).toBe(
         "All proposals related to renting a subnet, for example a subnet rental request."
       );
+    });
+  });
+
+  describe("tableNeuronsFromNeuronInfos", () => {
+    it("should convert neuronInfos to tableNeurons", () => {
+      const neuronId1 = 42n;
+      const neuronId2 = 342n;
+      const neuronInfo1 = {
+        ...mockNeuron,
+        neuronId: neuronId1,
+      };
+      const neuronInfo2 = {
+        ...mockNeuron,
+        neuronId: neuronId2,
+      };
+      const neuronInfos = [neuronInfo1, neuronInfo2];
+      const tableNeurons = tableNeuronsFromNeuronInfos(neuronInfos);
+      expect(tableNeurons).toEqual([
+        {
+          neuronId: neuronId1,
+        },
+        {
+          neuronId: neuronId2,
+        },
+      ]);
     });
   });
 });

--- a/frontend/src/tests/page-objects/NeuronsTable.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronsTable.page-object.ts
@@ -1,3 +1,4 @@
+import { NeuronsTableRowPo } from "$tests/page-objects/NeuronsTableRow.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -6,5 +7,9 @@ export class NeuronsTablePo extends BasePageObject {
 
   static under(element: PageObjectElement): NeuronsTablePo {
     return new NeuronsTablePo(element.byTestId(NeuronsTablePo.TID));
+  }
+
+  getNeuronsTableRowPos(): Promise<NeuronsTableRowPo[]> {
+    return NeuronsTableRowPo.allUnder(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/NeuronsTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronsTableRow.page-object.ts
@@ -1,0 +1,22 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NeuronsTableRowPo extends BasePageObject {
+  private static readonly TID = "neurons-table-row-component";
+
+  static under(element: PageObjectElement): NeuronsTableRowPo {
+    return new NeuronsTableRowPo(element.byTestId(NeuronsTableRowPo.TID));
+  }
+
+  static async allUnder(
+    element: PageObjectElement
+  ): Promise<NeuronsTableRowPo[]> {
+    return Array.from(await element.allByTestId(NeuronsTableRowPo.TID)).map(
+      (el) => new NeuronsTableRowPo(el)
+    );
+  }
+
+  getNeuronId(): Promise<string> {
+    return this.getText("neuron-id");
+  }
+}


### PR DESCRIPTION
# Motivation

Add more scaffolding for the neurons table without implementing anything real.

# Changes

1. Add `TableNeuron` type (with just 1 field for now) to be used to render neurons in the table. This abstracts away the difference between NNS neurons and SNS neurons so we'll be able to reuse the table for SNS.
2. Add `tableNeuronsFromNeuronInfos` to convert NNS `NeuronInfo`s to `TableNeuron`.
3. Create and pass `TableNeuron`s from `NnsNeurons` to `NeuronsTable`.
4. Add `NeuronsTableRow` component and use it in `NeuronsTable` component.

# Tests

Added unit tests and page objects.

Drive-by: Fix `"should not render the neurons table"` test description which was incorrectly copied.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet