### PR TITLE
Update proposal rendering dependencies

### DIFF
--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -14,92 +14,77 @@ pub struct EmptyRecord {}
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
-// use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
+// use candid::{self, CandidType, Deserialize, Principal};
 // use ic_cdk::api::call::CallResult as Result;
 
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronId {
     pub id: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Followees {
     pub followees: Vec<NeuronId>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct KnownNeuronData {
     pub name: String,
     pub description: Option<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct KnownNeuron {
     pub id: Option<NeuronId>,
     pub known_neuron_data: Option<KnownNeuronData>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Spawn {
     pub percentage_to_spawn: Option<u32>,
     pub new_controller: Option<Principal>,
     pub nonce: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Split {
     pub amount_e8s: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Follow {
     pub topic: i32,
     pub followees: Vec<NeuronId>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ClaimOrRefreshNeuronFromAccount {
     pub controller: Option<Principal>,
     pub memo: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum By {
     NeuronIdOrSubaccount(EmptyRecord),
     MemoAndController(ClaimOrRefreshNeuronFromAccount),
     Memo(u64),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ClaimOrRefresh {
     pub by: Option<By>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RemoveHotKey {
     pub hot_key_to_remove: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct AddHotKey {
     pub new_hot_key: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ChangeAutoStakeMaturity {
     pub requested_setting_for_auto_stake_maturity: bool,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct IncreaseDissolveDelay {
     pub additional_dissolve_delay_seconds: u32,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SetDissolveTimestamp {
     pub dissolve_timestamp_seconds: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Operation {
     RemoveHotKey(RemoveHotKey),
@@ -112,23 +97,19 @@ pub enum Operation {
     LeaveCommunityFund(EmptyRecord),
     SetDissolveTimestamp(SetDissolveTimestamp),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Configure {
     pub operation: Option<Operation>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RegisterVote {
     pub vote: i32,
     pub proposal: Option<NeuronId>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Merge {
     pub source_neuron_id: Option<NeuronId>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct DisburseToNeuron {
     pub dissolve_delay_seconds: u64,
@@ -137,33 +118,27 @@ pub struct DisburseToNeuron {
     pub new_controller: Option<Principal>,
     pub nonce: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct StakeMaturity {
     pub percentage_to_stake: Option<u32>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct MergeMaturity {
     pub percentage_to_merge: u32,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct AccountIdentifier {
     pub hash: serde_bytes::ByteBuf,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Amount {
     pub e8s: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Disburse {
     pub to_account: Option<AccountIdentifier>,
     pub amount: Option<Amount>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Command {
     Spawn(Spawn),
@@ -179,42 +154,35 @@ pub enum Command {
     MergeMaturity(MergeMaturity),
     Disburse(Disburse),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum NeuronIdOrSubaccount {
     Subaccount(serde_bytes::ByteBuf),
     NeuronId(NeuronId),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ManageNeuron {
     pub id: Option<NeuronId>,
     pub command: Option<Command>,
     pub neuron_id_or_subaccount: Option<NeuronIdOrSubaccount>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Percentage {
     pub basis_points: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Duration {
     pub seconds: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Tokens {
     pub e8s: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct VotingRewardParameters {
     pub reward_rate_transition_duration: Option<Duration>,
     pub initial_reward_rate: Option<Percentage>,
     pub final_reward_rate: Option<Percentage>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GovernanceParameters {
     pub neuron_maximum_dissolve_delay_bonus: Option<Percentage>,
@@ -228,12 +196,10 @@ pub struct GovernanceParameters {
     pub proposal_rejection_fee: Option<Tokens>,
     pub voting_reward_parameters: Option<VotingRewardParameters>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Image {
     pub base64_encoding: Option<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct LedgerParameters {
     pub transaction_fee: Option<Tokens>,
@@ -241,28 +207,23 @@ pub struct LedgerParameters {
     pub token_logo: Option<Image>,
     pub token_name: Option<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Canister {
     pub id: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronBasketConstructionParameters {
     pub dissolve_delay_interval: Option<Duration>,
     pub count: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GlobalTimeOfDay {
     pub seconds_after_utc_midnight: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Countries {
     pub iso_codes: Vec<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SwapParameters {
     pub minimum_participants: Option<u64>,
@@ -280,12 +241,10 @@ pub struct SwapParameters {
     pub neurons_fund_investment_icp: Option<Tokens>,
     pub restricted_countries: Option<Countries>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SwapDistribution {
     pub total: Option<Tokens>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronDistribution {
     pub controller: Option<Principal>,
@@ -294,19 +253,16 @@ pub struct NeuronDistribution {
     pub vesting_period: Option<Duration>,
     pub stake: Option<Tokens>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct DeveloperDistribution {
     pub developer_neurons: Vec<NeuronDistribution>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct InitialTokenDistribution {
     pub treasury_distribution: Option<SwapDistribution>,
     pub developer_distribution: Option<DeveloperDistribution>,
     pub swap_distribution: Option<SwapDistribution>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct CreateServiceNervousSystem {
     pub url: Option<String>,
@@ -320,48 +276,40 @@ pub struct CreateServiceNervousSystem {
     pub swap_parameters: Option<SwapParameters>,
     pub initial_token_distribution: Option<InitialTokenDistribution>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ExecuteNnsFunction {
     pub nns_function: i32,
     pub payload: serde_bytes::ByteBuf,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NodeProvider {
     pub id: Option<Principal>,
     pub reward_account: Option<AccountIdentifier>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RewardToNeuron {
     pub dissolve_delay_seconds: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RewardToAccount {
     pub to_account: Option<AccountIdentifier>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum RewardMode {
     RewardToNeuron(RewardToNeuron),
     RewardToAccount(RewardToAccount),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RewardNodeProvider {
     pub node_provider: Option<NodeProvider>,
     pub reward_mode: Option<RewardMode>,
     pub amount_e8s: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronBasketConstructionParameters1 {
     pub dissolve_delay_interval_seconds: u64,
     pub count: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Params {
     pub min_participant_icp_e8s: u64,
@@ -376,54 +324,45 @@ pub struct Params {
     pub min_icp_e8s: u64,
     pub max_direct_participation_icp_e8s: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct OpenSnsTokenSwap {
     pub community_fund_investment_e8s: Option<u64>,
     pub target_swap_canister_id: Option<Principal>,
     pub params: Option<Params>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct TimeWindow {
     pub start_timestamp_seconds: u64,
     pub end_timestamp_seconds: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SetOpenTimeWindowRequest {
     pub open_time_window: Option<TimeWindow>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SetSnsTokenSwapOpenTimeWindow {
     pub request: Option<SetOpenTimeWindowRequest>,
     pub swap_canister_id: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SetDefaultFollowees {
     pub default_followees: Vec<(i32, Followees)>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RewardNodeProviders {
     pub use_registry_derived_rewards: Option<bool>,
     pub rewards: Vec<RewardNodeProvider>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Decimal {
     pub human_readable: Option<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronsFundMatchedFundingCurveCoefficients {
     pub contribution_threshold_xdr: Option<Decimal>,
     pub one_third_participation_milestone_xdr: Option<Decimal>,
     pub full_participation_milestone_xdr: Option<Decimal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronsFundEconomics {
     pub maximum_icp_xdr_rate: Option<Percentage>,
@@ -431,7 +370,6 @@ pub struct NeuronsFundEconomics {
     pub max_theoretical_neurons_fund_participation_amount_xdr: Option<Decimal>,
     pub minimum_icp_xdr_rate: Option<Percentage>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NetworkEconomics {
     pub neuron_minimum_stake_e8s: u64,
@@ -444,28 +382,23 @@ pub struct NetworkEconomics {
     pub maximum_node_provider_rewards_e8s: u64,
     pub neurons_fund_economics: Option<NeuronsFundEconomics>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ApproveGenesisKyc {
     pub principals: Vec<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Change {
     ToRemove(NodeProvider),
     ToAdd(NodeProvider),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct AddOrRemoveNodeProvider {
     pub change: Option<Change>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Motion {
     pub motion_text: String,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Action {
     RegisterKnownNeuron(KnownNeuron),
@@ -482,7 +415,6 @@ pub enum Action {
     AddOrRemoveNodeProvider(AddOrRemoveNodeProvider),
     Motion(Motion),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Proposal {
     pub url: String,
@@ -490,20 +422,17 @@ pub struct Proposal {
     pub action: Option<Action>,
     pub summary: String,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct MakingSnsProposal {
     pub proposal: Option<Box<Proposal>>,
     pub caller: Option<Principal>,
     pub proposer_id: Option<NeuronId>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct MostRecentMonthlyNodeProviderRewards {
     pub timestamp: u64,
     pub rewards: Vec<RewardNodeProvider>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GovernanceCachedMetrics {
     pub total_maturity_e8s_equivalent: u64,
@@ -542,7 +471,6 @@ pub struct GovernanceCachedMetrics {
     pub timestamp_seconds: u64,
     pub seed_neuron_count: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RestoreAgingNeuronGroup {
     pub count: Option<u64>,
@@ -550,13 +478,11 @@ pub struct RestoreAgingNeuronGroup {
     pub current_total_stake_e8s: Option<u64>,
     pub group_type: i32,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RestoreAgingSummary {
     pub groups: Vec<RestoreAgingNeuronGroup>,
     pub timestamp_seconds: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RewardEvent {
     pub rounds_since_last_distribution: Option<u64>,
@@ -567,7 +493,6 @@ pub struct RewardEvent {
     pub distributed_e8s_equivalent: u64,
     pub settled_proposals: Vec<NeuronId>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronStakeTransfer {
     pub to_subaccount: serde_bytes::ByteBuf,
@@ -578,60 +503,50 @@ pub struct NeuronStakeTransfer {
     pub transfer_timestamp: u64,
     pub block_height: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Followers {
     pub followers: Vec<NeuronId>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct FollowersMap {
     pub followers_map: Vec<(u64, Followers)>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Progress {
     LastNeuronId(NeuronId),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Migration {
     pub status: Option<i32>,
     pub failure_reason: Option<String>,
     pub progress: Option<Progress>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Migrations {
     pub neuron_indexes_migration: Option<Migration>,
     pub copy_inactive_neurons_to_stable_memory_migration: Option<Migration>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GovernanceError {
     pub error_message: String,
     pub error_type: i32,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct CfNeuron {
     pub has_created_neuron_recipes: Option<bool>,
     pub nns_neuron_id: u64,
     pub amount_icp_e8s: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct CfParticipant {
     pub hotkey_principal: String,
     pub cf_neurons: Vec<CfNeuron>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Ballot {
     pub vote: i32,
     pub voting_power: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SwapParticipationLimits {
     pub min_participant_icp_e8s: Option<u64>,
@@ -639,7 +554,6 @@ pub struct SwapParticipationLimits {
     pub min_direct_participation_icp_e8s: Option<u64>,
     pub max_direct_participation_icp_e8s: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronsFundNeuronPortion {
     pub hotkey_principal: Option<Principal>,
@@ -648,17 +562,14 @@ pub struct NeuronsFundNeuronPortion {
     pub nns_neuron_id: Option<NeuronId>,
     pub amount_icp_e8s: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronsFundSnapshot {
     pub neurons_fund_neuron_portions: Vec<NeuronsFundNeuronPortion>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct IdealMatchedParticipationFunction {
     pub serialized_representation: Option<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronsFundParticipation {
     pub total_maturity_equivalent_icp_e8s: Option<u64>,
@@ -670,14 +581,12 @@ pub struct NeuronsFundParticipation {
     pub ideal_matched_participation_function: Option<IdealMatchedParticipationFunction>,
     pub allocated_neurons_fund_participation_icp_e8s: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronsFundData {
     pub final_neurons_fund_participation: Option<NeuronsFundParticipation>,
     pub initial_neurons_fund_participation: Option<NeuronsFundParticipation>,
     pub neurons_fund_refunds: Option<NeuronsFundSnapshot>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct CanisterStatusResultV2 {
     pub status: Option<i32>,
@@ -688,13 +597,11 @@ pub struct CanisterStatusResultV2 {
     pub idle_cycles_burned_per_day: Option<u64>,
     pub module_hash: serde_bytes::ByteBuf,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct CanisterSummary {
     pub status: Option<CanisterStatusResultV2>,
     pub canister_id: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SwapBackgroundInformation {
     pub ledger_index_canister_summary: Option<CanisterSummary>,
@@ -706,12 +613,10 @@ pub struct SwapBackgroundInformation {
     pub root_canister_summary: Option<CanisterSummary>,
     pub dapp_canister_summaries: Vec<CanisterSummary>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct DerivedProposalInformation {
     pub swap_background_information: Option<SwapBackgroundInformation>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Tally {
     pub no: u64,
@@ -719,12 +624,10 @@ pub struct Tally {
     pub total: u64,
     pub timestamp_seconds: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct WaitForQuietState {
     pub current_deadline_timestamp_seconds: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ProposalData {
     pub id: Option<NeuronId>,
@@ -746,13 +649,11 @@ pub struct ProposalData {
     pub executed_timestamp_seconds: u64,
     pub original_total_community_fund_maturity_e8s_equivalent: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct XdrConversionRate {
     pub xdr_permyriad_per_icp: Option<u64>,
     pub timestamp_seconds: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Command2 {
     Spawn(NeuronId),
@@ -765,25 +666,21 @@ pub enum Command2 {
     MergeMaturity(MergeMaturity),
     Disburse(Disburse),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronInFlightCommand {
     pub command: Option<Command2>,
     pub timestamp: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct BallotInfo {
     pub vote: i32,
     pub proposal_id: Option<NeuronId>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum DissolveState {
     DissolveDelaySeconds(u64),
     WhenDissolvedTimestampSeconds(u64),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Neuron {
     pub id: Option<NeuronId>,
@@ -808,7 +705,6 @@ pub struct Neuron {
     pub known_neuron_data: Option<KnownNeuronData>,
     pub spawn_at_timestamp_seconds: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Governance {
     pub default_followees: Vec<(i32, Followees)>,
@@ -834,42 +730,35 @@ pub struct Governance {
     pub neurons: Vec<(u64, Neuron)>,
     pub genesis_timestamp_seconds: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result_ {
     Ok,
     Err(GovernanceError),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result1 {
     Error(GovernanceError),
     NeuronId(NeuronId),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ClaimOrRefreshNeuronFromAccountResponse {
     pub result: Option<Result1>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result2 {
     Ok(Neuron),
     Err(GovernanceError),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result3 {
     Ok(GovernanceCachedMetrics),
     Err(GovernanceError),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result4 {
     Ok(RewardNodeProviders),
     Err(GovernanceError),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronInfo {
     pub dissolve_delay_seconds: u64,
@@ -884,47 +773,39 @@ pub struct NeuronInfo {
     pub voting_power: u64,
     pub age_seconds: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result5 {
     Ok(NeuronInfo),
     Err(GovernanceError),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetNeuronsFundAuditInfoRequest {
     pub nns_proposal_id: Option<NeuronId>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronsFundAuditInfo {
     pub final_neurons_fund_participation: Option<NeuronsFundParticipation>,
     pub initial_neurons_fund_participation: Option<NeuronsFundParticipation>,
     pub neurons_fund_refunds: Option<NeuronsFundSnapshot>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Ok {
     pub neurons_fund_audit_info: Option<NeuronsFundAuditInfo>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result6 {
     Ok(Ok),
     Err(GovernanceError),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetNeuronsFundAuditInfoResponse {
     pub result: Option<Result6>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result7 {
     Ok(NodeProvider),
     Err(GovernanceError),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ProposalInfo {
     pub id: Option<NeuronId>,
@@ -945,29 +826,24 @@ pub struct ProposalInfo {
     pub proposer: Option<NeuronId>,
     pub executed_timestamp_seconds: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ListKnownNeuronsResponse {
     pub known_neurons: Vec<KnownNeuron>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ListNeurons {
     pub neuron_ids: Vec<u64>,
     pub include_neurons_readable_by_caller: bool,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ListNeuronsResponse {
     pub neuron_infos: Vec<(u64, NeuronInfo)>,
     pub full_neurons: Vec<Neuron>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ListNodeProvidersResponse {
     pub node_providers: Vec<NodeProvider>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ListProposalInfo {
     pub include_reward_status: Vec<i32>,
@@ -978,22 +854,18 @@ pub struct ListProposalInfo {
     pub include_all_manage_neuron_proposals: Option<bool>,
     pub include_status: Vec<i32>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ListProposalInfoResponse {
     pub proposal_info: Vec<ProposalInfo>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SpawnResponse {
     pub created_neuron_id: Option<NeuronId>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ClaimOrRefreshResponse {
     pub refreshed_neuron_id: Option<NeuronId>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct MergeResponse {
     pub target_neuron: Option<Neuron>,
@@ -1001,30 +873,25 @@ pub struct MergeResponse {
     pub target_neuron_info: Option<NeuronInfo>,
     pub source_neuron_info: Option<NeuronInfo>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct MakeProposalResponse {
     pub message: Option<String>,
     pub proposal_id: Option<NeuronId>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct StakeMaturityResponse {
     pub maturity_e8s: u64,
     pub staked_maturity_e8s: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct MergeMaturityResponse {
     pub merged_maturity_e8s: u64,
     pub new_stake_e8s: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct DisburseResponse {
     pub transfer_block_height: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Command1 {
     Error(GovernanceError),
@@ -1041,50 +908,42 @@ pub enum Command1 {
     MergeMaturity(MergeMaturityResponse),
     Disburse(DisburseResponse),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ManageNeuronResponse {
     pub command: Option<Command1>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Committed {
     pub total_direct_contribution_icp_e8s: Option<u64>,
     pub total_neurons_fund_contribution_icp_e8s: Option<u64>,
     pub sns_governance_canister_id: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result8 {
     Committed(Committed),
     Aborted(EmptyRecord),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SettleCommunityFundParticipation {
     pub result: Option<Result8>,
     pub open_sns_token_swap_proposal_id: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Committed1 {
     pub total_direct_participation_icp_e8s: Option<u64>,
     pub total_neurons_fund_participation_icp_e8s: Option<u64>,
     pub sns_governance_canister_id: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result9 {
     Committed(Committed1),
     Aborted(EmptyRecord),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SettleNeuronsFundParticipationRequest {
     pub result: Option<Result9>,
     pub nns_proposal_id: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronsFundNeuron {
     pub hotkey_principal: Option<String>,
@@ -1092,23 +951,19 @@ pub struct NeuronsFundNeuron {
     pub nns_neuron_id: Option<u64>,
     pub amount_icp_e8s: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Ok1 {
     pub neurons_fund_neuron_portions: Vec<NeuronsFundNeuron>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result10 {
     Ok(Ok1),
     Err(GovernanceError),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SettleNeuronsFundParticipationResponse {
     pub result: Option<Result10>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateNodeProvider {
     pub reward_account: Option<AccountIdentifier>,

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -14,7 +14,7 @@ pub struct EmptyRecord {}
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
-// use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
+// use candid::{self, CandidType, Deserialize, Principal};
 // use ic_cdk::api::call::CallResult as Result;
 
 #[derive(Serialize, CandidType, Deserialize)]
@@ -22,7 +22,6 @@ pub struct AddApiBoundaryNodesPayload {
     pub version: String,
     pub node_ids: Vec<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum FirewallRulesScope {
     Node(Principal),
@@ -31,7 +30,6 @@ pub enum FirewallRulesScope {
     Subnet(Principal),
     Global,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct FirewallRule {
     pub ipv4_prefixes: Vec<String>,
@@ -42,7 +40,6 @@ pub struct FirewallRule {
     pub ipv6_prefixes: Vec<String>,
     pub ports: Vec<u32>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct AddFirewallRulesPayload {
     pub expected_hash: String,
@@ -50,14 +47,12 @@ pub struct AddFirewallRulesPayload {
     pub positions: Vec<i32>,
     pub rules: Vec<FirewallRule>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct IPv4Config {
     pub prefix_length: u32,
     pub gateway_ip_addr: String,
     pub ip_addr: String,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct AddNodePayload {
     pub prometheus_metrics_endpoint: String,
@@ -73,13 +68,11 @@ pub struct AddNodePayload {
     pub ni_dkg_dealing_encryption_pk: serde_bytes::ByteBuf,
     pub p2p_flow_endpoints: Vec<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result_ {
     Ok(Principal),
     Err(String),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct AddNodeOperatorPayload {
     pub ipv6: Option<String>,
@@ -89,19 +82,16 @@ pub struct AddNodeOperatorPayload {
     pub node_provider_principal_id: Option<Principal>,
     pub dc_id: String,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct AddNodesToSubnetPayload {
     pub subnet_id: Principal,
     pub node_ids: Vec<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Gps {
     pub latitude: f32,
     pub longitude: f32,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct DataCenterRecord {
     pub id: String,
@@ -109,13 +99,11 @@ pub struct DataCenterRecord {
     pub region: String,
     pub owner: String,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct AddOrRemoveDataCentersProposalPayload {
     pub data_centers_to_add: Vec<DataCenterRecord>,
     pub data_centers_to_remove: Vec<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct BlessReplicaVersionPayload {
     pub release_package_urls: Option<Vec<String>>,
@@ -128,57 +116,48 @@ pub struct BlessReplicaVersionPayload {
     pub node_manager_binary_url: String,
     pub binary_url: String,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ChangeSubnetMembershipPayload {
     pub node_ids_add: Vec<Principal>,
     pub subnet_id: Principal,
     pub node_ids_remove: Vec<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct CanisterIdRange {
     pub end: Principal,
     pub start: Principal,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct CompleteCanisterMigrationPayload {
     pub canister_id_ranges: Vec<CanisterIdRange>,
     pub migration_trace: Vec<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result1 {
     Ok,
     Err(String),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SubnetFeatures {
     pub canister_sandboxing: bool,
     pub http_requests: bool,
     pub sev_enabled: Option<bool>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum EcdsaCurve {
     #[serde(rename = "secp256k1")]
     Secp256K1,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct EcdsaKeyId {
     pub name: String,
     pub curve: EcdsaCurve,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct EcdsaKeyRequest {
     pub key_id: EcdsaKeyId,
     pub subnet_id: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct EcdsaInitialConfig {
     pub quadruples_to_create_in_advance: u32,
@@ -187,7 +166,6 @@ pub struct EcdsaInitialConfig {
     pub signature_request_timeout_ns: Option<u64>,
     pub idkg_key_rotation_period_ms: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum SubnetType {
     #[serde(rename = "application")]
@@ -197,7 +175,6 @@ pub enum SubnetType {
     #[serde(rename = "system")]
     System,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct CreateSubnetPayload {
     pub unit_delay_millis: u64,
@@ -231,23 +208,19 @@ pub struct CreateSubnetPayload {
     pub gossip_receive_check_cache_size: u32,
     pub node_ids: Vec<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct DeleteSubnetPayload {
     pub subnet_id: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct DeployGuestosToAllSubnetNodesPayload {
     pub subnet_id: Principal,
     pub replica_version_id: String,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct DeployGuestosToAllUnassignedNodesPayload {
     pub elected_replica_version: String,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NodeOperatorRecord {
     pub ipv6: Option<String>,
@@ -257,47 +230,39 @@ pub struct NodeOperatorRecord {
     pub node_provider_principal_id: serde_bytes::ByteBuf,
     pub dc_id: String,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result2 {
     Ok(Vec<(DataCenterRecord, NodeOperatorRecord)>),
     Err(String),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NodeProvidersMonthlyXdrRewards {
     pub rewards: Vec<(String, u64)>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result3 {
     Ok(NodeProvidersMonthlyXdrRewards),
     Err(String),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetSubnetForCanisterRequest {
     pub principal: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetSubnetForCanisterResponse {
     pub subnet_id: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result4 {
     Ok(GetSubnetForCanisterResponse),
     Err(String),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct PrepareCanisterMigrationPayload {
     pub canister_id_ranges: Vec<CanisterIdRange>,
     pub source_subnet: Principal,
     pub destination_subnet: Principal,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RecoverSubnetPayload {
     pub height: u64,
@@ -308,46 +273,38 @@ pub struct RecoverSubnetPayload {
     pub state_hash: serde_bytes::ByteBuf,
     pub time_ns: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RemoveApiBoundaryNodesPayload {
     pub node_ids: Vec<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RemoveFirewallRulesPayload {
     pub expected_hash: String,
     pub scope: FirewallRulesScope,
     pub positions: Vec<i32>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RemoveNodeDirectlyPayload {
     pub node_id: Principal,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RemoveNodeOperatorsPayload {
     pub node_operators_to_remove: Vec<serde_bytes::ByteBuf>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RemoveNodesPayload {
     pub node_ids: Vec<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RerouteCanisterRangesPayload {
     pub source_subnet: Principal,
     pub reassigned_canister_ranges: Vec<CanisterIdRange>,
     pub destination_subnet: Principal,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RetireReplicaVersionPayload {
     pub replica_version_ids: Vec<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ReviseElectedGuestosVersionsPayload {
     pub release_package_urls: Vec<String>,
@@ -356,14 +313,12 @@ pub struct ReviseElectedGuestosVersionsPayload {
     pub guest_launch_measurement_sha256_hex: Option<String>,
     pub release_package_sha256_hex: Option<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SetFirewallConfigPayload {
     pub ipv4_prefixes: Vec<String>,
     pub firewall_config: String,
     pub ipv6_prefixes: Vec<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateElectedHostosVersionsPayload {
     pub release_package_urls: Vec<String>,
@@ -371,24 +326,20 @@ pub struct UpdateElectedHostosVersionsPayload {
     pub hostos_versions_to_unelect: Vec<String>,
     pub release_package_sha256_hex: Option<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateNodeDirectlyPayload {
     pub idkg_dealing_encryption_pk: Option<serde_bytes::ByteBuf>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateNodeDomainDirectlyPayload {
     pub node_id: Principal,
     pub domain: Option<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateNodeIPv4ConfigDirectlyPayload {
     pub ipv4_config: Option<IPv4Config>,
     pub node_id: Principal,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateNodeOperatorConfigPayload {
     pub node_operator_id: Option<Principal>,
@@ -399,40 +350,33 @@ pub struct UpdateNodeOperatorConfigPayload {
     pub rewardable_nodes: Vec<(String, u32)>,
     pub dc_id: Option<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateNodeOperatorConfigDirectlyPayload {
     pub node_operator_id: Option<Principal>,
     pub node_provider_id: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NodeRewardRate {
     pub xdr_permyriad_per_node_per_month: u64,
     pub reward_coefficient_percent: Option<i32>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NodeRewardRates {
     pub rates: Vec<(String, NodeRewardRate)>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateNodeRewardsTableProposalPayload {
     pub new_entries: Vec<(String, NodeRewardRates)>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateNodesHostosVersionPayload {
     pub hostos_version_id: Option<String>,
     pub node_ids: Vec<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateSshReadOnlyAccessForAllUnassignedNodesPayload {
     pub ssh_readonly_keys: Vec<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct EcdsaConfig {
     pub quadruples_to_create_in_advance: u32,
@@ -441,7 +385,6 @@ pub struct EcdsaConfig {
     pub signature_request_timeout_ns: Option<u64>,
     pub idkg_key_rotation_period_ms: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateSubnetPayload {
     pub unit_delay_millis: Option<u64>,
@@ -476,7 +419,6 @@ pub struct UpdateSubnetPayload {
     pub subnet_type: Option<SubnetType>,
     pub ssh_readonly_access: Option<Vec<String>>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateUnassignedNodesConfigPayload {
     pub replica_version: Option<String>,

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -14,7 +14,7 @@ pub struct EmptyRecord {}
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
-// use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
+// use candid::{self, CandidType, Deserialize, Principal};
 // use ic_cdk::api::call::CallResult as Result;
 
 #[derive(Serialize, CandidType, Deserialize)]
@@ -23,52 +23,43 @@ pub struct SnsWasmCanisterInitPayload {
     pub access_controls_enabled: bool,
     pub sns_subnet_ids: Vec<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SnsWasm {
     pub wasm: serde_bytes::ByteBuf,
     pub proposal_id: Option<u64>,
     pub canister_type: i32,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct AddWasmRequest {
     pub hash: serde_bytes::ByteBuf,
     pub wasm: Option<SnsWasm>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SnsWasmError {
     pub message: String,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result_ {
     Error(SnsWasmError),
     Hash(serde_bytes::ByteBuf),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct AddWasmResponse {
     pub result: Option<Result_>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronBasketConstructionParameters {
     pub dissolve_delay_interval_seconds: u64,
     pub count: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Canister {
     pub id: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct DappCanisters {
     pub canisters: Vec<Canister>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct LinearScalingCoefficient {
     pub slope_numerator: Option<u64>,
@@ -77,12 +68,10 @@ pub struct LinearScalingCoefficient {
     pub slope_denominator: Option<u64>,
     pub to_direct_participation_icp_e8s: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct IdealMatchedParticipationFunction {
     pub serialized_representation: Option<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronsFundParticipationConstraints {
     pub coefficient_intervals: Vec<LinearScalingCoefficient>,
@@ -90,30 +79,25 @@ pub struct NeuronsFundParticipationConstraints {
     pub min_direct_participation_threshold_icp_e8s: Option<u64>,
     pub ideal_matched_participation_function: Option<IdealMatchedParticipationFunction>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct CfNeuron {
     pub has_created_neuron_recipes: Option<bool>,
     pub nns_neuron_id: u64,
     pub amount_icp_e8s: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct CfParticipant {
     pub hotkey_principal: String,
     pub cf_neurons: Vec<CfNeuron>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronsFundParticipants {
     pub participants: Vec<CfParticipant>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct TreasuryDistribution {
     pub total_e8s: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronDistribution {
     pub controller: Option<Principal>,
@@ -122,23 +106,19 @@ pub struct NeuronDistribution {
     pub stake_e8s: u64,
     pub vesting_period_seconds: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct DeveloperDistribution {
     pub developer_neurons: Vec<NeuronDistribution>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct AirdropDistribution {
     pub airdrop_neurons: Vec<NeuronDistribution>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SwapDistribution {
     pub total_e8s: u64,
     pub initial_swap_amount_e8s: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct FractionalDeveloperVotingPower {
     pub treasury_distribution: Option<TreasuryDistribution>,
@@ -146,17 +126,14 @@ pub struct FractionalDeveloperVotingPower {
     pub airdrop_distribution: Option<AirdropDistribution>,
     pub swap_distribution: Option<SwapDistribution>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum InitialTokenDistribution {
     FractionalDeveloperVotingPower(FractionalDeveloperVotingPower),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Countries {
     pub iso_codes: Vec<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SnsInitPayload {
     pub url: Option<String>,
@@ -199,19 +176,16 @@ pub struct SnsInitPayload {
     pub min_icp_e8s: Option<u64>,
     pub max_direct_participation_icp_e8s: Option<u64>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct DeployNewSnsRequest {
     pub sns_init_payload: Option<SnsInitPayload>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct DappCanistersTransferResult {
     pub restored_dapp_canisters: Vec<Canister>,
     pub nns_controlled_dapp_canisters: Vec<Canister>,
     pub sns_controlled_dapp_canisters: Vec<Canister>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SnsCanisterIds {
     pub root: Option<Principal>,
@@ -220,7 +194,6 @@ pub struct SnsCanisterIds {
     pub index: Option<Principal>,
     pub governance: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct DeployNewSnsResponse {
     pub dapp_canisters_transfer_result: Option<DappCanistersTransferResult>,
@@ -228,20 +201,16 @@ pub struct DeployNewSnsResponse {
     pub error: Option<SnsWasmError>,
     pub canisters: Option<SnsCanisterIds>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetAllowedPrincipalsArg {}
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetAllowedPrincipalsResponse {
     pub allowed_principals: Vec<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetDeployedSnsByProposalIdRequest {
     pub proposal_id: u64,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct DeployedSns {
     pub root_canister_id: Option<Principal>,
@@ -250,18 +219,15 @@ pub struct DeployedSns {
     pub swap_canister_id: Option<Principal>,
     pub ledger_canister_id: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum GetDeployedSnsByProposalIdResult {
     Error(SnsWasmError),
     DeployedSns(DeployedSns),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetDeployedSnsByProposalIdResponse {
     pub get_deployed_sns_by_proposal_id_result: Option<GetDeployedSnsByProposalIdResult>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SnsVersion {
     pub archive_wasm_hash: serde_bytes::ByteBuf,
@@ -271,96 +237,78 @@ pub struct SnsVersion {
     pub governance_wasm_hash: serde_bytes::ByteBuf,
     pub index_wasm_hash: serde_bytes::ByteBuf,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetNextSnsVersionRequest {
     pub governance_canister_id: Option<Principal>,
     pub current_version: Option<SnsVersion>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetNextSnsVersionResponse {
     pub next_version: Option<SnsVersion>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetSnsSubnetIdsArg {}
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetSnsSubnetIdsResponse {
     pub sns_subnet_ids: Vec<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetWasmRequest {
     pub hash: serde_bytes::ByteBuf,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetWasmResponse {
     pub wasm: Option<SnsWasm>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetWasmMetadataRequest {
     pub hash: Option<serde_bytes::ByteBuf>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct MetadataSection {
     pub contents: Option<serde_bytes::ByteBuf>,
     pub name: Option<String>,
     pub visibility: Option<String>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Ok {
     pub sections: Vec<MetadataSection>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result1 {
     Ok(Ok),
     Error(SnsWasmError),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetWasmMetadataResponse {
     pub result: Option<Result1>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SnsUpgrade {
     pub next_version: Option<SnsVersion>,
     pub current_version: Option<SnsVersion>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct InsertUpgradePathEntriesRequest {
     pub upgrade_path: Vec<SnsUpgrade>,
     pub sns_governance_canister_id: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct InsertUpgradePathEntriesResponse {
     pub error: Option<SnsWasmError>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ListDeployedSnsesArg {}
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ListDeployedSnsesResponse {
     pub instances: Vec<DeployedSns>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ListUpgradeStepsRequest {
     pub limit: u32,
     pub starting_at: Option<SnsVersion>,
     pub sns_governance_canister_id: Option<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct PrettySnsVersion {
     pub archive_wasm_hash: String,
@@ -370,41 +318,34 @@ pub struct PrettySnsVersion {
     pub governance_wasm_hash: String,
     pub index_wasm_hash: String,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ListUpgradeStep {
     pub pretty_version: Option<PrettySnsVersion>,
     pub version: Option<SnsVersion>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ListUpgradeStepsResponse {
     pub steps: Vec<ListUpgradeStep>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateAllowedPrincipalsRequest {
     pub added_principals: Vec<Principal>,
     pub removed_principals: Vec<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum UpdateAllowedPrincipalsResult {
     Error(SnsWasmError),
     AllowedPrincipals(GetAllowedPrincipalsResponse),
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateAllowedPrincipalsResponse {
     pub update_allowed_principals_result: Option<UpdateAllowedPrincipalsResult>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateSnsSubnetListRequest {
     pub sns_subnet_ids_to_add: Vec<Principal>,
     pub sns_subnet_ids_to_remove: Vec<Principal>,
 }
-
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateSnsSubnetListResponse {
     pub error: Option<SnsWasmError>,


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.
Even with no changes, just updating the reference is good practice.

# Changes
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.
  * Note: The candid files under `declarations/nns-$CANISTER` are used as inputs.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants