### PR TITLE
Update Candid for proposals and sns_aggregator independently

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -143,8 +143,10 @@ jobs:
           curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
       - name: Check didc
         run: command -v didc
-      - name: Run the ic_commit code generator
-        run: ./scripts/update_ic_commit --ic_commit "$(jq -re .defaults.build.config.IC_COMMIT dfx.json)"
+      - name: Run the ic_commit code generator for proposals
+        run: ./scripts/update_ic_commit --crate proposals --ic_commit "$(jq -re .defaults.build.config.IC_COMMIT_FOR_PROPOSALS dfx.json)"
+      - name: Run the ic_commit code generator for sns_aggregator
+        run: ./scripts/update_ic_commit --crate proposals --ic_commit "$(jq -re .defaults.build.config.IC_COMMIT_FOR_SNS_AGGREGATOR dfx.json)"
       - name: Verify that there are no code changes
         run: |
           if git diff | grep . ; then

--- a/dfx.json
+++ b/dfx.json
@@ -356,7 +356,8 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-05-14",
-        "IC_COMMIT": "release-2024-05-09_23-02-storage-layer"
+        "IC_COMMIT_FOR_PROPOSALS": "release-2024-05-09_23-02-storage-layer",
+        "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-05-09_23-02-storage-layer"
       },
       "packtool": ""
     }

--- a/rs/proposals/HACKING.md
+++ b/rs/proposals/HACKING.md
@@ -32,7 +32,7 @@ If the APIs of canisters controlled by the NNS have changed, proposal payloads m
 
 - Pick [a recent release of the `IC` repository](https://github.com/dfinity/ic/tags) that contains the changes you care about. Alternatively you may chose a commit, but release tags are preferred as their age is obvious.
 - Update the relevant `.did` files under `declarations` in the root of this repository.
-  - You can upgrade all `.did` files that come from the IC repository by running: `./scripts/update_ic_commit -c THE_RELEASE_TAG`
+  - You can upgrade all `.did` files that come from the IC repository by running: `./scripts/update_ic_commit --crate proposals --ic_commit THE_RELEASE_TAG`
     - Note: The above routine is likely to change soon. When it does, the command above needs to be updated.
     - Note: The command may require some manual intervention if the upstream changes are too radical.
   - You can update just a few canisters by manually by getting the corresponding `.did` files from the relevant upstream repositories. You will have to make any corresponding changes manually.

--- a/scripts/update_ic_commit
+++ b/scripts/update_ic_commit
@@ -31,7 +31,7 @@ fi
 
 : "Bump IC_COMMIT in dfx.json"
 bump_ic_commit() {
-  IC_COMMIT_CONFIG_FIELD="$1"
+  export IC_COMMIT_CONFIG_FIELD="$1"
   NEW_CONFIG="$(DFX_IC_COMMIT="$DFX_IC_COMMIT" jq '.defaults.build.config[env.IC_COMMIT_CONFIG_FIELD] = (env.DFX_IC_COMMIT)' "$SOURCE_DIR/../dfx.json")"
   [[ "$NEW_CONFIG" != "" ]] || {
     echo "ERROR: Failed to set ${IC_COMMIT_CONFIG_FIELD}  in dfx.json.  Please verify that dfx.json is valid JSON."

--- a/scripts/update_ic_commit
+++ b/scripts/update_ic_commit
@@ -11,8 +11,16 @@ print_help() {
 source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define short=c long=ic_commit desc="The IC commit to use" variable=DFX_IC_COMMIT default=""
+clap.define long=crate desc="'proposals' or 'sns_aggregator' or 'all'" variable=CRATE default="all"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
+
+if [[ "${CRATE:-}" = "all" ]]; then
+  for crate in proposals sns_aggregator; do
+    "$0" --ic_commit "$DFX_IC_COMMIT" --crate "$crate"
+  done
+  exit 0
+fi
 
 : "Make sure that DFX_IC_COMMIT is defined"
 [[ "${DFX_IC_COMMIT:-}" != "" ]] || {
@@ -22,10 +30,11 @@ source "$(clap.build)"
 } >&2
 
 : "Bump IC_COMMIT in dfx.json"
-{
-  NEW_CONFIG="$(DFX_IC_COMMIT="$DFX_IC_COMMIT" jq '.defaults.build.config.IC_COMMIT = (env.DFX_IC_COMMIT)' "$SOURCE_DIR/../dfx.json")"
+bump_ic_commit() {
+  IC_COMMIT_CONFIG_FIELD="$1"
+  NEW_CONFIG="$(DFX_IC_COMMIT="$DFX_IC_COMMIT" jq '.defaults.build.config[env.IC_COMMIT_CONFIG_FIELD] = (env.DFX_IC_COMMIT)' "$SOURCE_DIR/../dfx.json")"
   [[ "$NEW_CONFIG" != "" ]] || {
-    echo "ERROR: Failed to set IC_COMMIT in dfx.json.  Please verify that dfx.json is valid JSON."
+    echo "ERROR: Failed to set ${IC_COMMIT_CONFIG_FIELD}  in dfx.json.  Please verify that dfx.json is valid JSON."
     exit 1
   } >&2
   printf "%s\n" "$NEW_CONFIG" >"$SOURCE_DIR/../dfx.json"
@@ -46,14 +55,22 @@ source "$(clap.build)"
       curl -sfL --retry 5 "$IC_URL$upstream_path"
     } >"${local_path}"
   }
-  did_curl proposals nns_governance /rs/nns/governance/canister/governance.did
-  did_curl proposals nns_registry /rs/registry/canister/canister/registry.did
-  did_curl proposals sns_wasm /rs/nns/sns-wasm/canister/sns-wasm.did
-  did_curl sns_aggregator sns_governance /rs/sns/governance/canister/governance.did
-  did_curl sns_aggregator sns_root /rs/sns/root/canister/root.did
-  did_curl sns_aggregator sns_swap /rs/sns/swap/canister/swap.did
-  did_curl sns_aggregator sns_wasm /rs/nns/sns-wasm/canister/sns-wasm.did
-  did_curl sns_aggregator sns_ledger /rs/rosetta-api/icrc1/ledger/ledger.did
+  if [[ "$CRATE" = "proposals" ]]; then
+    bump_ic_commit IC_COMMIT_FOR_PROPOSALS
+    did_curl proposals nns_governance /rs/nns/governance/canister/governance.did
+    did_curl proposals nns_registry /rs/registry/canister/canister/registry.did
+    did_curl proposals sns_wasm /rs/nns/sns-wasm/canister/sns-wasm.did
+  elif [[ "$CRATE" = "sns_aggregator" ]]; then
+    bump_ic_commit IC_COMMIT_FOR_SNS_AGGREGATOR
+    did_curl sns_aggregator sns_governance /rs/sns/governance/canister/governance.did
+    did_curl sns_aggregator sns_root /rs/sns/root/canister/root.did
+    did_curl sns_aggregator sns_swap /rs/sns/swap/canister/swap.did
+    did_curl sns_aggregator sns_wasm /rs/nns/sns-wasm/canister/sns-wasm.did
+    did_curl sns_aggregator sns_ledger /rs/rosetta-api/icrc1/ledger/ledger.did
+  else
+    echo "ERROR: --crate should be 'proposals' or 'sns_aggregator' or 'all'."
+    exit 1
+  fi
 }
 
 : "All done"


### PR DESCRIPTION
# Motivation

See https://github.com/dfinity/nns-dapp/pull/4861 for motivation.
This PR is to make it possible to update candid for `proposals` and `sns_aggregator` independently.
In a future PR we'll use that possibility to make the proposed changes to the workflows.

# Changes

1. Add a `--crate` flag to `scripts/update_ic_commit` to specify for which crate we want to update the IC commit and Candid files.
2. Allow `all` (which is default) to keep the original behavior of updating all Candid files.
3. Keep separate fields in `dfx.json` instead of the single `IC_COMMIT` fields.

# Tests

1. Manually tested with `--crate proposals`, with `--crate sns_aggregator` and without `--crate`.
2. Updated the workflow test.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary