### PR TITLE
New actionable sns proposals store

### DIFF
--- a/frontend/src/lib/derived/actionable-proposals.derived.ts
+++ b/frontend/src/lib/derived/actionable-proposals.derived.ts
@@ -78,7 +78,7 @@ export const actionableProposalSupportedStore: Readable<ActionableProposalSuppor
 
 /** A store that contains sns universes with actionable support and their actionable proposals
  * in the same order as they are displayed in the UI. */
-export const sortedActionableSnsProposalsStore: Readable<
+export const actionableSnsProposalsByUniverseStore: Readable<
   Array<{
     universe: Universe;
     proposals: SnsProposalData[];

--- a/frontend/src/lib/derived/actionable-proposals.derived.ts
+++ b/frontend/src/lib/derived/actionable-proposals.derived.ts
@@ -2,11 +2,14 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { authSignedInStore } from "$lib/derived/auth.derived";
 import { pageStore } from "$lib/derived/page.derived";
+import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
+import type { Universe } from "$lib/types/universe";
 import { isSelectedPath } from "$lib/utils/navigation.utils";
 import { mapEntries } from "$lib/utils/utils";
+import type { SnsProposalData } from "@dfinity/sns";
 import { derived, type Readable } from "svelte/store";
 
 export interface ActionableProposalCountData {
@@ -72,3 +75,24 @@ export const actionableProposalSupportedStore: Readable<ActionableProposalSuppor
       ],
     }),
   }));
+
+/** A store that contains sns universes with actionable support and their actionable proposals
+ * in the same order as they are displayed in the UI. */
+export const sortedActionableSnsProposalsStore: Readable<
+  Array<{
+    universe: Universe;
+    proposals: SnsProposalData[];
+  }>
+> = derived(
+  [selectableUniversesStore, actionableSnsProposalsStore],
+  ([universes, actionableSnsProposals]) =>
+    universes
+      .filter(
+        ({ canisterId }) =>
+          actionableSnsProposals[canisterId]?.includeBallotsByCaller === true
+      )
+      .map((universe) => ({
+        universe,
+        proposals: actionableSnsProposals[universe.canisterId].proposals,
+      }))
+);

--- a/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
@@ -225,7 +225,7 @@ describe("actionable proposals derived stores", () => {
     });
   });
 
-  describe("sortedActionableSnsProposalsStore", () => {
+  describe("actionableSnsProposalsByUniverseStore", () => {
     const proposals0 = [createProposal(0n)];
     const proposals1 = [createProposal(1n)];
 

--- a/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
@@ -256,14 +256,13 @@ describe("actionable proposals derived stores", () => {
         includeBallotsByCaller: true,
       });
 
-      const result = get(sortedActionableSnsProposalsStore);
-      expect(result.map(({ universe: { canisterId } }) => canisterId)).toEqual([
-        principal0.toText(),
-        principal1.toText(),
-      ]);
-      expect(result.map(({ proposals }) => proposals)).toEqual([
-        proposals0,
-        proposals1,
+      expect(
+        get(sortedActionableSnsProposalsStore).map(
+          ({ universe: { canisterId }, proposals }) => [canisterId, proposals]
+        )
+      ).toEqual([
+        [principal0.toText(), proposals0],
+        [principal1.toText(), proposals1],
       ]);
     });
 

--- a/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
@@ -6,7 +6,7 @@ import {
   actionableProposalSupportedStore,
   actionableProposalTotalCountStore,
   actionableProposalsActiveStore,
-  sortedActionableSnsProposalsStore,
+  actionableSnsProposalsByUniverseStore,
 } from "$lib/derived/actionable-proposals.derived";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
@@ -230,7 +230,7 @@ describe("actionable proposals derived stores", () => {
     const proposals1 = [createProposal(1n)];
 
     it("should return snses with proposals", async () => {
-      expect(get(sortedActionableSnsProposalsStore)).toEqual([]);
+      expect(get(actionableSnsProposalsByUniverseStore)).toEqual([]);
 
       setSnsProjects([
         {
@@ -243,7 +243,7 @@ describe("actionable proposals derived stores", () => {
         },
       ]);
 
-      expect(get(sortedActionableSnsProposalsStore)).toEqual([]);
+      expect(get(actionableSnsProposalsByUniverseStore)).toEqual([]);
 
       actionableSnsProposalsStore.set({
         rootCanisterId: principal0,
@@ -257,7 +257,7 @@ describe("actionable proposals derived stores", () => {
       });
 
       expect(
-        get(sortedActionableSnsProposalsStore).map(
+        get(actionableSnsProposalsByUniverseStore).map(
           ({ universe: { canisterId }, proposals }) => [canisterId, proposals]
         )
       ).toEqual([
@@ -279,7 +279,7 @@ describe("actionable proposals derived stores", () => {
         includeBallotsByCaller: false,
       });
 
-      expect(get(sortedActionableSnsProposalsStore)).toEqual([]);
+      expect(get(actionableSnsProposalsByUniverseStore)).toEqual([]);
     });
   });
 });

--- a/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
@@ -158,10 +158,6 @@ describe("actionable proposals derived stores", () => {
     ];
     const snsProposals = [mockSnsProposal];
 
-    beforeEach(() => {
-      actionableNnsProposalsStore.reset();
-    });
-
     it("returns true for nns", async () => {
       expect(get(actionableProposalSupportedStore)).toEqual({
         [OWN_CANISTER_ID_TEXT]: true,

--- a/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
@@ -3,9 +3,10 @@ import { AppPath } from "$lib/constants/routes.constants";
 import {
   actionableProposalCountStore,
   actionableProposalIndicationEnabledStore,
-  actionableProposalsActiveStore,
   actionableProposalSupportedStore,
   actionableProposalTotalCountStore,
+  actionableProposalsActiveStore,
+  sortedActionableSnsProposalsStore,
 } from "$lib/derived/actionable-proposals.derived";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
@@ -14,11 +15,38 @@ import { page } from "$mocks/$app/stores";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
-import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
+import {
+  createSnsProposal,
+  mockSnsProposal,
+} from "$tests/mocks/sns-proposals.mock";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import type { ProposalInfo } from "@dfinity/nns";
+import {
+  SnsProposalDecisionStatus,
+  SnsProposalRewardStatus,
+  SnsSwapLifecycle,
+  type SnsProposalData,
+} from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("actionable proposals derived stores", () => {
+  const createProposal = (proposalId: bigint): SnsProposalData =>
+    createSnsProposal({
+      status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+      rewardStatus: SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
+      proposalId,
+    });
+  const principal0 = principal(0);
+  const principal1 = principal(1);
+  const principal2 = principal(2);
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetSnsProjects();
+    actionableNnsProposalsStore.reset();
+    actionableSnsProposalsStore.resetForTesting();
+  });
+
   describe("actionableProposalIndicationEnabledStore", () => {
     it("returns true when the user is signed-in and on proposals page", async () => {
       resetIdentity();
@@ -86,14 +114,6 @@ describe("actionable proposals derived stores", () => {
       },
     ];
     const snsProposals = [mockSnsProposal];
-    const principal0 = principal(0);
-    const principal1 = principal(1);
-    const principal2 = principal(2);
-
-    beforeEach(() => {
-      actionableNnsProposalsStore.reset();
-      actionableSnsProposalsStore.resetForTesting();
-    });
 
     it("returns actionable proposal count", async () => {
       expect(get(actionableProposalCountStore)).toEqual({
@@ -137,12 +157,9 @@ describe("actionable proposals derived stores", () => {
       },
     ];
     const snsProposals = [mockSnsProposal];
-    const principal0 = principal(0);
-    const principal1 = principal(1);
 
     beforeEach(() => {
       actionableNnsProposalsStore.reset();
-      actionableSnsProposalsStore.resetForTesting();
     });
 
     it("returns true for nns", async () => {
@@ -183,14 +200,6 @@ describe("actionable proposals derived stores", () => {
         },
       ];
       const snsProposals = [mockSnsProposal];
-      const principal0 = principal(0);
-      const principal1 = principal(1);
-      const principal2 = principal(2);
-
-      beforeEach(() => {
-        actionableNnsProposalsStore.reset();
-        actionableSnsProposalsStore.resetForTesting();
-      });
 
       it("returns total actionable proposal count", async () => {
         expect(get(actionableProposalTotalCountStore)).toEqual(0);
@@ -217,6 +226,65 @@ describe("actionable proposals derived stores", () => {
           nnsProposals.length + snsProposals.length * 2
         );
       });
+    });
+  });
+
+  describe("sortedActionableSnsProposalsStore", () => {
+    const proposals0 = [createProposal(0n)];
+    const proposals1 = [createProposal(1n)];
+
+    it("should return snses with proposals", async () => {
+      expect(get(sortedActionableSnsProposalsStore)).toEqual([]);
+
+      setSnsProjects([
+        {
+          lifecycle: SnsSwapLifecycle.Committed,
+          rootCanisterId: principal0,
+        },
+        {
+          lifecycle: SnsSwapLifecycle.Committed,
+          rootCanisterId: principal1,
+        },
+      ]);
+
+      expect(get(sortedActionableSnsProposalsStore)).toEqual([]);
+
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal0,
+        proposals: proposals0,
+        includeBallotsByCaller: true,
+      });
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal1,
+        proposals: proposals1,
+        includeBallotsByCaller: true,
+      });
+
+      const result = get(sortedActionableSnsProposalsStore);
+      expect(result.map(({ universe: { canisterId } }) => canisterId)).toEqual([
+        principal0.toText(),
+        principal1.toText(),
+      ]);
+      expect(result.map(({ proposals }) => proposals)).toEqual([
+        proposals0,
+        proposals1,
+      ]);
+    });
+
+    it("should filter out snses w/o actionable support", async () => {
+      setSnsProjects([
+        {
+          lifecycle: SnsSwapLifecycle.Committed,
+          rootCanisterId: principal0,
+        },
+      ]);
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal0,
+        proposals: proposals0,
+        includeBallotsByCaller: false,
+      });
+
+      expect(get(sortedActionableSnsProposalsStore)).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
# Motivation

To avoid having everything in one PR, this is the store that will be used in the actionable tab. It contains SNS universes (which support actionable proposals) and their actionable proposals, listed in the same order as they are displayed in the UI.

# Changes

- New store `actionableSnsProposalsByUniverseStore`.

# Tests

- Refactor `actionable-proposals.derived.spec` to reuse mock data and `beforeEach`.
- Tests for `actionableSnsProposalsByUniverseStore`.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.