### PR TITLE
Actionable query param support

### DIFF
--- a/frontend/src/lib/constants/routes.constants.ts
+++ b/frontend/src/lib/constants/routes.constants.ts
@@ -29,10 +29,10 @@ export const ROUTE_ID_GROUPS = [
 ];
 
 export const UNIVERSE_PARAM = "u";
-export const ACTIONABLE_PROPOSALS_PARAM = "actionable";
 
 export const CANISTER_PARAM = "canister";
 export const NEURON_PARAM = "neuron";
 export const PROJECT_PARAM = "project";
 export const PROPOSAL_PARAM = "proposal";
 export const ACCOUNT_PARAM = "account";
+export const ACTIONABLE_PROPOSALS_PARAM = "actionable";

--- a/frontend/src/lib/constants/routes.constants.ts
+++ b/frontend/src/lib/constants/routes.constants.ts
@@ -36,5 +36,3 @@ export const PROJECT_PARAM = "project";
 export const PROPOSAL_PARAM = "proposal";
 export const ACCOUNT_PARAM = "account";
 export const ACTIONABLE_PROPOSALS_PARAM = "actionable";
-
-export const ACTIONABLE_PROPOSALS_URL = `${AppPath.Proposals}/?${ACTIONABLE_PROPOSALS_PARAM}`;

--- a/frontend/src/lib/constants/routes.constants.ts
+++ b/frontend/src/lib/constants/routes.constants.ts
@@ -29,7 +29,7 @@ export const ROUTE_ID_GROUPS = [
 ];
 
 export const UNIVERSE_PARAM = "u";
-export const ACTIONABLE_PARAM = "actionable";
+export const ACTIONABLE_PROPOSALS_PARAM = "actionable";
 
 export const CANISTER_PARAM = "canister";
 export const NEURON_PARAM = "neuron";

--- a/frontend/src/lib/constants/routes.constants.ts
+++ b/frontend/src/lib/constants/routes.constants.ts
@@ -36,3 +36,5 @@ export const PROJECT_PARAM = "project";
 export const PROPOSAL_PARAM = "proposal";
 export const ACCOUNT_PARAM = "account";
 export const ACTIONABLE_PROPOSALS_PARAM = "actionable";
+
+export const ACTIONABLE_PROPOSALS_URL = `${AppPath.Proposals}/?${ACTIONABLE_PROPOSALS_PARAM}`;

--- a/frontend/src/lib/constants/routes.constants.ts
+++ b/frontend/src/lib/constants/routes.constants.ts
@@ -29,6 +29,7 @@ export const ROUTE_ID_GROUPS = [
 ];
 
 export const UNIVERSE_PARAM = "u";
+export const ACTIONABLE_PARAM = "actionable";
 
 export const CANISTER_PARAM = "canister";
 export const NEURON_PARAM = "neuron";

--- a/frontend/src/lib/derived/page.derived.ts
+++ b/frontend/src/lib/derived/page.derived.ts
@@ -12,13 +12,18 @@ import { derived, type Readable } from "svelte/store";
 
 export interface Page {
   universe: string;
+  actionable: boolean;
   path: AppPath | null;
 }
 
 export const pageStore = derived<Readable<PageType>, Page>(
   page,
-  ({ data: { universe }, route: { id: routeId } }) => ({
-    universe: universe ?? OWN_CANISTER_ID_TEXT,
-    path: routeId ? pathForRouteId(routeId) : null,
-  })
+  ({ data, route: { id: routeId } }) => {
+    const { universe, actionable } = data;
+    return {
+      universe: universe ?? OWN_CANISTER_ID_TEXT,
+      actionable,
+      path: routeId ? pathForRouteId(routeId) : null,
+    };
+  }
 );

--- a/frontend/src/lib/utils/navigation.utils.ts
+++ b/frontend/src/lib/utils/navigation.utils.ts
@@ -1,5 +1,6 @@
 import {
   ACCOUNT_PARAM,
+  ACTIONABLE_PARAM,
   AppPath,
   CANISTER_PARAM,
   NEURON_PARAM,
@@ -34,6 +35,9 @@ export const buildSwitchUniverseUrl = (universe: string): string => {
   const { pathname } = window.location;
   return `${pathname}?${UNIVERSE_PARAM}=${universe}`;
 };
+
+export const buildSwitchActionableUrl = (universe: string): string =>
+  `${buildSwitchUniverseUrl(universe)}&${ACTIONABLE_PARAM}`;
 
 const buildUrl = ({
   path,

--- a/frontend/src/lib/utils/navigation.utils.ts
+++ b/frontend/src/lib/utils/navigation.utils.ts
@@ -36,9 +36,6 @@ export const buildSwitchUniverseUrl = (universe: string): string => {
   return `${pathname}?${UNIVERSE_PARAM}=${universe}`;
 };
 
-export const buildSwitchActionableUrl = (universe: string): string =>
-  `${buildSwitchUniverseUrl(universe)}&${ACTIONABLE_PARAM}`;
-
 const buildUrl = ({
   path,
   universe,
@@ -46,10 +43,10 @@ const buildUrl = ({
 }: {
   path: AppPath;
   universe: string;
-  params?: Record<string, string>;
+  params?: Record<string, string | undefined>;
 }): string =>
   `${path}/?${UNIVERSE_PARAM}=${universe}${Object.entries(params)
-    .map(([key, value]) => `&${key}=${value}`)
+    .map(([key, value]) => (value === "" ? `&${key}` : `&${key}=${value}`))
     .join("")}`;
 
 export const buildAccountsUrl = ({ universe }: { universe: string }) =>
@@ -58,6 +55,16 @@ export const buildNeuronsUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Neurons, universe });
 export const buildProposalsUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Proposals, universe });
+export const buildActionableProposalsUrl = ({
+  universe,
+}: {
+  universe: string;
+}) =>
+  buildUrl({
+    path: AppPath.Proposals,
+    universe,
+    params: { [ACTIONABLE_PARAM]: "" },
+  });
 export const buildCanistersUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Canisters, universe });
 

--- a/frontend/src/lib/utils/navigation.utils.ts
+++ b/frontend/src/lib/utils/navigation.utils.ts
@@ -1,5 +1,6 @@
 import {
   ACCOUNT_PARAM,
+  ACTIONABLE_PROPOSALS_PARAM,
   AppPath,
   CANISTER_PARAM,
   NEURON_PARAM,
@@ -54,6 +55,15 @@ export const buildNeuronsUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Neurons, universe });
 export const buildProposalsUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Proposals, universe });
+export const buildActionableProposalsUrl = ({
+  universe,
+}: {
+  universe: string;
+}) =>
+  buildUrl({
+    path: AppPath.Proposals,
+    params: { [ACTIONABLE_PROPOSALS_PARAM]: "" },
+  });
 export const buildCanistersUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Canisters, universe });
 

--- a/frontend/src/lib/utils/navigation.utils.ts
+++ b/frontend/src/lib/utils/navigation.utils.ts
@@ -1,6 +1,5 @@
 import {
   ACCOUNT_PARAM,
-  ACTIONABLE_PROPOSALS_PARAM,
   AppPath,
   CANISTER_PARAM,
   NEURON_PARAM,
@@ -55,15 +54,6 @@ export const buildNeuronsUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Neurons, universe });
 export const buildProposalsUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Proposals, universe });
-export const buildActionableProposalsUrl = ({
-  universe,
-}: {
-  universe: string;
-}) =>
-  buildUrl({
-    path: AppPath.Proposals,
-    params: { [ACTIONABLE_PROPOSALS_PARAM]: "" },
-  });
 export const buildCanistersUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Canisters, universe });
 

--- a/frontend/src/lib/utils/navigation.utils.ts
+++ b/frontend/src/lib/utils/navigation.utils.ts
@@ -36,18 +36,38 @@ export const buildSwitchUniverseUrl = (universe: string): string => {
   return `${pathname}?${UNIVERSE_PARAM}=${universe}`;
 };
 
+const appendParams = ({
+  path,
+  params = {},
+}: {
+  path: string;
+  params?: Record<string, string>;
+}) => {
+  const queryString = Object.entries(params)
+    // Handling empty values: if the value is empty, we only append the key for the esthetic of the URL.
+    .map(([key, value]) =>
+      value === "" ? key : `${key}=${encodeURIComponent(value)}`
+    )
+    .join("&");
+  return queryString ? `${path}/?${queryString}` : path;
+};
+
 const buildUrl = ({
   path,
   universe,
   params = {},
 }: {
   path: AppPath;
-  universe: string;
+  universe?: string;
   params?: Record<string, string>;
 }): string =>
-  `${path}/?${UNIVERSE_PARAM}=${universe}${Object.entries(params)
-    .map(([key, value]) => (value === "" ? `&${key}` : `&${key}=${value}`))
-    .join("")}`;
+  appendParams({
+    path,
+    params: {
+      ...params,
+      ...(universe ? { [UNIVERSE_PARAM]: universe } : {}),
+    },
+  });
 
 export const buildAccountsUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Accounts, universe });
@@ -55,15 +75,10 @@ export const buildNeuronsUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Neurons, universe });
 export const buildProposalsUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Proposals, universe });
-export const buildActionableProposalsUrl = ({
-  universe,
-}: {
-  universe: string;
-}) =>
-  buildUrl({
-    path: AppPath.Proposals,
-    params: { [ACTIONABLE_PROPOSALS_PARAM]: "" },
-  });
+export const ACTIONABLE_PROPOSALS_URL = buildUrl({
+  path: AppPath.Proposals,
+  params: { [ACTIONABLE_PROPOSALS_PARAM]: "" },
+});
 export const buildCanistersUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Canisters, universe });
 

--- a/frontend/src/lib/utils/navigation.utils.ts
+++ b/frontend/src/lib/utils/navigation.utils.ts
@@ -64,8 +64,8 @@ const buildUrl = ({
   appendParams({
     path,
     params: {
-      ...params,
       ...(universe ? { [UNIVERSE_PARAM]: universe } : {}),
+      ...params,
     },
   });
 

--- a/frontend/src/lib/utils/navigation.utils.ts
+++ b/frontend/src/lib/utils/navigation.utils.ts
@@ -1,6 +1,6 @@
 import {
   ACCOUNT_PARAM,
-  ACTIONABLE_PARAM,
+  ACTIONABLE_PROPOSALS_PARAM,
   AppPath,
   CANISTER_PARAM,
   NEURON_PARAM,
@@ -63,7 +63,7 @@ export const buildActionableProposalsUrl = ({
   buildUrl({
     path: AppPath.Proposals,
     universe,
-    params: { [ACTIONABLE_PARAM]: "" },
+    params: { [ACTIONABLE_PROPOSALS_PARAM]: "" },
   });
 export const buildCanistersUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Canisters, universe });

--- a/frontend/src/lib/utils/navigation.utils.ts
+++ b/frontend/src/lib/utils/navigation.utils.ts
@@ -43,7 +43,7 @@ const buildUrl = ({
 }: {
   path: AppPath;
   universe: string;
-  params?: Record<string, string | undefined>;
+  params?: Record<string, string>;
 }): string =>
   `${path}/?${UNIVERSE_PARAM}=${universe}${Object.entries(params)
     .map(([key, value]) => (value === "" ? `&${key}` : `&${key}=${value}`))
@@ -62,7 +62,6 @@ export const buildActionableProposalsUrl = ({
 }) =>
   buildUrl({
     path: AppPath.Proposals,
-    universe,
     params: { [ACTIONABLE_PROPOSALS_PARAM]: "" },
   });
 export const buildCanistersUrl = ({ universe }: { universe: string }) =>

--- a/frontend/src/routes/(app)/+layout.ts
+++ b/frontend/src/routes/(app)/+layout.ts
@@ -1,7 +1,7 @@
 import { browser } from "$app/environment";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import {
-  ACTIONABLE_PARAM,
+  ACTIONABLE_PROPOSALS_PARAM,
   UNIVERSE_PARAM,
 } from "$lib/constants/routes.constants";
 import type { Page } from "$lib/derived/page.derived";
@@ -25,6 +25,6 @@ export const load: LayoutLoad = ($event: LoadEvent): Partial<Page> => {
     universe: searchParams?.get(UNIVERSE_PARAM) ?? undefined,
     // When the parameter is present but has no value in the URL(e.g., `?actionable` instead of `?actionable=yes`),
     // an empty string is returned by searchParams.
-    actionable: nonNullish(searchParams?.get(ACTIONABLE_PARAM)),
+    actionable: nonNullish(searchParams?.get(ACTIONABLE_PROPOSALS_PARAM)),
   };
 };

--- a/frontend/src/routes/(app)/+layout.ts
+++ b/frontend/src/routes/(app)/+layout.ts
@@ -23,6 +23,8 @@ export const load: LayoutLoad = ($event: LoadEvent): Partial<Page> => {
 
   return {
     universe: searchParams?.get(UNIVERSE_PARAM) ?? undefined,
+    // When the parameter is present but has no value in the URL(e.g., `?actionable` instead of `?actionable=yes`),
+    // an empty string is returned by searchParams.
     actionable: nonNullish(searchParams?.get(ACTIONABLE_PARAM)),
   };
 };

--- a/frontend/src/routes/(app)/+layout.ts
+++ b/frontend/src/routes/(app)/+layout.ts
@@ -1,7 +1,11 @@
 import { browser } from "$app/environment";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
-import { UNIVERSE_PARAM } from "$lib/constants/routes.constants";
+import {
+  ACTIONABLE_PARAM,
+  UNIVERSE_PARAM,
+} from "$lib/constants/routes.constants";
 import type { Page } from "$lib/derived/page.derived";
+import { nonNullish } from "@dfinity/utils";
 import type { LoadEvent } from "@sveltejs/kit";
 import type { LayoutLoad } from "./$types";
 
@@ -9,6 +13,7 @@ export const load: LayoutLoad = ($event: LoadEvent): Partial<Page> => {
   if (!browser) {
     return {
       universe: OWN_CANISTER_ID_TEXT,
+      actionable: false,
     };
   }
 
@@ -18,5 +23,6 @@ export const load: LayoutLoad = ($event: LoadEvent): Partial<Page> => {
 
   return {
     universe: searchParams?.get(UNIVERSE_PARAM) ?? undefined,
+    actionable: nonNullish(searchParams?.get(ACTIONABLE_PARAM)),
   };
 };

--- a/frontend/src/tests/lib/utils/navigation.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/navigation.utils.spec.ts
@@ -1,6 +1,7 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import {
   ACCOUNT_PARAM,
+  ACTIONABLE_PROPOSALS_PARAM,
   AppPath,
   CANISTER_PARAM,
   NEURON_PARAM,
@@ -9,6 +10,7 @@ import {
 } from "$lib/constants/routes.constants";
 import {
   buildAccountsUrl,
+  buildActionableProposalsUrl,
   buildCanisterUrl,
   buildCanistersUrl,
   buildNeuronUrl,
@@ -166,6 +168,14 @@ describe("navigation-utils", () => {
         })
       ).toEqual(
         `${AppPath.Proposals}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
+      );
+    });
+
+    it("should build voting url with actionable param", () => {
+      expect(
+        buildActionableProposalsUrl({ universe: OWN_CANISTER_ID_TEXT })
+      ).toEqual(
+        `${AppPath.Proposals}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}&${ACTIONABLE_PROPOSALS_PARAM}`
       );
     });
 

--- a/frontend/src/tests/lib/utils/navigation.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/navigation.utils.spec.ts
@@ -1,6 +1,7 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import {
   ACCOUNT_PARAM,
+  ACTIONABLE_PARAM,
   AppPath,
   CANISTER_PARAM,
   NEURON_PARAM,
@@ -9,6 +10,7 @@ import {
 } from "$lib/constants/routes.constants";
 import {
   buildAccountsUrl,
+  buildActionableProposalsUrl,
   buildCanisterUrl,
   buildCanistersUrl,
   buildNeuronUrl,
@@ -166,6 +168,14 @@ describe("navigation-utils", () => {
         })
       ).toEqual(
         `${AppPath.Proposals}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
+      );
+    });
+
+    it("should build voting url with actionable param", () => {
+      expect(
+        buildActionableProposalsUrl({ universe: OWN_CANISTER_ID_TEXT })
+      ).toEqual(
+        `${AppPath.Proposals}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}&${ACTIONABLE_PARAM}`
       );
     });
 

--- a/frontend/src/tests/lib/utils/navigation.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/navigation.utils.spec.ts
@@ -9,8 +9,8 @@ import {
   UNIVERSE_PARAM,
 } from "$lib/constants/routes.constants";
 import {
+  ACTIONABLE_PROPOSALS_URL,
   buildAccountsUrl,
-  buildActionableProposalsUrl,
   buildCanisterUrl,
   buildCanistersUrl,
   buildNeuronUrl,
@@ -171,11 +171,9 @@ describe("navigation-utils", () => {
       );
     });
 
-    it("should build voting url with actionable param", () => {
-      expect(
-        buildActionableProposalsUrl({ universe: OWN_CANISTER_ID_TEXT })
-      ).toEqual(
-        `${AppPath.Proposals}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}&${ACTIONABLE_PROPOSALS_PARAM}`
+    it("should build ACTIONABLE_PROPOSALS_URL const", () => {
+      expect(ACTIONABLE_PROPOSALS_URL).toEqual(
+        `${AppPath.Proposals}/?${ACTIONABLE_PROPOSALS_PARAM}`
       );
     });
 

--- a/frontend/src/tests/lib/utils/navigation.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/navigation.utils.spec.ts
@@ -1,7 +1,7 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import {
   ACCOUNT_PARAM,
-  ACTIONABLE_PARAM,
+  ACTIONABLE_PROPOSALS_PARAM,
   AppPath,
   CANISTER_PARAM,
   NEURON_PARAM,
@@ -175,7 +175,7 @@ describe("navigation-utils", () => {
       expect(
         buildActionableProposalsUrl({ universe: OWN_CANISTER_ID_TEXT })
       ).toEqual(
-        `${AppPath.Proposals}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}&${ACTIONABLE_PARAM}`
+        `${AppPath.Proposals}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}&${ACTIONABLE_PROPOSALS_PARAM}`
       );
     });
 

--- a/frontend/src/tests/lib/utils/navigation.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/navigation.utils.spec.ts
@@ -1,7 +1,6 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import {
   ACCOUNT_PARAM,
-  ACTIONABLE_PROPOSALS_PARAM,
   AppPath,
   CANISTER_PARAM,
   NEURON_PARAM,
@@ -10,7 +9,6 @@ import {
 } from "$lib/constants/routes.constants";
 import {
   buildAccountsUrl,
-  buildActionableProposalsUrl,
   buildCanisterUrl,
   buildCanistersUrl,
   buildNeuronUrl,
@@ -168,14 +166,6 @@ describe("navigation-utils", () => {
         })
       ).toEqual(
         `${AppPath.Proposals}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
-      );
-    });
-
-    it("should build voting url with actionable param", () => {
-      expect(
-        buildActionableProposalsUrl({ universe: OWN_CANISTER_ID_TEXT })
-      ).toEqual(
-        `${AppPath.Proposals}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}&${ACTIONABLE_PROPOSALS_PARAM}`
       );
     });
 

--- a/frontend/src/tests/lib/utils/universes.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/universes.utils.spec.ts
@@ -32,6 +32,7 @@ describe("universes-utils", () => {
         isAllTokensPath({
           universe: "not used here",
           path: AppPath.Accounts,
+          actionable: false,
         })
       ).toBeTruthy();
 
@@ -39,6 +40,7 @@ describe("universes-utils", () => {
         isAllTokensPath({
           universe: "not used here",
           path: AppPath.Wallet,
+          actionable: false,
         })
       ).toBeTruthy();
     });
@@ -48,6 +50,7 @@ describe("universes-utils", () => {
         isAllTokensPath({
           universe: "not used here",
           path: AppPath.Neurons,
+          actionable: false,
         })
       ).toBe(false);
 
@@ -55,6 +58,7 @@ describe("universes-utils", () => {
         isAllTokensPath({
           universe: "not used here",
           path: AppPath.Proposal,
+          actionable: false,
         })
       ).toBe(false);
     });


### PR DESCRIPTION
# Motivation

To enable linking to an actionable tab and allow navigation using browser history, a new query parameter - `actionable` has been added. It will serve as a flag indicating that the actionable tab should be displayed. The plan is to set this additional parameter when the user:

	1.	Clicks on “Voting” in the main menu.
	2.	Navigates to the proposals page without a specified universe query parameter (`u`).

# Changes

- New const `ACTIONABLE_PARAM`.
- Make layout to provide `actionable`  as a bool value.
- Make `actionable` available through the `pageStore`.
- New util `buildActionableProposalsUrl`

# Tests

- Update layout tests mock (expect actionable param).
- Test `buildActionableProposalsUrl`.
- Manually verified that the `pageStore` reflects the `actionable` parameter in the URL. Currently, there appears to be no straightforward method for unit testing this.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.