### PR TITLE
Update generated Rust files based on new didc

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -144,9 +144,13 @@ jobs:
       - name: Check didc
         run: command -v didc
       - name: Run the ic_commit code generator for proposals
-        run: ./scripts/update_ic_commit --crate proposals --ic_commit "$(jq -re .defaults.build.config.IC_COMMIT_FOR_PROPOSALS dfx.json)"
+        run: |
+          ./scripts/update_ic_commit --crate proposals --ic_commit "$(jq -re .defaults.build.config.IC_COMMIT_FOR_PROPOSALS dfx.json)"
+          ./scripts/proposals/did2rs
       - name: Run the ic_commit code generator for sns_aggregator
-        run: ./scripts/update_ic_commit --crate proposals --ic_commit "$(jq -re .defaults.build.config.IC_COMMIT_FOR_SNS_AGGREGATOR dfx.json)"
+        run: |
+          ./scripts/update_ic_commit --crate proposals --ic_commit "$(jq -re .defaults.build.config.IC_COMMIT_FOR_SNS_AGGREGATOR dfx.json)"
+          ./scripts/sns/aggregator/mk_nns_patch.sh
       - name: Verify that there are no code changes
         run: |
           if git diff | grep . ; then

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -702,6 +702,7 @@ pub struct SetMode {
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SetModeRet {}
+
 pub struct Service(pub Principal);
 impl Service {
     pub async fn claim_swap_neurons(&self, arg0: ClaimSwapNeuronsRequest) -> CallResult<(ClaimSwapNeuronsResponse,)> {

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -13,7 +13,7 @@ use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
-// use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
+// use candid::{self, CandidType, Deserialize, Principal};
 // use ic_cdk::api::call::CallResult as Result;
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -23,13 +23,11 @@ pub struct GenericNervousSystemFunction {
     pub validator_method_name: Option<String>,
     pub target_method_name: Option<String>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum FunctionType {
     NativeNervousSystemFunction(EmptyRecord),
     GenericNervousSystemFunction(GenericNervousSystemFunction),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NervousSystemFunction {
     pub id: u64,
@@ -37,7 +35,6 @@ pub struct NervousSystemFunction {
     pub description: Option<String>,
     pub function_type: Option<FunctionType>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GovernanceCachedMetrics {
     pub not_dissolving_neurons_e8s_buckets: Vec<(u64, f64)>,
@@ -56,33 +53,27 @@ pub struct GovernanceCachedMetrics {
     pub dissolving_neurons_e8s_buckets: Vec<(u64, f64)>,
     pub timestamp_seconds: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct MaturityModulation {
     pub current_basis_points: Option<i32>,
     pub updated_at_timestamp_seconds: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronId {
     pub id: serde_bytes::ByteBuf,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Followees {
     pub followees: Vec<NeuronId>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DefaultFollowees {
     pub followees: Vec<(u64, Followees)>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronPermissionList {
     pub permissions: Vec<i32>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct VotingRewardsParameters {
     pub final_reward_rate_basis_points: Option<u64>,
@@ -90,7 +81,6 @@ pub struct VotingRewardsParameters {
     pub reward_rate_transition_duration_seconds: Option<u64>,
     pub round_duration_seconds: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NervousSystemParameters {
     pub default_followees: Option<DefaultFollowees>,
@@ -114,7 +104,6 @@ pub struct NervousSystemParameters {
     pub maturity_modulation_disabled: Option<bool>,
     pub max_number_of_principals_per_neuron: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Version {
     pub archive_wasm_hash: serde_bytes::ByteBuf,
@@ -124,12 +113,10 @@ pub struct Version {
     pub governance_wasm_hash: serde_bytes::ByteBuf,
     pub index_wasm_hash: serde_bytes::ByteBuf,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ProposalId {
     pub id: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RewardEvent {
     pub rounds_since_last_distribution: Option<u64>,
@@ -140,7 +127,6 @@ pub struct RewardEvent {
     pub round: u64,
     pub settled_proposals: Vec<ProposalId>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct UpgradeInProgress {
     pub mark_failed_at_seconds: u64,
@@ -148,41 +134,34 @@ pub struct UpgradeInProgress {
     pub proposal_id: u64,
     pub target_version: Option<Version>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GovernanceError {
     pub error_message: String,
     pub error_type: i32,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Subaccount {
     pub subaccount: serde_bytes::ByteBuf,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Account {
     pub owner: Option<Principal>,
     pub subaccount: Option<Subaccount>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Decimal {
     pub human_readable: Option<String>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Tokens {
     pub e8s: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ValuationFactors {
     pub xdrs_per_icp: Option<Decimal>,
     pub icps_per_token: Option<Decimal>,
     pub tokens: Option<Tokens>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Valuation {
     pub token: Option<i32>,
@@ -190,30 +169,25 @@ pub struct Valuation {
     pub valuation_factors: Option<ValuationFactors>,
     pub timestamp_seconds: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct MintSnsTokensActionAuxiliary {
     pub valuation: Option<Valuation>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum ActionAuxiliary {
     TransferSnsTreasuryFunds(MintSnsTokensActionAuxiliary),
     MintSnsTokens(MintSnsTokensActionAuxiliary),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Ballot {
     pub vote: i32,
     pub cast_timestamp_seconds: u64,
     pub voting_power: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Percentage {
     pub basis_points: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Tally {
     pub no: u64,
@@ -221,7 +195,6 @@ pub struct Tally {
     pub total: u64,
     pub timestamp_seconds: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ManageDappCanisterSettings {
     pub freezing_threshold: Option<u64>,
@@ -232,12 +205,10 @@ pub struct ManageDappCanisterSettings {
     pub memory_allocation: Option<u64>,
     pub compute_allocation: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RegisterDappCanisters {
     pub canister_ids: Vec<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct TransferSnsTreasuryFunds {
     pub from_treasury: i32,
@@ -246,7 +217,6 @@ pub struct TransferSnsTreasuryFunds {
     pub memo: Option<u64>,
     pub amount_e8s: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct UpgradeSnsControlledCanister {
     pub new_canister_wasm: serde_bytes::ByteBuf,
@@ -254,13 +224,11 @@ pub struct UpgradeSnsControlledCanister {
     pub canister_id: Option<Principal>,
     pub canister_upgrade_arg: Option<serde_bytes::ByteBuf>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DeregisterDappCanisters {
     pub canister_ids: Vec<Principal>,
     pub new_controllers: Vec<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct MintSnsTokens {
     pub to_principal: Option<Principal>,
@@ -268,7 +236,6 @@ pub struct MintSnsTokens {
     pub memo: Option<u64>,
     pub amount_e8s: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ManageSnsMetadata {
     pub url: Option<String>,
@@ -276,13 +243,11 @@ pub struct ManageSnsMetadata {
     pub name: Option<String>,
     pub description: Option<String>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ExecuteGenericNervousSystemFunction {
     pub function_id: u64,
     pub payload: serde_bytes::ByteBuf,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ManageLedgerParameters {
     pub token_symbol: Option<String>,
@@ -290,12 +255,10 @@ pub struct ManageLedgerParameters {
     pub token_logo: Option<String>,
     pub token_name: Option<String>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Motion {
     pub motion_text: String,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Action {
     ManageNervousSystemParameters(NervousSystemParameters),
@@ -314,7 +277,6 @@ pub enum Action {
     ManageLedgerParameters(ManageLedgerParameters),
     Motion(Motion),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Proposal {
     pub url: String,
@@ -322,12 +284,10 @@ pub struct Proposal {
     pub action: Option<Action>,
     pub summary: String,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct WaitForQuietState {
     pub current_deadline_timestamp_seconds: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ProposalData {
     pub id: Option<ProposalId>,
@@ -353,40 +313,33 @@ pub struct ProposalData {
     pub is_eligible_for_rewards: bool,
     pub executed_timestamp_seconds: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Split {
     pub memo: u64,
     pub amount_e8s: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Follow {
     pub function_id: u64,
     pub followees: Vec<NeuronId>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DisburseMaturity {
     pub to_account: Option<Account>,
     pub percentage_to_disburse: u32,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ChangeAutoStakeMaturity {
     pub requested_setting_for_auto_stake_maturity: bool,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct IncreaseDissolveDelay {
     pub additional_dissolve_delay_seconds: u32,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SetDissolveTimestamp {
     pub dissolve_timestamp_seconds: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Operation {
     ChangeAutoStakeMaturity(ChangeAutoStakeMaturity),
@@ -395,69 +348,57 @@ pub enum Operation {
     IncreaseDissolveDelay(IncreaseDissolveDelay),
     SetDissolveTimestamp(SetDissolveTimestamp),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Configure {
     pub operation: Option<Operation>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RegisterVote {
     pub vote: i32,
     pub proposal: Option<ProposalId>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct FinalizeDisburseMaturity {
     pub amount_to_be_disbursed_e8s: u64,
     pub to_account: Option<Account>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct MemoAndController {
     pub controller: Option<Principal>,
     pub memo: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum By {
     MemoAndController(MemoAndController),
     NeuronId(EmptyRecord),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ClaimOrRefresh {
     pub by: Option<By>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RemoveNeuronPermissions {
     pub permissions_to_remove: Option<NeuronPermissionList>,
     pub principal_id: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct AddNeuronPermissions {
     pub permissions_to_add: Option<NeuronPermissionList>,
     pub principal_id: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct MergeMaturity {
     pub percentage_to_merge: u32,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Amount {
     pub e8s: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Disburse {
     pub to_account: Option<Account>,
     pub amount: Option<Amount>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Command2 {
     Split(Split),
@@ -474,25 +415,21 @@ pub enum Command2 {
     MergeMaturity(MergeMaturity),
     Disburse(Disburse),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronInFlightCommand {
     pub command: Option<Command2>,
     pub timestamp: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronPermission {
     pub principal: Option<Principal>,
     pub permission_type: Vec<i32>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum DissolveState {
     DissolveDelaySeconds(u64),
     WhenDissolvedTimestampSeconds(u64),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DisburseMaturityInProgress {
     pub timestamp_of_disbursement_seconds: u64,
@@ -500,7 +437,6 @@ pub struct DisburseMaturityInProgress {
     pub account_to_disburse_to: Option<Account>,
     pub finalize_disbursement_timestamp_seconds: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Neuron {
     pub id: Option<NeuronId>,
@@ -519,7 +455,6 @@ pub struct Neuron {
     pub followees: Vec<(u64, Followees)>,
     pub neuron_fees_e8s: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Governance {
     pub root_canister_id: Option<Principal>,
@@ -541,7 +476,6 @@ pub struct Governance {
     pub neurons: Vec<(String, Neuron)>,
     pub genesis_timestamp_seconds: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronParameters {
     pub controller: Option<Principal>,
@@ -552,51 +486,40 @@ pub struct NeuronParameters {
     pub hotkey: Option<Principal>,
     pub neuron_id: Option<NeuronId>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ClaimSwapNeuronsRequest {
     pub neuron_parameters: Vec<NeuronParameters>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SwapNeuron {
     pub id: Option<NeuronId>,
     pub status: i32,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ClaimedSwapNeurons {
     pub swap_neurons: Vec<SwapNeuron>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum ClaimSwapNeuronsResult {
     Ok(ClaimedSwapNeurons),
     Err(i32),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ClaimSwapNeuronsResponse {
     pub claim_swap_neurons_result: Option<ClaimSwapNeuronsResult>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct FailStuckUpgradeInProgressArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct FailStuckUpgradeInProgressRet {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetMaturityModulationArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetMaturityModulationResponse {
     pub maturity_modulation: Option<MaturityModulation>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetMetadataArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]
 pub struct GetMetadataResponse {
     pub url: Option<String>,
@@ -604,47 +527,38 @@ pub struct GetMetadataResponse {
     pub name: Option<String>,
     pub description: Option<String>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetModeArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetModeResponse {
     pub mode: Option<i32>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetNeuron {
     pub neuron_id: Option<NeuronId>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Result_ {
     Error(GovernanceError),
     Neuron(Neuron),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetNeuronResponse {
     pub result: Option<Result_>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetProposal {
     pub proposal_id: Option<ProposalId>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Result1 {
     Error(GovernanceError),
     Proposal(ProposalData),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetProposalResponse {
     pub result: Option<Result1>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum CanisterStatusType {
     #[serde(rename = "stopped")]
@@ -654,7 +568,6 @@ pub enum CanisterStatusType {
     #[serde(rename = "running")]
     Running,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DefiniteCanisterSettingsArgs {
     pub freezing_threshold: candid::Nat,
@@ -662,7 +575,6 @@ pub struct DefiniteCanisterSettingsArgs {
     pub memory_allocation: candid::Nat,
     pub compute_allocation: candid::Nat,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CanisterStatusResultV2 {
     pub status: CanisterStatusType,
@@ -672,42 +584,34 @@ pub struct CanisterStatusResultV2 {
     pub idle_cycles_burned_per_day: candid::Nat,
     pub module_hash: Option<serde_bytes::ByteBuf>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetRunningSnsVersionArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetRunningSnsVersionResponse {
     pub deployed_version: Option<Version>,
     pub pending_version: Option<UpgradeInProgress>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetSnsInitializationParametersArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetSnsInitializationParametersResponse {
     pub sns_initialization_parameters: String,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]
 pub struct ListNervousSystemFunctionsResponse {
     pub reserved_ids: Vec<u64>,
     pub functions: Vec<NervousSystemFunction>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListNeurons {
     pub of_principal: Option<Principal>,
     pub limit: u32,
     pub start_page_at: Option<NeuronId>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListNeuronsResponse {
     pub neurons: Vec<Neuron>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListProposals {
     pub include_reward_status: Vec<i32>,
@@ -716,18 +620,15 @@ pub struct ListProposals {
     pub exclude_type: Vec<u64>,
     pub include_status: Vec<i32>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListProposalsResponse {
     pub include_ballots_by_caller: Option<bool>,
     pub proposals: Vec<ProposalData>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct StakeMaturity {
     pub percentage_to_stake: Option<u32>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Command {
     Split(Split),
@@ -743,46 +644,38 @@ pub enum Command {
     MergeMaturity(MergeMaturity),
     Disburse(Disburse),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ManageNeuron {
     pub subaccount: serde_bytes::ByteBuf,
     pub command: Option<Command>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SplitResponse {
     pub created_neuron_id: Option<NeuronId>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DisburseMaturityResponse {
     pub amount_disbursed_e8s: u64,
     pub amount_deducted_e8s: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ClaimOrRefreshResponse {
     pub refreshed_neuron_id: Option<NeuronId>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct StakeMaturityResponse {
     pub maturity_e8s: u64,
     pub staked_maturity_e8s: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct MergeMaturityResponse {
     pub merged_maturity_e8s: u64,
     pub new_stake_e8s: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DisburseResponse {
     pub transfer_block_height: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Command1 {
     Error(GovernanceError),
@@ -799,20 +692,16 @@ pub enum Command1 {
     Disburse(DisburseResponse),
     AddNeuronPermission(EmptyRecord),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ManageNeuronResponse {
     pub command: Option<Command1>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SetMode {
     pub mode: i32,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SetModeRet {}
-
 pub struct Service(pub Principal);
 impl Service {
     pub async fn claim_swap_neurons(&self, arg0: ClaimSwapNeuronsRequest) -> CallResult<(ClaimSwapNeuronsResponse,)> {

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.patch
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.patch
@@ -1,29 +1,29 @@
 diff --git b/rs/sns_aggregator/src/types/ic_sns_ledger.rs a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-index 8ffaeb573..182a57e26 100644
+index 7566582df..00c91ff35 100644
 --- b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
 +++ a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
-@@ -143,7 +143,7 @@ pub struct GetBlocksResponseArchivedBlocksItem {
+@@ -129,7 +129,7 @@ pub struct GetBlocksResponseArchivedBlocksItem {
+     pub start: BlockIndex,
      pub length: candid::Nat,
  }
- 
 -#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 +#[derive(CandidType, Deserialize)]
  pub struct GetBlocksResponse {
      pub certificate: Option<serde_bytes::ByteBuf>,
      pub first_index: BlockIndex,
-@@ -229,7 +229,7 @@ pub struct GetTransactionsResponseArchivedTransactionsItem {
+@@ -205,7 +205,7 @@ pub struct GetTransactionsResponseArchivedTransactionsItem {
+     pub start: TxIndex,
      pub length: candid::Nat,
  }
- 
 -#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 +#[derive(CandidType, Deserialize)]
  pub struct GetTransactionsResponse {
      pub first_index: TxIndex,
      pub log_length: candid::Nat,
-@@ -381,7 +381,7 @@ pub struct GetBlocksResultArchivedBlocksItem {
+@@ -339,7 +339,7 @@ pub struct GetBlocksResultArchivedBlocksItem {
+     pub args: Vec<GetBlocksArgs>,
      pub callback: GetBlocksResultArchivedBlocksItemCallback,
  }
- 
 -#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 +#[derive(CandidType, Deserialize)]
  pub struct GetBlocksResult {

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -13,7 +13,7 @@ use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
-// use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
+// use candid::{self, CandidType, Deserialize, Principal};
 // use ic_cdk::api::call::CallResult as Result;
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -27,7 +27,6 @@ pub struct ChangeArchiveOptions {
     pub node_max_memory_size_bytes: Option<u64>,
     pub controller_id: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum MetadataValue {
     Int(candid::Int),
@@ -35,25 +34,21 @@ pub enum MetadataValue {
     Blob(serde_bytes::ByteBuf),
     Text(String),
 }
-
 pub type Subaccount = serde_bytes::ByteBuf;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Account {
     pub owner: Principal,
     pub subaccount: Option<Subaccount>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum ChangeFeeCollector {
     SetTo(Account),
     Unset,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct FeatureFlags {
     pub icrc2: bool,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct UpgradeArgs {
     pub change_archive_options: Option<ChangeArchiveOptions>,
@@ -67,7 +62,6 @@ pub struct UpgradeArgs {
     pub token_name: Option<String>,
     pub feature_flags: Option<FeatureFlags>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct InitArgsArchiveOptions {
     pub num_blocks_to_archive: u64,
@@ -79,7 +73,6 @@ pub struct InitArgsArchiveOptions {
     pub node_max_memory_size_bytes: Option<u64>,
     pub controller_id: Principal,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct InitArgs {
     pub decimals: Option<u8>,
@@ -96,13 +89,11 @@ pub struct InitArgs {
     pub token_name: String,
     pub feature_flags: Option<FeatureFlags>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum LedgerArg {
     Upgrade(Option<UpgradeArgs>),
     Init(InitArgs),
 }
-
 pub type BlockIndex = candid::Nat;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ArchiveInfo {
@@ -110,13 +101,11 @@ pub struct ArchiveInfo {
     pub canister_id: Principal,
     pub block_range_start: BlockIndex,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetBlocksArgs {
     pub start: BlockIndex,
     pub length: candid::Nat,
 }
-
 pub type Map = Vec<(String, Box<Value>)>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Value {
@@ -128,13 +117,11 @@ pub enum Value {
     Text(String),
     Array(Vec<Box<Value>>),
 }
-
 pub type Block = Box<Value>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct BlockRange {
     pub blocks: Vec<Block>,
 }
-
 pub type QueryBlockArchiveFn = candid::Func;
 #[derive(CandidType, Deserialize)]
 pub struct GetBlocksResponseArchivedBlocksItem {
@@ -142,7 +129,6 @@ pub struct GetBlocksResponseArchivedBlocksItem {
     pub start: BlockIndex,
     pub length: candid::Nat,
 }
-
 #[derive(CandidType, Deserialize)]
 pub struct GetBlocksResponse {
     pub certificate: Option<serde_bytes::ByteBuf>,
@@ -151,20 +137,17 @@ pub struct GetBlocksResponse {
     pub chain_length: u64,
     pub archived_blocks: Vec<GetBlocksResponseArchivedBlocksItem>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DataCertificate {
     pub certificate: Option<serde_bytes::ByteBuf>,
     pub hash_tree: serde_bytes::ByteBuf,
 }
-
 pub type TxIndex = candid::Nat;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetTransactionsRequest {
     pub start: TxIndex,
     pub length: candid::Nat,
 }
-
 pub type Timestamp = u64;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Burn {
@@ -174,7 +157,6 @@ pub struct Burn {
     pub amount: candid::Nat,
     pub spender: Option<Account>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Mint {
     pub to: Account,
@@ -182,7 +164,6 @@ pub struct Mint {
     pub created_at_time: Option<Timestamp>,
     pub amount: candid::Nat,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Approve {
     pub fee: Option<candid::Nat>,
@@ -194,7 +175,6 @@ pub struct Approve {
     pub expires_at: Option<Timestamp>,
     pub spender: Account,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Transfer {
     pub to: Account,
@@ -205,7 +185,6 @@ pub struct Transfer {
     pub amount: candid::Nat,
     pub spender: Option<Account>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Transaction {
     pub burn: Option<Burn>,
@@ -215,12 +194,10 @@ pub struct Transaction {
     pub timestamp: Timestamp,
     pub transfer: Option<Transfer>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct TransactionRange {
     pub transactions: Vec<Transaction>,
 }
-
 pub type QueryArchiveFn = candid::Func;
 #[derive(CandidType, Deserialize)]
 pub struct GetTransactionsResponseArchivedTransactionsItem {
@@ -228,7 +205,6 @@ pub struct GetTransactionsResponseArchivedTransactionsItem {
     pub start: TxIndex,
     pub length: candid::Nat,
 }
-
 #[derive(CandidType, Deserialize)]
 pub struct GetTransactionsResponse {
     pub first_index: TxIndex,
@@ -236,14 +212,12 @@ pub struct GetTransactionsResponse {
     pub transactions: Vec<Transaction>,
     pub archived_transactions: Vec<GetTransactionsResponseArchivedTransactionsItem>,
 }
-
 pub type Tokens = candid::Nat;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct StandardRecord {
     pub url: String,
     pub name: String,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct TransferArg {
     pub to: Account,
@@ -253,7 +227,6 @@ pub struct TransferArg {
     pub created_at_time: Option<Timestamp>,
     pub amount: Tokens,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum TransferError {
     GenericError { message: String, error_code: candid::Nat },
@@ -265,25 +238,21 @@ pub enum TransferError {
     TooOld,
     InsufficientFunds { balance: Tokens },
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum TransferResult {
     Ok(BlockIndex),
     Err(TransferError),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct AllowanceArgs {
     pub account: Account,
     pub spender: Account,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Allowance {
     pub allowance: candid::Nat,
     pub expires_at: Option<Timestamp>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ApproveArgs {
     pub fee: Option<candid::Nat>,
@@ -295,7 +264,6 @@ pub struct ApproveArgs {
     pub expires_at: Option<Timestamp>,
     pub spender: Account,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum ApproveError {
     GenericError { message: String, error_code: candid::Nat },
@@ -308,13 +276,11 @@ pub enum ApproveError {
     Expired { ledger_time: Timestamp },
     InsufficientFunds { balance: candid::Nat },
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum ApproveResult {
     Ok(BlockIndex),
     Err(ApproveError),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct TransferFromArgs {
     pub to: Account,
@@ -325,7 +291,6 @@ pub struct TransferFromArgs {
     pub created_at_time: Option<Timestamp>,
     pub amount: Tokens,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum TransferFromError {
     GenericError { message: String, error_code: candid::Nat },
@@ -338,25 +303,21 @@ pub enum TransferFromError {
     TooOld,
     InsufficientFunds { balance: Tokens },
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum TransferFromResult {
     Ok(BlockIndex),
     Err(TransferFromError),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetArchivesArgs {
     pub from: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetArchivesResultItem {
     pub end: candid::Nat,
     pub canister_id: Principal,
     pub start: candid::Nat,
 }
-
 pub type GetArchivesResult = Vec<GetArchivesResultItem>;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Icrc3Value {
@@ -367,39 +328,33 @@ pub enum Icrc3Value {
     Text(String),
     Array(Vec<Box<Icrc3Value>>),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetBlocksResultBlocksItem {
     pub id: candid::Nat,
     pub block: Box<Icrc3Value>,
 }
-
 pub type GetBlocksResultArchivedBlocksItemCallback = candid::Func;
 #[derive(CandidType, Deserialize)]
 pub struct GetBlocksResultArchivedBlocksItem {
     pub args: Vec<GetBlocksArgs>,
     pub callback: GetBlocksResultArchivedBlocksItemCallback,
 }
-
 #[derive(CandidType, Deserialize)]
 pub struct GetBlocksResult {
     pub log_length: candid::Nat,
     pub blocks: Vec<GetBlocksResultBlocksItem>,
     pub archived_blocks: Vec<GetBlocksResultArchivedBlocksItem>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Icrc3DataCertificate {
     pub certificate: serde_bytes::ByteBuf,
     pub hash_tree: serde_bytes::ByteBuf,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Icrc3SupportedBlockTypesRetItem {
     pub url: String,
     pub block_type: String,
 }
-
 pub struct Service(pub Principal);
 impl Service {
     pub async fn archives(&self) -> CallResult<(Vec<ArchiveInfo>,)> {

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -355,6 +355,7 @@ pub struct Icrc3SupportedBlockTypesRetItem {
     pub url: String,
     pub block_type: String,
 }
+
 pub struct Service(pub Principal);
 impl Service {
     pub async fn archives(&self) -> CallResult<(Vec<ArchiveInfo>,)> {

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -13,7 +13,7 @@ use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
-// use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
+// use candid::{self, CandidType, Deserialize, Principal};
 // use ic_cdk::api::call::CallResult as Result;
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -27,12 +27,10 @@ pub struct SnsRootCanister {
     pub swap_canister_id: Option<Principal>,
     pub ledger_canister_id: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CanisterIdRecord {
     pub canister_id: Principal,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum CanisterStatusType {
     #[serde(rename = "stopped")]
@@ -42,7 +40,6 @@ pub enum CanisterStatusType {
     #[serde(rename = "running")]
     Running,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DefiniteCanisterSettings {
     pub freezing_threshold: Option<candid::Nat>,
@@ -51,7 +48,6 @@ pub struct DefiniteCanisterSettings {
     pub memory_allocation: Option<candid::Nat>,
     pub compute_allocation: Option<candid::Nat>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CanisterStatusResult {
     pub status: CanisterStatusType,
@@ -62,7 +58,6 @@ pub struct CanisterStatusResult {
     pub module_hash: Option<serde_bytes::ByteBuf>,
     pub reserved_cycles: Option<candid::Nat>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum CanisterInstallMode {
     #[serde(rename = "reinstall")]
@@ -72,7 +67,6 @@ pub enum CanisterInstallMode {
     #[serde(rename = "install")]
     Install,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ChangeCanisterRequest {
     pub arg: serde_bytes::ByteBuf,
@@ -83,12 +77,10 @@ pub struct ChangeCanisterRequest {
     pub memory_allocation: Option<candid::Nat>,
     pub compute_allocation: Option<candid::Nat>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetSnsCanistersSummaryRequest {
     pub update_canister_list: Option<bool>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DefiniteCanisterSettingsArgs {
     pub freezing_threshold: candid::Nat,
@@ -96,7 +88,6 @@ pub struct DefiniteCanisterSettingsArgs {
     pub memory_allocation: candid::Nat,
     pub compute_allocation: candid::Nat,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CanisterStatusResultV2 {
     pub status: CanisterStatusType,
@@ -106,13 +97,11 @@ pub struct CanisterStatusResultV2 {
     pub idle_cycles_burned_per_day: candid::Nat,
     pub module_hash: Option<serde_bytes::ByteBuf>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CanisterSummary {
     pub status: Option<CanisterStatusResultV2>,
     pub canister_id: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetSnsCanistersSummaryResponse {
     pub root: Option<CanisterSummary>,
@@ -123,10 +112,8 @@ pub struct GetSnsCanistersSummaryResponse {
     pub dapps: Vec<CanisterSummary>,
     pub archives: Vec<CanisterSummary>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListSnsCanistersArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]
 pub struct ListSnsCanistersResponse {
     pub root: Option<Principal>,
@@ -137,7 +124,6 @@ pub struct ListSnsCanistersResponse {
     pub dapps: Vec<Principal>,
     pub archives: Vec<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ManageDappCanisterSettingsRequest {
     pub freezing_threshold: Option<u64>,
@@ -148,51 +134,41 @@ pub struct ManageDappCanisterSettingsRequest {
     pub memory_allocation: Option<u64>,
     pub compute_allocation: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ManageDappCanisterSettingsResponse {
     pub failure_reason: Option<String>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RegisterDappCanisterRequest {
     pub canister_id: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RegisterDappCanisterRet {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RegisterDappCanistersRequest {
     pub canister_ids: Vec<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RegisterDappCanistersRet {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SetDappControllersRequest {
     pub canister_ids: Option<RegisterDappCanistersRequest>,
     pub controller_principal_ids: Vec<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CanisterCallError {
     pub code: Option<i32>,
     pub description: String,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct FailedUpdate {
     pub err: Option<CanisterCallError>,
     pub dapp_canister_id: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SetDappControllersResponse {
     pub failed_updates: Vec<FailedUpdate>,
 }
-
 pub struct Service(pub Principal);
 impl Service {
     pub async fn canister_status(&self, arg0: CanisterIdRecord) -> CallResult<(CanisterStatusResult,)> {

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -169,6 +169,7 @@ pub struct FailedUpdate {
 pub struct SetDappControllersResponse {
     pub failed_updates: Vec<FailedUpdate>,
 }
+
 pub struct Service(pub Principal);
 impl Service {
     pub async fn canister_status(&self, arg0: CanisterIdRecord) -> CallResult<(CanisterStatusResult,)> {

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -482,6 +482,7 @@ pub struct RefreshBuyerTokensResponse {
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RestoreDappControllersArg {}
+
 pub struct Service(pub Principal);
 impl Service {
     pub async fn error_refund_icp(&self, arg0: ErrorRefundIcpRequest) -> CallResult<(ErrorRefundIcpResponse,)> {

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -13,7 +13,7 @@ use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
-// use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
+// use candid::{self, CandidType, Deserialize, Principal};
 // use ic_cdk::api::call::CallResult as Result;
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
@@ -21,7 +21,6 @@ pub struct NeuronBasketConstructionParameters {
     pub dissolve_delay_interval_seconds: u64,
     pub count: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
 pub struct LinearScalingCoefficient {
     pub slope_numerator: Option<u64>,
@@ -30,12 +29,10 @@ pub struct LinearScalingCoefficient {
     pub slope_denominator: Option<u64>,
     pub to_direct_participation_icp_e8s: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
 pub struct IdealMatchedParticipationFunction {
     pub serialized_representation: Option<String>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
 pub struct NeuronsFundParticipationConstraints {
     pub coefficient_intervals: Vec<LinearScalingCoefficient>,
@@ -43,30 +40,25 @@ pub struct NeuronsFundParticipationConstraints {
     pub min_direct_participation_threshold_icp_e8s: Option<u64>,
     pub ideal_matched_participation_function: Option<IdealMatchedParticipationFunction>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
 pub struct CfNeuron {
     pub has_created_neuron_recipes: Option<bool>,
     pub nns_neuron_id: u64,
     pub amount_icp_e8s: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
 pub struct CfParticipant {
     pub hotkey_principal: String,
     pub cf_neurons: Vec<CfNeuron>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
 pub struct NeuronsFundParticipants {
     pub cf_participants: Vec<CfParticipant>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
 pub struct Countries {
     pub iso_codes: Vec<String>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
 pub struct Init {
     pub nns_proposal_id: Option<u64>,
@@ -96,65 +88,53 @@ pub struct Init {
     pub min_icp_e8s: Option<u64>,
     pub max_direct_participation_icp_e8s: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ErrorRefundIcpRequest {
     pub source_principal_id: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Ok {
     pub block_height: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Err {
     pub description: Option<String>,
     pub error_type: Option<i32>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Result_ {
     Ok(Ok),
     Err(Err),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ErrorRefundIcpResponse {
     pub result: Option<Result_>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct FinalizeSwapArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CanisterCallError {
     pub code: Option<i32>,
     pub description: String,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct FailedUpdate {
     pub err: Option<CanisterCallError>,
     pub dapp_canister_id: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SetDappControllersResponse {
     pub failed_updates: Vec<FailedUpdate>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Possibility {
     Ok(SetDappControllersResponse),
     Err(CanisterCallError),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SetDappControllersCallResult {
     pub possibility: Option<Possibility>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SweepResult {
     pub failure: u32,
@@ -163,62 +143,51 @@ pub struct SweepResult {
     pub success: u32,
     pub global_failures: u32,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GovernanceError {
     pub error_message: String,
     pub error_type: i32,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Response {
     pub governance_error: Option<GovernanceError>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Possibility1 {
     Ok(Response),
     Err(CanisterCallError),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SettleCommunityFundParticipationResult {
     pub possibility: Option<Possibility1>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Ok1 {
     pub neurons_fund_participation_icp_e8s: Option<u64>,
     pub neurons_fund_neurons_count: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Error {
     pub message: Option<String>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Possibility2 {
     Ok(Ok1),
     Err(Error),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SettleNeuronsFundParticipationResult {
     pub possibility: Option<Possibility2>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Possibility3 {
     Ok(EmptyRecord),
     Err(CanisterCallError),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SetModeCallResult {
     pub possibility: Option<Possibility3>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct FinalizeSwapResponse {
     pub set_dapp_controllers_call_result: Option<SetDappControllersCallResult>,
@@ -231,22 +200,18 @@ pub struct FinalizeSwapResponse {
     pub claim_neuron_result: Option<SweepResult>,
     pub sweep_sns_result: Option<SweepResult>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetAutoFinalizationStatusArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetAutoFinalizationStatusResponse {
     pub auto_finalize_swap_response: Option<FinalizeSwapResponse>,
     pub has_auto_finalize_been_attempted: Option<bool>,
     pub is_auto_finalize_enabled: Option<bool>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetBuyerStateRequest {
     pub principal_id: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct TransferableAmount {
     pub transfer_fee_paid_e8s: Option<u64>,
@@ -255,29 +220,23 @@ pub struct TransferableAmount {
     pub amount_transferred_e8s: Option<u64>,
     pub transfer_success_timestamp_seconds: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct BuyerState {
     pub icp: Option<TransferableAmount>,
     pub has_created_neuron_recipes: Option<bool>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetBuyerStateResponse {
     pub buyer_state: Option<BuyerState>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetBuyersTotalArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetBuyersTotalResponse {
     pub buyers_total: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetCanisterStatusArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum CanisterStatusType {
     #[serde(rename = "stopped")]
@@ -287,7 +246,6 @@ pub enum CanisterStatusType {
     #[serde(rename = "running")]
     Running,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DefiniteCanisterSettingsArgs {
     pub freezing_threshold: candid::Nat,
@@ -295,7 +253,6 @@ pub struct DefiniteCanisterSettingsArgs {
     pub memory_allocation: candid::Nat,
     pub compute_allocation: candid::Nat,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CanisterStatusResultV2 {
     pub status: CanisterStatusType,
@@ -305,10 +262,8 @@ pub struct CanisterStatusResultV2 {
     pub idle_cycles_burned_per_day: candid::Nat,
     pub module_hash: Option<serde_bytes::ByteBuf>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetDerivedStateArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetDerivedStateResponse {
     pub sns_tokens_per_icp: Option<f64>,
@@ -319,34 +274,27 @@ pub struct GetDerivedStateResponse {
     pub direct_participant_count: Option<u64>,
     pub cf_neuron_count: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetInitArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetInitResponse {
     pub init: Option<Init>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetLifecycleArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetLifecycleResponse {
     pub decentralization_sale_open_timestamp_seconds: Option<u64>,
     pub lifecycle: Option<i32>,
     pub decentralization_swap_termination_timestamp_seconds: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetOpenTicketArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Icrc1Account {
     pub owner: Option<Principal>,
     pub subaccount: Option<serde_bytes::ByteBuf>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Ticket {
     pub creation_time: u64,
@@ -354,31 +302,25 @@ pub struct Ticket {
     pub account: Option<Icrc1Account>,
     pub amount_icp_e8s: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Ok2 {
     pub ticket: Option<Ticket>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Err1 {
     pub error_type: Option<i32>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Result1 {
     Ok(Ok2),
     Err(Err1),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetOpenTicketResponse {
     pub result: Option<Result1>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetSaleParametersArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
 pub struct Params {
     pub min_participant_icp_e8s: u64,
@@ -393,44 +335,36 @@ pub struct Params {
     pub min_icp_e8s: u64,
     pub max_direct_participation_icp_e8s: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetSaleParametersResponse {
     pub params: Option<Params>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetStateArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronId {
     pub id: serde_bytes::ByteBuf,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronAttributes {
     pub dissolve_delay_seconds: u64,
     pub memo: u64,
     pub followees: Vec<NeuronId>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CfInvestment {
     pub hotkey_principal: String,
     pub nns_neuron_id: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DirectInvestment {
     pub buyer_principal: String,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Investor {
     CommunityFund(CfInvestment),
     Direct(DirectInvestment),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SnsNeuronRecipe {
     pub sns: Option<TransferableAmount>,
@@ -438,7 +372,6 @@ pub struct SnsNeuronRecipe {
     pub neuron_attributes: Option<NeuronAttributes>,
     pub investor: Option<Investor>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Swap {
     pub auto_finalize_swap_response: Option<FinalizeSwapResponse>,
@@ -459,7 +392,6 @@ pub struct Swap {
     pub params: Option<Params>,
     pub open_sns_token_swap_proposal_id: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DerivedState {
     pub sns_tokens_per_icp: f32,
@@ -470,105 +402,86 @@ pub struct DerivedState {
     pub direct_participant_count: Option<u64>,
     pub cf_neuron_count: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]
 pub struct GetStateResponse {
     pub swap: Option<Swap>,
     pub derived: Option<DerivedState>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListCommunityFundParticipantsRequest {
     pub offset: Option<u64>,
     pub limit: Option<u32>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListDirectParticipantsRequest {
     pub offset: Option<u32>,
     pub limit: Option<u32>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Participant {
     pub participation: Option<BuyerState>,
     pub participant_id: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListDirectParticipantsResponse {
     pub participants: Vec<Participant>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListSnsNeuronRecipesRequest {
     pub offset: Option<u64>,
     pub limit: Option<u32>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListSnsNeuronRecipesResponse {
     pub sns_neuron_recipes: Vec<SnsNeuronRecipe>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NewSaleTicketRequest {
     pub subaccount: Option<serde_bytes::ByteBuf>,
     pub amount_icp_e8s: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct InvalidUserAmount {
     pub min_amount_icp_e8s_included: u64,
     pub max_amount_icp_e8s_included: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Err2 {
     pub invalid_user_amount: Option<InvalidUserAmount>,
     pub existing_ticket: Option<Ticket>,
     pub error_type: i32,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Result2 {
     Ok(Ok2),
     Err(Err2),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NewSaleTicketResponse {
     pub result: Option<Result2>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NotifyPaymentFailureArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct OpenRequest {
     pub cf_participants: Vec<CfParticipant>,
     pub params: Option<Params>,
     pub open_sns_token_swap_proposal_id: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct OpenRet {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RefreshBuyerTokensRequest {
     pub confirmation_text: Option<String>,
     pub buyer: String,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RefreshBuyerTokensResponse {
     pub icp_accepted_participation_e8s: u64,
     pub icp_ledger_account_balance_e8s: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct RestoreDappControllersArg {}
-
 pub struct Service(pub Principal);
 impl Service {
     pub async fn error_refund_icp(&self, arg0: ErrorRefundIcpRequest) -> CallResult<(ErrorRefundIcpResponse,)> {

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -13,7 +13,7 @@ use ic_cdk::api::call::CallResult;
 // This is an experimental feature to generate Rust binding from Candid.
 // You may want to manually adjust some of the types.
 // #![allow(dead_code, unused_imports)]
-// use candid::{self, CandidType, Decode, Deserialize, Encode, Principal};
+// use candid::{self, CandidType, Deserialize, Principal};
 // use ic_cdk::api::call::CallResult as Result;
 
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
@@ -22,52 +22,43 @@ pub struct SnsWasmCanisterInitPayload {
     pub access_controls_enabled: bool,
     pub sns_subnet_ids: Vec<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SnsWasm {
     pub wasm: serde_bytes::ByteBuf,
     pub proposal_id: Option<u64>,
     pub canister_type: i32,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct AddWasmRequest {
     pub hash: serde_bytes::ByteBuf,
     pub wasm: Option<SnsWasm>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SnsWasmError {
     pub message: String,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Result_ {
     Error(SnsWasmError),
     Hash(serde_bytes::ByteBuf),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct AddWasmResponse {
     pub result: Option<Result_>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronBasketConstructionParameters {
     pub dissolve_delay_interval_seconds: u64,
     pub count: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Canister {
     pub id: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DappCanisters {
     pub canisters: Vec<Canister>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct LinearScalingCoefficient {
     pub slope_numerator: Option<u64>,
@@ -76,12 +67,10 @@ pub struct LinearScalingCoefficient {
     pub slope_denominator: Option<u64>,
     pub to_direct_participation_icp_e8s: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct IdealMatchedParticipationFunction {
     pub serialized_representation: Option<String>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronsFundParticipationConstraints {
     pub coefficient_intervals: Vec<LinearScalingCoefficient>,
@@ -89,30 +78,25 @@ pub struct NeuronsFundParticipationConstraints {
     pub min_direct_participation_threshold_icp_e8s: Option<u64>,
     pub ideal_matched_participation_function: Option<IdealMatchedParticipationFunction>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CfNeuron {
     pub has_created_neuron_recipes: Option<bool>,
     pub nns_neuron_id: u64,
     pub amount_icp_e8s: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CfParticipant {
     pub hotkey_principal: String,
     pub cf_neurons: Vec<CfNeuron>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronsFundParticipants {
     pub participants: Vec<CfParticipant>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct TreasuryDistribution {
     pub total_e8s: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronDistribution {
     pub controller: Option<Principal>,
@@ -121,23 +105,19 @@ pub struct NeuronDistribution {
     pub stake_e8s: u64,
     pub vesting_period_seconds: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DeveloperDistribution {
     pub developer_neurons: Vec<NeuronDistribution>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct AirdropDistribution {
     pub airdrop_neurons: Vec<NeuronDistribution>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SwapDistribution {
     pub total_e8s: u64,
     pub initial_swap_amount_e8s: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct FractionalDeveloperVotingPower {
     pub treasury_distribution: Option<TreasuryDistribution>,
@@ -145,17 +125,14 @@ pub struct FractionalDeveloperVotingPower {
     pub airdrop_distribution: Option<AirdropDistribution>,
     pub swap_distribution: Option<SwapDistribution>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum InitialTokenDistribution {
     FractionalDeveloperVotingPower(FractionalDeveloperVotingPower),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Countries {
     pub iso_codes: Vec<String>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SnsInitPayload {
     pub url: Option<String>,
@@ -198,19 +175,16 @@ pub struct SnsInitPayload {
     pub min_icp_e8s: Option<u64>,
     pub max_direct_participation_icp_e8s: Option<u64>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DeployNewSnsRequest {
     pub sns_init_payload: Option<SnsInitPayload>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DappCanistersTransferResult {
     pub restored_dapp_canisters: Vec<Canister>,
     pub nns_controlled_dapp_canisters: Vec<Canister>,
     pub sns_controlled_dapp_canisters: Vec<Canister>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SnsCanisterIds {
     pub root: Option<Principal>,
@@ -219,7 +193,6 @@ pub struct SnsCanisterIds {
     pub index: Option<Principal>,
     pub governance: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct DeployNewSnsResponse {
     pub dapp_canisters_transfer_result: Option<DappCanistersTransferResult>,
@@ -227,20 +200,16 @@ pub struct DeployNewSnsResponse {
     pub error: Option<SnsWasmError>,
     pub canisters: Option<SnsCanisterIds>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetAllowedPrincipalsArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetAllowedPrincipalsResponse {
     pub allowed_principals: Vec<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetDeployedSnsByProposalIdRequest {
     pub proposal_id: u64,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]
 pub struct DeployedSns {
     pub root_canister_id: Option<Principal>,
@@ -249,18 +218,15 @@ pub struct DeployedSns {
     pub swap_canister_id: Option<Principal>,
     pub ledger_canister_id: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum GetDeployedSnsByProposalIdResult {
     Error(SnsWasmError),
     DeployedSns(DeployedSns),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetDeployedSnsByProposalIdResponse {
     pub get_deployed_sns_by_proposal_id_result: Option<GetDeployedSnsByProposalIdResult>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SnsVersion {
     pub archive_wasm_hash: serde_bytes::ByteBuf,
@@ -270,96 +236,78 @@ pub struct SnsVersion {
     pub governance_wasm_hash: serde_bytes::ByteBuf,
     pub index_wasm_hash: serde_bytes::ByteBuf,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetNextSnsVersionRequest {
     pub governance_canister_id: Option<Principal>,
     pub current_version: Option<SnsVersion>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetNextSnsVersionResponse {
     pub next_version: Option<SnsVersion>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetSnsSubnetIdsArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetSnsSubnetIdsResponse {
     pub sns_subnet_ids: Vec<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetWasmRequest {
     pub hash: serde_bytes::ByteBuf,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetWasmResponse {
     pub wasm: Option<SnsWasm>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetWasmMetadataRequest {
     pub hash: Option<serde_bytes::ByteBuf>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct MetadataSection {
     pub contents: Option<serde_bytes::ByteBuf>,
     pub name: Option<String>,
     pub visibility: Option<String>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Ok {
     pub sections: Vec<MetadataSection>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum Result1 {
     Ok(Ok),
     Error(SnsWasmError),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetWasmMetadataResponse {
     pub result: Option<Result1>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct SnsUpgrade {
     pub next_version: Option<SnsVersion>,
     pub current_version: Option<SnsVersion>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct InsertUpgradePathEntriesRequest {
     pub upgrade_path: Vec<SnsUpgrade>,
     pub sns_governance_canister_id: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct InsertUpgradePathEntriesResponse {
     pub error: Option<SnsWasmError>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListDeployedSnsesArg {}
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListDeployedSnsesResponse {
     pub instances: Vec<DeployedSns>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListUpgradeStepsRequest {
     pub limit: u32,
     pub starting_at: Option<SnsVersion>,
     pub sns_governance_canister_id: Option<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct PrettySnsVersion {
     pub archive_wasm_hash: String,
@@ -369,46 +317,38 @@ pub struct PrettySnsVersion {
     pub governance_wasm_hash: String,
     pub index_wasm_hash: String,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListUpgradeStep {
     pub pretty_version: Option<PrettySnsVersion>,
     pub version: Option<SnsVersion>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ListUpgradeStepsResponse {
     pub steps: Vec<ListUpgradeStep>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct UpdateAllowedPrincipalsRequest {
     pub added_principals: Vec<Principal>,
     pub removed_principals: Vec<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub enum UpdateAllowedPrincipalsResult {
     Error(SnsWasmError),
     AllowedPrincipals(GetAllowedPrincipalsResponse),
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct UpdateAllowedPrincipalsResponse {
     pub update_allowed_principals_result: Option<UpdateAllowedPrincipalsResult>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct UpdateSnsSubnetListRequest {
     pub sns_subnet_ids_to_add: Vec<Principal>,
     pub sns_subnet_ids_to_remove: Vec<Principal>,
 }
-
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct UpdateSnsSubnetListResponse {
     pub error: Option<SnsWasmError>,
 }
-
 pub struct Service(pub Principal);
 impl Service {
     pub async fn add_wasm(&self, arg0: AddWasmRequest) -> CallResult<(AddWasmResponse,)> {

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -349,6 +349,7 @@ pub struct UpdateSnsSubnetListRequest {
 pub struct UpdateSnsSubnetListResponse {
     pub error: Option<SnsWasmError>,
 }
+
 pub struct Service(pub Principal);
 impl Service {
     pub async fn add_wasm(&self, arg0: AddWasmRequest) -> CallResult<(AddWasmResponse,)> {


### PR DESCRIPTION
# Motivation

We're using a new [version](https://github.com/dfinity/nns-dapp/blob/c96d253521c13db187a7693b1c8dd3e61141fe4b/dfx.json#L377) of `didc` in nns-dapp.
This new version no longer adds blank lines between generated Rust types, and imports slightly different traits.
After generating Rust code we sometimes apply patch files.
Currently the patch files are thrown off by the line numbers differing too much (I think).

# Changes

1. Adjust the generated Rust files to be in line with the new `didc`.
2. Regenerate the patch file.

# Tests

1. Before the changes `scripts/sns/aggregator/mk_nns_patch.sh` broke ([like this](https://github.com/dfinity/nns-dapp/actions/runs/9116533871/job/25065348685)). With the changes it runs again without having to make changes to the generated code.
2. Added extra steps to the workflow to test that generated code is identical to committed code. This way we catch it next time the moment we update `didc` instead of later.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary