### PR TITLE
ckETH canisters in envVars

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -20,6 +20,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Support `ApiBoundaryNodes` in `FirewallRulesScope` of `AddFirewallRulesPayload`.
 * Support `SubnetRental` topic.
 * Support NNS function 52 for `SubnetRentalRequest`.
+* Get ckUSDC canister IDs from environment/configuration.
 
 #### Changed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -20,7 +20,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Support `ApiBoundaryNodes` in `FirewallRulesScope` of `AddFirewallRulesPayload`.
 * Support `SubnetRental` topic.
 * Support NNS function 52 for `SubnetRentalRequest`.
-* Get ckUSDC canister IDs from environment/configuration.
+* Get `ckUSDC` canister IDs from environment/configuration.
 
 #### Changed
 

--- a/frontend/src/lib/constants/ckusdc-canister-ids.constants.ts
+++ b/frontend/src/lib/constants/ckusdc-canister-ids.constants.ts
@@ -1,0 +1,28 @@
+import { getEnvVars } from "$lib/utils/env-vars.utils";
+import { Principal } from "@dfinity/principal";
+
+const envVars = getEnvVars();
+
+export const CKUSDCSEPOLIA_LEDGER_CANISTER_ID = Principal.fromText(
+  "yfumr-cyaaa-aaaar-qaela-cai"
+);
+
+export const CKUSDCSEPOLIA_INDEX_CANISTER_ID = Principal.fromText(
+  "ycvkf-paaaa-aaaar-qaelq-cai"
+);
+
+// TODO: Add mainnet canister IDs.
+const MAINNET_CKUSDC_LEDGER_CANISTER_ID = CKUSDCSEPOLIA_LEDGER_CANISTER_ID;
+const MAINNET_CKUSDC_INDEX_CANISTER_ID = CKUSDCSEPOLIA_INDEX_CANISTER_ID;
+
+export const CKUSDC_LEDGER_CANISTER_ID = Principal.fromText(
+  envVars.ckusdcLedgerCanisterId ?? MAINNET_CKUSDC_LEDGER_CANISTER_ID
+);
+export const CKUSDC_INDEX_CANISTER_ID = Principal.fromText(
+  envVars.ckusdcIndexCanisterId ?? MAINNET_CKUSDC_INDEX_CANISTER_ID
+);
+
+// Universes: the universe === the ledger canister ID
+export const CKUSDC_UNIVERSE_CANISTER_ID = CKUSDC_LEDGER_CANISTER_ID;
+export const CKUSDCSEPOLIA_UNIVERSE_CANISTER_ID =
+  CKUSDCSEPOLIA_LEDGER_CANISTER_ID;

--- a/frontend/src/lib/constants/ckusdc-canister-ids.constants.ts
+++ b/frontend/src/lib/constants/ckusdc-canister-ids.constants.ts
@@ -3,6 +3,10 @@ import { Principal } from "@dfinity/principal";
 
 const envVars = getEnvVars();
 
+// TODO: Use mainnet canister IDs when available. These are sepolia canister IDs.
+const MAINNET_CKUSDC_LEDGER_CANISTER_ID = "yfumr-cyaaa-aaaar-qaela-cai";
+const MAINNET_CKUSDC_INDEX_CANISTER_ID = "ycvkf-paaaa-aaaar-qaelq-cai";
+
 export const CKUSDCSEPOLIA_LEDGER_CANISTER_ID = Principal.fromText(
   "yfumr-cyaaa-aaaar-qaela-cai"
 );
@@ -10,10 +14,6 @@ export const CKUSDCSEPOLIA_LEDGER_CANISTER_ID = Principal.fromText(
 export const CKUSDCSEPOLIA_INDEX_CANISTER_ID = Principal.fromText(
   "ycvkf-paaaa-aaaar-qaelq-cai"
 );
-
-// TODO: Add mainnet canister IDs.
-const MAINNET_CKUSDC_LEDGER_CANISTER_ID = CKUSDCSEPOLIA_LEDGER_CANISTER_ID;
-const MAINNET_CKUSDC_INDEX_CANISTER_ID = CKUSDCSEPOLIA_INDEX_CANISTER_ID;
 
 export const CKUSDC_LEDGER_CANISTER_ID = Principal.fromText(
   envVars.ckusdcLedgerCanisterId ?? MAINNET_CKUSDC_LEDGER_CANISTER_ID

--- a/frontend/src/lib/utils/env-vars.utils.ts
+++ b/frontend/src/lib/utils/env-vars.utils.ts
@@ -10,6 +10,8 @@ type EnvironmentVars = {
   ckbtcMinterCanisterId?: string;
   ckethIndexCanisterId?: string;
   ckethLedgerCanisterId?: string;
+  ckusdcIndexCanisterId?: string;
+  ckusdcLedgerCanisterId?: string;
   cyclesMintingCanisterId: string;
   dfxNetwork: string;
   featureFlags: string;
@@ -103,6 +105,12 @@ const getBuildEnvVars = (): EnvironmentVars => {
     ),
     ckethLedgerCanisterId: convertEmtpyStringToUndefined(
       import.meta.env.VITE_CKETH_LEDGER_CANISTER_ID
+    ),
+    ckusdcIndexCanisterId: convertEmtpyStringToUndefined(
+      import.meta.env.VITE_CKUSDC_INDEX_CANISTER_ID
+    ),
+    ckusdcLedgerCanisterId: convertEmtpyStringToUndefined(
+      import.meta.env.VITE_CKUSDC_LEDGER_CANISTER_ID
     ),
     cyclesMintingCanisterId: convertEmtpyStringToUndefined(
       import.meta.env.VITE_CYCLES_MINTING_CANISTER_ID


### PR DESCRIPTION
This PR is modeled after https://github.com/dfinity/nns-dapp/pull/3886
# Motivation

We want to use ckUSDC canister IDs from the environment/configuration.

# Changes

1. Add `ckusdcLedgerCanisterId` and `ckusdcIndexCanisterId` fields to `EnvironmentVars` type.
2. Set the fields in `getBuildEnvVars`.
3. Use the fields in `frontend/src/lib/constants/ckusdc-canister-ids.constants.ts`.

# Tests

Not used yet, but CI should still pass.

# Todos

- [x] Add entry to changelog (if necessary).
