### PR TITLE
Don't restore state while replica is still running.

### DIFF
--- a/scripts/dfx-snapshot-install
+++ b/scripts/dfx-snapshot-install
@@ -184,8 +184,14 @@ install_state() {
 }
 
 output_restore_backup_script() {
-  echo "echo \"Restoring dfx state.\""
-  echo set -xeu
+  cat <<-EOF
+	if pgrep replica; then
+	  echo "A replica is still running. State should be restored automatically when the replica is stopped." >&2
+	  exit 1
+	fi
+	echo "Restoring dfx state."
+	set -xeu
+	EOF
   output_restore_dir LOCAL_REPLICA_DATA
   output_restore_dir CONFIG
   output_restore_dir NETWORK


### PR DESCRIPTION
# Motivation

When running an snsdemo snapshot, your dfx state (including identities) is replaced with state from the snapshot.
A `restore.sh` script is created, which is run when the replica is stopped.
If something goes wrong the restore script can also be run manually.
But you shouldn't do this if the replica is still running.

# Changes

Add a check in the restore script whether the replica is still running.

# Tests

Ran a snapshot and tried to restore it manually while it was still running.
Then checked that it got restored correctly when I stopped the replica.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary