### PR TITLE
Include ckUSDC canisters when importing IDs from URL

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -51,6 +51,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Added workflow to update IC cargo dependencies.
 * Include `ckUSDC` when generating `args.did` and `.env`.
+* Include `ckUSDC` canister IDs when importing from URL with `scripts/canister_ids`.
 
 #### Changed
 

--- a/scripts/canister_ids
+++ b/scripts/canister_ids
@@ -148,6 +148,8 @@ if [ "$command" = "import-from-index-html" ]; then
   ckbtcMinter="$(get_value_from_html data-ckbtc-minter-canister-id "$tmp_index_html")"
   ckethIndex="$(get_value_from_html data-cketh-index-canister-id "$tmp_index_html")"
   ckethLedger="$(get_value_from_html data-cketh-ledger-canister-id "$tmp_index_html")"
+  ckusdcIndex="$(get_value_from_html data-ckusdc-index-canister-id "$tmp_index_html")"
+  ckusdcLedger="$(get_value_from_html data-ckusdc-ledger-canister-id "$tmp_index_html")"
   snsWasm="$(get_value_from_html data-wasm-canister-id "$tmp_index_html")"
   nnsDapp="$(get_value_from_html data-own-canister-id "$tmp_index_html")"
 
@@ -159,6 +161,8 @@ if [ "$command" = "import-from-index-html" ]; then
     .ckbtc_minter[$network] = $ckbtcMinter |
     .cketh_index[$network] = $ckethIndex |
     .cketh_ledger[$network] = $ckethLedger |
+    .ckusdc_index[$network] = $ckusdcIndex |
+    .ckusdc_ledger[$network] = $ckusdcLedger |
     .["nns-sns-wasm"][$network] = $snsWasm |
     .internet_identity[$network] = $internetIdentity |
     .["nns-dapp"][$network] = $nnsDapp |
@@ -170,6 +174,8 @@ if [ "$command" = "import-from-index-html" ]; then
     --arg ckbtcMinter "$ckbtcMinter" \
     --arg ckethIndex "$ckethIndex" \
     --arg ckethLedger "$ckethLedger" \
+    --arg ckusdcIndex "$ckusdcIndex" \
+    --arg ckusdcLedger "$ckusdcLedger" \
     --arg snsWasm "$snsWasm" \
     --arg internetIdentity "$internetIdentity" \
     --arg nnsDapp "$nnsDapp" \

--- a/scripts/canister_ids.test
+++ b/scripts/canister_ids.test
@@ -38,6 +38,8 @@ cat >"$test_index_html" <<-EOF
         data-ckbtc-ledger-canister-id="st75y-vaaaa-aaaaa-aaalq-cai"
         data-ckbtc-minter-canister-id="t6rzw-2iaaa-aaaaa-aaama-cai"
         data-cketh-ledger-canister-id="omy6t-mmaaa-aaaaa-qabgq-cai"
+        data-ckusdc-ledger-canister-id="m7h5t-euaaa-aaaaa-qabia-cai"
+        data-ckusdc-index-canister-id="myg3h-jmaaa-aaaaa-qabiq-cai"
         data-cycles-minting-canister-id="rkp4c-7iaaa-aaaaa-aaaca-cai"
         data-dfx-network="staging"
         data-fetch-root-key="true"
@@ -164,6 +166,12 @@ if ! diff "$test_json_file" <(
   },
   "cketh_ledger": {
     "staging": "omy6t-mmaaa-aaaaa-qabgq-cai"
+  },
+  "ckusdc_index": {
+    "staging": "myg3h-jmaaa-aaaaa-qabiq-cai"
+  },
+  "ckusdc_ledger": {
+    "staging": "m7h5t-euaaa-aaaaa-qabia-cai"
   },
   "nns-sns-wasm": {
     "staging": "qaa6y-5yaaa-aaaaa-aaafa-cai"


### PR DESCRIPTION
# Motivation

When installing a release candidate on DevEnv, one of the steps is importing canister IDs from a URL so they can be used to deploy the release candidate.

# Changes

Include ckUSDC canister IDs when importing from URL in `scripts/canister_ids`.

# Tests

Test was updated.

# Todos

- [x] Add entry to changelog (if necessary).