### PR TITLE
Display 6 decimals for ckUSDC.

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -40,6 +40,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Successful swap message should not be shown when participant count is insufficient.
+* Rendering tokens with fewer than 8 decimals.
 
 #### Security
 

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -62,7 +62,7 @@ type RoundMode =
  * Jira GIX-1563:
  * - However, if requested, some amount might be displayed with a fix length of 8 decimals, regardless if leading zero or no leading zero
  */
-export const formatTokenUlps = ({
+const formatTokenUlps = ({
   value,
   tokenDecimals,
   defaultDisplayedDecimals,

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -125,14 +125,12 @@ export const formatTokenE8s = ({
   });
 };
 
-// TODO: This drops decimals after the 8th decimal place. Decide if this is the
-// desired behavior.
 export const formatTokenV2 = ({
   value,
   detailed = false,
   roundingMode,
 }: {
-  value?: TokenAmount | TokenAmountV2;
+  value: TokenAmount | TokenAmountV2;
   detailed?: boolean | "height_decimals";
   roundingMode?: RoundMode;
 }): string => {

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -1,7 +1,6 @@
 import {
   E8S_PER_ICP,
   ICP_DISPLAYED_DECIMALS,
-  ICP_DISPLAYED_DECIMALS_DETAILED,
   ICP_DISPLAYED_HEIGHT_DECIMALS,
 } from "$lib/constants/icp.constants";
 import type { UserToken } from "$lib/types/tokens-page";
@@ -63,12 +62,18 @@ type RoundMode =
  * Jira GIX-1563:
  * - However, if requested, some amount might be displayed with a fix length of 8 decimals, regardless if leading zero or no leading zero
  */
-export const formatTokenE8s = ({
+export const formatTokenUlps = ({
   value,
+  tokenDecimals,
+  defaultDisplayedDecimals,
+  maxDisplayedDecimals,
   detailed = false,
   roundingMode,
 }: {
   value: bigint;
+  tokenDecimals: number;
+  defaultDisplayedDecimals: number;
+  maxDisplayedDecimals: number;
   detailed?: boolean | "height_decimals";
   roundingMode?: RoundMode;
 }): string => {
@@ -76,19 +81,17 @@ export const formatTokenE8s = ({
     return "0";
   }
 
-  const converted = Number(value) / E8S_PER_ICP;
+  const converted = Number(value) / 10 ** tokenDecimals;
 
-  const decimalsICP = (): number =>
+  const decimalsForAmount = (): number =>
     converted < 0.01
-      ? Math.max(countDecimals(converted), ICP_DISPLAYED_DECIMALS)
+      ? Math.max(countDecimals(converted), defaultDisplayedDecimals)
       : detailed
-      ? Math.min(countDecimals(converted), ICP_DISPLAYED_DECIMALS_DETAILED)
-      : ICP_DISPLAYED_DECIMALS;
+      ? Math.min(countDecimals(converted), maxDisplayedDecimals)
+      : defaultDisplayedDecimals;
 
   const decimals =
-    detailed === "height_decimals"
-      ? ICP_DISPLAYED_HEIGHT_DECIMALS
-      : decimalsICP();
+    detailed === "height_decimals" ? maxDisplayedDecimals : decimalsForAmount();
 
   return new Intl.NumberFormat("en-US", {
     minimumFractionDigits: decimals,
@@ -103,6 +106,25 @@ export const formatTokenE8s = ({
     .replace(/,/g, "'");
 };
 
+export const formatTokenE8s = ({
+  value,
+  detailed = false,
+  roundingMode,
+}: {
+  value: bigint;
+  detailed?: boolean | "height_decimals";
+  roundingMode?: RoundMode;
+}): string => {
+  return formatTokenUlps({
+    value,
+    tokenDecimals: ICP_DISPLAYED_HEIGHT_DECIMALS,
+    defaultDisplayedDecimals: ICP_DISPLAYED_DECIMALS,
+    maxDisplayedDecimals: ICP_DISPLAYED_HEIGHT_DECIMALS,
+    detailed,
+    roundingMode,
+  });
+};
+
 // TODO: This drops decimals after the 8th decimal place. Decide if this is the
 // desired behavior.
 export const formatTokenV2 = ({
@@ -114,17 +136,28 @@ export const formatTokenV2 = ({
   detailed?: boolean | "height_decimals";
   roundingMode?: RoundMode;
 }): string => {
-  let e8s;
+  let ulps;
   if (isNullish(value)) {
-    e8s = 0n;
+    ulps = 0n;
   } else if (value instanceof TokenAmount) {
-    e8s = value.toE8s();
+    ulps = value.toE8s();
   } else {
-    const decimals = value.token.decimals;
-    const ulps = value.toUlps();
-    e8s = ulpsToE8s({ ulps, decimals });
+    ulps = value.toUlps();
   }
-  return formatTokenE8s({ value: e8s, detailed, roundingMode });
+  return formatTokenUlps({
+    value: ulps,
+    tokenDecimals: value.token.decimals,
+    defaultDisplayedDecimals: Math.min(
+      ICP_DISPLAYED_DECIMALS,
+      value.token.decimals
+    ),
+    maxDisplayedDecimals: Math.min(
+      ICP_DISPLAYED_HEIGHT_DECIMALS,
+      value.token.decimals
+    ),
+    detailed,
+    roundingMode,
+  });
 };
 
 export const sumAmounts = (...amounts: bigint[]): bigint =>

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -265,6 +265,89 @@ describe("token-utils", () => {
       });
     });
 
+    describe("with 6 decimals", () => {
+      const token = {
+        decimals: 6,
+        symbol: "ckUSDC",
+        name: "Chain key USDC",
+      };
+
+      const testFormat = (amount: string) => {
+        expect(
+          formatTokenV2({
+            value: TokenAmountV2.fromString({ amount, token }) as TokenAmountV2,
+          })
+        ).toEqual(amount);
+      };
+
+      const testFormatDetailed = (amount: string) => {
+        expect(
+          formatTokenV2({
+            value: TokenAmountV2.fromString({ amount, token }) as TokenAmountV2,
+            detailed: true,
+          })
+        ).toEqual(amount);
+      };
+
+      const testFormatHeightDecimals = (amount: string) => {
+        expect(
+          formatTokenV2({
+            value: TokenAmountV2.fromString({ amount, token }) as TokenAmountV2,
+            detailed: "height_decimals",
+          })
+        ).toEqual(amount);
+      };
+
+      it("should format token", () => {
+        testFormat("1.00");
+        testFormat("1'000'000.00");
+        testFormat("0.01");
+        testFormat("0.001");
+        testFormat("0.0001");
+        testFormat("0.00001");
+        testFormat("0.000001");
+        testFormat("1.01");
+        expect(
+          formatTokenV2({
+            value: TokenAmountV2.fromString({
+              amount: "1.001",
+              token,
+            }) as TokenAmountV2,
+          })
+        ).toEqual("1.00");
+      });
+
+      it("should format detailed token", () => {
+        testFormatDetailed("1.00");
+        testFormatDetailed("1'000'000.00");
+        testFormatDetailed("0.01");
+        testFormatDetailed("0.001");
+        testFormatDetailed("0.0001");
+        testFormatDetailed("0.00001");
+        testFormatDetailed("0.000001");
+        testFormatDetailed("1.01");
+        testFormatDetailed("1.001");
+        testFormatDetailed("1.0001");
+        testFormatDetailed("1.00001");
+        testFormatDetailed("1.000001");
+      });
+
+      it("should format height decimals token", () => {
+        testFormatHeightDecimals("1.000000");
+        testFormatHeightDecimals("1'000'000.000000");
+        testFormatHeightDecimals("0.010000");
+        testFormatHeightDecimals("0.001000");
+        testFormatHeightDecimals("0.000100");
+        testFormatHeightDecimals("0.000010");
+        testFormatHeightDecimals("0.000001");
+        testFormatHeightDecimals("1.010000");
+        testFormatHeightDecimals("1.001000");
+        testFormatHeightDecimals("1.000100");
+        testFormatHeightDecimals("1.000010");
+        testFormatHeightDecimals("1.000001");
+      });
+    });
+
     describe("with 18 decimals", () => {
       const token = {
         decimals: 18,
@@ -280,6 +363,24 @@ describe("token-utils", () => {
         ).toEqual(amount);
       };
 
+      const testFormatDetailed = (amount: string) => {
+        expect(
+          formatTokenV2({
+            value: TokenAmountV2.fromString({ amount, token }) as TokenAmountV2,
+            detailed: true,
+          })
+        ).toEqual(amount);
+      };
+
+      const testFormatHeightDecimals = (amount: string) => {
+        expect(
+          formatTokenV2({
+            value: TokenAmountV2.fromString({ amount, token }) as TokenAmountV2,
+            detailed: "height_decimals",
+          })
+        ).toEqual(amount);
+      };
+
       it("should format token", () => {
         testFormat("1.00");
         testFormat("1'000'000.00");
@@ -290,6 +391,49 @@ describe("token-utils", () => {
         testFormat("0.000001");
         testFormat("0.0000001");
         testFormat("0.00000001");
+        testFormat("1.01");
+        expect(
+          formatTokenV2({
+            value: TokenAmountV2.fromString({
+              amount: "1.001",
+              token,
+            }) as TokenAmountV2,
+          })
+        ).toEqual("1.00");
+      });
+
+      it("should format detailed token", () => {
+        testFormatDetailed("1.00");
+        testFormatDetailed("1'000'000.00");
+        testFormatDetailed("0.01");
+        testFormatDetailed("0.001");
+        testFormatDetailed("0.0001");
+        testFormatDetailed("0.00001");
+        testFormatDetailed("0.000001");
+        testFormatDetailed("1.01");
+        testFormatDetailed("1.001");
+        testFormatDetailed("1.0001");
+        testFormatDetailed("1.00001");
+        testFormatDetailed("1.000001");
+      });
+
+      it("should format height decimals token", () => {
+        testFormatHeightDecimals("1.00000000");
+        testFormatHeightDecimals("1'000'000.00000000");
+        testFormatHeightDecimals("0.01000000");
+        testFormatHeightDecimals("0.00100000");
+        testFormatHeightDecimals("0.00010000");
+        testFormatHeightDecimals("0.00001000");
+        testFormatHeightDecimals("0.00000100");
+        testFormatHeightDecimals("0.00000010");
+        testFormatHeightDecimals("0.00000001");
+        testFormatHeightDecimals("1.01000000");
+        testFormatHeightDecimals("1.00100000");
+        testFormatHeightDecimals("1.00010000");
+        testFormatHeightDecimals("1.00001000");
+        testFormatHeightDecimals("1.00000100");
+        testFormatHeightDecimals("1.00000010");
+        testFormatHeightDecimals("1.00000001");
       });
     });
   });


### PR DESCRIPTION
# Motivation

Currently we always display tokens with 8 decimal precision on the transaction review screen.
Even for ckETH, which supports 18 decimals because we don't think there is value in displaying so many decimals.
But ckUSDC only has 6 decimals, so we should add 2 meaningless zeros to display 8.

# Changes

1. Change `formatTokenE8s` to `formatTokenUlps` and make it generic in the number of decimals.
2. Call `formatTokenUlps` from `formatTokenE8s` with specific values for the number of displayed and detailed decimals.
3. Call `formatTokenUlps` instead of `formatTokenE8s` from `formatTokenV2`.

# Tests

1. Added unit tests.
2. Looked manually that the transaction screen looks good.


# Todos

- [x] Add entry to changelog (if necessary).
