### PR TITLE
Support fewer than 8 decimals in AmountInput

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -41,6 +41,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Successful swap message should not be shown when participant count is insufficient.
 * Rendering tokens with fewer than 8 decimals.
+* Don't allow inputting more decimals than the token supports.
 
 #### Security
 

--- a/frontend/src/lib/components/transaction/TransactionForm.svelte
+++ b/frontend/src/lib/components/transaction/TransactionForm.svelte
@@ -157,7 +157,7 @@
   {/if}
 
   <div class="amount">
-    <AmountInput bind:amount on:nnsMax={addMax} {max} {errorMessage} />
+    <AmountInput bind:amount on:nnsMax={addMax} {max} {errorMessage} {token} />
 
     {#if showLedgerFee}
       <TransactionFormFee {transactionFee} />

--- a/frontend/src/lib/components/ui/AmountInput.svelte
+++ b/frontend/src/lib/components/ui/AmountInput.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
+  import { ICP_DISPLAYED_DECIMALS_DETAILED } from "$lib/constants/icp.constants";
   import { i18n } from "$lib/stores/i18n";
   import { createEventDispatcher } from "svelte";
   import MaxButton from "$lib/components/common/MaxButton.svelte";
   import InputWithError from "./InputWithError.svelte";
+  import { type Token, isNullish } from "@dfinity/utils";
 
   export let amount: number | undefined = undefined;
   export let max: number | undefined = undefined;
+  export let token: Token | undefined = undefined;
   export let errorMessage: string | undefined = undefined;
+
+  let inputAmount: string | undefined = amount?.toString();
+  $: amount = isNullish(inputAmount) ? undefined : +inputAmount;
 
   const dispatch = createEventDispatcher();
   const setMax = () => dispatch("nnsMax");
@@ -16,9 +22,13 @@
   testId="amount-input-component"
   placeholderLabelKey="core.amount"
   name="amount"
-  bind:value={amount}
+  bind:value={inputAmount}
   {max}
-  inputType="icp"
+  inputType="currency"
+  decimals={Math.min(
+    token?.decimals ?? ICP_DISPLAYED_DECIMALS_DETAILED,
+    ICP_DISPLAYED_DECIMALS_DETAILED
+  )}
   {errorMessage}
 >
   <svelte:fragment slot="label">{$i18n.core.amount}</svelte:fragment>

--- a/frontend/src/lib/components/ui/AmountInput.svelte
+++ b/frontend/src/lib/components/ui/AmountInput.svelte
@@ -12,7 +12,11 @@
   export let errorMessage: string | undefined = undefined;
 
   let inputAmount: string | undefined = amount?.toString();
-  $: amount = isNullish(inputAmount) ? undefined : +inputAmount;
+  $: inputAmount = amount?.toString();
+
+  const onInput = () => {
+    amount = isNullish(inputAmount) ? undefined : +inputAmount;
+  };
 
   const dispatch = createEventDispatcher();
   const setMax = () => dispatch("nnsMax");
@@ -30,6 +34,7 @@
     ICP_DISPLAYED_DECIMALS_DETAILED
   )}
   {errorMessage}
+  on:nnsInput={onInput}
 >
   <svelte:fragment slot="label">{$i18n.core.amount}</svelte:fragment>
   <MaxButton on:click={setMax} slot="end" />

--- a/frontend/src/lib/components/ui/Input.svelte
+++ b/frontend/src/lib/components/ui/Input.svelte
@@ -4,7 +4,8 @@
 
   export let testId: string = "input-ui-element";
   export let name: string;
-  export let inputType: "icp" | "number" | "text" = "number";
+  export let inputType: "icp" | "currency" | "number" | "text" = "number";
+  export let decimals: number | undefined = undefined;
   export let required = true;
   export let spellcheck: boolean | undefined = undefined;
   export let step: number | "any" | undefined = undefined;
@@ -23,6 +24,7 @@
 <Input
   {testId}
   {inputType}
+  {decimals}
   {required}
   {spellcheck}
   {name}

--- a/frontend/src/lib/components/ui/InputWithError.svelte
+++ b/frontend/src/lib/components/ui/InputWithError.svelte
@@ -4,7 +4,8 @@
 
   // Same props as Input
   export let name: string;
-  export let inputType: "number" | "text" | "icp" = "number";
+  export let inputType: "number" | "text" | "icp" | "currency" = "number";
+  export let decimals: number | undefined = undefined;
   export let required = true;
   export let spellcheck: boolean | undefined = undefined;
   export let step: number | "any" | undefined = undefined;
@@ -26,6 +27,7 @@
 <div class="wrapper" data-tid={testId} class:error={hasError}>
   <Input
     {inputType}
+    {decimals}
     {required}
     {spellcheck}
     {name}

--- a/frontend/src/tests/lib/components/ui/AmountInput.spec.ts
+++ b/frontend/src/tests/lib/components/ui/AmountInput.spec.ts
@@ -1,5 +1,9 @@
 import AmountInput from "$lib/components/ui/AmountInput.svelte";
+import { mockCkETHToken } from "$tests/mocks/cketh-accounts.mock";
 import en from "$tests/mocks/i18n.mock";
+import { mockCkUSDCToken } from "$tests/mocks/tokens.mock";
+import { AmountInputPo } from "$tests/page-objects/AmountInput.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { fireEvent, render } from "@testing-library/svelte";
 
 describe("AmountInput", () => {
@@ -31,4 +35,47 @@ describe("AmountInput", () => {
       ) as HTMLButtonElement;
       fireEvent.click(button);
     }));
+
+  const renderComponent = (props) => {
+    const { container } = render(AmountInput, props);
+    return AmountInputPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should allow at most 8 decimals", async () => {
+    const po = renderComponent({});
+
+    // 8 decimals works
+    await po.getTextInput().typeText("0.12345678");
+    expect(await po.getAmount()).toBe("0.12345678");
+
+    // typing one more decimal does not change the input
+    await po.getTextInput().typeText("0.123456789");
+    expect(await po.getAmount()).toBe("0.12345678");
+  });
+
+  it("should allow at most 6 decimals for ckUSDC", async () => {
+    const po = renderComponent({ token: mockCkUSDCToken });
+
+    // 6 decimals works
+    await po.getTextInput().typeText("0.123456");
+    expect(await po.getAmount()).toBe("0.123456");
+
+    // typing one more decimal does not change the input
+    await po.getTextInput().typeText("0.1234567");
+    expect(await po.getAmount()).toBe("0.123456");
+  });
+
+  it("should allow at most 8 decimals even if the token allows more", async () => {
+    expect(mockCkETHToken.decimals).toBeGreaterThan(8);
+
+    const po = renderComponent({ token: mockCkETHToken });
+
+    // 8 decimals works
+    await po.getTextInput().typeText("0.12345678");
+    expect(await po.getAmount()).toBe("0.12345678");
+
+    // typing one more decimal does not change the input
+    await po.getTextInput().typeText("0.123456789");
+    expect(await po.getAmount()).toBe("0.12345678");
+  });
 });

--- a/frontend/src/tests/mocks/tokens.mock.ts
+++ b/frontend/src/tests/mocks/tokens.mock.ts
@@ -9,6 +9,7 @@ import {
 } from "$lib/constants/cketh-canister-ids.constants";
 import { NNS_TOKEN } from "$lib/constants/tokens.constants";
 import type { TokensStoreData } from "$lib/stores/tokens.store";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import {
   mockCkETHTESTToken,
   mockCkETHToken,
@@ -16,6 +17,13 @@ import {
 import type { Subscriber } from "svelte/store";
 import { mockCkBTCToken } from "./ckbtc-accounts.mock";
 import { mockSnsFullProject, mockSnsToken } from "./sns-projects.mock";
+
+export const mockCkUSDCToken: IcrcTokenMetadata = {
+  name: "ckUSDC",
+  symbol: "ckUSDC",
+  fee: 4_000n,
+  decimals: 6,
+};
 
 export const mockTokens = {
   [CKBTC_UNIVERSE_CANISTER_ID.toText()]: {


### PR DESCRIPTION
# Motivation

When entering an amount we allow entering up to 8 decimals.
Even though ckETH supports 18 decimals, we decided to support 8.
But ckUSDC only supports 6 decimals so we don't want to allow entering more than 6.
`Input` from gix-component already supports choosing the number of decimals if you use `inputType = "currency"` instead of `"icp"` but then the value is given as a string instead of a number.

# Changes

1. Allow setting `decimals` and `inputType = "currency"` on `Input` and `InputWithError`.
2. Use `inputType = "currency"` in `AmountInput` and convert back to a number.
3. Accept an optional `token` prop on `AmountInput` and pass `decimals` based on the token.

# Tests

Added unit tests with ckETH, ckUSDC and without token.

# Todos

- [x] Add entry to changelog (if necessary).
