### PR TITLE
Bump ic-js next with last Candid definition

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -250,9 +250,10 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.3.3-next-2024-05-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.3-next-2024-05-16.tgz",
-      "integrity": "sha512-XWpImmnJIUmCYkFFmht1cNpXnv8Ev7IpDMzxCHzWfcg6IAB9MoDaZxMlujzxT+SSFqAMmIloh1lMxbKirO34mw==",
+      "version": "2.3.3-next-2024-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.3-next-2024-05-21.tgz",
+      "integrity": "sha512-Vkhe0034CGBlnKl+9ZFDKUeIERXMiUOhBp5OHYs5FeCgEhMxSvWXfLJrJvJjjLzg7gxmC4B6cP07CAwPZD7qbQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -266,9 +267,10 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.0.5-next-2024-05-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.5-next-2024-05-16.tgz",
-      "integrity": "sha512-Mtyf61BTSI1V+Lk9z0uQSXqLeLKG/7QGufITC/VF0dbMQNFLtBzQsTHhvvmpZUfokTTBl6f7nuLxLzpeF8eOaA==",
+      "version": "3.0.5-next-2024-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.5-next-2024-05-21.tgz",
+      "integrity": "sha512-XlL/m2bz2D6wYtdCmCCKiKpvBekwRnFGLmFBTTf3DNso5r5aDMHIow9A/0OJ90QDxhMI1aL3vdadjS7NUTXGlQ==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -291,9 +293,10 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "4.0.0-next-2024-05-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-4.0.0-next-2024-05-16.tgz",
-      "integrity": "sha512-q7fwgVL56gOg3TaTu3A7Bx5IUbkPWiKX1kljjYnGc7TM0n4jIoFqg9JCL1Ky+e+sD91cDEOy31EClvNa78VFow==",
+      "version": "4.0.0-next-2024-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-4.0.0-next-2024-05-21.tgz",
+      "integrity": "sha512-yU9l8gl7c8JpIDr6Qbi1N15GtdI9w1FVU8t2VuzP33en2akbeDRSsT9CQJDeiM+naOc/ZzrPnZGVIB2wLWPGLQ==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -317,9 +320,10 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.2.4-next-2024-05-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.4-next-2024-05-16.tgz",
-      "integrity": "sha512-+Kj/JrDIOkBvYCUbkA+z3Ursawf6eZ8k1PriJbu1OF8p3GycNNRzri0MXYnJ7O2R9vnAOtvEjr4hBjTIEgqwJg==",
+      "version": "2.2.4-next-2024-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.4-next-2024-05-21.tgz",
+      "integrity": "sha512-jvPc0xGtBMzUKz89zDwqlOv0B3F/KW5XdT4oh+aqu/H+f8PsmmMzM4JeY34iJxZENszXabwtMctKRpfB3JgXkg==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -328,9 +332,10 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.3.1-next-2024-05-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.3.1-next-2024-05-16.tgz",
-      "integrity": "sha512-I0+2wSrG7z4DffDRPXMsX0Yv+yNis36dyXjARnq5KP5hw+SpTcN/yODthDpl/XkPJ7P8i4URGzvfVVi0DRXUpw==",
+      "version": "2.3.1-next-2024-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.3.1-next-2024-05-21.tgz",
+      "integrity": "sha512-5YsjNVDR97cfKBXa1Ti5Xg0cCd/laYnXv7SBN1Uc8ZnbEjLhtjSpjWKi0400OxYyK9CoBsq+StuDDEVmaFzWag==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -339,9 +344,10 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "5.1.0-next-2024-05-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.1.0-next-2024-05-16.tgz",
-      "integrity": "sha512-Hj937Cmd5X1M+mkFKVnYIvKiZSP+N/5IXZ9XaNf+ii6ceO/vRvO69+3tBPRs3hgwPtURLBVrBS1uqAAM2NTYfg==",
+      "version": "5.1.0-next-2024-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.1.0-next-2024-05-21.tgz",
+      "integrity": "sha512-SpAEnGKVz/advNnEd+l/ixigTuFVhgpsJijamXbB+uxUbT0SPCS+H52J0BrPcvNU0tU7TKtrl5u+leI8mZmNJw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -363,9 +369,10 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.0.4-next-2024-05-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.4-next-2024-05-16.tgz",
-      "integrity": "sha512-mupnoI6jsVrNfkJTWL5apfC3ERuORhan9bubRbTsdAzZ5H/99R1QwWJkQp7FnLAwFC/CVXUHx7Wd65DcMH+sYg==",
+      "version": "3.0.4-next-2024-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.4-next-2024-05-21.tgz",
+      "integrity": "sha512-s4uJyKl+Cw6EyRBN0B3SH3ubeyYlMLlfJ5P4WFLIsIKiwIfJKYLmzYnA4bdzyyDOpx5PCCAJzO8A3Esr4fKWMQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -378,9 +385,10 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.3.0-next-2024-05-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.3.0-next-2024-05-16.tgz",
-      "integrity": "sha512-bjua3paLtslsjZvleMdur4UHOKKcc2qyxZ2MbMqM7zDgB9yAhohHTXVUPY9EPWp187UVM19TjKFT91FKEU41Ng==",
+      "version": "2.3.0-next-2024-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.3.0-next-2024-05-21.tgz",
+      "integrity": "sha512-ruSWDX7L+piJSBlo1VStSqy3MjkJr2g8APhZLlQnoMgb8k+QGMDGKfhyhr/w6TxsNcIIBBzkdyVMKCnie8TBug==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -2021,6 +2029,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-1.0.5.tgz",
       "integrity": "sha512-LkkAPP8Zu+c0SVNRTRVDyMfKVORThX+rCViget00xdgLRrKkClCTz1T7cIrpr69ShwV5XJuuoZvMvJ43yURwkA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -2055,7 +2064,8 @@
     "node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "license": "MIT"
     },
     "node_modules/bignumber.js": {
       "version": "9.1.1",
@@ -5377,6 +5387,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -7031,9 +7042,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.3.3-next-2024-05-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.3-next-2024-05-16.tgz",
-      "integrity": "sha512-XWpImmnJIUmCYkFFmht1cNpXnv8Ev7IpDMzxCHzWfcg6IAB9MoDaZxMlujzxT+SSFqAMmIloh1lMxbKirO34mw==",
+      "version": "2.3.3-next-2024-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.3-next-2024-05-21.tgz",
+      "integrity": "sha512-Vkhe0034CGBlnKl+9ZFDKUeIERXMiUOhBp5OHYs5FeCgEhMxSvWXfLJrJvJjjLzg7gxmC4B6cP07CAwPZD7qbQ==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7041,9 +7052,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.0.5-next-2024-05-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.5-next-2024-05-16.tgz",
-      "integrity": "sha512-Mtyf61BTSI1V+Lk9z0uQSXqLeLKG/7QGufITC/VF0dbMQNFLtBzQsTHhvvmpZUfokTTBl6f7nuLxLzpeF8eOaA==",
+      "version": "3.0.5-next-2024-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.5-next-2024-05-21.tgz",
+      "integrity": "sha512-XlL/m2bz2D6wYtdCmCCKiKpvBekwRnFGLmFBTTf3DNso5r5aDMHIow9A/0OJ90QDxhMI1aL3vdadjS7NUTXGlQ==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7057,9 +7068,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "4.0.0-next-2024-05-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-4.0.0-next-2024-05-16.tgz",
-      "integrity": "sha512-q7fwgVL56gOg3TaTu3A7Bx5IUbkPWiKX1kljjYnGc7TM0n4jIoFqg9JCL1Ky+e+sD91cDEOy31EClvNa78VFow==",
+      "version": "4.0.0-next-2024-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-4.0.0-next-2024-05-21.tgz",
+      "integrity": "sha512-yU9l8gl7c8JpIDr6Qbi1N15GtdI9w1FVU8t2VuzP33en2akbeDRSsT9CQJDeiM+naOc/ZzrPnZGVIB2wLWPGLQ==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7073,21 +7084,21 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.2.4-next-2024-05-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.4-next-2024-05-16.tgz",
-      "integrity": "sha512-+Kj/JrDIOkBvYCUbkA+z3Ursawf6eZ8k1PriJbu1OF8p3GycNNRzri0MXYnJ7O2R9vnAOtvEjr4hBjTIEgqwJg==",
+      "version": "2.2.4-next-2024-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.4-next-2024-05-21.tgz",
+      "integrity": "sha512-jvPc0xGtBMzUKz89zDwqlOv0B3F/KW5XdT4oh+aqu/H+f8PsmmMzM4JeY34iJxZENszXabwtMctKRpfB3JgXkg==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.3.1-next-2024-05-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.3.1-next-2024-05-16.tgz",
-      "integrity": "sha512-I0+2wSrG7z4DffDRPXMsX0Yv+yNis36dyXjARnq5KP5hw+SpTcN/yODthDpl/XkPJ7P8i4URGzvfVVi0DRXUpw==",
+      "version": "2.3.1-next-2024-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.3.1-next-2024-05-21.tgz",
+      "integrity": "sha512-5YsjNVDR97cfKBXa1Ti5Xg0cCd/laYnXv7SBN1Uc8ZnbEjLhtjSpjWKi0400OxYyK9CoBsq+StuDDEVmaFzWag==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "5.1.0-next-2024-05-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.1.0-next-2024-05-16.tgz",
-      "integrity": "sha512-Hj937Cmd5X1M+mkFKVnYIvKiZSP+N/5IXZ9XaNf+ii6ceO/vRvO69+3tBPRs3hgwPtURLBVrBS1uqAAM2NTYfg==",
+      "version": "5.1.0-next-2024-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.1.0-next-2024-05-21.tgz",
+      "integrity": "sha512-SpAEnGKVz/advNnEd+l/ixigTuFVhgpsJijamXbB+uxUbT0SPCS+H52J0BrPcvNU0tU7TKtrl5u+leI8mZmNJw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -7102,17 +7113,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.0.4-next-2024-05-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.4-next-2024-05-16.tgz",
-      "integrity": "sha512-mupnoI6jsVrNfkJTWL5apfC3ERuORhan9bubRbTsdAzZ5H/99R1QwWJkQp7FnLAwFC/CVXUHx7Wd65DcMH+sYg==",
+      "version": "3.0.4-next-2024-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.4-next-2024-05-21.tgz",
+      "integrity": "sha512-s4uJyKl+Cw6EyRBN0B3SH3ubeyYlMLlfJ5P4WFLIsIKiwIfJKYLmzYnA4bdzyyDOpx5PCCAJzO8A3Esr4fKWMQ==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.3.0-next-2024-05-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.3.0-next-2024-05-16.tgz",
-      "integrity": "sha512-bjua3paLtslsjZvleMdur4UHOKKcc2qyxZ2MbMqM7zDgB9yAhohHTXVUPY9EPWp187UVM19TjKFT91FKEU41Ng==",
+      "version": "2.3.0-next-2024-05-21",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.3.0-next-2024-05-21.tgz",
+      "integrity": "sha512-ruSWDX7L+piJSBlo1VStSqy3MjkJr2g8APhZLlQnoMgb8k+QGMDGKfhyhr/w6TxsNcIIBBzkdyVMKCnie8TBug==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
+++ b/frontend/src/tests/lib/canisters/ic-management.canister.spec.ts
@@ -41,6 +41,12 @@ describe("ICManagementCanister", () => {
         module_hash: [],
         idle_cycles_burned_per_day: 30_000n,
         reserved_cycles: 1_000_000n,
+        query_stats: {
+          num_calls_total: 1n,
+          num_instructions_total: 2n,
+          request_payload_bytes_total: 3n,
+          response_payload_bytes_total: 4n,
+        },
       };
       const service = mock<IcManagementService>();
       service.canister_status.mockResolvedValue(response);

--- a/frontend/src/tests/lib/worker-api/canisters.worker-api.spec.ts
+++ b/frontend/src/tests/lib/worker-api/canisters.worker-api.spec.ts
@@ -23,6 +23,12 @@ describe("canisters-worker-api", () => {
     module_hash: [],
     idle_cycles_burned_per_day: 300n,
     reserved_cycles: 1_000_000n,
+    query_stats: {
+      num_calls_total: 1n,
+      num_instructions_total: 2n,
+      request_payload_bytes_total: 3n,
+      response_payload_bytes_total: 4n,
+    },
   };
 
   beforeEach(async () => {


### PR DESCRIPTION
# Motivation

Propagate last weekly Candid definition ([631](https://github.com/dfinity/ic-js/pull/631)).

# Notes

Query stats has been added to the spec in this PR [305](https://github.com/dfinity/interface-spec/pull/305).

# Changes

- `npm run upgrade:next`
- extend `CanisterStatusResponse` mock with `query_stats` in ic-mgmt and canister worker tests