### PR TITLE
Keep existing identities when installing snapshot

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -45,6 +45,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Keep existing `dfx` identities when running an `snsdemo` snapshot.
+
 #### Deprecated
 
 #### Removed

--- a/scripts/dfx-snapshot-install
+++ b/scripts/dfx-snapshot-install
@@ -180,7 +180,12 @@ install_dir() {
 }
 
 get_config_paths_to_install() {
+  # Shellcheck suggests using find instead of ls but that makes the code much
+  # more complicated and I don't expect any non-standard characters in these
+  # files.
+  # shellcheck disable=SC2010
   ls "$DFX_CONFIG_STATE_DIR" | grep -v '^identity$'
+  # shellcheck disable=SC2012
   ls "$DFX_CONFIG_STATE_DIR/identity" | sed -e 's@^@identity/@'
 }
 

--- a/scripts/dfx-snapshot-install
+++ b/scripts/dfx-snapshot-install
@@ -179,11 +179,22 @@ install_dir() {
   mv3 "$state_dir" "$dfx_dir" "$backup_dir"
 }
 
+get_config_paths_to_install() {
+  ls "$DFX_CONFIG_STATE_DIR" | grep -v '^identity$'
+  ls "$DFX_CONFIG_STATE_DIR/identity" | sed -e 's@^@identity/@'
+}
+
+install_config_dir() {
+  for config_path in $(get_config_paths_to_install); do
+    mv3 "${DFX_CONFIG_STATE_DIR}/${config_path}" "${DFX_CONFIG_DIR}/${config_path}" "${DFX_CONFIG_BACKUP_DIR}/${config_path}"
+  done
+}
+
 # Moves all the existing directories to the backup location and moves the state
 # directories in their place.
 install_state() {
   install_dir LOCAL_REPLICA_DATA
-  install_dir CONFIG
+  install_config_dir
   install_dir NETWORK
 }
 


### PR DESCRIPTION
# Motivation

When installing an snsdemo snapshot, the entire `~/.config/dfx` directory gets replaced with the one from the snapshot.
This includes all your identities.
So while a snapshot is running, you can't use your normal identities.

# Changes

Instead of replacing the entire `~/.config/dfx` directory, replace all its contents (according to the snapshot), except the `identity` directory, then replace only those identities that exist in the snapshot, keeping the others.

# Tests

Ran a snapshot. Checked that identities were still there.

# Todos

- [ ] Add entry to changelog (if necessary).
