### PR TITLE
Set mainnet ckUSDC canister IDs

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -243,7 +243,10 @@
       "wasm": "target/ic/ckusdc_ledger.wasm",
       "type": "custom",
       "remote": {
-        "id": {}
+        "id": {
+          "app": "xevnm-gaaaa-aaaar-qafnq-cai",
+          "mainnet": "xevnm-gaaaa-aaaar-qafnq-cai"
+        }
       }
     },
     "ckusdc_index": {
@@ -254,7 +257,10 @@
       "wasm": "target/ic/ckusdc_index.wasm",
       "type": "custom",
       "remote": {
-        "id": {}
+        "id": {
+          "app": "xrs4b-hiaaa-aaaar-qafoa-cai",
+          "mainnet": "xrs4b-hiaaa-aaaar-qafoa-cai"
+        }
       }
     },
     "tvl": {

--- a/scripts/nns-dapp/test-config-assets/app/arg.did
+++ b/scripts/nns-dapp/test-config-assets/app/arg.did
@@ -6,6 +6,8 @@
     record{ 0="CKBTC_MINTER_CANISTER_ID"; 1="mqygn-kiaaa-aaaar-qaadq-cai" };
     record{ 0="CKETH_INDEX_CANISTER_ID"; 1="s3zol-vqaaa-aaaar-qacpa-cai" };
     record{ 0="CKETH_LEDGER_CANISTER_ID"; 1="ss2fx-dyaaa-aaaar-qacoq-cai" };
+    record{ 0="CKUSDC_INDEX_CANISTER_ID"; 1="xrs4b-hiaaa-aaaar-qafoa-cai" };
+    record{ 0="CKUSDC_LEDGER_CANISTER_ID"; 1="xevnm-gaaaa-aaaar-qafnq-cai" };
     record{ 0="CYCLES_MINTING_CANISTER_ID"; 1="rkp4c-7iaaa-aaaaa-aaaca-cai" };
     record{ 0="DFX_NETWORK"; 1="app" };
     record{ 0="FEATURE_FLAGS"; 1="{\"ENABLE_ACTIONABLE_TAB\":false,\"ENABLE_CKBTC\":true,\"ENABLE_CKTESTBTC\":false,\"ENABLE_CKUSDC\":false,\"ENABLE_NEURONS_TABLE\":false}" };

--- a/scripts/nns-dapp/test-config-assets/app/env
+++ b/scripts/nns-dapp/test-config-assets/app/env
@@ -16,5 +16,5 @@ VITE_CKBTC_MINTER_CANISTER_ID=mqygn-kiaaa-aaaar-qaadq-cai
 VITE_CKBTC_INDEX_CANISTER_ID=n5wcd-faaaa-aaaar-qaaea-cai
 VITE_CKETH_LEDGER_CANISTER_ID=ss2fx-dyaaa-aaaar-qacoq-cai
 VITE_CKETH_INDEX_CANISTER_ID=s3zol-vqaaa-aaaar-qacpa-cai
-VITE_CKUSDC_LEDGER_CANISTER_ID=
-VITE_CKUSDC_INDEX_CANISTER_ID=
+VITE_CKUSDC_LEDGER_CANISTER_ID=xevnm-gaaaa-aaaar-qafnq-cai
+VITE_CKUSDC_INDEX_CANISTER_ID=xrs4b-hiaaa-aaaar-qafoa-cai

--- a/scripts/nns-dapp/test-config-assets/mainnet/arg.did
+++ b/scripts/nns-dapp/test-config-assets/mainnet/arg.did
@@ -6,6 +6,8 @@
     record{ 0="CKBTC_MINTER_CANISTER_ID"; 1="mqygn-kiaaa-aaaar-qaadq-cai" };
     record{ 0="CKETH_INDEX_CANISTER_ID"; 1="s3zol-vqaaa-aaaar-qacpa-cai" };
     record{ 0="CKETH_LEDGER_CANISTER_ID"; 1="ss2fx-dyaaa-aaaar-qacoq-cai" };
+    record{ 0="CKUSDC_INDEX_CANISTER_ID"; 1="xrs4b-hiaaa-aaaar-qafoa-cai" };
+    record{ 0="CKUSDC_LEDGER_CANISTER_ID"; 1="xevnm-gaaaa-aaaar-qafnq-cai" };
     record{ 0="CYCLES_MINTING_CANISTER_ID"; 1="rkp4c-7iaaa-aaaaa-aaaca-cai" };
     record{ 0="DFX_NETWORK"; 1="mainnet" };
     record{ 0="FEATURE_FLAGS"; 1="{\"ENABLE_ACTIONABLE_TAB\":false,\"ENABLE_CKBTC\":true,\"ENABLE_CKTESTBTC\":false,\"ENABLE_CKUSDC\":false,\"ENABLE_NEURONS_TABLE\":false}" };

--- a/scripts/nns-dapp/test-config-assets/mainnet/env
+++ b/scripts/nns-dapp/test-config-assets/mainnet/env
@@ -16,5 +16,5 @@ VITE_CKBTC_MINTER_CANISTER_ID=mqygn-kiaaa-aaaar-qaadq-cai
 VITE_CKBTC_INDEX_CANISTER_ID=n5wcd-faaaa-aaaar-qaaea-cai
 VITE_CKETH_LEDGER_CANISTER_ID=ss2fx-dyaaa-aaaar-qacoq-cai
 VITE_CKETH_INDEX_CANISTER_ID=s3zol-vqaaa-aaaar-qacpa-cai
-VITE_CKUSDC_LEDGER_CANISTER_ID=
-VITE_CKUSDC_INDEX_CANISTER_ID=
+VITE_CKUSDC_LEDGER_CANISTER_ID=xevnm-gaaaa-aaaar-qafnq-cai
+VITE_CKUSDC_INDEX_CANISTER_ID=xrs4b-hiaaa-aaaar-qafoa-cai


### PR DESCRIPTION
# Motivation

We need the canister IDs to support ckUSDC in NNS dapp.

I got these canister IDs from:
```
$ dfx canister --network ic call vxkom-oyaaa-aaaar-qafda-cai get_orchestrator_info
(
  record {
    cycles_management = record {
      cycles_top_up_increment = 10_000_000_000_000 : nat;
      cycles_for_ledger_creation = 150_000_000_000_000 : nat;
      cycles_for_archive_creation = 50_000_000_000_000 : nat;
      cycles_for_index_creation = 100_000_000_000_000 : nat;
    };
    managed_canisters = vec {
      record {
        erc20_contract = record {
          chain_id = 1 : nat;
          address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
        };
        ledger = opt variant {
          Installed = record {
            canister_id = principal "xevnm-gaaaa-aaaar-qafnq-cai";
            installed_wasm_hash = "4ca82938d223c77909dcf594a49ea72c07fd513726cfa7a367dd0be0d6abc679";
          }
        };
        index = opt variant {
          Installed = record {
            canister_id = principal "xrs4b-hiaaa-aaaar-qafoa-cai";
            installed_wasm_hash = "55dd5ea22b65adf877cea893765561ae290b52e7fdfdc043b5c18ffbaaa78f33";
          }
        };
        archives = vec {};
        ckerc20_token_symbol = "ckUSDC";
      };
    };
    more_controller_ids = vec { principal "r7inp-6aaaa-aaaaa-aaabq-cai" };
    minter_id = opt principal "sv3dd-oaaaa-aaaar-qacoa-cai";
  },
)
```

# Changes

1. Add `ckusdc_ledger` and `ckusdc_index` canister IDs for `mainnet` and `app` networks.
2. Ran `scripts/nns-dapp/test-config --update`.

# Tests

Deployed with https://github.com/dfinity/nns-dapp/actions/workflows/deploy-to-app.yaml for testing.

# Todos

- [ ] Add entry to changelog (if necessary).
covered by existing entry
