### PR TITLE
Remove outdated comment

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTableRow.svelte
@@ -105,9 +105,6 @@
   [role="row"] {
     @include interaction.tappable;
 
-    // If we use grid-template-areas, we need to specify all the areas.
-    // That makes it hard to have dynamic columns.
-    // Instead, we duplicate the actions. Once as the last cell, another within the title cell.
     display: grid;
     flex-direction: column;
     gap: var(--padding-2x);


### PR DESCRIPTION
# Motivation

In the `TokensTableRow` component there is a comment explaining why we duplicate the actions.
But we don't actually duplicate the actions so this comment shouldn't be there.

# Changes

Remove the comment.

# Tests

I checked with @lmuntaner who added it.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary