### PR TITLE
Actionable universe navigation

### DIFF
--- a/frontend/__mocks__/$app/stores.ts
+++ b/frontend/__mocks__/$app/stores.ts
@@ -25,7 +25,7 @@ const initPageStoreMock = () => {
       data = { universe: OWN_CANISTER_ID_TEXT },
     }: {
       routeId?: string;
-      data?: { universe: string | null } & Record<string, string>;
+      data?: { universe: string | null } & Record<string, string | boolean>;
     }) =>
       set({
         data,

--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -65,7 +65,8 @@
     {
       context: "proposals",
       href:
-        // Switch to actionable proposals page only when signed in to preserve the universe as the current behaviour.
+        // Switch to the actionable proposals page only when users are signed in.
+        // When users are signed out, we preserve the universe in the URL.
         $ENABLE_ACTIONABLE_TAB && $authSignedInStore
           ? ACTIONABLE_PROPOSALS_URL
           : $proposalsPathStore,

--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -19,9 +19,14 @@
     proposalsPathStore,
   } from "$lib/derived/paths.derived";
   import { pageStore } from "$lib/derived/page.derived";
-  import { isSelectedPath } from "$lib/utils/navigation.utils";
+  import {
+    ACTIONABLE_PROPOSALS_URL,
+    isSelectedPath,
+  } from "$lib/utils/navigation.utils";
   import MenuMetrics from "$lib/components/common/MenuMetrics.svelte";
   import ActionableProposalTotalCountBadge from "$lib/components/proposals/ActionableProposalTotalCountBadge.svelte";
+  import { ENABLE_ACTIONABLE_TAB } from "$lib/stores/feature-flags.store";
+  import { authSignedInStore } from "$lib/derived/auth.derived";
 
   let routes: {
     context: string;
@@ -59,7 +64,11 @@
     },
     {
       context: "proposals",
-      href: $proposalsPathStore,
+      href:
+        // Switch to actionable proposals page only when signed in to preserve the universe.
+        $ENABLE_ACTIONABLE_TAB && $authSignedInStore
+          ? ACTIONABLE_PROPOSALS_URL
+          : $proposalsPathStore,
       selected: isSelectedPath({
         currentPath: $pageStore.path,
         paths: [AppPath.Proposals, AppPath.Proposal],

--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -65,7 +65,7 @@
     {
       context: "proposals",
       href:
-        // Switch to actionable proposals page only when signed in to preserve the universe.
+        // Switch to actionable proposals page only when signed in to preserve the universe as the current behaviour.
         $ENABLE_ACTIONABLE_TAB && $authSignedInStore
           ? ACTIONABLE_PROPOSALS_URL
           : $proposalsPathStore,

--- a/frontend/src/lib/components/ui/Separator.svelte
+++ b/frontend/src/lib/components/ui/Separator.svelte
@@ -2,7 +2,11 @@
   export let spacing: "medium" | "large" | "none" = "large";
 </script>
 
-<hr class:medium={spacing === "medium"} class:no-margin={spacing === "none"} />
+<hr
+  data-tid="separator"
+  class:medium={spacing === "medium"}
+  class:no-margin={spacing === "none"}
+/>
 
 <style lang="scss">
   hr {

--- a/frontend/src/lib/components/ui/Separator.svelte
+++ b/frontend/src/lib/components/ui/Separator.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   export let spacing: "medium" | "large" | "none" = "large";
+  export let testId: string | undefined = undefined;
 </script>
 
 <hr
-  data-tid="separator"
+  data-tid={testId}
   class:medium={spacing === "medium"}
   class:no-margin={spacing === "none"}
 />

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -81,7 +81,7 @@
     >
       <span class="name">
         {#if universe === "all-actionable"}
-          {$i18n.voting.actionable_proposals}
+          <TestIdWrapper testId="universe-name">{$i18n.voting.actionable_proposals}</TestIdWrapper>
           {#if $actionableProposalIndicationEnabledStore}
             {#if $actionableProposalTotalCountStore > 0 && mounted}
               <div
@@ -95,7 +95,7 @@
             {/if}
           {/if}
         {:else}
-          {universe.title}
+          <TestIdWrapper testId="universe-name">{universe.title}</TestIdWrapper>
           {#if $actionableProposalIndicationEnabledStore}
             {#if nonNullish(actionableProposalCount) && actionableProposalCount > 0 && mounted}
               <ActionableProposalCountBadge

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -81,7 +81,9 @@
     >
       <span class="name">
         {#if universe === "all-actionable"}
-          <TestIdWrapper testId="universe-name">{$i18n.voting.actionable_proposals}</TestIdWrapper>
+          <TestIdWrapper testId="universe-name"
+            >{$i18n.voting.actionable_proposals}</TestIdWrapper
+          >
           {#if $actionableProposalIndicationEnabledStore}
             {#if $actionableProposalTotalCountStore > 0 && mounted}
               <div

--- a/frontend/src/lib/components/universe/SelectUniverseDropdown.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseDropdown.svelte
@@ -4,6 +4,10 @@
   import SelectUniverseCard from "$lib/components/universe/SelectUniverseCard.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import SelectUniverseModal from "$lib/modals/universe/SelectUniverseModal.svelte";
+  import { pageStore } from "$lib/derived/page.derived";
+  import { ENABLE_ACTIONABLE_TAB } from "$lib/stores/feature-flags.store";
+  import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { AppPath } from "$lib/constants/routes.constants";
 
   let showProjectPicker = false;
 
@@ -22,12 +26,29 @@
 <svelte:window bind:innerWidth />
 
 <TestIdWrapper testId="select-universe-dropdown-component">
-  <SelectUniverseCard
-    universe={$selectedUniverseStore}
-    selected={true}
-    role="dropdown"
-    on:click={() => (showProjectPicker = true)}
-  />
+  {#if $ENABLE_ACTIONABLE_TAB}
+    {#if $authSignedInStore && $pageStore.path === AppPath.Proposals && $pageStore.actionable}
+      <SelectUniverseCard
+        on:click={() => (showProjectPicker = true)}
+        selected={$pageStore.actionable}
+        universe="all-actionable"
+      />
+    {:else}
+      <SelectUniverseCard
+        universe={$selectedUniverseStore}
+        selected={true}
+        role="dropdown"
+        on:click={() => (showProjectPicker = true)}
+      />
+    {/if}
+  {:else}
+    <SelectUniverseCard
+      universe={$selectedUniverseStore}
+      selected={true}
+      role="dropdown"
+      on:click={() => (showProjectPicker = true)}
+    />
+  {/if}
 
   {#if showProjectPicker}
     <SelectUniverseModal on:nnsClose={() => (showProjectPicker = false)} />

--- a/frontend/src/lib/components/universe/SelectUniverseDropdown.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseDropdown.svelte
@@ -21,34 +21,24 @@
   };
 
   $: onWindowSizeChange(innerWidth);
+
+  let isActionableSelected = false;
+  $: isActionableSelected =
+    $ENABLE_ACTIONABLE_TAB &&
+    $authSignedInStore &&
+    $pageStore.path === AppPath.Proposals &&
+    $pageStore.actionable;
 </script>
 
 <svelte:window bind:innerWidth />
 
 <TestIdWrapper testId="select-universe-dropdown-component">
-  {#if $ENABLE_ACTIONABLE_TAB}
-    {#if $authSignedInStore && $pageStore.path === AppPath.Proposals && $pageStore.actionable}
-      <SelectUniverseCard
-        on:click={() => (showProjectPicker = true)}
-        selected={true}
-        universe="all-actionable"
-      />
-    {:else}
-      <SelectUniverseCard
-        universe={$selectedUniverseStore}
-        selected={true}
-        role="dropdown"
-        on:click={() => (showProjectPicker = true)}
-      />
-    {/if}
-  {:else}
-    <SelectUniverseCard
-      universe={$selectedUniverseStore}
-      selected={true}
-      role="dropdown"
-      on:click={() => (showProjectPicker = true)}
-    />
-  {/if}
+  <SelectUniverseCard
+    universe={isActionableSelected ? "all-actionable" : $selectedUniverseStore}
+    selected={true}
+    role="dropdown"
+    on:click={() => (showProjectPicker = true)}
+  />
 
   {#if showProjectPicker}
     <SelectUniverseModal on:nnsClose={() => (showProjectPicker = false)} />

--- a/frontend/src/lib/components/universe/SelectUniverseDropdown.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseDropdown.svelte
@@ -30,7 +30,7 @@
     {#if $authSignedInStore && $pageStore.path === AppPath.Proposals && $pageStore.actionable}
       <SelectUniverseCard
         on:click={() => (showProjectPicker = true)}
-        selected={$pageStore.actionable}
+        selected={true}
         universe="all-actionable"
       />
     {:else}

--- a/frontend/src/lib/components/universe/SelectUniverseList.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseList.svelte
@@ -14,7 +14,10 @@
 
   const dispatch = createEventDispatcher();
 
-  $: selectedUniverse = $ENABLE_ACTIONABLE_TAB && $pageStore.actionable ? "all-actionable" : $selectedUniverseIdStore.toText();
+  $: selectedUniverse =
+    $ENABLE_ACTIONABLE_TAB && $pageStore.actionable
+      ? "all-actionable"
+      : $selectedUniverseIdStore.toText();
 </script>
 
 <TestIdWrapper testId="select-universe-list-component">

--- a/frontend/src/lib/components/universe/SelectUniverseList.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseList.svelte
@@ -25,7 +25,7 @@
       selected={$pageStore.actionable}
       universe="all-actionable"
     />
-    <Separator spacing="medium" />
+    <Separator spacing="medium" testId="all-actionable-separator" />
   {/if}
 
   {#each $selectableUniversesStore as universe (universe.canisterId)}

--- a/frontend/src/lib/components/universe/SelectUniverseList.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseList.svelte
@@ -24,7 +24,7 @@
   {#if $ENABLE_ACTIONABLE_TAB && $authSignedInStore && $pageStore.path === AppPath.Proposals}
     <SelectUniverseCard
       on:click={() => dispatch("nnsSelectActionable")}
-      selected={selectedUniverse === "all-actionable"}
+      selected={"all-actionable" === selectedUniverse}
       universe="all-actionable"
     />
     <Separator spacing="medium" testId="all-actionable-separator" />

--- a/frontend/src/lib/components/universe/SelectUniverseList.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseList.svelte
@@ -18,7 +18,8 @@
   const dispatch = createEventDispatcher();
 
   let actionableProposalsSelected = false;
-  $: actionableProposalsSelected = $ENABLE_ACTIONABLE_TAB && $pageStore.actionable;
+  $: actionableProposalsSelected =
+    $ENABLE_ACTIONABLE_TAB && $pageStore.actionable;
 </script>
 
 <TestIdWrapper testId="select-universe-list-component">

--- a/frontend/src/lib/components/universe/SelectUniverseList.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseList.svelte
@@ -4,6 +4,11 @@
   import SelectUniverseCard from "$lib/components/universe/SelectUniverseCard.svelte";
   import { createEventDispatcher } from "svelte";
   import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived";
+  import { ENABLE_ACTIONABLE_TAB } from "$lib/stores/feature-flags.store";
+  import { pageStore } from "$lib/derived/page.derived";
+  import Separator from "$lib/components/ui/Separator.svelte";
+  import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { AppPath } from "$lib/constants/routes.constants";
 
   export let role: "link" | "button" = "link";
 
@@ -14,11 +19,21 @@
 </script>
 
 <TestIdWrapper testId="select-universe-list-component">
+  {#if $ENABLE_ACTIONABLE_TAB && $authSignedInStore && $pageStore.path === AppPath.Proposals}
+    <SelectUniverseCard
+      on:click={() => dispatch("nnsSelectActionable")}
+      selected={$pageStore.actionable}
+      universe="all-actionable"
+    />
+    <Separator spacing="medium" />
+  {/if}
+
   {#each $selectableUniversesStore as universe (universe.canisterId)}
     <SelectUniverseCard
       {universe}
       {role}
-      selected={universe.canisterId === selectedCanisterId}
+      selected={!($ENABLE_ACTIONABLE_TAB && $pageStore.actionable) &&
+        universe.canisterId === selectedCanisterId}
       on:click={() => dispatch("nnsSelectUniverse", universe.canisterId)}
     />
   {/each}

--- a/frontend/src/lib/components/universe/SelectUniverseList.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseList.svelte
@@ -24,7 +24,7 @@
   {#if $ENABLE_ACTIONABLE_TAB && $authSignedInStore && $pageStore.path === AppPath.Proposals}
     <SelectUniverseCard
       on:click={() => dispatch("nnsSelectActionable")}
-      selected={$pageStore.actionable}
+      selected={selectedUniverse === "all-actionable"}
       universe="all-actionable"
     />
     <Separator spacing="medium" testId="all-actionable-separator" />

--- a/frontend/src/lib/components/universe/SelectUniverseList.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseList.svelte
@@ -16,6 +16,9 @@
   $: selectedCanisterId = $selectedUniverseIdStore.toText();
 
   const dispatch = createEventDispatcher();
+
+  let actionableProposalsSelected = false;
+  $: actionableProposalsSelected = $ENABLE_ACTIONABLE_TAB && $pageStore.actionable;
 </script>
 
 <TestIdWrapper testId="select-universe-list-component">
@@ -32,7 +35,7 @@
     <SelectUniverseCard
       {universe}
       {role}
-      selected={!($ENABLE_ACTIONABLE_TAB && $pageStore.actionable) &&
+      selected={!actionableProposalsSelected &&
         universe.canisterId === selectedCanisterId}
       on:click={() => dispatch("nnsSelectUniverse", universe.canisterId)}
     />

--- a/frontend/src/lib/components/universe/SelectUniverseList.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseList.svelte
@@ -15,7 +15,7 @@
   const dispatch = createEventDispatcher();
 
   $: selectedUniverse =
-    $ENABLE_ACTIONABLE_TAB && $pageStore.actionable
+    $ENABLE_ACTIONABLE_TAB && $authSignedInStore && $pageStore.actionable
       ? "all-actionable"
       : $selectedUniverseIdStore.toText();
 </script>

--- a/frontend/src/lib/components/universe/SelectUniverseList.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseList.svelte
@@ -12,14 +12,9 @@
 
   export let role: "link" | "button" = "link";
 
-  let selectedCanisterId: string;
-  $: selectedCanisterId = $selectedUniverseIdStore.toText();
-
   const dispatch = createEventDispatcher();
 
-  let actionableProposalsSelected = false;
-  $: actionableProposalsSelected =
-    $ENABLE_ACTIONABLE_TAB && $pageStore.actionable;
+  $: selectedUniverse = $ENABLE_ACTIONABLE_TAB && $pageStore.actionable ? "all-actionable" : $selectedUniverseIdStore.toText();
 </script>
 
 <TestIdWrapper testId="select-universe-list-component">
@@ -36,8 +31,7 @@
     <SelectUniverseCard
       {universe}
       {role}
-      selected={!actionableProposalsSelected &&
-        universe.canisterId === selectedCanisterId}
+      selected={universe.canisterId === selectedUniverse}
       on:click={() => dispatch("nnsSelectUniverse", universe.canisterId)}
     />
   {/each}

--- a/frontend/src/lib/components/universe/SelectUniverseNavList.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseNavList.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
   import SelectUniverseList from "$lib/components/universe/SelectUniverseList.svelte";
   import { goto } from "$app/navigation";
-  import { buildSwitchUniverseUrl } from "$lib/utils/navigation.utils";
+  import {
+    ACTIONABLE_PROPOSALS_URL,
+    buildSwitchUniverseUrl,
+  } from "$lib/utils/navigation.utils";
 </script>
 
 <SelectUniverseList
   on:nnsSelectUniverse={async ({ detail }) =>
     await goto(buildSwitchUniverseUrl(detail))}
+  on:nnsSelectActionable={async () => await goto(ACTIONABLE_PROPOSALS_URL)}
 />

--- a/frontend/src/lib/modals/universe/SelectUniverseModal.svelte
+++ b/frontend/src/lib/modals/universe/SelectUniverseModal.svelte
@@ -3,7 +3,10 @@
   import SelectUniverseList from "$lib/components/universe/SelectUniverseList.svelte";
   import { createEventDispatcher } from "svelte";
   import { goto } from "$app/navigation";
-  import { buildSwitchUniverseUrl } from "$lib/utils/navigation.utils";
+  import {
+    ACTIONABLE_PROPOSALS_URL,
+    buildSwitchUniverseUrl,
+  } from "$lib/utils/navigation.utils";
   import { titleTokenSelectorStore } from "$lib/derived/title-token-selector.derived";
 
   const dispatcher = createEventDispatcher();
@@ -11,6 +14,11 @@
 
   const select = async (canisterId: string) => {
     await goto(buildSwitchUniverseUrl(canisterId));
+    close();
+  };
+
+  const selectActionable = async () => {
+    await goto(ACTIONABLE_PROPOSALS_URL);
     close();
   };
 </script>
@@ -24,6 +32,7 @@
     <SelectUniverseList
       role="button"
       on:nnsSelectUniverse={({ detail }) => select(detail)}
+      on:nnsSelectActionable={() => selectActionable()}
     />
   </Modal>
 </div>

--- a/frontend/src/lib/pages/ActionableProposals.svelte
+++ b/frontend/src/lib/pages/ActionableProposals.svelte
@@ -1,0 +1,4 @@
+<script lang="ts">
+</script>
+
+<h1>Under construction</h1>

--- a/frontend/src/lib/pages/ActionableProposals.svelte
+++ b/frontend/src/lib/pages/ActionableProposals.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 </script>
 
-<h1>Under construction</h1>
+<TestIdWrapper testId="actionable-proposals-component">
+  <h1>Under construction</h1>
+</TestIdWrapper>

--- a/frontend/src/lib/pages/ActionableProposals.svelte
+++ b/frontend/src/lib/pages/ActionableProposals.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 </script>
 
 <TestIdWrapper testId="actionable-proposals-component">

--- a/frontend/src/lib/routes/Proposals.svelte
+++ b/frontend/src/lib/routes/Proposals.svelte
@@ -5,14 +5,23 @@
   import SummaryUniverse from "$lib/components/summary/SummaryUniverse.svelte";
   import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
   import { nonNullish } from "@dfinity/utils";
+  import { pageStore } from "$lib/derived/page.derived";
+  import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { ENABLE_ACTIONABLE_TAB } from "$lib/stores/feature-flags.store";
+  import { onMount } from "svelte";
+  import ActionableProposals from "$lib/pages/ActionableProposals.svelte";
 </script>
 
 <main data-tid="proposals-component">
-  <SummaryUniverse />
+  {#if $ENABLE_ACTIONABLE_TAB && $authSignedInStore && $pageStore.actionable}
+    <ActionableProposals />
+  {:else}
+    <SummaryUniverse />
 
-  {#if $isNnsUniverseStore}
-    <Proposals />
-  {:else if nonNullish($snsProjectSelectedStore)}
-    <SnsProposals />
+    {#if $isNnsUniverseStore}
+      <Proposals />
+    {:else if nonNullish($snsProjectSelectedStore)}
+      <SnsProposals />
+    {/if}
   {/if}
 </main>

--- a/frontend/src/lib/routes/Proposals.svelte
+++ b/frontend/src/lib/routes/Proposals.svelte
@@ -8,7 +8,6 @@
   import { pageStore } from "$lib/derived/page.derived";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { ENABLE_ACTIONABLE_TAB } from "$lib/stores/feature-flags.store";
-  import { onMount } from "svelte";
   import ActionableProposals from "$lib/pages/ActionableProposals.svelte";
 </script>
 

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -111,7 +111,6 @@ describe("MenuItems", () => {
     });
 
     it("should have default proposal link when signedOut", async () => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_ACTIONABLE_TAB", true);
       setNoIdentity();
       page.mock({
         data: { universe: OWN_CANISTER_ID_TEXT },
@@ -126,6 +125,7 @@ describe("MenuItems", () => {
     });
 
     it("should have default proposal link when no feature flag set", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_ACTIONABLE_TAB", false);
       resetIdentity();
       page.mock({
         data: { universe: OWN_CANISTER_ID_TEXT },

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -111,6 +111,7 @@ describe("MenuItems", () => {
     });
 
     it("should have default proposal link when signedOut", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_ACTIONABLE_TAB", true);
       setNoIdentity();
       page.mock({
         data: { universe: OWN_CANISTER_ID_TEXT },

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -5,7 +5,7 @@ import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposal
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { page } from "$mocks/$app/stores";
-import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
@@ -36,15 +36,20 @@ describe("MenuItems", () => {
   const shouldRenderMenuItem = ({
     context,
     labelKey,
+    href,
   }: {
     context: string;
     labelKey: string;
+    href?: string;
   }) => {
     const { getByTestId } = render(MenuItems);
     const link = getByTestId(`menuitem-${context}`) as HTMLElement;
     expect(link).not.toBeNull();
     expect(link).toBeVisible();
     expect(link.textContent?.trim()).toEqual(en.navigation[labelKey]);
+    if (href) {
+      expect(link.getAttribute("href")).toEqual(href);
+    }
   };
 
   beforeEach(() => {
@@ -86,6 +91,56 @@ describe("MenuItems", () => {
 
       const accountsLink = getByTestId("menuitem-accounts");
       expect(accountsLink.classList.contains("selected")).toBe(true);
+    });
+  });
+
+  describe("actionable proposal link", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.reset();
+    });
+
+    it("should have actionable proposal link", async () => {
+      resetIdentity();
+      overrideFeatureFlagsStore.setFlag("ENABLE_ACTIONABLE_TAB", true);
+      page.mock({
+        data: { universe: OWN_CANISTER_ID_TEXT },
+        routeId: AppPath.Proposals,
+      });
+
+      shouldRenderMenuItem({
+        context: "proposals",
+        labelKey: "voting",
+        href: "/proposals/?actionable",
+      });
+    });
+
+    it("should have default proposal link when signedOut", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_ACTIONABLE_TAB", true);
+      setNoIdentity();
+      page.mock({
+        data: { universe: OWN_CANISTER_ID_TEXT },
+        routeId: AppPath.Proposals,
+      });
+
+      shouldRenderMenuItem({
+        context: "proposals",
+        labelKey: "voting",
+        href: "/proposals/?u=qhbym-qaaaa-aaaaa-aaafq-cai",
+      });
+    });
+
+    it("should have default proposal link when no feature flag set", async () => {
+      resetIdentity();
+      page.mock({
+        data: { universe: OWN_CANISTER_ID_TEXT },
+        routeId: AppPath.Proposals,
+      });
+
+      shouldRenderMenuItem({
+        context: "proposals",
+        labelKey: "voting",
+        href: "/proposals/?u=qhbym-qaaaa-aaaaa-aaafq-cai",
+      });
     });
   });
 

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -95,10 +95,6 @@ describe("MenuItems", () => {
   });
 
   describe("actionable proposal link", () => {
-    beforeEach(() => {
-      overrideFeatureFlagsStore.reset();
-    });
-
     it("should have actionable proposal link", async () => {
       resetIdentity();
       overrideFeatureFlagsStore.setFlag("ENABLE_ACTIONABLE_TAB", true);

--- a/frontend/src/tests/lib/components/universe/SelectUniverseDropdown.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseDropdown.spec.ts
@@ -1,7 +1,9 @@
 import SelectUniverseDropdown from "$lib/components/universe/SelectUniverseDropdown.svelte";
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { snsProjectSelectedStore } from "$lib/derived/sns/sns-selected-project.derived";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { page } from "$mocks/$app/stores";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
@@ -34,6 +36,7 @@ describe("SelectUniverseDropdown", () => {
     icrcAccountsStore.reset();
     resetSnsProjects();
     resetIdentity();
+    overrideFeatureFlagsStore.reset();
 
     page.mock({
       data: { universe: mockSnsFullProject.rootCanisterId.toText() },
@@ -75,6 +78,25 @@ describe("SelectUniverseDropdown", () => {
           .getUniverseAccountsBalancePo()
           .isLoading()
       ).toBe(true);
+    });
+  });
+
+  describe('"all actionable" card', () => {
+    beforeEach(() => {
+      page.mock({
+        data: { universe: OWN_CANISTER_ID_TEXT, actionable: true },
+        routeId: AppPath.Proposals,
+      });
+    });
+
+    it('should render "Actionable proposals" card', async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_ACTIONABLE_TAB", true);
+      resetIdentity();
+      const po = renderComponent();
+      expect(await po.getSelectUniverseCardPo().getName()).toEqual(
+        "Actionable Proposals"
+      );
+      expect(await po.getSelectUniverseCardPo().isSelected()).toEqual(true);
     });
   });
 

--- a/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
@@ -112,9 +112,7 @@ describe("SelectUniverseList", () => {
       const cardPos = await po.getSelectUniverseCardPos();
       // +1 for IC and +1 for "Actionable Proposals" entry
       expect(cardPos.length).toEqual(projects.length + 2);
-      expect((await cardPos[0].getText()).trim()).toEqual(
-        "Actionable Proposals"
-      );
+      expect(await cardPos[0].getText()).toEqual("Actionable Proposals");
       expect(await po.hasSeparator()).toEqual(true);
     });
 
@@ -128,9 +126,7 @@ describe("SelectUniverseList", () => {
 
       const po = renderComponent();
       const cardPos = await po.getSelectUniverseCardPos();
-      const titles = (
-        await Promise.all(cardPos.map((card) => card.getText()))
-      ).map((text) => text.trim());
+      const titles = await Promise.all(cardPos.map((card) => card.getText()));
       // +1 for IC
       expect(cardPos.length).toEqual(projects.length + 1);
       expect(titles.includes("Actionable Proposals")).toEqual(false);

--- a/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
@@ -112,7 +112,7 @@ describe("SelectUniverseList", () => {
       const cardPos = await po.getSelectUniverseCardPos();
       // +1 for IC and +1 for "Actionable Proposals" entry
       expect(cardPos.length).toEqual(projects.length + 2);
-      expect(await cardPos[0].getText()).toEqual("Actionable Proposals");
+      expect(await cardPos[0].getName()).toEqual("Actionable Proposals");
       expect(await po.hasSeparator()).toEqual(true);
     });
 
@@ -126,7 +126,7 @@ describe("SelectUniverseList", () => {
 
       const po = renderComponent();
       const cardPos = await po.getSelectUniverseCardPos();
-      const titles = await Promise.all(cardPos.map((card) => card.getText()));
+      const titles = await Promise.all(cardPos.map((card) => card.getName()));
       // +1 for IC
       expect(cardPos.length).toEqual(projects.length + 1);
       expect(titles.includes("Actionable Proposals")).toEqual(false);

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
@@ -91,12 +91,13 @@ describe("SelectUniverseNav", () => {
     // open project list
     await po.getSelectUniverseCardPo().click();
     expect(await po.getSelectUniverseListPo().isPresent()).toBe(true);
-    // nns is the first card
+    // "All proposals" is the first card
     const cardPos = await po
       .getSelectUniverseListPo()
       .getSelectUniverseCardPos();
-    expect(cardPos.length).toEqual(2);
-    expect((await cardPos[0].getActionableProposalCount()).trim()).toEqual("1");
-    expect((await cardPos[1].getActionableProposalCount()).trim()).toEqual("2");
+    expect(cardPos.length).toEqual(3);
+    // nns is the second card
+    expect((await cardPos[1].getActionableProposalCount()).trim()).toEqual("1");
+    expect((await cardPos[2].getActionableProposalCount()).trim()).toEqual("2");
   });
 });

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
@@ -98,5 +98,8 @@ describe("SelectUniverseNav", () => {
     expect(cardPos.length).toEqual(3);
     // nns is the second card
     expect(await cardPos[1].getName()).toEqual("Internet Computer");
+    expect((await cardPos[1].getActionableProposalCount()).trim()).toEqual("1");
+    expect(await cardPos[2].getName()).toEqual("Catalyze");
+    expect((await cardPos[2].getActionableProposalCount()).trim()).toEqual("2");
   });
 });

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
@@ -97,7 +97,6 @@ describe("SelectUniverseNav", () => {
       .getSelectUniverseCardPos();
     expect(cardPos.length).toEqual(3);
     // nns is the second card
-    expect((await cardPos[1].getActionableProposalCount()).trim()).toEqual("1");
-    expect((await cardPos[2].getActionableProposalCount()).trim()).toEqual("2");
+    expect(await cardPos[1].getName()).toEqual("Internet Computer");
   });
 });

--- a/frontend/src/tests/lib/routes/Proposals.spec.ts
+++ b/frontend/src/tests/lib/routes/Proposals.spec.ts
@@ -1,12 +1,17 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { AppPath } from "$lib/constants/routes.constants";
 import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import Proposals from "$lib/routes/Proposals.svelte";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { page } from "$mocks/$app/stores";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockProjectSubscribe,
   mockSnsFullProject,
 } from "$tests/mocks/sns-projects.mock";
-import { render } from "@testing-library/svelte";
+import { ProposalsPo } from "$tests/page-objects/Proposals.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
 
 vi.mock("$lib/services/$public/proposals.services", () => {
   return {
@@ -35,5 +40,44 @@ describe("Proposals", () => {
   it("should render NnsProposals by default", () => {
     const { queryByTestId } = render(Proposals);
     expect(queryByTestId("nns-proposal-list-component")).toBeInTheDocument();
+  });
+
+  describe("with ENABLE_ACTIONABLE_TAB", () => {
+    const renderComponent = () => {
+      const { container } = render(Proposals);
+      return ProposalsPo.under(new JestPageObjectElement(container));
+    };
+
+    beforeEach(() => {
+      page.reset();
+      overrideFeatureFlagsStore.setFlag("ENABLE_ACTIONABLE_TAB", true);
+    });
+
+    it('should display actionable proposals when "actionable" in URL', async () => {
+      resetIdentity();
+      page.mock({
+        data: {
+          universe: OWN_CANISTER_ID_TEXT,
+          routeId: AppPath.Proposals,
+          actionable: true,
+        },
+      });
+
+      const po = renderComponent();
+      expect(await po.getActionableProposalsPo().isPresent()).toBe(true);
+    });
+
+    it('should no display actionable proposals when not "actionable" in URL', async () => {
+      resetIdentity();
+      page.mock({
+        data: {
+          universe: OWN_CANISTER_ID_TEXT,
+          routeId: AppPath.Proposals,
+        },
+      });
+
+      const po = renderComponent();
+      expect(await po.getActionableProposalsPo().isPresent()).toBe(false);
+    });
   });
 });

--- a/frontend/src/tests/page-objects/ActionableProposals.page-object.ts
+++ b/frontend/src/tests/page-objects/ActionableProposals.page-object.ts
@@ -1,0 +1,12 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ActionableProposalsPo extends BasePageObject {
+  private static readonly TID = "actionable-proposals-component";
+
+  static under(element: PageObjectElement): ActionableProposalsPo {
+    return new ActionableProposalsPo(
+      element.byTestId(ActionableProposalsPo.TID)
+    );
+  }
+}

--- a/frontend/src/tests/page-objects/Proposals.page-object.ts
+++ b/frontend/src/tests/page-objects/Proposals.page-object.ts
@@ -1,3 +1,4 @@
+import { ActionableProposalsPo } from "$tests/page-objects/ActionableProposals.page-object";
 import { NnsProposalFiltersPo } from "$tests/page-objects/NnsProposalFilters.page-object";
 import { NnsProposalListPo } from "$tests/page-objects/NnsProposalList.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
@@ -20,5 +21,9 @@ export class ProposalsPo extends BasePageObject {
 
   getNnsProposalFiltersPo(): NnsProposalFiltersPo {
     return NnsProposalFiltersPo.under(this.root);
+  }
+
+  getActionableProposalsPo(): ActionableProposalsPo {
+    return ActionableProposalsPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
@@ -44,7 +44,7 @@ export class SelectUniverseCardPo extends CardPo {
   }
 
   async getName(): Promise<string> {
-    return (await this.root.querySelector("span.name").getText()).trim();
+    return this.getText("universe-name");
   }
 
   getLogoAltText(): Promise<string> {

--- a/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
@@ -78,4 +78,8 @@ export class SelectUniverseCardPo extends CardPo {
   getActionableProposalCount(): Promise<string> {
     return this.getActionableProposalCountBadgePo().getText();
   }
+
+  hasVoteIcon(): Promise<boolean> {
+    return this.root.querySelector('[data-tid="vote-icon"]').isPresent();
+  }
 }

--- a/frontend/src/tests/page-objects/SelectUniverseList.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectUniverseList.page-object.ts
@@ -22,6 +22,10 @@ export class SelectUniverseListPo extends BasePageObject {
     return SelectUniverseCardPo.allUnder(this.root);
   }
 
+  hasSeparator(): Promise<boolean> {
+    return this.isPresent("all-actionable-separator");
+  }
+
   isSnsName(name: string): boolean {
     return !SelectUniverseListPo.NON_SNS_NAMES.includes(name);
   }

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -44,7 +44,7 @@ vi.mock("./src/lib/utils/env-vars.utils.ts", () => ({
       ENABLE_CKUSDC: true,
       TEST_FLAG_EDITABLE: true,
       TEST_FLAG_NOT_EDITABLE: true,
-      ENABLE_ACTIONABLE_TAB: false,
+      ENABLE_ACTIONABLE_TAB: true,
     }),
     fetchRootKey: "false",
     host: "https://icp-api.io",

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -44,6 +44,7 @@ vi.mock("./src/lib/utils/env-vars.utils.ts", () => ({
       ENABLE_CKUSDC: true,
       TEST_FLAG_EDITABLE: true,
       TEST_FLAG_NOT_EDITABLE: true,
+      ENABLE_ACTIONABLE_TAB: false,
     }),
     fetchRootKey: "false",
     host: "https://icp-api.io",


### PR DESCRIPTION
# Motivation

The `Actionable Proposals` page should be shown when the user clicks `Voting` in the main navigation or when the `Actionable Proposals` card in the universe navigation is clicked. With this PR, we add the card to the universe navigation and update the main navigation link to navigate to “Actionable Proposals” when the user is logged-in.
There should be no actionable proposals visible for logged-out users.

# Changes

- Update main menu proposals link to navigate to "Actionable proposals".
- Add empty component for "Actionable proposals" page.
- Add "Actionable proposals" card to `SelectUniverseList` (Desktop. The card is always visible with the separator).
- Add "Actionable proposals" card to `SelectUniverseDropdown` (Mobile. The card is shown only when selected, w/o the separator).

# Tests

- Add `testId` param to Separator component.
- Add `ENABLE_ACTIONABLE_TAB` to `vites.setup` to rewrite it in the unit tests w/o a error.
- Update mock page store to support boolean parameters values (for `actionable`).
- Add test id to the `Separator` component.
- Add PO for `ActionableProposals` empty page.
- Tested manually that the actionable page is reachable.
- Should display "Actionable proposals" card in 

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet

# Screenshot

| Mobile | Desktop |
|--------|--------|
| <img width="269" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/fd98fbcb-3d53-4da5-98c5-bebfb32c492d"> | <img width="616" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/3f3b9444-66db-42b7-bebd-c3e163ac3e89"> | 





