### PR TITLE
Add missing canister ids to expected test data.

### DIFF
--- a/frontend/src/tests/lib/utils/env-vars.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/env-vars.utils.spec.ts
@@ -45,6 +45,8 @@ describe("env-vars-utils", () => {
     ckbtcMinterCanisterId: "o66jk-a4aaa-aaaaa-qabfq-cai",
     ckethIndexCanisterId: "of3vp-2eaaa-aaaaa-qabha-cai",
     ckethLedgerCanisterId: "omy6t-mmaaa-aaaaa-qabgq-cai",
+    ckusdcIndexCanisterId: "myg3h-jmaaa-aaaaa-qabiq-cai",
+    ckusdcLedgerCanisterId: "m7h5t-euaaa-aaaaa-qabia-cai",
     cyclesMintingCanisterId: "rkp4c-7iaaa-aaaaa-aaaca-cai",
     dfxNetwork: "local",
     featureFlags:


### PR DESCRIPTION
# Motivation

We need to have the same IDs both in test environment and in the expected test data.

# Changes

- Add `ckusdcIndexCanisterId` to `defaultExpectedEnvVars`.
- Add `ckusdcLedgerCanisterId` to `defaultExpectedEnvVars`.

# Tests

Pass.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary