### PR TITLE
Remove existing environment in env-vars.utils.spec.ts

### DIFF
--- a/frontend/src/tests/lib/utils/env-vars.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/env-vars.utils.spec.ts
@@ -7,6 +7,10 @@ vi.unmock("$lib/utils/env-vars.utils");
 
 describe("env-vars-utils", () => {
   beforeEach(() => {
+    // Make sure no non-stubbed environment variables are present
+    for (const envVar of Object.keys(import.meta.env)) {
+      vi.stubEnv(envVar, "");
+    }
     vi.stubEnv("VITE_DFX_NETWORK", "local");
     vi.stubEnv(
       "VITE_CYCLES_MINTING_CANISTER_ID",


### PR DESCRIPTION
# Motivation

Unit tests can depend on environment variables set in `frontend/.env` which can be different depending on how `./config.sh` is run.
In `frontend/src/tests/lib/utils/env-vars.utils.spec.ts` we stub out environment variables that we expect to read, but additional environment variables could potentially affect the test as well.

Currently, the following
```
DFX_NETWORK=mainnet ./config.sh
npm run test -- env-vars
```
fails with
```
 FAIL  src/tests/lib/utils/env-vars.utils.spec.ts > env-vars-utils > TVL canister ID is not mandatory
AssertionError: expected { …(20) } to deeply equal { …(18) }

- Expected
+ Received

  Object {
    "ckbtcIndexCanisterId": "olzyh-buaaa-aaaaa-qabga-cai",
    "ckbtcLedgerCanisterId": "oz7p6-neaaa-aaaaa-qabfa-cai",
    "ckbtcMinterCanisterId": "o66jk-a4aaa-aaaaa-qabfq-cai",
    "ckethIndexCanisterId": "of3vp-2eaaa-aaaaa-qabha-cai",
    "ckethLedgerCanisterId": "omy6t-mmaaa-aaaaa-qabgq-cai",
+   "ckusdcIndexCanisterId": "xrs4b-hiaaa-aaaar-qafoa-cai",
+   "ckusdcLedgerCanisterId": "xevnm-gaaaa-aaaar-qafnq-cai",
    "cyclesMintingCanisterId": "rkp4c-7iaaa-aaaaa-aaaca-cai",
    "dfxNetwork": "local",
    "featureFlags": "{\"ENABLE_CKBTC\":true,\"ENABLE_CKTESTBTC\":false,\"ENABLE_SNS\":true,\"ENABLE_SNS_2\":true,\"ENABLE_VOTING_INDICATION\":false}",
    "fetchRootKey": "true",
    "governanceCanisterId": "rrkah-fqaaa-aaaaa-aaaaq-cai",
    "host": "http://localhost:8080",
    "identityServiceUrl": "http://qhbym-qaaaa-aaaaa-aaafq-cai.localhost:8080",
    "indexCanisterId": "mecbw-6maaa-aaaaa-qabkq-cai",
    "ledgerCanisterId": "ryjl3-tyaaa-aaaaa-aaaba-cai",
    "ownCanisterId": "qsgjb-riaaa-aaaaa-aaaga-cai",
    "snsAggregatorUrl": "http://bd3sg-teaaa-aaaaa-qaaba-cai.localhost:8080",
    "tvlCanisterId": undefined,
    "wasmCanisterId": "qaa6y-5yaaa-aaaaa-aaafa-cai",
  }

 ❯ src/tests/lib/utils/env-vars.utils.spec.ts:116:26
    114|   it("TVL canister ID is not mandatory", () => {
    115|     vi.stubEnv("VITE_TVL_CANISTER_ID", "");
    116|     expect(getEnvVars()).toEqual({
       |                          ^
    117|       ...defaultExpectedEnvVars,
    118|       tvlCanisterId: undefined,

⎯⎯⎯⎯
```

# Changes

In `frontend/src/tests/lib/utils/env-vars.utils.spec.ts` unset all existing environment variables before stubbing a specific set of variables.

# Tests

Ran
```
DFX_NETWORK=mainnet ./config.sh
npm run test -- env-vars
```
which fails before this change and passes after.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary