### PR TITLE
Downgrade rust from 1.78 to 1.77

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -34,6 +34,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Security
 
+* Downgrade to Rust `1.77.2`.
+
 #### Not Published
 
 * Support `ckUSDC` behind a feature flag.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Please, from time to time, update this to the latest stable version on Rust Forge: https://forge.rust-lang.org/
-channel = "1.78.0"
+channel = "1.77.2"
 components = ["rustfmt", "clippy"]
 targets = [ "wasm32-unknown-unknown"]


### PR DESCRIPTION
# Motivation

There is a bug in Rust 1.78: https://github.com/rustwasm/wasm-bindgen/issues/3801
I'm not sure if it affects us but better safe than sorry.

# Changes

Go back to the version of Rust (1.77.2) we were using before https://github.com/dfinity/nns-dapp/pull/4822

# Tests

CI

# Todos

- [x] Add entry to changelog (if necessary).
