### PR TITLE
Remove data-title from TokensTableRow

### DIFF
--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -17,7 +17,7 @@ test("Test accounts requirements", async ({ page, context }) => {
   const accountsPo = appPo.getAccountsPo();
   const nnsAccountsPo = accountsPo.getNnsAccountsPo();
   const tokensTablePo = nnsAccountsPo.getTokensTablePo();
-  const mainAccountRow = tokensTablePo.getRowByName(mainAccountName);
+  const mainAccountRow = await tokensTablePo.getRowByName(mainAccountName);
   await mainAccountRow.waitFor();
 
   step("AU002: The user MUST be able to create an additional account");
@@ -41,7 +41,7 @@ test("Test accounts requirements", async ({ page, context }) => {
   // We wait until the table is loaded.
   await tokensTablePo.waitFor();
   // We wait until the subaccount row is loaded.
-  const subaccountRow = tokensTablePo.getRowByName(subAccountName);
+  const subaccountRow = await tokensTablePo.getRowByName(subAccountName);
   await subaccountRow.waitFor();
 
   expect(await accountNames()).toEqual([mainAccountName, subAccountName]);
@@ -51,7 +51,7 @@ test("Test accounts requirements", async ({ page, context }) => {
   // Get some ICP to be able to transfer
   await appPo.getIcpTokens(20);
   // Go back to /accounts page
-  const icRow = appPo
+  const icRow = await appPo
     .getTokensPo()
     .getTokensPagePo()
     .getTokensTable()

--- a/frontend/src/tests/e2e/disburse.spec.ts
+++ b/frontend/src/tests/e2e/disburse.spec.ts
@@ -26,7 +26,7 @@ test("Test disburse neuron", async ({ page, context }) => {
 
   step("Check account balance before disburse");
   await appPo.goToAccounts();
-  const icpRowBeforeDisburse = appPo
+  const icpRowBeforeDisburse = await appPo
     .getTokensPo()
     .getTokensPagePo()
     .getTokensTable()
@@ -49,7 +49,7 @@ test("Test disburse neuron", async ({ page, context }) => {
 
   step("Check account balance after disburse");
   await appPo.goToAccounts();
-  const icpRowAfterDisburse = appPo
+  const icpRowAfterDisburse = await appPo
     .getTokensPo()
     .getTokensPagePo()
     .getTokensTable()

--- a/frontend/src/tests/page-objects/Accounts.page-object.ts
+++ b/frontend/src/tests/page-objects/Accounts.page-object.ts
@@ -47,7 +47,7 @@ export class AccountsPo extends BasePageObject {
   }
 
   async getAccountAddress(accountName: string): Promise<string> {
-    const row = this.getNnsAccountsPo()
+    const row = await this.getNnsAccountsPo()
       .getTokensTablePo()
       .getRowByName(accountName);
     await row.clickReceive();

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -124,16 +124,18 @@ export class AppPo extends BasePageObject {
 
   async goToNnsMainAccountWallet(): Promise<void> {
     await this.goToAccounts();
-    await this.getTokensPo()
-      .getTokensPagePo()
-      .getTokensTable()
-      .getRowByName("Internet Computer")
-      .click();
-    await this.getAccountsPo()
-      .getNnsAccountsPo()
-      .getTokensTablePo()
-      .getRowByName("Main")
-      .click();
+    await (
+      await this.getTokensPo()
+        .getTokensPagePo()
+        .getTokensTable()
+        .getRowByName("Internet Computer")
+    ).click();
+    await (
+      await this.getAccountsPo()
+        .getNnsAccountsPo()
+        .getTokensTablePo()
+        .getRowByName("Main")
+    ).click();
   }
 
   async goToNeurons(): Promise<void> {

--- a/frontend/src/tests/page-objects/TokensTable.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTable.page-object.ts
@@ -47,13 +47,21 @@ export class TokensTablePo extends BasePageObject {
   async getRowByName(
     projectName: string
   ): Promise<TokensTableRowPo | undefined> {
-    await this.waitFor();
-    const rows = await this.getRows();
-    for (const row of rows) {
-      const name = await row.getProjectName();
-      if (name === projectName) {
-        return row;
+    while (true) {
+      const rows = await this.getRows();
+      for (const row of rows) {
+        const name = await row.getProjectName();
+        if (name === projectName) {
+          return row;
+        }
       }
+
+      // If we didn't find the row, wait for more rows to load and try again.
+      const moreRows = TokensTableRowPo.countUnder({
+        element: this.root,
+        count: rows.length + 1,
+      });
+      await moreRows.at(-1).waitFor();
     }
   }
 

--- a/frontend/src/tests/page-objects/TokensTable.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTable.page-object.ts
@@ -44,8 +44,17 @@ export class TokensTablePo extends BasePageObject {
     return Promise.all(rows.map((row) => row.getData()));
   }
 
-  getRowByName(projectName: string): TokensTableRowPo | undefined {
-    return TokensTableRowPo.byTitle({ element: this.root, title: projectName });
+  async getRowByName(
+    projectName: string
+  ): Promise<TokensTableRowPo | undefined> {
+    await this.waitFor();
+    const rows = await this.getRows();
+    for (const row of rows) {
+      const name = await row.getProjectName();
+      if (name === projectName) {
+        return row;
+      }
+    }
   }
 
   async getRowData(projectName: string): Promise<TokensTableRowData> {

--- a/frontend/src/tests/page-objects/TokensTable.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTable.page-object.ts
@@ -44,10 +44,8 @@ export class TokensTablePo extends BasePageObject {
     return Promise.all(rows.map((row) => row.getData()));
   }
 
-  async getRowByName(
-    projectName: string
-  ): Promise<TokensTableRowPo | undefined> {
-    while (true) {
+  async getRowByName(projectName: string): Promise<TokensTableRowPo> {
+    for (;;) {
       const rows = await this.getRows();
       for (const row of rows) {
         const name = await row.getProjectName();

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -529,17 +529,17 @@ describe("Tokens route", () => {
 
         const tablePo = po.getSignInTokensPagePo().getTokensTablePo();
 
-        const icpRow = tablePo.getRowByName("Internet Computer");
+        const icpRow = await tablePo.getRowByName("Internet Computer");
         expect(await icpRow.getHref()).toEqual(
           `/accounts/?u=${OWN_CANISTER_ID_TEXT}`
         );
 
-        const snsRow = tablePo.getRowByName("Tetris");
+        const snsRow = await tablePo.getRowByName("Tetris");
         expect(await snsRow.getHref()).toEqual(
           `/wallet/?u=${rootCanisterIdTetris.toText()}`
         );
 
-        const ckEthRow = tablePo.getRowByName("ckETH");
+        const ckEthRow = await tablePo.getRowByName("ckETH");
         expect(await ckEthRow.getHref()).toEqual(
           `/wallet/?u=${CKETH_UNIVERSE_CANISTER_ID.toText()}`
         );


### PR DESCRIPTION
# Motivation

Having an attribute on the `TokensTableRow` which is specific to the tokens data makes it more difficult to make the table generic so it can be reused for the neurons table.
This attribute was only used for testing.

# Changes

1. Remove `data-title` attribute.
2. Instead of using the `data-title` attribute to find a specific row, iterate over the rows and return the one that matches.
3. Use `await` where necessary because the method now has to be async.

# Tests

Pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary