### PR TITLE
Update snsdemo to release-2024-05-22

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.19.0",
+  "dfx": "0.20.0",
   "canisters": {
     "nns-governance": {
       "type": "custom",
@@ -387,7 +387,7 @@
         "DIDC_VERSION": "2024-05-14",
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2024-05-15",
+        "SNSDEMO_RELEASE": "release-2024-05-22",
         "IC_COMMIT_FOR_PROPOSALS": "release-2024-05-09_23-02-storage-layer",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-05-09_23-02-storage-layer"
       },


### PR DESCRIPTION
# Motivation
We would like to keep the testing environment, provided by snsdemo, up to date.

# Changes
* Updated `snsdemo` version in `dfx.json`.
* Ensured that the `dfx` version in `dfx.json` matches `snsdemo`.

# Tests
CI should pass.