### PR TITLE
Display nns actionable proposals

### DIFF
--- a/frontend/src/lib/components/proposals/UniverseWithActionableProposals.svelte
+++ b/frontend/src/lib/components/proposals/UniverseWithActionableProposals.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import type { Universe } from "$lib/types/universe";
+  import UniverseLogo from "$lib/components/universe/UniverseLogo.svelte";
+  import { InfiniteScroll } from "@dfinity/gix-components";
+
+  export let universe: Universe;
+</script>
+
+<div class="container" data-tid="universe-with-actionable-proposals-component">
+  <div class="summary" data-tid="projects-summary">
+    <h1 class="title">
+      <span class="title">{universe.title}</span>
+
+      <UniverseLogo {universe} framed />
+    </h1>
+  </div>
+
+  <InfiniteScroll layout="grid" disabled>
+    <slot />
+  </InfiniteScroll>
+</div>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/text";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+
+  .container {
+    margin-bottom: var(--padding-4x);
+  }
+
+  .summary {
+    display: flex;
+    flex-direction: column;
+
+    margin: 0 0 var(--padding-3x);
+  }
+
+  .title {
+    display: inline-flex;
+  }
+
+  span {
+    @include fonts.h3;
+
+    max-width: calc(100% - var(--padding-6x));
+    @include text.truncate;
+
+    margin: 0;
+  }
+</style>

--- a/frontend/src/lib/pages/ActionableProposals.svelte
+++ b/frontend/src/lib/pages/ActionableProposals.svelte
@@ -1,7 +1,18 @@
 <script lang="ts">
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import UniverseWithActionableProposals from "$lib/components/proposals/UniverseWithActionableProposals.svelte";
+  import { nnsUniverseStore } from "$lib/derived/nns-universe.derived";
+  import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
+  import NnsProposalCard from "$lib/components/proposals/NnsProposalCard.svelte";
+  import { actionableProposalTotalCountStore } from "$lib/derived/actionable-proposals.derived";
 </script>
 
 <TestIdWrapper testId="actionable-proposals-component">
-  <h1>Under construction</h1>
+  {#if $actionableProposalTotalCountStore > 0}
+    <UniverseWithActionableProposals universe={$nnsUniverseStore}>
+      {#each $actionableNnsProposalsStore?.proposals ?? [] as proposalInfo (proposalInfo.id)}
+        <NnsProposalCard actionable {proposalInfo} />
+      {/each}
+    </UniverseWithActionableProposals>
+  {/if}
 </TestIdWrapper>

--- a/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
@@ -1,0 +1,57 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { AppPath } from "$lib/constants/routes.constants";
+import ActionableProposals from "$lib/pages/ActionableProposals.svelte";
+import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
+import { page } from "$mocks/$app/stores";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockProposalInfo } from "$tests/mocks/proposal.mock";
+import { ActionableProposalsPo } from "$tests/page-objects/ActionableProposals.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+
+describe("ActionableProposals", () => {
+  const nnsProposal1 = {
+    ...mockProposalInfo,
+    id: 0n,
+  };
+  const nnsProposal2 = {
+    ...mockProposalInfo,
+    id: 1n,
+  };
+  const renderComponent = () => {
+    const { container } = render(ActionableProposals);
+    return ActionableProposalsPo.under(new JestPageObjectElement(container));
+  };
+
+  beforeEach(() => {
+    page.reset();
+    overrideFeatureFlagsStore.setFlag("ENABLE_ACTIONABLE_TAB", true);
+  });
+
+  it('should display Nns actionable proposals on "Actionable Proposals" page', async () => {
+    resetIdentity();
+    page.mock({
+      data: {
+        universe: OWN_CANISTER_ID_TEXT,
+        routeId: AppPath.Proposals,
+        actionable: true,
+      },
+    });
+    actionableNnsProposalsStore.setProposals([nnsProposal1, nnsProposal2]);
+
+    const po = renderComponent();
+    expect(await po.isPresent()).toBe(true);
+    const universeWithActionableProposalsPos =
+      await po.getUniverseWithActionableProposalsPos();
+    expect(universeWithActionableProposalsPos.length).toEqual(1);
+    expect(await universeWithActionableProposalsPos[0].getTitle()).toEqual(
+      "Internet Computer"
+    );
+    const nnsCardPos =
+      await universeWithActionableProposalsPos[0].getProposalCardPos();
+    expect(nnsCardPos.length).toEqual(2);
+    expect(await nnsCardPos[0].getProposalId()).toEqual("ID: 0");
+    expect(await nnsCardPos[1].getProposalId()).toEqual("ID: 1");
+  });
+});

--- a/frontend/src/tests/page-objects/ActionableProposals.page-object.ts
+++ b/frontend/src/tests/page-objects/ActionableProposals.page-object.ts
@@ -1,3 +1,4 @@
+import { UniverseWithActionableProposalsPo } from "$tests/page-objects/UniverseWithActionableProposals.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -8,5 +9,11 @@ export class ActionableProposalsPo extends BasePageObject {
     return new ActionableProposalsPo(
       element.byTestId(ActionableProposalsPo.TID)
     );
+  }
+
+  async getUniverseWithActionableProposalsPos(): Promise<
+    UniverseWithActionableProposalsPo[]
+  > {
+    return UniverseWithActionableProposalsPo.allUnder(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/UniverseWithActionableProposals.page-object.ts
+++ b/frontend/src/tests/page-objects/UniverseWithActionableProposals.page-object.ts
@@ -1,0 +1,32 @@
+import { ProposalCardPo } from "$tests/page-objects/ProposalCard.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { assertNonNullish } from "$tests/utils/utils.test-utils";
+
+export class UniverseWithActionableProposalsPo extends BasePageObject {
+  static readonly TID = "universe-with-actionable-proposals-component";
+
+  static under(element: PageObjectElement): UniverseWithActionableProposalsPo {
+    return new UniverseWithActionableProposalsPo(
+      element.byTestId(UniverseWithActionableProposalsPo.TID)
+    );
+  }
+
+  static async allUnder(
+    element: PageObjectElement
+  ): Promise<UniverseWithActionableProposalsPo[]> {
+    return Array.from(
+      await element.allByTestId(UniverseWithActionableProposalsPo.TID)
+    ).map((el) => new UniverseWithActionableProposalsPo(el));
+  }
+
+  async getTitle(): Promise<string> {
+    return (
+      await assertNonNullish(this.root.querySelector("h1")).getText()
+    ).trim();
+  }
+
+  getProposalCardPos(): Promise<ProposalCardPo[]> {
+    return ProposalCardPo.allUnder(this.root);
+  }
+}


### PR DESCRIPTION
# Motivation

The "Actionable Proposals" page should display all actionable proposals. Here we first include actionable Nns proposals. Other proposals and banners will come in subsequent PRs.

# Changes

- Add `UniverseWithActionableProposals` component to group proposals by their universe.
- Display Nns proposals on "Actionable Proposals" page.

# Tests

- Test that Nns proposals are visible on the "Actionable Proposals" page.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.