### PR TITLE
Rename userTokenData prop to rowData

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokenActionsCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenActionsCell.svelte
@@ -11,7 +11,7 @@
   import { nonNullish } from "@dfinity/utils";
   import type { SvelteComponent, ComponentType } from "svelte";
 
-  export let userTokenData: UserTokenData | UserTokenLoading;
+  export let rowData: UserTokenData | UserTokenLoading;
 
   const actionMapper: Record<
     UserTokenAction,
@@ -23,7 +23,7 @@
   };
 
   let userToken: UserTokenData | undefined;
-  $: userToken = isUserTokenData(userTokenData) ? userTokenData : undefined;
+  $: userToken = isUserTokenData(rowData) ? rowData : undefined;
 </script>
 
 {#if nonNullish(userToken)}

--- a/frontend/src/lib/components/tokens/TokensTable/TokenBalanceCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenBalanceCell.svelte
@@ -4,19 +4,19 @@
   import { Spinner } from "@dfinity/gix-components";
   import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 
-  export let userTokenData: UserTokenData | UserTokenLoading;
+  export let rowData: UserTokenData | UserTokenLoading;
 </script>
 
-{#if userTokenData.balance instanceof UnavailableTokenAmount}
+{#if rowData.balance instanceof UnavailableTokenAmount}
   <span data-tid="token-value-label"
-    >{`-/- ${userTokenData.balance.token.symbol}`}</span
+    >{`-/- ${rowData.balance.token.symbol}`}</span
   >
-{:else if userTokenData.balance === "loading"}
+{:else if rowData.balance === "loading"}
   <span data-tid="token-value-label" class="balance-spinner"
     ><Spinner inline size="tiny" /></span
   >
 {:else}
-  <AmountDisplay singleLine amount={userTokenData.balance} />
+  <AmountDisplay singleLine amount={rowData.balance} />
 {/if}
 
 <style lang="scss">

--- a/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
@@ -3,21 +3,16 @@
   import Logo from "../../ui/Logo.svelte";
   import { nonNullish } from "@dfinity/utils";
 
-  export let userTokenData: UserTokenData | UserTokenLoading;
+  export let rowData: UserTokenData | UserTokenLoading;
 </script>
 
 <div class="title-logo-wrapper">
-  <Logo
-    src={userTokenData.logo}
-    alt={userTokenData.title}
-    size="medium"
-    framed
-  />
+  <Logo src={rowData.logo} alt={rowData.title} size="medium" framed />
   <div class="title-wrapper">
-    <h5 data-tid="project-name">{userTokenData.title}</h5>
-    {#if nonNullish(userTokenData.subtitle)}
+    <h5 data-tid="project-name">{rowData.title}</h5>
+    {#if nonNullish(rowData.subtitle)}
       <span data-tid="project-subtitle" class="description"
-        >{userTokenData.subtitle}</span
+        >{rowData.subtitle}</span
       >
     {/if}
   </div>

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -6,7 +6,7 @@
   export let firstColumnHeader: string;
 </script>
 
-<ResponsiveTable {userTokensData} {firstColumnHeader} on:nnsAction>
+<ResponsiveTable tableData={userTokensData} {firstColumnHeader} on:nnsAction>
   <slot name="last-row" slot="last-row" />
   <slot name="header-icon" slot="header-icon" />
 </ResponsiveTable>

--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -6,7 +6,7 @@
   import ResponsiveTableRow from "$lib/components/ui/ResponsiveTableRow.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
-  export let userTokensData: Array<UserToken>;
+  export let tableData: Array<UserToken>;
   export let firstColumnHeader: string;
 
   // This will be useful when we create the generic table.
@@ -36,9 +36,9 @@
     </div>
   </div>
   <div role="rowgroup">
-    {#each userTokensData as userTokenData (userTokenData.rowHref)}
+    {#each tableData as rowData (rowData.rowHref)}
       <div class="row-wrapper" transition:heightTransition={{ duration: 250 }}>
-        <ResponsiveTableRow on:nnsAction {userTokenData} />
+        <ResponsiveTableRow on:nnsAction {rowData} />
       </div>
     {/each}
   </div>

--- a/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
@@ -5,7 +5,7 @@
   import TokenActionsCell from "$lib/components/tokens/TokensTable/TokenActionsCell.svelte";
   import { i18n } from "$lib/stores/i18n";
 
-  export let userTokenData: UserTokenData | UserTokenLoading;
+  export let rowData: UserTokenData | UserTokenLoading;
 
   // Should be the same as the area in the classes `rows-count-X`.
   const cellAreaName = (index: number) => `cell-${index}`;
@@ -18,23 +18,23 @@
 </script>
 
 <a
-  href={userTokenData.rowHref}
+  href={rowData.rowHref}
   role="row"
   tabindex="0"
   data-tid="tokens-table-row-component"
   class={mobileTemplateClass(2)}
-  data-title={userTokenData.title}
+  data-title={rowData.title}
 >
   <div role="cell" class="title-cell">
-    <TokenTitleCell {userTokenData} />
+    <TokenTitleCell {rowData} />
   </div>
 
   <div role="cell" class={`mobile-row-cell left-cell ${cellAreaName(0)}`}>
     <span class="mobile-only">{$i18n.tokens.balance_header}</span>
-    <TokenBalanceCell {userTokenData} />
+    <TokenBalanceCell {rowData} />
   </div>
   <div role="cell" class="actions-cell actions">
-    <TokenActionsCell {userTokenData} on:nnsAction />
+    <TokenActionsCell {rowData} on:nnsAction />
   </div>
 </a>
 


### PR DESCRIPTION
# Motivation

We want to evolve `ResponsiveTable`, which is currently specific to tokens to a fully generic table.
So its props should not refer to tokens in the name.

The token table cell components will remain specific to the tokens table, but because they will have to interact with the generic table, their props need to be generic as well.

# Changes

1. In `frontend/src/lib/components/ui/ResponsiveTable.svelte` change `userTokensData` to `tableData` and `userTokenData` to `rowData`.
2. In `frontend/src/lib/components/ui/ResponsiveTableRow.svelte` and in all the cell components, change `userTokenData` to `rowData`.

Note that each cell gets the data for the full row because it's the cell's responsibility to know which data from the row it needs to render.

# Tests

Existing tests continue to pass.
Tested manually as well.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary