### PR TITLE
New actionable proposals loaded store

### DIFF
--- a/frontend/src/lib/derived/actionable-proposals.derived.ts
+++ b/frontend/src/lib/derived/actionable-proposals.derived.ts
@@ -3,6 +3,7 @@ import { AppPath } from "$lib/constants/routes.constants";
 import { authSignedInStore } from "$lib/derived/auth.derived";
 import { pageStore } from "$lib/derived/page.derived";
 import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
+import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
@@ -10,6 +11,7 @@ import type { Universe } from "$lib/types/universe";
 import { isSelectedPath } from "$lib/utils/navigation.utils";
 import { mapEntries } from "$lib/utils/utils";
 import type { SnsProposalData } from "@dfinity/sns";
+import { nonNullish } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 
 export interface ActionableProposalCountData {
@@ -107,4 +109,19 @@ export const actionableSnsProposalsByUniverseStore: Readable<
         universe,
         proposals: actionableSnsProposals[universe.canisterId].proposals,
       }))
+);
+
+/** A store that returns true when all ‘Actionable Proposals’ have been loaded.
+ */
+export const actionableProposalsLoadedStore: Readable<boolean> = derived(
+  [
+    actionableNnsProposalsStore,
+    actionableSnsProposalsStore,
+    snsProjectsCommittedStore,
+  ],
+  ([nnsProposals, snsProposals, committedSnsProjects]) =>
+    nonNullish(nnsProposals.proposals) &&
+    // It is expected to have at least one SNS to cover when the projects have not yet been loaded.
+    committedSnsProjects.length > 0 &&
+    committedSnsProjects.length === Object.keys(snsProposals).length
 );

--- a/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
@@ -7,6 +7,7 @@ import {
   actionableProposalSupportedStore,
   actionableProposalTotalCountStore,
   actionableProposalsActiveStore,
+  actionableProposalsLoadedStore,
   actionableSnsProposalsByUniverseStore,
 } from "$lib/derived/actionable-proposals.derived";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
@@ -338,6 +339,61 @@ describe("actionable proposals derived stores", () => {
           ({ canisterId }) => canisterId
         )
       ).toEqual([principal0.toText(), principal1.toText()]);
+    });
+  });
+
+  describe("actionableProposalsLoadedStore", () => {
+    it("should return true when all actionable proposals are loaded", async () => {
+      expect(get(actionableProposalsLoadedStore)).toEqual(false);
+      setSnsProjects([
+        {
+          lifecycle: SnsSwapLifecycle.Committed,
+          rootCanisterId: principal0,
+        },
+      ]);
+
+      expect(get(actionableProposalsLoadedStore)).toEqual(false);
+
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal0,
+        proposals: [],
+        includeBallotsByCaller: true,
+      });
+
+      expect(get(actionableProposalsLoadedStore)).toEqual(false);
+      actionableNnsProposalsStore.setProposals([mockProposalInfo]);
+
+      expect(get(actionableProposalsLoadedStore)).toEqual(true);
+    });
+
+    it("should return false when actionable proposals are loaded not of all Snses", async () => {
+      expect(get(actionableProposalsLoadedStore)).toEqual(false);
+      setSnsProjects([
+        {
+          lifecycle: SnsSwapLifecycle.Committed,
+          rootCanisterId: principal0,
+        },
+        {
+          lifecycle: SnsSwapLifecycle.Committed,
+          rootCanisterId: principal1,
+        },
+      ]);
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal0,
+        proposals: [],
+        includeBallotsByCaller: false,
+      });
+      actionableNnsProposalsStore.setProposals([mockProposalInfo]);
+
+      expect(get(actionableProposalsLoadedStore)).toEqual(false);
+
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal1,
+        proposals: [],
+        includeBallotsByCaller: false,
+      });
+
+      expect(get(actionableProposalsLoadedStore)).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
# Motivation

We need to determine when the actionable proposals are fully loaded to display a loader. Here, we add a new store that returns true only when everything is preloaded. We can’t display a loader per SNS because we only know if the Sns needs to be displayed after fetching, based on the `includeBallotsByCaller` flag.

# Changes

- New derived store `actionableProposalsLoadedStore`

# Tests

- tests for the new store.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.