### PR TITLE
Pass column specification to ResponsiveTable

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -25,7 +25,7 @@
   ];
 </script>
 
-<ResponsiveTable {columns} tableData={userTokensData} on:nnsAction>
+<ResponsiveTable tableData={userTokensData} {columns} on:nnsAction>
   <slot name="last-row" slot="last-row" />
   <slot name="header-icon" slot="header-icon" />
 </ResponsiveTable>

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -1,12 +1,31 @@
 <script lang="ts">
-  import type { UserToken } from "$lib/types/tokens-page";
   import ResponsiveTable from "$lib/components/ui/ResponsiveTable.svelte";
+  import TokenTitleCell from "./TokenTitleCell.svelte";
+  import TokenBalanceCell from "./TokenBalanceCell.svelte";
+  import TokenActionsCell from "./TokenActionsCell.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import type { UserToken, TokensTableColumn } from "$lib/types/tokens-page";
 
   export let userTokensData: Array<UserToken>;
   export let firstColumnHeader: string;
+
+  const columns: TokensTableColumn[] = [
+    {
+      title: firstColumnHeader,
+      component: TokenTitleCell,
+    },
+    {
+      title: $i18n.tokens.balance_header,
+      component: TokenBalanceCell,
+    },
+    {
+      title: "",
+      component: TokenActionsCell,
+    },
+  ];
 </script>
 
-<ResponsiveTable tableData={userTokensData} {firstColumnHeader} on:nnsAction>
+<ResponsiveTable {columns} tableData={userTokensData} on:nnsAction>
   <slot name="last-row" slot="last-row" />
   <slot name="header-icon" slot="header-icon" />
 </ResponsiveTable>

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -12,15 +12,15 @@
   const columns: TokensTableColumn[] = [
     {
       title: firstColumnHeader,
-      component: TokenTitleCell,
+      cellComponent: TokenTitleCell,
     },
     {
       title: $i18n.tokens.balance_header,
-      component: TokenBalanceCell,
+      cellComponent: TokenBalanceCell,
     },
     {
       title: "",
-      component: TokenActionsCell,
+      cellComponent: TokenActionsCell,
     },
   ];
 </script>

--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -9,12 +9,12 @@
   export let tableData: Array<UserToken>;
   export let columns: ResponsiveTableColumn<UserToken>[];
 
+  // We don't render a header for the last column.
   let firstColumn: ResponsiveTableColumn<UserToken> | undefined;
   let middleColumns: ResponsiveTableColumn<UserToken>[];
 
   $: firstColumn = columns.at(0);
   $: middleColumns = columns.slice(1, -1);
-  // We don't render a header for the last column.
 
   // This will be useful when we create the generic table.
   // The column styles will depend on the columns metadata.

--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { i18n } from "$lib/stores/i18n";
+  import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
   import type { UserToken } from "$lib/types/tokens-page";
   import { heightTransition } from "$lib/utils/transition.utils";
   import { nonNullish } from "@dfinity/utils";
@@ -7,7 +7,14 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let tableData: Array<UserToken>;
-  export let firstColumnHeader: string;
+  export let columns: ResponsiveTableColumn<UserToken>[];
+
+  let firstColumn: ResponsiveTableColumn<UserToken> | undefined;
+  let middleColumns: ResponsiveTableColumn<UserToken>[];
+
+  $: firstColumn = columns.at(0);
+  $: middleColumns = columns.slice(1, -1);
+  // We don't render a header for the last column.
 
   // This will be useful when we create the generic table.
   // The column styles will depend on the columns metadata.
@@ -24,12 +31,18 @@
 >
   <div role="rowgroup">
     <div role="row" class="header-row">
-      <span role="columnheader" data-tid="column-header-1"
-        >{firstColumnHeader}</span
-      >
-      <span role="columnheader" data-tid="column-header-2" class="header-right"
-        >{$i18n.tokens.balance_header}</span
-      >
+      {#if firstColumn}
+        <span role="columnheader" data-tid="column-header-1"
+          >{firstColumn.title}</span
+        >
+      {/if}
+      {#each middleColumns as column, index}
+        <span
+          role="columnheader"
+          data-tid="column-header-{index + 2}"
+          class="header-right">{column.title}</span
+        >
+      {/each}
       <span role="columnheader" class="header-right header-icon">
         <slot name="header-icon" />
       </span>
@@ -38,7 +51,7 @@
   <div role="rowgroup">
     {#each tableData as rowData (rowData.rowHref)}
       <div class="row-wrapper" transition:heightTransition={{ duration: 250 }}>
-        <ResponsiveTableRow on:nnsAction {rowData} />
+        <ResponsiveTableRow on:nnsAction {rowData} {columns} />
       </div>
     {/each}
   </div>

--- a/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
@@ -6,8 +6,8 @@
   export let columns: ResponsiveTableColumn<UserToken>[];
 
   let firstColumn = columns.at(0);
-  let lastColumn = columns.at(-1);
   let middleColumns = columns.slice(1, -1);
+  let lastColumn = columns.at(-1);
 
   // Should be the same as the area in the classes `rows-count-X`.
   const cellAreaName = (index: number) => `cell-${index}`;

--- a/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
@@ -28,20 +28,24 @@
 >
   {#if firstColumn}
     <div role="cell" class="title-cell">
-      <svelte:component this={firstColumn.component} {rowData} />
+      <svelte:component this={firstColumn.cellComponent} {rowData} />
     </div>
   {/if}
 
   {#each middleColumns as column, index}
     <div role="cell" class={`mobile-row-cell left-cell ${cellAreaName(index)}`}>
       <span class="mobile-only">{column.title}</span>
-      <svelte:component this={column.component} {rowData} />
+      <svelte:component this={column.cellComponent} {rowData} />
     </div>
   {/each}
 
   {#if lastColumn}
     <div role="cell" class="actions-cell actions">
-      <svelte:component this={lastColumn.component} {rowData} on:nnsAction />
+      <svelte:component
+        this={lastColumn.cellComponent}
+        {rowData}
+        on:nnsAction
+      />
     </div>
   {/if}
 </a>

--- a/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
@@ -5,9 +5,13 @@
   export let rowData: UserToken;
   export let columns: ResponsiveTableColumn<UserToken>[];
 
-  let firstColumn = columns.at(0);
-  let middleColumns = columns.slice(1, -1);
-  let lastColumn = columns.at(-1);
+  let firstColumn: ResponsiveTableColumn<UserToken> | undefined;
+  let middleColumns: ResponsiveTableColumn<UserToken>[];
+  let lastColumn: ResponsiveTableColumn<UserToken> | undefined;
+
+  $: firstColumn = columns.at(0);
+  $: middleColumns = columns.slice(1, -1);
+  $: lastColumn = columns.at(-1);
 
   // Should be the same as the area in the classes `rows-count-X`.
   const cellAreaName = (index: number) => `cell-${index}`;

--- a/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
-  import type { UserTokenData, UserTokenLoading } from "$lib/types/tokens-page";
-  import TokenTitleCell from "$lib/components/tokens/TokensTable/TokenTitleCell.svelte";
-  import TokenBalanceCell from "$lib/components/tokens/TokensTable/TokenBalanceCell.svelte";
-  import TokenActionsCell from "$lib/components/tokens/TokensTable/TokenActionsCell.svelte";
-  import { i18n } from "$lib/stores/i18n";
+  import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
+  import type { UserToken } from "$lib/types/tokens-page";
 
-  export let rowData: UserTokenData | UserTokenLoading;
+  export let rowData: UserToken;
+  export let columns: ResponsiveTableColumn<UserToken>[];
+
+  let firstColumn = columns.at(0);
+  let lastColumn = columns.at(-1);
+  let middleColumns = columns.slice(1, -1);
 
   // Should be the same as the area in the classes `rows-count-X`.
   const cellAreaName = (index: number) => `cell-${index}`;
@@ -23,19 +25,25 @@
   tabindex="0"
   data-tid="tokens-table-row-component"
   class={mobileTemplateClass(2)}
-  data-title={rowData.title}
 >
-  <div role="cell" class="title-cell">
-    <TokenTitleCell {rowData} />
-  </div>
+  {#if firstColumn}
+    <div role="cell" class="title-cell">
+      <svelte:component this={firstColumn.component} {rowData} />
+    </div>
+  {/if}
 
-  <div role="cell" class={`mobile-row-cell left-cell ${cellAreaName(0)}`}>
-    <span class="mobile-only">{$i18n.tokens.balance_header}</span>
-    <TokenBalanceCell {rowData} />
-  </div>
-  <div role="cell" class="actions-cell actions">
-    <TokenActionsCell {rowData} on:nnsAction />
-  </div>
+  {#each middleColumns as column, index}
+    <div role="cell" class={`mobile-row-cell left-cell ${cellAreaName(index)}`}>
+      <span class="mobile-only">{column.title}</span>
+      <svelte:component this={column.component} {rowData} />
+    </div>
+  {/each}
+
+  {#if lastColumn}
+    <div role="cell" class="actions-cell actions">
+      <svelte:component this={lastColumn.component} {rowData} on:nnsAction />
+    </div>
+  {/if}
 </a>
 
 <style lang="scss">

--- a/frontend/src/lib/types/responsive-table.ts
+++ b/frontend/src/lib/types/responsive-table.ts
@@ -1,0 +1,12 @@
+import type { ComponentType, SvelteComponent } from "svelte";
+
+export interface ResponsiveTableRowData {
+  rowHref: string;
+}
+
+export interface ResponsiveTableColumn<
+  RowDataType extends ResponsiveTableRowData,
+> {
+  title: string;
+  component: ComponentType<SvelteComponent<{ rowData: RowDataType }>>;
+}

--- a/frontend/src/lib/types/responsive-table.ts
+++ b/frontend/src/lib/types/responsive-table.ts
@@ -8,5 +8,5 @@ export interface ResponsiveTableColumn<
   RowDataType extends ResponsiveTableRowData,
 > {
   title: string;
-  component: ComponentType<SvelteComponent<{ rowData: RowDataType }>>;
+  cellComponent: ComponentType<SvelteComponent<{ rowData: RowDataType }>>;
 }

--- a/frontend/src/lib/types/tokens-page.ts
+++ b/frontend/src/lib/types/tokens-page.ts
@@ -7,6 +7,7 @@
  * - `UserTokenAction` is a list of actions supported by the tokens page and hardcoded in the TokensTable.
  * - `UserToken` is the union of `UserTokenLoading` and `UserTokenData`.
  */
+import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
 import type { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import type { Principal } from "@dfinity/principal";
 import type { Token, TokenAmountV2 } from "@dfinity/utils";
@@ -49,3 +50,4 @@ export type UserTokenData = UserTokenBase & {
 };
 
 export type UserToken = UserTokenLoading | UserTokenData;
+export type TokensTableColumn = ResponsiveTableColumn<UserToken>;


### PR DESCRIPTION
# Motivation

We want to make `ResponsiveTable` generic to reuse it for the neurons table.
For this we need to customize which columns will be rendered for each row.

# Changes

1. Add type `ResponsiveTableColumn` which specifies a title for a single column and how to render cells in that column.
2. Pass a list of `ResponsiveTableColumn` from `TokensTable` to `ResponsiveTable`.
3. In `ResponsiveTable` render column headers based on the column specification.
4. In `ResponsiveTableRow` use components from the column specification to render the cells.

# Tests

Existing tokens table tests pass.
Will add tests for responsive table when it's fully generic.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary