### PR TITLE
Universe with actionable proposals component

### DIFF
--- a/frontend/src/lib/components/proposals/UniverseWithActionableProposals.svelte
+++ b/frontend/src/lib/components/proposals/UniverseWithActionableProposals.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import type { Universe } from "$lib/types/universe";
+  import UniverseLogo from "$lib/components/universe/UniverseLogo.svelte";
+  import { InfiniteScroll } from "@dfinity/gix-components";
+
+  export let universe: Universe;
+</script>
+
+<div class="container" data-tid="universe-with-actionable-proposals-component">
+  <div class="summary" data-tid="projects-summary">
+    <h1 class="title">
+      <span class="title">{universe.title}</span>
+
+      <UniverseLogo {universe} framed />
+    </h1>
+  </div>
+
+  <InfiniteScroll layout="grid" disabled>
+    <slot />
+  </InfiniteScroll>
+</div>
+
+<style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+  @use "@dfinity/gix-components/dist/styles/mixins/text";
+  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
+
+  .container {
+    margin-bottom: var(--padding-4x);
+  }
+
+  .summary {
+    display: flex;
+    flex-direction: column;
+
+    margin: 0 0 var(--padding-3x);
+  }
+
+  .title {
+    display: inline-flex;
+  }
+
+  span {
+    @include fonts.h3;
+
+    max-width: calc(100% - var(--padding-6x));
+    @include text.truncate;
+
+    margin: 0;
+  }
+</style>

--- a/frontend/src/lib/components/proposals/UniverseWithActionableProposals.svelte
+++ b/frontend/src/lib/components/proposals/UniverseWithActionableProposals.svelte
@@ -1,19 +1,13 @@
 <script lang="ts">
   import type { Universe } from "$lib/types/universe";
-  import UniverseLogo from "$lib/components/universe/UniverseLogo.svelte";
   import { InfiniteScroll } from "@dfinity/gix-components";
+  import UniversePageSummary from "$lib/components/universe/UniversePageSummary.svelte";
 
   export let universe: Universe;
 </script>
 
 <div class="container" data-tid="universe-with-actionable-proposals-component">
-  <div class="summary" data-tid="projects-summary">
-    <h1 class="title">
-      <span class="title">{universe.title}</span>
-
-      <UniverseLogo {universe} framed />
-    </h1>
-  </div>
+  <UniversePageSummary {universe} />
 
   <InfiniteScroll layout="grid" disabled>
     <slot />
@@ -21,31 +15,7 @@
 </div>
 
 <style lang="scss">
-  @use "@dfinity/gix-components/dist/styles/mixins/media";
-  @use "@dfinity/gix-components/dist/styles/mixins/text";
-  @use "@dfinity/gix-components/dist/styles/mixins/fonts";
-
   .container {
     margin-bottom: var(--padding-4x);
-  }
-
-  .summary {
-    display: flex;
-    flex-direction: column;
-
-    margin: 0 0 var(--padding-3x);
-  }
-
-  .title {
-    display: inline-flex;
-  }
-
-  span {
-    @include fonts.h3;
-
-    max-width: calc(100% - var(--padding-6x));
-    @include text.truncate;
-
-    margin: 0;
   }
 </style>

--- a/frontend/src/tests/lib/components/proposals/UniverseWithActionableProposals.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/UniverseWithActionableProposals.spec.ts
@@ -1,0 +1,34 @@
+import { mockUniverse } from "$tests/mocks/sns-projects.mock";
+import { UniverseWithActionableProposalsPo } from "$tests/page-objects/UniverseWithActionableProposals.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+import UniverseWithActionableProposalsTest from "./UniverseWithActionableProposalsTest.svelte";
+
+describe("UniverseWithActionableProposals", () => {
+  const renderComponent = (props) => {
+    const { container } = render(UniverseWithActionableProposalsTest, {
+      props,
+    });
+
+    return UniverseWithActionableProposalsPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should render a title", async () => {
+    const po = renderComponent({
+      universe: { ...mockUniverse, title: "Universe title" },
+    });
+
+    expect(await po.getTitle()).toEqual("Universe title");
+  });
+
+  it("should render slot content", async () => {
+    const po = renderComponent({
+      universe: { ...mockUniverse, title: "Universe title" },
+      testSlotContent: "Test slot content",
+    });
+
+    expect(await po.getText("slot")).toEqual("Test slot content");
+  });
+});

--- a/frontend/src/tests/lib/components/proposals/UniverseWithActionableProposalsTest.svelte
+++ b/frontend/src/tests/lib/components/proposals/UniverseWithActionableProposalsTest.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import UniverseWithActionableProposals from "$lib/components/proposals/UniverseWithActionableProposals.svelte"
-  import type {Universe} from "$lib/types/universe";
+  import UniverseWithActionableProposals from "$lib/components/proposals/UniverseWithActionableProposals.svelte";
+  import type { Universe } from "$lib/types/universe";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let universe: Universe;
@@ -8,5 +8,5 @@
 </script>
 
 <UniverseWithActionableProposals {universe}>
-    <TestIdWrapper testId="slot">{testSlotContent}</TestIdWrapper>
+  <TestIdWrapper testId="slot">{testSlotContent}</TestIdWrapper>
 </UniverseWithActionableProposals>

--- a/frontend/src/tests/lib/components/proposals/UniverseWithActionableProposalsTest.svelte
+++ b/frontend/src/tests/lib/components/proposals/UniverseWithActionableProposalsTest.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import UniverseWithActionableProposals from "$lib/components/proposals/UniverseWithActionableProposals.svelte"
+  import type {Universe} from "$lib/types/universe";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+
+  export let universe: Universe;
+  export let testSlotContent: string | undefined = undefined;
+</script>
+
+<UniverseWithActionableProposals {universe}>
+    <TestIdWrapper testId="slot">{testSlotContent}</TestIdWrapper>
+</UniverseWithActionableProposals>

--- a/frontend/src/tests/page-objects/UniverseWithActionableProposals.page-object.ts
+++ b/frontend/src/tests/page-objects/UniverseWithActionableProposals.page-object.ts
@@ -1,4 +1,3 @@
-import { ProposalCardPo } from "$tests/page-objects/ProposalCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { assertNonNullish } from "$tests/utils/utils.test-utils";
@@ -24,9 +23,5 @@ export class UniverseWithActionableProposalsPo extends BasePageObject {
     return (
       await assertNonNullish(this.root.querySelector("h1")).getText()
     ).trim();
-  }
-
-  getProposalCardPos(): Promise<ProposalCardPo[]> {
-    return ProposalCardPo.allUnder(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/UniverseWithActionableProposals.page-object.ts
+++ b/frontend/src/tests/page-objects/UniverseWithActionableProposals.page-object.ts
@@ -1,6 +1,6 @@
+import { UniversePageSummaryPo } from "$tests/page-objects/UniversePageSummary.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { assertNonNullish } from "$tests/utils/utils.test-utils";
 
 export class UniverseWithActionableProposalsPo extends BasePageObject {
   static readonly TID = "universe-with-actionable-proposals-component";
@@ -19,9 +19,11 @@ export class UniverseWithActionableProposalsPo extends BasePageObject {
     ).map((el) => new UniverseWithActionableProposalsPo(el));
   }
 
-  async getTitle(): Promise<string> {
-    return (
-      await assertNonNullish(this.root.querySelector("h1")).getText()
-    ).trim();
+  getSummaryPo(): UniversePageSummaryPo {
+    return UniversePageSummaryPo.under(this.root);
+  }
+
+  getTitle(): Promise<string> {
+    return this.getSummaryPo().getTitle();
   }
 }

--- a/frontend/src/tests/page-objects/UniverseWithActionableProposals.page-object.ts
+++ b/frontend/src/tests/page-objects/UniverseWithActionableProposals.page-object.ts
@@ -1,0 +1,32 @@
+import { ProposalCardPo } from "$tests/page-objects/ProposalCard.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { assertNonNullish } from "$tests/utils/utils.test-utils";
+
+export class UniverseWithActionableProposalsPo extends BasePageObject {
+  static readonly TID = "universe-with-actionable-proposals-component";
+
+  static under(element: PageObjectElement): UniverseWithActionableProposalsPo {
+    return new UniverseWithActionableProposalsPo(
+      element.byTestId(UniverseWithActionableProposalsPo.TID)
+    );
+  }
+
+  static async allUnder(
+    element: PageObjectElement
+  ): Promise<UniverseWithActionableProposalsPo[]> {
+    return Array.from(
+      await element.allByTestId(UniverseWithActionableProposalsPo.TID)
+    ).map((el) => new UniverseWithActionableProposalsPo(el));
+  }
+
+  async getTitle(): Promise<string> {
+    return (
+      await assertNonNullish(this.root.querySelector("h1")).getText()
+    ).trim();
+  }
+
+  getProposalCardPos(): Promise<ProposalCardPo[]> {
+    return ProposalCardPo.allUnder(this.root);
+  }
+}


### PR DESCRIPTION
# Motivation

The “Actionable Proposals” page should display all actionable proposals grouped by universe (Nns/Sns). Here, we add a wrapper component that will represent a universe and provide a slot for rendering universe proposals. Proposals can’t be provided via props because `Nns` and `Sns` have different types.

# Changes

- Add a new component.

# Tests

- Add PO for the new component.
- Add tests for UniverseWithActionableProposals.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
