### PR TITLE
Use a generic type for ResponsiveTable data

### DIFF
--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -1,17 +1,21 @@
-<script lang="ts">
+<script lang="ts" context="module">
+  import type { ResponsiveTableRowData } from "$lib/types/responsive-table";
+  type RowDataType = ResponsiveTableRowData;
+</script>
+
+<script lang="ts" generics="RowDataType extends ResponsiveTableRowData">
   import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
-  import type { UserToken } from "$lib/types/tokens-page";
   import { heightTransition } from "$lib/utils/transition.utils";
   import { nonNullish } from "@dfinity/utils";
   import ResponsiveTableRow from "$lib/components/ui/ResponsiveTableRow.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
-  export let tableData: Array<UserToken>;
-  export let columns: ResponsiveTableColumn<UserToken>[];
+  export let tableData: Array<RowDataType>;
+  export let columns: ResponsiveTableColumn<RowDataType>[];
 
   // We don't render a header for the last column.
-  let firstColumn: ResponsiveTableColumn<UserToken> | undefined;
-  let middleColumns: ResponsiveTableColumn<UserToken>[];
+  let firstColumn: ResponsiveTableColumn<RowDataType> | undefined;
+  let middleColumns: ResponsiveTableColumn<RowDataType>[];
 
   $: firstColumn = columns.at(0);
   $: middleColumns = columns.slice(1, -1);

--- a/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
@@ -1,13 +1,17 @@
-<script lang="ts">
+<script lang="ts" context="module">
+  import type { ResponsiveTableRowData } from "$lib/types/responsive-table";
+  type RowDataType = ResponsiveTableRowData;
+</script>
+
+<script lang="ts" generics="RowDataType extends ResponsiveTableRowData">
   import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
-  import type { UserToken } from "$lib/types/tokens-page";
 
-  export let rowData: UserToken;
-  export let columns: ResponsiveTableColumn<UserToken>[];
+  export let rowData: RowDataType;
+  export let columns: ResponsiveTableColumn<RowDataType>[];
 
-  let firstColumn: ResponsiveTableColumn<UserToken> | undefined;
-  let middleColumns: ResponsiveTableColumn<UserToken>[];
-  let lastColumn: ResponsiveTableColumn<UserToken> | undefined;
+  let firstColumn: ResponsiveTableColumn<RowDataType> | undefined;
+  let middleColumns: ResponsiveTableColumn<RowDataType>[];
+  let lastColumn: ResponsiveTableColumn<RowDataType> | undefined;
 
   $: firstColumn = columns.at(0);
   $: middleColumns = columns.slice(1, -1);


### PR DESCRIPTION
# Motivation

We want to use the `ResponsiveTable` with different types of data.

# Changes

Declare the `tableData` in `ResponsiveTable` and `rowData` in `ResponsiveTableRow` to be of a generic type.
I found this syntax [here](https://github.com/ciscoheat/sveltekit-superforms/issues/245#issuecomment-1698928562) and it seems to satisfy both the linter and the compiler.

# Tests

Existing tests pass.
I've also tested this with a preliminary neurons table in another branch.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary