### PR TITLE
Display actionable proposals nns

### DIFF
--- a/frontend/src/lib/components/proposals/ActionableNnsProposals.svelte
+++ b/frontend/src/lib/components/proposals/ActionableNnsProposals.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import NnsProposalCard from "./NnsProposalCard.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
+  import { nnsUniverseStore } from "$lib/derived/nns-universe.derived";
+  import UniverseWithActionableProposals from "$lib/components/proposals/UniverseWithActionableProposals.svelte";
+</script>
+
+<TestIdWrapper testId="actionable-nns-proposals-component">
+  {#if $actionableNnsProposalsStore?.proposals?.length ?? 0 > 0}
+    <UniverseWithActionableProposals universe={$nnsUniverseStore}>
+      {#each $actionableNnsProposalsStore?.proposals ?? [] as proposalInfo (proposalInfo.id)}
+        <NnsProposalCard actionable {proposalInfo} />
+      {/each}
+    </UniverseWithActionableProposals>
+  {/if}
+</TestIdWrapper>

--- a/frontend/src/lib/pages/ActionableProposals.svelte
+++ b/frontend/src/lib/pages/ActionableProposals.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import ActionableNnsProposals from "$lib/components/proposals/ActionableNnsProposals.svelte";
 </script>
 
 <TestIdWrapper testId="actionable-proposals-component">
-  <h1>Under construction</h1>
+  <!-- TODO: Loading state -->
+  <ActionableNnsProposals />
+  <!-- TODO: Actionable sns proposals -->
+  <!-- TODO: No proposals banner -->
 </TestIdWrapper>

--- a/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
@@ -1,0 +1,62 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { AppPath } from "$lib/constants/routes.constants";
+import ActionableProposals from "$lib/pages/ActionableProposals.svelte";
+import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
+import { page } from "$mocks/$app/stores";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockProposalInfo } from "$tests/mocks/proposal.mock";
+import { ActionableProposalsPo } from "$tests/page-objects/ActionableProposals.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { resetSnsProjects } from "$tests/utils/sns.test-utils";
+import { render } from "$tests/utils/svelte.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import type { ProposalInfo } from "@dfinity/nns";
+
+describe("ActionableProposals", () => {
+  const renderComponent = async () => {
+    const { container } = render(ActionableProposals);
+    await runResolvedPromises();
+    return ActionableProposalsPo.under(new JestPageObjectElement(container));
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetIdentity();
+    resetSnsProjects();
+    actionableNnsProposalsStore.reset();
+
+    page.mock({
+      data: { universe: OWN_CANISTER_ID_TEXT },
+      routeId: AppPath.Proposals,
+    });
+  });
+
+  describe("Actionable Nns proposals", () => {
+    const nnsProposal1: ProposalInfo = { ...mockProposalInfo, id: 11n };
+    const nnsProposal2: ProposalInfo = { ...mockProposalInfo, id: 22n };
+
+    it("should render actionable Nns proposals", async () => {
+      const po = await renderComponent();
+
+      expect(await po.hasActionableNnsProposals()).toEqual(false);
+
+      actionableNnsProposalsStore.setProposals([nnsProposal1, nnsProposal2]);
+      await runResolvedPromises();
+      expect(await po.hasActionableNnsProposals()).toEqual(true);
+
+      expect(
+        await po
+          .getActionableNnsProposalsPo()
+          .getUniverseWithActionableProposalsPo()
+          .getTitle()
+      ).toEqual("Internet Computer");
+
+      const proposalCardPos = await po
+        .getActionableNnsProposalsPo()
+        .getProposalCardPos();
+      expect(proposalCardPos.length).toEqual(2);
+      expect(await proposalCardPos[0].getProposalId()).toEqual("ID: 11");
+      expect(await proposalCardPos[1].getProposalId()).toEqual("ID: 22");
+    });
+  });
+});

--- a/frontend/src/tests/page-objects/ActionableNnsProposals.page-object.ts
+++ b/frontend/src/tests/page-objects/ActionableNnsProposals.page-object.ts
@@ -1,0 +1,22 @@
+import { ProposalCardPo } from "$tests/page-objects/ProposalCard.page-object";
+import { UniverseWithActionableProposalsPo } from "$tests/page-objects/UniverseWithActionableProposals.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ActionableNnsProposalsPo extends BasePageObject {
+  static readonly TID = "actionable-nns-proposals-component";
+
+  static under(element: PageObjectElement): ActionableNnsProposalsPo {
+    return new ActionableNnsProposalsPo(
+      element.byTestId(ActionableNnsProposalsPo.TID)
+    );
+  }
+
+  getUniverseWithActionableProposalsPo(): UniverseWithActionableProposalsPo {
+    return UniverseWithActionableProposalsPo.under(this.root);
+  }
+
+  getProposalCardPos(): Promise<ProposalCardPo[]> {
+    return ProposalCardPo.allUnder(this.root);
+  }
+}

--- a/frontend/src/tests/page-objects/ActionableProposals.page-object.ts
+++ b/frontend/src/tests/page-objects/ActionableProposals.page-object.ts
@@ -1,3 +1,4 @@
+import { ActionableNnsProposalsPo } from "$tests/page-objects/ActionableNnsProposals.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -8,5 +9,15 @@ export class ActionableProposalsPo extends BasePageObject {
     return new ActionableProposalsPo(
       element.byTestId(ActionableProposalsPo.TID)
     );
+  }
+
+  getActionableNnsProposalsPo(): ActionableNnsProposalsPo {
+    return ActionableNnsProposalsPo.under(this.root);
+  }
+
+  hasActionableNnsProposals(): Promise<boolean> {
+    return this.getActionableNnsProposalsPo()
+      .getUniverseWithActionableProposalsPo()
+      .isPresent();
   }
 }


### PR DESCRIPTION
# Motivation

The actionable proposals page should include all votable proposals. Here, we display Nns proposals that users can vote for.

# Changes

- Add `ActionableNnsProposals` component.
- Display actionable Nns proposals.

# Tests

- Add `ActionableNnsProposalsPo`.
- Test that actionable Nns proposals have been rendered.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.
