### PR TITLE
Display actionable Sns proposals

### DIFF
--- a/frontend/src/lib/components/proposals/ActionableSnsProposals.svelte
+++ b/frontend/src/lib/components/proposals/ActionableSnsProposals.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import UniverseWithActionableProposals from "$lib/components/proposals/UniverseWithActionableProposals.svelte";
+  import type { ProposalData } from "@dfinity/sns/dist/candid/sns_governance";
+  import type { RootCanisterIdText } from "$lib/types/sns";
+  import { fromNullable, nonNullish } from "@dfinity/utils";
+  import SnsProposalCard from "$lib/components/sns-proposals/SnsProposalCard.svelte";
+  import { createSnsNsFunctionsProjectStore } from "$lib/derived/sns-ns-functions-project.derived";
+  import type { SnsNervousSystemFunction } from "@dfinity/sns";
+  import { Principal } from "@dfinity/principal";
+  import type { Universe } from "$lib/types/universe";
+  import type { Readable } from "svelte/store";
+  import type { ActionableSnsProposalsByUniverseData } from "$lib/derived/actionable-proposals.derived";
+
+  export let actionableUniverse: ActionableSnsProposalsByUniverseData;
+
+  let universe: Universe;
+  let proposals: ProposalData[];
+  $: ({ universe, proposals } = actionableUniverse);
+
+  let rootCanisterId: RootCanisterIdText;
+  $: rootCanisterId = universe.canisterId;
+
+  let nsFunctionsStore: Readable<SnsNervousSystemFunction[] | undefined>;
+  $: nsFunctionsStore = createSnsNsFunctionsProjectStore(
+    Principal.fromText(rootCanisterId)
+  );
+  let nsFunctions: SnsNervousSystemFunction[] | undefined;
+  $: nsFunctions = nonNullish(nsFunctionsStore) ? $nsFunctionsStore : undefined;
+</script>
+
+<TestIdWrapper testId="actionable-sns-proposals-component">
+  {#if nonNullish(nsFunctions)}
+    <UniverseWithActionableProposals {universe}>
+      {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
+        <SnsProposalCard
+          actionable
+          {proposalData}
+          {nsFunctions}
+          {universe}
+        />
+      {/each}
+    </UniverseWithActionableProposals>
+  {/if}
+</TestIdWrapper>

--- a/frontend/src/lib/components/proposals/ActionableSnsProposals.svelte
+++ b/frontend/src/lib/components/proposals/ActionableSnsProposals.svelte
@@ -37,7 +37,6 @@
           actionable
           {proposalData}
           {nsFunctions}
-          {universe}
         />
       {/each}
     </UniverseWithActionableProposals>

--- a/frontend/src/lib/components/proposals/ActionableSnsProposals.svelte
+++ b/frontend/src/lib/components/proposals/ActionableSnsProposals.svelte
@@ -10,13 +10,9 @@
   import { Principal } from "@dfinity/principal";
   import type { Universe } from "$lib/types/universe";
   import type { Readable } from "svelte/store";
-  import type { ActionableSnsProposalsByUniverseData } from "$lib/derived/actionable-proposals.derived";
 
-  export let actionableUniverse: ActionableSnsProposalsByUniverseData;
-
-  let universe: Universe;
-  let proposals: ProposalData[];
-  $: ({ universe, proposals } = actionableUniverse);
+  export let universe: Universe;
+  export let proposals: ProposalData[];
 
   let rootCanisterId: RootCanisterIdText;
   $: rootCanisterId = universe.canisterId;

--- a/frontend/src/lib/components/proposals/ActionableSnsProposals.svelte
+++ b/frontend/src/lib/components/proposals/ActionableSnsProposals.svelte
@@ -33,11 +33,7 @@
   {#if nonNullish(nsFunctions)}
     <UniverseWithActionableProposals {universe}>
       {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
-        <SnsProposalCard
-          actionable
-          {proposalData}
-          {nsFunctions}
-        />
+        <SnsProposalCard actionable {proposalData} {nsFunctions} />
       {/each}
     </UniverseWithActionableProposals>
   {/if}

--- a/frontend/src/lib/components/proposals/ActionableSnses.svelte
+++ b/frontend/src/lib/components/proposals/ActionableSnses.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <TestIdWrapper testId="actionable-snses-component">
-  {#each actionableUniverses as {universe, proposals} (actionableUniverse.universe.canisterId)}
+  {#each actionableUniverses as {universe, proposals} (universe.canisterId)}
     <ActionableSnsProposals {universe} {proposals} />
   {/each}
 </TestIdWrapper>

--- a/frontend/src/lib/components/proposals/ActionableSnses.svelte
+++ b/frontend/src/lib/components/proposals/ActionableSnses.svelte
@@ -7,10 +7,9 @@
   import ActionableSnsProposals from "$lib/components/proposals/ActionableSnsProposals.svelte";
 
   let actionableUniverses: ActionableSnsProposalsByUniverseData[] = [];
-  $: actionableUniverses =
-    $actionableSnsProposalsByUniverseStore.filter(
-      ({ proposals }) => proposals.length > 0
-    );
+  $: actionableUniverses = $actionableSnsProposalsByUniverseStore.filter(
+    ({ proposals }) => proposals.length > 0
+  );
 </script>
 
 <TestIdWrapper testId="actionable-snses-component">

--- a/frontend/src/lib/components/proposals/ActionableSnses.svelte
+++ b/frontend/src/lib/components/proposals/ActionableSnses.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <TestIdWrapper testId="actionable-snses-component">
-  {#each actionableUniverses as actionableUniverse (actionableUniverse.universe.canisterId)}
-    <ActionableSnsProposals {actionableUniverse} />
+  {#each actionableUniverses as {universe, proposals} (actionableUniverse.universe.canisterId)}
+    <ActionableSnsProposals {universe} {proposals} />
   {/each}
 </TestIdWrapper>

--- a/frontend/src/lib/components/proposals/ActionableSnses.svelte
+++ b/frontend/src/lib/components/proposals/ActionableSnses.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import {
+    type ActionableSnsProposalsByUniverseData,
+    actionableSnsProposalsByUniverseStore,
+  } from "$lib/derived/actionable-proposals.derived";
+  import ActionableSnsProposals from "$lib/components/proposals/ActionableSnsProposals.svelte";
+
+  let actionableUniverses: ActionableSnsProposalsByUniverseData[] = [];
+  $: actionableUniverses =
+    $actionableSnsProposalsByUniverseStore.filter(
+      ({ proposals }) => proposals.length > 0
+    );
+</script>
+
+<TestIdWrapper testId="actionable-snses-component">
+  {#each actionableUniverses as actionableUniverse (actionableUniverse.universe.canisterId)}
+    <ActionableSnsProposals {actionableUniverse} />
+  {/each}
+</TestIdWrapper>

--- a/frontend/src/lib/components/proposals/ActionableSnses.svelte
+++ b/frontend/src/lib/components/proposals/ActionableSnses.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <TestIdWrapper testId="actionable-snses-component">
-  {#each actionableUniverses as {universe, proposals} (universe.canisterId)}
+  {#each actionableUniverses as { universe, proposals } (universe.canisterId)}
     <ActionableSnsProposals {universe} {proposals} />
   {/each}
 </TestIdWrapper>

--- a/frontend/src/lib/derived/actionable-proposals.derived.ts
+++ b/frontend/src/lib/derived/actionable-proposals.derived.ts
@@ -90,13 +90,15 @@ export const actionableProposalNotSupportedUniversesStore: Readable<
     )
 );
 
+export interface ActionableSnsProposalsByUniverseData {
+  universe: Universe;
+  proposals: SnsProposalData[];
+}
+
 /** A store that contains sns universes with actionable support and their actionable proposals
  * in the same order as they are displayed in the UI. */
 export const actionableSnsProposalsByUniverseStore: Readable<
-  Array<{
-    universe: Universe;
-    proposals: SnsProposalData[];
-  }>
+  Array<ActionableSnsProposalsByUniverseData>
 > = derived(
   [selectableUniversesStore, actionableSnsProposalsStore],
   ([universes, actionableSnsProposals]) =>

--- a/frontend/src/lib/pages/ActionableProposals.svelte
+++ b/frontend/src/lib/pages/ActionableProposals.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import ActionableSnses from "$lib/components/proposals/ActionableSnses.svelte";
 </script>
 
 <TestIdWrapper testId="actionable-proposals-component">
-  <h1>Under construction</h1>
+  <ActionableSnses />
 </TestIdWrapper>

--- a/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
@@ -1,0 +1,157 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { AppPath } from "$lib/constants/routes.constants";
+import ActionableProposals from "$lib/pages/ActionableProposals.svelte";
+import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
+import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
+import { page } from "$mocks/$app/stores";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
+import { ActionableProposalsPo } from "$tests/page-objects/ActionableProposals.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { render } from "$tests/utils/svelte.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import {
+  SnsProposalDecisionStatus,
+  SnsProposalRewardStatus,
+  SnsSwapLifecycle,
+  type SnsProposalData,
+} from "@dfinity/sns";
+import { beforeEach } from "vitest";
+
+describe("ActionableProposals", () => {
+  const renderComponent = async () => {
+    const { container } = render(ActionableProposals);
+    await runResolvedPromises();
+    return ActionableProposalsPo.under(new JestPageObjectElement(container));
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetIdentity();
+    resetSnsProjects();
+    actionableNnsProposalsStore.reset();
+    actionableSnsProposalsStore.resetForTesting();
+
+    page.mock({
+      data: { universe: OWN_CANISTER_ID_TEXT },
+      routeId: AppPath.Proposals,
+    });
+  });
+
+  describe("Actionable Sns proposals", () => {
+    const createProposal = (proposalId: bigint): SnsProposalData =>
+      createSnsProposal({
+        status: SnsProposalDecisionStatus.PROPOSAL_DECISION_STATUS_OPEN,
+        rewardStatus:
+          SnsProposalRewardStatus.PROPOSAL_REWARD_STATUS_ACCEPT_VOTES,
+        proposalId,
+      });
+    const proposal0 = createProposal(11n);
+    const proposal1 = createProposal(22n);
+    const proposal2 = createProposal(33n);
+    const principal0 = principal(0);
+    const principal1 = principal(1);
+    const principal2 = principal(2);
+    const principal3 = principal(3);
+
+    beforeEach(() => {
+      setSnsProjects([
+        {
+          lifecycle: SnsSwapLifecycle.Committed,
+          projectName: "Sns Project 0",
+          rootCanisterId: principal0,
+        },
+        {
+          lifecycle: SnsSwapLifecycle.Committed,
+          projectName: "Sns Project 1",
+          rootCanisterId: principal1,
+        },
+        {
+          lifecycle: SnsSwapLifecycle.Committed,
+          projectName: "Sns Project 2",
+          rootCanisterId: principal2,
+        },
+        {
+          lifecycle: SnsSwapLifecycle.Committed,
+          projectName: "Sns Project 3",
+          rootCanisterId: principal3,
+        },
+      ]);
+    });
+
+    it("should render actionable Sns proposals", async () => {
+      const po = await renderComponent();
+
+      expect(
+        await po.getActionableSnses().getActionableSnsProposalsPos()
+      ).toHaveLength(0);
+
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal0,
+        proposals: [proposal0],
+        includeBallotsByCaller: true,
+      });
+
+      await runResolvedPromises();
+      expect(
+        await po.getActionableSnses().getActionableSnsProposalsPos()
+      ).toHaveLength(1);
+
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal1,
+        // no proposals
+        proposals: [],
+        includeBallotsByCaller: true,
+      });
+
+      await runResolvedPromises();
+      expect(
+        await po.getActionableSnses().getActionableSnsProposalsPos()
+      ).toHaveLength(1);
+
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal2,
+        proposals: [proposal0],
+        // no ballots
+        includeBallotsByCaller: false,
+      });
+
+      await runResolvedPromises();
+      expect(
+        await po.getActionableSnses().getActionableSnsProposalsPos()
+      ).toHaveLength(1);
+
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal3,
+        proposals: [proposal1, proposal2],
+        includeBallotsByCaller: true,
+      });
+
+      await runResolvedPromises();
+      const snsProposalsPos = await po
+        .getActionableSnses()
+        .getActionableSnsProposalsPos();
+      expect(snsProposalsPos).toHaveLength(2);
+      expect(
+        await snsProposalsPos[0]
+          .getUniverseWithActionableProposalsPo()
+          .getTitle()
+      ).toEqual("Sns Project 0");
+      const proposalCardPos0 = await snsProposalsPos[0].getProposalCardPos();
+      expect(proposalCardPos0.length).toEqual(1);
+      expect(await proposalCardPos0[0].getProposalId()).toEqual("ID: 11");
+
+      expect(
+        await snsProposalsPos[1]
+          .getUniverseWithActionableProposalsPo()
+          .getTitle()
+      ).toEqual("Sns Project 3");
+      const proposalCardPos1 = await snsProposalsPos[1].getProposalCardPos();
+      expect(proposalCardPos1.length).toEqual(2);
+      expect(await proposalCardPos1[0].getProposalId()).toEqual("ID: 22");
+      expect(await proposalCardPos1[1].getProposalId()).toEqual("ID: 33");
+    });
+  });
+});

--- a/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
@@ -123,38 +123,8 @@ describe("ActionableProposals", () => {
         proposals: [proposal0],
         includeBallotsByCaller: true,
       });
-
-      await runResolvedPromises();
-      expect(
-        await po.getActionableSnses().getActionableSnsProposalsPos()
-      ).toHaveLength(1);
-
       actionableSnsProposalsStore.set({
         rootCanisterId: principal1,
-        // no proposals
-        proposals: [],
-        includeBallotsByCaller: true,
-      });
-
-      await runResolvedPromises();
-      expect(
-        await po.getActionableSnses().getActionableSnsProposalsPos()
-      ).toHaveLength(1);
-
-      actionableSnsProposalsStore.set({
-        rootCanisterId: principal2,
-        proposals: [proposal0],
-        // no ballots
-        includeBallotsByCaller: false,
-      });
-
-      await runResolvedPromises();
-      expect(
-        await po.getActionableSnses().getActionableSnsProposalsPos()
-      ).toHaveLength(1);
-
-      actionableSnsProposalsStore.set({
-        rootCanisterId: principal3,
         proposals: [proposal1, proposal2],
         includeBallotsByCaller: true,
       });
@@ -177,11 +147,48 @@ describe("ActionableProposals", () => {
         await snsProposalsPos[1]
           .getUniverseWithActionableProposalsPo()
           .getTitle()
-      ).toEqual("Sns Project 3");
+      ).toEqual("Sns Project 1");
       const proposalCardPos1 = await snsProposalsPos[1].getProposalCardPos();
       expect(proposalCardPos1.length).toEqual(2);
       expect(await proposalCardPos1[0].getProposalId()).toEqual("ID: 22");
       expect(await proposalCardPos1[1].getProposalId()).toEqual("ID: 33");
+    });
+
+    it("should ignore snses w/o ballot or actionable proposals", async () => {
+      const po = await renderComponent();
+
+      expect(
+        await po.getActionableSnses().getActionableSnsProposalsPos()
+      ).toHaveLength(0);
+
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal0,
+        // no proposals
+        proposals: [],
+        includeBallotsByCaller: true,
+      });
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal1,
+        proposals: [proposal0],
+        // no ballots
+        includeBallotsByCaller: false,
+      });
+
+      await runResolvedPromises();
+      expect(
+        await po.getActionableSnses().getActionableSnsProposalsPos()
+      ).toHaveLength(0);
+
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal2,
+        proposals: [proposal1, proposal2],
+        includeBallotsByCaller: true,
+      });
+
+      await runResolvedPromises();
+      expect(
+        await po.getActionableSnses().getActionableSnsProposalsPos()
+      ).toHaveLength(1);
     });
   });
 });

--- a/frontend/src/tests/page-objects/ActionableProposals.page-object.ts
+++ b/frontend/src/tests/page-objects/ActionableProposals.page-object.ts
@@ -1,3 +1,4 @@
+import { ActionableSnsesPo } from "$tests/page-objects/ActionableSnses.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -8,5 +9,9 @@ export class ActionableProposalsPo extends BasePageObject {
     return new ActionableProposalsPo(
       element.byTestId(ActionableProposalsPo.TID)
     );
+  }
+
+  getActionableSnses(): ActionableSnsesPo {
+    return ActionableSnsesPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/ActionableSnsProposals.page-object.ts
+++ b/frontend/src/tests/page-objects/ActionableSnsProposals.page-object.ts
@@ -1,0 +1,30 @@
+import { ProposalCardPo } from "$tests/page-objects/ProposalCard.page-object";
+import { UniverseWithActionableProposalsPo } from "$tests/page-objects/UniverseWithActionableProposals.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ActionableSnsProposalsPo extends BasePageObject {
+  static readonly TID = "actionable-sns-proposals-component";
+
+  static under(element: PageObjectElement): ActionableSnsProposalsPo {
+    return new ActionableSnsProposalsPo(
+      element.byTestId(ActionableSnsProposalsPo.TID)
+    );
+  }
+
+  static async allUnder(
+    element: PageObjectElement
+  ): Promise<ActionableSnsProposalsPo[]> {
+    return Array.from(
+      await element.allByTestId(ActionableSnsProposalsPo.TID)
+    ).map((el) => new ActionableSnsProposalsPo(el));
+  }
+
+  getUniverseWithActionableProposalsPo(): UniverseWithActionableProposalsPo {
+    return UniverseWithActionableProposalsPo.under(this.root);
+  }
+
+  getProposalCardPos(): Promise<ProposalCardPo[]> {
+    return ProposalCardPo.allUnder(this.root);
+  }
+}

--- a/frontend/src/tests/page-objects/ActionableSnses.page-object.ts
+++ b/frontend/src/tests/page-objects/ActionableSnses.page-object.ts
@@ -1,0 +1,15 @@
+import { ActionableSnsProposalsPo } from "$tests/page-objects/ActionableSnsProposals.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ActionableSnsesPo extends BasePageObject {
+  private static readonly TID = "actionable-snses-component";
+
+  static under(element: PageObjectElement): ActionableSnsesPo {
+    return new ActionableSnsesPo(element.byTestId(ActionableSnsesPo.TID));
+  }
+
+  getActionableSnsProposalsPos(): Promise<ActionableSnsProposalsPo[]> {
+    return ActionableSnsProposalsPo.allUnder(this.root);
+  }
+}


### PR DESCRIPTION
# Motivation

The actionable proposals page should include all votable proposals. Here, we display Sns proposals that users can vote for.

Note: should be merged after https://github.com/dfinity/nns-dapp/pull/4922

# Changes

- Add `ActionableSnsProposals` component.
- Add `ActionableSnses` component.
- Display actionable Sns proposals on actionable proposals page.

# Tests

- Add `ActionableSnsProposalsPo`.
- Add `ActionableSnsesPo`.
- Test that actionable Sns proposals have been rendered.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.
