### PR TITLE
bot: Update proposals candid bindings

### DIFF
--- a/declarations/used_by_proposals/nns_governance/nns_governance.did
+++ b/declarations/used_by_proposals/nns_governance/nns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-22_23-01-base/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;

--- a/declarations/used_by_proposals/nns_registry/nns_registry.did
+++ b/declarations/used_by_proposals/nns_registry/nns_registry.did
@@ -1,14 +1,26 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-22_23-01-base/rs/registry/canister/canister/registry.did>
+// A brief note about the history of this file: This file used to be
+// automatically generated, but now, it is hand-crafted, because the
+// auto-generator has some some pretty degenerate behaviors. The worst of those
+// behaviors are 1. type conflation 2. (unstable) numeric suffixes. These
+// behaviors made it impractical for clients to do the right thing: program
+// against registry.did (by using `didc bind`).
+//
+// test_implementated_interface_matches_declared_interface_exactly (defined in
+// ./tests.rs) ensures that the implementation stays in sync with this file.
+
 type AddApiBoundaryNodesPayload = record {
   version : text;
   node_ids : vec principal;
 };
+
 type AddFirewallRulesPayload = record {
   expected_hash : text;
   scope : FirewallRulesScope;
   positions : vec int32;
   rules : vec FirewallRule;
 };
+
 type AddNodeOperatorPayload = record {
   ipv6 : opt text;
   node_operator_principal_id : opt principal;
@@ -17,6 +29,7 @@ type AddNodeOperatorPayload = record {
   node_provider_principal_id : opt principal;
   dc_id : text;
 };
+
 type AddNodePayload = record {
   prometheus_metrics_endpoint : text;
   http_endpoint : text;
@@ -31,14 +44,17 @@ type AddNodePayload = record {
   ni_dkg_dealing_encryption_pk : blob;
   p2p_flow_endpoints : vec text;
 };
+
 type AddNodesToSubnetPayload = record {
   subnet_id : principal;
   node_ids : vec principal;
 };
+
 type AddOrRemoveDataCentersProposalPayload = record {
   data_centers_to_add : vec DataCenterRecord;
   data_centers_to_remove : vec text;
 };
+
 type BlessReplicaVersionPayload = record {
   release_package_urls : opt vec text;
   node_manager_sha256_hex : text;
@@ -50,16 +66,20 @@ type BlessReplicaVersionPayload = record {
   node_manager_binary_url : text;
   binary_url : text;
 };
+
 type CanisterIdRange = record { end : principal; start : principal };
+
 type ChangeSubnetMembershipPayload = record {
   node_ids_add : vec principal;
   subnet_id : principal;
   node_ids_remove : vec principal;
 };
+
 type CompleteCanisterMigrationPayload = record {
   canister_id_ranges : vec CanisterIdRange;
   migration_trace : vec principal;
 };
+
 type CreateSubnetPayload = record {
   unit_delay_millis : nat64;
   max_instructions_per_round : nat64;
@@ -92,20 +112,25 @@ type CreateSubnetPayload = record {
   gossip_receive_check_cache_size : nat32;
   node_ids : vec principal;
 };
+
 type DataCenterRecord = record {
   id : text;
   gps : opt Gps;
   region : text;
   owner : text;
 };
+
 type DeleteSubnetPayload = record { subnet_id : opt principal };
+
 type DeployGuestosToAllSubnetNodesPayload = record {
   subnet_id : principal;
   replica_version_id : text;
 };
+
 type DeployGuestosToAllUnassignedNodesPayload = record {
   elected_replica_version : text;
 };
+
 type EcdsaConfig = record {
   quadruples_to_create_in_advance : nat32;
   max_queue_size : opt nat32;
@@ -113,7 +138,9 @@ type EcdsaConfig = record {
   signature_request_timeout_ns : opt nat64;
   idkg_key_rotation_period_ms : opt nat64;
 };
+
 type EcdsaCurve = variant { secp256k1 };
+
 type EcdsaInitialConfig = record {
   quadruples_to_create_in_advance : nat32;
   max_queue_size : opt nat32;
@@ -121,11 +148,14 @@ type EcdsaInitialConfig = record {
   signature_request_timeout_ns : opt nat64;
   idkg_key_rotation_period_ms : opt nat64;
 };
+
 type EcdsaKeyId = record { name : text; curve : EcdsaCurve };
+
 type EcdsaKeyRequest = record {
   key_id : EcdsaKeyId;
   subnet_id : opt principal;
 };
+
 type FirewallRule = record {
   ipv4_prefixes : vec text;
   direction : opt int32;
@@ -135,6 +165,7 @@ type FirewallRule = record {
   ipv6_prefixes : vec text;
   ports : vec nat32;
 };
+
 type FirewallRulesScope = variant {
   Node : principal;
   ReplicaNodes;
@@ -142,14 +173,19 @@ type FirewallRulesScope = variant {
   Subnet : principal;
   Global;
 };
+
 type GetSubnetForCanisterRequest = record { "principal" : opt principal };
+
 type GetSubnetForCanisterResponse = record { subnet_id : opt principal };
+
 type Gps = record { latitude : float32; longitude : float32 };
+
 type IPv4Config = record {
   prefix_length : nat32;
   gateway_ip_addr : text;
   ip_addr : text;
 };
+
 type NodeOperatorRecord = record {
   ipv6 : opt text;
   node_operator_principal_id : blob;
@@ -158,19 +194,24 @@ type NodeOperatorRecord = record {
   node_provider_principal_id : blob;
   dc_id : text;
 };
+
 type NodeProvidersMonthlyXdrRewards = record {
   rewards : vec record { text; nat64 };
 };
+
 type NodeRewardRate = record {
   xdr_permyriad_per_node_per_month : nat64;
   reward_coefficient_percent : opt int32;
 };
+
 type NodeRewardRates = record { rates : vec record { text; NodeRewardRate } };
+
 type PrepareCanisterMigrationPayload = record {
   canister_id_ranges : vec CanisterIdRange;
   source_subnet : principal;
   destination_subnet : principal;
 };
+
 type RecoverSubnetPayload = record {
   height : nat64;
   replacement_nodes : opt vec principal;
@@ -180,31 +221,44 @@ type RecoverSubnetPayload = record {
   state_hash : blob;
   time_ns : nat64;
 };
+
 type RemoveApiBoundaryNodesPayload = record { node_ids : vec principal };
+
 type RemoveFirewallRulesPayload = record {
   expected_hash : text;
   scope : FirewallRulesScope;
   positions : vec int32;
 };
+
 type RemoveNodeDirectlyPayload = record { node_id : principal };
+
 type RemoveNodeOperatorsPayload = record {
   node_operators_to_remove : vec blob;
 };
+
 type RemoveNodesPayload = record { node_ids : vec principal };
+
 type RerouteCanisterRangesPayload = record {
   source_subnet : principal;
   reassigned_canister_ranges : vec CanisterIdRange;
   destination_subnet : principal;
 };
+
 type Result = variant { Ok : principal; Err : text };
+
 type Result_1 = variant { Ok; Err : text };
+
 type Result_2 = variant {
   Ok : vec record { DataCenterRecord; NodeOperatorRecord };
   Err : text;
 };
+
 type Result_3 = variant { Ok : NodeProvidersMonthlyXdrRewards; Err : text };
+
 type Result_4 = variant { Ok : GetSubnetForCanisterResponse; Err : text };
+
 type RetireReplicaVersionPayload = record { replica_version_ids : vec text };
+
 type ReviseElectedGuestosVersionsPayload = record {
   release_package_urls : vec text;
   replica_versions_to_unelect : vec text;
@@ -212,38 +266,47 @@ type ReviseElectedGuestosVersionsPayload = record {
   guest_launch_measurement_sha256_hex : opt text;
   release_package_sha256_hex : opt text;
 };
+
 type SetFirewallConfigPayload = record {
   ipv4_prefixes : vec text;
   firewall_config : text;
   ipv6_prefixes : vec text;
 };
+
 type SubnetFeatures = record {
   canister_sandboxing : bool;
   http_requests : bool;
   sev_enabled : opt bool;
 };
+
 type SubnetType = variant { application; verified_application; system };
+
 type UpdateElectedHostosVersionsPayload = record {
   release_package_urls : vec text;
   hostos_version_to_elect : opt text;
   hostos_versions_to_unelect : vec text;
   release_package_sha256_hex : opt text;
 };
+
 type UpdateNodeDirectlyPayload = record {
   idkg_dealing_encryption_pk : opt blob;
 };
+
 type UpdateNodeDomainDirectlyPayload = record {
   node_id : principal;
   domain : opt text;
 };
+
 type UpdateNodeIPv4ConfigDirectlyPayload = record {
   ipv4_config : opt IPv4Config;
   node_id : principal;
 };
+
 type UpdateNodeOperatorConfigDirectlyPayload = record {
   node_operator_id : opt principal;
   node_provider_id : opt principal;
 };
+
 type UpdateNodeOperatorConfigPayload = record {
   node_operator_id : opt principal;
   set_ipv6_to_none : opt bool;
@@ -253,16 +316,20 @@ type UpdateNodeOperatorConfigPayload = record {
   rewardable_nodes : vec record { text; nat32 };
   dc_id : opt text;
 };
+
 type UpdateNodeRewardsTableProposalPayload = record {
   new_entries : vec record { text; NodeRewardRates };
 };
+
 type UpdateNodesHostosVersionPayload = record {
   hostos_version_id : opt text;
   node_ids : vec principal;
 };
+
 type UpdateSshReadOnlyAccessForAllUnassignedNodesPayload = record {
   ssh_readonly_keys : vec text;
 };
+
 type UpdateSubnetPayload = record {
   unit_delay_millis : opt nat64;
   max_duplicity : opt nat32;
@@ -296,10 +363,12 @@ type UpdateSubnetPayload = record {
   subnet_type : opt SubnetType;
   ssh_readonly_access : opt vec text;
 };
+
 type UpdateUnassignedNodesConfigPayload = record {
   replica_version : opt text;
   ssh_readonly_access : opt vec text;
 };
+
 service : {
   add_api_boundary_nodes : (AddApiBoundaryNodesPayload) -> ();
   add_firewall_rules : (AddFirewallRulesPayload) -> ();

--- a/declarations/used_by_proposals/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_proposals/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-22_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };

--- a/dfx.json
+++ b/dfx.json
@@ -388,7 +388,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-05-22",
-        "IC_COMMIT_FOR_PROPOSALS": "release-2024-05-09_23-02-storage-layer",
+        "IC_COMMIT_FOR_PROPOSALS": "release-2024-05-22_23-01-base",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-05-09_23-02-storage-layer"
       },
       "packtool": ""

--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-22_23-01-base/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-22_23-01-base/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-09_23-02-storage-layer/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-22_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.
Even with no changes, just updating the reference is good practice.

# Changes
* Update the version of `IC_COMMIT_FOR_PROPOSALS` specified in `dfx.json`.
* Updated the `proposals` candid files to the versions in that commit.
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants