### PR TITLE
Add missing paths to candid bindings workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -149,7 +149,7 @@ jobs:
           ./scripts/proposals/did2rs
       - name: Run the ic_commit code generator for sns_aggregator
         run: |
-          ./scripts/update_ic_commit --crate proposals --ic_commit "$(jq -re .defaults.build.config.IC_COMMIT_FOR_SNS_AGGREGATOR dfx.json)"
+          ./scripts/update_ic_commit --crate sns_aggregator --ic_commit "$(jq -re .defaults.build.config.IC_COMMIT_FOR_SNS_AGGREGATOR dfx.json)"
           ./scripts/sns/aggregator/mk_nns_patch.sh
       - name: Verify that there are no code changes
         run: |

--- a/.github/workflows/update-aggregator.yml
+++ b/.github/workflows/update-aggregator.yml
@@ -65,7 +65,10 @@ jobs:
           base: main
           reviewers: mstrasinskis, dskloetd
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
-          add-paths: rs/sns_aggregator/src/types/*
+          add-paths: |
+            dfx.json
+            declarations/*/*.did
+            rs/sns_aggregator/src/types/*
           branch: bot-aggregator-update
           branch-suffix: timestamp
           delete-branch: true

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -72,7 +72,10 @@ jobs:
           branch-suffix: timestamp
           reviewers: mstrasinskis, dskloetd
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.
-          add-paths: rs/proposals/src/canisters/*/api.rs
+          add-paths: |
+            dfx.json
+            declarations/*/*.did
+            rs/proposals/src/canisters/*/api.rs
           delete-branch: true
           title: 'bot: Update proposals candid bindings'
           # Note: It is _likely_ but not guaranteed that the .did files match the `IC_COMMIT` in `dfx.json`.  The files in the PR have a header that give this information reliably.


### PR DESCRIPTION
# Motivation

In https://github.com/dfinity/nns-dapp/pull/4879 I combined the workflow to update Candid with the workflows to update Rust from Candid. Unfortunately I couldn't fully test it at the time because the IC release had failed that week.
Now it turns out that while the Candid may be updated correctly, it's not added to the PR created at the end.

# Changes

1. Add the paths that used to be added to the PR in that updated Candid ([here](https://github.com/dfinity/nns-dapp/blob/c2f02ac390759f9dbcd87da0712fadede589854d/.github/workflows/update-ic.yml#L87-L89)) to the PRs that now update Candid and Rust.

# Tests

These PRs were created from this branch:
1. https://github.com/dfinity/nns-dapp/pull/4936
2. https://github.com/dfinity/nns-dapp/pull/4935

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary