### PR TITLE
Fix crate flag on code generation test

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -149,7 +149,7 @@ jobs:
           ./scripts/proposals/did2rs
       - name: Run the ic_commit code generator for sns_aggregator
         run: |
-          ./scripts/update_ic_commit --crate proposals --ic_commit "$(jq -re .defaults.build.config.IC_COMMIT_FOR_SNS_AGGREGATOR dfx.json)"
+          ./scripts/update_ic_commit --crate sns_aggregator --ic_commit "$(jq -re .defaults.build.config.IC_COMMIT_FOR_SNS_AGGREGATOR dfx.json)"
           ./scripts/sns/aggregator/mk_nns_patch.sh
       - name: Verify that there are no code changes
         run: |


### PR DESCRIPTION
# Motivation

We have workflows to automatically update Candid files and generate Rust code from them.
We have tests to make sure the Rust code is always equal to what would be generated to make sure it's not manually edited.
I recently updated the workflows (https://github.com/dfinity/nns-dapp/pull/4875) and made a copy-paste mistake in the test, which now prevents us from updating the code.

# Changes

Fix the `--crate` flag passed to `./scripts/update_ic_commit` to match the IC commit the Candid files are from and the Rust generated from them.

# Tests

Not tested.
This test is currently failing in bot-generated PRs and needs to be fixed before we can test creating another bot PR through the workflow.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary