### PR TITLE
Update IC Cargo Dependencies to release-2024-05-22_23-01-base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,7 +1040,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1058,6 +1058,7 @@ dependencies = [
  "ic-ledger-core",
  "ic-management-canister-types",
  "ic-metrics-encoder",
+ "ic-nervous-system-common",
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-governance",
  "ic-nns-common",
@@ -1165,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "dfn_core",
@@ -1177,7 +1178,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1186,7 +1187,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "dfn_candid",
@@ -1198,7 +1199,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1210,7 +1211,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "on_wire",
  "prost",
@@ -1447,7 +1448,7 @@ dependencies = [
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1808,6 +1809,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -1951,7 +1961,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "ic-btc-interface 0.2.0 (git+https://github.com/dfinity/bitcoin-canister?rev=62a71e47c491fb842ccc257b1c675651501f4b82)",
@@ -1964,7 +1974,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ecdsa-secp256k1",
@@ -1977,7 +1987,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "serde",
 ]
@@ -1985,7 +1995,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.10",
@@ -1994,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "serde",
@@ -2107,12 +2117,12 @@ dependencies = [
 [[package]]
 name = "ic-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "k256",
  "lazy_static",
@@ -2126,19 +2136,21 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
+ "hkdf",
  "pem",
  "rand",
+ "sha2 0.10.8",
  "zeroize",
 ]
 
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "getrandom",
 ]
@@ -2146,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "hex",
  "ic-types",
@@ -2156,7 +2168,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -2178,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -2196,7 +2208,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2204,7 +2216,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2223,7 +2235,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2236,7 +2248,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -2244,7 +2256,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "base64 0.13.1",
  "cached",
@@ -2270,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2300,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "arrayvec 0.7.4",
  "hex",
@@ -2317,7 +2329,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2335,7 +2347,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "serde",
  "zeroize",
@@ -2344,7 +2356,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2352,7 +2364,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-test-utils-reproducible-rng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "rand",
  "rand_chacha",
@@ -2361,7 +2373,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2375,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "assert_matches",
  "ic-crypto-internal-types",
@@ -2389,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2399,7 +2411,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2409,7 +2421,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "ic-protobuf",
  "ic-utils",
@@ -2421,7 +2433,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "ciborium",
@@ -2443,7 +2455,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "ciborium",
@@ -2470,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "async-trait",
  "candid 0.10.8",
@@ -2498,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "ic-ledger-core",
@@ -2510,7 +2522,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "async-trait",
  "candid 0.10.8",
@@ -2528,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "ic-ledger-hash-of",
@@ -2540,7 +2552,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "hex",
@@ -2550,7 +2562,7 @@ dependencies = [
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "ic-base-types",
@@ -2575,16 +2587,21 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "async-trait",
  "candid 0.10.8",
+ "dfn_candid",
  "dfn_core",
  "ic-base-types",
  "ic-error-types",
+ "ic-ledger-core",
  "ic-management-canister-types",
+ "ic-nervous-system-common",
  "ic-nervous-system-proxied-canister-calls-tracker",
  "ic-nervous-system-runtime",
+ "icrc-ledger-client",
+ "icrc-ledger-types",
  "num-traits",
  "serde",
 ]
@@ -2592,12 +2609,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2633,12 +2650,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -2651,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -2663,12 +2680,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "comparable",
@@ -2681,7 +2698,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "ic-base-types",
 ]
@@ -2689,7 +2706,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "dfn_core",
@@ -2705,7 +2722,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "async-trait",
  "candid 0.10.8",
@@ -2718,12 +2735,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -2736,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "comparable",
@@ -2761,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "ic-base-types",
 ]
@@ -2769,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2832,12 +2849,12 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "async-trait",
  "candid 0.10.8",
@@ -2852,7 +2869,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "bincode",
  "candid 0.10.8",
@@ -2867,7 +2884,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "ic-base-types",
@@ -2879,7 +2896,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "ic-base-types",
@@ -2890,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "ic-management-canister-types",
@@ -2901,7 +2918,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "ic-protobuf",
@@ -2913,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "ic-base-types",
@@ -2925,7 +2942,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2982,7 +2999,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -2990,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -3001,7 +3018,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "async-trait",
  "candid 0.10.8",
@@ -3022,7 +3039,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "base64 0.13.1",
  "candid 0.10.8",
@@ -3049,7 +3066,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3078,7 +3095,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3116,7 +3133,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "comparable",
@@ -3131,7 +3148,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "async-trait",
  "candid 0.10.8",
@@ -3178,7 +3195,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3213,7 +3230,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "hex",
  "prost",
@@ -3299,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "comparable",
@@ -3329,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "async-trait",
  "candid 0.10.8",
@@ -3340,7 +3357,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.5"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "base32",
  "candid 0.10.8",
@@ -4066,7 +4083,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 
 [[package]]
 name = "once_cell"
@@ -4223,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "candid 0.10.8",
  "serde",
@@ -4727,7 +4744,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-05-09_23-02-storage-layer#9866a6f5cb43c54e3d87fa02a4eb80d0f159dddb"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-05-22_23-01-base#ec35ebd252d4ffb151d2cfceba3a86c4fb87c6d6"
 dependencies = [
  "build-info",
  "build-info-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,23 +13,23 @@ version = "2.0.77"
 ic-cdk = "0.13.3"
 ic-cdk-macros = "0.13.3"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
-ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-09_23-02-storage-layer" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
+ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-05-22_23-01-base" }
 
 [profile.release]
 lto = false


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
We want to keep our Cargo dependencies up to date.

# Changes
* Ran `scripts/update-ic-cargo-deps` to update the Cargo.toml dependencies to the latest IC release.

# Tests
* See CI