### PR TITLE
style: Add a space between universe title and proposals

### DIFF
--- a/frontend/src/lib/components/proposals/UniverseWithActionableProposals.svelte
+++ b/frontend/src/lib/components/proposals/UniverseWithActionableProposals.svelte
@@ -7,7 +7,9 @@
 </script>
 
 <div class="container" data-tid="universe-with-actionable-proposals-component">
-  <UniversePageSummary {universe} />
+  <div class="title">
+    <UniversePageSummary {universe} />
+  </div>
 
   <InfiniteScroll layout="grid" disabled>
     <slot />
@@ -17,5 +19,9 @@
 <style lang="scss">
   .container {
     margin-bottom: var(--padding-4x);
+  }
+
+  .title {
+    margin-bottom: var(--padding-3x);
   }
 </style>


### PR DESCRIPTION
# Motivation

To match the design, we are adding a missing spacing between the heading and the list.

# Changes

- Style changes only.

# Tests

- Manually.

| From | To |
|--------|--------|
| <img width="292" alt="Screenshot 2024-05-27 at 11 39 13" src="https://github.com/dfinity/nns-dapp/assets/98811342/7002a21c-1b17-44e6-a7f7-cf54ffe25c95"> | <img width="263" alt="Screenshot 2024-05-27 at 11 39 26" src="https://github.com/dfinity/nns-dapp/assets/98811342/e5d802fa-65ff-4ed6-a3d2-f38b4e71d681"> |

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.