### PR TITLE
Change schedule day for sns_aggregator candid workflow

### DIFF
--- a/.github/workflows/update-aggregator.yml
+++ b/.github/workflows/update-aggregator.yml
@@ -4,7 +4,7 @@ name: Update sns_aggregator candid bindings
 on:
   schedule:
     # Check for updates on candid interface for the aggregator every monday at 3:30am.
-    - cron: '30 3 * * MON'
+    - cron: '30 3 * * TUE'
   workflow_dispatch:
   push:
     branches:


### PR DESCRIPTION
# Motivation

We have 2 workflows that update candid (for [proposals](https://github.com/dfinity/nns-dapp/blob/main/.github/workflows/update-proposals.yml) and [sns_aggregator](https://github.com/dfinity/nns-dapp/blob/main/.github/workflows/update-aggregator.yml)).
They update [adjacent fields](https://github.com/dfinity/nns-dapp/blob/c2459e808ae46e54c58580a44ce2b26a3d8cb568/dfx.json#L391-L392) in dfx.json, which make their PRs conflict, requiring manual intervention.

# Changes

Run the `update-aggregator.yml` workflow on Tuesday instead of Monday to avoid conflicts between simultaneous PRs.

# Tests

not tested

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary