### PR TITLE
Update changelog after release

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -15,41 +15,23 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
-* Get `ckUSDC` canister IDs from environment/configuration.
-
 #### Changed
-
-* Set `Actionable Proposals` as the default selection.
 
 #### Deprecated
 
 #### Removed
 
-* Stop writing account transactions to stable memory.
-
 #### Fixed
-
-* Rendering tokens with fewer than 8 decimals.
-* Don't allow inputting more decimals than the token supports.
 
 #### Security
 
-* Downgrade to Rust `1.77.2`.
-
 #### Not Published
-
-* Support `ckUSDC` behind a feature flag.
 
 ### Operations
 
 #### Added
 
-* Include `ckUSDC` when generating `args.did` and `.env`.
-* Include `ckUSDC` canister IDs when importing from URL with `scripts/canister_ids`.
-
 #### Changed
-
-* Keep existing `dfx` identities when running an `snsdemo` snapshot.
 
 #### Deprecated
 

--- a/CHANGELOG-Nns-Dapp.md
+++ b/CHANGELOG-Nns-Dapp.md
@@ -11,6 +11,46 @@ The NNS Dapp is released through proposals in the Network Nervous System. Theref
 Unreleased changes are added to `CHANGELOG-Nns-Dapp-unreleased.md` and moved
 here after a successful release.
 
+## Proposal 130081
+
+### Application
+
+#### Added
+
+* Get `ckUSDC` canister IDs from environment/configuration.
+
+#### Changed
+
+* Set `Actionable Proposals` as the default selection.
+
+#### Removed
+
+* Stop writing account transactions to stable memory.
+
+#### Fixed
+
+* Rendering tokens with fewer than 8 decimals.
+* Don't allow inputting more decimals than the token supports.
+
+#### Security
+
+* Downgrade to Rust `1.77.2`.
+
+#### Not Published
+
+* Support `ckUSDC` behind a feature flag.
+
+### Operations
+
+#### Added
+
+* Include `ckUSDC` when generating `args.did` and `.env`.
+* Include `ckUSDC` canister IDs when importing from URL with `scripts/canister_ids`.
+
+#### Changed
+
+* Keep existing `dfx` identities when running an `snsdemo` snapshot.
+
 ## Proposal 129748
 
 ### Application

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3924,7 +3924,7 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nns-dapp"
-version = "2.0.77"
+version = "2.0.78"
 dependencies = [
  "anyhow",
  "base64 0.21.5",
@@ -4493,7 +4493,7 @@ dependencies = [
 
 [[package]]
 name = "proposals"
-version = "2.0.77"
+version = "2.0.78"
 dependencies = [
  "anyhow",
  "candid 0.10.8",
@@ -5346,7 +5346,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "sns_aggregator"
-version = "2.0.77"
+version = "2.0.78"
 dependencies = [
  "anyhow",
  "base64 0.21.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.77"
+version = "2.0.78"
 
 [workspace.dependencies]
 ic-cdk = "0.13.3"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/nns-dapp",
-  "version": "2.0.77",
+  "version": "2.0.78",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/nns-dapp",
-      "version": "2.0.77",
+      "version": "2.0.78",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@dfinity/agent": "^1.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/nns-dapp",
-  "version": "2.0.77",
+  "version": "2.0.78",
   "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {

--- a/scripts/nns-dapp/release-template
+++ b/scripts/nns-dapp/release-template
@@ -77,6 +77,7 @@ To build the wasm module yourself and verify its hash, run the following command
 \`\`\`
 git fetch  # to ensure you have the latest changes.
 git checkout "$(git rev-parse tags/release-candidate)"
+git merge-base --is-ancestor HEAD origin/main && echo "OK" || echo "Commit is not on main branch!"
 ./scripts/docker-build
 sha256sum nns-dapp.wasm.gz
 \`\`\`
@@ -103,6 +104,7 @@ To build the wasm module yourself and verify its hash, run the following command
 \`\`\`
 git fetch  # to ensure you have the latest changes.
 git checkout "$(git rev-parse tags/release-candidate)"
+git merge-base --is-ancestor HEAD origin/main && echo "OK" || echo "Commit is not on main branch!"
 ./scripts/docker-build
 sha256sum nns-dapp.wasm.gz
 \`\`\`


### PR DESCRIPTION
# Motivation

A release has been deployed to production.

# Changes

- Update `scripts/nns-dapp/release-template` to include an extra verification step to make sure the release commit is on the `main` branch.
- Changelog - split out the changes included in the release.
- Increment the patch version of the nns-dapp.

# Tested

Ran `git merge-base --is-ancestor HEAD origin/main && echo "OK" || echo "Commit is not on main branch!"` command in several branches.
A version without `origin/` was used in the [most recent proposal](https://dashboard.internetcomputer.org/proposal/130081) and there were some issues if the verifier had an old `main` branch.
Using `origin/main` should always work after `git fetch`.