### PR TITLE
Add test for ResponsiveTable

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -25,7 +25,12 @@
   ];
 </script>
 
-<ResponsiveTable tableData={userTokensData} {columns} on:nnsAction>
+<ResponsiveTable
+  testId="tokens-table-component"
+  tableData={userTokensData}
+  {columns}
+  on:nnsAction
+>
   <slot name="last-row" slot="last-row" />
   <slot name="header-icon" slot="header-icon" />
 </ResponsiveTable>

--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -10,6 +10,7 @@
   import ResponsiveTableRow from "$lib/components/ui/ResponsiveTableRow.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
+  export let testId = "responsive-table-component";
   export let tableData: Array<RowDataType>;
   export let columns: ResponsiveTableColumn<RowDataType>[];
 
@@ -30,7 +31,7 @@
 
 <div
   role="table"
-  data-tid="tokens-table-component"
+  data-tid={testId}
   style={`grid-template-columns: ${desktopColumnsStyle()};`}
 >
   <div role="rowgroup">

--- a/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
@@ -31,7 +31,7 @@
   href={rowData.rowHref}
   role="row"
   tabindex="0"
-  data-tid="tokens-table-row-component"
+  data-tid="responsive-table-row-component"
   class={mobileTemplateClass(2)}
 >
   {#if firstColumn}

--- a/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
@@ -1,0 +1,79 @@
+import ResponsiveTable from "$lib/components/ui/ResponsiveTable.svelte";
+import TestTableAgeCell from "$tests/lib/components/ui/TestTableAgeCell.svelte";
+import TestTableNameCell from "$tests/lib/components/ui/TestTableNameCell.svelte";
+import { ResponsiveTablePo } from "$tests/page-objects/ResponsiveTable.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+
+describe("ResponseTable", () => {
+  const columns = [
+    {
+      title: "Name",
+      cellComponent: TestTableNameCell,
+    },
+    {
+      title: "Age",
+      cellComponent: TestTableAgeCell,
+    },
+    {
+      title: "Actions",
+      // Normally each column would have a different cell component but for
+      // testing we reuse the name cell component.
+      cellComponent: TestTableNameCell,
+    },
+  ];
+
+  const tableData = [
+    {
+      rowHref: "alice/",
+      name: "Alice",
+      age: 45,
+    },
+    {
+      rowHref: "anna/",
+      name: "Anna",
+      age: 19,
+    },
+    {
+      rowHref: "anton/",
+      name: "Anton",
+      age: 31,
+    },
+  ];
+
+  const renderComponent = ({ columns, tableData }) => {
+    const { container } = render(ResponsiveTable, {
+      columns,
+      tableData,
+    });
+
+    return ResponsiveTablePo.under(new JestPageObjectElement(container));
+  };
+
+  it("should render column headers", async () => {
+    const po = renderComponent({ columns, tableData });
+    // The last column is reserved for actions and is never rendered with a
+    // header.
+    expect(await po.getColumnHeaders()).toEqual(["Name", "Age", ""]);
+  });
+
+  it("should render row data", async () => {
+    const po = renderComponent({ columns, tableData });
+    const rows = await po.getRows();
+    expect(rows).toHaveLength(3);
+    // The label is repeated in the cell for columns that aren't the first or
+    // the last column. They are hidden on desktop and shown on mobile.
+    expect(await rows[0].getCells()).toEqual(["Alice", "Age 45", "Alice"]);
+    expect(await rows[1].getCells()).toEqual(["Anna", "Age 19", "Anna"]);
+    expect(await rows[2].getCells()).toEqual(["Anton", "Age 31", "Anton"]);
+  });
+
+  it("should render row href", async () => {
+    const po = renderComponent({ columns, tableData });
+    const rows = await po.getRows();
+    expect(rows).toHaveLength(3);
+    expect(await rows[0].getHref()).toBe("alice/");
+    expect(await rows[1].getHref()).toBe("anna/");
+    expect(await rows[2].getHref()).toBe("anton/");
+  });
+});

--- a/frontend/src/tests/lib/components/ui/TestTableAgeCell.svelte
+++ b/frontend/src/tests/lib/components/ui/TestTableAgeCell.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  export let rowData: { age: number };
+</script>
+
+{rowData.age}

--- a/frontend/src/tests/lib/components/ui/TestTableNameCell.svelte
+++ b/frontend/src/tests/lib/components/ui/TestTableNameCell.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  export let rowData: { name: string };
+</script>
+
+{rowData.name}

--- a/frontend/src/tests/page-objects/ResponsiveTable.page-object.ts
+++ b/frontend/src/tests/page-objects/ResponsiveTable.page-object.ts
@@ -1,0 +1,23 @@
+import { ResponsiveTableRowPo } from "$tests/page-objects/ResponsiveTableRow.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ResponsiveTablePo extends BasePageObject {
+  private static readonly TID = "responsive-table-component";
+
+  static under(element: PageObjectElement): ResponsiveTablePo {
+    return new ResponsiveTablePo(element.byTestId(ResponsiveTablePo.TID));
+  }
+
+  async getColumnHeaders(): Promise<string[]> {
+    return Promise.all(
+      (await this.root.querySelectorAll("[role='columnheader']")).map((el) =>
+        el.getText()
+      )
+    );
+  }
+
+  getRows(): Promise<ResponsiveTableRowPo[]> {
+    return ResponsiveTableRowPo.allUnder(this.root);
+  }
+}

--- a/frontend/src/tests/page-objects/ResponsiveTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/ResponsiveTableRow.page-object.ts
@@ -1,0 +1,26 @@
+import type { PageObjectElement } from "$tests/types/page-object.types";
+import { BasePageObject } from "./base.page-object";
+
+export class ResponsiveTableRowPo extends BasePageObject {
+  private static readonly TID = "responsive-table-row-component";
+
+  static async allUnder(
+    element: PageObjectElement
+  ): Promise<ResponsiveTableRowPo[]> {
+    return Array.from(await element.allByTestId(ResponsiveTableRowPo.TID)).map(
+      (el) => new ResponsiveTableRowPo(el)
+    );
+  }
+
+  getHref(): Promise<string | null> {
+    return this.root.getAttribute("href");
+  }
+
+  async getCells(): Promise<string[]> {
+    return Promise.all(
+      (await this.root.querySelectorAll("[role='cell']")).map((el) =>
+        el.getText()
+      )
+    );
+  }
+}

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -8,7 +8,7 @@ export type TokensTableRowData = {
 };
 
 export class TokensTableRowPo extends BasePageObject {
-  private static readonly TID = "tokens-table-row-component";
+  private static readonly TID = "responsive-table-row-component";
 
   static async allUnder(
     element: PageObjectElement


### PR DESCRIPTION
# Motivation

A generic `ResponsiveTable` component was extracted from `TokensTable`.
So far we relied only on `TokensTable.spec.ts` for testing but the `ResponsiveTable` is now generic enough that it makes sense for it to have its own test.
I'll continue making it more generic but now it will also be possible to test separately.

# Changes

1. Add `testId` prop to `ResponsiveTable`.
2. Change `data-tid` on `ResponsiveTableRow`. This doesn't need to be a prop since once table only has one kind of row so there can never be confusion.
3. Add some cell components for testing.
4. Add page objects.
5. Add tests.

# Tests

Old and new tests pass.
Also did a quick manual check.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary