### PR TITLE
Actionable proposals loading state

### DIFF
--- a/frontend/src/lib/components/proposals/LoadingActionableProposals.svelte
+++ b/frontend/src/lib/components/proposals/LoadingActionableProposals.svelte
@@ -1,0 +1,24 @@
+<script>
+  import SkeletonCard from "../ui/SkeletonCard.svelte";
+  import { SkeletonText } from "@dfinity/gix-components";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+</script>
+
+<TestIdWrapper testId="loading-actionable-proposals">
+  <div class="headline">
+    <SkeletonText />
+  </div>
+  <div class="card-grid" data-tid="proposals-loading">
+    <SkeletonCard />
+    <SkeletonCard />
+    <SkeletonCard />
+  </div>
+</TestIdWrapper>
+
+<style lang="scss">
+  .headline {
+    margin-bottom: var(--padding-3x);
+    width: 210px;
+    height: var(--padding-3x);
+  }
+</style>

--- a/frontend/src/lib/components/proposals/LoadingActionableProposals.svelte
+++ b/frontend/src/lib/components/proposals/LoadingActionableProposals.svelte
@@ -4,7 +4,7 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 </script>
 
-<TestIdWrapper testId="loading-actionable-proposals">
+<TestIdWrapper testId="loading-actionable-proposals-component">
   <div class="headline">
     <SkeletonText />
   </div>

--- a/frontend/src/lib/pages/ActionableProposals.svelte
+++ b/frontend/src/lib/pages/ActionableProposals.svelte
@@ -2,11 +2,16 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import ActionableSnses from "$lib/components/proposals/ActionableSnses.svelte";
   import ActionableNnsProposals from "$lib/components/proposals/ActionableNnsProposals.svelte";
+  import { actionableProposalsLoadedStore } from "$lib/derived/actionable-proposals.derived";
+  import LoadingActionableProposals from "$lib/components/proposals/LoadingActionableProposals.svelte";
 </script>
 
 <TestIdWrapper testId="actionable-proposals-component">
-  <!-- TODO: Loading state -->
-  <ActionableNnsProposals />
-  <ActionableSnses />
+  {#if $actionableProposalsLoadedStore}
+    <ActionableNnsProposals />
+    <ActionableSnses />
+  {:else}
+    <LoadingActionableProposals />
+  {/if}
   <!-- TODO: No proposals banner -->
 </TestIdWrapper>

--- a/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
@@ -138,11 +138,6 @@ describe("ActionableProposals", () => {
         proposals: [proposal1, proposal2],
         includeBallotsByCaller: true,
       });
-      actionableSnsProposalsStore.set({
-        rootCanisterId: principal2,
-        proposals: [],
-        includeBallotsByCaller: true,
-      });
 
       await runResolvedPromises();
       const snsProposalsPos = await po

--- a/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
@@ -27,6 +27,24 @@ describe("ActionableProposals", () => {
     await runResolvedPromises();
     return ActionableProposalsPo.under(new JestPageObjectElement(container));
   };
+  const principal0 = principal(0);
+  const principal1 = principal(1);
+  const principal2 = principal(2);
+  const snsProject0 = {
+    lifecycle: SnsSwapLifecycle.Committed,
+    projectName: "Sns Project 0",
+    rootCanisterId: principal0,
+  };
+  const snsProject1 = {
+    lifecycle: SnsSwapLifecycle.Committed,
+    projectName: "Sns Project 1",
+    rootCanisterId: principal1,
+  };
+  const snsProject2 = {
+    lifecycle: SnsSwapLifecycle.Committed,
+    projectName: "Sns Project 2",
+    rootCanisterId: principal2,
+  };
 
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -96,24 +114,6 @@ describe("ActionableProposals", () => {
     const proposal0 = createProposal(11n);
     const proposal1 = createProposal(22n);
     const proposal2 = createProposal(33n);
-    const principal0 = principal(0);
-    const principal1 = principal(1);
-    const principal2 = principal(2);
-    const snsProject0 = {
-      lifecycle: SnsSwapLifecycle.Committed,
-      projectName: "Sns Project 0",
-      rootCanisterId: principal0,
-    };
-    const snsProject1 = {
-      lifecycle: SnsSwapLifecycle.Committed,
-      projectName: "Sns Project 1",
-      rootCanisterId: principal1,
-    };
-    const snsProject2 = {
-      lifecycle: SnsSwapLifecycle.Committed,
-      projectName: "Sns Project 2",
-      rootCanisterId: principal2,
-    };
 
     beforeEach(() => {
       // Ensure Nns proposals are loaded to avoid rendering skeletons

--- a/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
@@ -45,6 +45,21 @@ describe("ActionableProposals", () => {
     const nnsProposal1: ProposalInfo = { ...mockProposalInfo, id: 11n };
     const nnsProposal2: ProposalInfo = { ...mockProposalInfo, id: 22n };
 
+    beforeEach(() => {
+      // Ensure Sns proposals are loaded to avoid rendering skeletons
+      setSnsProjects([
+        {
+          lifecycle: SnsSwapLifecycle.Committed,
+          rootCanisterId: principal(0),
+        },
+      ]);
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal(0),
+        proposals: [],
+        includeBallotsByCaller: false,
+      });
+    });
+
     it("should render actionable Nns proposals", async () => {
       const po = await renderComponent();
 
@@ -84,34 +99,29 @@ describe("ActionableProposals", () => {
     const principal0 = principal(0);
     const principal1 = principal(1);
     const principal2 = principal(2);
-    const principal3 = principal(3);
+    const snsProject0 = {
+      lifecycle: SnsSwapLifecycle.Committed,
+      projectName: "Sns Project 0",
+      rootCanisterId: principal0,
+    };
+    const snsProject1 = {
+      lifecycle: SnsSwapLifecycle.Committed,
+      projectName: "Sns Project 1",
+      rootCanisterId: principal1,
+    };
+    const snsProject2 = {
+      lifecycle: SnsSwapLifecycle.Committed,
+      projectName: "Sns Project 2",
+      rootCanisterId: principal2,
+    };
 
     beforeEach(() => {
-      setSnsProjects([
-        {
-          lifecycle: SnsSwapLifecycle.Committed,
-          projectName: "Sns Project 0",
-          rootCanisterId: principal0,
-        },
-        {
-          lifecycle: SnsSwapLifecycle.Committed,
-          projectName: "Sns Project 1",
-          rootCanisterId: principal1,
-        },
-        {
-          lifecycle: SnsSwapLifecycle.Committed,
-          projectName: "Sns Project 2",
-          rootCanisterId: principal2,
-        },
-        {
-          lifecycle: SnsSwapLifecycle.Committed,
-          projectName: "Sns Project 3",
-          rootCanisterId: principal3,
-        },
-      ]);
+      // Ensure Nns proposals are loaded to avoid rendering skeletons
+      actionableNnsProposalsStore.setProposals([]);
     });
 
     it("should render actionable Sns proposals", async () => {
+      setSnsProjects([snsProject0, snsProject1]);
       const po = await renderComponent();
 
       expect(
@@ -126,6 +136,11 @@ describe("ActionableProposals", () => {
       actionableSnsProposalsStore.set({
         rootCanisterId: principal1,
         proposals: [proposal1, proposal2],
+        includeBallotsByCaller: true,
+      });
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal2,
+        proposals: [],
         includeBallotsByCaller: true,
       });
 
@@ -155,6 +170,7 @@ describe("ActionableProposals", () => {
     });
 
     it("should ignore snses w/o ballot or actionable proposals", async () => {
+      setSnsProjects([snsProject0, snsProject1, snsProject2]);
       const po = await renderComponent();
 
       expect(

--- a/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
@@ -202,4 +202,28 @@ describe("ActionableProposals", () => {
       ).toHaveLength(1);
     });
   });
+
+  it("should render skeletons while loading", async () => {
+    setSnsProjects([snsProject0]);
+    const po = await renderComponent();
+
+    expect(await po.hasActionableNnsProposals()).toEqual(false);
+    expect(await po.hasSkeletons()).toEqual(true);
+
+    actionableNnsProposalsStore.setProposals([{ ...mockProposalInfo }]);
+    await runResolvedPromises();
+
+    expect(await po.hasActionableNnsProposals()).toEqual(false);
+    expect(await po.hasSkeletons()).toEqual(true);
+
+    actionableSnsProposalsStore.set({
+      rootCanisterId: principal0,
+      proposals: [],
+      includeBallotsByCaller: true,
+    });
+    await runResolvedPromises();
+
+    expect(await po.hasActionableNnsProposals()).toEqual(true);
+    expect(await po.hasSkeletons()).toEqual(false);
+  });
 });

--- a/frontend/src/tests/page-objects/ActionableProposals.page-object.ts
+++ b/frontend/src/tests/page-objects/ActionableProposals.page-object.ts
@@ -25,4 +25,8 @@ export class ActionableProposalsPo extends BasePageObject {
       .getUniverseWithActionableProposalsPo()
       .isPresent();
   }
+
+  hasSkeletons(): Promise<boolean> {
+    return this.isPresent("loading-actionable-proposals-component");
+  }
 }


### PR DESCRIPTION
# Motivation

Added a preloader to improve the UX. The preloader provides feedback to the user, indicating that the proposals are still loading.

# Changes

- Add `LoadingActionableProposals` component (PO is not needed since there are no plans to reuse it elsewhere).
- Display `LoadingActionableProposals` while loading.
- 

# Tests

- Extend `ActionablePagePO` with `hasSkeletons`.
- Update other `ActionablePage` tests to respect loading state (to Nns proposals be shown, Sns proposals needs to be loaded and vice versa).
- Move some vars outside of a description block to reuse them in another test.
- Test that skeletons are shown while everything is not loaded and hidden afterwards.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

# Screenshots

| Desktop loading | Mobile loading | Loaded |
|--------|--------|--------|
| <img width="1331" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/b80a115e-0166-472d-9d02-b3bfe5508703"> | <img width="612" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/16c226b1-4c33-4f9a-8716-20c0dff1c6d1"> | <img width="612" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/c7a27fb8-0244-4e0b-b781-c97bfe4529d9"> | 







