### PR TITLE
No actionable proposals banner

### DIFF
--- a/frontend/src/lib/pages/ActionableProposals.svelte
+++ b/frontend/src/lib/pages/ActionableProposals.svelte
@@ -2,16 +2,23 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import ActionableSnses from "$lib/components/proposals/ActionableSnses.svelte";
   import ActionableNnsProposals from "$lib/components/proposals/ActionableNnsProposals.svelte";
-  import { actionableProposalsLoadedStore } from "$lib/derived/actionable-proposals.derived";
+  import {
+    actionableProposalsLoadedStore,
+    actionableProposalTotalCountStore,
+  } from "$lib/derived/actionable-proposals.derived";
   import LoadingActionableProposals from "$lib/components/proposals/LoadingActionableProposals.svelte";
+  import ActionableProposalsEmpty from "$lib/components/proposals/ActionableProposalsEmpty.svelte";
 </script>
 
 <TestIdWrapper testId="actionable-proposals-component">
   {#if $actionableProposalsLoadedStore}
-    <ActionableNnsProposals />
-    <ActionableSnses />
+    {#if $actionableProposalTotalCountStore > 0}
+      <ActionableNnsProposals />
+      <ActionableSnses />
+    {:else}
+      <ActionableProposalsEmpty />
+    {/if}
   {:else}
     <LoadingActionableProposals />
   {/if}
-  <!-- TODO: No proposals banner -->
 </TestIdWrapper>

--- a/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/ActionableProposals.spec.ts
@@ -226,4 +226,21 @@ describe("ActionableProposals", () => {
     expect(await po.hasActionableNnsProposals()).toEqual(true);
     expect(await po.hasSkeletons()).toEqual(false);
   });
+
+  it('should display "no actionable proposals" banner', async () => {
+    setSnsProjects([snsProject0]);
+    const po = await renderComponent();
+
+    expect(await po.hasActionableEmptyBanner()).toEqual(false);
+
+    actionableNnsProposalsStore.setProposals([]);
+    actionableSnsProposalsStore.set({
+      rootCanisterId: principal0,
+      proposals: [],
+      includeBallotsByCaller: true,
+    });
+    await runResolvedPromises();
+
+    expect(await po.hasActionableEmptyBanner()).toEqual(true);
+  });
 });

--- a/frontend/src/tests/page-objects/ActionableProposals.page-object.ts
+++ b/frontend/src/tests/page-objects/ActionableProposals.page-object.ts
@@ -1,5 +1,6 @@
 import { ActionableNnsProposalsPo } from "$tests/page-objects/ActionableNnsProposals.page-object";
 import { ActionableSnsesPo } from "$tests/page-objects/ActionableSnses.page-object";
+import { PageBannerPo } from "$tests/page-objects/PageBanner.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -28,5 +29,12 @@ export class ActionableProposalsPo extends BasePageObject {
 
   hasSkeletons(): Promise<boolean> {
     return this.isPresent("loading-actionable-proposals-component");
+  }
+
+  hasActionableEmptyBanner(): Promise<boolean> {
+    return PageBannerPo.under({
+      element: this.root,
+      testId: "actionable-proposals-empty",
+    }).isPresent();
   }
 }


### PR DESCRIPTION
# Motivation

To improve the UX with actionables, we display a banner when there are no actionable proposals available. Because SNS without actionable proposals are not displayed, it’s enough to handle only a single state for all universes.

# Changes

- Display `ActionableProposalsEmpty` banner in `ActionableProposals` component.

# Tests

- Add `hasActionableEmptyBanner` to PO.
- Test that the banner is shown.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

# Screenshot

| Mobile | Desktop |
|--------|--------|
| <img width="407" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/a8f00e49-e379-47b4-b892-d78aff5c285e"> | <img width="1220" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/b12c6eaf-60f2-46bf-aa3a-645d6200b6ef"> | 




