### PR TITLE
Back to actionable navigation

### DIFF
--- a/frontend/src/lib/components/proposals/ActionableNnsProposals.svelte
+++ b/frontend/src/lib/components/proposals/ActionableNnsProposals.svelte
@@ -10,7 +10,7 @@
   {#if $actionableNnsProposalsStore?.proposals?.length ?? 0 > 0}
     <UniverseWithActionableProposals universe={$nnsUniverseStore}>
       {#each $actionableNnsProposalsStore?.proposals ?? [] as proposalInfo (proposalInfo.id)}
-        <NnsProposalCard actionable {proposalInfo} />
+        <NnsProposalCard actionable fromActionablePage {proposalInfo} />
       {/each}
     </UniverseWithActionableProposals>
   {/if}

--- a/frontend/src/lib/components/proposals/ActionableSnsProposals.svelte
+++ b/frontend/src/lib/components/proposals/ActionableSnsProposals.svelte
@@ -29,7 +29,12 @@
   {#if nonNullish(nsFunctions)}
     <UniverseWithActionableProposals {universe}>
       {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
-        <SnsProposalCard actionable {proposalData} {nsFunctions} />
+        <SnsProposalCard
+          actionable
+          {proposalData}
+          {nsFunctions}
+          rootCanisterId={universe.canisterId}
+        />
       {/each}
     </UniverseWithActionableProposals>
   {/if}

--- a/frontend/src/lib/components/proposals/ActionableSnsProposals.svelte
+++ b/frontend/src/lib/components/proposals/ActionableSnsProposals.svelte
@@ -31,6 +31,7 @@
       {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
         <SnsProposalCard
           actionable
+          fromActionablePage
           {proposalData}
           {nsFunctions}
           rootCanisterId={universe.canisterId}

--- a/frontend/src/lib/components/proposals/NnsProposalCard.svelte
+++ b/frontend/src/lib/components/proposals/NnsProposalCard.svelte
@@ -12,6 +12,7 @@
   export let proposalInfo: ProposalInfo;
   export let hidden = false;
   export let actionable = false;
+  export let fromActionablePage = false;
 
   let id: ProposalId | undefined;
   let title: string | undefined;
@@ -25,6 +26,7 @@
   $: href = buildProposalUrl({
     universe: $pageStore.universe,
     proposalId: id as ProposalId,
+    actionable: fromActionablePage,
   });
 
   let status: UniversalProposalStatus | undefined;

--- a/frontend/src/lib/components/sns-proposals/SnsProposalCard.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalCard.svelte
@@ -19,6 +19,7 @@
   export let nsFunctions: SnsNervousSystemFunction[] | undefined;
   export let rootCanisterId: RootCanisterIdText;
   export let actionable = false;
+  export let fromActionablePage = false;
   export let hidden = false;
 
   let id: SnsProposalId | undefined;
@@ -45,6 +46,7 @@
   $: href = buildProposalUrl({
     universe: rootCanisterId,
     proposalId: `${id?.id}`,
+    actionable: fromActionablePage,
   });
 </script>
 

--- a/frontend/src/lib/components/sns-proposals/SnsProposalCard.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalCard.svelte
@@ -3,7 +3,6 @@
     getUniversalProposalStatus,
     mapProposalInfo,
   } from "$lib/utils/sns-proposals.utils";
-  import { pageStore } from "$lib/derived/page.derived";
   import { buildProposalUrl } from "$lib/utils/navigation.utils";
   import ProposalCard from "$lib/components/proposals/ProposalCard.svelte";
   import type {
@@ -14,9 +13,11 @@
   } from "@dfinity/sns";
   import { subaccountToHexString } from "$lib/utils/sns-neuron.utils";
   import type { UniversalProposalStatus } from "$lib/types/proposals";
+  import type { RootCanisterIdText } from "$lib/types/sns";
 
   export let proposalData: SnsProposalData;
   export let nsFunctions: SnsNervousSystemFunction[] | undefined;
+  export let rootCanisterId: RootCanisterIdText;
   export let actionable = false;
   export let hidden = false;
 
@@ -42,7 +43,7 @@
 
   let href: string;
   $: href = buildProposalUrl({
-    universe: $pageStore.universe,
+    universe: rootCanisterId,
     proposalId: `${id?.id}`,
   });
 </script>

--- a/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
@@ -14,6 +14,7 @@
   import ActionableProposalsNotSupported from "$lib/components/proposals/ActionableProposalsNotSupported.svelte";
   import ActionableProposalsEmpty from "$lib/components/proposals/ActionableProposalsEmpty.svelte";
   import type { SnsProposalActionableData } from "$lib/derived/sns/sns-filtered-actionable-proposals.derived";
+  import { pageStore } from "$lib/derived/page.derived";
 
   export let snsName: string;
   export let proposals: SnsProposalActionableData[] | undefined;
@@ -45,6 +46,7 @@
                 actionable={proposalData.isActionable}
                 {proposalData}
                 {nsFunctions}
+                rootCanisterId={$pageStore.universe}
               />
             {/each}
           </InfiniteScroll>
@@ -67,6 +69,7 @@
             <SnsProposalCard
               actionable={proposalData.isActionable}
               {proposalData}
+              rootCanisterId={$pageStore.universe}
               {nsFunctions}
             />
           {/each}

--- a/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
+++ b/frontend/src/lib/components/sns-proposals/SnsProposalsList.svelte
@@ -44,6 +44,7 @@
             {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
               <SnsProposalCard
                 actionable={proposalData.isActionable}
+                fromActionablePage={false}
                 {proposalData}
                 {nsFunctions}
                 rootCanisterId={$pageStore.universe}
@@ -68,6 +69,7 @@
           {#each proposals as proposalData (fromNullable(proposalData.id)?.id)}
             <SnsProposalCard
               actionable={proposalData.isActionable}
+              fromActionablePage={false}
               {proposalData}
               rootCanisterId={$pageStore.universe}
               {nsFunctions}

--- a/frontend/src/lib/derived/paths.derived.ts
+++ b/frontend/src/lib/derived/paths.derived.ts
@@ -19,7 +19,7 @@ export const neuronsPathStore = derived<Readable<Page>, string>(
 
 export const proposalsPathStore = derived<Readable<Page>, string>(
   pageStore,
-  ({ universe }) => buildProposalsUrl({ universe })
+  ({ universe, actionable }) => buildProposalsUrl({ universe, actionable })
 );
 
 export const canistersPathStore = derived<Readable<Page>, string>(

--- a/frontend/src/lib/utils/navigation.utils.ts
+++ b/frontend/src/lib/utils/navigation.utils.ts
@@ -73,8 +73,18 @@ export const buildAccountsUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Accounts, universe });
 export const buildNeuronsUrl = ({ universe }: { universe: string }) =>
   buildUrl({ path: AppPath.Neurons, universe });
-export const buildProposalsUrl = ({ universe }: { universe: string }) =>
-  buildUrl({ path: AppPath.Proposals, universe });
+export const buildProposalsUrl = ({
+  universe,
+  actionable,
+}: {
+  universe: string;
+  actionable?: boolean;
+}) =>
+  buildUrl({
+    path: AppPath.Proposals,
+    universe,
+    params: { ...(actionable && { [ACTIONABLE_PROPOSALS_PARAM]: "" }) },
+  });
 export const ACTIONABLE_PROPOSALS_URL = buildUrl({
   path: AppPath.Proposals,
   params: { [ACTIONABLE_PROPOSALS_PARAM]: "" },
@@ -111,14 +121,19 @@ export const buildNeuronUrl = ({
 export const buildProposalUrl = ({
   universe,
   proposalId,
+  actionable,
 }: {
   universe: string;
   proposalId: ProposalId | string;
+  actionable?: boolean;
 }): string =>
   buildUrl({
     path: AppPath.Proposal,
     universe,
-    params: { [PROPOSAL_PARAM]: `${proposalId}` },
+    params: {
+      [PROPOSAL_PARAM]: `${proposalId}`,
+      ...(actionable && { [ACTIONABLE_PROPOSALS_PARAM]: "" }),
+    },
   });
 
 export const buildCanisterUrl = ({

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalCard.spec.ts
@@ -6,6 +6,7 @@ import {
   createSnsProposal,
   mockSnsProposal,
 } from "$tests/mocks/sns-proposals.mock";
+import { mockSnsCanisterIdText } from "$tests/mocks/sns.api.mock";
 import {
   SnsProposalDecisionStatus,
   SnsProposalRewardStatus,
@@ -14,7 +15,11 @@ import {
 import { render } from "@testing-library/svelte";
 
 describe("SnsProposalCard", () => {
-  const props = { proposalData: mockSnsProposal, nsFunctions: [] };
+  const props = {
+    proposalData: mockSnsProposal,
+    nsFunctions: [],
+    rootCanisterId: mockSnsCanisterIdText,
+  };
   const now = 1698139468000;
   const nowInSeconds = Math.ceil(now / 1000);
   beforeEach(() => {
@@ -40,6 +45,7 @@ describe("SnsProposalCard", () => {
           action: nervousSystemFunctionMock.id,
         },
         nsFunctions: [nervousSystemFunctionMock],
+        rootCanisterId: mockSnsCanisterIdText,
       },
     });
 
@@ -89,6 +95,7 @@ describe("SnsProposalCard", () => {
       props: {
         proposalData,
         nsFunctions: [],
+        rootCanisterId: mockSnsCanisterIdText,
       },
     });
 
@@ -105,6 +112,7 @@ describe("SnsProposalCard", () => {
       props: {
         proposalData,
         nsFunctions: [],
+        rootCanisterId: mockSnsCanisterIdText,
       },
     });
 
@@ -129,6 +137,7 @@ describe("SnsProposalCard", () => {
       props: {
         proposalData,
         nsFunctions: [],
+        rootCanisterId: mockSnsCanisterIdText,
       },
     });
 

--- a/frontend/src/tests/lib/components/sns-proposals/SnsProposalCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-proposals/SnsProposalCard.spec.ts
@@ -143,4 +143,25 @@ describe("SnsProposalCard", () => {
 
     expect(container.querySelector(".executed")).not.toBeNull();
   });
+
+  it("should use provided rootCanisterId for a link", () => {
+    const { getByTestId } = render(SnsProposalCard, {
+      props: {
+        ...props,
+        proposalData: {
+          ...mockSnsProposal,
+          id: [
+            {
+              id: 77n,
+            },
+          ],
+        },
+        rootCanisterId: "aaaaa-aa",
+      },
+    });
+
+    expect(getByTestId("proposal-card").getAttribute("href")).toEqual(
+      "/proposal/?u=aaaaa-aa&proposal=77"
+    );
+  });
 });

--- a/frontend/src/tests/lib/derived/paths.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/paths.derived.spec.ts
@@ -74,6 +74,17 @@ describe("paths derived stores", () => {
         `${AppPath.Proposals}/?${UNIVERSE_PARAM}=${mockSnsCanisterIdText}`
       );
     });
+
+    it("should preserve actionable parameter in path", () => {
+      page.mock({
+        data: { universe: mockSnsCanisterIdText, actionable: true },
+      });
+
+      const $store = get(proposalsPathStore);
+      expect($store).toBe(
+        `${AppPath.Proposals}/?${UNIVERSE_PARAM}=${mockSnsCanisterIdText}&actionable`
+      );
+    });
   });
 
   describe("canistersPathStore", () => {

--- a/frontend/src/tests/lib/utils/navigation.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/navigation.utils.spec.ts
@@ -131,6 +131,18 @@ describe("navigation-utils", () => {
       );
     });
 
+    it("should build proposal url with actionable param", () => {
+      expect(
+        buildProposalUrl({
+          universe: OWN_CANISTER_ID_TEXT,
+          proposalId: "123",
+          actionable: true,
+        })
+      ).toEqual(
+        `${AppPath.Proposal}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}&${PROPOSAL_PARAM}=123&${ACTIONABLE_PROPOSALS_PARAM}`
+      );
+    });
+
     it("should build canister url", () => {
       expect(
         buildCanisterUrl({
@@ -168,6 +180,17 @@ describe("navigation-utils", () => {
         })
       ).toEqual(
         `${AppPath.Proposals}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}`
+      );
+    });
+
+    it("should build voting url with actionable param", () => {
+      expect(
+        buildProposalsUrl({
+          universe: OWN_CANISTER_ID_TEXT,
+          actionable: true,
+        })
+      ).toEqual(
+        `${AppPath.Proposals}/?${UNIVERSE_PARAM}=${OWN_CANISTER_ID_TEXT}&${ACTIONABLE_PROPOSALS_PARAM}`
       );
     });
 


### PR DESCRIPTION
# Motivation

After opening the proposal details from the actionable proposals page, users should be able to return to the actionable page. Because there are proposals from multiple universes presented on a single page, the back button can no longer rely on the pageStore for back functionality.

# Changes

- Add an actionable parameter to the buildProposalUrl and buildProposalsUrl functions.
- Add rootCanisterId to the SnsProposalCard and use it for href generation.
- Add a fromActionablePage parameter to SnsProposalCard and NnsProposalCard to determine when to return to the actionable page.
- Modify proposalsPathStore to preserve the actionable query parameter.


# Tests

- Update the SnsProposalCard test to account for the new parameters.
- Test that buildProposalUrl and buildProposalsUrl utilize the actionable parameter.
- Test that SnsProposalCard utilizes the provided rootCanisterId prop.
- Test that proposalsPathStore preserves the actionable parameter in the path.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.