### PR TITLE
Support styling different numbers of columns in ResponsiveTable

### DIFF
--- a/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
@@ -19,12 +19,6 @@
 
   // Should be the same as the area in the classes `rows-count-X`.
   const cellAreaName = (index: number) => `cell-${index}`;
-  // This will allow us to have different number of rows depending on the number of columns.
-  // It's not really necessary for the TokensTable becuase we know we want only 1 row.
-  // But this should be moved when we make the generic table.
-  const mobileTemplateClass = (rowsCount: number) => {
-    return `rows-count-${rowsCount}`;
-  };
 </script>
 
 <a
@@ -32,7 +26,6 @@
   role="row"
   tabindex="0"
   data-tid="responsive-table-row-component"
-  class={mobileTemplateClass(2)}
 >
   {#if firstColumn}
     <div role="cell" class="title-cell">
@@ -41,7 +34,11 @@
   {/if}
 
   {#each middleColumns as column, index}
-    <div role="cell" class={`mobile-row-cell left-cell ${cellAreaName(index)}`}>
+    <div
+      role="cell"
+      class={`mobile-row-cell left-cell`}
+      style="--grid-area-name: {cellAreaName(index)}"
+    >
       <span class="mobile-only">{column.title}</span>
       <svelte:component this={column.cellComponent} {rowData} />
     </div>
@@ -72,18 +69,7 @@
 
     text-decoration: none;
 
-    &.rows-count-2 {
-      grid-template-areas:
-        "first-cell last-cell"
-        "cell-0 cell-0";
-    }
-
-    &.rows-count-3 {
-      grid-template-areas:
-        "first-cell last-cell"
-        "cell-0 cell-0"
-        "cell-1 cell-1";
-    }
+    grid-template-areas: var(--mobile-grid-template-areas);
 
     @include media.min-width(medium) {
       @include grid-table.row;
@@ -132,20 +118,10 @@
       display: flex;
       justify-content: space-between;
 
-      &.cell-0 {
-        grid-area: cell-0;
+      grid-area: var(--grid-area-name);
 
-        @include media.min-width(medium) {
-          grid-area: revert;
-        }
-      }
-
-      &.cell-1 {
-        grid-area: cell-1;
-
-        @include media.min-width(medium) {
-          grid-area: revert;
-        }
+      @include media.min-width(medium) {
+        grid-area: revert;
       }
 
       @include media.min-width(medium) {

--- a/frontend/src/lib/utils/responsive-table.utils.ts
+++ b/frontend/src/lib/utils/responsive-table.utils.ts
@@ -1,0 +1,1 @@
+export const getCellGridAreaName = (index: number) => `cell-${index}`;

--- a/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
@@ -76,4 +76,50 @@ describe("ResponseTable", () => {
     expect(await rows[1].getHref()).toBe("anna/");
     expect(await rows[2].getHref()).toBe("anton/");
   });
+
+  it("should render column styles depending on the number of columns", async () => {
+    // 3 columns
+    const po1 = renderComponent({ columns, tableData });
+    expect(await po1.getDesktopGridTemplateColumns()).toBe(
+      "1fr max-content max-content"
+    );
+    expect(await po1.getMobileGridTemplateAreas()).toBe(
+      '"first-cell last-cell" "cell-0 cell-0"'
+    );
+
+    // 6 columns
+    const po2 = renderComponent({
+      columns: [...columns, ...columns],
+      tableData,
+    });
+    expect(await po2.getDesktopGridTemplateColumns()).toBe(
+      "1fr max-content max-content max-content max-content max-content"
+    );
+    expect(await po2.getMobileGridTemplateAreas()).toBe(
+      '"first-cell last-cell" "cell-0 cell-0" "cell-1 cell-1" "cell-2 cell-2" "cell-3 cell-3"'
+    );
+  });
+
+  it("should have a different grid area for cells in different columns", async () => {
+    // 6 columns
+    const po = renderComponent({
+      columns: [...columns, ...columns],
+      tableData,
+    });
+
+    // The first and last cell have grid areas set in CSS directly rather than
+    // through the style attribute.
+    const expectedStyles = [
+      null,
+      "--grid-area-name: cell-0;",
+      "--grid-area-name: cell-1;",
+      "--grid-area-name: cell-2;",
+      "--grid-area-name: cell-3;",
+      null,
+    ];
+
+    const rows = await po.getRows();
+    expect(rows).toHaveLength(3);
+    expect(await rows[0].getCellStyles()).toEqual(expectedStyles);
+  });
 });

--- a/frontend/src/tests/page-objects/ResponsiveTable.page-object.ts
+++ b/frontend/src/tests/page-objects/ResponsiveTable.page-object.ts
@@ -20,4 +20,25 @@ export class ResponsiveTablePo extends BasePageObject {
   getRows(): Promise<ResponsiveTableRowPo[]> {
     return ResponsiveTableRowPo.allUnder(this.root);
   }
+
+  getStyle(): Promise<string> {
+    return this.root.getAttribute("style");
+  }
+
+  async getStyleVariable(varName: string): Promise<string> {
+    const style = await this.getStyle();
+    const match = style.match(new RegExp(`--${varName}: ([^;]+)`));
+    if (!match) {
+      throw new Error(`Could not find --${varName} in style attribute`);
+    }
+    return match[1];
+  }
+
+  getDesktopGridTemplateColumns(): Promise<string> {
+    return this.getStyleVariable("desktop-grid-template-columns");
+  }
+
+  getMobileGridTemplateAreas(): Promise<string> {
+    return this.getStyleVariable("mobile-grid-template-areas");
+  }
 }

--- a/frontend/src/tests/page-objects/ResponsiveTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/ResponsiveTableRow.page-object.ts
@@ -23,4 +23,12 @@ export class ResponsiveTableRowPo extends BasePageObject {
       )
     );
   }
+
+  async getCellStyles(): Promise<string[]> {
+    return Promise.all(
+      (await this.root.querySelectorAll("[role='cell']")).map((el) =>
+        el.getAttribute("style")
+      )
+    );
+  }
 }


### PR DESCRIPTION
# Motivation

We want to reuse the `ResponsiveTable`, that was extracted from the `TokensTable`, for the neurons table.
The neurons table has a different number of columns, which requires different styling.

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
