### PR TITLE
Remove topic rename message

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -23,6 +23,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Removed
 
+* Message informing about proposal topic changes.
+
 #### Fixed
 
 #### Security

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -31,8 +31,7 @@
     "receive_with_token": "Receive $token",
     "receive": "Receive",
     "send_with_token": "Send $token",
-    "collapse_all": "Collapse All",
-    "learn_more": "Learn more"
+    "collapse_all": "Collapse All"
   },
   "error": {
     "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser.",
@@ -239,8 +238,6 @@
   "neurons": {
     "title": "Neurons",
     "text": "Earn voting rewards by staking your ICP in neurons. Neurons allow you to participate in governance on the Internet Computer by submitting and voting on Network Nervous System (NNS) proposals.",
-    "rename_topic_message": "There were changes made to proposal topics. Review your neuron following to confirm it is set up according to your preferences.",
-    "rename_topic_learn_more_label": "Learn more about the changes made to proposal topics.",
     "stake_token": "Stake $token",
     "merge_neurons": "Merge Neurons",
     "merge_neurons_modal_title": "Select two neurons to merge",

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -11,7 +11,7 @@
     definedNeuronsStore,
   } from "$lib/stores/neurons.store";
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
-  import { IconInfo, Tooltip } from "@dfinity/gix-components";
+  import { Tooltip } from "@dfinity/gix-components";
   import { isSpawning } from "$lib/utils/neuron.utils";
   import { pageStore } from "$lib/derived/page.derived";
   import { buildNeuronUrl } from "$lib/utils/navigation.utils";

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -34,22 +34,6 @@
 </script>
 
 <TestIdWrapper testId="nns-neurons-component">
-  {#if !isLoading && $sortedNeuronStore.length > 0}
-    <div class="topic-rename-message" data-tid="topic-rename-message">
-      <div class="icon-info">
-        <IconInfo />
-      </div>
-      <span>
-        {$i18n.neurons.rename_topic_message}
-        <a
-          href="https://forum.dfinity.org/t/bringing-clarity-to-icp-upgrade-proposals/29626"
-          rel="noopener noreferrer"
-          aria-label={$i18n.neurons.rename_topic_learn_more_label}
-          target="_blank">{$i18n.core.learn_more}</a
-        >
-      </span>
-    </div>
-  {/if}
   {#if $ENABLE_NEURONS_TABLE}
     <NeuronsTable neurons={tableNeurons} />
   {:else}
@@ -89,22 +73,3 @@
     <EmptyMessage>{$i18n.neurons.text}</EmptyMessage>
   {/if}
 </TestIdWrapper>
-
-<style lang="scss">
-  .topic-rename-message {
-    display: flex;
-    gap: var(--padding);
-    align-items: center;
-
-    background-color: var(--card-background);
-    border-radius: var(--border-radius);
-    margin-bottom: var(--padding-2x);
-    padding: var(--padding-2x);
-
-    .icon-info {
-      padding: var(--padding);
-      background-color: var(--tooltip-border-color);
-      border-radius: 50%;
-    }
-  }
-</style>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -35,7 +35,6 @@ interface I18nCore {
   receive: string;
   send_with_token: string;
   collapse_all: string;
-  learn_more: string;
 }
 
 interface I18nError {
@@ -250,8 +249,6 @@ interface I18nNeuron_types {
 interface I18nNeurons {
   title: string;
   text: string;
-  rename_topic_message: string;
-  rename_topic_learn_more_label: string;
   stake_token: string;
   merge_neurons: string;
   merge_neurons_modal_title: string;

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -81,12 +81,6 @@ describe("NnsNeurons", () => {
         expect(await po.hasEmptyMessage()).toBe(false);
       });
 
-      it("should render topic rename message", async () => {
-        const po = await renderComponent();
-
-        expect(await po.hasTopicRenameMessage()).toBe(true);
-      });
-
       it("should not render the neurons table", async () => {
         const po = await renderComponent();
 
@@ -134,12 +128,6 @@ describe("NnsNeurons", () => {
 
       expect(await po.hasEmptyMessage()).toBe(true);
     });
-
-    it("should not render topic rename message", async () => {
-      const po = await renderComponent();
-
-      expect(await po.hasTopicRenameMessage()).toBe(false);
-    });
   });
 
   describe("while loading", () => {
@@ -158,12 +146,6 @@ describe("NnsNeurons", () => {
       const po = await renderComponent();
 
       expect(await po.hasEmptyMessage()).toBe(false);
-    });
-
-    it("should not render topic rename message", async () => {
-      const po = await renderComponent();
-
-      expect(await po.hasTopicRenameMessage()).toBe(false);
     });
   });
 

--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -55,8 +55,4 @@ export class NnsNeuronsPo extends BasePageObject {
   hasEmptyMessage(): Promise<boolean> {
     return this.isPresent("empty-message-component");
   }
-
-  async hasTopicRenameMessage(): Promise<boolean> {
-    return this.isPresent("topic-rename-message");
-  }
 }


### PR DESCRIPTION
# Motivation

This message was always meant to be temporary.
It was first added in https://github.com/dfinity/nns-dapp/pull/4719, then removed in https://github.com/dfinity/nns-dapp/pull/4743 and added back in https://github.com/dfinity/nns-dapp/pull/4795.

# Changes

Undo most changes from https://github.com/dfinity/nns-dapp/pull/4719

# Tests

Also removed

# Todos

- [x] Add entry to changelog (if necessary).
