### PR TITLE
Update actionable page gaps

### DIFF
--- a/frontend/src/lib/components/proposals/ActionableSnses.svelte
+++ b/frontend/src/lib/components/proposals/ActionableSnses.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import {
     type ActionableSnsProposalsByUniverseData,
     actionableSnsProposalsByUniverseStore,
@@ -12,8 +11,16 @@
   );
 </script>
 
-<TestIdWrapper testId="actionable-snses-component">
+<div class="container" data-tid="actionable-snses-component">
   {#each actionableUniverses as { universe, proposals } (universe.canisterId)}
     <ActionableSnsProposals {universe} {proposals} />
   {/each}
-</TestIdWrapper>
+</div>
+
+<style lang="scss">
+  .container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--actionable-page-gap);
+  }
+</style>

--- a/frontend/src/lib/components/proposals/ActionableSnses.svelte
+++ b/frontend/src/lib/components/proposals/ActionableSnses.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import {
     type ActionableSnsProposalsByUniverseData,
     actionableSnsProposalsByUniverseStore,
   } from "$lib/derived/actionable-proposals.derived";
   import ActionableSnsProposals from "$lib/components/proposals/ActionableSnsProposals.svelte";
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   let actionableUniverses: ActionableSnsProposalsByUniverseData[] = [];
   $: actionableUniverses = $actionableSnsProposalsByUniverseStore.filter(

--- a/frontend/src/lib/components/proposals/ActionableSnses.svelte
+++ b/frontend/src/lib/components/proposals/ActionableSnses.svelte
@@ -4,6 +4,7 @@
     actionableSnsProposalsByUniverseStore,
   } from "$lib/derived/actionable-proposals.derived";
   import ActionableSnsProposals from "$lib/components/proposals/ActionableSnsProposals.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   let actionableUniverses: ActionableSnsProposalsByUniverseData[] = [];
   $: actionableUniverses = $actionableSnsProposalsByUniverseStore.filter(
@@ -11,16 +12,8 @@
   );
 </script>
 
-<div class="container" data-tid="actionable-snses-component">
+<TestIdWrapper testId="actionable-snses-component">
   {#each actionableUniverses as { universe, proposals } (universe.canisterId)}
     <ActionableSnsProposals {universe} {proposals} />
   {/each}
-</div>
-
-<style lang="scss">
-  .container {
-    display: flex;
-    flex-direction: column;
-    gap: var(--actionable-page-gap);
-  }
-</style>
+</TestIdWrapper>

--- a/frontend/src/lib/components/proposals/LoadingActionableProposals.svelte
+++ b/frontend/src/lib/components/proposals/LoadingActionableProposals.svelte
@@ -1,10 +1,9 @@
 <script>
   import SkeletonCard from "../ui/SkeletonCard.svelte";
   import { SkeletonText } from "@dfinity/gix-components";
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 </script>
 
-<TestIdWrapper testId="loading-actionable-proposals-component">
+<div data-tid="loading-actionable-proposals-component">
   <div class="headline">
     <SkeletonText />
   </div>
@@ -13,7 +12,7 @@
     <SkeletonCard />
     <SkeletonCard />
   </div>
-</TestIdWrapper>
+</div>
 
 <style lang="scss">
   .headline {

--- a/frontend/src/lib/components/proposals/UniverseWithActionableProposals.svelte
+++ b/frontend/src/lib/components/proposals/UniverseWithActionableProposals.svelte
@@ -17,10 +17,6 @@
 </div>
 
 <style lang="scss">
-  .container {
-    margin-bottom: var(--padding-4x);
-  }
-
   .title {
     margin-bottom: var(--padding-3x);
   }

--- a/frontend/src/lib/pages/ActionableProposals.svelte
+++ b/frontend/src/lib/pages/ActionableProposals.svelte
@@ -24,11 +24,8 @@
 
 <style lang="scss">
   .container {
-    // The gap between blocks on the page (e.g. between the universes and banners)
-    --actionable-page-gap: var(--padding-4x);
-
     display: flex;
     flex-direction: column;
-    gap: var(--actionable-page-gap);
+    gap: var(--padding-4x);
   }
 </style>

--- a/frontend/src/lib/pages/ActionableProposals.svelte
+++ b/frontend/src/lib/pages/ActionableProposals.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import ActionableSnses from "$lib/components/proposals/ActionableSnses.svelte";
   import ActionableNnsProposals from "$lib/components/proposals/ActionableNnsProposals.svelte";
   import {
@@ -10,7 +9,7 @@
   import ActionableProposalsEmpty from "$lib/components/proposals/ActionableProposalsEmpty.svelte";
 </script>
 
-<TestIdWrapper testId="actionable-proposals-component">
+<div class="container" data-tid="actionable-proposals-component">
   {#if $actionableProposalsLoadedStore}
     {#if $actionableProposalTotalCountStore > 0}
       <ActionableNnsProposals />
@@ -21,4 +20,15 @@
   {:else}
     <LoadingActionableProposals />
   {/if}
-</TestIdWrapper>
+</div>
+
+<style lang="scss">
+  .container {
+    // The gap between blocks on the page (e.g. between the universes and banners)
+    --actionable-page-gap: var(--padding-4x);
+
+    display: flex;
+    flex-direction: column;
+    gap: var(--actionable-page-gap);
+  }
+</style>


### PR DESCRIPTION
# Motivation

Different types of components will be rendered on the actionable page, and it will be easier to control the gaps between them from the page component itself. This PR changes how the gaps are set, switching from `margin-bottom` in child components to flex `gap` in the parent component.

# Changes

- Use flex `gap` to set the spacing between the direct children of the page component..
- Remove bottom margin from `UniverseWithActionableProposals`, but the same gap was added to it's parent component `ActionableSnses`.
- Switch from `TestIdWrapper` to `div` in skeleton component to avoid container gaps.

# Tests

- Pass.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.