### PR TITLE
NNS1-3091: Make rowHref optional on ResponsiveTable

### DIFF
--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -64,7 +64,7 @@
     </div>
   </div>
   <div role="rowgroup">
-    {#each tableData as rowData (rowData.rowHref)}
+    {#each tableData as rowData (rowData.domKey)}
       <div class="row-wrapper" transition:heightTransition={{ duration: 250 }}>
         <ResponsiveTableRow on:nnsAction {rowData} {columns} />
       </div>

--- a/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
@@ -61,7 +61,9 @@
   @use "../../themes/mixins/grid-table";
 
   [role="row"] {
-    @include interaction.tappable;
+    a {
+      @include interaction.tappable;
+    }
 
     display: grid;
     flex-direction: column;

--- a/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
@@ -61,10 +61,6 @@
   @use "../../themes/mixins/grid-table";
 
   [role="row"] {
-    a {
-      @include interaction.tappable;
-    }
-
     display: grid;
     flex-direction: column;
     gap: var(--padding-2x);

--- a/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
@@ -6,6 +6,7 @@
 <script lang="ts" generics="RowDataType extends ResponsiveTableRowData">
   import { getCellGridAreaName } from "$lib/utils/responsive-table.utils";
   import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
+  import { nonNullish } from "@dfinity/utils";
 
   export let rowData: RowDataType;
   export let columns: ResponsiveTableColumn<RowDataType>[];
@@ -19,7 +20,8 @@
   $: lastColumn = columns.at(-1);
 </script>
 
-<a
+<svelte:element
+  this={nonNullish(rowData.rowHref) ? "a" : "div"}
   href={rowData.rowHref}
   role="row"
   tabindex="0"
@@ -51,7 +53,7 @@
       />
     </div>
   {/if}
-</a>
+</svelte:element>
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/interaction";

--- a/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-user.derived.ts
@@ -35,6 +35,7 @@ const convertAccountToUserTokenData = ({
       logo: nnsUniverse.logo,
       actions: [],
       rowHref,
+      domKey: rowHref,
     };
   }
 
@@ -62,6 +63,7 @@ const convertAccountToUserTokenData = ({
       token: NNS_TOKEN_DATA,
     }),
     rowHref,
+    domKey: rowHref,
     accountIdentifier: account.identifier,
     actions: [UserTokenAction.Receive, UserTokenAction.Send],
   };

--- a/frontend/src/lib/derived/icp-tokens-list-visitors.derived.ts
+++ b/frontend/src/lib/derived/icp-tokens-list-visitors.derived.ts
@@ -12,20 +12,24 @@ import { nnsUniverseStore } from "./nns-universe.derived";
 export const icpTokensListVisitors = derived<
   Readable<Universe>,
   UserTokenData[]
->(nnsUniverseStore, (nnsUniverse) => [
-  {
-    universeId: Principal.fromText(nnsUniverse.canisterId),
-    title: nnsUniverse.title,
-    balance: new UnavailableTokenAmount(NNS_TOKEN_DATA),
-    logo: nnsUniverse.logo,
-    token: NNS_TOKEN_DATA,
-    fee: TokenAmountV2.fromUlps({
-      amount: NNS_TOKEN_DATA.fee,
+>(nnsUniverseStore, (nnsUniverse) => {
+  const rowHref = buildWalletUrl({
+    universe: OWN_CANISTER_ID_TEXT,
+  });
+  return [
+    {
+      universeId: Principal.fromText(nnsUniverse.canisterId),
+      title: nnsUniverse.title,
+      balance: new UnavailableTokenAmount(NNS_TOKEN_DATA),
+      logo: nnsUniverse.logo,
       token: NNS_TOKEN_DATA,
-    }),
-    actions: [UserTokenAction.GoToDetail],
-    rowHref: buildWalletUrl({
-      universe: OWN_CANISTER_ID_TEXT,
-    }),
-  },
-]);
+      fee: TokenAmountV2.fromUlps({
+        amount: NNS_TOKEN_DATA.fee,
+        token: NNS_TOKEN_DATA,
+      }),
+      actions: [UserTokenAction.GoToDetail],
+      rowHref,
+      domKey: rowHref,
+    },
+  ];
+});

--- a/frontend/src/lib/derived/tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-user.derived.ts
@@ -38,6 +38,7 @@ const convertToUserTokenData = ({
       balance: "loading",
       actions: [],
       rowHref,
+      domKey: rowHref,
     };
   }
   const fee = TokenAmountV2.fromUlps({ amount: token.fee, token });
@@ -65,6 +66,7 @@ const convertToUserTokenData = ({
     ],
     accountIdentifier,
     rowHref,
+    domKey: rowHref,
   };
 };
 

--- a/frontend/src/lib/derived/tokens-list-visitors.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-visitors.derived.ts
@@ -31,6 +31,7 @@ const convertToUserToken = ({
       balance: "loading",
       actions: [],
       rowHref,
+      domKey: rowHref,
     };
   }
   return {
@@ -40,6 +41,7 @@ const convertToUserToken = ({
     fee: TokenAmountV2.fromUlps({ amount: token.fee, token }),
     actions: [UserTokenAction.GoToDetail],
     rowHref,
+    domKey: rowHref,
   };
 };
 

--- a/frontend/src/lib/types/responsive-table.ts
+++ b/frontend/src/lib/types/responsive-table.ts
@@ -1,7 +1,10 @@
 import type { ComponentType, SvelteComponent } from "svelte";
 
 export interface ResponsiveTableRowData {
-  rowHref: string;
+  // Used in forEach for consistent rendering. Must be unique per table.
+  domKey: string;
+  // If absent, the row will not be clickable.
+  rowHref?: string;
 }
 
 export interface ResponsiveTableColumn<

--- a/frontend/src/lib/types/tokens-page.ts
+++ b/frontend/src/lib/types/tokens-page.ts
@@ -37,6 +37,7 @@ export type UserTokenLoading = UserTokenBase & {
   balance: "loading";
   actions: [];
   rowHref: string;
+  domKey: string;
 };
 
 export type UserTokenData = UserTokenBase & {
@@ -47,6 +48,7 @@ export type UserTokenData = UserTokenBase & {
   // Fees are included in the metadata of ICRC tokens, but this is not a list of only ICRC tokens
   fee: TokenAmountV2;
   rowHref: string;
+  domKey: string;
 };
 
 export type UserToken = UserTokenLoading | UserTokenData;

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -132,6 +132,7 @@ describe("TokensTable", () => {
       universeId: OWN_CANISTER_ID,
       balance: TokenAmount.fromE8s({ amount: 314000000n, token: ICPToken }),
       rowHref: href,
+      domKey: href,
     });
     const po = renderTable({ userTokensData: [token1] });
 
@@ -247,6 +248,7 @@ describe("TokensTable", () => {
     const userToken = createUserToken({
       actions: [UserTokenAction.Send],
       rowHref: AppPath.Neurons,
+      domKey: AppPath.Neurons,
     });
 
     const po = renderTable({
@@ -274,6 +276,7 @@ describe("TokensTable", () => {
     const userToken = createUserToken({
       actions: [UserTokenAction.Receive],
       rowHref: AppPath.Neurons,
+      domKey: AppPath.Neurons,
     });
 
     const po = renderTable({

--- a/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
@@ -26,16 +26,18 @@ describe("ResponseTable", () => {
   const tableData = [
     {
       rowHref: "alice/",
+      domKey: "1",
       name: "Alice",
       age: 45,
     },
     {
       rowHref: "anna/",
+      domKey: "2",
       name: "Anna",
       age: 19,
     },
     {
-      rowHref: "anton/",
+      domKey: "3",
       name: "Anton",
       age: 31,
     },
@@ -74,7 +76,16 @@ describe("ResponseTable", () => {
     expect(rows).toHaveLength(3);
     expect(await rows[0].getHref()).toBe("alice/");
     expect(await rows[1].getHref()).toBe("anna/");
-    expect(await rows[2].getHref()).toBe("anton/");
+    expect(await rows[2].getHref()).toBe(null);
+  });
+
+  it("should render rows with href as link", async () => {
+    const po = renderComponent({ columns, tableData });
+    const rows = await po.getRows();
+    expect(rows).toHaveLength(3);
+    expect(await rows[0].getTagName()).toBe("A");
+    expect(await rows[1].getTagName()).toBe("A");
+    expect(await rows[2].getTagName()).toBe("DIV");
   });
 
   it("should render column styles depending on the number of columns", async () => {

--- a/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-user.derived.spec.ts
@@ -27,14 +27,16 @@ describe("icp-tokens-list-user.derived", () => {
   const icpTokenUser: UserTokenData = createIcpUserToken({
     actions: [UserTokenAction.Receive, UserTokenAction.Send],
   });
+  const mainAccountHref = buildWalletUrl({
+    universe: OWN_CANISTER_ID_TEXT,
+  });
   const loadingUserTokenData: UserTokenLoading = {
     ...icpTokenBase,
     title: "Main",
     balance: "loading",
     actions: [],
-    rowHref: buildWalletUrl({
-      universe: OWN_CANISTER_ID_TEXT,
-    }),
+    rowHref: mainAccountHref,
+    domKey: mainAccountHref,
   };
   const mainUserTokenData: UserTokenData = {
     ...icpTokenUser,
@@ -44,9 +46,8 @@ describe("icp-tokens-list-user.derived", () => {
     }),
     title: "Main",
     subtitle: undefined,
-    rowHref: buildWalletUrl({
-      universe: OWN_CANISTER_ID_TEXT,
-    }),
+    rowHref: mainAccountHref,
+    domKey: mainAccountHref,
     accountIdentifier: mockMainAccount.identifier,
   };
   const subaccountUserTokenData = (
@@ -57,6 +58,10 @@ describe("icp-tokens-list-user.derived", () => {
       balanceUlps === mockSubAccount.balanceUlps
         ? mockSubAccount.identifier
         : `${balanceUlps}`;
+    const subaccountHref = buildWalletUrl({
+      universe: OWN_CANISTER_ID_TEXT,
+      account: accountIdentifier,
+    });
     return {
       ...icpTokenUser,
       balance: TokenAmountV2.fromUlps({
@@ -65,10 +70,8 @@ describe("icp-tokens-list-user.derived", () => {
       }),
       title: mockSubAccount.name,
       subtitle: undefined,
-      rowHref: buildWalletUrl({
-        universe: OWN_CANISTER_ID_TEXT,
-        account: accountIdentifier,
-      }),
+      rowHref: subaccountHref,
+      domKey: subaccountHref,
       accountIdentifier,
     };
   };
@@ -80,6 +83,10 @@ describe("icp-tokens-list-user.derived", () => {
       balanceUlps === mockHardwareWalletAccount.balanceUlps
         ? mockHardwareWalletAccount.identifier
         : `${balanceUlps}`;
+    const hwHref = buildWalletUrl({
+      universe: OWN_CANISTER_ID_TEXT,
+      account: accountIdentifier,
+    });
     return {
       ...icpTokenUser,
       balance: TokenAmountV2.fromUlps({
@@ -88,10 +95,8 @@ describe("icp-tokens-list-user.derived", () => {
       }),
       title: mockHardwareWalletAccount.name,
       subtitle: "Hardware Wallet Controlled",
-      rowHref: buildWalletUrl({
-        universe: OWN_CANISTER_ID_TEXT,
-        account: accountIdentifier,
-      }),
+      rowHref: hwHref,
+      domKey: hwHref,
       accountIdentifier,
     };
   };

--- a/frontend/src/tests/lib/derived/icp-tokens-list-visitors.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icp-tokens-list-visitors.derived.spec.ts
@@ -6,9 +6,11 @@ import { createIcpUserToken } from "$tests/mocks/tokens-page.mock";
 import { get } from "svelte/store";
 
 describe("icp-tokens-list-visitors.derived", () => {
+  const href = `/wallet/?u=${OWN_CANISTER_ID_TEXT}`;
   const expectedIcpTokenVisitor: UserTokenData = createIcpUserToken({
     actions: [UserTokenAction.GoToDetail],
-    rowHref: `/wallet/?u=${OWN_CANISTER_ID_TEXT}`,
+    rowHref: href,
+    domKey: href,
   });
 
   describe("icpTokensListVisitors", () => {

--- a/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-user.derived.spec.ts
@@ -48,20 +48,23 @@ import { TokenAmountV2 } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("tokens-list-user.derived", () => {
+  const icpHref = buildAccountsUrl({ universe: OWN_CANISTER_ID_TEXT });
   const icpUserToken: UserTokenData = createIcpUserToken({
     balance: TokenAmountV2.fromUlps({
       amount: mockMainAccount.balanceUlps,
       token: NNS_TOKEN_DATA,
     }),
     actions: [UserTokenAction.GoToDetail],
-    rowHref: buildAccountsUrl({ universe: OWN_CANISTER_ID_TEXT }),
+    rowHref: icpHref,
+    domKey: icpHref,
     accountIdentifier: undefined,
   });
   const icpUserTokenLoading: UserTokenLoading = {
     ...icpTokenBase,
     balance: "loading",
     actions: [],
-    rowHref: buildAccountsUrl({ universe: OWN_CANISTER_ID_TEXT }),
+    rowHref: icpHref,
+    domKey: icpHref,
   };
   const snsTetrisToken = mockSnsToken;
   const tetrisRootCanisterId = rootCanisterIdMock;
@@ -96,6 +99,7 @@ describe("tokens-list-user.derived", () => {
     balance: "loading",
     actions: [],
     rowHref: tetrisHref,
+    domKey: tetrisHref,
   };
   const tetrisUserToken: UserTokenData = {
     ...tetrisTokenLoading,
@@ -110,6 +114,7 @@ describe("tokens-list-user.derived", () => {
       token: snsTetris.tokenMetadata,
     }),
     rowHref: tetrisHref,
+    domKey: tetrisHref,
     accountIdentifier: mockSnsMainAccount.identifier,
   };
   const pacmanHref = buildWalletUrl({
@@ -122,6 +127,7 @@ describe("tokens-list-user.derived", () => {
     balance: "loading",
     actions: [],
     rowHref: pacmanHref,
+    domKey: pacmanHref,
   };
   const pacmanUserToken: UserTokenData = {
     ...pacmanTokenLoading,
@@ -136,6 +142,7 @@ describe("tokens-list-user.derived", () => {
       token: snsPacman.tokenMetadata,
     }),
     rowHref: pacmanHref,
+    domKey: pacmanHref,
     accountIdentifier: mockSnsMainAccount.identifier,
   };
   const ckBTCHref = buildWalletUrl({
@@ -146,6 +153,7 @@ describe("tokens-list-user.derived", () => {
     balance: "loading",
     actions: [],
     rowHref: ckBTCHref,
+    domKey: ckBTCHref,
   };
   const ckTESTBTCHref = buildWalletUrl({
     universe: ckTESTBTCTokenBase.universeId.toText(),
@@ -155,6 +163,7 @@ describe("tokens-list-user.derived", () => {
     balance: "loading",
     actions: [],
     rowHref: ckTESTBTCHref,
+    domKey: ckTESTBTCHref,
   };
   const ckBTCUserToken: UserTokenData = {
     ...ckBTCTokenBase,
@@ -169,6 +178,7 @@ describe("tokens-list-user.derived", () => {
       token: mockCkBTCToken,
     }),
     rowHref: ckBTCHref,
+    domKey: ckBTCHref,
     accountIdentifier: mockCkBTCMainAccount.identifier,
   };
   const ckETHHref = buildWalletUrl({
@@ -179,6 +189,7 @@ describe("tokens-list-user.derived", () => {
     balance: "loading",
     actions: [],
     rowHref: ckETHHref,
+    domKey: ckETHHref,
   };
   const ckETHUserToken: UserTokenData = {
     ...ckETHTokenBase,
@@ -192,6 +203,7 @@ describe("tokens-list-user.derived", () => {
       token: mockCkETHToken,
     }),
     rowHref: ckETHHref,
+    domKey: ckETHHref,
     actions: [UserTokenAction.Receive, UserTokenAction.Send],
     accountIdentifier: mockCkETHMainAccount.identifier,
   };

--- a/frontend/src/tests/lib/derived/tokens-list-visitors.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/tokens-list-visitors.derived.spec.ts
@@ -52,10 +52,12 @@ describe("tokens-list-base.derived", () => {
     name: "ckTESTBTC",
   };
 
+  const icpHref = `/accounts/?u=${OWN_CANISTER_ID_TEXT}`;
   const icpVisitorToken: UserTokenData = createIcpUserToken({
     balance: new UnavailableTokenAmount(NNS_TOKEN_DATA),
     actions: [UserTokenAction.GoToDetail],
-    rowHref: `/accounts/?u=${OWN_CANISTER_ID_TEXT}`,
+    rowHref: icpHref,
+    domKey: icpHref,
   });
   const tetrisHref = `/wallet/?u=${snsTetris.rootCanisterId.toText()}`;
   const tetrisTokenLoading: UserTokenLoading = {
@@ -65,6 +67,7 @@ describe("tokens-list-base.derived", () => {
     balance: "loading",
     actions: [],
     rowHref: tetrisHref,
+    domKey: tetrisHref,
   };
   const tetrisVisitorToken: UserTokenData = {
     ...tetrisTokenLoading,
@@ -76,6 +79,7 @@ describe("tokens-list-base.derived", () => {
       token: snsTetris.tokenMetadata,
     }),
     rowHref: tetrisHref,
+    domKey: tetrisHref,
   };
   const pacmanHref = `/wallet/?u=${snsPacman.rootCanisterId.toText()}`;
   const pacmanTokenLoading: UserTokenLoading = {
@@ -85,6 +89,7 @@ describe("tokens-list-base.derived", () => {
     balance: "loading",
     actions: [],
     rowHref: pacmanHref,
+    domKey: pacmanHref,
   };
   const pacmanVisitorToken: UserTokenData = {
     ...pacmanTokenLoading,
@@ -96,6 +101,7 @@ describe("tokens-list-base.derived", () => {
       token: snsPacman.tokenMetadata,
     }),
     rowHref: pacmanHref,
+    domKey: pacmanHref,
   };
   const ckBTCHref = `/wallet/?u=${CKBTC_UNIVERSE_CANISTER_ID.toText()}`;
   const ckBTCTokenLoading: UserTokenLoading = {
@@ -103,6 +109,7 @@ describe("tokens-list-base.derived", () => {
     balance: "loading",
     actions: [],
     rowHref: ckBTCHref,
+    domKey: ckBTCHref,
   };
   const ckTESTBTCHref = `/wallet/?u=${CKTESTBTC_UNIVERSE_CANISTER_ID.toText()}`;
   const ckTESTBTCTokenLoading: UserTokenLoading = {
@@ -110,6 +117,7 @@ describe("tokens-list-base.derived", () => {
     balance: "loading",
     actions: [],
     rowHref: ckTESTBTCHref,
+    domKey: ckTESTBTCHref,
   };
   const ckTESTBTCVisitorToken: UserTokenData = {
     ...ckTESTBTCTokenBase,
@@ -121,6 +129,7 @@ describe("tokens-list-base.derived", () => {
       token: mockCkTESTBTCToken,
     }),
     rowHref: ckTESTBTCHref,
+    domKey: ckTESTBTCHref,
   };
   const ckBTCVisitorToken: UserTokenData = {
     ...ckBTCTokenBase,
@@ -132,7 +141,9 @@ describe("tokens-list-base.derived", () => {
       token: mockCkBTCToken,
     }),
     rowHref: ckBTCHref,
+    domKey: ckBTCHref,
   };
+  const ckETHHref = `/wallet/?u=${ckETHTokenBase.universeId.toText()}`;
   const ckETHVisitorToken: UserTokenData = {
     ...ckETHTokenBase,
     balance: new UnavailableTokenAmount(mockCkETHToken),
@@ -142,7 +153,8 @@ describe("tokens-list-base.derived", () => {
       token: mockCkETHToken,
     }),
     actions: [UserTokenAction.GoToDetail],
-    rowHref: `/wallet/?u=${ckETHTokenBase.universeId.toText()}`,
+    rowHref: ckETHHref,
+    domKey: ckETHHref,
   };
 
   describe("tokensListVisitorsStore", () => {

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -54,6 +54,7 @@ describe("NnsAccounts", () => {
           token: NNS_TOKEN_DATA,
         }),
         rowHref: "/main",
+        domKey: "/main",
       });
       const subaccountTokenData = createUserToken({
         title: "Subaccount test",
@@ -62,6 +63,7 @@ describe("NnsAccounts", () => {
           token: NNS_TOKEN_DATA,
         }),
         rowHref: "/subaccount",
+        domKey: "/subaccount",
       });
       const po = renderComponent([mainTokenData, subaccountTokenData]);
       expect(await po.getTokensTablePo().getRowsData()).toEqual([
@@ -84,6 +86,7 @@ describe("NnsAccounts", () => {
           token: NNS_TOKEN_DATA,
         }),
         rowHref: "/main",
+        domKey: "/main",
       });
       const subaccountTokenData = createUserToken({
         title: "Subaccount test",
@@ -92,6 +95,7 @@ describe("NnsAccounts", () => {
           token: NNS_TOKEN_DATA,
         }),
         rowHref: "/subaccount",
+        domKey: "/subaccount",
       });
       const po = renderComponent([mainTokenData, subaccountTokenData]);
       expect(await po.getAddAccountRowTabindex()).toBe("0");

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -808,14 +808,16 @@ describe("token-utils", () => {
   });
 
   describe("sortUserTokens", () => {
+    const icpHref = buildWalletUrl({
+      universe: OWN_CANISTER_ID_TEXT,
+    });
     const loadingUserToken: UserToken = {
       ...icpTokenBase,
       title: "Main",
       balance: "loading",
       actions: [],
-      rowHref: buildWalletUrl({
-        universe: OWN_CANISTER_ID_TEXT,
-      }),
+      rowHref: icpHref,
+      domKey: icpHref,
     };
     const userToken = (balanceUlps: bigint): UserToken => ({
       universeId: Principal.fromText(nnsUniverseMock.canisterId),
@@ -832,6 +834,7 @@ describe("token-utils", () => {
         token: NNS_TOKEN_DATA,
       }),
       rowHref: "row href",
+      domKey: "row href",
       accountIdentifier: mockSubAccount.identifier,
       actions: [UserTokenAction.Receive, UserTokenAction.Send],
     });

--- a/frontend/src/tests/mocks/tokens-page.mock.ts
+++ b/frontend/src/tests/mocks/tokens-page.mock.ts
@@ -19,7 +19,7 @@ import {
   type UserTokenLoading,
 } from "$lib/types/tokens-page";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
-import { TokenAmountV2, isNullish, nonNullish } from "@dfinity/utils";
+import { TokenAmountV2 } from "@dfinity/utils";
 import { mockCkBTCToken } from "./ckbtc-accounts.mock";
 import { mockSnsToken, principal } from "./sns-projects.mock";
 
@@ -29,6 +29,7 @@ export const icpTokenBase: UserTokenBase = {
   logo: IC_LOGO_ROUNDED,
   actions: [],
 };
+const icpHref = `/accounts/?u=${OWN_CANISTER_ID_TEXT}`;
 const icpTokenNoBalance: UserTokenData = {
   ...icpTokenBase,
   balance: new UnavailableTokenAmount(NNS_TOKEN_DATA),
@@ -37,7 +38,8 @@ const icpTokenNoBalance: UserTokenData = {
     amount: NNS_TOKEN_DATA.fee,
     token: NNS_TOKEN_DATA,
   }),
-  rowHref: `/accounts/?u=${OWN_CANISTER_ID_TEXT}`,
+  rowHref: icpHref,
+  domKey: icpHref,
 };
 const snsTetrisToken = mockSnsToken;
 const snsPackmanToken = {
@@ -63,6 +65,7 @@ export const ckTESTBTCTokenBase: UserTokenBase = {
   actions: [],
 };
 
+const snsHref = `/wallet/?u=${principal(0).toText()}`;
 export const userTokenPageMock: UserTokenData = {
   universeId: principal(0),
   title: "Test SNS",
@@ -77,9 +80,11 @@ export const userTokenPageMock: UserTokenData = {
     token: mockCkBTCToken,
   }),
   actions: [UserTokenAction.Send, UserTokenAction.Receive],
-  rowHref: `/wallet/?u=${principal(0).toText()}`,
+  rowHref: snsHref,
+  domKey: snsHref,
 };
 
+const ckBTCHref = `/wallet/?u=${CKBTC_UNIVERSE_CANISTER_ID.toText()}`;
 export const userTokensPageMock: UserTokenData[] = [
   {
     ...icpTokenNoBalance,
@@ -94,7 +99,8 @@ export const userTokensPageMock: UserTokenData[] = [
       token: mockCkBTCToken,
     }),
     actions: [UserTokenAction.Send, UserTokenAction.Receive],
-    rowHref: `/wallet/?u=${CKBTC_UNIVERSE_CANISTER_ID.toText()}`,
+    rowHref: ckBTCHref,
+    domKey: ckBTCHref,
   },
   {
     universeId: principal(0),
@@ -111,6 +117,7 @@ export const userTokensPageMock: UserTokenData[] = [
     logo: "sns-logo.svg",
     actions: [UserTokenAction.Send, UserTokenAction.Receive],
     rowHref: `/wallet/?u=${principal(0).toText()}`,
+    domKey: `/wallet/?u=${principal(0).toText()}`,
   },
   {
     universeId: principal(1),
@@ -127,16 +134,19 @@ export const userTokensPageMock: UserTokenData[] = [
     logo: "sns-logo-2.svg",
     actions: [UserTokenAction.Send, UserTokenAction.Receive],
     rowHref: `/wallet/?u=${principal(1).toText()}`,
+    domKey: `/wallet/?u=${principal(1).toText()}`,
   },
 ];
 
-export const createUserToken = (params: Partial<UserTokenData> = {}) => ({
-  ...userTokenPageMock,
-  ...params,
-  ...(isNullish(params.rowHref) && nonNullish(params.universeId)
-    ? { rowHref: `/wallet/?u=${params.universeId.toText()}` }
-    : {}),
-});
+export const createUserToken = (params: Partial<UserTokenData> = {}) => {
+  const rowHref = params.rowHref ?? `/wallet/?u=${params.universeId.toText()}`;
+  return {
+    ...userTokenPageMock,
+    ...params,
+    rowHref,
+    domKey: rowHref,
+  };
+};
 
 export const createIcpUserToken = (params: Partial<UserTokenData> = {}) => ({
   ...icpTokenNoBalance,
@@ -150,6 +160,7 @@ export const defaultUserTokenLoading: UserTokenLoading = {
   logo: "sns-logo.svg",
   actions: [],
   rowHref: `/wallet/?u=${principal(0).toText()}`,
+  domKey: `/wallet/?u=${principal(0).toText()}`,
 };
 
 export const createUserTokenLoading = (

--- a/frontend/src/tests/mocks/tokens-page.mock.ts
+++ b/frontend/src/tests/mocks/tokens-page.mock.ts
@@ -19,7 +19,7 @@ import {
   type UserTokenLoading,
 } from "$lib/types/tokens-page";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
-import { TokenAmountV2 } from "@dfinity/utils";
+import { TokenAmountV2, nonNullish } from "@dfinity/utils";
 import { mockCkBTCToken } from "./ckbtc-accounts.mock";
 import { mockSnsToken, principal } from "./sns-projects.mock";
 
@@ -139,7 +139,11 @@ export const userTokensPageMock: UserTokenData[] = [
 ];
 
 export const createUserToken = (params: Partial<UserTokenData> = {}) => {
-  const rowHref = params.rowHref ?? `/wallet/?u=${params.universeId.toText()}`;
+  const rowHref = nonNullish(params.rowHref)
+    ? params.rowHref
+    : nonNullish(params.universeId)
+    ? `/wallet/?u=${params.universeId.toText()}`
+    : userTokenPageMock.rowHref;
   return {
     ...userTokenPageMock,
     ...params,

--- a/frontend/src/tests/page-objects/ResponsiveTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/ResponsiveTableRow.page-object.ts
@@ -31,4 +31,8 @@ export class ResponsiveTableRowPo extends BasePageObject {
       )
     );
   }
+
+  async getTagName(): Promise<string> {
+    return this.root.getTagName();
+  }
 }

--- a/frontend/src/tests/page-objects/jest.page-object.ts
+++ b/frontend/src/tests/page-objects/jest.page-object.ts
@@ -181,4 +181,9 @@ export class JestPageObjectElement implements PageObjectElement {
   async getDocumentBody(): Promise<JestPageObjectElement> {
     return new JestPageObjectElement(document.body);
   }
+
+  async getTagName(): Promise<string> {
+    await this.waitFor();
+    return this.getElement()?.tagName ?? "";
+  }
 }

--- a/frontend/src/tests/page-objects/playwright.page-object.ts
+++ b/frontend/src/tests/page-objects/playwright.page-object.ts
@@ -155,4 +155,8 @@ export class PlaywrightPageObjectElement implements PageObjectElement {
   async getDocumentBody(): Promise<PlaywrightPageObjectElement> {
     return PlaywrightPageObjectElement.fromPage(this.page);
   }
+
+  async getTagName(): Promise<string> {
+    throw new Error("Not implement");
+  }
 }

--- a/frontend/src/tests/types/page-object.types.ts
+++ b/frontend/src/tests/types/page-object.types.ts
@@ -38,4 +38,5 @@ export interface PageObjectElement {
   innerHtmlForDebugging(): Promise<string>;
   addEventListener(eventType: string, fn: (e: Event) => void): Promise<void>;
   getDocumentBody(): Promise<PageObjectElement>;
+  getTagName(): Promise<string>;
 }


### PR DESCRIPTION
# Motivation

When rendering table rows in a `{#each}` we need to assign a uniq DOM key to each row so Svelte can keep track of rows for the purpose of transitions.
For the tokens table we used the token URL for this because each row had a unique URL anyway.
But for the neurons table, we need to be able to render rows for spawning neurons, which do not have a details page and so do not have a URL.
So we need another way to assign the DOM key without have a URL.

# Changes

1. Add a new `domKey` field to `ResponsiveTableRowData`.
2. Make `rowHref` optional.
3. Use `domKey` instead of `rowHref` in the `{#each}` in `frontend/src/lib/components/ui/ResponsiveTable.svelte`.
4. Render rows which do not have a URL as `div` instead of `a`. (This was also done before https://github.com/dfinity/nns-dapp/pull/4647)
5. Remove the `@include interaction.tappable;` style. Links already have the correct style (pointer cursor) and non-links should not have this style.
6. For the tokens table data, assign `domKey` everywhere to be identical to `rowHref`. Something else could work as well but this is what we've been using and it works.

# Tests

1. Assign `domKey` equal to `rowHref` in all the tokens table tests.
2. Add a unit test to check that `rowHref` can be absent and results in a `<div>` row instead of `<a>`.
3. Manually tests by arbitrarily omitting some `rowHref`s in the tokens table.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary