### PR TITLE
NNS1-3093: Make neuronId a string in TableNeuron

### DIFF
--- a/frontend/src/lib/types/neurons-table.ts
+++ b/frontend/src/lib/types/neurons-table.ts
@@ -1,3 +1,3 @@
 export type TableNeuron = {
-  neuronId: bigint;
+  neuronId: string;
 };

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -1043,6 +1043,6 @@ export const tableNeuronsFromNeuronInfos = (
   neuronInfos: NeuronInfo[]
 ): TableNeuron[] => {
   return neuronInfos.map(({ neuronId }) => ({
-    neuronId,
+    neuronId: neuronId.toString(),
   }));
 };

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -6,10 +6,10 @@ import { render } from "$tests/utils/svelte.test-utils";
 
 describe("NeuronsTable", () => {
   const neuron1: TableNeuron = {
-    neuronId: 10n,
+    neuronId: "10",
   };
   const neuron2: TableNeuron = {
-    neuronId: 99n,
+    neuronId: "99",
   };
   const renderComponent = () => {
     const { container } = render(NeuronsTable, {
@@ -22,7 +22,7 @@ describe("NeuronsTable", () => {
     const po = renderComponent();
     const rowPos = await po.getNeuronsTableRowPos();
     expect(rowPos).toHaveLength(2);
-    expect(await rowPos[0].getNeuronId()).toBe(neuron1.neuronId.toString());
-    expect(await rowPos[1].getNeuronId()).toBe(neuron2.neuronId.toString());
+    expect(await rowPos[0].getNeuronId()).toBe(neuron1.neuronId);
+    expect(await rowPos[1].getNeuronId()).toBe(neuron2.neuronId);
   });
 });

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTableRow.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTableRow.spec.ts
@@ -6,7 +6,7 @@ import { render } from "$tests/utils/svelte.test-utils";
 
 describe("NeuronsTableRow", () => {
   const neuron: TableNeuron = {
-    neuronId: 10n,
+    neuronId: "10",
   };
   const renderComponent = () => {
     const { container } = render(NeuronsTableRow, {
@@ -17,6 +17,6 @@ describe("NeuronsTableRow", () => {
 
   it("should render table row", async () => {
     const po = renderComponent();
-    expect(await po.getNeuronId()).toBe(neuron.neuronId.toString());
+    expect(await po.getNeuronId()).toBe(neuron.neuronId);
   });
 });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -2851,10 +2851,10 @@ describe("neuron-utils", () => {
       const tableNeurons = tableNeuronsFromNeuronInfos(neuronInfos);
       expect(tableNeurons).toEqual([
         {
-          neuronId: neuronId1,
+          neuronId: "42",
         },
         {
-          neuronId: neuronId2,
+          neuronId: "342",
         },
       ]);
     });


### PR DESCRIPTION
# Motivation

We want to support both NNS and SNS with the neurons table.
NNS neuron IDs are `bigint`s but SNS neuron IDs are `string`s.
It's easier to convert `bigint` to `string` than the other way around so let's already use `string`s for neuron IDs.

# Changes

1. Make `TableNeuron.neuronId` a string.
2. Update utils and tests.

# Tests

Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary