### PR TITLE
Display unsupported snses in all-voted banner

### DIFF
--- a/frontend/src/lib/components/proposals/ActionableProposalsEmpty.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalsEmpty.svelte
@@ -1,6 +1,20 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { IconProposalsPage, PageBanner } from "@dfinity/gix-components";
+  import { actionableProposalNotSupportedUniversesStore } from "$lib/derived/actionable-proposals.derived";
+  import { joinWithOr, replacePlaceholders } from "$lib/utils/i18n.utils";
+
+  let unsupportedUniverseNames: string[] = [];
+  $: unsupportedUniverseNames =
+    $actionableProposalNotSupportedUniversesStore.map(({ title }) => title);
+
+  let text = "";
+  $: text =
+    unsupportedUniverseNames.length > 0
+      ? replacePlaceholders($i18n.actionable_proposals_empty.text_unsupported, {
+          $snsNames: joinWithOr(unsupportedUniverseNames),
+        })
+      : $i18n.actionable_proposals_empty.text;
 </script>
 
 <PageBanner testId="actionable-proposals-empty">
@@ -8,7 +22,5 @@
   <svelte:fragment slot="title"
     >{$i18n.actionable_proposals_empty.title}</svelte:fragment
   >
-  <p class="description" slot="description">
-    {$i18n.actionable_proposals_empty.text}
-  </p>
+  <p class="description" slot="description">{text}</p>
 </PageBanner>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -384,7 +384,8 @@
   },
   "actionable_proposals_empty": {
     "title": "You're all caught up.",
-    "text": "Check back later!"
+    "text": "Check back later!",
+    "text_unsupported": "Check back later! Note, that not all SNS DAOs support actionable proposals. You will need to check proposals manually if you hold $snsNames neurons."
   },
   "actionable_proposals_not_supported": {
     "title": "$snsName doesn't yet support actionable proposals.",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -31,7 +31,8 @@
     "receive_with_token": "Receive $token",
     "receive": "Receive",
     "send_with_token": "Send $token",
-    "collapse_all": "Collapse All"
+    "collapse_all": "Collapse All",
+    "or": "or"
   },
   "error": {
     "auth_sync": "There was an unexpected issue while syncing the status of your authentication. Try to refresh your browser.",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -401,6 +401,7 @@ interface I18nActionable_proposals_sign_in {
 interface I18nActionable_proposals_empty {
   title: string;
   text: string;
+  text_unsupported: string;
 }
 
 interface I18nActionable_proposals_not_supported {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -35,6 +35,7 @@ interface I18nCore {
   receive: string;
   send_with_token: string;
   collapse_all: string;
+  or: string;
 }
 
 interface I18nError {

--- a/frontend/src/lib/utils/i18n.utils.ts
+++ b/frontend/src/lib/utils/i18n.utils.ts
@@ -65,3 +65,13 @@ export const replacePlaceholders = (
 
   return result;
 };
+
+/**
+ * Similar to Array.join(", ") but uses " or " before the last element.
+ * @example
+ * ["Example", "Sample", "Test"] -> "Example, Sample or Test"
+ */
+export const joinWithOr = (text: string[]): string =>
+  text.length > 1
+    ? `${text.slice(0, -1).join(", ")} ${get(i18n).core.or} ${text.slice(-1)}`
+    : text.join(", ");

--- a/frontend/src/tests/lib/components/proposals/ActionableProposalsEmpty.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/ActionableProposalsEmpty.spec.ts
@@ -1,0 +1,72 @@
+import ActionableProposalsEmpty from "$lib/components/proposals/ActionableProposalsEmpty.svelte";
+import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { PageBannerPo } from "$tests/page-objects/PageBanner.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { allowLoggingInOneTestForDebugging } from "$tests/utils/console.test-utils";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { render } from "$tests/utils/svelte.test-utils";
+import { SnsSwapLifecycle } from "@dfinity/sns";
+
+describe("ActionableProposalsEmpty", () => {
+  const addSnsesWithSupport = (includeBallotsByCallerList: boolean[]) => {
+    const snsProjects = Array.from(
+      new Array(includeBallotsByCallerList.length)
+    ).map((_, i) => ({
+      lifecycle: SnsSwapLifecycle.Committed,
+      rootCanisterId: principal(i),
+      projectName: `SNS-${i}`,
+    }));
+    setSnsProjects(snsProjects);
+
+    Array.from(new Array(includeBallotsByCallerList.length)).forEach((_, i) =>
+      actionableSnsProposalsStore.set({
+        rootCanisterId: principal(i),
+        proposals: [],
+        includeBallotsByCaller: includeBallotsByCallerList[i],
+      })
+    );
+  };
+
+  const renderComponent = () => {
+    const { container } = render(ActionableProposalsEmpty);
+
+    return PageBannerPo.under({
+      element: new JestPageObjectElement(container),
+    });
+  };
+
+  beforeEach(() => {
+    resetSnsProjects();
+    actionableSnsProposalsStore.resetForTesting();
+    allowLoggingInOneTestForDebugging();
+  });
+
+  it("should display a title", async () => {
+    addSnsesWithSupport([true]);
+    const po = renderComponent();
+    expect(await po.getTitleText()).toEqual("You're all caught up.");
+  });
+
+  it("should display a static text when there is no unsupported Snses", async () => {
+    addSnsesWithSupport([true]);
+    const po = renderComponent();
+    expect(await po.getDescriptionText()).toEqual("Check back later!");
+  });
+
+  it("should display an unsupported Sns name in description", async () => {
+    addSnsesWithSupport([false]);
+    const po = renderComponent();
+    expect(await po.getDescriptionText()).toEqual(
+      "Check back later! Note, that not all SNS DAOs support actionable proposals. You will need to check proposals manually if you hold SNS-0 neurons."
+    );
+  });
+
+  it("should display multiple unsupported Sns names in description", async () => {
+    addSnsesWithSupport([false, true, false, true, false]);
+    const po = renderComponent();
+    expect(await po.getDescriptionText()).toEqual(
+      "Check back later! Note, that not all SNS DAOs support actionable proposals. You will need to check proposals manually if you hold SNS-0, SNS-2 or SNS-4 neurons."
+    );
+  });
+});

--- a/frontend/src/tests/lib/components/proposals/ActionableProposalsEmpty.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/ActionableProposalsEmpty.spec.ts
@@ -3,23 +3,20 @@ import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposal
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { PageBannerPo } from "$tests/page-objects/PageBanner.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { allowLoggingInOneTestForDebugging } from "$tests/utils/console.test-utils";
 import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { render } from "$tests/utils/svelte.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
 
 describe("ActionableProposalsEmpty", () => {
   const addSnsesWithSupport = (includeBallotsByCallerList: boolean[]) => {
-    const snsProjects = Array.from(
-      new Array(includeBallotsByCallerList.length)
-    ).map((_, i) => ({
+    const snsProjects = includeBallotsByCallerList.map((_, i) => ({
       lifecycle: SnsSwapLifecycle.Committed,
       rootCanisterId: principal(i),
       projectName: `SNS-${i}`,
     }));
     setSnsProjects(snsProjects);
 
-    Array.from(new Array(includeBallotsByCallerList.length)).forEach((_, i) =>
+    includeBallotsByCallerList.forEach((_, i) =>
       actionableSnsProposalsStore.set({
         rootCanisterId: principal(i),
         proposals: [],
@@ -40,7 +37,6 @@ describe("ActionableProposalsEmpty", () => {
   beforeEach(() => {
     resetSnsProjects();
     actionableSnsProposalsStore.resetForTesting();
-    allowLoggingInOneTestForDebugging();
   });
 
   it("should display a title", async () => {

--- a/frontend/src/tests/lib/components/proposals/ActionableProposalsEmpty.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/ActionableProposalsEmpty.spec.ts
@@ -33,6 +33,7 @@ describe("ActionableProposalsEmpty", () => {
 
     return PageBannerPo.under({
       element: new JestPageObjectElement(container),
+      testId: "actionable-proposals-empty",
     });
   };
 

--- a/frontend/src/tests/lib/components/proposals/ActionableProposalsNotSupportedSnses.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/ActionableProposalsNotSupportedSnses.spec.ts
@@ -9,16 +9,14 @@ import { SnsSwapLifecycle } from "@dfinity/sns";
 
 describe("ActionableProposalsNotSupportedSnses", () => {
   const addSnsesWithSupport = (includeBallotsByCallerList: boolean[]) => {
-    const snsProjects = Array.from(
-      new Array(includeBallotsByCallerList.length)
-    ).map((_, i) => ({
+    const snsProjects = includeBallotsByCallerList.map((_, i) => ({
       lifecycle: SnsSwapLifecycle.Committed,
       rootCanisterId: principal(i),
       projectName: `SNS-${i}`,
     }));
     setSnsProjects(snsProjects);
 
-    Array.from(new Array(includeBallotsByCallerList.length)).forEach((_, i) =>
+    includeBallotsByCallerList.forEach((_, i) =>
       actionableSnsProposalsStore.set({
         rootCanisterId: principal(i),
         proposals: [],

--- a/frontend/src/tests/lib/utils/i18n.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/i18n.utils.spec.ts
@@ -1,4 +1,8 @@
-import { replacePlaceholders, translate } from "$lib/utils/i18n.utils";
+import {
+  joinWithOr,
+  replacePlaceholders,
+  translate,
+} from "$lib/utils/i18n.utils";
 
 describe("i18n-utils", () => {
   it("should translate", () => {
@@ -56,6 +60,23 @@ describe("i18n-utils", () => {
           "{1}": "dog",
         })
       ).toBe("The quick brown fox jumps over the lazy dog");
+    });
+  });
+
+  describe("joinWithOr", () => {
+    it("should add or", () => {
+      expect(joinWithOr(["Example", "Sample", "Test"])).toBe(
+        "Example, Sample or Test"
+      );
+      expect(joinWithOr(["Sample", "Test"])).toBe("Sample or Test");
+    });
+
+    it("should return a single entry only", () => {
+      expect(joinWithOr(["Example"])).toBe("Example");
+    });
+
+    it("should return empty text", () => {
+      expect(joinWithOr([])).toBe("");
     });
   });
 });

--- a/frontend/src/tests/page-objects/PageBanner.page-object.ts
+++ b/frontend/src/tests/page-objects/PageBanner.page-object.ts
@@ -9,9 +9,9 @@ export class PageBannerPo extends BasePageObject {
     testId,
   }: {
     element: PageObjectElement;
-    testId?: string;
+    testId: string;
   }): PageBannerPo {
-    return new PageBannerPo(testId ? element.byTestId(testId) : element);
+    return new PageBannerPo(element.byTestId(testId));
   }
 
   getTitle(): PageObjectElement {

--- a/frontend/src/tests/page-objects/PageBanner.page-object.ts
+++ b/frontend/src/tests/page-objects/PageBanner.page-object.ts
@@ -9,9 +9,9 @@ export class PageBannerPo extends BasePageObject {
     testId,
   }: {
     element: PageObjectElement;
-    testId: string;
+    testId?: string;
   }): PageBannerPo {
-    return new PageBannerPo(element.byTestId(testId));
+    return new PageBannerPo(testId ? element.byTestId(testId) : element);
   }
 
   getTitle(): PageObjectElement {


### PR DESCRIPTION
# Motivation

In cases where the user has voted on all available actionable proposals, we currently display the `ActionableProposalsEmpty` banner with the text "You’re all caught up." However, if some SNSes still don’t support actionable proposals, we cannot be sure that there are no votable proposals for these SNSes. To make this clear, the `ActionableProposalsEmpty` banner should display more detailed information. In this PR, we update the description to display the SNSes that may contain votable proposals.

# Changes

- New `joinWithOr` util.
- Display unsupported Snses in `ActionableProposalsEmpty` banner description.
- Not related refactoring: removed redundant array creation [here](https://github.com/dfinity/nns-dapp/pull/4960/files#diff-bdabfefb322354658061b1e40e4e4b5a1fc2feab676ffcd43e37d91b9b7d4894R12).

# Tests

- Test for `joinWithOr`.
- Update `PageBannerPo`.`under` arguments to support it's creation from the root component.
- Test for `ActionableProposalsEmpty` component (now it makes sense, since it includes a dynamic text).

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.