### PR TITLE
NNS1-3092: Make spawning neurons non-clickable in neurons table

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronActionsCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronActionsCell.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import { IconRight } from "@dfinity/gix-components";
   import type { TableNeuron } from "$lib/types/neurons-table";
+  import { nonNullish } from "@dfinity/utils";
 
   export let rowData: TableNeuron;
 </script>
 
-{#if false}
-  We need to reference {rowData} to satisfy the linter. We'll reference it properly
-  in a future change.
+{#if nonNullish(rowData.rowHref)}
+  <TestIdWrapper testId="go-to-neuron-detail-action">
+    <IconRight />
+  </TestIdWrapper>
 {/if}
-<IconRight />

--- a/frontend/src/lib/types/neurons-table.ts
+++ b/frontend/src/lib/types/neurons-table.ts
@@ -2,7 +2,7 @@ import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
 import type { TokenAmountV2 } from "@dfinity/utils";
 
 export type TableNeuron = {
-  rowHref: string;
+  rowHref?: string;
   domKey: string;
   neuronId: string;
   stake: TokenAmountV2;

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -1052,12 +1052,15 @@ export const tableNeuronsFromNeuronInfos = (
   return neuronInfos.map((neuronInfo) => {
     const { neuronId } = neuronInfo;
     const neuronIdString = neuronId.toString();
-    const rowHref = buildNeuronUrl({
-      universe: OWN_CANISTER_ID_TEXT,
-      neuronId,
-    });
+    const isSpawningNeuron = isSpawning(neuronInfo);
+    const rowHref = isSpawningNeuron
+      ? undefined
+      : buildNeuronUrl({
+          universe: OWN_CANISTER_ID_TEXT,
+          neuronId,
+        });
     return {
-      rowHref,
+      ...(rowHref && { rowHref }),
       domKey: neuronIdString,
       neuronId: neuronIdString,
       stake: TokenAmountV2.fromUlps({

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -24,15 +24,23 @@ describe("NeuronsTable", () => {
       token: ICPToken,
     }),
   };
-  const renderComponent = () => {
+  const spawningNeuron: TableNeuron = {
+    domKey: "101",
+    neuronId: "101",
+    stake: TokenAmountV2.fromUlps({
+      amount: 300_000_000n,
+      token: ICPToken,
+    }),
+  };
+  const renderComponent = ({ neurons }) => {
     const { container } = render(NeuronsTable, {
-      neurons: [neuron1, neuron2],
+      neurons,
     });
     return NeuronsTablePo.under(new JestPageObjectElement(container));
   };
 
   it("should render neuron URL", async () => {
-    const po = renderComponent();
+    const po = renderComponent({ neurons: [neuron1, neuron2] });
     const rowPos = await po.getNeuronsTableRowPos();
     expect(rowPos).toHaveLength(2);
     expect(await rowPos[0].getHref()).toBe(neuron1.rowHref);
@@ -40,7 +48,7 @@ describe("NeuronsTable", () => {
   });
 
   it("should render neuron ID", async () => {
-    const po = renderComponent();
+    const po = renderComponent({ neurons: [neuron1, neuron2] });
     const rowPos = await po.getNeuronsTableRowPos();
     expect(rowPos).toHaveLength(2);
     expect(await rowPos[0].getNeuronId()).toBe(neuron1.neuronId);
@@ -48,10 +56,20 @@ describe("NeuronsTable", () => {
   });
 
   it("should render neuron stake", async () => {
-    const po = renderComponent();
+    const po = renderComponent({ neurons: [neuron1, neuron2] });
     const rowPos = await po.getNeuronsTableRowPos();
     expect(rowPos).toHaveLength(2);
     expect(await rowPos[0].getStake()).toBe("5.00 ICP");
     expect(await rowPos[1].getStake()).toBe("13.00 ICP");
+  });
+
+  it("should render go-to-detail button iff there is a URL", async () => {
+    const po = renderComponent({ neurons: [neuron1, spawningNeuron] });
+    const rowPos = await po.getNeuronsTableRowPos();
+    expect(rowPos).toHaveLength(2);
+    expect(await rowPos[0].getHref()).toBe(neuron1.rowHref);
+    expect(await rowPos[0].hasGoToDetailButton()).toBe(true);
+    expect(await rowPos[1].getHref()).toBe(null);
+    expect(await rowPos[1].hasGoToDetailButton()).toBe(false);
   });
 });

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -4,6 +4,7 @@ import NnsNeurons from "$lib/pages/NnsNeurons.svelte";
 import * as authServices from "$lib/services/auth.services";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
+import { isSpawning } from "$lib/utils/neuron.utils";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronsPo } from "$tests/page-objects/NnsNeurons.page-object";
@@ -111,6 +112,20 @@ describe("NnsNeurons", () => {
 
         const neuronCards = await po.getNeuronCardPos();
         expect(neuronCards.length).toBe(0);
+      });
+
+      it("should render an go-to-detail button for non-spawning neurons", async () => {
+        const po = await renderComponent();
+
+        const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
+        expect(rows).toHaveLength(3);
+        expect(neurons).toHaveLength(3);
+        expect(isSpawning(neurons[0])).toBe(false);
+        expect(await rows[0].hasGoToDetailButton()).toBe(true);
+        expect(isSpawning(neurons[1])).toBe(true);
+        expect(await rows[1].hasGoToDetailButton()).toBe(false);
+        expect(isSpawning(neurons[2])).toBe(false);
+        expect(await rows[2].hasGoToDetailButton()).toBe(true);
       });
     });
   });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -2880,5 +2880,31 @@ describe("neuron-utils", () => {
         },
       ]);
     });
+
+    it("should convert neuronInfo for spawning neuron without href", () => {
+      const neuronId = 52n;
+      const spawningNeuronInfo = {
+        ...mockNeuron,
+        neuronId: neuronId,
+        state: NeuronState.Spawning,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          cachedNeuronStake: 0n,
+          spawnAtTimesSeconds: 12_312_313n,
+        },
+      };
+      const neuronInfos = [spawningNeuronInfo];
+      const tableNeurons = tableNeuronsFromNeuronInfos(neuronInfos);
+      expect(tableNeurons).toEqual([
+        {
+          domKey: "52",
+          neuronId: "52",
+          stake: TokenAmountV2.fromUlps({
+            amount: 0n,
+            token: ICPToken,
+          }),
+        },
+      ]);
+    });
   });
 });

--- a/frontend/src/tests/page-objects/NeuronsTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronsTableRow.page-object.ts
@@ -21,4 +21,8 @@ export class NeuronsTableRowPo extends ResponsiveTableRowPo {
   getStake(): Promise<string> {
     return this.getText("neuron-stake-cell-component");
   }
+
+  hasGoToDetailButton(): Promise<boolean> {
+    return this.isPresent("go-to-neuron-detail-action");
+  }
 }


### PR DESCRIPTION
# Motivation

Spawning neurons don't have a neuron details page. The current neuron cards are not clickable for spawning neurons.
So the rows in the neurons table also should not be clickable for spawning neurons.

# Changes

1. Make `rowHref` an optional field on `TableNeuron`.
2. Create `TableNeuron` objects without `rowHref` for spawning neurons.
3. Render `TableNeuron`s without `rowHref` also without "go-to-detail" action (i.e. the right pointing chevron).
4. 

# Tests

Added unit tests for
1. `frontend/src/lib/utils/neuron.utils.ts`
2. `frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts`, and
3. `frontend/src/tests/lib/pages/NnsNeurons.spec.ts`

# Todos

- [ ] Add entry to changelog (if necessary).
not yet