### PR TITLE
NNS1-3092: Add dissolve delay column to neurons table

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronDissolveDelayCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronDissolveDelayCell.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import type { TableNeuron } from "$lib/types/neurons-table";
+  import { secondsToDuration } from "@dfinity/utils";
+  import { i18n } from "$lib/stores/i18n";
+
+  export let rowData: TableNeuron;
+
+  let dissolveDelayDuration: string;
+  $: dissolveDelayDuration = secondsToDuration({
+    seconds: rowData.dissolveDelaySeconds,
+    i18n: $i18n.time,
+  });
+</script>
+
+<div data-tid="neuron-dissolve-delay-cell-component">
+  {dissolveDelayDuration}
+</div>

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
@@ -7,6 +7,7 @@
   } from "$lib/types/neurons-table";
   import NeuronIdCell from "$lib/components/neurons/NeuronsTable/NeuronIdCell.svelte";
   import NeuronStakeCell from "$lib/components/neurons/NeuronsTable/NeuronStakeCell.svelte";
+  import NeuronDissolveDelayCell from "$lib/components/neurons/NeuronsTable/NeuronDissolveDelayCell.svelte";
   import NeuronActionsCell from "$lib/components/neurons/NeuronsTable/NeuronActionsCell.svelte";
 
   export let neurons: TableNeuron[];
@@ -19,6 +20,10 @@
     {
       title: $i18n.neuron_detail.stake,
       cellComponent: NeuronStakeCell,
+    },
+    {
+      title: $i18n.neurons.dissolve_delay_title,
+      cellComponent: NeuronDissolveDelayCell,
     },
     {
       title: "",

--- a/frontend/src/lib/types/neurons-table.ts
+++ b/frontend/src/lib/types/neurons-table.ts
@@ -6,6 +6,7 @@ export type TableNeuron = {
   domKey: string;
   neuronId: string;
   stake: TokenAmountV2;
+  dissolveDelaySeconds: bigint;
 };
 
 export type NeuronsTableColumn = ResponsiveTableColumn<TableNeuron>;

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -1050,7 +1050,7 @@ export const tableNeuronsFromNeuronInfos = (
   neuronInfos: NeuronInfo[]
 ): TableNeuron[] => {
   return neuronInfos.map((neuronInfo) => {
-    const { neuronId } = neuronInfo;
+    const { neuronId, dissolveDelaySeconds } = neuronInfo;
     const neuronIdString = neuronId.toString();
     const isSpawningNeuron = isSpawning(neuronInfo);
     const rowHref = isSpawningNeuron
@@ -1067,6 +1067,7 @@ export const tableNeuronsFromNeuronInfos = (
         amount: neuronStake(neuronInfo),
         token: ICPToken,
       }),
+      dissolveDelaySeconds,
     };
   });
 };

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -1,4 +1,9 @@
 import NeuronsTable from "$lib/components/neurons/NeuronsTable/NeuronsTable.svelte";
+import {
+  SECONDS_IN_DAY,
+  SECONDS_IN_EIGHT_YEARS,
+  SECONDS_IN_MONTH,
+} from "$lib/constants/constants";
 import type { TableNeuron } from "$lib/types/neurons-table";
 import { NeuronsTablePo } from "$tests/page-objects/NeuronsTable.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -14,7 +19,9 @@ describe("NeuronsTable", () => {
       amount: 500_000_000n,
       token: ICPToken,
     }),
+    dissolveDelaySeconds: BigInt(6 * SECONDS_IN_MONTH),
   };
+
   const neuron2: TableNeuron = {
     rowHref: "/neurons/99",
     domKey: "99",
@@ -23,7 +30,9 @@ describe("NeuronsTable", () => {
       amount: 1_300_000_000n,
       token: ICPToken,
     }),
+    dissolveDelaySeconds: BigInt(SECONDS_IN_EIGHT_YEARS),
   };
+
   const spawningNeuron: TableNeuron = {
     domKey: "101",
     neuronId: "101",
@@ -31,7 +40,9 @@ describe("NeuronsTable", () => {
       amount: 300_000_000n,
       token: ICPToken,
     }),
+    dissolveDelaySeconds: BigInt(5 * SECONDS_IN_DAY),
   };
+
   const renderComponent = ({ neurons }) => {
     const { container } = render(NeuronsTable, {
       neurons,
@@ -61,6 +72,14 @@ describe("NeuronsTable", () => {
     expect(rowPos).toHaveLength(2);
     expect(await rowPos[0].getStake()).toBe("5.00 ICP");
     expect(await rowPos[1].getStake()).toBe("13.00 ICP");
+  });
+
+  it("should render dissolve delay", async () => {
+    const po = renderComponent({ neurons: [neuron1, neuron2] });
+    const rowPos = await po.getNeuronsTableRowPos();
+    expect(rowPos).toHaveLength(2);
+    expect(await rowPos[0].getDissolveDelay()).toBe("182 days, 15 hours");
+    expect(await rowPos[1].getDissolveDelay()).toBe("8 years");
   });
 
   it("should render go-to-detail button iff there is a URL", async () => {

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -2841,6 +2841,8 @@ describe("neuron-utils", () => {
       const neuronId2 = 342n;
       const stake1 = 500_000_000n;
       const stake2 = 600_000_000n;
+      const dissolveDelay1 = 15778800n;
+      const dissolveDelay2 = 252460800n;
       const neuronInfo1 = {
         ...mockNeuron,
         neuronId: neuronId1,
@@ -2848,6 +2850,7 @@ describe("neuron-utils", () => {
           ...mockNeuron.fullNeuron,
           cachedNeuronStake: stake1,
         },
+        dissolveDelaySeconds: dissolveDelay1,
       };
       const neuronInfo2 = {
         ...mockNeuron,
@@ -2856,6 +2859,7 @@ describe("neuron-utils", () => {
           ...mockNeuron.fullNeuron,
           cachedNeuronStake: stake2,
         },
+        dissolveDelaySeconds: dissolveDelay2,
       };
       const neuronInfos = [neuronInfo1, neuronInfo2];
       const tableNeurons = tableNeuronsFromNeuronInfos(neuronInfos);
@@ -2868,6 +2872,7 @@ describe("neuron-utils", () => {
             amount: 500_000_000n,
             token: ICPToken,
           }),
+          dissolveDelaySeconds: dissolveDelay1,
         },
         {
           rowHref: "/neuron/?u=qhbym-qaaaa-aaaaa-aaafq-cai&neuron=342",
@@ -2877,12 +2882,14 @@ describe("neuron-utils", () => {
             amount: 600_000_000n,
             token: ICPToken,
           }),
+          dissolveDelaySeconds: dissolveDelay2,
         },
       ]);
     });
 
     it("should convert neuronInfo for spawning neuron without href", () => {
       const neuronId = 52n;
+      const dissolveDelaySeconds = BigInt(5 * SECONDS_IN_DAY);
       const spawningNeuronInfo = {
         ...mockNeuron,
         neuronId: neuronId,
@@ -2892,6 +2899,7 @@ describe("neuron-utils", () => {
           cachedNeuronStake: 0n,
           spawnAtTimesSeconds: 12_312_313n,
         },
+        dissolveDelaySeconds,
       };
       const neuronInfos = [spawningNeuronInfo];
       const tableNeurons = tableNeuronsFromNeuronInfos(neuronInfos);
@@ -2903,6 +2911,7 @@ describe("neuron-utils", () => {
             amount: 0n,
             token: ICPToken,
           }),
+          dissolveDelaySeconds,
         },
       ]);
     });

--- a/frontend/src/tests/page-objects/NeuronsTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronsTableRow.page-object.ts
@@ -22,6 +22,10 @@ export class NeuronsTableRowPo extends ResponsiveTableRowPo {
     return this.getText("neuron-stake-cell-component");
   }
 
+  getDissolveDelay(): Promise<string> {
+    return this.getText("neuron-dissolve-delay-cell-component");
+  }
+
   hasGoToDetailButton(): Promise<boolean> {
     return this.isPresent("go-to-neuron-detail-action");
   }


### PR DESCRIPTION
# Motivation

Showing neuron dissolve delay in the neurons table.

# Changes

1. Add `NeuronDissolveDelayCell` to render the dissolve delay.
2. Add column to column spec in `frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte`
3. Add `dissolveDelaySeconds` field to `TableNeuron` type.
4. Add dissolve delay conversion in `tableNeuronsFromNeuronInfos`.

# Tests

1. Unit tests added.
2. Manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [ ] Add entry to changelog (if necessary).
not yet