### PR TITLE
NNS1-3092: Show spinner while neurons table is loading

### DIFF
--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -11,7 +11,7 @@
     definedNeuronsStore,
   } from "$lib/stores/neurons.store";
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
-  import { Tooltip } from "@dfinity/gix-components";
+  import { Spinner, Tooltip } from "@dfinity/gix-components";
   import { isSpawning } from "$lib/utils/neuron.utils";
   import { pageStore } from "$lib/derived/page.derived";
   import { buildNeuronUrl } from "$lib/utils/navigation.utils";
@@ -35,7 +35,11 @@
 
 <TestIdWrapper testId="nns-neurons-component">
   {#if $ENABLE_NEURONS_TABLE}
-    <NeuronsTable neurons={tableNeurons} />
+    {#if isLoading}
+      <Spinner />
+    {:else if tableNeurons.length > 0}
+      <NeuronsTable neurons={tableNeurons} />
+    {/if}
   {:else}
     <div class="card-grid" data-tid="neurons-body">
       {#if isLoading}

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -138,10 +138,28 @@ describe("NnsNeurons", () => {
       vi.spyOn(api, "queryNeurons").mockResolvedValue([]);
     });
 
-    it("should render an empty message", async () => {
-      const po = await renderComponent();
+    describe("with ENABLE_NEURONS_TABLE disabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", false);
+      });
 
-      expect(await po.hasEmptyMessage()).toBe(true);
+      it("should render an empty message", async () => {
+        const po = await renderComponent();
+
+        expect(await po.hasEmptyMessage()).toBe(true);
+      });
+    });
+
+    describe("with ENABLE_NEURONS_TABLE enabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", true);
+      });
+
+      it("should render an empty message", async () => {
+        const po = await renderComponent();
+
+        expect(await po.hasEmptyMessage()).toBe(true);
+      });
     });
   });
 
@@ -157,10 +175,42 @@ describe("NnsNeurons", () => {
       );
     });
 
-    it("should not render an empty message", async () => {
-      const po = await renderComponent();
+    describe("with ENABLE_NEURONS_TABLE disabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", false);
+      });
 
-      expect(await po.hasEmptyMessage()).toBe(false);
+      it("should render skeleton cards", async () => {
+        const po = await renderComponent();
+
+        expect(await po.getSkeletonCardPo().isPresent()).toBe(true);
+        expect(await po.hasSpinner()).toBe(false);
+      });
+
+      it("should not render an empty message", async () => {
+        const po = await renderComponent();
+
+        expect(await po.hasEmptyMessage()).toBe(false);
+      });
+    });
+
+    describe("with ENABLE_NEURONS_TABLE enabled", () => {
+      beforeEach(() => {
+        overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", true);
+      });
+
+      it("should render a spinner", async () => {
+        const po = await renderComponent();
+
+        expect(await po.hasSpinner()).toBe(true);
+        expect(await po.getSkeletonCardPo().isPresent()).toBe(false);
+      });
+
+      it("should not render an empty message", async () => {
+        const po = await renderComponent();
+
+        expect(await po.hasEmptyMessage()).toBe(false);
+      });
     });
   });
 

--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -24,8 +24,12 @@ export class NnsNeuronsPo extends BasePageObject {
   }
 
   async isContentLoaded(): Promise<boolean> {
+    return (await this.isPresent()) && !(await this.isContentLoading());
+  }
+
+  async isContentLoading(): Promise<boolean> {
     return (
-      (await this.isPresent()) && !(await this.getSkeletonCardPo().isPresent())
+      (await this.getSkeletonCardPo().isPresent()) || (await this.hasSpinner())
     );
   }
 
@@ -54,5 +58,9 @@ export class NnsNeuronsPo extends BasePageObject {
 
   hasEmptyMessage(): Promise<boolean> {
     return this.isPresent("empty-message-component");
+  }
+
+  hasSpinner(): Promise<boolean> {
+    return this.isPresent("spinner");
   }
 }


### PR DESCRIPTION
# Motivation

While the neurons page is loading, we currently show skeleton cards.
This doesn't make sense if after loading a table appears instead of cards.

Also, if there are zero neurons, we should not show anything except the empty message.
With cards this is automatic because we just show zero cards.
But we don't want to show a table header with zero rows if there are zero neurons.

# Changes

1. If neurons are loading, show a spinner.
2. If neurons are loaded but there are no neurons, hide the table.

# Tests

Unit tests added for spinner, skeleton cards and empty message with and without feature flag.

Drive-by: Update `isContentLoaded` to take into account that we might have a spinner instead of skeleton cards. This is not used yet but we're going to need it eventually.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet