### PR TITLE
NNS1-3092: Sorting utils for neurons table

### DIFF
--- a/frontend/src/lib/types/neurons-table.ts
+++ b/frontend/src/lib/types/neurons-table.ts
@@ -9,4 +9,8 @@ export type TableNeuron = {
   dissolveDelaySeconds: bigint;
 };
 
+// Should define a partial ordering on TableNeuron by return -1 if a < b, +1 if
+// a > b and 0 if a and b are equivalent.
+export type TableNeuronComparator = (a: TableNeuron, b: TableNeuron) => number;
+
 export type NeuronsTableColumn = ResponsiveTableColumn<TableNeuron>;

--- a/frontend/src/lib/utils/neurons-table.utils.ts
+++ b/frontend/src/lib/utils/neurons-table.utils.ts
@@ -1,0 +1,69 @@
+import type {
+  TableNeuron,
+  TableNeuronComparator,
+} from "$lib/types/neurons-table";
+
+// Takes a list of comparators and returns a single comparator by first applying
+// the first comparator and using subsequent comparators to break ties.
+const mergeComparators = (
+  comparators: TableNeuronComparator[]
+): TableNeuronComparator => {
+  return (a, b) => {
+    for (const comparator of comparators) {
+      const result = comparator(a, b);
+      if (result !== 0) {
+        return result;
+      }
+    }
+    return 0;
+  };
+};
+
+// Creates a comparator for sorting in descending order based on the value
+// returned by the getter function.
+const createComparator = <T>(
+  getter: (neuron: TableNeuron) => T
+): TableNeuronComparator => {
+  return (a, b) => {
+    const valueA = getter(a);
+    const valueB = getter(b);
+    if (valueA < valueB) return 1;
+    if (valueA > valueB) return -1;
+    return 0;
+  };
+};
+
+// Same as createComparator but returns a comparator for sorting in ascending
+// order.
+const createAscendingComparator = <T>(
+  getter: (neuron: TableNeuron) => T
+): TableNeuronComparator => {
+  const descendingComparator = createComparator(getter);
+  return (a, b) => -descendingComparator(a, b);
+};
+
+export const compareByStake = createComparator((neuron) =>
+  neuron.stake.toUlps()
+);
+
+export const compareByDissolveDelay = createComparator(
+  (neuron) => neuron.dissolveDelaySeconds
+);
+
+// Orders strings as if they are positive integers, so "9" < "10" < "11", by
+// ordering first by length and then legicographically.
+export const compareById = mergeComparators([
+  createAscendingComparator((neuron) => neuron.neuronId.length),
+  createAscendingComparator((neuron) => neuron.neuronId),
+]);
+
+// Sorts neurons based on a provided custom ordering.
+export const sortNeurons = ({
+  neurons,
+  order,
+}: {
+  neurons: TableNeuron[];
+  order: TableNeuronComparator[];
+}): TableNeuron[] => {
+  return [...neurons].sort(mergeComparators(order));
+};

--- a/frontend/src/tests/lib/utils/neurons-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neurons-table.utils.spec.ts
@@ -1,0 +1,122 @@
+import {
+  compareByDissolveDelay,
+  compareById,
+  compareByStake,
+  sortNeurons,
+} from "$lib/utils/neurons-table.utils";
+import { mockTableNeuron } from "$tests/mocks/neurons.mock";
+import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
+
+describe("neurons-table.utils", () => {
+  const makeStake = (amount: bigint) =>
+    TokenAmountV2.fromUlps({
+      amount,
+      token: ICPToken,
+    });
+
+  const neurons = [
+    {
+      ...mockTableNeuron,
+      neuronId: "9",
+      stake: makeStake(100_000_000n),
+      dissolveDelaySeconds: 8640000n,
+    },
+    {
+      ...mockTableNeuron,
+      neuronId: "88",
+      stake: makeStake(300_000_000n),
+      dissolveDelaySeconds: 864000n,
+    },
+    {
+      ...mockTableNeuron,
+      neuronId: "10",
+      stake: makeStake(200_000_000n),
+      dissolveDelaySeconds: 86400000n,
+    },
+    {
+      ...mockTableNeuron,
+      neuronId: "777",
+      stake: makeStake(100_000_000n),
+      dissolveDelaySeconds: 86400000n,
+    },
+    {
+      ...mockTableNeuron,
+      neuronId: "200",
+      stake: makeStake(300_000_000n),
+      dissolveDelaySeconds: 864000n,
+    },
+    {
+      ...mockTableNeuron,
+      neuronId: "11111",
+      stake: makeStake(200_000_000n),
+      dissolveDelaySeconds: 8640000n,
+    },
+    {
+      ...mockTableNeuron,
+      neuronId: "3000",
+      stake: makeStake(200_000_000n),
+      dissolveDelaySeconds: 8640000n,
+    },
+  ];
+
+  it("should sort neurons by decreasing stake", () => {
+    expect(
+      sortNeurons({ neurons, order: [compareByStake] }).map((neuron) =>
+        neuron.stake.toUlps()
+      )
+    ).toEqual([
+      300_000_000n,
+      300_000_000n,
+      200_000_000n,
+      200_000_000n,
+      200_000_000n,
+      100_000_000n,
+      100_000_000n,
+    ]);
+  });
+
+  it("should sort neurons by decreasing dissolve delay", () => {
+    expect(
+      sortNeurons({ neurons, order: [compareByDissolveDelay] }).map(
+        (neuron) => neuron.dissolveDelaySeconds
+      )
+    ).toEqual([
+      86400000n,
+      86400000n,
+      8640000n,
+      8640000n,
+      8640000n,
+      864000n,
+      864000n,
+    ]);
+  });
+
+  it("should sort neurons by increasing neuron ID", () => {
+    expect(
+      sortNeurons({ neurons, order: [compareById] }).map(
+        (neuron) => neuron.neuronId
+      )
+    ).toEqual(["9", "10", "88", "200", "777", "3000", "11111"]);
+  });
+
+  it("should sort neurons by stake, then dissolve delay, then ID", () => {
+    expect(
+      sortNeurons({
+        neurons,
+        order: [compareByStake, compareByDissolveDelay, compareById],
+      }).map((neuron) => [
+        neuron.stake.toUlps(),
+        neuron.dissolveDelaySeconds,
+        neuron.neuronId,
+      ])
+    ).toEqual([
+      [300_000_000n, 864000n, "88"],
+      [300_000_000n, 864000n, "200"],
+      [200_000_000n, 86400000n, "10"],
+      [200_000_000n, 8640000n, "3000"],
+      [200_000_000n, 8640000n, "11111"],
+      [100_000_000n, 86400000n, "777"],
+      [100_000_000n, 8640000n, "9"],
+    ]);
+  });
+});

--- a/frontend/src/tests/mocks/neurons.mock.ts
+++ b/frontend/src/tests/mocks/neurons.mock.ts
@@ -1,6 +1,8 @@
 import type { NeuronsStore } from "$lib/stores/neurons.store";
+import type { TableNeuron } from "$lib/types/neurons-table";
 import type { KnownNeuron, Neuron, NeuronInfo } from "@dfinity/nns";
 import { NeuronState } from "@dfinity/nns";
+import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
 import { mockIdentity } from "./auth.store.mock";
 
@@ -99,4 +101,15 @@ export const mockNeuronNotControlled = {
     ...mockFullNeuron,
     hotKeys: ["not-current-principal"],
   },
+};
+
+export const mockTableNeuron: TableNeuron = {
+  rowHref: "/",
+  domKey: "0",
+  neuronId: "0",
+  stake: TokenAmountV2.fromUlps({
+    amount: 1n,
+    token: ICPToken,
+  }),
+  dissolveDelaySeconds: 1n,
 };


### PR DESCRIPTION
# Motivation

We'll want to provide custom sorting in the neurons table by clicking on the column headers.
So we'll need to be able to sort based on different criteria.
In this PR we provide some utilities for custom sorting.

# Changes

1. Implement neuron comparators based on stake, dissolve delay and neuron ID. We'll add more later.
2. Implement a neuron sorting function which takes an ordered list of comparators to define the sorting order.

# Tests

Unit tests are added.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet