### PR TITLE
Proposal navigation utilities

### DIFF
--- a/frontend/src/lib/types/proposals.ts
+++ b/frontend/src/lib/types/proposals.ts
@@ -29,6 +29,6 @@ export type BasisPoints = bigint;
 
 // An entry for proposal navigation on the proposal detail page.
 export interface ProposalsNavigationId {
-  proposalId: ProposalId;
-  universe: UniverseCanisterIdText;
+  proposalId: string;
+  universe: string;
 }

--- a/frontend/src/lib/types/proposals.ts
+++ b/frontend/src/lib/types/proposals.ts
@@ -29,6 +29,6 @@ export type BasisPoints = bigint;
 
 // An entry for proposal navigation on the proposal detail page.
 export interface ProposalsNavigationId {
-  proposalId: string;
+  proposalId: bigint;
   universe: string;
 }

--- a/frontend/src/lib/types/proposals.ts
+++ b/frontend/src/lib/types/proposals.ts
@@ -26,3 +26,9 @@ export interface VotingNeuron {
 
 // 100% -> 10000 basis points
 export type BasisPoints = bigint;
+
+// An entry for proposal navigation on the proposal detail page.
+export interface ProposalsNavigationId {
+  proposalId: ProposalId;
+  universe: UniverseCanisterIdText;
+}

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -4,6 +4,7 @@ import { i18n } from "$lib/stores/i18n";
 import type { ProposalsFiltersStore } from "$lib/stores/proposals.store";
 import type { VoteRegistrationStoreEntry } from "$lib/stores/vote-registration.store";
 import type {
+  ProposalsNavigationId,
   UniversalProposalStatus,
   VotingNeuron,
 } from "$lib/types/proposals";
@@ -618,9 +619,7 @@ export const newerProposalNavigationId = ({
     ids,
     universes,
   });
-  // console.log("idsByUniverse", idsByUniverse);
   const currentUniverseIndex = universes.indexOf(currentId.universe);
-  // console.log("currentUniverseIndex", currentUniverseIndex);
   for (
     let universeIndex = currentUniverseIndex;
     universeIndex >= 0;
@@ -634,7 +633,6 @@ export const newerProposalNavigationId = ({
           )
         : universeIds.at(-1);
     if (res) {
-      // console.log("res", res);
       return res;
     }
   }
@@ -658,9 +656,7 @@ export const olderProposalNavigationId = ({
     ids,
     universes,
   });
-  // console.log("idsByUniverse", idsByUniverse);
   const currentUniverseIndex = universes.indexOf(currentId.universe);
-  // console.log("currentUniverseIndex", currentUniverseIndex);
   for (
     let universeIndex = currentUniverseIndex;
     universeIndex < idsByUniverse.length;
@@ -674,7 +670,6 @@ export const olderProposalNavigationId = ({
           )
         : universeIds[0];
     if (res) {
-      // console.log("res", res);
       return res;
     }
   }

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -34,7 +34,6 @@ import {
   proposalActionRewardNodeProvider,
 } from "$tests/mocks/proposal.mock";
 import { mockProposals } from "$tests/mocks/proposals.store.mock";
-import { allowLoggingInOneTestForDebugging } from "$tests/utils/console.test-utils";
 import type {
   Action,
   Ballot,
@@ -1004,10 +1003,6 @@ describe("proposals-utils", () => {
   });
 
   describe("newerProposalId", () => {
-    beforeEach(() => {
-      allowLoggingInOneTestForDebugging();
-    });
-
     it("should return newer id from same universe", () => {
       expect(
         newerProposalNavigationId({
@@ -1144,10 +1139,6 @@ describe("proposals-utils", () => {
   });
 
   describe("olderProposalNavigationId", () => {
-    beforeEach(() => {
-      allowLoggingInOneTestForDebugging();
-    });
-
     it("should return older id from same universe", () => {
       expect(
         olderProposalNavigationId({


### PR DESCRIPTION
# Motivation

To be able to navigate between proposals from multiple universes we need to solve situations when the current proposalId or universe is not presented in the list anymore (e.g. user has already voted on proposal); Here we add 2 utilities that we gonna used for navigation later.

# Changes

- New type `ProposalsNavigationId` that represents a proposal navigation entry.
- New utility `newerProposalNavigationId`.
- New utility `olderProposalNavigationId`.

# Tests

- Tests for new functions.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.