### PR TITLE
Make NnsNeurons.spec.ts more realistic

### DIFF
--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -41,6 +41,8 @@ describe("NnsNeurons", () => {
       neuronId: 224n,
       fullNeuron: {
         ...mockFullNeuron,
+        cachedNeuronStake: 0n,
+        maturityE8sEquivalent: 10_000_000_000n,
         spawnAtTimesSeconds: 12_312_313n,
       },
     };
@@ -65,8 +67,8 @@ describe("NnsNeurons", () => {
         expect(neuronCards.length).toBe(3);
 
         expect(await neuronCards[0].isDisabled()).toBe(false);
-        expect(await neuronCards[1].isDisabled()).toBe(true);
-        expect(await neuronCards[2].isDisabled()).toBe(false);
+        expect(await neuronCards[1].isDisabled()).toBe(false);
+        expect(await neuronCards[2].isDisabled()).toBe(true);
       });
 
       it("should render the NeuronCards", async () => {

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -68,6 +68,7 @@ describe("NnsNeurons", () => {
 
         expect(await neuronCards[0].isDisabled()).toBe(false);
         expect(await neuronCards[1].isDisabled()).toBe(false);
+        // Spawning neuron comes last because it has no stake.
         expect(await neuronCards[2].isDisabled()).toBe(true);
       });
 


### PR DESCRIPTION
# Motivation

Spawning neurons don't have stake but do have maturity. This means that they always appear last when we sort neurons by descending stake.

In `frontend/src/tests/lib/pages/NnsNeurons.spec.ts` there is a spawning neuron with positive stake, which makes the test unrealistic and confusing.

# Changes

1. Give the spawning neuron a stake of 0 and a large maturity.
2. Update the test to reflect that after sorting the spawning neuron comes last.

# Tests

pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary