### PR TITLE
NNS1-3092: Sort neurons in table

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
@@ -9,8 +9,22 @@
   import NeuronStakeCell from "$lib/components/neurons/NeuronsTable/NeuronStakeCell.svelte";
   import NeuronDissolveDelayCell from "$lib/components/neurons/NeuronsTable/NeuronDissolveDelayCell.svelte";
   import NeuronActionsCell from "$lib/components/neurons/NeuronsTable/NeuronActionsCell.svelte";
+  import {
+    sortNeurons,
+    compareByStake,
+    compareByDissolveDelay,
+    compareById,
+  } from "$lib/utils/neurons-table.utils";
 
   export let neurons: TableNeuron[];
+
+  const order = [compareByStake, compareByDissolveDelay, compareById];
+
+  let sortedNeurons: TableNeuron[];
+  $: sortedNeurons = sortNeurons({
+    neurons,
+    order,
+  });
 
   const columns: NeuronsTableColumn[] = [
     {
@@ -32,5 +46,8 @@
   ];
 </script>
 
-<ResponsiveTable testId="neurons-table-component" {columns} tableData={neurons}
+<ResponsiveTable
+  testId="neurons-table-component"
+  {columns}
+  tableData={sortedNeurons}
 ></ResponsiveTable>

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -4,7 +4,6 @@ import NnsNeurons from "$lib/pages/NnsNeurons.svelte";
 import * as authServices from "$lib/services/auth.services";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
-import { isSpawning } from "$lib/utils/neuron.utils";
 import { mockIdentity } from "$tests/mocks/auth.store.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { NnsNeuronsPo } from "$tests/page-objects/NnsNeurons.page-object";
@@ -123,12 +122,13 @@ describe("NnsNeurons", () => {
         const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
         expect(rows).toHaveLength(3);
         expect(neurons).toHaveLength(3);
-        expect(isSpawning(neurons[0])).toBe(false);
+        expect(await rows[0].getStake()).not.toBe("0 ICP");
         expect(await rows[0].hasGoToDetailButton()).toBe(true);
-        expect(isSpawning(neurons[1])).toBe(true);
-        expect(await rows[1].hasGoToDetailButton()).toBe(false);
-        expect(isSpawning(neurons[2])).toBe(false);
-        expect(await rows[2].hasGoToDetailButton()).toBe(true);
+        expect(await rows[1].getStake()).not.toBe("0 ICP");
+        expect(await rows[1].hasGoToDetailButton()).toBe(true);
+        // Spawning neuron without stake comes last.
+        expect(await rows[2].getStake()).toBe("0 ICP");
+        expect(await rows[2].hasGoToDetailButton()).toBe(false);
       });
     });
   });


### PR DESCRIPTION
# Motivation

Neuron cards are sorted by stake and then dissolve delay.
We want the same for the neurons table until we implement custom sorting.

Currently we tie break on creation time but:
1. That's not guaranteed to be unique because on the IC time is constant for the duration of a message
2. Is not visible in the UI

So we decided to tie break on neuron ID instead.

# Changes

1. Order neurons by decreasing stake, then decreasing dissolve delay, then increasing ID.

# Tests

1. Unit tests added and updated.
2. Manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/neurons/?u=qsgjb-riaaa-aaaaa-aaaga-cai

# Todos

- [ ] Add entry to changelog (if necessary).
not yet