### PR TITLE
Move tableNeuronsFromNeuronInfos to neurons-table.utils.ts

### DIFF
--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -18,7 +18,7 @@
   import EmptyMessage from "$lib/components/ui/EmptyMessage.svelte";
   import { onMount } from "svelte";
   import { listNeurons } from "$lib/services/neurons.services";
-  import { tableNeuronsFromNeuronInfos } from "$lib/utils/neuron.utils";
+  import { tableNeuronsFromNeuronInfos } from "$lib/utils/neurons-table.utils";
 
   let isLoading = false;
   $: isLoading = $neuronsStore.neurons === undefined;

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -22,8 +22,6 @@ import type { IcpAccountsStoreData } from "$lib/derived/icp-accounts.derived";
 import type { NeuronsStore } from "$lib/stores/neurons.store";
 import type { VoteRegistrationStoreData } from "$lib/stores/vote-registration.store";
 import type { Account } from "$lib/types/account";
-import type { TableNeuron } from "$lib/types/neurons-table";
-import { buildNeuronUrl } from "$lib/utils/navigation.utils";
 import type { Identity } from "@dfinity/agent";
 import type { WizardStep } from "@dfinity/gix-components";
 import {
@@ -47,13 +45,7 @@ import {
   type ProposalInfo,
   type RewardEvent,
 } from "@dfinity/nns";
-import {
-  ICPToken,
-  TokenAmountV2,
-  fromNullable,
-  isNullish,
-  nonNullish,
-} from "@dfinity/utils";
+import { ICPToken, fromNullable, isNullish, nonNullish } from "@dfinity/utils";
 import type { ComponentType } from "svelte";
 import {
   getAccountByPrincipal,
@@ -1044,30 +1036,4 @@ export const getTopicSubtitle = ({
     [Topic.SubnetRental]: i18n.follow_neurons.topic_16_subtitle,
   };
   return mapper[topic];
-};
-
-export const tableNeuronsFromNeuronInfos = (
-  neuronInfos: NeuronInfo[]
-): TableNeuron[] => {
-  return neuronInfos.map((neuronInfo) => {
-    const { neuronId, dissolveDelaySeconds } = neuronInfo;
-    const neuronIdString = neuronId.toString();
-    const isSpawningNeuron = isSpawning(neuronInfo);
-    const rowHref = isSpawningNeuron
-      ? undefined
-      : buildNeuronUrl({
-          universe: OWN_CANISTER_ID_TEXT,
-          neuronId,
-        });
-    return {
-      ...(rowHref && { rowHref }),
-      domKey: neuronIdString,
-      neuronId: neuronIdString,
-      stake: TokenAmountV2.fromUlps({
-        amount: neuronStake(neuronInfo),
-        token: ICPToken,
-      }),
-      dissolveDelaySeconds,
-    };
-  });
 };

--- a/frontend/src/lib/utils/neurons-table.utils.ts
+++ b/frontend/src/lib/utils/neurons-table.utils.ts
@@ -1,7 +1,38 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import type {
   TableNeuron,
   TableNeuronComparator,
 } from "$lib/types/neurons-table";
+import { buildNeuronUrl } from "$lib/utils/navigation.utils";
+import { isSpawning, neuronStake } from "$lib/utils/neuron.utils";
+import type { NeuronInfo } from "@dfinity/nns";
+import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
+
+export const tableNeuronsFromNeuronInfos = (
+  neuronInfos: NeuronInfo[]
+): TableNeuron[] => {
+  return neuronInfos.map((neuronInfo) => {
+    const { neuronId, dissolveDelaySeconds } = neuronInfo;
+    const neuronIdString = neuronId.toString();
+    const isSpawningNeuron = isSpawning(neuronInfo);
+    const rowHref = isSpawningNeuron
+      ? undefined
+      : buildNeuronUrl({
+          universe: OWN_CANISTER_ID_TEXT,
+          neuronId,
+        });
+    return {
+      ...(rowHref && { rowHref }),
+      domKey: neuronIdString,
+      neuronId: neuronIdString,
+      stake: TokenAmountV2.fromUlps({
+        amount: neuronStake(neuronInfo),
+        token: ICPToken,
+      }),
+      dissolveDelaySeconds,
+    };
+  });
+};
 
 // Takes a list of comparators and returns a single comparator by first applying
 // the first comparator and using subsequent comparators to break ties.

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -63,7 +63,6 @@ import {
   neuronVotingPower,
   neuronsVotingPower,
   sortNeuronsByStake,
-  tableNeuronsFromNeuronInfos,
   topicsToFollow,
   userAuthorizedNeuron,
   validTopUpAmount,
@@ -98,7 +97,7 @@ import {
   type ProposalInfo,
   type RewardEvent,
 } from "@dfinity/nns";
-import { ICPToken, TokenAmount, TokenAmountV2 } from "@dfinity/utils";
+import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("neuron-utils", () => {
@@ -2832,88 +2831,6 @@ describe("neuron-utils", () => {
       expect(getTopicSubtitle({ topic: Topic.SubnetRental, i18n: en })).toBe(
         "All proposals related to renting a subnet, for example a subnet rental request."
       );
-    });
-  });
-
-  describe("tableNeuronsFromNeuronInfos", () => {
-    it("should convert neuronInfos to tableNeurons", () => {
-      const neuronId1 = 42n;
-      const neuronId2 = 342n;
-      const stake1 = 500_000_000n;
-      const stake2 = 600_000_000n;
-      const dissolveDelay1 = 15778800n;
-      const dissolveDelay2 = 252460800n;
-      const neuronInfo1 = {
-        ...mockNeuron,
-        neuronId: neuronId1,
-        fullNeuron: {
-          ...mockNeuron.fullNeuron,
-          cachedNeuronStake: stake1,
-        },
-        dissolveDelaySeconds: dissolveDelay1,
-      };
-      const neuronInfo2 = {
-        ...mockNeuron,
-        neuronId: neuronId2,
-        fullNeuron: {
-          ...mockNeuron.fullNeuron,
-          cachedNeuronStake: stake2,
-        },
-        dissolveDelaySeconds: dissolveDelay2,
-      };
-      const neuronInfos = [neuronInfo1, neuronInfo2];
-      const tableNeurons = tableNeuronsFromNeuronInfos(neuronInfos);
-      expect(tableNeurons).toEqual([
-        {
-          rowHref: "/neuron/?u=qhbym-qaaaa-aaaaa-aaafq-cai&neuron=42",
-          domKey: "42",
-          neuronId: "42",
-          stake: TokenAmountV2.fromUlps({
-            amount: 500_000_000n,
-            token: ICPToken,
-          }),
-          dissolveDelaySeconds: dissolveDelay1,
-        },
-        {
-          rowHref: "/neuron/?u=qhbym-qaaaa-aaaaa-aaafq-cai&neuron=342",
-          domKey: "342",
-          neuronId: "342",
-          stake: TokenAmountV2.fromUlps({
-            amount: 600_000_000n,
-            token: ICPToken,
-          }),
-          dissolveDelaySeconds: dissolveDelay2,
-        },
-      ]);
-    });
-
-    it("should convert neuronInfo for spawning neuron without href", () => {
-      const neuronId = 52n;
-      const dissolveDelaySeconds = BigInt(5 * SECONDS_IN_DAY);
-      const spawningNeuronInfo = {
-        ...mockNeuron,
-        neuronId: neuronId,
-        state: NeuronState.Spawning,
-        fullNeuron: {
-          ...mockNeuron.fullNeuron,
-          cachedNeuronStake: 0n,
-          spawnAtTimesSeconds: 12_312_313n,
-        },
-        dissolveDelaySeconds,
-      };
-      const neuronInfos = [spawningNeuronInfo];
-      const tableNeurons = tableNeuronsFromNeuronInfos(neuronInfos);
-      expect(tableNeurons).toEqual([
-        {
-          domKey: "52",
-          neuronId: "52",
-          stake: TokenAmountV2.fromUlps({
-            amount: 0n,
-            token: ICPToken,
-          }),
-          dissolveDelaySeconds,
-        },
-      ]);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/neurons-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neurons-table.utils.spec.ts
@@ -1,10 +1,13 @@
+import { SECONDS_IN_DAY } from "$lib/constants/constants";
 import {
   compareByDissolveDelay,
   compareById,
   compareByStake,
   sortNeurons,
+  tableNeuronsFromNeuronInfos,
 } from "$lib/utils/neurons-table.utils";
-import { mockTableNeuron } from "$tests/mocks/neurons.mock";
+import { mockNeuron, mockTableNeuron } from "$tests/mocks/neurons.mock";
+import { NeuronState } from "@dfinity/nns";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 
 describe("neurons-table.utils", () => {
@@ -14,109 +17,184 @@ describe("neurons-table.utils", () => {
       token: ICPToken,
     });
 
-  const neurons = [
-    {
-      ...mockTableNeuron,
-      neuronId: "9",
-      stake: makeStake(100_000_000n),
-      dissolveDelaySeconds: 8640000n,
-    },
-    {
-      ...mockTableNeuron,
-      neuronId: "88",
-      stake: makeStake(300_000_000n),
-      dissolveDelaySeconds: 864000n,
-    },
-    {
-      ...mockTableNeuron,
-      neuronId: "10",
-      stake: makeStake(200_000_000n),
-      dissolveDelaySeconds: 86400000n,
-    },
-    {
-      ...mockTableNeuron,
-      neuronId: "777",
-      stake: makeStake(100_000_000n),
-      dissolveDelaySeconds: 86400000n,
-    },
-    {
-      ...mockTableNeuron,
-      neuronId: "200",
-      stake: makeStake(300_000_000n),
-      dissolveDelaySeconds: 864000n,
-    },
-    {
-      ...mockTableNeuron,
-      neuronId: "11111",
-      stake: makeStake(200_000_000n),
-      dissolveDelaySeconds: 8640000n,
-    },
-    {
-      ...mockTableNeuron,
-      neuronId: "3000",
-      stake: makeStake(200_000_000n),
-      dissolveDelaySeconds: 8640000n,
-    },
-  ];
+  describe("tableNeuronsFromNeuronInfos", () => {
+    it("should convert neuronInfos to tableNeurons", () => {
+      const neuronId1 = 42n;
+      const neuronId2 = 342n;
+      const stake1 = 500_000_000n;
+      const stake2 = 600_000_000n;
+      const dissolveDelay1 = 15778800n;
+      const dissolveDelay2 = 252460800n;
+      const neuronInfo1 = {
+        ...mockNeuron,
+        neuronId: neuronId1,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          cachedNeuronStake: stake1,
+        },
+        dissolveDelaySeconds: dissolveDelay1,
+      };
+      const neuronInfo2 = {
+        ...mockNeuron,
+        neuronId: neuronId2,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          cachedNeuronStake: stake2,
+        },
+        dissolveDelaySeconds: dissolveDelay2,
+      };
+      const neuronInfos = [neuronInfo1, neuronInfo2];
+      const tableNeurons = tableNeuronsFromNeuronInfos(neuronInfos);
+      expect(tableNeurons).toEqual([
+        {
+          rowHref: "/neuron/?u=qhbym-qaaaa-aaaaa-aaafq-cai&neuron=42",
+          domKey: "42",
+          neuronId: "42",
+          stake: makeStake(500_000_000n),
+          dissolveDelaySeconds: dissolveDelay1,
+        },
+        {
+          rowHref: "/neuron/?u=qhbym-qaaaa-aaaaa-aaafq-cai&neuron=342",
+          domKey: "342",
+          neuronId: "342",
+          stake: makeStake(600_000_000n),
+          dissolveDelaySeconds: dissolveDelay2,
+        },
+      ]);
+    });
 
-  it("should sort neurons by decreasing stake", () => {
-    expect(
-      sortNeurons({ neurons, order: [compareByStake] }).map((neuron) =>
-        neuron.stake.toUlps()
-      )
-    ).toEqual([
-      300_000_000n,
-      300_000_000n,
-      200_000_000n,
-      200_000_000n,
-      200_000_000n,
-      100_000_000n,
-      100_000_000n,
-    ]);
+    it("should convert neuronInfo for spawning neuron without href", () => {
+      const neuronId = 52n;
+      const dissolveDelaySeconds = BigInt(5 * SECONDS_IN_DAY);
+      const spawningNeuronInfo = {
+        ...mockNeuron,
+        neuronId: neuronId,
+        state: NeuronState.Spawning,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          cachedNeuronStake: 0n,
+          spawnAtTimesSeconds: 12_312_313n,
+        },
+        dissolveDelaySeconds,
+      };
+      const neuronInfos = [spawningNeuronInfo];
+      const tableNeurons = tableNeuronsFromNeuronInfos(neuronInfos);
+      expect(tableNeurons).toEqual([
+        {
+          domKey: "52",
+          neuronId: "52",
+          stake: makeStake(0n),
+          dissolveDelaySeconds,
+        },
+      ]);
+    });
   });
 
-  it("should sort neurons by decreasing dissolve delay", () => {
-    expect(
-      sortNeurons({ neurons, order: [compareByDissolveDelay] }).map(
-        (neuron) => neuron.dissolveDelaySeconds
-      )
-    ).toEqual([
-      86400000n,
-      86400000n,
-      8640000n,
-      8640000n,
-      8640000n,
-      864000n,
-      864000n,
-    ]);
-  });
+  describe("sortNeurons", () => {
+    const neurons = [
+      {
+        ...mockTableNeuron,
+        neuronId: "9",
+        stake: makeStake(100_000_000n),
+        dissolveDelaySeconds: 8640000n,
+      },
+      {
+        ...mockTableNeuron,
+        neuronId: "88",
+        stake: makeStake(300_000_000n),
+        dissolveDelaySeconds: 864000n,
+      },
+      {
+        ...mockTableNeuron,
+        neuronId: "10",
+        stake: makeStake(200_000_000n),
+        dissolveDelaySeconds: 86400000n,
+      },
+      {
+        ...mockTableNeuron,
+        neuronId: "777",
+        stake: makeStake(100_000_000n),
+        dissolveDelaySeconds: 86400000n,
+      },
+      {
+        ...mockTableNeuron,
+        neuronId: "200",
+        stake: makeStake(300_000_000n),
+        dissolveDelaySeconds: 864000n,
+      },
+      {
+        ...mockTableNeuron,
+        neuronId: "11111",
+        stake: makeStake(200_000_000n),
+        dissolveDelaySeconds: 8640000n,
+      },
+      {
+        ...mockTableNeuron,
+        neuronId: "3000",
+        stake: makeStake(200_000_000n),
+        dissolveDelaySeconds: 8640000n,
+      },
+    ];
 
-  it("should sort neurons by increasing neuron ID", () => {
-    expect(
-      sortNeurons({ neurons, order: [compareById] }).map(
-        (neuron) => neuron.neuronId
-      )
-    ).toEqual(["9", "10", "88", "200", "777", "3000", "11111"]);
-  });
+    it("should sort neurons by decreasing stake", () => {
+      expect(
+        sortNeurons({ neurons, order: [compareByStake] }).map((neuron) =>
+          neuron.stake.toUlps()
+        )
+      ).toEqual([
+        300_000_000n,
+        300_000_000n,
+        200_000_000n,
+        200_000_000n,
+        200_000_000n,
+        100_000_000n,
+        100_000_000n,
+      ]);
+    });
 
-  it("should sort neurons by stake, then dissolve delay, then ID", () => {
-    expect(
-      sortNeurons({
-        neurons,
-        order: [compareByStake, compareByDissolveDelay, compareById],
-      }).map((neuron) => [
-        neuron.stake.toUlps(),
-        neuron.dissolveDelaySeconds,
-        neuron.neuronId,
-      ])
-    ).toEqual([
-      [300_000_000n, 864000n, "88"],
-      [300_000_000n, 864000n, "200"],
-      [200_000_000n, 86400000n, "10"],
-      [200_000_000n, 8640000n, "3000"],
-      [200_000_000n, 8640000n, "11111"],
-      [100_000_000n, 86400000n, "777"],
-      [100_000_000n, 8640000n, "9"],
-    ]);
+    it("should sort neurons by decreasing dissolve delay", () => {
+      expect(
+        sortNeurons({ neurons, order: [compareByDissolveDelay] }).map(
+          (neuron) => neuron.dissolveDelaySeconds
+        )
+      ).toEqual([
+        86400000n,
+        86400000n,
+        8640000n,
+        8640000n,
+        8640000n,
+        864000n,
+        864000n,
+      ]);
+    });
+
+    it("should sort neurons by increasing neuron ID", () => {
+      expect(
+        sortNeurons({ neurons, order: [compareById] }).map(
+          (neuron) => neuron.neuronId
+        )
+      ).toEqual(["9", "10", "88", "200", "777", "3000", "11111"]);
+    });
+
+    it("should sort neurons by stake, then dissolve delay, then ID", () => {
+      expect(
+        sortNeurons({
+          neurons,
+          order: [compareByStake, compareByDissolveDelay, compareById],
+        }).map((neuron) => [
+          neuron.stake.toUlps(),
+          neuron.dissolveDelaySeconds,
+          neuron.neuronId,
+        ])
+      ).toEqual([
+        [300_000_000n, 864000n, "88"],
+        [300_000_000n, 864000n, "200"],
+        [200_000_000n, 86400000n, "10"],
+        [200_000_000n, 8640000n, "3000"],
+        [200_000_000n, 8640000n, "11111"],
+        [100_000_000n, 86400000n, "777"],
+        [100_000_000n, 8640000n, "9"],
+      ]);
+    });
   });
 });


### PR DESCRIPTION
# Motivation

I originally added `tableNeuronsFromNeuronInfos` to `neuron.utils.ts`, which is already very big.
Then I added `neurons-table.utils.ts` specifically for the neurons table.
So it seems suitable to put `tableNeuronsFromNeuronInfos` there as well.

# Changes

1. Move `tableNeuronsFromNeuronInfos`.
2. Update imports.
3. Move tests.
4. Put existing tests in `frontend/src/tests/lib/utils/neurons-table.utils.spec.ts` in a separate `describe` block.
5. Use `makeStake` from `neurons-table.utils.ts` for the tests that moved there.

# Tests

moved
pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary