### PR TITLE
Improve initialization of actionable proposals

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -28,6 +28,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Render neurons with minimum dissolve delay correctly with voting power.
+* Actionable proposals initialization before Snses were loaded.
 
 #### Security
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -28,7 +28,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Render neurons with minimum dissolve delay correctly with voting power.
-* Actionable proposals initialization before Snses were loaded.
+* Actionable proposals initialization before Sns-es were loaded.
 
 #### Security
 

--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -1,9 +1,9 @@
+import { loadActionableProposals } from "$lib/services/actionable-proposals.services";
+import { loadActionableSnsProposals } from "$lib/services/actionable-sns-proposals.services";
 import { loadSnsProjects } from "./$public/sns.services";
 import { initAccounts } from "./icp-accounts.services";
 
-export const initAppPrivateData = (): Promise<
-  [PromiseSettledResult<void[]>, PromiseSettledResult<void[]>]
-> => {
+export const initAppPrivateData = async (): Promise<void> => {
   const initNns: Promise<void>[] = [initAccounts()];
   // Reload the SNS projects even if they were loaded.
   // Get latest data and create wrapper caches for the logged in identity.
@@ -12,5 +12,11 @@ export const initAppPrivateData = (): Promise<
   /**
    * If Nns load but Sns load fails it is "fine" to go on because Nns are core features.
    */
-  return Promise.allSettled([Promise.all(initNns), Promise.all(initSns)]);
+  await Promise.allSettled([Promise.all(initNns), Promise.all(initSns)]);
+
+  // Load the actionable proposals only after the Nns and Sns projects have been loaded, because it's a non-critical enhancement.
+  Promise.allSettled([
+    loadActionableProposals(),
+    loadActionableSnsProposals(),
+  ]).then();
 };

--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -14,7 +14,8 @@ export const initAppPrivateData = async (): Promise<void> => {
    */
   await Promise.allSettled([Promise.all(initNns), Promise.all(initSns)]);
 
-  // Load the actionable proposals only after the Nns and Sns projects have been loaded, because it's a non-critical enhancement.
+  // Load the actionable proposals only after the Nns and Sns projects have been loaded.
+  // Because it's a non-critical enhancement, the loading of actionable proposals should not delay the execution of this function.
   Promise.allSettled([
     loadActionableProposals(),
     loadActionableSnsProposals(),

--- a/frontend/src/lib/services/app.services.ts
+++ b/frontend/src/lib/services/app.services.ts
@@ -16,8 +16,6 @@ export const initAppPrivateData = async (): Promise<void> => {
 
   // Load the actionable proposals only after the Nns and Sns projects have been loaded.
   // Because it's a non-critical enhancement, the loading of actionable proposals should not delay the execution of this function.
-  Promise.allSettled([
-    loadActionableProposals(),
-    loadActionableSnsProposals(),
-  ]).then();
+  loadActionableProposals();
+  loadActionableSnsProposals();
 };

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -48,12 +48,6 @@
   });
 
   $: syncAuth($authStore);
-
-  $: $authSignedInStore && loadActionableProposals();
-  // Check for the committed projects length in case the sns list is not yet loaded
-  $: $authSignedInStore &&
-    $snsProjectsCommittedStore.length > 0 &&
-    loadActionableSnsProposals();
 </script>
 
 <slot />

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -8,10 +8,6 @@
   } from "$lib/services/worker-auth.services";
   import { initAppPrivateDataProxy } from "$lib/proxy/app.services.proxy";
   import { toastsClean } from "$lib/stores/toasts.store";
-  import { loadActionableProposals } from "$lib/services/actionable-proposals.services";
-  import { snsProjectsCommittedStore } from "$lib/derived/sns/sns-projects.derived";
-  import { authSignedInStore } from "$lib/derived/auth.derived";
-  import { loadActionableSnsProposals } from "$lib/services/actionable-sns-proposals.services";
 
   let ready = false;
 

--- a/frontend/src/tests/routes/layout.spec.ts
+++ b/frontend/src/tests/routes/layout.spec.ts
@@ -1,14 +1,10 @@
 import { initAppPrivateDataProxy } from "$lib/proxy/app.services.proxy";
-import * as actionableProposalsServices from "$lib/services/actionable-proposals.services";
-import * as actionableSnsProposalsServices from "$lib/services/actionable-sns-proposals.services";
 import { initAuthWorker } from "$lib/services/worker-auth.services";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import App from "$routes/+layout.svelte";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
-import { SnsSwapLifecycle } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
 vi.mock("$lib/services/worker-auth.services", () => ({
@@ -68,60 +64,5 @@ describe("Layout", () => {
     await runResolvedPromises();
 
     expect(spy).toBeCalled();
-  });
-
-  describe("loadActionableProposals", () => {
-    let spyLoadActionableProposals;
-    let spyLoadActionableSnsProposals;
-
-    beforeEach(() => {
-      resetSnsProjects();
-      spyLoadActionableProposals = vi
-        .spyOn(actionableProposalsServices, "loadActionableProposals")
-        .mockResolvedValue();
-      spyLoadActionableSnsProposals = vi
-        .spyOn(actionableSnsProposalsServices, "loadActionableSnsProposals")
-        .mockResolvedValue();
-    });
-
-    it("should call loadActionableProposals on startup", async () => {
-      expect(spyLoadActionableProposals).toHaveBeenCalledTimes(0);
-      resetIdentity();
-      render(App);
-      await runResolvedPromises();
-      expect(spyLoadActionableProposals).toHaveBeenCalledTimes(1);
-    });
-
-    it("should call loadActionableProposals after sign-in", async () => {
-      expect(spyLoadActionableProposals).toHaveBeenCalledTimes(0);
-      render(App);
-      await runResolvedPromises();
-      expect(spyLoadActionableProposals).toHaveBeenCalledTimes(0);
-      resetIdentity();
-      await runResolvedPromises();
-      expect(spyLoadActionableProposals).toHaveBeenCalledTimes(1);
-    });
-
-    it("should call loadActionableSnsProposals on startup", async () => {
-      expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(0);
-      resetIdentity();
-      setSnsProjects([{ lifecycle: SnsSwapLifecycle.Committed }]);
-      render(App);
-      await runResolvedPromises();
-      expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(1);
-    });
-
-    it("should call loadActionableSnsProposals after sign-in and sns availability", async () => {
-      expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(0);
-      render(App);
-      await runResolvedPromises();
-      expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(0);
-      resetIdentity();
-      await runResolvedPromises();
-      expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(0);
-      setSnsProjects([{ lifecycle: SnsSwapLifecycle.Committed }]);
-      await runResolvedPromises();
-      expect(spyLoadActionableSnsProposals).toHaveBeenCalledTimes(1);
-    });
   });
 });


### PR DESCRIPTION
# Motivation

Move the initialization of actionable proposals to `initAppPrivateData` to ensure that all necessary Nns and Snses data has already been loaded.

# Changes

- Change the return type of `initAppPrivateData` function to be void, since its result is not used anywhere.
- Wait for Nns and Snses  initialization inside `initAppPrivateData`. This should not affect [the current behaviour](https://github.com/dfinity/nns-dapp/blob/150c24f17ef684633cbfebb222faaa4dc8a2da9b/frontend/src/routes/%2Blayout.svelte#L42).
- Move the actionable initialization to `initAppPrivateData`.

# Tests

- Remove from layout tests.
- Added to app.services.spec.

# Todos

- [x] Add entry to changelog (if necessary).