### PR TITLE
NNS1-3092: Shorten neuron ID in table

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import type { TableNeuron } from "$lib/types/neurons-table";
+  import IdentifierHash from "$lib/components/ui/IdentifierHash.svelte";
 
   export let rowData: TableNeuron;
 </script>
 
 <div data-tid="neuron-id-cell-component">
-  {rowData.neuronId}
+  <IdentifierHash identifier={rowData.neuronId} />
 </div>

--- a/frontend/src/tests/page-objects/NeuronIdCell.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronIdCell.page-object.ts
@@ -1,0 +1,19 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { IdentifierHashPo } from "$tests/page-objects/IdentifierHash.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NeuronIdCellPo extends BasePageObject {
+  private static readonly TID = "neuron-id-cell-component";
+
+  static under(element: PageObjectElement): NeuronIdCellPo {
+    return new NeuronIdCellPo(element.byTestId(NeuronIdCellPo.TID));
+  }
+
+  getIdentifierHashPo(): IdentifierHashPo {
+    return IdentifierHashPo.under(this.root);
+  }
+
+  getNeurondId(): Promise<string> {
+    return this.getIdentifierHashPo().getFullText();
+  }
+}

--- a/frontend/src/tests/page-objects/NeuronsTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronsTableRow.page-object.ts
@@ -1,3 +1,4 @@
+import { NeuronIdCellPo } from "$tests/page-objects/NeuronIdCell.page-object";
 import { ResponsiveTableRowPo } from "$tests/page-objects/ResponsiveTableRow.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -14,8 +15,12 @@ export class NeuronsTableRowPo extends ResponsiveTableRowPo {
     );
   }
 
+  getNeuronIdCellPo(): NeuronIdCellPo {
+    return NeuronIdCellPo.under(this.root);
+  }
+
   getNeuronId(): Promise<string> {
-    return this.getText("neuron-id-cell-component");
+    return this.getNeuronIdCellPo().getNeurondId();
   }
 
   getStake(): Promise<string> {


### PR DESCRIPTION
# Motivation

The neuron ID can take up a lot of space, especially for SNS neurons, and is not very meaningful.

# Changes

Use `IdentifierHash` component to shorten the neuron ID and add a copy button.

# Tests

1. Page object updated.
2. Tested manually.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet