### PR TITLE
NNS1-3093: Convert SNS neurons for table rendering

### DIFF
--- a/frontend/src/lib/utils/neurons-table.utils.ts
+++ b/frontend/src/lib/utils/neurons-table.utils.ts
@@ -3,10 +3,17 @@ import type {
   TableNeuron,
   TableNeuronComparator,
 } from "$lib/types/neurons-table";
+import type { UniverseCanisterIdText } from "$lib/types/universe";
 import { buildNeuronUrl } from "$lib/utils/navigation.utils";
 import { isSpawning, neuronStake } from "$lib/utils/neuron.utils";
+import {
+  getSnsDissolveDelaySeconds,
+  getSnsNeuronIdAsHexString,
+  getSnsNeuronStake,
+} from "$lib/utils/sns-neuron.utils";
 import type { NeuronInfo } from "@dfinity/nns";
-import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
+import type { SnsNeuron } from "@dfinity/sns";
+import { ICPToken, TokenAmountV2, type Token } from "@dfinity/utils";
 
 export const tableNeuronsFromNeuronInfos = (
   neuronInfos: NeuronInfo[]
@@ -28,6 +35,35 @@ export const tableNeuronsFromNeuronInfos = (
       stake: TokenAmountV2.fromUlps({
         amount: neuronStake(neuronInfo),
         token: ICPToken,
+      }),
+      dissolveDelaySeconds,
+    };
+  });
+};
+
+export const tableNeuronsFromSnsNeurons = ({
+  universe,
+  token,
+  snsNeurons,
+}: {
+  universe: UniverseCanisterIdText;
+  token: Token;
+  snsNeurons: SnsNeuron[];
+}): TableNeuron[] => {
+  return snsNeurons.map((snsNeuron) => {
+    const dissolveDelaySeconds = getSnsDissolveDelaySeconds(snsNeuron) ?? 0n;
+    const neuronIdString = getSnsNeuronIdAsHexString(snsNeuron);
+    const rowHref = buildNeuronUrl({
+      universe,
+      neuronId: neuronIdString,
+    });
+    return {
+      rowHref,
+      domKey: neuronIdString,
+      neuronId: neuronIdString,
+      stake: TokenAmountV2.fromUlps({
+        amount: getSnsNeuronStake(snsNeuron),
+        token,
       }),
       dissolveDelaySeconds,
     };

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -18,7 +18,11 @@ import type {
   DisburseMaturityInProgress,
   NeuronPermission,
 } from "@dfinity/sns/dist/candid/sns_governance";
-import { arrayOfNumberToUint8Array, isNullish } from "@dfinity/utils";
+import {
+  arrayOfNumberToUint8Array,
+  isNullish,
+  nonNullish,
+} from "@dfinity/utils";
 import type { Subscriber } from "svelte/store";
 import { mockIdentity, mockPrincipal } from "./auth.store.mock";
 import { rootCanisterIdMock } from "./sns.api.mock";
@@ -74,6 +78,9 @@ export const createMockSnsNeuron = ({
   sourceNnsNeuronId?: NeuronId;
   activeDisbursementsE8s?: bigint[];
 }): SnsNeuron => {
+  if (isNullish(state) && nonNullish(dissolveDelaySeconds)) {
+    state = NeuronState.Locked;
+  }
   return {
     id: [{ id: arrayOfNumberToUint8Array(id) }],
     permissions,

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -48,7 +48,7 @@ export const createMockSnsNeuron = ({
   permissions = [],
   vesting,
   votingPowerMultiplier = 100n,
-  dissolveDelaySeconds = BigInt(Math.floor(3600 * 24 * 365 * 2)),
+  dissolveDelaySeconds,
   whenDissolvedTimestampSeconds = BigInt(
     Math.floor(Date.now() / 1000 + 3600 * 24 * 365 * 2)
   ),
@@ -80,6 +80,12 @@ export const createMockSnsNeuron = ({
 }): SnsNeuron => {
   if (isNullish(state) && nonNullish(dissolveDelaySeconds)) {
     state = NeuronState.Locked;
+  } else if (
+    nonNullish(state) &&
+    state !== NeuronState.Dissolved &&
+    isNullish(dissolveDelaySeconds)
+  ) {
+    dissolveDelaySeconds = BigInt(Math.floor(3600 * 24 * 365 * 2));
   }
   return {
     id: [{ id: arrayOfNumberToUint8Array(id) }],


### PR DESCRIPTION
# Motivation

We want to use the neurons table for SNS neurons as well.
The neurons table takes neurons in a specific `TableNeuron` type.
So we need to convert `SnsNeuron`s to `TableNeuron`s.

# Changes

Add utility function `tableNeuronsFromSnsNeurons` to convert `SnsNeuron`n to `TableNeuron`s.

# Tests

1. Conveniently set the neuron state in `createMockSnsNeuron` if it wasn't provided but a dissolve delay was specified.
2. Add unit tests for `tableNeuronsFromSnsNeurons`.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet