### PR TITLE
Upgrade gix components

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -28,6 +28,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Render neurons with minimum dissolve delay correctly with voting power.
+* Nns-dapp may crash while finishing an empty receive.
 
 #### Security
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "4.2.0-next-2024-05-21.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.2.0-next-2024-05-21.2.tgz",
-      "integrity": "sha512-6BvB8Q3txxljJEyB4flp9PCsg9flqGpDkBSW1kWbHzQJNkWAs31DEa9lGXK+lhC80Q5HY2ooy5a11sRTOi/Ihw==",
+      "version": "4.2.0-next-2024-05-31",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.2.0-next-2024-05-31.tgz",
+      "integrity": "sha512-3dNRvUJ5vir9u6/J0aTWNBTt2CZXBOuxtgkbCeTvgkyFYNFiud/8JkIST+PamdiBVA8MA2fQkTUVhey5UJg6gQ==",
       "dependencies": {
         "dompurify": "^3.0.8",
         "html5-qrcode": "^2.3.8",
@@ -7058,9 +7058,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "4.2.0-next-2024-05-21.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.2.0-next-2024-05-21.2.tgz",
-      "integrity": "sha512-6BvB8Q3txxljJEyB4flp9PCsg9flqGpDkBSW1kWbHzQJNkWAs31DEa9lGXK+lhC80Q5HY2ooy5a11sRTOi/Ihw==",
+      "version": "4.2.0-next-2024-05-31",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.2.0-next-2024-05-31.tgz",
+      "integrity": "sha512-3dNRvUJ5vir9u6/J0aTWNBTt2CZXBOuxtgkbCeTvgkyFYNFiud/8JkIST+PamdiBVA8MA2fQkTUVhey5UJg6gQ==",
       "requires": {
         "dompurify": "^3.0.8",
         "html5-qrcode": "^2.3.8",


### PR DESCRIPTION
# Motivation

To get the [crashed nns-dapp fix](https://github.com/dfinity/gix-components/pull/427) we need to upgrade the gix-components.

# Changes

- `npm run upgrade:gix`

# Tests

- Tested manually that the bug can not be reproduced locally.

# Todos

- [ ] Add entry to changelog (if necessary).
