### PR TITLE
bot: Update proposals candid bindings

### DIFF
--- a/declarations/used_by_proposals/nns_governance/nns_governance.did
+++ b/declarations/used_by_proposals/nns_governance/nns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-22_23-01-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-29_23-02-base/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;

--- a/declarations/used_by_proposals/nns_registry/nns_registry.did
+++ b/declarations/used_by_proposals/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-22_23-01-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-29_23-02-base/rs/registry/canister/canister/registry.did>
 // A brief note about the history of this file: This file used to be
 // automatically generated, but now, it is hand-crafted, because the
 // auto-generator has some some pretty degenerate behaviors. The worst of those
@@ -238,6 +238,8 @@ type RemoveNodeOperatorsPayload = record {
 
 type RemoveNodesPayload = record { node_ids : vec principal };
 
+type RemoveNodesFromSubnetPayload = record { node_ids : vec principal };
+
 type RerouteCanisterRangesPayload = record {
   source_subnet : principal;
   reassigned_canister_ranges : vec CanisterIdRange;
@@ -281,11 +283,23 @@ type SubnetFeatures = record {
 
 type SubnetType = variant { application; verified_application; system };
 
+type UpdateApiBoundaryNodesVersionPayload = record {
+  version : text;
+  node_ids : vec principal;
+};
+
 type UpdateElectedHostosVersionsPayload = record {
   release_package_urls : vec text;
   hostos_version_to_elect : opt text;
   hostos_versions_to_unelect : vec text;
   release_package_sha256_hex : opt text;
+};
+
+type UpdateFirewallRulesPayload = record {
+  expected_hash : text;
+  scope : FirewallRulesScope;
+  positions : vec int32;
+  rules : vec FirewallRule;
 };
 
 type UpdateNodeDirectlyPayload = record {
@@ -401,15 +415,15 @@ service : {
   remove_node_directly : (RemoveNodeDirectlyPayload) -> ();
   remove_node_operators : (RemoveNodeOperatorsPayload) -> ();
   remove_nodes : (RemoveNodesPayload) -> ();
-  remove_nodes_from_subnet : (RemoveNodesPayload) -> ();
+  remove_nodes_from_subnet : (RemoveNodesFromSubnetPayload) -> ();
   reroute_canister_ranges : (RerouteCanisterRangesPayload) -> (Result_1);
   retire_replica_version : (RetireReplicaVersionPayload) -> ();
   revise_elected_replica_versions : (ReviseElectedGuestosVersionsPayload) -> ();
   set_firewall_config : (SetFirewallConfigPayload) -> ();
-  update_api_boundary_nodes_version : (AddApiBoundaryNodesPayload) -> ();
+  update_api_boundary_nodes_version : (UpdateApiBoundaryNodesVersionPayload) -> ();
   update_elected_hostos_versions : (UpdateElectedHostosVersionsPayload) -> ();
   update_elected_replica_versions : (ReviseElectedGuestosVersionsPayload) -> ();
-  update_firewall_rules : (AddFirewallRulesPayload) -> ();
+  update_firewall_rules : (UpdateFirewallRulesPayload) -> ();
   update_node_directly : (UpdateNodeDirectlyPayload) -> (Result_1);
   update_node_domain_directly : (UpdateNodeDomainDirectlyPayload) -> (Result_1);
   update_node_ipv4_config_directly : (UpdateNodeIPv4ConfigDirectlyPayload) -> (

--- a/declarations/used_by_proposals/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_proposals/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-22_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-29_23-02-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
@@ -58,6 +58,8 @@ type GetNextSnsVersionRequest = record {
   current_version : opt SnsVersion;
 };
 type GetNextSnsVersionResponse = record { next_version : opt SnsVersion };
+type GetProposalIdThatAddedWasmRequest = record { hash : blob };
+type GetProposalIdThatAddedWasmResponse = record { proposal_id : opt nat64 };
 type GetSnsSubnetIdsResponse = record { sns_subnet_ids : vec principal };
 type GetWasmMetadataRequest = record { hash : opt blob };
 type GetWasmMetadataResponse = record { result : opt Result_1 };
@@ -228,6 +230,9 @@ service : (SnsWasmCanisterInitPayload) -> {
   get_latest_sns_version_pretty : (null) -> (vec record { text; text }) query;
   get_next_sns_version : (GetNextSnsVersionRequest) -> (
       GetNextSnsVersionResponse,
+    ) query;
+  get_proposal_id_that_added_wasm : (GetProposalIdThatAddedWasmRequest) -> (
+      GetProposalIdThatAddedWasmResponse,
     ) query;
   get_sns_subnet_ids : (record {}) -> (GetSnsSubnetIdsResponse) query;
   get_wasm : (GetWasmRequest) -> (GetWasmResponse) query;

--- a/dfx.json
+++ b/dfx.json
@@ -388,7 +388,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-05-29",
-        "IC_COMMIT_FOR_PROPOSALS": "release-2024-05-22_23-01-base",
+        "IC_COMMIT_FOR_PROPOSALS": "release-2024-05-29_23-02-base",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-05-22_23-01-base"
       },
       "packtool": ""

--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-22_23-01-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-29_23-02-base/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-22_23-01-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-29_23-02-base/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -296,6 +296,10 @@ pub struct RemoveNodesPayload {
     pub node_ids: Vec<Principal>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct RemoveNodesFromSubnetPayload {
+    pub node_ids: Vec<Principal>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct RerouteCanisterRangesPayload {
     pub source_subnet: Principal,
     pub reassigned_canister_ranges: Vec<CanisterIdRange>,
@@ -320,11 +324,23 @@ pub struct SetFirewallConfigPayload {
     pub ipv6_prefixes: Vec<String>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct UpdateApiBoundaryNodesVersionPayload {
+    pub version: String,
+    pub node_ids: Vec<Principal>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateElectedHostosVersionsPayload {
     pub release_package_urls: Vec<String>,
     pub hostos_version_to_elect: Option<String>,
     pub hostos_versions_to_unelect: Vec<String>,
     pub release_package_sha256_hex: Option<String>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct UpdateFirewallRulesPayload {
+    pub expected_hash: String,
+    pub scope: FirewallRulesScope,
+    pub positions: Vec<i32>,
+    pub rules: Vec<FirewallRule>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateNodeDirectlyPayload {
@@ -508,7 +524,7 @@ impl Service {
     pub async fn remove_nodes(&self, arg0: RemoveNodesPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "remove_nodes", (arg0,)).await
     }
-    pub async fn remove_nodes_from_subnet(&self, arg0: RemoveNodesPayload) -> CallResult<()> {
+    pub async fn remove_nodes_from_subnet(&self, arg0: RemoveNodesFromSubnetPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "remove_nodes_from_subnet", (arg0,)).await
     }
     pub async fn reroute_canister_ranges(&self, arg0: RerouteCanisterRangesPayload) -> CallResult<(Result1,)> {
@@ -523,7 +539,10 @@ impl Service {
     pub async fn set_firewall_config(&self, arg0: SetFirewallConfigPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "set_firewall_config", (arg0,)).await
     }
-    pub async fn update_api_boundary_nodes_version(&self, arg0: AddApiBoundaryNodesPayload) -> CallResult<()> {
+    pub async fn update_api_boundary_nodes_version(
+        &self,
+        arg0: UpdateApiBoundaryNodesVersionPayload,
+    ) -> CallResult<()> {
         ic_cdk::call(self.0, "update_api_boundary_nodes_version", (arg0,)).await
     }
     pub async fn update_elected_hostos_versions(&self, arg0: UpdateElectedHostosVersionsPayload) -> CallResult<()> {
@@ -532,7 +551,7 @@ impl Service {
     pub async fn update_elected_replica_versions(&self, arg0: ReviseElectedGuestosVersionsPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "update_elected_replica_versions", (arg0,)).await
     }
-    pub async fn update_firewall_rules(&self, arg0: AddFirewallRulesPayload) -> CallResult<()> {
+    pub async fn update_firewall_rules(&self, arg0: UpdateFirewallRulesPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "update_firewall_rules", (arg0,)).await
     }
     pub async fn update_node_directly(&self, arg0: UpdateNodeDirectlyPayload) -> CallResult<(Result1,)> {

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-22_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-29_23-02-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -247,6 +247,14 @@ pub struct GetNextSnsVersionResponse {
     pub next_version: Option<SnsVersion>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct GetProposalIdThatAddedWasmRequest {
+    pub hash: serde_bytes::ByteBuf,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct GetProposalIdThatAddedWasmResponse {
+    pub proposal_id: Option<u64>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct GetSnsSubnetIdsArg {}
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetSnsSubnetIdsResponse {
@@ -379,6 +387,12 @@ impl Service {
         arg0: GetNextSnsVersionRequest,
     ) -> CallResult<(GetNextSnsVersionResponse,)> {
         ic_cdk::call(self.0, "get_next_sns_version", (arg0,)).await
+    }
+    pub async fn get_proposal_id_that_added_wasm(
+        &self,
+        arg0: GetProposalIdThatAddedWasmRequest,
+    ) -> CallResult<(GetProposalIdThatAddedWasmResponse,)> {
+        ic_cdk::call(self.0, "get_proposal_id_that_added_wasm", (arg0,)).await
     }
     pub async fn get_sns_subnet_ids(&self, arg0: GetSnsSubnetIdsArg) -> CallResult<(GetSnsSubnetIdsResponse,)> {
         ic_cdk::call(self.0, "get_sns_subnet_ids", (arg0,)).await


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.
Even with no changes, just updating the reference is good practice.

# Changes
* Update the version of `IC_COMMIT_FOR_PROPOSALS` specified in `dfx.json`.
* Updated the `proposals` candid files to the versions in that commit.
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants