### PR TITLE
NNS1-3092: Add state field to TableNeuron

### DIFF
--- a/frontend/src/lib/types/neurons-table.ts
+++ b/frontend/src/lib/types/neurons-table.ts
@@ -1,4 +1,5 @@
 import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
+import type { NeuronState } from "@dfinity/nns";
 import type { TokenAmountV2 } from "@dfinity/utils";
 
 export type TableNeuron = {
@@ -7,6 +8,7 @@ export type TableNeuron = {
   neuronId: string;
   stake: TokenAmountV2;
   dissolveDelaySeconds: bigint;
+  state: NeuronState;
 };
 
 // Should define a partial ordering on TableNeuron by return -1 if a < b, +1 if

--- a/frontend/src/lib/utils/neurons-table.utils.ts
+++ b/frontend/src/lib/utils/neurons-table.utils.ts
@@ -10,6 +10,7 @@ import {
   getSnsDissolveDelaySeconds,
   getSnsNeuronIdAsHexString,
   getSnsNeuronStake,
+  getSnsNeuronState,
 } from "$lib/utils/sns-neuron.utils";
 import type { NeuronInfo } from "@dfinity/nns";
 import type { SnsNeuron } from "@dfinity/sns";
@@ -37,6 +38,7 @@ export const tableNeuronsFromNeuronInfos = (
         token: ICPToken,
       }),
       dissolveDelaySeconds,
+      state: neuronInfo.state,
     };
   });
 };
@@ -66,6 +68,7 @@ export const tableNeuronsFromSnsNeurons = ({
         token,
       }),
       dissolveDelaySeconds,
+      state: getSnsNeuronState(snsNeuron),
     };
   });
 };

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -6,6 +6,7 @@ import {
   SECONDS_IN_YEAR,
 } from "$lib/constants/constants";
 import type { TableNeuron } from "$lib/types/neurons-table";
+import { mockTableNeuron } from "$tests/mocks/neurons.mock";
 import { NeuronsTablePo } from "$tests/page-objects/NeuronsTable.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
@@ -19,6 +20,7 @@ describe("NeuronsTable", () => {
     });
 
   const neuron1: TableNeuron = {
+    ...mockTableNeuron,
     rowHref: "/neurons/10",
     domKey: "10",
     neuronId: "10",
@@ -27,6 +29,7 @@ describe("NeuronsTable", () => {
   };
 
   const neuron2: TableNeuron = {
+    ...mockTableNeuron,
     rowHref: "/neurons/99",
     domKey: "99",
     neuronId: "99",
@@ -35,6 +38,7 @@ describe("NeuronsTable", () => {
   };
 
   const neuron3: TableNeuron = {
+    ...mockTableNeuron,
     rowHref: "/neurons/200",
     domKey: "200",
     neuronId: "200",
@@ -43,6 +47,7 @@ describe("NeuronsTable", () => {
   };
 
   const neuron4: TableNeuron = {
+    ...mockTableNeuron,
     rowHref: "/neurons/1111",
     domKey: "1111",
     neuronId: "1111",
@@ -51,6 +56,7 @@ describe("NeuronsTable", () => {
   };
 
   const spawningNeuron: TableNeuron = {
+    ...mockTableNeuron,
     domKey: "101",
     neuronId: "101",
     stake: TokenAmountV2.fromUlps({

--- a/frontend/src/tests/lib/utils/neurons-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neurons-table.utils.spec.ts
@@ -178,6 +178,10 @@ describe("neurons-table.utils", () => {
       const snsNeurons = [
         createMockSnsNeuron({
           ...defaultCreateMockSnsNeuronParams,
+          state: NeuronState.Locked,
+        }),
+        createMockSnsNeuron({
+          ...defaultCreateMockSnsNeuronParams,
           whenDissolvedTimestampSeconds:
             BigInt(Math.floor(now.getTime() / 1000)) + dissolveDelaySeconds,
           state: NeuronState.Dissolving,
@@ -194,6 +198,10 @@ describe("neurons-table.utils", () => {
         snsNeurons: snsNeurons,
       });
       expect(tableNeurons).toEqual([
+        {
+          ...expectedTableNeuron,
+          state: NeuronState.Locked,
+        },
         {
           ...expectedTableNeuron,
           state: NeuronState.Dissolving,

--- a/frontend/src/tests/mocks/neurons.mock.ts
+++ b/frontend/src/tests/mocks/neurons.mock.ts
@@ -104,7 +104,6 @@ export const mockNeuronNotControlled = {
 };
 
 export const mockTableNeuron: TableNeuron = {
-  rowHref: "/",
   domKey: "0",
   neuronId: "0",
   stake: TokenAmountV2.fromUlps({
@@ -112,4 +111,5 @@ export const mockTableNeuron: TableNeuron = {
     token: ICPToken,
   }),
   dissolveDelaySeconds: 1n,
+  state: NeuronState.Locked,
 };


### PR DESCRIPTION
# Motivation

We want to render neuron state in the neurons table.
For this, we need the neuron state in the `TableNeuron` type which is used to render the neurons table.

# Changes

1. Add `state` field to `TableNeuron` type.
2. Populate the state field in `frontend/src/lib/utils/neurons-table.utils.ts` for both NNS and SNS neurons.
3. Destructure `mockTableNeuron` in neurons in `NeuronsTable.spec.ts` so new fields don't need to be added immediately in the test and can be updated in a separate PR when we update the UI.
4. Remove `rowHref` from `mockTableNeuron` as it's an optional field and it should be possible to destructure `mockTableNeuron` and not specify `rowHref`.

# Tests

1. Unit tests added for `frontend/src/lib/utils/neurons-table.utils.ts`.
2. Tested manually in another branch which also has UI changes.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet