### PR TITLE
NNS1-3092: Add neuron state column to neurons table

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronStateCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronStateCell.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import NeuronStateInfo from "$lib/components/neurons/NeuronStateInfo.svelte";
+  import type { TableNeuron } from "$lib/types/neurons-table";
+
+  export let rowData: TableNeuron;
+</script>
+
+<NeuronStateInfo state={rowData.state} />

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
@@ -6,6 +6,7 @@
     NeuronsTableColumn,
   } from "$lib/types/neurons-table";
   import NeuronIdCell from "$lib/components/neurons/NeuronsTable/NeuronIdCell.svelte";
+  import NeuronStateCell from "$lib/components/neurons/NeuronsTable/NeuronStateCell.svelte";
   import NeuronStakeCell from "$lib/components/neurons/NeuronsTable/NeuronStakeCell.svelte";
   import NeuronDissolveDelayCell from "$lib/components/neurons/NeuronsTable/NeuronDissolveDelayCell.svelte";
   import NeuronActionsCell from "$lib/components/neurons/NeuronsTable/NeuronActionsCell.svelte";
@@ -34,6 +35,10 @@
     {
       title: $i18n.neuron_detail.stake,
       cellComponent: NeuronStakeCell,
+    },
+    {
+      title: $i18n.neurons.state,
+      cellComponent: NeuronStateCell,
     },
     {
       title: $i18n.neurons.dissolve_delay_title,

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -311,7 +311,8 @@
     "merge_neurons_select_info": "The order of selection matters. The neuron that you select first will be merged into the second one.",
     "merge_neurons_source_neuron_disappear": "The neuron <strong>$neuronId</strong> will disappear.",
     "merge_neurons_more_info": "Learn more about merging neurons <a href=\"https://medium.com/dfinity/internet-computer-nns-neurons-can-now-be-merged-8b4e44584dc2\" rel=\"noopener noreferrer\" aria-label=\"more info about merging neurons\" target=\"_blank\">here</a>.",
-    "stake_amount": "Stake Amount"
+    "stake_amount": "Stake Amount",
+    "state": "State"
   },
   "new_followee": {
     "title": "Enter New Followee",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -323,6 +323,7 @@ interface I18nNeurons {
   merge_neurons_source_neuron_disappear: string;
   merge_neurons_more_info: string;
   stake_amount: string;
+  state: string;
 }
 
 interface I18nNew_followee {

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -10,6 +10,7 @@ import { mockTableNeuron } from "$tests/mocks/neurons.mock";
 import { NeuronsTablePo } from "$tests/page-objects/NeuronsTable.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
+import { NeuronState } from "@dfinity/nns";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 
 describe("NeuronsTable", () => {
@@ -26,6 +27,7 @@ describe("NeuronsTable", () => {
     neuronId: "10",
     stake: makeStake(1_300_000_000n),
     dissolveDelaySeconds: BigInt(6 * SECONDS_IN_MONTH),
+    state: NeuronState.Dissolving,
   };
 
   const neuron2: TableNeuron = {
@@ -35,6 +37,7 @@ describe("NeuronsTable", () => {
     neuronId: "99",
     stake: makeStake(500_000_000n),
     dissolveDelaySeconds: BigInt(SECONDS_IN_EIGHT_YEARS),
+    state: NeuronState.Locked,
   };
 
   const neuron3: TableNeuron = {
@@ -44,6 +47,7 @@ describe("NeuronsTable", () => {
     neuronId: "200",
     stake: makeStake(500_000_000n),
     dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR),
+    state: NeuronState.Dissolving,
   };
 
   const neuron4: TableNeuron = {
@@ -53,6 +57,7 @@ describe("NeuronsTable", () => {
     neuronId: "1111",
     stake: makeStake(500_000_000n),
     dissolveDelaySeconds: BigInt(SECONDS_IN_YEAR),
+    state: NeuronState.Locked,
   };
 
   const spawningNeuron: TableNeuron = {
@@ -64,6 +69,7 @@ describe("NeuronsTable", () => {
       token: ICPToken,
     }),
     dissolveDelaySeconds: BigInt(5 * SECONDS_IN_DAY),
+    state: NeuronState.Spawning,
   };
 
   const renderComponent = ({ neurons }) => {
@@ -72,6 +78,17 @@ describe("NeuronsTable", () => {
     });
     return NeuronsTablePo.under(new JestPageObjectElement(container));
   };
+
+  it("should render headers", async () => {
+    const po = renderComponent({ neurons: [neuron1, neuron2] });
+    expect(await po.getColumnHeaders()).toEqual([
+      "Neuron ID",
+      "Stake",
+      "State",
+      "Dissolve Delay",
+      "", // No header for actions column.
+    ]);
+  });
 
   it("should render neuron URL", async () => {
     const po = renderComponent({ neurons: [neuron1, neuron2] });
@@ -95,6 +112,14 @@ describe("NeuronsTable", () => {
     expect(rowPos).toHaveLength(2);
     expect(await rowPos[0].getStake()).toBe("13.00 ICP");
     expect(await rowPos[1].getStake()).toBe("5.00 ICP");
+  });
+
+  it("should render neuron state", async () => {
+    const po = renderComponent({ neurons: [neuron1, neuron2] });
+    const rowPos = await po.getNeuronsTableRowPos();
+    expect(rowPos).toHaveLength(2);
+    expect(await rowPos[0].getState()).toBe("Dissolving");
+    expect(await rowPos[1].getState()).toBe("Locked");
   });
 
   it("should sort neurons", async () => {

--- a/frontend/src/tests/page-objects/NeuronStateInfo.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronStateInfo.page-object.ts
@@ -1,0 +1,14 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NeuronStateInfoPo extends BasePageObject {
+  private static readonly TID = "neuron-state-info";
+
+  static under(element: PageObjectElement): NeuronStateInfoPo {
+    return new NeuronStateInfoPo(element.byTestId(NeuronStateInfoPo.TID));
+  }
+
+  async getState(): Promise<string> {
+    return (await this.getText()).trim();
+  }
+}

--- a/frontend/src/tests/page-objects/NeuronsTable.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronsTable.page-object.ts
@@ -1,8 +1,8 @@
 import { NeuronsTableRowPo } from "$tests/page-objects/NeuronsTableRow.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { ResponsiveTablePo } from "$tests/page-objects/ResponsiveTable.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
-export class NeuronsTablePo extends BasePageObject {
+export class NeuronsTablePo extends ResponsiveTablePo {
   private static readonly TID = "neurons-table-component";
 
   static under(element: PageObjectElement): NeuronsTablePo {

--- a/frontend/src/tests/page-objects/NeuronsTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronsTableRow.page-object.ts
@@ -1,4 +1,5 @@
 import { NeuronIdCellPo } from "$tests/page-objects/NeuronIdCell.page-object";
+import { NeuronStateInfoPo } from "$tests/page-objects/NeuronStateInfo.page-object";
 import { ResponsiveTableRowPo } from "$tests/page-objects/ResponsiveTableRow.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -19,12 +20,20 @@ export class NeuronsTableRowPo extends ResponsiveTableRowPo {
     return NeuronIdCellPo.under(this.root);
   }
 
+  getNeuronStateInfoPo(): NeuronStateInfoPo {
+    return NeuronStateInfoPo.under(this.root);
+  }
+
   getNeuronId(): Promise<string> {
     return this.getNeuronIdCellPo().getNeurondId();
   }
 
   getStake(): Promise<string> {
     return this.getText("neuron-stake-cell-component");
+  }
+
+  getState(): Promise<string> {
+    return this.getNeuronStateInfoPo().getState();
   }
 
   getDissolveDelay(): Promise<string> {

--- a/frontend/src/tests/page-objects/ResponsiveTable.page-object.ts
+++ b/frontend/src/tests/page-objects/ResponsiveTable.page-object.ts
@@ -3,10 +3,12 @@ import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ResponsiveTablePo extends BasePageObject {
-  private static readonly TID = "responsive-table-component";
+  private static readonly RESPONSIVE_TABLE_TID = "responsive-table-component";
 
   static under(element: PageObjectElement): ResponsiveTablePo {
-    return new ResponsiveTablePo(element.byTestId(ResponsiveTablePo.TID));
+    return new ResponsiveTablePo(
+      element.byTestId(ResponsiveTablePo.RESPONSIVE_TABLE_TID)
+    );
   }
 
   async getColumnHeaders(): Promise<string[]> {


### PR DESCRIPTION
# Motivation

Add more information to the neurons table.

# Changes

1. Add `NeuronStateCell` comonent.
2. Add neuron state column to `NeuronsTable` component.

# Tests

1. Add missing unit test for table headers.
2. Add unit test for state column.
3. Add page object.
4. Make `NeuronsTablePo` extend `ResponsiveTablePo` to access `getColumnHeaders()`.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet