### PR TITLE
Restore proposal detail title

### DIFF
--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -43,7 +43,7 @@
 
 <TestIdWrapper testId="nns-proposal-component">
   {#if $store?.proposal?.id !== undefined && nonNullish(proposalIds)}
-    {#if $referrerPathStore !== AppPath.Launchpad && !$pageStore.actionable}
+    {#if $referrerPathStore !== AppPath.Launchpad}
       <ProposalNavigation
         title={proposalType}
         currentProposalId={$store.proposal.id}

--- a/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposal.svelte
@@ -24,7 +24,6 @@
   import { nonNullish } from "@dfinity/utils";
   import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
   import { actionableProposalsActiveStore } from "$lib/derived/actionable-proposals.derived";
-  import { pageStore } from "$lib/derived/page.derived";
 
   const { store } = getContext<SelectedProposalContext>(
     SELECTED_PROPOSAL_CONTEXT_KEY

--- a/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
@@ -8,6 +8,7 @@
   import type { UniversalProposalStatus } from "$lib/types/proposals";
   import ProposalStatusTag from "$lib/components/ui/ProposalStatusTag.svelte";
   import { triggerDebugReport } from "$lib/directives/debug.directives";
+  import { pageStore } from "$lib/derived/page.derived";
 
   export let currentProposalId: bigint;
   export let title: string | undefined = undefined;
@@ -54,30 +55,32 @@
     </span>
     <TestIdWrapper testId="title">{title ?? ""}</TestIdWrapper>
   </h2>
-  <button
-    class="ghost newer"
-    type="button"
-    aria-label={$i18n.proposal_detail.newer}
-    on:click={selectNewer}
-    class:hidden={isNullish(newerId)}
-    data-tid="proposal-nav-newer"
-    data-test-proposal-id={newerId?.toString() ?? ""}
-  >
-    <IconLeft />
-    {$i18n.proposal_detail.newer_short}</button
-  >
-  <button
-    class="ghost older"
-    type="button"
-    aria-label={$i18n.proposal_detail.older}
-    on:click={selectOlder}
-    class:hidden={isNullish(olderId)}
-    data-tid="proposal-nav-older"
-    data-test-proposal-id={olderId?.toString() ?? ""}
-  >
-    {$i18n.proposal_detail.older_short}
-    <IconRight />
-  </button>
+  {#if !$pageStore.actionable}
+    <button
+      class="ghost newer"
+      type="button"
+      aria-label={$i18n.proposal_detail.newer}
+      on:click={selectNewer}
+      class:hidden={isNullish(newerId)}
+      data-tid="proposal-nav-newer"
+      data-test-proposal-id={newerId?.toString() ?? ""}
+    >
+      <IconLeft />
+      {$i18n.proposal_detail.newer_short}</button
+    >
+    <button
+      class="ghost older"
+      type="button"
+      aria-label={$i18n.proposal_detail.older}
+      on:click={selectOlder}
+      class:hidden={isNullish(olderId)}
+      data-tid="proposal-nav-older"
+      data-test-proposal-id={olderId?.toString() ?? ""}
+    >
+      {$i18n.proposal_detail.older_short}
+      <IconRight />
+    </button>
+  {/if}
 </div>
 
 <style lang="scss">

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -222,7 +222,7 @@
 </script>
 
 <TestIdWrapper testId="sns-proposal-details-grid">
-  {#if nonNullish(proposalIdText) && !updating && nonNullish(proposal) && nonNullish(universeCanisterId) && !$pageStore.actionable}
+  {#if nonNullish(proposalIdText) && !updating && nonNullish(proposal) && nonNullish(universeCanisterId)}
     <ProposalNavigation
       title={proposalNavigationTitle}
       currentProposalId={BigInt(proposalIdText)}

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposal.spec.ts
@@ -137,7 +137,7 @@ describe("Proposal", () => {
     expect(await po.isPresent()).toBe(false);
   });
 
-  it("should not render proposal navigation when from actionable page", async () => {
+  it("should not render proposal navigation buttons when from actionable page", async () => {
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT, actionable: true },
       routeId: AppPath.Proposals,
@@ -150,6 +150,8 @@ describe("Proposal", () => {
     const { container } = renderProposalModern(5n);
     const po = ProposalNavigationPo.under(new JestPageObjectElement(container));
 
-    expect(await po.isPresent()).toBe(false);
+    expect(await po.isPresent()).toBe(true);
+    expect(await po.getNewerButtonPo().isPresent()).toBe(false);
+    expect(await po.getOlderButtonPo().isPresent()).toBe(false);
   });
 });

--- a/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsProposalDetail.spec.ts
@@ -352,7 +352,7 @@ describe("SnsProposalDetail", () => {
     });
   });
 
-  it("should not display proposal navigation when user comes from actionable page", async () => {
+  it("should not display proposal navigation buttons when user comes from actionable page", async () => {
     resetIdentity();
     setSnsProjects([
       {
@@ -402,14 +402,17 @@ describe("SnsProposalDetail", () => {
     expect(await po.isContentLoaded()).toBe(true);
 
     const navigationPo = po.getProposalNavigationPo();
-    expect(await navigationPo.isPresent()).toBe(false);
+    expect(await navigationPo.isPresent()).toBe(true);
+    expect(await navigationPo.getNewerButtonPo().isPresent()).toBe(false);
+    expect(await navigationPo.getOlderButtonPo().isPresent()).toBe(false);
 
     page.mock({
       data: { universe: rootCanisterId.toText(), actionable: false },
     });
 
     await runResolvedPromises();
-    expect(await navigationPo.isPresent()).toBe(true);
+    expect(await navigationPo.getNewerButtonPo().isPresent()).toBe(true);
+    expect(await navigationPo.getOlderButtonPo().isPresent()).toBe(true);
   });
 
   describe("not logged in that logs in afterwards", () => {


### PR DESCRIPTION
# Motivation

In the [previous PR](https://github.com/dfinity/nns-dapp/pull/4956), the whole navigation component was mistakenly hidden on the active proposal details page. Unfortunately, this component is also responsible for displaying the header with the project logo. Here we are restoring the header display (see screenshots).

# Changes

- Remove the hide-on-actionable-page logic from `ProposalNavigation` component and apply it to navigation buttons only.

# Tests

- Tests updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary since the feature is behind the feature flag.

# Screenshots

| Before | After |
|--------|--------|
| <img width="1255" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/4bd41f8e-3520-4c3c-bbdf-6b5a57b23c57"> | <img width="1251" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/554fb5b6-a526-4d8d-92af-d7ea0ba79b37"> | 



