### PR TITLE
NNS1-3093: Add getSnsNeuronTags

### DIFF
--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -11,6 +11,7 @@ import {
   type CompactNeuronInfo,
   type IneligibleNeuronData,
   type NeuronIneligibilityReason,
+  type NeuronTagData,
 } from "$lib/utils/neuron.utils";
 import { mapNervousSystemParameters } from "$lib/utils/sns-parameters.utils";
 import { formatTokenE8s } from "$lib/utils/token.utils";
@@ -546,6 +547,24 @@ export const formattedStakedMaturity = (
  */
 export const isCommunityFund = ({ source_nns_neuron_id }: SnsNeuron): boolean =>
   nonNullish(fromNullable(source_nns_neuron_id));
+
+export const getSnsNeuronTags = ({
+  neuron,
+  identity,
+  i18n,
+}: {
+  neuron: SnsNeuron;
+  identity: Identity | undefined | null;
+  i18n: I18n;
+}): NeuronTagData[] => {
+  const tags: NeuronTagData[] = [];
+  if (isCommunityFund(neuron)) {
+    tags.push({ text: i18n.neurons.community_fund });
+  } else if (isUserHotkey({ neuron, identity })) {
+    tags.push({ text: i18n.neurons.hotkey_control });
+  }
+  return tags;
+};
 
 /**
  * Returns true if the neuron needs to be refreshed.

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -27,6 +27,7 @@ import {
   getSnsNeuronIdAsHexString,
   getSnsNeuronStake,
   getSnsNeuronState,
+  getSnsNeuronTags,
   getSnsNeuronVote,
   hasEnoughMaturityToDisburse,
   hasEnoughMaturityToStake,
@@ -65,6 +66,7 @@ import {
 } from "$lib/utils/sns-neuron.utils";
 import { bytesToHexString } from "$lib/utils/utils";
 import { mockIdentity, mockPrincipal } from "$tests/mocks/auth.store.mock";
+import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
 import {
@@ -1496,6 +1498,55 @@ describe("sns-neuron utils", () => {
         source_nns_neuron_id: [],
       };
       expect(isCommunityFund(neuron)).toBe(false);
+    });
+  });
+
+  describe("getSnsNeuronTags", () => {
+    it("should return no tags", () => {
+      const tags = getSnsNeuronTags({
+        neuron: mockSnsNeuron,
+        identity: mockIdentity,
+        i18n: en,
+      });
+      expect(tags).toEqual([]);
+    });
+
+    it("should return hotkey tag", () => {
+      const hotkeyNeuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        permissions: [
+          {
+            principal: [mockIdentity.getPrincipal()],
+            permission_type: Int32Array.from(HOTKEY_PERMISSIONS),
+          },
+        ],
+      };
+      const tags = getSnsNeuronTags({
+        neuron: hotkeyNeuron,
+        identity: mockIdentity,
+        i18n: en,
+      });
+      expect(tags).toEqual([{ text: "Hotkey control" }]);
+    });
+
+    it("should return NF tag", () => {
+      const fundNeuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        permissions: [
+          {
+            principal: [mockIdentity.getPrincipal()],
+            permission_type: Int32Array.from(HOTKEY_PERMISSIONS),
+          },
+        ],
+        source_nns_neuron_id: [2n],
+        staked_maturity_e8s_equivalent: [] as [] | [bigint],
+      };
+      const tags = getSnsNeuronTags({
+        neuron: fundNeuron,
+        identity: mockIdentity,
+        i18n: en,
+      });
+      expect(tags).toEqual([{ text: "Neurons' fund" }]);
     });
   });
 


### PR DESCRIPTION
# Motivation

We want to render tags such as "Hardware Wallet Controlled" and "Hotkey control" in the neurons table.
NNs neurons have a specific function to produce these tags: https://github.com/dfinity/nns-dapp/blob/29f6ac77d2c0cde192e513c3adcca28c99e6a7ae/frontend/src/lib/utils/neuron.utils.ts#L406
And SNS neurons don't.

# Changes

1. Add `getSnsNeuronTags` similar to `getNeuronTags`.

# Tests

Unit tests added.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet