### PR TITLE
NNS1-3092: Add tags field to TableNeuron

### DIFF
--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -2,6 +2,8 @@
   import { ENABLE_NEURONS_TABLE } from "$lib/stores/feature-flags.store";
   import type { TableNeuron } from "$lib/types/neurons-table";
   import { i18n } from "$lib/stores/i18n";
+  import { authStore } from "$lib/stores/auth.store";
+  import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import NnsNeuronCard from "$lib/components/neurons/NnsNeuronCard.svelte";
   import NeuronsTable from "$lib/components/neurons/NeuronsTable/NeuronsTable.svelte";
@@ -29,7 +31,12 @@
 
   let tableNeurons: TableNeuron[] = [];
   $: tableNeurons = $ENABLE_NEURONS_TABLE
-    ? tableNeuronsFromNeuronInfos($definedNeuronsStore)
+    ? tableNeuronsFromNeuronInfos({
+        identity: $authStore.identity,
+        accounts: $icpAccountsStore,
+        i18n: $i18n,
+        neuronInfos: $definedNeuronsStore,
+      })
     : [];
 </script>
 

--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -8,6 +8,7 @@
     sortedSnsUserNeuronsStore,
   } from "$lib/derived/sns/sns-sorted-neurons.derived";
   import { i18n } from "$lib/stores/i18n";
+  import { authStore } from "$lib/stores/auth.store";
   import { syncSnsNeurons } from "$lib/services/sns-neurons.services";
   import SnsNeuronCard from "$lib/components/sns-neurons/SnsNeuronCard.svelte";
   import type { Principal } from "@dfinity/principal";
@@ -68,6 +69,8 @@
       ? tableNeuronsFromSnsNeurons({
           universe: $pageStore.universe,
           token: summary.token,
+          identity: $authStore.identity,
+          i18n: $i18n,
           snsNeurons: $snsNeuronsStore[$pageStore.universe]?.neurons ?? [],
         })
       : [];

--- a/frontend/src/lib/types/neurons-table.ts
+++ b/frontend/src/lib/types/neurons-table.ts
@@ -9,6 +9,7 @@ export type TableNeuron = {
   stake: TokenAmountV2;
   dissolveDelaySeconds: bigint;
   state: NeuronState;
+  tags: string[];
 };
 
 // Should define a partial ordering on TableNeuron by return -1 if a < b, +1 if

--- a/frontend/src/lib/utils/neurons-table.utils.ts
+++ b/frontend/src/lib/utils/neurons-table.utils.ts
@@ -1,24 +1,39 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import type { IcpAccountsStoreData } from "$lib/derived/icp-accounts.derived";
 import type {
   TableNeuron,
   TableNeuronComparator,
 } from "$lib/types/neurons-table";
 import type { UniverseCanisterIdText } from "$lib/types/universe";
 import { buildNeuronUrl } from "$lib/utils/navigation.utils";
-import { isSpawning, neuronStake } from "$lib/utils/neuron.utils";
+import {
+  getNeuronTags,
+  isSpawning,
+  neuronStake,
+} from "$lib/utils/neuron.utils";
 import {
   getSnsDissolveDelaySeconds,
   getSnsNeuronIdAsHexString,
   getSnsNeuronStake,
   getSnsNeuronState,
+  getSnsNeuronTags,
 } from "$lib/utils/sns-neuron.utils";
+import type { Identity } from "@dfinity/agent";
 import type { NeuronInfo } from "@dfinity/nns";
 import type { SnsNeuron } from "@dfinity/sns";
 import { ICPToken, TokenAmountV2, type Token } from "@dfinity/utils";
 
-export const tableNeuronsFromNeuronInfos = (
-  neuronInfos: NeuronInfo[]
-): TableNeuron[] => {
+export const tableNeuronsFromNeuronInfos = ({
+  neuronInfos,
+  identity,
+  accounts,
+  i18n,
+}: {
+  neuronInfos: NeuronInfo[];
+  identity?: Identity | undefined | null;
+  accounts: IcpAccountsStoreData;
+  i18n: I18n;
+}): TableNeuron[] => {
   return neuronInfos.map((neuronInfo) => {
     const { neuronId, dissolveDelaySeconds } = neuronInfo;
     const neuronIdString = neuronId.toString();
@@ -39,18 +54,28 @@ export const tableNeuronsFromNeuronInfos = (
       }),
       dissolveDelaySeconds,
       state: neuronInfo.state,
+      tags: getNeuronTags({
+        neuron: neuronInfo,
+        identity,
+        accounts,
+        i18n,
+      }).map(({ text }) => text),
     };
   });
 };
 
 export const tableNeuronsFromSnsNeurons = ({
+  snsNeurons,
   universe,
   token,
-  snsNeurons,
+  identity,
+  i18n,
 }: {
+  snsNeurons: SnsNeuron[];
   universe: UniverseCanisterIdText;
   token: Token;
-  snsNeurons: SnsNeuron[];
+  identity: Identity | undefined | null;
+  i18n: I18n;
 }): TableNeuron[] => {
   return snsNeurons.map((snsNeuron) => {
     const dissolveDelaySeconds = getSnsDissolveDelaySeconds(snsNeuron) ?? 0n;
@@ -69,6 +94,11 @@ export const tableNeuronsFromSnsNeurons = ({
       }),
       dissolveDelaySeconds,
       state: getSnsNeuronState(snsNeuron),
+      tags: getSnsNeuronTags({
+        neuron: snsNeuron,
+        identity,
+        i18n,
+      }).map(({ text }) => text),
     };
   });
 };

--- a/frontend/src/tests/mocks/neurons.mock.ts
+++ b/frontend/src/tests/mocks/neurons.mock.ts
@@ -112,4 +112,5 @@ export const mockTableNeuron: TableNeuron = {
   }),
   dissolveDelaySeconds: 1n,
   state: NeuronState.Locked,
+  tags: [],
 };


### PR DESCRIPTION
# Motivation

We want to render tags such as "Hardware Wallet Controlled" and "Hotkey control" in the neurons table.
In this PR we add the information to the `TableNeuron` type.
Actually rendering it will happen in the next PR.

# Changes

1. Add `tags: string[]` field to `TableNeuron`.
2. Include tags in result in `tableNeuronsFromNeuronInfos` and `tableNeuronsFromSnsNeurons`.
3. Pass newly required parameters from `NnsNeurons.svelte` and `SnsNeurons.svelte`.

# Tests

Added unit tests.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet