### PR TITLE
build: bump gix-cmp for next version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "@dfinity/candid": "^1.3.0",
         "@dfinity/ckbtc": "next",
         "@dfinity/cmc": "next",
-        "@dfinity/gix-components": "^4.3.0-next-2024-06-04",
+        "@dfinity/gix-components": "next",
         "@dfinity/ic-management": "next",
         "@dfinity/identity": "^1.3.0",
         "@dfinity/ledger-icp": "next",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2831,10 +2831,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.5.tgz",
-      "integrity": "sha512-lwG+n5h8QNpxtyrJW/gJWckL+1/DQiYMX8f7t8Z2AZTPw1esVrqjI63i7Zc2Gz0aKzLVMYC1V1PL/ky+aY/NgA==",
-      "license": "(MPL-2.0 OR Apache-2.0)"
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.8.tgz",
+      "integrity": "sha512-b7uwreMYL2eZhrSCRC4ahLTeZcPZxSmYfmcQGXGkXiZSNW1X85v+SDM5KsWcpivIiUBH47Ji7NtyUdpLeF5JZQ=="
     },
     "node_modules/dotenv": {
       "version": "16.3.1",
@@ -3805,8 +3804,7 @@
     "node_modules/html5-qrcode": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/html5-qrcode/-/html5-qrcode-2.3.8.tgz",
-      "integrity": "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ=="
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -5356,8 +5354,7 @@
     "node_modules/qr-creator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/qr-creator/-/qr-creator-1.0.0.tgz",
-      "integrity": "sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ==",
-      "license": "MIT"
+      "integrity": "sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ=="
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -8775,9 +8772,9 @@
       }
     },
     "dompurify": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.5.tgz",
-      "integrity": "sha512-lwG+n5h8QNpxtyrJW/gJWckL+1/DQiYMX8f7t8Z2AZTPw1esVrqjI63i7Zc2Gz0aKzLVMYC1V1PL/ky+aY/NgA=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.8.tgz",
+      "integrity": "sha512-b7uwreMYL2eZhrSCRC4ahLTeZcPZxSmYfmcQGXGkXiZSNW1X85v+SDM5KsWcpivIiUBH47Ji7NtyUdpLeF5JZQ=="
     },
     "dotenv": {
       "version": "16.3.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "@dfinity/candid": "^1.3.0",
         "@dfinity/ckbtc": "next",
         "@dfinity/cmc": "next",
-        "@dfinity/gix-components": "next",
+        "@dfinity/gix-components": "^4.3.0-next-2024-06-04",
         "@dfinity/ic-management": "next",
         "@dfinity/identity": "^1.3.0",
         "@dfinity/ledger-icp": "next",
@@ -279,9 +279,10 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "4.2.0-next-2024-05-31",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.2.0-next-2024-05-31.tgz",
-      "integrity": "sha512-3dNRvUJ5vir9u6/J0aTWNBTt2CZXBOuxtgkbCeTvgkyFYNFiud/8JkIST+PamdiBVA8MA2fQkTUVhey5UJg6gQ==",
+      "version": "4.3.0-next-2024-06-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.3.0-next-2024-06-04.tgz",
+      "integrity": "sha512-g+O9FbzqO5s6NPpQDmNzclKtGrkmrs66mu/t2TZsIrWl/Z7qQ6JNB1M/yWDhSwmV5Gbvde1BlPj910i0c3przQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.0.8",
         "html5-qrcode": "^2.3.8",
@@ -2830,9 +2831,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.8.tgz",
-      "integrity": "sha512-b7uwreMYL2eZhrSCRC4ahLTeZcPZxSmYfmcQGXGkXiZSNW1X85v+SDM5KsWcpivIiUBH47Ji7NtyUdpLeF5JZQ=="
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.5.tgz",
+      "integrity": "sha512-lwG+n5h8QNpxtyrJW/gJWckL+1/DQiYMX8f7t8Z2AZTPw1esVrqjI63i7Zc2Gz0aKzLVMYC1V1PL/ky+aY/NgA==",
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/dotenv": {
       "version": "16.3.1",
@@ -3803,7 +3805,8 @@
     "node_modules/html5-qrcode": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/html5-qrcode/-/html5-qrcode-2.3.8.tgz",
-      "integrity": "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ=="
+      "integrity": "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -5353,7 +5356,8 @@
     "node_modules/qr-creator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/qr-creator/-/qr-creator-1.0.0.tgz",
-      "integrity": "sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ=="
+      "integrity": "sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ==",
+      "license": "MIT"
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -7058,9 +7062,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "4.2.0-next-2024-05-31",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.2.0-next-2024-05-31.tgz",
-      "integrity": "sha512-3dNRvUJ5vir9u6/J0aTWNBTt2CZXBOuxtgkbCeTvgkyFYNFiud/8JkIST+PamdiBVA8MA2fQkTUVhey5UJg6gQ==",
+      "version": "4.3.0-next-2024-06-04",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.3.0-next-2024-06-04.tgz",
+      "integrity": "sha512-g+O9FbzqO5s6NPpQDmNzclKtGrkmrs66mu/t2TZsIrWl/Z7qQ6JNB1M/yWDhSwmV5Gbvde1BlPj910i0c3przQ==",
       "requires": {
         "dompurify": "^3.0.8",
         "html5-qrcode": "^2.3.8",
@@ -8771,9 +8775,9 @@
       }
     },
     "dompurify": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.8.tgz",
-      "integrity": "sha512-b7uwreMYL2eZhrSCRC4ahLTeZcPZxSmYfmcQGXGkXiZSNW1X85v+SDM5KsWcpivIiUBH47Ji7NtyUdpLeF5JZQ=="
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.5.tgz",
+      "integrity": "sha512-lwG+n5h8QNpxtyrJW/gJWckL+1/DQiYMX8f7t8Z2AZTPw1esVrqjI63i7Zc2Gz0aKzLVMYC1V1PL/ky+aY/NgA=="
     },
     "dotenv": {
       "version": "16.3.1",


### PR DESCRIPTION
# Motivation

We released gix-cmp v4.3.0 and updated the library to this new version. This update advances the library to the latest version number.

# Changes

- `npm run update:gix`
