### PR TITLE
NNS1-3092: Render neuron tags in table

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
@@ -1,10 +1,23 @@
 <script lang="ts">
   import type { TableNeuron } from "$lib/types/neurons-table";
   import IdentifierHash from "$lib/components/ui/IdentifierHash.svelte";
+  import { Tag } from "@dfinity/gix-components";
 
   export let rowData: TableNeuron;
 </script>
 
 <div data-tid="neuron-id-cell-component">
   <IdentifierHash identifier={rowData.neuronId} />
+  <div class="tags">
+    {#each rowData.tags as tag}
+      <Tag testId="neuron-tag">{tag}</Tag>
+    {/each}
+  </div>
 </div>
+
+<style lang="scss">
+  .tags {
+    display: flex;
+    gap: var(--padding);
+  }
+</style>

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -153,4 +153,24 @@ describe("NeuronsTable", () => {
     expect(await rowPos[1].getHref()).toBe(null);
     expect(await rowPos[1].hasGoToDetailButton()).toBe(false);
   });
+
+  it("should render tags", async () => {
+    const tags = ["Neuron's fund", "Hotkey control"];
+    const po = renderComponent({
+      neurons: [
+        {
+          ...neuron1,
+          tags: [],
+        },
+        {
+          ...neuron2,
+          tags,
+        },
+      ],
+    });
+    const rowPos = await po.getNeuronsTableRowPos();
+    expect(rowPos).toHaveLength(2);
+    expect(await rowPos[0].getTags()).toEqual([]);
+    expect(await rowPos[1].getTags()).toEqual(tags);
+  });
 });

--- a/frontend/src/tests/page-objects/NeuronIdCell.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronIdCell.page-object.ts
@@ -16,4 +16,9 @@ export class NeuronIdCellPo extends BasePageObject {
   getNeurondId(): Promise<string> {
     return this.getIdentifierHashPo().getFullText();
   }
+
+  async getTags(): Promise<string[]> {
+    const tagElements = await this.root.allByTestId("neuron-tag");
+    return Promise.all(tagElements.map((el) => el.getText()));
+  }
 }

--- a/frontend/src/tests/page-objects/NeuronsTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronsTableRow.page-object.ts
@@ -28,6 +28,10 @@ export class NeuronsTableRowPo extends ResponsiveTableRowPo {
     return this.getNeuronIdCellPo().getNeurondId();
   }
 
+  getTags(): Promise<string[]> {
+    return this.getNeuronIdCellPo().getTags();
+  }
+
   getStake(): Promise<string> {
     return this.getText("neuron-stake-cell-component");
   }


### PR DESCRIPTION
# Motivation

We want to render tags such as "Hardware Wallet Controlled" and "Hotkey control" in the neurons table.

# Changes

1. Render tags in the `NeuronIdCell'.

The alignment is not great but will be addressed in another PR.

<img width="858" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/b9d22c63-66dd-45ce-af52-c1c0dec9dd5b">

# Tests

1. Unit test added.
2. Manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/neurons/?u=qsgjb-riaaa-aaaaa-aaaga-cai

# Todos

- [ ] Add entry to changelog (if necessary).
not yet