### PR TITLE
NNS1-3092: Left-align neuron state column

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
@@ -31,22 +31,27 @@
     {
       title: $i18n.neurons.neuron_id,
       cellComponent: NeuronIdCell,
+      alignment: "left",
     },
     {
       title: $i18n.neuron_detail.stake,
       cellComponent: NeuronStakeCell,
+      alignment: "right",
     },
     {
       title: $i18n.neurons.state,
       cellComponent: NeuronStateCell,
+      alignment: "left",
     },
     {
       title: $i18n.neurons.dissolve_delay_title,
       cellComponent: NeuronDissolveDelayCell,
+      alignment: "right",
     },
     {
       title: "",
       cellComponent: NeuronActionsCell,
+      alignment: "right",
     },
   ];
 </script>

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -13,14 +13,17 @@
     {
       title: firstColumnHeader,
       cellComponent: TokenTitleCell,
+      alignment: "left",
     },
     {
       title: $i18n.tokens.balance_header,
       cellComponent: TokenBalanceCell,
+      alignment: "right",
     },
     {
       title: "",
       cellComponent: TokenActionsCell,
+      alignment: "right",
     },
   ];
 </script>

--- a/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
@@ -28,7 +28,7 @@
   data-tid="responsive-table-row-component"
 >
   {#if firstColumn}
-    <div role="cell" class="title-cell">
+    <div role="cell" class="title-cell desktop-align-{firstColumn.alignment}">
       <svelte:component this={firstColumn.cellComponent} {rowData} />
     </div>
   {/if}
@@ -36,7 +36,7 @@
   {#each middleColumns as column, index}
     <div
       role="cell"
-      class={`mobile-row-cell left-cell`}
+      class="mobile-row-cell desktop-align-{column.alignment}"
       style="--grid-area-name: {getCellGridAreaName(index)}"
     >
       <span class="mobile-only">{column.title}</span>
@@ -45,7 +45,10 @@
   {/each}
 
   {#if lastColumn}
-    <div role="cell" class="actions-cell actions">
+    <div
+      role="cell"
+      class="actions-cell actions desktop-align-{lastColumn.alignment}"
+    >
       <svelte:component
         this={lastColumn.cellComponent}
         {rowData}
@@ -121,11 +124,15 @@
       @include media.min-width(medium) {
         grid-area: revert;
       }
+    }
 
-      @include media.min-width(medium) {
-        &.left-cell {
-          justify-content: flex-end;
-        }
+    @include media.min-width(medium) {
+      &.desktop-align-left {
+        justify-content: flex-start;
+      }
+
+      &.desktop-align-right {
+        justify-content: flex-end;
       }
     }
   }

--- a/frontend/src/lib/types/responsive-table.ts
+++ b/frontend/src/lib/types/responsive-table.ts
@@ -7,9 +7,12 @@ export interface ResponsiveTableRowData {
   rowHref?: string;
 }
 
+export type ColumnAlignment = "left" | "right";
+
 export interface ResponsiveTableColumn<
   RowDataType extends ResponsiveTableRowData,
 > {
   title: string;
   cellComponent: ComponentType<SvelteComponent<{ rowData: RowDataType }>>;
+  alignment: ColumnAlignment;
 }

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -90,6 +90,18 @@ describe("NeuronsTable", () => {
     ]);
   });
 
+  it("should render cell alignment classes", async () => {
+    const po = renderComponent({ neurons: [neuron1, neuron2] });
+    const rows = await po.getRows();
+    expect(await rows[0].getCellClasses()).toEqual([
+      expect.arrayContaining(["desktop-align-left"]), // Neuron ID
+      expect.arrayContaining(["desktop-align-right"]), // Stake
+      expect.arrayContaining(["desktop-align-left"]), // State
+      expect.arrayContaining(["desktop-align-right"]), // Dissolve Delay
+      expect.arrayContaining(["desktop-align-right"]), // Actions
+    ]);
+  });
+
   it("should render neuron URL", async () => {
     const po = renderComponent({ neurons: [neuron1, neuron2] });
     const rowPos = await po.getNeuronsTableRowPos();

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -66,6 +66,33 @@ describe("TokensTable", () => {
     expect(await po.getFirstColumnHeader()).toEqual(firstColumnHeader);
   });
 
+  it("should render headers", async () => {
+    const firstColumnHeader = "Accounts";
+    const token1 = createUserToken({
+      universeId: OWN_CANISTER_ID,
+    });
+    const po = renderTable({ userTokensData: [token1], firstColumnHeader });
+    expect(await po.getColumnHeaders()).toEqual([
+      "Accounts",
+      "Balance",
+      "", // No header for actions column.
+    ]);
+  });
+
+  it("should render cell alignment classes", async () => {
+    const firstColumnHeader = "Accounts";
+    const token1 = createUserToken({
+      universeId: OWN_CANISTER_ID,
+    });
+    const po = renderTable({ userTokensData: [token1], firstColumnHeader });
+    const rows = await po.getRows();
+    expect(await rows[0].getCellClasses()).toEqual([
+      expect.arrayContaining(["desktop-align-left"]), // Accounts
+      expect.arrayContaining(["desktop-align-right"]), // Balance
+      expect.arrayContaining(["desktop-align-right"]), // Actions
+    ]);
+  });
+
   it("should render the last-row slot", async () => {
     const lastRowText = "Add Account";
     const token1 = createUserToken({

--- a/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
@@ -10,16 +10,19 @@ describe("ResponseTable", () => {
     {
       title: "Name",
       cellComponent: TestTableNameCell,
+      alignment: "left",
     },
     {
       title: "Age",
       cellComponent: TestTableAgeCell,
+      alignment: "left",
     },
     {
       title: "Actions",
       // Normally each column would have a different cell component but for
       // testing we reuse the name cell component.
       cellComponent: TestTableNameCell,
+      alignment: "right",
     },
   ];
 
@@ -86,6 +89,16 @@ describe("ResponseTable", () => {
     expect(await rows[0].getTagName()).toBe("A");
     expect(await rows[1].getTagName()).toBe("A");
     expect(await rows[2].getTagName()).toBe("DIV");
+  });
+
+  it("should render classes based on column alignment", async () => {
+    const po = renderComponent({ columns, tableData });
+    const rows = await po.getRows();
+    expect(await rows[0].getCellClasses()).toEqual([
+      expect.arrayContaining(["desktop-align-left"]),
+      expect.arrayContaining(["desktop-align-left"]),
+      expect.arrayContaining(["desktop-align-right"]),
+    ]);
   });
 
   it("should render column styles depending on the number of columns", async () => {

--- a/frontend/src/tests/page-objects/ResponsiveTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/ResponsiveTableRow.page-object.ts
@@ -32,6 +32,14 @@ export class ResponsiveTableRowPo extends BasePageObject {
     );
   }
 
+  async getCellClasses(): Promise<string[][]> {
+    return Promise.all(
+      (await this.root.querySelectorAll("[role='cell']")).map((el) =>
+        el.getClasses()
+      )
+    );
+  }
+
   async getTagName(): Promise<string> {
     return this.root.getTagName();
   }

--- a/frontend/src/tests/page-objects/TokensTable.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTable.page-object.ts
@@ -1,12 +1,12 @@
+import { ResponsiveTablePo } from "$tests/page-objects/ResponsiveTable.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { isNullish } from "@dfinity/utils";
 import {
   TokensTableRowPo,
   type TokensTableRowData,
 } from "./TokensTableRow.page-object";
-import { BasePageObject } from "./base.page-object";
 
-export class TokensTablePo extends BasePageObject {
+export class TokensTablePo extends ResponsiveTablePo {
   private static readonly TID = "tokens-table-component";
 
   // There will be multiple ckETH projects and arbitrary ICRC tokens in the future.

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -1,19 +1,17 @@
+import { ResponsiveTableRowPo } from "$tests/page-objects/ResponsiveTableRow.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AmountDisplayPo } from "./AmountDisplay.page-object";
-import { BasePageObject } from "./base.page-object";
 
 export type TokensTableRowData = {
   projectName: string;
   balance: string;
 };
 
-export class TokensTableRowPo extends BasePageObject {
-  private static readonly TID = "responsive-table-row-component";
-
+export class TokensTableRowPo extends ResponsiveTableRowPo {
   static async allUnder(
     element: PageObjectElement
   ): Promise<TokensTableRowPo[]> {
-    return Array.from(await element.allByTestId(TokensTableRowPo.TID)).map(
+    return Array.from(await element.allByTestId(ResponsiveTableRowPo.TID)).map(
       (el) => new TokensTableRowPo(el)
     );
   }
@@ -39,7 +37,7 @@ export class TokensTableRowPo extends BasePageObject {
   }): TokensTableRowPo[] {
     return element
       .countByTestId({
-        tid: TokensTableRowPo.TID,
+        tid: ResponsiveTableRowPo.TID,
         count,
       })
       .map((el) => new TokensTableRowPo(el));


### PR DESCRIPTION
# Motivation

We want icons in the neurons table to be aligned across columns.
In this PR we address the neuron state icons by left-aligning the cells in that column.

<img width="879" alt="Screenshot 2024-06-05 at 09 37 53" src="https://github.com/dfinity/nns-dapp/assets/122978264/ef6af009-f85f-4b2f-b6e0-b992b118a36b">

# Changes

1. Add `alignment` field to the `ResponsiveTableColumn` type.
2. Add a class to cells in the `ResponsiveTable` based on the `alignment` field on the column spec.
3. Align cells based on the class.
4. Set `alignment` on all the columns in the `NeuronsTable` and `TokensTable` components.
5. Set `left` alignment for the "State" column.

# Tests

1. Make tokens table POs extend responsive table POs.
2. Add unit tests for `ResponsiveTable`, `TokensTable` and `NeuronsTable`.
3. Manually tested at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/neurons/?u=qsgjb-riaaa-aaaaa-aaaga-cai

# Todos

- [ ] Add entry to changelog (if necessary).
not yet