### PR TITLE
Always call sns get proposal on details page

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,6 +30,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Render neurons with minimum dissolve delay correctly with voting power.
 * Nns-dapp may crash while finishing an empty receive.
 * Actionable proposals initialization before Sns-es were loaded.
+* Missing Sns proposal payload rendering under certain conditions.
 
 #### Security
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,7 +30,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Render neurons with minimum dissolve delay correctly with voting power.
 * Nns-dapp may crash while finishing an empty receive.
 * Actionable proposals initialization before Sns-es were loaded.
-* Missing Sns proposal payload rendering under certain conditions.
+* Missing SNS proposal payload rendering under certain conditions.
 
 #### Security
 

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -140,7 +140,7 @@
         updating = true;
 
         await Promise.all([
-          // skip neurons call when not signedIn or when neurons are ready available
+          // skip neurons call when not signedIn or when neurons are ready
           neuronsReady || !$authSignedInStore
             ? undefined
             : syncSnsNeurons(universeId),

--- a/frontend/src/lib/pages/SnsProposalDetail.svelte
+++ b/frontend/src/lib/pages/SnsProposalDetail.svelte
@@ -11,7 +11,6 @@
   import SnsProposalSummarySection from "$lib/components/sns-proposals/SnsProposalSummarySection.svelte";
   import SkeletonDetails from "$lib/components/ui/SkeletonDetails.svelte";
   import SnsProposalPayloadSection from "$lib/components/sns-proposals/SnsProposalPayloadSection.svelte";
-  import { sortedSnsUserNeuronsStore } from "$lib/derived/sns/sns-sorted-neurons.derived";
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import type { UniverseCanisterIdText } from "$lib/types/universe";
   import { pageStore } from "$lib/derived/page.derived";


### PR DESCRIPTION
# Motivation

After the recent Sns Governance behavior change, `list_proposals: payload_text_rendering` is no longer returned as part of a proposal. This breaks the `nns-dapp`, causing the Sns payload to not be rendered under certain conditions.

To reproduce:
- Sign in
- Open any Sns proposals page.
- Wait about 10 seconds to ensure a certified version of the `list_proposals` response is received.
- Click on any proposal card to see its details.
- The proposal payload is not rendered.

# Changes

- Make `getSnsProposalById` to not use the `snsProposalsStore`.
- Removed `getProposalFromStoreById`.

# Tests

- Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
