### PR TITLE
NNS1-3092: Support custom column templates in responsive table

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
@@ -32,26 +32,31 @@
       title: $i18n.neurons.neuron_id,
       cellComponent: NeuronIdCell,
       alignment: "left",
+      templateColumns: ["1fr"],
     },
     {
       title: $i18n.neuron_detail.stake,
       cellComponent: NeuronStakeCell,
       alignment: "right",
+      templateColumns: ["max-content"],
     },
     {
       title: $i18n.neurons.state,
       cellComponent: NeuronStateCell,
       alignment: "left",
+      templateColumns: ["max-content"],
     },
     {
       title: $i18n.neurons.dissolve_delay_title,
       cellComponent: NeuronDissolveDelayCell,
       alignment: "right",
+      templateColumns: ["max-content"],
     },
     {
       title: "",
       cellComponent: NeuronActionsCell,
       alignment: "right",
+      templateColumns: ["max-content"],
     },
   ];
 </script>

--- a/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokensTable.svelte
@@ -14,16 +14,19 @@
       title: firstColumnHeader,
       cellComponent: TokenTitleCell,
       alignment: "left",
+      templateColumns: ["1fr"],
     },
     {
       title: $i18n.tokens.balance_header,
       cellComponent: TokenBalanceCell,
       alignment: "right",
+      templateColumns: ["max-content"],
     },
     {
       title: "",
       cellComponent: TokenActionsCell,
       alignment: "right",
+      templateColumns: ["max-content"],
     },
   ];
 </script>

--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -22,12 +22,17 @@
   $: firstColumn = columns.at(0);
   $: middleColumns = columns.slice(1, -1);
 
-  const getTableStyle = (columnCount: number) => {
+  const getTableStyle = (columns: ResponsiveTableColumn<RowDataType>[]) => {
     // On desktop the first column gets all the remaining space after other
     // columns get as much as their content needs.
-    const desktopGridTemplateColumns = `1fr${" max-content".repeat(
-      columnCount - 1
-    )}`;
+    const desktopGridTemplateColumns = columns
+      .flatMap((column) => column.templateColumns)
+      .join(" ");
+
+    const columnCount = columns.length;
+    const firstColumnTemplate = columns[0].templateColumns;
+    const lastColumnTemplate = columns[columnCount - 1].templateColumns;
+
     // On mobile, instead of a single row per data item, we have one row for the
     // first and last cell combined and a separate labeled row for each other
     // cell.
@@ -36,11 +41,19 @@
       const areaName = getCellGridAreaName(i);
       mobileGridTemplateAreas += ` "${areaName} ${areaName}"`;
     }
-    return `--desktop-grid-template-columns: ${desktopGridTemplateColumns}; --mobile-grid-template-areas: ${mobileGridTemplateAreas};`;
+    const mobileGridTemplateColumns = [
+      ...firstColumnTemplate,
+      ...lastColumnTemplate,
+    ].join(" ");
+    return (
+      `--desktop-grid-template-columns: ${desktopGridTemplateColumns}; ` +
+      `--mobile-grid-template-areas: ${mobileGridTemplateAreas};` +
+      `--mobile-grid-template-columns: ${mobileGridTemplateColumns};`
+    );
   };
 
   let tableStyle: string;
-  $: tableStyle = getTableStyle(columns.length);
+  $: tableStyle = getTableStyle(columns);
 </script>
 
 <div role="table" data-tid={testId} style={tableStyle}>

--- a/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
@@ -71,6 +71,7 @@
     text-decoration: none;
 
     grid-template-areas: var(--mobile-grid-template-areas);
+    grid-template-columns: var(--mobile-grid-template-columns);
 
     @include media.min-width(medium) {
       @include grid-table.row;

--- a/frontend/src/lib/types/responsive-table.ts
+++ b/frontend/src/lib/types/responsive-table.ts
@@ -8,6 +8,7 @@ export interface ResponsiveTableRowData {
 }
 
 export type ColumnAlignment = "left" | "right";
+export type TemplateItem = "max-content" | "1fr";
 
 export interface ResponsiveTableColumn<
   RowDataType extends ResponsiveTableRowData,
@@ -15,4 +16,5 @@ export interface ResponsiveTableColumn<
   title: string;
   cellComponent: ComponentType<SvelteComponent<{ rowData: RowDataType }>>;
   alignment: ColumnAlignment;
+  templateColumns: TemplateItem[];
 }

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -102,6 +102,18 @@ describe("NeuronsTable", () => {
     ]);
   });
 
+  it("should use correct template columns", async () => {
+    const po = renderComponent({ neurons: [neuron1] });
+
+    expect(await po.getDesktopGridTemplateColumns()).toBe(
+      "1fr max-content max-content max-content max-content"
+    );
+    expect(await po.getMobileGridTemplateColumns()).toBe("1fr max-content");
+    expect(await po.getMobileGridTemplateAreas()).toBe(
+      '"first-cell last-cell" "cell-0 cell-0" "cell-1 cell-1" "cell-2 cell-2"'
+    );
+  });
+
   it("should render neuron URL", async () => {
     const po = renderComponent({ neurons: [neuron1, neuron2] });
     const rowPos = await po.getNeuronsTableRowPos();

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -93,6 +93,22 @@ describe("TokensTable", () => {
     ]);
   });
 
+  it("should use correct template columns", async () => {
+    const firstColumnHeader = "Accounts";
+    const token1 = createUserToken({
+      universeId: OWN_CANISTER_ID,
+    });
+    const po = renderTable({ userTokensData: [token1], firstColumnHeader });
+
+    expect(await po.getDesktopGridTemplateColumns()).toBe(
+      "1fr max-content max-content"
+    );
+    expect(await po.getMobileGridTemplateColumns()).toBe("1fr max-content");
+    expect(await po.getMobileGridTemplateAreas()).toBe(
+      '"first-cell last-cell" "cell-0 cell-0"'
+    );
+  });
+
   it("should render the last-row slot", async () => {
     const lastRowText = "Add Account";
     const token1 = createUserToken({

--- a/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
@@ -11,11 +11,13 @@ describe("ResponseTable", () => {
       title: "Name",
       cellComponent: TestTableNameCell,
       alignment: "left",
+      templateColumns: ["1fr"],
     },
     {
       title: "Age",
       cellComponent: TestTableAgeCell,
       alignment: "left",
+      templateColumns: ["1fr"],
     },
     {
       title: "Actions",
@@ -23,6 +25,7 @@ describe("ResponseTable", () => {
       // testing we reuse the name cell component.
       cellComponent: TestTableNameCell,
       alignment: "right",
+      templateColumns: ["max-content"],
     },
   ];
 
@@ -105,8 +108,9 @@ describe("ResponseTable", () => {
     // 3 columns
     const po1 = renderComponent({ columns, tableData });
     expect(await po1.getDesktopGridTemplateColumns()).toBe(
-      "1fr max-content max-content"
+      "1fr 1fr max-content"
     );
+    expect(await po1.getMobileGridTemplateColumns()).toBe("1fr max-content");
     expect(await po1.getMobileGridTemplateAreas()).toBe(
       '"first-cell last-cell" "cell-0 cell-0"'
     );
@@ -117,7 +121,7 @@ describe("ResponseTable", () => {
       tableData,
     });
     expect(await po2.getDesktopGridTemplateColumns()).toBe(
-      "1fr max-content max-content max-content max-content max-content"
+      "1fr 1fr max-content 1fr 1fr max-content"
     );
     expect(await po2.getMobileGridTemplateAreas()).toBe(
       '"first-cell last-cell" "cell-0 cell-0" "cell-1 cell-1" "cell-2 cell-2" "cell-3 cell-3"'

--- a/frontend/src/tests/page-objects/ResponsiveTable.page-object.ts
+++ b/frontend/src/tests/page-objects/ResponsiveTable.page-object.ts
@@ -40,6 +40,10 @@ export class ResponsiveTablePo extends BasePageObject {
     return this.getStyleVariable("desktop-grid-template-columns");
   }
 
+  getMobileGridTemplateColumns(): Promise<string> {
+    return this.getStyleVariable("mobile-grid-template-columns");
+  }
+
   getMobileGridTemplateAreas(): Promise<string> {
     return this.getStyleVariable("mobile-grid-template-areas");
   }


### PR DESCRIPTION
# Motivation

We want to align the neuron ID copy icons across different rows in the neuron table.
For this we nee a subgrid within the neuron ID cell, with an extra grid line aligning the icons.
The first step for this is to allow customizing the template columns.
In the next step we'll allow multiple grid columns/rows per table column/row so the `templateColumns` field on the `ResponsiveTableColumn` is already an array, even though for now, arrays with a size unequal to 1 don't work yet.

Currently we assume that the template columns are always `1fr` for the first column and `max-content` for every other column. In this PR we make that explicit. And in a future PR we'll actually customize it.

# Changes

1. Add `TemplateItem` type and `templateColumns` field in `ResponsiveTableColumn`.
2. Specify the `templateColumns` for each column in the column spec of the `TokensTable` and `NeuronsTable`.
3. Generate `desktopGridTemplateColumns` based on the column spec instead of always assuming `1fr max-content max-content ...`.
4. Use the template from the first and last column in the mobile grid template columns.

# Tests

1. Unit tests added/updated.
2. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [ ] Add entry to changelog (if necessary).
not yet