### PR TITLE
build: bump to next version numer

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -250,9 +250,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.3.3-next-2024-05-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.3-next-2024-05-27.tgz",
-      "integrity": "sha512-5bXzY/wgVe/Wc0F5bZ4q3F7Dea9aODJqxJN/tMYrrrMe6mqi4D8Of4XBVbRQlm4fIjf5yUQxtGlXjWm5EO9FDw==",
+      "version": "2.4.0-next-2024-06-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.4.0-next-2024-06-05.1.tgz",
+      "integrity": "sha512-4M/byDTJjgI5arotfYmi/OaTA3Kf6+nOAMMCWB7FjJYDslzZbZhZe7lmf/fdIt3VsitrEUiohGvDudNn0NuFxQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.0.5-next-2024-05-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.5-next-2024-05-27.tgz",
-      "integrity": "sha512-MPHYO2/pBgNS+ryce3UBpavQ3KCyhSuefoUq2WSGsKVzbkCS3et4xOSM1oR6RYYuuVxKkDO+8ikFDK6yy53Pyw==",
+      "version": "3.0.6-next-2024-06-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.6-next-2024-06-05.1.tgz",
+      "integrity": "sha512-8X8G0LrBiWI5QlKSq2cG4Z8lnmshJm0OsuIKZaVmFhJ6q0+d3dbXIw4D6jv3dTRRygwtXCvCIfdflno/WEoEfQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -294,9 +294,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "4.0.0-next-2024-05-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-4.0.0-next-2024-05-27.tgz",
-      "integrity": "sha512-kR1eWSwdKmFYLotIv0r9VQee40EjuaFSB2x+b282hzA8Ayq6He4apx/1mGnmBFsps5pD3G9UddL293Tij63zEQ==",
+      "version": "5.0.0-next-2024-06-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.0.0-next-2024-06-05.1.tgz",
+      "integrity": "sha512-ykdgxZdHuTyS/zoNqBlr4jnqq2pqBw3jcmXp9KWmqEXnUwNOf8v/uIf0ZcFQtV0nEOvVdKmRVdPGUtCG/Zsvqg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -321,9 +321,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.2.4-next-2024-05-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.4-next-2024-05-27.tgz",
-      "integrity": "sha512-fOa9caedbZwcjKQTHnGWWrnin2ZyrQ3cVpacQycHisfu0qMFWeI9SAZANpGA4iaYcJbbNUZxx9ojmh7MFvRzgw==",
+      "version": "2.3.0-next-2024-06-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.3.0-next-2024-06-05.1.tgz",
+      "integrity": "sha512-8fjvNpe00pTJcGRsNvH98xeaB1BG2yLDqt5qlsmvcvBk1bLq4bOd7C3KlASv3Ws+th6HpxEbQID3NOOiONGxvQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -333,9 +333,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.3.1-next-2024-05-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.3.1-next-2024-05-27.tgz",
-      "integrity": "sha512-N4AtH7XLVVHnBdrukMTFAqwmvw/VBuMztAs9M23QpBfa172jCu2IjT5/LE/m/SXjq9lg4G6GoT5LImY2bFFtlw==",
+      "version": "2.3.2-next-2024-06-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.3.2-next-2024-06-05.1.tgz",
+      "integrity": "sha512-MIc9Qtv1F4WAIgDsUt5xiXSWlA80zAfeR7+f/fB21IFMX16CKlBO01Cx2SRJXs8VUZ1xDgE/rSUcnrFxZJ5Dzw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -345,9 +345,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "5.1.0-next-2024-05-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.1.0-next-2024-05-27.tgz",
-      "integrity": "sha512-vfsBg8xGdQnMHf8by4xNjMjnOCQ0JH+Vf3eegsNiEmsC7YZZ0sAk0hF/1dmtZ+vYlJ0iu4u3qJkVfzCnx1qorQ==",
+      "version": "5.1.1-next-2024-06-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.1.1-next-2024-06-05.1.tgz",
+      "integrity": "sha512-nLosRF+UOCIK8BhKpfJJlgWj5Ux664viYjjp5jqsvprHjsLeA9rBjGARXoLDFrRU4ChZ0WwpTofLQpnpFuZfsQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -370,9 +370,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.0.4-next-2024-05-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.4-next-2024-05-27.tgz",
-      "integrity": "sha512-dYZQntrY01iabbT5oPKEww7YuhddyseCqz8M0zWAonsVTxmnU50iDei/7xcDFFrT3mSIh7E4JAQyRVdOiBDitA==",
+      "version": "3.0.5-next-2024-06-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.5-next-2024-06-05.1.tgz",
+      "integrity": "sha512-Yyy7Ckp4ymXobUG5f27/zh7g2xJfGTNRZCFeP5nh22RHc0roK8vp3X8MRclTGRKNAenL1F6cIQnzxLEVKnQeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
@@ -386,9 +386,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.3.0-next-2024-05-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.3.0-next-2024-05-27.tgz",
-      "integrity": "sha512-Uv/SuwPQpzdMl8yZ+hf4sU5YDQYpOkSwUO+AFr5nlusBifFTFLqHQESGTg+OuYPsNyH26+F/9IVGuHnpz7kiZQ==",
+      "version": "2.3.0-next-2024-06-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.3.0-next-2024-06-05.1.tgz",
+      "integrity": "sha512-gZbLQwu07Hc80O0C+YeFYq1jpl/U1tFsI/wqbIanv1oo/O4wxwBrp7i4Ca41hklSJNe/sZdasfDPNC5LkPH6Cw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -7043,9 +7043,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.3.3-next-2024-05-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.3.3-next-2024-05-27.tgz",
-      "integrity": "sha512-5bXzY/wgVe/Wc0F5bZ4q3F7Dea9aODJqxJN/tMYrrrMe6mqi4D8Of4XBVbRQlm4fIjf5yUQxtGlXjWm5EO9FDw==",
+      "version": "2.4.0-next-2024-06-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.4.0-next-2024-06-05.1.tgz",
+      "integrity": "sha512-4M/byDTJjgI5arotfYmi/OaTA3Kf6+nOAMMCWB7FjJYDslzZbZhZe7lmf/fdIt3VsitrEUiohGvDudNn0NuFxQ==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7053,9 +7053,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.0.5-next-2024-05-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.5-next-2024-05-27.tgz",
-      "integrity": "sha512-MPHYO2/pBgNS+ryce3UBpavQ3KCyhSuefoUq2WSGsKVzbkCS3et4xOSM1oR6RYYuuVxKkDO+8ikFDK6yy53Pyw==",
+      "version": "3.0.6-next-2024-06-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.6-next-2024-06-05.1.tgz",
+      "integrity": "sha512-8X8G0LrBiWI5QlKSq2cG4Z8lnmshJm0OsuIKZaVmFhJ6q0+d3dbXIw4D6jv3dTRRygwtXCvCIfdflno/WEoEfQ==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7069,9 +7069,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "4.0.0-next-2024-05-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-4.0.0-next-2024-05-27.tgz",
-      "integrity": "sha512-kR1eWSwdKmFYLotIv0r9VQee40EjuaFSB2x+b282hzA8Ayq6He4apx/1mGnmBFsps5pD3G9UddL293Tij63zEQ==",
+      "version": "5.0.0-next-2024-06-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.0.0-next-2024-06-05.1.tgz",
+      "integrity": "sha512-ykdgxZdHuTyS/zoNqBlr4jnqq2pqBw3jcmXp9KWmqEXnUwNOf8v/uIf0ZcFQtV0nEOvVdKmRVdPGUtCG/Zsvqg==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7085,21 +7085,21 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.2.4-next-2024-05-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.2.4-next-2024-05-27.tgz",
-      "integrity": "sha512-fOa9caedbZwcjKQTHnGWWrnin2ZyrQ3cVpacQycHisfu0qMFWeI9SAZANpGA4iaYcJbbNUZxx9ojmh7MFvRzgw==",
+      "version": "2.3.0-next-2024-06-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.3.0-next-2024-06-05.1.tgz",
+      "integrity": "sha512-8fjvNpe00pTJcGRsNvH98xeaB1BG2yLDqt5qlsmvcvBk1bLq4bOd7C3KlASv3Ws+th6HpxEbQID3NOOiONGxvQ==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.3.1-next-2024-05-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.3.1-next-2024-05-27.tgz",
-      "integrity": "sha512-N4AtH7XLVVHnBdrukMTFAqwmvw/VBuMztAs9M23QpBfa172jCu2IjT5/LE/m/SXjq9lg4G6GoT5LImY2bFFtlw==",
+      "version": "2.3.2-next-2024-06-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.3.2-next-2024-06-05.1.tgz",
+      "integrity": "sha512-MIc9Qtv1F4WAIgDsUt5xiXSWlA80zAfeR7+f/fB21IFMX16CKlBO01Cx2SRJXs8VUZ1xDgE/rSUcnrFxZJ5Dzw==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "5.1.0-next-2024-05-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.1.0-next-2024-05-27.tgz",
-      "integrity": "sha512-vfsBg8xGdQnMHf8by4xNjMjnOCQ0JH+Vf3eegsNiEmsC7YZZ0sAk0hF/1dmtZ+vYlJ0iu4u3qJkVfzCnx1qorQ==",
+      "version": "5.1.1-next-2024-06-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.1.1-next-2024-06-05.1.tgz",
+      "integrity": "sha512-nLosRF+UOCIK8BhKpfJJlgWj5Ux664viYjjp5jqsvprHjsLeA9rBjGARXoLDFrRU4ChZ0WwpTofLQpnpFuZfsQ==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -7114,17 +7114,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.0.4-next-2024-05-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.4-next-2024-05-27.tgz",
-      "integrity": "sha512-dYZQntrY01iabbT5oPKEww7YuhddyseCqz8M0zWAonsVTxmnU50iDei/7xcDFFrT3mSIh7E4JAQyRVdOiBDitA==",
+      "version": "3.0.5-next-2024-06-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.5-next-2024-06-05.1.tgz",
+      "integrity": "sha512-Yyy7Ckp4ymXobUG5f27/zh7g2xJfGTNRZCFeP5nh22RHc0roK8vp3X8MRclTGRKNAenL1F6cIQnzxLEVKnQeDw==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.3.0-next-2024-05-27",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.3.0-next-2024-05-27.tgz",
-      "integrity": "sha512-Uv/SuwPQpzdMl8yZ+hf4sU5YDQYpOkSwUO+AFr5nlusBifFTFLqHQESGTg+OuYPsNyH26+F/9IVGuHnpz7kiZQ==",
+      "version": "2.3.0-next-2024-06-05.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.3.0-next-2024-06-05.1.tgz",
+      "integrity": "sha512-gZbLQwu07Hc80O0C+YeFYq1jpl/U1tFsI/wqbIanv1oo/O4wxwBrp7i4Ca41hklSJNe/sZdasfDPNC5LkPH6Cw==",
       "requires": {}
     },
     "@esbuild/android-arm": {


### PR DESCRIPTION
# Motivation

We release ic-js [2024.06.05-0835Z](https://github.com/dfinity/ic-js/releases/tag/2024.06.05-0835Z) earlier today. This PR hooks the libraries to their new version number for the next versions.

# Changes

```
npm rm @dfinity/nns @dfinity/cmc @dfinity/sns @dfinity/utils @dfinity/ledger-icrc @dfinity/ledger-icp @dfinity/ckbtc @dfinity/ic-management && npm i @dfinity/utils@next @dfinity/ledger-icrc@next @dfinity/ledger-icp@next @dfinity/nns@next @dfinity/cmc@next @dfinity/sns@next @dfinity/ckbtc@next @dfinity/ic-management@next && ../scripts/revert-next.sh
```
