### PR TITLE
NNS1-3092: Add horizontal scrollbar to neurons table

### DIFF
--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -89,7 +89,7 @@
 
     border-radius: var(--border-radius);
     // Otherwise the non-rounded corners of the header and last row would be visible.
-    overflow: hidden;
+    overflow-y: auto;
 
     @include media.min-width(medium) {
       display: grid;


### PR DESCRIPTION
# Motivation

The neurons can be cut off on a narrow viewport and we plan to add even more columns.
We need to make sure that the whole table can be reached.

# Changes

Change `overflow: hidden` to `overflow-y: auto` on the responsive table.

# Tests

Manually.
I tried to make a screen recording but somehow while recording the scrollbar doesn't appear.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet