### PR TITLE
NNS1-3092: Align neuron ID copy icons in table

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
@@ -1,13 +1,23 @@
-<script lang="ts">
-  import type { TableNeuron } from "$lib/types/neurons-table";
-  import IdentifierHash from "$lib/components/ui/IdentifierHash.svelte";
-  import { Tag } from "@dfinity/gix-components";
-
-  export let rowData: TableNeuron;
+<script lang="ts" context="module">
+  let nextElementIdNumber = 0;
 </script>
 
-<div data-tid="neuron-id-cell-component">
-  <IdentifierHash identifier={rowData.neuronId} />
+<script lang="ts">
+  import type { TableNeuron } from "$lib/types/neurons-table";
+  import Hash from "$lib/components/ui/Hash.svelte";
+  import { Copy, Tag } from "@dfinity/gix-components";
+
+  export let rowData: TableNeuron;
+
+  let elementId = `neuron-id-cell-${nextElementIdNumber}`;
+  ++nextElementIdNumber;
+</script>
+
+<div data-tid="neuron-id-cell-component" class="container">
+  <span class="hash"
+    ><Hash text={rowData.neuronId} tagName="span" id={elementId} /></span
+  >
+  <Copy value={rowData.neuronId} />
   <div class="tags">
     {#each rowData.tags as tag}
       <Tag testId="neuron-tag">{tag}</Tag>
@@ -16,8 +26,22 @@
 </div>
 
 <style lang="scss">
+  .container {
+    display: grid;
+    grid-row: span 2;
+    grid-column: span 3;
+    grid-template-rows: subgrid;
+    grid-template-columns: subgrid;
+    gap: 0;
+  }
+
+  .hash {
+    align-self: center;
+  }
+
   .tags {
     display: flex;
     gap: var(--padding);
+    grid-column: 1/-1;
   }
 </style>

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
@@ -32,7 +32,7 @@
       title: $i18n.neurons.neuron_id,
       cellComponent: NeuronIdCell,
       alignment: "left",
-      templateColumns: ["1fr"],
+      templateColumns: ["max-content", "max-content", "1fr"],
     },
     {
       title: $i18n.neuron_detail.stake,
@@ -64,5 +64,6 @@
 <ResponsiveTable
   testId="neurons-table-component"
   {columns}
+  gridRowsPerTableRow="2"
   tableData={sortedNeurons}
 ></ResponsiveTable>

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
@@ -64,6 +64,6 @@
 <ResponsiveTable
   testId="neurons-table-component"
   {columns}
-  gridRowsPerTableRow="2"
+  gridRowsPerTableRow={2}
   tableData={sortedNeurons}
 ></ResponsiveTable>

--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -14,13 +14,15 @@
   export let testId = "responsive-table-component";
   export let tableData: Array<RowDataType>;
   export let columns: ResponsiveTableColumn<RowDataType>[];
+  export let gridRowsPerTableRow = 1;
 
-  // We don't render a header for the last column.
   let firstColumn: ResponsiveTableColumn<RowDataType> | undefined;
   let middleColumns: ResponsiveTableColumn<RowDataType>[];
+  let lastColumn: ResponsiveTableColumn<RowDataType> | undefined;
 
   $: firstColumn = columns.at(0);
   $: middleColumns = columns.slice(1, -1);
+  $: lastColumn = columns.at(-1);
 
   const getTableStyle = (columns: ResponsiveTableColumn<RowDataType>[]) => {
     // On desktop the first column gets all the remaining space after other
@@ -38,6 +40,7 @@
       mobileGridTemplateAreas += ` "${areaName} ${areaName}"`;
     }
     return (
+      `--grid-rows-per-table-row: ${gridRowsPerTableRow}; ` +
       `--desktop-grid-template-columns: ${desktopGridTemplateColumns}; ` +
       `--mobile-grid-template-areas: ${mobileGridTemplateAreas};`
     );
@@ -51,18 +54,25 @@
   <div role="rowgroup">
     <div role="row" class="header-row">
       {#if firstColumn}
-        <span role="columnheader" data-tid="column-header-1"
-          >{firstColumn.title}</span
+        <span
+          role="columnheader"
+          style="--column-span: {firstColumn.templateColumns.length}"
+          data-tid="column-header-1">{firstColumn.title}</span
         >
       {/if}
       {#each middleColumns as column, index}
         <span
           role="columnheader"
+          style="--column-span: {column.templateColumns.length}"
           data-tid="column-header-{index + 2}"
           class="header-right">{column.title}</span
         >
       {/each}
-      <span role="columnheader" class="header-right header-icon">
+      <span
+        role="columnheader"
+        style="--column-span: {lastColumn.templateColumns.length}"
+        class="header-right header-icon"
+      >
         <slot name="header-icon" />
       </span>
     </div>
@@ -119,6 +129,8 @@
 
       [role="columnheader"] {
         display: none;
+
+        grid-column: span var(--column-span);
 
         &:first-child,
         &:last-child {

--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -68,13 +68,15 @@
           class="header-right">{column.title}</span
         >
       {/each}
-      <span
-        role="columnheader"
-        style="--column-span: {lastColumn.templateColumns.length}"
-        class="header-right header-icon"
-      >
-        <slot name="header-icon" />
-      </span>
+      {#if lastColumn}
+        <span
+          role="columnheader"
+          style="--column-span: {lastColumn.templateColumns.length}"
+          class="header-right header-icon"
+        >
+          <slot name="header-icon" />
+        </span>
+      {/if}
     </div>
   </div>
   <div role="rowgroup">

--- a/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
@@ -126,7 +126,7 @@
     // But the cells that expect to be in a grid, still need their grid
     // defined. This happens in the cell-body div. On desktop these get
     // `display: contents` to get their grid lines from the larger grid, while
-    // on desktop they get their own grid from `--mobile-template-columns`.
+    // on mobile they get their own grid from `--mobile-template-columns`.
 
     // Styles applied to desktop and mobile:
 

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -106,7 +106,13 @@ describe("NeuronsTable", () => {
     const po = renderComponent({ neurons: [neuron1] });
 
     expect(await po.getDesktopGridTemplateColumns()).toBe(
-      "1fr max-content max-content max-content max-content"
+      [
+        "max-content max-content 1fr", // Neuron ID
+        "max-content", // Stake
+        "max-content", // State
+        "max-content", // Dissolve Delay
+        "max-content", // Actions
+      ].join(" ")
     );
     expect(await po.getMobileGridTemplateAreas()).toBe(
       '"first-cell last-cell" "cell-0 cell-0" "cell-1 cell-1" "cell-2 cell-2"'

--- a/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
@@ -148,12 +148,12 @@ describe("ResponseTable", () => {
     // The first and last cell have grid areas set in CSS directly rather than
     // through the style attribute.
     const expectedStyles = [
-      "--column-span: 2; --template-columns: 1fr max-content;",
-      "--grid-area-name: cell-0; --column-span: 1; --template-columns: 1fr;",
-      "--grid-area-name: cell-1; --column-span: 1; --template-columns: max-content;",
-      "--grid-area-name: cell-2; --column-span: 2; --template-columns: 1fr max-content;",
-      "--grid-area-name: cell-3; --column-span: 1; --template-columns: 1fr;",
-      "--column-span: 1; --template-columns: max-content;",
+      "--desktop-column-span: 2;--mobile-template-columns: 1fr max-content;",
+      "--desktop-column-span: 1;--mobile-template-columns: 1fr;--grid-area-name: cell-0;",
+      "--desktop-column-span: 1;--mobile-template-columns: max-content;--grid-area-name: cell-1;",
+      "--desktop-column-span: 2;--mobile-template-columns: 1fr max-content;--grid-area-name: cell-2;",
+      "--desktop-column-span: 1;--mobile-template-columns: 1fr;--grid-area-name: cell-3;",
+      "--desktop-column-span: 1;--mobile-template-columns: max-content;",
     ];
 
     const rows = await po.getRows();

--- a/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
@@ -11,7 +11,7 @@ describe("ResponseTable", () => {
       title: "Name",
       cellComponent: TestTableNameCell,
       alignment: "left",
-      templateColumns: ["1fr"],
+      templateColumns: ["1fr", "max-content"],
     },
     {
       title: "Age",
@@ -108,7 +108,11 @@ describe("ResponseTable", () => {
     // 3 columns
     const po1 = renderComponent({ columns, tableData });
     expect(await po1.getDesktopGridTemplateColumns()).toBe(
-      "1fr 1fr max-content"
+      [
+        "1fr max-content", // Name
+        "1fr", // Age
+        "max-content", // Actions
+      ].join(" ")
     );
     expect(await po1.getMobileGridTemplateAreas()).toBe(
       '"first-cell last-cell" "cell-0 cell-0"'
@@ -120,7 +124,14 @@ describe("ResponseTable", () => {
       tableData,
     });
     expect(await po2.getDesktopGridTemplateColumns()).toBe(
-      "1fr 1fr max-content 1fr 1fr max-content"
+      [
+        "1fr max-content", // Name
+        "1fr", // Age
+        "max-content", // Actions
+        "1fr max-content", // Name
+        "1fr", // Age
+        "max-content", // Actions
+      ].join(" ")
     );
     expect(await po2.getMobileGridTemplateAreas()).toBe(
       '"first-cell last-cell" "cell-0 cell-0" "cell-1 cell-1" "cell-2 cell-2" "cell-3 cell-3"'
@@ -137,12 +148,12 @@ describe("ResponseTable", () => {
     // The first and last cell have grid areas set in CSS directly rather than
     // through the style attribute.
     const expectedStyles = [
-      null,
-      "--grid-area-name: cell-0;",
-      "--grid-area-name: cell-1;",
-      "--grid-area-name: cell-2;",
-      "--grid-area-name: cell-3;",
-      null,
+      "--column-span: 2; --template-columns: 1fr max-content;",
+      "--grid-area-name: cell-0; --column-span: 1; --template-columns: 1fr;",
+      "--grid-area-name: cell-1; --column-span: 1; --template-columns: max-content;",
+      "--grid-area-name: cell-2; --column-span: 2; --template-columns: 1fr max-content;",
+      "--grid-area-name: cell-3; --column-span: 1; --template-columns: 1fr;",
+      "--column-span: 1; --template-columns: max-content;",
     ];
 
     const rows = await po.getRows();

--- a/frontend/src/tests/page-objects/NeuronIdCell.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronIdCell.page-object.ts
@@ -1,5 +1,5 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
-import { IdentifierHashPo } from "$tests/page-objects/IdentifierHash.page-object";
+import { HashPo } from "$tests/page-objects/Hash.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NeuronIdCellPo extends BasePageObject {
@@ -9,12 +9,12 @@ export class NeuronIdCellPo extends BasePageObject {
     return new NeuronIdCellPo(element.byTestId(NeuronIdCellPo.TID));
   }
 
-  getIdentifierHashPo(): IdentifierHashPo {
-    return IdentifierHashPo.under(this.root);
+  getHashPo(): HashPo {
+    return HashPo.under(this.root);
   }
 
   getNeurondId(): Promise<string> {
-    return this.getIdentifierHashPo().getFullText();
+    return this.getHashPo().getFullText();
   }
 
   async getTags(): Promise<string[]> {


### PR DESCRIPTION
# Motivation

Because we don't use a fixed-width font for the neuron IDs, they don't all have exactly the same width.
This means the copy icons right after them are not aligned, which looks off.

To solve this we define extra grid lines in the table and use them to align the copy icons.

# Changes

1. Allow specifying multiple grid columns per table columns and multiple grid rows per table row.
2. Specify 2 grid rows per table row and 3 grid columns for the first table column of the neurons table.
3. Use the extra grid columns for the copy icon and the empty space and the extra row for the neuron tags.
4. Change the `NeuronIdCell` component to use separate elements for the ID and the copy icon so they go into separate columns.

# Tests

1. Unit tests updated.
2. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/


# Todos

- [ ] Add entry to changelog (if necessary).
not yet