### PR TITLE
Update rust version to 1.78.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Please, from time to time, update this to the latest stable version on Rust Forge: https://forge.rust-lang.org/
-channel = "1.77.2"
+channel = "1.78.0"
 components = ["rustfmt", "clippy"]
 targets = [ "wasm32-unknown-unknown"]


### PR DESCRIPTION
# Motivation
A new verion of Rust is available.

# Automated changes
* Update Rust version.

# Manual changes
- [ ] Fix clippy lints (if necessary)
- [ ] Write a changelog entry.