### PR TITLE
NNS1-3092: Tooltip on spawning neuron state

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronStateCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronStateCell.svelte
@@ -1,8 +1,19 @@
 <script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
+  import { Tooltip } from "@dfinity/gix-components";
   import NeuronStateInfo from "$lib/components/neurons/NeuronStateInfo.svelte";
   import type { TableNeuron } from "$lib/types/neurons-table";
+  import { NeuronState } from "@dfinity/nns";
 
   export let rowData: TableNeuron;
 </script>
 
-<NeuronStateInfo state={rowData.state} />
+<Tooltip
+  testId="neuron-state-cell-component"
+  id="spawning-neuron-{rowData.neuronId}"
+  text={rowData.state === NeuronState.Spawning
+    ? $i18n.neuron_detail.spawning_neuron_info
+    : undefined}
+>
+  <NeuronStateInfo state={rowData.state} />
+</Tooltip>

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -177,6 +177,22 @@ describe("NeuronsTable", () => {
     expect(await rowPos[1].hasGoToDetailButton()).toBe(false);
   });
 
+  it("should have a tooltip for spawning neurons", async () => {
+    const po = renderComponent({ neurons: [neuron1, spawningNeuron] });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const rowPos = await po.getNeuronsTableRowPos();
+    expect(rowPos).toHaveLength(2);
+    expect(await rowPos[0].getNeuronStateCellPo().isTooltipEnabled()).toBe(
+      false
+    );
+    expect(await rowPos[1].getNeuronStateCellPo().isTooltipEnabled()).toBe(
+      true
+    );
+    expect(await rowPos[1].getNeuronStateCellPo().getTooltipText()).toBe(
+      "When this neuron has finished spawning, newly minted ICP will be added. The quantity of new ICP minted will depend on the ICP price trend. You will then be able to disburse this new ICP if you wish."
+    );
+  });
+
   it("should render tags", async () => {
     const tags = ["Neuron's fund", "Hotkey control"];
     const po = renderComponent({

--- a/frontend/src/tests/page-objects/NeuronStateCell.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronStateCell.page-object.ts
@@ -1,0 +1,19 @@
+import { NeuronStateInfoPo } from "$tests/page-objects/NeuronStateInfo.page-object";
+import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class NeuronStateCellPo extends TooltipPo {
+  private static readonly TID = "neuron-state-cell-component";
+
+  static under(element: PageObjectElement): NeuronStateCellPo {
+    return new NeuronStateCellPo(element.byTestId(NeuronStateCellPo.TID));
+  }
+
+  getNeuronStateInfoPo(): NeuronStateInfoPo {
+    return NeuronStateInfoPo.under(this.root);
+  }
+
+  getState(): Promise<string> {
+    return this.getNeuronStateInfoPo().getState();
+  }
+}

--- a/frontend/src/tests/page-objects/NeuronsTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronsTableRow.page-object.ts
@@ -1,5 +1,5 @@
 import { NeuronIdCellPo } from "$tests/page-objects/NeuronIdCell.page-object";
-import { NeuronStateInfoPo } from "$tests/page-objects/NeuronStateInfo.page-object";
+import { NeuronStateCellPo } from "$tests/page-objects/NeuronStateCell.page-object";
 import { ResponsiveTableRowPo } from "$tests/page-objects/ResponsiveTableRow.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -20,8 +20,8 @@ export class NeuronsTableRowPo extends ResponsiveTableRowPo {
     return NeuronIdCellPo.under(this.root);
   }
 
-  getNeuronStateInfoPo(): NeuronStateInfoPo {
-    return NeuronStateInfoPo.under(this.root);
+  getNeuronStateCellPo(): NeuronStateCellPo {
+    return NeuronStateCellPo.under(this.root);
   }
 
   getNeuronId(): Promise<string> {
@@ -37,7 +37,7 @@ export class NeuronsTableRowPo extends ResponsiveTableRowPo {
   }
 
   getState(): Promise<string> {
-    return this.getNeuronStateInfoPo().getState();
+    return this.getNeuronStateCellPo().getState();
   }
 
   getDissolveDelay(): Promise<string> {

--- a/frontend/src/tests/page-objects/Tooltip.page-object.ts
+++ b/frontend/src/tests/page-objects/Tooltip.page-object.ts
@@ -3,10 +3,10 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 import { assertNonNullish } from "$tests/utils/utils.test-utils";
 
 export class TooltipPo extends BasePageObject {
-  private static readonly TID = "tooltip-component";
+  private static readonly TOOLTIP_TID = "tooltip-component";
 
   static under(element: PageObjectElement): TooltipPo {
-    return new TooltipPo(element.byTestId(TooltipPo.TID));
+    return new TooltipPo(element.byTestId(TooltipPo.TOOLTIP_TID));
   }
 
   async getTooltipText(): Promise<string> {
@@ -23,11 +23,17 @@ export class TooltipPo extends BasePageObject {
     return (await this.getTooltipElement()).getAttribute("id");
   }
 
+  async isTooltipEnabled(): Promise<boolean> {
+    return !(await (await this.getTooltipElement()).getClasses()).includes(
+      "not-rendered"
+    );
+  }
+
   async getTooltipElement(): Promise<PageObjectElement> {
     const id = await this.getAriaDescribedBy();
     const body = await this.root.getDocumentBody();
-    const tooltipElemenet = body.querySelector(`#${id}`);
-    return tooltipElemenet;
+    const tooltipElement = body.querySelector(`#${id}`);
+    return tooltipElement;
   }
 
   async getDisplayedText(): Promise<string> {


### PR DESCRIPTION
# Motivation

Spawning neuron cards have a tooltip explaining spawning.
To keep feature parity, we should have the same tooltip in the neurons table.

# Changes

Add a tooltip on the neuron state table cell if it's a spawning neuron state.

# Tests

1. Unit test added
2. Page objects added/updated.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet