### PR TITLE
NNS1-3092: Neurons table column spacing

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
@@ -38,19 +38,19 @@
       title: $i18n.neuron_detail.stake,
       cellComponent: NeuronStakeCell,
       alignment: "right",
-      templateColumns: ["max-content"],
+      templateColumns: ["1fr"],
     },
     {
       title: $i18n.neurons.state,
       cellComponent: NeuronStateCell,
-      alignment: "left",
-      templateColumns: ["max-content"],
+      alignment: "right",
+      templateColumns: ["1fr"],
     },
     {
       title: $i18n.neurons.dissolve_delay_title,
       cellComponent: NeuronDissolveDelayCell,
       alignment: "right",
-      templateColumns: ["max-content"],
+      templateColumns: ["1fr"],
     },
     {
       title: "",

--- a/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
@@ -93,7 +93,6 @@
   [role="row"] {
     display: grid;
     flex-direction: column;
-    gap: var(--padding-2x);
 
     text-decoration: none;
 

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -96,7 +96,7 @@ describe("NeuronsTable", () => {
     expect(await rows[0].getCellClasses()).toEqual([
       expect.arrayContaining(["desktop-align-left"]), // Neuron ID
       expect.arrayContaining(["desktop-align-right"]), // Stake
-      expect.arrayContaining(["desktop-align-left"]), // State
+      expect.arrayContaining(["desktop-align-right"]), // State
       expect.arrayContaining(["desktop-align-right"]), // Dissolve Delay
       expect.arrayContaining(["desktop-align-right"]), // Actions
     ]);
@@ -108,9 +108,9 @@ describe("NeuronsTable", () => {
     expect(await po.getDesktopGridTemplateColumns()).toBe(
       [
         "max-content max-content 1fr", // Neuron ID
-        "max-content", // Stake
-        "max-content", // State
-        "max-content", // Dissolve Delay
+        "1fr", // Stake
+        "1fr", // State
+        "1fr", // Dissolve Delay
         "max-content", // Actions
       ].join(" ")
     );


### PR DESCRIPTION
# Motivation

Share the additional space more equally between columns.

# Changes

1. Apply `1fr` column template to every column except the actions column.
2. Make the neuron state right-aligned again.

Drive-by: Remove the `gap` style on the `ResponsiveTableRow` because the table already defines a `column-gap` [here](https://github.com/dfinity/nns-dapp/blob/c8319c303d93cbc0c12181a78054ed0ae815ed85/frontend/src/lib/components/ui/ResponsiveTable.svelte#L113).

# Tests

Tested manually.

<img width="885" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/095d033f-bfbf-40d6-bad3-641b69345220">


# Todos

- [ ] Add entry to changelog (if necessary).
not yet