### PR TITLE
Remove obsolete record from the unreleased changelog

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -15,7 +15,6 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
-* Enabled `ENABLE_CKUSDC` feature flag.
 * Actionable proposals page.
 
 #### Changed


### PR DESCRIPTION
# Motivation

Remove [already released entry](https://github.com/dfinity/nns-dapp/blob/cfa63fc45bd2e6c751fe2eb0a38e4246b23439ef/CHANGELOG-Nns-Dapp.md?plain=1#L20) from the unreleased changelog to keep it clean.

This line was already removed in https://github.com/dfinity/nns-dapp/pull/5008 after the previous release.
But it was accidentally merged back in https://github.com/dfinity/nns-dapp/pull/5014.

# Changes

- Remove 1 entry.

# Tests

Changelog only changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.