### PR TITLE
bot: Update proposals candid bindings

### DIFF
--- a/declarations/used_by_proposals/nns_governance/nns_governance.did
+++ b/declarations/used_by_proposals/nns_governance/nns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-29_23-02-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-05_23-01-base/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;

--- a/declarations/used_by_proposals/nns_registry/nns_registry.did
+++ b/declarations/used_by_proposals/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-29_23-02-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-05_23-01-base/rs/registry/canister/canister/registry.did>
 // A brief note about the history of this file: This file used to be
 // automatically generated, but now, it is hand-crafted, because the
 // auto-generator has some some pretty degenerate behaviors. The worst of those
@@ -174,9 +174,22 @@ type FirewallRulesScope = variant {
   Global;
 };
 
+type GetNodeOperatorsAndDcsOfNodeProviderResponse = variant {
+  Ok : vec record { DataCenterRecord; NodeOperatorRecord };
+  Err : text;
+};
+
+type GetNodeProvidersMonthlyXdrRewardsResponse = variant {
+  Ok : NodeProvidersMonthlyXdrRewards;
+  Err : text;
+};
+
 type GetSubnetForCanisterRequest = record { "principal" : opt principal };
 
-type GetSubnetForCanisterResponse = record { subnet_id : opt principal };
+type GetSubnetForCanisterResponse = variant {
+  Ok : record { subnet_id : opt principal };
+  Err : text;
+};
 
 type Gps = record { latitude : float32; longitude : float32 };
 
@@ -246,19 +259,6 @@ type RerouteCanisterRangesPayload = record {
   destination_subnet : principal;
 };
 
-type Result = variant { Ok : principal; Err : text };
-
-type Result_1 = variant { Ok; Err : text };
-
-type Result_2 = variant {
-  Ok : vec record { DataCenterRecord; NodeOperatorRecord };
-  Err : text;
-};
-
-type Result_3 = variant { Ok : NodeProvidersMonthlyXdrRewards; Err : text };
-
-type Result_4 = variant { Ok : GetSubnetForCanisterResponse; Err : text };
-
 type RetireReplicaVersionPayload = record { replica_version_ids : vec text };
 
 type ReviseElectedGuestosVersionsPayload = record {
@@ -311,10 +311,14 @@ type UpdateNodeDomainDirectlyPayload = record {
   domain : opt text;
 };
 
+type UpdateNodeDomainDirectlyResponse = variant { Ok; Err : text };
+
 type UpdateNodeIPv4ConfigDirectlyPayload = record {
   ipv4_config : opt IPv4Config;
   node_id : principal;
 };
+
+type UpdateNodeIpv4ConfigDirectlyResponse = variant { Ok; Err : text };
 
 type UpdateNodeOperatorConfigDirectlyPayload = record {
   node_operator_id : opt principal;
@@ -386,16 +390,14 @@ type UpdateUnassignedNodesConfigPayload = record {
 service : {
   add_api_boundary_nodes : (AddApiBoundaryNodesPayload) -> ();
   add_firewall_rules : (AddFirewallRulesPayload) -> ();
-  add_node : (AddNodePayload) -> (Result);
+  add_node : (AddNodePayload) -> (principal);
   add_node_operator : (AddNodeOperatorPayload) -> ();
   add_nodes_to_subnet : (AddNodesToSubnetPayload) -> ();
   add_or_remove_data_centers : (AddOrRemoveDataCentersProposalPayload) -> ();
   bless_replica_version : (BlessReplicaVersionPayload) -> ();
   change_subnet_membership : (ChangeSubnetMembershipPayload) -> ();
   clear_provisional_whitelist : () -> ();
-  complete_canister_migration : (CompleteCanisterMigrationPayload) -> (
-      Result_1,
-    );
+  complete_canister_migration : (CompleteCanisterMigrationPayload) -> ();
   create_subnet : (CreateSubnetPayload) -> ();
   delete_subnet : (DeleteSubnetPayload) -> ();
   deploy_guestos_to_all_subnet_nodes : (
@@ -405,18 +407,18 @@ service : {
       DeployGuestosToAllUnassignedNodesPayload,
     ) -> ();
   get_build_metadata : () -> (text) query;
-  get_node_operators_and_dcs_of_node_provider : (principal) -> (Result_2) query;
-  get_node_providers_monthly_xdr_rewards : () -> (Result_3) query;
-  get_subnet_for_canister : (GetSubnetForCanisterRequest) -> (Result_4) query;
-  prepare_canister_migration : (PrepareCanisterMigrationPayload) -> (Result_1);
+  get_node_operators_and_dcs_of_node_provider : (principal) -> (GetNodeOperatorsAndDcsOfNodeProviderResponse) query;
+  get_node_providers_monthly_xdr_rewards : () -> (GetNodeProvidersMonthlyXdrRewardsResponse) query;
+  get_subnet_for_canister : (GetSubnetForCanisterRequest) -> (GetSubnetForCanisterResponse) query;
+  prepare_canister_migration : (PrepareCanisterMigrationPayload) -> ();
   recover_subnet : (RecoverSubnetPayload) -> ();
   remove_api_boundary_nodes : (RemoveApiBoundaryNodesPayload) -> ();
   remove_firewall_rules : (RemoveFirewallRulesPayload) -> ();
   remove_node_directly : (RemoveNodeDirectlyPayload) -> ();
   remove_node_operators : (RemoveNodeOperatorsPayload) -> ();
   remove_nodes : (RemoveNodesPayload) -> ();
-  remove_nodes_from_subnet : (RemoveNodesFromSubnetPayload) -> ();
-  reroute_canister_ranges : (RerouteCanisterRangesPayload) -> (Result_1);
+  remove_nodes_from_subnet : (RemoveNodesPayload) -> ();
+  reroute_canister_ranges : (RerouteCanisterRangesPayload) -> ();
   retire_replica_version : (RetireReplicaVersionPayload) -> ();
   revise_elected_replica_versions : (ReviseElectedGuestosVersionsPayload) -> ();
   set_firewall_config : (SetFirewallConfigPayload) -> ();
@@ -424,10 +426,10 @@ service : {
   update_elected_hostos_versions : (UpdateElectedHostosVersionsPayload) -> ();
   update_elected_replica_versions : (ReviseElectedGuestosVersionsPayload) -> ();
   update_firewall_rules : (UpdateFirewallRulesPayload) -> ();
-  update_node_directly : (UpdateNodeDirectlyPayload) -> (Result_1);
-  update_node_domain_directly : (UpdateNodeDomainDirectlyPayload) -> (Result_1);
+  update_node_directly : (UpdateNodeDirectlyPayload) -> ();
+  update_node_domain_directly : (UpdateNodeDomainDirectlyPayload) -> (UpdateNodeDomainDirectlyResponse);
   update_node_ipv4_config_directly : (UpdateNodeIPv4ConfigDirectlyPayload) -> (
-      Result_1,
+      UpdateNodeIpv4ConfigDirectlyResponse,
     );
   update_node_operator_config : (UpdateNodeOperatorConfigPayload) -> ();
   update_node_operator_config_directly : (

--- a/declarations/used_by_proposals/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_proposals/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-29_23-02-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-05_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };

--- a/dfx.json
+++ b/dfx.json
@@ -388,7 +388,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-06-05",
-        "IC_COMMIT_FOR_PROPOSALS": "release-2024-05-29_23-02-base",
+        "IC_COMMIT_FOR_PROPOSALS": "release-2024-06-05_23-01-base",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-05-29_23-02-base"
       },
       "packtool": ""

--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-29_23-02-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-05_23-01-base/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-29_23-02-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-05_23-01-base/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -69,11 +69,6 @@ pub struct AddNodePayload {
     pub p2p_flow_endpoints: Vec<String>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
-pub enum Result_ {
-    Ok(Principal),
-    Err(String),
-}
-#[derive(Serialize, CandidType, Deserialize)]
 pub struct AddNodeOperatorPayload {
     pub ipv6: Option<String>,
     pub node_operator_principal_id: Option<Principal>,
@@ -131,11 +126,6 @@ pub struct CanisterIdRange {
 pub struct CompleteCanisterMigrationPayload {
     pub canister_id_ranges: Vec<CanisterIdRange>,
     pub migration_trace: Vec<Principal>,
-}
-#[derive(Serialize, CandidType, Deserialize)]
-pub enum Result1 {
-    Ok,
-    Err(String),
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SubnetFeatures {
@@ -231,7 +221,7 @@ pub struct NodeOperatorRecord {
     pub dc_id: String,
 }
 #[derive(Serialize, CandidType, Deserialize)]
-pub enum Result2 {
+pub enum GetNodeOperatorsAndDcsOfNodeProviderResponse {
     Ok(Vec<(DataCenterRecord, NodeOperatorRecord)>),
     Err(String),
 }
@@ -240,7 +230,7 @@ pub struct NodeProvidersMonthlyXdrRewards {
     pub rewards: Vec<(String, u64)>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
-pub enum Result3 {
+pub enum GetNodeProvidersMonthlyXdrRewardsResponse {
     Ok(NodeProvidersMonthlyXdrRewards),
     Err(String),
 }
@@ -249,12 +239,8 @@ pub struct GetSubnetForCanisterRequest {
     pub principal: Option<Principal>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
-pub struct GetSubnetForCanisterResponse {
-    pub subnet_id: Option<Principal>,
-}
-#[derive(Serialize, CandidType, Deserialize)]
-pub enum Result4 {
-    Ok(GetSubnetForCanisterResponse),
+pub enum GetSubnetForCanisterResponse {
+    Ok { subnet_id: Option<Principal> },
     Err(String),
 }
 #[derive(Serialize, CandidType, Deserialize)]
@@ -293,10 +279,6 @@ pub struct RemoveNodeOperatorsPayload {
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct RemoveNodesPayload {
-    pub node_ids: Vec<Principal>,
-}
-#[derive(Serialize, CandidType, Deserialize)]
-pub struct RemoveNodesFromSubnetPayload {
     pub node_ids: Vec<Principal>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
@@ -352,9 +334,19 @@ pub struct UpdateNodeDomainDirectlyPayload {
     pub domain: Option<String>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
+pub enum UpdateNodeDomainDirectlyResponse {
+    Ok,
+    Err(String),
+}
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateNodeIPv4ConfigDirectlyPayload {
     pub ipv4_config: Option<IPv4Config>,
     pub node_id: Principal,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub enum UpdateNodeIpv4ConfigDirectlyResponse {
+    Ok,
+    Err(String),
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateNodeOperatorConfigPayload {
@@ -449,7 +441,7 @@ impl Service {
     pub async fn add_firewall_rules(&self, arg0: AddFirewallRulesPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "add_firewall_rules", (arg0,)).await
     }
-    pub async fn add_node(&self, arg0: AddNodePayload) -> CallResult<(Result_,)> {
+    pub async fn add_node(&self, arg0: AddNodePayload) -> CallResult<(Principal,)> {
         ic_cdk::call(self.0, "add_node", (arg0,)).await
     }
     pub async fn add_node_operator(&self, arg0: AddNodeOperatorPayload) -> CallResult<()> {
@@ -470,7 +462,7 @@ impl Service {
     pub async fn clear_provisional_whitelist(&self) -> CallResult<()> {
         ic_cdk::call(self.0, "clear_provisional_whitelist", ()).await
     }
-    pub async fn complete_canister_migration(&self, arg0: CompleteCanisterMigrationPayload) -> CallResult<(Result1,)> {
+    pub async fn complete_canister_migration(&self, arg0: CompleteCanisterMigrationPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "complete_canister_migration", (arg0,)).await
     }
     pub async fn create_subnet(&self, arg0: CreateSubnetPayload) -> CallResult<()> {
@@ -494,16 +486,24 @@ impl Service {
     pub async fn get_build_metadata(&self) -> CallResult<(String,)> {
         ic_cdk::call(self.0, "get_build_metadata", ()).await
     }
-    pub async fn get_node_operators_and_dcs_of_node_provider(&self, arg0: Principal) -> CallResult<(Result2,)> {
+    pub async fn get_node_operators_and_dcs_of_node_provider(
+        &self,
+        arg0: Principal,
+    ) -> CallResult<(GetNodeOperatorsAndDcsOfNodeProviderResponse,)> {
         ic_cdk::call(self.0, "get_node_operators_and_dcs_of_node_provider", (arg0,)).await
     }
-    pub async fn get_node_providers_monthly_xdr_rewards(&self) -> CallResult<(Result3,)> {
+    pub async fn get_node_providers_monthly_xdr_rewards(
+        &self,
+    ) -> CallResult<(GetNodeProvidersMonthlyXdrRewardsResponse,)> {
         ic_cdk::call(self.0, "get_node_providers_monthly_xdr_rewards", ()).await
     }
-    pub async fn get_subnet_for_canister(&self, arg0: GetSubnetForCanisterRequest) -> CallResult<(Result4,)> {
+    pub async fn get_subnet_for_canister(
+        &self,
+        arg0: GetSubnetForCanisterRequest,
+    ) -> CallResult<(GetSubnetForCanisterResponse,)> {
         ic_cdk::call(self.0, "get_subnet_for_canister", (arg0,)).await
     }
-    pub async fn prepare_canister_migration(&self, arg0: PrepareCanisterMigrationPayload) -> CallResult<(Result1,)> {
+    pub async fn prepare_canister_migration(&self, arg0: PrepareCanisterMigrationPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "prepare_canister_migration", (arg0,)).await
     }
     pub async fn recover_subnet(&self, arg0: RecoverSubnetPayload) -> CallResult<()> {
@@ -524,10 +524,10 @@ impl Service {
     pub async fn remove_nodes(&self, arg0: RemoveNodesPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "remove_nodes", (arg0,)).await
     }
-    pub async fn remove_nodes_from_subnet(&self, arg0: RemoveNodesFromSubnetPayload) -> CallResult<()> {
+    pub async fn remove_nodes_from_subnet(&self, arg0: RemoveNodesPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "remove_nodes_from_subnet", (arg0,)).await
     }
-    pub async fn reroute_canister_ranges(&self, arg0: RerouteCanisterRangesPayload) -> CallResult<(Result1,)> {
+    pub async fn reroute_canister_ranges(&self, arg0: RerouteCanisterRangesPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "reroute_canister_ranges", (arg0,)).await
     }
     pub async fn retire_replica_version(&self, arg0: RetireReplicaVersionPayload) -> CallResult<()> {
@@ -554,16 +554,19 @@ impl Service {
     pub async fn update_firewall_rules(&self, arg0: UpdateFirewallRulesPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "update_firewall_rules", (arg0,)).await
     }
-    pub async fn update_node_directly(&self, arg0: UpdateNodeDirectlyPayload) -> CallResult<(Result1,)> {
+    pub async fn update_node_directly(&self, arg0: UpdateNodeDirectlyPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "update_node_directly", (arg0,)).await
     }
-    pub async fn update_node_domain_directly(&self, arg0: UpdateNodeDomainDirectlyPayload) -> CallResult<(Result1,)> {
+    pub async fn update_node_domain_directly(
+        &self,
+        arg0: UpdateNodeDomainDirectlyPayload,
+    ) -> CallResult<(UpdateNodeDomainDirectlyResponse,)> {
         ic_cdk::call(self.0, "update_node_domain_directly", (arg0,)).await
     }
     pub async fn update_node_ipv_4_config_directly(
         &self,
         arg0: UpdateNodeIPv4ConfigDirectlyPayload,
-    ) -> CallResult<(Result1,)> {
+    ) -> CallResult<(UpdateNodeIpv4ConfigDirectlyResponse,)> {
         ic_cdk::call(self.0, "update_node_ipv4_config_directly", (arg0,)).await
     }
     pub async fn update_node_operator_config(&self, arg0: UpdateNodeOperatorConfigPayload) -> CallResult<()> {

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-05-29_23-02-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-05_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.
Even with no changes, just updating the reference is good practice.

# Changes
* Update the version of `IC_COMMIT_FOR_PROPOSALS` specified in `dfx.json`.
* Updated the `proposals` candid files to the versions in that commit.
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants