### PR TITLE
Universe selector icon size adjustment

### DIFF
--- a/frontend/src/lib/components/layout/UniverseSplitContent.svelte
+++ b/frontend/src/lib/components/layout/UniverseSplitContent.svelte
@@ -25,6 +25,7 @@
   // Temporarily redefine default values of the SplitContent until the proper redesign is implemented.
   .container {
     display: contents;
-    --content-start-height: calc(92px + var(--padding-2x));
+    // Selected universe card (60px) + .select-universe:margin-top * 2x
+    --content-start-height: calc(60px + var(--padding-3x));
   }
 </style>

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -133,7 +133,7 @@
   .container {
     display: flex;
     align-items: center;
-    gap: var(--padding-2x);
+    gap: var(--padding);
     // Same as Card padding
     // We want to padding in the container to use the hover effect on ALL the card surface.
     padding: calc(var(--padding-2x) - var(--card-border-size));

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -67,7 +67,7 @@
 >
   <div class="container" class:selected>
     {#if universe !== "all-actionable"}
-      <UniverseLogo size="big" {universe} framed={true} />
+      <UniverseLogo size="small" {universe} framed={true} horizontalPadding={false} />
     {:else}
       <div data-tid="vote-icon" class="icon">
         <IconVote size="24px" />

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -67,7 +67,12 @@
 >
   <div class="container" class:selected>
     {#if universe !== "all-actionable"}
-      <UniverseLogo size="small" {universe} framed={true} horizontalPadding={false} />
+      <UniverseLogo
+        size="small"
+        {universe}
+        framed={true}
+        horizontalPadding={false}
+      />
     {:else}
       <div data-tid="vote-icon" class="icon">
         <IconVote size="24px" />
@@ -152,7 +157,7 @@
   }
 
   .icon {
-    // Align with small framed universe logo 
+    // Align with small framed universe logo
     width: var(--padding-3x);
     height: var(--padding-3x);
     display: flex;

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -151,6 +151,16 @@
     }
   }
 
+  .icon {
+    // Align with small framed universe logo 
+    width: var(--padding-3x);
+    height: var(--padding-3x);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: var(--padding-0_25x);
+  }
+
   .content {
     display: flex;
     flex-direction: column;

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -74,7 +74,7 @@
         horizontalPadding={false}
       />
     {:else}
-      <div data-tid="vote-icon" class="icon">
+      <div data-tid="vote-icon" class="vote-icon">
         <IconVote size="24px" />
       </div>
     {/if}
@@ -156,7 +156,7 @@
     }
   }
 
-  .icon {
+  .vote-icon {
     // Align with small framed universe logo
     width: var(--padding-3x);
     height: var(--padding-3x);


### PR DESCRIPTION
# Motivation

To improve the appearance of the universe selector, making it look more organic and matching the icon size, and provide more information on the mobile view, we decreased the universe logo size.

# Changes

- Decrease universe icon size.
- Update gap between the icon and the title.
- Decrease the mobile dropdown container height to ensure consistent top and bottom padding.

# Tests

Style changes only.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.

# Before
<img width="475" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/3cd290c4-45f8-4169-bc83-90e0115164f6">

# After
<img width="474" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/54f34eb5-bdbc-4df0-a0f0-29a0dc99f0e8">

# Before
<img width="701" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/aa712bf9-d9b8-4531-bb9b-0ecff54612ef">

# After
<img width="560" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/ba6bf061-460d-48a9-8a44-e37ec53e91b1">
