### PR TITLE
Check that there is only 1 tooltip with matching ID

### DIFF
--- a/frontend/src/tests/page-objects/Tooltip.page-object.ts
+++ b/frontend/src/tests/page-objects/Tooltip.page-object.ts
@@ -32,8 +32,13 @@ export class TooltipPo extends BasePageObject {
   async getTooltipElement(): Promise<PageObjectElement> {
     const id = await this.getAriaDescribedBy();
     const body = await this.root.getDocumentBody();
-    const tooltipElement = body.querySelector(`#${id}`);
-    return tooltipElement;
+    const tooltipElements = await body.querySelectorAll(`#${id}`);
+    if (tooltipElements.length !== 1) {
+      throw new Error(
+        `Found ${tooltipElements.length} tooltip elements with id ${id}`
+      );
+    }
+    return tooltipElements[0];
   }
 
   async getDisplayedText(): Promise<string> {


### PR DESCRIPTION
# Motivation

Tooltip targets have a `describedby` attribute that should match the `id` attribute of the tooltip.
This helps both screen readers and tests match targets too the correct tooltip.

# Changes

In `Tooltip.page-object.ts` throw an error if there is not exactly one tooltip matching the ID.
This does not catch cases where only one tooltip is created during the test so this is not guaranteed to help screen readers.
But it does help avoid confusion when debugging tests.

# Tests

Changed the [tooltip ID](https://github.com/dfinity/nns-dapp/blob/4c3d659b021f418be35d4e28934cebc6eb3cda54/frontend/src/lib/components/neurons/NeuronsTable/NeuronStateCell.svelte#L13) in NeuronStateCell to be not unique and noticed the `NeuronsTable.spec.ts` test fail.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary