### PR TITLE
Use Tooltip idPrefix to make the code cleaner

### DIFF
--- a/frontend/src/lib/components/ic/VotingPowerDisplay.svelte
+++ b/frontend/src/lib/components/ic/VotingPowerDisplay.svelte
@@ -1,7 +1,3 @@
-<script lang="ts" context="module">
-  let nextTooltipIdNumber = 0;
-</script>
-
 <script lang="ts">
   import { Tooltip } from "@dfinity/gix-components";
   import {
@@ -12,14 +8,11 @@
   export let valueTestId: string;
   export let valueAriaLabel: string | undefined = undefined;
   export let votingPowerE8s: bigint;
-
-  let tooltipId = `voting-power-tooltip-${nextTooltipIdNumber}`;
-  ++nextTooltipIdNumber;
 </script>
 
 <Tooltip
   testId="voting-power-display-component"
-  id={tooltipId}
+  idPrefix="voting-power-tooltip"
   text={formatVotingPowerDetailed(votingPowerE8s)}
 >
   <span data-tid={valueTestId} aria-label={valueAriaLabel}

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
@@ -1,16 +1,9 @@
-<script lang="ts" context="module">
-  let nextElementIdNumber = 0;
-</script>
-
 <script lang="ts">
   import type { TableNeuron } from "$lib/types/neurons-table";
   import Hash from "$lib/components/ui/Hash.svelte";
   import { Copy, Tag } from "@dfinity/gix-components";
 
   export let rowData: TableNeuron;
-
-  let elementId = `neuron-id-cell-${nextElementIdNumber}`;
-  ++nextElementIdNumber;
 </script>
 
 <div data-tid="neuron-id-cell-component" class="container">
@@ -19,7 +12,7 @@
       testId="neuron-id"
       text={rowData.neuronId}
       tagName="span"
-      id={elementId}
+      idPrefix="neuron-id-cell"
     /></span
   >
   <Copy value={rowData.neuronId} />

--- a/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
+++ b/frontend/src/lib/components/proposals/ActionableProposalCountBadge.svelte
@@ -1,7 +1,3 @@
-<script lang="ts" context="module">
-  let nextTooltipIdNumber = 0;
-</script>
-
 <script lang="ts">
   import { scale } from "svelte/transition";
   import { cubicOut } from "svelte/easing";
@@ -15,8 +11,6 @@
 
   export let count: number;
   export let universe: Universe | "all";
-
-  let tooltipId = `actionable-count-tooltip-${nextTooltipIdNumber++}`;
 
   let tooltipText = "";
   $: tooltipText =
@@ -38,7 +32,7 @@
 </script>
 
 <TestIdWrapper testId="actionable-proposal-count-badge-component">
-  <Tooltip id={tooltipId} text={tooltipText} top={true}
+  <Tooltip idPrefix="actionable-count-tooltip" text={tooltipText} top={true}
     ><span
       transition:scale={{
         duration: 250,

--- a/frontend/src/lib/components/ui/Hash.svelte
+++ b/frontend/src/lib/components/ui/Hash.svelte
@@ -6,7 +6,8 @@
 
   export let tagName: "h3" | "p" | "span" | "h5" = "h3";
   export let testId: string | undefined = undefined;
-  export let id: string;
+  export let id: string | undefined = undefined;
+  export let idPrefix: string = "hash";
   export let text: string;
   export let showCopy = false;
   export let className: string | undefined = undefined;
@@ -21,7 +22,7 @@
 </script>
 
 <span data-tid="hash-component">
-  <Tooltip top={tooltipTop} {id} {text}>
+  <Tooltip top={tooltipTop} {id} {idPrefix} {text}>
     <svelte:element
       this={tagName}
       data-tid={testId}

--- a/frontend/src/lib/components/ui/IdentifierHash.svelte
+++ b/frontend/src/lib/components/ui/IdentifierHash.svelte
@@ -1,19 +1,12 @@
-<script lang="ts" context="module">
-  let nextElementIdNumber = 0;
-</script>
-
 <script lang="ts">
   import Hash from "$lib/components/ui/Hash.svelte";
 
   export let identifier: string;
   export let splitLength: number | undefined = undefined;
-
-  let elementId = `identifier-${nextElementIdNumber}`;
-  ++nextElementIdNumber;
 </script>
 
 <Hash
-  id={elementId}
+  idPrefix="identifier"
   tagName="p"
   testId="identifier"
   text={identifier}

--- a/frontend/src/lib/components/ui/TooltipIcon.svelte
+++ b/frontend/src/lib/components/ui/TooltipIcon.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import { IconInfo, Tooltip } from "@dfinity/gix-components";
 
-  export let tooltipId: string;
+  export let tooltipId: string | undefined;
+  export let tooltipIdPrefix = "tooltip-icon";
   export let text: string;
 </script>
 
 <div class="wrapper" data-tid="tooltip-icon-component">
-  <Tooltip id={tooltipId} {text}>
+  <Tooltip id={tooltipId} idPrefix={tooltipIdPrefix} {text}>
     <IconInfo />
   </Tooltip>
 </div>

--- a/frontend/src/tests/lib/components/ui/TooltipIcon.spec.ts
+++ b/frontend/src/tests/lib/components/ui/TooltipIcon.spec.ts
@@ -6,25 +6,50 @@ import { render } from "@testing-library/svelte";
 describe("TooltipIcon", () => {
   const text = "This is the text displayed in the tooltip";
   const tooltipId = "example-tooltip-id";
+  const tooltipIdPrefix = "example-tooltip-id-prefix";
 
-  const renderComponent = () => {
-    const { container } = render(TooltipIcon, { text, tooltipId });
+  const renderComponent = ({
+    tooltipId,
+    tooltipIdPrefix,
+  }: {
+    tooltipId?: string;
+    tooltipIdPrefix?: string;
+  }) => {
+    const { container } = render(TooltipIcon, {
+      text,
+      tooltipId,
+      tooltipIdPrefix,
+    });
     return TooltipIconPo.under(new JestPageObjectElement(container));
   };
 
   it("should have an info icon", async () => {
-    const po = renderComponent();
+    const po = renderComponent({ tooltipId });
     expect(await po.isPresent("icon-info")).toBe(true);
   });
 
   it("should have the tooltip text", async () => {
-    const po = renderComponent();
+    const po = renderComponent({ tooltipId });
     expect(await po.getText()).toBe(text);
   });
 
   it("should have the tooltip ID", async () => {
-    const po = renderComponent().getTooltipPo();
+    const po = renderComponent({ tooltipId }).getTooltipPo();
     expect(await po.getAriaDescribedBy()).toBe(tooltipId);
     expect(await po.getTooltipId()).toBe(tooltipId);
+  });
+
+  it("should have the tooltip ID prefix", async () => {
+    const po = renderComponent({ tooltipIdPrefix }).getTooltipPo();
+    const describedBy = await po.getAriaDescribedBy();
+    expect(describedBy).toMatch(new RegExp(`${tooltipIdPrefix}-`));
+    expect(await po.getTooltipId()).toBe(describedBy);
+  });
+
+  it("should have the default tooltip ID prefix", async () => {
+    const po = renderComponent({}).getTooltipPo();
+    const describedBy = await po.getAriaDescribedBy();
+    expect(describedBy).toMatch(new RegExp(`tooltip-icon-`));
+    expect(await po.getTooltipId()).toBe(describedBy);
   });
 });


### PR DESCRIPTION
# Motivation

We have several components where we create tooltip IDs dynamically because they need to be uniq across multiple tooltips.
This is now supported by the `Tooltip` component itself via `idPrefix`.

# Changes

1. Remove custom code to generate unique tooltip IDs and use `idPrefix` instead.
2. Support forwarding `idPrefix` in `Hash` and `TooltipId` components.

# Tests

1. Unit tests added.
2. Existing tests pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary