### PR TITLE
Make vote icon consistent with universe icons

### DIFF
--- a/frontend/src/lib/components/ui/Logo.svelte
+++ b/frontend/src/lib/components/ui/Logo.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import LogoWrapper from "$lib/components/ui/LogoWrapper.svelte";
+
   export let src: string;
   export let alt: string;
   export let size: "huge" | "big" | "medium" | "small" = "small";
@@ -6,46 +8,25 @@
   export let testId: string | undefined = undefined;
 </script>
 
-<img
-  {src}
-  {alt}
-  role="presentation"
-  loading="lazy"
-  draggable="false"
-  data-tid={testId}
-  class:huge={size === "huge"}
-  class:big={size === "big"}
-  class:medium={size === "medium"}
-  class:framed
-/>
+<LogoWrapper {size} {framed}>
+  <img
+    {src}
+    {alt}
+    class:framed
+    role="presentation"
+    loading="lazy"
+    draggable="false"
+    data-tid={testId}
+  />
+</LogoWrapper>
 
 <style lang="scss">
   img {
-    width: var(--padding-3x);
-    height: var(--padding-3x);
+    width: 100%;
+    height: 100%;
 
-    user-select: none;
-    -webkit-user-drag: none;
-  }
-
-  .framed {
-    border-radius: 50%;
-    background: var(--logo-framed-background, var(--background));
-    padding: var(--padding-0_25x);
-  }
-
-  .huge {
-    width: var(--padding-8x);
-    height: var(--padding-8x);
-  }
-
-  .big {
-    width: var(--padding-6x);
-    height: var(--padding-6x);
-  }
-
-  .medium {
-    width: var(--padding-4x);
-    height: var(--padding-4x);
+    &.framed {
+      border-radius: 50%;
+    }
   }
 </style>

--- a/frontend/src/lib/components/ui/Logo.svelte
+++ b/frontend/src/lib/components/ui/Logo.svelte
@@ -8,7 +8,7 @@
   export let testId: string | undefined = undefined;
 </script>
 
-<LogoWrapper {size} {framed}>
+<LogoWrapper {size} {framed} testId="logo-component">
   <img
     {src}
     {alt}

--- a/frontend/src/lib/components/ui/LogoWrapper.svelte
+++ b/frontend/src/lib/components/ui/LogoWrapper.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  export let testId = "logo-wrapper-component";
+  export let size: "huge" | "big" | "medium" | "small" = "small";
+  export let framed = true;
+</script>
+
+<div
+  data-tid={testId}
+  class:huge={size === "huge"}
+  class:big={size === "big"}
+  class:medium={size === "medium"}
+  class:framed
+  class="wrapper"
+>
+  <slot />
+</div>
+
+<style lang="scss">
+  .wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: var(--padding-3x);
+    height: var(--padding-3x);
+
+    user-select: none;
+    -webkit-user-drag: none;
+  }
+
+  .framed {
+    border-radius: 50%;
+    background: var(--logo-framed-background, var(--background));
+    padding: var(--padding-0_25x);
+    overflow: hidden;
+  }
+
+  .huge {
+    width: var(--padding-8x);
+    height: var(--padding-8x);
+  }
+
+  .big {
+    width: var(--padding-6x);
+    height: var(--padding-6x);
+  }
+
+  .medium {
+    width: var(--padding-4x);
+    height: var(--padding-4x);
+  }
+</style>

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Card, IconVote, Tooltip } from "@dfinity/gix-components";
+  import { Card, Tooltip } from "@dfinity/gix-components";
+  import VoteLogo from "$lib/components/universe/VoteLogo.svelte";
   import UniverseLogo from "$lib/components/universe/UniverseLogo.svelte";
   import UniverseAccountsBalance from "$lib/components/universe/UniverseAccountsBalance.svelte";
   import { pageStore } from "$lib/derived/page.derived";
@@ -53,6 +54,9 @@
   // Always rerender to trigger animation start
   let mounted = false;
   onMount(() => (mounted = true));
+
+  const logoSize = "big";
+  const logoFramed = true;
 </script>
 
 <Card
@@ -67,11 +71,9 @@
 >
   <div class="container" class:selected>
     {#if universe !== "all-actionable"}
-      <UniverseLogo size="big" {universe} framed={true} />
+      <UniverseLogo size={logoSize} {universe} framed={logoFramed} />
     {:else}
-      <div data-tid="vote-icon" class="icon">
-        <IconVote size="24px" />
-      </div>
+      <VoteLogo size={logoSize} framed={logoFramed} />
     {/if}
 
     <div

--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { Card, Tooltip } from "@dfinity/gix-components";
-  import VoteLogo from "$lib/components/universe/VoteLogo.svelte";
   import UniverseLogo from "$lib/components/universe/UniverseLogo.svelte";
   import UniverseAccountsBalance from "$lib/components/universe/UniverseAccountsBalance.svelte";
   import { pageStore } from "$lib/derived/page.derived";
@@ -54,9 +53,6 @@
   // Always rerender to trigger animation start
   let mounted = false;
   onMount(() => (mounted = true));
-
-  const logoSize = "big";
-  const logoFramed = true;
 </script>
 
 <Card
@@ -70,11 +66,7 @@
   noMargin
 >
   <div class="container" class:selected>
-    {#if universe !== "all-actionable"}
-      <UniverseLogo size={logoSize} {universe} framed={logoFramed} />
-    {:else}
-      <VoteLogo size={logoSize} framed={logoFramed} />
-    {/if}
+    <UniverseLogo size="big" {universe} framed={true} />
 
     <div
       class={`content ${role}`}

--- a/frontend/src/lib/components/universe/UniverseLogo.svelte
+++ b/frontend/src/lib/components/universe/UniverseLogo.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
   import Logo from "$lib/components/ui/Logo.svelte";
+  import VoteLogo from "$lib/components/universe/VoteLogo.svelte";
   import type { Universe } from "$lib/types/universe";
   import { universeLogoAlt } from "$lib/utils/universe.utils";
 
-  export let universe: Universe;
+  export let universe: Universe | "all-actionable";
   export let size: "big" | "medium" | "small" = "small";
   export let framed = false;
   export let horizontalPadding = true;
 
   let title: string;
-  $: title = universeLogoAlt(universe);
+  $: title = universe !== "all-actionable" ? universeLogoAlt(universe) : "";
 </script>
 
 <span
@@ -17,7 +18,11 @@
   class:horizontalPadding
   data-tid="project-logo"
 >
-  <Logo src={universe.logo} alt={title} {size} {framed} testId="logo" />
+  {#if universe !== "all-actionable"}
+    <Logo src={universe.logo} alt={title} {size} {framed} testId="logo" />
+  {:else}
+    <VoteLogo {size} {framed} />
+  {/if}
 </span>
 
 <style lang="scss">

--- a/frontend/src/lib/components/universe/VoteLogo.svelte
+++ b/frontend/src/lib/components/universe/VoteLogo.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import LogoWrapper from "$lib/components/ui/LogoWrapper.svelte";
+  import { Card, IconVote, Tooltip } from "@dfinity/gix-components";
+
+  export let size: "huge" | "big" | "medium" | "small" = "small";
+  export let framed = true;
+</script>
+
+<LogoWrapper {size} {framed} testId="vote-logo-component">
+  <div data-tid="vote-icon">
+    <IconVote size="24px" />
+  </div>
+</LogoWrapper>

--- a/frontend/src/lib/components/universe/VoteLogo.svelte
+++ b/frontend/src/lib/components/universe/VoteLogo.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import LogoWrapper from "$lib/components/ui/LogoWrapper.svelte";
-  import { Card, IconVote, Tooltip } from "@dfinity/gix-components";
+  import { IconVote } from "@dfinity/gix-components";
 
   export let size: "huge" | "big" | "medium" | "small" = "small";
   export let framed = true;

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -97,6 +97,17 @@ describe("SelectUniverseCard", () => {
       });
       expect(await po.getName()).toBe(en.core.ic);
     });
+
+    it("should use a big framed logo", async () => {
+      const po = await renderComponent({
+        props,
+      });
+      const logo = po.getUniverseLogoPo().getLogoWrapperPo();
+      expect(await logo.isPresent()).toBe(true);
+      expect(await logo.getSize()).toBe("big");
+      expect(await logo.isFramed()).toBe(true);
+      expect(await po.getVoteLogoPo().isPresent()).toBe(false);
+    });
   });
 
   describe("sns", () => {
@@ -113,6 +124,17 @@ describe("SelectUniverseCard", () => {
         props: { universe: mockSnsUniverse, selected: false },
       });
       expect(await po.getName()).toBe(mockSummary.metadata.name);
+    });
+
+    it("should use a big framed logo", async () => {
+      const po = await renderComponent({
+        props,
+      });
+      const logo = po.getUniverseLogoPo().getLogoWrapperPo();
+      expect(await logo.isPresent()).toBe(true);
+      expect(await logo.getSize()).toBe("big");
+      expect(await logo.isFramed()).toBe(true);
+      expect(await po.getVoteLogoPo().isPresent()).toBe(false);
     });
   });
 
@@ -384,6 +406,23 @@ describe("SelectUniverseCard", () => {
 
       expect(await po.hasVoteIcon()).toBe(true);
       expect(await po.getName()).toBe("Actionable Proposals");
+    });
+
+    it("should use a big framed vote logo", async () => {
+      page.mock({
+        data: { universe: OWN_CANISTER_ID_TEXT },
+        routeId: AppPath.Proposals,
+      });
+
+      const po = await renderComponent({
+        props: { universe: "all-actionable", selected: false },
+      });
+
+      const logo = po.getVoteLogoPo();
+      expect(await logo.isPresent()).toBe(true);
+      expect(await logo.getSize()).toBe("big");
+      expect(await logo.isFramed()).toBe(true);
+      expect(await po.getUniverseLogoPo().isPresent()).toBe(false);
     });
 
     it('should not display custom icon and text when not "all-actionable"', async () => {

--- a/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseCard.spec.ts
@@ -102,11 +102,13 @@ describe("SelectUniverseCard", () => {
       const po = await renderComponent({
         props,
       });
-      const logo = po.getUniverseLogoPo().getLogoWrapperPo();
+      const logo = po.getUniverseLogoPo().getLogoPo();
       expect(await logo.isPresent()).toBe(true);
       expect(await logo.getSize()).toBe("big");
       expect(await logo.isFramed()).toBe(true);
-      expect(await po.getVoteLogoPo().isPresent()).toBe(false);
+      expect(await po.getUniverseLogoPo().getVoteLogoPo().isPresent()).toBe(
+        false
+      );
     });
   });
 
@@ -130,11 +132,13 @@ describe("SelectUniverseCard", () => {
       const po = await renderComponent({
         props,
       });
-      const logo = po.getUniverseLogoPo().getLogoWrapperPo();
+      const logo = po.getUniverseLogoPo().getLogoPo();
       expect(await logo.isPresent()).toBe(true);
       expect(await logo.getSize()).toBe("big");
       expect(await logo.isFramed()).toBe(true);
-      expect(await po.getVoteLogoPo().isPresent()).toBe(false);
+      expect(await po.getUniverseLogoPo().getVoteLogoPo().isPresent()).toBe(
+        false
+      );
     });
   });
 
@@ -418,11 +422,11 @@ describe("SelectUniverseCard", () => {
         props: { universe: "all-actionable", selected: false },
       });
 
-      const logo = po.getVoteLogoPo();
+      const logo = po.getUniverseLogoPo().getVoteLogoPo();
       expect(await logo.isPresent()).toBe(true);
       expect(await logo.getSize()).toBe("big");
       expect(await logo.isFramed()).toBe(true);
-      expect(await po.getUniverseLogoPo().isPresent()).toBe(false);
+      expect(await po.getUniverseLogoPo().getLogoPo().isPresent()).toBe(false);
     });
 
     it('should not display custom icon and text when not "all-actionable"', async () => {

--- a/frontend/src/tests/lib/components/universe/VoteLogo.spec.ts
+++ b/frontend/src/tests/lib/components/universe/VoteLogo.spec.ts
@@ -1,0 +1,26 @@
+import VoteLogo from "$lib/components/universe/VoteLogo.svelte";
+import { VoteLogoPo } from "$tests/page-objects/VoteLogo.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+import { describe } from "vitest";
+
+describe("VoteLogo", () => {
+  const renderComponent = (props) => {
+    const { container } = render(VoteLogo, props);
+    return VoteLogoPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should pass size to logo wrapper", async () => {
+    for (const size of ["huge", "big", "medium", "small"]) {
+      const po = renderComponent({ size });
+      expect(await po.getSize()).toBe(size);
+    }
+  });
+
+  it("should pass framed to logo wrapper", async () => {
+    for (const framed of [true, false]) {
+      const po = renderComponent({ framed });
+      expect(await po.isFramed()).toBe(framed);
+    }
+  });
+});

--- a/frontend/src/tests/page-objects/Logo.page-object.ts
+++ b/frontend/src/tests/page-objects/Logo.page-object.ts
@@ -1,0 +1,11 @@
+import { LogoWrapperPo } from "$tests/page-objects/LogoWrapper.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class LogoPo extends LogoWrapperPo {
+  private static readonly TID = "logo-component";
+
+  static under(element: PageObjectElement): LogoPo {
+    return new LogoPo(element.byTestId(LogoPo.TID));
+  }
+}

--- a/frontend/src/tests/page-objects/Logo.page-object.ts
+++ b/frontend/src/tests/page-objects/Logo.page-object.ts
@@ -1,5 +1,4 @@
 import { LogoWrapperPo } from "$tests/page-objects/LogoWrapper.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class LogoPo extends LogoWrapperPo {

--- a/frontend/src/tests/page-objects/LogoWrapper.page-object.ts
+++ b/frontend/src/tests/page-objects/LogoWrapper.page-object.ts
@@ -1,0 +1,25 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class LogoWrapperPo extends BasePageObject {
+  private static readonly LOGO_WRAPPER_TID = "logo-wrapper-component";
+  private static readonly CUSTOM_SIZES = ["huge", "big", "medium"];
+  private static readonly DEFAULT_SIZE = "small";
+
+  static under(element: PageObjectElement): LogoWrapperPo {
+    return new LogoWrapperPo(element.byTestId(LogoWrapperPo.LOGO_WRAPPER_TID));
+  }
+
+  async isFramed(): Promise<boolean> {
+    const classes = await this.root.getClasses();
+    return classes.includes("framed");
+  }
+
+  async getSize(): Promise<string> {
+    const classes = await this.root.getClasses();
+    return (
+      classes.filter((c) => LogoWrapperPo.CUSTOM_SIZES.includes(c))[0] ??
+      LogoWrapperPo.DEFAULT_SIZE
+    );
+  }
+}

--- a/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
@@ -3,6 +3,7 @@ import { CardPo } from "$tests/page-objects/Card.page-object";
 import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import { UniverseAccountsBalancePo } from "$tests/page-objects/UniverseAccountsBalance.page-object";
 import { UniverseLogoPo } from "$tests/page-objects/UniverseLogo.page-object";
+import { VoteLogoPo } from "$tests/page-objects/VoteLogo.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SelectUniverseCardPo extends CardPo {
@@ -43,6 +44,10 @@ export class SelectUniverseCardPo extends CardPo {
     return UniverseLogoPo.under(this.root);
   }
 
+  getVoteLogoPo(): VoteLogoPo {
+    return VoteLogoPo.under(this.root);
+  }
+
   async getName(): Promise<string> {
     return this.getText("universe-name");
   }
@@ -80,6 +85,6 @@ export class SelectUniverseCardPo extends CardPo {
   }
 
   hasVoteIcon(): Promise<boolean> {
-    return this.root.querySelector('[data-tid="vote-icon"]').isPresent();
+    return this.getVoteLogoPo().isPresent();
   }
 }

--- a/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
+++ b/frontend/src/tests/page-objects/SelectUniverseCard.page-object.ts
@@ -3,7 +3,6 @@ import { CardPo } from "$tests/page-objects/Card.page-object";
 import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
 import { UniverseAccountsBalancePo } from "$tests/page-objects/UniverseAccountsBalance.page-object";
 import { UniverseLogoPo } from "$tests/page-objects/UniverseLogo.page-object";
-import { VoteLogoPo } from "$tests/page-objects/VoteLogo.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class SelectUniverseCardPo extends CardPo {
@@ -44,10 +43,6 @@ export class SelectUniverseCardPo extends CardPo {
     return UniverseLogoPo.under(this.root);
   }
 
-  getVoteLogoPo(): VoteLogoPo {
-    return VoteLogoPo.under(this.root);
-  }
-
   async getName(): Promise<string> {
     return this.getText("universe-name");
   }
@@ -85,6 +80,6 @@ export class SelectUniverseCardPo extends CardPo {
   }
 
   hasVoteIcon(): Promise<boolean> {
-    return this.getVoteLogoPo().isPresent();
+    return this.getUniverseLogoPo().getVoteLogoPo().isPresent();
   }
 }

--- a/frontend/src/tests/page-objects/UniverseLogo.page-object.ts
+++ b/frontend/src/tests/page-objects/UniverseLogo.page-object.ts
@@ -1,3 +1,4 @@
+import { LogoWrapperPo } from "$tests/page-objects/LogoWrapper.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -6,6 +7,10 @@ export class UniverseLogoPo extends BasePageObject {
 
   static under(element: PageObjectElement): UniverseLogoPo {
     return new UniverseLogoPo(element.byTestId(UniverseLogoPo.TID));
+  }
+
+  getLogoWrapperPo(): LogoWrapperPo {
+    return LogoWrapperPo.under(this.root);
   }
 
   getLogoAltText(): Promise<string> {

--- a/frontend/src/tests/page-objects/UniverseLogo.page-object.ts
+++ b/frontend/src/tests/page-objects/UniverseLogo.page-object.ts
@@ -1,4 +1,5 @@
-import { LogoWrapperPo } from "$tests/page-objects/LogoWrapper.page-object";
+import { LogoPo } from "$tests/page-objects/Logo.page-object";
+import { VoteLogoPo } from "$tests/page-objects/VoteLogo.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -9,8 +10,12 @@ export class UniverseLogoPo extends BasePageObject {
     return new UniverseLogoPo(element.byTestId(UniverseLogoPo.TID));
   }
 
-  getLogoWrapperPo(): LogoWrapperPo {
-    return LogoWrapperPo.under(this.root);
+  getLogoPo(): LogoPo {
+    return LogoPo.under(this.root);
+  }
+
+  getVoteLogoPo(): VoteLogoPo {
+    return VoteLogoPo.under(this.root);
   }
 
   getLogoAltText(): Promise<string> {

--- a/frontend/src/tests/page-objects/VoteLogo.page-object.ts
+++ b/frontend/src/tests/page-objects/VoteLogo.page-object.ts
@@ -1,0 +1,11 @@
+import { LogoWrapperPo } from "$tests/page-objects/LogoWrapper.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class VoteLogoPo extends LogoWrapperPo {
+  private static readonly TID = "vote-logo-component";
+
+  static under(element: PageObjectElement): VoteLogoPo {
+    return new VoteLogoPo(element.byTestId(VoteLogoPo.TID));
+  }
+}

--- a/frontend/src/tests/page-objects/VoteLogo.page-object.ts
+++ b/frontend/src/tests/page-objects/VoteLogo.page-object.ts
@@ -1,5 +1,4 @@
 import { LogoWrapperPo } from "$tests/page-objects/LogoWrapper.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class VoteLogoPo extends LogoWrapperPo {


### PR DESCRIPTION
# Motivation

For consistency, the logo on the "all actionable proposals" tab should have the same size as the logos on the other universe tabs.

# Changes

1. Extract `LogoWrapper` component from `Logo` component. The wrapper takes care of the size and framing.
2. Use the `LogoWrapper` component in a new `VoteLogo` component.
3. Use the `VoteLogo` component in `UniverseLogo` component.

# Tests

1. Unit tests added.
2. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/proposals/?u=qsgjb-riaaa-aaaaa-aaaga-cai

Before:
<img width="301" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/557a8efc-e865-4f65-b0f3-f8b6730b18c9">


After:
<img width="300" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/17068e04-0ffc-421e-99a8-2978b1186abc">


# Todos

- [ ] Add entry to changelog (if necessary).
not necessary