### PR TITLE
build: bump next

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -250,9 +250,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.4.0-next-2024-06-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.4.0-next-2024-06-11.tgz",
-      "integrity": "sha512-GLVndkQqo/1zQy++U38fxeesleekDrGTddr5tS+mQgdBC+sSjJWDY5HxjqEgJ2rqt2IYhV7KgD/1IcoQyzkGQQ==",
+      "version": "2.4.1-next-2024-06-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.4.1-next-2024-06-11.tgz",
+      "integrity": "sha512-xdSO1ikx/7s3DmgQS/QRjVLdBEIn7iV2QeknAp+flH1uaGjhZkctmVSuO8EsnyMd3NdDimSso8C8ESybk/PSfg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.0.6-next-2024-06-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.6-next-2024-06-11.tgz",
-      "integrity": "sha512-coArJd7XALcs2FmKYe2cDwRraYTAWiOEEtJLJVZPribuCKlmK4sAuwD7OCgPRLK4D1selRf3yylIkOBz1lUuSw==",
+      "version": "3.0.7-next-2024-06-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.7-next-2024-06-11.tgz",
+      "integrity": "sha512-UDxk5UeH01q2DlerT8v5zBnCKPEFGMIaeOAv2fF3c+6Mcz5J9Z4cuhyqwd1topWt9gdNASmRP5W5NxjkDI+7Kw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -294,9 +294,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "5.0.0-next-2024-06-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.0.0-next-2024-06-11.tgz",
-      "integrity": "sha512-6By/alfknjV4cGEu9lwumRAmcz0Ib19MlF5WgRIxNwYcbohfjMmDl52UAus1xvHosXEyZDDqotzvMP2e3GXo5g==",
+      "version": "5.0.1-next-2024-06-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.0.1-next-2024-06-11.tgz",
+      "integrity": "sha512-9i6wYOJKgGU0TURZwEjmmJCBtULeaoWk/2q9UYBTJuejDI1+j+b2a8ThUAVJsM2umOk1YEJ6Czndoqwydmn6yQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -321,9 +321,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.3.0-next-2024-06-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.3.0-next-2024-06-11.tgz",
-      "integrity": "sha512-7YBwnw0WCNpFpodsl8c9GUb+J00d5YEm8S0TREFSaLnodiCPar7pfQUaZHssmHgF2uygeicN3CMTqYmAHh28Kg==",
+      "version": "2.3.1-next-2024-06-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.3.1-next-2024-06-11.tgz",
+      "integrity": "sha512-leTksINZ21shyDFnszFo6gq6+cok+ojuFrlCoXxeGFqzNE2jliQEfcga8QY5p59MTuny2pCaWFCYa+oLdGG4Tw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -333,9 +333,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.3.2-next-2024-06-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.3.2-next-2024-06-11.tgz",
-      "integrity": "sha512-h0GnHltlAttIJVSYI0Bw40E6x4/Z1t7Nz+P2PkcgQphJClnZSc6aLhzght6q9NMahd9nHnUTtpwGTMO69nnrQQ==",
+      "version": "2.3.3-next-2024-06-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.3.3-next-2024-06-11.tgz",
+      "integrity": "sha512-RIUW7gfUkHX3d7iH4T20a0bSShtnSPlGOjfE3FpJZ0p9B1jXBkJE3oIuauQcJpbPoU5I8YhYsk/3p/V/h8fXcg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -345,9 +345,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "5.1.1-next-2024-06-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.1.1-next-2024-06-11.tgz",
-      "integrity": "sha512-Ei81tdicQmmWzyBnWP2hCCW7NVySB5p+P2eVSaCvnkBA5JkbYBUD8MwIsf2ApcBqlVEyVPxe7L6aSz4+rRx6Pg==",
+      "version": "5.1.2-next-2024-06-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.1.2-next-2024-06-11.tgz",
+      "integrity": "sha512-nZMgesauZa0PYwkKCO4Ie23mGWEEjCeONyQJvYw1ShoLtsN3tGsa9ZCbMCsbrOJoiuKJJF4YfaPF/uE/h4TXqw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -370,9 +370,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.0.5-next-2024-06-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.5-next-2024-06-11.tgz",
-      "integrity": "sha512-GwWJzfxbCrI0eKpSne91+fFqKdhcO6GY4KyhsSy9qV6buxK0Nv8nqQ5Ds7Ik+9SWIMjdLcOWXAbhiE70gRkh2g==",
+      "version": "3.0.6-next-2024-06-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.6-next-2024-06-11.tgz",
+      "integrity": "sha512-b0QMIsWSP40GAtl9zBP7gnHFLHkGNyq2qL64ZcYeTu7ppeRNVRfDY7YtMcQ/AevXRVJDsCjE0hvIR6+8T29f+g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
@@ -386,9 +386,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.3.0-next-2024-06-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.3.0-next-2024-06-11.tgz",
-      "integrity": "sha512-wRwg8YZYJisDQLsH71UOvmGo7qABv6yUASjJC6s8C/68bnxoKzq0l6vc/ortiVy3StaJ8Rn/7VIhVvE9hFsvDg==",
+      "version": "2.3.1-next-2024-06-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.3.1-next-2024-06-11.tgz",
+      "integrity": "sha512-T/087arIe5V0yDzhKqGgiaEYU+mSWovc/PNcKM3ZOLVs/NfPAgw1FSqCkRKEgQBtROcAytZkvqcn7vUsFbAGxg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -7043,9 +7043,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.4.0-next-2024-06-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.4.0-next-2024-06-11.tgz",
-      "integrity": "sha512-GLVndkQqo/1zQy++U38fxeesleekDrGTddr5tS+mQgdBC+sSjJWDY5HxjqEgJ2rqt2IYhV7KgD/1IcoQyzkGQQ==",
+      "version": "2.4.1-next-2024-06-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.4.1-next-2024-06-11.tgz",
+      "integrity": "sha512-xdSO1ikx/7s3DmgQS/QRjVLdBEIn7iV2QeknAp+flH1uaGjhZkctmVSuO8EsnyMd3NdDimSso8C8ESybk/PSfg==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7053,9 +7053,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.0.6-next-2024-06-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.6-next-2024-06-11.tgz",
-      "integrity": "sha512-coArJd7XALcs2FmKYe2cDwRraYTAWiOEEtJLJVZPribuCKlmK4sAuwD7OCgPRLK4D1selRf3yylIkOBz1lUuSw==",
+      "version": "3.0.7-next-2024-06-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.0.7-next-2024-06-11.tgz",
+      "integrity": "sha512-UDxk5UeH01q2DlerT8v5zBnCKPEFGMIaeOAv2fF3c+6Mcz5J9Z4cuhyqwd1topWt9gdNASmRP5W5NxjkDI+7Kw==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7069,9 +7069,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "5.0.0-next-2024-06-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.0.0-next-2024-06-11.tgz",
-      "integrity": "sha512-6By/alfknjV4cGEu9lwumRAmcz0Ib19MlF5WgRIxNwYcbohfjMmDl52UAus1xvHosXEyZDDqotzvMP2e3GXo5g==",
+      "version": "5.0.1-next-2024-06-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.0.1-next-2024-06-11.tgz",
+      "integrity": "sha512-9i6wYOJKgGU0TURZwEjmmJCBtULeaoWk/2q9UYBTJuejDI1+j+b2a8ThUAVJsM2umOk1YEJ6Czndoqwydmn6yQ==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7085,21 +7085,21 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.3.0-next-2024-06-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.3.0-next-2024-06-11.tgz",
-      "integrity": "sha512-7YBwnw0WCNpFpodsl8c9GUb+J00d5YEm8S0TREFSaLnodiCPar7pfQUaZHssmHgF2uygeicN3CMTqYmAHh28Kg==",
+      "version": "2.3.1-next-2024-06-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.3.1-next-2024-06-11.tgz",
+      "integrity": "sha512-leTksINZ21shyDFnszFo6gq6+cok+ojuFrlCoXxeGFqzNE2jliQEfcga8QY5p59MTuny2pCaWFCYa+oLdGG4Tw==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.3.2-next-2024-06-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.3.2-next-2024-06-11.tgz",
-      "integrity": "sha512-h0GnHltlAttIJVSYI0Bw40E6x4/Z1t7Nz+P2PkcgQphJClnZSc6aLhzght6q9NMahd9nHnUTtpwGTMO69nnrQQ==",
+      "version": "2.3.3-next-2024-06-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.3.3-next-2024-06-11.tgz",
+      "integrity": "sha512-RIUW7gfUkHX3d7iH4T20a0bSShtnSPlGOjfE3FpJZ0p9B1jXBkJE3oIuauQcJpbPoU5I8YhYsk/3p/V/h8fXcg==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "5.1.1-next-2024-06-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.1.1-next-2024-06-11.tgz",
-      "integrity": "sha512-Ei81tdicQmmWzyBnWP2hCCW7NVySB5p+P2eVSaCvnkBA5JkbYBUD8MwIsf2ApcBqlVEyVPxe7L6aSz4+rRx6Pg==",
+      "version": "5.1.2-next-2024-06-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.1.2-next-2024-06-11.tgz",
+      "integrity": "sha512-nZMgesauZa0PYwkKCO4Ie23mGWEEjCeONyQJvYw1ShoLtsN3tGsa9ZCbMCsbrOJoiuKJJF4YfaPF/uE/h4TXqw==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -7114,17 +7114,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.0.5-next-2024-06-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.5-next-2024-06-11.tgz",
-      "integrity": "sha512-GwWJzfxbCrI0eKpSne91+fFqKdhcO6GY4KyhsSy9qV6buxK0Nv8nqQ5Ds7Ik+9SWIMjdLcOWXAbhiE70gRkh2g==",
+      "version": "3.0.6-next-2024-06-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.0.6-next-2024-06-11.tgz",
+      "integrity": "sha512-b0QMIsWSP40GAtl9zBP7gnHFLHkGNyq2qL64ZcYeTu7ppeRNVRfDY7YtMcQ/AevXRVJDsCjE0hvIR6+8T29f+g==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.3.0-next-2024-06-11",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.3.0-next-2024-06-11.tgz",
-      "integrity": "sha512-wRwg8YZYJisDQLsH71UOvmGo7qABv6yUASjJC6s8C/68bnxoKzq0l6vc/ortiVy3StaJ8Rn/7VIhVvE9hFsvDg==",
+      "version": "2.3.1-next-2024-06-11",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.3.1-next-2024-06-11.tgz",
+      "integrity": "sha512-T/087arIe5V0yDzhKqGgiaEYU+mSWovc/PNcKM3ZOLVs/NfPAgw1FSqCkRKEgQBtROcAytZkvqcn7vUsFbAGxg==",
       "requires": {}
     },
     "@esbuild/android-arm": {


### PR DESCRIPTION
# Motivation

We release release ic-js [2024.06.11-1630Z](https://github.com/dfinity/ic-js/releases/tag/2024.06.11-1630Z). This PR upgrade the libraries to hook on the new version number.

# Changes

- `npm run upgrade:next`
