### PR TITLE
Change dfx state directory logic

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -39,6 +39,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Put snapshot state directories in home directory instead of `dfx` cache.
+
 #### Deprecated
 
 #### Removed

--- a/scripts/dfx-snapshot-install
+++ b/scripts/dfx-snapshot-install
@@ -48,14 +48,17 @@ extract() {
   fi
 }
 
-# Make sure the dfx cache is installed.
-if ! [ -d "$(dfx cache show)" ]; then
-  dfx cache install
-fi
-
 STATE_HASH="$(sha256sum "$SNAPSHOT_ARCHIVE" | cut -d' ' -f1)"
 
-STATE_DIR="$(dfx cache show)/snsdemo-state-$STATE_HASH"
+OLD_STATE_DIR="$(find "$(dirname "$(dfx cache show)")" -name "snsdemo-state-$STATE_HASH" | sort | tail -1)"
+PREFERRED_STATE_DIR="$HOME/.snsdemo-state/$STATE_HASH"
+
+if [ -d "$OLD_STATE_DIR" ] && ! [ -d "$PREFERRED_STATE_DIR" ]; then
+  echo "Using state from old location: $OLD_STATE_DIR"
+  STATE_DIR="$OLD_STATE_DIR"
+else
+  STATE_DIR="$PREFERRED_STATE_DIR"
+fi
 
 if [ -d "$STATE_DIR" ] && [ "$CLEAN" = "false" ]; then
   echo "Reusing existing state in $STATE_DIR"
@@ -63,6 +66,8 @@ else
   if [ -d "$STATE_DIR" ]; then
     echo "Removing existing state in $STATE_DIR"
     rm -rf "$STATE_DIR"
+    # Once the directorly is deleted, we can use the preferred state directory.
+    STATE_DIR="$PREFERRED_STATE_DIR"
   fi
   echo "Extracting state into $STATE_DIR"
   mkdir -p "$STATE_DIR"


### PR DESCRIPTION
# Motivation

When extracting an snsdemo snapshot, we put the data in a directory in the dfx cache.
There are several problems with this:
1. The snapshot determines which version of dfx it is run with. But we don't know this until after the state is extracted. So when we determine the dfx cache directory, it might be a cache directory for a different version than the snapshot is created for.
2. This also means that if your dfx version is updated, the install script will look for the state in a different cache directory and not find it. This means you get a clean snapshot while you may have wanted to reuse the state you've created earlier.
3. On DevEnv, the cache directory exists on a different disk volume. This means that moving the directories in place is as slow as copying.

# Changes

1. Search across all dfx cache directories to find the dfx state directory, preferring newer versions.
2. If no existing state is found, or if it's deleted because of `--clean`, put the state directory in `$HOME/.snsdemo-state` (regardless of dfx version) instead of in the dfx cache.

# Tests

Manually with existing state directories in different places and without existing state directory.

# Todos

- [x] Add entry to changelog (if necessary).
