### PR TITLE
NNS1-3092: Fix wrapping of empty tags element

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronIdCell.svelte
@@ -14,11 +14,13 @@
     idPrefix="neuron-id-cell"
     showCopy
   />
-  <span class="tags">
-    {#each rowData.tags as tag}
-      <Tag testId="neuron-tag">{tag}</Tag>
-    {/each}
-  </span>
+  {#if rowData.tags.length > 0}
+    <span class="tags" data-tid="neuron-tags">
+      {#each rowData.tags as tag}
+        <Tag testId="neuron-tag">{tag}</Tag>
+      {/each}
+    </span>
+  {/if}
 </div>
 
 <style lang="scss">

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -224,7 +224,11 @@ describe("NeuronsTable", () => {
     });
     const rowPos = await po.getNeuronsTableRowPos();
     expect(rowPos).toHaveLength(2);
-    expect(await rowPos[0].getTags()).toEqual([]);
-    expect(await rowPos[1].getTags()).toEqual(tags);
+    const cell1 = rowPos[0].getNeuronIdCellPo();
+    expect(await cell1.getTags()).toEqual([]);
+    expect(await cell1.hasTagsElement()).toBe(false);
+    const cell2 = rowPos[1].getNeuronIdCellPo();
+    expect(await cell2.getTags()).toEqual(tags);
+    expect(await cell2.hasTagsElement()).toBe(true);
   });
 });

--- a/frontend/src/tests/page-objects/NeuronIdCell.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronIdCell.page-object.ts
@@ -17,6 +17,10 @@ export class NeuronIdCellPo extends BasePageObject {
     return this.getHashPo().getFullText();
   }
 
+  hasTagsElement(): Promise<boolean> {
+    return this.root.byTestId("neuron-tags").isPresent();
+  }
+
   async getTags(): Promise<string[]> {
     const tagElements = await this.root.allByTestId("neuron-tag");
     return Promise.all(tagElements.map((el) => el.getText()));


### PR DESCRIPTION
# Motivation

When there are no tags, the empty tags element can still cause line wrapping in the neuron ID cell.
See

https://github.com/dfinity/nns-dapp/assets/122978264/1cc50a20-0fde-416c-85e5-e919d1a130cf



# Changes

Remove the tags element if there are no tags.

# Tests

1. Unit test added.
2. Tested manually.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary