### PR TITLE
Vim script to sort svelte imports

### DIFF
--- a/scripts/sort-svelte-imports
+++ b/scripts/sort-svelte-imports
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+print_help() {
+  cat <<-EOF
+
+	Usage: sort-svelte-imports [FILE...]
+	Sorts the imports in Svelte files.
+
+	If FILE arguments are provided, sorts the imports in those files.
+	If directories are provided, sorts the imports in all Svelte files in those directories, recursively.
+	If no arguments are provided, sorts the imports in any Svelte files changed relative to the main branch.
+	If there are no changes, sorts the imports in all Svelte files in the project
+	exit
+	EOF
+}
+
+if [[ "$1" == "--help" ]]; then
+  print_help
+  exit 0
+fi
+
+TOP_DIR=$(git rev-parse --show-toplevel)
+
+list_files_to_sort() {
+  if [[ "$#" -ne 0 ]]; then
+    find "$@" -type f -name '*.svelte' -exec readlink -f {} \;
+    return
+  fi
+
+  ancestor=$(git merge-base HEAD main)
+  if git diff --quiet "$ancestor" --exit-code; then
+    git ls-files '*.svelte' | sed "s@^@$TOP_DIR/@"
+    return
+  fi
+
+  git diff --name-only "$ancestor" | grep '\.svelte$' | sed "s@^@$TOP_DIR/@"
+}
+
+mapfile -t FILES < <(list_files_to_sort "$@")
+
+vim -n -c "set nomore" -c "source $TOP_DIR/scripts/sort-svelte-imports.vim" -c "argdo call SortSvelteImports() | update" -c "qa" "${FILES[@]}"
+
+# The vim scripts puts every import on a single line. We call prettier to format
+# the imports in case they were on multiple lines.
+cd "$TOP_DIR/frontend"
+npx prettier --write "${FILES[@]}"

--- a/scripts/sort-svelte-imports
+++ b/scripts/sort-svelte-imports
@@ -22,8 +22,13 @@ fi
 
 TOP_DIR=$(git rev-parse --show-toplevel)
 
+# Outputs a list of files to sort. See help text above for how the list is
+# determined.
+# Files are given as absolute paths so they also work from the frontend
+# directory where we have to be to run prettier.
 list_files_to_sort() {
   if [[ "$#" -ne 0 ]]; then
+    # readlink makes the paths absolute
     find "$@" -type f -name '*.svelte' -exec readlink -f {} \;
     return
   fi

--- a/scripts/sort-svelte-imports.vim
+++ b/scripts/sort-svelte-imports.vim
@@ -1,0 +1,35 @@
+" Sorts imports in the current Svelte file.
+" First it joins all the lines that are part of the same import statement.
+" Then it modifies the lines by putting a copy of the path at the front of the line.
+" Then it sorts the lines.
+" Then it removes the path from the front of the line.
+" It does this separately for each contiguous block of import statements.
+function! SortSvelteImports()
+  let l:path_import_separator = ' #### path import separator #### '
+  let l:old_lines = line('$')
+  " Join all the lines that are part of the same import statement
+  while 1
+    silent! execute '%g/^\s*import\s\+.*[^;]$/normal J'
+    let l:new_lines = line('$')
+    if l:new_lines == l:old_lines
+      break
+    endif
+    let l:old_lines = l:new_lines
+  endwhile
+  " Jump to the first line
+  1
+  while 1
+    let l:first_import = search('^\s*import', 'W')
+    if first_import == 0
+      break
+    endif
+    let l:last_import = search('\v^(\s*import\s)@!', 'W') - 1
+    let l:range = first_import . ',' . last_import
+    " Put a copy of the path at the front of the line
+    execute range . 's@^\s*import\s\+.*\s*from\s*"\([^"]*\)"\s*;\s*$@\1' . path_import_separator . '&@'
+    " Sort the lines based on the path
+    execute range . '!sort'
+    " Remove the path from the front of the line
+    execute range 's@.*' . path_import_separator . '@@'
+  endwhile
+endfunction

--- a/scripts/sort-svelte-imports.vim
+++ b/scripts/sort-svelte-imports.vim
@@ -4,6 +4,10 @@
 " Then it sorts the lines.
 " Then it removes the path from the front of the line.
 " It does this separately for each contiguous block of import statements.
+"
+" To use this in Vim, you can add the following to your .vimrc to make
+" the 'gs' keyboard shortcut sort the imports in a Svelte file:
+" autocmd FileType svelte nnoremap gs :silent call SortSvelteImports()<CR>
 function! SortSvelteImports()
   let l:path_import_separator = ' #### path import separator #### '
   let l:old_lines = line('$')


### PR DESCRIPTION
# Motivation

I made a Vim keyboard shortcut for myself to sort Svelte imports and I thought it could be useful if made available as a script.

# Changes

1. Add a Vim script file to provide a function to sort Svelte imports.
2. Add a bash script which can run the Vim function on specified files.

# Tests

Manually

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary