### PR TITLE
Move nns actionable reloading

### DIFF
--- a/frontend/src/lib/services/nns-vote-registration.services.ts
+++ b/frontend/src/lib/services/nns-vote-registration.services.ts
@@ -1,11 +1,13 @@
 import { governanceApiService } from "$lib/api-services/governance.api-service";
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+import { loadActionableProposals } from "$lib/services/actionable-proposals.services";
 import {
   manageVotesRegistration,
   processRegisterVoteErrors,
   updateVoteRegistrationToastMessage,
   voteRegistrationByProposal,
 } from "$lib/services/vote-registration.services";
+import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { proposalsStore } from "$lib/stores/proposals.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { voteRegistrationStore } from "$lib/stores/vote-registration.store";
@@ -18,8 +20,6 @@ import { get } from "svelte/store";
 import { loadProposal } from "./$public/proposals.services";
 import { getAuthenticatedIdentity } from "./auth.services";
 import { listNeurons } from "./neurons.services";
-import {actionableNnsProposalsStore} from "$lib/stores/actionable-nns-proposals.store";
-import {loadActionableProposals} from "$lib/services/actionable-proposals.services";
 
 /**
  * Makes multiple registerVote calls (1 per neuronId).

--- a/frontend/src/lib/services/nns-vote-registration.services.ts
+++ b/frontend/src/lib/services/nns-vote-registration.services.ts
@@ -18,6 +18,8 @@ import { get } from "svelte/store";
 import { loadProposal } from "./$public/proposals.services";
 import { getAuthenticatedIdentity } from "./auth.services";
 import { listNeurons } from "./neurons.services";
+import {actionableNnsProposalsStore} from "$lib/stores/actionable-nns-proposals.store";
+import {loadActionableProposals} from "$lib/services/actionable-proposals.services";
 
 /**
  * Makes multiple registerVote calls (1 per neuronId).

--- a/frontend/src/lib/services/nns-vote-registration.services.ts
+++ b/frontend/src/lib/services/nns-vote-registration.services.ts
@@ -62,6 +62,10 @@ export const registerNnsVotes = async ({
       // the one that was called
       proposalsStore.replaceProposals([updatedProposalInfo]);
       updateProposalContext(updatedProposalInfo);
+
+      // Reset and reload actionable nns proposals.
+      actionableNnsProposalsStore.reset();
+      loadActionableProposals().then();
     },
   });
 };

--- a/frontend/src/lib/services/vote-registration.services.ts
+++ b/frontend/src/lib/services/vote-registration.services.ts
@@ -1,5 +1,3 @@
-import { loadActionableProposals } from "$lib/services/actionable-proposals.services";
-import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { i18n } from "$lib/stores/i18n";
 import {
   toastsError,

--- a/frontend/src/lib/services/vote-registration.services.ts
+++ b/frontend/src/lib/services/vote-registration.services.ts
@@ -86,10 +86,6 @@ export const manageVotesRegistration = async ({
       proposalIdString,
       canisterId: universeCanisterId,
     });
-
-    // Reset and reload actionable nns proposals.
-    actionableNnsProposalsStore.reset();
-    loadActionableProposals().then();
   } catch (err: unknown) {
     console.error("vote unknown:", err);
 

--- a/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
@@ -1,4 +1,5 @@
 import * as api from "$lib/api/sns-governance.api";
+import * as actionableProposalsService from "$lib/services/actionable-proposals.services";
 import * as snsGovernanceApi from "$lib/api/sns-governance.api";
 import { registerSnsVotes } from "$lib/services/sns-vote-registration.services";
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
@@ -277,6 +278,46 @@ describe("sns-vote-registration-services", () => {
           includeBallotsByCaller: true,
         },
       });
+    });
+
+    it("should not reset actionable nns proposals after voting", async () => {
+      vi.spyOn(snsGovernanceApi, "registerVote").mockResolvedValue();
+      const spyLoadActionableProposalsNns = vi
+        .spyOn(actionableProposalsService, "loadActionableProposals");
+      const rootCanisterId2 = principal(13);
+      actionableSnsProposalsStore.set({
+        rootCanisterId,
+        proposals: [proposal1, proposal2],
+        includeBallotsByCaller: true,
+      });
+      actionableSnsProposalsStore.set({
+        rootCanisterId: rootCanisterId2,
+        proposals: [proposal1, proposal2],
+        includeBallotsByCaller: true,
+      });
+
+      expect(get(actionableSnsProposalsStore)).toEqual({
+        [rootCanisterId.toText()]: {
+          proposals: [proposal1, proposal2],
+          includeBallotsByCaller: true,
+        },
+        [rootCanisterId2.toText()]: {
+          proposals: [proposal1, proposal2],
+          includeBallotsByCaller: true,
+        },
+      });
+      expect(spyQuerySnsProposals).toBeCalledTimes(0);
+      expect(spyLoadActionableProposalsNns).toBeCalledTimes(0);
+
+      await callRegisterVote({
+        vote: SnsVote.Yes,
+        reloadProposalCallback: () => {
+          // do nothing
+        },
+      });
+
+      expect(spyQuerySnsProposals).toBeCalledTimes(1);
+      expect(spyLoadActionableProposalsNns).toBeCalledTimes(0);
     });
 
     it("should display a correct error details", async () => {

--- a/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-vote-registration.services.spec.ts
@@ -1,6 +1,6 @@
 import * as api from "$lib/api/sns-governance.api";
-import * as actionableProposalsService from "$lib/services/actionable-proposals.services";
 import * as snsGovernanceApi from "$lib/api/sns-governance.api";
+import * as actionableProposalsService from "$lib/services/actionable-proposals.services";
 import { registerSnsVotes } from "$lib/services/sns-vote-registration.services";
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
@@ -282,8 +282,10 @@ describe("sns-vote-registration-services", () => {
 
     it("should not reset actionable nns proposals after voting", async () => {
       vi.spyOn(snsGovernanceApi, "registerVote").mockResolvedValue();
-      const spyLoadActionableProposalsNns = vi
-        .spyOn(actionableProposalsService, "loadActionableProposals");
+      const spyLoadActionableProposalsNns = vi.spyOn(
+        actionableProposalsService,
+        "loadActionableProposals"
+      );
       const rootCanisterId2 = principal(13);
       actionableSnsProposalsStore.set({
         rootCanisterId,


### PR DESCRIPTION
# Motivation

Voting for the SNS proposals should not trigger the reloading of NNS actionable items.

# Changes

- Moved the NNS actionable reloading logic from the general function (used by both NNS and SNS) to an NNS-specific function.

# Tests

- Added a test to ensure that voting on SNS proposals does not trigger NNS reloading. Verified that the test fails without the changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.