### PR TITLE
Bump Rust to 1.79 and fix lint

### DIFF
--- a/rs/backend/src/accounts_store/schema/proxy/migration.rs
+++ b/rs/backend/src/accounts_store/schema/proxy/migration.rs
@@ -65,7 +65,7 @@ impl AccountsDbAsProxy {
     ///   - This may be no larger than `Self::MIGRATION_STEP_SIZE_MAX`.  If it is larger, it will be reduced.
     pub fn step_migration(&mut self, step_size: u32) {
         // Ensure that the step size is modest:
-        let step_size = step_size.min(Self::MIGRATION_STEP_SIZE_MAX).max(1);
+        let step_size = step_size.clamp(1, Self::MIGRATION_STEP_SIZE_MAX);
         if let Some(migration) = &mut self.migration {
             if let Some(next_to_migrate) = &migration.next_to_migrate {
                 println!("Stepping migration: {:?} -> {:?}", self.authoritative_db, migration.db);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Please, from time to time, update this to the latest stable version on Rust Forge: https://forge.rust-lang.org/
-channel = "1.78.0"
+channel = "1.79.0"
 components = ["rustfmt", "clippy"]
 targets = [ "wasm32-unknown-unknown"]


### PR DESCRIPTION
# Motivation

The automatic [Rust version upgrade](https://github.com/dfinity/nns-dapp/pull/5051) failed because of a [lint error](https://github.com/dfinity/nns-dapp/actions/runs/9510216178/job/26214335680?pr=5051).

# Changes

1. Bump Rust to 1.79.0
2. Fix the lint error.

# Tests

`scripts/lint-rs` passes

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary