### PR TITLE
NNS1-3093: Filter out SNS neurons without stake

### DIFF
--- a/frontend/src/lib/derived/sns/sns-sorted-neurons.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-sorted-neurons.derived.ts
@@ -8,14 +8,19 @@ import type { SnsNeuron } from "@dfinity/sns";
 import { derived, type Readable } from "svelte/store";
 import { selectedUniverseIdStore } from "../selected-universe.derived";
 
-export const snsSortedNeuronStore: Readable<SnsNeuron[]> = derived(
+export const definedSnsNeuronStore: Readable<SnsNeuron[]> = derived(
   [snsNeuronsStore, selectedUniverseIdStore],
   ([store, selectedSnsRootCanisterId]) => {
     const projectStore = store[selectedSnsRootCanisterId.toText()];
     return projectStore === undefined
       ? []
-      : sortSnsNeuronsByStake(projectStore.neurons.filter(hasValidStake));
+      : projectStore.neurons.filter(hasValidStake);
   }
+);
+
+export const snsSortedNeuronStore: Readable<SnsNeuron[]> = derived(
+  definedSnsNeuronStore,
+  (store) => sortSnsNeuronsByStake(store)
 );
 
 export const sortedSnsUserNeuronsStore: Readable<SnsNeuron[]> = derived(

--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -2,10 +2,10 @@
   import { ENABLE_NEURONS_TABLE } from "$lib/stores/feature-flags.store";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
-  import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import {
     sortedSnsCFNeuronsStore,
     sortedSnsUserNeuronsStore,
+    definedSnsNeuronStore,
   } from "$lib/derived/sns/sns-sorted-neurons.derived";
   import { i18n } from "$lib/stores/i18n";
   import { authStore } from "$lib/stores/auth.store";
@@ -71,7 +71,7 @@
           token: summary.token,
           identity: $authStore.identity,
           i18n: $i18n,
-          snsNeurons: $snsNeuronsStore[$pageStore.universe]?.neurons ?? [],
+          snsNeurons: $definedSnsNeuronStore,
         })
       : [];
 </script>

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -34,6 +34,12 @@ describe("SnsNeurons", () => {
     id: [1, 2, 4],
     stake: neuron2Stake,
   });
+  const disbursedNeuronStake = 0n;
+  const disbursedNeuron = createMockSnsNeuron({
+    id: [1, 2, 5],
+    stake: disbursedNeuronStake,
+    maturity: 0n,
+  });
   const neuronNFStake = 400_000_000n;
   const neuronNF: SnsNeuron = {
     ...createMockSnsNeuron({
@@ -49,6 +55,9 @@ describe("SnsNeurons", () => {
     }
     if (neuronId === neuron2.id[0]) {
       return neuron2Stake;
+    }
+    if (neuronId === disbursedNeuron.id[0]) {
+      return disbursedNeuronStake;
     }
     if (neuronId === neuronNF.id[0]) {
       return neuronNFStake;
@@ -239,6 +248,18 @@ describe("SnsNeurons", () => {
         const po = await renderComponent();
 
         expect(await po.hasEmptyMessage()).toBe(false);
+      });
+
+      it("should not render disbursed neurons", async () => {
+        vi.spyOn(snsGovernanceApi, "querySnsNeurons").mockResolvedValue([
+          neuron1,
+          disbursedNeuron,
+          neuronNF,
+        ]);
+        const po = await renderComponent();
+
+        const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
+        expect(rows).toHaveLength(2);
       });
     });
   });


### PR DESCRIPTION
# Motivation

We don't show neurons without stake or maturity.
With the neurons table for SNS neurons, this logic was accidentally lost.
Because the neurons table does its own sorting, we weren't using the sorted stores, but the sorted stores also took care of the filtering.

# Changes

1. Define `definedSnsNeuronStore`, analogous to [definedNeuronsStore](https://github.com/dfinity/nns-dapp/blob/3315aa7c51fe405c3139673bc269ece6979ea70d/frontend/src/lib/stores/neurons.store.ts#L87) for NNS neurons.
2. Use `definedSnsNeuronStore` in `SnsNeurons.svelte`.

# Tests

1. Unit tests for `definedSnsNeuronStore`.
2. Add tests for `SnsNeurons`.
3. Add analogous tests for `NnsNeurons`.
4. Test manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/neurons/?u=br5f7-7uaaa-aaaaa-qaaca-cai

# Todos

- [ ] Add entry to changelog (if necessary).
not yet