### PR TITLE
NNS1-3092: Show detailed neuron stake in table

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronStakeCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronStakeCell.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <div data-tid="neuron-stake-cell-component" class="container">
-  <AmountDisplay singleLine amount={rowData.stake} />
+  <AmountDisplay singleLine amount={rowData.stake} detailed />
 </div>
 
 <style lang="scss">

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -152,6 +152,20 @@ describe("NeuronsTable", () => {
     expect(await rowPos[1].getStake()).toBe("5.00 ICP");
   });
 
+  it("should render detailed neuron stake", async () => {
+    const po = renderComponent({
+      neurons: [
+        {
+          ...neuron1,
+          stake: makeStake(999_990_000n),
+        },
+      ],
+    });
+    const rowPos = await po.getNeuronsTableRowPos();
+    expect(rowPos).toHaveLength(1);
+    expect(await rowPos[0].getStake()).toBe("9.9999 ICP");
+  });
+
   it("should render neuron state", async () => {
     const po = renderComponent({ neurons: [neuron1, neuron2] });
     const rowPos = await po.getNeuronsTableRowPos();


### PR DESCRIPTION
# Motivation

In the neuron cards we set the `detailed` prop on the `AmountDisplay` to show more digits if necessary:
https://github.com/dfinity/nns-dapp/blob/a85f919cbde9f18faae5bed08c70d6a91b72b0a3/frontend/src/lib/components/neurons/NnsNeuronAmount.svelte#L32

So for consistency we should do the same in the neurons table.

# Changes

Add `detailed` prop in `NeuronStakeCell.svelte`.

# Tests

Unit test added.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet