### PR TITLE
Prevent clicking on tooltip icons to follow links

### DIFF
--- a/frontend/src/lib/components/ui/TooltipIcon.svelte
+++ b/frontend/src/lib/components/ui/TooltipIcon.svelte
@@ -6,7 +6,9 @@
   export let text: string;
 </script>
 
-<div class="wrapper" data-tid="tooltip-icon-component">
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<div class="wrapper" data-tid="tooltip-icon-component" on:click|preventDefault>
   <Tooltip id={tooltipId} idPrefix={tooltipIdPrefix} {text}>
     <IconInfo />
   </Tooltip>


### PR DESCRIPTION
# Motivation

We want to put tooltip icons in the neurons table rows.
On mobile, you have to touch the tooltip target for the tooltip to appear.
The table rows are actually links so if you touch anything in it, it opens the neuron details view.

# Changes

1. Add a `preventDefault` click handler on the tooltip icon component.

# Tests

Can't really be unit tests because of limitations in the testing framework.
Tested manually in another branch.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary