### PR TITLE
Rename TooltipIconPo.getText() to getTooltipText()

### DIFF
--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
@@ -159,7 +159,7 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
     };
     const po = renderComponent(neuron);
 
-    expect(await po.getTooltipIconPo().getText()).toBe(
+    expect(await po.getTooltipIconPo().getTooltipText()).toBe(
       "Dissolve delay is the minimum amount of time you have to wait for the neuron to unlock, and ICP to be available again. If your neuron is dissolving, your ICP will be available in 2 years, 12 hours."
     );
   });
@@ -172,7 +172,7 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
     };
     const po = renderComponent(neuron);
 
-    expect(await po.getTooltipIconPo().getText()).toBe(
+    expect(await po.getTooltipIconPo().getTooltipText()).toBe(
       "Dissolve delay is the minimum amount of time you have to wait for the neuron to unlock, and ICP to be available again. If your neuron is dissolving, your ICP will be available in 2 years, 12 hours."
     );
   });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.spec.ts
@@ -124,7 +124,7 @@ describe("SnsAvailableMaturityItemAction", () => {
     });
     const po = renderComponent(neuron);
 
-    expect(await po.getTooltipIconPo().getText()).toBe(
+    expect(await po.getTooltipIconPo().getTooltipText()).toBe(
       "Available maturity can be staked, or burned to disburse an amount of REAL that is subject to a non-deterministic process, called maturity modulation."
     );
   });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.spec.ts
@@ -169,7 +169,7 @@ describe("SnsNeuronDissolveDelayItemAction", () => {
     });
     const po = renderComponent(neuron);
 
-    expect(await po.getTooltipIconPo().getText()).toBe(
+    expect(await po.getTooltipIconPo().getTooltipText()).toBe(
       "Dissolve delay is the minimum amount of time you have to wait for the neuron to unlock, and ZXCV to be available again. If your neuron is dissolving, your ZXCV will be available in 4 years."
     );
   });
@@ -186,7 +186,7 @@ describe("SnsNeuronDissolveDelayItemAction", () => {
     });
     const po = renderComponent(neuron);
 
-    expect(await po.getTooltipIconPo().getText()).toBe(
+    expect(await po.getTooltipIconPo().getTooltipText()).toBe(
       "Dissolve delay is the minimum amount of time you have to wait for the neuron to unlock, and ZXCV to be available again. If your neuron is dissolving, your ZXCV will be available in 4 years."
     );
   });

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronMaturitySection.spec.ts
@@ -51,7 +51,10 @@ describe("SnsNeuronMaturitySection", () => {
     const po = renderComponent(mockNeuron);
 
     expect(
-      await po.getAvailableMaturityItemActionPo().getTooltipIconPo().getText()
+      await po
+        .getAvailableMaturityItemActionPo()
+        .getTooltipIconPo()
+        .getTooltipText()
     ).toBe(
       "Available maturity can be staked, or burned to disburse an amount of BLOB that is subject to a non-deterministic process, called maturity modulation."
     );

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.spec.ts
@@ -178,6 +178,8 @@ describe("SnsNeuronStateItemAction", () => {
     });
     const po = renderComponent(neuron);
 
-    expect(await po.getTooltipIconPo().getText()).toContain(token.symbol);
+    expect(await po.getTooltipIconPo().getTooltipText()).toContain(
+      token.symbol
+    );
   });
 });

--- a/frontend/src/tests/lib/components/ui/CommonItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/ui/CommonItemAction.spec.ts
@@ -26,7 +26,7 @@ describe("CommonItemAction", () => {
   it("should render the tooltip text", async () => {
     const po = renderComponent();
 
-    expect(await po.getTooltipIconPo().getText()).toBe(tooltipText);
+    expect(await po.getTooltipIconPo().getTooltipText()).toBe(tooltipText);
   });
 
   it("should render the tooltip id", async () => {

--- a/frontend/src/tests/lib/components/ui/TooltipIcon.spec.ts
+++ b/frontend/src/tests/lib/components/ui/TooltipIcon.spec.ts
@@ -30,7 +30,7 @@ describe("TooltipIcon", () => {
 
   it("should have the tooltip text", async () => {
     const po = renderComponent({ tooltipId });
-    expect(await po.getText()).toBe(text);
+    expect(await po.getTooltipText()).toBe(text);
   });
 
   it("should have the tooltip ID", async () => {

--- a/frontend/src/tests/page-objects/TooltipIcon.page-object.ts
+++ b/frontend/src/tests/page-objects/TooltipIcon.page-object.ts
@@ -13,7 +13,7 @@ export class TooltipIconPo extends BasePageObject {
     return TooltipPo.under(this.root);
   }
 
-  getText(): Promise<string> {
+  getTooltipText(): Promise<string> {
     return this.getTooltipPo().getTooltipText();
   }
 }


### PR DESCRIPTION
# Motivation

`TooltipIconPo.getText()` is masking `getText()` on the base class.
I want to add the possibility to pass the tooltip content as a slot to the `TooltipIcon` component and I want to add a test which calls `TooltipIconPo.getText()` (from the base class) to make sure the slot doesn't end up in the tooltip target as opposed to the tooltip content.

# Changes

Rename TooltipIconPo.getText() to getTooltipText()

# Tests

Unit tests updated.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary