### PR TITLE
Support content slot in TooltipIcon

### DIFF
--- a/frontend/src/lib/components/ui/TooltipIcon.svelte
+++ b/frontend/src/lib/components/ui/TooltipIcon.svelte
@@ -3,7 +3,7 @@
 
   export let tooltipId: string | undefined;
   export let tooltipIdPrefix = "tooltip-icon";
-  export let text: string;
+  export let text: string | undefined = undefined;
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -11,6 +11,7 @@
 <div class="wrapper" data-tid="tooltip-icon-component" on:click|preventDefault>
   <Tooltip id={tooltipId} idPrefix={tooltipIdPrefix} {text}>
     <IconInfo />
+    <slot slot="tooltip-content" />
   </Tooltip>
 </div>
 

--- a/frontend/src/tests/lib/components/ui/TooltipIcon.spec.ts
+++ b/frontend/src/tests/lib/components/ui/TooltipIcon.spec.ts
@@ -1,7 +1,8 @@
 import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
-import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
+import TooltipIconTest from "./TooltipIconTest.svelte";
 
 describe("TooltipIcon", () => {
   const text = "This is the text displayed in the tooltip";
@@ -51,5 +52,32 @@ describe("TooltipIcon", () => {
     const describedBy = await po.getAriaDescribedBy();
     expect(describedBy).toMatch(new RegExp(`tooltip-icon-`));
     expect(await po.getTooltipId()).toBe(describedBy);
+  });
+
+  it("should not render any text or whitespace in the tooltip target", async () => {
+    const po = renderComponent({});
+    expect(`'${await po.getText()}'`).toBe("''");
+  });
+
+  describe("when the tooltip content is passed as a slot", () => {
+    const renderComponentWithSlot = (text: string) => {
+      const { container } = render(TooltipIconTest, {
+        text,
+        tooltipId,
+        tooltipIdPrefix,
+      });
+      return TooltipIconPo.under(new JestPageObjectElement(container));
+    };
+
+    it("should not render any text or whitespace in the tooltip target", async () => {
+      const po = renderComponentWithSlot(text);
+      expect(`'${await po.getText()}'`).toBe("''");
+    });
+
+    it("should render the slot in the tooltip", async () => {
+      const text = "Tooltip text passed as slot";
+      const po = renderComponentWithSlot(text);
+      expect(await po.getTooltipPo().getTooltipText()).toBe(text);
+    });
   });
 });

--- a/frontend/src/tests/lib/components/ui/TooltipIconTest.svelte
+++ b/frontend/src/tests/lib/components/ui/TooltipIconTest.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
+
+  export let tooltipId: string | undefined;
+  export let tooltipIdPrefix = "tooltip-icon";
+  export let text: string;
+</script>
+
+<TooltipIcon {tooltipId} {tooltipIdPrefix}>
+  <div data-tid="tooltip-content-slot">
+    {text}
+  </div>
+</TooltipIcon>


### PR DESCRIPTION
# Motivation

We want to be able to use rich tooltips with tooltip icons to display maturity in the neurons table.
Tooltips already support rich content by using a slot instead of a prop.

# Changes

1. Make `text` optional on `TooltipIcon`
2. Pass the `slot` (if present) on to `Tooltip` as tooltip content.

# Tests

1. Unit test added.
2. Tested manually in another branch.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary