### PR TITLE
NNS1-3134: Add maturity fields to TableNeuron

### DIFF
--- a/frontend/src/lib/types/neurons-table.ts
+++ b/frontend/src/lib/types/neurons-table.ts
@@ -7,6 +7,8 @@ export type TableNeuron = {
   domKey: string;
   neuronId: string;
   stake: TokenAmountV2;
+  availableMaturity: bigint;
+  stakedMaturity: bigint;
   dissolveDelaySeconds: bigint;
   state: NeuronState;
   tags: string[];

--- a/frontend/src/lib/utils/neurons-table.utils.ts
+++ b/frontend/src/lib/utils/neurons-table.utils.ts
@@ -21,7 +21,12 @@ import {
 import type { Identity } from "@dfinity/agent";
 import type { NeuronInfo } from "@dfinity/nns";
 import type { SnsNeuron } from "@dfinity/sns";
-import { ICPToken, TokenAmountV2, type Token } from "@dfinity/utils";
+import {
+  ICPToken,
+  TokenAmountV2,
+  fromNullable,
+  type Token,
+} from "@dfinity/utils";
 
 export const tableNeuronsFromNeuronInfos = ({
   neuronInfos,
@@ -52,6 +57,8 @@ export const tableNeuronsFromNeuronInfos = ({
         amount: neuronStake(neuronInfo),
         token: ICPToken,
       }),
+      availableMaturity: neuronInfo.fullNeuron?.maturityE8sEquivalent ?? 0n,
+      stakedMaturity: neuronInfo.fullNeuron?.stakedMaturityE8sEquivalent ?? 0n,
       dissolveDelaySeconds,
       state: neuronInfo.state,
       tags: getNeuronTags({
@@ -92,6 +99,9 @@ export const tableNeuronsFromSnsNeurons = ({
         amount: getSnsNeuronStake(snsNeuron),
         token,
       }),
+      availableMaturity: snsNeuron.maturity_e8s_equivalent ?? 0n,
+      stakedMaturity:
+        fromNullable(snsNeuron.staked_maturity_e8s_equivalent) ?? 0n,
       dissolveDelaySeconds,
       state: getSnsNeuronState(snsNeuron),
       tags: getSnsNeuronTags({

--- a/frontend/src/tests/mocks/neurons.mock.ts
+++ b/frontend/src/tests/mocks/neurons.mock.ts
@@ -110,6 +110,8 @@ export const mockTableNeuron: TableNeuron = {
     amount: 1n,
     token: ICPToken,
   }),
+  availableMaturity: 0n,
+  stakedMaturity: 0n,
   dissolveDelaySeconds: 1n,
   state: NeuronState.Locked,
   tags: [],


### PR DESCRIPTION
# Motivation

We want to show maturity in the neurons table.
In this PR we just add fields to the `TableNeuron` type and don't display anything yet.

# Changes

1. Add `availableMaturity` and `stakedMaturity` fields to the `TableNeuron` type.
2. Populate the fields in `tableNeuronsFromNeuronInfos` and `tableNeuronsFromSnsNeurons`.

# Tests

1. Unit tests added.
2. Mock updated.
3. Fixed a few cases where we weren't using the default test values but we hadn't noticed yet because the value we used didn't differ in relevant way (but now it does).

# Todos

- [ ] Add entry to changelog (if necessary).
not yet