### PR TITLE
Remove unnecessary step from did2rs.sh

### DIFF
--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -125,10 +125,6 @@ cd "$GIT_ROOT"
             # Comment out the header "use", "//!" and "#!" lines.
 	    s@^(use |//!|#!)@// &@;
 
-	    # Make types and fields public:
-            s/^(struct|enum|type) /pub &/;
-            s/^    [a-z].*:/    pub&/;s/^( *pub ) *pub /\1/;
-
 	    # Add traits
             s/#\[derive\(/&'"${TRAITS:-}${TRAITS:+, }"'/;
 

--- a/scripts/did2rs.sh
+++ b/scripts/did2rs.sh
@@ -100,7 +100,6 @@ cd "$GIT_ROOT"
   #
   # sed:
   #   - Comments out the header provided by didc; we provide our own and the two conflict.
-  #   - Makes structures and their fields "pub", so that they can be used.
   #   - Adds additional traits after "Deserialize".
   #   - Makes API call response types "CallResult".  The alternative convention is to have:
   #       use ic_cdk::api::call::CallResult as Result;


### PR DESCRIPTION
# Motivation

`did2rs.sh` uses `didc` to create Rust from Candid files.
It adds a step to make types and fields public.
But newer versions of `didc` already do this.
So the extra step is not necessary anymore.
And in a beta version I tried this unnecessary step was causing problems.

# Changes

Remove the step to add `pub` to types and fields.

# Tests

CI has [tests](https://github.com/dfinity/nns-dapp/blob/ca8d8c26be5d64d9319e3ccfce8a2b7e4e3a1a1d/.github/workflows/checks.yml#L146-L153) to make sure generated code is the same.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary