### PR TITLE
bot: Update proposals candid bindings

### DIFF
--- a/declarations/used_by_proposals/nns_governance/nns_governance.did
+++ b/declarations/used_by_proposals/nns_governance/nns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-12_23-01-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-base/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
@@ -202,11 +202,13 @@ type GovernanceCachedMetrics = record {
   not_dissolving_neurons_count : nat64;
   total_locked_e8s : nat64;
   neurons_fund_total_active_neurons : nat64;
+  total_voting_power_non_self_authenticating_controller : opt nat64;
   total_staked_maturity_e8s_equivalent : nat64;
   not_dissolving_neurons_e8s_buckets_ect : vec record { nat64; float64 };
   total_staked_e8s_ect : nat64;
   not_dissolving_neurons_staked_maturity_e8s_equivalent_sum : nat64;
   dissolved_neurons_e8s : nat64;
+  total_staked_e8s_non_self_authenticating_controller : opt nat64;
   dissolving_neurons_e8s_buckets_seed : vec record { nat64; float64 };
   neurons_with_less_than_6_months_dissolve_delay_e8s : nat64;
   not_dissolving_neurons_staked_maturity_e8s_equivalent_buckets : vec record {

--- a/declarations/used_by_proposals/nns_registry/nns_registry.did
+++ b/declarations/used_by_proposals/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-12_23-01-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-base/rs/registry/canister/canister/registry.did>
 // A brief note about the history of this file: This file used to be
 // automatically generated, but now, it is hand-crafted, because the
 // auto-generator has some some pretty degenerate behaviors. The worst of those
@@ -119,8 +119,6 @@ type DataCenterRecord = record {
   region : text;
   owner : text;
 };
-
-type DeleteSubnetPayload = record { subnet_id : opt principal };
 
 type DeployGuestosToAllSubnetNodesPayload = record {
   subnet_id : principal;

--- a/declarations/used_by_proposals/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_proposals/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-12_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };

--- a/dfx.json
+++ b/dfx.json
@@ -388,7 +388,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-06-12",
-        "IC_COMMIT_FOR_PROPOSALS": "release-2024-06-12_23-01-base",
+        "IC_COMMIT_FOR_PROPOSALS": "release-2024-06-19_23-01-base",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-06-05_23-01-storage-layer-disabled"
       },
       "packtool": ""

--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-12_23-01-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-base/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -453,11 +453,13 @@ pub struct GovernanceCachedMetrics {
     pub not_dissolving_neurons_count: u64,
     pub total_locked_e8s: u64,
     pub neurons_fund_total_active_neurons: u64,
+    pub total_voting_power_non_self_authenticating_controller: Option<u64>,
     pub total_staked_maturity_e8s_equivalent: u64,
     pub not_dissolving_neurons_e8s_buckets_ect: Vec<(u64, f64)>,
     pub total_staked_e8s_ect: u64,
     pub not_dissolving_neurons_staked_maturity_e8s_equivalent_sum: u64,
     pub dissolved_neurons_e8s: u64,
+    pub total_staked_e8s_non_self_authenticating_controller: Option<u64>,
     pub dissolving_neurons_e8s_buckets_seed: Vec<(u64, f64)>,
     pub neurons_with_less_than_6_months_dissolve_delay_e8s: u64,
     pub not_dissolving_neurons_staked_maturity_e8s_equivalent_buckets: Vec<(u64, f64)>,

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-12_23-01-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-base/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-12_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.
Even with no changes, just updating the reference is good practice.

# Changes
* Update the version of `IC_COMMIT_FOR_PROPOSALS` specified in `dfx.json`.
* Updated the `proposals` candid files to the versions in that commit.
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants