### PR TITLE
Update proposals candid bindings for tSchnorr

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Maturity visible in neurons table.
+* Support rendering `tSchnorr` proposal parameters.
 
 #### Changed
 

--- a/declarations/used_by_proposals/nns_governance/nns_governance.did
+++ b/declarations/used_by_proposals/nns_governance/nns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/2538538e0132b394f302c49fd91da23fc4cee284/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;

--- a/declarations/used_by_proposals/nns_registry/nns_registry.did
+++ b/declarations/used_by_proposals/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/2538538e0132b394f302c49fd91da23fc4cee284/rs/registry/canister/canister/registry.did>
 // A brief note about the history of this file: This file used to be
 // automatically generated, but now, it is hand-crafted, because the
 // auto-generator has some some pretty degenerate behaviors. The worst of those
@@ -96,6 +96,7 @@ type CreateSubnetPayload = record {
   max_ingress_messages_per_block : nat64;
   max_number_of_canisters : nat64;
   ecdsa_config : opt EcdsaInitialConfig;
+  chain_key_config : opt InitialChainKeyConfig;
   gossip_max_artifact_streams_per_peer : nat32;
   replica_version_id : text;
   gossip_max_duplicity : nat32;
@@ -128,6 +129,29 @@ type DeployGuestosToAllSubnetNodesPayload = record {
 type DeployGuestosToAllUnassignedNodesPayload = record {
   elected_replica_version : text;
 };
+
+type InitialChainKeyConfig = record {
+  key_configs : vec KeyConfigRequest;
+  signature_request_timeout_ns : opt nat64;
+  idkg_key_rotation_period_ms : opt nat64;
+};
+
+type KeyConfigRequest = record {
+  key_config : opt KeyConfig;
+  subnet_id : opt principal;
+};
+
+type KeyConfig = record {
+  key_id : opt MasterPublicKeyId;
+  pre_signatures_to_create_in_advance : opt nat32;
+  max_queue_size : opt nat32;
+};
+
+type MasterPublicKeyId = variant { Schnorr : SchnorrKeyId; Ecdsa : EcdsaKeyId };
+
+type SchnorrKeyId = record { algorithm : SchnorrAlgorithm; name : text };
+
+type SchnorrAlgorithm = variant { ed25519; bip340secp256k1 };
 
 type EcdsaConfig = record {
   quadruples_to_create_in_advance : nat32;
@@ -229,6 +253,7 @@ type RecoverSubnetPayload = record {
   subnet_id : principal;
   registry_store_uri : opt record { text; text; nat64 };
   ecdsa_config : opt EcdsaInitialConfig;
+  chain_key_config : opt InitialChainKeyConfig;
   state_hash : blob;
   time_ns : nat64;
 };
@@ -358,26 +383,35 @@ type UpdateSubnetPayload = record {
   subnet_id : principal;
   max_ingress_bytes_per_message : opt nat64;
   dkg_dealings_per_block : opt nat64;
-  ecdsa_key_signing_disable : opt vec EcdsaKeyId;
   max_block_payload_size : opt nat64;
   max_instructions_per_install_code : opt nat64;
   start_as_nns : opt bool;
   is_halted : opt bool;
   max_ingress_messages_per_block : opt nat64;
   max_number_of_canisters : opt nat64;
-  ecdsa_config : opt EcdsaConfig;
   retransmission_request_ms : opt nat32;
   dkg_interval_length : opt nat64;
   registry_poll_period_ms : opt nat32;
   max_chunk_wait_ms : opt nat32;
   receive_check_cache_size : opt nat32;
-  ecdsa_key_signing_enable : opt vec EcdsaKeyId;
   ssh_backup_access : opt vec text;
   max_chunk_size : opt nat32;
   initial_notary_delay_millis : opt nat64;
   max_artifact_streams_per_peer : opt nat32;
   subnet_type : opt SubnetType;
   ssh_readonly_access : opt vec text;
+  chain_key_config : opt ChainKeyConfig;
+  chain_key_signing_enable : opt vec MasterPublicKeyId;
+  chain_key_signing_disable : opt vec MasterPublicKeyId;
+  ecdsa_config : opt EcdsaConfig;
+  ecdsa_key_signing_enable : opt vec EcdsaKeyId;
+  ecdsa_key_signing_disable : opt vec EcdsaKeyId;
+};
+
+type ChainKeyConfig = record {
+  key_configs : vec KeyConfig;
+  signature_request_timeout_ns : opt nat64;
+  idkg_key_rotation_period_ms : opt nat64;
 };
 
 type UpdateUnassignedNodesConfigPayload = record {

--- a/declarations/used_by_proposals/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_proposals/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/2538538e0132b394f302c49fd91da23fc4cee284/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };

--- a/dfx.json
+++ b/dfx.json
@@ -388,7 +388,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-06-19",
-        "IC_COMMIT_FOR_PROPOSALS": "release-2024-06-19_23-01-base",
+        "IC_COMMIT_FOR_PROPOSALS": "2538538e0132b394f302c49fd91da23fc4cee284",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-06-05_23-01-storage-layer-disabled"
       },
       "packtool": ""

--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/2538538e0132b394f302c49fd91da23fc4cee284/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/2538538e0132b394f302c49fd91da23fc4cee284/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -157,6 +157,40 @@ pub struct EcdsaInitialConfig {
     pub idkg_key_rotation_period_ms: Option<u64>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
+pub enum SchnorrAlgorithm {
+    #[serde(rename = "ed25519")]
+    Ed25519,
+    #[serde(rename = "bip340secp256k1")]
+    Bip340Secp256K1,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct SchnorrKeyId {
+    pub algorithm: SchnorrAlgorithm,
+    pub name: String,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub enum MasterPublicKeyId {
+    Schnorr(SchnorrKeyId),
+    Ecdsa(EcdsaKeyId),
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct KeyConfig {
+    pub max_queue_size: Option<u32>,
+    pub key_id: Option<MasterPublicKeyId>,
+    pub pre_signatures_to_create_in_advance: Option<u32>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct KeyConfigRequest {
+    pub subnet_id: Option<Principal>,
+    pub key_config: Option<KeyConfig>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct InitialChainKeyConfig {
+    pub signature_request_timeout_ns: Option<u64>,
+    pub key_configs: Vec<KeyConfigRequest>,
+    pub idkg_key_rotation_period_ms: Option<u64>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
 pub enum SubnetType {
     #[serde(rename = "application")]
     Application,
@@ -191,6 +225,7 @@ pub struct CreateSubnetPayload {
     pub ssh_backup_access: Vec<String>,
     pub ingress_bytes_per_block_soft_cap: u64,
     pub initial_notary_delay_millis: u64,
+    pub chain_key_config: Option<InitialChainKeyConfig>,
     pub gossip_max_chunk_size: u32,
     pub subnet_type: SubnetType,
     pub ssh_readonly_access: Vec<String>,
@@ -253,6 +288,7 @@ pub struct RecoverSubnetPayload {
     pub registry_store_uri: Option<(String, String, u64)>,
     pub ecdsa_config: Option<EcdsaInitialConfig>,
     pub state_hash: serde_bytes::ByteBuf,
+    pub chain_key_config: Option<InitialChainKeyConfig>,
     pub time_ns: u64,
 }
 #[derive(Serialize, CandidType, Deserialize)]
@@ -390,6 +426,12 @@ pub struct EcdsaConfig {
     pub idkg_key_rotation_period_ms: Option<u64>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct ChainKeyConfig {
+    pub signature_request_timeout_ns: Option<u64>,
+    pub key_configs: Vec<KeyConfig>,
+    pub idkg_key_rotation_period_ms: Option<u64>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateSubnetPayload {
     pub unit_delay_millis: Option<u64>,
     pub max_duplicity: Option<u32>,
@@ -407,6 +449,7 @@ pub struct UpdateSubnetPayload {
     pub max_instructions_per_install_code: Option<u64>,
     pub start_as_nns: Option<bool>,
     pub is_halted: Option<bool>,
+    pub chain_key_signing_enable: Option<Vec<MasterPublicKeyId>>,
     pub max_ingress_messages_per_block: Option<u64>,
     pub max_number_of_canisters: Option<u64>,
     pub ecdsa_config: Option<EcdsaConfig>,
@@ -419,9 +462,11 @@ pub struct UpdateSubnetPayload {
     pub ssh_backup_access: Option<Vec<String>>,
     pub max_chunk_size: Option<u32>,
     pub initial_notary_delay_millis: Option<u64>,
+    pub chain_key_config: Option<ChainKeyConfig>,
     pub max_artifact_streams_per_peer: Option<u32>,
     pub subnet_type: Option<SubnetType>,
     pub ssh_readonly_access: Option<Vec<String>>,
+    pub chain_key_signing_disable: Option<Vec<MasterPublicKeyId>>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct UpdateUnassignedNodesConfigPayload {

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/2538538e0132b394f302c49fd91da23fc4cee284/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]


### PR DESCRIPTION
# Motivation

There are new proposal parameters to support tSchnorr.
See https://forum.dfinity.org/t/threshold-schnorr-facilitating-brc-20-trading-solana-integration-certificate-signing-and-more/28993
We want to be able to render them in NNS dapp.

# Changes

Ran
```
./scripts/update_ic_commit --crate proposals --ic_commit 2538538e0132b394f302c49fd91da23fc4cee284
./scripts/proposals/did2rs
```

# Tests

I'll add a test to `scripts/nns-dapp/test-proposal-payload` once `ic-admin` supports the new parameters.

# Todos

- [x] Add entry to changelog (if necessary).
