### PR TITLE
Merge logic for first and middle column headers

### DIFF
--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -18,12 +18,10 @@
   export let getRowStyle: (rowData: RowDataType) => string | undefined = (_) =>
     undefined;
 
-  let firstColumn: ResponsiveTableColumn<RowDataType> | undefined;
-  let middleColumns: ResponsiveTableColumn<RowDataType>[];
+  let nonLastColumns: ResponsiveTableColumn<RowDataType>[];
   let lastColumn: ResponsiveTableColumn<RowDataType> | undefined;
 
-  $: firstColumn = columns.at(0);
-  $: middleColumns = columns.slice(1, -1);
+  $: nonLastColumns = columns.slice(0, -1);
   $: lastColumn = columns.at(-1);
 
   const getTableStyle = (columns: ResponsiveTableColumn<RowDataType>[]) => {
@@ -57,20 +55,11 @@
 <div role="table" data-tid={testId} style={tableStyle}>
   <div role="rowgroup">
     <div role="row" class="header-row">
-      {#if firstColumn}
-        <span
-          role="columnheader"
-          style="--column-span: {firstColumn.templateColumns.length}"
-          data-tid="column-header-1"
-          class="desktop-align-{firstColumn.alignment}"
-          >{firstColumn.title}</span
-        >
-      {/if}
-      {#each middleColumns as column, index}
+      {#each nonLastColumns as column, index}
         <span
           role="columnheader"
           style="--column-span: {column.templateColumns.length}"
-          data-tid="column-header-{index + 2}"
+          data-tid="column-header-{index + 1}"
           class="desktop-align-{column.alignment}">{column.title}</span
         >
       {/each}


### PR DESCRIPTION
# Motivation

The rendering logic for the first column header in the `ResponsiveTable` component is now identical to the logic for the middle columns. So we can simply this by merging the logic.

# Changes

Remove the logic for the first column header and rely on the logic for the middle columns.

# Tests

Existing tests pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary