### PR TITLE
Move generic sorting methods from neurons-table.utils to responsive-table.utils

### DIFF
--- a/frontend/src/lib/types/neurons-table.ts
+++ b/frontend/src/lib/types/neurons-table.ts
@@ -1,4 +1,7 @@
-import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
+import type {
+  Comparator,
+  ResponsiveTableColumn,
+} from "$lib/types/responsive-table";
 import type { NeuronState } from "@dfinity/nns";
 import type { TokenAmountV2 } from "@dfinity/utils";
 
@@ -16,6 +19,6 @@ export type TableNeuron = {
 
 // Should define a partial ordering on TableNeuron by return -1 if a < b, +1 if
 // a > b and 0 if a and b are equivalent.
-export type TableNeuronComparator = (a: TableNeuron, b: TableNeuron) => number;
+export type TableNeuronComparator = Comparator<TableNeuron>;
 
 export type NeuronsTableColumn = ResponsiveTableColumn<TableNeuron>;

--- a/frontend/src/lib/types/responsive-table.ts
+++ b/frontend/src/lib/types/responsive-table.ts
@@ -22,3 +22,8 @@ export interface ResponsiveTableColumn<
   alignment: ColumnAlignment;
   templateColumns: TemplateItem[];
 }
+
+export type Comparator<RowDataType> = (
+  a: RowDataType,
+  b: RowDataType
+) => number;

--- a/frontend/src/lib/utils/neurons-table.utils.ts
+++ b/frontend/src/lib/utils/neurons-table.utils.ts
@@ -12,6 +12,12 @@ import {
   neuronStake,
 } from "$lib/utils/neuron.utils";
 import {
+  createAscendingComparator,
+  createDescendingComparator,
+  mergeComparators,
+  sortTableData,
+} from "$lib/utils/responsive-table.utils";
+import {
   getSnsDissolveDelaySeconds,
   getSnsNeuronIdAsHexString,
   getSnsNeuronStake,
@@ -113,58 +119,19 @@ export const tableNeuronsFromSnsNeurons = ({
   });
 };
 
-// Takes a list of comparators and returns a single comparator by first applying
-// the first comparator and using subsequent comparators to break ties.
-const mergeComparators = (
-  comparators: TableNeuronComparator[]
-): TableNeuronComparator => {
-  return (a, b) => {
-    for (const comparator of comparators) {
-      const result = comparator(a, b);
-      if (result !== 0) {
-        return result;
-      }
-    }
-    return 0;
-  };
-};
-
-// Creates a comparator for sorting in descending order based on the value
-// returned by the getter function.
-const createComparator = <T>(
-  getter: (neuron: TableNeuron) => T
-): TableNeuronComparator => {
-  return (a, b) => {
-    const valueA = getter(a);
-    const valueB = getter(b);
-    if (valueA < valueB) return 1;
-    if (valueA > valueB) return -1;
-    return 0;
-  };
-};
-
-// Same as createComparator but returns a comparator for sorting in ascending
-// order.
-const createAscendingComparator = <T>(
-  getter: (neuron: TableNeuron) => T
-): TableNeuronComparator => {
-  const descendingComparator = createComparator(getter);
-  return (a, b) => -descendingComparator(a, b);
-};
-
-export const compareByStake = createComparator((neuron) =>
-  neuron.stake.toUlps()
+export const compareByStake = createDescendingComparator(
+  (neuron: TableNeuron) => neuron.stake.toUlps()
 );
 
-export const compareByDissolveDelay = createComparator(
-  (neuron) => neuron.dissolveDelaySeconds
+export const compareByDissolveDelay = createDescendingComparator(
+  (neuron: TableNeuron) => neuron.dissolveDelaySeconds
 );
 
 // Orders strings as if they are positive integers, so "9" < "10" < "11", by
 // ordering first by length and then legicographically.
 export const compareById = mergeComparators([
-  createAscendingComparator((neuron) => neuron.neuronId.length),
-  createAscendingComparator((neuron) => neuron.neuronId),
+  createAscendingComparator((neuron: TableNeuron) => neuron.neuronId.length),
+  createAscendingComparator((neuron: TableNeuron) => neuron.neuronId),
 ]);
 
 // Sorts neurons based on a provided custom ordering.
@@ -175,5 +142,8 @@ export const sortNeurons = ({
   neurons: TableNeuron[];
   order: TableNeuronComparator[];
 }): TableNeuron[] => {
-  return [...neurons].sort(mergeComparators(order));
+  return sortTableData({
+    tableData: neurons,
+    order,
+  });
 };

--- a/frontend/src/lib/utils/responsive-table.utils.ts
+++ b/frontend/src/lib/utils/responsive-table.utils.ts
@@ -1,1 +1,54 @@
+import type { Comparator } from "$lib/types/responsive-table";
+
 export const getCellGridAreaName = (index: number) => `cell-${index}`;
+
+// Takes a list of comparators and returns a single comparator by first applying
+// the first comparator and using subsequent comparators to break ties.
+export const mergeComparators = <RowDataType>(
+  comparators: Comparator<RowDataType>[]
+): Comparator<RowDataType> => {
+  return (a, b) => {
+    for (const comparator of comparators) {
+      const result = comparator(a, b);
+      if (result !== 0) {
+        return result;
+      }
+    }
+    return 0;
+  };
+};
+
+// Creates a comparator for sorting in descending order based on the value
+// returned by the getter function.
+export const createDescendingComparator = <RowDataType, Comparable>(
+  getter: (rowData: RowDataType) => Comparable
+): Comparator<RowDataType> => {
+  return (a, b) => {
+    const valueA = getter(a);
+    const valueB = getter(b);
+    if (valueA < valueB) return 1;
+    if (valueA > valueB) return -1;
+    return 0;
+  };
+};
+
+// Same as createDescendingComparator but returns a comparator for sorting in
+// ascending order.
+export const createAscendingComparator = <RowDataType, Comparable>(
+  getter: (rowData: RowDataType) => Comparable
+): Comparator<RowDataType> => {
+  const descendingComparator = createDescendingComparator(getter);
+  // `|| 0` is to avoid the value `-0`.
+  return (a, b) => -descendingComparator(a, b) || 0;
+};
+
+// Sorts rows based on a provided custom ordering.
+export const sortTableData = <RowDataType>({
+  tableData,
+  order,
+}: {
+  tableData: RowDataType[];
+  order: Comparator<RowDataType>[];
+}): RowDataType[] => {
+  return [...tableData].sort(mergeComparators(order));
+};

--- a/frontend/src/tests/lib/utils/responsive-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/responsive-table.utils.spec.ts
@@ -1,0 +1,86 @@
+import {
+  createAscendingComparator,
+  createDescendingComparator,
+  getCellGridAreaName,
+  mergeComparators,
+  sortTableData,
+} from "$lib/utils/responsive-table.utils";
+
+describe("responsive-table.utils", () => {
+  describe("getCellGridAreaName", () => {
+    it("should return a different name for different index", () => {
+      expect(getCellGridAreaName(0)).toBe("cell-0");
+      expect(getCellGridAreaName(1)).toBe("cell-1");
+      expect(getCellGridAreaName(7)).toBe("cell-7");
+    });
+  });
+
+  describe("createDescendingComparator", () => {
+    it("should return a comparator that sorts in descending order", () => {
+      const item1 = { value: 10 };
+      const item2 = { value: 20 };
+      const comparator = createDescendingComparator(({ value }) => value);
+      expect(comparator(item1, item2)).toBe(1);
+      expect(comparator(item2, item1)).toBe(-1);
+      expect(comparator(item1, item1)).toBe(0);
+    });
+  });
+
+  describe("createAscendingComparator", () => {
+    it("should return a comparator that sorts in ascending order", () => {
+      const item1 = { value: 10 };
+      const item2 = { value: 20 };
+      const comparator = createAscendingComparator(({ value }) => value);
+      expect(comparator(item1, item2)).toBe(-1);
+      expect(comparator(item2, item1)).toBe(1);
+      expect(comparator(item1, item1)).toBe(0);
+    });
+  });
+
+  describe("mergeComparators", () => {
+    it("should create a lexicographic comparator", () => {
+      const item1 = { a: 10, b: 10 };
+      const item2 = { a: 10, b: 20 };
+      const item3 = { a: 20, b: 10 };
+      const item4 = { a: 20, b: 20 };
+      const comparatorA = createAscendingComparator(({ a }) => a);
+      const comparatorB = createAscendingComparator(({ b }) => b);
+      const comparator = mergeComparators([comparatorA, comparatorB]);
+      expect(comparator(item1, item2)).toBe(-1);
+      expect(comparator(item2, item1)).toBe(1);
+      expect(comparator(item2, item3)).toBe(-1);
+      expect(comparator(item3, item2)).toBe(1);
+      expect(comparator(item3, item4)).toBe(-1);
+      expect(comparator(item4, item3)).toBe(1);
+    });
+  });
+
+  describe("sortTableData", () => {
+    it("should sort based on list of comparators", () => {
+      const item1 = { a: 10, b: 10 };
+      const item2 = { a: 10, b: 20 };
+      const item3 = { a: 20, b: 10 };
+      const item4 = { a: 20, b: 20 };
+      const comparatorA = createAscendingComparator(({ a }) => a);
+      const comparatorB = createAscendingComparator(({ b }) => b);
+      expect(
+        sortTableData({
+          tableData: [item3, item1, item4, item2],
+          order: [comparatorA, comparatorB],
+        })
+      ).toEqual([item1, item2, item3, item4]);
+      expect(
+        sortTableData({
+          tableData: [item4, item3, item2, item1],
+          order: [comparatorA, comparatorB],
+        })
+      ).toEqual([item1, item2, item3, item4]);
+      expect(
+        sortTableData({
+          tableData: [item1, item2, item3, item4],
+          order: [comparatorA, comparatorB],
+        })
+      ).toEqual([item1, item2, item3, item4]);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

We want to allow custom sorting in the neurons table.
It should potentially work on a places where the `ResponsiveTable` is used.
We have so sorting utility functions that are not specific to the neurons table that will be used by the responsive table.

# Changes

Move the generic table sorting utility functions from `neurons-table.utils.ts` to `responsive-table.utils.ts`.

# Tests

Unit tests were added.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary