### PR TITLE
bot: Update sns_aggregator candid bindings

### DIFF
--- a/declarations/used_by_sns_aggregator/sns_governance/sns_governance.did
+++ b/declarations/used_by_sns_aggregator/sns_governance/sns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-05_23-01-storage-layer-disabled/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-cycle-hotfix/rs/sns/governance/canister/governance.did>
 type Account = record { owner : opt principal; subaccount : opt Subaccount };
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;

--- a/declarations/used_by_sns_aggregator/sns_ledger/sns_ledger.did
+++ b/declarations/used_by_sns_aggregator/sns_ledger/sns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-05_23-01-storage-layer-disabled/rs/rosetta-api/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-cycle-hotfix/rs/rosetta-api/icrc1/ledger/ledger.did>
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.
@@ -426,6 +426,62 @@ type ICRC3DataCertificate = record {
   hash_tree : blob;
 };
 
+type icrc21_consent_message_metadata = record {
+    language: text;
+};
+
+type icrc21_consent_message_spec = record {
+    metadata: icrc21_consent_message_metadata;
+    device_spec: opt variant {
+        GenericDisplay;
+        LineDisplay: record {
+            characters_per_line: nat16;
+            lines_per_page: nat16;
+        };
+    };
+};
+
+type icrc21_consent_message_request = record {
+    method: text;
+    arg: blob;
+    user_preferences: icrc21_consent_message_spec;
+};
+
+type icrc21_consent_message = variant {
+    GenericDisplayMessage: text;
+    LineDisplayMessage: record {
+        pages: vec record {
+            lines: vec text;
+        };
+    };
+};
+
+type icrc21_consent_info = record {
+    consent_message: icrc21_consent_message;
+    metadata: icrc21_consent_message_metadata;
+};
+
+type icrc21_error_info = record {
+    description: text;
+};
+
+type icrc21_error = variant {
+    UnsupportedCanisterCall: icrc21_error_info;
+    ConsentMessageUnavailable: icrc21_error_info;
+    InsufficientPayment: icrc21_error_info;
+
+    // Any error not covered by the above variants.
+    GenericError: record {
+       error_code: nat;
+       description: text;
+   };
+};
+
+type icrc21_consent_message_response = variant {
+    Ok: icrc21_consent_info;
+    Err: icrc21_error;
+};
+
 service : (ledger_arg : LedgerArg) -> {
     archives : () -> (vec ArchiveInfo) query;
     get_transactions : (GetTransactionsRequest) -> (GetTransactionsResponse) query;
@@ -451,4 +507,7 @@ service : (ledger_arg : LedgerArg) -> {
     icrc3_get_tip_certificate : () -> (opt ICRC3DataCertificate) query;
     icrc3_get_blocks : (vec GetBlocksArgs) -> (GetBlocksResult) query;
     icrc3_supported_block_types : () -> (vec record { block_type : text; url : text }) query;
+
+    icrc21_canister_call_consent_message: (icrc21_consent_message_request) -> (icrc21_consent_message_response);
+    icrc10_supported_standards : () -> (vec record { name : text; url : text }) query;
 }

--- a/declarations/used_by_sns_aggregator/sns_root/sns_root.did
+++ b/declarations/used_by_sns_aggregator/sns_root/sns_root.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-05_23-01-storage-layer-disabled/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-cycle-hotfix/rs/sns/root/canister/root.did>
 type CanisterCallError = record { code : opt int32; description : text };
 type CanisterIdRecord = record { canister_id : principal };
 type CanisterInstallMode = variant { reinstall; upgrade; install };

--- a/declarations/used_by_sns_aggregator/sns_swap/sns_swap.did
+++ b/declarations/used_by_sns_aggregator/sns_swap/sns_swap.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-05_23-01-storage-layer-disabled/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-cycle-hotfix/rs/sns/swap/canister/swap.did>
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;
@@ -308,5 +308,4 @@ service : (Init) -> {
   refresh_buyer_tokens : (RefreshBuyerTokensRequest) -> (
       RefreshBuyerTokensResponse,
     );
-  restore_dapp_controllers : (record {}) -> (SetDappControllersCallResult);
 }

--- a/declarations/used_by_sns_aggregator/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_sns_aggregator/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-05_23-01-storage-layer-disabled/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-cycle-hotfix/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };

--- a/dfx.json
+++ b/dfx.json
@@ -389,7 +389,7 @@
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-06-19",
         "IC_COMMIT_FOR_PROPOSALS": "2538538e0132b394f302c49fd91da23fc4cee284",
-        "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-06-05_23-01-storage-layer-disabled"
+        "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-06-19_23-01-cycle-hotfix"
       },
       "packtool": ""
     }

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_governance --out ic_sns_governance.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-05_23-01-storage-layer-disabled/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-cycle-hotfix/rs/sns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_ledger --out ic_sns_ledger.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-05_23-01-storage-layer-disabled/rs/rosetta-api/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-cycle-hotfix/rs/rosetta-api/icrc1/ledger/ledger.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
@@ -212,6 +212,11 @@ pub struct GetTransactionsResponse {
     pub transactions: Vec<Transaction>,
     pub archived_transactions: Vec<GetTransactionsResponseArchivedTransactionsItem>,
 }
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Icrc10SupportedStandardsRetItem {
+    pub url: String,
+    pub name: String,
+}
 pub type Tokens = candid::Nat;
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct StandardRecord {
@@ -242,6 +247,64 @@ pub enum TransferError {
 pub enum TransferResult {
     Ok(BlockIndex),
     Err(TransferError),
+}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Icrc21ConsentMessageMetadata {
+    pub language: String,
+}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub enum Icrc21ConsentMessageSpecDeviceSpecInner {
+    GenericDisplay,
+    LineDisplay {
+        characters_per_line: u16,
+        lines_per_page: u16,
+    },
+}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Icrc21ConsentMessageSpec {
+    pub metadata: Icrc21ConsentMessageMetadata,
+    pub device_spec: Option<Icrc21ConsentMessageSpecDeviceSpecInner>,
+}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Icrc21ConsentMessageRequest {
+    pub arg: serde_bytes::ByteBuf,
+    pub method: String,
+    pub user_preferences: Icrc21ConsentMessageSpec,
+}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Icrc21ConsentMessageLineDisplayMessagePagesItem {
+    pub lines: Vec<String>,
+}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub enum Icrc21ConsentMessage {
+    LineDisplayMessage {
+        pages: Vec<Icrc21ConsentMessageLineDisplayMessagePagesItem>,
+    },
+    GenericDisplayMessage(String),
+}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Icrc21ConsentInfo {
+    pub metadata: Icrc21ConsentMessageMetadata,
+    pub consent_message: Icrc21ConsentMessage,
+}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Icrc21ErrorInfo {
+    pub description: String,
+}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub enum Icrc21Error {
+    GenericError {
+        description: String,
+        error_code: candid::Nat,
+    },
+    InsufficientPayment(Icrc21ErrorInfo),
+    UnsupportedCanisterCall(Icrc21ErrorInfo),
+    ConsentMessageUnavailable(Icrc21ErrorInfo),
+}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub enum Icrc21ConsentMessageResponse {
+    Ok(Icrc21ConsentInfo),
+    Err(Icrc21Error),
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct AllowanceArgs {
@@ -370,6 +433,9 @@ impl Service {
     pub async fn get_transactions(&self, arg0: GetTransactionsRequest) -> CallResult<(GetTransactionsResponse,)> {
         ic_cdk::call(self.0, "get_transactions", (arg0,)).await
     }
+    pub async fn icrc_10_supported_standards(&self) -> CallResult<(Vec<Icrc10SupportedStandardsRetItem>,)> {
+        ic_cdk::call(self.0, "icrc10_supported_standards", ()).await
+    }
     pub async fn icrc_1_balance_of(&self, arg0: Account) -> CallResult<(Tokens,)> {
         ic_cdk::call(self.0, "icrc1_balance_of", (arg0,)).await
     }
@@ -399,6 +465,12 @@ impl Service {
     }
     pub async fn icrc_1_transfer(&self, arg0: TransferArg) -> CallResult<(TransferResult,)> {
         ic_cdk::call(self.0, "icrc1_transfer", (arg0,)).await
+    }
+    pub async fn icrc_21_canister_call_consent_message(
+        &self,
+        arg0: Icrc21ConsentMessageRequest,
+    ) -> CallResult<(Icrc21ConsentMessageResponse,)> {
+        ic_cdk::call(self.0, "icrc21_canister_call_consent_message", (arg0,)).await
     }
     pub async fn icrc_2_allowance(&self, arg0: AllowanceArgs) -> CallResult<(Allowance,)> {
         ic_cdk::call(self.0, "icrc2_allowance", (arg0,)).await

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_root --out ic_sns_root.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-05_23-01-storage-layer-disabled/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-cycle-hotfix/rs/sns/root/canister/root.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_swap --out ic_sns_swap.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-05_23-01-storage-layer-disabled/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-cycle-hotfix/rs/sns/swap/canister/swap.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
@@ -480,8 +480,6 @@ pub struct RefreshBuyerTokensResponse {
     pub icp_accepted_participation_e8s: u64,
     pub icp_ledger_account_balance_e8s: u64,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub struct RestoreDappControllersArg {}
 
 pub struct Service(pub Principal);
 impl Service {
@@ -556,11 +554,5 @@ impl Service {
         arg0: RefreshBuyerTokensRequest,
     ) -> CallResult<(RefreshBuyerTokensResponse,)> {
         ic_cdk::call(self.0, "refresh_buyer_tokens", (arg0,)).await
-    }
-    pub async fn restore_dapp_controllers(
-        &self,
-        arg0: RestoreDappControllersArg,
-    ) -> CallResult<(SetDappControllersCallResult,)> {
-        ic_cdk::call(self.0, "restore_dapp_controllers", (arg0,)).await
     }
 }

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out ic_sns_wasm.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-05_23-01-storage-layer-disabled/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-06-19_23-01-cycle-hotfix/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
We would like to parse all the latest SNS data. To do so, we update the candid interfaces for the SNS aggregator.
Even with no changes, just updating the reference is good practice.

# Changes
* Update the version of `IC_COMMIT_FOR_SNS_AGGREGATOR` specified in `dfx.json`.
* Updated the `sns_aggregator` candid files to the versions in that commit.
* Updated the Rust code derived from `.did` files in the aggregator.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  Breaking changes are:
    * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants