### PR TITLE
Change neuron ID column title to 'Neurons'

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -20,6 +20,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Change neuron ID column title to "Neurons".
+
 #### Deprecated
 
 #### Removed

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
@@ -31,7 +31,7 @@
 
   const columns: NeuronsTableColumn[] = [
     {
-      title: $i18n.neurons.neuron_id,
+      title: $i18n.neurons.title,
       cellComponent: NeuronIdCell,
       alignment: "left",
       templateColumns: ["minmax(min-content, max-content)"],

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -86,7 +86,7 @@ describe("NeuronsTable", () => {
   it("should render headers", async () => {
     const po = renderComponent({ neurons: [neuron1, neuron2] });
     expect(await po.getColumnHeaders()).toEqual([
-      "Neuron ID",
+      "Neurons",
       "",
       "Stake",
       "",


### PR DESCRIPTION
# Motivation

In mobile view, only the first column header of the neurons and tokens tables is visible.
In this case "Neurons" fits better as table header than "Neuron ID".
So we agreed with UX to change the first column title of the neurons table from "Neuron ID" to "Neurons" for both mobile and desktop view.

# Changes

Change the title of the neuron ID column to `"Neurons"`.

# Tests

1. Unit test updated.
2. Screenshots updated.

# Todos

- [x] Add entry to changelog (if necessary).
