### PR TITLE
Add scripts/setup to HACKING

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -28,6 +28,7 @@ That is why we are providing a `./config.sh` script that generate the above envi
 
 To run the dapp against canisters deployed locally on a simulated IC network, use the steps below:
 
+- Run `scripts/setup` to install necessary tools.
 - Clone the [snsdemo](https://github.com/dfinity/snsdemo/) repository. We'll use it to set up the test environment.
 - In the `snsdemo` repo, run:
   - `bin/dfx-sns-demo-install` (to install necessary tools)


### PR DESCRIPTION
# Motivation

Make the documentation more usable for external people.

# Changes

And a step to run `scripts/setup` at the beginning of instructions to run nns-dapp.

# Tests

not tested

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary