### PR TITLE
NNS1-3135: Add util for table resorting logic

### DIFF
--- a/frontend/src/lib/types/responsive-table.ts
+++ b/frontend/src/lib/types/responsive-table.ts
@@ -30,4 +30,7 @@ export type Comparator<RowDataType> = (
   b: RowDataType
 ) => number;
 
-export type ResponsiveTableOrder = Array<{ columnId: string }>;
+export type ResponsiveTableOrder = Array<{
+  columnId: string;
+  reversed?: boolean;
+}>;

--- a/frontend/src/lib/utils/responsive-table.utils.ts
+++ b/frontend/src/lib/utils/responsive-table.utils.ts
@@ -37,14 +37,40 @@ export const createDescendingComparator = <RowDataType, Comparable>(
   };
 };
 
+const negate = <T>(comparator: Comparator<T>): Comparator<T> => {
+  // `|| 0` is to avoid the value `-0`.
+  return (a, b) => -comparator(a, b) || 0;
+};
+
 // Same as createDescendingComparator but returns a comparator for sorting in
 // ascending order.
 export const createAscendingComparator = <RowDataType, Comparable>(
   getter: (rowData: RowDataType) => Comparable
-): Comparator<RowDataType> => {
-  const descendingComparator = createDescendingComparator(getter);
-  // `|| 0` is to avoid the value `-0`.
-  return (a, b) => -descendingComparator(a, b) || 0;
+): Comparator<RowDataType> => negate(createDescendingComparator(getter));
+
+// Creates the new table order resulting from clicking on a column header.  This
+// means reversing the order if the selected column is already the primary
+// order, or making the selected column the primary order if it is not.
+export const selectPrimaryOrder = ({
+  order,
+  selectedColumnId,
+}: {
+  order: ResponsiveTableOrder;
+  selectedColumnId: string;
+}): ResponsiveTableOrder => {
+  if (order[0].columnId === selectedColumnId) {
+    return [
+      {
+        columnId: order[0].columnId,
+        ...(order[0].reversed ? {} : { reversed: true }),
+      },
+      ...order.slice(1),
+    ];
+  }
+  return [
+    { columnId: selectedColumnId },
+    ...order.filter((order) => order.columnId !== selectedColumnId),
+  ];
 };
 
 // Sorts rows based on a provided custom ordering.
@@ -60,8 +86,9 @@ export const sortTableData = <RowDataType extends ResponsiveTableRowData>({
   const comparatorByColumnId = Object.fromEntries(
     columns.filter((c) => c.id && c.comparator).map((c) => [c.id, c.comparator])
   );
-  const comparators = order.map(
-    ({ columnId }) => comparatorByColumnId[columnId]
-  );
+  const comparators = order.map(({ columnId, reversed }) => {
+    const comparator = comparatorByColumnId[columnId];
+    return reversed ? negate(comparator) : comparator;
+  });
   return [...tableData].sort(mergeComparators(comparators));
 };

--- a/frontend/src/tests/lib/utils/responsive-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/responsive-table.utils.spec.ts
@@ -4,6 +4,7 @@ import {
   createDescendingComparator,
   getCellGridAreaName,
   mergeComparators,
+  selectPrimaryOrder,
   sortTableData,
 } from "$lib/utils/responsive-table.utils";
 
@@ -53,6 +54,53 @@ describe("responsive-table.utils", () => {
       expect(comparator(item3, item2)).toBe(1);
       expect(comparator(item3, item4)).toBe(-1);
       expect(comparator(item4, item3)).toBe(1);
+    });
+  });
+
+  describe("selectPrimaryOrder", () => {
+    it("should add a new order to the front", () => {
+      expect(
+        selectPrimaryOrder({
+          order: [{ columnId: "a" }],
+          selectedColumnId: "b",
+        })
+      ).toEqual([{ columnId: "b" }, { columnId: "a" }]);
+    });
+
+    it("should move an exist order to the front", () => {
+      expect(
+        selectPrimaryOrder({
+          order: [{ columnId: "a" }, { columnId: "b" }, { columnId: "c" }],
+          selectedColumnId: "b",
+        })
+      ).toEqual([{ columnId: "b" }, { columnId: "a" }, { columnId: "c" }]);
+    });
+
+    it("should reverse an existing primary order", () => {
+      expect(
+        selectPrimaryOrder({
+          order: [{ columnId: "a" }, { columnId: "b" }],
+          selectedColumnId: "a",
+        })
+      ).toEqual([{ columnId: "a", reversed: true }, { columnId: "b" }]);
+    });
+
+    it("should un-reverse an existing primary order", () => {
+      expect(
+        selectPrimaryOrder({
+          order: [{ columnId: "a", reversed: true }, { columnId: "b" }],
+          selectedColumnId: "a",
+        })
+      ).toEqual([{ columnId: "a" }, { columnId: "b" }]);
+    });
+
+    it("should keep an existing order reversed as it becomes secondary", () => {
+      expect(
+        selectPrimaryOrder({
+          order: [{ columnId: "a", reversed: true }, { columnId: "b" }],
+          selectedColumnId: "b",
+        })
+      ).toEqual([{ columnId: "b" }, { columnId: "a", reversed: true }]);
     });
   });
 
@@ -114,6 +162,20 @@ describe("responsive-table.utils", () => {
           columns,
         })
       ).toEqual([item1, item3, item2, item4]);
+      expect(
+        sortTableData({
+          tableData: [item1, item2, item3, item4],
+          order: [{ columnId: "a", reversed: true }, { columnId: "b" }],
+          columns,
+        })
+      ).toEqual([item3, item4, item1, item2]);
+      expect(
+        sortTableData({
+          tableData: [item1, item2, item3, item4],
+          order: [{ columnId: "a" }, { columnId: "b", reversed: true}],
+          columns,
+        })
+      ).toEqual([item2, item1, item4, item3]);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/responsive-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/responsive-table.utils.spec.ts
@@ -172,7 +172,7 @@ describe("responsive-table.utils", () => {
       expect(
         sortTableData({
           tableData: [item1, item2, item3, item4],
-          order: [{ columnId: "a" }, { columnId: "b", reversed: true}],
+          order: [{ columnId: "a" }, { columnId: "b", reversed: true }],
           columns,
         })
       ).toEqual([item2, item1, item4, item3]);

--- a/frontend/src/tests/lib/utils/responsive-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/responsive-table.utils.spec.ts
@@ -102,6 +102,18 @@ describe("responsive-table.utils", () => {
         })
       ).toEqual([{ columnId: "b" }, { columnId: "a", reversed: true }]);
     });
+
+    it("should not keep an existing order reversed as it becomes primary", () => {
+      expect(
+        selectPrimaryOrder({
+          order: [
+            { columnId: "a", reversed: true },
+            { columnId: "b", reversed: true },
+          ],
+          selectedColumnId: "b",
+        })
+      ).toEqual([{ columnId: "b" }, { columnId: "a", reversed: true }]);
+    });
   });
 
   describe("sortTableData", () => {


### PR DESCRIPTION
# Motivation

When we make the neurons table sortable we want to use the following logic:
1. If you click on a column header, the rows should be sorted by that column.
2. If you click again on the same column header, the rows should be sorted by the reverse of that column.
3. When changing sort order, ties in the chosen column should be broken based on the previous order.

So if you sort by stake and then by dissolve delay, neurons with the same dissolve delay should be sorted by stake because that was the previous order.

This PR does not make any UI changes but adds the utility that implements the above logic.

# Changes

1. Add optional `reversed` field to the elements of `ResponsiveTableOrder`.
2. Add `selectPrimaryOrder` function which creates a new order following the above logic.
3. Support the `reversed` field in `sortTableData`.

# Tests

1. Unit tests added for `selectPrimaryOrder`.
2. Unit test extended for `sortTableData` with `reversed: true` items.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary