### PR TITLE
NNS1-3135: Neurons table order store

### DIFF
--- a/frontend/src/lib/stores/neurons-table.store.ts
+++ b/frontend/src/lib/stores/neurons-table.store.ts
@@ -1,0 +1,30 @@
+import type { ResponsiveTableOrder } from "$lib/types/responsive-table";
+import { writable } from "svelte/store";
+
+const initialNeuronsTableOrder: ResponsiveTableOrder = [
+  {
+    columnId: "stake",
+  },
+  {
+    columnId: "dissolveDelay",
+  },
+  {
+    columnId: "id",
+  },
+];
+
+const initNeuronsTableOrderStore = () => {
+  const { subscribe, set } = writable<ResponsiveTableOrder>(
+    initialNeuronsTableOrder
+  );
+
+  return {
+    subscribe,
+    set,
+    reset() {
+      set(initialNeuronsTableOrder);
+    },
+  };
+};
+
+export const neuronsTableOrderStore = initNeuronsTableOrderStore();

--- a/frontend/src/tests/lib/stores/neurons-table.store.spec.ts
+++ b/frontend/src/tests/lib/stores/neurons-table.store.spec.ts
@@ -1,0 +1,48 @@
+import { neuronsTableOrderStore } from "$lib/stores/neurons-table.store";
+import { get } from "svelte/store";
+
+describe("neurons-table.store", () => {
+  describe("neuronsTableOrderStore", () => {
+    it("should have an initial value", () => {
+      expect(get(neuronsTableOrderStore)).toEqual([
+        {
+          columnId: "stake",
+        },
+        {
+          columnId: "dissolveDelay",
+        },
+        {
+          columnId: "id",
+        },
+      ]);
+    });
+
+    it("should set and reset", () => {
+      neuronsTableOrderStore.set([
+        {
+          columnId: "dissolveDelay",
+        },
+      ]);
+
+      expect(get(neuronsTableOrderStore)).toEqual([
+        {
+          columnId: "dissolveDelay",
+        },
+      ]);
+
+      neuronsTableOrderStore.reset();
+
+      expect(get(neuronsTableOrderStore)).toEqual([
+        {
+          columnId: "stake",
+        },
+        {
+          columnId: "dissolveDelay",
+        },
+        {
+          columnId: "id",
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

When changing the sorting order on the neurons table, we want to be able to navigate without losing the order.
(Resetting the order on page reload is OK, at least for now.)

This PR adds a Svelte store to keep the ordering across navigation but does not use it yet.

# Changes

Add `neuronsTableOrderStore`.

# Tests

1. Unit test added.
2. Tested manually in another branch.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary