### PR TITLE
NNS1-3135: Refactor column header hiding logic

### DIFF
--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -74,7 +74,8 @@
           role="columnheader"
           style="--column-span: {column.templateColumns.length}"
           data-tid="column-header-{index + 1}"
-          class="desktop-align-{column.alignment}">{column.title}</span
+          class="desktop-align-{column.alignment}"
+          class:desktop-only={index > 0}>{column.title}</span
         >
       {/each}
       {#if lastColumn}
@@ -144,17 +145,12 @@
       border-bottom: 1px solid var(--elements-divider);
 
       [role="columnheader"] {
-        display: none;
-
         grid-column: span var(--column-span);
 
-        &:first-child,
-        &:last-child {
-          display: block;
-        }
-
         @include media.min-width(medium) {
-          display: block;
+          &.desktop-only {
+            display: none;
+          }
         }
       }
 

--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -147,9 +147,13 @@
       [role="columnheader"] {
         grid-column: span var(--column-span);
 
+        &.desktop-only {
+          display: none;
+        }
+
         @include media.min-width(medium) {
           &.desktop-only {
-            display: none;
+            display: block;
           }
         }
       }

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -83,9 +83,9 @@ describe("NeuronsTable", () => {
     return NeuronsTablePo.under(new JestPageObjectElement(container));
   };
 
-  it("should render headers", async () => {
+  it("should render desktop headers", async () => {
     const po = renderComponent({ neurons: [neuron1, neuron2] });
-    expect(await po.getColumnHeaders()).toEqual([
+    expect(await po.getDesktopColumnHeaders()).toEqual([
       "Neurons",
       "",
       "Stake",
@@ -95,6 +95,14 @@ describe("NeuronsTable", () => {
       "Dissolve Delay",
       "",
       "State",
+      "", // No header for actions column.
+    ]);
+  });
+
+  it("should render mobile headers", async () => {
+    const po = renderComponent({ neurons: [neuron1, neuron2] });
+    expect(await po.getMobileColumnHeaders()).toEqual([
+      "Neurons",
       "", // No header for actions column.
     ]);
   });

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -66,15 +66,27 @@ describe("TokensTable", () => {
     expect(await po.getFirstColumnHeader()).toEqual(firstColumnHeader);
   });
 
-  it("should render headers", async () => {
+  it("should render desktop headers", async () => {
     const firstColumnHeader = "Accounts";
     const token1 = createUserToken({
       universeId: OWN_CANISTER_ID,
     });
     const po = renderTable({ userTokensData: [token1], firstColumnHeader });
-    expect(await po.getColumnHeaders()).toEqual([
+    expect(await po.getDesktopColumnHeaders()).toEqual([
       "Accounts",
       "Balance",
+      "", // No header for actions column.
+    ]);
+  });
+
+  it("should render mobile headers", async () => {
+    const firstColumnHeader = "Accounts";
+    const token1 = createUserToken({
+      universeId: OWN_CANISTER_ID,
+    });
+    const po = renderTable({ userTokensData: [token1], firstColumnHeader });
+    expect(await po.getMobileColumnHeaders()).toEqual([
+      "Accounts",
       "", // No header for actions column.
     ]);
   });

--- a/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
@@ -73,11 +73,18 @@ describe("ResponsiveTable", () => {
     return ResponsiveTablePo.under(new JestPageObjectElement(container));
   };
 
-  it("should render column headers", async () => {
+  it("should render desktop column headers", async () => {
     const po = renderComponent({ columns, tableData });
     // The last column is reserved for actions and is never rendered with a
     // header.
-    expect(await po.getColumnHeaders()).toEqual(["Name", "", "Age", ""]);
+    expect(await po.getDesktopColumnHeaders()).toEqual(["Name", "", "Age", ""]);
+  });
+
+  it("should render mobile column headers", async () => {
+    const po = renderComponent({ columns, tableData });
+    // The last column is reserved for actions and is never rendered with a
+    // header.
+    expect(await po.getMobileColumnHeaders()).toEqual(["Name", ""]);
   });
 
   it("should render column header alignments", async () => {

--- a/frontend/src/tests/page-objects/ResponsiveTable.page-object.ts
+++ b/frontend/src/tests/page-objects/ResponsiveTable.page-object.ts
@@ -11,11 +11,21 @@ export class ResponsiveTablePo extends BasePageObject {
     );
   }
 
-  async getColumnHeaders(): Promise<string[]> {
+  async getDesktopColumnHeaders(): Promise<string[]> {
     return Promise.all(
       (await this.root.querySelectorAll("[role='columnheader']")).map((el) =>
         el.getText()
       )
+    );
+  }
+
+  async getMobileColumnHeaders(): Promise<string[]> {
+    return Promise.all(
+      (
+        await this.root.querySelectorAll(
+          "[role='columnheader']:not(.desktop-only)"
+        )
+      ).map((el) => el.getText())
     );
   }
 


### PR DESCRIPTION
# Motivation

We want to make table columns sortable by clicking on them, if there is a sort order defined for that column.
In mobile view we only show the first column, but sorting is not done by clicking on the column headers.
So we might have to show 2 versions of the first column header.

To make this easier, this PR only changes the way by which columns are hidden by using an explicit class instead of always hiding everything but the first and last column headers.

# Changes

1. Add a `desktop-only` class to column headers that should be hidden on mobile.
2. Change the CSS to use this class instead of `:first-child` and `:last-child` selectors.

# Tests

Add separate unit tests for mobile and desktop column headers.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary