### PR TITLE
NNS1-3135: Sort neurons table based on store order

### DIFF
--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
@@ -7,11 +7,11 @@
   import NeuronStateCell from "$lib/components/neurons/NeuronsTable/NeuronStateCell.svelte";
   import ResponsiveTable from "$lib/components/ui/ResponsiveTable.svelte";
   import { i18n } from "$lib/stores/i18n";
+  import { neuronsTableOrderStore } from "$lib/stores/neurons-table.store";
   import type {
     TableNeuron,
     NeuronsTableColumn,
   } from "$lib/types/neurons-table";
-  import type { ResponsiveTableOrder } from "$lib/types/responsive-table";
   import {
     compareByStake,
     compareByDissolveDelay,
@@ -20,18 +20,6 @@
   import { NeuronState } from "@dfinity/nns";
 
   export let neurons: TableNeuron[];
-
-  const order: ResponsiveTableOrder = [
-    {
-      columnId: "stake",
-    },
-    {
-      columnId: "dissolveDelay",
-    },
-    {
-      columnId: "id",
-    },
-  ];
 
   const columns: NeuronsTableColumn[] = [
     {
@@ -110,6 +98,6 @@
   testId="neurons-table-component"
   {columns}
   tableData={neurons}
-  {order}
+  order={$neuronsTableOrderStore}
   {getRowStyle}
 ></ResponsiveTable>

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -5,6 +5,7 @@ import {
   SECONDS_IN_MONTH,
   SECONDS_IN_YEAR,
 } from "$lib/constants/constants";
+import { neuronsTableOrderStore } from "$lib/stores/neurons-table.store";
 import type { TableNeuron } from "$lib/types/neurons-table";
 import { mockTableNeuron } from "$tests/mocks/neurons.mock";
 import { NeuronsTablePo } from "$tests/page-objects/NeuronsTable.page-object";
@@ -82,6 +83,10 @@ describe("NeuronsTable", () => {
     });
     return NeuronsTablePo.under(new JestPageObjectElement(container));
   };
+
+  beforeEach(() => {
+    neuronsTableOrderStore.reset();
+  });
 
   it("should render desktop headers", async () => {
     const po = renderComponent({ neurons: [neuron1, neuron2] });
@@ -216,6 +221,40 @@ describe("NeuronsTable", () => {
     expect(await rowPos[1].getNeuronId()).toBe(neuron2.neuronId);
     expect(await rowPos[2].getNeuronId()).toBe(neuron3.neuronId);
     expect(await rowPos[3].getNeuronId()).toBe(neuron4.neuronId);
+  });
+
+  it("should change order based on order store", async () => {
+    const po = renderComponent({
+      neurons: [neuron1, neuron2, neuron3, neuron4],
+    });
+    {
+      const rowPos = await po.getNeuronsTableRowPos();
+      expect(rowPos).toHaveLength(4);
+      expect(await rowPos[0].getNeuronId()).toBe(neuron1.neuronId);
+      expect(await rowPos[1].getNeuronId()).toBe(neuron2.neuronId);
+      expect(await rowPos[2].getNeuronId()).toBe(neuron3.neuronId);
+      expect(await rowPos[3].getNeuronId()).toBe(neuron4.neuronId);
+    }
+
+    neuronsTableOrderStore.set([
+      {
+        columnId: "dissolveDelay",
+      },
+      {
+        columnId: "id",
+        reversed: true,
+      },
+    ]);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    {
+      const rowPos = await po.getNeuronsTableRowPos();
+      expect(rowPos).toHaveLength(4);
+      expect(await rowPos[0].getNeuronId()).toBe(neuron2.neuronId);
+      expect(await rowPos[1].getNeuronId()).toBe(neuron4.neuronId);
+      expect(await rowPos[2].getNeuronId()).toBe(neuron3.neuronId);
+      expect(await rowPos[3].getNeuronId()).toBe(neuron1.neuronId);
+    }
   });
 
   it("should render dissolve delay", async () => {


### PR DESCRIPTION
# Motivation

Once we support custom sorting, we want to keep the sort order between navigations.
In this PR we just hook up the sort order to the store. There is no visible difference because there is no way yet for the user to change the contents of the store.

# Changes

Sort the neurons table based on the order in the `neuronsTableOrderStore` instead of a constant in the component.

# Tests

Unit test added where the store contents is changed.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary