### PR TITLE
Unwrap enable actionable tab tests

### DIFF
--- a/frontend/src/tests/lib/routes/Proposals.spec.ts
+++ b/frontend/src/tests/lib/routes/Proposals.spec.ts
@@ -60,7 +60,7 @@ describe("Proposals", () => {
     expect(await po.getActionableProposalsPo().isPresent()).toBe(true);
   });
 
-  it('should no display actionable proposals when not "actionable" in URL', async () => {
+  it('should not display actionable proposals when no "actionable" in URL', async () => {
     resetIdentity();
     page.mock({
       data: {

--- a/frontend/src/tests/lib/routes/Proposals.spec.ts
+++ b/frontend/src/tests/lib/routes/Proposals.spec.ts
@@ -27,24 +27,23 @@ vi.mock("$lib/services/$public/sns-proposals.services", () => {
 vi.mock("$lib/api/governance.api");
 
 describe("Proposals", () => {
-  vi.spyOn(snsProjectsCommittedStore, "subscribe").mockImplementation(
-    mockProjectSubscribe([mockSnsFullProject])
-  );
+  const renderComponent = () => {
+    const { container } = render(Proposals);
+    return ProposalsPo.under(new JestPageObjectElement(container));
+  };
 
   beforeEach(() => {
     // Reset to default value
     page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
+    vi.spyOn(snsProjectsCommittedStore, "subscribe").mockImplementation(
+      mockProjectSubscribe([mockSnsFullProject])
+    );
   });
 
   it("should render NnsProposals by default", () => {
     const { queryByTestId } = render(Proposals);
     expect(queryByTestId("nns-proposal-list-component")).toBeInTheDocument();
   });
-
-  const renderComponent = () => {
-    const { container } = render(Proposals);
-    return ProposalsPo.under(new JestPageObjectElement(container));
-  };
 
   it('should display actionable proposals when "actionable" in URL', async () => {
     resetIdentity();

--- a/frontend/src/tests/lib/routes/Proposals.spec.ts
+++ b/frontend/src/tests/lib/routes/Proposals.spec.ts
@@ -41,42 +41,35 @@ describe("Proposals", () => {
     expect(queryByTestId("nns-proposal-list-component")).toBeInTheDocument();
   });
 
-  // TODO(max): unwrap
-  describe("with ENABLE_ACTIONABLE_TAB", () => {
-    const renderComponent = () => {
-      const { container } = render(Proposals);
-      return ProposalsPo.under(new JestPageObjectElement(container));
-    };
+  const renderComponent = () => {
+    const { container } = render(Proposals);
+    return ProposalsPo.under(new JestPageObjectElement(container));
+  };
 
-    beforeEach(() => {
-      page.reset();
+  it('should display actionable proposals when "actionable" in URL', async () => {
+    resetIdentity();
+    page.mock({
+      data: {
+        universe: OWN_CANISTER_ID_TEXT,
+        routeId: AppPath.Proposals,
+        actionable: true,
+      },
     });
 
-    it('should display actionable proposals when "actionable" in URL', async () => {
-      resetIdentity();
-      page.mock({
-        data: {
-          universe: OWN_CANISTER_ID_TEXT,
-          routeId: AppPath.Proposals,
-          actionable: true,
-        },
-      });
+    const po = renderComponent();
+    expect(await po.getActionableProposalsPo().isPresent()).toBe(true);
+  });
 
-      const po = renderComponent();
-      expect(await po.getActionableProposalsPo().isPresent()).toBe(true);
+  it('should no display actionable proposals when not "actionable" in URL', async () => {
+    resetIdentity();
+    page.mock({
+      data: {
+        universe: OWN_CANISTER_ID_TEXT,
+        routeId: AppPath.Proposals,
+      },
     });
 
-    it('should no display actionable proposals when not "actionable" in URL', async () => {
-      resetIdentity();
-      page.mock({
-        data: {
-          universe: OWN_CANISTER_ID_TEXT,
-          routeId: AppPath.Proposals,
-        },
-      });
-
-      const po = renderComponent();
-      expect(await po.getActionableProposalsPo().isPresent()).toBe(false);
-    });
+    const po = renderComponent();
+    expect(await po.getActionableProposalsPo().isPresent()).toBe(false);
   });
 });


### PR DESCRIPTION
# Motivation

To maintain clean and up-to-date tests, we’re removing an outdated describe block as the `ENABLE_ACTIONABLE_TAB` feature flag has been removed and the feature is always enabled.

# Changes

- Unwrap the outdated describe block (not the content).
- Fix a typo ([second commit](https://github.com/dfinity/nns-dapp/commit/3482ddc44fae66dcab27c5fdc7e36e5a589ce959)).

# Tests

- Pass

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.