### PR TITLE
Rename actionable indication store

### DIFF
--- a/frontend/src/lib/components/universe/SelectUniverseCard.svelte
+++ b/frontend/src/lib/components/universe/SelectUniverseCard.svelte
@@ -7,7 +7,7 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import {
     actionableProposalCountStore,
-    actionableProposalIndicationEnabledStore,
+    actionableProposalIndicationVisibleStore,
     actionableProposalSupportedStore,
     actionableProposalTotalCountStore,
   } from "$lib/derived/actionable-proposals.derived";
@@ -78,7 +78,7 @@
           <TestIdWrapper testId="universe-name"
             >{$i18n.voting.actionable_proposals}</TestIdWrapper
           >
-          {#if $actionableProposalIndicationEnabledStore}
+          {#if $actionableProposalIndicationVisibleStore}
             {#if $actionableProposalTotalCountStore > 0 && mounted}
               <div
                 in:scale={{
@@ -92,7 +92,7 @@
           {/if}
         {:else}
           <TestIdWrapper testId="universe-name">{universe.title}</TestIdWrapper>
-          {#if $actionableProposalIndicationEnabledStore}
+          {#if $actionableProposalIndicationVisibleStore}
             {#if nonNullish(actionableProposalCount) && actionableProposalCount > 0 && mounted}
               <ActionableProposalCountBadge
                 count={actionableProposalCount}

--- a/frontend/src/lib/derived/actionable-proposals.derived.ts
+++ b/frontend/src/lib/derived/actionable-proposals.derived.ts
@@ -25,7 +25,7 @@ export interface ActionableProposalCountData {
 
 /** Returns true when the indication needs to be shown */
 // TODO(max): rename into actionableProposalIndicationVisibleStore (related to the visibility on neurons page bug)
-export const actionableProposalIndicationEnabledStore: Readable<boolean> =
+export const actionableProposalIndicationVisibleStore: Readable<boolean> =
   derived(
     [pageStore, authSignedInStore],
     ([{ path: currentPath }, isSignedIn]) =>

--- a/frontend/src/lib/derived/actionable-proposals.derived.ts
+++ b/frontend/src/lib/derived/actionable-proposals.derived.ts
@@ -24,7 +24,6 @@ export interface ActionableProposalCountData {
 }
 
 /** Returns true when the indication needs to be shown */
-// TODO(max): rename into actionableProposalIndicationVisibleStore (related to the visibility on neurons page bug)
 export const actionableProposalIndicationVisibleStore: Readable<boolean> =
   derived(
     [pageStore, authSignedInStore],

--- a/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/actionable-proposals.derived.spec.ts
@@ -2,7 +2,7 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import {
   actionableProposalCountStore,
-  actionableProposalIndicationEnabledStore,
+  actionableProposalIndicationVisibleStore,
   actionableProposalNotSupportedUniversesStore,
   actionableProposalSupportedStore,
   actionableProposalTotalCountStore,
@@ -56,14 +56,14 @@ describe("actionable proposals derived stores", () => {
     failedActionableSnsesStore.resetForTesting();
   });
 
-  describe("actionableProposalIndicationEnabledStore", () => {
+  describe("actionableProposalIndicationVisibleStore", () => {
     it("returns true when the user is signed-in and on proposals page", async () => {
       resetIdentity();
       page.mock({
         data: { universe: OWN_CANISTER_ID_TEXT },
         routeId: AppPath.Proposals,
       });
-      expect(get(actionableProposalIndicationEnabledStore)).toBe(true);
+      expect(get(actionableProposalIndicationVisibleStore)).toBe(true);
     });
 
     it("returns false when the user is not signed-in", async () => {
@@ -72,7 +72,7 @@ describe("actionable proposals derived stores", () => {
         data: { universe: OWN_CANISTER_ID_TEXT },
         routeId: AppPath.Proposals,
       });
-      expect(get(actionableProposalIndicationEnabledStore)).toBe(false);
+      expect(get(actionableProposalIndicationVisibleStore)).toBe(false);
     });
 
     it("returns false when the user is not on proposals page", async () => {
@@ -81,7 +81,7 @@ describe("actionable proposals derived stores", () => {
           data: { universe: OWN_CANISTER_ID_TEXT },
           routeId,
         });
-        expect(get(actionableProposalIndicationEnabledStore)).toBe(false);
+        expect(get(actionableProposalIndicationVisibleStore)).toBe(false);
       };
       resetIdentity();
 


### PR DESCRIPTION
# Motivation

The store `actionableProposalIndicationEnabledStore` has a misleading name because it can’t be enabled/disabled but relies on the current page. Additionally, the old name can be confused with enabling the actionable by selector state.

# Changes

- Rename `actionableProposalIndicationEnabledStore` to `actionableProposalIndicationVisibleStore`.

# Tests

- Pass.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
