### PR TITLE
Small test cleanups

### DIFF
--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -245,7 +245,7 @@ describe("NeuronsTable", () => {
         reversed: true,
       },
     ]);
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await runResolvedPromises();
 
     {
       const rowPos = await po.getNeuronsTableRowPos();

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -11,6 +11,7 @@ import { mockTableNeuron } from "$tests/mocks/neurons.mock";
 import { NeuronsTablePo } from "$tests/page-objects/NeuronsTable.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { NeuronState } from "@dfinity/nns";
 import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 

--- a/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
@@ -154,13 +154,21 @@ describe("ResponsiveTable", () => {
     expect(await rows[2].getStyle()).toBe("color: grey;");
   });
 
+  it("should not set empty style attribute", async () => {
+    const po = renderComponent({
+      columns,
+      tableData,
+      getRowStyle: (_) => undefined,
+    });
+    const rows = await po.getRows();
+    expect(await rows[0].getStyle()).toBeNull();
+  });
+
   it("should sort rows based on name", async () => {
     const po = renderComponent({
       columns,
       tableData,
       order: [{ columnId: "name" }],
-      getRowStyle: (rowData) =>
-        rowData.rowHref ? "color: black;" : "color: grey;",
     });
     const rows = await po.getRows();
     expect(rows).toHaveLength(3);
@@ -175,8 +183,6 @@ describe("ResponsiveTable", () => {
       columns,
       tableData,
       order: [{ columnId: "age" }],
-      getRowStyle: (rowData) =>
-        rowData.rowHref ? "color: black;" : "color: grey;",
     });
     const rows = await po.getRows();
     expect(rows).toHaveLength(3);
@@ -184,16 +190,6 @@ describe("ResponsiveTable", () => {
     expect(await rows[0].getCells()).toEqual(["Anya", "", "Age 19", "Anya"]);
     expect(await rows[1].getCells()).toEqual(["Anton", "", "Age 31", "Anton"]);
     expect(await rows[2].getCells()).toEqual(["Alice", "", "Age 45", "Alice"]);
-  });
-
-  it("should not set empty style attribute", async () => {
-    const po = renderComponent({
-      columns,
-      tableData,
-      getRowStyle: (_) => undefined,
-    });
-    const rows = await po.getRows();
-    expect(await rows[0].getStyle()).toBeNull();
   });
 
   it("should render column styles depending on the number of columns", async () => {


### PR DESCRIPTION
# Motivation

Some small things I noticed that I don't want to clutter another large PR with.

# Changes

1. Use `runResolvedPromises` instead of `setTimeout`.
2. Remove `getRowStyle` from tests for which it's unrelated.
3. Put `getRowStyle` related tests together. 

# Tests

yes

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary