### PR TITLE
Exclude empty neurons with listNeurons

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -23,6 +23,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Change neuron ID column title to "Neurons".
+* Excluded non-displayed empty neurons when loading neurons.
 
 #### Deprecated
 

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -362,6 +362,7 @@ export const queryNeurons = async ({
 
   const response = await canister.listNeurons({
     certified,
+    includeEmptyNeurons: false,
   });
   logWithTimestamp(`Querying Neurons certified:${certified} complete.`);
   return response;

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -126,7 +126,11 @@ describe("neurons-api", () => {
 
     await queryNeurons({ identity: mockIdentity, certified: false });
 
-    expect(mockGovernanceCanister.listNeurons).toBeCalled();
+    expect(mockGovernanceCanister.listNeurons).toBeCalledWith({
+      certified: false,
+      includeEmptyNeurons: false,
+    });
+    expect(mockGovernanceCanister.listNeurons).toBeCalledTimes(1);
   });
 
   it("queryKnownNeurons fetches known neurons", async () => {


### PR DESCRIPTION
# Motivation

NNS dapp does not display empty neurons and just filters them out.
The governance canister is going to have a new feature where empty neurons can be excluded.
The API was already added so we can start passing the relevant parameter to benefit from it as soon as it's available.

# Changes

Pass `includeEmptyNeurons: false` to `listNeurons`.

# Tests

1. Unit test updated.
2. Tested manually that nothing breaks, but the functionality is not implemented yet so couldn't be tested.

# Todos

- [ ] Add entry to changelog (if necessary).
