### PR TITLE
bot: Update snsdemo to release-2024-06-26

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -385,7 +385,7 @@
         "DIDC_VERSION": "2024-05-14",
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2024-06-19",
+        "SNSDEMO_RELEASE": "release-2024-06-26",
         "IC_COMMIT_FOR_PROPOSALS": "2538538e0132b394f302c49fd91da23fc4cee284",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-06-19_23-01-cycle-hotfix"
       },


### PR DESCRIPTION
# Motivation
We would like to keep the testing environment, provided by snsdemo, up to date.

# Changes
* Updated `snsdemo` version in `dfx.json`.
* Ensured that the `dfx` version in `dfx.json` matches `snsdemo`.

# Tests
CI should pass.