### PR TITLE
Svelte import sorting fixes

### DIFF
--- a/scripts/sort-svelte-imports
+++ b/scripts/sort-svelte-imports
@@ -29,15 +29,14 @@ TOP_DIR=$(git rev-parse --show-toplevel)
 list_files_to_sort() {
   if [[ "$#" -ne 0 ]]; then
     echo "Using script arguments to find svelte files." >&2
-    # readlink makes the paths absolute
-    find "$@" -type f -name '*.svelte' -exec readlink -f {} \;
+    git ls-files --full-name "$@" | grep -E '\.svelte$' | sed "s@^@$TOP_DIR/@"
     return
   fi
 
   ancestor=$(git merge-base HEAD main)
   if git diff --quiet "$ancestor" --exit-code; then
     echo "No changes in branch. Sorting all svelte files." >&2
-    git ls-files '*.svelte' | sed "s@^@$TOP_DIR/@"
+    git ls-files --full-name '*.svelte' | sed "s@^@$TOP_DIR/@"
     return
   fi
 


### PR DESCRIPTION
# Motivation

The svelte import sorting script sort import statements based on the imported path, but it does not sort the things imported within a single import statement.

Also the script wasn't working properly when run from a different directory.

# Changes

1. Add code to the Vim script that finds imports that import multiple things, puts those things on individual lines and then sorts them (putting imports prefixed with `type ` last, similar to how `pretties` does it.
2. Drive-by: Some small changes to make the regexes more strict.
3. Fix the shell script to produce the correct absolute paths with the script is run from a different directory.

# Tests

Manually

# Todos

- [ ] Add entry to changelog (if necessary).
