### PR TITLE
bot: Update IC Cargo Dependencies to release-2024-06-26_23-01-base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1140,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1152,7 +1152,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1164,7 +1164,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "on_wire",
  "prost",
@@ -1372,7 +1372,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1861,7 +1861,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -1888,7 +1888,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -1901,7 +1901,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ecdsa-secp256k1",
@@ -1914,7 +1914,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "serde",
 ]
@@ -1922,7 +1922,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -1931,7 +1931,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "serde",
@@ -2058,12 +2058,12 @@ dependencies = [
 [[package]]
 name = "ic-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "k256",
  "lazy_static",
@@ -2077,7 +2077,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -2091,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "getrandom",
 ]
@@ -2099,7 +2099,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "hex",
  "ic-types",
@@ -2109,7 +2109,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -2131,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -2149,7 +2149,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2157,7 +2157,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2176,7 +2176,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2189,7 +2189,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -2197,7 +2197,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "base64 0.13.1",
  "cached",
@@ -2223,7 +2223,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2253,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "arrayvec 0.7.4",
  "hex",
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2288,7 +2288,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "serde",
  "zeroize",
@@ -2297,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2305,7 +2305,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2318,7 +2318,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -2331,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2341,7 +2341,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2351,7 +2351,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "ic-protobuf",
  "ic-utils",
@@ -2363,7 +2363,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "ciborium",
@@ -2385,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "ciborium",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "async-trait",
  "candid",
@@ -2441,7 +2441,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -2453,7 +2453,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "async-trait",
  "candid",
@@ -2471,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -2483,7 +2483,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "hex",
@@ -2493,7 +2493,7 @@ dependencies = [
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2518,7 +2518,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "async-trait",
  "candid",
@@ -2541,12 +2541,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2582,12 +2582,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -2600,7 +2600,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -2612,12 +2612,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "comparable",
@@ -2630,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "ic-base-types",
 ]
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "dfn_core",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "async-trait",
  "candid",
@@ -2667,12 +2667,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -2685,7 +2685,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "comparable",
@@ -2711,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -2720,7 +2720,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2783,12 +2783,12 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "async-trait",
  "candid",
@@ -2803,12 +2803,11 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "bincode",
  "candid",
  "erased-serde",
- "maplit",
  "prost",
  "serde",
  "serde_json",
@@ -2818,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2830,7 +2829,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2841,7 +2840,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "ic-management-canister-types",
@@ -2852,7 +2851,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -2864,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2876,7 +2875,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2933,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -2941,7 +2940,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -2952,7 +2951,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "async-trait",
  "candid",
@@ -2973,7 +2972,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -3000,7 +2999,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3029,7 +3028,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3067,7 +3066,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "comparable",
@@ -3082,7 +3081,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "async-trait",
  "candid",
@@ -3129,7 +3128,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3164,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3249,7 +3248,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "comparable",
@@ -3280,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "async-trait",
  "candid",
@@ -3291,7 +3290,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.5"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "base32",
  "candid",
@@ -3910,7 +3909,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 
 [[package]]
 name = "once_cell"
@@ -4074,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "candid",
  "serde",
@@ -4621,12 +4620,11 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-19_23-01-base#e3fca54d11e19dc7134e374d9f472c5929f755f9"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
 dependencies = [
  "build-info",
  "build-info-build",
  "candid",
- "cycles-minting-canister",
  "dfn_candid",
  "dfn_core",
  "dfn_http_metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,23 +13,23 @@ version = "2.0.82"
 ic-cdk = "0.14.0"
 ic-cdk-macros = "0.14.0"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
-ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-19_23-01-base" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
 
 [profile.release]
 lto = false


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
We want to keep our Cargo dependencies up to date.

# Changes
* Ran `scripts/update-ic-cargo-deps` to update the Cargo.toml dependencies to the latest IC release.

# Tests
* See CI