### PR TITLE
Disable sorting by neuron ID

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,6 +26,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Removed
 
+* Disable sorting the neurons table by neuron ID.
+
 #### Fixed
 
 #### Security

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
@@ -25,7 +25,8 @@
 
   // Make sure there is a consistent order even if the selected sorting
   // criteria don't tiebreak all neurons.
-  let neuronsSortedById = [...neurons].sort(compareById);
+  let neuronsSortedById: TableNeuron[];
+  $: neuronsSortedById = [...neurons].sort(compareById);
 
   const columns: NeuronsTableColumn[] = [
     {

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronsTable.svelte
@@ -23,6 +23,10 @@
 
   export let neurons: TableNeuron[];
 
+  // Make sure there is a consistent order even if the selected sorting
+  // criteria don't tiebreak all neurons.
+  let neuronsSortedById = [...neurons].sort(compareById);
+
   const columns: NeuronsTableColumn[] = [
     {
       id: "id",
@@ -30,7 +34,6 @@
       cellComponent: NeuronIdCell,
       alignment: "left",
       templateColumns: ["minmax(min-content, max-content)"],
-      comparator: compareById,
     },
     {
       title: "",
@@ -103,7 +106,7 @@
 <ResponsiveTable
   testId="neurons-table-component"
   {columns}
-  tableData={neurons}
+  tableData={neuronsSortedById}
   bind:order={$neuronsTableOrderStore}
   {getRowStyle}
 ></ResponsiveTable>

--- a/frontend/src/lib/stores/neurons-table.store.ts
+++ b/frontend/src/lib/stores/neurons-table.store.ts
@@ -8,9 +8,6 @@ const initialNeuronsTableOrder: ResponsiveTableOrder = [
   {
     columnId: "dissolveDelay",
   },
-  {
-    columnId: "id",
-  },
 ];
 
 const initNeuronsTableOrderStore = () => {

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -261,6 +261,37 @@ describe("NeuronsTable", () => {
     expect(await rowPos[3].getNeuronId()).toBe(neuron4.neuronId);
   });
 
+  it("should sort neurons tie breaking on ID", async () => {
+    // Neurons passed in out of order ...
+    const po = renderComponent({
+      neurons: [
+        {
+          ...neuron3,
+          stake: makeStake(300_000_000n),
+        },
+        {
+          ...neuron4,
+          stake: makeStake(300_000_000n),
+        },
+        {
+          ...neuron2,
+          stake: makeStake(800_000_000n),
+        },
+        {
+          ...neuron1,
+          stake: makeStake(800_000_000n),
+        },
+      ],
+    });
+    const rowPos = await po.getNeuronsTableRowPos();
+    expect(rowPos).toHaveLength(4);
+    // ... appear in the UI in sorted order.
+    expect(await rowPos[0].getNeuronId()).toBe(neuron1.neuronId);
+    expect(await rowPos[1].getNeuronId()).toBe(neuron2.neuronId);
+    expect(await rowPos[2].getNeuronId()).toBe(neuron3.neuronId);
+    expect(await rowPos[3].getNeuronId()).toBe(neuron4.neuronId);
+  });
+
   it("should change order based on order store", async () => {
     const po = renderComponent({
       neurons: [
@@ -300,7 +331,7 @@ describe("NeuronsTable", () => {
         columnId: "dissolveDelay",
       },
       {
-        columnId: "id",
+        columnId: "stake",
         reversed: true,
       },
     ]);
@@ -324,19 +355,18 @@ describe("NeuronsTable", () => {
     expect(get(neuronsTableOrderStore)).toEqual([
       { columnId: "stake" },
       { columnId: "dissolveDelay" },
-      { columnId: "id" },
     ]);
 
     await po.clickColumnHeader("Stake");
     expect(get(neuronsTableOrderStore)).toEqual([
       { columnId: "stake", reversed: true },
       { columnId: "dissolveDelay" },
-      { columnId: "id" },
     ]);
 
+    // The Neuron ID column is not sortable so clicking it does not change the
+    // order.
     await po.clickColumnHeader("Neurons");
     expect(get(neuronsTableOrderStore)).toEqual([
-      { columnId: "id" },
       { columnId: "stake", reversed: true },
       { columnId: "dissolveDelay" },
     ]);
@@ -344,7 +374,6 @@ describe("NeuronsTable", () => {
     await po.clickColumnHeader("Maturity");
     expect(get(neuronsTableOrderStore)).toEqual([
       { columnId: "maturity" },
-      { columnId: "id" },
       { columnId: "stake", reversed: true },
       { columnId: "dissolveDelay" },
     ]);
@@ -353,7 +382,6 @@ describe("NeuronsTable", () => {
     expect(get(neuronsTableOrderStore)).toEqual([
       { columnId: "dissolveDelay" },
       { columnId: "maturity" },
-      { columnId: "id" },
       { columnId: "stake", reversed: true },
     ]);
 
@@ -362,7 +390,6 @@ describe("NeuronsTable", () => {
       { columnId: "state" },
       { columnId: "dissolveDelay" },
       { columnId: "maturity" },
-      { columnId: "id" },
       { columnId: "stake", reversed: true },
     ]);
   });

--- a/frontend/src/tests/lib/stores/neurons-table.store.spec.ts
+++ b/frontend/src/tests/lib/stores/neurons-table.store.spec.ts
@@ -11,9 +11,6 @@ describe("neurons-table.store", () => {
         {
           columnId: "dissolveDelay",
         },
-        {
-          columnId: "id",
-        },
       ]);
     });
 
@@ -38,9 +35,6 @@ describe("neurons-table.store", () => {
         },
         {
           columnId: "dissolveDelay",
-        },
-        {
-          columnId: "id",
         },
       ]);
     });


### PR DESCRIPTION
# Motivation

It's not really useful to sort neurons by ID and it can also be confusing. So UX asked to disable sorting by neuron ID.

# Changes

1. Disable sorting by neuron ID.
2. Sort neurons by neuron ID in the `NeuronsTable` component before passing them to the `ResponsiveTable` component. This makes sure ties are always broken by neuron ID even though we can no longer indicate this in the table order.

# Tests

Unit test updated.

# Todos

- [x] Add entry to changelog (if necessary).
