### PR TITLE
NNS1-3136: Add modal for mobile table sorting

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -772,6 +772,10 @@
     "token_stake": "$amount $token Stake",
     "min_dissolve_delay_description": "Voting power is given to neurons with a dissolve delay of at least $duration."
   },
+  "responsive_table": {
+    "sort_by": "Sort by",
+    "tap_to_reverse": "Tap to reverse"
+  },
   "time": {
     "year": "year",
     "year_plural": "years",

--- a/frontend/src/lib/modals/common/ResponsiveTableSortModal.svelte
+++ b/frontend/src/lib/modals/common/ResponsiveTableSortModal.svelte
@@ -27,7 +27,9 @@
 </script>
 
 <Modal testId="responsive-table-sort-modal-component" on:nnsClose>
-  <div slot="title">{$i18n.responsive_table.sort_by}</div>
+  <svelte:fragment slot="title"
+    >{$i18n.responsive_table.sort_by}</svelte:fragment
+  >
   {#each columns as column}
     {#if nonNullish(column.comparator)}
       <button
@@ -67,6 +69,7 @@
 
     .arrow-icon {
       color: var(--primary);
+      // Should match the size="16" of the IconSouth above.
       height: 16px;
       margin-left: var(--padding);
 

--- a/frontend/src/lib/modals/common/ResponsiveTableSortModal.svelte
+++ b/frontend/src/lib/modals/common/ResponsiveTableSortModal.svelte
@@ -1,0 +1,85 @@
+<script lang="ts" context="module">
+  import type { ResponsiveTableRowData } from "$lib/types/responsive-table";
+  type RowDataType = ResponsiveTableRowData;
+</script>
+
+<script lang="ts" generics="RowDataType extends ResponsiveTableRowData">
+  import { i18n } from "$lib/stores/i18n";
+  import type {
+    ResponsiveTableColumn,
+    ResponsiveTableOrder,
+  } from "$lib/types/responsive-table";
+  import { selectPrimaryOrder } from "$lib/utils/responsive-table.utils";
+  import { IconSouth, Modal } from "@dfinity/gix-components";
+  import { assertNonNullish, nonNullish } from "@dfinity/utils";
+  import { createEventDispatcher } from "svelte";
+
+  export let columns: ResponsiveTableColumn<RowDataType>[];
+  export let order: ResponsiveTableOrder;
+
+  const dispatch = createEventDispatcher();
+
+  const orderBy = (column: ResponsiveTableColumn<RowDataType>) => {
+    assertNonNullish(column.id);
+    order = selectPrimaryOrder({ order, selectedColumnId: column.id });
+    dispatch("nnsClose");
+  };
+</script>
+
+<Modal testId="responsive-table-sort-modal-component" on:nnsClose>
+  <div slot="title">{$i18n.responsive_table.sort_by}</div>
+  {#each columns as column}
+    {#if nonNullish(column.comparator)}
+      <button
+        data-tid="sort-option"
+        class="sort-label"
+        class:selected={order[0]?.columnId === column.id}
+        on:click={() => orderBy(column)}
+      >
+        <span data-tid="sort-option-title">{column.title}</span>
+        {#if order[0]?.columnId === column.id}<span class="reverse-description"
+            >{$i18n.responsive_table.tap_to_reverse}<span
+              data-tid="arrow"
+              class="arrow-icon"
+              class:reversed={order[0].reversed}><IconSouth size="16" /></span
+            ></span
+          >{/if}</button
+      >
+    {/if}
+  {/each}
+</Modal>
+
+<style lang="scss">
+  .sort-label {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+
+    font-weight: var(--font-weight-bold);
+    padding: var(--padding-2x);
+
+    .reverse-description {
+      display: flex;
+      align-items: center;
+      color: var(--primary);
+      font-size: var(--font-size-small);
+    }
+
+    .arrow-icon {
+      color: var(--primary);
+      height: 16px;
+      margin-left: var(--padding);
+
+      &.reversed {
+        transform: rotate(180deg);
+      }
+    }
+
+    border: 2px solid transparent;
+    border-radius: var(--border-radius);
+
+    &.selected {
+      border-color: var(--primary);
+    }
+  }
+</style>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -805,6 +805,11 @@ interface I18nSns_neurons {
   min_dissolve_delay_description: string;
 }
 
+interface I18nResponsive_table {
+  sort_by: string;
+  tap_to_reverse: string;
+}
+
 interface I18nTime {
   year: string;
   year_plural: string;
@@ -1331,6 +1336,7 @@ interface I18n {
   sns_sale: I18nSns_sale;
   sns_neuron_detail: I18nSns_neuron_detail;
   sns_neurons: I18nSns_neurons;
+  responsive_table: I18nResponsive_table;
   time: I18nTime;
   error__ledger: I18nError__ledger;
   error__attach_wallet: I18nError__attach_wallet;

--- a/frontend/src/tests/lib/modals/common/ResponsiveTableSortModal.spec.ts
+++ b/frontend/src/tests/lib/modals/common/ResponsiveTableSortModal.spec.ts
@@ -1,0 +1,115 @@
+import ResponsiveTableSortModal from "$lib/modals/common/ResponsiveTableSortModal.svelte";
+import type {
+  ResponsiveTableColumn,
+  ResponsiveTableOrder,
+} from "$lib/types/responsive-table";
+import { createAscendingComparator } from "$lib/utils/responsive-table.utils";
+import TestTableAgeCell from "$tests/lib/components/ui/TestTableAgeCell.svelte";
+import TestTableNameCell from "$tests/lib/components/ui/TestTableNameCell.svelte";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { ResponsiveTableSortModalPo } from "$tests/page-objects/ResponsiveTableSortModal.page-object";
+import { render } from "@testing-library/svelte";
+import { get, writable, type Writable } from "svelte/store";
+
+describe("ResponsiveTableSortModal", () => {
+  type TestRowData = {
+    domKey: string;
+    rowHref?: string;
+    name: string;
+    age: number;
+  };
+
+  const columns: ResponsiveTableColumn<TestRowData>[] = [
+    {
+      id: "name",
+      title: "Name",
+      cellComponent: TestTableNameCell,
+      alignment: "left",
+      templateColumns: ["1fr", "max-content"],
+      comparator: createAscendingComparator((rowData) => rowData.name),
+    },
+    {
+      id: "age",
+      title: "Age",
+      cellComponent: TestTableAgeCell,
+      alignment: "left",
+      templateColumns: ["1fr"],
+      comparator: createAscendingComparator((rowData) => rowData.age),
+    },
+  ];
+
+  const order = [{ columnId: "name" }, { columnId: "age" }];
+
+  const renderComponent = ({
+    columns,
+    order,
+    orderStore,
+    onClose,
+  }: {
+    columns: ResponsiveTableColumn<TestRowData>[];
+    order: ResponsiveTableOrder;
+    orderStore?: Writable<ResponsiveTableOrder>;
+    onClose?: () => void;
+  }) => {
+    const { container, component } = render(ResponsiveTableSortModal, {
+      columns,
+      order,
+    });
+    component.$on("nnsClose", () => {
+      orderStore?.set(component.$$.ctx[component.$$.props["order"]]);
+      onClose?.();
+    });
+
+    return ResponsiveTableSortModalPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should render modal title", async () => {
+    const po = renderComponent({ columns, order });
+    expect(await po.getModalTitle()).toBe("Sort by");
+  });
+
+  it("should render columns", async () => {
+    const po = renderComponent({ columns, order });
+    expect(await po.getOptions()).toEqual(["Name", "Age"]);
+  });
+
+  it("should render arrow", async () => {
+    const order = [{ columnId: "name" }];
+    const po = renderComponent({ columns, order });
+    expect(await po.getOptionWithArrow()).toBe("Name");
+  });
+
+  it("should change order", async () => {
+    const order = [{ columnId: "name" }];
+    const orderStore = writable(order);
+    const po = renderComponent({ columns, order, orderStore });
+    await po.clickOption("Age");
+    expect(await po.getOptionWithArrow()).toBe("Age");
+    expect(get(orderStore)).toEqual([
+      { columnId: "age" },
+      { columnId: "name" },
+    ]);
+  });
+
+  it("should reverse order", async () => {
+    const order = [{ columnId: "name" }];
+    const orderStore = writable(order);
+    const po = renderComponent({ columns, order, orderStore });
+    expect(await po.isReversed()).toBe(false);
+    await po.clickOption("Name");
+    expect(get(orderStore)).toEqual([{ columnId: "name", reversed: true }]);
+    expect(await po.isReversed()).toBe(true);
+    await po.clickOption("Age");
+    expect(await po.isReversed()).toBe(false);
+  });
+
+  it("should close modal when selecting an option", async () => {
+    const close = vi.fn();
+    const po = renderComponent({ columns, order, onClose: close });
+    expect(close).not.toBeCalled();
+    await po.clickOption("Name");
+    expect(close).toBeCalledTimes(1);
+  });
+});

--- a/frontend/src/tests/page-objects/ResponsiveTableSortModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ResponsiveTableSortModal.page-object.ts
@@ -1,4 +1,3 @@
-import { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 

--- a/frontend/src/tests/page-objects/ResponsiveTableSortModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ResponsiveTableSortModal.page-object.ts
@@ -1,0 +1,58 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ResponsiveTableSortModalPo extends ModalPo {
+  private static TID = "responsive-table-sort-modal-component";
+
+  static under(element: PageObjectElement): ResponsiveTableSortModalPo {
+    return new ResponsiveTableSortModalPo(
+      element.byTestId(ResponsiveTableSortModalPo.TID)
+    );
+  }
+
+  async getOptions(): Promise<string[]> {
+    const elements = await this.root.allByTestId("sort-option-title");
+    return Promise.all(elements.map((element) => element.getText()));
+  }
+
+  async getMatchingOption(
+    filter: (PageObjectElement) => Promise<boolean>
+  ): Promise<PageObjectElement> {
+    const elements = await this.root.allByTestId("sort-option");
+    const matchingElements = await Promise.all(
+      elements.map(async (element) => ({
+        element,
+        isMatching: await filter(element),
+      }))
+    );
+    const matchingCount = matchingElements.filter(
+      (element) => element.isMatching
+    ).length;
+    if (matchingCount !== 1) {
+      throw new Error(`Expected 1 matching, but found ${matchingCount}`);
+    }
+    return matchingElements.find((element) => element.isMatching).element;
+  }
+
+  async getOptionWithArrow(): Promise<string> {
+    const element = await this.getMatchingOption(async (element) =>
+      element.byTestId("arrow").isPresent()
+    );
+    return element.byTestId("sort-option-title").getText();
+  }
+
+  async clickOption(optionTitle: string): Promise<void> {
+    const element = await this.getMatchingOption(
+      async (element) =>
+        (await element.byTestId("sort-option-title").getText()) === optionTitle
+    );
+    return element.click();
+  }
+
+  async isReversed(): Promise<boolean> {
+    return (await this.root.byTestId("arrow").getClasses()).includes(
+      "reversed"
+    );
+  }
+}


### PR DESCRIPTION
# Motivation

When sorting the table on desktop, you can click on the column headers.
For mobile we need a different UI with a modal to select a sorting option.
This PR just adds that modal but does not connect it to the table yet.

Here is a demo of it integrated in the neurons table: https://mecbw-6maaa-aaaaa-qabkq-cai.dskloet-ingress.devenv.dfinity.network/neurons/?u=mecbw-6maaa-aaaaa-qabkq-cai

<img width="565" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/ff5cad62-d09b-4e6c-931b-6d27447b600b">


# Changes

Add `frontend/src/lib/modals/common/ResponsiveTableSortModal.svelte` component.
The modal binds and updates the `order` prop and closes as soon as a selection is made.

# Tests

1. Unit test added.
2. Manually

# Todos

- [ ] Add entry to changelog (if necessary).
not yet