### PR TITLE
Update snsdemo to release-2024-07-01

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -386,7 +386,7 @@
         "DIDC_VERSION": "2024-05-14",
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2024-06-26",
+        "SNSDEMO_RELEASE": "release-2024-07-01",
         "IC_COMMIT_FOR_PROPOSALS": "release-2024-06-26_23-01-base",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-06-19_23-01-cycle-hotfix"
       },

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -105,7 +105,12 @@ test("Test merge neurons", async ({ page, context }) => {
   await transactionList.waitForLoaded();
   const transactions = await transactionList.getTransactionCardPos();
   expect(await Promise.all(transactions.map((tx) => tx.getHeadline()))).toEqual(
-    ["Top-up Neuron", "Staked", "Staked", "Received"]
+    [
+      "Sent", // This would be "Top-up Neuron" but we don't know the neuron anymore.
+      "Staked",
+      "Sent", // This would be "Staked" but we don't know the neuron anymore.
+      "Received",
+    ]
   );
   expect(await Promise.all(transactions.map((tx) => tx.getAmount()))).toEqual([
     "-2.0001",


### PR DESCRIPTION
# Motivation
We would like to keep the testing environment, provided by snsdemo, up to date.

The new test environment includes [this MR](https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/20113), which means the [PR to exclude empty neurons](https://github.com/dfinity/nns-dapp/pull/5123) starts to have an effect. Because of this we are no longer aware of the neuron accounts of empty neurons, which means that "Stake" and "Top-up" transactions to those neuron accounts will now just render as "Sent" transactions.

# Changes
* Updated `snsdemo` version in `dfx.json`.
* Update `frontend/src/tests/e2e/merge-neurons.spec.ts` to match reality.

# Tests
CI should pass.