### PR TITLE
Change top-right table icon color

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -21,6 +21,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Change neuron ID column title to "Neurons".
 * Excluded non-displayed empty neurons when loading neurons.
+* Change the color of the settings icon on the tokens table.
 
 #### Deprecated
 

--- a/frontend/src/lib/components/ui/ResponsiveTable.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTable.svelte
@@ -233,6 +233,8 @@
         // Prevents the element taking up more height than the icon by adding
         // space for descenders.
         line-height: 0;
+
+        color: var(--primary);
       }
     }
 


### PR DESCRIPTION
# Motivation

UX asked to be changed to make the icon look more actionable and for consistency with the icon that will be added to the neurons table for sorting.

Before:

<img width="340" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/47d26227-c7d5-4374-93f8-18fcb88a2118">

<br>

<img width="346" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/2e593c76-5e9b-4d4b-9031-1622f2cef547">

After:

<img width="342" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/b0207e06-6905-4217-abba-2217fe69c517">

<br>

<img width="346" alt="image" src="https://github.com/dfinity/nns-dapp/assets/122978264/4cf15ec3-c193-45fe-a4b8-ae2c40dfd267">


# Changes

Change the table header icon to `--primary` color.

# Tests

Manually

# Todos

- [x] Add entry to changelog (if necessary).
