### PR TITLE
Clean up ENABLE_NEURONS_TABLE

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -273,7 +273,6 @@
     "remaining": "Remaining",
     "age": "Age",
     "vestion_period": "Remaining vesting period",
-    "aria_label_neuron_card": "Go to neuron details",
     "neuron_id": "Neuron ID",
     "neuron_balance": "Balance",
     "current_dissolve_delay": "Current Dissolve Delay",
@@ -759,8 +758,6 @@
   },
   "sns_neuron_detail": {
     "vesting_period_tooltip": "This function is not available during your vesting period. Vesting will last another $remainingVesting",
-    "community_fund_section": "Neurons' Fund",
-    "community_fund_section_description": "You are not the controller of the SNS neurons below. To facilitate bootstrapping the SNS DAO governance, the NNS treasury has temporarily granted hotkey access to you for voting and following. <a href=\"https://internetcomputer.org/docs/current/tokenomics/nns/neurons-fund\" rel=\"noopener noreferrer\" aria-label=\"more info about neurons' fund\" target=\"_blank\">Learn more</a>.",
     "add_hotkey_info": "To vote with this neuron from another dapp, add the principal id you have in the other dapp as a hotkey.",
     "add_hotkey_tooltip": "To vote with this neuron from another dapp, add the principal id you have in the other dapp as a hotkey."
   },

--- a/frontend/src/lib/pages/NnsNeurons.svelte
+++ b/frontend/src/lib/pages/NnsNeurons.svelte
@@ -1,25 +1,15 @@
 <script lang="ts">
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import NeuronsTable from "$lib/components/neurons/NeuronsTable/NeuronsTable.svelte";
-  import NnsNeuronCard from "$lib/components/neurons/NnsNeuronCard.svelte";
   import EmptyMessage from "$lib/components/ui/EmptyMessage.svelte";
-  import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
   import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
-  import { pageStore } from "$lib/derived/page.derived";
   import { listNeurons } from "$lib/services/neurons.services";
   import { authStore } from "$lib/stores/auth.store";
-  import { ENABLE_NEURONS_TABLE } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
-  import {
-    neuronsStore,
-    sortedNeuronStore,
-    definedNeuronsStore,
-  } from "$lib/stores/neurons.store";
+  import { definedNeuronsStore, neuronsStore } from "$lib/stores/neurons.store";
   import type { TableNeuron } from "$lib/types/neurons-table";
-  import { buildNeuronUrl } from "$lib/utils/navigation.utils";
-  import { isSpawning } from "$lib/utils/neuron.utils";
   import { tableNeuronsFromNeuronInfos } from "$lib/utils/neurons-table.utils";
-  import { Spinner, Tooltip } from "@dfinity/gix-components";
+  import { Spinner } from "@dfinity/gix-components";
   import { onMount } from "svelte";
 
   let isLoading = false;
@@ -30,57 +20,20 @@
   });
 
   let tableNeurons: TableNeuron[] = [];
-  $: tableNeurons = $ENABLE_NEURONS_TABLE
-    ? tableNeuronsFromNeuronInfos({
-        identity: $authStore.identity,
-        accounts: $icpAccountsStore,
-        i18n: $i18n,
-        neuronInfos: $definedNeuronsStore,
-      })
-    : [];
+  $: tableNeurons = tableNeuronsFromNeuronInfos({
+    identity: $authStore.identity,
+    accounts: $icpAccountsStore,
+    i18n: $i18n,
+    neuronInfos: $definedNeuronsStore,
+  });
 </script>
 
 <TestIdWrapper testId="nns-neurons-component">
-  {#if $ENABLE_NEURONS_TABLE}
-    {#if isLoading}
-      <Spinner />
-    {:else if tableNeurons.length > 0}
-      <NeuronsTable neurons={tableNeurons} />
-    {/if}
+  {#if isLoading}
+    <Spinner />
+  {:else if tableNeurons.length > 0}
+    <NeuronsTable neurons={tableNeurons} />
   {:else}
-    <div class="card-grid" data-tid="neurons-body">
-      {#if isLoading}
-        <SkeletonCard />
-        <SkeletonCard />
-      {:else}
-        {#each $sortedNeuronStore as neuron}
-          {#if isSpawning(neuron)}
-            <Tooltip
-              id="spawning-neuron-card"
-              text={$i18n.neuron_detail.spawning_neuron_info}
-            >
-              <NnsNeuronCard
-                disabled
-                ariaLabel={$i18n.neurons.aria_label_neuron_card}
-                {neuron}
-              />
-            </Tooltip>
-          {:else}
-            <NnsNeuronCard
-              ariaLabel={$i18n.neurons.aria_label_neuron_card}
-              href={buildNeuronUrl({
-                universe: $pageStore.universe,
-                neuronId: neuron.neuronId,
-              })}
-              {neuron}
-            />
-          {/if}
-        {/each}
-      {/if}
-    </div>
-  {/if}
-
-  {#if !isLoading && $sortedNeuronStore.length === 0}
     <EmptyMessage>{$i18n.neurons.text}</EmptyMessage>
   {/if}
 </TestIdWrapper>

--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -1,33 +1,23 @@
 <script lang="ts">
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import NeuronsTable from "$lib/components/neurons/NeuronsTable/NeuronsTable.svelte";
-  import SnsNeuronCard from "$lib/components/sns-neurons/SnsNeuronCard.svelte";
   import EmptyMessage from "$lib/components/ui/EmptyMessage.svelte";
-  import SkeletonCard from "$lib/components/ui/SkeletonCard.svelte";
   import { pageStore } from "$lib/derived/page.derived";
   import {
     snsOnlyProjectStore,
     snsProjectSelectedStore,
   } from "$lib/derived/sns/sns-selected-project.derived";
-  import {
-    sortedSnsCFNeuronsStore,
-    sortedSnsUserNeuronsStore,
-    definedSnsNeuronStore,
-  } from "$lib/derived/sns/sns-sorted-neurons.derived";
+  import { definedSnsNeuronStore } from "$lib/derived/sns/sns-sorted-neurons.derived";
   import { loadSnsAccounts } from "$lib/services/sns-accounts.services";
   import { syncSnsNeurons } from "$lib/services/sns-neurons.services";
   import { authStore } from "$lib/stores/auth.store";
-  import { ENABLE_NEURONS_TABLE } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import type { TableNeuron } from "$lib/types/neurons-table";
   import type { SnsSummary } from "$lib/types/sns";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
-  import { buildNeuronUrl } from "$lib/utils/navigation.utils";
   import { tableNeuronsFromSnsNeurons } from "$lib/utils/neurons-table.utils";
-  import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
-  import { Html, Spinner } from "@dfinity/gix-components";
+  import { Spinner } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
-  import type { SnsNeuron } from "@dfinity/sns";
   import { nonNullish } from "@dfinity/utils";
 
   let loading = true;
@@ -47,85 +37,27 @@
 
   $: syncNeuronsForProject($snsOnlyProjectStore);
 
-  const buildNeuronDetailsUrl = (neuron: SnsNeuron): string => {
-    const neuronId = getSnsNeuronIdAsHexString(neuron);
-    return buildNeuronUrl({
-      universe: $pageStore.universe,
-      neuronId,
-    });
-  };
-
-  let empty: boolean;
-  $: empty =
-    $sortedSnsUserNeuronsStore.length === 0 &&
-    $sortedSnsCFNeuronsStore.length === 0;
-
   let summary: SnsSummary | undefined;
   $: summary = $snsProjectSelectedStore?.summary;
 
   let tableNeurons: TableNeuron[] = [];
-  $: tableNeurons =
-    $ENABLE_NEURONS_TABLE && nonNullish(summary)
-      ? tableNeuronsFromSnsNeurons({
-          universe: $pageStore.universe,
-          token: summary.token,
-          identity: $authStore.identity,
-          i18n: $i18n,
-          snsNeurons: $definedSnsNeuronStore,
-        })
-      : [];
+  $: tableNeurons = nonNullish(summary)
+    ? tableNeuronsFromSnsNeurons({
+        universe: $pageStore.universe,
+        token: summary.token,
+        identity: $authStore.identity,
+        i18n: $i18n,
+        snsNeurons: $definedSnsNeuronStore,
+      })
+    : [];
 </script>
 
 <TestIdWrapper testId="sns-neurons-component">
-  {#if $ENABLE_NEURONS_TABLE}
-    {#if loading}
-      <Spinner />
-    {:else if tableNeurons.length > 0}
-      <NeuronsTable neurons={tableNeurons} />
-    {/if}
-  {:else}
-    {#if $sortedSnsUserNeuronsStore.length > 0 || loading}
-      <div class="card-grid" data-tid="sns-neurons-body">
-        {#if loading}
-          <SkeletonCard />
-          <SkeletonCard />
-        {:else}
-          {#each $sortedSnsUserNeuronsStore as neuron (getSnsNeuronIdAsHexString(neuron))}
-            <SnsNeuronCard
-              {neuron}
-              ariaLabel={$i18n.neurons.aria_label_neuron_card}
-              href={buildNeuronDetailsUrl(neuron)}
-            />
-          {/each}
-        {/if}
-      </div>
-    {/if}
-
-    {#if $sortedSnsCFNeuronsStore.length > 0}
-      <h2
-        data-tid="community-fund-title"
-        class={$sortedSnsUserNeuronsStore.length > 0 ? "top-margin" : ""}
-      >
-        {$i18n.sns_neuron_detail.community_fund_section}
-      </h2>
-      <p data-tid="community-fund-description" class="bottom-margin">
-        <Html
-          text={$i18n.sns_neuron_detail.community_fund_section_description}
-        />
-      </p>
-      <div class="card-grid" data-tid="fund-neurons-grid">
-        {#each $sortedSnsCFNeuronsStore as neuron (getSnsNeuronIdAsHexString(neuron))}
-          <SnsNeuronCard
-            {neuron}
-            ariaLabel={$i18n.neurons.aria_label_neuron_card}
-            href={buildNeuronDetailsUrl(neuron)}
-          />
-        {/each}
-      </div>
-    {/if}
-  {/if}
-
-  {#if !loading && empty && nonNullish(summary)}
+  {#if loading}
+    <Spinner />
+  {:else if tableNeurons.length > 0}
+    <NeuronsTable neurons={tableNeurons} />
+  {:else if nonNullish(summary)}
     <EmptyMessage
       >{replacePlaceholders($i18n.sns_neurons.text, {
         $project: summary.metadata.name,
@@ -134,12 +66,3 @@
     >
   {/if}
 </TestIdWrapper>
-
-<style lang="scss">
-  .top-margin {
-    margin-top: var(--padding-4x);
-  }
-  .bottom-margin {
-    margin-bottom: var(--padding-4x);
-  }
-</style>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -284,7 +284,6 @@ interface I18nNeurons {
   remaining: string;
   age: string;
   vestion_period: string;
-  aria_label_neuron_card: string;
   neuron_id: string;
   neuron_balance: string;
   current_dissolve_delay: string;
@@ -790,8 +789,6 @@ interface I18nSns_sale {
 
 interface I18nSns_neuron_detail {
   vesting_period_tooltip: string;
-  community_fund_section: string;
-  community_fund_section_description: string;
   add_hotkey_info: string;
   add_hotkey_tooltip: string;
 }

--- a/frontend/src/tests/e2e/disburse.spec.ts
+++ b/frontend/src/tests/e2e/disburse.spec.ts
@@ -1,20 +1,11 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test disburse neuron", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_NEURONS_TABLE",
-    value: true,
-  });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -1,20 +1,11 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test merge neurons", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_NEURONS_TABLE",
-    value: true,
-  });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
+++ b/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
@@ -1,21 +1,12 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { getNnsNeuronCardsIds } from "$tests/utils/e2e.nns-neuron.test-utils";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test neuron increase stake", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_NEURONS_TABLE",
-    value: true,
-  });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/neurons-table.spec.ts
+++ b/frontend/src/tests/e2e/neurons-table.spec.ts
@@ -2,7 +2,6 @@ import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import {
   replaceContent,
-  setFeatureFlag,
   signInWithNewUser,
   step,
 } from "$tests/utils/e2e.test-utils";
@@ -26,11 +25,6 @@ const createHotkeyNeuronsInOtherAccount = async ({
   const page = await context.newPage();
   await page.goto("/");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_NEURONS_TABLE",
-    value: true,
-  });
   await signInWithNewUser({ page, context });
 
   const appPo = new AppPo(PlaywrightPageObjectElement.fromPage(page));
@@ -67,11 +61,6 @@ const createHotkeyNeuronsInOtherAccount = async ({
 test("Test neurons table", async ({ page, context, browser }) => {
   await page.goto("/canisters");
   await expect(page).toHaveTitle("Canisters / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_NEURONS_TABLE",
-    value: true,
-  });
 
   const appPo = new AppPo(PlaywrightPageObjectElement.fromPage(page));
 

--- a/frontend/src/tests/e2e/neurons.spec.ts
+++ b/frontend/src/tests/e2e/neurons.spec.ts
@@ -2,21 +2,12 @@ import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { getNnsNeuronCardsIds } from "$tests/utils/e2e.nns-neuron.test-utils";
 import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test neuron voting", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_NEURONS_TABLE",
-    value: true,
-  });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -2,22 +2,13 @@ import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { ProposalStatus, Topic } from "@dfinity/nns";
 import { expect, test } from "@playwright/test";
 
 test("Test proposals", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_NEURONS_TABLE",
-    value: true,
-  });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -1,20 +1,11 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test SNS governance", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_NEURONS_TABLE",
-    value: true,
-  });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -65,108 +65,46 @@ describe("NnsNeurons", () => {
       vi.spyOn(api, "queryNeurons").mockResolvedValue(neurons);
     });
 
-    describe("with ENABLE_NEURONS_TABLE disabled", () => {
-      beforeEach(() => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", false);
-      });
+    it("should render the neurons table", async () => {
+      const po = await renderComponent();
 
-      it("should render spawning neurons as disabled", async () => {
-        const po = await renderComponent();
-
-        const neuronCards = await po.getNeuronCardPos();
-        expect(neuronCards.length).toBe(3);
-
-        expect(await neuronCards[0].isDisabled()).toBe(false);
-        expect(await neuronCards[1].isDisabled()).toBe(false);
-        // Spawning neuron comes last because it has no stake.
-        expect(await neuronCards[2].isDisabled()).toBe(true);
-      });
-
-      it("should render the NeuronCards", async () => {
-        const po = await renderComponent();
-
-        const neuronCards = await po.getNeuronCardPos();
-        expect(neuronCards.length).toBe(neurons.length);
-      });
-
-      it("should filter out disbursed neurons", async () => {
-        vi.spyOn(api, "queryNeurons").mockResolvedValue([
-          mockNeuron,
-          disbursedNeuron,
-          mockNeuron2,
-        ]);
-        const po = await renderComponent();
-
-        const neuronCards = await po.getNeuronCardPos();
-        expect(neuronCards.length).toBe(2);
-      });
-
-      it("should not render an empty message", async () => {
-        const po = await renderComponent();
-
-        expect(await po.hasEmptyMessage()).toBe(false);
-      });
-
-      it("should not render the neurons table", async () => {
-        const po = await renderComponent();
-
-        expect(await po.getNeuronsTablePo().isPresent()).toBe(false);
-      });
+      expect(await po.getNeuronsTablePo().isPresent()).toBe(true);
     });
 
-    describe("with ENABLE_NEURONS_TABLE enabled", () => {
-      beforeEach(() => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", true);
-      });
+    it("should render neurons table rows", async () => {
+      const po = await renderComponent();
 
-      it("should render the neurons table", async () => {
-        const po = await renderComponent();
+      const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
+      expect(rows).toHaveLength(3);
+    });
 
-        expect(await po.getNeuronsTablePo().isPresent()).toBe(true);
-      });
+    it("should filter out disbursed neurons", async () => {
+      vi.spyOn(api, "queryNeurons").mockResolvedValue([
+        mockNeuron,
+        disbursedNeuron,
+        mockNeuron2,
+      ]);
+      const po = await renderComponent();
 
-      it("should render neurons table rows", async () => {
-        const po = await renderComponent();
+      const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
+      expect(rows).toHaveLength(2);
+      expect(await rows[0].getStake()).not.toBe("0 ICP");
+      expect(await rows[1].getStake()).not.toBe("0 ICP");
+    });
 
-        const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
-        expect(rows).toHaveLength(3);
-      });
+    it("should render an go-to-detail button for non-spawning neurons", async () => {
+      const po = await renderComponent();
 
-      it("should filter out disbursed neurons", async () => {
-        vi.spyOn(api, "queryNeurons").mockResolvedValue([
-          mockNeuron,
-          disbursedNeuron,
-          mockNeuron2,
-        ]);
-        const po = await renderComponent();
-
-        const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
-        expect(rows).toHaveLength(2);
-        expect(await rows[0].getStake()).not.toBe("0 ICP");
-        expect(await rows[1].getStake()).not.toBe("0 ICP");
-      });
-
-      it("should not render the NeuronCards", async () => {
-        const po = await renderComponent();
-
-        const neuronCards = await po.getNeuronCardPos();
-        expect(neuronCards.length).toBe(0);
-      });
-
-      it("should render an go-to-detail button for non-spawning neurons", async () => {
-        const po = await renderComponent();
-
-        const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
-        expect(rows).toHaveLength(3);
-        expect(neurons).toHaveLength(3);
-        expect(await rows[0].getStake()).not.toBe("0 ICP");
-        expect(await rows[0].hasGoToDetailButton()).toBe(true);
-        expect(await rows[1].getStake()).not.toBe("0 ICP");
-        expect(await rows[1].hasGoToDetailButton()).toBe(true);
-        // Spawning neuron without stake comes last.
-        expect(await rows[2].getStake()).toBe("0 ICP");
-        expect(await rows[2].hasGoToDetailButton()).toBe(false);
-      });
+      const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
+      expect(rows).toHaveLength(3);
+      expect(neurons).toHaveLength(3);
+      expect(await rows[0].getStake()).not.toBe("0 ICP");
+      expect(await rows[0].hasGoToDetailButton()).toBe(true);
+      expect(await rows[1].getStake()).not.toBe("0 ICP");
+      expect(await rows[1].hasGoToDetailButton()).toBe(true);
+      // Spawning neuron without stake comes last.
+      expect(await rows[2].getStake()).toBe("0 ICP");
+      expect(await rows[2].hasGoToDetailButton()).toBe(false);
     });
   });
 
@@ -178,42 +116,17 @@ describe("NnsNeurons", () => {
       vi.spyOn(api, "queryNeurons").mockResolvedValue([]);
     });
 
-    describe("with ENABLE_NEURONS_TABLE disabled", () => {
-      beforeEach(() => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", false);
-      });
+    it("should render an empty message", async () => {
+      const po = await renderComponent();
 
-      it("should render an empty message", async () => {
-        const po = await renderComponent();
-
-        expect(await po.hasEmptyMessage()).toBe(true);
-      });
-
-      it("should render an empty message with disbursed neurons", async () => {
-        vi.spyOn(api, "queryNeurons").mockResolvedValue([disbursedNeuron]);
-        const po = await renderComponent();
-
-        expect(await po.hasEmptyMessage()).toBe(true);
-      });
+      expect(await po.hasEmptyMessage()).toBe(true);
     });
 
-    describe("with ENABLE_NEURONS_TABLE enabled", () => {
-      beforeEach(() => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", true);
-      });
+    it("should render an empty message with disbursed neurons", async () => {
+      vi.spyOn(api, "queryNeurons").mockResolvedValue([disbursedNeuron]);
+      const po = await renderComponent();
 
-      it("should render an empty message", async () => {
-        const po = await renderComponent();
-
-        expect(await po.hasEmptyMessage()).toBe(true);
-      });
-
-      it("should render an empty message with disbursed neurons", async () => {
-        vi.spyOn(api, "queryNeurons").mockResolvedValue([disbursedNeuron]);
-        const po = await renderComponent();
-
-        expect(await po.hasEmptyMessage()).toBe(true);
-      });
+      expect(await po.hasEmptyMessage()).toBe(true);
     });
   });
 
@@ -229,42 +142,16 @@ describe("NnsNeurons", () => {
       );
     });
 
-    describe("with ENABLE_NEURONS_TABLE disabled", () => {
-      beforeEach(() => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", false);
-      });
+    it("should render a spinner", async () => {
+      const po = await renderComponent();
 
-      it("should render skeleton cards", async () => {
-        const po = await renderComponent();
-
-        expect(await po.getSkeletonCardPo().isPresent()).toBe(true);
-        expect(await po.hasSpinner()).toBe(false);
-      });
-
-      it("should not render an empty message", async () => {
-        const po = await renderComponent();
-
-        expect(await po.hasEmptyMessage()).toBe(false);
-      });
+      expect(await po.hasSpinner()).toBe(true);
     });
 
-    describe("with ENABLE_NEURONS_TABLE enabled", () => {
-      beforeEach(() => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", true);
-      });
+    it("should not render an empty message", async () => {
+      const po = await renderComponent();
 
-      it("should render a spinner", async () => {
-        const po = await renderComponent();
-
-        expect(await po.hasSpinner()).toBe(true);
-        expect(await po.getSkeletonCardPo().isPresent()).toBe(false);
-      });
-
-      it("should not render an empty message", async () => {
-        const po = await renderComponent();
-
-        expect(await po.hasEmptyMessage()).toBe(false);
-      });
+      expect(await po.hasEmptyMessage()).toBe(false);
     });
   });
 

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -29,11 +29,6 @@ describe("SnsNeurons", () => {
     id: [1, 2, 3],
     stake: neuron1Stake,
   });
-  const neuron2Stake = 100_000_000n;
-  const neuron2 = createMockSnsNeuron({
-    id: [1, 2, 4],
-    stake: neuron2Stake,
-  });
   const disbursedNeuronStake = 0n;
   const disbursedNeuron = createMockSnsNeuron({
     id: [1, 2, 5],
@@ -52,9 +47,6 @@ describe("SnsNeurons", () => {
   const getNeuronBalanceMock = async ({ neuronId }) => {
     if (neuronId === neuron1.id[0]) {
       return neuron1Stake;
-    }
-    if (neuronId === neuron2.id[0]) {
-      return neuron2Stake;
     }
     if (neuronId === disbursedNeuron.id[0]) {
       return disbursedNeuronStake;

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -102,68 +102,11 @@ describe("SnsNeurons", () => {
       );
     });
 
-    describe("with ENABLE_NEURONS_TABLE disabled", () => {
-      beforeEach(() => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", false);
-      });
-
-      it("should render skeleton cards", async () => {
-        const po = await renderComponent();
-
-        expect(await po.getSkeletonCardPo().isPresent()).toBe(true);
-        expect(await po.hasSpinner()).toBe(false);
-      });
-
-      it("should not render empty text", async () => {
-        const po = await renderComponent();
-
-        expect(await po.hasEmptyMessage()).toBe(false);
-      });
-    });
-
-    describe("with ENABLE_NEURONS_TABLE enabled", () => {
-      beforeEach(() => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", true);
-      });
-
-      it("should render a spinner", async () => {
-        const po = await renderComponent();
-
-        expect(await po.hasSpinner()).toBe(true);
-        expect(await po.getSkeletonCardPo().isPresent()).toBe(false);
-      });
-
-      it("should not render empty text", async () => {
-        const po = await renderComponent();
-
-        expect(await po.hasEmptyMessage()).toBe(false);
-      });
-    });
-  });
-
-  describe("with normal neurons without neurons from CF", () => {
-    beforeEach(() => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", false);
-      vi.spyOn(snsGovernanceApi, "querySnsNeurons").mockResolvedValue([
-        neuron1,
-        neuron2,
-      ]);
-      vi.spyOn(snsGovernanceApi, "getNeuronBalance").mockImplementation(
-        getNeuronBalanceMock
-      );
-    });
-
-    it("should render SnsNeuronCards for each neuron", async () => {
+    it("should render a spinner", async () => {
       const po = await renderComponent();
 
-      expect(await po.getNeuronCardPos()).toHaveLength(2);
-    });
-
-    it("should not render NF neurons grids", async () => {
-      const po = await renderComponent();
-
-      expect(await po.hasNonNeuronFundNeuronsGrid()).toBe(true);
-      expect(await po.hasNeuronFundNeuronsGrid()).toBe(false);
+      expect(await po.hasSpinner()).toBe(true);
+      expect(await po.getSkeletonCardPo().isPresent()).toBe(false);
     });
 
     it("should not render empty text", async () => {
@@ -179,105 +122,22 @@ describe("SnsNeurons", () => {
         neuron1,
         neuronNF,
       ]);
+      vi.spyOn(snsGovernanceApi, "getNeuronBalance").mockImplementation(
+        getNeuronBalanceMock
+      );
     });
 
-    describe("with ENABLE_NEURONS_TABLE disabled", () => {
-      beforeEach(() => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", false);
-      });
-
-      it("should render SnsNeuronCards for each neuron", async () => {
-        const po = await renderComponent();
-
-        expect(await po.getNeuronCardPos()).toHaveLength(2);
-      });
-
-      it("should render NF neurons grids", async () => {
-        const po = await renderComponent();
-
-        expect(await po.hasNonNeuronFundNeuronsGrid()).toBe(true);
-        expect(await po.hasNeuronFundNeuronsGrid()).toBe(true);
-      });
-
-      it("should not render empty text", async () => {
-        const po = await renderComponent();
-
-        expect(await po.hasEmptyMessage()).toBe(false);
-      });
-
-      it("should not render the neurons table", async () => {
-        const po = await renderComponent();
-
-        expect(await po.getNeuronsTablePo().isPresent()).toBe(false);
-      });
-    });
-
-    describe("with ENABLE_NEURONS_TABLE enabled", () => {
-      beforeEach(() => {
-        overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", true);
-      });
-
-      it("should render the neurons table", async () => {
-        const po = await renderComponent();
-
-        expect(await po.getNeuronsTablePo().isPresent()).toBe(true);
-      });
-
-      it("should render neurons table rows", async () => {
-        const po = await renderComponent();
-
-        const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
-        expect(rows).toHaveLength(2);
-      });
-
-      it("should not render the NeuronCards", async () => {
-        const po = await renderComponent();
-
-        const neuronCards = await po.getNeuronCardPos();
-        expect(neuronCards.length).toBe(0);
-      });
-
-      it("should not render neurons grids", async () => {
-        const po = await renderComponent();
-
-        expect(await po.hasNonNeuronFundNeuronsGrid()).toBe(false);
-        expect(await po.hasNeuronFundNeuronsGrid()).toBe(false);
-      });
-
-      it("should not render empty text", async () => {
-        const po = await renderComponent();
-
-        expect(await po.hasEmptyMessage()).toBe(false);
-      });
-
-      it("should not render disbursed neurons", async () => {
-        vi.spyOn(snsGovernanceApi, "querySnsNeurons").mockResolvedValue([
-          neuron1,
-          disbursedNeuron,
-          neuronNF,
-        ]);
-        const po = await renderComponent();
-
-        const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
-        expect(rows).toHaveLength(2);
-      });
-    });
-  });
-
-  describe("with only neurons from CF", () => {
-    beforeEach(() => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", false);
-      vi.spyOn(snsGovernanceApi, "querySnsNeurons").mockResolvedValue([
-        neuronNF,
-      ]);
-    });
-
-    it("should render one grid", async () => {
+    it("should render the neurons table", async () => {
       const po = await renderComponent();
 
-      expect(await po.hasNonNeuronFundNeuronsGrid()).toBe(false);
-      expect(await po.hasNeuronFundNeuronsGrid()).toBe(true);
-      expect(await po.hasEmptyMessage()).toBe(false);
+      expect(await po.getNeuronsTablePo().isPresent()).toBe(true);
+    });
+
+    it("should render neurons table rows", async () => {
+      const po = await renderComponent();
+
+      const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
+      expect(rows).toHaveLength(2);
     });
 
     it("should not render empty text", async () => {
@@ -285,19 +145,29 @@ describe("SnsNeurons", () => {
 
       expect(await po.hasEmptyMessage()).toBe(false);
     });
+
+    it("should not render disbursed neurons", async () => {
+      vi.spyOn(snsGovernanceApi, "querySnsNeurons").mockResolvedValue([
+        neuron1,
+        disbursedNeuron,
+        neuronNF,
+      ]);
+      const po = await renderComponent();
+
+      const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
+      expect(rows).toHaveLength(2);
+    });
   });
 
-  describe("no neurons", () => {
+  describe.skip("no neurons", () => {
     beforeEach(() => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", false);
       vi.spyOn(snsGovernanceApi, "querySnsNeurons").mockResolvedValue([]);
     });
 
-    it("should not render either grid", async () => {
+    it("should not render the neurons table", async () => {
       const po = await renderComponent();
 
-      expect(await po.hasNonNeuronFundNeuronsGrid()).toBe(false);
-      expect(await po.hasNeuronFundNeuronsGrid()).toBe(false);
+      expect(await po.getNeuronsTablePo().isPresent()).toBe(false);
     });
 
     it("should render empty text if no neurons", async () => {

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -159,7 +159,7 @@ describe("SnsNeurons", () => {
     });
   });
 
-  describe.skip("no neurons", () => {
+  describe("no neurons", () => {
     beforeEach(() => {
       vi.spyOn(snsGovernanceApi, "querySnsNeurons").mockResolvedValue([]);
     });

--- a/frontend/src/tests/lib/routes/Neurons.spec.ts
+++ b/frontend/src/tests/lib/routes/Neurons.spec.ts
@@ -73,8 +73,6 @@ describe("Neurons", () => {
   });
 
   it("should render NnsNeurons by default", async () => {
-    overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", true);
-
     fakeGovernanceApi.pause();
     page.mock({
       data: { universe: OWN_CANISTER_ID_TEXT },
@@ -99,7 +97,6 @@ describe("Neurons", () => {
   });
 
   it("should render project page when a committed project is selected", async () => {
-    overrideFeatureFlagsStore.setFlag("ENABLE_NEURONS_TABLE", true);
     fakeSnsGovernanceApi.pause();
     page.mock({
       data: { universe: testCommittedSnsCanisterId.toText() },

--- a/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsNeurons.page-object.ts
@@ -1,7 +1,5 @@
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import { NeuronsTablePo } from "$tests/page-objects/NeuronsTable.page-object";
-import { NnsNeuronCardPo } from "$tests/page-objects/NnsNeuronCard.page-object";
-import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NnsNeuronsPo extends BasePageObject {
@@ -15,45 +13,22 @@ export class NnsNeuronsPo extends BasePageObject {
     return NeuronsTablePo.under(this.root);
   }
 
-  getSkeletonCardPo(): SkeletonCardPo {
-    return SkeletonCardPo.under(this.root);
-  }
-
-  getNeuronCardPos(): Promise<NnsNeuronCardPo[]> {
-    return NnsNeuronCardPo.allUnder(this.root);
-  }
-
   async isContentLoaded(): Promise<boolean> {
     return (await this.isPresent()) && !(await this.isContentLoading());
   }
 
-  async isContentLoading(): Promise<boolean> {
-    return (
-      (await this.getSkeletonCardPo().isPresent()) || (await this.hasSpinner())
-    );
+  isContentLoading(): Promise<boolean> {
+    return this.hasSpinner();
   }
 
   async waitForContentLoaded(): Promise<void> {
     await this.waitFor();
-    await this.getSkeletonCardPo().waitForAbsent();
+    await this.waitForAbsent("spinner");
   }
 
   async getNeuronIds(): Promise<string[]> {
     const rows = await this.getNeuronsTablePo().getNeuronsTableRowPos();
     return Promise.all(rows.map((row) => row.getNeuronId()));
-  }
-
-  async getNeuronCardPo(neuronId: string): Promise<NnsNeuronCardPo> {
-    const neuronCards = await this.getNeuronCardPos();
-
-    for (const neuronCard of neuronCards) {
-      const id = await neuronCard.getNeuronId();
-      if (id === neuronId) {
-        return neuronCard;
-      }
-    }
-
-    throw new Error(`Neuron card with id ${neuronId} not found`);
   }
 
   hasEmptyMessage(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/simple-base.page-object.ts
+++ b/frontend/src/tests/page-objects/simple-base.page-object.ts
@@ -24,8 +24,8 @@ export class SimpleBasePageObject {
     return this.getElement(tid).waitFor();
   }
 
-  waitForAbsent(timeout?: number): Promise<void> {
-    return this.root.waitForAbsent(timeout);
+  waitForAbsent(tid: string | undefined = undefined): Promise<void> {
+    return this.getElement(tid).waitForAbsent();
   }
 
   click(tid: string | undefined = undefined): Promise<void> {


### PR DESCRIPTION
# Motivation

Feature flag `ENABLE_NEURONS_TABLE` has been enabled since 2 releases.

# Changes

1. Remove the code conditional on `ENABLE_NEURONS_TABLE`.
2. Remove unused i18n messages.

# Tests

1. Remove tests where `ENABLE_NEURONS_TABLE` is disabled.
3. Stop enableing `ENABLE_NEURONS_TABLE` in unit tests and e2e tests.
4. Remove unused methods from page objects.
5. Remove `timeout` param from `waitForAbsent`, which was added in https://github.com/dfinity/nns-dapp/pull/2542 and never used.
6. Add `tid` param to `waitForAbsent` so it can be used to wait for the spinner to disappear instead of the skeleton cards.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary