### PR TITLE
Add a delay before closing the sorting modal

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Make neurons table sortable on desktop and mobile.
+* A short delay before closing the mobile table sorting modal.
 
 #### Changed
 

--- a/frontend/src/lib/modals/common/ResponsiveTableSortModal.svelte
+++ b/frontend/src/lib/modals/common/ResponsiveTableSortModal.svelte
@@ -10,6 +10,7 @@
     ResponsiveTableOrder,
   } from "$lib/types/responsive-table";
   import { selectPrimaryOrder } from "$lib/utils/responsive-table.utils";
+  import { waitForMilliseconds } from "$lib/utils/utils";
   import { IconSouth, Modal } from "@dfinity/gix-components";
   import { assertNonNullish, nonNullish } from "@dfinity/utils";
   import { createEventDispatcher } from "svelte";
@@ -19,9 +20,11 @@
 
   const dispatch = createEventDispatcher();
 
-  const orderBy = (column: ResponsiveTableColumn<RowDataType>) => {
+  const orderBy = async (column: ResponsiveTableColumn<RowDataType>) => {
     assertNonNullish(column.id);
     order = selectPrimaryOrder({ order, selectedColumnId: column.id });
+    // Delay so the user can see the new selection before the modal closes.
+    await waitForMilliseconds(400);
     dispatch("nnsClose");
   };
 </script>

--- a/frontend/src/tests/lib/modals/common/ResponsiveTableSortModal.spec.ts
+++ b/frontend/src/tests/lib/modals/common/ResponsiveTableSortModal.spec.ts
@@ -6,8 +6,9 @@ import type {
 import { createAscendingComparator } from "$lib/utils/responsive-table.utils";
 import TestTableAgeCell from "$tests/lib/components/ui/TestTableAgeCell.svelte";
 import TestTableNameCell from "$tests/lib/components/ui/TestTableNameCell.svelte";
-import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { ResponsiveTableSortModalPo } from "$tests/page-objects/ResponsiveTableSortModal.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { advanceTime } from "$tests/utils/timers.test-utils";
 import { render } from "@testing-library/svelte";
 import { get, writable, type Writable } from "svelte/store";
 
@@ -65,6 +66,10 @@ describe("ResponsiveTableSortModal", () => {
     );
   };
 
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
   it("should render modal title", async () => {
     const po = renderComponent({ columns, order });
     expect(await po.getModalTitle()).toBe("Sort by");
@@ -86,6 +91,7 @@ describe("ResponsiveTableSortModal", () => {
     const orderStore = writable(order);
     const po = renderComponent({ columns, order, orderStore });
     await po.clickOption("Age");
+    await advanceTime(400);
     expect(await po.getOptionWithArrow()).toBe("Age");
     expect(get(orderStore)).toEqual([
       { columnId: "age" },
@@ -99,17 +105,21 @@ describe("ResponsiveTableSortModal", () => {
     const po = renderComponent({ columns, order, orderStore });
     expect(await po.isReversed()).toBe(false);
     await po.clickOption("Name");
+    await advanceTime(400);
     expect(get(orderStore)).toEqual([{ columnId: "name", reversed: true }]);
     expect(await po.isReversed()).toBe(true);
     await po.clickOption("Age");
     expect(await po.isReversed()).toBe(false);
   });
 
-  it("should close modal when selecting an option", async () => {
+  it("should close modal with delay when selecting an option", async () => {
     const close = vi.fn();
     const po = renderComponent({ columns, order, onClose: close });
     expect(close).not.toBeCalled();
     await po.clickOption("Name");
+    await advanceTime(300);
+    expect(close).not.toBeCalled();
+    await advanceTime(200);
     expect(close).toBeCalledTimes(1);
   });
 });


### PR DESCRIPTION
# Motivation

To provide feedback that a selection was made, we add a delay before closing the mobile table sort modal.

# Changes

In `frontend/src/lib/modals/common/ResponsiveTableSortModal.svelte` add a delay before dispatching the close event.

# Tests

1. Use fake timers to test the delay in unit tests.
2. Manually at https://mwewp-s4aaa-aaaaa-qabjq-cai.dskloet-ingress.devenv.dfinity.network/neurons/?u=mwewp-s4aaa-aaaaa-qabjq-cai

# Todos

- [x] Add entry to changelog (if necessary).
