### PR TITLE
Shorter sort modal delay

### DIFF
--- a/frontend/src/lib/modals/common/ResponsiveTableSortModal.svelte
+++ b/frontend/src/lib/modals/common/ResponsiveTableSortModal.svelte
@@ -24,7 +24,7 @@
     assertNonNullish(column.id);
     order = selectPrimaryOrder({ order, selectedColumnId: column.id });
     // Delay so the user can see the new selection before the modal closes.
-    await waitForMilliseconds(400);
+    await waitForMilliseconds(250);
     dispatch("nnsClose");
   };
 </script>

--- a/frontend/src/tests/lib/modals/common/ResponsiveTableSortModal.spec.ts
+++ b/frontend/src/tests/lib/modals/common/ResponsiveTableSortModal.spec.ts
@@ -117,9 +117,9 @@ describe("ResponsiveTableSortModal", () => {
     const po = renderComponent({ columns, order, onClose: close });
     expect(close).not.toBeCalled();
     await po.clickOption("Name");
-    await advanceTime(300);
-    expect(close).not.toBeCalled();
     await advanceTime(200);
+    expect(close).not.toBeCalled();
+    await advanceTime(100);
     expect(close).toBeCalledTimes(1);
   });
 });


### PR DESCRIPTION
# Motivation

PM/UX wanted a shorter delay.

# Changes

Change the delay from 400ms to 250ms.

# Tests

1. Unit test updated.
2. Manually at https://mwewp-s4aaa-aaaaa-qabjq-cai.dskloet-ingress.devenv.dfinity.network/neurons/?u=mwewp-s4aaa-aaaaa-qabjq-cai

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary