### PR TITLE
NNS1-3094: Add staking path

### DIFF
--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -12,6 +12,7 @@
     neuronsPathStore,
     proposalsPathStore,
   } from "$lib/derived/paths.derived";
+  import { ENABLE_PROJECTS_TABLE } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
   import {
     ACTIONABLE_PROPOSALS_URL,
@@ -19,9 +20,9 @@
   } from "$lib/utils/navigation.utils";
   import {
     IconExplore,
-    IconVote,
     IconNeurons,
     IconRocketLaunch,
+    IconVote,
     IconWallet,
     MenuItem,
   } from "@dfinity/gix-components";
@@ -53,10 +54,10 @@
     },
     {
       context: "neurons",
-      href: $neuronsPathStore,
+      href: $ENABLE_PROJECTS_TABLE ? AppPath.Staking : $neuronsPathStore,
       selected: isSelectedPath({
         currentPath: $pageStore.path,
-        paths: [AppPath.Neurons, AppPath.Neuron],
+        paths: [AppPath.Staking, AppPath.Neurons, AppPath.Neuron],
       }),
       title: $i18n.navigation.neurons,
       icon: IconNeurons,

--- a/frontend/src/lib/constants/routes.constants.ts
+++ b/frontend/src/lib/constants/routes.constants.ts
@@ -1,6 +1,7 @@
 export enum AppPath {
   Accounts = "/accounts",
   Wallet = "/wallet",
+  Staking = "/staking",
   Neurons = "/neurons",
   Neuron = "/neuron",
   Proposals = "/proposals",

--- a/frontend/src/lib/routes/Staking.svelte
+++ b/frontend/src/lib/routes/Staking.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
-  import { buildNeuronsUrl } from "$lib/utils/navigation.utils";
 </script>
 
 <main data-tid="staking-component">

--- a/frontend/src/lib/routes/Staking.svelte
+++ b/frontend/src/lib/routes/Staking.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
+  import { buildNeuronsUrl } from "$lib/utils/navigation.utils";
+</script>
+
+<main data-tid="staking-component">
+  <h1>STAKING PROJECTS TABLE UNDER CONSTRUCTION</h1>
+</main>

--- a/frontend/src/routes/(app)/(nns)/staking/+layout.svelte
+++ b/frontend/src/routes/(app)/(nns)/staking/+layout.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import Content from "$lib/components/layout/Content.svelte";
+  import Layout from "$lib/components/layout/Layout.svelte";
+  import LayoutList from "$lib/components/layout/LayoutList.svelte";
+  import { i18n } from "$lib/stores/i18n";
+</script>
+
+<LayoutList title={$i18n.navigation.neurons}>
+  <Layout>
+    <Content>
+      <slot />
+    </Content>
+  </Layout>
+</LayoutList>

--- a/frontend/src/routes/(app)/(nns)/staking/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/staking/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import Staking from "$lib/routes/Staking.svelte";
+</script>
+
+<Staking />

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -1,9 +1,9 @@
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import MenuItems from "$lib/components/common/MenuItems.svelte";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { page } from "$mocks/$app/stores";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -1,3 +1,4 @@
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import MenuItems from "$lib/components/common/MenuItems.svelte";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
@@ -53,10 +54,28 @@ describe("MenuItems", () => {
 
   it("should render accounts menu item", () =>
     shouldRenderMenuItem({ context: "accounts", labelKey: "tokens" }));
-  it("should render neurons menu item", () =>
-    shouldRenderMenuItem({ context: "neurons", labelKey: "neurons" }));
+
+  it("should render neurons menu item without projects table", () => {
+    overrideFeatureFlagsStore.setFlag("ENABLE_PROJECTS_TABLE", false);
+    shouldRenderMenuItem({
+      context: "neurons",
+      labelKey: "neurons",
+      href: "/neurons/?u=qhbym-qaaaa-aaaaa-aaafq-cai",
+    });
+  });
+
+  it("should render neurons menu item with projects table", () => {
+    overrideFeatureFlagsStore.setFlag("ENABLE_PROJECTS_TABLE", true);
+    shouldRenderMenuItem({
+      context: "neurons",
+      labelKey: "neurons",
+      href: "/staking",
+    });
+  });
+
   it("should render voting menu item", () =>
     shouldRenderMenuItem({ context: "proposals", labelKey: "voting" }));
+
   it("should render canisters menu item", () =>
     shouldRenderMenuItem({ context: "canisters", labelKey: "canisters" }));
 


### PR DESCRIPTION
# Motivation

Currently the neurons view has a universe picker on the left.
We plan to make it more like the tokens table where there is no left-nav but rather a first step where you choose the project and then a view with a back button just for that project.

The table with projects with be at `/staking` and the neurons table , but without universe picker left-nav, will continue to be at `/neurons.

In this PR we just add the scaffolding for the `/staking` path.

# Changes

1. Add `AppPath.Staking` constant.
2. Add mostly empty route files for `/staking`.
3. Making the "Neurons Staking" tab navigate to `/staking` instead of `/neurons?u=...` when `ENABLE_PROJECTS_TABLE` is enabled.

# Tests

1. Unit test added.
2. Tested manually.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet