### PR TITLE
NNS1-3094: Remove universe nav and add back button on neurons page

### DIFF
--- a/frontend/src/routes/(app)/(u)/(list)/neurons/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(list)/neurons/+layout.svelte
@@ -1,14 +1,26 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
+  import Content from "$lib/components/layout/Content.svelte";
   import Layout from "$lib/components/layout/Layout.svelte";
   import LayoutList from "$lib/components/layout/LayoutList.svelte";
   import UniverseSplitContent from "$lib/components/layout/UniverseSplitContent.svelte";
+  import { AppPath } from "$lib/constants/routes.constants";
+  import { ENABLE_PROJECTS_TABLE } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
+
+  const back = (): Promise<void> => goto(AppPath.Staking);
 </script>
 
 <LayoutList title={$i18n.navigation.neurons}>
   <Layout>
-    <UniverseSplitContent>
-      <slot />
-    </UniverseSplitContent>
+    {#if $ENABLE_PROJECTS_TABLE}
+      <Content {back}>
+        <slot />
+      </Content>
+    {:else}
+      <UniverseSplitContent>
+        <slot />
+      </UniverseSplitContent>
+    {/if}
   </Layout>
 </LayoutList>

--- a/frontend/src/tests/routes/app/neurons/layout.spec.ts
+++ b/frontend/src/tests/routes/app/neurons/layout.spec.ts
@@ -1,9 +1,19 @@
+import { AppPath } from "$lib/constants/routes.constants";
+import { pageStore } from "$lib/derived/page.derived";
+import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import NeuronsLayout from "$routes/(app)/(u)/(list)/neurons/+layout.svelte";
+import { SelectUniverseDropdownPo } from "$tests/page-objects/SelectUniverseDropdown.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Neurons layout", () => {
+  const hasUniverseNav = (container: HTMLElement): Promise<boolean> =>
+    SelectUniverseDropdownPo.under(
+      new JestPageObjectElement(container)
+    ).isPresent();
+
   beforeEach(() => {
     layoutTitleStore.set({ title: "" });
   });
@@ -14,6 +24,43 @@ describe("Neurons layout", () => {
     expect(get(layoutTitleStore)).toEqual({
       title: "Neuron Staking",
       header: "Neuron Staking",
+    });
+  });
+
+  describe("when ENABLE_PROJECTS_TABLE is disabled", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_PROJECTS_TABLE", false);
+    });
+
+    it("should not have a back button", () => {
+      const { getByTestId } = render(NeuronsLayout);
+      expect(() => getByTestId("back")).toThrow();
+    });
+
+    it("should have universe navigation", async () => {
+      const { container } = render(NeuronsLayout);
+      expect(await hasUniverseNav(container)).toBe(true);
+    });
+  });
+
+  describe("when ENABLE_PROJECTS_TABLE is enabled", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_PROJECTS_TABLE", true);
+    });
+
+    it("should have a back button", () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_PROJECTS_TABLE", true);
+      const { getByTestId } = render(NeuronsLayout);
+      const backButton = getByTestId("back");
+      expect(backButton).toBeInTheDocument();
+      expect(get(pageStore).path).not.toBe(AppPath.Staking);
+      backButton.click();
+      expect(get(pageStore).path).toBe(AppPath.Staking);
+    });
+
+    it("should not have universe navigation", async () => {
+      const { container } = render(NeuronsLayout);
+      expect(await hasUniverseNav(container)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
# Motivation

When we have the staking projects table, it will replace the universe navigation for neurons.
In that case we also need a back button to get back from the neurons page to the staking projects page.

# Changes

When `ENABLE_PROJECTS_TABLE` is enabled on the neurons page:
1. Remove the universe navigation
2. Add a back button

# Tests

1. Unit tests added.
2. Tested manually on https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [ ] Add entry to changelog (if necessary).
not yet