### PR TITLE
NNS1-3094: Add TableProject type

### DIFF
--- a/frontend/src/lib/types/staking.ts
+++ b/frontend/src/lib/types/staking.ts
@@ -1,0 +1,6 @@
+export type TableProject = {
+  rowHref?: string;
+  domKey: string;
+  title: string;
+  logo: string;
+};

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -1,0 +1,16 @@
+import type { TableProject } from "$lib/types/staking";
+import type { Universe } from "$lib/types/universe";
+import { buildNeuronsUrl } from "$lib/utils/navigation.utils";
+
+export const getTableProjects = ({
+  universes,
+}: {
+  universes: Universe[];
+}): TableProject[] => {
+  return universes.map((universe) => ({
+    rowHref: buildNeuronsUrl({ universe: universe.canisterId }),
+    domKey: universe.canisterId,
+    title: universe.title,
+    logo: universe.logo,
+  }));
+};

--- a/frontend/src/tests/lib/utils/staking.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking.utils.spec.ts
@@ -1,0 +1,43 @@
+import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import type { Universe } from "$lib/types/universe";
+import { getTableProjects } from "$lib/utils/staking.utils";
+import { principal } from "$tests/mocks/sns-projects.mock";
+
+describe("staking.utils", () => {
+  describe("getTableProjects", () => {
+    const universeId2 = principal(2).toText();
+
+    it("should return an array of TableProject objects", () => {
+      const universes: Universe[] = [
+        {
+          canisterId: OWN_CANISTER_ID_TEXT,
+          title: "Internet Computer",
+          logo: IC_LOGO_ROUNDED,
+        },
+        {
+          canisterId: universeId2,
+          title: "title2",
+          logo: "logo2",
+        },
+      ];
+
+      const tableProjects = getTableProjects({ universes });
+
+      expect(tableProjects).toEqual([
+        {
+          rowHref: `/neurons/?u=${OWN_CANISTER_ID_TEXT}`,
+          domKey: OWN_CANISTER_ID_TEXT,
+          title: "Internet Computer",
+          logo: IC_LOGO_ROUNDED,
+        },
+        {
+          rowHref: `/neurons/?u=${universeId2}`,
+          domKey: universeId2,
+          title: "title2",
+          logo: "logo2",
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

We want to use the `ResponsiveTable` component for the staking projects table.
In this PR we define a `TableProject` type to use as the row data for the table and add a simple first version of a function to create the row data.

# Changes

1. Add `frontend/src/lib/types/staking.ts` with the `TableProject` type.
2. Add `frontend/src/lib/utils/staking.utils.ts` with `getTableProjects` to create the row data for the projects table (which will be added in another PR).

# Tests

1. Unit test added.
2. Tested manually in another branch which already has a simple projects table: https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/staking/

# Todos

- [ ] Add entry to changelog (if necessary).
not yet