### PR TITLE
human: Update snsdemo to release-2024-07-03

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -386,7 +386,7 @@
         "DIDC_VERSION": "2024-05-14",
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2024-07-01",
+        "SNSDEMO_RELEASE": "release-2024-07-03",
         "IC_COMMIT_FOR_PROPOSALS": "release-2024-06-26_23-01-base",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-06-26_23-01-base"
       },

--- a/dfx.json
+++ b/dfx.json
@@ -386,7 +386,7 @@
         "DIDC_VERSION": "2024-05-14",
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2024-07-03",
+        "SNSDEMO_RELEASE": "release-2024-07-05",
         "IC_COMMIT_FOR_PROPOSALS": "release-2024-06-26_23-01-base",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-06-26_23-01-base"
       },

--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -21,8 +21,8 @@ test("Test SNS governance", async ({ page, context }) => {
   const snsUniverseRow = snsUniverseRows[0];
   const snsProjectName = await snsUniverseRow.getProjectName();
 
-  // Our test SNS project names are always 5 uppercase letters.
-  expect(snsProjectName).toMatch(/[A-Z]{5}/);
+  // Our first test SNS project is always named "Alfa Centauri".
+  expect(snsProjectName).toBe("Alfa Centauri");
 
   step("Acquire tokens");
   const askedAmount = 20;

--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -40,7 +40,7 @@ test("Test SNS governance", async ({ page, context }) => {
   expect(
     await appPo.getNeuronsPo().getSnsNeuronsPo().getEmptyMessage()
   ).toEqual(
-    `You have no ${snsProjectName} neurons. Create a neuron by staking ${snsProjectName} to vote on ${snsProjectName} proposals.`
+    "You have no Alfa Centauri neurons. Create a neuron by staking ALF to vote on Alfa Centauri proposals."
   );
 
   const stake = 5;


### PR DESCRIPTION
# Motivation

This PR replaces the bot PR at https://github.com/dfinity/nns-dapp/pull/5151.
The test environment now has deterministic names instead of random 5 letter names.

# Changes

1. Updated snsdemo version in dfx.json.
2. Change the expectation on the SNS name in `frontend/src/tests/e2e/sns-governance.spec.ts`.

# Tests

CI

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary