### PR TITLE
NNS1-3094: Use responsive table on staking page

### DIFF
--- a/frontend/src/lib/components/staking/ProjectActionsCell.svelte
+++ b/frontend/src/lib/components/staking/ProjectActionsCell.svelte
@@ -18,7 +18,6 @@
   .container {
     color: var(--primary);
     display: flex;
-    height: 20px;
     align-items: center;
   }
 </style>

--- a/frontend/src/lib/components/staking/ProjectActionsCell.svelte
+++ b/frontend/src/lib/components/staking/ProjectActionsCell.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import type { TableProject } from "$lib/types/staking";
+  import { IconRight } from "@dfinity/gix-components";
+
+  export let rowData: TableProject;
+</script>
+
+{#if false}
+  <!-- Satisfy the linter as it doesn't like unused props. -->
+  {rowData.title}
+{/if}
+
+<div class="container">
+  <IconRight />
+</div>
+
+<style lang="scss">
+  .container {
+    color: var(--primary);
+    display: flex;
+    height: 20px;
+    align-items: center;
+  }
+</style>

--- a/frontend/src/lib/components/staking/ProjectTitleCell.svelte
+++ b/frontend/src/lib/components/staking/ProjectTitleCell.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import Logo from "$lib/components/ui/Logo.svelte";
+  import type { TableProject } from "$lib/types/staking";
+
+  export let rowData: TableProject;
+</script>
+
+<div data-tid="project-title-cell-component" class="title-logo-wrapper">
+  <Logo src={rowData.logo} alt={rowData.title} size="medium" framed />
+  <div class="title-wrapper">
+    <h5 data-tid="project-title">{rowData.title}</h5>
+  </div>
+</div>
+
+<style lang="scss">
+  h5 {
+    margin: 0;
+  }
+
+  .title-logo-wrapper {
+    display: flex;
+    align-items: center;
+    gap: var(--padding);
+
+    .title-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: var(--padding-0_5x);
+    }
+  }
+</style>

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import ProjectActionsCell from "$lib/components/staking/ProjectActionsCell.svelte";
+  import ProjectTitleCell from "$lib/components/staking/ProjectTitleCell.svelte";
+  import ResponsiveTable from "$lib/components/ui/ResponsiveTable.svelte";
+  import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
+  import { i18n } from "$lib/stores/i18n";
+  import type { ProjectsTableColumn, TableProject } from "$lib/types/staking";
+  import { getTableProjects } from "$lib/utils/staking.utils";
+
+  const columns: ProjectsTableColumn[] = [
+    {
+      title: $i18n.staking.nervous_systems,
+      cellComponent: ProjectTitleCell,
+      alignment: "left",
+      templateColumns: ["1fr"],
+    },
+    {
+      title: "",
+      cellComponent: ProjectActionsCell,
+      alignment: "right",
+      templateColumns: ["max-content"],
+    },
+  ];
+
+  let tableProjects: TableProject[];
+  $: tableProjects = getTableProjects({
+    universes: $selectableUniversesStore,
+  });
+</script>
+
+<ResponsiveTable
+  testId="projects-table-component"
+  tableData={tableProjects}
+  {columns}
+></ResponsiveTable>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -236,6 +236,9 @@
     "seed": "Seed",
     "ect": "Early Contributor Token"
   },
+  "staking": {
+    "nervous_systems": "Nervous Systems"
+  },
   "neurons": {
     "title": "Neurons",
     "text": "Earn voting rewards by staking your ICP in neurons. Neurons allow you to participate in governance on the Internet Computer by submitting and voting on Network Nervous System (NNS) proposals.",

--- a/frontend/src/lib/routes/Staking.svelte
+++ b/frontend/src/lib/routes/Staking.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import ProjectsTable from "$lib/components/staking/ProjectsTable.svelte";
+  import { Island } from "@dfinity/gix-components";
 </script>
 
-<main data-tid="staking-component">
-  <h1>STAKING PROJECTS TABLE UNDER CONSTRUCTION</h1>
-</main>
+<Island>
+  <ProjectsTable />
+</Island>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -247,6 +247,10 @@ interface I18nNeuron_types {
   ect: string;
 }
 
+interface I18nStaking {
+  nervous_systems: string;
+}
+
 interface I18nNeurons {
   title: string;
   text: string;
@@ -1311,6 +1315,7 @@ interface I18n {
   auth: I18nAuth;
   accounts: I18nAccounts;
   neuron_types: I18nNeuron_types;
+  staking: I18nStaking;
   neurons: I18nNeurons;
   new_followee: I18nNew_followee;
   follow_neurons: I18nFollow_neurons;

--- a/frontend/src/lib/types/staking.ts
+++ b/frontend/src/lib/types/staking.ts
@@ -1,6 +1,10 @@
+import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
+
 export type TableProject = {
   rowHref?: string;
   domKey: string;
   title: string;
   logo: string;
 };
+
+export type ProjectsTableColumn = ResponsiveTableColumn<TableProject>;

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -1,0 +1,113 @@
+import ProjectsTable from "$lib/components/staking/ProjectsTable.svelte";
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { AppPath } from "$lib/constants/routes.constants";
+import { page } from "$mocks/$app/stores";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { ProjectsTablePo } from "$tests/page-objects/ProjectsTable.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { render } from "$tests/utils/svelte.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+
+describe("ProjectsTable", () => {
+  const snsTitle = "SNS-1";
+  const snsCanisterId = principal(1111);
+
+  const renderComponent = () => {
+    const { container } = render(ProjectsTable);
+    return ProjectsTablePo.under(new JestPageObjectElement(container));
+  };
+
+  beforeEach(() => {
+    resetSnsProjects();
+    vi.useFakeTimers();
+
+    page.mock({
+      routeId: AppPath.Staking,
+    });
+    setSnsProjects([
+      {
+        projectName: snsTitle,
+        rootCanisterId: snsCanisterId,
+      },
+    ]);
+  });
+
+  it("should render desktop headers", async () => {
+    const po = renderComponent();
+    expect(await po.getDesktopColumnHeaders()).toEqual([
+      "Nervous Systems",
+      "", // No header for actions column.
+    ]);
+  });
+
+  it("should render mobile headers", async () => {
+    const po = renderComponent();
+    expect(await po.getMobileColumnHeaders()).toEqual([
+      "Nervous Systems",
+      "", // No header for actions column.
+    ]);
+  });
+
+  it("should render cell alignment classes", async () => {
+    const po = renderComponent();
+    const rows = await po.getRows();
+    expect(await rows[0].getCellAlignments()).toEqual([
+      "desktop-align-left", // Nervous Systems
+      "desktop-align-right", // Actions
+    ]);
+  });
+
+  it("should use correct template columns", async () => {
+    const po = renderComponent();
+
+    expect(await po.getDesktopGridTemplateColumns()).toBe(
+      [
+        "1fr", // Nerous Systems
+        "max-content", // Actions
+      ].join(" ")
+    );
+    expect(await po.getMobileGridTemplateAreas()).toBe(
+      '"first-cell last-cell"'
+    );
+  });
+
+  it("should render neurons URL", async () => {
+    const po = renderComponent();
+    const rowPos = await po.getProjectsTableRowPos();
+    expect(rowPos).toHaveLength(2);
+    expect(await rowPos[0].getHref()).toBe(
+      `/neurons/?u=${OWN_CANISTER_ID_TEXT}`
+    );
+    expect(await rowPos[1].getHref()).toBe(`/neurons/?u=${snsCanisterId}`);
+  });
+
+  it("should render project title", async () => {
+    const po = renderComponent();
+    const rowPos = await po.getProjectsTableRowPos();
+    expect(rowPos).toHaveLength(2);
+    expect(await rowPos[0].getProjectTitle()).toBe("Internet Computer");
+    expect(await rowPos[1].getProjectTitle()).toBe(snsTitle);
+  });
+
+  it("should update table when universes store changes", async () => {
+    const po = renderComponent();
+
+    await runResolvedPromises();
+    expect(await po.getProjectsTableRowPos()).toHaveLength(2);
+
+    setSnsProjects([
+      {
+        projectName: snsTitle,
+        rootCanisterId: snsCanisterId,
+      },
+      {
+        projectName: "Another SNS",
+        rootCanisterId: principal(2222),
+      },
+    ]);
+
+    await runResolvedPromises();
+    expect(await po.getProjectsTableRowPos()).toHaveLength(3);
+  });
+});

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -20,7 +20,6 @@ describe("ProjectsTable", () => {
 
   beforeEach(() => {
     resetSnsProjects();
-    vi.useFakeTimers();
 
     page.mock({
       routeId: AppPath.Staking,

--- a/frontend/src/tests/mocks/staking.mock.ts
+++ b/frontend/src/tests/mocks/staking.mock.ts
@@ -1,0 +1,10 @@
+import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import type { TableProject } from "$lib/types/staking";
+
+export const mockTableProject: TableProject = {
+  rowHref: `/neurons/?u=${OWN_CANISTER_ID_TEXT}`,
+  domKey: OWN_CANISTER_ID_TEXT,
+  title: "Internet Computer",
+  logo: IC_LOGO_ROUNDED,
+};

--- a/frontend/src/tests/page-objects/ProjectTitleCell.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectTitleCell.page-object.ts
@@ -1,0 +1,14 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ProjectTitleCellPo extends BasePageObject {
+  private static readonly TID = "project-title-cell-component";
+
+  static under(element: PageObjectElement): ProjectTitleCellPo {
+    return new ProjectTitleCellPo(element.byTestId(ProjectTitleCellPo.TID));
+  }
+
+  getProjectTitle(): Promise<string> {
+    return this.getText("project-title");
+  }
+}

--- a/frontend/src/tests/page-objects/ProjectsTable.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectsTable.page-object.ts
@@ -1,0 +1,15 @@
+import { ProjectsTableRowPo } from "$tests/page-objects/ProjectsTableRow.page-object";
+import { ResponsiveTablePo } from "$tests/page-objects/ResponsiveTable.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ProjectsTablePo extends ResponsiveTablePo {
+  private static readonly TID = "projects-table-component";
+
+  static under(element: PageObjectElement): ProjectsTablePo {
+    return new ProjectsTablePo(element.byTestId(ProjectsTablePo.TID));
+  }
+
+  getProjectsTableRowPos(): Promise<ProjectsTableRowPo[]> {
+    return ProjectsTableRowPo.allUnder(this.root);
+  }
+}

--- a/frontend/src/tests/page-objects/ProjectsTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectsTableRow.page-object.ts
@@ -1,0 +1,25 @@
+import { ProjectTitleCellPo } from "$tests/page-objects/ProjectTitleCell.page-object";
+import { ResponsiveTableRowPo } from "$tests/page-objects/ResponsiveTableRow.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ProjectsTableRowPo extends ResponsiveTableRowPo {
+  static under(element: PageObjectElement): ProjectsTableRowPo {
+    return new ProjectsTableRowPo(element.byTestId(ResponsiveTableRowPo.TID));
+  }
+
+  static async allUnder(
+    element: PageObjectElement
+  ): Promise<ProjectsTableRowPo[]> {
+    return Array.from(await element.allByTestId(ResponsiveTableRowPo.TID)).map(
+      (el) => new ProjectsTableRowPo(el)
+    );
+  }
+
+  getProjectTitleCellPo(): ProjectTitleCellPo {
+    return ProjectTitleCellPo.under(this.root);
+  }
+
+  async getProjectTitle(): Promise<string> {
+    return this.getProjectTitleCellPo().getProjectTitle();
+  }
+}


### PR DESCRIPTION
# Motivation

To render a table of staking projects to choose from to navigate to a neurons page.

# Changes

1. Add `ProjectTitleCell` which is mostly a copy of [TokenTitleCell](https://github.com/dfinity/nns-dapp/blob/main/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte).
2. Add `ProjectActionsCell` which just has the right angle icon indicating that there are more details.
3. Add `ProjectsTable` with just 2 columns. More will be added later.

# Tests

1. Unit tests added.
4. Page objects added.
5. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/staking/

# Todos

- [ ] Add entry to changelog (if necessary).
not yet