### PR TITLE
Clear default proposal filters

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,6 +30,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Removed
 
 * Disable sorting the neurons table by neuron ID.
+* Remove default topic and proposal status filters.
 
 #### Fixed
 

--- a/frontend/src/lib/constants/proposals.constants.ts
+++ b/frontend/src/lib/constants/proposals.constants.ts
@@ -1,19 +1,12 @@
 import type { BasisPoints } from "$lib/types/proposals";
 import { ProposalStatus, Topic } from "@dfinity/nns";
 
-// TODO: suggest to move into the store and add typing
-export const DEFAULT_PROPOSALS_FILTERS = {
-  topics: [
-    Topic.NetworkEconomics,
-    Topic.Governance,
-    Topic.NodeAdmin,
-    Topic.ParticipantManagement,
-    Topic.SubnetManagement,
-    Topic.NetworkCanisterManagement,
-    Topic.NodeProviderRewards,
-    Topic.SnsAndCommunityFund,
-  ],
-  status: [ProposalStatus.Open],
+export const DEFAULT_PROPOSALS_FILTERS: {
+  topics: Topic[];
+  status: ProposalStatus[];
+} = {
+  topics: [],
+  status: [],
 };
 
 export const DEPRECATED_TOPICS = [Topic.SnsDecentralizationSale];

--- a/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
@@ -2,7 +2,6 @@ import { resetNeuronsApiService } from "$lib/api-services/governance.api-service
 import * as governanceApi from "$lib/api/governance.api";
 import { queryProposal } from "$lib/api/proposals.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
-import { DEFAULT_PROPOSALS_FILTERS } from "$lib/constants/proposals.constants";
 import NnsProposalDetail from "$lib/pages/NnsProposalDetail.svelte";
 import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
 import { authStore } from "$lib/stores/auth.store";
@@ -16,7 +15,12 @@ import {
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import { AnonymousIdentity } from "@dfinity/agent";
-import { ProposalRewardStatus, Vote } from "@dfinity/nns";
+import {
+  ProposalRewardStatus,
+  ProposalStatus,
+  Topic,
+  Vote,
+} from "@dfinity/nns";
 import { waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
 import { tick } from "svelte";
@@ -25,9 +29,9 @@ vi.mock("$lib/api/governance.api");
 
 const proposal = {
   ...mockProposalInfo,
-  topic: DEFAULT_PROPOSALS_FILTERS.topics[0],
+  topic: Topic.NetworkEconomics,
   rewardStatus: ProposalRewardStatus.AcceptVotes,
-  status: DEFAULT_PROPOSALS_FILTERS.status[0],
+  status: ProposalStatus.Open,
   ballots: [
     {
       neuronId: mockNeuron.neuronId,

--- a/frontend/src/tests/workflows/NnsProposals.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposals.spec.ts
@@ -14,16 +14,16 @@ import {
 } from "$tests/mocks/auth.store.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import { AnonymousIdentity } from "@dfinity/agent";
-import { ProposalRewardStatus } from "@dfinity/nns";
+import { ProposalRewardStatus, ProposalStatus, Topic } from "@dfinity/nns";
 import { waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
 import type { Subscriber } from "svelte/store";
 
 const proposal = {
   ...mockProposalInfo,
-  topic: DEFAULT_PROPOSALS_FILTERS.topics[0],
+  topic: Topic.NetworkEconomics,
   rewardStatus: ProposalRewardStatus.AcceptVotes,
-  status: DEFAULT_PROPOSALS_FILTERS.status[0],
+  status: ProposalStatus.Open,
 };
 
 vi.mock("$lib/api/proposals.api", () => {


### PR DESCRIPTION
# Motivation

When you choose "All Proposals" on the Voting tab, by default we do not show all proposals.
By default we only show proposals with 8/15 topics and 1/5 proposal statuses.
I checked with PM and they see no reason for doing this.

# Changes

Make the default topic and status filters empty.

# Tests

1. Unit tests updated.
2. Tested manually at: https://mrfq3-7eaaa-aaaaa-qabja-cai.dskloet-ingress.devenv.dfinity.network/proposals/?u=mrfq3-7eaaa-aaaaa-qabja-cai
3. Also tested that this only applies if you hadn't already used nns dapp with your browser profile.

# Todos

- [x] Add entry to changelog (if necessary).
