### PR TITLE
Script to convert between ID formats

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -44,6 +44,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+* Script to convert between ID formats
+
 #### Changed
 
 #### Deprecated

--- a/scripts/convert-id
+++ b/scripts/convert-id
@@ -104,6 +104,7 @@ function hex_to_account_identifier() {
   hex=$(cat)
   subaccount_hex=$(get_subaccount_hex)
 
+  # Logic translated from https://github.com/dfinity/ic/blob/6aceb6a35248ef2735ddd9ca99d8a1c6f4a13908/rs/rosetta-api/icp_ledger/src/account_identifier.rs#L58-L68
   hash_input="0a$(echo -n account-id | xxd -p)${hex}${subaccount_hex}"
   hash_output="$(echo -n "$hash_input" | xxd -r -p | openssl dgst -sha224 | awk '{print $2}')"
   checksum=$(echo -n "$hash_output" | xxd -r -p | /usr/bin/crc32 /dev/stdin)

--- a/scripts/convert-id
+++ b/scripts/convert-id
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+print_help() {
+  cat <<-EOF
+
+	Convert IDs between different formats.
+	Formats are: text, hex, blob, and account_identifier.
+
+	USAGE:
+	  $(basename $0) --input <format> --output <format> [--as_subaccount] [--subaccount_format <format>] <id> [<subaccount>]
+
+	FORMAT EXAMPLES:
+	  text: 3vbe6-ysauy-vhiiq-dkhzp-ndzfr-6knc4-45rwt-youy4-dwtze-oqoo3-nae
+	  hex: 40A62A74220351F2F68F258F94D1739D8DA787531C1DA7923A0E76DA02
+	  blob: \\40\\A6\\2A\\74\\22\\03\\51\\F2\\F6\\8F\\25\\8F\\94\\D1\\73\\9D\\8D\\A7\\87\\53\\1C\\1D\\A7\\92\\3A\\0E\\76\\DA\\02
+	  account_identifier: e8865cf776c7cd1ffeb4491208f94d601570755bfe410e217497a0e626bef101
+
+	USAGE EXAMPLES:
+	  $(basename $0) --input text --output hex 3vbe6-ysauy-vhiiq-dkhzp-ndzfr-6knc4-45rwt-youy4-dwtze-oqoo3-nae
+	  $(basename $0) --input hex --output blob 40A62A74220351F2F68F258F94D1739D8DA787531C1DA7923A0E76DA02
+	  $(basename $0) --input text --output account_identifier --subaccount_format index 3vbe6-ysauy-vhiiq-dkhzp-ndzfr-6knc4-45rwt-youy4-dwtze-oqoo3-nae 1
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=i long=input desc="The input format" variable=INPUT_FORMAT default="text"
+clap.define short=o long=output desc="The output format" variable=OUTPUT_FORMAT default="hex"
+clap.define long=as_subaccount desc="To be used as ICP subaccount" variable=AS_SUBACCOUNT nargs=0
+clap.define long=subaccount_format desc="Formet of the subaccount parameter for account_identifier" variable=SUBACCOUNT_FORMAT default="index"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+function check_format() {
+  case $1 in
+  text | hex | blob | account_identifier) ;;
+  *)
+    echo "Invalid format: $1" >&2
+    echo "Valid formats are: text, hex and blob" >&2
+    exit 1
+    ;;
+  esac
+}
+
+# Copied from https://internetcomputer.org/docs/current/references/ic-interface-spec/#textual-representation-of-principals
+function textual_encode() {
+  (
+    echo "$1" | xxd -r -p | /usr/bin/crc32 /dev/stdin
+    echo -n "$1"
+  ) |
+    xxd -r -p | base32 | tr '[:upper:]' '[:lower:]' |
+    tr -d = | fold -w5 | paste -sd'-' -
+}
+
+function textual_decode() {
+  echo -n "$1" | tr -d - | tr '[:lower:]' '[:upper:]' |
+    fold -w 8 | xargs -n1 printf '%-8s' | tr ' ' = |
+    base32 -d | xxd -p | tr -d '\n' | cut -b9- | tr '[:lower:]' '[:upper:]'
+}
+
+function hex_to_hex() {
+  cat
+}
+
+function hex_to_text() {
+  textual_encode "$(cat)"
+}
+
+function text_to_hex() {
+  textual_decode "$(cat)"
+}
+
+function hex_to_blob() {
+  sed -e 's@..@\\&@g'
+}
+
+function blob_to_hex() {
+  sed -e 's@\\@@g'
+}
+
+function get_subaccount_hex() {
+  if [[ "$SUBACCOUNT_FORMAT" = "index" ]]; then
+    SUBACCOUNT_ARG="${SUBACCOUNT_ARG:-0}"
+    if ! [[ "$SUBACCOUNT_ARG" =~ ^[0-9]+$ ]]; then
+      echo "Subaccount index must be a decimal number." >&2
+      exit 1
+    fi
+    printf "%064x" "$SUBACCOUNT_ARG"
+    return
+  fi
+
+  if ! [[ "$SUBACCOUNT_FORMAT" = "text" ]]; then
+    "$0" --input "$SUBACCOUNT_FORMAT" --output hex "$SUBACCOUNT_ARG"
+    return
+  fi
+
+  "$0" --input "$SUBACCOUNT_FORMAT" --output hex --as_subaccount "$SUBACCOUNT_ARG"
+}
+
+function hex_to_account_identifier() {
+  hex=$(cat)
+  subaccount_hex=$(get_subaccount_hex)
+
+  hash_input="0a$(echo -n account-id | xxd -p)${hex}${subaccount_hex}"
+  hash_output="$(echo -n "$hash_input" | xxd -r -p | openssl dgst -sha224 | awk '{print $2}')"
+  checksum=$(echo -n "$hash_output" | xxd -r -p | /usr/bin/crc32 /dev/stdin)
+  echo "${checksum}${hash_output}"
+}
+
+function account_identifier_to_hex() {
+  echo "Account identifiers can't be reversed." >&2
+  exit 1
+}
+
+function check_hex() {
+  if ! [[ $1 =~ ^([0-9a-fA-F]{2})+$ ]]; then
+    echo "Invalid hex: $1" >&2
+    exit 1
+  fi
+}
+
+function check_blob() {
+  if ! [[ $1 =~ ^(\\[0-9a-fA-F]{2})+$ ]]; then
+    echo "Invalid blob: $1" >&2
+    exit 1
+  fi
+}
+
+function check_text() {
+  if ! [[ $1 =~ ^[a-z0-9-]+$ ]]; then
+    echo "Invalid text: $1" >&2
+    exit 1
+  fi
+}
+
+function maybe_as_subaccount() {
+  if [ "${AS_SUBACCOUNT:-}" != "true" ]; then
+    cat
+    return
+  fi
+  hex=$(cat)
+  length=$(($(echo -n "$hex" | wc -c) / 2))
+  printf '%02X%-062s' $length "$hex" | tr ' ' '0'
+}
+
+check_format "$INPUT_FORMAT"
+check_format "$OUTPUT_FORMAT"
+check_"$INPUT_FORMAT" "$1"
+
+SUBACCOUNT_ARG="${2:-}"
+
+echo -n "$1" | "${INPUT_FORMAT}_to_hex" | maybe_as_subaccount | "hex_to_${OUTPUT_FORMAT}"

--- a/scripts/convert-id
+++ b/scripts/convert-id
@@ -9,7 +9,7 @@ print_help() {
 	Formats are: text, hex, blob, and account_identifier.
 
 	USAGE:
-	  $(basename $0) --input <format> --output <format> [--as_subaccount] [--subaccount_format <format>] <id> [<subaccount>]
+	  $(basename "$0") --input <format> --output <format> [--as_subaccount] [--subaccount_format <format>] <id> [<subaccount>]
 
 	FORMAT EXAMPLES:
 	  text: 3vbe6-ysauy-vhiiq-dkhzp-ndzfr-6knc4-45rwt-youy4-dwtze-oqoo3-nae
@@ -18,9 +18,9 @@ print_help() {
 	  account_identifier: e8865cf776c7cd1ffeb4491208f94d601570755bfe410e217497a0e626bef101
 
 	USAGE EXAMPLES:
-	  $(basename $0) --input text --output hex 3vbe6-ysauy-vhiiq-dkhzp-ndzfr-6knc4-45rwt-youy4-dwtze-oqoo3-nae
-	  $(basename $0) --input hex --output blob 40A62A74220351F2F68F258F94D1739D8DA787531C1DA7923A0E76DA02
-	  $(basename $0) --input text --output account_identifier --subaccount_format index 3vbe6-ysauy-vhiiq-dkhzp-ndzfr-6knc4-45rwt-youy4-dwtze-oqoo3-nae 1
+	  $(basename "$0") --input text --output hex 3vbe6-ysauy-vhiiq-dkhzp-ndzfr-6knc4-45rwt-youy4-dwtze-oqoo3-nae
+	  $(basename "$0") --input hex --output blob 40A62A74220351F2F68F258F94D1739D8DA787531C1DA7923A0E76DA02
+	  $(basename "$0") --input text --output account_identifier --subaccount_format index 3vbe6-ysauy-vhiiq-dkhzp-ndzfr-6knc4-45rwt-youy4-dwtze-oqoo3-nae 1
 	EOF
 }
 

--- a/scripts/convert-id.test
+++ b/scripts/convert-id.test
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+function expect_convert() {
+  expected_output="$1"
+  shift
+  actual_output=$("$SOURCE_DIR/convert-id" "$@")
+  if [ "$expected_output" != "$actual_output" ]; then
+    printf "Command: %s " "$(basename "$0")"
+    printf " %q" "$@"
+    echo
+    echo "Expected: $expected_output"
+    echo "Actual: $actual_output"
+    exit 1
+  fi
+}
+
+TEXT="w7xx4-wq2fm-6a"
+HEX="1A2B3C"
+BLOB="\\1A\\2B\\3C"
+ACCOUNT_IDENTIFIER="66b308004b77291769646f70ebe4f392741ef6a44c5f7ab83cd2d42b20588d2b"
+
+expect_convert "$TEXT" --output text --input text "$TEXT"
+expect_convert "$TEXT" --output text --input hex "$HEX"
+expect_convert "$TEXT" --output text --input blob "$BLOB"
+expect_convert "$HEX" --output hex --input text "$TEXT"
+expect_convert "$HEX" --output hex --input hex "$HEX"
+expect_convert "$HEX" --output hex --input blob "$BLOB"
+expect_convert "$BLOB" --output blob --input text "$TEXT"
+expect_convert "$BLOB" --output blob --input hex "$HEX"
+expect_convert "$BLOB" --output blob --input blob "$BLOB"
+
+expect_convert "$ACCOUNT_IDENTIFIER" --output account_identifier --input text "$TEXT"
+
+TEXT2="3vbe6-ysauy-vhiiq-dkhzp-ndzfr-6knc4-45rwt-youy4-dwtze-oqoo3-nae"
+HEX2="40A62A74220351F2F68F258F94D1739D8DA787531C1DA7923A0E76DA02"
+BLOB2="\\40\\A6\\2A\\74\\22\\03\\51\\F2\\F6\\8F\\25\\8F\\94\\D1\\73\\9D\\8D\\A7\\87\\53\\1C\\1D\\A7\\92\\3A\\0E\\76\\DA\\02"
+ACCOUNT_IDENTIFIER2="e8865cf776c7cd1ffeb4491208f94d601570755bfe410e217497a0e626bef101"
+ACCOUNT_IDENTIFIER2_INDEX_1="9de8d877dd08d3a376d4dfd30ecc0624353e24b69479a62d79360de08e30a5e8"
+
+expect_convert "$TEXT2" --output text --input text "$TEXT2"
+expect_convert "$TEXT2" --output text --input hex "$HEX2"
+expect_convert "$TEXT2" --output text --input blob "$BLOB2"
+expect_convert "$HEX2" --output hex --input text "$TEXT2"
+expect_convert "$HEX2" --output hex --input hex "$HEX2"
+expect_convert "$HEX2" --output hex --input blob "$BLOB2"
+expect_convert "$BLOB2" --output blob --input text "$TEXT2"
+expect_convert "$BLOB2" --output blob --input hex "$HEX2"
+expect_convert "$BLOB2" --output blob --input blob "$BLOB2"
+
+expect_convert "$ACCOUNT_IDENTIFIER2" --output account_identifier --input text "$TEXT2"
+expect_convert "$ACCOUNT_IDENTIFIER2_INDEX_1" --output account_identifier --input text "$TEXT2" 1
+
+SUBACCOUNT_IDENTIFIER="0a0b22efafb70f6bc7b93951e7bf40feeb0d3a07b7b2e4a6ae37c4f17793360f"
+HEX_AS_SUBACCOUNT="031A2B3C00000000000000000000000000000000000000000000000000000000"
+expect_convert "$SUBACCOUNT_IDENTIFIER" --output account_identifier --input text --subaccount_format text "$TEXT2" "$TEXT"
+expect_convert "$HEX_AS_SUBACCOUNT" --output hex --as_subaccount --input text "$TEXT"
+expect_convert "$SUBACCOUNT_IDENTIFIER" --output account_identifier --input text --subaccount_format hex "$TEXT2" "$HEX_AS_SUBACCOUNT"
+
+echo PASS


### PR DESCRIPTION
# Motivation

I was looking for a tool to conveniently convert between text, hex, blob and account_identifier but I couldn't find one so I made this.

# Changes

Script to convert between text, hex, blob and account_identifier formats.

# Tests

1. Unit tests added.
2. Tested manually to create a canister by using the script to create the CMC subaccount to transfer ICP to.

# Todos

- [x] Add entry to changelog (if necessary).
