### PR TITLE
bot: Update IC Cargo Dependencies to release-2024-07-03_23-01-storage-layer-disabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1140,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1152,7 +1152,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1164,7 +1164,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "on_wire",
  "prost",
@@ -1372,7 +1372,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1861,7 +1861,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -1888,7 +1888,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -1901,7 +1901,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ecdsa-secp256k1",
@@ -1914,7 +1914,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "serde",
 ]
@@ -1922,7 +1922,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -1931,7 +1931,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "serde",
@@ -2072,12 +2072,12 @@ dependencies = [
 [[package]]
 name = "ic-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "k256",
  "lazy_static",
@@ -2091,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -2105,7 +2105,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "getrandom",
 ]
@@ -2113,7 +2113,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "hex",
  "ic-types",
@@ -2123,12 +2123,13 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
  "ed25519-consensus",
  "hex",
+ "ic-crypto-ed25519",
  "ic-crypto-internal-basic-sig-der-utils",
  "ic-crypto-internal-seed",
  "ic-crypto-internal-types",
@@ -2145,7 +2146,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -2163,7 +2164,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2171,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2190,7 +2191,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2203,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -2211,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "base64 0.13.1",
  "cached",
@@ -2237,7 +2238,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2267,7 +2268,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "arrayvec 0.7.4",
  "hex",
@@ -2284,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2302,7 +2303,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "serde",
  "zeroize",
@@ -2311,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2319,7 +2320,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2332,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -2345,7 +2346,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2355,7 +2356,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2365,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "ic-protobuf",
  "ic-utils",
@@ -2377,7 +2378,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "ciborium",
@@ -2399,7 +2400,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "ciborium",
@@ -2427,7 +2428,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "async-trait",
  "candid",
@@ -2455,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -2467,7 +2468,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "async-trait",
  "candid",
@@ -2485,7 +2486,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -2497,7 +2498,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "hex",
@@ -2507,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2532,7 +2533,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "async-trait",
  "candid",
@@ -2555,12 +2556,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2596,12 +2597,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -2614,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -2626,12 +2627,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "comparable",
@@ -2644,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "ic-base-types",
 ]
@@ -2652,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "dfn_core",
@@ -2668,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "async-trait",
  "candid",
@@ -2681,12 +2682,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -2699,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "comparable",
@@ -2725,7 +2726,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -2734,7 +2735,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2797,12 +2798,12 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "async-trait",
  "candid",
@@ -2817,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "bincode",
  "candid",
@@ -2831,7 +2832,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2843,7 +2844,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2854,7 +2855,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "ic-management-canister-types",
@@ -2865,7 +2866,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -2877,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2889,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2946,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -2954,7 +2955,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -2965,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "async-trait",
  "candid",
@@ -2986,7 +2987,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -3013,7 +3014,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3042,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3080,7 +3081,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "comparable",
@@ -3095,7 +3096,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "async-trait",
  "candid",
@@ -3142,7 +3143,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3177,7 +3178,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3262,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "comparable",
@@ -3293,7 +3294,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "async-trait",
  "candid",
@@ -3304,7 +3305,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.5"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "base32",
  "candid",
@@ -3923,7 +3924,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 
 [[package]]
 name = "once_cell"
@@ -4087,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "candid",
  "serde",
@@ -4634,7 +4635,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-06-26_23-01-base#2e269c77aa2f6b2353ddad6a4ac3d5ddcac196b1"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
 dependencies = [
  "build-info",
  "build-info-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,23 +13,23 @@ version = "2.0.82"
 ic-cdk = "0.14.0"
 ic-cdk-macros = "0.15.0"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
-ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-06-26_23-01-base" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
 
 [profile.release]
 lto = false


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
We want to keep our Cargo dependencies up to date.

# Changes
* Ran `scripts/update-ic-cargo-deps` to update the Cargo.toml dependencies to the latest IC release.

# Tests
* See CI