### PR TITLE
Test CMC notify fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,6 +211,8 @@ jobs:
           popd
       - name: Test getting proposal payloads
         run: scripts/nns-dapp/test-proposal-payload
+      - name: Test CMC notify fallback mechanism
+        run: scripts/nns-dapp/test-cmc-notify
       - name: Verify that arguments are set in index.html
         run: |
           for ((i=5; i>0; i--)); do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
         uses: dfinity/setup-dfx@main
       - name: Install tools
         run: |
-          sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
+          sudo apt-get update -yy && sudo apt-get install -yy moreutils libarchive-zip-perl && command -v sponge
           cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)" && idl2json --version
       - name: Run uprade-downgrade test
         run: ./scripts/nns-dapp/upgrade-downgrade-test --wasm out/nns-dapp_test.wasm.gz --args out/nns-dapp-arg-local.did --github_step_summary "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
         uses: dfinity/setup-dfx@main
       - name: Install tools
         run: |
-          sudo apt-get update -yy && sudo apt-get install -yy moreutils libarchive-zip-perl && command -v sponge
+          sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
           cargo binstall --no-confirm "idl2json_cli@$(jq -r .defaults.build.config.IDL2JSON_VERSION dfx.json)" && idl2json --version
       - name: Run uprade-downgrade test
         run: ./scripts/nns-dapp/upgrade-downgrade-test --wasm out/nns-dapp_test.wasm.gz --args out/nns-dapp-arg-local.did --github_step_summary "$GITHUB_STEP_SUMMARY"
@@ -211,6 +211,10 @@ jobs:
           popd
       - name: Test getting proposal payloads
         run: scripts/nns-dapp/test-proposal-payload
+      - name: Install tools
+        run: |
+          # libarchive-zip-perl is needed for crc32, used by test-cmc-notify.
+          sudo apt-get update -yy && sudo apt-get install -yy libarchive-zip-perl
       - name: Test CMC notify fallback mechanism
         run: scripts/nns-dapp/test-cmc-notify
       - name: Verify that arguments are set in index.html

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -38,6 +38,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Script to convert between ID formats
+* Test cycles minting canister notification mechnism of the nns-dapp.
 
 #### Changed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -38,7 +38,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Script to convert between ID formats
-* Test cycles minting canister notification mechnism of the nns-dapp.
+* Test cycles minting canister notification mechanism of the nns-dapp.
 
 #### Changed
 

--- a/scripts/nns-dapp/test-cmc-notify
+++ b/scripts/nns-dapp/test-cmc-notify
@@ -43,7 +43,7 @@ function hex_to_blob() {
 
 function get_cmc_account_identifier() {
   subaccount="$1"
-  convert --output account_identifier --subaccount_format text $CMC_ID "$subaccount"
+  convert --output account_identifier --subaccount_format text "$CMC_ID" "$subaccount"
 }
 
 function get_user_canisters() {

--- a/scripts/nns-dapp/test-cmc-notify
+++ b/scripts/nns-dapp/test-cmc-notify
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.."
+
+print_help() {
+  cat <<-EOF
+
+	Creating or topping up a canister is a 2-step process:
+	1. Sending ICP to a subaccount of the CMC.
+	2. Notifying the CMC about the transaction.
+	Both steps are done in the frontend, but if the process is interrupted and
+	the second step is not performed, the ICP could go missing.
+	So the nns-dapp canister monitors the ledger for such transactions and also
+	notifies the CMC about them.
+
+	This script tests that fallback notification mechanism of the nns-dapp
+	canister.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=i long=identity desc="Identity to use to create proposals" variable=DFX_IDENTITY default="snsdemo8"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+export DFX_IDENTITY
+
+# Magic numbers defined at https://github.com/dfinity/ic/blob/be47f18b190689a055c7b198030a85e8cc816b65/rs/nns/cmc/src/lib.rs#L229-L230
+CREATE_CANISTER_MEMO="$((16#41455243))" # 1095062083
+TOP_UP_CANISTER_MEMO="$((16#50555054))" # 1347768404
+
+ICP=11000000
+
+function convert() {
+  "$SOURCE_DIR/convert-id" "$@"
+}
+
+function hex_to_blob() {
+  convert --input hex --output blob "$1"
+}
+
+function get_cmc_account_identifier() {
+  subaccount="$1"
+  convert --output account_identifier --subaccount_format text $CMC_ID "$subaccount"
+}
+
+function get_user_canisters() {
+  dfx canister call nns-dapp get_canisters | idl2json | jq -r '.[] | .canister_id'
+}
+
+function get_cycles_balance() {
+  canister_id="$1"
+  dfx canister status "$canister_id" | grep "Balance:" | sed -e 's@Balance: \(.*\) Cycles@\1@' | sed -e 's@_@@g'
+}
+
+# Make sure we have an account so nns-dapp tracks our transactions
+dfx canister call nns-dapp add_account
+
+OLD_CANISTERS="$(get_user_canisters)"
+
+CMC_ID="$(dfx canister id nns-cycles-minting)"
+
+CYCLES_RATE="$(dfx canister call nns-cycles-minting get_icp_xdr_conversion_rate | idl2json | jq -r '.data.xdr_permyriad_per_icp')"
+
+PRINCIPAL="$(dfx identity get-principal)"
+CREATE_CANISTER_ACCOUNT_IDENTIFIER="$(get_cmc_account_identifier "$PRINCIPAL")"
+
+dfx canister call nns-ledger transfer "(
+  record {
+    to = blob \"$(hex_to_blob "$CREATE_CANISTER_ACCOUNT_IDENTIFIER")\";
+    fee = record { e8s = 10_000 : nat64 };
+    memo = $CREATE_CANISTER_MEMO : nat64;
+    amount = record { e8s = $ICP : nat64 };
+  }
+)"
+
+for ((try = 30; try > 0; try--)); do
+  ALL_CANISTERS="$(get_user_canisters)"
+  if [[ "$ALL_CANISTERS" != "$OLD_CANISTERS" ]]; then
+    break
+  fi
+  echo "Waiting for canister to be created..."
+  sleep 1
+done
+
+NEW_CANISTER="$(echo "$ALL_CANISTERS $OLD_CANISTERS" | sed -e 's@ @\n@g' | sort | uniq -u)"
+
+if [[ -z "$NEW_CANISTER" ]]; then
+  echo "No new canister found"
+  exit 1
+fi
+
+echo "Created canister ID $NEW_CANISTER"
+
+EXPECTED_CYCLES="$((ICP * CYCLES_RATE))"
+
+ACTUAL_CYCLES="$(get_cycles_balance "$NEW_CANISTER")"
+
+echo "Cycles balance: $ACTUAL_CYCLES"
+
+if [[ "$ACTUAL_CYCLES" != "$EXPECTED_CYCLES" ]]; then
+  echo "Expected $EXPECTED_CYCLES cycles, got $ACTUAL_CYCLES"
+  exit 1
+fi
+
+TOP_UP_ACCOUNT_IDENTIFIER="$(get_cmc_account_identifier "$NEW_CANISTER")"
+
+dfx canister call nns-ledger transfer "(
+  record {
+    to = blob \"$(hex_to_blob "$TOP_UP_ACCOUNT_IDENTIFIER")\";
+    fee = record { e8s = 10_000 : nat64 };
+    memo = $TOP_UP_CANISTER_MEMO : nat64;
+    amount = record { e8s = $ICP : nat64 };
+  }
+)"
+
+EXPECTED_CYCLES="$((2 * ICP * CYCLES_RATE))"
+OLD_CYCLES="$ACTUAL_CYCLES"
+
+for ((try = 30; try > 0; try--)); do
+  ACTUAL_CYCLES="$(get_cycles_balance "$NEW_CANISTER")"
+  if [[ "ACTUAL_CYCLES" != "$OLD_CYCLES" ]]; then
+    break
+  fi
+  echo "Waiting for canister to be topped up..."
+  sleep 1
+done
+
+echo "Cycles balance: $ACTUAL_CYCLES"
+
+if [[ "$ACTUAL_CYCLES" != "$EXPECTED_CYCLES" ]]; then
+  echo "Expected $EXPECTED_CYCLES cycles, got $ACTUAL_CYCLES"
+  exit 1
+fi
+
+echo PASS

--- a/scripts/nns-dapp/test-cmc-notify
+++ b/scripts/nns-dapp/test-cmc-notify
@@ -25,8 +25,6 @@ clap.define short=i long=identity desc="Identity to use to create proposals" var
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
-set -x
-
 export DFX_IDENTITY
 
 # Magic numbers defined at https://github.com/dfinity/ic/blob/be47f18b190689a055c7b198030a85e8cc816b65/rs/nns/cmc/src/lib.rs#L229-L230
@@ -87,7 +85,7 @@ for ((try = 30; try > 0; try--)); do
   sleep 1
 done
 
-NEW_CANISTER="$(echo "$ALL_CANISTERS $OLD_CANISTERS" | sed -e 's@ @\n@g' | sort | uniq -u)"
+NEW_CANISTER="$(echo "$ALL_CANISTERS $OLD_CANISTERS" | sed -e 's@ @\n@g' | sort | uniq -u | grep -v '^$')"
 
 if [[ -z "$NEW_CANISTER" ]]; then
   echo "No new canister found"

--- a/scripts/nns-dapp/test-cmc-notify
+++ b/scripts/nns-dapp/test-cmc-notify
@@ -31,7 +31,7 @@ export DFX_IDENTITY
 CREATE_CANISTER_MEMO="$((16#41455243))" # 1095062083
 TOP_UP_CANISTER_MEMO="$((16#50555054))" # 1347768404
 
-ICP=11000000
+ICP_E8S=11000000
 
 function convert() {
   "$SOURCE_DIR/convert-id" "$@"
@@ -52,7 +52,10 @@ function get_user_canisters() {
 
 function get_cycles_balance() {
   canister_id="$1"
-  dfx canister status "$canister_id" | grep "Balance:" | sed -e 's@Balance: \(.*\) Cycles@\1@' | sed -e 's@_@@g'
+  dfx canister status "$canister_id" |
+    grep "Balance:" |
+    sed -e 's@Balance: \(.*\) Cycles@\1@' |
+    sed -e 's@_@@g'
 }
 
 # Make sure we have an account so nns-dapp tracks our transactions
@@ -62,20 +65,26 @@ OLD_CANISTERS="$(get_user_canisters)"
 
 CMC_ID="$(dfx canister id nns-cycles-minting)"
 
-CYCLES_RATE="$(dfx canister call nns-cycles-minting get_icp_xdr_conversion_rate | idl2json | jq -r '.data.xdr_permyriad_per_icp')"
+CYCLES_PER_ICP_E8="$(
+  dfx canister call nns-cycles-minting get_icp_xdr_conversion_rate |
+    idl2json |
+    jq -r '.data.xdr_permyriad_per_icp'
+)"
 
 PRINCIPAL="$(dfx identity get-principal)"
-CREATE_CANISTER_ACCOUNT_IDENTIFIER="$(get_cmc_account_identifier "$PRINCIPAL")"
 
+CREATE_CANISTER_ACCOUNT_IDENTIFIER="$(get_cmc_account_identifier "$PRINCIPAL")"
 dfx canister call nns-ledger transfer "(
   record {
     to = blob \"$(hex_to_blob "$CREATE_CANISTER_ACCOUNT_IDENTIFIER")\";
     fee = record { e8s = 10_000 : nat64 };
     memo = $CREATE_CANISTER_MEMO : nat64;
-    amount = record { e8s = $ICP : nat64 };
+    amount = record { e8s = $ICP_E8S : nat64 };
   }
 )"
 
+# Wait for the nns-dapp canister to see the transaction, to notify the CMC and
+# to add the canister to the list of user canisters.
 for ((try = 30; try > 0; try--)); do
   ALL_CANISTERS="$(get_user_canisters)"
   if [[ "$ALL_CANISTERS" != "$OLD_CANISTERS" ]]; then
@@ -85,7 +94,13 @@ for ((try = 30; try > 0; try--)); do
   sleep 1
 done
 
-NEW_CANISTER="$(echo "$ALL_CANISTERS $OLD_CANISTERS" | sed -e 's@ @\n@g' | sort | uniq -u | grep -v '^$')"
+NEW_CANISTER="$(
+  echo "$ALL_CANISTERS $OLD_CANISTERS" |
+    sed -e 's@ @\n@g' |
+    sort |
+    uniq -u |
+    grep -v '^$'
+)"
 
 if [[ -z "$NEW_CANISTER" ]]; then
   echo "No new canister found"
@@ -94,7 +109,7 @@ fi
 
 echo "Created canister ID $NEW_CANISTER"
 
-EXPECTED_CYCLES="$((ICP * CYCLES_RATE))"
+EXPECTED_CYCLES="$((ICP_E8S * CYCLES_PER_ICP_E8))"
 
 ACTUAL_CYCLES="$(get_cycles_balance "$NEW_CANISTER")"
 
@@ -106,19 +121,20 @@ if [[ "$ACTUAL_CYCLES" != "$EXPECTED_CYCLES" ]]; then
 fi
 
 TOP_UP_ACCOUNT_IDENTIFIER="$(get_cmc_account_identifier "$NEW_CANISTER")"
-
 dfx canister call nns-ledger transfer "(
   record {
     to = blob \"$(hex_to_blob "$TOP_UP_ACCOUNT_IDENTIFIER")\";
     fee = record { e8s = 10_000 : nat64 };
     memo = $TOP_UP_CANISTER_MEMO : nat64;
-    amount = record { e8s = $ICP : nat64 };
+    amount = record { e8s = $ICP_E8S : nat64 };
   }
 )"
 
-EXPECTED_CYCLES="$((2 * ICP * CYCLES_RATE))"
+EXPECTED_CYCLES="$((2 * ICP_E8S * CYCLES_PER_ICP_E8))"
 OLD_CYCLES="$ACTUAL_CYCLES"
 
+# Wait for the nns-dapp canister to see the transaction, for it to notify the
+# CMC and for the CMC to update the canister's cycles balance.
 for ((try = 30; try > 0; try--)); do
   ACTUAL_CYCLES="$(get_cycles_balance "$NEW_CANISTER")"
   if [[ "ACTUAL_CYCLES" != "$OLD_CYCLES" ]]; then
@@ -135,4 +151,4 @@ if [[ "$ACTUAL_CYCLES" != "$EXPECTED_CYCLES" ]]; then
   exit 1
 fi
 
-echo PASS
+echo "✅ PASS"

--- a/scripts/nns-dapp/test-cmc-notify
+++ b/scripts/nns-dapp/test-cmc-notify
@@ -25,6 +25,8 @@ clap.define short=i long=identity desc="Identity to use to create proposals" var
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
+set -x
+
 export DFX_IDENTITY
 
 # Magic numbers defined at https://github.com/dfinity/ic/blob/be47f18b190689a055c7b198030a85e8cc816b65/rs/nns/cmc/src/lib.rs#L229-L230


### PR DESCRIPTION
# Motivation

Creating or topping up a canister is a 2-step process:

1. Sending ICP to a subaccount of the CMC.
2. Notifying the CMC about the transaction.

Both steps are done in the frontend, but if the process is interrupted and
the second step is not performed, the ICP could go missing.
So the nns-dapp canister monitors the ledger for such transactions and also
notifies the CMC about them.

Because this is fallback behavior, it's easy not to notice it when this is not working.

And indeed this recently got broken on the test environment because in order to fix a vulnerability in the CMC, the nns-dapp got exclusively whitelisted to do this notifying on behalf or other principals. But on the test environment, nns-dapp has a different canister ID so it wasn't whitelisted.

This is now fixed and I want to put a test in place to make sure it doesn't break again without us noticing.

# Changes

1. A bash script which transfer ICP to the correct subaccount of the CMC and checks that a canister is created or topped up.
2. Added the test to CI.

# Tests

Ran the test on Mac and on CI (Linux).

# Todos

- [x] Add entry to changelog (if necessary).
