### PR TITLE
Refresh SNS neuron from details page if needed

### DIFF
--- a/frontend/src/lib/stores/checked-neurons.store.ts
+++ b/frontend/src/lib/stores/checked-neurons.store.ts
@@ -1,0 +1,56 @@
+import { writable } from "svelte/store";
+
+interface UniverseCheckedNeuronSubaccountStore {
+  [subaccountHex: string]: true;
+}
+
+interface CheckedNeuronSubaccountsStore {
+  [universeId: string]: UniverseCheckedNeuronSubaccountStore;
+}
+
+// Staking or topping up a neuron is a 2-step process. If the process gets
+// interrupted, we can check the balance of a neuron's subaccount to see if the
+// process needs to be resumed. Since this is just a fallback mechanism, we
+// don't need to do it more than once per neuron per session. This store keeps
+// track of the neurons that have already been checked this session.
+const initCheckedNeuronSubaccountsStore = () => {
+  const { subscribe, update, set } = writable<CheckedNeuronSubaccountsStore>(
+    {}
+  );
+
+  return {
+    subscribe,
+
+    // Returns true if the subaccount was added this time and false if it was
+    // already in the store.
+    addSubaccount({
+      universeId,
+      subaccountHex,
+    }: {
+      universeId: string;
+      subaccountHex: string;
+    }): boolean {
+      let result = true;
+      update((currentState: CheckedNeuronSubaccountsStore) => {
+        const isPresent = currentState[universeId]?.[subaccountHex] ?? false;
+        result = !isPresent;
+        return isPresent
+          ? currentState
+          : {
+              ...currentState,
+              [universeId]: {
+                ...currentState[universeId],
+                [subaccountHex]: true,
+              },
+            };
+      });
+      return result;
+    },
+    reset() {
+      set({});
+    },
+  };
+};
+
+export const checkedNeuronSubaccountsStore =
+  initCheckedNeuronSubaccountsStore();

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -144,7 +144,7 @@ describe("SnsNeuronDetail", () => {
             })
         );
 
-      const po = await renderComponent({
+      await renderComponent({
         neuronId: validNeuronIdAsHexString,
       });
 
@@ -167,7 +167,7 @@ describe("SnsNeuronDetail", () => {
             })
         );
 
-      const po = await renderComponent({
+      await renderComponent({
         neuronId: validNeuronIdAsHexString,
       });
 

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -8,6 +8,7 @@ import {
 } from "$lib/constants/sns-neurons.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import SnsNeuronDetail from "$lib/pages/SnsNeuronDetail.svelte";
+import * as checkNeuronsService from "$lib/services/sns-neurons-check-balances.services";
 import { authStore } from "$lib/stores/auth.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { snsFunctionsStore } from "$lib/stores/sns-functions.store";
@@ -130,6 +131,52 @@ describe("SnsNeuronDetail", () => {
       expect(await po.getAdvancedSectionPo().isPresent()).toBe(true);
       expect(await po.getFollowingCardPo().isPresent()).toBe(true);
       expect(await po.getHotkeysCardPo().isPresent()).toBe(true);
+    });
+
+    it("should reload neuron if refreshed", async () => {
+      let resolveRefreshNeuronIfNeeded;
+      const spyRefreshNeuronIfNeeded = vi
+        .spyOn(checkNeuronsService, "refreshNeuronIfNeeded")
+        .mockImplementation(
+          () =>
+            new Promise<boolean>((resolve) => {
+              resolveRefreshNeuronIfNeeded = resolve;
+            })
+        );
+
+      const po = await renderComponent({
+        neuronId: validNeuronIdAsHexString,
+      });
+
+      expect(spyRefreshNeuronIfNeeded).toBeCalled();
+      expect(snsGovernanceApi.getSnsNeuron).toBeCalledTimes(2);
+
+      resolveRefreshNeuronIfNeeded(true);
+      await runResolvedPromises();
+      expect(snsGovernanceApi.getSnsNeuron).toBeCalledTimes(4);
+    });
+
+    it("should not reload neuron if not refreshed", async () => {
+      let resolveRefreshNeuronIfNeeded;
+      const spyRefreshNeuronIfNeeded = vi
+        .spyOn(checkNeuronsService, "refreshNeuronIfNeeded")
+        .mockImplementation(
+          () =>
+            new Promise<boolean>((resolve) => {
+              resolveRefreshNeuronIfNeeded = resolve;
+            })
+        );
+
+      const po = await renderComponent({
+        neuronId: validNeuronIdAsHexString,
+      });
+
+      expect(spyRefreshNeuronIfNeeded).toBeCalled();
+      expect(snsGovernanceApi.getSnsNeuron).toBeCalledTimes(2);
+
+      resolveRefreshNeuronIfNeeded(false);
+      await runResolvedPromises();
+      expect(snsGovernanceApi.getSnsNeuron).toBeCalledTimes(2);
     });
   });
 

--- a/frontend/src/tests/lib/stores/checked-neurons.store.spec.ts
+++ b/frontend/src/tests/lib/stores/checked-neurons.store.spec.ts
@@ -1,0 +1,52 @@
+import { checkedNeuronSubaccountsStore } from "$lib/stores/checked-neurons.store";
+import { get } from "svelte/store";
+
+describe("checked-neurons.store", () => {
+  describe("checkedNeuronSubaccountsStore", () => {
+    beforeEach(() => {
+      checkedNeuronSubaccountsStore.reset();
+    });
+
+    it("should initially be empty", () => {
+      expect(get(checkedNeuronSubaccountsStore)).toEqual({});
+    });
+
+    it("should add a subaccount", () => {
+      expect(get(checkedNeuronSubaccountsStore)).toEqual({});
+      const universeId = "abc-efg-cai";
+      const subaccountHex = "12ab90";
+      checkedNeuronSubaccountsStore.addSubaccount({
+        universeId,
+        subaccountHex,
+      });
+      expect(get(checkedNeuronSubaccountsStore)).toEqual({
+        [universeId]: {
+          [subaccountHex]: true,
+        },
+      });
+    });
+
+    it("should return whether a subaccount was added", () => {
+      const universeId = "abc-efg-cai";
+      const subaccountHex = "12ab90";
+      expect(
+        checkedNeuronSubaccountsStore.addSubaccount({
+          universeId,
+          subaccountHex,
+        })
+      ).toBe(true);
+      expect(
+        checkedNeuronSubaccountsStore.addSubaccount({
+          universeId,
+          subaccountHex,
+        })
+      ).toBe(false);
+      expect(
+        checkedNeuronSubaccountsStore.addSubaccount({
+          universeId,
+          subaccountHex,
+        })
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

Topping up a neuron is a 2 step process.
1. Transfer tokens to the neuron account.
2. Notifying the governance canister to refresh the neuron.

If the process is interrupted between step 1 and 2, your tokens are now missing.
Because of this possibility, we compare the neuron account balance of SNS neurons with the neuron stake and refresh the neuron if there is a difference.

Currently we do this for all neurons of an SNS every time we load the neurons of that SNS, which is when you navigate to the neurons table for that SNS. This is overkill since this is really only a fallback mechanism. It also resulted in loading neurons in a different way for actionable proposals to avoid doing the check even more often.

It should be enough to only check a neuron when opening its details page and at most once per session for the same neuron.

This PR adds the check on the neuron details page but does not yet remove any existing checks.

# Changes

1. Add a store to keep track of neurons which have already been checked.
2. Refactor `checkNeurons` to extract `checkNeuron` to check a single neuron.
3. Add `refreshNeuronIfNeeded` which uses the store to make sure the same neuron is only checked once and then refreshes the neuron if needed.
4. Call `refreshNeuronIfNeeded` from `SnsNeuronDetails` and reload the neuron if it was refreshed.

# Tests

1. Unit tests added.
2. Tested in a branch where the other check has already been removed, by manually transferring tokens to the neuron account and seeing the stake update after opening the details page.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary