### PR TITLE
Support icrc1 format in convert-id

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -360,7 +360,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - run: scripts/convert-id.test
+      - name: Install tools
+        run: |
+          # libarchive-zip-perl is needed for crc32, used by convert-id.
+          sudo apt-get update -yy && sudo apt-get install -yy libarchive-zip-perl
+      - name: Run test
+        run: scripts/convert-id.test
   version-match:
     name: The nns-dapp npm and cargo versions should match
     runs-on: ubuntu-20.04

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -355,6 +355,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: scripts/unused-i18n
+  convert-id:
+    name: Test the ID conversion script
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: scripts/convert-id.test
   version-match:
     name: The nns-dapp npm and cargo versions should match
     runs-on: ubuntu-20.04

--- a/scripts/convert-id
+++ b/scripts/convert-id
@@ -88,7 +88,7 @@ function get_subaccount_hex() {
       exit 1
     fi
     subaccount_part=$(echo -n "$ID_ARG" | sed 's@^[^.]*\.@@')
-    printf '%064s' "$subaccount_part"
+    printf '%064d%s' 0 "$subaccount_part" | tail -c 64
     return
   fi
   if [[ "$SUBACCOUNT_FORMAT" = "index" ]]; then

--- a/scripts/convert-id
+++ b/scripts/convert-id
@@ -88,7 +88,9 @@ function get_subaccount_hex() {
       exit 1
     fi
     subaccount_part=$(echo -n "$ID_ARG" | sed 's@^[^.]*\.@@')
-    printf '%064d%s' 0 "$subaccount_part" | tail -c 64
+    # Some version of bash produce leading spaces instead of zeros.
+    # tr ' ' '0' is used to replace them with zeros.
+    printf '%064s' "$subaccount_part" | tr ' ' '0'
     return
   fi
   if [[ "$SUBACCOUNT_FORMAT" = "index" ]]; then

--- a/scripts/convert-id
+++ b/scripts/convert-id
@@ -36,7 +36,7 @@ source "$(clap.build)"
 
 function check_format() {
   case $1 in
-  text | hex | blob | account_identifier) ;;
+  text | hex | blob | account_identifier | icrc1) ;;
   *)
     echo "Invalid format: $1" >&2
     echo "Valid formats are: text, hex and blob" >&2
@@ -82,6 +82,15 @@ function blob_to_hex() {
 }
 
 function get_subaccount_hex() {
+  if [[ "$INPUT_FORMAT" = "icrc1" ]]; then
+    if [[ -n "${SUBACCOUNT_ARG}" ]]; then
+      echo "The ICRC1 format includes the subaccount so you can't specify a separate subaccount as well." >&2
+      exit 1
+    fi
+    subaccount_part=$(echo -n "$ID_ARG" | sed 's@^[^.]*\.@@')
+    printf '%064s' "$subaccount_part"
+    return
+  fi
   if [[ "$SUBACCOUNT_FORMAT" = "index" ]]; then
     SUBACCOUNT_ARG="${SUBACCOUNT_ARG:-0}"
     if ! [[ "$SUBACCOUNT_ARG" =~ ^[0-9]+$ ]]; then
@@ -116,6 +125,27 @@ function account_identifier_to_hex() {
   exit 1
 }
 
+function icrc1_to_hex() {
+  sed 's@-[^-]*$@@' | text_to_hex
+}
+
+function hex_to_icrc1() {
+  hex=$(cat)
+
+  subaccount_hex="$(get_subaccount_hex)"
+
+  subaccount_hex="$(echo -n "$subaccount_hex" | sed -e 's@^0*@@')"
+
+  if [[ -z "$subaccount_hex" ]]; then
+    echo -n "$hex" | hex_to_text
+    return
+  fi
+
+  checksum="$(echo -n "${hex}${subaccount_hex}" | xxd -r -p | /usr/bin/crc32 /dev/stdin | xxd -p -r | base32 | tr -d = | tr '[:upper:]' '[:lower:]')"
+
+  echo "$(echo "$hex" | hex_to_text)-${checksum}.${subaccount_hex}"
+}
+
 function check_hex() {
   if ! [[ $1 =~ ^([0-9a-fA-F]{2})+$ ]]; then
     echo "Invalid hex: $1" >&2
@@ -137,6 +167,13 @@ function check_text() {
   fi
 }
 
+function check_icrc1() {
+  if ! [[ $1 =~ ^[a-z0-9-]+\.[0-9a-f]+$ ]]; then
+    echo "Invalid icrc1: $1" >&2
+    exit 1
+  fi
+}
+
 function maybe_as_subaccount() {
   if [ "${AS_SUBACCOUNT:-}" != "true" ]; then
     cat
@@ -151,6 +188,7 @@ check_format "$INPUT_FORMAT"
 check_format "$OUTPUT_FORMAT"
 check_"$INPUT_FORMAT" "$1"
 
+ID_ARG="$1"
 SUBACCOUNT_ARG="${2:-}"
 
 echo -n "$1" | "${INPUT_FORMAT}_to_hex" | maybe_as_subaccount | "hex_to_${OUTPUT_FORMAT}"

--- a/scripts/convert-id
+++ b/scripts/convert-id
@@ -131,11 +131,17 @@ function icrc1_to_hex() {
   sed 's@-[^-]*$@@' | text_to_hex
 }
 
+# See https://internetcomputer.org/docs/current/references/icrc1-standard#textual-encoding-of-accounts
+# The ICRC-1 format is: <principal>-<checksum>.<compressed-subaccount>
+# where <compressed-subaccount> is the lower-case hex representation the
+# subaccount with leading zeros removed.
+# If the subaccount is only zeros, the ICRC-1 format is just the principal.
 function hex_to_icrc1() {
   hex=$(cat)
 
   subaccount_hex="$(get_subaccount_hex)"
 
+  # Remove leading zeros.
   subaccount_hex="$(echo -n "$subaccount_hex" | sed -e 's@^0*@@')"
 
   if [[ -z "$subaccount_hex" ]]; then

--- a/scripts/convert-id.test
+++ b/scripts/convert-id.test
@@ -5,9 +5,10 @@ SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 function expect_convert() {
   expected_output="$1"
   shift
-  actual_output=$("$SOURCE_DIR/convert-id" "$@")
+  SCRIPT_UNDER_TEST="$SOURCE_DIR/convert-id"
+  actual_output=$("$SCRIPT_UNDER_TEST" "$@")
   if [ "$expected_output" != "$actual_output" ]; then
-    printf "Command: %s " "$(basename "$0")"
+    printf "Command: %s " "$(basename "$SCRIPT_UNDER_TEST")"
     printf " %q" "$@"
     echo
     echo "Expected: $expected_output"

--- a/scripts/convert-id.test
+++ b/scripts/convert-id.test
@@ -58,4 +58,10 @@ expect_convert "$SUBACCOUNT_IDENTIFIER" --output account_identifier --input text
 expect_convert "$HEX_AS_SUBACCOUNT" --output hex --as_subaccount --input text "$TEXT"
 expect_convert "$SUBACCOUNT_IDENTIFIER" --output account_identifier --input text --subaccount_format hex "$TEXT2" "$HEX_AS_SUBACCOUNT"
 
+ICRC1_CHECKSUM="3vbe6yq"
+ICRC1="$TEXT2-$ICRC1_CHECKSUM.1"
+expect_convert "$ICRC1" --output icrc1 --input icrc1 "$ICRC1"
+expect_convert "$ICRC1" --output icrc1 --input text "$TEXT2" 1
+expect_convert "$ACCOUNT_IDENTIFIER2_INDEX_1" --output account_identifier --input icrc1 "$ICRC1"
+
 echo PASS


### PR DESCRIPTION
# Motivation

It can be useful to create or parse addresses in the [ICRC1 format](https://internetcomputer.org/docs/current/references/icrc1-standard#textual-encoding-of-accounts).

# Changes

Add `icrc1` as a supported input and output format to `scripts/convert-id`.

# Tests

1. Unit test script extended.
2. Unit test script added to CI.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary