### PR TITLE
Remove old CMC notify mechanism

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -24,7 +24,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Removed
 
 * Remove default topic and proposal status filters.
-* Remove old canister creation/topup mechanism that hasn't been used for 2 years.
+* Remove old canister creation/top-up mechanism that hasn't been used for 2 years.
 
 #### Fixed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -24,6 +24,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Removed
 
 * Remove default topic and proposal status filters.
+* Remove old canister creation/topup mechanism that hasn't been used for 2 years.
 
 #### Fixed
 

--- a/rs/backend/src/canisters/ledger.rs
+++ b/rs/backend/src/canisters/ledger.rs
@@ -1,5 +1,5 @@
 use dfn_core::CanisterId;
-use dfn_protobuf::{protobuf, ToProto};
+use dfn_protobuf::protobuf;
 use ic_ledger_core::block::EncodedBlock;
 use ic_nns_constants::LEDGER_CANISTER_ID;
 use icp_ledger::protobuf::get_blocks_response::GetBlocksContent;
@@ -7,22 +7,7 @@ use icp_ledger::protobuf::{
     ArchiveIndexResponse as ArchiveIndexResponsePb, GetBlocksResponse as GetBlocksResponsePb,
     TipOfChainRequest as TipOfChainRequestPb, TipOfChainResponse as TipOfChainResponsePb,
 };
-use icp_ledger::{AccountBalanceArgs, BlockIndex, GetBlocksArgs, SendArgs, Tokens};
-
-pub async fn send(request: SendArgs) -> Result<BlockIndex, String> {
-    dfn_core::call(LEDGER_CANISTER_ID, "send_pb", protobuf, request.into_proto())
-        .await
-        .map_err(|e| e.1)
-}
-
-pub async fn account_balance(request: AccountBalanceArgs) -> Result<Tokens, String> {
-    let tokens: icp_ledger::protobuf::Tokens =
-        dfn_core::call(LEDGER_CANISTER_ID, "account_balance_pb", protobuf, request.into_proto())
-            .await
-            .map_err(|e| e.1)?;
-
-    Ok(Tokens::from_e8s(tokens.e8s))
-}
+use icp_ledger::{BlockIndex, GetBlocksArgs};
 
 pub async fn tip_of_chain() -> Result<BlockIndex, String> {
     let response: TipOfChainResponsePb =

--- a/rs/backend/src/multi_part_transactions_processor.rs
+++ b/rs/backend/src/multi_part_transactions_processor.rs
@@ -1,4 +1,3 @@
-use crate::accounts_store::{CreateCanisterArgs, RefundTransactionArgs, TopUpCanisterArgs};
 use candid::CandidType;
 use ic_base_types::{CanisterId, PrincipalId};
 use icp_ledger::AccountIdentifier;
@@ -15,9 +14,6 @@ pub struct MultiPartTransactionsProcessor {
 pub enum MultiPartTransactionToBeProcessed {
     StakeNeuron(PrincipalId, Memo),
     TopUpNeuron(PrincipalId, Memo),
-    CreateCanister(CreateCanisterArgs),
-    TopUpCanister(TopUpCanisterArgs),
-    RefundTransaction(RefundTransactionArgs),
     CreateCanisterV2(PrincipalId),
     TopUpCanisterV2(PrincipalId, CanisterId),
     // ParticipateSwap(buyer_id, from, to, swap_canister_id)

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -1,18 +1,12 @@
-use crate::accounts_store::{CreateCanisterArgs, RefundTransactionArgs, TopUpCanisterArgs};
-use crate::canisters::ledger;
 use crate::canisters::{cmc, governance};
-use crate::constants::{MEMO_CREATE_CANISTER, MEMO_TOP_UP_CANISTER};
 use crate::multi_part_transactions_processor::MultiPartTransactionToBeProcessed;
 use crate::state::STATE;
 use crate::{ledger_sync, Cycles};
 use cycles_minting_canister::{NotifyCreateCanister, NotifyError, NotifyTopUp};
 use dfn_core::api::{CanisterId, PrincipalId};
 use ic_nns_common::types::NeuronId;
-use ic_nns_constants::CYCLES_MINTING_CANISTER_ID;
 use ic_nns_governance::pb::v1::{claim_or_refresh_neuron_from_account_response, ClaimOrRefreshNeuronFromAccount};
-use icp_ledger::{
-    AccountBalanceArgs, AccountIdentifier, BlockIndex, Memo, SendArgs, Subaccount, Tokens, DEFAULT_TRANSFER_FEE,
-};
+use icp_ledger::{BlockIndex, Memo};
 
 pub async fn run_periodic_tasks() {
     ledger_sync::sync_transactions().await;
@@ -34,15 +28,6 @@ pub async fn run_periodic_tasks() {
             }
             MultiPartTransactionToBeProcessed::TopUpNeuron(principal, memo) => {
                 handle_top_up_neuron(principal, memo).await;
-            }
-            MultiPartTransactionToBeProcessed::CreateCanister(args) => {
-                handle_create_canister(block_height, args).await;
-            }
-            MultiPartTransactionToBeProcessed::TopUpCanister(args) => {
-                handle_top_up_canister(block_height, args).await;
-            }
-            MultiPartTransactionToBeProcessed::RefundTransaction(args) => {
-                handle_refund(args).await;
             }
             MultiPartTransactionToBeProcessed::CreateCanisterV2(controller) => {
                 handle_create_canister_v2(block_height, controller).await;
@@ -92,41 +77,6 @@ async fn handle_create_canister_v2(block_height: BlockIndex, controller: Princip
     }
 }
 
-async fn handle_create_canister(block_height: BlockIndex, args: CreateCanisterArgs) {
-    match create_canister(args.controller, args.amount).await {
-        Ok(Ok(canister_id)) => STATE.with(|s| {
-            s.accounts_store
-                .borrow_mut()
-                .attach_newly_created_canister(args.controller, canister_id);
-        }),
-        Ok(Err(error)) => {
-            let was_refunded = matches!(error, NotifyError::Refunded { .. });
-            if was_refunded {
-                let subaccount = (&args.controller).into();
-                enqueue_create_or_top_up_canister_refund(
-                    args.controller,
-                    subaccount,
-                    block_height,
-                    args.refund_address,
-                    error.to_string(),
-                )
-                .await;
-            }
-        }
-        Err(error) => {
-            let subaccount = (&args.controller).into();
-            enqueue_create_or_top_up_canister_refund(
-                args.controller,
-                subaccount,
-                block_height,
-                args.refund_address,
-                error,
-            )
-            .await;
-        }
-    }
-}
-
 async fn handle_top_up_canister_v2(block_height: BlockIndex, principal: PrincipalId, canister_id: CanisterId) {
     match top_up_canister_v2(block_height, canister_id).await {
         Ok(Ok(_)) => (),
@@ -139,53 +89,6 @@ async fn handle_top_up_canister_v2(block_height: BlockIndex, principal: Principa
             });
         }
         Ok(Err(_error)) => (),
-        Err(_error) => (),
-    }
-}
-
-async fn handle_top_up_canister(block_height: BlockIndex, args: TopUpCanisterArgs) {
-    match top_up_canister(args.canister_id, args.amount).await {
-        Ok(Ok(_)) => (),
-        Ok(Err(error)) => {
-            let was_refunded = matches!(error, NotifyError::Refunded { .. });
-            if was_refunded {
-                let subaccount = (&args.principal).into();
-                enqueue_create_or_top_up_canister_refund(
-                    args.principal,
-                    subaccount,
-                    block_height,
-                    args.refund_address,
-                    error.to_string(),
-                )
-                .await;
-            }
-        }
-        Err(error) => {
-            let subaccount = (&args.principal).into();
-            enqueue_create_or_top_up_canister_refund(
-                args.principal,
-                subaccount,
-                block_height,
-                args.refund_address,
-                error,
-            )
-            .await;
-        }
-    }
-}
-
-async fn handle_refund(args: RefundTransactionArgs) {
-    let send_request = SendArgs {
-        memo: Memo(0),
-        amount: args.amount,
-        fee: DEFAULT_TRANSFER_FEE,
-        from_subaccount: Some(args.from_sub_account),
-        to: args.refund_address,
-        created_at_time: None,
-    };
-
-    match ledger::send(send_request.clone()).await {
-        Ok(_block_height) => (),
         Err(_error) => (),
     }
 }
@@ -222,34 +125,6 @@ async fn create_canister_v2(
     cmc::notify_create_canister(notify_request).await
 }
 
-async fn create_canister(principal: PrincipalId, amount: Tokens) -> Result<Result<CanisterId, NotifyError>, String> {
-    // We need to hold back 1 transaction fee for the 'send' and also 1 for the 'notify'
-    let send_amount = Tokens::from_e8s(amount.get_e8s() - (2 * DEFAULT_TRANSFER_FEE.get_e8s()));
-    let subaccount: Subaccount = (&principal).into();
-
-    let send_request = SendArgs {
-        memo: MEMO_CREATE_CANISTER,
-        amount: send_amount,
-        fee: DEFAULT_TRANSFER_FEE,
-        from_subaccount: Some(subaccount),
-        to: AccountIdentifier::new(CYCLES_MINTING_CANISTER_ID.into(), Some(subaccount)),
-        created_at_time: None,
-    };
-
-    let block_index = ledger::send(send_request.clone()).await?;
-
-    #[allow(deprecated)]
-    let notify_request = NotifyCreateCanister {
-        block_index,
-        controller: principal,
-        subnet_type: None,
-        subnet_selection: None,
-        settings: None,
-    };
-
-    cmc::notify_create_canister(notify_request).await
-}
-
 async fn top_up_canister_v2(
     block_index: BlockIndex,
     canister_id: CanisterId,
@@ -260,61 +135,4 @@ async fn top_up_canister_v2(
     };
 
     cmc::notify_top_up_canister(notify_request).await
-}
-
-async fn top_up_canister(canister_id: CanisterId, amount: Tokens) -> Result<Result<Cycles, NotifyError>, String> {
-    // We need to hold back 1 transaction fee for the 'send' and also 1 for the 'notify'
-    let send_amount = Tokens::from_e8s(amount.get_e8s() - (2 * DEFAULT_TRANSFER_FEE.get_e8s()));
-    let subaccount: Subaccount = (&canister_id).into();
-
-    let send_request = SendArgs {
-        memo: MEMO_TOP_UP_CANISTER,
-        amount: send_amount,
-        fee: DEFAULT_TRANSFER_FEE,
-        from_subaccount: Some(subaccount),
-        to: AccountIdentifier::new(CYCLES_MINTING_CANISTER_ID.into(), Some(subaccount)),
-        created_at_time: None,
-    };
-
-    let block_index = ledger::send(send_request.clone()).await?;
-
-    let notify_request = NotifyTopUp {
-        block_index,
-        canister_id,
-    };
-
-    cmc::notify_top_up_canister(notify_request).await
-}
-
-async fn enqueue_create_or_top_up_canister_refund(
-    principal: PrincipalId,
-    subaccount: Subaccount,
-    block_height: BlockIndex,
-    refund_address: AccountIdentifier,
-    error_message: String,
-) {
-    let from_account = AccountIdentifier::new(dfn_core::api::id().get(), Some(subaccount));
-    let balance_request = AccountBalanceArgs { account: from_account };
-
-    match ledger::account_balance(balance_request).await {
-        Ok(balance) => {
-            let refund_amount_e8s = balance.get_e8s().saturating_sub(DEFAULT_TRANSFER_FEE.get_e8s());
-            if refund_amount_e8s > 0 {
-                let refund_args = RefundTransactionArgs {
-                    recipient_principal: principal,
-                    from_sub_account: subaccount,
-                    amount: Tokens::from_e8s(refund_amount_e8s),
-                    original_transaction_block_height: block_height,
-                    refund_address,
-                    error_message,
-                };
-                STATE.with(|s| {
-                    s.accounts_store
-                        .borrow_mut()
-                        .enqueue_transaction_to_be_refunded(refund_args);
-                });
-            }
-        }
-        Err(_error) => (),
-    };
 }


### PR DESCRIPTION
# Motivation

When an NNS dapp user creates or tops up a canister, the FE make a transaction to the CMC. The nns-dapp canister sees this transaction (because it looks at every ICP ledger transaction) and then notifies the CMC to finish the creation/topup.

More than 2 years ago we had a different mechanism where the FE makes a transaction to the nns-dapp. Then nns-dapp sees that transaction of forwards the ICP to the CMC and notifies it.

The code for this second mechanism still exists in the nns-dapp canister but hasn't been used by the frontend for over 2 years.

Having the extra code is confusing and a maintenance burden so we should remove it.

# Changes

Remove the canister code for the old canister creation/topup flow.

# Tests

The test added in https://github.com/dfinity/nns-dapp/pull/5166 still passes.

# Todos

- [x] Add entry to changelog (if necessary).
