### PR TITLE
Replace GIX_BOT_PAT with GIX_CREATE_PR_PAT

### DIFF
--- a/.github/workflows/update-aggregator.yml
+++ b/.github/workflows/update-aggregator.yml
@@ -58,7 +58,7 @@ jobs:
         # Note: If there were no changes, this step creates no PR.
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.GIX_BOT_PAT }}
+          token: ${{ secrets.GIX_CREATE_PR_PAT }}
           commit-message: Update aggregator
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -44,7 +44,7 @@ jobs:
         if: ${{ steps.update.outputs.updated == '1' }}
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.GIX_BOT_PAT }}
+          token: ${{ secrets.GIX_CREATE_PR_PAT }}
           base: main
           reviewers: mstrasinskis, dskloetd
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.

--- a/.github/workflows/update-ic-cargo-deps.yaml
+++ b/.github/workflows/update-ic-cargo-deps.yaml
@@ -25,7 +25,7 @@ jobs:
         if: ${{ steps.update.outputs.updated == '1' }}
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.GIX_BOT_PAT }}
+          token: ${{ secrets.GIX_CREATE_PR_PAT }}
           base: main
           reviewers: mstrasinskis, dskloetd, nns-team
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -64,7 +64,7 @@ jobs:
         # Note: If there were no changes, this step creates no PR.
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.GIX_BOT_PAT }}
+          token: ${{ secrets.GIX_CREATE_PR_PAT }}
           commit-message: Update proposals
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -58,7 +58,7 @@ jobs:
         if: ${{ steps.update.outputs.updated == '1' }}
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.GIX_BOT_PAT }}
+          token: ${{ secrets.GIX_CREATE_PR_PAT }}
           base: main
           reviewers: mstrasinskis, dskloetd
           # Note: Please be careful when updating the add-paths field.  We have had the snsdemo committed by accident, with a pattern that matches nothing seemingly committing everything.

--- a/.github/workflows/update-sns-aggregator-response.yml
+++ b/.github/workflows/update-sns-aggregator-response.yml
@@ -23,7 +23,7 @@ jobs:
         # Note: If there were no changes, this step creates no PR.
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.GIX_BOT_PAT }}
+          token: ${{ secrets.GIX_CREATE_PR_PAT }}
           commit-message: Update SNS aggregator response
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>

--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -58,7 +58,7 @@ jobs:
         if: ${{ steps.update.outputs.updated == '1' }}
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.GIX_BOT_PAT }}
+          token: ${{ secrets.GIX_CREATE_PR_PAT }}
           commit-message: Update snsdemo to ${{ steps.update.outputs.release }}
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>


### PR DESCRIPTION
# Motivation

Reduce the maintenance burden on IDX.

# Changes

Use the `GIX_CREATE_PR_PAT` GitHub secret instead of `GIX_BOT_PAT`.

# Tests

CI should still pass.
If things break later, we'll deal with it then.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary