### PR TITLE
Import token button

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1020,6 +1020,7 @@
     "hide_zero_balances": "Hide zero balances",
     "hide_zero_balances_toggle_label": "Switch between showing and hiding tokens with a balance of zero",
     "zero_balance_hidden": "Tokens with 0 balances are hidden.",
-    "show_all": "Show all"
+    "show_all": "Show all",
+    "import_token": "Import Token"
   }
 }

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -7,9 +7,10 @@
   import { i18n } from "$lib/stores/i18n";
   import type { UserToken } from "$lib/types/tokens-page";
   import { heightTransition } from "$lib/utils/transition.utils";
-  import { IconSettings } from "@dfinity/gix-components";
+  import { IconPlus, IconSettings } from "@dfinity/gix-components";
   import { Popover } from "@dfinity/gix-components";
   import { TokenAmountV2 } from "@dfinity/utils";
+  import { ENABLE_IMPORT_TOKEN } from "$lib/stores/feature-flags.store";
 
   export let userTokensData: UserToken[];
 
@@ -39,6 +40,12 @@
   const showAll = () => {
     hideZeroBalancesStore.set("show");
   };
+
+  const importToken = async () => {
+    // TBD: Implement import token.
+  };
+
+  // TODO(Import token): After removing ENABLE_IMPORT_TOKEN combine divs -> <div slot="last-row" class="last-row">
 </script>
 
 <TestIdWrapper testId="tokens-page-component">
@@ -57,7 +64,30 @@
       >
     </div>
     <div slot="last-row">
-      {#if shouldHideZeroBalances}
+      {#if $ENABLE_IMPORT_TOKEN}
+        <div class="last-row">
+          {#if shouldHideZeroBalances}
+            <div class="show-all-button-container">
+              {$i18n.tokens.zero_balance_hidden}
+              <button
+                data-tid="show-all-button"
+                class="ghost show-all"
+                on:click={showAll}
+              >
+                {$i18n.tokens.show_all}</button
+              >
+            </div>
+          {/if}
+
+          <button
+            data-tid="import-token-button"
+            class="ghost with-icon import-token-button"
+            on:click={importToken}
+          >
+            <IconPlus />{$i18n.tokens.import_token}
+          </button>
+        </div>
+      {:else if shouldHideZeroBalances}
         <div
           class="show-all-row"
           transition:heightTransition={{ duration: 250 }}
@@ -86,6 +116,7 @@
 
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/effect";
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
 
   .settings-button {
     --content-color: var(--text-description);
@@ -102,6 +133,7 @@
     grid-column: 1 / -1;
   }
 
+  // TODO(Import token): Remove after enabling ENABLE_IMPORT_TOKEN
   .show-all-row {
     color: var(--text-description);
     padding: var(--padding-2x);
@@ -109,6 +141,45 @@
 
     button.show-all {
       text-decoration: underline;
+    }
+  }
+
+  .last-row {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--padding-2x);
+
+    padding: calc(3 * var(--padding)) var(--padding-2x);
+    background: var(--table-row-background);
+    border-top: 1px solid var(--elements-divider);
+    text-align: center;
+
+    @include media.min-width(medium) {
+      flex-direction: row;
+      justify-content: space-between;
+      padding: var(--padding-2x);
+      text-align: left;
+      gap: var(--padding);
+
+      .show-all-button-container {
+        // Show-all button should be on right on desktop.
+        order: 1;
+      }
+    }
+
+    .show-all-button-container {
+      color: var(--text-description);
+      background: var(--table-row-background);
+
+      button.show-all {
+        text-decoration: underline;
+      }
+    }
+
+    .import-token-button {
+      gap: var(--padding);
+      color: var(--primary);
     }
   }
 </style>

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1079,6 +1079,7 @@ interface I18nTokens {
   hide_zero_balances_toggle_label: string;
   zero_balance_hidden: string;
   show_all: string;
+  import_token: string;
 }
 
 interface I18nNeuron_state {

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -190,4 +190,35 @@ describe("Tokens page", () => {
       "Zero balance",
     ]);
   });
+
+  describe("when import token feature flag is enabled", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_IMPORT_TOKEN", true);
+    });
+
+    it("should show import token button", async () => {
+      const po = renderPage([positiveBalance, zeroBalance]);
+      expect(await po.getImportTokenButtonPo().isPresent()).toBe(true);
+    });
+
+    it("should show import token and show all buttons", async () => {
+      const po = renderPage([positiveBalance, zeroBalance]);
+      await po.getSettingsButtonPo().click();
+      await po.getHideZeroBalancesTogglePo().getTogglePo().toggle();
+
+      expect(await po.getShowAllButtonPo().isPresent()).toBe(true);
+      expect(await po.getImportTokenButtonPo().isPresent()).toBe(true);
+    });
+  });
+
+  describe("when import token feature flag is disabled", () => {
+    beforeEach(() => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_IMPORT_TOKEN", false);
+    });
+
+    it("should not show import token button", async () => {
+      const po = renderPage([positiveBalance, zeroBalance]);
+      expect(await po.getImportTokenButtonPo().isPresent()).toBe(false);
+    });
+  });
 });

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -203,6 +203,9 @@ describe("Tokens page", () => {
 
     it("should show import token and show all buttons", async () => {
       const po = renderPage([positiveBalance, zeroBalance]);
+
+      expect(await po.getShowAllButtonPo().isPresent()).toBe(false);
+
       await po.getSettingsButtonPo().click();
       await po.getHideZeroBalancesTogglePo().getTogglePo().toggle();
 

--- a/frontend/src/tests/page-objects/TokensPage.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensPage.page-object.ts
@@ -33,6 +33,10 @@ export class TokensPagePo extends BasePageObject {
     return this.getButton("show-all-button");
   }
 
+  getImportTokenButtonPo(): ButtonPo {
+    return this.getButton("import-token-button");
+  }
+
   hasTokensTable(): Promise<boolean> {
     return this.getTokensTable().isPresent();
   }


### PR DESCRIPTION
# Motivation

This PR introduces a button to initiate the import token process, as part of the broader import token feature. It’s behind a feature flag, ensuring no changes are visible to the end user.

# Changes

- Added a new label.
- Added a new button in the token table.

# Tests

- Tested the button visibility with and without the feature flag enabled.

<img width="819" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/66e4f958-8c9d-4feb-a114-673fd987715b">

<img width="818" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/55e0d722-aace-445b-b407-21c4a26dcaf5">

<img width="494" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/39242b5a-b6c7-4599-8681-c087da811cef">

<img width="497" alt="image" src="https://github.com/dfinity/nns-dapp/assets/98811342/c7b1b308-88cf-4f2f-af78-a5174fe47bbf">

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet