### PR TITLE
Support neuron subaccounts in convert-id

### DIFF
--- a/scripts/convert-id
+++ b/scripts/convert-id
@@ -10,6 +10,7 @@ print_help() {
 
 	USAGE:
 	  $(basename "$0") --input <format> --output <format> [--as_subaccount] [--subaccount_format <format>] <id> [<subaccount>]
+	  $(basename "$0") --input <format> --output <format> --as_neuron_subaccount] <id> <nonce>
 
 	FORMAT EXAMPLES:
 	  text: 3vbe6-ysauy-vhiiq-dkhzp-ndzfr-6knc4-45rwt-youy4-dwtze-oqoo3-nae
@@ -30,6 +31,7 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=i long=input desc="The input format" variable=INPUT_FORMAT default="text"
 clap.define short=o long=output desc="The output format" variable=OUTPUT_FORMAT default="hex"
 clap.define long=as_subaccount desc="To be used as ICP subaccount" variable=AS_SUBACCOUNT nargs=0
+clap.define long=as_neuron_subaccount desc="To be used as neuron subaccount" variable=AS_NEURON_SUBACCOUNT nargs=0
 clap.define long=subaccount_format desc="Formet of the subaccount parameter for account_identifier" variable=SUBACCOUNT_FORMAT default="index"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
@@ -183,6 +185,14 @@ function check_icrc1() {
 }
 
 function maybe_as_subaccount() {
+  if [ "${AS_NEURON_SUBACCOUNT:-}" = "true" ]; then
+    hex=$(cat)
+    # Logic translated from https://github.com/dfinity/ic/blob/1ec57bd3ac00a716eb6e58ba2f49cf4e9c3e6b03/rs/nervous_system/common/src/ledger.rs#L211-L223
+    nonce=$(printf "%016x" "$NONCE_ARG")
+    hash_input="0c$(echo -n neuron-stake | xxd -p)${hex}${nonce}"
+    echo -n "$hash_input" | xxd -r -p | openssl dgst -sha256 | awk '{print $2}'
+    return
+  fi
   if [ "${AS_SUBACCOUNT:-}" != "true" ]; then
     cat
     return
@@ -198,5 +208,6 @@ check_"$INPUT_FORMAT" "$1"
 
 ID_ARG="$1"
 SUBACCOUNT_ARG="${2:-}"
+NONCE_ARG="${2:-}"
 
 echo -n "$1" | "${INPUT_FORMAT}_to_hex" | maybe_as_subaccount | "hex_to_${OUTPUT_FORMAT}"

--- a/scripts/convert-id.test
+++ b/scripts/convert-id.test
@@ -65,4 +65,15 @@ expect_convert "$ICRC1" --output icrc1 --input icrc1 "$ICRC1"
 expect_convert "$ICRC1" --output icrc1 --input text "$TEXT2" 1
 expect_convert "$ACCOUNT_IDENTIFIER2_INDEX_1" --output account_identifier --input icrc1 "$ICRC1"
 
+NONCE="1"
+NEURON_SUBACCOUNT="13de0411947c35e473401a686c70366f0ee9407f6805352aa700392edaf17958"
+expect_convert "$NEURON_SUBACCOUNT" --output hex --input text --as_neuron_subaccount "$TEXT2" "$NONCE"
+
+NONCE2="2651852402133984091"
+NEURON_SUBACCOUNT2="edd9ba59cb70fe4cff968f282cfba36aef011003d7bdebaa49102e374641f72f"
+NEURON_ACCOUNT2="240ddb2ab0fc6d74d9147839a974ca0a7d2408e122180411c204517b09c25010"
+GOVERNANCE_CANISTER_ID="rrkah-fqaaa-aaaaa-aaaaq-cai"
+expect_convert "$NEURON_SUBACCOUNT2" --output hex --input text --as_neuron_subaccount "$TEXT2" "$NONCE2"
+expect_convert "$NEURON_ACCOUNT2" --output account_identifier --input text --subaccount_format hex "$GOVERNANCE_CANISTER_ID" "$NEURON_SUBACCOUNT2"
+
 echo PASS


### PR DESCRIPTION
# Motivation

I had to figure out how to create a neuron subaccount to debug something and once I figured it out, I thought it would be useful to add it to the conversion script so I don't have to figure it out again in the future.

# Changes

Add `--as_neuron_subaccount` flag to `convert-id` which can be used to create the subaccount used to create neuron accounts.

# Tests

1. Added unit test with made up data.
2. Added unit test with data matching my test environment.
3. Tested manually to recreate my own prod neuron account, like this:
```
MY_PRINCIPAL="..." # from my account
MY_NEURON_NONCE="..."  # from the staking transaction on the dashboard
GOVERNANCE_CANISTER_ID="rrkah-fqaaa-aaaaa-aaaaq-cai"
NEURON_SUBACCOUNT="$(scripts/convert-id --input text --output hex --as_neuron_subaccount "$MY_PRINCIPAL" "$MY_NEURON_NONCE")"
scripts/convert-id --input text --output account_identifier --subaccount_format hex "$GOVERNANCE_CANISTER_ID" "$NEURON_SUBACCOUNT"
```

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary