### PR TITLE
Add claimNextNeuronIfNeeded function

### DIFF
--- a/frontend/src/lib/services/sns-neurons-check-balances.services.ts
+++ b/frontend/src/lib/services/sns-neurons-check-balances.services.ts
@@ -7,21 +7,22 @@ import {
 } from "$lib/api/sns-governance.api";
 import { MAX_NEURONS_SUBACCOUNTS } from "$lib/constants/sns-neurons.constants";
 import { getAuthenticatedIdentity } from "$lib/services/auth.services";
+import { loadSnsParameters } from "$lib/services/sns-parameters.services";
 import { checkedNeuronSubaccountsStore } from "$lib/stores/checked-neurons.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
+import { snsParametersStore } from "$lib/stores/sns-parameters.store";
 import {
   getSnsNeuronIdAsHexString,
   needsRefresh,
+  nextMemo,
   subaccountToHexString,
 } from "$lib/utils/sns-neuron.utils";
 import { AnonymousIdentity, type Identity } from "@dfinity/agent";
 import type { Principal } from "@dfinity/principal";
-import {
-  neuronSubaccount,
-  type SnsNeuron,
-  type SnsNeuronId,
-} from "@dfinity/sns";
-import { fromNullable, isNullish } from "@dfinity/utils";
+import type { SnsNeuron, SnsNeuronId } from "@dfinity/sns";
+import { neuronSubaccount } from "@dfinity/sns";
+import { fromDefinedNullable, fromNullable, isNullish } from "@dfinity/utils";
+import { get } from "svelte/store";
 
 const loadNeuron = async ({
   rootCanisterId,
@@ -416,5 +417,97 @@ export const refreshNeuronIfNeeded = async ({
     identity,
     rootCanisterId,
     neuron,
+  });
+};
+
+const getNeuronMinimumStake = async ({
+  rootCanisterId,
+}: {
+  rootCanisterId: Principal;
+}): Promise<bigint> => {
+  await loadSnsParameters(rootCanisterId);
+  return fromDefinedNullable(
+    get(snsParametersStore)?.[rootCanisterId.toText()]?.parameters
+      ?.neuron_minimum_stake_e8s
+  );
+};
+
+const claimNeuronIfNeeded = async ({
+  rootCanisterId,
+  memo,
+  subaccount,
+  identity,
+}: {
+  rootCanisterId: Principal;
+  memo: bigint;
+  subaccount: Uint8Array | number[];
+  identity: Identity;
+}): Promise<void> => {
+  // We only check neurons to recover from an interrupted stake/top-up.
+  // Doing this once per neuron per session is often enough.
+  if (
+    !checkedNeuronSubaccountsStore.addSubaccount({
+      universeId: rootCanisterId.toText(),
+      subaccountHex: subaccountToHexString(subaccount),
+    })
+  ) {
+    return;
+  }
+
+  const neuronId: SnsNeuronId = { id: subaccount };
+  // We use certified: false for performance reasons.
+  // A bad actor will only get that we call refresh or claim on a neuron.
+  const neuronAccountBalance = await getNeuronBalance({
+    rootCanisterId,
+    neuronId,
+    certified: false,
+    identity,
+  });
+
+  if (neuronAccountBalance === 0n) {
+    return;
+  }
+
+  const neuronMinimumStake = await getNeuronMinimumStake({ rootCanisterId });
+  if (neuronAccountBalance < neuronMinimumStake) {
+    return;
+  }
+
+  await claimAndLoadNeuron({
+    rootCanisterId,
+    identity,
+    controller: identity.getPrincipal(),
+    memo,
+    subaccount,
+  });
+};
+
+export const claimNextNeuronIfNeeded = async ({
+  rootCanisterId,
+  neurons,
+}: {
+  rootCanisterId: Principal | undefined;
+  neurons: SnsNeuron[] | undefined;
+}): Promise<void> => {
+  if (isNullish(rootCanisterId)) {
+    return;
+  }
+  if (isNullish(neurons)) {
+    return;
+  }
+  const identity = await getAuthenticatedIdentity();
+  const memo = nextMemo({
+    identity,
+    neurons,
+  });
+  const subaccount = neuronSubaccount({
+    controller: identity.getPrincipal(),
+    index: Number(memo),
+  });
+  await claimNeuronIfNeeded({
+    rootCanisterId,
+    memo,
+    subaccount,
+    identity,
   });
 };

--- a/frontend/src/lib/services/sns-neurons-check-balances.services.ts
+++ b/frontend/src/lib/services/sns-neurons-check-balances.services.ts
@@ -469,7 +469,7 @@ const claimNeuronIfNeeded = async ({
   }
 
   const neuronMinimumStake = await getNeuronMinimumStake({ rootCanisterId });
-   // Don't claim a neuron if there's not enough balance to stake.
+  // Don't claim a neuron if there's not enough balance to stake.
   if (neuronAccountBalance < neuronMinimumStake) {
     return;
   }

--- a/frontend/src/lib/services/sns-neurons-check-balances.services.ts
+++ b/frontend/src/lib/services/sns-neurons-check-balances.services.ts
@@ -469,6 +469,7 @@ const claimNeuronIfNeeded = async ({
   }
 
   const neuronMinimumStake = await getNeuronMinimumStake({ rootCanisterId });
+   // Don't claim a neuron if there's not enough balance to stake.
   if (neuronAccountBalance < neuronMinimumStake) {
     return;
   }


### PR DESCRIPTION
# Motivation

Staking an SNS neuron is a 2-step process:

1. Transfer tokens to the neuron account.
2. Notify the governance canister to claim the neuron.

If the process is interrupted between steps 1 and 2, the tokens are now missing.
To be able to recover from this, we create neuron accounts in a deterministic sequence.

Currently every time you go to the neurons table view we check all the neuron accounts of all the existing neurons and the non-existing neurons until the first account without balance. This is all done in a single function.

Because this is just a fall-back mechanism, this is overkill.
We want to only check neuron accounts once per neuron per session.
1. For existing neurons we do this only when you visit their neuron details page. This is done in https://github.com/dfinity/nns-dapp/pull/5169
2. For new neurons we want to do this when you visit the neurons table page.

Currently `checkSnsNeuronBalances` does both (1) and (2) so in order to replace it, this PR adds a function to do just (2).
The next PRs will call the new function from the neurons table view and stop calling the existing function.

This PR adds a function to 

# Changes

Add `claimNextNeuronIfNeeded` which
1. For an SNS finds the first neuron subaccount for which there is no neuron
2. Check if that subaccount is already checked
3. And if not, checks the balance
4. And if it's at least the minimum stake, claim and loads the neuron.

# Tests

1. Unit tests added.
2. Tested manually in a branch which replaces the existing function with the new function.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary