### PR TITLE
Do not show transferred SNS neurons after claiming

### DIFF
--- a/frontend/src/lib/services/sns-neurons-check-balances.services.ts
+++ b/frontend/src/lib/services/sns-neurons-check-balances.services.ts
@@ -41,6 +41,19 @@ const loadNeuron = async ({
     neuronId,
     certified,
   });
+  if (userHasNoPermissions({ neuron, controller: identity.getPrincipal() })) {
+    // This neuron does not belong to the user.
+    // It's possible for an SNS neuron to be transferred to another user
+    // by removing the permissions for one user and adding permissions for
+    // another user. For example idgeek.app has a service to sell SNS
+    // neurons. This service also works with NNS dapp controlled neurons
+    // because they fully take over your Internet Identity. Since this
+    // will not change the ID of the neuron, it will still appear in the
+    // sequence of neuron IDs for the original user. So we must take extra
+    // care to make sure it does not appear in the UI for the original
+    // user.
+    return;
+  }
   snsNeuronsStore.addNeurons({
     rootCanisterId,
     certified,

--- a/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons-check-balances.services.spec.ts
@@ -622,15 +622,9 @@ describe("sns-neurons-check-balances-services", () => {
           index,
         });
         return {
-          ...mockSnsNeuron,
+          ...userNeuron,
           id: [{ id: subaccount }],
           cached_neuron_stake_e8s: neuronAccountBalance,
-          permissions: [
-            {
-              principal: [mockIdentity.getPrincipal()],
-              permission_type: allPermissions,
-            },
-          ],
         };
       };
       const existingNeurons = [
@@ -701,12 +695,11 @@ describe("sns-neurons-check-balances-services", () => {
         id: subaccountUnclaimedNeuron,
       };
       const unclaimedNeuron: SnsNeuron = {
-        ...userNeuron,
+        // The current user does not have any permissions because this neuron
+        // no longer belongs to this user.
+        ...transferredNeuron,
         id: [unclaimedNeuronId] as [SnsNeuronId],
         cached_neuron_stake_e8s: neuronAccountBalance,
-        // The user does not have any permissions because this neuron no longer
-        // belongs to this user.
-        permissions: [],
       };
 
       spyNeuronBalance.mockResolvedValue(neuronAccountBalance);


### PR DESCRIPTION
# Motivation

It's possible for an SNS neuron to be transferred to another user by removing the permissions for one user and adding permissions for another user. For example idgeek.app has a service to sell SNS neurons. This service also works with NNS dapp controlled neurons because they fully take over your Internet Identity. Since this will not change the ID of the neuron, it will still appear in the sequence of neuron IDs for the original user. So we must take extra care to make sure it does not appear in the UI for the original user.
This actually happened and was reported by a user on the forum here: https://forum.dfinity.org/t/staking-problems-within-nns-app/3204/83

It was fixed in https://github.com/dfinity/nns-dapp/pull/4484 but would have been broken again by the [recently added](https://github.com/dfinity/nns-dapp/pull/5175) `claimNextNeuronIfNeeded` if used in its current form.

# Changes

When loading a neuron after claiming it in the fallback mechanism, check if the neuron belongs to the user before adding it to the store (which would make it appear in the UI).

Claiming an already existing neuron belonging to another user does not cause problems in itself and I expect this to be sufficiently rare that we can ignore it.

It does mean that users that have transferred an SNS neuron can no longer rely on the fallback mechanism to find new unclaimed neurons. We may or may not decide to fix this in another PR.

# Tests

1. Change the existing unit test that does expect the claimed neuron to appear in the store, to actually have the right permissions.
2. Add another unit test that exists a neuron without permissions for the user not to appear in the store.
3. Tested manually in another branch which uses `claimNextNeuronIfNeeded`, by using the test-only feature to manually add and remove user permissions.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary, the function wasn't used yet