### PR TITLE
Remove refresh from getSnsNeuron

### DIFF
--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -7,7 +7,6 @@ import {
   getSnsNeuron as getSnsNeuronApi,
   querySnsNeuron,
   querySnsNeurons,
-  refreshNeuron,
   removeNeuronPermissions,
   setDissolveDelay,
   setFollowees,
@@ -70,10 +69,7 @@ import {
 import { get } from "svelte/store";
 import { getAuthenticatedIdentity } from "./auth.services";
 import { loadSnsAccounts } from "./sns-accounts.services";
-import {
-  checkSnsNeuronBalances,
-  neuronNeedsRefresh,
-} from "./sns-neurons-check-balances.services";
+import { checkSnsNeuronBalances } from "./sns-neurons-check-balances.services";
 import { queryAndUpdate } from "./utils.services";
 
 /**
@@ -242,24 +238,6 @@ export const getSnsNeuron = async ({
       }),
     onLoad: async ({ response: neuron, certified }) => {
       onLoad({ neuron, certified });
-
-      if (certified) {
-        // Check that the neuron's stake is in sync with the subaccount's balance
-        const neuronId = fromNullable(neuron.id);
-        if (neuronId !== undefined) {
-          const identity = await getSnsNeuronIdentity();
-          if (await neuronNeedsRefresh({ rootCanisterId, neuron, identity })) {
-            await refreshNeuron({ rootCanisterId, identity, neuronId });
-            const updatedNeuron = await getSnsNeuronApi({
-              identity,
-              rootCanisterId,
-              neuronId,
-              certified,
-            });
-            onLoad({ neuron: updatedNeuron, certified });
-          }
-        }
-      }
     },
     onError: ({ certified, error }) => {
       onError?.({ certified, error });

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -360,12 +360,6 @@ describe("sns-neurons-services", () => {
           ...mockSnsNeuron,
           id: [neuronId] as [SnsNeuronId],
         };
-        const spyNeuronBalance = vi
-          .spyOn(governanceApi, "getNeuronBalance")
-          .mockImplementationOnce(() =>
-            Promise.resolve(mockSnsNeuron.cached_neuron_stake_e8s)
-          )
-          .mockImplementation(() => Promise.resolve(0n));
         const spyQuery = vi
           .spyOn(governanceApi, "getSnsNeuron")
           .mockImplementation(() => Promise.resolve(neuron));

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -379,53 +379,6 @@ describe("sns-neurons-services", () => {
           expect(spyQuery).toBeCalled();
           expect(neuronToLoad).toEqual(neuron);
           if (certified) {
-            await waitFor(() => expect(spyNeuronBalance).toBeCalled());
-            done();
-          }
-        };
-        getSnsNeuron({
-          neuronIdHex: bytesToHexString(
-            Array.from(mockSnsNeuron.id[0]?.id as Uint8Array)
-          ),
-          rootCanisterId: mockPrincipal,
-          onLoad,
-        });
-      }));
-
-    it("should refresh neuron if balance does not match and load again", () =>
-      new Promise<void>((done) => {
-        const stake = neuron.cached_neuron_stake_e8s + 10_000n;
-        const updatedNeuron = {
-          ...neuron,
-          cached_neuron_stake_e8s: stake,
-        };
-        const spyNeuronBalance = vi
-          .spyOn(governanceApi, "getNeuronBalance")
-          .mockImplementationOnce(() => Promise.resolve(stake))
-          .mockImplementation(() => Promise.resolve(0n));
-        const spyQuery = vi
-          .spyOn(governanceApi, "getSnsNeuron")
-          // First is the query call and returns old neuron
-          .mockImplementationOnce(() => Promise.resolve(neuron))
-          // Second is the update call and returns old neuron. It will be checked.
-          .mockImplementationOnce(() => Promise.resolve(neuron))
-          // After refreshing we get the updated neuron.
-          .mockImplementation(() => Promise.resolve(updatedNeuron));
-        const spyRefreshNeuron = vi
-          .spyOn(governanceApi, "refreshNeuron")
-          .mockImplementation(() => Promise.resolve(undefined));
-        const onLoad = ({
-          neuron: neuronToLoad,
-        }: {
-          neuron: SnsNeuron;
-          certified: boolean;
-        }) => {
-          // Wait until we get the updated neuron to finish the test.
-          if (neuronToLoad.cached_neuron_stake_e8s === stake) {
-            expect(spyQuery).toBeCalledTimes(3);
-            expect(spyNeuronBalance).toBeCalledTimes(1);
-            expect(spyRefreshNeuron).toBeCalledTimes(1);
-            expect(neuronToLoad).toEqual(updatedNeuron);
             done();
           }
         };


### PR DESCRIPTION
# Motivation

We refresh a neuron if needed once per session per neuron if you visit the neuron details page.
This is a fallback mechanism only needed in case a neuron top-up gets interrupted so we don't need to do it very often as long as there is some way to recover.

I found that `getSnsNeuron` actually also does this every time.
This is overkill.

# Changes

Remove the neuron refresh code from `getSnsNeuron`.

# Tests

1. Unit tests adapted and removed.
2. Tested manually that transferring tokens to the neuron account still results in a top-up after visiting the neuron details page.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary