### PR TITLE
Reduce fallback neuron refreshing

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -19,6 +19,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Reduce the frequency of checking if SNS neurons need to be refreshed.
+
 #### Deprecated
 
 #### Removed

--- a/frontend/src/lib/pages/SnsNeurons.svelte
+++ b/frontend/src/lib/pages/SnsNeurons.svelte
@@ -9,9 +9,11 @@
   } from "$lib/derived/sns/sns-selected-project.derived";
   import { definedSnsNeuronStore } from "$lib/derived/sns/sns-sorted-neurons.derived";
   import { loadSnsAccounts } from "$lib/services/sns-accounts.services";
+  import { claimNextNeuronIfNeeded } from "$lib/services/sns-neurons-check-balances.services";
   import { syncSnsNeurons } from "$lib/services/sns-neurons.services";
   import { authStore } from "$lib/stores/auth.store";
   import { i18n } from "$lib/stores/i18n";
+  import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import type { TableNeuron } from "$lib/types/neurons-table";
   import type { SnsSummary } from "$lib/types/sns";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -50,6 +52,13 @@
         snsNeurons: $definedSnsNeuronStore,
       })
     : [];
+
+  $: claimNextNeuronIfNeeded({
+    rootCanisterId: $snsOnlyProjectStore,
+    neurons:
+      $snsOnlyProjectStore &&
+      $snsNeuronsStore[$snsOnlyProjectStore.toText()]?.neurons,
+  });
 </script>
 
 <TestIdWrapper testId="sns-neurons-component">

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
@@ -297,6 +297,8 @@ describe("SnsVotingCard", () => {
           ...createMockSnsNeuron({
             id: [3],
             state: NeuronState.Unspecified,
+            // Neuron is ineligible because it has no vote permission
+            permissions: [],
           }),
         },
       ],

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -4,6 +4,7 @@ import SnsNeurons from "$lib/pages/SnsNeurons.svelte";
 import { checkedNeuronSubaccountsStore } from "$lib/stores/checked-neurons.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { snsParametersStore } from "$lib/stores/sns-parameters.store";
+import { enumValues } from "$lib/utils/enum.utils";
 import { page } from "$mocks/$app/stores";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
@@ -12,14 +13,15 @@ import {
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
-import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { SnsNeuronsPo } from "$tests/page-objects/SnsNeurons.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import type { SnsNeuron } from "@dfinity/sns";
 import {
-  neuronSubaccount,
+  SnsNeuronPermissionType,
   SnsSwapLifecycle,
+  neuronSubaccount,
+  type SnsNeuron,
   type SnsNeuronId,
 } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
@@ -162,6 +164,14 @@ describe("SnsNeurons", () => {
       };
       const unclaimedNeuron1 = createMockSnsNeuron({
         id: Array.from(unclaimedNeuronId1.id),
+        permissions: [
+          {
+            principal: [mockIdentity.getPrincipal()],
+            permission_type: Int32Array.from(
+              enumValues(SnsNeuronPermissionType)
+            ),
+          },
+        ],
       });
 
       const spyGetNeuronBalance = vi

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -1,22 +1,27 @@
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import * as snsGovernanceApi from "$lib/api/sns-governance.api";
 import SnsNeurons from "$lib/pages/SnsNeurons.svelte";
+import { checkedNeuronSubaccountsStore } from "$lib/stores/checked-neurons.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { snsParametersStore } from "$lib/stores/sns-parameters.store";
 import { page } from "$mocks/$app/stores";
-import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import {
   createMockSnsNeuron,
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
 import { rootCanisterIdMock } from "$tests/mocks/sns.api.mock";
-import { SnsNeuronsPo } from "$tests/page-objects/SnsNeurons.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { SnsNeuronsPo } from "$tests/page-objects/SnsNeurons.page-object";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import type { SnsNeuron } from "@dfinity/sns";
-import { SnsSwapLifecycle } from "@dfinity/sns";
+import {
+  neuronSubaccount,
+  SnsSwapLifecycle,
+  type SnsNeuronId,
+} from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
 vi.mock("$lib/api/sns-governance.api");
@@ -44,20 +49,10 @@ describe("SnsNeurons", () => {
     source_nns_neuron_id: [123n],
   };
   const projectName = "Tetris";
-  const getNeuronBalanceMock = async ({ neuronId }) => {
-    if (neuronId === neuron1.id[0]) {
-      return neuron1Stake;
-    }
-    if (neuronId === disbursedNeuron.id[0]) {
-      return disbursedNeuronStake;
-    }
-    if (neuronId === neuronNF.id[0]) {
-      return neuronNFStake;
-    }
-  };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    checkedNeuronSubaccountsStore.reset();
     overrideFeatureFlagsStore.reset();
     page.mock({ data: { universe: rootCanisterId.toText() } });
     resetIdentity();
@@ -77,6 +72,7 @@ describe("SnsNeurons", () => {
         projectName,
       },
     ]);
+    vi.spyOn(snsGovernanceApi, "getNeuronBalance").mockResolvedValue(0n);
   });
 
   const renderComponent = async () => {
@@ -114,9 +110,6 @@ describe("SnsNeurons", () => {
         neuron1,
         neuronNF,
       ]);
-      vi.spyOn(snsGovernanceApi, "getNeuronBalance").mockImplementation(
-        getNeuronBalanceMock
-      );
     });
 
     it("should render the neurons table", async () => {
@@ -148,6 +141,65 @@ describe("SnsNeurons", () => {
 
       const rows = await po.getNeuronsTablePo().getNeuronsTableRowPos();
       expect(rows).toHaveLength(2);
+    });
+
+    it("should claim unclaimed neuron", async () => {
+      const unclaimedNeuronIndex1 = 0;
+      const unclaimedNeuronIndex2 = 1;
+      const unclaimedNeuronSubaccount1 = neuronSubaccount({
+        controller: mockIdentity.getPrincipal(),
+        index: unclaimedNeuronIndex1,
+      });
+      const unclaimedNeuronSubaccount2 = neuronSubaccount({
+        controller: mockIdentity.getPrincipal(),
+        index: unclaimedNeuronIndex2,
+      });
+      const unclaimedNeuronId1: SnsNeuronId = {
+        id: unclaimedNeuronSubaccount1,
+      };
+      const unclaimedNeuronId2: SnsNeuronId = {
+        id: unclaimedNeuronSubaccount2,
+      };
+      const unclaimedNeuron1 = createMockSnsNeuron({
+        id: Array.from(unclaimedNeuronId1.id),
+      });
+
+      const spyGetNeuronBalance = vi
+        .spyOn(snsGovernanceApi, "getNeuronBalance")
+        .mockResolvedValueOnce(100_000_000n)
+        .mockResolvedValueOnce(0n);
+      const spyClaimNeuron = vi
+        .spyOn(snsGovernanceApi, "claimNeuron")
+        .mockResolvedValue(unclaimedNeuronId1);
+      vi.spyOn(snsGovernanceApi, "getSnsNeuron").mockResolvedValue(
+        unclaimedNeuron1
+      );
+
+      expect(spyGetNeuronBalance).toBeCalledTimes(0);
+
+      await renderComponent();
+
+      expect(spyGetNeuronBalance).toBeCalledTimes(2);
+      expect(spyGetNeuronBalance).toBeCalledWith({
+        rootCanisterId,
+        neuronId: unclaimedNeuronId1,
+        certified: false,
+        identity: mockIdentity,
+      });
+      expect(spyGetNeuronBalance).toBeCalledWith({
+        rootCanisterId,
+        neuronId: unclaimedNeuronId2,
+        certified: false,
+        identity: mockIdentity,
+      });
+      expect(spyClaimNeuron).toBeCalledTimes(1);
+      expect(spyClaimNeuron).toBeCalledWith({
+        rootCanisterId,
+        subaccount: unclaimedNeuronSubaccount1,
+        memo: BigInt(unclaimedNeuronIndex1),
+        controller: mockIdentity.getPrincipal(),
+        identity: mockIdentity,
+      });
     });
   });
 

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -45,7 +45,7 @@ export const createMockSnsNeuron = ({
   stake = 1_000_000_000n,
   id,
   state,
-  permissions = [],
+  permissions,
   vesting,
   votingPowerMultiplier = 100n,
   dissolveDelaySeconds,
@@ -89,7 +89,12 @@ export const createMockSnsNeuron = ({
   }
   return {
     id: [{ id: arrayOfNumberToUint8Array(id) }],
-    permissions,
+    permissions: permissions ?? [
+      {
+        principal: [mockIdentity.getPrincipal()],
+        permission_type: Int32Array.from(enumValues(SnsNeuronPermissionType)),
+      },
+    ],
     source_nns_neuron_id: isNullish(sourceNnsNeuronId)
       ? []
       : [sourceNnsNeuronId],

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -45,7 +45,7 @@ export const createMockSnsNeuron = ({
   stake = 1_000_000_000n,
   id,
   state,
-  permissions,
+  permissions = [],
   vesting,
   votingPowerMultiplier = 100n,
   dissolveDelaySeconds,
@@ -89,12 +89,7 @@ export const createMockSnsNeuron = ({
   }
   return {
     id: [{ id: arrayOfNumberToUint8Array(id) }],
-    permissions: permissions ?? [
-      {
-        principal: [mockIdentity.getPrincipal()],
-        permission_type: Int32Array.from(enumValues(SnsNeuronPermissionType)),
-      },
-    ],
+    permissions,
     source_nns_neuron_id: isNullish(sourceNnsNeuronId)
       ? []
       : [sourceNnsNeuronId],


### PR DESCRIPTION
# Motivation

Staking or topping up an SNS neuron is a 2-step process:
1. Transfer tokens to the neuron account
2. Claim or refresh the neuron
If the process is interrupted after step 1, your tokens might go missing. So we want to be able to recover from this.

Currently we check the neuron account balance of all your neurons every time neurons are synced, for example when you navigate to the neurons table.

We already added checking a neuron when you navigate to its details page in https://github.com/dfinity/nns-dapp/pull/5169

So as long as we are able to recover newly staked neurons we can stop doing this every time we sync neurons.

# Changes

1. Call `claimNextNeuronIfNeeded` from `SnsNeurons`.
2. Remove neuron checking code from `syncSnsNeurons`.

# Tests

1. Unit test added for `SnsNeurons.svelte`.
2. Unit test removed for `syncSnsNeurons`.
3. Tested manually by transferring tokens to a neuron account of a neuron that doesn't exist yet and seeing it appear in the table.
4. Add default permissions on the `mockSnsNeuron` as this is what a default non-hotkey neuron would have.

Drive-by: Explicitly set empty permissions on an ineligible neuron in `SnsVotingCard.spec.ts` to make it clear that's why it's ineligible.

# Todos

- [x] Add entry to changelog (if necessary).
