### PR TITLE
Combine small CI tests in a single job

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -348,10 +348,10 @@ jobs:
           if command -v apt-get; then
             sudo apt-get update -yy && sudo apt-get install -yy moreutils libarchive-zip-perl && command -v sponge
           fi
-      - name: Install bash if on Mac
+      - name: Install tools on Mac
         run: |
           if command -v brew ; then
-            brew install bash
+            brew install bash coreutils
           fi
       - name: Test split-changelog script
         run: scripts/nns-dapp/split-changelog.test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -284,26 +284,6 @@ jobs:
                   exit 1
           } >&2
           # TODO: Verify that the commits contain the expected changes.
-  download-nns-dapp-ci-wasm:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-20.04, macos-13]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install bash and sha256sum if on Mac
-        run: |
-          if command -v brew ; then
-            brew install bash
-            brew install coreutils
-          fi
-      - name: Download NNS-dapp CI wasm
-        run: |
-          MAIN_COMMIT="$(git ls-remote --refs https://github.com/dfinity/nns-dapp.git main | awk '{print $1}')"
-          scripts/nns-dapp/download-ci-wasm.test --commit "$MAIN_COMMIT"
-    env:
-      GH_TOKEN: ${{ github.token }}
   version-match:
     name: The nns-dapp npm and cargo versions should match
     runs-on: ubuntu-20.04
@@ -336,10 +316,16 @@ jobs:
       - name: Install tools on Mac
         run: |
           if command -v brew ; then
-            # coreutils is needed for base32, used by convert-id.test
+            # coreutils is needed for
+            #   base32, used by convert-id.test, and
+            #   sha256sum, used download-ci-wasm.test
             # moreutils is needed for sponge, used by network-config.test
             brew install bash coreutils moreutils
           fi
+      - name: Download NNS-dapp CI wasm
+        run: |
+          MAIN_COMMIT="$(git ls-remote --refs https://github.com/dfinity/nns-dapp.git main | awk '{print $1}')"
+          scripts/nns-dapp/download-ci-wasm.test --commit "$MAIN_COMMIT"
       - name: Test canister_ids tool
         run: scripts/canister_ids.test
       - name: Test release-sop script
@@ -365,7 +351,6 @@ jobs:
       - config-check
       - asset-chunking-works
       - docker-build-cli-flags
-      - download-nns-dapp-ci-wasm
       - minor-version-bump-works
       - migration-test-utils-work
       - version-match

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -319,21 +319,21 @@ jobs:
             brew install bash
           fi
       - run: scripts/canister_ids.test
-  release-sop:
-    name: Test release-sop script
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-20.04, macos-13]
-    runs-on: ${{ matrix.os }}
+  version-match:
+    name: The nns-dapp npm and cargo versions should match
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install bash if on Mac
+      - name: Backend and frontend have the same version
         run: |
-          if command -v brew ; then
-            brew install bash
-          fi
-      - run: scripts/nns-dapp/release-sop.test
+          backend_version="$(cargo metadata | jq -r '.packages[] | select(.name == "nns-dapp").version')"
+          frontend_version="$(jq -r .version frontend/package.json)"
+          [[ "${backend_version}" == "${frontend_version}" ]] || {
+                  echo "ERROR: The nns-dapp frontend and backend should have the same version but:"
+                  echo "Backend:  $backend_version"
+                  echo "Frontend: $frontend_version"
+                  exit 1
+          } >&2
   small-tests:
     strategy:
       fail-fast: false
@@ -355,22 +355,14 @@ jobs:
             # moreutils is needed for sponge, used by network-config.test
             brew install bash coreutils moreutils
           fi
+      - name: Test release-sop script
+        run: scripts/nns-dapp/release-sop.test
       - name: Test split-changelog script
         run: scripts/nns-dapp/split-changelog.test
       - name: Find unused i18n messages
         run: scripts/unused-i18n
       - name: Test the ID conversion script
         run: scripts/convert-id.test
-      - name: The nns-dapp npm and cargo versions should match
-        run: |
-          backend_version="$(cargo metadata | jq -r '.packages[] | select(.name == "nns-dapp").version')"
-          frontend_version="$(jq -r .version frontend/package.json)"
-          [[ "${backend_version}" == "${frontend_version}" ]] || {
-                  echo "ERROR: The nns-dapp frontend and backend should have the same version but:"
-                  echo "Backend:  $backend_version"
-                  echo "Frontend: $frontend_version"
-                  exit 1
-          } >&2
       - name: Getting network config works
         run: scripts/network-config.test
   checks-pass:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -380,9 +380,9 @@ jobs:
       - docker-build-cli-flags
       - download-nns-dapp-ci-wasm
       - canister-ids-tool
-      - release-sop
       - minor-version-bump-works
       - migration-test-utils-work
+      - version-match
       - small-tests
     if: ${{ always() }}
     runs-on: ubuntu-20.04

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -343,15 +343,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install tools on Linux
-        # libarchive-zip-perl is needed for crc32, used by convert-id.
         run: |
           if command -v apt-get; then
+            # libarchive-zip-perl is needed for crc32, used by convert-id.test
             sudo apt-get update -yy && sudo apt-get install -yy moreutils libarchive-zip-perl && command -v sponge
           fi
       - name: Install tools on Mac
         run: |
           if command -v brew ; then
-            brew install bash coreutils
+            # coreutils is needed for base32, used by convert-id.test
+            # moreutils is needed for sponge, used by network-config.test
+            brew install bash coreutils moreutils
           fi
       - name: Test split-changelog script
         run: scripts/nns-dapp/split-changelog.test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -391,9 +391,8 @@ jobs:
       - release-sop
       - split-changelog
       - minor-version-bump-works
-      - version-match
-      - network-config
       - migration-test-utils-work
+      - small-tests
     if: ${{ always() }}
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -247,12 +247,6 @@ jobs:
         uses: dfinity/setup-dfx@main
       - name: Test getting proposal args
         run: scripts/dfx-nns-proposal-args.test
-  docker-build-cli-flags:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: docker-build prints help
-        run: ./scripts/docker-build --help | grep -i usage
   minor-version-bump-works:
     runs-on: ubuntu-20.04
     steps:
@@ -325,6 +319,8 @@ jobs:
             # moreutils is needed for sponge, used by network-config.test
             brew install bash coreutils moreutils
           fi
+      - name: docker-build prints help
+        run: ./scripts/docker-build --help | grep -i usage
       - name: Download NNS-dapp CI wasm
         run: |
           MAIN_COMMIT="$(git ls-remote --refs https://github.com/dfinity/nns-dapp.git main | awk '{print $1}')"
@@ -353,7 +349,6 @@ jobs:
       - release-templating-works
       - config-check
       - asset-chunking-works
-      - docker-build-cli-flags
       - minor-version-bump-works
       - migration-test-utils-work
       - version-match

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -368,7 +368,6 @@ jobs:
           } >&2
       - name: Getting network config works
         run: scripts/network-config.test
-  
   checks-pass:
     needs:
       - formatting

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -305,6 +305,9 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-13]
     runs-on: ${{ matrix.os }}
+    env:
+      # Used by download-ci-wasm.test
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
       - name: Install tools on Linux

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -342,9 +342,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install tools
+      - name: Install tools on Linux
         # libarchive-zip-perl is needed for crc32, used by convert-id.
-        run: sudo apt-get update -yy && sudo apt-get install -yy moreutils libarchive-zip-perl && command -v sponge
+        run: |
+          if command -v apt-get; then
+            sudo apt-get update -yy && sudo apt-get install -yy moreutils libarchive-zip-perl && command -v sponge
+          fi
       - name: Install bash if on Mac
         run: |
           if command -v brew ; then

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -304,21 +304,6 @@ jobs:
           scripts/nns-dapp/download-ci-wasm.test --commit "$MAIN_COMMIT"
     env:
       GH_TOKEN: ${{ github.token }}
-  canister-ids-tool:
-    name: Test canister_ids tool
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-20.04, macos-13]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install bash if on Mac
-        run: |
-          if command -v brew ; then
-            brew install bash
-          fi
-      - run: scripts/canister_ids.test
   version-match:
     name: The nns-dapp npm and cargo versions should match
     runs-on: ubuntu-20.04
@@ -355,6 +340,8 @@ jobs:
             # moreutils is needed for sponge, used by network-config.test
             brew install bash coreutils moreutils
           fi
+      - name: Test canister_ids tool
+        run: scripts/canister_ids.test
       - name: Test release-sop script
         run: scripts/nns-dapp/release-sop.test
       - name: Test split-changelog script
@@ -379,7 +366,6 @@ jobs:
       - asset-chunking-works
       - docker-build-cli-flags
       - download-nns-dapp-ci-wasm
-      - canister-ids-tool
       - minor-version-bump-works
       - migration-test-utils-work
       - version-match

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -349,29 +349,18 @@ jobs:
             brew install bash
           fi
       - run: scripts/nns-dapp/split-changelog.test
-  unused-i18n:
-    name: Find unused i18n messages
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-      - run: scripts/unused-i18n
-  convert-id:
-    name: Test the ID conversion script
+  small-tests:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: Install tools
-        run: |
-          # libarchive-zip-perl is needed for crc32, used by convert-id.
-          sudo apt-get update -yy && sudo apt-get install -yy libarchive-zip-perl
-      - name: Run test
+        # libarchive-zip-perl is needed for crc32, used by convert-id.
+        run: sudo apt-get update -yy && sudo apt-get install -yy moreutils libarchive-zip-perl && command -v sponge
+      - name: Find unused i18n messages
+        run: scripts/unused-i18n
+      - name: Test the ID conversion script
         run: scripts/convert-id.test
-  version-match:
-    name: The nns-dapp npm and cargo versions should match
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Backend and frontend have the same version
+      - name: The nns-dapp npm and cargo versions should match
         run: |
           backend_version="$(cargo metadata | jq -r '.packages[] | select(.name == "nns-dapp").version')"
           frontend_version="$(jq -r .version frontend/package.json)"
@@ -381,14 +370,9 @@ jobs:
                   echo "Frontend: $frontend_version"
                   exit 1
           } >&2
-  network-config:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install sponge
-        run: sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
       - name: Getting network config works
         run: scripts/network-config.test
+  
   checks-pass:
     needs:
       - formatting

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -334,8 +334,7 @@ jobs:
             brew install bash
           fi
       - run: scripts/nns-dapp/release-sop.test
-  split-changelog:
-    name: Test split-changelog script
+  small-tests:
     strategy:
       fail-fast: false
       matrix:
@@ -343,19 +342,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Install tools
+        # libarchive-zip-perl is needed for crc32, used by convert-id.
+        run: sudo apt-get update -yy && sudo apt-get install -yy moreutils libarchive-zip-perl && command -v sponge
       - name: Install bash if on Mac
         run: |
           if command -v brew ; then
             brew install bash
           fi
-      - run: scripts/nns-dapp/split-changelog.test
-  small-tests:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install tools
-        # libarchive-zip-perl is needed for crc32, used by convert-id.
-        run: sudo apt-get update -yy && sudo apt-get install -yy moreutils libarchive-zip-perl && command -v sponge
+      - name: Test split-changelog script
+        run: scripts/nns-dapp/split-changelog.test
       - name: Find unused i18n messages
         run: scripts/unused-i18n
       - name: Test the ID conversion script
@@ -389,7 +385,6 @@ jobs:
       - download-nns-dapp-ci-wasm
       - canister-ids-tool
       - release-sop
-      - split-changelog
       - minor-version-bump-works
       - migration-test-utils-work
       - small-tests


### PR DESCRIPTION
# Motivation

We have a number of small bash scripts which are used to test something on CI.
Currently each of these is run on a separate GitHub runner instance which installs its own tools it needs.
This seems like overkill.

# Changes

1. Combined a number of jobs into a single `small-tests` job.
2. Run this job on both MacOS and Linux.

There are a few more small jobs that don't currently work on MacOS so I didn't change them.

# Tests

See https://github.com/dfinity/nns-dapp/actions/runs/9892524481

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary