### PR TITLE
NNS1-3094: Add neuronCount field to TableProject

### DIFF
--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -27,7 +27,7 @@
   let tableProjects: TableProject[];
   $: tableProjects = getTableProjects({
     universes: $selectableUniversesStore,
-    nnsNeurons: $definedNeuronsStore,
+    definedNnsNeurons: $definedNeuronsStore,
     snsNeurons: $snsNeuronsStore,
   });
 </script>

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -4,6 +4,8 @@
   import ResponsiveTable from "$lib/components/ui/ResponsiveTable.svelte";
   import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
   import { i18n } from "$lib/stores/i18n";
+  import { definedNeuronsStore } from "$lib/stores/neurons.store";
+  import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import type { ProjectsTableColumn, TableProject } from "$lib/types/staking";
   import { getTableProjects } from "$lib/utils/staking.utils";
 
@@ -25,6 +27,8 @@
   let tableProjects: TableProject[];
   $: tableProjects = getTableProjects({
     universes: $selectableUniversesStore,
+    nnsNeurons: $definedNeuronsStore,
+    snsNeurons: $snsNeuronsStore,
   });
 </script>
 

--- a/frontend/src/lib/types/staking.ts
+++ b/frontend/src/lib/types/staking.ts
@@ -5,6 +5,7 @@ export type TableProject = {
   domKey: string;
   title: string;
   logo: string;
+  neuronCount: number;
 };
 
 export type ProjectsTableColumn = ResponsiveTableColumn<TableProject>;

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -1,16 +1,32 @@
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import type { TableProject } from "$lib/types/staking";
 import type { Universe } from "$lib/types/universe";
 import { buildNeuronsUrl } from "$lib/utils/navigation.utils";
+import { hasValidStake } from "$lib/utils/sns-neuron.utils";
+import type { NeuronInfo } from "@dfinity/nns";
+import type { SnsNeuron } from "@dfinity/sns";
 
 export const getTableProjects = ({
   universes,
+  nnsNeurons,
+  snsNeurons,
 }: {
   universes: Universe[];
+  nnsNeurons: NeuronInfo[];
+  snsNeurons: { [rootCanisterId: string]: { neurons: SnsNeuron[] } };
 }): TableProject[] => {
-  return universes.map((universe) => ({
-    rowHref: buildNeuronsUrl({ universe: universe.canisterId }),
-    domKey: universe.canisterId,
-    title: universe.title,
-    logo: universe.logo,
-  }));
+  return universes.map((universe) => {
+    const neuronCount =
+      universe.canisterId === OWN_CANISTER_ID_TEXT
+        ? nnsNeurons.length
+        : snsNeurons[universe.canisterId]?.neurons.filter(hasValidStake)
+            .length ?? 0;
+    return {
+      rowHref: buildNeuronsUrl({ universe: universe.canisterId }),
+      domKey: universe.canisterId,
+      title: universe.title,
+      logo: universe.logo,
+      neuronCount,
+    };
+  });
 };

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -6,19 +6,21 @@ import { hasValidStake } from "$lib/utils/sns-neuron.utils";
 import type { NeuronInfo } from "@dfinity/nns";
 import type { SnsNeuron } from "@dfinity/sns";
 
+// Will filter out neurons without stake from snsNeurons, but assumes neurons
+// without stake have already been filtered out from definedNnsNeurons
 export const getTableProjects = ({
   universes,
-  nnsNeurons,
+  definedNnsNeurons,
   snsNeurons,
 }: {
   universes: Universe[];
-  nnsNeurons: NeuronInfo[];
+  definedNnsNeurons: NeuronInfo[];
   snsNeurons: { [rootCanisterId: string]: { neurons: SnsNeuron[] } };
 }): TableProject[] => {
   return universes.map((universe) => {
     const neuronCount =
       universe.canisterId === OWN_CANISTER_ID_TEXT
-        ? nnsNeurons.length
+        ? definedNnsNeurons.length
         : snsNeurons[universe.canisterId]?.neurons.filter(hasValidStake)
             .length ?? 0;
     return {

--- a/frontend/src/tests/lib/utils/staking.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking.utils.spec.ts
@@ -2,40 +2,87 @@ import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import type { Universe } from "$lib/types/universe";
 import { getTableProjects } from "$lib/utils/staking.utils";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 
 describe("staking.utils", () => {
   describe("getTableProjects", () => {
     const universeId2 = principal(2).toText();
 
-    it("should return an array of TableProject objects", () => {
-      const universes: Universe[] = [
-        {
-          canisterId: OWN_CANISTER_ID_TEXT,
-          title: "Internet Computer",
-          logo: IC_LOGO_ROUNDED,
-        },
-        {
-          canisterId: universeId2,
-          title: "title2",
-          logo: "logo2",
-        },
-      ];
+    const nnsUniverse = {
+      canisterId: OWN_CANISTER_ID_TEXT,
+      title: "Internet Computer",
+      logo: IC_LOGO_ROUNDED,
+    };
 
-      const tableProjects = getTableProjects({ universes });
+    const snsUniverse = {
+      canisterId: universeId2,
+      title: "title2",
+      logo: "logo2",
+    };
+
+    const defaultExpectedNnsTableProject = {
+      rowHref: `/neurons/?u=${OWN_CANISTER_ID_TEXT}`,
+      domKey: OWN_CANISTER_ID_TEXT,
+      title: "Internet Computer",
+      logo: IC_LOGO_ROUNDED,
+      neuronCount: 0,
+    };
+
+    const defaultExpectedSnsTableProject = {
+      rowHref: `/neurons/?u=${universeId2}`,
+      domKey: universeId2,
+      title: "title2",
+      logo: "logo2",
+      neuronCount: 0,
+    };
+
+    it("should return an array of TableProject objects", () => {
+      const universes: Universe[] = [nnsUniverse, snsUniverse];
+
+      const tableProjects = getTableProjects({
+        universes,
+        nnsNeurons: [],
+        snsNeurons: {},
+      });
+
+      expect(tableProjects).toEqual([
+        defaultExpectedNnsTableProject,
+        defaultExpectedSnsTableProject,
+      ]);
+    });
+
+    it("should include number of NNS neurons", () => {
+      const tableProjects = getTableProjects({
+        universes: [nnsUniverse],
+        nnsNeurons: [mockNeuron, mockNeuron, mockNeuron],
+        snsNeurons: {},
+      });
 
       expect(tableProjects).toEqual([
         {
-          rowHref: `/neurons/?u=${OWN_CANISTER_ID_TEXT}`,
-          domKey: OWN_CANISTER_ID_TEXT,
-          title: "Internet Computer",
-          logo: IC_LOGO_ROUNDED,
+          ...defaultExpectedNnsTableProject,
+          neuronCount: 3,
         },
+      ]);
+    });
+
+    it("should include number of SNS neurons", () => {
+      const tableProjects = getTableProjects({
+        universes: [snsUniverse],
+        nnsNeurons: [],
+        snsNeurons: {
+          [universeId2]: {
+            neurons: [mockSnsNeuron, mockSnsNeuron],
+          },
+        },
+      });
+
+      expect(tableProjects).toEqual([
         {
-          rowHref: `/neurons/?u=${universeId2}`,
-          domKey: universeId2,
-          title: "title2",
-          logo: "logo2",
+          ...defaultExpectedSnsTableProject,
+          neuronCount: 2,
         },
       ]);
     });

--- a/frontend/src/tests/mocks/staking.mock.ts
+++ b/frontend/src/tests/mocks/staking.mock.ts
@@ -7,4 +7,5 @@ export const mockTableProject: TableProject = {
   domKey: OWN_CANISTER_ID_TEXT,
   title: "Internet Computer",
   logo: IC_LOGO_ROUNDED,
+  neuronCount: 0,
 };


### PR DESCRIPTION
# Motivation

We want to render the number of neurons per project in the staking projects table.

This PR just added the field to the data but does not render it yet.

# Changes

1. Add `neuronCount` field to `TableProject`.
2. Pass `neuronsStore` and `snsNeuronsStore` to `getTableProjects` to get the number of neurons for each project.

# Tests

Unit test added for `getTableProjects`.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet