### PR TITLE
NNS1-3094: And neuron count column to projects table

### DIFF
--- a/frontend/src/lib/components/staking/ProjectNeuronsCell.svelte
+++ b/frontend/src/lib/components/staking/ProjectNeuronsCell.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import type { TableProject } from "$lib/types/staking";
+
+  export let rowData: TableProject;
+</script>
+
+<div data-tid="project-neurons-cell-component" class="title-logo-wrapper">
+  {rowData.neuronCount}
+</div>

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import ProjectActionsCell from "$lib/components/staking/ProjectActionsCell.svelte";
+  import ProjectNeuronsCell from "$lib/components/staking/ProjectNeuronsCell.svelte";
   import ProjectTitleCell from "$lib/components/staking/ProjectTitleCell.svelte";
   import ResponsiveTable from "$lib/components/ui/ResponsiveTable.svelte";
   import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
@@ -14,6 +15,12 @@
       title: $i18n.staking.nervous_systems,
       cellComponent: ProjectTitleCell,
       alignment: "left",
+      templateColumns: ["1fr"],
+    },
+    {
+      title: $i18n.neurons.title,
+      cellComponent: ProjectNeuronsCell,
+      alignment: "right",
       templateColumns: ["1fr"],
     },
     {

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -1,11 +1,11 @@
-import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import ProjectsTable from "$lib/components/staking/ProjectsTable.svelte";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
-import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
+import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { page } from "$mocks/$app/stores";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
+import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { ProjectsTablePo } from "$tests/page-objects/ProjectsTable.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -1,7 +1,11 @@
+import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import ProjectsTable from "$lib/components/staking/ProjectsTable.svelte";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
+import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
+import { neuronsStore } from "$lib/stores/neurons.store";
 import { page } from "$mocks/$app/stores";
+import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { ProjectsTablePo } from "$tests/page-objects/ProjectsTable.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -19,6 +23,8 @@ describe("ProjectsTable", () => {
   };
 
   beforeEach(() => {
+    neuronsStore.reset();
+    snsNeuronsStore.reset();
     resetSnsProjects();
 
     page.mock({
@@ -36,6 +42,7 @@ describe("ProjectsTable", () => {
     const po = renderComponent();
     expect(await po.getDesktopColumnHeaders()).toEqual([
       "Nervous Systems",
+      "Neurons",
       "", // No header for actions column.
     ]);
   });
@@ -53,6 +60,7 @@ describe("ProjectsTable", () => {
     const rows = await po.getRows();
     expect(await rows[0].getCellAlignments()).toEqual([
       "desktop-align-left", // Nervous Systems
+      "desktop-align-right", // Neurons
       "desktop-align-right", // Actions
     ]);
   });
@@ -63,11 +71,12 @@ describe("ProjectsTable", () => {
     expect(await po.getDesktopGridTemplateColumns()).toBe(
       [
         "1fr", // Nerous Systems
+        "1fr", // Neurons
         "max-content", // Actions
       ].join(" ")
     );
     expect(await po.getMobileGridTemplateAreas()).toBe(
-      '"first-cell last-cell"'
+      '"first-cell last-cell" "cell-0 cell-0"'
     );
   });
 
@@ -87,6 +96,90 @@ describe("ProjectsTable", () => {
     expect(rowPos).toHaveLength(2);
     expect(await rowPos[0].getProjectTitle()).toBe("Internet Computer");
     expect(await rowPos[1].getProjectTitle()).toBe(snsTitle);
+  });
+
+  describe("neuron counts", () => {
+    const nnsNeuronWithStake = {
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        cachedNeuronStake: 100_000_000n,
+      },
+    };
+
+    const nnsNeuronWithoutStake = {
+      ...mockNeuron,
+      fullNeuron: {
+        ...mockNeuron.fullNeuron,
+        cachedNeuronStake: 0n,
+        maturityE8sEquivalent: 0n,
+      },
+    };
+
+    const snsNeuronWithStake = createMockSnsNeuron({
+      stake: 100_000_000n,
+      id: [1, 1, 3],
+    });
+
+    const snsNeuronWithoutStake = createMockSnsNeuron({
+      stake: 0n,
+      maturity: 0n,
+      id: [7, 7, 9],
+    });
+
+    it("should render NNS neurons count", async () => {
+      neuronsStore.setNeurons({
+        neurons: [nnsNeuronWithStake, nnsNeuronWithStake],
+        certified: true,
+      });
+      const po = renderComponent();
+      const rowPos = await po.getProjectsTableRowPos();
+      expect(rowPos).toHaveLength(2);
+      expect(await rowPos[0].getNeuronCount()).toBe("2");
+      expect(await rowPos[1].getNeuronCount()).toBe("0");
+    });
+
+    it("should render SNS neurons count", async () => {
+      snsNeuronsStore.setNeurons({
+        rootCanisterId: snsCanisterId,
+        neurons: [snsNeuronWithStake, snsNeuronWithStake, snsNeuronWithStake],
+        certified: true,
+      });
+      const po = renderComponent();
+      const rowPos = await po.getProjectsTableRowPos();
+      expect(rowPos).toHaveLength(2);
+      expect(await rowPos[0].getNeuronCount()).toBe("0");
+      expect(await rowPos[1].getNeuronCount()).toBe("3");
+    });
+
+    it("should filter NNS neurons without stake", async () => {
+      neuronsStore.setNeurons({
+        neurons: [nnsNeuronWithStake, nnsNeuronWithoutStake],
+        certified: true,
+      });
+      const po = renderComponent();
+      const rowPos = await po.getProjectsTableRowPos();
+      expect(rowPos).toHaveLength(2);
+      expect(await rowPos[0].getNeuronCount()).toBe("1");
+      expect(await rowPos[1].getNeuronCount()).toBe("0");
+    });
+
+    it("should filter SNS neurons without stake", async () => {
+      snsNeuronsStore.setNeurons({
+        rootCanisterId: snsCanisterId,
+        neurons: [
+          snsNeuronWithStake,
+          snsNeuronWithoutStake,
+          snsNeuronWithStake,
+        ],
+        certified: true,
+      });
+      const po = renderComponent();
+      const rowPos = await po.getProjectsTableRowPos();
+      expect(rowPos).toHaveLength(2);
+      expect(await rowPos[0].getNeuronCount()).toBe("0");
+      expect(await rowPos[1].getNeuronCount()).toBe("2");
+    });
   });
 
   it("should update table when universes store changes", async () => {

--- a/frontend/src/tests/page-objects/ProjectNeuronsCell.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectNeuronsCell.page-object.ts
@@ -1,0 +1,14 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ProjectNeuronsCellPo extends BasePageObject {
+  private static readonly TID = "project-neurons-cell-component";
+
+  static under(element: PageObjectElement): ProjectNeuronsCellPo {
+    return new ProjectNeuronsCellPo(element.byTestId(ProjectNeuronsCellPo.TID));
+  }
+
+  async getNeuronCount(): Promise<string> {
+    return await this.getText();
+  }
+}

--- a/frontend/src/tests/page-objects/ProjectsTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectsTableRow.page-object.ts
@@ -1,3 +1,4 @@
+import { ProjectNeuronsCellPo } from "$tests/page-objects/ProjectNeuronsCell.page-object";
 import { ProjectTitleCellPo } from "$tests/page-objects/ProjectTitleCell.page-object";
 import { ResponsiveTableRowPo } from "$tests/page-objects/ResponsiveTableRow.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -19,7 +20,15 @@ export class ProjectsTableRowPo extends ResponsiveTableRowPo {
     return ProjectTitleCellPo.under(this.root);
   }
 
-  async getProjectTitle(): Promise<string> {
+  getProjectNeuronsCellPo(): ProjectNeuronsCellPo {
+    return ProjectNeuronsCellPo.under(this.root);
+  }
+
+  getProjectTitle(): Promise<string> {
     return this.getProjectTitleCellPo().getProjectTitle();
+  }
+
+  getNeuronCount(): Promise<string> {
+    return this.getProjectNeuronsCellPo().getNeuronCount();
   }
 }


### PR DESCRIPTION
# Motivation

We want to show the number of neurons a user has in each project.

# Changes

1. Add `ProjectNeuronsCell` component.
2. Add a column for the `ProjectNeuronsCell` to the `ProjectsTable` component.

# Tests

1. Unit tests added.
2. Page objects added.
3. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/staking/

# Todos

- [ ] Add entry to changelog (if necessary).
not yet