### PR TITLE
Get summary lifecycle through getLifecycle

### DIFF
--- a/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
@@ -2,11 +2,12 @@
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import ProjectUserCommitmentLabel from "$lib/components/project-detail/ProjectUserCommitmentLabel.svelte";
   import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
+  import { getLifecycle } from "$lib/getters/sns-summary";
   import { i18n } from "$lib/stores/i18n";
   import type {
     SnsSummary,
-    SnsSwapCommitment,
     SnsSummarySwap,
+    SnsSwapCommitment,
   } from "$lib/types/sns";
   import {
     durationTillSwapDeadline,
@@ -31,9 +32,7 @@
   $: ({ swap } = summary);
 
   let lifecycle: number;
-  $: ({
-    swap: { lifecycle },
-  } = summary);
+  $: lifecycle = getLifecycle(summary);
 
   let durationTillDeadline: bigint | undefined;
   $: durationTillDeadline = durationTillSwapDeadline(swap);

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -3,6 +3,7 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import SpinnerText from "$lib/components/ui/SpinnerText.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
+  import { getLifecycle } from "$lib/getters/sns-summary";
   import ParticipateSwapModal from "$lib/modals/sns/sale/ParticipateSwapModal.svelte";
   import { i18n } from "$lib/stores/i18n";
   import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
@@ -11,11 +12,10 @@
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
   } from "$lib/types/project-detail.context";
-  import type { SnsSummary } from "$lib/types/sns";
   import {
     hasUserParticipatedToSwap,
-    type ParticipationButtonStatus,
     participateButtonStatus,
+    type ParticipationButtonStatus,
   } from "$lib/utils/projects.utils";
   import { BottomSheet } from "@dfinity/gix-components";
   import { Tooltip } from "@dfinity/gix-components";
@@ -29,13 +29,8 @@
   );
 
   let lifecycle: number;
-  $: ({
-    swap: { lifecycle },
-  } =
-    $projectDetailStore.summary ??
-    ({
-      swap: { state: { lifecycle: SnsSwapLifecycle.Unspecified } },
-    } as unknown as SnsSummary));
+  $: lifecycle =
+    getLifecycle($projectDetailStore.summary) ?? SnsSwapLifecycle.Unspecified;
 
   let showModal = false;
   const openModal = () => (showModal = true);

--- a/frontend/src/lib/components/project-detail/ProjectMetadataSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectMetadataSection.svelte
@@ -2,6 +2,7 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import Logo from "$lib/components/ui/Logo.svelte";
   import SkeletonDetails from "$lib/components/ui/SkeletonDetails.svelte";
+  import { getLifecycle } from "$lib/getters/sns-summary";
   import { i18n } from "$lib/stores/i18n";
   import type { IcrcTokenMetadata } from "$lib/types/icrc";
   import {
@@ -26,7 +27,7 @@
   $: rootCanisterId = summary?.rootCanisterId;
 
   let lifecycle: SnsSwapLifecycle | undefined;
-  $: lifecycle = summary?.swap.lifecycle;
+  $: lifecycle = getLifecycle(summary);
 
   let metadata: SnsSummaryMetadata | undefined;
   let token: IcrcTokenMetadata | undefined;

--- a/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
+  import { getLifecycle } from "$lib/getters/sns-summary";
   import {
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
   } from "$lib/types/project-detail.context";
-  import type { SnsSwapCommitment, SnsSummary } from "$lib/types/sns";
+  import type { SnsSwapCommitment } from "$lib/types/sns";
   import { getCommitmentE8s } from "$lib/utils/sns.utils";
   import ParticipateButton from "./ParticipateButton.svelte";
   import ProjectCommitment from "./ProjectCommitment.svelte";
   import ProjectStatus from "./ProjectStatus.svelte";
   import ProjectTimelineUserCommitment from "./ProjectTimelineUserCommitment.svelte";
   import { SnsSwapLifecycle } from "@dfinity/sns";
-  import { TokenAmount, ICPToken, nonNullish } from "@dfinity/utils";
+  import { ICPToken, TokenAmount, nonNullish } from "@dfinity/utils";
   import { isNullish } from "@dfinity/utils";
   import { getContext } from "svelte";
 
@@ -34,13 +35,8 @@
   $: loadingSummary = isNullish($projectDetailStore.summary);
 
   let lifecycle: number;
-  $: ({
-    swap: { lifecycle },
-  } =
-    $projectDetailStore.summary ??
-    ({
-      swap: { state: { lifecycle: SnsSwapLifecycle.Unspecified } },
-    } as unknown as SnsSummary));
+  $: lifecycle =
+    getLifecycle($projectDetailStore.summary) ?? SnsSwapLifecycle.Unspecified;
 
   let displayStatusSection = false;
   $: displayStatusSection =

--- a/frontend/src/lib/components/project-detail/ProjectTimelineUserCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectTimelineUserCommitment.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { getLifecycle } from "$lib/getters/sns-summary";
   import { i18n } from "$lib/stores/i18n";
   import type {
     SnsSummary,
@@ -12,7 +13,7 @@
   import AmountDisplay from "../ic/AmountDisplay.svelte";
   import Separator from "../ui/Separator.svelte";
   import ProjectUserCommitmentLabel from "./ProjectUserCommitmentLabel.svelte";
-  import { Value, KeyValuePair } from "@dfinity/gix-components";
+  import { KeyValuePair, Value } from "@dfinity/gix-components";
   import { SnsSwapLifecycle } from "@dfinity/sns";
   import { TokenAmount, nonNullish } from "@dfinity/utils";
   import { secondsToDuration } from "@dfinity/utils";
@@ -31,11 +32,14 @@
   let durationTillStart: bigint | undefined;
   $: durationTillStart = durationTillSwapStart(swap);
 
+  let lifecycle: SnsSwapLifecycle;
+  $: lifecycle = getLifecycle(summary);
+
   let isOpen: boolean;
-  $: isOpen = swap.lifecycle === SnsSwapLifecycle.Open;
+  $: isOpen = lifecycle === SnsSwapLifecycle.Open;
 
   let isAdopted: boolean;
-  $: isAdopted = swap.lifecycle === SnsSwapLifecycle.Adopted;
+  $: isAdopted = lifecycle === SnsSwapLifecycle.Adopted;
 
   let hasParticipated: boolean;
   $: hasParticipated = nonNullish(myCommitment) && myCommitment.toE8s() > 0n;

--- a/frontend/src/lib/getters/sns-summary.ts
+++ b/frontend/src/lib/getters/sns-summary.ts
@@ -1,6 +1,7 @@
 import type { CountryCode } from "$lib/types/location";
 import type { SnsSummary } from "$lib/types/sns";
 import type { ProposalId } from "@dfinity/nns";
+import type { SnsSwapLifecycle } from "@dfinity/sns";
 import { fromNullable } from "@dfinity/utils";
 
 export const getDeniedCountries = (_summary: SnsSummary): CountryCode[] =>
@@ -39,3 +40,14 @@ export const getMaxNeuronsFundParticipation = ({
 export const getProjectProposal = (
   summary: SnsSummary
 ): ProposalId | undefined => fromNullable(summary.init?.nns_proposal_id ?? []);
+
+export function getLifecycle(summary: SnsSummary): SnsSwapLifecycle;
+export function getLifecycle(
+  summary: SnsSummary | null | undefined
+): SnsSwapLifecycle | undefined;
+export function getLifecycle(
+  summary: SnsSummary | null | undefined
+): SnsSwapLifecycle | null | undefined {
+  // TODO: Get from summary.lifecycle instead of summary.swap.
+  return summary?.swap.lifecycle;
+}

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -11,6 +11,7 @@
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { debugSelectedProjectStore } from "$lib/derived/debug.derived";
   import { snsTotalSupplyTokenAmountStore } from "$lib/derived/sns/sns-total-supply-token-amount.derived";
+  import { getLifecycle } from "$lib/getters/sns-summary";
   import SaleInProgressModal from "$lib/modals/sns/sale/SaleInProgressModal.svelte";
   import { loadSnsFinalizationStatus } from "$lib/services/sns-finalization.services";
   import {
@@ -19,9 +20,9 @@
   } from "$lib/services/sns-sale.services";
   import { loadSnsSwapMetrics } from "$lib/services/sns-swap-metrics.services";
   import {
+    loadSnsDerivedState,
     loadSnsLifecycle,
     loadSnsSwapCommitment,
-    loadSnsDerivedState,
     watchSnsTotalCommitment,
   } from "$lib/services/sns.services";
   import { loadUserCountry } from "$lib/services/user-country.services";
@@ -42,7 +43,7 @@
   import { Principal } from "@dfinity/principal";
   import { SnsSwapLifecycle } from "@dfinity/sns";
   import { isNullish, nonNullish } from "@dfinity/utils";
-  import { setContext, onDestroy } from "svelte";
+  import { onDestroy, setContext } from "svelte";
   import { writable } from "svelte/store";
 
   export let rootCanisterId: string | undefined | null;
@@ -148,7 +149,7 @@
 
   let enableOpenProjectWatchers = false;
   $: enableOpenProjectWatchers =
-    $projectDetailStore?.summary?.swap.lifecycle === SnsSwapLifecycle.Open;
+    getLifecycle($projectDetailStore?.summary) === SnsSwapLifecycle.Open;
 
   let swapCanisterId: Principal | undefined;
   $: swapCanisterId = $projectDetailStore.summary?.swapCanisterId;
@@ -175,7 +176,7 @@
 
   $: if (
     nonNullish(rootCanisterId) &&
-    $projectDetailStore.summary?.swap.lifecycle === SnsSwapLifecycle.Committed
+    getLifecycle($projectDetailStore.summary) === SnsSwapLifecycle.Committed
   ) {
     loadSnsFinalizationStatus({
       rootCanisterId: Principal.fromText(rootCanisterId),
@@ -235,7 +236,7 @@
   // - no root canister id
   // - ticket already in progress for the same root canister id
   $: if (
-    $projectDetailStore.summary?.swap.lifecycle === SnsSwapLifecycle.Open &&
+    getLifecycle($projectDetailStore.summary) === SnsSwapLifecycle.Open &&
     $authSignedInStore &&
     nonNullish(userCommitment) &&
     nonNullish(swapCanisterId) &&

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -9,6 +9,7 @@ import {
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { mainTransactionFeeE8sStore } from "$lib/derived/main-transaction-fee.derived";
+import { getLifecycle } from "$lib/getters/sns-summary";
 import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/icp-ledger.services.proxy";
 import { loadActionableProposals } from "$lib/services/actionable-proposals.services";
@@ -983,10 +984,7 @@ export const makeDummyProposals = async (neuronId: NeuronId): Promise<void> => {
     const { snsSummariesStore } = await import("../stores/sns.store");
     const projects = get(snsSummariesStore);
     const pendingProject = projects.find(
-      ({
-        swap: { lifecycle },
-        // Use 1 instead of using enum to avoid importing sns-js
-      }) => lifecycle === 1
+      (summary) => getLifecycle(summary) === 1
     );
     await makeDummyProposalsApi({
       neuronId,

--- a/frontend/src/lib/services/sns-finalization.services.ts
+++ b/frontend/src/lib/services/sns-finalization.services.ts
@@ -1,5 +1,6 @@
 import { queryFinalizationStatus } from "$lib/api/sns-sale.api";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
+import { getLifecycle } from "$lib/getters/sns-summary";
 import { getOrCreateSnsFinalizationStatusStore } from "$lib/stores/sns-finalization-status.store";
 import { snsSummariesStore } from "$lib/stores/sns.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
@@ -31,7 +32,7 @@ export const loadSnsFinalizationStatus = async ({
   if (
     !forceFetch &&
     (isNullish(summary) ||
-      summary.swap.lifecycle !== SnsSwapLifecycle.Committed ||
+      getLifecycle(summary) !== SnsSwapLifecycle.Committed ||
       swapEndedMoreThanOneWeekAgo({ summary, nowInSeconds: nowInSeconds() }))
   ) {
     return;

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -2,6 +2,7 @@ import { NOT_LOADED } from "$lib/constants/stores.constants";
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
 import {
   getDeniedCountries,
+  getLifecycle,
   getMaxDirectParticipation,
   getMinDirectParticipation,
   getNeuronsFundParticipation,
@@ -34,13 +35,7 @@ export const filterProjectsStatus = ({
   swapLifecycle: SnsSwapLifecycle;
   projects: SnsFullProject[];
 }): SnsFullProject[] =>
-  projects.filter(
-    ({
-      summary: {
-        swap: { lifecycle },
-      },
-    }) => swapLifecycle === lifecycle
-  );
+  projects.filter(({ summary }) => swapLifecycle === getLifecycle(summary));
 
 export const filterCommittedProjects = (
   projects: SnsFullProject[]
@@ -60,17 +55,12 @@ export const filterCommittedProjects = (
 export const filterActiveProjects = (
   projects: SnsFullProject[]
 ): SnsFullProject[] =>
-  projects?.filter(
-    ({
-      summary: {
-        swap: { lifecycle },
-      },
-    }) =>
-      [
-        SnsSwapLifecycle.Committed,
-        SnsSwapLifecycle.Open,
-        SnsSwapLifecycle.Adopted,
-      ].includes(lifecycle)
+  projects?.filter(({ summary }) =>
+    [
+      SnsSwapLifecycle.Committed,
+      SnsSwapLifecycle.Open,
+      SnsSwapLifecycle.Adopted,
+    ].includes(getLifecycle(summary))
   );
 
 /**
@@ -119,7 +109,7 @@ export const projectRemainingAmount = ({ swap, derived }: SnsSummary): bigint =>
   swap.params.max_icp_e8s - derived.buyer_total_icp_e8s;
 
 const isProjectOpen = (summary: SnsSummary): boolean =>
-  summary.swap.lifecycle === SnsSwapLifecycle.Open;
+  getLifecycle(summary) === SnsSwapLifecycle.Open;
 // Checks whether the amount that the user wants to contribute is lower than the minimum for the project.
 // It takes into account the current commitment of the user.
 const commitmentTooSmall = ({

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1,5 +1,6 @@
 import { NOT_LOADED } from "$lib/constants/stores.constants";
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
+import { getLifecycle } from "$lib/getters/sns-summary";
 import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import {
@@ -53,19 +54,21 @@ describe("project-utils", () => {
   describe("filter", () => {
     it("should filter by status", () => {
       expect(
-        filterProjectsStatus({
-          projects: [
-            {
-              ...mockSnsFullProject,
-              summary: summaryForLifecycle(SnsSwapLifecycle.Open),
-            },
-            {
-              ...mockSnsFullProject,
-              summary: summaryForLifecycle(SnsSwapLifecycle.Committed),
-            },
-          ],
-          swapLifecycle: SnsSwapLifecycle.Open,
-        })[0].summary.swap.lifecycle
+        getLifecycle(
+          filterProjectsStatus({
+            projects: [
+              {
+                ...mockSnsFullProject,
+                summary: summaryForLifecycle(SnsSwapLifecycle.Open),
+              },
+              {
+                ...mockSnsFullProject,
+                summary: summaryForLifecycle(SnsSwapLifecycle.Committed),
+              },
+            ],
+            swapLifecycle: SnsSwapLifecycle.Open,
+          })[0].summary
+        )
       ).toEqual(SnsSwapLifecycle.Open);
 
       expect(


### PR DESCRIPTION
# Motivation

We want to stop using the `summary.swap` field because it's deprecated and everything on it is available in other ways.
One of the things we get from the `swap` field is the `lifecycle`.
In this PR we introduce a getter to determine in a single place how we get the lifecycle.
This will make it easy to switch over in another PR.

# Changes

1. Add `getLifecycle` which returns the lifecycle from an `SnsSummary`.
2. Use `getLifecycle` instead of getting `summary.swap.lifecycle` directly.

# Tests

Existing tests pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary