### PR TITLE
bot: Update proposals candid bindings

### DIFF
--- a/declarations/used_by_proposals/nns_governance/nns_governance.did
+++ b/declarations/used_by_proposals/nns_governance/nns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-03_23-01-storage-layer-disabled/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-10_23-01-base/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
@@ -159,7 +159,7 @@ type GlobalTimeOfDay = record { seconds_after_utc_midnight : opt nat64 };
 type Governance = record {
   default_followees : vec record { int32; Followees };
   making_sns_proposal : opt MakingSnsProposal;
-  most_recent_monthly_node_provider_rewards : opt MostRecentMonthlyNodeProviderRewards;
+  most_recent_monthly_node_provider_rewards : opt MonthlyNodeProviderRewards;
   maturity_modulation_last_updated_at_timestamp_seconds : opt nat64;
   wait_for_quiet_threshold_seconds : nat64;
   metrics : opt GovernanceCachedMetrics;
@@ -217,6 +217,7 @@ type GovernanceCachedMetrics = record {
   };
   dissolving_neurons_count_buckets : vec record { nat64; nat64 };
   dissolving_neurons_e8s_buckets_ect : vec record { nat64; float64 };
+  non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
   dissolving_neurons_count : nat64;
   dissolving_neurons_e8s_buckets : vec record { nat64; float64 };
   total_staked_maturity_e8s_equivalent_seed : nat64;
@@ -318,9 +319,14 @@ type Migrations = record {
   neuron_indexes_migration : opt Migration;
   copy_inactive_neurons_to_stable_memory_migration : opt Migration;
 };
-type MostRecentMonthlyNodeProviderRewards = record {
+type MonthlyNodeProviderRewards = record {
+  minimum_xdr_permyriad_per_icp : opt nat64;
+  registry_version : opt nat64;
+  node_providers : vec NodeProvider;
   timestamp : nat64;
   rewards : vec RewardNodeProvider;
+  xdr_conversion_rate : opt XdrConversionRate;
+  maximum_node_provider_rewards_e8s : opt nat64;
 };
 type Motion = record { motion_text : text };
 type NetworkEconomics = record {
@@ -399,6 +405,18 @@ type NeuronStakeTransfer = record {
   from_subaccount : blob;
   transfer_timestamp : nat64;
   block_height : nat64;
+};
+type NeuronSubsetMetrics = record {
+  total_maturity_e8s_equivalent : opt nat64;
+  maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
+  voting_power_buckets : vec record { nat64; nat64 };
+  total_staked_e8s : opt nat64;
+  count : opt nat64;
+  total_staked_maturity_e8s_equivalent : opt nat64;
+  staked_maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
+  staked_e8s_buckets : vec record { nat64; nat64 };
+  total_voting_power : opt nat64;
+  count_buckets : vec record { nat64; nat64 };
 };
 type NeuronsFundAuditInfo = record {
   final_neurons_fund_participation : opt NeuronsFundParticipation;
@@ -675,7 +693,7 @@ service : (Governance) -> {
   get_metrics : () -> (Result_3) query;
   get_monthly_node_provider_rewards : () -> (Result_4);
   get_most_recent_monthly_node_provider_rewards : () -> (
-      opt MostRecentMonthlyNodeProviderRewards,
+      opt MonthlyNodeProviderRewards,
     ) query;
   get_network_economics_parameters : () -> (NetworkEconomics) query;
   get_neuron_ids : () -> (vec nat64) query;

--- a/declarations/used_by_proposals/nns_registry/nns_registry.did
+++ b/declarations/used_by_proposals/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-03_23-01-storage-layer-disabled/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-10_23-01-base/rs/registry/canister/canister/registry.did>
 // A brief note about the history of this file: This file used to be
 // automatically generated, but now, it is hand-crafted, because the
 // auto-generator has some some pretty degenerate behaviors. The worst of those

--- a/declarations/used_by_proposals/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_proposals/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-03_23-01-storage-layer-disabled/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-10_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };

--- a/dfx.json
+++ b/dfx.json
@@ -387,7 +387,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-07-10",
-        "IC_COMMIT_FOR_PROPOSALS": "release-2024-07-03_23-01-storage-layer-disabled",
+        "IC_COMMIT_FOR_PROPOSALS": "release-2024-07-10_23-01-base",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-07-03_23-01-storage-layer-disabled"
       },
       "packtool": ""

--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-03_23-01-storage-layer-disabled/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-10_23-01-base/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -429,9 +429,32 @@ pub struct MakingSnsProposal {
     pub proposer_id: Option<NeuronId>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
-pub struct MostRecentMonthlyNodeProviderRewards {
+pub struct XdrConversionRate {
+    pub xdr_permyriad_per_icp: Option<u64>,
+    pub timestamp_seconds: Option<u64>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct MonthlyNodeProviderRewards {
+    pub minimum_xdr_permyriad_per_icp: Option<u64>,
+    pub registry_version: Option<u64>,
+    pub node_providers: Vec<NodeProvider>,
     pub timestamp: u64,
     pub rewards: Vec<RewardNodeProvider>,
+    pub xdr_conversion_rate: Option<XdrConversionRate>,
+    pub maximum_node_provider_rewards_e8s: Option<u64>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct NeuronSubsetMetrics {
+    pub total_maturity_e8s_equivalent: Option<u64>,
+    pub maturity_e8s_equivalent_buckets: Vec<(u64, u64)>,
+    pub voting_power_buckets: Vec<(u64, u64)>,
+    pub total_staked_e8s: Option<u64>,
+    pub count: Option<u64>,
+    pub total_staked_maturity_e8s_equivalent: Option<u64>,
+    pub staked_maturity_e8s_equivalent_buckets: Vec<(u64, u64)>,
+    pub staked_e8s_buckets: Vec<(u64, u64)>,
+    pub total_voting_power: Option<u64>,
+    pub count_buckets: Vec<(u64, u64)>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GovernanceCachedMetrics {
@@ -465,6 +488,7 @@ pub struct GovernanceCachedMetrics {
     pub not_dissolving_neurons_staked_maturity_e8s_equivalent_buckets: Vec<(u64, f64)>,
     pub dissolving_neurons_count_buckets: Vec<(u64, u64)>,
     pub dissolving_neurons_e8s_buckets_ect: Vec<(u64, f64)>,
+    pub non_self_authenticating_controller_neuron_subset_metrics: Option<NeuronSubsetMetrics>,
     pub dissolving_neurons_count: u64,
     pub dissolving_neurons_e8s_buckets: Vec<(u64, f64)>,
     pub total_staked_maturity_e8s_equivalent_seed: u64,
@@ -652,11 +676,6 @@ pub struct ProposalData {
     pub original_total_community_fund_maturity_e8s_equivalent: Option<u64>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
-pub struct XdrConversionRate {
-    pub xdr_permyriad_per_icp: Option<u64>,
-    pub timestamp_seconds: Option<u64>,
-}
-#[derive(Serialize, CandidType, Deserialize)]
 pub enum Command2 {
     Spawn(NeuronId),
     Split(Split),
@@ -711,7 +730,7 @@ pub struct Neuron {
 pub struct Governance {
     pub default_followees: Vec<(i32, Followees)>,
     pub making_sns_proposal: Option<MakingSnsProposal>,
-    pub most_recent_monthly_node_provider_rewards: Option<MostRecentMonthlyNodeProviderRewards>,
+    pub most_recent_monthly_node_provider_rewards: Option<MonthlyNodeProviderRewards>,
     pub maturity_modulation_last_updated_at_timestamp_seconds: Option<u64>,
     pub wait_for_quiet_threshold_seconds: u64,
     pub metrics: Option<GovernanceCachedMetrics>,
@@ -1003,7 +1022,7 @@ impl Service {
     }
     pub async fn get_most_recent_monthly_node_provider_rewards(
         &self,
-    ) -> CallResult<(Option<MostRecentMonthlyNodeProviderRewards>,)> {
+    ) -> CallResult<(Option<MonthlyNodeProviderRewards>,)> {
         ic_cdk::call(self.0, "get_most_recent_monthly_node_provider_rewards", ()).await
     }
     pub async fn get_network_economics_parameters(&self) -> CallResult<(NetworkEconomics,)> {

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-03_23-01-storage-layer-disabled/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-10_23-01-base/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-03_23-01-storage-layer-disabled/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-10_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.
Even with no changes, just updating the reference is good practice.

# Changes
* Update the version of `IC_COMMIT_FOR_PROPOSALS` specified in `dfx.json`.
* Updated the `proposals` candid files to the versions in that commit.
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants