### PR TITLE
Get summary lifecycle through SnsSummaryWrapper

### DIFF
--- a/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
+++ b/frontend/src/lib/components/launchpad/ProjectCardSwapInfo.svelte
@@ -3,11 +3,8 @@
   import ProjectUserCommitmentLabel from "$lib/components/project-detail/ProjectUserCommitmentLabel.svelte";
   import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
   import { i18n } from "$lib/stores/i18n";
-  import type {
-    SnsSummary,
-    SnsSwapCommitment,
-    SnsSummarySwap,
-  } from "$lib/types/sns";
+  import type { SnsSummarySwap, SnsSwapCommitment } from "$lib/types/sns";
+  import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
   import {
     durationTillSwapDeadline,
     durationTillSwapStart,
@@ -23,7 +20,7 @@
   // The data to know whether it's finalizing or not is not in the SnsFullProject.
   export let isFinalizing: boolean;
 
-  let summary: SnsSummary;
+  let summary: SnsSummaryWrapper;
   let swapCommitment: SnsSwapCommitment | undefined;
   $: ({ summary, swapCommitment } = project);
 
@@ -31,9 +28,7 @@
   $: ({ swap } = summary);
 
   let lifecycle: number;
-  $: ({
-    swap: { lifecycle },
-  } = summary);
+  $: lifecycle = summary.getLifecycle();
 
   let durationTillDeadline: bigint | undefined;
   $: durationTillDeadline = durationTillSwapDeadline(swap);

--- a/frontend/src/lib/components/project-detail/ParticipateButton.svelte
+++ b/frontend/src/lib/components/project-detail/ParticipateButton.svelte
@@ -11,11 +11,10 @@
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
   } from "$lib/types/project-detail.context";
-  import type { SnsSummary } from "$lib/types/sns";
   import {
     hasUserParticipatedToSwap,
-    type ParticipationButtonStatus,
     participateButtonStatus,
+    type ParticipationButtonStatus,
   } from "$lib/utils/projects.utils";
   import { BottomSheet } from "@dfinity/gix-components";
   import { Tooltip } from "@dfinity/gix-components";
@@ -29,13 +28,8 @@
   );
 
   let lifecycle: number;
-  $: ({
-    swap: { lifecycle },
-  } =
-    $projectDetailStore.summary ??
-    ({
-      swap: { state: { lifecycle: SnsSwapLifecycle.Unspecified } },
-    } as unknown as SnsSummary));
+  $: lifecycle =
+    $projectDetailStore.summary?.getLifecycle() ?? SnsSwapLifecycle.Unspecified;
 
   let showModal = false;
   const openModal = () => (showModal = true);

--- a/frontend/src/lib/components/project-detail/ProjectMetadataSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectMetadataSection.svelte
@@ -8,7 +8,8 @@
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
   } from "$lib/types/project-detail.context";
-  import type { SnsSummary, SnsSummaryMetadata } from "$lib/types/sns";
+  import type { SnsSummaryMetadata } from "$lib/types/sns";
+  import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
   import { snsProjectDashboardUrl } from "$lib/utils/projects.utils";
   import type { Principal } from "@dfinity/principal";
   import { SnsSwapLifecycle } from "@dfinity/sns";
@@ -19,14 +20,14 @@
     PROJECT_DETAIL_CONTEXT_KEY
   );
 
-  let summary: SnsSummary | undefined | null;
+  let summary: SnsSummaryWrapper | undefined | null;
   $: summary = $projectDetailStore.summary;
 
   let rootCanisterId: Principal | undefined;
   $: rootCanisterId = summary?.rootCanisterId;
 
   let lifecycle: SnsSwapLifecycle | undefined;
-  $: lifecycle = summary?.swap.lifecycle;
+  $: lifecycle = summary?.getLifecycle();
 
   let metadata: SnsSummaryMetadata | undefined;
   let token: IcrcTokenMetadata | undefined;

--- a/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatusSection.svelte
@@ -3,14 +3,14 @@
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
   } from "$lib/types/project-detail.context";
-  import type { SnsSwapCommitment, SnsSummary } from "$lib/types/sns";
+  import type { SnsSwapCommitment } from "$lib/types/sns";
   import { getCommitmentE8s } from "$lib/utils/sns.utils";
   import ParticipateButton from "./ParticipateButton.svelte";
   import ProjectCommitment from "./ProjectCommitment.svelte";
   import ProjectStatus from "./ProjectStatus.svelte";
   import ProjectTimelineUserCommitment from "./ProjectTimelineUserCommitment.svelte";
   import { SnsSwapLifecycle } from "@dfinity/sns";
-  import { TokenAmount, ICPToken, nonNullish } from "@dfinity/utils";
+  import { ICPToken, TokenAmount, nonNullish } from "@dfinity/utils";
   import { isNullish } from "@dfinity/utils";
   import { getContext } from "svelte";
 
@@ -34,13 +34,8 @@
   $: loadingSummary = isNullish($projectDetailStore.summary);
 
   let lifecycle: number;
-  $: ({
-    swap: { lifecycle },
-  } =
-    $projectDetailStore.summary ??
-    ({
-      swap: { state: { lifecycle: SnsSwapLifecycle.Unspecified } },
-    } as unknown as SnsSummary));
+  $: lifecycle =
+    $projectDetailStore.summary?.getLifecycle() ?? SnsSwapLifecycle.Unspecified;
 
   let displayStatusSection = false;
   $: displayStatusSection =

--- a/frontend/src/lib/components/project-detail/ProjectTimelineUserCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectTimelineUserCommitment.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import type {
-    SnsSummary,
-    SnsSummarySwap,
-    SnsSwapCommitment,
-  } from "$lib/types/sns";
+  import type { SnsSummarySwap, SnsSwapCommitment } from "$lib/types/sns";
+  import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
   import {
     durationTillSwapDeadline,
     durationTillSwapStart,
@@ -12,13 +9,13 @@
   import AmountDisplay from "../ic/AmountDisplay.svelte";
   import Separator from "../ui/Separator.svelte";
   import ProjectUserCommitmentLabel from "./ProjectUserCommitmentLabel.svelte";
-  import { Value, KeyValuePair } from "@dfinity/gix-components";
+  import { KeyValuePair, Value } from "@dfinity/gix-components";
   import { SnsSwapLifecycle } from "@dfinity/sns";
   import { TokenAmount, nonNullish } from "@dfinity/utils";
   import { secondsToDuration } from "@dfinity/utils";
 
   export let myCommitment: TokenAmount | undefined;
-  export let summary: SnsSummary;
+  export let summary: SnsSummaryWrapper;
   export let swapCommitment: SnsSwapCommitment | undefined | null;
 
   let swap: SnsSummarySwap;
@@ -31,11 +28,14 @@
   let durationTillStart: bigint | undefined;
   $: durationTillStart = durationTillSwapStart(swap);
 
+  let lifecycle: SnsSwapLifecycle;
+  $: lifecycle = summary.getLifecycle();
+
   let isOpen: boolean;
-  $: isOpen = swap.lifecycle === SnsSwapLifecycle.Open;
+  $: isOpen = lifecycle === SnsSwapLifecycle.Open;
 
   let isAdopted: boolean;
-  $: isAdopted = swap.lifecycle === SnsSwapLifecycle.Adopted;
+  $: isAdopted = lifecycle === SnsSwapLifecycle.Adopted;
 
   let hasParticipated: boolean;
   $: hasParticipated = nonNullish(myCommitment) && myCommitment.toE8s() > 0n;

--- a/frontend/src/lib/components/project-detail/ProjectUserCommitmentLabel.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectUserCommitmentLabel.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
+  import type { SnsSwapCommitment } from "$lib/types/sns";
+  import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
   import { canUserParticipateToSwap } from "$lib/utils/projects.utils";
 
-  export let summary: SnsSummary | undefined | null;
+  export let summary: SnsSummaryWrapper | undefined | null;
   export let swapCommitment: SnsSwapCommitment | undefined | null;
 
   let canParticipate = false;

--- a/frontend/src/lib/derived/sns/sns-projects.derived.ts
+++ b/frontend/src/lib/derived/sns/sns-projects.derived.ts
@@ -3,11 +3,8 @@ import {
   snsSwapCommitmentsStore,
   type SnsSwapCommitmentsStore,
 } from "$lib/stores/sns.store";
-import type {
-  RootCanisterIdText,
-  SnsSummary,
-  SnsSwapCommitment,
-} from "$lib/types/sns";
+import type { RootCanisterIdText, SnsSwapCommitment } from "$lib/types/sns";
+import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import {
   filterActiveProjects,
   filterCommittedProjects,
@@ -21,7 +18,7 @@ import { derived, type Readable } from "svelte/store";
 
 export interface SnsFullProject {
   rootCanisterId: Principal;
-  summary: SnsSummary;
+  summary: SnsSummaryWrapper;
   swapCommitment: SnsSwapCommitment | undefined;
 }
 
@@ -32,7 +29,7 @@ export interface SnsFullProject {
  * @return SnsFullProject[] | undefined What we called project - i.e. the summary and swap of a Sns with the user commitment
  */
 export const snsProjectsStore = derived<
-  [Readable<SnsSummary[]>, SnsSwapCommitmentsStore],
+  [Readable<SnsSummaryWrapper[]>, SnsSwapCommitmentsStore],
   SnsFullProject[]
 >(
   [snsSummariesStore, snsSwapCommitmentsStore],

--- a/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
+++ b/frontend/src/lib/modals/sns/sale/ParticipateSwapModal.svelte
@@ -19,7 +19,8 @@
     type ProjectDetailContext,
   } from "$lib/types/project-detail.context";
   import { SaleStep } from "$lib/types/sale";
-  import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
+  import type { SnsSwapCommitment } from "$lib/types/sns";
+  import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
   import type {
     NewTransaction,
     ValidateAmountFn,
@@ -36,7 +37,7 @@
     hasOpenTicketInProcess,
   } from "$lib/utils/sns.utils";
   import type { WizardStep } from "@dfinity/gix-components";
-  import { TokenAmount, ICPToken } from "@dfinity/utils";
+  import { ICPToken, TokenAmount } from "@dfinity/utils";
   import { nonNullish } from "@dfinity/utils";
   import {
     createEventDispatcher,
@@ -56,10 +57,10 @@
   const { store: projectDetailStore, reload } =
     getContext<ProjectDetailContext>(PROJECT_DETAIL_CONTEXT_KEY);
 
-  let summary: SnsSummary;
+  let summary: SnsSummaryWrapper;
   let swapCommitment: SnsSwapCommitment | undefined | null;
   // type safety validation is done in ProjectDetail component
-  $: summary = $projectDetailStore.summary as SnsSummary;
+  $: summary = $projectDetailStore.summary as SnsSummaryWrapper;
   $: swapCommitment = $projectDetailStore.swapCommitment;
   let userHasParticipatedToSwap = false;
   $: userHasParticipatedToSwap = hasUserParticipatedToSwap({

--- a/frontend/src/lib/pages/ProjectDetail.svelte
+++ b/frontend/src/lib/pages/ProjectDetail.svelte
@@ -19,9 +19,9 @@
   } from "$lib/services/sns-sale.services";
   import { loadSnsSwapMetrics } from "$lib/services/sns-swap-metrics.services";
   import {
+    loadSnsDerivedState,
     loadSnsLifecycle,
     loadSnsSwapCommitment,
-    loadSnsDerivedState,
     watchSnsTotalCommitment,
   } from "$lib/services/sns.services";
   import { loadUserCountry } from "$lib/services/user-country.services";
@@ -42,7 +42,7 @@
   import { Principal } from "@dfinity/principal";
   import { SnsSwapLifecycle } from "@dfinity/sns";
   import { isNullish, nonNullish } from "@dfinity/utils";
-  import { setContext, onDestroy } from "svelte";
+  import { onDestroy, setContext } from "svelte";
   import { writable } from "svelte/store";
 
   export let rootCanisterId: string | undefined | null;
@@ -148,7 +148,7 @@
 
   let enableOpenProjectWatchers = false;
   $: enableOpenProjectWatchers =
-    $projectDetailStore?.summary?.swap.lifecycle === SnsSwapLifecycle.Open;
+    $projectDetailStore?.summary?.getLifecycle() === SnsSwapLifecycle.Open;
 
   let swapCanisterId: Principal | undefined;
   $: swapCanisterId = $projectDetailStore.summary?.swapCanisterId;
@@ -175,7 +175,7 @@
 
   $: if (
     nonNullish(rootCanisterId) &&
-    $projectDetailStore.summary?.swap.lifecycle === SnsSwapLifecycle.Committed
+    $projectDetailStore.summary?.getLifecycle() === SnsSwapLifecycle.Committed
   ) {
     loadSnsFinalizationStatus({
       rootCanisterId: Principal.fromText(rootCanisterId),
@@ -235,7 +235,7 @@
   // - no root canister id
   // - ticket already in progress for the same root canister id
   $: if (
-    $projectDetailStore.summary?.swap.lifecycle === SnsSwapLifecycle.Open &&
+    $projectDetailStore.summary?.getLifecycle() === SnsSwapLifecycle.Open &&
     $authSignedInStore &&
     nonNullish(userCommitment) &&
     nonNullish(swapCanisterId) &&

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -983,10 +983,7 @@ export const makeDummyProposals = async (neuronId: NeuronId): Promise<void> => {
     const { snsSummariesStore } = await import("../stores/sns.store");
     const projects = get(snsSummariesStore);
     const pendingProject = projects.find(
-      ({
-        swap: { lifecycle },
-        // Use 1 instead of using enum to avoid importing sns-js
-      }) => lifecycle === 1
+      (summary) => summary.getLifecycle() === 1
     );
     await makeDummyProposalsApi({
       neuronId,

--- a/frontend/src/lib/services/sns-finalization.services.ts
+++ b/frontend/src/lib/services/sns-finalization.services.ts
@@ -31,7 +31,7 @@ export const loadSnsFinalizationStatus = async ({
   if (
     !forceFetch &&
     (isNullish(summary) ||
-      summary.swap.lifecycle !== SnsSwapLifecycle.Committed ||
+      summary.getLifecycle() !== SnsSwapLifecycle.Committed ||
       swapEndedMoreThanOneWeekAgo({ summary, nowInSeconds: nowInSeconds() }))
   ) {
     return;

--- a/frontend/src/lib/stores/sns.store.ts
+++ b/frontend/src/lib/stores/sns.store.ts
@@ -1,4 +1,4 @@
-import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
+import type { SnsSwapCommitment } from "$lib/types/sns";
 import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import { convertDtoToSnsSummary } from "$lib/utils/sns-aggregator-converters.utils";
 import { ProposalStatus, type ProposalInfo } from "@dfinity/nns";
@@ -151,7 +151,7 @@ const overrideLifecycle =
  */
 export const snsSummariesStore = derived<
   [SnsAggregatorStore, SnsDerivedStateStore, SnsLifecycleStore],
-  SnsSummary[]
+  SnsSummaryWrapper[]
 >(
   [snsAggregatorStore, snsDerivedStateStore, snsLifecycleStore],
   ([aggregatorData, derivedStates, lifecycles]) => {

--- a/frontend/src/lib/types/project-detail.context.ts
+++ b/frontend/src/lib/types/project-detail.context.ts
@@ -1,6 +1,7 @@
+import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import type { TokenAmountV2 } from "@dfinity/utils";
 import type { Writable } from "svelte/store";
-import type { SnsSummary, SnsSwapCommitment } from "./sns";
+import type { SnsSwapCommitment } from "./sns";
 
 /**
  * SnsSummary or SnsSwapCommitment is a valid project
@@ -9,7 +10,7 @@ import type { SnsSummary, SnsSwapCommitment } from "./sns";
  * `undefined` means not found
  */
 export type ProjectDetailStore = {
-  summary: SnsSummary | undefined | null;
+  summary: SnsSummaryWrapper | undefined | null;
   swapCommitment: SnsSwapCommitment | undefined | null;
   totalTokensSupply?: TokenAmountV2 | undefined | null;
 };

--- a/frontend/src/lib/types/sns-summary-wrapper.ts
+++ b/frontend/src/lib/types/sns-summary-wrapper.ts
@@ -10,6 +10,7 @@ import type {
   SnsParams,
   SnsSwapDerivedState,
   SnsSwapInit,
+  SnsSwapLifecycle,
 } from "@dfinity/sns";
 import { fromNullable, isNullish } from "@dfinity/utils";
 
@@ -56,6 +57,10 @@ export class SnsSummaryWrapper implements SnsSummary {
     return this.summary.lifecycle;
   }
 
+  getLifecycle(): SnsSwapLifecycle {
+    return this.swap.lifecycle;
+  }
+
   public overrideDerivedState(
     newDerivedState: SnsSwapDerivedState
   ): SnsSummaryWrapper {
@@ -83,6 +88,20 @@ export class SnsSummaryWrapper implements SnsSummary {
         decentralization_sale_open_timestamp_seconds: saleOpenTimestamp,
       },
       lifecycle: newLifecycle,
+    });
+  }
+
+  public overrideLifecycle(lifecycle: SnsSwapLifecycle): SnsSummaryWrapper {
+    return this.overrideLifecycleResponse({
+      ...this.lifecycle,
+      lifecycle: [lifecycle],
+    });
+  }
+
+  public override(summary: Partial<SnsSummary>): SnsSummaryWrapper {
+    return new SnsSummaryWrapper({
+      ...this.summary,
+      ...summary,
     });
   }
 }

--- a/frontend/src/lib/utils/projects.utils.ts
+++ b/frontend/src/lib/utils/projects.utils.ts
@@ -12,6 +12,7 @@ import type {
   SnsSummarySwap,
   SnsSwapCommitment,
 } from "$lib/types/sns";
+import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import type { StoreData } from "$lib/types/store";
 import type { Principal } from "@dfinity/principal";
 import { SnsSwapLifecycle, type SnsSwapTicket } from "@dfinity/sns";
@@ -34,13 +35,7 @@ export const filterProjectsStatus = ({
   swapLifecycle: SnsSwapLifecycle;
   projects: SnsFullProject[];
 }): SnsFullProject[] =>
-  projects.filter(
-    ({
-      summary: {
-        swap: { lifecycle },
-      },
-    }) => swapLifecycle === lifecycle
-  );
+  projects.filter(({ summary }) => swapLifecycle === summary.getLifecycle());
 
 export const filterCommittedProjects = (
   projects: SnsFullProject[]
@@ -60,17 +55,12 @@ export const filterCommittedProjects = (
 export const filterActiveProjects = (
   projects: SnsFullProject[]
 ): SnsFullProject[] =>
-  projects?.filter(
-    ({
-      summary: {
-        swap: { lifecycle },
-      },
-    }) =>
-      [
-        SnsSwapLifecycle.Committed,
-        SnsSwapLifecycle.Open,
-        SnsSwapLifecycle.Adopted,
-      ].includes(lifecycle)
+  projects?.filter(({ summary }) =>
+    [
+      SnsSwapLifecycle.Committed,
+      SnsSwapLifecycle.Open,
+      SnsSwapLifecycle.Adopted,
+    ].includes(summary.getLifecycle())
   );
 
 /**
@@ -118,8 +108,8 @@ export const currentUserMaxCommitment = ({
 export const projectRemainingAmount = ({ swap, derived }: SnsSummary): bigint =>
   swap.params.max_icp_e8s - derived.buyer_total_icp_e8s;
 
-const isProjectOpen = (summary: SnsSummary): boolean =>
-  summary.swap.lifecycle === SnsSwapLifecycle.Open;
+const isProjectOpen = (summary: SnsSummaryWrapper): boolean =>
+  summary.getLifecycle() === SnsSwapLifecycle.Open;
 // Checks whether the amount that the user wants to contribute is lower than the minimum for the project.
 // It takes into account the current commitment of the user.
 const commitmentTooSmall = ({
@@ -160,7 +150,7 @@ export const canUserParticipateToSwap = ({
   summary,
   swapCommitment,
 }: {
-  summary: SnsSummary | undefined | null;
+  summary: SnsSummaryWrapper | undefined | null;
   swapCommitment: SnsSwapCommitment | undefined | null;
 }): boolean => {
   const myCommitment = getCommitmentE8s(swapCommitment) ?? 0n;
@@ -190,7 +180,7 @@ export const userCountryIsNeeded = ({
   swapCommitment,
   loggedIn,
 }: {
-  summary: SnsSummary | undefined | null;
+  summary: SnsSummaryWrapper | undefined | null;
   swapCommitment: SnsSwapCommitment | undefined | null;
   loggedIn: boolean;
 }): boolean =>
@@ -331,7 +321,7 @@ export const participateButtonStatus = ({
   ticket,
   userCountry,
 }: {
-  summary: SnsSummary | undefined | null;
+  summary: SnsSummaryWrapper | undefined | null;
   swapCommitment: SnsSwapCommitment | undefined | null;
   loggedIn: boolean;
   ticket: SnsSwapTicket | undefined | null;

--- a/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectCommitment.spec.ts
@@ -1,6 +1,7 @@
 import ProjectCommitment from "$lib/components/project-detail/ProjectCommitment.svelte";
 import { snsSwapMetricsStore } from "$lib/stores/sns-swap-metrics.store";
-import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
+import type { SnsSwapCommitment } from "$lib/types/sns";
+import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import {
   createSummary,
   mockSnsFullProject,
@@ -14,7 +15,7 @@ describe("ProjectCommitment", () => {
   const saleBuyerCount = 1_000_000;
 
   const renderComponent = (
-    summary: SnsSummary,
+    summary: SnsSummaryWrapper,
     swapCommitment: SnsSwapCommitment = mockSnsFullProject.swapCommitment
   ) => {
     const { container } = renderContextCmp({

--- a/frontend/src/tests/lib/components/project-detail/ProjectInfoSection.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectInfoSection.spec.ts
@@ -4,14 +4,14 @@ import {
   type ProjectDetailContext,
   type ProjectDetailStore,
 } from "$lib/types/project-detail.context";
-import type { SnsSummary } from "$lib/types/sns";
+import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import ContextWrapperTest from "$tests/lib/components/ContextWrapperTest.svelte";
 import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
 import { render } from "@testing-library/svelte";
 import { writable } from "svelte/store";
 
 describe("ProjectInfoSection", () => {
-  const renderProjectInfoSection = (summary: SnsSummary | undefined) =>
+  const renderProjectInfoSection = (summary: SnsSummaryWrapper | undefined) =>
     render(ContextWrapperTest, {
       props: {
         contextKey: PROJECT_DETAIL_CONTEXT_KEY,

--- a/frontend/src/tests/lib/components/project-detail/ProjectMetadataSection.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectMetadataSection.spec.ts
@@ -4,7 +4,7 @@ import {
   type ProjectDetailContext,
   type ProjectDetailStore,
 } from "$lib/types/project-detail.context";
-import type { SnsSummary } from "$lib/types/sns";
+import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import ContextWrapperTest from "$tests/lib/components/ContextWrapperTest.svelte";
 import {
   createSummary,
@@ -17,7 +17,9 @@ import { render } from "@testing-library/svelte";
 import { writable } from "svelte/store";
 
 describe("ProjectMetadataSection", () => {
-  const renderProjectMetadataSection = (summary: SnsSummary | undefined) =>
+  const renderProjectMetadataSection = (
+    summary: SnsSummaryWrapper | undefined
+  ) =>
     render(ContextWrapperTest, {
       props: {
         contextKey: PROJECT_DETAIL_CONTEXT_KEY,

--- a/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
@@ -1,7 +1,8 @@
 import ProjectStatusSection from "$lib/components/project-detail/ProjectStatusSection.svelte";
 import { authStore } from "$lib/stores/auth.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
-import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
+import type { SnsSwapCommitment } from "$lib/types/sns";
+import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
 import {
   createBuyersState,
@@ -25,7 +26,7 @@ describe("ProjectStatusSection", () => {
     summary,
     swapCommitment,
   }: {
-    summary?: SnsSummary;
+    summary?: SnsSummaryWrapper;
     swapCommitment?: SnsSwapCommitment;
   }): ProjectStatusSectionPo => {
     const { container } = renderContextCmp({

--- a/frontend/src/tests/lib/components/project-detail/ProjectTimelineUserCommitment.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectTimelineUserCommitment.spec.ts
@@ -40,15 +40,14 @@ describe("ProjectTimelineUserCommitment", () => {
 
   it("should render starting info if status Adopted", () => {
     const summaryData = summaryForLifecycle(SnsSwapLifecycle.Adopted);
-    const summary = {
-      ...summaryData,
+    const summary = summaryData.override({
       swap: {
         ...summaryData.swap,
         decentralization_sale_open_timestamp_seconds: BigInt(
           now + SECONDS_IN_DAY
         ),
       },
-    };
+    });
     const { queryByText } = render(ProjectTimelineUserCommitment, {
       summary,
       swapCommitment: mockSnsFullProject.swapCommitment as SnsSwapCommitment,

--- a/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseList.spec.ts
@@ -19,14 +19,13 @@ describe("SelectUniverseList", () => {
     {
       ...mockSnsFullProject,
       rootCanisterId: principal(1),
-      summary: {
-        ...mockSnsFullProject.summary,
+      summary: mockSnsFullProject.summary.override({
         rootCanisterId: principal(1),
         metadata: {
           ...mockSnsFullProject.summary.metadata,
           name: "another name",
         },
-      },
+      }),
     },
   ];
 

--- a/frontend/src/tests/lib/types/sns-summary-wrapper.spec.ts
+++ b/frontend/src/tests/lib/types/sns-summary-wrapper.spec.ts
@@ -1,0 +1,124 @@
+import type { SnsSummarySwap } from "$lib/types/sns";
+import {
+  mockDerived,
+  mockInit,
+  mockLifecycleResponse,
+  mockMetadata,
+  mockSnsParams,
+  mockSummary,
+  mockSwap,
+  mockToken,
+  principal,
+} from "$tests/mocks/sns-projects.mock";
+import type {
+  SnsGetLifecycleResponse,
+  SnsParams,
+  SnsSwapDerivedState,
+  SnsSwapInit,
+} from "@dfinity/sns";
+import { SnsSwapLifecycle } from "@dfinity/sns";
+
+describe("SnsSummaryWrapper", () => {
+  it("should return rootCanisterId", () => {
+    const rootCanisterId = principal(323);
+    const summary = mockSummary.override({ rootCanisterId });
+    expect(summary.rootCanisterId.toText()).toBe(rootCanisterId.toText());
+  });
+
+  it("should return swapCanisterId", () => {
+    const swapCanisterId = principal(324);
+    const summary = mockSummary.override({ swapCanisterId });
+    expect(summary.swapCanisterId.toText()).toBe(swapCanisterId.toText());
+  });
+
+  it("should return governanceCanisterId", () => {
+    const governanceCanisterId = principal(325);
+    const summary = mockSummary.override({ governanceCanisterId });
+    expect(summary.governanceCanisterId.toText()).toBe(
+      governanceCanisterId.toText()
+    );
+  });
+
+  it("should return ledgerCanisterId", () => {
+    const ledgerCanisterId = principal(326);
+    const summary = mockSummary.override({ ledgerCanisterId });
+    expect(summary.ledgerCanisterId.toText()).toBe(ledgerCanisterId.toText());
+  });
+
+  it("should return indexCanisterId", () => {
+    const indexCanisterId = principal(327);
+    const summary = mockSummary.override({ indexCanisterId });
+    expect(summary.indexCanisterId.toText()).toBe(indexCanisterId.toText());
+  });
+
+  it("should return indexCanisterId", () => {
+    const indexCanisterId = principal(328);
+    const summary = mockSummary.override({ indexCanisterId });
+    expect(summary.indexCanisterId.toText()).toBe(indexCanisterId.toText());
+  });
+
+  it("should return metadata", () => {
+    const metadata = {
+      ...mockMetadata,
+      url: "https://example.com/wrapper-test",
+    };
+    const summary = mockSummary.override({ metadata });
+    expect(summary.metadata).toBe(metadata);
+  });
+
+  it("should return token", () => {
+    const token = {
+      ...mockToken,
+      name: "Wrapper token",
+    };
+    const summary = mockSummary.override({ token });
+    expect(summary.token).toBe(token);
+  });
+
+  it("should return swap", () => {
+    const swap: SnsSummarySwap = {
+      ...mockSwap,
+      next_ticket_id: [457831n],
+    };
+    const summary = mockSummary.override({ swap });
+    expect(summary.swap).toBe(swap);
+  });
+
+  it("should return derived", () => {
+    const derived: SnsSwapDerivedState = {
+      ...mockDerived,
+      direct_participant_count: [34294n],
+    };
+    const summary = mockSummary.overrideDerivedState(derived);
+    expect(summary.derived).toBe(derived);
+  });
+
+  it("should return init", () => {
+    const init: SnsSwapInit = {
+      ...mockInit,
+      nns_proposal_id: [91n],
+    };
+    const summary = mockSummary.override({ init });
+    expect(summary.init).toBe(init);
+  });
+
+  it("should return swapParams", () => {
+    const swapParams: SnsParams = {
+      ...mockSnsParams,
+      max_icp_e8s: 13_785_000_000n,
+    };
+    const summary = mockSummary.override({ swapParams });
+    expect(summary.swapParams).toBe(swapParams);
+  });
+
+  it("should return lifecycle", () => {
+    const lifecycle: SnsGetLifecycleResponse = {
+      ...mockLifecycleResponse,
+      lifecycle: [SnsSwapLifecycle.Aborted],
+      decentralization_sale_open_timestamp_seconds: [168_100_000n],
+    };
+    const summary = mockSummary.overrideLifecycleResponse(lifecycle);
+    expect(summary.lifecycle).toBe(lifecycle);
+    expect(summary.getLifecycle()).toBe(SnsSwapLifecycle.Aborted);
+  });
+});

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1,6 +1,7 @@
 import { NOT_LOADED } from "$lib/constants/stores.constants";
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
 import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
+import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import {
   canUserParticipateToSwap,
@@ -37,11 +38,11 @@ import { SnsSwapLifecycle, type SnsSwapTicket } from "@dfinity/sns";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 
 describe("project-utils", () => {
-  const summaryUsRestricted: SnsSummary = createSummary({
+  const summaryUsRestricted: SnsSummaryWrapper = createSummary({
     lifecycle: SnsSwapLifecycle.Open,
     restrictedCountries: ["US"],
   });
-  const summaryNoRestricted: SnsSummary = createSummary({
+  const summaryNoRestricted: SnsSummaryWrapper = createSummary({
     lifecycle: SnsSwapLifecycle.Open,
     restrictedCountries: [],
   });
@@ -65,7 +66,7 @@ describe("project-utils", () => {
             },
           ],
           swapLifecycle: SnsSwapLifecycle.Open,
-        })[0].summary.swap.lifecycle
+        })[0].summary.getLifecycle()
       ).toEqual(SnsSwapLifecycle.Open);
 
       expect(
@@ -114,13 +115,12 @@ describe("project-utils", () => {
         filterActiveProjects([
           {
             ...mockSnsFullProject,
-            summary: {
-              ...mockSnsFullProject.summary,
+            summary: mockSnsFullProject.summary.override({
               swap: {
                 ...mockSwap,
                 lifecycle: SnsSwapLifecycle.Pending,
               },
-            },
+            }),
           },
         ])?.length
       ).toEqual(0);
@@ -473,8 +473,7 @@ describe("project-utils", () => {
       const userMax = 1_000_000_000n;
       const validProject: SnsFullProject = {
         ...mockSnsFullProject,
-        summary: {
-          ...mockSnsFullProject.summary,
+        summary: mockSnsFullProject.summary.override({
           derived: {
             buyer_total_icp_e8s: 0n,
             sns_tokens_per_icp: 1,
@@ -493,7 +492,7 @@ describe("project-utils", () => {
               max_icp_e8s: projectMax,
             },
           },
-        },
+        }),
         swapCommitment: undefined,
       };
       expect(currentUserMaxCommitment(validProject)).toEqual(userMax);
@@ -505,8 +504,7 @@ describe("project-utils", () => {
       const userCommitment = 400_000_000n;
       const validProject: SnsFullProject = {
         ...mockSnsFullProject,
-        summary: {
-          ...mockSnsFullProject.summary,
+        summary: mockSnsFullProject.summary.override({
           derived: {
             buyer_total_icp_e8s: userCommitment,
             sns_tokens_per_icp: 1,
@@ -525,7 +523,7 @@ describe("project-utils", () => {
               max_icp_e8s: projectMax,
             },
           },
-        },
+        }),
         swapCommitment: {
           ...(mockSnsFullProject.swapCommitment as SnsSwapCommitment),
           myCommitment: {
@@ -545,8 +543,7 @@ describe("project-utils", () => {
       const projectCommitment = 9_500_000_000n;
       const validProject: SnsFullProject = {
         ...mockSnsFullProject,
-        summary: {
-          ...mockSnsFullProject.summary,
+        summary: mockSnsFullProject.summary.override({
           derived: {
             buyer_total_icp_e8s: projectCommitment,
             sns_tokens_per_icp: 1,
@@ -565,7 +562,7 @@ describe("project-utils", () => {
               max_icp_e8s: projectMax,
             },
           },
-        },
+        }),
         swapCommitment: undefined,
       };
       expect(currentUserMaxCommitment(validProject)).toEqual(
@@ -580,8 +577,7 @@ describe("project-utils", () => {
       const userCommitment = 400_000_000n;
       const validProject: SnsFullProject = {
         ...mockSnsFullProject,
-        summary: {
-          ...mockSnsFullProject.summary,
+        summary: mockSnsFullProject.summary.override({
           derived: {
             buyer_total_icp_e8s: projectCommitment,
             sns_tokens_per_icp: 1,
@@ -600,7 +596,7 @@ describe("project-utils", () => {
               max_icp_e8s: projectMax,
             },
           },
-        },
+        }),
         swapCommitment: {
           ...(mockSnsFullProject.swapCommitment as SnsSwapCommitment),
           myCommitment: {
@@ -619,8 +615,7 @@ describe("project-utils", () => {
     it("returns remaining amount taking into account current commitment", () => {
       const projectMax = 10_000_000_000n;
       const projectCommitment = 9_200_000_000n;
-      const summary: SnsSummary = {
-        ...mockSnsFullProject.summary,
+      const summary: SnsSummary = mockSnsFullProject.summary.override({
         derived: {
           buyer_total_icp_e8s: projectCommitment,
           sns_tokens_per_icp: 1,
@@ -639,7 +634,7 @@ describe("project-utils", () => {
             max_icp_e8s: projectMax,
           },
         },
-      };
+      });
       expect(projectRemainingAmount(summary)).toEqual(
         projectMax - projectCommitment
       );
@@ -650,8 +645,7 @@ describe("project-utils", () => {
     const validAmountE8s = 1_000_000_000n;
     const validProject: SnsFullProject = {
       ...mockSnsFullProject,
-      summary: {
-        ...mockSnsFullProject.summary,
+      summary: mockSnsFullProject.summary.override({
         derived: {
           buyer_total_icp_e8s: 0n,
           sns_tokens_per_icp: 1,
@@ -671,7 +665,7 @@ describe("project-utils", () => {
             max_icp_e8s: validAmountE8s + 10_000n,
           },
         },
-      },
+      }),
       swapCommitment: {
         ...(mockSnsFullProject.swapCommitment as SnsSwapCommitment),
         myCommitment: {
@@ -694,13 +688,12 @@ describe("project-utils", () => {
     it("returns false if project committed", () => {
       const project = {
         ...validProject,
-        summary: {
-          ...validProject.summary,
+        summary: validProject.summary.override({
           swap: {
             ...validProject.summary.swap,
             lifecycle: SnsSwapLifecycle.Committed,
           },
-        },
+        }),
       };
       const { valid } = validParticipation({
         project,
@@ -715,13 +708,12 @@ describe("project-utils", () => {
     it("returns false if project pending", () => {
       const project = {
         ...validProject,
-        summary: {
-          ...validProject.summary,
+        summary: validProject.summary.override({
           swap: {
             ...validProject.summary.swap,
             lifecycle: SnsSwapLifecycle.Pending,
           },
-        },
+        }),
       };
       const { valid } = validParticipation({
         project,
@@ -736,8 +728,7 @@ describe("project-utils", () => {
     it("returns false if amount is larger than maximum per participant", () => {
       const project = {
         ...validProject,
-        summary: {
-          ...validProject.summary,
+        summary: validProject.summary.override({
           swap: {
             ...validProject.summary.swap,
             params: {
@@ -745,7 +736,7 @@ describe("project-utils", () => {
               max_participant_icp_e8s: validAmountE8s,
             },
           },
-        },
+        }),
       };
       const { valid } = validParticipation({
         project,
@@ -760,8 +751,7 @@ describe("project-utils", () => {
     it("takes into account current participation to calculate the maximum per participant", () => {
       const project: SnsFullProject = {
         ...validProject,
-        summary: {
-          ...validProject.summary,
+        summary: validProject.summary.override({
           swap: {
             ...validProject.summary.swap,
             params: {
@@ -769,7 +759,7 @@ describe("project-utils", () => {
               max_participant_icp_e8s: validAmountE8s * 2n,
             },
           },
-        },
+        }),
         swapCommitment: {
           ...(validProject.swapCommitment as SnsSwapCommitment),
           myCommitment: {
@@ -794,8 +784,7 @@ describe("project-utils", () => {
       const currentE8s = 950_000_000n;
       const project: SnsFullProject = {
         ...validProject,
-        summary: {
-          ...validProject.summary,
+        summary: validProject.summary.override({
           derived: {
             buyer_total_icp_e8s: currentE8s,
             sns_tokens_per_icp: 1,
@@ -812,7 +801,7 @@ describe("project-utils", () => {
               max_participant_icp_e8s: maxE8s,
             },
           },
-        },
+        }),
       };
       const { valid } = validParticipation({
         project,
@@ -833,8 +822,7 @@ describe("project-utils", () => {
       const newParticipation = 600_000_000n;
       const project: SnsFullProject = {
         ...validProject,
-        summary: {
-          ...validProject.summary,
+        summary: validProject.summary.override({
           derived: {
             buyer_total_icp_e8s: currentProjectParticipation,
             sns_tokens_per_icp: 1,
@@ -853,7 +841,7 @@ describe("project-utils", () => {
               max_icp_e8s: maxProject,
             },
           },
-        },
+        }),
         swapCommitment: {
           ...(validProject.swapCommitment as SnsSwapCommitment),
           myCommitment: {
@@ -879,8 +867,7 @@ describe("project-utils", () => {
     const maxPerUser = 2_000_000_000n;
     const project: SnsFullProject = {
       ...mockSnsFullProject,
-      summary: {
-        ...mockSnsFullProject.summary,
+      summary: mockSnsFullProject.summary.override({
         derived: {
           buyer_total_icp_e8s: 0n,
           sns_tokens_per_icp: 1,
@@ -900,7 +887,7 @@ describe("project-utils", () => {
             max_icp_e8s: maxProject,
           },
         },
-      },
+      }),
       swapCommitment: undefined,
     };
     it("user flow check", () => {
@@ -995,8 +982,7 @@ describe("project-utils", () => {
       const maxE8s = 1_000_000_000n;
       const participationE8s = 100_000_000n;
       const currentE8s = 950_000_000n;
-      const summary: SnsSummary = {
-        ...mockSnsFullProject.summary,
+      const summary = mockSnsFullProject.summary.override({
         derived: {
           buyer_total_icp_e8s: currentE8s,
           sns_tokens_per_icp: 1,
@@ -1013,7 +999,7 @@ describe("project-utils", () => {
             max_icp_e8s: maxE8s,
           },
         },
-      };
+      });
       const expected = commitmentExceedsAmountLeft({
         summary,
         amountE8s: participationE8s,
@@ -1025,8 +1011,7 @@ describe("project-utils", () => {
       const maxE8s = 1_000_000_000n;
       const participationE8s = 100_000_000n;
       const currentE8s = 850_000_000n;
-      const summary: SnsSummary = {
-        ...mockSnsFullProject.summary,
+      const summary = mockSnsFullProject.summary.override({
         derived: {
           buyer_total_icp_e8s: currentE8s,
           sns_tokens_per_icp: 1,
@@ -1043,7 +1028,7 @@ describe("project-utils", () => {
             max_icp_e8s: maxE8s,
           },
         },
-      };
+      });
       const expected = commitmentExceedsAmountLeft({
         summary,
         amountE8s: participationE8s,
@@ -1053,17 +1038,14 @@ describe("project-utils", () => {
   });
 
   describe("participateButtonStatus", () => {
-    const summary: SnsSummary = {
-      ...mockSnsFullProject.summary,
-    };
+    const summary = mockSnsFullProject.summary;
 
-    const notOpenSummary: SnsSummary = {
-      ...mockSnsFullProject.summary,
+    const notOpenSummary = mockSnsFullProject.summary.override({
       swap: {
         ...mockSnsFullProject.summary.swap,
         lifecycle: SnsSwapLifecycle.Committed,
       },
-    };
+    });
 
     const userNoCommitment: SnsSwapCommitment = {
       rootCanisterId: mockSnsFullProject.rootCanisterId,
@@ -1268,13 +1250,12 @@ describe("project-utils", () => {
     });
 
     it("should return the different summaries", () => {
-      const sameButDifferent: SnsSummary = {
-        ...summaryNoRestricted,
+      const sameButDifferent = summaryNoRestricted.override({
         token: {
           ...summaryNoRestricted.token,
           name: "not the same",
         },
-      };
+      });
       expect(
         differentSummaries(
           [summaryUsRestricted, sameButDifferent],

--- a/frontend/src/tests/mocks/sns-projects.mock.ts
+++ b/frontend/src/tests/mocks/sns-projects.mock.ts
@@ -1,11 +1,11 @@
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import type {
-  SnsSummary,
   SnsSummaryMetadata,
   SnsSummarySwap,
   SnsSwapCommitment,
 } from "$lib/types/sns";
+import { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import type { QuerySnsMetadata } from "$lib/types/sns.query";
 import type { Universe } from "$lib/types/universe";
 import {
@@ -213,7 +213,7 @@ export const mockLifecycleResponse: SnsGetLifecycleResponse = {
   decentralization_swap_termination_timestamp_seconds: [],
 };
 
-export const mockSnsSummaryList: SnsSummary[] = [
+export const mockSnsSummaryList: SnsSummaryWrapper[] = [
   {
     rootCanisterId: principal(0),
     swapCanisterId: principal(3),
@@ -303,7 +303,7 @@ export const mockSnsSummaryList: SnsSummary[] = [
     swapParams: mockSnsParams,
     lifecycle: mockLifecycleResponse,
   },
-];
+].map((summary) => new SnsSummaryWrapper(summary));
 
 export const mockSummary = mockSnsSummaryList[0];
 
@@ -319,13 +319,7 @@ export const mockSnsFullProject: SnsFullProject = {
 
 export const summaryForLifecycle = (
   lifecycle: SnsSwapLifecycle
-): SnsSummary => ({
-  ...mockSnsFullProject.summary,
-  swap: {
-    ...mockSwap,
-    lifecycle,
-  },
-});
+): SnsSummaryWrapper => mockSnsFullProject.summary.overrideLifecycle(lifecycle);
 
 type SnsSummaryParams = {
   lifecycle?: SnsSwapLifecycle;
@@ -377,7 +371,7 @@ export const createSummary = ({
   rootCanisterId,
   projectName,
   logo,
-}: SnsSummaryParams): SnsSummary => {
+}: SnsSummaryParams): SnsSummaryWrapper => {
   const init: SnsSwapInit = {
     ...mockInit,
     swap_due_timestamp_seconds: [swapDueTimestampSeconds],
@@ -428,8 +422,7 @@ export const createSummary = ({
     logo: logo ?? mockMetadata.logo,
   };
   const summary = summaryForLifecycle(lifecycle);
-  return {
-    ...summary,
+  return summary.override({
     rootCanisterId: rootCanisterId ?? summary.rootCanisterId,
     metadata,
     swap: {
@@ -440,7 +433,7 @@ export const createSummary = ({
     },
     derived,
     init,
-  };
+  });
 };
 
 export const createMockSnsFullProject = ({

--- a/frontend/src/tests/mocks/sns.mock.ts
+++ b/frontend/src/tests/mocks/sns.mock.ts
@@ -3,7 +3,8 @@ import {
   type ProjectDetailContext,
   type ProjectDetailStore,
 } from "$lib/types/project-detail.context";
-import type { SnsSummary, SnsSwapCommitment, SnsTicket } from "$lib/types/sns";
+import type { SnsSwapCommitment, SnsTicket } from "$lib/types/sns";
+import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import { numberToE8s } from "$lib/utils/token.utils";
 import ContextWrapperTest from "$tests/lib/components/ContextWrapperTest.svelte";
@@ -44,7 +45,7 @@ export const renderContextCmp = ({
   totalTokensSupply,
   reload,
 }: {
-  summary?: SnsSummary;
+  summary?: SnsSummaryWrapper;
   swapCommitment?: SnsSwapCommitment;
   totalTokensSupply?: TokenAmountV2;
   Component: typeof SvelteComponent;


### PR DESCRIPTION
# Motivation

We want to stop using the `summary.swap` field because it's deprecated and everything on it is available in other ways.
One of the things we get from the `swap` field is the `lifecycle`.
In this PR we introduce a getter on `SnsSummaryWrapper` to determine in a single place how we get the lifecycle.
This will make it easy to switch over in another PR.

# Changes

1. Add `getLifecycle()` to `SnsSummaryWrapper` which returns the lifecycle from an `SnsSummary`.
2. Use `SnsSummaryWrapper` and `getLifecycle()` instead of getting `summary.swap.lifecycle` directly.
3. Add `override()` to `SnsSummaryWrapper` because `SnsSummaryWrapper` can't be spread into a new `SnsSummary` object.

# Tests

1. Unit tests added for `SnsSummaryWrapper`.
2. Existing unt tests updated.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary