### PR TITLE
Work around list_neuron not working with HW

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -33,6 +33,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Button disable state glitch when voting with neurons where one follows another.
 * Fix "the current proposals response is too large" error on proposals page.
 * Visibility of "Neuron Management" proposals in actionable list.
+* Fix "Show neurons" for hardware wallet.
 
 #### Security
 

--- a/frontend/src/lib/api-services/governance.api-service.ts
+++ b/frontend/src/lib/api-services/governance.api-service.ts
@@ -29,6 +29,7 @@ import {
   type ApiManageNeuronParams,
   type ApiMergeNeuronsParams,
   type ApiQueryNeuronParams,
+  type ApiQueryNeuronsParams,
   type ApiQueryParams,
   type ApiSetFolloweesParams,
   type ApiSpawnNeuronParams,
@@ -129,7 +130,7 @@ export const governanceApiService = {
   queryNeuron(params: ApiQueryNeuronParams) {
     return queryNeuron(params);
   },
-  async queryNeurons(params: ApiQueryParams) {
+  async queryNeurons(params: ApiQueryNeuronsParams) {
     if (nonNullish(neuronsCache) && hasValidCachedNeurons(params.identity)) {
       return neuronsCache.neurons;
     }

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -353,16 +353,22 @@ export const setFollowees = async ({
   logWithTimestamp(`Setting Followees (${hashCode(neuronId)}) complete.`);
 };
 
+export type ApiQueryNeuronsParams = ApiQueryParams & {
+  // undefined is interpreted as true by the backend.
+  includeEmptyNeurons?: boolean | undefined;
+};
+
 export const queryNeurons = async ({
   identity,
   certified,
-}: ApiQueryParams): Promise<NeuronInfo[]> => {
+  includeEmptyNeurons,
+}: ApiQueryNeuronsParams): Promise<NeuronInfo[]> => {
   logWithTimestamp(`Querying Neurons certified:${certified} call...`);
   const { canister } = await governanceCanister({ identity });
 
   const response = await canister.listNeurons({
     certified,
-    includeEmptyNeurons: false,
+    includeEmptyNeurons,
   });
   logWithTimestamp(`Querying Neurons certified:${certified} complete.`);
   return response;

--- a/frontend/src/lib/services/icp-ledger.services.ts
+++ b/frontend/src/lib/services/icp-ledger.services.ts
@@ -176,6 +176,8 @@ export const listNeuronsHardwareWallet = async (): Promise<{
     const neurons: NeuronInfo[] = await queryNeurons({
       identity: ledgerIdentity,
       certified: true,
+      // Must be undefined for compatibility with Ledger app 2.4.9.
+      includeEmptyNeurons: undefined,
     });
 
     return { neurons };

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -251,7 +251,11 @@ export const listNeurons = async ({
   return queryAndUpdate<NeuronInfo[], unknown>({
     strategy: strategy ?? FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
-      governanceApiService.queryNeurons({ certified, identity }),
+      governanceApiService.queryNeurons({
+        certified,
+        identity,
+        includeEmptyNeurons: false,
+      }),
     onLoad: async ({ response: neurons, certified }) => {
       neuronsStore.setNeurons({ neurons, certified });
 

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -124,7 +124,11 @@ describe("neurons-api", () => {
   it("queryNeurons fetches neurons", async () => {
     expect(mockGovernanceCanister.listNeurons).not.toBeCalled();
 
-    await queryNeurons({ identity: mockIdentity, certified: false });
+    await queryNeurons({
+      identity: mockIdentity,
+      certified: false,
+      includeEmptyNeurons: false,
+    });
 
     expect(mockGovernanceCanister.listNeurons).toBeCalledWith({
       certified: false,

--- a/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsNeurons.spec.ts
@@ -170,11 +170,13 @@ describe("NnsNeurons", () => {
         expect(api.queryNeurons).toHaveBeenCalledWith({
           identity: mockIdentity,
           certified: true,
+          includeEmptyNeurons: false,
         })
       );
       expect(api.queryNeurons).toHaveBeenCalledWith({
         identity: mockIdentity,
         certified: false,
+        includeEmptyNeurons: false,
       });
     });
 
@@ -185,11 +187,13 @@ describe("NnsNeurons", () => {
         expect(api.queryNeurons).toHaveBeenCalledWith({
           identity: mockIdentity,
           certified: true,
+          includeEmptyNeurons: false,
         })
       );
       expect(api.queryNeurons).toHaveBeenCalledWith({
         identity: mockIdentity,
         certified: false,
+        includeEmptyNeurons: false,
       });
 
       await renderComponent();

--- a/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
@@ -78,11 +78,13 @@ describe("ProposalDetail", () => {
         expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
           identity: mockIdentity,
           certified: true,
+          includeEmptyNeurons: false,
         })
       );
       expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
         identity: mockIdentity,
         certified: false,
+        includeEmptyNeurons: false,
       });
       expect(governanceApi.queryNeurons).toHaveBeenCalledTimes(2);
     });

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -85,11 +85,13 @@ describe("NnsProposals", () => {
           expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
             identity: mockIdentity,
             certified: true,
+            includeEmptyNeurons: false,
           })
         );
         expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
           identity: mockIdentity,
           certified: false,
+          includeEmptyNeurons: false,
         });
       });
     });

--- a/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
@@ -320,6 +320,13 @@ describe("icp-ledger.services", () => {
         const { neurons } = await listNeuronsHardwareWallet();
 
         expect(neurons).toEqual(mockNeurons);
+        expect(api.queryNeurons).toBeCalledWith({
+          certified: true,
+          identity: mockLedgerIdentity,
+          // Must be undefined for compatibility with Ledger app 2.4.9.
+          includeEmptyNeurons: undefined,
+        });
+        expect(api.queryNeurons).toBeCalledTimes(1);
       });
     });
 

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -353,10 +353,12 @@ describe("neurons-services", () => {
       expect(spyQueryNeurons).toBeCalledWith({
         certified: false,
         identity: mockIdentity,
+        includeEmptyNeurons: false,
       });
       expect(spyQueryNeurons).toBeCalledWith({
         certified: true,
         identity: mockIdentity,
+        includeEmptyNeurons: false,
       });
       expect(spyQueryNeurons).toBeCalledTimes(2);
 
@@ -371,11 +373,13 @@ describe("neurons-services", () => {
       expect(spyQueryNeurons).toBeCalledWith({
         identity: mockIdentity,
         certified: true,
+        includeEmptyNeurons: false,
       });
 
       expect(spyQueryNeurons).toBeCalledWith({
         identity: mockIdentity,
         certified: false,
+        includeEmptyNeurons: false,
       });
 
       expect(spyQueryNeurons).toBeCalledTimes(2);

--- a/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
@@ -113,6 +113,7 @@ describe("Proposal detail page when not logged in user", () => {
         expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
           identity: mockIdentity,
           certified: true,
+          includeEmptyNeurons: false,
         })
       );
 
@@ -160,11 +161,13 @@ describe("Proposal detail page when not logged in user", () => {
         expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
           identity: mockIdentity,
           certified: true,
+          includeEmptyNeurons: false,
         })
       );
       expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
         identity: mockIdentity,
         certified: false,
+        includeEmptyNeurons: false,
       });
     });
   });

--- a/frontend/src/tests/workflows/NnsProposals.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposals.spec.ts
@@ -91,11 +91,13 @@ describe('NnsProposals when "all proposals" selected', () => {
         expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
           identity: mockIdentity,
           certified: true,
+          includeEmptyNeurons: false,
         })
       );
       expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
         identity: mockIdentity,
         certified: false,
+        includeEmptyNeurons: false,
       });
     });
   });


### PR DESCRIPTION
# Motivation

`list_neurons` is broken with the Ledger HW (current version 2.4.9) because it does not accept a `ListNeurons` with the `includeEmptyNeurons` field.

# Changes

1. Make `includeEmptyNeurons` a parameter on `queryNeurons`.
2. Set `includeEmptyNeurons` to `undefined` when calling `queryNeurons` for the hardware wallet.
3. and to `false` otherwise.

# Tests

1. Unit tests updated.
2. Manually tested.

# Todos

- [x] Add entry to changelog (if necessary).
