### PR TITLE
NNS1-3094: Staking sign-in banner text

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -237,6 +237,8 @@
     "ect": "Early Contributor Token"
   },
   "staking": {
+    "title": "Stake and earn voting rewards",
+    "text": "Earn voting rewards by staking your tokens in neurons. Neurons allow you to participate in governance of the Internet Computer, and DAOs deployed on the Internet Computer.",
     "nervous_systems": "Nervous Systems"
   },
   "neurons": {

--- a/frontend/src/lib/routes/Staking.svelte
+++ b/frontend/src/lib/routes/Staking.svelte
@@ -10,8 +10,8 @@
   {#if !$authSignedInStore}
     <PageBanner testId="staking-page-banner">
       <IconNeuronsPage slot="image" />
-      <svelte:fragment slot="title">{$i18n.auth_neurons.title}</svelte:fragment>
-      <p class="description" slot="description">{$i18n.neurons.text}</p>
+      <svelte:fragment slot="title">{$i18n.staking.title}</svelte:fragment>
+      <p class="description" slot="description">{$i18n.staking.text}</p>
       <SignIn slot="actions" />
     </PageBanner>
   {/if}

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -248,6 +248,8 @@ interface I18nNeuron_types {
 }
 
 interface I18nStaking {
+  title: string;
+  text: string;
   nervous_systems: string;
 }
 


### PR DESCRIPTION
# Motivation

Match the design in [Figma](https://www.figma.com/design/x8dk5axQUf8Bi43uUsqCHc/NNS-Production-%26-Hand-over?node-id=3518-50771&t=PEo9Sxph834Vxh5a-4).

# Changes

Change the title and text in the sign-in banner on the staking projects table page.

# Tests

Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/staking/

# Todos

- [ ] Add entry to changelog (if necessary).
not yet