### PR TITLE
NNS1-3094: Show -/- instead of 0 when neuron count not available

### DIFF
--- a/frontend/src/lib/components/staking/ProjectNeuronsCell.svelte
+++ b/frontend/src/lib/components/staking/ProjectNeuronsCell.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
   import type { TableProject } from "$lib/types/staking";
+  import { nonNullish } from "@dfinity/utils";
 
   export let rowData: TableProject;
 </script>
 
 <div data-tid="project-neurons-cell-component" class="title-logo-wrapper">
-  {rowData.neuronCount}
+  {#if nonNullish(rowData.neuronCount)}
+    {rowData.neuronCount}
+  {:else}
+    -/-
+  {/if}
 </div>

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -3,9 +3,10 @@
   import ProjectNeuronsCell from "$lib/components/staking/ProjectNeuronsCell.svelte";
   import ProjectTitleCell from "$lib/components/staking/ProjectTitleCell.svelte";
   import ResponsiveTable from "$lib/components/ui/ResponsiveTable.svelte";
+  import { authSignedInStore } from "$lib/derived/auth.derived";
   import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
   import { i18n } from "$lib/stores/i18n";
-  import { definedNeuronsStore } from "$lib/stores/neurons.store";
+  import { neuronsStore } from "$lib/stores/neurons.store";
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import type { ProjectsTableColumn, TableProject } from "$lib/types/staking";
   import { getTableProjects } from "$lib/utils/staking.utils";
@@ -34,7 +35,8 @@
   let tableProjects: TableProject[];
   $: tableProjects = getTableProjects({
     universes: $selectableUniversesStore,
-    definedNnsNeurons: $definedNeuronsStore,
+    isSignedIn: $authSignedInStore,
+    nnsNeurons: $neuronsStore?.neurons,
     snsNeurons: $snsNeuronsStore,
   });
 </script>

--- a/frontend/src/lib/types/staking.ts
+++ b/frontend/src/lib/types/staking.ts
@@ -5,7 +5,7 @@ export type TableProject = {
   domKey: string;
   title: string;
   logo: string;
-  neuronCount: number;
+  neuronCount: number | undefined;
 };
 
 export type ProjectsTableColumn = ResponsiveTableColumn<TableProject>;

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -2,27 +2,29 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import type { TableProject } from "$lib/types/staking";
 import type { Universe } from "$lib/types/universe";
 import { buildNeuronsUrl } from "$lib/utils/navigation.utils";
-import { hasValidStake } from "$lib/utils/sns-neuron.utils";
+import { hasValidStake as nnsHasValidStake } from "$lib/utils/neuron.utils";
+import { hasValidStake as snsHasValidStake } from "$lib/utils/sns-neuron.utils";
 import type { NeuronInfo } from "@dfinity/nns";
 import type { SnsNeuron } from "@dfinity/sns";
 
-// Will filter out neurons without stake from snsNeurons, but assumes neurons
-// without stake have already been filtered out from definedNnsNeurons
 export const getTableProjects = ({
   universes,
-  definedNnsNeurons,
+  isSignedIn,
+  nnsNeurons,
   snsNeurons,
 }: {
   universes: Universe[];
-  definedNnsNeurons: NeuronInfo[];
+  isSignedIn: boolean;
+  nnsNeurons: NeuronInfo[] | undefined;
   snsNeurons: { [rootCanisterId: string]: { neurons: SnsNeuron[] } };
 }): TableProject[] => {
   return universes.map((universe) => {
-    const neuronCount =
-      universe.canisterId === OWN_CANISTER_ID_TEXT
-        ? definedNnsNeurons.length
-        : snsNeurons[universe.canisterId]?.neurons.filter(hasValidStake)
-            .length ?? 0;
+    const neuronCount = !isSignedIn
+      ? undefined
+      : universe.canisterId === OWN_CANISTER_ID_TEXT
+      ? nnsNeurons?.filter(nnsHasValidStake).length
+      : snsNeurons[universe.canisterId]?.neurons.filter(snsHasValidStake)
+          .length;
     return {
       rowHref: buildNeuronsUrl({ universe: universe.canisterId }),
       domKey: universe.canisterId,

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -4,6 +4,7 @@ import { AppPath } from "$lib/constants/routes.constants";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { page } from "$mocks/$app/stores";
+import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
@@ -26,6 +27,7 @@ describe("ProjectsTable", () => {
     neuronsStore.reset();
     snsNeuronsStore.reset();
     resetSnsProjects();
+    resetIdentity();
 
     page.mock({
       routeId: AppPath.Staking,
@@ -136,7 +138,6 @@ describe("ProjectsTable", () => {
       const rowPos = await po.getProjectsTableRowPos();
       expect(rowPos).toHaveLength(2);
       expect(await rowPos[0].getNeuronCount()).toBe("2");
-      expect(await rowPos[1].getNeuronCount()).toBe("0");
     });
 
     it("should render SNS neurons count", async () => {
@@ -148,7 +149,6 @@ describe("ProjectsTable", () => {
       const po = renderComponent();
       const rowPos = await po.getProjectsTableRowPos();
       expect(rowPos).toHaveLength(2);
-      expect(await rowPos[0].getNeuronCount()).toBe("0");
       expect(await rowPos[1].getNeuronCount()).toBe("3");
     });
 
@@ -161,7 +161,6 @@ describe("ProjectsTable", () => {
       const rowPos = await po.getProjectsTableRowPos();
       expect(rowPos).toHaveLength(2);
       expect(await rowPos[0].getNeuronCount()).toBe("1");
-      expect(await rowPos[1].getNeuronCount()).toBe("0");
     });
 
     it("should filter SNS neurons without stake", async () => {
@@ -177,8 +176,29 @@ describe("ProjectsTable", () => {
       const po = renderComponent();
       const rowPos = await po.getProjectsTableRowPos();
       expect(rowPos).toHaveLength(2);
-      expect(await rowPos[0].getNeuronCount()).toBe("0");
       expect(await rowPos[1].getNeuronCount()).toBe("2");
+    });
+
+    it("should not render neurons count when not signed in", async () => {
+      setNoIdentity();
+      snsNeuronsStore.setNeurons({
+        rootCanisterId: snsCanisterId,
+        neurons: [],
+        certified: true,
+      });
+      const po = renderComponent();
+      const rowPos = await po.getProjectsTableRowPos();
+      expect(rowPos).toHaveLength(2);
+      expect(await rowPos[0].getNeuronCount()).toBe("-/-");
+      expect(await rowPos[1].getNeuronCount()).toBe("-/-");
+    });
+
+    it("should not render SNS neurons count when not loaded", async () => {
+      const po = renderComponent();
+      const rowPos = await po.getProjectsTableRowPos();
+      expect(rowPos).toHaveLength(2);
+      expect(await rowPos[0].getNeuronCount()).toBe("-/-");
+      expect(await rowPos[1].getNeuronCount()).toBe("-/-");
     });
   });
 


### PR DESCRIPTION
# Motivation

To make it clear that the neuron count is not 0 when the user is not signed in or the neurons haven't loaded yet.

# Changes

1. Pass `neuronsStore` instead of `definedNeuronsStore` to be able to tell if NNS neurons were loaded.
2. Filter NNS neurons without valid stake as was previously done in `definedNeuronsStore`.
3. Use `undefined` when the user is not signed in, or neurons haven't loaded, to indicate that neuron count is unavailable.
4. Render `undefined` as `-/-` in the neurons cell.

# Tests

1. Unit tests added.
2. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/staking/

# Todos

- [ ] Add entry to changelog (if necessary).
not yet