### PR TITLE
NNS1-3094: Make rows without neurons not clickable

### DIFF
--- a/frontend/src/lib/components/staking/ProjectActionsCell.svelte
+++ b/frontend/src/lib/components/staking/ProjectActionsCell.svelte
@@ -1,18 +1,16 @@
 <script lang="ts">
   import type { TableProject } from "$lib/types/staking";
   import { IconRight } from "@dfinity/gix-components";
+  import { nonNullish } from "@dfinity/utils";
 
   export let rowData: TableProject;
 </script>
 
-{#if false}
-  <!-- Satisfy the linter as it doesn't like unused props. -->
-  {rowData.title}
+{#if nonNullish(rowData.rowHref)}
+  <div data-tid="go-to-neurons-table-action" class="container">
+    <IconRight />
+  </div>
 {/if}
-
-<div class="container">
-  <IconRight />
-</div>
 
 <style lang="scss">
   .container {

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -25,8 +25,12 @@ export const getTableProjects = ({
       ? nnsNeurons?.filter(nnsHasValidStake).length
       : snsNeurons[universe.canisterId]?.neurons.filter(snsHasValidStake)
           .length;
+    const rowHref =
+      (neuronCount ?? 0) > 0
+        ? buildNeuronsUrl({ universe: universe.canisterId })
+        : undefined;
     return {
-      rowHref: buildNeuronsUrl({ universe: universe.canisterId }),
+      rowHref,
       domKey: universe.canisterId,
       title: universe.title,
       logo: universe.logo,

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -82,16 +82,6 @@ describe("ProjectsTable", () => {
     );
   });
 
-  it("should render neurons URL", async () => {
-    const po = renderComponent();
-    const rowPos = await po.getProjectsTableRowPos();
-    expect(rowPos).toHaveLength(2);
-    expect(await rowPos[0].getHref()).toBe(
-      `/neurons/?u=${OWN_CANISTER_ID_TEXT}`
-    );
-    expect(await rowPos[1].getHref()).toBe(`/neurons/?u=${snsCanisterId}`);
-  });
-
   it("should render project title", async () => {
     const po = renderComponent();
     const rowPos = await po.getProjectsTableRowPos();
@@ -138,6 +128,10 @@ describe("ProjectsTable", () => {
       const rowPos = await po.getProjectsTableRowPos();
       expect(rowPos).toHaveLength(2);
       expect(await rowPos[0].getNeuronCount()).toBe("2");
+      expect(await rowPos[0].getHref()).toBe(
+        `/neurons/?u=${OWN_CANISTER_ID_TEXT}`
+      );
+      expect(await rowPos[0].hasGoToNeuronsTableAction()).toBe(true);
     });
 
     it("should render SNS neurons count", async () => {
@@ -150,6 +144,8 @@ describe("ProjectsTable", () => {
       const rowPos = await po.getProjectsTableRowPos();
       expect(rowPos).toHaveLength(2);
       expect(await rowPos[1].getNeuronCount()).toBe("3");
+      expect(await rowPos[1].getHref()).toBe(`/neurons/?u=${snsCanisterId}`);
+      expect(await rowPos[1].hasGoToNeuronsTableAction()).toBe(true);
     });
 
     it("should filter NNS neurons without stake", async () => {
@@ -190,7 +186,11 @@ describe("ProjectsTable", () => {
       const rowPos = await po.getProjectsTableRowPos();
       expect(rowPos).toHaveLength(2);
       expect(await rowPos[0].getNeuronCount()).toBe("-/-");
+      expect(await rowPos[0].getHref()).toBe(null);
+      expect(await rowPos[0].hasGoToNeuronsTableAction()).toBe(false);
       expect(await rowPos[1].getNeuronCount()).toBe("-/-");
+      expect(await rowPos[1].getHref()).toBe(null);
+      expect(await rowPos[1].hasGoToNeuronsTableAction()).toBe(false);
     });
 
     it("should not render SNS neurons count when not loaded", async () => {
@@ -198,7 +198,32 @@ describe("ProjectsTable", () => {
       const rowPos = await po.getProjectsTableRowPos();
       expect(rowPos).toHaveLength(2);
       expect(await rowPos[0].getNeuronCount()).toBe("-/-");
+      expect(await rowPos[0].getHref()).toBe(null);
+      expect(await rowPos[0].hasGoToNeuronsTableAction()).toBe(false);
       expect(await rowPos[1].getNeuronCount()).toBe("-/-");
+      expect(await rowPos[0].getHref()).toBe(null);
+      expect(await rowPos[1].hasGoToNeuronsTableAction()).toBe(false);
+    });
+
+    it("should not render clickable row with zero neurons", async () => {
+      neuronsStore.setNeurons({
+        neurons: [],
+        certified: true,
+      });
+      snsNeuronsStore.setNeurons({
+        rootCanisterId: snsCanisterId,
+        neurons: [],
+        certified: true,
+      });
+      const po = renderComponent();
+      const rowPos = await po.getProjectsTableRowPos();
+      expect(rowPos).toHaveLength(2);
+      expect(await rowPos[0].getNeuronCount()).toBe("0");
+      expect(await rowPos[0].getHref()).toBe(null);
+      expect(await rowPos[0].hasGoToNeuronsTableAction()).toBe(false);
+      expect(await rowPos[1].getNeuronCount()).toBe("0");
+      expect(await rowPos[1].getHref()).toBe(null);
+      expect(await rowPos[1].hasGoToNeuronsTableAction()).toBe(false);
     });
   });
 

--- a/frontend/src/tests/lib/utils/staking.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking.utils.spec.ts
@@ -22,8 +22,11 @@ describe("staking.utils", () => {
       logo: "logo2",
     };
 
+    const nnsHref = `/neurons/?u=${OWN_CANISTER_ID_TEXT}`;
+    const snsHref = `/neurons/?u=${universeId2}`;
+
     const defaultExpectedNnsTableProject = {
-      rowHref: `/neurons/?u=${OWN_CANISTER_ID_TEXT}`,
+      rowHref: undefined,
       domKey: OWN_CANISTER_ID_TEXT,
       title: "Internet Computer",
       logo: IC_LOGO_ROUNDED,
@@ -31,7 +34,7 @@ describe("staking.utils", () => {
     };
 
     const defaultExpectedSnsTableProject = {
-      rowHref: `/neurons/?u=${universeId2}`,
+      rowHref: undefined,
       domKey: universeId2,
       title: "title2",
       logo: "logo2",
@@ -95,6 +98,7 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedNnsTableProject,
+          rowHref: nnsHref,
           neuronCount: 3,
         },
       ]);
@@ -115,6 +119,7 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedSnsTableProject,
+          rowHref: snsHref,
           neuronCount: 2,
         },
       ]);
@@ -135,6 +140,7 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedNnsTableProject,
+          rowHref: nnsHref,
           neuronCount: 1,
         },
       ]);
@@ -160,6 +166,7 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedSnsTableProject,
+          rowHref: snsHref,
           neuronCount: 1,
         },
       ]);
@@ -180,10 +187,12 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedNnsTableProject,
+          rowHref: undefined,
           neuronCount: undefined,
         },
         {
           ...defaultExpectedSnsTableProject,
+          rowHref: undefined,
           neuronCount: undefined,
         },
       ]);
@@ -202,10 +211,12 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedNnsTableProject,
+          rowHref: undefined,
           neuronCount: undefined,
         },
         {
           ...defaultExpectedSnsTableProject,
+          rowHref: undefined,
           neuronCount: undefined,
         },
       ]);

--- a/frontend/src/tests/page-objects/ProjectsTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectsTableRow.page-object.ts
@@ -31,4 +31,8 @@ export class ProjectsTableRowPo extends ResponsiveTableRowPo {
   getNeuronCount(): Promise<string> {
     return this.getProjectNeuronsCellPo().getNeuronCount();
   }
+
+  hasGoToNeuronsTableAction(): Promise<boolean> {
+    return this.isPresent("go-to-neurons-table-action");
+  }
 }


### PR DESCRIPTION
# Motivation

We don't want people to navigate to an empty neurons table.
So the table rows for projects without neurons should not be clickable and should not have an `>` icon.

# Changes

1. Set `rowHref` to `undefined` for rows that don't have a positive number of neurons.
2. Do not render the action icon if `rowHref` is undefined.

# Tests

1. Row href is now tested in the same tests as neuron counts to make the relationship clear.
2. Unit test added.
3. Manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/staking/

# Todos

- [ ] Add entry to changelog (if necessary).
not yet