### PR TITLE
Remove default button padding

### DIFF
--- a/frontend/src/lib/components/header/Logout.svelte
+++ b/frontend/src/lib/components/header/Logout.svelte
@@ -22,5 +22,6 @@
 
   button {
     @include account-menu.button;
+    padding: 0;
   }
 </style>

--- a/frontend/src/lib/components/header/SettingsButton.svelte
+++ b/frontend/src/lib/components/header/SettingsButton.svelte
@@ -24,5 +24,6 @@
 
   button {
     @include account-menu.button;
+    padding: 0;
   }
 </style>


### PR DESCRIPTION
# Motivation

Some account menu entries are rendered as links, while others are rendered as buttons. By default the buttons have an extra padding before and after them.

# Changes

- Remove default button padding from account menu entries.

# Tests

- Manually.

| Before | After |
|--------|--------|
| <img width="255" alt="Screenshot 2024-07-16 at 17 32 11" src="https://github.com/user-attachments/assets/82b0f31a-1773-46e6-99ed-b46948a22861"> | <img width="254" alt="Screenshot 2024-07-16 at 17 40 47" src="https://github.com/user-attachments/assets/dc15da3d-2ac3-4652-b844-42bcbbe1f183"> | 



# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.