### PR TITLE
Remove raw from icons url

### DIFF
--- a/frontend/static/manifest.json
+++ b/frontend/static/manifest.json
@@ -10,12 +10,12 @@
   "prefer_related_applications": false,
   "icons": [
     {
-      "src": "https://nns.raw.ic0.app/assets/favicons/icon-192x192.png",
+      "src": "https://nns.ic0.app/assets/favicons/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "https://nns.raw.ic0.app/assets/favicons/icon-512x512.png",
+      "src": "https://nns.ic0.app/assets/favicons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/frontend/static/manifest.json
+++ b/frontend/static/manifest.json
@@ -10,12 +10,12 @@
   "prefer_related_applications": false,
   "icons": [
     {
-      "src": "https://nns.ic0.app/assets/favicons/icon-192x192.png",
+      "src": "/assets/favicons/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "https://nns.ic0.app/assets/favicons/icon-512x512.png",
+      "src": "/assets/favicons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
# Motivation

Using `.raw` for the mobile icons is no longer necessary.

# Changes

- remove `.raw` from the manifest icon section.

# Tests

Demo link: https://qsgjb-riaaa-aaaaa-aaaga-cai.mstr-ingress.devenv.dfinity.network/

- Manually added to the home screen and tested that the icon looks the same as the current version from the mainnet on both iOS and Android.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary