### PR TITLE
Stop getting lifecycle from swap state

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectStatus.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectStatus.svelte
@@ -5,7 +5,7 @@
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
   } from "$lib/types/project-detail.context";
-  import type { SnsSummary, SnsSummarySwap } from "$lib/types/sns";
+  import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
   import { keyOf } from "$lib/utils/utils";
   import { Tag } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
@@ -17,10 +17,12 @@
     PROJECT_DETAIL_CONTEXT_KEY
   );
 
-  let swap: SnsSummarySwap;
-  let rootCanisterId: Principal;
+  let summary: SnsSummaryWrapper;
   // type safety validation is done in ProjectStatusSection component
-  $: ({ swap, rootCanisterId } = $projectDetailStore.summary as SnsSummary);
+  $: summary = $projectDetailStore.summary as SnsSummaryWrapper;
+
+  let rootCanisterId: Principal;
+  $: rootCanisterId = summary.rootCanisterId;
 
   const statusTextMapper = {
     [SnsSwapLifecycle.Unspecified]: $i18n.sns_project_detail.status_unspecified,
@@ -32,7 +34,7 @@
   };
 
   let lifecycle: number;
-  $: ({ lifecycle } = swap);
+  $: lifecycle = summary.getLifecycle();
 
   let isFinalizingStore: Readable<boolean>;
   $: isFinalizingStore = createIsSnsFinalizingStore(rootCanisterId);

--- a/frontend/src/lib/types/sns-summary-wrapper.ts
+++ b/frontend/src/lib/types/sns-summary-wrapper.ts
@@ -12,7 +12,7 @@ import type {
   SnsSwapInit,
   SnsSwapLifecycle,
 } from "@dfinity/sns";
-import { fromNullable, isNullish } from "@dfinity/utils";
+import { fromDefinedNullable, fromNullable, isNullish } from "@dfinity/utils";
 
 export class SnsSummaryWrapper implements SnsSummary {
   private readonly summary: SnsSummary;
@@ -58,7 +58,9 @@ export class SnsSummaryWrapper implements SnsSummary {
   }
 
   getLifecycle(): SnsSwapLifecycle {
-    return this.swap.lifecycle;
+    // lifecycle was added as an optional field for backwards compatibility but
+    // is always defined in current SNSes.
+    return fromDefinedNullable(this.lifecycle.lifecycle);
   }
 
   public overrideDerivedState(


### PR DESCRIPTION
# Motivation

We want to stop using the `summary.swap` field because it's deprecated and everything on it is available in other ways.
In this PR we stop getting the `lifecycle` from the `summary.swap`.

# Changes

1. Update`ProjectStatus.svelte` which (I believe) was the last place where weren't getting the lifecycle via `SnsSummaryWrapper.getLifecycle`.
2. Change `SnsSummaryWrapper.getLifecycle` to get the lifecycle from the lifecycle field instead of the swap fields.

# Tests

Existing tests pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary