### PR TITLE
Use named parameters in LedgerErrorKey

### DIFF
--- a/frontend/src/lib/api/icrc-ledger.api.ts
+++ b/frontend/src/lib/api/icrc-ledger.api.ts
@@ -42,7 +42,7 @@ export const queryIcrcToken = async ({
   const token = mapOptionalToken(tokenData);
 
   if (isNullish(token)) {
-    throw new LedgerErrorKey("error.icrc_token_load");
+    throw new LedgerErrorKey({ message: "error.icrc_token_load" });
   }
 
   return token;

--- a/frontend/src/lib/identities/ledger.identity.ts
+++ b/frontend/src/lib/identities/ledger.identity.ts
@@ -94,7 +94,9 @@ export class LedgerIdentity extends SignIdentity {
     if (
       smallerVersion({ minVersion: ALL_CANDID_TXS_VERSION, currentVersion })
     ) {
-      throw new LedgerErrorKey("error__ledger.app_version_not_supported");
+      throw new LedgerErrorKey({
+        message: "error__ledger.app_version_not_supported",
+      });
     }
   };
 
@@ -207,13 +209,17 @@ export class LedgerIdentity extends SignIdentity {
         if (
           (err as LedgerHQTransportError)?.message.includes("not supported")
         ) {
-          throw new LedgerErrorKey("error__ledger.browser_not_supported");
+          throw new LedgerErrorKey({
+            message: "error__ledger.browser_not_supported",
+          });
         }
-        throw new LedgerErrorKey("error__ledger.access_denied");
+        throw new LedgerErrorKey({ message: "error__ledger.access_denied" });
       }
 
       if ((err as LedgerHQTransportError)?.id === "NoDeviceFound") {
-        throw new LedgerErrorKey("error__ledger.connect_no_device");
+        throw new LedgerErrorKey({
+          message: "error__ledger.connect_no_device",
+        });
       }
 
       if (
@@ -221,7 +227,9 @@ export class LedgerIdentity extends SignIdentity {
           "cannot open device with path"
         )
       ) {
-        throw new LedgerErrorKey("error__ledger.connect_many_apps");
+        throw new LedgerErrorKey({
+          message: "error__ledger.connect_many_apps",
+        });
       }
 
       // Unsupported browser. Data on browser compatibility is taken from https://caniuse.com/webhid
@@ -262,7 +270,9 @@ export class LedgerIdentity extends SignIdentity {
         });
 
       if (JSON.stringify(devicePublicKey) !== JSON.stringify(this.publicKey)) {
-        throw new LedgerErrorKey("error__ledger.unexpected_wallet");
+        throw new LedgerErrorKey({
+          message: "error__ledger.unexpected_wallet",
+        });
       }
 
       // Run the provided function.

--- a/frontend/src/lib/services/sns-sale.services.ts
+++ b/frontend/src/lib/services/sns-sale.services.ts
@@ -454,7 +454,7 @@ export const initiateSnsSaleParticipation = async ({
 
     if (!valid) {
       // TODO: Rename LedgerErroKey to NnsDappErrorKey?
-      throw new LedgerErrorKey(labelKey, substitutions);
+      throw new LedgerErrorKey({ message: labelKey, substitutions });
     }
 
     // Step 1.

--- a/frontend/src/lib/types/ledger.errors.ts
+++ b/frontend/src/lib/types/ledger.errors.ts
@@ -4,7 +4,13 @@ export class LedgerErrorKey extends Error {
   // Optional substitutions values that can be used to fill the error message
   substitutions?: I18nSubstitutions;
 
-  constructor(message?: string, substitutions?: I18nSubstitutions) {
+  constructor({
+    message,
+    substitutions,
+  }: {
+    message?: string;
+    substitutions?: I18nSubstitutions;
+  }) {
     super(message);
 
     this.substitutions = substitutions;

--- a/frontend/src/lib/utils/ledger.utils.ts
+++ b/frontend/src/lib/utils/ledger.utils.ts
@@ -27,17 +27,17 @@ export const decodePublicKey = async ({
   const code: AllLedgerError = returnCode as AllLedgerError;
 
   if (code === ExtendedLedgerError.AppNotOpen) {
-    throw new LedgerErrorKey("error__ledger.please_open");
+    throw new LedgerErrorKey({ message: "error__ledger.please_open" });
   }
 
   const { LedgerError } = await import("@zondax/ledger-icp");
 
   if (code === LedgerError.TransactionRejected) {
-    throw new LedgerErrorKey("error__ledger.locked");
+    throw new LedgerErrorKey({ message: "error__ledger.locked" });
   }
 
   if (code === ExtendedLedgerError.CannotFetchPublicKey) {
-    throw new LedgerErrorKey("error__ledger.fetch_public_key");
+    throw new LedgerErrorKey({ message: "error__ledger.fetch_public_key" });
   }
 
   const publicKey: Secp256k1PublicKey = Secp256k1PublicKey.fromRaw(
@@ -48,7 +48,7 @@ export const decodePublicKey = async ({
     principalText !==
     Principal.selfAuthenticating(new Uint8Array(publicKey.toDer())).toText()
   ) {
-    throw new LedgerErrorKey("error__ledger.principal_not_match");
+    throw new LedgerErrorKey({ message: "error__ledger.principal_not_match" });
   }
 
   return publicKey;
@@ -57,7 +57,9 @@ export const decodePublicKey = async ({
 const checkResponseCode = async (returnCode: LedgerError): Promise<void> => {
   const { LedgerError } = await import("@zondax/ledger-icp");
   if (returnCode === LedgerError.TransactionRejected) {
-    throw new LedgerErrorKey("error__ledger.user_rejected_transaction");
+    throw new LedgerErrorKey({
+      message: "error__ledger.user_rejected_transaction",
+    });
   }
 };
 

--- a/frontend/src/tests/lib/identities/ledger.identity.spec.ts
+++ b/frontend/src/tests/lib/identities/ledger.identity.spec.ts
@@ -246,7 +246,9 @@ describe("LedgerIdentity", () => {
 
       const call = () => identity.transformRequest(mockHttpRequest1);
       expect(call).rejects.toThrowError(
-        new LedgerErrorKey("error__ledger.app_version_not_supported")
+        new LedgerErrorKey({
+          message: "error__ledger.app_version_not_supported",
+        })
       );
       expect(mockLedgerApp.signUpdateCall).not.toBeCalled();
     });
@@ -269,7 +271,9 @@ describe("LedgerIdentity", () => {
 
       const call = () => identity.transformRequest(mockHttpRequest1);
       expect(call).rejects.toThrowError(
-        new LedgerErrorKey("error__ledger.app_version_not_supported")
+        new LedgerErrorKey({
+          message: "error__ledger.app_version_not_supported",
+        })
       );
       expect(mockLedgerApp.sign).not.toBeCalled();
     });

--- a/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
@@ -98,7 +98,9 @@ describe("icp-ledger.services", () => {
 
       it("should display a toast for the error assuming the browser is not supported", async () => {
         vi.spyOn(LedgerIdentity, "create").mockImplementation(() => {
-          throw new LedgerErrorKey("error__ledger.browser_not_supported");
+          throw new LedgerErrorKey({
+            message: "error__ledger.browser_not_supported",
+          });
         });
         const spyToastError = vi.spyOn(toastsStore, "toastsError");
 
@@ -282,7 +284,9 @@ describe("icp-ledger.services", () => {
     describe("error", () => {
       it("should not display info if ledger throw an error", async () => {
         spy.mockImplementation(() => {
-          throw new LedgerErrorKey("error__ledger.unexpected_wallet");
+          throw new LedgerErrorKey({
+            message: "error__ledger.unexpected_wallet",
+          });
         });
 
         const spyToastError = vi.spyOn(toastsStore, "toastsError");
@@ -334,7 +338,7 @@ describe("icp-ledger.services", () => {
       beforeAll(() => {
         vi.spyOn(LedgerIdentity, "create").mockImplementation(
           async (): Promise<LedgerIdentity> => {
-            throw new LedgerErrorKey("error__ledger.please_open");
+            throw new LedgerErrorKey({ message: "error__ledger.please_open" });
           }
         );
       });

--- a/frontend/src/tests/lib/utils/ledger.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/ledger.utils.spec.ts
@@ -27,7 +27,7 @@ describe("ledger-utils", () => {
         } as ResponseAddress);
 
       expect(call).rejects.toThrow(
-        new LedgerErrorKey("error__ledger.please_open")
+        new LedgerErrorKey({ message: "error__ledger.please_open" })
       );
     });
 
@@ -39,7 +39,9 @@ describe("ledger-utils", () => {
           returnCode: LedgerError.TransactionRejected,
         } as ResponseAddress);
 
-      expect(call).rejects.toThrow(new LedgerErrorKey("error__ledger.locked"));
+      expect(call).rejects.toThrow(
+        new LedgerErrorKey({ message: "error__ledger.locked" })
+      );
     });
 
     it("should throw an error because public key cannot be fetched", () => {
@@ -52,7 +54,7 @@ describe("ledger-utils", () => {
         } as ResponseAddress);
 
       expect(call).rejects.toThrow(
-        new LedgerErrorKey("error__ledger.fetch_public_key")
+        new LedgerErrorKey({ message: "error__ledger.fetch_public_key" })
       );
     });
 
@@ -64,7 +66,7 @@ describe("ledger-utils", () => {
         } as ResponseAddress);
 
       expect(call).rejects.toThrow(
-        new LedgerErrorKey("error__ledger.principal_not_match")
+        new LedgerErrorKey({ message: "error__ledger.principal_not_match" })
       );
     });
 
@@ -88,9 +90,9 @@ describe("ledger-utils", () => {
         } as unknown as ResponseSign);
 
       expect(call).rejects.toThrow(
-        new LedgerErrorKey(
-          `A ledger error happened during signature. undefined (code ${LedgerError.UnknownError}).`
-        )
+        new LedgerErrorKey({
+          message: `A ledger error happened during signature. undefined (code ${LedgerError.UnknownError}).`,
+        })
       );
     });
 
@@ -102,7 +104,9 @@ describe("ledger-utils", () => {
         } as unknown as ResponseSign);
 
       expect(call).rejects.toThrow(
-        new LedgerErrorKey("error__ledger.user_rejected_transaction")
+        new LedgerErrorKey({
+          message: "error__ledger.user_rejected_transaction",
+        })
       );
     });
 
@@ -116,9 +120,9 @@ describe("ledger-utils", () => {
         } as unknown as ResponseSign);
 
       expect(call).rejects.toThrow(
-        new LedgerErrorKey(
-          `Signature must be 64 bytes long (is ${test.length})`
-        )
+        new LedgerErrorKey({
+          message: `Signature must be 64 bytes long (is ${test.length})`,
+        })
       );
     });
 


### PR DESCRIPTION
# Motivation

When a function or constructor has multiple parameters, we agreed to use named parameters.
The `LedgerErrorKey` constructor has 2 (optional) parameters which are positional parameters.

# Changes

Use named parameters in the `LedgerErrorKey` constructor.

# Tests

Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary