### PR TITLE
Do not render error messages as HTML by default

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -36,6 +36,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Fix "the current proposals response is too large" error on proposals page.
 * Visibility of "Neuron Management" proposals in actionable list.
 * Fix "Show neurons" for hardware wallet.
+* HTML injection in error toast.
 
 #### Security
 

--- a/frontend/src/lib/identities/ledger.identity.ts
+++ b/frontend/src/lib/identities/ledger.identity.ts
@@ -96,6 +96,7 @@ export class LedgerIdentity extends SignIdentity {
     ) {
       throw new LedgerErrorKey({
         message: "error__ledger.app_version_not_supported",
+        renderAsHtml: true,
       });
     }
   };

--- a/frontend/src/lib/stores/toasts.store.ts
+++ b/frontend/src/lib/stores/toasts.store.ts
@@ -46,10 +46,12 @@ export const toastsError = ({
   labelKey,
   err,
   substitutions,
+  renderAsHtml,
 }: {
   labelKey: string;
   err?: unknown;
   substitutions?: I18nSubstitutions;
+  renderAsHtml?: boolean;
 }): symbol => {
   if (err !== undefined) {
     console.error(err);
@@ -60,8 +62,7 @@ export const toastsError = ({
     level: "error",
     detail: errorToString(err),
     substitutions,
-    // We don't have any use-case to not render as HTML, so no need to add complexity here.
-    renderAsHtml: true,
+    renderAsHtml,
   });
 };
 

--- a/frontend/src/lib/types/ledger.errors.ts
+++ b/frontend/src/lib/types/ledger.errors.ts
@@ -3,17 +3,22 @@ import type { I18nSubstitutions } from "$lib/utils/i18n.utils";
 export class LedgerErrorKey extends Error {
   // Optional substitutions values that can be used to fill the error message
   substitutions?: I18nSubstitutions;
+  // Whether to render the error message as HTML.
+  renderAsHtml: boolean;
 
   constructor({
     message,
     substitutions,
+    renderAsHtml = false,
   }: {
     message?: string;
     substitutions?: I18nSubstitutions;
+    renderAsHtml?: boolean;
   }) {
     super(message);
 
     this.substitutions = substitutions;
+    this.renderAsHtml = renderAsHtml;
   }
 }
 

--- a/frontend/src/lib/utils/error.utils.ts
+++ b/frontend/src/lib/utils/error.utils.ts
@@ -130,12 +130,18 @@ export const toToastError = ({
   renderAsHtml: boolean;
 } => {
   let errorKey = false;
-  const message: string | undefined = (err as Error)?.message;
+  const error = err as Error | undefined;
+  const message: string | undefined = error?.message;
 
   if (message !== undefined) {
     const label = translate({ labelKey: message });
     errorKey = label !== message;
   }
+
+  const renderAsHtml =
+    nonNullish(error) && "renderAsHtml" in error
+      ? (error.renderAsHtml as boolean)
+      : false;
 
   type ErrorSubstitutions = { substitutions?: I18nSubstitutions };
 
@@ -148,7 +154,7 @@ export const toToastError = ({
       undefined && {
       substitutions: (err as ErrorSubstitutions).substitutions,
     }),
-    renderAsHtml: true,
+    renderAsHtml,
   };
 };
 

--- a/frontend/src/tests/lib/identities/ledger.identity.spec.ts
+++ b/frontend/src/tests/lib/identities/ledger.identity.spec.ts
@@ -1,6 +1,5 @@
 import { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { Secp256k1PublicKey } from "$lib/keys/secp256k1";
-import { LedgerErrorKey } from "$lib/types/ledger.errors";
 import { getRequestId } from "$lib/utils/ledger.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
@@ -245,11 +244,10 @@ describe("LedgerIdentity", () => {
       const identity = await LedgerIdentity.create();
 
       const call = () => identity.transformRequest(mockHttpRequest1);
-      expect(call).rejects.toThrowError(
-        new LedgerErrorKey({
-          message: "error__ledger.app_version_not_supported",
-        })
-      );
+      expect(call).rejects.toMatchObject({
+        message: "error__ledger.app_version_not_supported",
+        renderAsHtml: true,
+      });
       expect(mockLedgerApp.signUpdateCall).not.toBeCalled();
     });
 
@@ -270,11 +268,10 @@ describe("LedgerIdentity", () => {
       identity.flagUpcomingStakeNeuron();
 
       const call = () => identity.transformRequest(mockHttpRequest1);
-      expect(call).rejects.toThrowError(
-        new LedgerErrorKey({
-          message: "error__ledger.app_version_not_supported",
-        })
-      );
+      expect(call).rejects.toMatchObject({
+        message: "error__ledger.app_version_not_supported",
+        renderAsHtml: true,
+      });
       expect(mockLedgerApp.sign).not.toBeCalled();
     });
   });

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -536,7 +536,7 @@ describe("icp-accounts.services", () => {
       expect(spyToastError).toBeCalledWith({
         labelKey: "error__account.create_subaccount",
         err: new Error(en.error.missing_identity),
-        renderAsHtml: true,
+        renderAsHtml: false,
       });
 
       resetIdentity();
@@ -729,7 +729,7 @@ describe("icp-accounts.services", () => {
       expect(spyToastError).toBeCalledWith({
         labelKey: "error.rename_subaccount",
         err: new Error(en.error.missing_identity),
-        renderAsHtml: true,
+        renderAsHtml: false,
       });
 
       resetIdentity();
@@ -748,7 +748,7 @@ describe("icp-accounts.services", () => {
       expect(spyToastError).toBeCalled();
       expect(spyToastError).toBeCalledWith({
         labelKey: "error.rename_subaccount_no_account",
-        renderAsHtml: true,
+        renderAsHtml: false,
       });
 
       spyToastError.mockClear();
@@ -765,7 +765,7 @@ describe("icp-accounts.services", () => {
       expect(spyToastError).toBeCalled();
       expect(spyToastError).toBeCalledWith({
         labelKey: "error.rename_subaccount_type",
-        renderAsHtml: true,
+        renderAsHtml: false,
       });
 
       spyToastError.mockClear();

--- a/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-ledger.services.spec.ts
@@ -296,7 +296,7 @@ describe("icp-ledger.services", () => {
         expect(spyToastError).toBeCalled();
         expect(spyToastError).toBeCalledWith({
           labelKey: "error__ledger.unexpected_wallet",
-          renderAsHtml: true,
+          renderAsHtml: false,
         });
 
         spyToastError.mockRestore();
@@ -351,7 +351,7 @@ describe("icp-ledger.services", () => {
         expect(spyToastError).toBeCalled();
         expect(spyToastError).toBeCalledWith({
           labelKey: "error__ledger.please_open",
-          renderAsHtml: true,
+          renderAsHtml: false,
         });
 
         expect(err).not.toBeUndefined();

--- a/frontend/src/tests/lib/utils/error.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/error.utils.spec.ts
@@ -1,3 +1,5 @@
+import { LedgerErrorKey } from "$lib/types/ledger.errors";
+
 import { HardwareWalletAttachError } from "$lib/canisters/nns-dapp/nns-dapp.errors";
 import {
   errorToString,
@@ -44,7 +46,7 @@ describe("error-utils", () => {
           fallbackErrorLabelKey: "test.test",
           err: undefined,
         })
-      ).toEqual({ labelKey: "test.test", renderAsHtml: true });
+      ).toEqual({ labelKey: "test.test", renderAsHtml: false });
 
       const err = new HardwareWalletAttachError("test");
 
@@ -53,14 +55,14 @@ describe("error-utils", () => {
           fallbackErrorLabelKey: "test.test",
           err,
         })
-      ).toEqual({ labelKey: "test.test", err, renderAsHtml: true });
+      ).toEqual({ labelKey: "test.test", err, renderAsHtml: false });
 
       expect(
         toToastError({
           fallbackErrorLabelKey: "test.test",
           err,
         })
-      ).toEqual({ labelKey: "test.test", err, renderAsHtml: true });
+      ).toEqual({ labelKey: "test.test", err, renderAsHtml: false });
     });
 
     it("should use error message key", () => {
@@ -71,7 +73,24 @@ describe("error-utils", () => {
           fallbackErrorLabelKey: "test.test",
           err,
         })
-      ).toEqual({ labelKey: "error.rename_subaccount", renderAsHtml: true });
+      ).toEqual({ labelKey: "error.rename_subaccount", renderAsHtml: false });
+    });
+
+    it("should pass on renderAsHtml", () => {
+      const err = new LedgerErrorKey({
+        message: "error__ledger.app_version_not_supported",
+        renderAsHtml: true,
+      });
+
+      expect(
+        toToastError({
+          fallbackErrorLabelKey: "test.test",
+          err,
+        })
+      ).toEqual({
+        labelKey: "error__ledger.app_version_not_supported",
+        renderAsHtml: true,
+      });
     });
   });
 

--- a/frontend/src/tests/lib/utils/ledger.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/ledger.utils.spec.ts
@@ -1,5 +1,5 @@
 import { ExtendedLedgerError } from "$lib/constants/ledger.constants";
-import { LedgerErrorKey } from "$lib/types/ledger.errors";
+import { LedgerErrorMessage } from "$lib/types/ledger.errors";
 import { decodePublicKey, decodeSignature } from "$lib/utils/ledger.utils";
 import { mockPrincipalText } from "$tests/mocks/auth.store.mock";
 import {
@@ -26,9 +26,10 @@ describe("ledger-utils", () => {
           returnCode: ExtendedLedgerError.AppNotOpen as unknown as LedgerError,
         } as ResponseAddress);
 
-      expect(call).rejects.toThrow(
-        new LedgerErrorKey({ message: "error__ledger.please_open" })
-      );
+      expect(call).rejects.toMatchObject({
+        message: "error__ledger.please_open",
+        renderAsHtml: false,
+      });
     });
 
     it("should throw an error because ledger is locked", () => {
@@ -39,9 +40,10 @@ describe("ledger-utils", () => {
           returnCode: LedgerError.TransactionRejected,
         } as ResponseAddress);
 
-      expect(call).rejects.toThrow(
-        new LedgerErrorKey({ message: "error__ledger.locked" })
-      );
+      expect(call).rejects.toMatchObject({
+        message: "error__ledger.locked",
+        renderAsHtml: false,
+      });
     });
 
     it("should throw an error because public key cannot be fetched", () => {
@@ -53,9 +55,10 @@ describe("ledger-utils", () => {
             ExtendedLedgerError.CannotFetchPublicKey as unknown as LedgerError,
         } as ResponseAddress);
 
-      expect(call).rejects.toThrow(
-        new LedgerErrorKey({ message: "error__ledger.fetch_public_key" })
-      );
+      expect(call).rejects.toMatchObject({
+        message: "error__ledger.fetch_public_key",
+        renderAsHtml: false,
+      });
     });
 
     it("should throw an error because principal does not match", async () => {
@@ -65,9 +68,10 @@ describe("ledger-utils", () => {
           publicKey: fromHexString(rawPublicKeyHex) as unknown as Buffer,
         } as ResponseAddress);
 
-      expect(call).rejects.toThrow(
-        new LedgerErrorKey({ message: "error__ledger.principal_not_match" })
-      );
+      expect(call).rejects.toMatchObject({
+        message: "error__ledger.principal_not_match",
+        renderAsHtml: false,
+      });
     });
 
     it("should return a Secp256k1 public key", async () => {
@@ -90,9 +94,9 @@ describe("ledger-utils", () => {
         } as unknown as ResponseSign);
 
       expect(call).rejects.toThrow(
-        new LedgerErrorKey({
-          message: `A ledger error happened during signature. undefined (code ${LedgerError.UnknownError}).`,
-        })
+        new LedgerErrorMessage(
+          `A ledger error happened during signature. undefined (code ${LedgerError.UnknownError}).`
+        )
       );
     });
 
@@ -103,11 +107,10 @@ describe("ledger-utils", () => {
           returnCode: LedgerError.TransactionRejected,
         } as unknown as ResponseSign);
 
-      expect(call).rejects.toThrow(
-        new LedgerErrorKey({
-          message: "error__ledger.user_rejected_transaction",
-        })
-      );
+      expect(call).rejects.toMatchObject({
+        message: "error__ledger.user_rejected_transaction",
+        renderAsHtml: false,
+      });
     });
 
     it("should throw an error if signature too short", () => {
@@ -120,9 +123,9 @@ describe("ledger-utils", () => {
         } as unknown as ResponseSign);
 
       expect(call).rejects.toThrow(
-        new LedgerErrorKey({
-          message: `Signature must be 64 bytes long (is ${test.length})`,
-        })
+        new LedgerErrorMessage(
+          `Signature must be 64 bytes long (is ${test.length})`
+        )
       );
     });
 


### PR DESCRIPTION
# Motivation

Some error messages include URL params, for example if the URL contains a canister ID or account ID that's invalid.
The invalid ID is that repeated in the error message and rendered as HTML instead of text.
This allows HTML injection.
For examples (require being signed in):
* https://nns.ic0.app/wallet/?u=qoctq-giaaa-aaaaa-aaaea-cai&account=%3Ch1%3Ehello%3C/h1%3E
* https://nns.ic0.app/canister/?canister=%3Ch1%3Ehello%3C/h1%3E

One error message needs to be rendered as HTML because it includes a link.
This message was added in https://github.com/dfinity/nns-dapp/pull/4373
To facilitate this, the PR changes error rendering to HTML by default, which is not safe.

We should render text by default and only render HTML when we know the error does not contain user input.

# Changes

1. Instead of always rendering toast errors as HTML, accept a parameter which is not set by default.
2. Add a `renderAsHtml` parameter to `LedgerErrorKey` which can be used to indicate that the error should be rendered as HTML.
3. Set this to true for `app_version_not_supported` which includes a link to a forum post.
4. When converting an error to a toast, check if the error has the `renderAsHtml` field set to true, and only then render the toast as HTML.

# Tests

1. When expecting calls to throw `LedgerErrorKey`, instead of `toThrow` (which only compares the message) use `toMatchObject` to check `renderAsHtml`.
2. Test that `app_version_not_supported` is rendered as HTML.
3. Test that other errors are not rendered as HTML.

# Todos

- [x] Add entry to changelog (if necessary).
