### PR TITLE
Add canister method to store imported tokens

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,7 +18,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Add 2 new topics `ProtocolCanisterMangement` and
 * Make the WASM accessible via beta subdomains so we can deploy early versions there.
 * Enable warning dialog on beta deployment.
-* Backend support for storing imported tokens.
+* Back-end support for storing imported tokens.
 
 #### Changed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Add 2 new topics `ProtocolCanisterMangement` and
 * Make the WASM accessible via beta subdomains so we can deploy early versions there.
 * Enable warning dialog on beta deployment.
+* Backend support for storing imported tokens.
 
 #### Changed
 

--- a/rs/backend/nns-dapp-exports-production.txt
+++ b/rs/backend/nns-dapp-exports-production.txt
@@ -7,6 +7,7 @@ canister_query get_canisters
 canister_query get_exceptional_transactions
 canister_query get_histogram
 canister_query get_stats
+canister_query get_imported_tokens
 canister_query http_request
 canister_update add_account
 canister_update add_assets_tar_xz
@@ -18,5 +19,6 @@ canister_update get_proposal_payload
 canister_update register_hardware_wallet
 canister_update rename_canister
 canister_update rename_sub_account
+canister_update set_imported_tokens
 canister_update step_migration
 main

--- a/rs/backend/nns-dapp-exports-test.txt
+++ b/rs/backend/nns-dapp-exports-test.txt
@@ -8,6 +8,7 @@ canister_query get_exceptional_transactions
 canister_query get_histogram
 canister_query get_stats
 canister_query get_toy_account
+canister_query get_imported_tokens
 canister_query http_request
 canister_update add_account
 canister_update add_assets_tar_xz
@@ -20,5 +21,6 @@ canister_update get_proposal_payload
 canister_update register_hardware_wallet
 canister_update rename_canister
 canister_update rename_sub_account
+canister_update set_imported_tokens
 canister_update step_migration
 main

--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -193,6 +193,27 @@ type SchemaLabel = variant {
     AccountsInStableMemory;
 };
 
+type ImportedToken = record {
+  ledger_canister_id: principal;
+  index_canister_id: opt principal;
+};
+
+type ImportedTokens = record {
+  imported_tokens: vec ImportedToken;
+};
+
+type SetImportedTokensResponse =
+    variant {
+        Ok;
+        AccountNotFound;
+    };
+
+type GetImportedTokensResponse =
+    variant {
+        Ok: ImportedTokens;
+        AccountNotFound;
+    };
+
 service: (opt Config) -> {
     get_account: () -> (GetAccountResponse) query;
     add_account: () -> (AccountIdentifier);
@@ -216,4 +237,7 @@ service: (opt Config) -> {
 
     // Methods available in the test build only:
     get_toy_account: (nat64) -> (GetAccountResponse) query;
+  
+    set_imported_tokens: (ImportedTokens) -> (SetImportedTokensResponse);
+    get_imported_tokens: () -> (GetImportedTokensResponse) query;
 }

--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -227,6 +227,8 @@ service: (opt Config) -> {
     attach_canister: (AttachCanisterRequest) -> (AttachCanisterResponse);
     rename_canister: (RenameCanisterRequest) -> (RenameCanisterResponse);
     detach_canister: (DetachCanisterRequest) -> (DetachCanisterResponse);
+    set_imported_tokens: (ImportedTokens) -> (SetImportedTokensResponse);
+    get_imported_tokens: () -> (GetImportedTokensResponse) query;
     get_proposal_payload: (nat64) -> (GetProposalPayloadResponse);
     get_stats: () -> (Stats) query;
     get_histogram: () -> (Histogram) query;
@@ -240,7 +242,4 @@ service: (opt Config) -> {
 
     // Methods available in the test build only:
     get_toy_account: (nat64) -> (GetAccountResponse) query;
-  
-    set_imported_tokens: (ImportedTokens) -> (SetImportedTokensResponse);
-    get_imported_tokens: () -> (GetImportedTokensResponse) query;
 }

--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -193,14 +193,16 @@ type SchemaLabel = variant {
     AccountsInStableMemory;
 };
 
-type ImportedToken = record {
-  ledger_canister_id: principal;
-  index_canister_id: opt principal;
-};
+type ImportedToken =
+    record {
+        ledger_canister_id: principal;
+        index_canister_id: opt principal;
+    };
 
-type ImportedTokens = record {
-  imported_tokens: vec ImportedToken;
-};
+type ImportedTokens =
+    record {
+        imported_tokens: vec ImportedToken;
+    };
 
 type SetImportedTokensResponse =
     variant {

--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -206,6 +206,7 @@ type SetImportedTokensResponse =
     variant {
         Ok;
         AccountNotFound;
+        TooManyImportedTokens: record{limit: int32};
     };
 
 type GetImportedTokensResponse =

--- a/rs/backend/src/accounts_store.rs
+++ b/rs/backend/src/accounts_store.rs
@@ -37,7 +37,9 @@ use self::schema::SchemaLabel;
 /// accounts we avoid some complications.
 const PRE_MIGRATION_LIMIT: u64 = 300_000;
 
-const MAX_IMPORTED_TOKENS: i32 = 10;
+// Conservatively limit the number of imported tokens to prevent using too much memory.
+// Can be revisited if users find this too restrictive.
+const MAX_IMPORTED_TOKENS: i32 = 20;
 
 /// Accounts, transactions and related data.
 ///

--- a/rs/backend/src/accounts_store/schema/tests.rs
+++ b/rs/backend/src/accounts_store/schema/tests.rs
@@ -24,6 +24,7 @@ pub fn toy_account(account_index: u64, num_canisters: u64) -> Account {
         sub_accounts: HashMap::new(),
         hardware_wallet_accounts: Vec::new(),
         canisters: Vec::new(),
+        imported_tokens: None,
     };
     // Attaches canisters to the account.
     for canister_index in 0..num_canisters {

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -780,6 +780,62 @@ fn detach_canister_canister_not_found() {
 }
 
 #[test]
+fn set_and_get_imported_tokens() {
+    let mut store = setup_test_store();
+    let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
+    let ledger_canister_id = PrincipalId::from_str(TEST_ACCOUNT_2).unwrap();
+    let index_canister_id = PrincipalId::from_str(TEST_ACCOUNT_3).unwrap();
+
+    assert_eq!(
+        store.get_imported_tokens(principal),
+        GetImportedTokensResponse::Ok(ImportedTokens::default())
+    );
+
+    assert_eq!(
+        store.set_imported_tokens(
+            principal,
+            ImportedTokens {
+                imported_tokens: vec![ImportedToken {
+                    ledger_canister_id: ledger_canister_id,
+                    index_canister_id: Some(index_canister_id),
+                }],
+            },
+        ),
+        SetImportedTokensResponse::Ok
+    );
+
+    assert_eq!(
+        store.get_imported_tokens(principal),
+        GetImportedTokensResponse::Ok(ImportedTokens {
+            imported_tokens: vec![ImportedToken {
+                ledger_canister_id: ledger_canister_id,
+                index_canister_id: Some(index_canister_id),
+            }],
+        })
+    );
+}
+
+#[test]
+fn set_imported_tokens_account_not_found() {
+    let mut store = setup_test_store();
+    let non_existing_principal = PrincipalId::from_str(TEST_ACCOUNT_3).unwrap();
+    assert_eq!(
+        store.set_imported_tokens(non_existing_principal, ImportedTokens::default()),
+        SetImportedTokensResponse::AccountNotFound
+    );
+}
+
+#[test]
+fn get_imported_tokens_account_not_found() {
+    let mut store = setup_test_store();
+    let non_existing_principal = PrincipalId::from_str(TEST_ACCOUNT_3).unwrap();
+    assert_eq!(
+        store.get_imported_tokens(non_existing_principal),
+        GetImportedTokensResponse::AccountNotFound
+    );
+}
+
+#[test]
 fn sub_account_name_too_long() {
     let mut store = setup_test_store();
 

--- a/rs/backend/src/accounts_store/tests.rs
+++ b/rs/backend/src/accounts_store/tests.rs
@@ -848,8 +848,17 @@ fn set_and_get_imported_tokens_without_index_canister() {
     );
 }
 
+fn get_unique_imported_tokens(count: u64) -> Vec<ImportedToken> {
+    (0..count)
+        .map(|i| ImportedToken {
+            ledger_canister_id: PrincipalId::new_user_test_id(i),
+            index_canister_id: Some(PrincipalId::new_user_test_id(i + 1000)),
+        })
+        .collect()
+}
+
 #[test]
-fn set_and_get_10_imported_tokens() {
+fn set_and_get_20_imported_tokens() {
     let mut store = setup_test_store();
     let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
 
@@ -858,12 +867,7 @@ fn set_and_get_10_imported_tokens() {
         GetImportedTokensResponse::Ok(ImportedTokens::default())
     );
 
-    let imported_tokens: Vec<ImportedToken> = (0..10)
-        .map(|i| ImportedToken {
-            ledger_canister_id: PrincipalId::new_user_test_id(i as u64),
-            index_canister_id: Some(PrincipalId::new_user_test_id(i as u64 + 100)),
-        })
-        .collect();
+    let imported_tokens = get_unique_imported_tokens(20);
 
     assert_eq!(
         store.set_imported_tokens(
@@ -895,22 +899,12 @@ fn set_imported_tokens_account_not_found() {
 fn set_imported_tokens_too_many() {
     let mut store = setup_test_store();
     let principal = PrincipalId::from_str(TEST_ACCOUNT_1).unwrap();
-    let ledger_canister_id = PrincipalId::new_user_test_id(101);
-    let index_canister_id = PrincipalId::new_user_test_id(102);
 
-    let imported_token = ImportedToken {
-        ledger_canister_id,
-        index_canister_id: Some(index_canister_id),
-    };
+    let imported_tokens = get_unique_imported_tokens(21);
 
     assert_eq!(
-        store.set_imported_tokens(
-            principal,
-            ImportedTokens {
-                imported_tokens: vec![imported_token.clone(); 11],
-            },
-        ),
-        SetImportedTokensResponse::TooManyImportedTokens { limit: 10 }
+        store.set_imported_tokens(principal, ImportedTokens { imported_tokens },),
+        SetImportedTokensResponse::TooManyImportedTokens { limit: 20 }
     );
 }
 

--- a/rs/backend/src/accounts_store/toy_data.rs
+++ b/rs/backend/src/accounts_store/toy_data.rs
@@ -59,6 +59,7 @@ pub fn toy_account(account_index: u64, size: ToyAccountSize) -> Account {
         sub_accounts: HashMap::new(),
         hardware_wallet_accounts: Vec::new(),
         canisters: Vec::new(),
+        imported_tokens: None,
     };
     // Creates linked sub-accounts:
     // Note: Successive accounts have 0, 1, 2 ... MAX_SUB_ACCOUNTS_PER_ACCOUNT-1 sub accounts, restarting at 0.

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -1,8 +1,9 @@
 use crate::accounts_store::histogram::AccountsStoreHistogram;
 use crate::accounts_store::{
     AccountDetails, AttachCanisterRequest, AttachCanisterResponse, CreateSubAccountResponse, DetachCanisterRequest,
-    DetachCanisterResponse, NamedCanister, RegisterHardwareWalletRequest, RegisterHardwareWalletResponse,
-    RenameCanisterRequest, RenameCanisterResponse, RenameSubAccountRequest, RenameSubAccountResponse,
+    DetachCanisterResponse, GetImportedTokensResponse, ImportedTokens, NamedCanister, RegisterHardwareWalletRequest,
+    RegisterHardwareWalletResponse, RenameCanisterRequest, RenameCanisterResponse, RenameSubAccountRequest,
+    RenameSubAccountResponse, SetImportedTokensResponse,
 };
 use crate::arguments::{set_canister_arguments, CanisterArguments, CANISTER_ARGUMENTS};
 use crate::assets::{hash_bytes, insert_asset, insert_tar_xz, Asset};
@@ -236,6 +237,26 @@ pub fn detach_canister() {
 fn detach_canister_impl(request: DetachCanisterRequest) -> DetachCanisterResponse {
     let principal = dfn_core::api::caller();
     STATE.with(|s| s.accounts_store.borrow_mut().detach_canister(principal, request))
+}
+
+#[export_name = "canister_update set_imported_tokens"]
+pub fn set_imported_tokens() {
+    over(candid_one, set_imported_tokens_impl);
+}
+
+fn set_imported_tokens_impl(settings: ImportedTokens) -> SetImportedTokensResponse {
+    let principal = dfn_core::api::caller();
+    STATE.with(|s| s.accounts_store.borrow_mut().set_imported_tokens(principal, settings))
+}
+
+#[export_name = "canister_query get_imported_tokens"]
+pub fn get_imported_tokens() {
+    over(candid_one, |()| get_imported_tokens_impl());
+}
+
+fn get_imported_tokens_impl() -> GetImportedTokensResponse {
+    let principal = dfn_core::api::caller();
+    STATE.with(|s| s.accounts_store.borrow_mut().get_imported_tokens(principal))
 }
 
 #[export_name = "canister_update get_proposal_payload"]


### PR DESCRIPTION
# Motivation

We want to allow users to import custom tokens in NNS dapp by specifying a ledger canister ID and optional index canister ID.
The imported tokens should be persisted with the account so we need to store them in the nns-dapp backend canister.
We need to limit the number of tokens per user to have a bound on the amount of storage used.
We arbitrarily set the limit to 10 and can increase it later if we want.
We store the tokens in the user account which is stored in stable structures.
To keep things simple we just support setting and getting the full list of tokens.

# Changes

Add `set_imported_tokens` and `get_imported_tokens` canister methods.

# Tests

1. Unit tests added.
2. Tested manually with dfx:
```
$ dfx canister call nns-dapp get_imported_tokens --candid rs/backend/nns-dapp.did
(variant { AccountNotFound })

$ dfx canister call nns-dapp  --candid rs/backend/nns-dapp.did add_account
("a6e3ccdf7ede8e4b95c522d990a7be4d9d970b1f7bdcedf3baec857b65f7d8bd")

$ dfx canister call nns-dapp --candid rs/backend/nns-dapp.did get_imported_tokens
(variant { Ok = record { imported_tokens = vec {} } })

$ dfx canister call nns-dapp --candid rs/backend/nns-dapp.did set_imported_tokens '(record{imported_tokens = vec{ record{ledger_canister_id=principal"xnjld-hqaaa-aaaal-qb56q-cai"}  }})'
(variant { Ok })

$ dfx canister call nns-dapp --candid rs/backend/nns-dapp.did get_imported_tokens
(
  variant {
    Ok = record {
      imported_tokens = vec {
        record {
          index_canister_id = null;
          ledger_canister_id = principal "xnjld-hqaaa-aaaal-qb56q-cai";
        };
      };
    }
  },
)

$ dfx canister call nns-dapp --candid rs/backend/nns-dapp.did set_imported_tokens '(record{imported_tokens = vec{ record{ledger_canister_id=principal"xnjld-hqaaa-aaaal-qb56q-cai"};record{ledger_canister_id=principal"xnjld-hqaaa-aaaal-qb56q-cai"};record{ledger_canister_id=principal"xnjld-hqaaa-aaaal-qb56q-cai"};record{ledger_canister_id=principal"xnjld-hqaaa-aaaal-qb56q-cai"};record{ledger_canister_id=principal"xnjld-hqaaa-aaaal-qb56q-cai"};record{ledger_canister_id=principal"xnjld-hqaaa-aaaal-qb56q-cai"};record{ledger_canister_id=principal"xnjld-hqaaa-aaaal-qb56q-cai"};record{ledger_canister_id=principal"xnjld-hqaaa-aaaal-qb56q-cai"};record{ledger_canister_id=principal"xnjld-hqaaa-aaaal-qb56q-cai"};record{ledger_canister_id=principal"xnjld-hqaaa-aaaal-qb56q-cai"};record{ledger_canister_id=principal"xnjld-hqaaa-aaaal-qb56q-cai"};  }})'
(variant { TooManyImportedTokens = record { limit = 10 : int32 } })
```
3. Max tested it in his branch with the frontend code.

# Todos

- [x] Add entry to changelog (if necessary).
