### PR TITLE
fix: Show unrecognized topic and "Unknown Topic (...)"

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -1,4 +1,3 @@
-
 # Unreleased changelog NNS Dapp
 
 All notable changes to the NNS Dapp will be documented in this file.
@@ -15,31 +14,31 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
-* A short delay before closing the mobile table sorting modal.
-* Add 2 new topics `ProtocolCanisterMangement` and
+- A short delay before closing the mobile table sorting modal.
+- Add 2 new topics `ProtocolCanisterMangement` and
   `ServiceNervousSystemManagement` while not allowing following to be set.
 
 #### Changed
 
-* Reduce the frequency of checking if SNS neurons need to be refreshed.
-* New token table order. 
-* Update nns-dapp icons for consistent style and line thickness.
+- Reduce the frequency of checking if SNS neurons need to be refreshed.
+- New token table order.
+- Update nns-dapp icons for consistent style and line thickness.
 
 #### Deprecated
 
 #### Removed
 
-* Remove default topic and proposal status filters.
-* Remove old canister creation/top-up mechanism that hasn't been used for 2 years.
+- Remove default topic and proposal status filters.
+- Remove old canister creation/top-up mechanism that hasn't been used for 2 years.
 
 #### Fixed
 
-* Button disable state glitch when voting with neurons where one follows another.
-* Fix "the current proposals response is too large" error on proposals page.
-* Visibility of "Neuron Management" proposals in actionable list.
-* Fix "Show neurons" for hardware wallet.
-* HTML injection in error toast.
-* Skip unrecognized topics when displaying neuron followees.
+- Button disable state glitch when voting with neurons where one follows another.
+- Fix "the current proposals response is too large" error on proposals page.
+- Visibility of "Neuron Management" proposals in actionable list.
+- Fix "Show neurons" for hardware wallet.
+- HTML injection in error toast.
+- Show unknown topic as "Unknown Topic (...")"
 
 #### Security
 
@@ -49,8 +48,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
-* Script to convert between ID formats
-* Test cycles minting canister notification mechanism of the nns-dapp.
+- Script to convert between ID formats
+- Test cycles minting canister notification mechanism of the nns-dapp.
 
 #### Changed
 
@@ -58,7 +57,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Removed
 
-* Deleted Reproducible Assets workflow.
+- Deleted Reproducible Assets workflow.
 
 #### Fixed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -1,3 +1,4 @@
+
 # Unreleased changelog NNS Dapp
 
 All notable changes to the NNS Dapp will be documented in this file.
@@ -14,31 +15,31 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
-- A short delay before closing the mobile table sorting modal.
-- Add 2 new topics `ProtocolCanisterMangement` and
+* A short delay before closing the mobile table sorting modal.
+* Add 2 new topics `ProtocolCanisterMangement` and
   `ServiceNervousSystemManagement` while not allowing following to be set.
 
 #### Changed
 
-- Reduce the frequency of checking if SNS neurons need to be refreshed.
-- New token table order.
-- Update nns-dapp icons for consistent style and line thickness.
+* Reduce the frequency of checking if SNS neurons need to be refreshed.
+* New token table order. 
+* Update nns-dapp icons for consistent style and line thickness.
 
 #### Deprecated
 
 #### Removed
 
-- Remove default topic and proposal status filters.
-- Remove old canister creation/top-up mechanism that hasn't been used for 2 years.
+* Remove default topic and proposal status filters.
+* Remove old canister creation/top-up mechanism that hasn't been used for 2 years.
 
 #### Fixed
 
-- Button disable state glitch when voting with neurons where one follows another.
-- Fix "the current proposals response is too large" error on proposals page.
-- Visibility of "Neuron Management" proposals in actionable list.
-- Fix "Show neurons" for hardware wallet.
-- HTML injection in error toast.
-- Show unknown topic as "Unknown Topic (...")"
+* Button disable state glitch when voting with neurons where one follows another.
+* Fix "the current proposals response is too large" error on proposals page.
+* Visibility of "Neuron Management" proposals in actionable list.
+* Fix "Show neurons" for hardware wallet.
+* HTML injection in error toast.
+* Show unknown topic as "Unknown Topic (...")".
 
 #### Security
 
@@ -48,8 +49,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
-- Script to convert between ID formats
-- Test cycles minting canister notification mechanism of the nns-dapp.
+* Script to convert between ID formats
+* Test cycles minting canister notification mechanism of the nns-dapp.
 
 #### Changed
 
@@ -57,7 +58,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Removed
 
-- Deleted Reproducible Assets workflow.
+* Deleted Reproducible Assets workflow.
 
 #### Fixed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -39,6 +39,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Visibility of "Neuron Management" proposals in actionable list.
 * Fix "Show neurons" for hardware wallet.
 * HTML injection in error toast.
+* Skip unrecognized topics when displaying neuron followees.
 
 #### Security
 

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -371,7 +371,8 @@
     "topic_18_title": "Service Nervous System Management",
     "topic_18_subtitle": "Proposals related to managing the canisters related to service nervous system (SNS).",
     "current_followees": "Currently Following",
-    "add": "Add Followee"
+    "add": "Add Followee",
+    "unknown_topic_title": "Unknown Topic ($topicId)"
   },
   "voting": {
     "topics": "Topics",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -386,6 +386,7 @@ interface I18nFollow_neurons {
   topic_18_subtitle: string;
   current_followees: string;
   add: string;
+  unknown_topic_title: string;
 }
 
 interface I18nVoting {

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -208,9 +208,9 @@ export const bonusMultiplier = ({
 }): number =>
   1 +
   multiplier *
-    (Math.min(Number(amount), max) /
-      // to avoid NaN
-      (max === 0 ? 1 : max));
+  (Math.min(Number(amount), max) /
+    // to avoid NaN
+    (max === 0 ? 1 : max));
 
 // TODO: Do we need this? What does it mean to have a valid stake?
 // TODO: https://dfinity.atlassian.net/browse/L2-507
@@ -218,16 +218,16 @@ export const hasValidStake = (neuron: NeuronInfo): boolean =>
   // Ignore if we can't validate the stake
   nonNullish(neuron.fullNeuron)
     ? neuron.fullNeuron.cachedNeuronStake +
-        neuron.fullNeuron.maturityE8sEquivalent >
-      BigInt(DEFAULT_TRANSACTION_FEE_E8S)
+    neuron.fullNeuron.maturityE8sEquivalent >
+    BigInt(DEFAULT_TRANSACTION_FEE_E8S)
     : false;
 
 export const getDissolvingTimestampSeconds = (
   neuron: NeuronInfo
 ): bigint | undefined =>
   neuron.state === NeuronState.Dissolving &&
-  neuron.fullNeuron?.dissolveState !== undefined &&
-  "WhenDissolvedTimestampSeconds" in neuron.fullNeuron.dissolveState
+    neuron.fullNeuron?.dissolveState !== undefined &&
+    "WhenDissolvedTimestampSeconds" in neuron.fullNeuron.dissolveState
     ? neuron.fullNeuron.dissolveState.WhenDissolvedTimestampSeconds
     : undefined;
 
@@ -283,7 +283,7 @@ export const formattedMaturity = ({ fullNeuron }: NeuronInfo): string =>
 export const formattedTotalMaturity = ({ fullNeuron }: NeuronInfo): string =>
   formatMaturity(
     (fullNeuron?.maturityE8sEquivalent ?? 0n) +
-      (fullNeuron?.stakedMaturityE8sEquivalent ?? 0n)
+    (fullNeuron?.stakedMaturityE8sEquivalent ?? 0n)
   );
 
 /**
@@ -369,7 +369,7 @@ export const isNeuronControllable = ({
   fullNeuron?.controller !== undefined &&
   (fullNeuron.controller === identity?.getPrincipal().toText() ||
     getAccountByPrincipal({ principal: fullNeuron.controller, accounts }) !==
-      undefined);
+    undefined);
 
 export const isNeuronControlledByHardwareWallet = ({
   neuron,
@@ -487,6 +487,9 @@ export const followeesNeurons = (neuron: NeuronInfo): FolloweesNeuron[] => {
     result.find(({ neuronId: id }) => id === neuronId);
 
   for (const { followees, topic } of neuron.fullNeuron.followees) {
+    if (!(topic in Topic)) {
+      continue;
+    }
     for (const neuronId of followees) {
       const followeesNeuron = resultNeuron(neuronId);
       if (followeesNeuron === undefined) {
@@ -735,12 +738,12 @@ export const canBeMerged = (
   }
   return sameManageNeuronFollowees(neurons)
     ? {
-        isValid: true,
-      }
+      isValid: true,
+    }
     : {
-        isValid: false,
-        messageKey: "error.merge_neurons_not_same_manage_neuron_followees",
-      };
+      isValid: false,
+      messageKey: "error.merge_neurons_not_same_manage_neuron_followees",
+    };
 };
 
 export const mapNeuronIds = ({
@@ -977,7 +980,7 @@ export const maturityLastDistribution = ({
   return (
     actual_timestamp_seconds -
     (fromNullable(rounds_since_last_distribution) ?? 1n) *
-      BigInt(SECONDS_IN_DAY)
+    BigInt(SECONDS_IN_DAY)
   );
 };
 

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -23,6 +23,7 @@ import type { IcpAccountsStoreData } from "$lib/derived/icp-accounts.derived";
 import type { NeuronsStore } from "$lib/stores/neurons.store";
 import type { VoteRegistrationStoreData } from "$lib/stores/vote-registration.store";
 import type { Account } from "$lib/types/account";
+import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import type { Identity } from "@dfinity/agent";
 import type { WizardStep } from "@dfinity/gix-components";
 import {
@@ -487,9 +488,6 @@ export const followeesNeurons = (neuron: NeuronInfo): FolloweesNeuron[] => {
     result.find(({ neuronId: id }) => id === neuronId);
 
   for (const { followees, topic } of neuron.fullNeuron.followees) {
-    if (!(topic in Topic)) {
-      continue;
-    }
     for (const neuronId of followees) {
       const followeesNeuron = resultNeuron(neuronId);
       if (followeesNeuron === undefined) {
@@ -1015,7 +1013,12 @@ export const getTopicTitle = ({
     [Topic.ProtocolCanisterManagement]: i18n.follow_neurons.topic_17_title,
     [Topic.ServiceNervousSystemManagement]: i18n.follow_neurons.topic_18_title,
   };
-  return mapper[topic];
+  return (
+    mapper[topic] ??
+    replacePlaceholders(i18n.follow_neurons.unknown_topic_title, {
+      $topicId: topic.toString(),
+    })
+  );
 };
 
 export const getTopicSubtitle = ({

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -208,9 +208,9 @@ export const bonusMultiplier = ({
 }): number =>
   1 +
   multiplier *
-  (Math.min(Number(amount), max) /
-    // to avoid NaN
-    (max === 0 ? 1 : max));
+    (Math.min(Number(amount), max) /
+      // to avoid NaN
+      (max === 0 ? 1 : max));
 
 // TODO: Do we need this? What does it mean to have a valid stake?
 // TODO: https://dfinity.atlassian.net/browse/L2-507
@@ -218,16 +218,16 @@ export const hasValidStake = (neuron: NeuronInfo): boolean =>
   // Ignore if we can't validate the stake
   nonNullish(neuron.fullNeuron)
     ? neuron.fullNeuron.cachedNeuronStake +
-    neuron.fullNeuron.maturityE8sEquivalent >
-    BigInt(DEFAULT_TRANSACTION_FEE_E8S)
+        neuron.fullNeuron.maturityE8sEquivalent >
+      BigInt(DEFAULT_TRANSACTION_FEE_E8S)
     : false;
 
 export const getDissolvingTimestampSeconds = (
   neuron: NeuronInfo
 ): bigint | undefined =>
   neuron.state === NeuronState.Dissolving &&
-    neuron.fullNeuron?.dissolveState !== undefined &&
-    "WhenDissolvedTimestampSeconds" in neuron.fullNeuron.dissolveState
+  neuron.fullNeuron?.dissolveState !== undefined &&
+  "WhenDissolvedTimestampSeconds" in neuron.fullNeuron.dissolveState
     ? neuron.fullNeuron.dissolveState.WhenDissolvedTimestampSeconds
     : undefined;
 
@@ -283,7 +283,7 @@ export const formattedMaturity = ({ fullNeuron }: NeuronInfo): string =>
 export const formattedTotalMaturity = ({ fullNeuron }: NeuronInfo): string =>
   formatMaturity(
     (fullNeuron?.maturityE8sEquivalent ?? 0n) +
-    (fullNeuron?.stakedMaturityE8sEquivalent ?? 0n)
+      (fullNeuron?.stakedMaturityE8sEquivalent ?? 0n)
   );
 
 /**
@@ -369,7 +369,7 @@ export const isNeuronControllable = ({
   fullNeuron?.controller !== undefined &&
   (fullNeuron.controller === identity?.getPrincipal().toText() ||
     getAccountByPrincipal({ principal: fullNeuron.controller, accounts }) !==
-    undefined);
+      undefined);
 
 export const isNeuronControlledByHardwareWallet = ({
   neuron,
@@ -738,12 +738,12 @@ export const canBeMerged = (
   }
   return sameManageNeuronFollowees(neurons)
     ? {
-      isValid: true,
-    }
+        isValid: true,
+      }
     : {
-      isValid: false,
-      messageKey: "error.merge_neurons_not_same_manage_neuron_followees",
-    };
+        isValid: false,
+        messageKey: "error.merge_neurons_not_same_manage_neuron_followees",
+      };
 };
 
 export const mapNeuronIds = ({
@@ -980,7 +980,7 @@ export const maturityLastDistribution = ({
   return (
     actual_timestamp_seconds -
     (fromNullable(rounds_since_last_distribution) ?? 1n) *
-    BigInt(SECONDS_IN_DAY)
+      BigInt(SECONDS_IN_DAY)
   );
 };
 

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1054,10 +1054,6 @@ describe("neuron-utils", () => {
               topic: Topic.Governance,
               followees: [0n, 1n, 2n],
             },
-            {
-              topic: 100 as Topic,
-              followees: [3n, 4n],
-            },
           ],
         },
       };
@@ -2785,6 +2781,9 @@ describe("neuron-utils", () => {
       ).toBe("API Boundary Node Management");
       expect(getTopicTitle({ topic: Topic.SubnetRental, i18n: en })).toBe(
         "Subnet Rental"
+      );
+      expect(getTopicTitle({ topic: 1000 as Topic, i18n: en })).toBe(
+        "Unknown Topic (1000)"
       );
     });
   });

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -2782,6 +2782,9 @@ describe("neuron-utils", () => {
       expect(getTopicTitle({ topic: Topic.SubnetRental, i18n: en })).toBe(
         "Subnet Rental"
       );
+    });
+
+    it("should render unknown topics", () => {
       expect(getTopicTitle({ topic: 1000 as Topic, i18n: en })).toBe(
         "Unknown Topic (1000)"
       );

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1054,6 +1054,10 @@ describe("neuron-utils", () => {
               topic: Topic.Governance,
               followees: [0n, 1n, 2n],
             },
+            {
+              topic: 100 as Topic,
+              followees: [3n, 4n],
+            }
           ],
         },
       };

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -1057,7 +1057,7 @@ describe("neuron-utils", () => {
             {
               topic: 100 as Topic,
               followees: [3n, 4n],
-            }
+            },
           ],
         },
       };


### PR DESCRIPTION
# Motivation

Currently, if a new topic is added in NNS Governance, we need to follow the following steps:

1. Define new topics in NNS Governance, while disallowing to set followees on them
2. Add new topics to ic-js and NNS Dapp, so that following on them can be shown, but cannot be set
3. Update NNS Governance to allow following to be set
4. Update NNS Dapp to allow following to be set.

After this change, the procedure will be the following:

1. Define new topics in NNS Governance, while followees CAN be set on them
2. Add new topics to ic-js and NNS Dapp, so that following can be shown and set

# Changes

Show unrecognized topic as "Unknown Topic ($topicId)"

# Tests

unit tests and manual test

![Screenshot 2024-07-18 at 2 35 46 PM](https://github.com/user-attachments/assets/0e1f39cd-8aca-4118-9dc8-51af0eea8010)


# Todos

- [x] Add entry to changelog (if necessary).
