### PR TITLE
NNS1-3094: Make projects without neurons clickable again

### DIFF
--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -103,10 +103,7 @@ export const getTableProjects = ({
       nnsNeurons,
       snsNeurons,
     });
-    const rowHref =
-      (neuronCount ?? 0) > 0
-        ? buildNeuronsUrl({ universe: universe.canisterId })
-        : undefined;
+    const rowHref = buildNeuronsUrl({ universe: universe.canisterId });
     return {
       rowHref,
       domKey: universe.canisterId,

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -186,11 +186,13 @@ describe("ProjectsTable", () => {
       const rowPos = await po.getProjectsTableRowPos();
       expect(rowPos).toHaveLength(2);
       expect(await rowPos[0].getNeuronCount()).toBe("-/-");
-      expect(await rowPos[0].getHref()).toBe(null);
-      expect(await rowPos[0].hasGoToNeuronsTableAction()).toBe(false);
+      expect(await rowPos[0].getHref()).toBe(
+        `/neurons/?u=${OWN_CANISTER_ID_TEXT}`
+      );
+      expect(await rowPos[0].hasGoToNeuronsTableAction()).toBe(true);
       expect(await rowPos[1].getNeuronCount()).toBe("-/-");
-      expect(await rowPos[1].getHref()).toBe(null);
-      expect(await rowPos[1].hasGoToNeuronsTableAction()).toBe(false);
+      expect(await rowPos[1].getHref()).toBe(`/neurons/?u=${snsCanisterId}`);
+      expect(await rowPos[1].hasGoToNeuronsTableAction()).toBe(true);
     });
 
     it("should not render SNS neurons count when not loaded", async () => {
@@ -198,11 +200,13 @@ describe("ProjectsTable", () => {
       const rowPos = await po.getProjectsTableRowPos();
       expect(rowPos).toHaveLength(2);
       expect(await rowPos[0].getNeuronCount()).toBe("-/-");
-      expect(await rowPos[0].getHref()).toBe(null);
-      expect(await rowPos[0].hasGoToNeuronsTableAction()).toBe(false);
+      expect(await rowPos[0].getHref()).toBe(
+        `/neurons/?u=${OWN_CANISTER_ID_TEXT}`
+      );
+      expect(await rowPos[0].hasGoToNeuronsTableAction()).toBe(true);
       expect(await rowPos[1].getNeuronCount()).toBe("-/-");
-      expect(await rowPos[0].getHref()).toBe(null);
-      expect(await rowPos[1].hasGoToNeuronsTableAction()).toBe(false);
+      expect(await rowPos[1].getHref()).toBe(`/neurons/?u=${snsCanisterId}`);
+      expect(await rowPos[1].hasGoToNeuronsTableAction()).toBe(true);
     });
 
     it("should not render clickable row with zero neurons", async () => {
@@ -219,11 +223,13 @@ describe("ProjectsTable", () => {
       const rowPos = await po.getProjectsTableRowPos();
       expect(rowPos).toHaveLength(2);
       expect(await rowPos[0].getNeuronCount()).toBe("0");
-      expect(await rowPos[0].getHref()).toBe(null);
-      expect(await rowPos[0].hasGoToNeuronsTableAction()).toBe(false);
+      expect(await rowPos[0].getHref()).toBe(
+        `/neurons/?u=${OWN_CANISTER_ID_TEXT}`
+      );
+      expect(await rowPos[0].hasGoToNeuronsTableAction()).toBe(true);
       expect(await rowPos[1].getNeuronCount()).toBe("0");
-      expect(await rowPos[1].getHref()).toBe(null);
-      expect(await rowPos[1].hasGoToNeuronsTableAction()).toBe(false);
+      expect(await rowPos[1].getHref()).toBe(`/neurons/?u=${snsCanisterId}`);
+      expect(await rowPos[1].hasGoToNeuronsTableAction()).toBe(true);
     });
   });
 

--- a/frontend/src/tests/lib/utils/staking.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking.utils.spec.ts
@@ -34,7 +34,7 @@ describe("staking.utils", () => {
     const snsHref = `/neurons/?u=${universeId2}`;
 
     const defaultExpectedNnsTableProject = {
-      rowHref: undefined,
+      rowHref: nnsHref,
       domKey: OWN_CANISTER_ID_TEXT,
       title: "Internet Computer",
       logo: IC_LOGO_ROUNDED,
@@ -46,7 +46,7 @@ describe("staking.utils", () => {
     };
 
     const defaultExpectedSnsTableProject = {
-      rowHref: undefined,
+      rowHref: snsHref,
       domKey: universeId2,
       title: "title2",
       logo: "logo2",
@@ -223,13 +223,11 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedNnsTableProject,
-          rowHref: undefined,
           neuronCount: undefined,
           stake: undefined,
         },
         {
           ...defaultExpectedSnsTableProject,
-          rowHref: undefined,
           neuronCount: undefined,
           stake: undefined,
         },
@@ -249,13 +247,11 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedNnsTableProject,
-          rowHref: undefined,
           neuronCount: undefined,
           stake: undefined,
         },
         {
           ...defaultExpectedSnsTableProject,
-          rowHref: undefined,
           neuronCount: undefined,
           stake: undefined,
         },


### PR DESCRIPTION
# Motivation

In https://github.com/dfinity/nns-dapp/pull/5202 I made projects without neurons not clickable.
But this makes it not possible to stake those tokens.
We are still working on a way to stake tokens from the projects table but this doesn't need to be part of the MVP.
So we want to make all projects clickable again for now.

# Changes

Give every `TableProject` a `rowHref` regardless of neurons.

# Tests

1. As we may go back again on this once there is a way to stake from the projects table, I kept the structure of the tests the same but just changed the expectations.
2. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/staking/

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary