### PR TITLE
Add getters on SnsSummaryWrapper for fields from swap.params

### DIFF
--- a/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectCommitment.svelte
@@ -7,7 +7,7 @@
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
   } from "$lib/types/project-detail.context";
-  import type { SnsSummary } from "$lib/types/sns";
+  import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
   import {
     getProjectCommitmentSplit,
     isCommitmentSplitWithNeuronsFund,
@@ -22,7 +22,6 @@
     KeyValuePair,
     KeyValuePairInfo,
   } from "@dfinity/gix-components";
-  import type { SnsParams } from "@dfinity/sns";
   import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
   import { nonNullish } from "@dfinity/utils";
   import { getContext } from "svelte";
@@ -31,17 +30,16 @@
     PROJECT_DETAIL_CONTEXT_KEY
   );
 
-  let summary: SnsSummary;
+  let summary: SnsSummaryWrapper;
   // type safety validation is done in ProjectStatusSection component
-  $: summary = $projectDetailStore.summary as SnsSummary;
-
-  let params: SnsParams;
-  $: ({ params } = summary.swap);
+  $: summary = $projectDetailStore.summary as SnsSummaryWrapper;
 
   let min_icp_e8s: bigint;
   let max_icp_e8s: bigint;
   let min_participants: number;
-  $: ({ min_icp_e8s, max_icp_e8s, min_participants } = params);
+  $: min_icp_e8s = summary.getMinIcpE8s();
+  $: max_icp_e8s = summary.getMaxIcpE8s();
+  $: min_participants = summary.getMinParticipants();
 
   let projectCommitments: ProjectCommitmentSplit;
   $: projectCommitments = getProjectCommitmentSplit(summary);

--- a/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectSwapDetails.svelte
@@ -11,12 +11,11 @@
     PROJECT_DETAIL_CONTEXT_KEY,
     type ProjectDetailContext,
   } from "$lib/types/project-detail.context";
-  import type { SnsSummary } from "$lib/types/sns";
+  import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
   import { formatNumber } from "$lib/utils/format.utils";
   import TestIdWrapper from "../common/TestIdWrapper.svelte";
   import AmountDisplay from "../ic/AmountDisplay.svelte";
   import { KeyValuePair } from "@dfinity/gix-components";
-  import type { SnsParams } from "@dfinity/sns";
   import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
   import { nonNullish } from "@dfinity/utils";
   import { getContext } from "svelte";
@@ -26,30 +25,27 @@
   );
 
   // type safety validation is done in ProjectDetail component
-  let summary: SnsSummary;
-  $: summary = $projectDetailStore.summary as SnsSummary;
+  let summary: SnsSummaryWrapper;
+  $: summary = $projectDetailStore.summary as SnsSummaryWrapper;
 
-  let params: SnsParams;
   let token: IcrcTokenMetadata;
-  $: ({
-    swap: { params },
-    token,
-  } = summary);
+  $: token = summary.token;
 
   let minCommitmentIcp: TokenAmountV2;
   $: minCommitmentIcp = TokenAmountV2.fromUlps({
-    amount: params.min_participant_icp_e8s,
+    amount: summary.getMinParticipantIcpE8s(),
     token: ICPToken,
   });
+
   let maxCommitmentIcp: TokenAmountV2;
   $: maxCommitmentIcp = TokenAmountV2.fromUlps({
-    amount: params.max_participant_icp_e8s,
+    amount: summary.getMaxParticipantIcpE8s(),
     token: ICPToken,
   });
 
   let snsTokens: TokenAmountV2;
   $: snsTokens = TokenAmountV2.fromUlps({
-    amount: params.sns_token_e8s,
+    amount: summary.getSnsTokenE8s(),
     token,
   });
 
@@ -83,7 +79,7 @@
   <KeyValuePair testId="project-swap-min-participants">
     <span slot="key">{$i18n.sns_project_detail.min_participants} </span>
     <span slot="value"
-      >{formatNumber(params.min_participants, {
+      >{formatNumber(summary.getMinParticipants(), {
         minFraction: 0,
         maxFraction: 0,
       })}</span
@@ -118,7 +114,7 @@
     <span slot="key">{$i18n.sns_project_detail.sale_end} </span>
     <DateSeconds
       slot="value"
-      seconds={Number(params.swap_due_timestamp_seconds ?? 0n)}
+      seconds={Number(summary.getSwapDueTimestampSeconds() ?? 0n)}
       tagName="span"
     />
   </KeyValuePair>

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -987,6 +987,7 @@ export const makeDummyProposals = async (neuronId: NeuronId): Promise<void> => {
     const { snsSummariesStore } = await import("../stores/sns.store");
     const projects = get(snsSummariesStore);
     const pendingProject = projects.find(
+      // Use 1 instead of using enum to avoid importing sns-js
       (summary) => summary.getLifecycle() === 1
     );
     await makeDummyProposalsApi({

--- a/frontend/src/lib/types/sns-summary-wrapper.ts
+++ b/frontend/src/lib/types/sns-summary-wrapper.ts
@@ -63,6 +63,34 @@ export class SnsSummaryWrapper implements SnsSummary {
     return fromDefinedNullable(this.lifecycle.lifecycle);
   }
 
+  getSwapDueTimestampSeconds(): bigint {
+    return this.swap.params.swap_due_timestamp_seconds;
+  }
+
+  getMinIcpE8s(): bigint {
+    return this.swap.params.min_icp_e8s;
+  }
+
+  getMaxIcpE8s(): bigint {
+    return this.swap.params.max_icp_e8s;
+  }
+
+  getMinParticipants(): number {
+    return this.swap.params.min_participants;
+  }
+
+  getMinParticipantIcpE8s(): bigint {
+    return this.swap.params.min_participant_icp_e8s;
+  }
+
+  getMaxParticipantIcpE8s(): bigint {
+    return this.swap.params.max_participant_icp_e8s;
+  }
+
+  getSnsTokenE8s(): bigint {
+    return this.swap.params.sns_token_e8s;
+  }
+
   public overrideDerivedState(
     newDerivedState: SnsSwapDerivedState
   ): SnsSummaryWrapper {

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -2,7 +2,8 @@ import { SECONDS_IN_DAY } from "$lib/constants/constants";
 import { MIN_VALID_SNS_GENERIC_NERVOUS_SYSTEM_FUNCTION_ID } from "$lib/constants/sns-proposals.constants";
 import type { SnsTicketsStoreData } from "$lib/stores/sns-tickets.store";
 import type { TicketStatus } from "$lib/types/sale";
-import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
+import type { SnsSwapCommitment } from "$lib/types/sns";
+import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import { AccountIdentifier, SubAccount } from "@dfinity/ledger-icp";
 import type { Principal } from "@dfinity/principal";
 import type {
@@ -167,11 +168,11 @@ export const swapEndedMoreThanOneWeekAgo = ({
   summary,
   nowInSeconds,
 }: {
-  summary: SnsSummary;
+  summary: SnsSummaryWrapper;
   nowInSeconds: number;
 }) => {
   const oneWeekAgoInSeconds = BigInt(nowInSeconds - SECONDS_IN_DAY * 7);
-  return oneWeekAgoInSeconds > summary.swap.params.swap_due_timestamp_seconds;
+  return oneWeekAgoInSeconds > summary.getSwapDueTimestampSeconds();
 };
 
 /**

--- a/frontend/src/tests/lib/utils/projects.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/projects.utils.spec.ts
@@ -1,6 +1,6 @@
 import { NOT_LOADED } from "$lib/constants/stores.constants";
 import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
-import type { SnsSummary, SnsSwapCommitment } from "$lib/types/sns";
+import type { SnsSwapCommitment } from "$lib/types/sns";
 import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import { nowInSeconds } from "$lib/utils/date.utils";
 import {
@@ -612,7 +612,7 @@ describe("project-utils", () => {
     it("returns remaining amount taking into account current commitment", () => {
       const projectMax = 10_000_000_000n;
       const projectCommitment = 9_200_000_000n;
-      const summary: SnsSummary = mockSnsFullProject.summary.override({
+      const summary = mockSnsFullProject.summary.override({
         derived: {
           buyer_total_icp_e8s: projectCommitment,
           sns_tokens_per_icp: 1,


### PR DESCRIPTION
# Motivation

We want to stop using the `summary.swap` field because it's deprecated and everything on it is available in other ways.
One of the things we get from the `swap` field is the `params` object which in turn has several fields.
In this PR we introduce a getters on `SnsSummaryWrapper` to get the fields we care about from `swap.params`.
This will make it easy to switch over in another PR.

# Changes

1. Add `getSwapDueTimestampSeconds`, `getMinIcpE8s`, `getMaxIcpE8s`, `getMinParticipants`, `getMinParticipantIcpE8s`, `getMaxParticipantIcpE8s`, and `getSnsTokenE8s` to `SnsSummaryWrapper` which returns the corresponding fields from `summary.swap.params`.
2. Use these getters instead of getting fields directly from `summary.swap.params`.
3. Drive-by: Restore `// Use 1 instead of using enum to avoid importing sns-js` comment which was accidentally removed in https://github.com/dfinity/nns-dapp/pull/5192

# Tests

1. Existing unit tests updated.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary