### PR TITLE
NNS1-3094: Render stake in the projects table

### DIFF
--- a/frontend/src/lib/components/staking/ProjectStakeCell.svelte
+++ b/frontend/src/lib/components/staking/ProjectStakeCell.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
+  import type { TableProject } from "$lib/types/staking";
+  import { nonNullish } from "@dfinity/utils";
+
+  export let rowData: TableProject;
+</script>
+
+<div data-tid="project-stake-cell-component">
+  {#if nonNullish(rowData.stake)}
+    {#if rowData.stake.toUlps() > 0}
+      <AmountDisplay singleLine amount={rowData.stake} />
+    {/if}
+  {:else}
+    <span>-/-</span>
+  {/if}
+</div>

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import ProjectActionsCell from "$lib/components/staking/ProjectActionsCell.svelte";
   import ProjectNeuronsCell from "$lib/components/staking/ProjectNeuronsCell.svelte";
+  import ProjectStakeCell from "$lib/components/staking/ProjectStakeCell.svelte";
   import ProjectTitleCell from "$lib/components/staking/ProjectTitleCell.svelte";
   import ResponsiveTable from "$lib/components/ui/ResponsiveTable.svelte";
   import { authSignedInStore } from "$lib/derived/auth.derived";
@@ -16,6 +17,12 @@
       title: $i18n.staking.nervous_systems,
       cellComponent: ProjectTitleCell,
       alignment: "left",
+      templateColumns: ["1fr"],
+    },
+    {
+      title: $i18n.neuron_detail.stake,
+      cellComponent: ProjectStakeCell,
+      alignment: "right",
       templateColumns: ["1fr"],
     },
     {

--- a/frontend/src/tests/page-objects/ProjectStakeCell.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectStakeCell.page-object.ts
@@ -1,0 +1,14 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ProjectStakeCellPo extends BasePageObject {
+  private static readonly TID = "project-stake-cell-component";
+
+  static under(element: PageObjectElement): ProjectStakeCellPo {
+    return new ProjectStakeCellPo(element.byTestId(ProjectStakeCellPo.TID));
+  }
+
+  async getStake(): Promise<string> {
+    return await this.getText();
+  }
+}

--- a/frontend/src/tests/page-objects/ProjectsTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectsTableRow.page-object.ts
@@ -1,4 +1,5 @@
 import { ProjectNeuronsCellPo } from "$tests/page-objects/ProjectNeuronsCell.page-object";
+import { ProjectStakeCellPo } from "$tests/page-objects/ProjectStakeCell.page-object";
 import { ProjectTitleCellPo } from "$tests/page-objects/ProjectTitleCell.page-object";
 import { ResponsiveTableRowPo } from "$tests/page-objects/ResponsiveTableRow.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
@@ -20,12 +21,20 @@ export class ProjectsTableRowPo extends ResponsiveTableRowPo {
     return ProjectTitleCellPo.under(this.root);
   }
 
+  getProjectStakeCellPo(): ProjectStakeCellPo {
+    return ProjectStakeCellPo.under(this.root);
+  }
+
   getProjectNeuronsCellPo(): ProjectNeuronsCellPo {
     return ProjectNeuronsCellPo.under(this.root);
   }
 
   getProjectTitle(): Promise<string> {
     return this.getProjectTitleCellPo().getProjectTitle();
+  }
+
+  getStake(): Promise<string> {
+    return this.getProjectStakeCellPo().getStake();
   }
 
   getNeuronCount(): Promise<string> {


### PR DESCRIPTION
# Motivation

We want to show the total stake per project in the projects table.

# Changes

1. Add `ProjectStakeCell` component to render the stake. When neurons aren't loaded, we render `-/-`. When neurons are loaded but the user doesn't have neurons we render nothing. This matches Figma.
2. Add a column in `ProjectsTable.svelte`

# Tests

1. Page objects and unit tests added.
2. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/staking/

# Todos

- [ ] Add entry to changelog (if necessary).
not yet