### PR TITLE
Bump agent-js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.83",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@dfinity/agent": "^1.3.0",
+        "@dfinity/agent": "^1.4.0",
         "@dfinity/auth-client": "^1.3.0",
         "@dfinity/candid": "^1.3.0",
         "@dfinity/ckbtc": "next",
@@ -212,9 +212,9 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-1.3.0.tgz",
-      "integrity": "sha512-gFc2CqjWURv/Th+vxwHIb7Y39TpRZccjyRm8c51LtyAGLYSpSwJDWbzM/y66h++DSSc3A+1DjN/dRT+6ik3xLw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-1.4.0.tgz",
+      "integrity": "sha512-/zgGajZpxtbu+kLXtFx2e9V2+HbMUjrtGWx9ZEwtVwhVxKgVi/2kGQpFRPEDFJ461V7wdTwCig4OkMxVU4shTw==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
@@ -224,8 +224,8 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^1.3.0",
-        "@dfinity/principal": "^1.3.0"
+        "@dfinity/candid": "^1.4.0",
+        "@dfinity/principal": "^1.4.0"
       }
     },
     "node_modules/@dfinity/auth-client": {
@@ -242,11 +242,11 @@
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-1.3.0.tgz",
-      "integrity": "sha512-tt5NYfpv8C+3iKS3Awbi+NAIxjwjIRUOLT+1ys/xpA+6DNEqwgfU8WZu0+bKnf/xlASCyJXUmoMzQ6I01GBp9A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-1.4.0.tgz",
+      "integrity": "sha512-PsTJVn63ZM4A/6Xs5coI0zMFevSwJ8hcyh38LdH/92n6wi9UOTis1yc4qL5MZvvRCUAD0c3rVjELL+49E9sPyA==",
       "peerDependencies": {
-        "@dfinity/principal": "^1.3.0"
+        "@dfinity/principal": "^1.4.0"
       }
     },
     "node_modules/@dfinity/ckbtc": {
@@ -356,9 +356,9 @@
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.3.0.tgz",
-      "integrity": "sha512-04Ly9/VxztgmSk3LeUv1H+aA/8zCfed5gzgydVKBv9U0pk2lcCjUOMhv3G+1UCUSd8GwzrWaSwIsrzrAcHZm/g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.4.0.tgz",
+      "integrity": "sha512-SuTBVlc71ub89ji0WN5/T100zUG2uIMn5x4+We4vS4nJ0R3/Xt89XJsHepjd5SQTSQPOvP7eQ+S8cQKWRz/RkA==",
       "dependencies": {
         "@noble/hashes": "^1.3.1"
       }
@@ -7005,9 +7005,9 @@
       }
     },
     "@dfinity/agent": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-1.3.0.tgz",
-      "integrity": "sha512-gFc2CqjWURv/Th+vxwHIb7Y39TpRZccjyRm8c51LtyAGLYSpSwJDWbzM/y66h++DSSc3A+1DjN/dRT+6ik3xLw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-1.4.0.tgz",
+      "integrity": "sha512-/zgGajZpxtbu+kLXtFx2e9V2+HbMUjrtGWx9ZEwtVwhVxKgVi/2kGQpFRPEDFJ461V7wdTwCig4OkMxVU4shTw==",
       "requires": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
@@ -7026,9 +7026,9 @@
       }
     },
     "@dfinity/candid": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-1.3.0.tgz",
-      "integrity": "sha512-tt5NYfpv8C+3iKS3Awbi+NAIxjwjIRUOLT+1ys/xpA+6DNEqwgfU8WZu0+bKnf/xlASCyJXUmoMzQ6I01GBp9A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-1.4.0.tgz",
+      "integrity": "sha512-PsTJVn63ZM4A/6Xs5coI0zMFevSwJ8hcyh38LdH/92n6wi9UOTis1yc4qL5MZvvRCUAD0c3rVjELL+49E9sPyA==",
       "requires": {}
     },
     "@dfinity/ckbtc": {
@@ -7095,9 +7095,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.3.0.tgz",
-      "integrity": "sha512-04Ly9/VxztgmSk3LeUv1H+aA/8zCfed5gzgydVKBv9U0pk2lcCjUOMhv3G+1UCUSd8GwzrWaSwIsrzrAcHZm/g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.4.0.tgz",
+      "integrity": "sha512-SuTBVlc71ub89ji0WN5/T100zUG2uIMn5x4+We4vS4nJ0R3/Xt89XJsHepjd5SQTSQPOvP7eQ+S8cQKWRz/RkA==",
       "requires": {
         "@noble/hashes": "^1.3.1"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@dfinity/agent": "^1.3.0",
+    "@dfinity/agent": "^1.4.0",
     "@dfinity/auth-client": "^1.3.0",
     "@dfinity/candid": "^1.3.0",
     "@dfinity/ckbtc": "next",


### PR DESCRIPTION
# Motivation

Agent-js version 1.4.0 does not require `unsafe-eval` anymore which means that we might be able to remove it from our CSP.

# Changes

Ran `npm install @dfinity/agent@^1.4.0`.

# Tests

Not tested. Existing tests should pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary