### PR TITLE
Support UnavailableTokenAmount in AmountDisplay

### DIFF
--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+  import { UnavailableTokenAmount } from "$lib/utils/token.utils";
   import { formatTokenV2 } from "$lib/utils/token.utils";
   import { Copy } from "@dfinity/gix-components";
   import type { TokenAmount, TokenAmountV2 } from "@dfinity/utils";
 
-  // TODO: should we expose two properties - an amount in bigint and a token Token - and build the TokenAmount.fromE8s in this component?
-  export let amount: TokenAmount | TokenAmountV2;
+  export let amount: TokenAmount | TokenAmountV2 | UnavailableTokenAmount;
   export let label: string | undefined = undefined;
   export let inline = false;
   export let singleLine = false;
@@ -31,10 +31,14 @@
     data-tid="token-value"
     class="value"
     class:tabular-num={detailed === "height_decimals"}
-    >{`${sign}${formatTokenV2({ value: amount, detailed })}`}</span
+    >{#if amount instanceof UnavailableTokenAmount}
+      -/-
+    {:else}
+      {`${sign}${formatTokenV2({ value: amount, detailed })}`}
+    {/if}</span
   >
   <span class="label">{label !== undefined ? label : amount.token.symbol}</span
-  >{#if copy}
+  >{#if copy && !(amount instanceof UnavailableTokenAmount)}
     {" "}
     <Copy value={formatTokenV2({ value: amount, detailed: true })} />
   {/if}

--- a/frontend/src/lib/components/tokens/TokensTable/TokenBalanceCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenBalanceCell.svelte
@@ -1,17 +1,12 @@
 <script lang="ts">
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import type { UserTokenData, UserTokenLoading } from "$lib/types/tokens-page";
-  import { UnavailableTokenAmount } from "$lib/utils/token.utils";
   import { Spinner } from "@dfinity/gix-components";
 
   export let rowData: UserTokenData | UserTokenLoading;
 </script>
 
-{#if rowData.balance instanceof UnavailableTokenAmount}
-  <span data-tid="token-value-label"
-    >{`-/- ${rowData.balance.token.symbol}`}</span
-  >
-{:else if rowData.balance === "loading"}
+{#if rowData.balance === "loading"}
   <span data-tid="token-value-label" class="balance-spinner"
     ><Spinner inline size="tiny" /></span
   >

--- a/frontend/src/tests/lib/components/ic/AmountDisplay.spec.ts
+++ b/frontend/src/tests/lib/components/ic/AmountDisplay.spec.ts
@@ -1,4 +1,6 @@
 import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
+import { UnavailableTokenAmount } from "$lib/utils/token.utils";
+import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
 import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
@@ -18,6 +20,10 @@ describe("AmountDisplay", () => {
     const { container } = render(AmountDisplay, props);
     return AmountDisplayPo.under(new JestPageObjectElement(container));
   };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it("should render an token amount", async () => {
     const po = renderComponent(props);
@@ -57,5 +63,62 @@ describe("AmountDisplay", () => {
       },
     });
     expect(await po.getAmount()).toEqual("1'234'567.8901");
+  });
+
+  it("should not have a copy button by default", async () => {
+    const po = renderComponent(props);
+    expect(await po.getCopyButtonPo().isPresent()).toBe(false);
+  });
+
+  it("should have a copy button", async () => {
+    const po = renderComponent({
+      ...props,
+      copy: true,
+    });
+    expect(await po.getCopyButtonPo().isPresent()).toBe(true);
+  });
+
+  it("should copy amount to clipboard", async () => {
+    const copySpy = vi.fn();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: copySpy,
+      },
+    });
+
+    const po = renderComponent({
+      ...props,
+      copy: true,
+    });
+    expect(copySpy).not.toBeCalled();
+    await po.getCopyButtonPo().click();
+    expect(copySpy).toBeCalledWith("1'234'567.8901");
+    expect(copySpy).toBeCalledTimes(1);
+  });
+
+  it("should render unavailable ICP amount", async () => {
+    const po = renderComponent({
+      amount: new UnavailableTokenAmount(ICPToken),
+    });
+    expect(await po.getText()).toBe("-/- ICP");
+  });
+
+  it("should render unavailable token amount", async () => {
+    const token = {
+      ...mockSnsToken,
+      symbol: "TOKEN",
+    };
+    const po = renderComponent({
+      amount: new UnavailableTokenAmount(token),
+    });
+    expect(await po.getText()).toBe("-/- TOKEN");
+  });
+
+  it("should never render a copy button for unavailable amount", async () => {
+    const po = renderComponent({
+      amount: new UnavailableTokenAmount(ICPToken),
+      copy: true,
+    });
+    expect(await po.getCopyButtonPo().isPresent()).toBe(false);
   });
 });

--- a/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
+++ b/frontend/src/tests/page-objects/AmountDisplay.page-object.ts
@@ -1,3 +1,4 @@
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { assertNonNullish } from "$tests/utils/utils.test-utils";
@@ -13,5 +14,9 @@ export class AmountDisplayPo extends BasePageObject {
     return assertNonNullish(
       await this.root.querySelector(`[data-tid="token-value"]`).getText()
     );
+  }
+
+  getCopyButtonPo(): ButtonPo {
+    return this.getButton("copy-component");
   }
 }


### PR DESCRIPTION
# Motivation

Make it easy to render absent token amounts as -/- in a consistent way.
This will be reused in another PR for the stake in the projects table when unavailable.

# Changes

1. Support `UnavailableTokenAmount` type in `AmountDisplay`.
2. Never render the copy button when the amount is unavailable.
3. Pass `UnavailableTokenAmount` from `TokenBalanceCell` to `AmountDisplay` instead of having separate logic.

# Tests

1. Added missing unit tests for the copy button in `AmountDisplay`.
2. Added unit tests for `UnavailableTokenAmount`.
3. Existing tokens table tests for `-/-` pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary