### PR TITLE
bot: Update proposals candid bindings

### DIFF
--- a/declarations/used_by_proposals/nns_governance/nns_governance.did
+++ b/declarations/used_by_proposals/nns_governance/nns_governance.did
@@ -1,8 +1,9 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-10_23-01-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-18_01-30--github-base/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
   ManageNeuron : ManageNeuron;
+  InstallCode : InstallCode;
   CreateServiceNervousSystem : CreateServiceNervousSystem;
   ExecuteNnsFunction : ExecuteNnsFunction;
   RewardNodeProvider : RewardNodeProvider;
@@ -11,7 +12,7 @@ type Action = variant {
   SetDefaultFollowees : SetDefaultFollowees;
   RewardNodeProviders : RewardNodeProviders;
   ManageNetworkEconomics : NetworkEconomics;
-  ApproveGenesisKyc : ApproveGenesisKyc;
+  ApproveGenesisKyc : Principals;
   AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
   Motion : Motion;
 };
@@ -251,6 +252,13 @@ type InitialTokenDistribution = record {
   developer_distribution : opt DeveloperDistribution;
   swap_distribution : opt SwapDistribution;
 };
+type InstallCode = record {
+  arg : opt blob;
+  wasm_module : opt blob;
+  skip_stopping_before_installing : opt bool;
+  canister_id : opt principal;
+  install_mode : opt int32;
+};
 type KnownNeuron = record {
   id : opt NeuronId;
   known_neuron_data : opt KnownNeuronData;
@@ -440,13 +448,17 @@ type NeuronsFundMatchedFundingCurveCoefficients = record {
   full_participation_milestone_xdr : opt Decimal;
 };
 type NeuronsFundNeuron = record {
+  controller : opt principal;
   hotkey_principal : opt text;
+  hotkeys : opt Principals;
   is_capped : opt bool;
   nns_neuron_id : opt nat64;
   amount_icp_e8s : opt nat64;
 };
 type NeuronsFundNeuronPortion = record {
+  controller : opt principal;
   hotkey_principal : opt principal;
+  hotkeys : vec principal;
   is_capped : opt bool;
   maturity_equivalent_icp_e8s : opt nat64;
   nns_neuron_id : opt NeuronId;
@@ -501,6 +513,7 @@ type Params = record {
   max_direct_participation_icp_e8s : opt nat64;
 };
 type Percentage = record { basis_points : opt nat64 };
+type Principals = record { principals : vec principal };
 type Progress = variant { LastNeuronId : NeuronId };
 type Proposal = record {
   url : text;

--- a/declarations/used_by_proposals/nns_registry/nns_registry.did
+++ b/declarations/used_by_proposals/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-10_23-01-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-18_01-30--github-base/rs/registry/canister/canister/registry.did>
 // A brief note about the history of this file: This file used to be
 // automatically generated, but now, it is hand-crafted, because the
 // auto-generator has some some pretty degenerate behaviors. The worst of those

--- a/declarations/used_by_proposals/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_proposals/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-10_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-18_01-30--github-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };

--- a/dfx.json
+++ b/dfx.json
@@ -387,7 +387,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-07-17",
-        "IC_COMMIT_FOR_PROPOSALS": "release-2024-07-10_23-01-base",
+        "IC_COMMIT_FOR_PROPOSALS": "release-2024-07-18_01-30--github-base",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-07-10_23-01-base"
       },
       "packtool": ""

--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-10_23-01-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-18_01-30--github-base/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -164,6 +164,14 @@ pub struct ManageNeuron {
     pub id: Option<NeuronId>,
     pub command: Option<Command>,
     pub neuron_id_or_subaccount: Option<NeuronIdOrSubaccount>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct InstallCode {
+    pub arg: Option<serde_bytes::ByteBuf>,
+    pub wasm_module: Option<serde_bytes::ByteBuf>,
+    pub skip_stopping_before_installing: Option<bool>,
+    pub canister_id: Option<Principal>,
+    pub install_mode: Option<i32>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Percentage {
@@ -383,7 +391,7 @@ pub struct NetworkEconomics {
     pub neurons_fund_economics: Option<NeuronsFundEconomics>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
-pub struct ApproveGenesisKyc {
+pub struct Principals {
     pub principals: Vec<Principal>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
@@ -403,6 +411,7 @@ pub struct Motion {
 pub enum Action {
     RegisterKnownNeuron(KnownNeuron),
     ManageNeuron(ManageNeuron),
+    InstallCode(InstallCode),
     CreateServiceNervousSystem(CreateServiceNervousSystem),
     ExecuteNnsFunction(ExecuteNnsFunction),
     RewardNodeProvider(RewardNodeProvider),
@@ -411,7 +420,7 @@ pub enum Action {
     SetDefaultFollowees(SetDefaultFollowees),
     RewardNodeProviders(RewardNodeProviders),
     ManageNetworkEconomics(NetworkEconomics),
-    ApproveGenesisKyc(ApproveGenesisKyc),
+    ApproveGenesisKyc(Principals),
     AddOrRemoveNodeProvider(AddOrRemoveNodeProvider),
     Motion(Motion),
 }
@@ -582,7 +591,9 @@ pub struct SwapParticipationLimits {
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronsFundNeuronPortion {
+    pub controller: Option<Principal>,
     pub hotkey_principal: Option<Principal>,
+    pub hotkeys: Vec<Principal>,
     pub is_capped: Option<bool>,
     pub maturity_equivalent_icp_e8s: Option<u64>,
     pub nns_neuron_id: Option<NeuronId>,
@@ -968,7 +979,9 @@ pub struct SettleNeuronsFundParticipationRequest {
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronsFundNeuron {
+    pub controller: Option<Principal>,
     pub hotkey_principal: Option<String>,
+    pub hotkeys: Option<Principals>,
     pub is_capped: Option<bool>,
     pub nns_neuron_id: Option<u64>,
     pub amount_icp_e8s: Option<u64>,

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-10_23-01-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-18_01-30--github-base/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-10_23-01-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-18_01-30--github-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.
Even with no changes, just updating the reference is good practice.

# Changes
* Update the version of `IC_COMMIT_FOR_PROPOSALS` specified in `dfx.json`.
* Updated the `proposals` candid files to the versions in that commit.
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants