### PR TITLE
NNS1-3094: Show token symbol for unavailable stake

### DIFF
--- a/frontend/src/lib/components/staking/ProjectStakeCell.svelte
+++ b/frontend/src/lib/components/staking/ProjectStakeCell.svelte
@@ -1,17 +1,13 @@
 <script lang="ts">
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
   import type { TableProject } from "$lib/types/staking";
-  import { nonNullish } from "@dfinity/utils";
+  import { TokenAmountV2 } from "@dfinity/utils";
 
   export let rowData: TableProject;
 </script>
 
 <div data-tid="project-stake-cell-component">
-  {#if nonNullish(rowData.stake)}
-    {#if rowData.stake.toUlps() > 0}
-      <AmountDisplay singleLine amount={rowData.stake} />
-    {/if}
-  {:else}
-    <span>-/-</span>
+  {#if !(rowData.stake instanceof TokenAmountV2) || rowData.stake.toUlps() > 0}
+    <AmountDisplay singleLine amount={rowData.stake} />
   {/if}
 </div>

--- a/frontend/src/lib/types/staking.ts
+++ b/frontend/src/lib/types/staking.ts
@@ -1,4 +1,5 @@
 import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
+import type { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import type { TokenAmountV2 } from "@dfinity/utils";
 
 export type TableProject = {
@@ -7,7 +8,7 @@ export type TableProject = {
   title: string;
   logo: string;
   neuronCount: number | undefined;
-  stake: TokenAmountV2 | undefined;
+  stake: TokenAmountV2 | UnavailableTokenAmount;
 };
 
 export type ProjectsTableColumn = ResponsiveTableColumn<TableProject>;

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -102,8 +102,8 @@ describe("ProjectsTable", () => {
     const po = renderComponent();
     const rowPos = await po.getProjectsTableRowPos();
     expect(rowPos).toHaveLength(2);
-    expect(await rowPos[0].getStake()).toBe("-/-");
-    expect(await rowPos[1].getStake()).toBe("-/-");
+    expect(await rowPos[0].getStake()).toBe("-/- ICP");
+    expect(await rowPos[1].getStake()).toBe("-/- TOK");
   });
 
   it("should not render stake when user has no neurons", async () => {

--- a/frontend/src/tests/lib/utils/staking.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking.utils.spec.ts
@@ -2,6 +2,7 @@ import IC_LOGO_ROUNDED from "$lib/assets/icp-rounded.svg";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import type { Universe } from "$lib/types/universe";
 import { getTableProjects, sortTableProjects } from "$lib/utils/staking.utils";
+import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import {
@@ -225,12 +226,12 @@ describe("staking.utils", () => {
         {
           ...defaultExpectedNnsTableProject,
           neuronCount: undefined,
-          stake: undefined,
+          stake: new UnavailableTokenAmount(ICPToken),
         },
         {
           ...defaultExpectedSnsTableProject,
           neuronCount: undefined,
-          stake: undefined,
+          stake: new UnavailableTokenAmount(mockSnsToken),
         },
       ]);
     });
@@ -249,12 +250,12 @@ describe("staking.utils", () => {
         {
           ...defaultExpectedNnsTableProject,
           neuronCount: undefined,
-          stake: undefined,
+          stake: new UnavailableTokenAmount(ICPToken),
         },
         {
           ...defaultExpectedSnsTableProject,
           neuronCount: undefined,
-          stake: undefined,
+          stake: new UnavailableTokenAmount(mockSnsToken),
         },
       ]);
     });


### PR DESCRIPTION
# Motivation

In the staking projects table, we show total stake per project.
When the user isn't signed in, or neurons aren't loaded yet, we show `-/-` for the total stake of a project.
We want to include the token symbol in this, as we do in the tokens table.

# Changes

1. Use `UnavailableTokenAmount` instead of `undefined` to indicate that a stake amount isn't available for a project.
2. Rely on `AmountDisplay` to render the unavailable token amount. (Zero is still not rendered at all.)

# Tests

1. Unit tests updated.
2. Tested manually on [DevEnv](https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/staking/) (with feature flag ENABLE_PROJECTS_TABLE)

Before:
<img width="717" alt="image" src="https://github.com/user-attachments/assets/c07cf4e8-2cf4-4338-b471-6c1edebe3f37">

After:
<img width="711" alt="image" src="https://github.com/user-attachments/assets/69fcf46e-6799-4841-a200-bbd8ba2873b1">


# Todos

- [ ] Add entry to changelog (if necessary).
not yet