### PR TITLE
Remove 'unsafe-eval' from CSP

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -31,6 +31,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Remove default topic and proposal status filters.
 * Remove old canister creation/top-up mechanism that hasn't been used for 2 years.
+* Removed `unsafe-eval` from Content Security Policy.
 
 #### Fixed
 

--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -180,9 +180,7 @@ const updateCSP = (indexHtml) => {
         img-src 'self' data: https://nns.internetcomputer.org/ https://nns.ic0.app/ https://nns.raw.ic0.app/ \${{SNS_AGGREGATOR_URL}};
         child-src 'self';
         manifest-src 'self';
-        script-src 'unsafe-inline' 'strict-dynamic' ${indexHashes.join(
-          " "
-        )};
+        script-src 'unsafe-inline' 'strict-dynamic' ${indexHashes.join(" ")};
         base-uri 'self';
         form-action 'none';
         style-src 'self' 'unsafe-inline';

--- a/frontend/scripts/build.csp.mjs
+++ b/frontend/scripts/build.csp.mjs
@@ -143,11 +143,6 @@ const extractStartScript = (htmlFile) => {
  *
  * Note about the rules:
  *
- * - script-src 'unsafe-eval' is required because:
- * 1. agent-js uses a WebAssembly module for the validation of bls signatures.
- *    source: II https://github.com/dfinity/internet-identity/blob/c5709518ce3daaf7fdd9c7994120b66bd613f01b/src/internet_identity/src/main.rs#L824
- * 2. nns-js auto-generated proto js code (base_types_pb.js and ledger_pb.js) require 'unsafe-eval' as well
- *
  * - script-src and usage of 'integrity':
  * Ideally we would like to secure the scripts that are loaded with the 'integrity=sha256-...' hashes attributes - e.g. https://stackoverflow.com/a/68492689/5404186.
  * However, this is currently only supported by Chrome. Firefox issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1409200
@@ -185,7 +180,7 @@ const updateCSP = (indexHtml) => {
         img-src 'self' data: https://nns.internetcomputer.org/ https://nns.ic0.app/ https://nns.raw.ic0.app/ \${{SNS_AGGREGATOR_URL}};
         child-src 'self';
         manifest-src 'self';
-        script-src 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' ${indexHashes.join(
+        script-src 'unsafe-inline' 'strict-dynamic' ${indexHashes.join(
           " "
         )};
         base-uri 'self';


### PR DESCRIPTION
# Motivation

We allow `'unsafe-eval'` in the Content Security Policy because it's required by:
1. agent-js
2. protobuf

However
1. Agent-js no longer requires it since [version 1.4.0](https://github.com/dfinity/agent-js/releases/tag/v1.4.0) because "ObservableLog no longer extends Function".
2. NNS dapp no longer depends on protobuf since https://github.com/dfinity/nns-dapp/pull/4672

# Changes

Remove `'unsafe-eval'` from the CSP.

# Tests

1. Deployed to https://mkam6-f4aaa-aaaaa-qablq-cai.dskloet-ingress.devenv.dfinity.network/
2. Manually checked that the CSP no longer contains `unsafe-eval`.
3. Clicked around and things don't seem to be completely broken.

Current CSP element:
```
<meta http-equiv="Content-Security-Policy" content="default-src 'none';
        connect-src 'self' https://qhbym-qaaaa-aaaaa-aaafq-cai.dskloet-ingress.devenv.dfinity.network https://identity.ic0.app https://nns.ic0.app https://api.geoiplookup.net https://api.iplocation.net 'self' https://dskloet-ingress.devenv.dfinity.network https://be2us-64aaa-aaaaa-qaabq-cai.dskloet-ingress.devenv.dfinity.network https://2hx64-daaaa-aaaaq-aaana-cai.raw.icp0.io https://7hi6i-7iaaa-aaaaq-aaaqq-cai.raw.icp0.io https://7sppf-6aaaa-aaaaq-aaata-cai.raw.icp0.io https://zcdfx-6iaaa-aaaaq-aaagq-cai.raw.icp0.io https://be2us-64aaa-aaaaa-qaabq-cai.dskloet-ingress.devenv.dfinity.network;
        img-src 'self' data: https://nns.internetcomputer.org/ https://nns.ic0.app/ https://nns.raw.ic0.app/ https://be2us-64aaa-aaaaa-qaabq-cai.dskloet-ingress.devenv.dfinity.network;
        child-src 'self';
        manifest-src 'self';
        script-src 'unsafe-inline' 'strict-dynamic' 'sha256-z3re+V1Zk4tynXGrjrFoz8XdETFOQRY3SuiOP5WFHgQ=' 'sha256-5jvyMAjtYX4LBiTZYnv4rE0QmgsPCJ94RCKdzPXG1Mc=' 'sha256-gy87KdMwRAxWQJW/QU14NXUU8Hn/tBIzxZZ651zgco8=' 'sha256-i1pRBZV0fanq+nJev/437aOatMKcFZ7DwZNzo/bxQRg=';
        base-uri 'self';
        form-action 'none';
        style-src 'self' 'unsafe-inline';
        font-src 'self';
        upgrade-insecure-requests;">
```

# Todos

- [x] Add entry to changelog (if necessary).
