### PR TITLE
NNS1-3094: Projects table column styling

### DIFF
--- a/frontend/src/lib/components/staking/ProjectNeuronsCell.svelte
+++ b/frontend/src/lib/components/staking/ProjectNeuronsCell.svelte
@@ -5,7 +5,7 @@
   export let rowData: TableProject;
 </script>
 
-<div data-tid="project-neurons-cell-component" class="title-logo-wrapper">
+<div data-tid="project-neurons-cell-component">
   {#if nonNullish(rowData.neuronCount)}
     {rowData.neuronCount}
   {:else}

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -20,19 +20,29 @@
       title: $i18n.staking.nervous_systems,
       cellComponent: ProjectTitleCell,
       alignment: "left",
+      templateColumns: ["minmax(min-content, max-content)"],
+    },
+    {
+      title: "",
+      alignment: "left",
       templateColumns: ["1fr"],
     },
     {
       title: $i18n.neuron_detail.stake,
       cellComponent: ProjectStakeCell,
       alignment: "right",
+      templateColumns: ["max-content"],
+    },
+    {
+      title: "",
+      alignment: "left",
       templateColumns: ["1fr"],
     },
     {
       title: $i18n.neurons.title,
       cellComponent: ProjectNeuronsCell,
       alignment: "right",
-      templateColumns: ["1fr"],
+      templateColumns: ["max-content"],
     },
     {
       title: "",

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -49,7 +49,9 @@ describe("ProjectsTable", () => {
     const po = renderComponent();
     expect(await po.getDesktopColumnHeaders()).toEqual([
       "Nervous Systems",
+      "",
       "Stake",
+      "",
       "Neurons",
       "", // No header for actions column.
     ]);
@@ -68,7 +70,9 @@ describe("ProjectsTable", () => {
     const rows = await po.getRows();
     expect(await rows[0].getCellAlignments()).toEqual([
       "desktop-align-left", // Nervous Systems
+      expect.any(String), // gap
       "desktop-align-right", // Stake
+      expect.any(String), // gap
       "desktop-align-right", // Neurons
       "desktop-align-right", // Actions
     ]);
@@ -79,14 +83,16 @@ describe("ProjectsTable", () => {
 
     expect(await po.getDesktopGridTemplateColumns()).toBe(
       [
-        "1fr", // Nerous Systems
-        "1fr", // Stake
-        "1fr", // Neurons
+        "minmax(min-content, max-content)", // Nerous Systems
+        "1fr", // gap
+        "max-content", // Stake
+        "1fr", // gap
+        "max-content", // Neurons
         "max-content", // Actions
       ].join(" ")
     );
     expect(await po.getMobileGridTemplateAreas()).toBe(
-      '"first-cell last-cell" "cell-0 cell-0" "cell-1 cell-1"'
+      '"first-cell last-cell" "cell-1 cell-1" "cell-3 cell-3"'
     );
   });
 

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -83,7 +83,7 @@ describe("ProjectsTable", () => {
 
     expect(await po.getDesktopGridTemplateColumns()).toBe(
       [
-        "minmax(min-content, max-content)", // Nerous Systems
+        "minmax(min-content, max-content)", // Nervous Systems
         "1fr", // gap
         "max-content", // Stake
         "1fr", // gap


### PR DESCRIPTION
# Motivation

Currently the "Nervous Systems", "Stake" and "Neurons" columns each get an equal amount of space.
Because the first one is left aligned and the other 2 are right aligned but at the same time the project name tends to be longer, it looks like the gaps between the columns are divided equally.
But if one project has a really long name, it might have to wrap while there is actually still enough space if the other columns would give up some.

In the neurons table, we switched to the content columns getting the width they need and adding additional columns in between to take up the additional space.

# Changes

1. Add empty columns between the "Nervous Systems", "Stake" and "Neurons" columns.
2. Give the empty columns style `1fr` to take up additional space.
3. Give the "Nervous Systems" column style `minmax(min-content, max-content)` so that it doesn't wrap unnecessarily but can wrap if necessary.
4. Give the "Stake" and "Neurons" columns style `max-content` so they get the space they need.
5. Drive-by fix: Remove unused `class="title-logo-wrapper"` from `ProjectNeuronsCell.svelte` which was accidentally copied from another file.

# Tests

1. Unit tests updated.
2. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/staking/
3. Tested manually with mainnet project names.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet