### PR TITLE
Add beta subdomains

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,7 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Add 2 new topics `ProtocolCanisterMangement` and
-* Make the wasm accessible via beta subdomains so we can deploy early versions there.
+* Make the WASM accessible via beta subdomains so we can deploy early versions there.
 
 #### Changed
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Added
 
 * Add 2 new topics `ProtocolCanisterMangement` and
+* Make the wasm accessible via beta subdomains so we can deploy early versions there.
 
 #### Changed
 

--- a/frontend/src/lib/constants/origin.constants.ts
+++ b/frontend/src/lib/constants/origin.constants.ts
@@ -3,4 +3,6 @@ export const NNS_IC_ORG_ALTERNATIVE_ORIGINS = [
   "https://nns.internetcomputer.org",
   "https://wallet.internetcomputer.org",
   "https://wallet.ic0.app",
+  "https://beta.nns.internetcomputer.org",
+  "https://beta.nns.ic0.app",
 ];

--- a/frontend/src/tests/lib/utils/env.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/env.utils.spec.ts
@@ -38,6 +38,12 @@ describe("env-utils", () => {
 
       setOrigin("https://wallet.ic0.app");
       expect(isNnsAlternativeOrigin()).toBeTruthy();
+
+      setOrigin("https://beta.nns.internetcomputer.org");
+      expect(isNnsAlternativeOrigin()).toBeTruthy();
+
+      setOrigin("https://beta.nns.ic0.app");
+      expect(isNnsAlternativeOrigin()).toBeTruthy();
     });
 
     it("should not be an alternative origin", () => {
@@ -54,6 +60,12 @@ describe("env-utils", () => {
       expect(isNnsAlternativeOrigin()).toBe(false);
 
       setOrigin("https://ii.internetcomputer.org");
+      expect(isNnsAlternativeOrigin()).toBe(false);
+
+      setOrigin("https://beta.internetcomputer.org");
+      expect(isNnsAlternativeOrigin()).toBe(false);
+
+      setOrigin("https://beta.ic0.app");
       expect(isNnsAlternativeOrigin()).toBe(false);
     });
   });

--- a/frontend/static/.well-known/ic-domains
+++ b/frontend/static/.well-known/ic-domains
@@ -1,3 +1,5 @@
 nns.internetcomputer.org
 wallet.internetcomputer.org
 wallet.ic0.app
+beta.nns.internetcomputer.org
+beta.nns.ic0.app

--- a/frontend/static/.well-known/ii-alternative-origins
+++ b/frontend/static/.well-known/ii-alternative-origins
@@ -1,1 +1,1 @@
-{"alternativeOrigins": ["https://nns.internetcomputer.org", "https://wallet.internetcomputer.org", "https://wallet.ic0.app"]}
+{"alternativeOrigins": ["https://nns.internetcomputer.org", "https://wallet.internetcomputer.org", "https://wallet.ic0.app", "https://beta.nns.internetcomputer.org", "https://beta.nns.ic0.app"]}


### PR DESCRIPTION
# Motivation

We want to be able to deploy unreleased versions of the NNS dapp which can be used with the same mainnet principal as the real NNS dapp.

This PR is based on https://github.com/dfinity/nns-dapp/pull/3255

# Changes

1. Add the domains to `.well-known/ic-domains` so that the boundary node can see that the canister wants to serve on those domains.
2. Add the domains to `.well-known/ii-alternative-origins` so the internet identity known those domains are allowed to use the same derivation origin.
3. Add the domains to `NNS_IC_ORG_ALTERNATIVE_ORIGINS` so that nns-dapp knows to request the canonical derivation origin from internet identity when serving from those domains.

# Tests

1. Unit tests added.
2. Downloaded https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/.well-known/ic-domains and got
```
nns.internetcomputer.org
wallet.internetcomputer.org
wallet.ic0.app
beta.nns.internetcomputer.org
beta.nns.ic0.app
```
3. Downloaded https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/.well-known/ii-alternative-origins and got
```
{"alternativeOrigins": ["https://nns.internetcomputer.org", "https://wallet.internetcomputer.org", "https://wallet.ic0.app", "https://beta.nns.internetcomputer.org", "https://beta.nns.ic0.app"]}
```

# Todos

- [x] Add entry to changelog (if necessary).
