### PR TITLE
Activate warning dialog for beta deployment

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Add 2 new topics `ProtocolCanisterMangement` and
 * Make the WASM accessible via beta subdomains so we can deploy early versions there.
+* Enable warning dialog on beta deployment.
 
 #### Changed
 

--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -64,6 +64,7 @@ export const IS_TESTNET: boolean =
   FETCH_ROOT_KEY === true &&
   !(HOST.includes(".icp-api.io") || HOST.includes(".ic0.app"));
 
-// TODO: display test environment warning on mainnet according configuration
-// DFX_NETWORK === new_environment_to_be_configured
-export const IS_TEST_MAINNET = false;
+// This is the network name used in the dfx.json file
+const BETA_TEST_DFX_NETWORK = "app";
+
+export const IS_TEST_MAINNET = envVars.dfxNetwork === BETA_TEST_DFX_NETWORK;


### PR DESCRIPTION
# Motivation

We will release code that hasn't been voted on by the community to beta.nns.ic0.app.
To make sure people are aware they are using a test deployment, we have a warning dialog on sign-in.
This was already implemented a while ago in https://github.com/dfinity/nns-dapp/pull/2570 but never enabled.

# Changes

Enable `IS_TEST_MAINNET` when the `DFX_NETWORK` in the canister args is set to `"app"`, which is the network we currently use to deploy the beta.

# Tests

1. The warning dialog itself was tested in https://github.com/dfinity/nns-dapp/pull/2570
2. Enabling it was tested manually by deploying to https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/ with different values in the canister args.

When you sign in, you see this every time:
<img width="530" alt="image" src="https://github.com/user-attachments/assets/e7e9b007-3baa-4397-be47-b37e4dd26b9d">


# Todos

- [x] Add entry to changelog (if necessary).
