### PR TITLE
Update rust version to 1.80.0

### DIFF
--- a/rs/proposals/src/canisters/nns_governance/internal.rs
+++ b/rs/proposals/src/canisters/nns_governance/internal.rs
@@ -9,6 +9,7 @@
 /// Note: The type is published in multiple places under the same name:
 ///  - In the IC repo in `rs/nns/governance/src/governance.rs`
 ///  - in the `ic_cdk`.
+///
 /// The public type is probably better.  Maybe we can ask upstream to use the public type?
 pub use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Please, from time to time, update this to the latest stable version on Rust Forge: https://forge.rust-lang.org/
-channel = "1.79.0"
+channel = "1.80.0"
 components = ["rustfmt", "clippy"]
 targets = [ "wasm32-unknown-unknown"]


### PR DESCRIPTION
# Motivation

The [bot PR](https://github.com/dfinity/nns-dapp/pull/5241) failed because the new rust version has stricter linting.
```
error: doc list item missing indentation
  --> rs/proposals/src/canisters/nns_governance/internal.rs:12:5
   |
12 | /// The public type is probably better.  Maybe we can ask upstream to use the public type?
   |     ^
   |
   = help: if this is supposed to be its own paragraph, add a blank line
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
   = note: `-D clippy::doc-lazy-continuation` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::doc_lazy_continuation)]`
help: indent this line
   |
12 | ///    The public type is probably better.  Maybe we can ask upstream to use the public type?
   |     +++
```

# Changes

1. Update rust to 1.80.0
2. Add a blank line in a comment to satisfy the linter.

# Tests

Lint passes.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary