### PR TITLE
Fix bot PR instructions

### DIFF
--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -78,8 +78,8 @@ jobs:
             * Update Rust version.
 
             # Manual changes
-            - [ ] Fix clippy lints (if necessary)
-            - [ ] Write a changelog entry.
+            If manual changes are required, please make a separate PR.
+            PRs created by bots should only contain automated changes to avoid any confusion.
       - name: Notify Slack on failure
         # Since the this is a scheduled job, a failure won't be shown on any
         # PR status. To notify the team, we send a message to our Slack channel on failure.


### PR DESCRIPTION
# Motivation

PRs created by bots should never contain manual changes. That way, when reading through a list of PRs, it's always obvious that bot PRs are fully automated.

# Changes

Replace the section about manual changes in the Rust update bot PR descriptions.

# Tests

Not tested.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary