### PR TITLE
NNS1-3139: Extract MaturityWithTooltip from NeuronMaturityCell

### DIFF
--- a/frontend/src/lib/components/neurons/MaturityWithTooltip.svelte
+++ b/frontend/src/lib/components/neurons/MaturityWithTooltip.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import Separator from "$lib/components/ui/Separator.svelte";
+  import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { formatMaturity } from "$lib/utils/neuron.utils";
+
+  export let availableMaturity: bigint;
+  export let stakedMaturity: bigint;
+  let totalMaturity = availableMaturity + stakedMaturity;
+</script>
+
+<div data-tid="maturity-with-tooltip-component" class="container">
+  <span data-tid="total-maturity">
+    {formatMaturity(totalMaturity)}
+  </span>
+  <TooltipIcon tooltipIdPrefix="maturity-cell-tooltip">
+    <div class="tooltip-content">
+      <div class="maturity-row">
+        <div class="maturity-label">
+          {$i18n.neuron_detail.available_description}
+        </div>
+        <div class="maturity-value" data-tid="available-maturity">
+          {formatMaturity(availableMaturity)}
+        </div>
+      </div>
+      <Separator spacing="none" />
+      <div class="maturity-row">
+        <div class="maturity-label">
+          {$i18n.neuron_detail.staked_description}
+        </div>
+        <div class="maturity-value" data-tid="staked-maturity">
+          {formatMaturity(stakedMaturity)}
+        </div>
+      </div>
+    </div>
+  </TooltipIcon>
+</div>
+
+<style lang="scss">
+  .container {
+    display: flex;
+    align-items: center;
+    gap: var(--padding-0_5x);
+  }
+
+  .tooltip-content {
+    --elements-divider: var(--tooltip-divider);
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-0_5x);
+
+    .maturity-row {
+      display: flex;
+      gap: var(--padding-2x);
+      justify-content: space-between;
+
+      .maturity-label {
+        color: var(--tooltip-description-color);
+      }
+    }
+  }
+</style>

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronMaturityCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronMaturityCell.svelte
@@ -1,62 +1,13 @@
 <script lang="ts">
-  import Separator from "$lib/components/ui/Separator.svelte";
-  import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
-  import { i18n } from "$lib/stores/i18n";
+  import MaturityWithTooltip from "$lib/components/neurons/MaturityWithTooltip.svelte";
   import type { TableNeuron } from "$lib/types/neurons-table";
-  import { formatMaturity } from "$lib/utils/neuron.utils";
 
   export let rowData: TableNeuron;
-  let totalMaturity = rowData.availableMaturity + rowData.stakedMaturity;
 </script>
 
 <div data-tid="neuron-maturity-cell-component" class="container">
-  <span data-tid="total-maturity">
-    {formatMaturity(totalMaturity)}
-  </span>
-  <TooltipIcon tooltipIdPrefix="maturity-cell-tooltip">
-    <div class="tooltip-content">
-      <div class="maturity-row">
-        <div class="maturity-label">
-          {$i18n.neuron_detail.available_description}
-        </div>
-        <div class="maturity-value" data-tid="available-maturity">
-          {formatMaturity(rowData.availableMaturity)}
-        </div>
-      </div>
-      <Separator spacing="none" />
-      <div class="maturity-row">
-        <div class="maturity-label">
-          {$i18n.neuron_detail.staked_description}
-        </div>
-        <div class="maturity-value" data-tid="staked-maturity">
-          {formatMaturity(rowData.stakedMaturity)}
-        </div>
-      </div>
-    </div>
-  </TooltipIcon>
+  <MaturityWithTooltip
+    availableMaturity={rowData.availableMaturity}
+    stakedMaturity={rowData.stakedMaturity}
+  />
 </div>
-
-<style lang="scss">
-  .container {
-    display: flex;
-    align-items: center;
-    gap: var(--padding-0_5x);
-  }
-
-  .tooltip-content {
-    --elements-divider: var(--tooltip-divider);
-    display: flex;
-    flex-direction: column;
-    gap: var(--padding-0_5x);
-
-    .maturity-row {
-      display: flex;
-      gap: var(--padding-2x);
-      justify-content: space-between;
-
-      .maturity-label {
-        color: var(--tooltip-description-color);
-      }
-    }
-  }
-</style>

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronMaturityCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronMaturityCell.svelte
@@ -5,7 +5,7 @@
   export let rowData: TableNeuron;
 </script>
 
-<div data-tid="neuron-maturity-cell-component" class="container">
+<div data-tid="neuron-maturity-cell-component">
   <MaturityWithTooltip
     availableMaturity={rowData.availableMaturity}
     stakedMaturity={rowData.stakedMaturity}

--- a/frontend/src/tests/lib/components/neurons/MaturityWithTooltip.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/MaturityWithTooltip.spec.ts
@@ -1,0 +1,22 @@
+import MaturityWithTooltip from "$lib/components/neurons/MaturityWithTooltip.svelte";
+import { MaturityWithTooltipPo } from "$tests/page-objects/MaturityWithTooltip.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "@testing-library/svelte";
+
+describe("MaturityWithTooltip", () => {
+  const renderComponent = (props) => {
+    const { container } = render(MaturityWithTooltip, props);
+    return MaturityWithTooltipPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should render maturity", async () => {
+    const po = renderComponent({
+      availableMaturity: 100_000_000n,
+      stakedMaturity: 200_000_000n,
+    });
+
+    expect(await po.getAvailableMaturity()).toBe("1.00");
+    expect(await po.getStakedMaturity()).toBe("2.00");
+    expect(await po.getTotalMaturity()).toBe("3.00");
+  });
+});

--- a/frontend/src/tests/page-objects/MaturityWithTooltip.page-object.ts
+++ b/frontend/src/tests/page-objects/MaturityWithTooltip.page-object.ts
@@ -1,0 +1,33 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class MaturityWithTooltipPo extends BasePageObject {
+  private static readonly TID = "maturity-with-tooltip-component";
+
+  static under(element: PageObjectElement): MaturityWithTooltipPo {
+    return new MaturityWithTooltipPo(
+      element.byTestId(MaturityWithTooltipPo.TID)
+    );
+  }
+
+  getTooltipIconPo(): TooltipIconPo {
+    return TooltipIconPo.under(this.root);
+  }
+
+  getTotalMaturity(): Promise<string> {
+    return this.getText("total-maturity");
+  }
+
+  async getAvailableMaturity(): Promise<string> {
+    return (await this.getTooltipIconPo().getTooltipPo().getTooltipElement())
+      .byTestId("available-maturity")
+      .getText();
+  }
+
+  async getStakedMaturity(): Promise<string> {
+    return (await this.getTooltipIconPo().getTooltipPo().getTooltipElement())
+      .byTestId("staked-maturity")
+      .getText();
+  }
+}

--- a/frontend/src/tests/page-objects/NeuronMaturityCell.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronMaturityCell.page-object.ts
@@ -1,5 +1,5 @@
+import { MaturityWithTooltipPo } from "$tests/page-objects/MaturityWithTooltip.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
-import { TooltipIconPo } from "$tests/page-objects/TooltipIcon.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class NeuronMaturityCellPo extends BasePageObject {
@@ -9,23 +9,19 @@ export class NeuronMaturityCellPo extends BasePageObject {
     return new NeuronMaturityCellPo(element.byTestId(NeuronMaturityCellPo.TID));
   }
 
-  getTooltipIconPo(): TooltipIconPo {
-    return TooltipIconPo.under(this.root);
+  getMaturityWithTooltipPo(): MaturityWithTooltipPo {
+    return MaturityWithTooltipPo.under(this.root);
   }
 
   getTotalMaturity(): Promise<string> {
-    return this.getText("total-maturity");
+    return this.getMaturityWithTooltipPo().getTotalMaturity();
   }
 
-  async getAvailableMaturity(): Promise<string> {
-    return (await this.getTooltipIconPo().getTooltipPo().getTooltipElement())
-      .byTestId("available-maturity")
-      .getText();
+  getAvailableMaturity(): Promise<string> {
+    return this.getMaturityWithTooltipPo().getAvailableMaturity();
   }
 
-  async getStakedMaturity(): Promise<string> {
-    return (await this.getTooltipIconPo().getTooltipPo().getTooltipElement())
-      .byTestId("staked-maturity")
-      .getText();
+  getStakedMaturity(): Promise<string> {
+    return this.getMaturityWithTooltipPo().getStakedMaturity();
   }
 }


### PR DESCRIPTION
# Motivation

We want to show maturity in the projects table, similar to the neurons table, with a tooltip that shows separate available and staked maturity. However there will be some different logic for when the value isn't available so we can't reuse the full cell component.

# Changes

Extract `MaturityWithTooltip` component from `NeuronMaturityCell`.

# Tests

1. Unit test added.
2. Existing NeuronsTable tests pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary