### PR TITLE
Making e2e navigation less brittle

### DIFF
--- a/frontend/src/tests/e2e/accounts.spec.ts
+++ b/frontend/src/tests/e2e/accounts.spec.ts
@@ -72,7 +72,7 @@ test("Test accounts requirements", async ({ page, context }) => {
     expectedAccountAddress: subAccountAddress,
     amount: 5,
   });
-  await appPo.goBack({ waitAbsent: false });
+  await appPo.goBack();
 
   expect(await mainAccountRow.getBalance()).toEqual("15.00 ICP");
   expect(await subaccountRow.getBalance()).toEqual("5.00 ICP");

--- a/frontend/src/tests/e2e/disburse.spec.ts
+++ b/frontend/src/tests/e2e/disburse.spec.ts
@@ -48,6 +48,8 @@ test("Test disburse neuron", async ({ page, context }) => {
 
   step("Disburse the neuron");
   await appPo.getNeuronDetailPo().getNnsNeuronDetailPo().disburseNeuron();
+  // After disburing, the app navigatings to the neurons table.
+  await appPo.getNeuronDetailPo().waitForAbsent();
 
   step("Check account balance after disburse");
   await appPo.goToAccounts();

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -60,8 +60,6 @@ test("Test merge neurons", async ({ page, context }) => {
     .getNeuronDetailPo()
     .getNnsNeuronDetailPo()
     .increaseStake({ amount: finalStake1 - initialStake1 });
-  // Go back to make the menu button visible again.
-  await appPo.goBack();
 
   step("Merge neurons");
   await appPo.goToNeurons();

--- a/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
+++ b/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
@@ -85,7 +85,7 @@ test("Test neuron increase stake", async ({ page, context }) => {
     amount: increase2,
   });
 
-  await appPo.goBack({ waitAbsent: false });
+  await appPo.goBack();
   await appPo.getAccountsPo().waitFor();
   await appPo.goBack();
   await appPo.goToNeuronDetails(neuronId);

--- a/frontend/src/tests/e2e/neurons.spec.ts
+++ b/frontend/src/tests/e2e/neurons.spec.ts
@@ -51,8 +51,6 @@ test("Test neuron voting", async ({ page, context }) => {
 
   // vp=stake*2 when max dissolve delay (https://support.dfinity.org/hc/en-us/articles/4404284534420-What-is-voting-power-)
   expect(neuronAVotingPower).toBe(stake * 2);
-  // back to neurons otherwise the menu is not available
-  await appPo.goBack();
 
   step("Open proposals list");
   await appPo.goToProposals();

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -229,6 +229,9 @@ export class AppPo extends BasePageObject {
     currentView.waitForAbsent();
   }
 
+  // Can be called regardless of whether a back button is present.
+  // The back button will be called as long as there is a back button, until the
+  // menu button appears.
   async goBackAllTheWay(): Promise<void> {
     for (;;) {
       const currentView = await this.getCurrentViewWithBackButtonPo();


### PR DESCRIPTION
# Motivation

There are 2 issues with the back button in end-to-end tests:
1. After clicking the back button, it may be replaced with the menu button or there might still be a back button.
2. When navigating to another tab, we need to click on the menu button, but this is not possible if there is a back button.

This PR solves this by making the `AppPo` aware of which views have a back button.

# Changes

1. Add `getCurrentViewWithBackButton` method to `AppPo` which knows which views have a back button and checks if any of them is currently present to return it.
2. Remove the conditional option to wait for the back button to be absent from `AppPo.goBack` and instead wait for the current view to be absent.
3. Add a `goBackAllTheWay` method which can be used before navigating to another tab without having to know if a back button first needs to be clicked one or more times.
4. Remove calls to `goBack()` before navigating because that's now taken care of by the navigation functions.

# Tests

Test pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary