### PR TITLE
Mstr/imported tokens store

### DIFF
--- a/frontend/src/lib/stores/imported-tokens.store.ts
+++ b/frontend/src/lib/stores/imported-tokens.store.ts
@@ -1,0 +1,43 @@
+import type { ImportedTokenData } from "$lib/types/imported-tokens";
+import { writable } from "svelte/store";
+
+export interface ImportedTokensStore {
+  importedTokens: ImportedTokenData[] | undefined;
+  certified: boolean | undefined;
+}
+
+/**
+ * A store that contains user imported tokens
+ */
+const initImportedTokensStore = () => {
+  const { subscribe, set } = writable<ImportedTokensStore>({
+    importedTokens: undefined,
+    certified: undefined,
+  });
+
+  return {
+    subscribe,
+
+    set({
+      importedTokens,
+      certified,
+    }: {
+      importedTokens: ImportedTokenData[];
+      certified: boolean;
+    }) {
+      set({
+        importedTokens,
+        certified,
+      });
+    },
+
+    reset() {
+      set({
+        importedTokens: undefined,
+        certified: undefined,
+      });
+    },
+  };
+};
+
+export const importedTokensStore = initImportedTokensStore();

--- a/frontend/src/lib/types/imported-tokens.ts
+++ b/frontend/src/lib/types/imported-tokens.ts
@@ -1,0 +1,6 @@
+import type { Principal } from "@dfinity/principal";
+
+export interface ImportedTokenData {
+  ledgerCanisterId: Principal;
+  indexCanisterId: Principal | undefined;
+}

--- a/frontend/src/lib/utils/imported-tokens.utils.ts
+++ b/frontend/src/lib/utils/imported-tokens.utils.ts
@@ -1,0 +1,19 @@
+import type { ImportedToken } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import type { ImportedTokenData } from "$lib/types/imported-tokens";
+import { fromNullable, toNullable } from "@dfinity/utils";
+
+export const toImportedTokenData = ({
+  ledger_canister_id,
+  index_canister_id,
+}: ImportedToken): ImportedTokenData => ({
+  ledgerCanisterId: ledger_canister_id,
+  indexCanisterId: fromNullable(index_canister_id),
+});
+
+export const fromImportedTokenData = ({
+  ledgerCanisterId,
+  indexCanisterId,
+}: ImportedTokenData): ImportedToken => ({
+  ledger_canister_id: ledgerCanisterId,
+  index_canister_id: toNullable(indexCanisterId),
+});

--- a/frontend/src/tests/lib/stores/imported-tokens.store.spec.ts
+++ b/frontend/src/tests/lib/stores/imported-tokens.store.spec.ts
@@ -1,0 +1,55 @@
+import { importedTokensStore } from "$lib/stores/imported-tokens.store";
+import type { ImportedTokenData } from "$lib/types/imported-tokens";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { get } from "svelte/store";
+
+describe("imported-tokens-store", () => {
+  afterEach(() => importedTokensStore.reset());
+
+  describe("importedTokensStore", () => {
+    const importedTokenA: ImportedTokenData = {
+      ledgerCanisterId: principal(0),
+      indexCanisterId: principal(1),
+    };
+    const importedTokenB: ImportedTokenData = {
+      ledgerCanisterId: principal(2),
+      indexCanisterId: principal(3),
+    };
+
+    it("should set imported tokens", () => {
+      const importedTokens = [importedTokenA, importedTokenB];
+      expect(get(importedTokensStore)).toEqual({
+        importedTokens: undefined,
+        certified: undefined,
+      });
+
+      importedTokensStore.set({ importedTokens, certified: true });
+
+      expect(get(importedTokensStore)).toEqual({
+        importedTokens,
+        certified: true,
+      });
+    });
+
+    it("should reset imported tokens", () => {
+      const importedTokens = [importedTokenA, importedTokenB];
+      expect(get(importedTokensStore)).toEqual({
+        importedTokens: undefined,
+        certified: undefined,
+      });
+
+      importedTokensStore.set({ importedTokens, certified: true });
+
+      expect(get(importedTokensStore)).toEqual({
+        importedTokens,
+        certified: true,
+      });
+      importedTokensStore.reset();
+
+      expect(get(importedTokensStore)).toEqual({
+        importedTokens: undefined,
+        certified: undefined,
+      });
+    });
+  });
+});

--- a/frontend/src/tests/lib/stores/imported-tokens.store.spec.ts
+++ b/frontend/src/tests/lib/stores/imported-tokens.store.spec.ts
@@ -13,7 +13,7 @@ describe("imported-tokens-store", () => {
     };
     const importedTokenB: ImportedTokenData = {
       ledgerCanisterId: principal(2),
-      indexCanisterId: principal(3),
+      indexCanisterId: undefined,
     };
 
     it("should set imported tokens", () => {

--- a/frontend/src/tests/lib/utils/imported-tokens.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/imported-tokens.utils.spec.ts
@@ -1,0 +1,54 @@
+import type { ImportedToken } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import type { ImportedTokenData } from "$lib/types/imported-tokens";
+import {
+  fromImportedTokenData,
+  toImportedTokenData,
+} from "$lib/utils/imported-tokens.utils";
+import { principal } from "$tests/mocks/sns-projects.mock";
+
+describe("imported tokens utils", () => {
+  const importedToken: ImportedToken = {
+    ledger_canister_id: principal(0),
+    index_canister_id: [principal(1)],
+  };
+  const importedTokenData: ImportedTokenData = {
+    ledgerCanisterId: principal(0),
+    indexCanisterId: principal(1),
+  };
+  const importedTokenWithoutIndex: ImportedToken = {
+    ledger_canister_id: principal(2),
+    index_canister_id: [],
+  };
+  const importedTokenDataWithoutIndex: ImportedTokenData = {
+    ledgerCanisterId: principal(2),
+    indexCanisterId: undefined,
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("toImportedTokenData", () => {
+    it("should convert imported token", () => {
+      expect(toImportedTokenData(importedToken)).toEqual(importedTokenData);
+    });
+
+    it("should convert imported token without index canister", () => {
+      expect(toImportedTokenData(importedTokenWithoutIndex)).toEqual(
+        importedTokenDataWithoutIndex
+      );
+    });
+  });
+
+  describe("fromImportedTokenData", () => {
+    it("should convert imported token", () => {
+      expect(fromImportedTokenData(importedTokenData)).toEqual(importedToken);
+    });
+
+    it("should convert imported token without index canister", () => {
+      expect(fromImportedTokenData(importedTokenDataWithoutIndex)).toEqual(
+        importedTokenWithoutIndex
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

To simplify working with fetched imported tokens, we need to convert and store them in a simple format.

# Changes

- New type `ImportedTokenData`.
- New util functions to convert to and from `ImportedTokenData`.
- New store `importedTokensStore`.

# Tests

- Tests for new utils.
- Tests for new store.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.