### PR TITLE
Output canister logs during deploy-to-app

### DIFF
--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -104,10 +104,20 @@ jobs:
           # Note: inputs.mode is set if this workflow is run manually, using `workflow_dispatch` defined above.
           #       If the workflow is triggered in another way, the inputs are not defined so we need to specify a default again.
           ARGUMENT="$(cat "out/nns-dapp-arg-${DFX_NETWORK}.did")"
+          # There have been issues with the uploading of assets causing
+          # "heap out of bounds" so we output logs to help debug when it happens
+          # again.
+          # The canister only keeps a small amount of logs so we output them
+          # before and after every step to miss as little as possible.
+          dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
           dfx canister install --mode "${{ inputs.mode || 'upgrade' }}" --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --argument "$ARGUMENT" --wasm out/nns-dapp_noassets.wasm.gz
+          dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
           ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xaa.tar.xz
+          dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
           ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xab.tar.xz
+          dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
           ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xac.tar.xz
+          dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
       - name: Deploy sns_aggregator
         if: (inputs.canisters == 'all') || (inputs.canisters == 'sns_aggregator') || ( github.event_name != 'workflow_dispatch' )
         run: |


### PR DESCRIPTION
# Motivation

There have been issues with the uploading of assets causing "heap out of bounds" so we output logs to help debug when it happens again.

# Changes

Fetch logs before installing the canister and between uploading of each asset chunk.

# Tests

Tested in this run: https://github.com/dfinity/nns-dapp/actions/runs/10113087618/job/27968618074

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary