### PR TITLE
bot: Update proposals candid bindings

### DIFF
--- a/declarations/used_by_proposals/nns_governance/nns_governance.did
+++ b/declarations/used_by_proposals/nns_governance/nns_governance.did
@@ -1,9 +1,10 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-18_01-30--github-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-25_21-03-base/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
   ManageNeuron : ManageNeuron;
   InstallCode : InstallCode;
+  StopOrStartCanister : StopOrStartCanister;
   CreateServiceNervousSystem : CreateServiceNervousSystem;
   ExecuteNnsFunction : ExecuteNnsFunction;
   RewardNodeProvider : RewardNodeProvider;
@@ -43,10 +44,12 @@ type CanisterSummary = record {
 };
 type CfNeuron = record {
   has_created_neuron_recipes : opt bool;
+  hotkeys : opt Principals;
   nns_neuron_id : nat64;
   amount_icp_e8s : nat64;
 };
 type CfParticipant = record {
+  controller : opt principal;
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
 };
@@ -367,6 +370,7 @@ type Neuron = record {
   dissolve_state : opt DissolveState;
   followees : vec record { int32; Followees };
   neuron_fees_e8s : nat64;
+  visibility : opt int32;
   transfer : opt NeuronStakeTransfer;
   known_neuron_data : opt KnownNeuronData;
   spawn_at_timestamp_seconds : opt nat64;
@@ -401,6 +405,7 @@ type NeuronInfo = record {
   stake_e8s : nat64;
   joined_community_fund_timestamp_seconds : opt nat64;
   retrieved_at_timestamp_seconds : nat64;
+  visibility : opt int32;
   known_neuron_data : opt KnownNeuronData;
   voting_power : nat64;
   age_seconds : nat64;
@@ -495,6 +500,7 @@ type Operation = variant {
   StopDissolving : record {};
   StartDissolving : record {};
   IncreaseDissolveDelay : IncreaseDissolveDelay;
+  SetVisibility : SetVisibility;
   JoinCommunityFund : record {};
   LeaveCommunityFund : record {};
   SetDissolveTimestamp : SetDissolveTimestamp;
@@ -616,6 +622,7 @@ type SetSnsTokenSwapOpenTimeWindow = record {
   request : opt SetOpenTimeWindowRequest;
   swap_canister_id : opt principal;
 };
+type SetVisibility = record { visibility : opt int32 };
 type SettleCommunityFundParticipation = record {
   result : opt Result_8;
   open_sns_token_swap_proposal_id : opt nat64;
@@ -636,6 +643,10 @@ type StakeMaturity = record { percentage_to_stake : opt nat32 };
 type StakeMaturityResponse = record {
   maturity_e8s : nat64;
   staked_maturity_e8s : nat64;
+};
+type StopOrStartCanister = record {
+  action : opt int32;
+  canister_id : opt principal;
 };
 type SwapBackgroundInformation = record {
   ledger_index_canister_summary : opt CanisterSummary;

--- a/declarations/used_by_proposals/nns_registry/nns_registry.did
+++ b/declarations/used_by_proposals/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-18_01-30--github-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-25_21-03-base/rs/registry/canister/canister/registry.did>
 // A brief note about the history of this file: This file used to be
 // automatically generated, but now, it is hand-crafted, because the
 // auto-generator has some some pretty degenerate behaviors. The worst of those
@@ -82,14 +82,11 @@ type CompleteCanisterMigrationPayload = record {
 
 type CreateSubnetPayload = record {
   unit_delay_millis : nat64;
-  max_instructions_per_round : nat64;
   features : SubnetFeatures;
-  max_instructions_per_message : nat64;
   gossip_registry_poll_period_ms : nat32;
   max_ingress_bytes_per_message : nat64;
   dkg_dealings_per_block : nat64;
   max_block_payload_size : nat64;
-  max_instructions_per_install_code : nat64;
   start_as_nns : bool;
   is_halted : bool;
   gossip_pfn_evaluation_period_ms : nat32;
@@ -232,7 +229,7 @@ type NodeOperatorRecord = record {
 
 type NodeProvidersMonthlyXdrRewards = record {
   rewards : vec record { text; nat64 };
-  registry_version: opt nat64;
+  registry_version : opt nat64;
 };
 
 type NodeRewardRate = record {
@@ -375,17 +372,14 @@ type UpdateSshReadOnlyAccessForAllUnassignedNodesPayload = record {
 type UpdateSubnetPayload = record {
   unit_delay_millis : opt nat64;
   max_duplicity : opt nat32;
-  max_instructions_per_round : opt nat64;
   features : opt SubnetFeatures;
   set_gossip_config_to_default : bool;
-  max_instructions_per_message : opt nat64;
   halt_at_cup_height : opt bool;
   pfn_evaluation_period_ms : opt nat32;
   subnet_id : principal;
   max_ingress_bytes_per_message : opt nat64;
   dkg_dealings_per_block : opt nat64;
   max_block_payload_size : opt nat64;
-  max_instructions_per_install_code : opt nat64;
   start_as_nns : opt bool;
   is_halted : opt bool;
   max_ingress_messages_per_block : opt nat64;
@@ -433,11 +427,11 @@ service : {
   complete_canister_migration : (CompleteCanisterMigrationPayload) -> ();
   create_subnet : (CreateSubnetPayload) -> ();
   deploy_guestos_to_all_subnet_nodes : (
-      DeployGuestosToAllSubnetNodesPayload,
-    ) -> ();
+    DeployGuestosToAllSubnetNodesPayload
+  ) -> ();
   deploy_guestos_to_all_unassigned_nodes : (
-      DeployGuestosToAllUnassignedNodesPayload,
-    ) -> ();
+    DeployGuestosToAllUnassignedNodesPayload
+  ) -> ();
   get_build_metadata : () -> (text) query;
   get_node_operators_and_dcs_of_node_provider : (principal) -> (GetNodeOperatorsAndDcsOfNodeProviderResponse) query;
   get_node_providers_monthly_xdr_rewards : () -> (GetNodeProvidersMonthlyXdrRewardsResponse) query;
@@ -461,18 +455,18 @@ service : {
   update_node_directly : (UpdateNodeDirectlyPayload) -> ();
   update_node_domain_directly : (UpdateNodeDomainDirectlyPayload) -> (UpdateNodeDomainDirectlyResponse);
   update_node_ipv4_config_directly : (UpdateNodeIPv4ConfigDirectlyPayload) -> (
-      UpdateNodeIpv4ConfigDirectlyResponse,
-    );
+    UpdateNodeIpv4ConfigDirectlyResponse
+  );
   update_node_operator_config : (UpdateNodeOperatorConfigPayload) -> ();
   update_node_operator_config_directly : (
-      UpdateNodeOperatorConfigDirectlyPayload,
-    ) -> ();
+    UpdateNodeOperatorConfigDirectlyPayload
+  ) -> ();
   update_node_rewards_table : (UpdateNodeRewardsTableProposalPayload) -> ();
   update_nodes_hostos_version : (UpdateNodesHostosVersionPayload) -> ();
   update_ssh_readonly_access_for_all_unassigned_nodes : (
-      UpdateSshReadOnlyAccessForAllUnassignedNodesPayload,
-    ) -> ();
+    UpdateSshReadOnlyAccessForAllUnassignedNodesPayload
+  ) -> ();
   update_subnet : (UpdateSubnetPayload) -> ();
   update_subnet_replica_version : (DeployGuestosToAllSubnetNodesPayload) -> ();
   update_unassigned_nodes_config : (UpdateUnassignedNodesConfigPayload) -> ();
-}
+};

--- a/declarations/used_by_proposals/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_proposals/sns_wasm/sns_wasm.did
@@ -1,14 +1,16 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-18_01-30--github-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-25_21-03-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
 type Canister = record { id : opt principal };
 type CfNeuron = record {
   has_created_neuron_recipes : opt bool;
+  hotkeys : opt Principals;
   nns_neuron_id : nat64;
   amount_icp_e8s : nat64;
 };
 type CfParticipant = record {
+  controller : opt principal;
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
 };
@@ -126,6 +128,7 @@ type PrettySnsVersion = record {
   governance_wasm_hash : text;
   index_wasm_hash : text;
 };
+type Principals = record { principals : vec principal };
 type Result = variant { Error : SnsWasmError; Hash : blob };
 type Result_1 = variant { Ok : Ok; Error : SnsWasmError };
 type SnsCanisterIds = record {

--- a/dfx.json
+++ b/dfx.json
@@ -387,7 +387,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-07-24",
-        "IC_COMMIT_FOR_PROPOSALS": "release-2024-07-18_01-30--github-base",
+        "IC_COMMIT_FOR_PROPOSALS": "release-2024-07-25_21-03-base",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-07-18_01-30--github-base"
       },
       "packtool": ""

--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-18_01-30--github-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-25_21-03-base/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -82,6 +82,10 @@ pub struct IncreaseDissolveDelay {
     pub additional_dissolve_delay_seconds: u32,
 }
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct SetVisibility {
+    pub visibility: Option<i32>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct SetDissolveTimestamp {
     pub dissolve_timestamp_seconds: u64,
 }
@@ -93,6 +97,7 @@ pub enum Operation {
     StopDissolving(EmptyRecord),
     StartDissolving(EmptyRecord),
     IncreaseDissolveDelay(IncreaseDissolveDelay),
+    SetVisibility(SetVisibility),
     JoinCommunityFund(EmptyRecord),
     LeaveCommunityFund(EmptyRecord),
     SetDissolveTimestamp(SetDissolveTimestamp),
@@ -172,6 +177,11 @@ pub struct InstallCode {
     pub skip_stopping_before_installing: Option<bool>,
     pub canister_id: Option<Principal>,
     pub install_mode: Option<i32>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct StopOrStartCanister {
+    pub action: Option<i32>,
+    pub canister_id: Option<Principal>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Percentage {
@@ -412,6 +422,7 @@ pub enum Action {
     RegisterKnownNeuron(KnownNeuron),
     ManageNeuron(ManageNeuron),
     InstallCode(InstallCode),
+    StopOrStartCanister(StopOrStartCanister),
     CreateServiceNervousSystem(CreateServiceNervousSystem),
     ExecuteNnsFunction(ExecuteNnsFunction),
     RewardNodeProvider(RewardNodeProvider),
@@ -569,11 +580,13 @@ pub struct GovernanceError {
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct CfNeuron {
     pub has_created_neuron_recipes: Option<bool>,
+    pub hotkeys: Option<Principals>,
     pub nns_neuron_id: u64,
     pub amount_icp_e8s: u64,
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct CfParticipant {
+    pub controller: Option<Principal>,
     pub hotkey_principal: String,
     pub cf_neurons: Vec<CfNeuron>,
 }
@@ -733,6 +746,7 @@ pub struct Neuron {
     pub dissolve_state: Option<DissolveState>,
     pub followees: Vec<(i32, Followees)>,
     pub neuron_fees_e8s: u64,
+    pub visibility: Option<i32>,
     pub transfer: Option<NeuronStakeTransfer>,
     pub known_neuron_data: Option<KnownNeuronData>,
     pub spawn_at_timestamp_seconds: Option<u64>,
@@ -801,6 +815,7 @@ pub struct NeuronInfo {
     pub stake_e8s: u64,
     pub joined_community_fund_timestamp_seconds: Option<u64>,
     pub retrieved_at_timestamp_seconds: u64,
+    pub visibility: Option<i32>,
     pub known_neuron_data: Option<KnownNeuronData>,
     pub voting_power: u64,
     pub age_seconds: u64,

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-18_01-30--github-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-25_21-03-base/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -202,14 +202,11 @@ pub enum SubnetType {
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct CreateSubnetPayload {
     pub unit_delay_millis: u64,
-    pub max_instructions_per_round: u64,
     pub features: SubnetFeatures,
-    pub max_instructions_per_message: u64,
     pub gossip_registry_poll_period_ms: u32,
     pub max_ingress_bytes_per_message: u64,
     pub dkg_dealings_per_block: u64,
     pub max_block_payload_size: u64,
-    pub max_instructions_per_install_code: u64,
     pub start_as_nns: bool,
     pub is_halted: bool,
     pub gossip_pfn_evaluation_period_ms: u32,
@@ -436,10 +433,8 @@ pub struct ChainKeyConfig {
 pub struct UpdateSubnetPayload {
     pub unit_delay_millis: Option<u64>,
     pub max_duplicity: Option<u32>,
-    pub max_instructions_per_round: Option<u64>,
     pub features: Option<SubnetFeatures>,
     pub set_gossip_config_to_default: bool,
-    pub max_instructions_per_message: Option<u64>,
     pub halt_at_cup_height: Option<bool>,
     pub pfn_evaluation_period_ms: Option<u32>,
     pub subnet_id: Principal,
@@ -447,7 +442,6 @@ pub struct UpdateSubnetPayload {
     pub dkg_dealings_per_block: Option<u64>,
     pub ecdsa_key_signing_disable: Option<Vec<EcdsaKeyId>>,
     pub max_block_payload_size: Option<u64>,
-    pub max_instructions_per_install_code: Option<u64>,
     pub start_as_nns: Option<bool>,
     pub is_halted: Option<bool>,
     pub chain_key_signing_enable: Option<Vec<MasterPublicKeyId>>,

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-18_01-30--github-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-07-25_21-03-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -80,13 +80,19 @@ pub struct NeuronsFundParticipationConstraints {
     pub ideal_matched_participation_function: Option<IdealMatchedParticipationFunction>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct Principals {
+    pub principals: Vec<Principal>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct CfNeuron {
     pub has_created_neuron_recipes: Option<bool>,
+    pub hotkeys: Option<Principals>,
     pub nns_neuron_id: u64,
     pub amount_icp_e8s: u64,
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct CfParticipant {
+    pub controller: Option<Principal>,
     pub hotkey_principal: String,
     pub cf_neurons: Vec<CfNeuron>,
 }


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.
Even with no changes, just updating the reference is good practice.

# Changes
* Update the version of `IC_COMMIT_FOR_PROPOSALS` specified in `dfx.json`.
* Updated the `proposals` candid files to the versions in that commit.
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants