### PR TITLE
Add missing imported tokens api types

### DIFF
--- a/frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js
+++ b/frontend/src/lib/canisters/nns-dapp/nns-dapp.idl.js
@@ -48,6 +48,17 @@ export const idlFactory = ({ IDL }) => {
     name: IDL.Text,
     canister_id: IDL.Principal,
   });
+  const ImportedToken = IDL.Record({
+    index_canister_id: IDL.Opt(IDL.Principal),
+    ledger_canister_id: IDL.Principal,
+  });
+  const ImportedTokens = IDL.Record({
+    imported_tokens: IDL.Vec(ImportedToken),
+  });
+  const GetImportedTokensResponse = IDL.Variant({
+    Ok: ImportedTokens,
+    AccountNotFound: IDL.Null,
+  });
   const BlockHeight = IDL.Nat64;
   const NeuronId = IDL.Nat64;
   const GetProposalPayloadResponse = IDL.Variant({
@@ -108,6 +119,11 @@ export const idlFactory = ({ IDL }) => {
     SubAccountNotFound: IDL.Null,
     NameTooLong: IDL.Null,
   });
+  const SetImportedTokensResponse = IDL.Variant({
+    Ok: IDL.Null,
+    AccountNotFound: IDL.Null,
+    TooManyImportedTokens: IDL.Record({ limit: IDL.Int32 }),
+  });
   return IDL.Service({
     add_account: IDL.Func([], [AccountIdentifier], []),
     add_stable_asset: IDL.Func([IDL.Vec(IDL.Nat8)], [], []),
@@ -129,6 +145,7 @@ export const idlFactory = ({ IDL }) => {
     ),
     get_account: IDL.Func([], [GetAccountResponse], ["query"]),
     get_canisters: IDL.Func([], [IDL.Vec(CanisterDetails)], ["query"]),
+    get_imported_tokens: IDL.Func([], [GetImportedTokensResponse], ["query"]),
     get_proposal_payload: IDL.Func(
       [IDL.Nat64],
       [GetProposalPayloadResponse],
@@ -144,6 +161,11 @@ export const idlFactory = ({ IDL }) => {
     rename_sub_account: IDL.Func(
       [RenameSubAccountRequest],
       [RenameSubAccountResponse],
+      []
+    ),
+    set_imported_tokens: IDL.Func(
+      [ImportedTokens],
+      [SetImportedTokensResponse],
       []
     ),
   });


### PR DESCRIPTION
# Motivation

During testing, we found that `non-certified` types were missing after adding [imported tokens api](https://github.com/dfinity/nns-dapp/pull/5239). This occurred because only certified calls were tested.

# Changes

- Add missing type definitions (copied from [certified version](https://github.com/dfinity/nns-dapp/pull/5239/files#diff-2b4b1800a3d79b37a6d64bc8a3f292b923ed05ff68546470c4b32f41858494a0R148)).

# Tests

- Manually tested against a local replica.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.