### PR TITLE
Parse and trim InstallCode proposal payload

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Enable warning dialog on beta deployment.
 * Back-end support for storing imported tokens.
 * Message informing users of the System Canister Management topic split.
+* Parse and trim proposal payload for `InstallCode` within the `get_proposal_payload` back-end endpoint.
 
 #### Changed
 

--- a/rs/proposals/src/def.rs
+++ b/rs/proposals/src/def.rs
@@ -7,9 +7,15 @@
 //!
 //! Thus the types come from a variety of sources.  Each type is annotated with a versioned URL that points to the source of the type.  Updates are NOT automated yet.
 #![allow(missing_docs)]
-use crate::canister_arg_types;
-use crate::canisters::sns_wasm::api::{SnsUpgrade, SnsVersion};
-use crate::{decode_arg, Json};
+use crate::{
+    canister_arg_types,
+    canisters::{
+        nns_governance::api::InstallCode,
+        sns_wasm::api::{SnsUpgrade, SnsVersion},
+    },
+    decode_arg, Json,
+};
+
 use candid::{CandidType, Principal};
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_crypto_sha2::Sha256;
@@ -504,4 +510,29 @@ pub struct SubnetRentalRequest {
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, Clone, Copy, Debug)]
 pub enum RentalConditionId {
     App13CH,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone)]
+pub struct InstallCodeTrimmed {
+    pub wasm_module_hash: String,
+    pub arg_hex: String,
+    pub arg_hash: String,
+}
+
+impl From<&InstallCode> for InstallCodeTrimmed {
+    fn from(install_code: &InstallCode) -> Self {
+        InstallCodeTrimmed {
+            wasm_module_hash: install_code
+                .wasm_module
+                .as_ref()
+                .map(|wasm_module| calculate_hash_string(wasm_module))
+                .unwrap_or_default(),
+            arg_hex: install_code.arg.as_ref().map(hex::encode).unwrap_or_default(),
+            arg_hash: install_code
+                .arg
+                .as_ref()
+                .map(|arg| calculate_hash_string(arg))
+                .unwrap_or_default(),
+        }
+    }
 }

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -124,17 +124,8 @@ pub fn process_proposal_payload(proposal_info: &ProposalInfo) -> Json {
             })
         }
         Some(Action::InstallCode(install_code)) => {
-            let InstallCodeTrimmed {
-                wasm_module_hash,
-                arg_hex,
-                arg_hash,
-            } = InstallCodeTrimmed::from(install_code);
-            json!({
-                "wasm_module_hash": wasm_module_hash,
-                "arg_hex": arg_hex,
-                "arg_hash": arg_hash,
-            })
-            .to_string()
+            let trimmed = InstallCodeTrimmed::from(install_code);
+            json!(trimmed).to_string()
         }
         _ => serde_json::to_string("Proposal has no payload")
             .unwrap_or_else(|err| unreachable!("Surely a fixed string can be serialized as JSON?  Err: {err:?}")),

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -9,8 +9,8 @@ use crate::def::{
     ChangeSubnetTypeAssignmentArgs, CompleteCanisterMigrationPayload, CreateSubnetPayload,
     DeployGuestosToAllSubnetNodesPayload, DeployGuestosToAllUnassignedNodesPayload,
     DeployGuestosToSomeApiBoundaryNodesPayload, DeployHostosToSomeNodesPayload, InsertUpgradePathEntriesRequest,
-    InsertUpgradePathEntriesRequestHumanReadable, PrepareCanisterMigrationPayload, RecoverSubnetPayload,
-    RemoveApiBoundaryNodesPayload, RemoveFirewallRulesPayload, RemoveNodeOperatorsPayload,
+    InsertUpgradePathEntriesRequestHumanReadable, InstallCodeTrimmed, PrepareCanisterMigrationPayload,
+    RecoverSubnetPayload, RemoveApiBoundaryNodesPayload, RemoveFirewallRulesPayload, RemoveNodeOperatorsPayload,
     RemoveNodeOperatorsPayloadHumanReadable, RemoveNodesFromSubnetPayload, RemoveNodesPayload,
     RerouteCanisterRangesPayload, RetireReplicaVersionPayload, ReviseElectedGuestosVersionsPayload,
     ReviseElectedHostosVersionsPayload, SetAuthorizedSubnetworkListArgs, SetFirewallConfigPayload,
@@ -114,14 +114,26 @@ fn decode_arg(arg: &[u8], arg_types: &IDLTypes) -> String {
 /// Checks if the proposal has a payload.  If yes, de-serializes it then converts it to JSON.
 #[must_use]
 pub fn process_proposal_payload(proposal_info: &ProposalInfo) -> Json {
-    if let Some(Action::ExecuteNnsFunction(f)) = proposal_info.proposal.as_ref().and_then(|p| p.action.as_ref()) {
-        transform_payload_to_json(f.nns_function, &f.payload).unwrap_or_else(|e| {
-            let error_msg = "Unable to deserialize payload";
-            serde_json::to_string(&format!("{error_msg}: {e:.400}")).unwrap_or_else(|_| format!("\"{error_msg}\""))
-        })
-    } else {
-        serde_json::to_string("Proposal has no payload")
-            .unwrap_or_else(|err| unreachable!("Surely a fixed string can be serialized as JSON?  Err: {err:?}"))
+    let action = proposal_info.proposal.as_ref().and_then(|p| p.action.as_ref());
+    match action {
+        Some(Action::ExecuteNnsFunction(f)) => {
+            transform_payload_to_json(f.nns_function, &f.payload).unwrap_or_else(|e| {
+                let error_msg = "Unable to deserialize payload";
+                serde_json::to_string(&format!("{error_msg}: {e:.400}")).unwrap_or_else(|_| format!("\"{error_msg}\""))
+            })
+        }
+        Some(Action::InstallCode(install_code)) => {
+            let InstallCodeTrimmed {
+                wasm_module_hash,
+                arg_hex,
+                arg_hash,
+            } = InstallCodeTrimmed::from(install_code);
+            format!(
+                "{{\"wasm_module_hash\":\"{wasm_module_hash}\",\"arg_hex\":\"{arg_hex}\",\"arg_hash\":\"{arg_hash}\"}}"
+            )
+        }
+        _ => serde_json::to_string("Proposal has no payload")
+            .unwrap_or_else(|err| unreachable!("Surely a fixed string can be serialized as JSON?  Err: {err:?}")),
     }
 }
 

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -30,6 +30,7 @@ use idl2json::candid_types::internal_candid_type_to_idl_type;
 use idl2json::{idl_args2json_with_weak_names, BytesFormat, Idl2JsonOptions};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde_json::json;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
@@ -128,9 +129,12 @@ pub fn process_proposal_payload(proposal_info: &ProposalInfo) -> Json {
                 arg_hex,
                 arg_hash,
             } = InstallCodeTrimmed::from(install_code);
-            format!(
-                "{{\"wasm_module_hash\":\"{wasm_module_hash}\",\"arg_hex\":\"{arg_hex}\",\"arg_hash\":\"{arg_hash}\"}}"
-            )
+            json!({
+                "wasm_module_hash": wasm_module_hash,
+                "arg_hex": arg_hex,
+                "arg_hash": arg_hash,
+            })
+            .to_string()
         }
         _ => serde_json::to_string("Proposal has no payload")
             .unwrap_or_else(|err| unreachable!("Surely a fixed string can be serialized as JSON?  Err: {err:?}")),

--- a/rs/proposals/src/tests/mod.rs
+++ b/rs/proposals/src/tests/mod.rs
@@ -1,6 +1,12 @@
 //! Tests that the proposals crate can indeed express proposals as JSON.
-use crate::tests::payloads::get_payloads;
-use crate::transform_payload_to_json;
+use super::*;
+
+use crate::{
+    canisters::nns_governance::api::{InstallCode, NeuronId, Proposal},
+    tests::payloads::get_payloads,
+};
+
+use ic_principal::Principal;
 
 mod args;
 mod payloads;
@@ -12,4 +18,52 @@ fn payload_deserialization() {
         assert!(transformed.is_ok());
         println!("{}", transformed.unwrap());
     }
+}
+
+/// Constructs a `ProposalInfo` with the given action for testing.
+fn proposal_info_with_action(action: Action) -> ProposalInfo {
+    ProposalInfo {
+        id: Some(NeuronId { id: 1 }),
+        status: 1,
+        topic: 1,
+        failure_reason: None,
+        ballots: vec![],
+        proposal_timestamp_seconds: 1,
+        reward_event_round: 1,
+        deadline_timestamp_seconds: None,
+        failed_timestamp_seconds: 0,
+        reject_cost_e8s: 0,
+        derived_proposal_information: None,
+        latest_tally: None,
+        reward_status: 1,
+        decided_timestamp_seconds: 1,
+        proposal: Some(Box::new(Proposal {
+            url: "".to_string(),
+            summary: "".to_string(),
+            title: None,
+            action: Some(action),
+        })),
+        proposer: None,
+        executed_timestamp_seconds: 1,
+    }
+}
+
+#[test]
+fn process_proposal_payload_install_code() {
+    let install_code_action = Action::InstallCode(InstallCode {
+        canister_id: Some(Principal::from_text("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap()),
+        wasm_module: Some(vec![1, 2, 3, 4].into()),
+        arg: Some(vec![5, 6, 7, 8].into()),
+        skip_stopping_before_installing: Some(false),
+        install_mode: Some(1),
+    });
+    let proposal_info = proposal_info_with_action(install_code_action);
+
+    assert_eq!(
+        process_proposal_payload(&proposal_info),
+        "{\"wasm_module_hash\":\"9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a\",\
+         \"arg_hex\":\"05060708\",\
+         \"arg_hash\":\"55e5509f8052998294266ee5b50cb592938191fb5d67f73cac2e60b0276b1bdd\"}"
+            .to_string()
+    );
 }

--- a/rs/proposals/src/tests/mod.rs
+++ b/rs/proposals/src/tests/mod.rs
@@ -61,9 +61,9 @@ fn process_proposal_payload_install_code() {
 
     assert_eq!(
         process_proposal_payload(&proposal_info),
-        "{\"wasm_module_hash\":\"9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a\",\
+        "{\"arg_hash\":\"55e5509f8052998294266ee5b50cb592938191fb5d67f73cac2e60b0276b1bdd\",\
          \"arg_hex\":\"05060708\",\
-         \"arg_hash\":\"55e5509f8052998294266ee5b50cb592938191fb5d67f73cac2e60b0276b1bdd\"}"
+         \"wasm_module_hash\":\"9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a\"}"
             .to_string()
     );
 }


### PR DESCRIPTION
# Motivation

The InstallCode proposal can be large, and we want to avoid letting the client download the entire WASM to calculate the hash.

# Changes

Returns wasm hash and upgrade args hex and hash for InstallCode proposals

# Tests

* Unit tests


# Todos

- [x] Add entry to changelog (if necessary).
