### PR TITLE
Basic Imported Tokens Modal

### DIFF
--- a/frontend/src/lib/components/accounts/ImportTokenCanisterId.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenCanisterId.svelte
@@ -4,12 +4,13 @@
   import LinkIcon from "$lib/components/common/LinkIcon.svelte";
 
   export let label: string;
+  export let testId: string = "import-token-canister-id-component";
   export let canisterId: string | undefined = undefined;
   export let canisterLinkHref: string | undefined = undefined;
   export let canisterIdFallback: string | undefined = undefined;
 </script>
 
-<div class="container" data-tid="import-token-canister-id-component">
+<div class="container" data-tid={testId}>
   <span data-tid="label">{label}</span>
   <div class="canister-id">
     {#if nonNullish(canisterId)}

--- a/frontend/src/lib/components/accounts/ImportTokenForm.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenForm.svelte
@@ -42,7 +42,7 @@
       <Html slot="label" text={$i18n.import_token.index_label_optional} />
     </PrincipalInput>
 
-    <p data-tid="index-canister-description" class="description">
+    <p class="description">
       <Html text={$i18n.import_token.index_canister_description} />
     </p>
 
@@ -53,7 +53,7 @@
         class="secondary"
         type="button"
         data-tid="cancel-button"
-        on:click={() => dispatch("nnsClose")}
+        on:click={() => dispatch("nnsCancel")}
       >
         {$i18n.core.cancel}
       </button>

--- a/frontend/src/lib/components/accounts/ImportTokenForm.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenForm.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import type { Principal } from "@dfinity/principal";
+  import PrincipalInput from "$lib/components/ui/PrincipalInput.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { Html } from "@dfinity/gix-components";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import { createEventDispatcher } from "svelte";
+  import { isNullish } from "@dfinity/utils";
+  import CalloutWarning from "$lib/components/common/CalloutWarning.svelte";
+
+  export let ledgerCanisterId: Principal | undefined = undefined;
+  export let indexCanisterId: Principal | undefined = undefined;
+
+  const dispatch = createEventDispatcher();
+
+  let disabled = true;
+  $: disabled = isNullish(ledgerCanisterId);
+</script>
+
+<TestIdWrapper testId="import-token-form-component">
+  <p class="description">{$i18n.import_token.description}</p>
+
+  <form on:submit|preventDefault={() => dispatch("nnsSubmit")}>
+    <PrincipalInput
+      bind:principal={ledgerCanisterId}
+      placeholderLabelKey="import_token.placeholder"
+      name="ledger-canister-id"
+      testId="ledger-canister-id"
+    >
+      <svelte:fragment slot="label"
+        >{$i18n.import_token.ledger_label}</svelte:fragment
+      >
+    </PrincipalInput>
+
+    <PrincipalInput
+      bind:principal={indexCanisterId}
+      required={false}
+      placeholderLabelKey="import_token.placeholder"
+      name="index-canister-id"
+      testId="index-canister-id"
+    >
+      <Html slot="label" text={$i18n.import_token.index_label_optional} />
+    </PrincipalInput>
+
+    <p data-tid="index-canister-description" class="description">
+      <Html text={$i18n.import_token.index_canister_description} />
+    </p>
+
+    <CalloutWarning htmlText={$i18n.import_token.warning} />
+
+    <div class="toolbar">
+      <button
+        class="secondary"
+        type="button"
+        data-tid="cancel-button"
+        on:click={() => dispatch("nnsClose")}
+      >
+        {$i18n.core.cancel}
+      </button>
+
+      <button data-tid="next-button" class="primary" type="submit" {disabled}>
+        {$i18n.core.next}
+      </button>
+    </div>
+  </form>
+</TestIdWrapper>
+
+<style lang="scss">
+  p.description {
+    margin: 0 0 var(--padding-2x);
+  }
+</style>

--- a/frontend/src/lib/components/accounts/ImportTokenReview.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenReview.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import type { Principal } from "@dfinity/principal";
+  import { i18n } from "$lib/stores/i18n";
+  import { createEventDispatcher } from "svelte";
+  import type { IcrcTokenMetadata } from "$lib/types/icrc";
+  import Logo from "$lib/components/ui/Logo.svelte";
+  import ImportTokenCanisterId from "$lib/components/accounts/ImportTokenCanisterId.svelte";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { isNullish } from "@dfinity/utils";
+  import CalloutWarning from "$lib/components/common/CalloutWarning.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+
+  export let ledgerCanisterId: Principal;
+  export let indexCanisterId: Principal | undefined = undefined;
+  export let tokenMetaData: IcrcTokenMetadata;
+
+  const dispatch = createEventDispatcher();
+
+  let ledgerCanisterHref: string;
+  $: ledgerCanisterHref = replacePlaceholders(
+    $i18n.import_token.link_to_canister,
+    {
+      $canisterId: ledgerCanisterId.toText(),
+    }
+  );
+  let indexCanisterHref: string | undefined;
+  $: indexCanisterHref = isNullish(indexCanisterId)
+    ? undefined
+    : replacePlaceholders($i18n.import_token.link_to_canister, {
+        $canisterId: ledgerCanisterId.toText(),
+      });
+</script>
+
+<div class="container" data-tid="import-token-review-component">
+  <div class="meta">
+    <Logo
+      testId="token-logo"
+      src={tokenMetaData?.logo ?? ""}
+      alt={tokenMetaData.name}
+      size="medium"
+      framed
+    />
+    <div class="token-name">
+      <div data-tid="token-name">{tokenMetaData.name}</div>
+      <div data-tid="token-symbol" class="description">
+        {tokenMetaData.symbol}
+      </div>
+    </div>
+  </div>
+
+  <TestIdWrapper testId="ledger-canister-id">
+    <ImportTokenCanisterId
+      label={$i18n.import_token.ledger_label}
+      canisterId={ledgerCanisterId.toText()}
+      canisterLinkHref={ledgerCanisterHref}
+    />
+  </TestIdWrapper>
+
+  <TestIdWrapper testId="index-canister-id">
+    <ImportTokenCanisterId
+      label={$i18n.import_token.index_label}
+      canisterId={indexCanisterId?.toText()}
+      canisterLinkHref={indexCanisterHref}
+      canisterIdFallback={$i18n.import_token.index_fallback_label}
+    />
+  </TestIdWrapper>
+
+  <CalloutWarning htmlText={$i18n.import_token.warning} />
+
+  <div class="toolbar">
+    <button
+      class="secondary"
+      data-tid="back-button"
+      on:click={() => dispatch("nnsBack")}
+    >
+      {$i18n.core.back}
+    </button>
+
+    <button
+      data-tid="confirm-button"
+      class="primary"
+      on:click={() => dispatch("nnsConfirm")}
+    >
+      {$i18n.import_token.import_button}
+    </button>
+  </div>
+</div>
+
+<style lang="scss">
+  .container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-3x);
+  }
+
+  .meta {
+    display: flex;
+    align-items: center;
+    gap: var(--padding-1_5x);
+    padding: var(--padding) var(--padding-1_5x);
+  }
+
+  .token-name {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-0_5x);
+  }
+</style>

--- a/frontend/src/lib/components/accounts/ImportTokenReview.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenReview.svelte
@@ -8,7 +8,6 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { isNullish } from "@dfinity/utils";
   import CalloutWarning from "$lib/components/common/CalloutWarning.svelte";
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let ledgerCanisterId: Principal;
   export let indexCanisterId: Principal | undefined = undefined;
@@ -48,22 +47,20 @@
     </div>
   </div>
 
-  <TestIdWrapper testId="ledger-canister-id">
-    <ImportTokenCanisterId
-      label={$i18n.import_token.ledger_label}
-      canisterId={ledgerCanisterId.toText()}
-      canisterLinkHref={ledgerCanisterHref}
-    />
-  </TestIdWrapper>
+  <ImportTokenCanisterId
+    testId="ledger-canister-id"
+    label={$i18n.import_token.ledger_label}
+    canisterId={ledgerCanisterId.toText()}
+    canisterLinkHref={ledgerCanisterHref}
+  />
 
-  <TestIdWrapper testId="index-canister-id">
-    <ImportTokenCanisterId
-      label={$i18n.import_token.index_label}
-      canisterId={indexCanisterId?.toText()}
-      canisterLinkHref={indexCanisterHref}
-      canisterIdFallback={$i18n.import_token.index_fallback_label}
-    />
-  </TestIdWrapper>
+  <ImportTokenCanisterId
+    testId="index-canister-id"
+    label={$i18n.import_token.index_label}
+    canisterId={indexCanisterId?.toText()}
+    canisterLinkHref={indexCanisterHref}
+    canisterIdFallback={$i18n.import_token.index_fallback_label}
+  />
 
   <CalloutWarning htmlText={$i18n.import_token.warning} />
 

--- a/frontend/src/lib/components/ui/PrincipalInput.svelte
+++ b/frontend/src/lib/components/ui/PrincipalInput.svelte
@@ -7,6 +7,8 @@
   export let placeholderLabelKey: string;
   export let name: string;
   export let principal: Principal | undefined = undefined;
+  export let required: boolean | undefined = undefined;
+  export let testId: string | undefined = undefined;
 
   let address = principal?.toText() ?? "";
   $: principal = getPrincipalFromString(address);
@@ -23,10 +25,12 @@
   inputType="text"
   {placeholderLabelKey}
   {name}
+  {testId}
   bind:value={address}
   errorMessage={showError ? $i18n.error.principal_not_valid : undefined}
   on:blur={showErrorIfAny}
   showInfo={$$slots.label !== undefined}
+  {required}
 >
   <slot name="label" slot="label" />
 </InputWithError>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1051,8 +1051,6 @@
     "verifying": "Veryifying token details...",
     "review_token_info": "Review token info",
     "import_button": "Import",
-    "link_to_canister": "https://dashboard.internetcomputer.org/canister/$canisterId",
-    "add_imported_token_success": "New token has been successfully imported!",
-    "remove_imported_token_success": "The token has been successfully removed!"
+    "link_to_canister": "https://dashboard.internetcomputer.org/canister/$canisterId"
   }
 }

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1036,7 +1036,9 @@
     "hide_zero_balances": "Hide zero balances",
     "hide_zero_balances_toggle_label": "Switch between showing and hiding tokens with a balance of zero",
     "zero_balance_hidden": "Tokens with 0 balances are hidden.",
-    "show_all": "Show all"
+    "show_all": "Show all",
+    "add_imported_token_success": "New token has been successfully imported!",
+    "remove_imported_token_success": "The token has been successfully removed!"
   },
   "import_token": {
     "import_token": "Import Token",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1036,8 +1036,22 @@
     "hide_zero_balances": "Hide zero balances",
     "hide_zero_balances_toggle_label": "Switch between showing and hiding tokens with a balance of zero",
     "zero_balance_hidden": "Tokens with 0 balances are hidden.",
-    "show_all": "Show all",
+    "show_all": "Show all"
+  },
+  "import_token": {
     "import_token": "Import Token",
+    "description": "To import a new token to your NNS dapp wallet, you will need to find, and paste the ledger canister id of the token. If you want to see your transaction history, you need to import the token’s index canister.",
+    "ledger_label": "Ledger Canister ID",
+    "index_label_optional": "Index Canister ID <span class='description'>(Optional)</span>",
+    "index_label": "Index Canister ID",
+    "index_fallback_label": "Transaction history won’t be displayed.",
+    "placeholder": "00000-00000-00000-00000-000",
+    "index_canister_description": "Index Canister allows to display a token balance and transaction history. <strong>Note:</strong> not all tokens have index canisters.",
+    "warning": "<strong>Warning:</strong> Be careful what token you import! Anyone can create a token including one with the same name as existing tokens, such as ckBTC",
+    "verifying": "Veryifying token details...",
+    "review_token_info": "Review token info",
+    "import_button": "Import",
+    "link_to_canister": "https://dashboard.internetcomputer.org/canister/$canisterId",
     "add_imported_token_success": "New token has been successfully imported!",
     "remove_imported_token_success": "The token has been successfully removed!"
   }

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1051,6 +1051,7 @@
     "verifying": "Veryifying token details...",
     "review_token_info": "Review token info",
     "import_button": "Import",
+    "ledger_canister_loading_error": "Unable to load token details using the provided Ledger Canister ID.",
     "link_to_canister": "https://dashboard.internetcomputer.org/canister/$canisterId"
   }
 }

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1047,7 +1047,7 @@
     "index_fallback_label": "Transaction history won’t be displayed.",
     "placeholder": "00000-00000-00000-00000-000",
     "index_canister_description": "Index Canister allows to display a token balance and transaction history. <strong>Note:</strong> not all tokens have index canisters.",
-    "warning": "<strong>Warning:</strong> Be careful what token you import! Anyone can create a token including one with the same name as existing tokens, such as ckBTC",
+    "warning": "<strong>Warning:</strong> Be careful what token you import! Anyone can create a token including one with the same name as existing tokens, such as ckBTC.",
     "verifying": "Veryifying token details...",
     "review_token_info": "Review token info",
     "import_button": "Import",

--- a/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
@@ -14,7 +14,7 @@
   import { fetchIcrcTokenMetaData } from "$lib/services/icrc-accounts.services";
   import { toastsError } from "$lib/stores/toasts.store";
 
-  export let currentStep: WizardStep | undefined = undefined;
+  let currentStep: WizardStep | undefined = undefined;
 
   const STEP_FORM = "Form";
   const STEP_REVIEW = "Review";
@@ -58,6 +58,10 @@
   };
 
   const onUserInput = async () => {
+    if (isNullish(ledgerCanisterId)) {
+      return;
+    }
+
     startBusy({
       initiator: "import-token-validation",
       labelKey: "import_token.verifying",
@@ -78,7 +82,7 @@
 </script>
 
 <WizardModal
-  testId="import-token-modal"
+  testId="import-token-modal-component"
   {steps}
   bind:currentStep
   bind:this={modal}

--- a/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import {
+    WizardModal,
+    type WizardStep,
+    type WizardSteps,
+  } from "@dfinity/gix-components";
+  import { i18n } from "$lib/stores/i18n";
+  import type { Principal } from "@dfinity/principal";
+  import ImportTokenForm from "$lib/components/accounts/ImportTokenForm.svelte";
+  import type { IcrcTokenMetadata } from "$lib/types/icrc";
+  import { isNullish, nonNullish } from "@dfinity/utils";
+  import ImportTokenReview from "$lib/components/accounts/ImportTokenReview.svelte";
+  import { startBusy, stopBusy } from "$lib/stores/busy.store";
+  import { fetchIcrcTokenMetaData } from "$lib/services/icrc-accounts.services";
+  import { toastsError } from "$lib/stores/toasts.store";
+
+  export let currentStep: WizardStep | undefined = undefined;
+
+  const STEP_FORM = "Form";
+  const STEP_REVIEW = "Review";
+
+  const steps: WizardSteps = [
+    {
+      name: STEP_FORM,
+      title: $i18n.import_token.import_token,
+    },
+    {
+      name: STEP_REVIEW,
+      title: $i18n.import_token.review_token_info,
+    },
+  ];
+
+  let modal: WizardModal;
+  const next = () => {
+    modal?.next();
+  };
+  const back = () => {
+    modal?.back();
+  };
+
+  let ledgerCanisterId: Principal | undefined;
+  let indexCanisterId: Principal | undefined;
+  let tokenMetaData: IcrcTokenMetadata | undefined;
+
+  const updateTokenMetaData = async () => {
+    if (isNullish(ledgerCanisterId)) {
+      return;
+    }
+    const meta = await fetchIcrcTokenMetaData({ ledgerCanisterId });
+    if (isNullish(meta)) {
+      tokenMetaData = undefined;
+      toastsError({
+        labelKey: "import_token.ledger_canister_loading_error",
+      });
+      return;
+    }
+    tokenMetaData = meta;
+  };
+
+  const onUserInput = async () => {
+    startBusy({
+      initiator: "import-token-validation",
+      labelKey: "import_token.verifying",
+    });
+    await updateTokenMetaData();
+    // TODO: validate index canister id here (if provided)
+    stopBusy("import-token-validation");
+
+    if (nonNullish(tokenMetaData)) {
+      next();
+    }
+  };
+
+  const onUserConfirm = async () => {
+    // TODO: save imported token to the backend canister
+    // TODO: navigate to imported token details page
+  };
+</script>
+
+<WizardModal
+  testId="import-token-modal"
+  {steps}
+  bind:currentStep
+  bind:this={modal}
+  on:nnsClose
+>
+  <svelte:fragment slot="title">{currentStep?.title}</svelte:fragment>
+
+  {#if currentStep?.name === STEP_FORM}
+    <ImportTokenForm
+      bind:ledgerCanisterId
+      bind:indexCanisterId
+      on:nnsClose
+      on:nnsSubmit={onUserInput}
+    />
+  {/if}
+  {#if currentStep?.name === STEP_REVIEW && nonNullish(ledgerCanisterId) && nonNullish(tokenMetaData)}
+    <ImportTokenReview
+      {ledgerCanisterId}
+      {indexCanisterId}
+      {tokenMetaData}
+      on:nnsBack={back}
+      on:nnsConfirm={onUserConfirm}
+    />
+  {/if}
+</WizardModal>

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -11,6 +11,7 @@
   import { Popover } from "@dfinity/gix-components";
   import { TokenAmountV2 } from "@dfinity/utils";
   import { ENABLE_IMPORT_TOKEN } from "$lib/stores/feature-flags.store";
+  import ImportTokenModal from "$lib/modals/accounts/ImportTokenModal.svelte";
 
   export let userTokensData: UserToken[];
 
@@ -41,9 +42,7 @@
     hideZeroBalancesStore.set("show");
   };
 
-  const importToken = async () => {
-    // TBD: Implement import token.
-  };
+  let showImportTokenModal = false;
 
   // TODO(Import token): After removing ENABLE_IMPORT_TOKEN combine divs -> <div slot="last-row" class="last-row">
 </script>
@@ -82,9 +81,9 @@
           <button
             data-tid="import-token-button"
             class="ghost with-icon import-token-button"
-            on:click={importToken}
+            on:click={() => (showImportTokenModal = true)}
           >
-            <IconPlus />{$i18n.tokens.import_token}
+            <IconPlus />{$i18n.import_token.import_token}
           </button>
         </div>
       {:else if shouldHideZeroBalances}
@@ -112,6 +111,10 @@
   >
     <HideZeroBalancesToggle />
   </Popover>
+
+  {#if showImportTokenModal}
+    <ImportTokenModal on:nnsClose={() => (showImportTokenModal = false)} />
+  {/if}
 </TestIdWrapper>
 
 <style lang="scss">

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -35,7 +35,9 @@ export const getIcrcAccountIdentity = (_: Account): Promise<Identity> => {
   return getAuthenticatedIdentity();
 };
 
-// Returns null if the token is not found
+/** Simple fetch of the token metadata from the icrc1 ledger canister.
+ * Return null on any error.
+ */
 export const fetchIcrcTokenMetaData = async ({
   ledgerCanisterId,
 }: {
@@ -45,7 +47,10 @@ export const fetchIcrcTokenMetaData = async ({
     identity: getCurrentIdentity(),
     canisterId: ledgerCanisterId,
     certified: false,
-  }).catch(() => null);
+  }).catch(() => {
+    // TODO: Improve error handling if needed
+    return null;
+  });
 };
 
 export const loadIcrcToken = ({

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -5,7 +5,10 @@ import {
 } from "$lib/api/icrc-ledger.api";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { snsTokensByLedgerCanisterIdStore } from "$lib/derived/sns/sns-tokens.derived";
-import { getAuthenticatedIdentity } from "$lib/services/auth.services";
+import {
+  getAuthenticatedIdentity,
+  getCurrentIdentity,
+} from "$lib/services/auth.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { toastsError } from "$lib/stores/toasts.store";
@@ -30,6 +33,19 @@ import { queryAndUpdate, type QueryAndUpdateStrategy } from "./utils.services";
 export const getIcrcAccountIdentity = (_: Account): Promise<Identity> => {
   // TODO: Support Hardware Wallets
   return getAuthenticatedIdentity();
+};
+
+// Returns null if the token is not found
+export const fetchIcrcTokenMetaData = async ({
+  ledgerCanisterId,
+}: {
+  ledgerCanisterId: Principal;
+}): Promise<IcrcTokenMetadata | null> => {
+  return queryIcrcToken({
+    identity: getCurrentIdentity(),
+    canisterId: ledgerCanisterId,
+    certified: false,
+  }).catch(() => null);
 };
 
 export const loadIcrcToken = ({

--- a/frontend/src/lib/stores/busy.store.ts
+++ b/frontend/src/lib/stores/busy.store.ts
@@ -45,7 +45,8 @@ export type BusyStateInitiatorType =
   | "dev-add-sns-neuron-maturity"
   | "dev-add-nns-neuron-maturity"
   | "update-ckbtc-balance"
-  | "reload-receive-account";
+  | "reload-receive-account"
+  | "import-token-validation";
 
 export interface BusyState {
   initiator: BusyStateInitiatorType;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1097,7 +1097,22 @@ interface I18nTokens {
   hide_zero_balances_toggle_label: string;
   zero_balance_hidden: string;
   show_all: string;
+}
+
+interface I18nImport_token {
   import_token: string;
+  description: string;
+  ledger_label: string;
+  index_label_optional: string;
+  index_label: string;
+  index_fallback_label: string;
+  placeholder: string;
+  index_canister_description: string;
+  warning: string;
+  verifying: string;
+  review_token_info: string;
+  import_button: string;
+  link_to_canister: string;
   add_imported_token_success: string;
   remove_imported_token_success: string;
 }
@@ -1386,6 +1401,7 @@ interface I18n {
   settings: I18nSettings;
   sync: I18nSync;
   tokens: I18nTokens;
+  import_token: I18nImport_token;
   neuron_state: I18nNeuron_state;
   topics: I18nTopics;
   topics_description: I18nTopics_description;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1113,8 +1113,6 @@ interface I18nImport_token {
   review_token_info: string;
   import_button: string;
   link_to_canister: string;
-  add_imported_token_success: string;
-  remove_imported_token_success: string;
 }
 
 interface I18nNeuron_state {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1097,6 +1097,8 @@ interface I18nTokens {
   hide_zero_balances_toggle_label: string;
   zero_balance_hidden: string;
   show_all: string;
+  add_imported_token_success: string;
+  remove_imported_token_success: string;
 }
 
 interface I18nImport_token {
@@ -1112,6 +1114,7 @@ interface I18nImport_token {
   verifying: string;
   review_token_info: string;
   import_button: string;
+  ledger_canister_loading_error: string;
   link_to_canister: string;
 }
 

--- a/frontend/src/tests/lib/components/accounts/ImportTokenCanisterId.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenCanisterId.spec.ts
@@ -14,7 +14,9 @@ describe("ImportTokenCanisterId", () => {
     const { container } = render(ImportTokenCanisterId, {
       props,
     });
-    return ImportTokenCanisterIdPo.under(new JestPageObjectElement(container));
+    return ImportTokenCanisterIdPo.under({
+      element: new JestPageObjectElement(container),
+    });
   };
 
   it("should render label, canister id and buttons", async () => {

--- a/frontend/src/tests/lib/components/accounts/ImportTokenForm.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenForm.spec.ts
@@ -1,0 +1,151 @@
+import ImportTokenForm from "$lib/components/accounts/ImportTokenForm.svelte";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { ImportTokenFormPo } from "$tests/page-objects/ImportTokenForm.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+import type { Principal } from "@dfinity/principal";
+
+describe("ImportTokenForm", () => {
+  const renderComponent = (props: {
+    ledgerCanisterId: Principal | undefined;
+    indexCanisterId: Principal | undefined;
+  }) => {
+    const { container, component } = render(ImportTokenForm, {
+      props,
+    });
+
+    const onSubmit = vi.fn();
+    component.$on("nnsSubmit", onSubmit);
+    const nnsClose = vi.fn();
+    component.$on("nnsCancel", nnsClose);
+    const getPropLedgerCanisterId = () =>
+      component.$$.ctx[component.$$.props["ledgerCanisterId"]];
+    const getPropIndexCanisterId = () =>
+      component.$$.ctx[component.$$.props["indexCanisterId"]];
+
+    return {
+      po: ImportTokenFormPo.under(new JestPageObjectElement(container)),
+      onSubmit,
+      nnsClose,
+      getPropLedgerCanisterId,
+      getPropIndexCanisterId,
+    };
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should render ledger canister id", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+    });
+
+    expect((await po.getLedgerCanisterInputPo().getText()).trim()).toEqual(
+      "Ledger Canister ID"
+    );
+    expect(await po.getLedgerCanisterInputPo().getValue()).toEqual(
+      principal(0).toText()
+    );
+    expect(await po.getLedgerCanisterInputPo().isRequired()).toEqual(true);
+  });
+
+  it("should render index canister id", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+    });
+
+    expect((await po.getIndexCanisterInputPo().getText()).trim()).toEqual(
+      "Index Canister ID (Optional)"
+    );
+    expect(await po.getIndexCanisterInputPo().getValue()).toEqual("");
+    expect(await po.getIndexCanisterInputPo().isRequired()).toEqual(false);
+  });
+
+  it("should render a warning message", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+    });
+
+    expect((await po.getWarningPo().getText()).trim()).toEqual(
+      "Warning: Be careful what token you import! Anyone can create a token including one with the same name as existing tokens, such as ckBTC."
+    );
+  });
+
+  it("should enable the next button only when the ledger canister id is valid", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: undefined,
+      indexCanisterId: undefined,
+    });
+
+    expect(await po.getNextButtonPo().isDisabled()).toEqual(true);
+
+    // Enter a valid canister id
+    await po.getLedgerCanisterInputPo().getTextInputPo().typeText("aaaaa-aa");
+
+    expect(await po.getNextButtonPo().isDisabled()).toEqual(false);
+  });
+
+  it("should disable the next button when the ledger canister id is invalid", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+    });
+
+    expect(await po.getNextButtonPo().isDisabled()).toEqual(false);
+
+    // Enter an invalid canister id
+    await po
+      .getLedgerCanisterInputPo()
+      .getTextInputPo()
+      .typeText("invalid-canister-id");
+
+    expect(await po.getNextButtonPo().isDisabled()).toEqual(true);
+  });
+
+  it("should bind canister ids props to inputs", async () => {
+    const principal1 = principal(1);
+    const principal2 = principal(2);
+    const { po, getPropLedgerCanisterId, getPropIndexCanisterId } =
+      renderComponent({
+        ledgerCanisterId: undefined,
+        indexCanisterId: undefined,
+      });
+
+    // Enter canister ids
+    await po
+      .getLedgerCanisterInputPo()
+      .getTextInputPo()
+      .typeText(principal1.toText());
+    await po
+      .getIndexCanisterInputPo()
+      .getTextInputPo()
+      .typeText(principal2.toText());
+
+    expect(getPropLedgerCanisterId()).toEqual(principal1);
+    expect(getPropIndexCanisterId()).toEqual(principal2);
+  });
+
+  it("should dispatch events on buttons click", async () => {
+    const { po, onSubmit, nnsClose } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(nnsClose).not.toHaveBeenCalled();
+
+    await po.getCancelButtonPo().click();
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(nnsClose).toBeCalledTimes(1);
+
+    await po.getNextButtonPo().click();
+
+    expect(onSubmit).toBeCalledTimes(1);
+    expect(nnsClose).toBeCalledTimes(1);
+  });
+});

--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -1,0 +1,119 @@
+import * as ledgerApi from "$lib/api/icrc-ledger.api";
+import ImportTokenModal from "$lib/modals/accounts/ImportTokenModal.svelte";
+import * as busyServices from "$lib/stores/busy.store";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { ImportTokenModalPo } from "$tests/page-objects/ImportTokenModal.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import type { SpyInstance } from "vitest";
+
+describe("ImportTokenModal", () => {
+  const ledgerCanisterId = principal(0);
+  const indexCanisterId = principal(1);
+  const tokenMetaData = {
+    name: "Tetris",
+    symbol: "TET",
+    logo: "https://tetris.tet/logo.png",
+  } as IcrcTokenMetadata;
+
+  const renderComponent = () => {
+    const { container, component } = render(ImportTokenModal);
+
+    const onClose = vi.fn();
+    component.$on("nnsClose", onClose);
+
+    const po = ImportTokenModalPo.under(new JestPageObjectElement(container));
+
+    return {
+      po,
+      formPo: po.getImportTokenFormPo(),
+      reviewPo: po.getImportTokenReviewPo(),
+      onClose,
+    };
+  };
+  let queryIcrcTokenSpy: SpyInstance;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    queryIcrcTokenSpy = vi
+      .spyOn(ledgerApi, "queryIcrcToken")
+      .mockResolvedValue(tokenMetaData);
+  });
+
+  it("should display modal", async () => {
+    const { po } = renderComponent();
+
+    expect(await po.getModalTitle()).toEqual("Import Token");
+  });
+
+  it("should call queryIcrcToken to get a token meta data", async () => {
+    const { formPo } = renderComponent();
+
+    await formPo.getLedgerCanisterInputPo().typeText(ledgerCanisterId.toText());
+
+    expect(queryIcrcTokenSpy).not.toHaveBeenCalled();
+
+    await formPo.getNextButtonPo().click();
+
+    expect(queryIcrcTokenSpy).toBeCalledTimes(1);
+  });
+
+  it("should display a busy screen when fetching meta data", async () => {
+    const startBusySpy = vi.spyOn(busyServices, "startBusy");
+    const { formPo } = renderComponent();
+
+    await formPo.getLedgerCanisterInputPo().typeText(ledgerCanisterId.toText());
+    await formPo.getNextButtonPo().click();
+
+    expect(startBusySpy).toHaveBeenCalledTimes(1);
+    expect(startBusySpy).toHaveBeenCalledWith({
+      initiator: "import-token-validation",
+      labelKey: "import_token.verifying",
+    });
+  });
+
+  it("should display entered canisters info on the review step", async () => {
+    const { formPo, reviewPo } = renderComponent();
+
+    await formPo.getLedgerCanisterInputPo().typeText(ledgerCanisterId.toText());
+    await formPo.getIndexCanisterInputPo().typeText(indexCanisterId.toText());
+    await formPo.getNextButtonPo().click();
+
+    // Wait for ModalWizard step animation.
+    await runResolvedPromises();
+
+    expect(await reviewPo.getLedgerCanisterIdPo().getCanisterIdText()).toEqual(
+      ledgerCanisterId.toText()
+    );
+    expect(await reviewPo.getIndexCanisterIdPo().getCanisterIdText()).toEqual(
+      indexCanisterId.toText()
+    );
+    expect(await reviewPo.getTokenName()).toEqual(tokenMetaData.name);
+    expect(await reviewPo.getTokenSymbol()).toEqual(tokenMetaData.symbol);
+    expect(await reviewPo.getLogoSource()).toEqual(tokenMetaData.logo);
+  });
+
+  it('should navigate back to form on "Back" button click', async () => {
+    const { formPo, reviewPo } = renderComponent();
+
+    expect(await formPo.isPresent()).toEqual(true);
+    expect(await reviewPo.isPresent()).toEqual(false);
+
+    await formPo.getLedgerCanisterInputPo().typeText(ledgerCanisterId.toText());
+    await formPo.getNextButtonPo().click();
+
+    // Wait for ModalWizard step animation.
+    await runResolvedPromises();
+
+    expect(await formPo.isPresent()).toEqual(false);
+    expect(await reviewPo.isPresent()).toEqual(true);
+
+    await reviewPo.getBackButtonPo().click();
+
+    expect(await formPo.isPresent()).toEqual(true);
+    expect(await reviewPo.isPresent()).toEqual(false);
+  });
+});

--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -83,11 +83,11 @@ describe("ImportTokenModal", () => {
     });
   });
 
-  it("should an error toast when failed to load the token meta data", async () => {
+  it("should an error toast when failed to load the token meta data, and stay on first step", async () => {
     vi.spyOn(ledgerApi, "queryIcrcToken").mockRejectedValue(
       new Error("Not a ledger canister")
     );
-    const { formPo } = renderComponent();
+    const { formPo, reviewPo } = renderComponent();
 
     expect(toastsError).not.toBeCalled();
 
@@ -101,6 +101,9 @@ describe("ImportTokenModal", () => {
     expect(toastsError).toBeCalledWith({
       labelKey: "import_token.ledger_canister_loading_error",
     });
+
+    expect(await formPo.isPresent()).toEqual(true);
+    expect(await reviewPo.isPresent()).toEqual(false);
   });
 
   it("should display entered canisters info on the review step", async () => {

--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -102,6 +102,7 @@ describe("ImportTokenModal", () => {
       labelKey: "import_token.ledger_canister_loading_error",
     });
 
+    // Stays on the first step.
     expect(await formPo.isPresent()).toEqual(true);
     expect(await reviewPo.isPresent()).toEqual(false);
   });

--- a/frontend/src/tests/lib/components/accounts/ImportTokenReview.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenReview.spec.ts
@@ -1,0 +1,114 @@
+import ImportTokenReview from "$lib/components/accounts/ImportTokenReview.svelte";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { ImportTokenReviewPo } from "$tests/page-objects/ImportTokenReview.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+import type { Principal } from "@dfinity/principal";
+
+describe("ImportTokenReview", () => {
+  const tokenMetaData = {
+    name: "Tetris",
+    symbol: "TET",
+    logo: "https://tetris.tet/logo.png",
+  } as IcrcTokenMetadata;
+  const renderComponent = (props: {
+    ledgerCanisterId: Principal;
+    indexCanisterId: Principal | undefined;
+    tokenMetaData: IcrcTokenMetadata;
+  }) => {
+    const { container, component } = render(ImportTokenReview, {
+      props,
+    });
+
+    const onConfirm = vi.fn();
+    component.$on("nnsConfirm", onConfirm);
+    const onBack = vi.fn();
+    component.$on("nnsBack", onBack);
+
+    return {
+      po: ImportTokenReviewPo.under(new JestPageObjectElement(container)),
+      onConfirm,
+      onBack,
+    };
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should render token meta information", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+      tokenMetaData,
+    });
+
+    expect(await po.getTokenName()).toEqual("Tetris");
+    expect(await po.getTokenSymbol()).toEqual("TET");
+    expect(await po.getLogoSource()).toEqual("https://tetris.tet/logo.png");
+  });
+
+  it("should render ledger canister id", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+      tokenMetaData,
+    });
+
+    expect(await po.getLedgerCanisterIdPo().getCanisterIdText()).toEqual(
+      principal(0).toText()
+    );
+    expect(await po.getLedgerCanisterIdPo().getLabelText()).toEqual(
+      "Ledger Canister ID"
+    );
+  });
+
+  it("should render index canister id", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: principal(1),
+      tokenMetaData,
+    });
+
+    expect(await po.getIndexCanisterIdPo().getCanisterIdText()).toEqual(
+      principal(1).toText()
+    );
+    expect(await po.getIndexCanisterIdPo().getLabelText()).toEqual(
+      "Index Canister ID"
+    );
+  });
+
+  it("should render a warning message", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+      tokenMetaData,
+    });
+
+    expect((await po.getWarningPo().getText()).trim()).toEqual(
+      "Warning: Be careful what token you import! Anyone can create a token including one with the same name as existing tokens, such as ckBTC."
+    );
+  });
+
+  it("should dispatch events on buttons click", async () => {
+    const { po, onBack, onConfirm } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+      tokenMetaData,
+    });
+
+    expect(onBack).not.toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    await po.getConfirmButtonPo().click();
+
+    expect(onBack).not.toHaveBeenCalled();
+    expect(onConfirm).toBeCalledTimes(1);
+
+    await po.getBackButtonPo().click();
+
+    expect(onBack).toBeCalledTimes(1);
+    expect(onConfirm).toBeCalledTimes(1);
+  });
+});

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -212,6 +212,14 @@ describe("Tokens page", () => {
       expect(await po.getShowAllButtonPo().isPresent()).toBe(true);
       expect(await po.getImportTokenButtonPo().isPresent()).toBe(true);
     });
+
+    it("should open import token modal", async () => {
+      const po = renderPage([positiveBalance, zeroBalance]);
+
+      await po.getImportTokenButtonPo().click();
+
+      expect(await po.getImportTokenModalPo().isPresent()).toBe(true);
+    });
   });
 
   describe("when import token feature flag is disabled", () => {

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -6,6 +6,7 @@ import {
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
 import {
+  fetchIcrcTokenMetaData,
   getIcrcAccountIdentity,
   loadAccounts,
   loadIcrcToken,
@@ -429,6 +430,36 @@ describe("icrc-accounts-services", () => {
       const finalAccount =
         get(icrcAccountsStore)[ledgerCanisterId.toText()]?.accounts[0];
       expect(finalAccount.balanceUlps).toEqual(balanceE8s);
+    });
+  });
+
+  describe("fetchIcrcTokenMetaData", () => {
+    it("calls queryIcrcToken from icrc ledger api", async () => {
+      const result = await fetchIcrcTokenMetaData({
+        ledgerCanisterId,
+      });
+      expect(ledgerApi.queryIcrcToken).toHaveBeenCalledTimes(1);
+      expect(ledgerApi.queryIcrcToken).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        certified: false,
+        canisterId: ledgerCanisterId,
+      });
+      expect(result).toEqual(mockToken);
+    });
+
+    it("returns null on error", async () => {
+      vi.spyOn(ledgerApi, "queryIcrcToken").mockRejectedValue(undefined);
+
+      const result = await fetchIcrcTokenMetaData({
+        ledgerCanisterId,
+      });
+      expect(ledgerApi.queryIcrcToken).toHaveBeenCalledTimes(1);
+      expect(ledgerApi.queryIcrcToken).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        certified: false,
+        canisterId: ledgerCanisterId,
+      });
+      expect(result).toEqual(null);
     });
   });
 });

--- a/frontend/src/tests/page-objects/ImportTokenCanisterId.page-object.ts
+++ b/frontend/src/tests/page-objects/ImportTokenCanisterId.page-object.ts
@@ -6,9 +6,15 @@ import type { PageObjectElement } from "$tests/types/page-object.types";
 export class ImportTokenCanisterIdPo extends BasePageObject {
   private static readonly TID = "import-token-canister-id-component";
 
-  static under(element: PageObjectElement): ImportTokenCanisterIdPo {
+  static under({
+    element,
+    testId,
+  }: {
+    element: PageObjectElement;
+    testId?: string;
+  }): ImportTokenCanisterIdPo {
     return new ImportTokenCanisterIdPo(
-      element.byTestId(ImportTokenCanisterIdPo.TID)
+      element.byTestId(testId ?? ImportTokenCanisterIdPo.TID)
     );
   }
 

--- a/frontend/src/tests/page-objects/ImportTokenForm.page-object.ts
+++ b/frontend/src/tests/page-objects/ImportTokenForm.page-object.ts
@@ -1,0 +1,49 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { CalloutWarningPo } from "$tests/page-objects/CalloutWarning.page-object";
+import { InputWithErrorPo } from "$tests/page-objects/InputWithError.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ImportTokenFormPo extends BasePageObject {
+  private static readonly TID = "import-token-form-component";
+
+  static under(element: PageObjectElement): ImportTokenFormPo {
+    return new ImportTokenFormPo(element.byTestId(ImportTokenFormPo.TID));
+  }
+
+  getLedgerCanisterInputPo(): InputWithErrorPo {
+    return InputWithErrorPo.under({
+      element: this.root,
+      testId: "ledger-canister-id",
+    });
+  }
+
+  getIndexCanisterInputPo(): InputWithErrorPo {
+    return InputWithErrorPo.under({
+      element: this.root,
+      testId: "index-canister-id",
+    });
+  }
+
+  getWarningPo(): CalloutWarningPo {
+    return CalloutWarningPo.under(this.root);
+  }
+
+  getCancelButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "cancel-button",
+    });
+  }
+
+  getNextButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "next-button",
+    });
+  }
+
+  isNextButtonDisabled(): Promise<boolean> {
+    return this.getNextButtonPo().isDisabled();
+  }
+}

--- a/frontend/src/tests/page-objects/ImportTokenForm.page-object.ts
+++ b/frontend/src/tests/page-objects/ImportTokenForm.page-object.ts
@@ -42,8 +42,4 @@ export class ImportTokenFormPo extends BasePageObject {
       testId: "next-button",
     });
   }
-
-  isNextButtonDisabled(): Promise<boolean> {
-    return this.getNextButtonPo().isDisabled();
-  }
 }

--- a/frontend/src/tests/page-objects/ImportTokenModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ImportTokenModal.page-object.ts
@@ -1,0 +1,20 @@
+import { ImportTokenFormPo } from "$tests/page-objects/ImportTokenForm.page-object";
+import { ImportTokenReviewPo } from "$tests/page-objects/ImportTokenReview.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ImportTokenModalPo extends ModalPo {
+  private static readonly TID = "import-token-modal-component";
+
+  static under(element: PageObjectElement): ImportTokenModalPo {
+    return new ImportTokenModalPo(element.byTestId(ImportTokenModalPo.TID));
+  }
+
+  getImportTokenFormPo(): ImportTokenFormPo {
+    return ImportTokenFormPo.under(this.root);
+  }
+
+  getImportTokenReviewPo(): ImportTokenReviewPo {
+    return ImportTokenReviewPo.under(this.root);
+  }
+}

--- a/frontend/src/tests/page-objects/ImportTokenReview.page-object.ts
+++ b/frontend/src/tests/page-objects/ImportTokenReview.page-object.ts
@@ -1,0 +1,57 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { CalloutWarningPo } from "$tests/page-objects/CalloutWarning.page-object";
+import { ImportTokenCanisterIdPo } from "$tests/page-objects/ImportTokenCanisterId.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ImportTokenReviewPo extends BasePageObject {
+  private static readonly TID = "import-token-review-component";
+
+  static under(element: PageObjectElement): ImportTokenReviewPo {
+    return new ImportTokenReviewPo(element.byTestId(ImportTokenReviewPo.TID));
+  }
+
+  getLogoSource(): Promise<string> {
+    return this.getElement("token-logo").getAttribute("src");
+  }
+
+  getTokenName(): Promise<string> {
+    return this.getText("token-name");
+  }
+
+  getTokenSymbol(): Promise<string> {
+    return this.getText("token-symbol");
+  }
+
+  getLedgerCanisterIdPo(): ImportTokenCanisterIdPo {
+    return ImportTokenCanisterIdPo.under({
+      element: this.root,
+      testId: "ledger-canister-id",
+    });
+  }
+
+  getIndexCanisterIdPo(): ImportTokenCanisterIdPo {
+    return ImportTokenCanisterIdPo.under({
+      element: this.root,
+      testId: "index-canister-id",
+    });
+  }
+
+  getWarningPo(): CalloutWarningPo {
+    return CalloutWarningPo.under(this.root);
+  }
+
+  getBackButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "back-button",
+    });
+  }
+
+  getConfirmButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "confirm-button",
+    });
+  }
+}

--- a/frontend/src/tests/page-objects/TokensPage.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensPage.page-object.ts
@@ -1,3 +1,4 @@
+import { ImportTokenModalPo } from "$tests/page-objects/ImportTokenModal.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { BackdropPo } from "./Backdrop.page-object";
@@ -35,6 +36,10 @@ export class TokensPagePo extends BasePageObject {
 
   getImportTokenButtonPo(): ButtonPo {
     return this.getButton("import-token-button");
+  }
+
+  getImportTokenModalPo(): ImportTokenModalPo {
+    return ImportTokenModalPo.under(this.root);
   }
 
   hasTokensTable(): Promise<boolean> {


### PR DESCRIPTION
# Motivation

We need to implement a modal for importing custom tokens. This modal will consist of two steps:

1. Step 1: The user can enter a ledger canister ID and, optionally, an index canister ID.
2. Step 2: After clicking the “Next” button, a review step will display the entered IDs and the token’s meta information. If the dapp fails to load the meta information, the user will remain on the first step and an error toast will be shown.

**Note:** This PR does not include index canister validation or saving the imported token in the NNS-dapp canister.

| Import button (existed) | Step 1 | Step 2 |
|--------|--------|--------|
| <img width="795" alt="Screenshot 2024-07-31 at 15 56 34" src="https://github.com/user-attachments/assets/d51cc9c3-2d28-447b-8a15-d99b84d2a812"> | <img width="620" alt="Screenshot 2024-07-31 at 15 56 51" src="https://github.com/user-attachments/assets/cd322ed4-8413-489d-b1ff-363e75123db8"> | <img width="622" alt="Screenshot 2024-07-31 at 15 57 01" src="https://github.com/user-attachments/assets/267f2b39-2f5f-47e4-b5ad-fe6985a311bf"> | 

# Changes

- New components:
  - `ImportTokenModal`
    - step 1: `ImportTokenForm`
    - step 2: `ImportTokenReview`
- `fetchIcrcTokenMetaData` service.
- Open `ImportTokenModal` on "Import Token" button click.

# Tests

- Manually agains localhost.
- Added unit tests for new components.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.