### PR TITLE
Remove custom added PartialEq from SNS aggregator types

### DIFF
--- a/rs/sns_aggregator/src/types/ic_sns_swap.edit
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.edit
@@ -2,14 +2,4 @@
 set -euxo pipefail
 
 # Commands to run after creating the rust file with didc:
-scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_swap.rs --type NeuronBasketConstructionParameters --trait PartialEq
-scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_swap.rs --type LinearScalingCoefficient --trait PartialEq
-scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_swap.rs --type NeuronsFundParticipationConstraints --trait PartialEq
-scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_swap.rs --type IdealMatchedParticipationFunction --trait PartialEq
-scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_swap.rs --type CfNeuron --trait PartialEq
-scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_swap.rs --type CfParticipant --trait PartialEq
-scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_swap.rs --type NeuronsFundParticipants --trait PartialEq
-scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_swap.rs --type Countries --trait PartialEq
-scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_swap.rs --type Params --trait PartialEq
-scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_swap.rs --type Init --trait PartialEq
 scripts/rust-add-trait -f rs/sns_aggregator/src/types/ic_sns_swap.rs --type GetStateResponse --trait Default

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -16,12 +16,12 @@ use ic_cdk::api::call::CallResult;
 // use candid::{self, CandidType, Deserialize, Principal};
 // use ic_cdk::api::call::CallResult as Result;
 
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronBasketConstructionParameters {
     pub dissolve_delay_interval_seconds: u64,
     pub count: u64,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct LinearScalingCoefficient {
     pub slope_numerator: Option<u64>,
     pub intercept_icp_e8s: Option<u64>,
@@ -29,37 +29,37 @@ pub struct LinearScalingCoefficient {
     pub slope_denominator: Option<u64>,
     pub to_direct_participation_icp_e8s: Option<u64>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct IdealMatchedParticipationFunction {
     pub serialized_representation: Option<String>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronsFundParticipationConstraints {
     pub coefficient_intervals: Vec<LinearScalingCoefficient>,
     pub max_neurons_fund_participation_icp_e8s: Option<u64>,
     pub min_direct_participation_threshold_icp_e8s: Option<u64>,
     pub ideal_matched_participation_function: Option<IdealMatchedParticipationFunction>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CfNeuron {
     pub has_created_neuron_recipes: Option<bool>,
     pub nns_neuron_id: u64,
     pub amount_icp_e8s: u64,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct CfParticipant {
     pub hotkey_principal: String,
     pub cf_neurons: Vec<CfNeuron>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct NeuronsFundParticipants {
     pub cf_participants: Vec<CfParticipant>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Countries {
     pub iso_codes: Vec<String>,
 }
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Init {
     pub nns_proposal_id: Option<u64>,
     pub sns_root_canister_id: String,
@@ -321,7 +321,7 @@ pub struct GetOpenTicketResponse {
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetSaleParametersArg {}
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize, PartialEq)]
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Params {
     pub min_participant_icp_e8s: u64,
     pub neuron_basket_construction_parameters: Option<NeuronBasketConstructionParameters>,

--- a/rs/sns_aggregator/src/types/slow.rs
+++ b/rs/sns_aggregator/src/types/slow.rs
@@ -130,7 +130,7 @@ pub fn logo_binary(data_url: &str) -> Vec<u8> {
 }
 
 /// Slowly changing information about an SNS canister's swap state.
-#[derive(candid::CandidType, candid::Deserialize, Clone, Debug, PartialEq, serde::Serialize)]
+#[derive(candid::CandidType, candid::Deserialize, Clone, Debug, serde::Serialize)]
 pub struct SlowSwapState {
     /// Slowly changing information extracted directly from an SNS canister.
     pub swap: Option<SlowSwap>,
@@ -147,7 +147,7 @@ impl From<&GetStateResponse> for SlowSwapState {
 }
 
 /// Slow information about an SNS extracted from its swap canister.
-#[derive(candid::CandidType, candid::Deserialize, Clone, Debug, PartialEq, serde::Serialize)]
+#[derive(candid::CandidType, candid::Deserialize, Clone, Debug, serde::Serialize)]
 pub struct SlowSwap {
     /// The current lifecycle of the swap.
     pub lifecycle: i32,


### PR DESCRIPTION
# Motivation

We have custom code that adds the `PartialEq` trait to some sns aggregator Rust types derived from Candid.
Sometimes this breaks the build because a new type must receive the `PartialEq` trait as well for the old types to be able to keep the `PartialEq` trait.

But removing the `PartialEq` trait and the custom code that adds it doesn't seem to break anything.

# Changes

Remove custom code to add `PartialEq` to types that don't need it.

# Tests

CI passes.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary