### PR TITLE
Enable following on the new topics

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -22,6 +22,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Replace the nervous system left navigation on the staking tab with a new table.
 * Bump ic-js to a version with new proposal types and neuron visibility.
+* Enable following on the new topics `ProtocolCansiterManagement` and `ServiceNervousSystemManagement`.
 
 #### Deprecated
 

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -21,13 +21,6 @@ const FIRST_TOPICS = [
 ];
 const LAST_TOPICS = [Topic.ExchangeRate];
 
-// Topics that neurons cannot yet set following for.
-// TODO: Remove this list when the NNS Governance supports following on those topics.
-export const TOPICS_WITH_FOLLOWING_DISABLED = [
-  Topic.ProtocolCanisterManagement,
-  Topic.ServiceNervousSystemManagement,
-];
-
 // This list should include ALL topics ordered as we want.
 // Filtering out topics is done in the utils.
 export const TOPICS_TO_FOLLOW_NNS = [

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -16,7 +16,6 @@ import {
   MAX_NEURONS_MERGED,
   MIN_NEURON_STAKE,
   TOPICS_TO_FOLLOW_NNS,
-  TOPICS_WITH_FOLLOWING_DISABLED,
 } from "$lib/constants/neurons.constants";
 import { DEPRECATED_TOPICS } from "$lib/constants/proposals.constants";
 import type { IcpAccountsStoreData } from "$lib/derived/icp-accounts.derived";
@@ -822,11 +821,7 @@ export const topicsToFollow = (neuron: NeuronInfo): Topic[] =>
   (followeesByTopic({ neuron, topic: Topic.ManageNeuron }) === undefined
     ? TOPICS_TO_FOLLOW_NNS.filter((topic) => topic !== Topic.ManageNeuron)
     : TOPICS_TO_FOLLOW_NNS
-  ).filter(
-    (topic) =>
-      !DEPRECATED_TOPICS.includes(topic) &&
-      !TOPICS_WITH_FOLLOWING_DISABLED.includes(topic)
-  );
+  ).filter((topic) => !DEPRECATED_TOPICS.includes(topic));
 
 // NeuronInfo is public info.
 // fullNeuron is only for users with access.

--- a/frontend/src/tests/e2e/following.spec.ts
+++ b/frontend/src/tests/e2e/following.spec.ts
@@ -39,7 +39,7 @@ test("Test neuron following", async ({ page, context }) => {
     .getFollowNnsTopicSectionPos();
 
   step("Follow topics");
-  expect(followNnsTopicSections.length).toBe(15);
+  expect(followNnsTopicSections.length).toBe(17);
   // Go through sections in reverse order because the later ones are the ones
   // most likely to fail.
   followNnsTopicSections.reverse();

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -2210,7 +2210,7 @@ describe("neuron-utils", () => {
       },
     };
 
-    it("should not return deprecated or disabled topics", () => {
+    it("should not return deprecated topics", () => {
       expect(topicsToFollow(neuronWithoutManageNeuron)).toEqual([
         Topic.Unspecified,
         Topic.Governance,
@@ -2226,6 +2226,8 @@ describe("neuron-utils", () => {
         Topic.ReplicaVersionManagement,
         Topic.ApiBoundaryNodeManagement,
         Topic.SubnetRental,
+        Topic.ProtocolCanisterManagement,
+        Topic.ServiceNervousSystemManagement,
         Topic.ExchangeRate,
       ]);
       expect(topicsToFollow(neuronWithoutFollowees)).toEqual([
@@ -2243,6 +2245,8 @@ describe("neuron-utils", () => {
         Topic.ReplicaVersionManagement,
         Topic.ApiBoundaryNodeManagement,
         Topic.SubnetRental,
+        Topic.ProtocolCanisterManagement,
+        Topic.ServiceNervousSystemManagement,
         Topic.ExchangeRate,
       ]);
     });
@@ -2264,6 +2268,8 @@ describe("neuron-utils", () => {
         Topic.ReplicaVersionManagement,
         Topic.ApiBoundaryNodeManagement,
         Topic.SubnetRental,
+        Topic.ProtocolCanisterManagement,
+        Topic.ServiceNervousSystemManagement,
         Topic.ExchangeRate,
       ]);
     });


### PR DESCRIPTION
# Motivation

Previously, following on the new topics cannot be set on the NNS Dapp, because NNS Governance did not support it yet. Now NNS Governance has supported it.

# Changes

Remove a filtering of topic enums that prevented the new topics from appearing on the followee edit modal. Note that the mechanism to disable following by `TOPICS_WITH_FOLLOWING_DISABLED` won't be needed in the future because of https://github.com/dfinity/nns-dapp/pull/5213.

# Tests

* Unit tests
* Manual test to set followees on the new topics:
![Screenshot 2024-08-05 at 3 06 27 PM](https://github.com/user-attachments/assets/d2da3385-f3a9-46e2-a624-375acf9474f3)


# Todos

- [x] Add entry to changelog (if necessary).
