### PR TITLE
Remove cd / from spellcheck

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,7 +44,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Install spellcheck
         run: |
-          cd /
           sudo apt-get update
           sudo apt-get install -yy hunspell hunspell-en-gb hunspell-en-us clang libclang-dev
           cargo install --locked --target x86_64-unknown-linux-gnu cargo-spellcheck@0.13.1


### PR DESCRIPTION
# Motivation

We are trying to move some CI jobs to DFINITY's custom runners.
One difference between GitHub runners and DFINITY runners is that GitHub runners have a default Rust version specified while DFINITY runners don't.
If `cargo` is run from within the repo directory, the version from `rust-toolchain.toml` is taken, but outside of the repo, the version must be specified or default.

The spellcheck job moves outside the repo to avoid getting the configuration from the repo according to [this comment](https://github.com/dfinity/nns-dapp/pull/3378/files#r1343204264),

> To avoid any `.cargo` configuration intended for the local project affecting the build. Not normally necessary but this crate fails to install with just a vanilla `cargo install spellcheck` so I am being (possibly excessively) cautious.

but this now means that the cargo version isn't specified on the DFINITY runner, resulting in [this error](https://github.com/dfinity/nns-dapp/actions/runs/10175444363/job/28143335035):

```
+ cargo install --locked --target x86_64-unknown-linux-gnu cargo-spellcheck@0.13.1
error: rustup could not choose a version of cargo to run, because one wasn't specified explicitly, and no default is configured.
help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
```


Given the comment, it seems safe to remove the `cd /` as long as the spellcheck is still being installed and working.

# Changes

Remove the `cd /` command from the install step on the spellcheck job.

# Tests

CI passes: https://github.com/dfinity/nns-dapp/actions/runs/10261557915/job/28389516744

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary