### PR TITLE
Fix IC cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -93,33 +93,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ad1373757efa0f70ec53939aabc7152e1591cb485208052993070ac8d2429d"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -176,13 +176,13 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
  "synstructure",
 ]
 
@@ -194,18 +194,18 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -337,9 +337,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitvec"
@@ -351,15 +351,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -391,7 +382,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
  "syn_derive",
 ]
 
@@ -506,9 +497,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cached"
@@ -563,7 +554,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -609,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.99"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
 
 [[package]]
 name = "cfg-if"
@@ -635,7 +626,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -684,23 +675,23 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.5",
+ "clap_derive 4.5.13",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.1",
+ "clap_lex 0.7.2",
  "strsim 0.11.1",
 ]
 
@@ -719,14 +710,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.5"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -740,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "codespan-reporting"
@@ -756,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "comparable"
@@ -948,9 +939,9 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
- "group 0.13.0",
+ "group",
  "rand_core",
  "rustc_version",
  "subtle",
@@ -965,26 +956,13 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core",
- "subtle-ng",
- "zeroize",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1018,7 +996,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_cbor",
- "sha2 0.9.9",
+ "sha2",
  "yansi",
 ]
 
@@ -1113,13 +1091,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1131,7 +1109,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1140,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1152,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1164,7 +1142,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "on_wire",
  "prost",
@@ -1178,20 +1156,11 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -1220,13 +1189,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1248,7 +1217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1266,21 +1235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-consensus"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
-dependencies = [
- "curve25519-dalek-ng",
- "hex",
- "rand_core",
- "serde",
- "sha2 0.9.9",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
 name = "ed25519-dalek"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,7 +1245,7 @@ dependencies = [
  "merlin",
  "rand_core",
  "serde",
- "sha2 0.10.8",
+ "sha2",
  "signature",
  "subtle",
  "zeroize",
@@ -1299,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -1311,10 +1265,10 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
- "ff 0.13.0",
+ "digest",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "pem-rfc7468",
  "pkcs8",
  "rand_core",
@@ -1372,7 +1326,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1380,16 +1334,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "rand_core",
- "subtle",
 ]
 
 [[package]]
@@ -1428,9 +1372,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1519,7 +1463,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1599,22 +1543,11 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.0",
+ "ff",
  "rand_core",
  "subtle",
 ]
@@ -1631,7 +1564,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1739,7 +1672,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1755,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
@@ -1784,9 +1726,9 @@ checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1823,9 +1765,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1867,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -1892,9 +1834,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-btc-types-internal"
+name = "ic-btc-replica-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -1907,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ecdsa-secp256k1",
@@ -1920,7 +1862,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "serde",
 ]
@@ -1928,7 +1870,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -1937,7 +1879,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "serde",
@@ -2009,7 +1951,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_tokenstream 0.2.1",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2047,7 +1989,7 @@ source = "git+https://github.com/dfinity/cdk-rs?rev=58791941b72471e09e3d9e733f2a
 dependencies = [
  "serde",
  "serde_bytes",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -2058,19 +2000,20 @@ checksum = "6adc65afeffc619a7cd19553c66c79820908c12f42191af90cfb39e2e93c4431"
 dependencies = [
  "serde",
  "serde_bytes",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
 name = "ic-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
+ "hmac",
  "k256",
  "lazy_static",
  "num-bigint",
@@ -2083,21 +2026,21 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "hkdf",
  "pem",
  "rand",
- "sha2 0.10.8",
+ "thiserror",
  "zeroize",
 ]
 
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "getrandom",
 ]
@@ -2105,7 +2048,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "hex",
  "ic-types",
@@ -2115,11 +2058,10 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
- "ed25519-consensus",
  "hex",
  "ic-crypto-ed25519",
  "ic-crypto-internal-basic-sig-der-utils",
@@ -2138,7 +2080,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -2148,7 +2090,7 @@ dependencies = [
  "paste",
  "rand",
  "rand_chacha",
- "sha2 0.9.9",
+ "sha2",
  "subtle",
  "zeroize",
 ]
@@ -2156,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2164,7 +2106,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2183,7 +2125,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2196,15 +2138,15 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "base64 0.13.1",
  "cached",
@@ -2230,11 +2172,11 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
- "group 0.13.0",
+ "group",
  "hex",
  "hex-literal",
  "ic-crypto-internal-hmac",
@@ -2251,7 +2193,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "strum 0.26.2",
+ "strum 0.26.3",
  "strum_macros",
  "subtle",
  "zeroize",
@@ -2260,7 +2202,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "arrayvec 0.7.4",
  "hex",
@@ -2268,7 +2210,7 @@ dependencies = [
  "phantom_newtype",
  "serde",
  "serde_cbor",
- "strum 0.26.2",
+ "strum 0.26.3",
  "strum_macros",
  "thiserror",
  "zeroize",
@@ -2277,7 +2219,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2295,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "serde",
  "zeroize",
@@ -2304,7 +2246,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2312,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2325,7 +2267,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -2338,7 +2280,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2348,7 +2290,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2358,19 +2300,19 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "ic-protobuf",
  "ic-utils",
  "serde",
- "strum 0.26.2",
+ "strum 0.26.3",
  "strum_macros",
 ]
 
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "ciborium",
@@ -2392,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "ciborium",
@@ -2420,7 +2362,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "async-trait",
  "candid",
@@ -2448,7 +2390,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -2460,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "async-trait",
  "candid",
@@ -2478,7 +2420,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -2490,7 +2432,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "hex",
@@ -2500,19 +2442,20 @@ dependencies = [
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "ic-base-types",
  "ic-btc-interface",
- "ic-btc-types-internal",
+ "ic-btc-replica-types",
  "ic-error-types",
  "ic-protobuf",
+ "ic-utils",
  "num-traits",
  "serde",
  "serde_bytes",
  "serde_cbor",
- "strum 0.26.2",
+ "strum 0.26.3",
  "strum_macros",
 ]
 
@@ -2525,7 +2468,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "async-trait",
  "candid",
@@ -2548,12 +2491,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2589,12 +2532,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -2607,7 +2550,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -2619,12 +2562,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "comparable",
@@ -2637,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "ic-base-types",
 ]
@@ -2645,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "dfn_core",
@@ -2661,7 +2604,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "async-trait",
  "candid",
@@ -2674,12 +2617,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -2692,7 +2635,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "comparable",
@@ -2712,13 +2655,13 @@ dependencies = [
  "prost",
  "serde",
  "serde_bytes",
- "sha2 0.9.9",
+ "sha2",
 ]
 
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -2727,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2746,6 +2689,7 @@ dependencies = [
  "ic-crypto-getrandom-for-wasm",
  "ic-crypto-sha2",
  "ic-ledger-core",
+ "ic-management-canister-types",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
  "ic-nervous-system-common",
@@ -2758,6 +2702,8 @@ dependencies = [
  "ic-neurons-fund",
  "ic-nns-common",
  "ic-nns-constants",
+ "ic-nns-governance-api",
+ "ic-nns-governance-init",
  "ic-nns-gtc-accounts",
  "ic-protobuf",
  "ic-sns-init",
@@ -2766,6 +2712,7 @@ dependencies = [
  "ic-sns-wasm",
  "ic-stable-structures",
  "ic-types",
+ "ic-utils",
  "icp-ledger",
  "itertools 0.12.1",
  "lazy_static",
@@ -2774,6 +2721,7 @@ dependencies = [
  "num-traits",
  "on_wire",
  "pretty_assertions",
+ "prometheus-parse",
  "prost",
  "rand",
  "rand_chacha",
@@ -2783,19 +2731,62 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "strum 0.26.2",
+ "strum 0.26.3",
  "strum_macros",
+]
+
+[[package]]
+name = "ic-nns-governance-api"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+dependencies = [
+ "bytes",
+ "candid",
+ "comparable",
+ "ic-base-types",
+ "ic-nervous-system-clients",
+ "ic-nervous-system-proto",
+ "ic-nns-common",
+ "ic-protobuf",
+ "ic-sns-root",
+ "ic-sns-swap",
+ "ic-types",
+ "ic-utils",
+ "icp-ledger",
+ "itertools 0.12.1",
+ "prost",
+ "serde",
+ "serde_bytes",
+ "strum 0.26.3",
+ "strum_macros",
+]
+
+[[package]]
+name = "ic-nns-governance-init"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+dependencies = [
+ "csv",
+ "ic-base-types",
+ "ic-nervous-system-common",
+ "ic-nervous-system-common-build-metadata",
+ "ic-nervous-system-common-test-keys",
+ "ic-nns-common",
+ "ic-nns-governance-api",
+ "icp-ledger",
+ "rand",
+ "rand_chacha",
 ]
 
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "async-trait",
  "candid",
@@ -2810,7 +2801,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "bincode",
  "candid",
@@ -2824,7 +2815,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2836,7 +2827,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2847,7 +2838,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "ic-management-canister-types",
@@ -2858,19 +2849,19 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "ic-protobuf",
  "serde",
- "strum 0.26.2",
+ "strum 0.26.3",
  "strum_macros",
 ]
 
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2882,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2932,14 +2923,14 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_bytes",
- "strum 0.26.2",
+ "strum 0.26.3",
  "strum_macros",
 ]
 
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -2947,7 +2938,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -2958,7 +2949,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "async-trait",
  "candid",
@@ -2979,7 +2970,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -3006,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3035,7 +3026,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3073,7 +3064,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "comparable",
@@ -3088,7 +3079,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "async-trait",
  "candid",
@@ -3135,7 +3126,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3143,7 +3134,7 @@ dependencies = [
  "chrono",
  "hex",
  "ic-base-types",
- "ic-btc-types-internal",
+ "ic-btc-replica-types",
  "ic-constants",
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -3161,7 +3152,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "serde_with",
- "strum 0.26.2",
+ "strum 0.26.3",
  "strum_macros",
  "thiserror",
  "thousands",
@@ -3170,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3186,7 +3177,7 @@ checksum = "a1f3f1ec63f08807d176691225de0b993e832b1fff71c631ed897df5888c7be4"
 dependencies = [
  "anyhow",
  "candid",
- "clap 4.5.7",
+ "clap 4.5.13",
  "libflate 2.1.0",
  "rustc-demangle",
  "serde",
@@ -3225,13 +3216,13 @@ checksum = "8de254dd67bbd58073e23dc1c8553ba12fa1dc610a19de94ad2bbcd0460c067f"
 
 [[package]]
 name = "ic_bls12_381"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682cb199cd8fcb582a6023325d571a6464edda26c8063fe04b6f6082a1a363c"
+checksum = "3fb94c398e5a5bc56a8f0ff995b2679829e2bbc5f145d9c3ea58d303036e05f2"
 dependencies = [
- "digest 0.9.0",
- "ff 0.12.1",
- "group 0.12.1",
+ "digest",
+ "ff",
+ "group",
  "pairing",
  "rand_core",
  "subtle",
@@ -3248,14 +3239,14 @@ dependencies = [
  "crc32fast",
  "data-encoding",
  "serde",
- "sha2 0.10.8",
+ "sha2",
  "thiserror",
 ]
 
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "comparable",
@@ -3275,18 +3266,17 @@ dependencies = [
  "num-traits",
  "on_wire",
  "prost",
- "prost-derive",
  "serde",
  "serde_bytes",
  "serde_cbor",
- "strum 0.26.2",
+ "strum 0.26.3",
  "strum_macros",
 ]
 
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "async-trait",
  "candid",
@@ -3296,8 +3286,8 @@ dependencies = [
 
 [[package]]
 name = "icrc-ledger-types"
-version = "0.1.5"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+version = "0.1.6"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "base32",
  "candid",
@@ -3308,8 +3298,127 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_bytes",
- "sha2 0.10.8",
- "strum 0.26.2",
+ "sha2",
+ "strum 0.26.3",
+ "time",
+]
+
+[[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3333,7 +3442,7 @@ dependencies = [
  "candid",
  "candid_parser",
  "serde_json",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -3344,6 +3453,18 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd69211b9b519e98303c015e21a007e293db403b6c85b9b124e133d25e242cdd"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+ "smallvec",
+ "utf8_iter",
 ]
 
 [[package]]
@@ -3358,9 +3479,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -3383,9 +3504,9 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "isocountry"
@@ -3460,7 +3581,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.8",
+ "sha2",
  "signature",
 ]
 
@@ -3581,7 +3702,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -3590,6 +3711,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "lock_api"
@@ -3603,9 +3730,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "logos"
@@ -3627,7 +3754,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3726,13 +3853,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3759,14 +3887,14 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "multimap"
-version = "0.10.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -3815,7 +3943,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "sha2 0.10.8",
+ "sha2",
  "strum 0.25.0",
  "strum_macros",
  "tar",
@@ -3843,9 +3971,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3906,20 +4034,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
-]
-
-[[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
 dependencies = [
  "memchr",
 ]
@@ -3936,19 +4054,13 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 
 [[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
@@ -3977,16 +4089,16 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
 name = "pairing"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group 0.12.1",
+ "group",
 ]
 
 [[package]]
@@ -4007,9 +4119,9 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.2",
+ "redox_syscall 0.5.3",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4044,9 +4156,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.10"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
+checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
 dependencies = [
  "memchr",
  "thiserror",
@@ -4055,9 +4167,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.10"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
+checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4065,26 +4177,26 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.10"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
+checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.10"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
+checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
 dependencies = [
  "once_cell",
  "pest",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -4094,13 +4206,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
 ]
 
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "candid",
  "serde",
@@ -4139,7 +4251,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4185,7 +4297,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "sha2 0.10.8",
+ "sha2",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -4200,9 +4312,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -4212,9 +4327,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
 dependencies = [
  "anstyle",
  "predicates-core",
@@ -4222,15 +4337,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -4264,7 +4379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4327,11 +4442,23 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "811031bea65e5a401fb2e1f37d802cca6601e204ac463809a3189352d13b78a5"
+dependencies = [
+ "chrono",
+ "itertools 0.12.1",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]
@@ -4371,7 +4498,7 @@ checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -4385,9 +4512,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "5a5a410fc7882af66deb8d01d01737353cf3ad6204c408177ba494291a626312"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -4395,13 +4522,13 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.6"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+checksum = "1fa3d084c8704911bfefb2771be2f9b6c5c0da7343a71e0021ee3c665cada738"
 dependencies = [
  "bytes",
- "heck 0.5.0",
- "itertools 0.12.1",
+ "heck 0.4.1",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -4410,8 +4537,9 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.66",
+ "syn 2.0.72",
  "tempfile",
+ "which",
 ]
 
 [[package]]
@@ -4424,14 +4552,14 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "8339f32236f590281e2f6368276441394fcd1b2133b549cc895d0ae80f2f9a52"
 dependencies = [
  "prost",
 ]
@@ -4473,9 +4601,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+checksum = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -4483,6 +4611,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -4490,9 +4619,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
 dependencies = [
  "bytes",
  "rand",
@@ -4507,9 +4636,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
 dependencies = [
  "libc",
  "once_cell",
@@ -4583,11 +4712,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -4648,7 +4777,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-07-03_23-01-storage-layer-disabled#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
 dependencies = [
  "build-info",
  "build-info-build",
@@ -4677,6 +4806,7 @@ dependencies = [
  "ic-registry-subnet-type",
  "ic-registry-transport",
  "ic-types",
+ "idna 1.0.2",
  "ipnet",
  "lazy_static",
  "leb128",
@@ -4822,9 +4952,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal_macros"
-version = "1.34.2"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e418701588729bef95e7a655f2b483ad64bb97c46e8e79fde83efd92aaab6d82"
+checksum = "a05bf7103af0797dbce0667c471946b29b9eaea34652eff67324f360fec027de"
 dependencies = [
  "quote",
  "rust_decimal",
@@ -4838,9 +4968,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc_version"
@@ -4866,7 +4996,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4875,9 +5005,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "once_cell",
  "ring",
@@ -4889,9 +5019,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
@@ -4902,9 +5032,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
  "base64 0.22.1",
  "rustls-pki-types",
@@ -4918,9 +5048,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4990,7 +5120,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5027,11 +5157,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5040,9 +5170,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5093,7 +5223,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5104,7 +5234,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5139,7 +5269,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5182,24 +5312,11 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -5210,7 +5327,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -5237,7 +5354,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core",
 ]
 
@@ -5321,7 +5438,7 @@ dependencies = [
  "serde_cbor",
  "serde_derive",
  "serde_json",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -5402,9 +5519,9 @@ checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros",
 ]
@@ -5419,20 +5536,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "subtle"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
-
-[[package]]
-name = "subtle-ng"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -5447,9 +5558,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5465,7 +5576,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5482,7 +5593,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5504,12 +5615,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "b8fcd239983515c23a32fb82099f97d0b11b8c72f654ed659363a95c3dad7a53"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -5548,22 +5660,22 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5623,10 +5735,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
+name = "tinystr"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5639,32 +5761,31 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5680,9 +5801,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-socks"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
 dependencies = [
  "either",
  "futures-util",
@@ -5705,9 +5826,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
@@ -5715,7 +5836,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "toml_datetime",
  "winnow",
 ]
@@ -5778,7 +5899,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5930,15 +6051,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
+ "serde",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -5948,9 +6082,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 
 [[package]]
 name = "valuable"
@@ -5960,9 +6094,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -6047,7 +6181,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -6081,7 +6215,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6140,6 +6274,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6157,11 +6303,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6176,7 +6322,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6194,7 +6340,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6214,18 +6369,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -6236,9 +6391,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6248,9 +6403,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6260,15 +6415,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6278,9 +6433,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6290,9 +6445,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6302,9 +6457,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6314,9 +6469,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -6336,6 +6491,18 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wyz"
@@ -6390,23 +6557,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
-name = "zerocopy"
-version = "0.7.34"
+name = "yoke"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
 dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+ "synstructure",
 ]
 
 [[package]]
@@ -6426,5 +6639,27 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,23 +13,23 @@ version = "2.0.85"
 ic-cdk = "0.15.0"
 ic-cdk-macros = "0.15.0"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
-ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-07-03_23-01-storage-layer-disabled" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
 
 [profile.release]
 lto = false


### PR DESCRIPTION
# Motivation

Updating the IC cargo dependencies has been failing:
https://github.com/dfinity/nns-dapp/actions/workflows/update-ic-cargo-deps.yaml
https://github.com/dfinity/nns-dapp/actions/runs/10244577609/job/28337826321
```
error: failed to select a version for `num-bigint`.
    ... required by package `icrc-ledger-types v0.1.6 (https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10)`
    ... which satisfies git dependency `icrc-ledger-types` of package `cycles-minting-canister v0.9.0 (https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10)`
    ... which satisfies git dependency `cycles-minting-canister` of package `nns-dapp v2.0.85 (/home/runner/work/nns-dapp/nns-dapp/rs/backend)`
versions that meet the requirements `^0.4.6` are: 0.4.6

all possible versions conflict with previously selected packages.

  previously selected package `num-bigint v0.4.5`
    ... which satisfies dependency `num-bigint = "^0.4"` (locked to 0.4.5) of package `candid v0.10.9`
    ... which satisfies dependency `candid = "^0.10.9"` (locked to 0.10.9) of package `nns-dapp v2.0.85 (/home/runner/work/nns-dapp/nns-dapp/rs/backend)`

failed to select a version for `num-bigint` which could resolve this conflict
```

The `num-bigint` issue goes away after deleting the `Cargo.lock` file but then another issue appears:
```
$ rm Cargo.lock
$ scripts/update-ic-cargo-deps --ref "release-2024-08-02_01-30-base"
Updating Cargo.toml, changing 'release-2024-08-02_01-30-base' to 'release-2024-08-02_01-30-base'.
    Updating crates.io index
    Updating git repository `https://github.com/dfinity/ic`
    Updating git repository `https://github.com/dfinity/cdk-rs`
    Updating git repository `https://github.com/dfinity-lab/build-info`
error: failed to select a version for the requirement `ic_bls12_381 = "=0.9.2"`
candidate versions found which didn't match: 0.10.0, 0.9.1, 0.9.0, ...
location searched: crates.io index
required by package `ic-crypto-internal-bls12-381-type v0.9.0 (https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10)`
    ... which satisfies git dependency `ic-crypto-internal-bls12-381-type` of package `ic-crypto-internal-multi-sig-bls12381 v0.9.0 (https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10)`
    ... which satisfies git dependency `ic-crypto-internal-multi-sig-bls12381` of package `ic-crypto-node-key-validation v0.9.0 (https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10)`
    ... which satisfies git dependency `ic-crypto-node-key-validation` of package `registry-canister v0.9.0 (https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10)`
    ... which satisfies git dependency `registry-canister` of package `ic-nns-governance v0.9.0 (https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10)`
    ... which satisfies git dependency `ic-nns-governance` of package `nns-dapp v2.0.84 (/Users/dskloet/dev/nns-dapp/tree8/rs/backend)`
```

This happens because the IC repo depends on version 0.9.2 of ic_bls12_381, but [this version was yanked](https://crates.io/crates/ic_bls12_381/versions) so NNS dapp is unable to depend on it.

It seems that IC can still depend on it because it [already had the entry](https://github.com/dfinity/ic/blob/54a37653eb61174bbcba44fa8ad42ed03ce672cf/Cargo.lock#L12855-L12868) in its `Cargo.lock` file so the work-around for now is to add the same entry in the NNS dapp `Cargo.lock` file.

We expect the IC repo to update its dependency soon: https://dfinity.slack.com/archives/CH07MRJQ7/p1722933995226969

After this, `scripts/update-ic-cargo-deps --ref "release-2024-08-02_01-30-base"` which runs `cargo update --workspace` passed, but `cargo build` still [fails](https://github.com/dfinity/nns-dapp/actions/runs/10263507749/job/28395518922?pr=5282) with:
```
error[E0277]: the trait bound `Arc<std::vec::Vec<u8>>: _::_serde::Serialize` is not satisfied
#32 77.17     --> /opt/cargo/git/checkouts/ic-ca00ee28655ee32e/3d0b3f1/rs/types/types/src/consensus/idkg/schnorr.rs:204:38
#32 77.17      |
#32 77.17 204  | #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
#32 77.17      |                                      ^^^^^^^^^ the trait `_::_serde::Serialize` is not implemented for `Arc<std::vec::Vec<u8>>`
#32 77.17 ...
#32 77.17 208  |     pub message: Arc<Vec<u8>>,
#32 77.17      |     --- required by a bound introduced by this call
#32 77.17      |
#32 77.17      = note: for local types consider adding `#[derive(serde::Serialize)]` to your `Arc<std::vec::Vec<u8>>` type
#32 77.17      = note: for types from other crates check whether the crate offers a `serde` feature flag
#32 77.17      = help: the following other types implement trait `_::_serde::Serialize`:
#32 77.17                &'a T
#32 77.17                &'a mut T
#32 77.17                ()
#32 77.17                (T,)
#32 77.17                (T0, T1)
#32 77.17                (T0, T1, T2)
#32 77.17                (T0, T1, T2, T3)
#32 77.17                (T0, T1, T2, T3, T4)
#32 77.17              and 606 others
#32 77.17 note: required by a bound in `_::_serde::ser::SerializeStruct::serialize_field`
#32 77.17     --> /opt/cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.204/src/ser/mod.rs:1867:21
#32 77.17      |
#32 77.17 1865 |     fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
#32 77.17      |        --------------- required by a bound in this associated function
#32 77.17 1866 |     where
#32 77.17 1867 |         T: ?Sized + Serialize;
#32 77.17      |                     ^^^^^^^^^ required by this bound in `SerializeStruct::serialize_field`
#32 77.17      = note: this error originates in the derive macro `Serialize` (in Nightly builds, run with -Z macro-backtrace for more info)
#32 77.17 
```
etc.

This was caused by https://github.com/dfinity/ic/pull/344 and the fix for this is in https://github.com/dfinity/ic/commit/799cf9f94c0fbaeae9c328f64da03640d37b0480 but that's not yet part of a release so we use that rev directly.

# Changes

1. Replace the entire `Cargo.lock` file with just
```
[[package]]
name = "ic_bls12_381"
version = "0.9.2"
source = "registry+https://github.com/rust-lang/crates.io-index"
checksum = "3fb94c398e5a5bc56a8f0ff995b2679829e2bbc5f145d9c3ea58d303036e05f2"
dependencies = [
 "digest",
 "ff",
 "group",
 "pairing",
 "rand_core",
 "subtle",
 "zeroize",
]
```
2. Run `scripts/update-ic-cargo-deps --ref 799cf9f94c0fbaeae9c328f64da03640d37b0480`

# Tests

Dependencies are updated and CI passes.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary