### PR TITLE
build: update gix-cmp

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -279,12 +279,12 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "4.5.0-next-2024-07-22",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.5.0-next-2024-07-22.tgz",
-      "integrity": "sha512-Vi07NQyaZStW2q7oAzuVJvf83JmJ4pJ8CFVH90qj0Uvl8KOsHloXG8dOlD+QTAs3/gqrKnSCbaUAJg+HSYqu5w==",
+      "version": "4.6.0-next-2024-08-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.6.0-next-2024-08-06.tgz",
+      "integrity": "sha512-oic5/+OqocCRoTBHIcsrrgrpBPDYYSytMcDyYtl1w7nW6ObOxoJig5IM9IBt8w0+J64S67rWnIA+UwQXUK1ufQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "dompurify": "^3.1.5",
+        "dompurify": "^3.1.6",
         "html5-qrcode": "^2.3.8",
         "qr-creator": "^1.0.0"
       },
@@ -2831,9 +2831,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.5.tgz",
-      "integrity": "sha512-lwG+n5h8QNpxtyrJW/gJWckL+1/DQiYMX8f7t8Z2AZTPw1esVrqjI63i7Zc2Gz0aKzLVMYC1V1PL/ky+aY/NgA=="
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
+      "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/dotenv": {
       "version": "16.3.1",
@@ -7059,11 +7060,11 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "4.5.0-next-2024-07-22",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.5.0-next-2024-07-22.tgz",
-      "integrity": "sha512-Vi07NQyaZStW2q7oAzuVJvf83JmJ4pJ8CFVH90qj0Uvl8KOsHloXG8dOlD+QTAs3/gqrKnSCbaUAJg+HSYqu5w==",
+      "version": "4.6.0-next-2024-08-06",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.6.0-next-2024-08-06.tgz",
+      "integrity": "sha512-oic5/+OqocCRoTBHIcsrrgrpBPDYYSytMcDyYtl1w7nW6ObOxoJig5IM9IBt8w0+J64S67rWnIA+UwQXUK1ufQ==",
       "requires": {
-        "dompurify": "^3.1.5",
+        "dompurify": "^3.1.6",
         "html5-qrcode": "^2.3.8",
         "qr-creator": "^1.0.0"
       }
@@ -8772,9 +8773,9 @@
       }
     },
     "dompurify": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.5.tgz",
-      "integrity": "sha512-lwG+n5h8QNpxtyrJW/gJWckL+1/DQiYMX8f7t8Z2AZTPw1esVrqjI63i7Zc2Gz0aKzLVMYC1V1PL/ky+aY/NgA=="
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
+      "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
     },
     "dotenv": {
       "version": "16.3.1",


### PR DESCRIPTION
# Motivation

We have release gix-cmp. It might be useful to upgrade as it contains support for `sass` v1.77.8. Useful if the dependency is ever upgraded here as well.

# Changes

- `npm run update:gix`
