### PR TITLE
NNS1-3139: Include maturity in TableProject type

### DIFF
--- a/frontend/src/lib/types/staking.ts
+++ b/frontend/src/lib/types/staking.ts
@@ -9,6 +9,8 @@ export type TableProject = {
   logo: string;
   neuronCount: number | undefined;
   stake: TokenAmountV2 | UnavailableTokenAmount;
+  availableMaturity: bigint | undefined;
+  stakedMaturity: bigint | undefined;
 };
 
 export type ProjectsTableColumn = ResponsiveTableColumn<TableProject>;

--- a/frontend/src/tests/mocks/staking.mock.ts
+++ b/frontend/src/tests/mocks/staking.mock.ts
@@ -13,4 +13,6 @@ export const mockTableProject: TableProject = {
     amount: 100_000_000n,
     token: ICPToken,
   }),
+  availableMaturity: 0n,
+  stakedMaturity: 0n,
 };


### PR DESCRIPTION
# Motivation

We want to show aggregate maturity in the staking projects table.
This PR includes the data in the type, but does not yet display it on the page.

# Changes

1. Add `availableMaturity` and `stakedMaturity` fields to `TableProject` type.
2. Rename `getNeuronCountAndStake` to `getNeuronAggregateInfo` and include the maturity values in the result.

# Tests

1. Unit tests added.
2. Fields added to mock.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet