### PR TITLE
Imported tokens table sorting

### DIFF
--- a/frontend/src/lib/utils/tokens-table.utils.ts
+++ b/frontend/src/lib/utils/tokens-table.utils.ts
@@ -46,7 +46,6 @@ export const compareTokensAlphabetically = createAscendingComparator(
   ({ title }: UserToken) => title.toLowerCase()
 );
 
-// TODO: update unit tests
 export const compareTokensForTokensTable = ({
   importedTokenIds,
 }: {

--- a/frontend/src/lib/utils/tokens-table.utils.ts
+++ b/frontend/src/lib/utils/tokens-table.utils.ts
@@ -17,9 +17,16 @@ export const compareTokensIcpFirst = createDescendingComparator(
   (token: UserToken) => token.universeId.toText() === OWN_CANISTER_ID_TEXT
 );
 
-export const compareTokensWithBalanceFirst = createDescendingComparator(
-  (token: UserToken) => getTokenBalanceOrZero(token) > 0n
-);
+export const compareTokensWithBalanceOrImportedFirst = ({
+  importedTokenIds,
+}: {
+  importedTokenIds: Set<string>;
+}) =>
+  createDescendingComparator(
+    (token: UserToken) =>
+      getTokenBalanceOrZero(token) > 0n ||
+      importedTokenIds.has(token.universeId.toText())
+  );
 
 // These tokens should be placed before others (but after ICP)
 // because they have significance within the Internet Computer ecosystem and deserve to be highlighted.
@@ -39,9 +46,15 @@ export const compareTokensAlphabetically = createAscendingComparator(
   ({ title }: UserToken) => title.toLowerCase()
 );
 
-export const compareTokensForTokensTable = mergeComparators([
-  compareTokensIcpFirst,
-  compareTokensWithBalanceFirst,
-  compareTokensByImportance,
-  compareTokensAlphabetically,
-]);
+// TODO: update unit tests
+export const compareTokensForTokensTable = ({
+  importedTokenIds,
+}: {
+  importedTokenIds: Set<string>;
+}) =>
+  mergeComparators([
+    compareTokensIcpFirst,
+    compareTokensWithBalanceOrImportedFirst({ importedTokenIds }),
+    compareTokensByImportance,
+    compareTokensAlphabetically,
+  ]);

--- a/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
+++ b/frontend/src/routes/(app)/(nns)/tokens/+page.svelte
@@ -40,6 +40,7 @@
   import { nonNullish } from "@dfinity/utils";
   import { onMount } from "svelte";
   import { compareTokensForTokensTable } from "$lib/utils/tokens-table.utils";
+  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
 
   onMount(() => {
     loadCkBTCTokens();
@@ -197,8 +198,15 @@
     }
   };
 
+  let importedTokenIds: Set<string> = new Set();
+  $: importedTokenIds = new Set(
+    ($importedTokensStore.importedTokens ?? []).map(({ ledgerCanisterId }) =>
+      ledgerCanisterId.toText()
+    )
+  );
+
   const sortTokens = (tokens: UserToken[]) =>
-    [...tokens].sort(compareTokensForTokensTable);
+    [...tokens].sort(compareTokensForTokensTable({ importedTokenIds }));
 </script>
 
 <TestIdWrapper testId="tokens-route-component">

--- a/frontend/src/tests/lib/utils/tokens-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/tokens-table.utils.spec.ts
@@ -1,11 +1,12 @@
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { CKETH_UNIVERSE_CANISTER_ID } from "$lib/constants/cketh-canister-ids.constants";
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
+import type { UserTokenData } from "$lib/types/tokens-page";
 import {
   compareTokensAlphabetically,
   compareTokensByImportance,
   compareTokensIcpFirst,
-  compareTokensWithBalanceFirst,
+  compareTokensWithBalanceOrImportedFirst,
 } from "$lib/utils/tokens-table.utils";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import {
@@ -17,14 +18,6 @@ import {
 import { TokenAmountV2 } from "@dfinity/utils";
 
 describe("tokens-table.utils", () => {
-  const tokenWithBalance = (amount: bigint) =>
-    createUserToken({
-      universeId: principal(Number(amount)),
-      balance: TokenAmountV2.fromUlps({
-        amount,
-        token: { name: `T${amount}`, symbol: `T${amount}`, decimals: 8 },
-      }),
-    });
   const ckBTCToken = createUserToken({
     universeId: CKBTC_UNIVERSE_CANISTER_ID,
   });
@@ -34,6 +27,24 @@ describe("tokens-table.utils", () => {
   const ckUSDCToken = createUserToken({
     universeId: CKUSDC_UNIVERSE_CANISTER_ID,
   });
+  const createTokenWithBalance = ({
+    id,
+    amount,
+  }: {
+    id: number;
+    amount: bigint;
+  }) =>
+    createUserToken({
+      universeId: principal(id),
+      balance: TokenAmountV2.fromUlps({
+        amount,
+        token: {
+          name: `T${id}`,
+          symbol: `T${id}`,
+          decimals: 8,
+        },
+      }),
+    }) as UserTokenData;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -50,53 +61,9 @@ describe("tokens-table.utils", () => {
     });
   });
 
-  describe("compareTokensWithBalanceFirst", () => {
-    it("should keep tokens with balance first", () => {
-      expect(
-        compareTokensWithBalanceFirst(
-          tokenWithBalance(1n),
-          tokenWithBalance(0n)
-        )
-      ).toEqual(-1);
-      expect(
-        compareTokensWithBalanceFirst(
-          tokenWithBalance(0n),
-          tokenWithBalance(1n)
-        )
-      ).toEqual(1);
-      expect(
-        compareTokensWithBalanceFirst(
-          tokenWithBalance(0n),
-          tokenWithBalance(0n)
-        )
-      ).toEqual(0);
-      expect(
-        compareTokensWithBalanceFirst(
-          tokenWithBalance(1n),
-          tokenWithBalance(1n)
-        )
-      ).toEqual(0);
-    });
-
-    it("should treat token in loading state as having a balance of 0", () => {
-      expect(
-        compareTokensWithBalanceFirst(
-          createUserTokenLoading(),
-          tokenWithBalance(1n)
-        )
-      ).toEqual(1);
-      expect(
-        compareTokensWithBalanceFirst(
-          tokenWithBalance(1n),
-          createUserTokenLoading()
-        )
-      ).toEqual(-1);
-    });
-  });
-
   describe("compareTokensByImportance", () => {
     it("should sort tokens by importance", () => {
-      const token0 = tokenWithBalance(0n);
+      const token0 = createTokenWithBalance({ id: 0, amount: 0n });
       const expectedOrder = [ckBTCToken, ckETHTToken, ckUSDCToken, token0];
       expect(
         [token0, ckUSDCToken, ckETHTToken, ckBTCToken].sort(
@@ -134,6 +101,100 @@ describe("tokens-table.utils", () => {
       ).toEqual(-1);
       expect(
         compareTokensAlphabetically(annaToken, albertTokenLowerCase)
+      ).toEqual(1);
+    });
+  });
+
+  describe("compareTokensWithBalanceOrImportedFirst", () => {
+    const token0 = createTokenWithBalance({ id: 0, amount: 0n });
+    const token1 = createTokenWithBalance({ id: 1, amount: 1n });
+    const importedTokenWithBalance = createTokenWithBalance({
+      id: 2,
+      amount: 1n,
+    });
+    const importedTokenNoBalance = createTokenWithBalance({
+      id: 3,
+      amount: 0n,
+    });
+    const importedTokenIds = new Set([
+      importedTokenWithBalance.universeId.toText(),
+      importedTokenNoBalance.universeId.toText(),
+    ]);
+
+    it("should compare by balance", () => {
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(token1, token0)
+      ).toEqual(-1);
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(token0, token1)
+      ).toEqual(1);
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(token1, token1)
+      ).toEqual(0);
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(token0, token0)
+      ).toEqual(0);
+    });
+
+    it("should compare by imported", () => {
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(importedTokenNoBalance, token0)
+      ).toEqual(-1);
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(token0, importedTokenNoBalance)
+      ).toEqual(1);
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(importedTokenWithBalance, importedTokenNoBalance)
+      ).toEqual(0);
+    });
+
+    it("should compare by balance and imported", () => {
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(importedTokenNoBalance, token1)
+      ).toEqual(0);
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(token0, importedTokenNoBalance)
+      ).toEqual(1);
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(importedTokenWithBalance, token0)
+      ).toEqual(-1);
+    });
+
+    it("should treat token in loading state as having a balance of 0", () => {
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(createUserTokenLoading(), token0)
+      ).toEqual(0);
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(token1, createUserTokenLoading())
+      ).toEqual(-1);
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(createUserTokenLoading(), importedTokenNoBalance)
       ).toEqual(1);
     });
   });

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -92,15 +92,15 @@ describe("Tokens route", () => {
     pending_utxos: [],
     required_confirmations: 0,
   });
-  const ckToken1Id = principal(100);
-  const ckToken1Metadata = {
+  const importedToken1Id = principal(100);
+  const importedToken1Metadata = {
     name: "ZTOKEN1",
     symbol: "ZTOKEN1",
     fee: 4_000n,
     decimals: 6,
   } as IcrcTokenMetadata;
-  const ckToken2Id = principal(101);
-  const ckToken2Metadata = {
+  const importedToken2Id = principal(101);
+  const importedToken2Metadata = {
     name: "ATOKEN2",
     symbol: "ATOKEN2",
     fee: 4_000n,
@@ -133,8 +133,8 @@ describe("Tokens route", () => {
             [CKETHSEPOLIA_UNIVERSE_CANISTER_ID.toText()]: mockCkTESTBTCToken,
             [CKUSDC_UNIVERSE_CANISTER_ID.toText()]: mockCkUSDCToken,
             // imported tokens
-            [ckToken1Id.toText()]: ckToken1Metadata,
-            [ckToken2Id.toText()]: ckToken2Metadata,
+            [importedToken1Id.toText()]: importedToken1Metadata,
+            [importedToken2Id.toText()]: importedToken2Metadata,
           };
           if (isNullish(tokenMap[canisterId.toText()])) {
             throw new Error(
@@ -566,12 +566,12 @@ describe("Tokens route", () => {
         });
 
         describe("imported tokens", () => {
-          const ckToken1Data: ImportedTokenData = {
-            ledgerCanisterId: ckToken1Id,
+          const importedToken1Data: ImportedTokenData = {
+            ledgerCanisterId: importedToken1Id,
             indexCanisterId: principal(111),
           };
-          const ckToken2Data: ImportedTokenData = {
-            ledgerCanisterId: ckToken2Id,
+          const importedToken2Data: ImportedTokenData = {
+            ledgerCanisterId: importedToken2Id,
             indexCanisterId: undefined,
           };
 
@@ -589,8 +589,8 @@ describe("Tokens route", () => {
                     ckETHBalanceUlps,
                   [ledgerCanisterIdTetris.toText()]: tetrisBalanceE8s,
                   [ledgerCanisterIdPacman.toText()]: 0n,
-                  [ckToken1Id.toText()]: 10n,
-                  [ckToken2Id.toText()]: 0n,
+                  [importedToken1Id.toText()]: 10n,
+                  [importedToken2Id.toText()]: 0n,
                 };
                 if (isNullish(balancesMap[canisterId.toText()])) {
                   throw new Error(
@@ -603,24 +603,24 @@ describe("Tokens route", () => {
 
             // Add 2 imported tokens
             tokensStore.setToken({
-              canisterId: ckToken1Id,
-              token: ckToken1Metadata,
+              canisterId: importedToken1Id,
+              token: importedToken1Metadata,
             });
             icrcCanistersStore.setCanisters({
-              ledgerCanisterId: ckToken1Id,
+              ledgerCanisterId: importedToken1Id,
               indexCanisterId: undefined,
             });
             tokensStore.setToken({
-              canisterId: ckToken2Id,
-              token: ckToken2Metadata,
+              canisterId: importedToken2Id,
+              token: importedToken2Metadata,
             });
             icrcCanistersStore.setCanisters({
-              ledgerCanisterId: ckToken2Id,
+              ledgerCanisterId: importedToken2Id,
               indexCanisterId: undefined,
             });
 
             importedTokensStore.set({
-              importedTokens: [ckToken1Data, ckToken2Data],
+              importedTokens: [importedToken1Data, importedToken2Data],
               certified: true,
             });
           });

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -121,6 +121,7 @@ describe("Tokens route", () => {
       icrcAccountsStore.reset();
       tokensStore.reset();
       icrcCanistersStore.reset();
+      importedTokensStore.reset();
       ckBTCBalanceE8s = ckBTCDefaultBalanceE8s;
       ckETHBalanceUlps = ckETHDefaultBalanceUlps;
       tetrisBalanceE8s = tetrisDefaultBalanceE8s;
@@ -576,8 +577,6 @@ describe("Tokens route", () => {
           };
 
           beforeEach(() => {
-            importedTokensStore.reset();
-
             vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockImplementation(
               async ({ canisterId }) => {
                 const balancesMap = {

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -634,9 +634,9 @@ describe("Tokens route", () => {
               "ckUSDC",
               // Imported tokens should be placed with the SNS tokens that have a non-zero balance
               // and should be sorted alphabetically.
-              "ATOKEN2", // Imported
+              "ATOKEN2", // Imported without balance
               "Tetris", // SNS with balance
-              "ZTOKEN1", // Imported
+              "ZTOKEN1", // Imported with balance
               // Zero balance
               "ckETH",
               "Pacman",


### PR DESCRIPTION
# Motivation

Important tokens should be displayed together with SNS tokens that have a balance (between the important ck-tokens with a balance and ck-tokens without a balance). All tokens should be sorted alphabetically.

# Changes

- Replace `compareTokensWithBalanceFirst` with `compareTokensWithBalanceOrImportedFirst` comparator.
- Provide imported tokens id to the token table sorting function.

# Tests

- Unit tests were updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not yet.