### PR TITLE
NNS1-3139: Add maturity column in projects table

### DIFF
--- a/frontend/src/lib/components/staking/ProjectMaturityCell.svelte
+++ b/frontend/src/lib/components/staking/ProjectMaturityCell.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import MaturityWithTooltip from "$lib/components/neurons/MaturityWithTooltip.svelte";
+  import type { TableProject } from "$lib/types/staking";
+  import { isNullish } from "@dfinity/utils";
+
+  export let rowData: TableProject;
+</script>
+
+<div data-tid="project-maturity-cell-component">
+  {#if isNullish(rowData.neuronCount) || isNullish(rowData.availableMaturity) || isNullish(rowData.stakedMaturity)}
+    -/-
+  {:else if rowData.neuronCount > 0}
+    <MaturityWithTooltip
+      availableMaturity={rowData.availableMaturity}
+      stakedMaturity={rowData.stakedMaturity}
+    />
+  {/if}
+</div>

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import ProjectActionsCell from "$lib/components/staking/ProjectActionsCell.svelte";
+  import ProjectMaturityCell from "$lib/components/staking/ProjectMaturityCell.svelte";
   import ProjectNeuronsCell from "$lib/components/staking/ProjectNeuronsCell.svelte";
   import ProjectStakeCell from "$lib/components/staking/ProjectStakeCell.svelte";
   import ProjectTitleCell from "$lib/components/staking/ProjectTitleCell.svelte";
@@ -30,6 +31,17 @@
     {
       title: $i18n.neuron_detail.stake,
       cellComponent: ProjectStakeCell,
+      alignment: "right",
+      templateColumns: ["max-content"],
+    },
+    {
+      title: "",
+      alignment: "left",
+      templateColumns: ["1fr"],
+    },
+    {
+      title: $i18n.neuron_detail.maturity_title,
+      cellComponent: ProjectMaturityCell,
       alignment: "right",
       templateColumns: ["max-content"],
     },

--- a/frontend/src/tests/page-objects/ProjectMaturityCell.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectMaturityCell.page-object.ts
@@ -1,0 +1,29 @@
+import { MaturityWithTooltipPo } from "$tests/page-objects/MaturityWithTooltip.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ProjectMaturityCellPo extends BasePageObject {
+  private static readonly TID = "project-maturity-cell-component";
+
+  static under(element: PageObjectElement): ProjectMaturityCellPo {
+    return new ProjectMaturityCellPo(
+      element.byTestId(ProjectMaturityCellPo.TID)
+    );
+  }
+
+  getMaturityWithTooltipPo(): MaturityWithTooltipPo {
+    return MaturityWithTooltipPo.under(this.root);
+  }
+
+  getTotalMaturity(): Promise<string> {
+    return this.getMaturityWithTooltipPo().getTotalMaturity();
+  }
+
+  getAvailableMaturity(): Promise<string> {
+    return this.getMaturityWithTooltipPo().getAvailableMaturity();
+  }
+
+  getStakedMaturity(): Promise<string> {
+    return this.getMaturityWithTooltipPo().getStakedMaturity();
+  }
+}

--- a/frontend/src/tests/page-objects/ProjectsTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectsTableRow.page-object.ts
@@ -1,3 +1,4 @@
+import { ProjectMaturityCellPo } from "$tests/page-objects/ProjectMaturityCell.page-object";
 import { ProjectNeuronsCellPo } from "$tests/page-objects/ProjectNeuronsCell.page-object";
 import { ProjectStakeCellPo } from "$tests/page-objects/ProjectStakeCell.page-object";
 import { ProjectTitleCellPo } from "$tests/page-objects/ProjectTitleCell.page-object";
@@ -23,6 +24,10 @@ export class ProjectsTableRowPo extends ResponsiveTableRowPo {
 
   getProjectStakeCellPo(): ProjectStakeCellPo {
     return ProjectStakeCellPo.under(this.root);
+  }
+
+  getProjectMaturityCellPo(): ProjectMaturityCellPo {
+    return ProjectMaturityCellPo.under(this.root);
   }
 
   getProjectNeuronsCellPo(): ProjectNeuronsCellPo {


### PR DESCRIPTION
# Motivation

We want to make it easy to see all the maturity on all projects by adding a column to the staking projects table.

# Changes

1. Add `ProjectMaturityCell` component which renders either `-/-` of there is no data, the maturity if there is data, or nothing if the user doesn't have neurons for that project.
2. Use the cell component to add a column in the `ProjectsTable`.

# Tests

1. Page objects and unit tests added.
2. Manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/staking/

# Todos

- [ ] Add entry to changelog (if necessary).
We haven't done a release yet since the projects table was enabled so that entry covers this as well.