### PR TITLE
Render the payload section for InstallCode

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -19,6 +19,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Back-end support for storing imported tokens.
 * Message informing users of the System Canister Management topic split.
 * Parse and trim proposal payload for `InstallCode` within the `get_proposal_payload` back-end endpoint.
+* Support rendering `InstallCode` proposal payload by calling `get_proposal_payload`.
 
 #### Changed
 

--- a/frontend/src/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { loadProposalPayload } from "$lib/services/$public/proposals.services";
   import { proposalPayloadsStore } from "$lib/stores/proposals.store";
-  import { getNnsFunctionKey } from "$lib/utils/proposals.utils";
+  import { hasProposalPayload } from "$lib/utils/proposals.utils";
   import ProposalProposerPayloadEntry from "./ProposalProposerPayloadEntry.svelte";
   import type { Proposal } from "@dfinity/nns";
   import type { ProposalId } from "@dfinity/nns";
@@ -11,8 +11,8 @@
 
   let payload: object | undefined | null;
   // Only proposals with nnsFunctionKey and proposalId have payload
-  let nnsFunctionKey: string | undefined;
-  $: nnsFunctionKey = getNnsFunctionKey(proposal);
+  let shouldDisplayPayload: boolean;
+  $: shouldDisplayPayload = hasProposalPayload(proposal);
 
   $: $proposalPayloadsStore,
     (payload =
@@ -21,7 +21,7 @@
         : undefined);
   $: if (
     proposalId !== undefined &&
-    nnsFunctionKey !== undefined &&
+    shouldDisplayPayload &&
     !$proposalPayloadsStore.has(proposalId)
   ) {
     loadProposalPayload({
@@ -30,7 +30,6 @@
   }
 </script>
 
-<!-- Only proposals with nnsFunctionKey and proposalId have payload -->
-{#if nnsFunctionKey !== undefined && proposalId !== undefined}
+{#if shouldDisplayPayload && proposalId !== undefined}
   <ProposalProposerPayloadEntry {payload} />
 {/if}

--- a/frontend/src/lib/i18n/en.governance.json
+++ b/frontend/src/lib/i18n/en.governance.json
@@ -90,7 +90,10 @@
     "Motion": "Motion",
     "SetSnsTokenSwapOpenTimeWindow": "Start Decentralization Swap",
     "OpenSnsTokenSwap": "Open Decentralization Swap",
-    "CreateServiceNervousSystem": "Create Service Nervous System (SNS)"
+    "CreateServiceNervousSystem": "Create Service Nervous System (SNS)",
+    "InstallCode": "Install Code",
+    "StopOrStartCanister": "Stop or Start Canister",
+    "UpdateCanisterSettings": "Update Canister Settings"
   },
   "actions_description": {
     "RegisterKnownNeuron": "This proposal registers an existing neuron as a “known neuron,” giving it a name and an optional description, and adding the neuron to the list of known neurons.",
@@ -104,7 +107,10 @@
     "Motion": "A motion is a text that can be adopted or rejected. No code is executed when a motion is adopted. An adopted motion should guide the future strategy of the Internet Computer ecosystem.",
     "SetSnsTokenSwapOpenTimeWindow": "Start decentralization swap.",
     "OpenSnsTokenSwap": "Open decentralization swap.",
-    "CreateServiceNervousSystem": "Create a new Service Nervous System (SNS)."
+    "CreateServiceNervousSystem": "Create a new Service Nervous System (SNS).",
+    "InstallCode": "Calls install_code for a canister (install, reinstall, or upgrade).",
+    "StopOrStartCanister": "Stops or starts a canister controlled by NNS Root.",
+    "UpdateCanisterSettings": "Updates settings of a canister controlled by NNS Root (or NNS Root itself)."
   },
   "nns_functions": {
     "Unspecified": "Unspecified",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1214,6 +1214,9 @@ interface I18nActions {
   SetSnsTokenSwapOpenTimeWindow: string;
   OpenSnsTokenSwap: string;
   CreateServiceNervousSystem: string;
+  InstallCode: string;
+  StopOrStartCanister: string;
+  UpdateCanisterSettings: string;
 }
 
 interface I18nActions_description {
@@ -1229,6 +1232,9 @@ interface I18nActions_description {
   SetSnsTokenSwapOpenTimeWindow: string;
   OpenSnsTokenSwap: string;
   CreateServiceNervousSystem: string;
+  InstallCode: string;
+  StopOrStartCanister: string;
+  UpdateCanisterSettings: string;
 }
 
 interface I18nNns_functions {

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -75,6 +75,16 @@ export const getNnsFunctionKey = (
   return NnsFunction[nnsFunctionId];
 };
 
+export const hasProposalPayload = (proposal: Proposal | undefined): boolean => {
+  const action = proposalFirstActionKey(proposal);
+  // ExecuteNnsFunction has proposal payloads that we need to load from the NNS Dapp backend,
+  // because of 2 reasons: (1) candid files from various canisters (e.g. registry) are needed to
+  // decode the payload, which is not done in ic-js. (2) the payload can be large and we want to
+  // avoid loading on the client side, so NNS Dapp backend is used for calculating and caching the
+  // hash of the large payloads. For InstallCode, however, only the reason (2) applies.
+  return action === "ExecuteNnsFunction" || action === "InstallCode";
+};
+
 /**
  * Hide proposal that don't match filters
  */

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -9,6 +9,7 @@ import {
   getVotingBallot,
   getVotingPower,
   hasMatchingProposals,
+  hasProposalPayload,
   hideProposal,
   isProposalDeadlineInTheFuture,
   lastProposalId,
@@ -843,6 +844,49 @@ describe("proposals-utils", () => {
 
     it("should return undefined if undefined", () => {
       expect(getNnsFunctionKey(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("hasProposalPayload", () => {
+    it("should return true for ExecuteNnsFunction", () => {
+      expect(
+        hasProposalPayload({
+          ...mockProposalInfo.proposal,
+          action: {
+            ExecuteNnsFunction: {
+              nnsFunctionId: 4,
+            },
+          },
+        } as Proposal)
+      ).toBe(true);
+    });
+
+    it("should return true for InstallCode", () => {
+      expect(
+        hasProposalPayload({
+          ...mockProposalInfo.proposal,
+          action: {
+            InstallCode: {
+              skipStoppingBeforeInstalling: false,
+              canisterId: "rrkah-fqaaa-aaaaa-aaaaq-cai",
+              installMode: 3,
+            },
+          },
+        } as Proposal)
+      ).toBe(true);
+    });
+
+    it("should return false for Motion", () => {
+      expect(
+        hasProposalPayload({
+          ...mockProposalInfo.proposal,
+          action: {
+            Motion: {
+              motionText: "motion text",
+            },
+          },
+        } as Proposal)
+      ).toBe(false);
     });
   });
 

--- a/frontend/src/tests/mocks/proposal.mock.ts
+++ b/frontend/src/tests/mocks/proposal.mock.ts
@@ -46,6 +46,16 @@ export const proposalActionNnsFunction21 = {
   },
 } as Action;
 
+export const proposalActionInstallCode = {
+  InstallCode: {
+    canisterId: "aaaaa-aa",
+    wasmModule: new Uint8Array([1, 2, 3]),
+    arg: new Uint8Array([4, 5, 6]),
+    skipStoppingBeforeInstalling: false,
+    installMode: 3,
+  },
+} as Action;
+
 // Not a valid `ProposalInfo` object. Only related to the test fields are included
 export const mockProposalInfo: ProposalInfo = {
   id: 10_000n,


### PR DESCRIPTION
# Motivation

The InstallCode proposal can be large, and we want to avoid letting the client download the entire WASM to calculate the hash.

# Changes

Calls `get_proposal_payload` endpoint so that the parts of the proposal that can be large will be rendered.

# Tests

* Unit tests
* Manual test
![Screenshot 2024-08-05 at 2 12 42 PM](https://github.com/user-attachments/assets/a4b04c2a-bc79-476e-9c69-e310039153f2)



# Todos

- [x] Add entry to changelog (if necessary).
