### PR TITLE
Fetch icrc token metadata

### DIFF
--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -35,9 +35,7 @@ export const getIcrcAccountIdentity = (_: Account): Promise<Identity> => {
   return getAuthenticatedIdentity();
 };
 
-/** Fetch token metadata from the icrc1 ledger canister.
- * Return null on any error.
- */
+/// Fetch token metadata from the icrc1 ledger canister.
 export const getIcrcTokenMetaData = async ({
   ledgerCanisterId,
 }: {
@@ -47,9 +45,6 @@ export const getIcrcTokenMetaData = async ({
     identity: getCurrentIdentity(),
     canisterId: ledgerCanisterId,
     certified: false,
-  }).catch((err) => {
-    console.error(err);
-    return null;
   });
 };
 

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -38,7 +38,7 @@ export const getIcrcAccountIdentity = (_: Account): Promise<Identity> => {
 /** Fetch token metadata from the icrc1 ledger canister.
  * Return null on any error.
  */
-export const fetchIcrcTokenMetaData = async ({
+export const getIcrcTokenMetaData = async ({
   ledgerCanisterId,
 }: {
   ledgerCanisterId: Principal;

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -5,7 +5,10 @@ import {
 } from "$lib/api/icrc-ledger.api";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { snsTokensByLedgerCanisterIdStore } from "$lib/derived/sns/sns-tokens.derived";
-import { getAuthenticatedIdentity } from "$lib/services/auth.services";
+import {
+  getAuthenticatedIdentity,
+  getCurrentIdentity,
+} from "$lib/services/auth.services";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { icrcTransactionsStore } from "$lib/stores/icrc-transactions.store";
 import { toastsError } from "$lib/stores/toasts.store";
@@ -30,6 +33,24 @@ import { queryAndUpdate, type QueryAndUpdateStrategy } from "./utils.services";
 export const getIcrcAccountIdentity = (_: Account): Promise<Identity> => {
   // TODO: Support Hardware Wallets
   return getAuthenticatedIdentity();
+};
+
+/** Fetch token metadata from the icrc1 ledger canister.
+ * Return null on any error.
+ */
+export const fetchIcrcTokenMetaData = async ({
+  ledgerCanisterId,
+}: {
+  ledgerCanisterId: Principal;
+}): Promise<IcrcTokenMetadata | null> => {
+  return queryIcrcToken({
+    identity: getCurrentIdentity(),
+    canisterId: ledgerCanisterId,
+    certified: false,
+  }).catch((err) => {
+    console.error(err);
+    return null;
+  });
 };
 
 export const loadIcrcToken = ({

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -447,19 +447,24 @@ describe("icrc-accounts-services", () => {
       expect(result).toEqual(mockToken);
     });
 
-    it("returns null on error", async () => {
-      vi.spyOn(ledgerApi, "queryIcrcToken").mockRejectedValue(undefined);
+    it("throws an error", async () => {
+      const testError = new Error("test");
+      vi.spyOn(ledgerApi, "queryIcrcToken").mockRejectedValue(testError);
 
-      const result = await getIcrcTokenMetaData({
-        ledgerCanisterId,
-      });
+      expect(ledgerApi.queryIcrcToken).toHaveBeenCalledTimes(0);
+
+      const call = () =>
+        getIcrcTokenMetaData({
+          ledgerCanisterId,
+        });
+
+      expect(call).rejects.toThrow(testError);
       expect(ledgerApi.queryIcrcToken).toHaveBeenCalledTimes(1);
       expect(ledgerApi.queryIcrcToken).toHaveBeenCalledWith({
         identity: mockIdentity,
         certified: false,
         canisterId: ledgerCanisterId,
       });
-      expect(result).toEqual(null);
     });
   });
 });

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -6,8 +6,8 @@ import {
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
 import {
-  fetchIcrcTokenMetaData,
   getIcrcAccountIdentity,
+  getIcrcTokenMetaData,
   loadAccounts,
   loadIcrcToken,
   syncAccounts,
@@ -433,9 +433,9 @@ describe("icrc-accounts-services", () => {
     });
   });
 
-  describe("fetchIcrcTokenMetaData", () => {
+  describe("getIcrcTokenMetaData", () => {
     it("calls queryIcrcToken from icrc ledger api", async () => {
-      const result = await fetchIcrcTokenMetaData({
+      const result = await getIcrcTokenMetaData({
         ledgerCanisterId,
       });
       expect(ledgerApi.queryIcrcToken).toHaveBeenCalledTimes(1);
@@ -450,7 +450,7 @@ describe("icrc-accounts-services", () => {
     it("returns null on error", async () => {
       vi.spyOn(ledgerApi, "queryIcrcToken").mockRejectedValue(undefined);
 
-      const result = await fetchIcrcTokenMetaData({
+      const result = await getIcrcTokenMetaData({
         ledgerCanisterId,
       });
       expect(ledgerApi.queryIcrcToken).toHaveBeenCalledTimes(1);

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -6,6 +6,7 @@ import {
 } from "$lib/constants/ckbtc-canister-ids.constants";
 import { ckBTCTokenStore } from "$lib/derived/universes-tokens.derived";
 import {
+  fetchIcrcTokenMetaData,
   getIcrcAccountIdentity,
   loadAccounts,
   loadIcrcToken,
@@ -429,6 +430,36 @@ describe("icrc-accounts-services", () => {
       const finalAccount =
         get(icrcAccountsStore)[ledgerCanisterId.toText()]?.accounts[0];
       expect(finalAccount.balanceUlps).toEqual(balanceE8s);
+    });
+  });
+
+  describe("fetchIcrcTokenMetaData", () => {
+    it("calls queryIcrcToken from icrc ledger api", async () => {
+      const result = await fetchIcrcTokenMetaData({
+        ledgerCanisterId,
+      });
+      expect(ledgerApi.queryIcrcToken).toHaveBeenCalledTimes(1);
+      expect(ledgerApi.queryIcrcToken).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        certified: false,
+        canisterId: ledgerCanisterId,
+      });
+      expect(result).toEqual(mockToken);
+    });
+
+    it("returns null on error", async () => {
+      vi.spyOn(ledgerApi, "queryIcrcToken").mockRejectedValue(undefined);
+
+      const result = await fetchIcrcTokenMetaData({
+        ledgerCanisterId,
+      });
+      expect(ledgerApi.queryIcrcToken).toHaveBeenCalledTimes(1);
+      expect(ledgerApi.queryIcrcToken).toHaveBeenCalledWith({
+        identity: mockIdentity,
+        certified: false,
+        canisterId: ledgerCanisterId,
+      });
+      expect(result).toEqual(null);
     });
   });
 });


### PR DESCRIPTION
# Motivation

We need a way to fetch imported token metadata to display it during the review step.

# Changes

- Introduced a new service `fetchIcrcTokenMetaData`.

# Tests

- Tests have been added.
- Tested against localhost replica.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.