### PR TITLE
Import token modal

### DIFF
--- a/frontend/src/lib/components/accounts/ImportTokenForm.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenForm.svelte
@@ -58,7 +58,7 @@
         {$i18n.core.cancel}
       </button>
 
-      <button data-tid="next-button" class="primary" type="submit" {disabled}>
+      <button data-tid="submit-button" class="primary" type="submit" {disabled}>
         {$i18n.core.next}
       </button>
     </div>

--- a/frontend/src/lib/components/accounts/ImportTokenForm.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenForm.svelte
@@ -13,8 +13,8 @@
 
   const dispatch = createEventDispatcher();
 
-  let disabled = true;
-  $: disabled = isNullish(ledgerCanisterId);
+  let isSubmitDisabled = true;
+  $: isSubmitDisabled = isNullish(ledgerCanisterId);
 </script>
 
 <TestIdWrapper testId="import-token-form-component">
@@ -58,7 +58,7 @@
         {$i18n.core.cancel}
       </button>
 
-      <button data-tid="submit-button" class="primary" type="submit" {disabled}>
+      <button data-tid="submit-button" class="primary" type="submit" disabled={isSubmitDisabled}>
         {$i18n.core.next}
       </button>
     </div>

--- a/frontend/src/lib/components/accounts/ImportTokenForm.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenForm.svelte
@@ -58,7 +58,12 @@
         {$i18n.core.cancel}
       </button>
 
-      <button data-tid="submit-button" class="primary" type="submit" disabled={isSubmitDisabled}>
+      <button
+        data-tid="submit-button"
+        class="primary"
+        type="submit"
+        disabled={isSubmitDisabled}
+      >
         {$i18n.core.next}
       </button>
     </div>

--- a/frontend/src/lib/components/accounts/ImportTokenForm.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenForm.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import type { Principal } from "@dfinity/principal";
+  import PrincipalInput from "$lib/components/ui/PrincipalInput.svelte";
+  import { i18n } from "$lib/stores/i18n";
+  import { Html } from "@dfinity/gix-components";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import { createEventDispatcher } from "svelte";
+  import { isNullish } from "@dfinity/utils";
+  import CalloutWarning from "$lib/components/common/CalloutWarning.svelte";
+
+  export let ledgerCanisterId: Principal | undefined = undefined;
+  export let indexCanisterId: Principal | undefined = undefined;
+
+  const dispatch = createEventDispatcher();
+
+  let disabled = true;
+  $: disabled = isNullish(ledgerCanisterId);
+</script>
+
+<TestIdWrapper testId="import-token-form-component">
+  <p class="description">{$i18n.import_token.description}</p>
+
+  <form on:submit|preventDefault={() => dispatch("nnsSubmit")}>
+    <PrincipalInput
+      bind:principal={ledgerCanisterId}
+      placeholderLabelKey="import_token.placeholder"
+      name="ledger-canister-id"
+      testId="ledger-canister-id"
+    >
+      <svelte:fragment slot="label"
+        >{$i18n.import_token.ledger_label}</svelte:fragment
+      >
+    </PrincipalInput>
+
+    <PrincipalInput
+      bind:principal={indexCanisterId}
+      required={false}
+      placeholderLabelKey="import_token.placeholder"
+      name="index-canister-id"
+      testId="index-canister-id"
+    >
+      <Html slot="label" text={$i18n.import_token.index_label_optional} />
+    </PrincipalInput>
+
+    <p class="description">
+      <Html text={$i18n.import_token.index_canister_description} />
+    </p>
+
+    <CalloutWarning htmlText={$i18n.import_token.warning} />
+
+    <div class="toolbar">
+      <button
+        class="secondary"
+        type="button"
+        data-tid="cancel-button"
+        on:click={() => dispatch("nnsClose")}
+      >
+        {$i18n.core.cancel}
+      </button>
+
+      <button data-tid="next-button" class="primary" type="submit" {disabled}>
+        {$i18n.core.next}
+      </button>
+    </div>
+  </form>
+</TestIdWrapper>
+
+<style lang="scss">
+  p.description {
+    margin: 0 0 var(--padding-2x);
+  }
+</style>

--- a/frontend/src/lib/components/ui/PrincipalInput.svelte
+++ b/frontend/src/lib/components/ui/PrincipalInput.svelte
@@ -7,6 +7,8 @@
   export let placeholderLabelKey: string;
   export let name: string;
   export let principal: Principal | undefined = undefined;
+  export let required: boolean | undefined = undefined;
+  export let testId: string | undefined = undefined;
 
   let address = principal?.toText() ?? "";
   $: principal = getPrincipalFromString(address);
@@ -23,10 +25,12 @@
   inputType="text"
   {placeholderLabelKey}
   {name}
+  {testId}
   bind:value={address}
   errorMessage={showError ? $i18n.error.principal_not_valid : undefined}
   on:blur={showErrorIfAny}
   showInfo={$$slots.label !== undefined}
+  {required}
 >
   <slot name="label" slot="label" />
 </InputWithError>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1048,7 +1048,6 @@
     "description": "To import a new token to your NNS dapp wallet, you will need to find, and paste the ledger canister id of the token. If you want to see your transaction history, you need to import the token’s index canister.",
     "ledger_label": "Ledger Canister ID",
     "index_label_optional": "Index Canister ID <span class='description'>(Optional)</span>",
-    "index_label": "Index Canister ID",
     "placeholder": "00000-00000-00000-00000-000",
     "index_canister_description": "Index Canister allows to display a token balance and transaction history. <strong>Note:</strong> not all tokens have index canisters.",
     "review_token_info": "Review token info",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1040,11 +1040,11 @@
     "hide_zero_balances_toggle_label": "Switch between showing and hiding tokens with a balance of zero",
     "zero_balance_hidden": "Tokens with 0 balances are hidden.",
     "show_all": "Show all",
-    "import_token": "Import Token",
     "add_imported_token_success": "New token has been successfully imported!",
     "remove_imported_token_success": "The token has been successfully removed!"
   },
   "import_token": {
+    "import_token": "Import Token",
     "description": "To import a new token to your NNS dapp wallet, you will need to find, and paste the ledger canister id of the token. If you want to see your transaction history, you need to import the token’s index canister.",
     "ledger_label": "Ledger Canister ID",
     "index_label_optional": "Index Canister ID <span class='description'>(Optional)</span>",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1043,5 +1043,15 @@
     "import_token": "Import Token",
     "add_imported_token_success": "New token has been successfully imported!",
     "remove_imported_token_success": "The token has been successfully removed!"
+  },
+  "import_token": {
+    "description": "To import a new token to your NNS dapp wallet, you will need to find, and paste the ledger canister id of the token. If you want to see your transaction history, you need to import the token’s index canister.",
+    "ledger_label": "Ledger Canister ID",
+    "index_label_optional": "Index Canister ID <span class='description'>(Optional)</span>",
+    "index_label": "Index Canister ID",
+    "placeholder": "00000-00000-00000-00000-000",
+    "index_canister_description": "Index Canister allows to display a token balance and transaction history. <strong>Note:</strong> not all tokens have index canisters.",
+    "review_token_info": "Review token info",
+    "warning": "<strong>Warning:</strong> Be careful what token you import! Anyone can create a token including one with the same name as existing tokens, such as ckBTC."
   }
 }

--- a/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import {
+    WizardModal,
+    type WizardStep,
+    type WizardSteps,
+  } from "@dfinity/gix-components";
+  import { i18n } from "$lib/stores/i18n";
+  import type { Principal } from "@dfinity/principal";
+  import ImportTokenForm from "$lib/components/accounts/ImportTokenForm.svelte";
+  import type { IcrcTokenMetadata } from "$lib/types/icrc";
+  import { nonNullish } from "@dfinity/utils";
+  let currentStep: WizardStep | undefined = undefined;
+  const STEP_FORM = "Form";
+  const STEP_REVIEW = "Review";
+  const steps: WizardSteps = [
+    {
+      name: STEP_FORM,
+      title: $i18n.import_token.import_token,
+    },
+    {
+      name: STEP_REVIEW,
+      title: $i18n.import_token.review_token_info,
+    },
+  ];
+  let modal: WizardModal;
+  const next = () => {
+    modal?.next();
+  };
+  let ledgerCanisterId: Principal | undefined;
+  let indexCanisterId: Principal | undefined;
+  let tokenMetaData: IcrcTokenMetadata | undefined;
+  const onUserInput = async () => {
+    // TODO: load metadata and validation
+    next();
+  };
+</script>
+
+<WizardModal
+  testId="import-token-modal-component"
+  {steps}
+  bind:currentStep
+  bind:this={modal}
+  on:nnsClose
+>
+  <svelte:fragment slot="title">{currentStep?.title}</svelte:fragment>
+
+  {#if currentStep?.name === STEP_FORM}
+    <ImportTokenForm
+      bind:ledgerCanisterId
+      bind:indexCanisterId
+      on:nnsClose
+      on:nnsSubmit={onUserInput}
+    />
+  {/if}
+  {#if currentStep?.name === STEP_REVIEW && nonNullish(ledgerCanisterId) && nonNullish(tokenMetaData)}
+    TBD: Review imported token
+  {/if}
+</WizardModal>

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -83,7 +83,7 @@
             class="ghost with-icon import-token-button"
             on:click={() => (showImportTokenModal = true)}
           >
-            <IconPlus />{$i18n.tokens.import_token}
+            <IconPlus />{$i18n.import_token.import_token}
           </button>
         </div>
       {:else if shouldHideZeroBalances}

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -11,6 +11,7 @@
   import { Popover } from "@dfinity/gix-components";
   import { TokenAmountV2 } from "@dfinity/utils";
   import { ENABLE_IMPORT_TOKEN } from "$lib/stores/feature-flags.store";
+  import ImportTokenModal from "$lib/modals/accounts/ImportTokenModal.svelte";
 
   export let userTokensData: UserToken[];
 
@@ -41,9 +42,7 @@
     hideZeroBalancesStore.set("show");
   };
 
-  const importToken = async () => {
-    // TBD: Implement import token.
-  };
+  let showImportTokenModal = false;
 
   // TODO(Import token): After removing ENABLE_IMPORT_TOKEN combine divs -> <div slot="last-row" class="last-row">
 </script>
@@ -82,7 +81,7 @@
           <button
             data-tid="import-token-button"
             class="ghost with-icon import-token-button"
-            on:click={importToken}
+            on:click={() => (showImportTokenModal = true)}
           >
             <IconPlus />{$i18n.tokens.import_token}
           </button>
@@ -112,6 +111,10 @@
   >
     <HideZeroBalancesToggle />
   </Popover>
+
+  {#if showImportTokenModal}
+    <ImportTokenModal on:nnsClose={() => (showImportTokenModal = false)} />
+  {/if}
 </TestIdWrapper>
 
 <style lang="scss">

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1100,12 +1100,12 @@ interface I18nTokens {
   hide_zero_balances_toggle_label: string;
   zero_balance_hidden: string;
   show_all: string;
-  import_token: string;
   add_imported_token_success: string;
   remove_imported_token_success: string;
 }
 
 interface I18nImport_token {
+  import_token: string;
   description: string;
   ledger_label: string;
   index_label_optional: string;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1109,7 +1109,6 @@ interface I18nImport_token {
   description: string;
   ledger_label: string;
   index_label_optional: string;
-  index_label: string;
   placeholder: string;
   index_canister_description: string;
   review_token_info: string;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1105,6 +1105,17 @@ interface I18nTokens {
   remove_imported_token_success: string;
 }
 
+interface I18nImport_token {
+  description: string;
+  ledger_label: string;
+  index_label_optional: string;
+  index_label: string;
+  placeholder: string;
+  index_canister_description: string;
+  review_token_info: string;
+  warning: string;
+}
+
 interface I18nNeuron_state {
   Unspecified: string;
   Locked: string;
@@ -1389,6 +1400,7 @@ interface I18n {
   settings: I18nSettings;
   sync: I18nSync;
   tokens: I18nTokens;
+  import_token: I18nImport_token;
   neuron_state: I18nNeuron_state;
   topics: I18nTopics;
   topics_description: I18nTopics_description;

--- a/frontend/src/tests/lib/components/accounts/ImportTokenForm.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenForm.spec.ts
@@ -1,0 +1,161 @@
+import ImportTokenForm from "$lib/components/accounts/ImportTokenForm.svelte";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { ImportTokenFormPo } from "$tests/page-objects/ImportTokenForm.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+import type { Principal } from "@dfinity/principal";
+
+describe("ImportTokenForm", () => {
+  const renderComponent = (props: {
+    ledgerCanisterId: Principal | undefined;
+    indexCanisterId: Principal | undefined;
+  }) => {
+    const { container, component } = render(ImportTokenForm, {
+      props,
+    });
+
+    const nnsSubmit = vi.fn();
+    component.$on("nnsSubmit", nnsSubmit);
+    const nnsClose = vi.fn();
+    component.$on("nnsClose", nnsClose);
+    const getPropLedgerCanisterId = () =>
+      component.$$.ctx[component.$$.props["ledgerCanisterId"]];
+    const getPropIndexCanisterId = () =>
+      component.$$.ctx[component.$$.props["indexCanisterId"]];
+
+    return {
+      po: ImportTokenFormPo.under(new JestPageObjectElement(container)),
+      nnsSubmit,
+      nnsClose,
+      getPropLedgerCanisterId,
+      getPropIndexCanisterId,
+    };
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should render ledger canister id", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+    });
+
+    expect((await po.getLedgerCanisterInputPo().getText()).trim()).toEqual(
+      "Ledger Canister ID"
+    );
+    expect(await po.getLedgerCanisterInputPo().getValue()).toEqual(
+      principal(0).toText()
+    );
+    expect(await po.getLedgerCanisterInputPo().isRequired()).toEqual(true);
+  });
+
+  it("should render index canister id", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+    });
+
+    expect((await po.getIndexCanisterInputPo().getText()).trim()).toEqual(
+      "Index Canister ID (Optional)"
+    );
+    expect(await po.getIndexCanisterInputPo().getValue()).toEqual("");
+    expect(await po.getIndexCanisterInputPo().isRequired()).toEqual(false);
+  });
+
+  it("should render a warning message", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+    });
+
+    expect((await po.getWarningPo().getText()).trim()).toEqual(
+      "Warning: Be careful what token you import! Anyone can create a token including one with the same name as existing tokens, such as ckBTC."
+    );
+  });
+
+  it("should enable the next button only when the ledger canister id is valid", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: undefined,
+      indexCanisterId: undefined,
+    });
+
+    expect(await po.getSubmitButtonPo().isDisabled()).toEqual(true);
+
+    // Enter a valid canister id
+    await po.getLedgerCanisterInputPo().getTextInputPo().typeText("aaaaa-aa");
+
+    expect(await po.getSubmitButtonPo().isDisabled()).toEqual(false);
+  });
+
+  it("should disable the next button when the ledger canister id is invalid", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+    });
+
+    expect(await po.getSubmitButtonPo().isDisabled()).toEqual(false);
+
+    // Enter an invalid canister id
+    await po
+      .getLedgerCanisterInputPo()
+      .getTextInputPo()
+      .typeText("invalid-canister-id");
+
+    expect(await po.getSubmitButtonPo().isDisabled()).toEqual(true);
+  });
+
+  it("should bind canister ids props to inputs", async () => {
+    const principal1 = principal(1);
+    const principal2 = principal(2);
+    const { po, getPropLedgerCanisterId, getPropIndexCanisterId } =
+      renderComponent({
+        ledgerCanisterId: undefined,
+        indexCanisterId: undefined,
+      });
+
+    // Enter canister ids
+    await po
+      .getLedgerCanisterInputPo()
+      .getTextInputPo()
+      .typeText(principal1.toText());
+    await po
+      .getIndexCanisterInputPo()
+      .getTextInputPo()
+      .typeText(principal2.toText());
+
+    expect(getPropLedgerCanisterId()).toEqual(principal1);
+    expect(getPropIndexCanisterId()).toEqual(principal2);
+  });
+
+  it("should dispatch nnsClose event", async () => {
+    const { po, nnsSubmit, nnsClose } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+    });
+
+    expect(nnsSubmit).not.toHaveBeenCalled();
+    expect(nnsClose).not.toHaveBeenCalled();
+
+    await po.getCancelButtonPo().click();
+
+    expect(nnsSubmit).not.toHaveBeenCalled();
+    expect(nnsClose).toBeCalledTimes(1);
+  });
+
+  it("should dispatch nnsSubmit event", async () => {
+    const { po, nnsSubmit, nnsClose } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+    });
+
+    expect(nnsSubmit).not.toHaveBeenCalled();
+    expect(nnsClose).not.toHaveBeenCalled();
+
+    await po.getSubmitButtonPo().click();
+
+    expect(nnsSubmit).toBeCalledTimes(1);
+    expect(nnsClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -1,0 +1,27 @@
+import ImportTokenModal from "$lib/modals/accounts/ImportTokenModal.svelte";
+import { ImportTokenModalPo } from "$tests/page-objects/ImportTokenModal.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+
+describe("ImportTokenModal", () => {
+  const renderComponent = () => {
+    const { container, component } = render(ImportTokenModal);
+
+    const onClose = vi.fn();
+    component.$on("nnsClose", onClose);
+
+    const po = ImportTokenModalPo.under(new JestPageObjectElement(container));
+
+    return {
+      po,
+      formPo: po.getImportTokenFormPo(),
+      onClose,
+    };
+  };
+
+  it("should display a title", async () => {
+    const { po } = renderComponent();
+
+    expect(await po.getModalTitle()).toEqual("Import Token");
+  });
+});

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -212,6 +212,14 @@ describe("Tokens page", () => {
       expect(await po.getShowAllButtonPo().isPresent()).toBe(true);
       expect(await po.getImportTokenButtonPo().isPresent()).toBe(true);
     });
+
+    it("should open import token modal", async () => {
+      const po = renderPage([positiveBalance, zeroBalance]);
+
+      await po.getImportTokenButtonPo().click();
+
+      expect(await po.getImportTokenModalPo().isPresent()).toBe(true);
+    });
   });
 
   describe("when import token feature flag is disabled", () => {

--- a/frontend/src/tests/page-objects/ImportTokenForm.page-object.ts
+++ b/frontend/src/tests/page-objects/ImportTokenForm.page-object.ts
@@ -1,0 +1,45 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { CalloutWarningPo } from "$tests/page-objects/CalloutWarning.page-object";
+import { InputWithErrorPo } from "$tests/page-objects/InputWithError.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ImportTokenFormPo extends BasePageObject {
+  private static readonly TID = "import-token-form-component";
+
+  static under(element: PageObjectElement): ImportTokenFormPo {
+    return new ImportTokenFormPo(element.byTestId(ImportTokenFormPo.TID));
+  }
+
+  getLedgerCanisterInputPo(): InputWithErrorPo {
+    return InputWithErrorPo.under({
+      element: this.root,
+      testId: "ledger-canister-id",
+    });
+  }
+
+  getIndexCanisterInputPo(): InputWithErrorPo {
+    return InputWithErrorPo.under({
+      element: this.root,
+      testId: "index-canister-id",
+    });
+  }
+
+  getWarningPo(): CalloutWarningPo {
+    return CalloutWarningPo.under(this.root);
+  }
+
+  getCancelButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "cancel-button",
+    });
+  }
+
+  getSubmitButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "submit-button",
+    });
+  }
+}

--- a/frontend/src/tests/page-objects/ImportTokenModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ImportTokenModal.page-object.ts
@@ -1,0 +1,15 @@
+import { ImportTokenFormPo } from "$tests/page-objects/ImportTokenForm.page-object";
+import { ModalPo } from "$tests/page-objects/Modal.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ImportTokenModalPo extends ModalPo {
+  private static readonly TID = "import-token-modal-component";
+
+  static under(element: PageObjectElement): ImportTokenModalPo {
+    return new ImportTokenModalPo(element.byTestId(ImportTokenModalPo.TID));
+  }
+
+  getImportTokenFormPo(): ImportTokenFormPo {
+    return ImportTokenFormPo.under(this.root);
+  }
+}

--- a/frontend/src/tests/page-objects/TokensPage.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensPage.page-object.ts
@@ -1,3 +1,4 @@
+import { ImportTokenModalPo } from "$tests/page-objects/ImportTokenModal.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { BackdropPo } from "./Backdrop.page-object";
@@ -35,6 +36,10 @@ export class TokensPagePo extends BasePageObject {
 
   getImportTokenButtonPo(): ButtonPo {
     return this.getButton("import-token-button");
+  }
+
+  getImportTokenModalPo(): ImportTokenModalPo {
+    return ImportTokenModalPo.under(this.root);
   }
 
   hasTokensTable(): Promise<boolean> {


### PR DESCRIPTION
# Motivation

To allow users to import custom tokens, we need to provide a modal with a form for entering the ledger and optional index canister IDs. This PR focuses on creating the form to input these IDs, without including validation, reviewing or additional functionality at this stage.

Demo is available at [beta](https://beta.nns.ic0.app/).

# Changes

- New ImportTokenForm component.
- New ImportTokenModal component.
- Bind canister IDs to be editable in the form and accessible in the modal.
- Show modal on "Import token" button click. The button is behind the feature flag.

**Ancillary changes**

- Move the `import_token` label under the `import_token`, because same wordings we user for the modal title.
- Expose `testId` and `require` props for the `PrincipaInput` component.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.