### PR TITLE
Round maturity to 2 decimals in neurons tables

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -24,6 +24,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Replace the nervous system left navigation on the staking tab with a new table.
 * Bump ic-js to a version with new proposal types and neuron visibility.
 * Enable following on the new topics `ProtocolCansiterManagement` and `ServiceNervousSystemManagement`.
+* Round maturity to 2 decimals in tables.
 
 #### Deprecated
 

--- a/frontend/src/lib/components/neurons/MaturityWithTooltip.svelte
+++ b/frontend/src/lib/components/neurons/MaturityWithTooltip.svelte
@@ -3,15 +3,24 @@
   import TooltipIcon from "$lib/components/ui/TooltipIcon.svelte";
   import { i18n } from "$lib/stores/i18n";
   import { formatMaturity } from "$lib/utils/neuron.utils";
+  import { formatTokenE8s } from "$lib/utils/token.utils";
 
   export let availableMaturity: bigint;
   export let stakedMaturity: bigint;
   let totalMaturity = availableMaturity + stakedMaturity;
+
+  const formatMaturityForTable = (maturity: bigint) => {
+    const formattedMaturity = formatTokenE8s({
+      value: maturity,
+      extraDetailForSmallAmount: false,
+    });
+    return formattedMaturity == "0.00" ? "0" : formattedMaturity;
+  };
 </script>
 
 <div data-tid="maturity-with-tooltip-component" class="container">
   <span data-tid="total-maturity">
-    {formatMaturity(totalMaturity)}
+    {formatMaturityForTable(totalMaturity)}
   </span>
   <TooltipIcon tooltipIdPrefix="maturity-cell-tooltip">
     <div class="tooltip-content">

--- a/frontend/src/lib/utils/token.utils.ts
+++ b/frontend/src/lib/utils/token.utils.ts
@@ -69,6 +69,7 @@ const formatTokenUlps = ({
   maxDisplayedDecimals,
   detailed = false,
   roundingMode,
+  extraDetailForSmallAmount = true,
 }: {
   value: bigint;
   tokenDecimals: number;
@@ -76,6 +77,7 @@ const formatTokenUlps = ({
   maxDisplayedDecimals: number;
   detailed?: boolean | "height_decimals";
   roundingMode?: RoundMode;
+  extraDetailForSmallAmount?: boolean;
 }): string => {
   if (value === 0n) {
     return "0";
@@ -84,7 +86,7 @@ const formatTokenUlps = ({
   const converted = Number(value) / 10 ** tokenDecimals;
 
   const decimalsForAmount = (): number =>
-    converted < 0.01
+    converted < 0.01 && extraDetailForSmallAmount
       ? Math.max(countDecimals(converted), defaultDisplayedDecimals)
       : detailed
       ? Math.min(countDecimals(converted), maxDisplayedDecimals)
@@ -110,10 +112,12 @@ export const formatTokenE8s = ({
   value,
   detailed = false,
   roundingMode,
+  extraDetailForSmallAmount = true,
 }: {
   value: bigint;
   detailed?: boolean | "height_decimals";
   roundingMode?: RoundMode;
+  extraDetailForSmallAmount?: boolean;
 }): string => {
   return formatTokenUlps({
     value,
@@ -122,6 +126,7 @@ export const formatTokenE8s = ({
     maxDisplayedDecimals: ICP_DISPLAYED_HEIGHT_DECIMALS,
     detailed,
     roundingMode,
+    extraDetailForSmallAmount,
   });
 };
 
@@ -129,10 +134,12 @@ export const formatTokenV2 = ({
   value,
   detailed = false,
   roundingMode,
+  extraDetailForSmallAmount = true,
 }: {
   value: TokenAmount | TokenAmountV2;
   detailed?: boolean | "height_decimals";
   roundingMode?: RoundMode;
+  extraDetailForSmallAmount?: boolean;
 }): string => {
   let ulps;
   if (isNullish(value)) {
@@ -155,6 +162,7 @@ export const formatTokenV2 = ({
     ),
     detailed,
     roundingMode,
+    extraDetailForSmallAmount,
   });
 };
 

--- a/frontend/src/tests/lib/components/neurons/MaturityWithTooltip.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/MaturityWithTooltip.spec.ts
@@ -19,4 +19,26 @@ describe("MaturityWithTooltip", () => {
     expect(await po.getStakedMaturity()).toBe("2.00");
     expect(await po.getTotalMaturity()).toBe("3.00");
   });
+
+  it("should never use more than 2 decimals in the table", async () => {
+    const po = renderComponent({
+      availableMaturity: 200_000n,
+      stakedMaturity: 300_000n,
+    });
+
+    expect(await po.getAvailableMaturity()).toBe("0.002");
+    expect(await po.getStakedMaturity()).toBe("0.003");
+    expect(await po.getTotalMaturity()).toBe("0.01");
+  });
+
+  it("should render 0.00 as 0", async () => {
+    const po = renderComponent({
+      availableMaturity: 100_000n,
+      stakedMaturity: 200_000n,
+    });
+
+    expect(await po.getAvailableMaturity()).toBe("0.001");
+    expect(await po.getStakedMaturity()).toBe("0.002");
+    expect(await po.getTotalMaturity()).toBe("0");
+  });
 });

--- a/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -28,8 +28,7 @@ import { ICPToken, TokenAmount, TokenAmountV2 } from "@dfinity/utils";
 describe("token-utils", () => {
   it("should format token", () => {
     expect(formatTokenE8s({ value: 0n })).toEqual("0");
-    // TODO: this following test used to equals 0.0000001 but because of the new ICP conversion it now renders 0.00
-    // expect(formatTokenE8s({value: 10n})).toEqual("0.0000001");
+    expect(formatTokenE8s({ value: 10n })).toEqual("0.0000001");
     expect(formatTokenE8s({ value: 100n })).toEqual("0.000001");
     expect(formatTokenE8s({ value: 100_000_000n })).toEqual("1.00");
     expect(formatTokenE8s({ value: 1_000_000_000n })).toEqual("10.00");
@@ -146,20 +145,24 @@ describe("token-utils", () => {
         value,
         detailed,
         roundingMode,
+        extraDetailForSmallAmount,
       }: {
         value: bigint;
         detailed?: boolean | "height_decimals";
         roundingMode?: "ceil";
+        extraDetailForSmallAmount?: boolean;
       }) => {
         const format1 = formatTokenE8s({
           value,
           detailed,
           roundingMode,
+          extraDetailForSmallAmount,
         });
         const format2 = formatTokenV2({
           value: TokenAmountV2.fromUlps({ amount: value, token }),
           detailed,
           roundingMode,
+          extraDetailForSmallAmount,
         });
         expect(format1).toBe(format2);
         return format2;
@@ -167,8 +170,7 @@ describe("token-utils", () => {
 
       it("should format token", () => {
         expect(testFormat({ value: 0n })).toEqual("0");
-        // TODO: this following test used to equals 0.0000001 but because of the new ICP conversion it now renders 0.00
-        // expect(testFormat({value: 10n})).toEqual("0.0000001");
+        expect(testFormat({ value: 10n })).toEqual("0.0000001");
         expect(testFormat({ value: 100n })).toEqual("0.000001");
         expect(testFormat({ value: 100_000_000n })).toEqual("1.00");
         expect(testFormat({ value: 1_000_000_000n })).toEqual("10.00");
@@ -251,6 +253,21 @@ describe("token-utils", () => {
             detailed: "height_decimals",
           })
         ).toEqual(`2'000'000.00000000`);
+      });
+
+      it("should format token without extra detail", () => {
+        expect(
+          testFormat({ value: 0n, extraDetailForSmallAmount: false })
+        ).toEqual("0");
+        expect(
+          testFormat({ value: 400_000n, extraDetailForSmallAmount: false })
+        ).toEqual("0.00");
+        expect(
+          testFormat({ value: 600_000n, extraDetailForSmallAmount: false })
+        ).toEqual("0.01");
+        expect(
+          testFormat({ value: 1_400_000n, extraDetailForSmallAmount: false })
+        ).toEqual("0.01");
       });
 
       it("should use roundingMode", () => {


### PR DESCRIPTION
# Motivation

To make numbers more aligned in the neurons/projects tables we agreed to always round maturity to 2 decimals.
The tooltip will still show the detailed amount for available and staked maturity.

# Changes

1. Add an optional parameter `extraDetailForSmallAmount` to `formatToken*` functions, to configure the detault behavior of showing more decimals for numbers < 0.01.
2. In the `MaturityWithTooltip` component, which is used in the neurons table and projects table, set `extraDetailForSmallAmount: false` and also render 0.00 as 0.

# Tests

1. Unit tests for `formatToken`.
2. Unit tests for `MaturityWithTooltip`.
3. Drive-by: Remove an old TODO.

# Todos

- [x] Add entry to changelog (if necessary).
