### PR TITLE
Show detailed stake on neuron details page

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -25,6 +25,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Bump ic-js to a version with new proposal types and neuron visibility.
 * Enable following on the new topics `ProtocolCansiterManagement` and `ServiceNervousSystemManagement`.
 * Round maturity to 2 decimals in tables.
+* Show detailed stake amount in neuron details page.
 
 #### Deprecated
 

--- a/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/neuron-detail/NnsNeuronPageHeading.svelte
@@ -40,7 +40,7 @@
 </script>
 
 <PageHeading testId="nns-neuron-page-heading-component">
-  <AmountDisplay slot="title" {amount} size="huge" singleLine />
+  <AmountDisplay slot="title" {amount} size="huge" singleLine detailed />
   <HeadingSubtitle slot="subtitle" testId="voting-power">
     {#if canVote}
       {replacePlaceholders($i18n.neuron_detail.voting_power_subtitle, {

--- a/frontend/src/lib/components/neuron-detail/StakeItemAction.svelte
+++ b/frontend/src/lib/components/neuron-detail/StakeItemAction.svelte
@@ -25,7 +25,7 @@
   <div class="content">
     <h4 class="token-value">
       <span data-tid="stake-value"
-        >{formatTokenE8s({ value: neuronStake })}</span
+        >{formatTokenE8s({ value: neuronStake, detailed: true })}</span
       ><span data-tid="token-symbol">{token.symbol}</span>
     </h4>
     <p class="description" data-tid="staked-description">

--- a/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
+++ b/frontend/src/lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte
@@ -14,7 +14,7 @@
   import AmountDisplay from "../ic/AmountDisplay.svelte";
   import { Tag } from "@dfinity/gix-components";
   import type { SnsNervousSystemParameters, SnsNeuron } from "@dfinity/sns";
-  import { type Token, nonNullish, TokenAmountV2 } from "@dfinity/utils";
+  import { TokenAmountV2, nonNullish, type Token } from "@dfinity/utils";
 
   export let neuron: SnsNeuron;
   export let parameters: SnsNervousSystemParameters;
@@ -44,7 +44,7 @@
 <PageHeading testId="sns-neuron-page-heading-component">
   <svelte:fragment slot="title">
     {#if nonNullish(amount)}
-      <AmountDisplay {amount} size="huge" singleLine />
+      <AmountDisplay {amount} size="huge" singleLine detailed />
     {/if}
   </svelte:fragment>
   <HeadingSubtitle slot="subtitle" testId="voting-power">

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
@@ -33,7 +33,7 @@ describe("NnsNeuronPageHeading", () => {
   });
 
   it("should render the neuron's stake", async () => {
-    const stake = 314_000_000n;
+    const stake = 314_560_000n;
     const po = renderComponent({
       ...mockNeuron,
       fullNeuron: {
@@ -43,7 +43,7 @@ describe("NnsNeuronPageHeading", () => {
       },
     });
 
-    expect(await po.getStake()).toEqual("3.14");
+    expect(await po.getStake()).toEqual("3.1456");
   });
 
   it("should render neuron's voting power", async () => {

--- a/frontend/src/tests/lib/components/neuron-detail/StakeItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/StakeItemAction.spec.ts
@@ -22,10 +22,10 @@ describe("StakeItemAction", () => {
   };
 
   it("should render stake of the neuron", async () => {
-    const neuronStake = 314000000n;
+    const neuronStake = 314560000n;
     const po = renderComponent({ neuronStake });
 
-    expect(await po.getStake()).toBe("3.14");
+    expect(await po.getStake()).toBe("3.1456");
   });
 
   it("should render token symbol", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeading.spec.ts
@@ -35,13 +35,13 @@ describe("SnsNeuronPageHeading", () => {
   });
 
   it("should render the neuron's stake", async () => {
-    const stake = 314_000_000n;
+    const stake = 314_560_000n;
     const po = renderSnsNeuronCmp({
       ...mockSnsNeuron,
       cached_neuron_stake_e8s: stake,
     });
 
-    expect(await po.getStake()).toEqual("3.14");
+    expect(await po.getStake()).toEqual("3.1456");
   });
 
   it("should render the neuron's voting power", async () => {


### PR DESCRIPTION
# Motivation

The neuron details page shows details for a single neuron. There's no reason not to show the stake in full detail.
Also we want to round the stake in the table (in another PR) so it's good to have the detailed stake displayed on the details page.

# Changes

1. Show detailed stake in the heading (for both NNS and SNS).
2. Show detailed stake in the stake action (which is shared between NNS and SNS).

<img width="786" alt="Screenshot 2024-08-09 at 13 03 54" src="https://github.com/user-attachments/assets/5e74d49d-879d-42b5-adc7-5a3b4e28156e">


# Tests

1. Unit test updated
2. Test manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [x] Add entry to changelog (if necessary).
