### PR TITLE
Round neuron stake in table

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -24,7 +24,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Replace the nervous system left navigation on the staking tab with a new table.
 * Bump ic-js to a version with new proposal types and neuron visibility.
 * Enable following on the new topics `ProtocolCansiterManagement` and `ServiceNervousSystemManagement`.
-* Round maturity to 2 decimals in tables.
+* Round neuron stake and maturity to 2 decimals in tables.
 
 #### Deprecated
 

--- a/frontend/src/lib/components/neurons/NeuronsTable/NeuronStakeCell.svelte
+++ b/frontend/src/lib/components/neurons/NeuronsTable/NeuronStakeCell.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <div data-tid="neuron-stake-cell-component" class="container">
-  <AmountDisplay singleLine amount={rowData.stake} detailed />
+  <AmountDisplay singleLine amount={rowData.stake} />
 </div>
 
 <style lang="scss">

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -78,14 +78,15 @@ test("Test merge neurons", async ({ page, context }) => {
     targetNeuronId: neuronId2,
   });
 
-  const transactionFee = 0.0001;
+  // The stake is also reduced by the transaction fee, but the difference isn't
+  // visible after rounding.
   expect(
     Number(
       await (
         await neuronsPo.getNeuronsTablePo().getNeuronsTableRowPo(neuronId2)
       ).getStakeBalance()
     )
-  ).toBe(finalStake1 + stake2 - transactionFee);
+  ).toBe(finalStake1 + stake2);
 
   expect(await neuronsPo.getNeuronIds()).not.toContain(neuronId1);
 

--- a/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NeuronsTable/NeuronsTable.spec.ts
@@ -182,7 +182,7 @@ describe("NeuronsTable", () => {
     expect(await rowPos[1].getStake()).toBe("5.00 ICP");
   });
 
-  it("should render detailed neuron stake", async () => {
+  it("should not render detailed neuron stake", async () => {
     const po = renderComponent({
       neurons: [
         {
@@ -193,7 +193,7 @@ describe("NeuronsTable", () => {
     });
     const rowPos = await po.getNeuronsTableRowPos();
     expect(rowPos).toHaveLength(1);
-    expect(await rowPos[0].getStake()).toBe("9.9999 ICP");
+    expect(await rowPos[0].getStake()).toBe("10.00 ICP");
   });
 
   it("should render neuron maturity", async () => {


### PR DESCRIPTION
# Motivation

To make numbers more aligned in the neurons table we agreed to round stake to 2 decimals.

# Changes

Remove the `detailed` attribute from `AmountDisplay` in the `NeuronStakeCell` component.

# Tests

Unit test updated.

# Todos

- [x] Add entry to changelog (if necessary).
