### PR TITLE
NNS1-3250: Always show arrow icon on projects table row

### DIFF
--- a/frontend/src/lib/components/staking/ProjectActionsCell.svelte
+++ b/frontend/src/lib/components/staking/ProjectActionsCell.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
   import type { TableProject } from "$lib/types/staking";
   import { IconRight } from "@dfinity/gix-components";
-  import { nonNullish } from "@dfinity/utils";
 
   export let rowData: TableProject;
 </script>
 
-{#if nonNullish(rowData.rowHref)}
-  <div data-tid="go-to-neurons-table-action" class="container">
-    <IconRight />
-  </div>
+{#if false}
+  <!-- Satisfy the linter as it doesn't like unused props. -->
+  {rowData.title}
 {/if}
+
+<div data-tid="go-to-neurons-table-action" class="container">
+  <IconRight />
+</div>
 
 <style lang="scss">
   .container {


### PR DESCRIPTION
# Motivation

When a user has no neurons for a project, instead of navigating to the (empty) neurons table page to stake there, we want to open the staking modal when the user click on the row for that project. After the user stakes a neuron, they should then be navigated to the neurons table page for that project.

This means that rows for projects without neurons should not be a link anymore, but they should still have the `>` icon.

So in this PR we once again always show the `>` regardless of whether the row is a link or not.

This is a partial rollback of https://github.com/dfinity/nns-dapp/pull/5202

# Changes

Change `ProjectActionsCell` to always show the `IconRight` component.

# Tests

Because the component was already showing the icon for all rows with a URL, and currently all rows have a URL, there is no change in behavior.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary