### PR TITLE
Upgrade ic-js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -250,10 +250,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.5.0-next-2024-07-30",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.5.0-next-2024-07-30.tgz",
-      "integrity": "sha512-Oj1hGhfv8kDP8Dq+QmPh3Gm6pHMJNnbYqNJ0pLHDyjnw7H+9XrHfFRvew+iPQ1YuyHQg+WjtuqY7Ph87TJCGFQ==",
-      "license": "Apache-2.0",
+      "version": "2.5.0-next-2024-08-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.5.0-next-2024-08-10.tgz",
+      "integrity": "sha512-rAhnQ9i4lDHAOx+axm8m3NwqGLZFFa4BayDis+bEYp8ufkCgqDjF6v3BeJU3pN7dehUKpg97t8mA0rHGPYFE+A==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -267,10 +266,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.1.0-next-2024-07-30",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.1.0-next-2024-07-30.tgz",
-      "integrity": "sha512-d9TtZxI1fuQ0QzogMSTLfyy/WtCTahWgms0R9Htd85z3jZWVJ1+jH85MuG1kfPBQPsLH99izdcM96JlBTqv20w==",
-      "license": "Apache-2.0",
+      "version": "3.1.0-next-2024-08-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.1.0-next-2024-08-10.tgz",
+      "integrity": "sha512-msb4dX0wmdfSaTIVred1NkfNOdLonwzQ83RVF1O/Y0U1q++NHFzMAsFc5hS4sig0hCcIgMw/HJ1ZXhNgweBfCw==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -294,10 +292,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "5.1.0-next-2024-07-30",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.1.0-next-2024-07-30.tgz",
-      "integrity": "sha512-FvjFqlOMpQ6x58sl9b/B9AEhZ+M8LwZK7Dxe2kKjzroBQ7yFVfuujkogICzk6p/xV6dlMuT/lVNTfFb2JEwd6g==",
-      "license": "Apache-2.0",
+      "version": "5.1.0-next-2024-08-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.1.0-next-2024-08-10.tgz",
+      "integrity": "sha512-MVeiGQQTs2cKh1myzwEAZYK0ihyu8tFgToEqeUrP000830cRpkBpAmAde4GzmpeA9aRHatYUrvH1Mtu9L/Gr1A==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -321,10 +318,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.4.0-next-2024-07-30",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.4.0-next-2024-07-30.tgz",
-      "integrity": "sha512-pma0yUdZjyjD+L2lJEtt5YQ3U7OgQ/dGRfyNeECsrZxTXTwJbNR1QrqNzpJQ9pOGaLf7mKcMHb6dUxwdjV63Eg==",
-      "license": "Apache-2.0",
+      "version": "2.4.0-next-2024-08-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.4.0-next-2024-08-10.tgz",
+      "integrity": "sha512-aVpUCrvH1/rZ1Us6d42czdSp40/sSXoi6I21lFajDXqOG4Cpqduos/4ICHyAd5rxcWz7DvzmHUGJMgl0FCvJGA==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -333,10 +329,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.4.0-next-2024-07-30",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.4.0-next-2024-07-30.tgz",
-      "integrity": "sha512-CJnq4XquTa5eUlOV5eqMJhQWOA2ClUepm9ooTrxse18ka/6r/axb4JEpwK+1Ee7iyNJGa5Ij135bHdc2w2Qw1A==",
-      "license": "Apache-2.0",
+      "version": "2.4.0-next-2024-08-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.4.0-next-2024-08-10.tgz",
+      "integrity": "sha512-jK/Xz8uCBBQ6QnQs0vJp17GO7q4VACMyOgvdvo4mDpdhAasEaceqOGeaghlU+E8nYqD9nH/ZPHKYa79Gai0j2g==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -345,10 +340,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "5.2.0-next-2024-07-30",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.2.0-next-2024-07-30.tgz",
-      "integrity": "sha512-VfaLTP15hFiZOh7moTKAgTzCMSMdYCZuP8v0piJ4qLkOIwdlhJMpobf97X2MedL5oaOkTISsU6rKyH5X+RwKmg==",
-      "license": "Apache-2.0",
+      "version": "5.2.0-next-2024-08-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.2.0-next-2024-08-10.tgz",
+      "integrity": "sha512-WvD9OX9LzrOuExi8HPbGKUUZKkuy7i2rRSNUwcVHsN4pahio6HncTnKLLkgIQ2nf7iGHntCvTtJ00Xz3E6iKzg==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -370,10 +364,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.1.0-next-2024-07-30",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.1.0-next-2024-07-30.tgz",
-      "integrity": "sha512-lG25m6F8capAVZTdSX07rq3OwbxoNNtaV+jwBrlxX2TO14u0bLrfJ5EiM101wIxfaomF8O/bNJSgrtyPB2Qemg==",
-      "license": "Apache-2.0",
+      "version": "3.1.0-next-2024-08-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.1.0-next-2024-08-10.tgz",
+      "integrity": "sha512-D9B/+/IcKEz4TriOoh1q+k3VfWPt6FfwMjFMBlRGHcrOsgut8G5P0TUsK03dX50muLGLRpxwjWMAfF0sI04vjQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -386,10 +379,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.4.0-next-2024-07-30",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.4.0-next-2024-07-30.tgz",
-      "integrity": "sha512-e+S6n4JX+ZtF1HzjG32tfVLWM2TMY0Xcbf0sRXmgx4S+DmKr8NA705dq4MmCike/W4RhT2jEljoNIixZwhkV1g==",
-      "license": "Apache-2.0",
+      "version": "2.4.0-next-2024-08-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.4.0-next-2024-08-10.tgz",
+      "integrity": "sha512-17YrSzkw1E5pIq/yUYKraItdpXhu9XIS5+CX52a8xkChQYkKR4wpQu1r6a9wW53NZq+LOsa+lAl/clJAzTJi7g==",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -2030,7 +2022,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-1.0.5.tgz",
       "integrity": "sha512-LkkAPP8Zu+c0SVNRTRVDyMfKVORThX+rCViget00xdgLRrKkClCTz1T7cIrpr69ShwV5XJuuoZvMvJ43yURwkA==",
-      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -2065,8 +2056,7 @@
     "node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "license": "MIT"
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/bignumber.js": {
       "version": "9.1.1",
@@ -5389,7 +5379,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -7044,9 +7033,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.5.0-next-2024-07-30",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.5.0-next-2024-07-30.tgz",
-      "integrity": "sha512-Oj1hGhfv8kDP8Dq+QmPh3Gm6pHMJNnbYqNJ0pLHDyjnw7H+9XrHfFRvew+iPQ1YuyHQg+WjtuqY7Ph87TJCGFQ==",
+      "version": "2.5.0-next-2024-08-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.5.0-next-2024-08-10.tgz",
+      "integrity": "sha512-rAhnQ9i4lDHAOx+axm8m3NwqGLZFFa4BayDis+bEYp8ufkCgqDjF6v3BeJU3pN7dehUKpg97t8mA0rHGPYFE+A==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7054,9 +7043,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.1.0-next-2024-07-30",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.1.0-next-2024-07-30.tgz",
-      "integrity": "sha512-d9TtZxI1fuQ0QzogMSTLfyy/WtCTahWgms0R9Htd85z3jZWVJ1+jH85MuG1kfPBQPsLH99izdcM96JlBTqv20w==",
+      "version": "3.1.0-next-2024-08-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.1.0-next-2024-08-10.tgz",
+      "integrity": "sha512-msb4dX0wmdfSaTIVred1NkfNOdLonwzQ83RVF1O/Y0U1q++NHFzMAsFc5hS4sig0hCcIgMw/HJ1ZXhNgweBfCw==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7070,9 +7059,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "5.1.0-next-2024-07-30",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.1.0-next-2024-07-30.tgz",
-      "integrity": "sha512-FvjFqlOMpQ6x58sl9b/B9AEhZ+M8LwZK7Dxe2kKjzroBQ7yFVfuujkogICzk6p/xV6dlMuT/lVNTfFb2JEwd6g==",
+      "version": "5.1.0-next-2024-08-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.1.0-next-2024-08-10.tgz",
+      "integrity": "sha512-MVeiGQQTs2cKh1myzwEAZYK0ihyu8tFgToEqeUrP000830cRpkBpAmAde4GzmpeA9aRHatYUrvH1Mtu9L/Gr1A==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7086,21 +7075,21 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.4.0-next-2024-07-30",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.4.0-next-2024-07-30.tgz",
-      "integrity": "sha512-pma0yUdZjyjD+L2lJEtt5YQ3U7OgQ/dGRfyNeECsrZxTXTwJbNR1QrqNzpJQ9pOGaLf7mKcMHb6dUxwdjV63Eg==",
+      "version": "2.4.0-next-2024-08-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.4.0-next-2024-08-10.tgz",
+      "integrity": "sha512-aVpUCrvH1/rZ1Us6d42czdSp40/sSXoi6I21lFajDXqOG4Cpqduos/4ICHyAd5rxcWz7DvzmHUGJMgl0FCvJGA==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.4.0-next-2024-07-30",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.4.0-next-2024-07-30.tgz",
-      "integrity": "sha512-CJnq4XquTa5eUlOV5eqMJhQWOA2ClUepm9ooTrxse18ka/6r/axb4JEpwK+1Ee7iyNJGa5Ij135bHdc2w2Qw1A==",
+      "version": "2.4.0-next-2024-08-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.4.0-next-2024-08-10.tgz",
+      "integrity": "sha512-jK/Xz8uCBBQ6QnQs0vJp17GO7q4VACMyOgvdvo4mDpdhAasEaceqOGeaghlU+E8nYqD9nH/ZPHKYa79Gai0j2g==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "5.2.0-next-2024-07-30",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.2.0-next-2024-07-30.tgz",
-      "integrity": "sha512-VfaLTP15hFiZOh7moTKAgTzCMSMdYCZuP8v0piJ4qLkOIwdlhJMpobf97X2MedL5oaOkTISsU6rKyH5X+RwKmg==",
+      "version": "5.2.0-next-2024-08-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.2.0-next-2024-08-10.tgz",
+      "integrity": "sha512-WvD9OX9LzrOuExi8HPbGKUUZKkuy7i2rRSNUwcVHsN4pahio6HncTnKLLkgIQ2nf7iGHntCvTtJ00Xz3E6iKzg==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -7115,17 +7104,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.1.0-next-2024-07-30",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.1.0-next-2024-07-30.tgz",
-      "integrity": "sha512-lG25m6F8capAVZTdSX07rq3OwbxoNNtaV+jwBrlxX2TO14u0bLrfJ5EiM101wIxfaomF8O/bNJSgrtyPB2Qemg==",
+      "version": "3.1.0-next-2024-08-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.1.0-next-2024-08-10.tgz",
+      "integrity": "sha512-D9B/+/IcKEz4TriOoh1q+k3VfWPt6FfwMjFMBlRGHcrOsgut8G5P0TUsK03dX50muLGLRpxwjWMAfF0sI04vjQ==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.4.0-next-2024-07-30",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.4.0-next-2024-07-30.tgz",
-      "integrity": "sha512-e+S6n4JX+ZtF1HzjG32tfVLWM2TMY0Xcbf0sRXmgx4S+DmKr8NA705dq4MmCike/W4RhT2jEljoNIixZwhkV1g==",
+      "version": "2.4.0-next-2024-08-10",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.4.0-next-2024-08-10.tgz",
+      "integrity": "sha512-17YrSzkw1E5pIq/yUYKraItdpXhu9XIS5+CX52a8xkChQYkKR4wpQu1r6a9wW53NZq+LOsa+lAl/clJAzTJi7g==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/lib/types/sns-aggregator.ts
+++ b/frontend/src/lib/types/sns-aggregator.ts
@@ -95,9 +95,15 @@ export type CachedSwapInitParamsDto = {
     // NeuronsFundParticipants
     cf_participants: Array<{
       // CfParticipant
+      controller: null | string;
       hotkey_principal: string;
       cf_neurons: Array<{
         // CfNeuron
+        has_created_neuron_recipes: null | boolean;
+        hotkeys: null | {
+          // Principals
+          principals: string[];
+        };
         nns_neuron_id: number;
         amount_icp_e8s: number;
       }>;

--- a/frontend/src/lib/types/sns-aggregator.ts
+++ b/frontend/src/lib/types/sns-aggregator.ts
@@ -95,15 +95,9 @@ export type CachedSwapInitParamsDto = {
     // NeuronsFundParticipants
     cf_participants: Array<{
       // CfParticipant
-      controller: null | string;
       hotkey_principal: string;
       cf_neurons: Array<{
         // CfNeuron
-        has_created_neuron_recipes: null | boolean;
-        hotkeys: null | {
-          // Principals
-          principals: string[];
-        };
         nns_neuron_id: number;
         amount_icp_e8s: number;
       }>;

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -170,12 +170,15 @@ const convertSwapInitParams = (
                   ({ hotkey_principal, cf_neurons }) => ({
                     // CfParticipant
                     hotkey_principal,
+                    hotkeys: [],
+                    controller: [],
                     cf_neurons: cf_neurons.map(
                       ({ nns_neuron_id, amount_icp_e8s }) => ({
                         // CfNeuron
                         nns_neuron_id: BigInt(nns_neuron_id),
                         amount_icp_e8s: BigInt(amount_icp_e8s),
                         has_created_neuron_recipes: [],
+                        hotkeys: [],
                       })
                     ),
                   })


### PR DESCRIPTION
# Motivation

To make [getLedgerId api](https://github.com/dfinity/ic-js/pull/693) available in `nns-dapp` the `ic-js` package needs to be upgraded.

# Changes

- `npm run upgrade:next`.
- Add `[]` to some new optional fields in `convertSwapInitParams` to fix type checking errors.

# Tests

- Pass

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary