### PR TITLE
bot: Update IC Cargo Dependencies to release-2024-08-02_01-30-base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,7 +962,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1097,7 +1097,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1109,7 +1109,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1142,7 +1142,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "on_wire",
  "prost",
@@ -1326,7 +1326,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -1836,7 +1836,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-replica-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -1849,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ecdsa-secp256k1",
@@ -1862,7 +1862,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "serde",
 ]
@@ -1870,7 +1870,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -1879,7 +1879,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "serde",
@@ -2006,14 +2006,13 @@ dependencies = [
 [[package]]
 name = "ic-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
- "hmac",
  "k256",
  "lazy_static",
  "num-bigint",
@@ -2026,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -2040,7 +2039,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "getrandom",
 ]
@@ -2048,7 +2047,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "hex",
  "ic-types",
@@ -2058,7 +2057,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -2080,7 +2079,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -2098,7 +2097,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2106,7 +2105,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2125,7 +2124,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2138,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "sha2",
 ]
@@ -2146,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "base64 0.13.1",
  "cached",
@@ -2172,7 +2171,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2202,7 +2201,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "arrayvec 0.7.4",
  "hex",
@@ -2219,7 +2218,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2237,7 +2236,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "serde",
  "zeroize",
@@ -2246,7 +2245,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2254,7 +2253,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2267,7 +2266,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -2280,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2290,7 +2289,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2300,7 +2299,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "ic-protobuf",
  "ic-utils",
@@ -2312,7 +2311,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "ciborium",
@@ -2334,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "ciborium",
@@ -2362,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "async-trait",
  "candid",
@@ -2390,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -2402,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "async-trait",
  "candid",
@@ -2420,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -2432,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "hex",
@@ -2442,7 +2441,7 @@ dependencies = [
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2468,7 +2467,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "async-trait",
  "candid",
@@ -2491,12 +2490,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2532,12 +2531,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -2550,7 +2549,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -2562,12 +2561,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "comparable",
@@ -2580,7 +2579,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "ic-base-types",
 ]
@@ -2588,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "dfn_core",
@@ -2604,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "async-trait",
  "candid",
@@ -2617,12 +2616,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -2635,7 +2634,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "comparable",
@@ -2661,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -2670,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2738,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "bytes",
  "candid",
@@ -2764,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "csv",
  "ic-base-types",
@@ -2781,12 +2780,12 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "async-trait",
  "candid",
@@ -2801,7 +2800,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "bincode",
  "candid",
@@ -2815,7 +2814,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2827,7 +2826,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2838,7 +2837,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "ic-management-canister-types",
@@ -2849,7 +2848,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -2861,7 +2860,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2873,7 +2872,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2930,7 +2929,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -2938,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -2949,7 +2948,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "async-trait",
  "candid",
@@ -2970,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -2997,7 +2996,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3026,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3064,7 +3063,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "comparable",
@@ -3079,7 +3078,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "async-trait",
  "candid",
@@ -3126,7 +3125,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3161,7 +3160,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3246,7 +3245,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "comparable",
@@ -3276,7 +3275,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "async-trait",
  "candid",
@@ -3287,7 +3286,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.6"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "base32",
  "candid",
@@ -4055,7 +4054,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 
 [[package]]
 name = "once_cell"
@@ -4213,7 +4212,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "candid",
  "serde",
@@ -4778,7 +4777,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=799cf9f94c0fbaeae9c328f64da03640d37b0480#799cf9f94c0fbaeae9c328f64da03640d37b0480"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-08-02_01-30-base#3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d"
 dependencies = [
  "build-info",
  "build-info-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,23 +13,23 @@ version = "2.0.85"
 ic-cdk = "0.15.0"
 ic-cdk-macros = "0.15.0"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
-ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "799cf9f94c0fbaeae9c328f64da03640d37b0480" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
+ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-02_01-30-base" }
 
 [profile.release]
 lto = false


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
We want to keep our Cargo dependencies up to date.

# Changes
* Ran `scripts/update-ic-cargo-deps` to update the Cargo.toml dependencies to the latest IC release.

# Tests
* See CI