### PR TITLE
Add universeId and tokenSymbol to TableProject

### DIFF
--- a/frontend/src/lib/types/staking.ts
+++ b/frontend/src/lib/types/staking.ts
@@ -5,8 +5,10 @@ import type { TokenAmountV2 } from "@dfinity/utils";
 export type TableProject = {
   rowHref?: string;
   domKey: string;
+  universeId: string;
   title: string;
   logo: string;
+  tokenSymbol: string;
   neuronCount: number | undefined;
   stake: TokenAmountV2 | UnavailableTokenAmount;
   availableMaturity: bigint | undefined;

--- a/frontend/src/tests/mocks/staking.mock.ts
+++ b/frontend/src/tests/mocks/staking.mock.ts
@@ -6,6 +6,7 @@ import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 export const mockTableProject: TableProject = {
   rowHref: `/neurons/?u=${OWN_CANISTER_ID_TEXT}`,
   domKey: OWN_CANISTER_ID_TEXT,
+  universeId: OWN_CANISTER_ID_TEXT,
   title: "Internet Computer",
   logo: IC_LOGO_ROUNDED,
   neuronCount: 0,
@@ -13,6 +14,7 @@ export const mockTableProject: TableProject = {
     amount: 100_000_000n,
     token: ICPToken,
   }),
+  tokenSymbol: ICPToken.symbol,
   availableMaturity: 0n,
   stakedMaturity: 0n,
 };


### PR DESCRIPTION
# Motivation

We want to add a button on staking project rows for which the user doesn't have any neurons yet, to allow the user to start staking those tokens.

<img width="786" alt="image" src="https://github.com/user-attachments/assets/f92bff2b-851c-4b1f-9eda-9f208a79d722">

We need to know the token symbol to render the button, and the universe ID to open the staking modal when the button is clicked.

So this PR adds those 2 pieces of information to the `TableProject` type to be used in the next PR.

# Changes

1. Add `universeId` and `tokenSymbol` fields to `TableProject`.
2. Fix `compareIcpFirst` to use the new `universeId` field instead of depending on the `domKey`.

# Tests

Unit tests added.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet