### PR TITLE
Remove log spam from sns aggregator

### DIFF
--- a/rs/sns_aggregator/src/state.rs
+++ b/rs/sns_aggregator/src/state.rs
@@ -14,7 +14,6 @@ use crate::{
 use anyhow::anyhow;
 use ic_cdk::api::management_canister::provisional::CanisterId;
 use ic_cdk::api::time;
-use ic_cdk::println;
 use ic_cdk_timers::TimerId;
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -119,10 +118,9 @@ thread_local! {
     pub static STATE: State = State::default();
 }
 
-/// Log to console and store for retrieval by query calls.
+/// Store for retrieval by query calls.
 #[allow(clippy::needless_pass_by_value)] // The value is actually consumed.
 pub fn log(message: String) {
-    println!("{}", &message);
     let now = time();
     let message = format!("{now}: {message}");
     STATE.with(|state| {


### PR DESCRIPTION
# Motivation

The aggregator outputs a lot which makes looking at replica logs while testing not so easy.

# Changes

Remove the `println` statement from `log`. It still logs to memory, which can be retrieved via canister call.

# Tests

1. Installed sns_aggregator
2. Checked that the replica logs are quiet
3. Ran `dfx canister call sns_aggregator tail_log | idl2json | jq -r '.'` to make sure it still outputs logs.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary