### PR TITLE
fix: dogmi fee interpretation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -250,9 +250,10 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.5.0-next-2024-08-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.5.0-next-2024-08-12.tgz",
-      "integrity": "sha512-OwUa2w+kWVgdVRJ8tFqGe29tNTaA+pc+byLaGcMmKlBHa3CAQIqJOgdlO8xSy5OcAYiQdxXH0wLGoL2okxESSA==",
+      "version": "2.5.0-next-2024-08-13",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.5.0-next-2024-08-13.tgz",
+      "integrity": "sha512-HVKFBExKtExmCMigez81T3Rq0h24QJeZKasRHyLSm7c8FWijX/rixPyy39TDoDrYbhqkodIBD0CzV+i6BQe6Kg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -266,9 +267,10 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.1.0-next-2024-08-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.1.0-next-2024-08-12.tgz",
-      "integrity": "sha512-G4JK2n0gd0c841RWeDkyJs7H6oPNSbd68D7+9UEWx/OmVpgVrT6QAVizzHVwMN+2yiak6nZhDtwRDqfd/k4IXA==",
+      "version": "3.1.0-next-2024-08-13",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.1.0-next-2024-08-13.tgz",
+      "integrity": "sha512-ai+O2EvdvlVD6AiTVeTvBQ85x7DoPdcDn9dhJ61MtddOMxFFBPDUlFkocfolmMdJjezhTokk0M43No/S9ZzxDw==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -292,9 +294,10 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "5.1.0-next-2024-08-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.1.0-next-2024-08-12.tgz",
-      "integrity": "sha512-dILy75826mKbyOwU6HNweT0BBsvD3Z7ewsDPwi6MQpHT2zfIfGvCBkkInEtFnKRWd7ihmrRd+KX/An3X2bvNVw==",
+      "version": "5.1.0-next-2024-08-13",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.1.0-next-2024-08-13.tgz",
+      "integrity": "sha512-b9our0H5shmbd6+9edcoTnrhug/BDJCEvi+gKT2NBhYKsswA87w98q9Bk2R3KafcF6fqBzex5iLyRkyEfPdiTg==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -318,9 +321,10 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.4.0-next-2024-08-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.4.0-next-2024-08-12.tgz",
-      "integrity": "sha512-Asez7G00pAJEbI+0frCojnvVsl5tCVr93jmzKMtwwVZueL0MWjm+RX7ri8WHft2b1TrLY8BIxBd/Col7YnhRDA==",
+      "version": "2.4.0-next-2024-08-13",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.4.0-next-2024-08-13.tgz",
+      "integrity": "sha512-jPNPkonCtaRXmE4ekbGgAIRz8Ji6N5b7tXAh4bRCNP5vWrpK1zOjSR80yedXmCUGtVVbi0zagWf4Jy+qgPXnkA==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -329,9 +333,10 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.4.0-next-2024-08-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.4.0-next-2024-08-12.tgz",
-      "integrity": "sha512-vLozM0kBmrNMFKcv2qhZHzFHmZSxHXjfLKaQUOFQNZPUAr1nZkqwnRPE/kgoPerBr9aWRfLK+SIeJSduJrqz3A==",
+      "version": "2.4.0-next-2024-08-13",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.4.0-next-2024-08-13.tgz",
+      "integrity": "sha512-G1MpyQIV73e7Ri+zKlWZLqLjO7qODp9bzVzlfc980M7wKYsWwcE2Y7Za7W7DO6Y7EXyaivwOoT2Y8IuiwcvNDA==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -340,9 +345,10 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "5.2.0-next-2024-08-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.2.0-next-2024-08-12.tgz",
-      "integrity": "sha512-gs6H30dVOVDQ8XRIPBvhsZ+ksu/phqZXzvHTJER3qCO847zO5OeSnC5OckKJemBu4Ja+IPU5BP3+MhmR5avNVA==",
+      "version": "5.2.0-next-2024-08-13",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.2.0-next-2024-08-13.tgz",
+      "integrity": "sha512-lfABPfq538DSxlAOqBtthsDomD2W4THholCPew3A3XxL2HUUqanwqejD4qcNaAWAJaPmp5wQ8jJ9rLu24m4rEQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -364,9 +370,10 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.1.0-next-2024-08-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.1.0-next-2024-08-12.tgz",
-      "integrity": "sha512-CI6UA9E6k6u8bzRLQ4rv0L7YgvPkeym8TOyvg+tRbGoRDQsQrkIjnoREcad7jVqCE+cOmaix6PYbEr6awYJZMg==",
+      "version": "3.1.0-next-2024-08-13",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.1.0-next-2024-08-13.tgz",
+      "integrity": "sha512-NcBOI5c+W7StXvj3xzFpIYELmOiKdCTFJBKDHtPuxZ4r+NhEOjmHZAk6GLH7KVsIUSkqnCoP2qUD23qc/20ieg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
       },
@@ -379,9 +386,10 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.4.0-next-2024-08-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.4.0-next-2024-08-12.tgz",
-      "integrity": "sha512-Ry0oecUOYOXKrSiU/GPGYRI64eevuQadTWWUF7XOslzgQw3O8g8SRm0gS2qzWfSyZCEqiw90pOrn+BEbfWzHZQ==",
+      "version": "2.4.0-next-2024-08-13",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.4.0-next-2024-08-13.tgz",
+      "integrity": "sha512-E7JpD6I+WQKeXXhoKyqPxHCvNsdHP5zYmMYuDZW1OPsPMutEWYluRopDsUWLC4SQa4mixPt33jnyjNgpUKWOjQ==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
         "@dfinity/candid": "*",
@@ -2022,6 +2030,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-1.0.5.tgz",
       "integrity": "sha512-LkkAPP8Zu+c0SVNRTRVDyMfKVORThX+rCViget00xdgLRrKkClCTz1T7cIrpr69ShwV5XJuuoZvMvJ43yURwkA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -2056,7 +2065,8 @@
     "node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "license": "MIT"
     },
     "node_modules/bignumber.js": {
       "version": "9.1.1",
@@ -5379,6 +5389,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -7033,9 +7044,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.5.0-next-2024-08-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.5.0-next-2024-08-12.tgz",
-      "integrity": "sha512-OwUa2w+kWVgdVRJ8tFqGe29tNTaA+pc+byLaGcMmKlBHa3CAQIqJOgdlO8xSy5OcAYiQdxXH0wLGoL2okxESSA==",
+      "version": "2.5.0-next-2024-08-13",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.5.0-next-2024-08-13.tgz",
+      "integrity": "sha512-HVKFBExKtExmCMigez81T3Rq0h24QJeZKasRHyLSm7c8FWijX/rixPyy39TDoDrYbhqkodIBD0CzV+i6BQe6Kg==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7043,9 +7054,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.1.0-next-2024-08-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.1.0-next-2024-08-12.tgz",
-      "integrity": "sha512-G4JK2n0gd0c841RWeDkyJs7H6oPNSbd68D7+9UEWx/OmVpgVrT6QAVizzHVwMN+2yiak6nZhDtwRDqfd/k4IXA==",
+      "version": "3.1.0-next-2024-08-13",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.1.0-next-2024-08-13.tgz",
+      "integrity": "sha512-ai+O2EvdvlVD6AiTVeTvBQ85x7DoPdcDn9dhJ61MtddOMxFFBPDUlFkocfolmMdJjezhTokk0M43No/S9ZzxDw==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7059,9 +7070,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "5.1.0-next-2024-08-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.1.0-next-2024-08-12.tgz",
-      "integrity": "sha512-dILy75826mKbyOwU6HNweT0BBsvD3Z7ewsDPwi6MQpHT2zfIfGvCBkkInEtFnKRWd7ihmrRd+KX/An3X2bvNVw==",
+      "version": "5.1.0-next-2024-08-13",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.1.0-next-2024-08-13.tgz",
+      "integrity": "sha512-b9our0H5shmbd6+9edcoTnrhug/BDJCEvi+gKT2NBhYKsswA87w98q9Bk2R3KafcF6fqBzex5iLyRkyEfPdiTg==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7075,21 +7086,21 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.4.0-next-2024-08-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.4.0-next-2024-08-12.tgz",
-      "integrity": "sha512-Asez7G00pAJEbI+0frCojnvVsl5tCVr93jmzKMtwwVZueL0MWjm+RX7ri8WHft2b1TrLY8BIxBd/Col7YnhRDA==",
+      "version": "2.4.0-next-2024-08-13",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.4.0-next-2024-08-13.tgz",
+      "integrity": "sha512-jPNPkonCtaRXmE4ekbGgAIRz8Ji6N5b7tXAh4bRCNP5vWrpK1zOjSR80yedXmCUGtVVbi0zagWf4Jy+qgPXnkA==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.4.0-next-2024-08-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.4.0-next-2024-08-12.tgz",
-      "integrity": "sha512-vLozM0kBmrNMFKcv2qhZHzFHmZSxHXjfLKaQUOFQNZPUAr1nZkqwnRPE/kgoPerBr9aWRfLK+SIeJSduJrqz3A==",
+      "version": "2.4.0-next-2024-08-13",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.4.0-next-2024-08-13.tgz",
+      "integrity": "sha512-G1MpyQIV73e7Ri+zKlWZLqLjO7qODp9bzVzlfc980M7wKYsWwcE2Y7Za7W7DO6Y7EXyaivwOoT2Y8IuiwcvNDA==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "5.2.0-next-2024-08-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.2.0-next-2024-08-12.tgz",
-      "integrity": "sha512-gs6H30dVOVDQ8XRIPBvhsZ+ksu/phqZXzvHTJER3qCO847zO5OeSnC5OckKJemBu4Ja+IPU5BP3+MhmR5avNVA==",
+      "version": "5.2.0-next-2024-08-13",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.2.0-next-2024-08-13.tgz",
+      "integrity": "sha512-lfABPfq538DSxlAOqBtthsDomD2W4THholCPew3A3XxL2HUUqanwqejD4qcNaAWAJaPmp5wQ8jJ9rLu24m4rEQ==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -7104,17 +7115,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.1.0-next-2024-08-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.1.0-next-2024-08-12.tgz",
-      "integrity": "sha512-CI6UA9E6k6u8bzRLQ4rv0L7YgvPkeym8TOyvg+tRbGoRDQsQrkIjnoREcad7jVqCE+cOmaix6PYbEr6awYJZMg==",
+      "version": "3.1.0-next-2024-08-13",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.1.0-next-2024-08-13.tgz",
+      "integrity": "sha512-NcBOI5c+W7StXvj3xzFpIYELmOiKdCTFJBKDHtPuxZ4r+NhEOjmHZAk6GLH7KVsIUSkqnCoP2qUD23qc/20ieg==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.4.0-next-2024-08-12",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.4.0-next-2024-08-12.tgz",
-      "integrity": "sha512-Ry0oecUOYOXKrSiU/GPGYRI64eevuQadTWWUF7XOslzgQw3O8g8SRm0gS2qzWfSyZCEqiw90pOrn+BEbfWzHZQ==",
+      "version": "2.4.0-next-2024-08-13",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.4.0-next-2024-08-13.tgz",
+      "integrity": "sha512-E7JpD6I+WQKeXXhoKyqPxHCvNsdHP5zYmMYuDZW1OPsPMutEWYluRopDsUWLC4SQa4mixPt33jnyjNgpUKWOjQ==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/lib/types/sns-aggregator.ts
+++ b/frontend/src/lib/types/sns-aggregator.ts
@@ -170,7 +170,7 @@ export type CachedSnsTokenMetadataDto = [
     | { Nat: [number, number?] }
     | { Blob: Uint8Array }
     | { Text: string }
-  )
+  ),
 ][];
 
 // Export for testing purposes

--- a/frontend/src/lib/types/sns-aggregator.ts
+++ b/frontend/src/lib/types/sns-aggregator.ts
@@ -166,11 +166,11 @@ export type CachedLifecycleResponseDto = {
 export type CachedSnsTokenMetadataDto = [
   string | IcrcMetadataResponseEntries,
   (
-    | { Int: [number] }
+    | { Int: [number, number?] }
     | { Nat: [number, number?] }
     | { Blob: Uint8Array }
     | { Text: string }
-  ),
+  )
 ][];
 
 // Export for testing purposes

--- a/frontend/src/lib/types/sns-aggregator.ts
+++ b/frontend/src/lib/types/sns-aggregator.ts
@@ -167,7 +167,7 @@ export type CachedSnsTokenMetadataDto = [
   string | IcrcMetadataResponseEntries,
   (
     | { Int: [number] }
-    | { Nat: [number] }
+    | { Nat: [number, number?] }
     | { Blob: Uint8Array }
     | { Text: string }
   ),

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -32,7 +32,12 @@ import type {
   SnsSwapDerivedState,
   SnsSwapInit,
 } from "@dfinity/sns";
-import {candidNatArrayToBigInt, isNullish, nonNullish, toNullable} from "@dfinity/utils";
+import {
+  candidNatArrayToBigInt,
+  isNullish,
+  nonNullish,
+  toNullable,
+} from "@dfinity/utils";
 import { mapOptionalToken } from "./icrc-tokens.utils";
 import { isPngAsset } from "./utils";
 
@@ -76,12 +81,9 @@ const convertFunctionType = (
   };
 };
 
-export const convertNervousFunction = ({
-  id,
-  name,
-  description,
-  function_type,
-}: CachedNervousFunctionDto): SnsNervousSystemFunction => ({
+export const convertNervousFunction = (
+  { id, name, description, function_type }: CachedNervousFunctionDto
+): SnsNervousSystemFunction => ({
   id: BigInt(id),
   name: name,
   description: toNullable(description),
@@ -94,13 +96,15 @@ const convertNeuronsFundParticipationConstraints = (
   constraints: CachedNeuronsFundParticipationConstraints
 ): SnsNeuronsFundParticipationConstraints => ({
   coefficient_intervals: constraints.coefficient_intervals.map(
-    ({
-      slope_numerator,
-      intercept_icp_e8s,
-      from_direct_participation_icp_e8s,
-      slope_denominator,
-      to_direct_participation_icp_e8s,
-    }) => ({
+    (
+      {
+        slope_numerator,
+        intercept_icp_e8s,
+        from_direct_participation_icp_e8s,
+        slope_denominator,
+        to_direct_participation_icp_e8s,
+      }
+    ) => ({
       slope_numerator: toNullable(convertOptionalNumToBigInt(slope_numerator)),
       intercept_icp_e8s: toNullable(
         convertOptionalNumToBigInt(intercept_icp_e8s)
@@ -251,15 +255,17 @@ const convertSwapParams = (params: CachedSwapParamsDto): SnsParams => ({
   ),
 });
 
-const convertDerived = ({
-  sns_tokens_per_icp,
-  buyer_total_icp_e8s,
-  cf_participant_count,
-  direct_participant_count,
-  cf_neuron_count,
-  direct_participation_icp_e8s,
-  neurons_fund_participation_icp_e8s,
-}: CachedSnsSwapDerivedDto): SnsSwapDerivedState => ({
+const convertDerived = (
+  {
+    sns_tokens_per_icp,
+    buyer_total_icp_e8s,
+    cf_participant_count,
+    direct_participant_count,
+    cf_neuron_count,
+    direct_participation_icp_e8s,
+    neurons_fund_participation_icp_e8s,
+  }: CachedSnsSwapDerivedDto
+): SnsSwapDerivedState => ({
   sns_tokens_per_icp,
   buyer_total_icp_e8s: BigInt(buyer_total_icp_e8s),
   cf_participant_count: nonNullish(cf_participant_count)
@@ -399,22 +405,24 @@ const isValidSummary = (entry: PartialSummary): entry is SnsSummary =>
   nonNullish(entry.init) &&
   nonNullish(entry.swapParams);
 
-export const convertDtoToSnsSummary = ({
-  canister_ids: {
-    root_canister_id,
-    swap_canister_id,
-    governance_canister_id,
-    ledger_canister_id,
-    index_canister_id,
-  },
-  meta,
-  icrc1_metadata,
-  swap_state,
-  derived_state,
-  init,
-  swap_params,
-  lifecycle,
-}: CachedSnsDto): SnsSummaryWrapper | undefined => {
+export const convertDtoToSnsSummary = (
+  {
+    canister_ids: {
+      root_canister_id,
+      swap_canister_id,
+      governance_canister_id,
+      ledger_canister_id,
+      index_canister_id,
+    },
+    meta,
+    icrc1_metadata,
+    swap_state,
+    derived_state,
+    init,
+    swap_params,
+    lifecycle,
+  }: CachedSnsDto
+): SnsSummaryWrapper | undefined => {
   const partialSummary: PartialSummary = {
     rootCanisterId: Principal.from(root_canister_id),
     swapCanisterId: Principal.from(swap_canister_id),

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -81,12 +81,9 @@ const convertFunctionType = (
   };
 };
 
-export const convertNervousFunction = ({
-  id,
-  name,
-  description,
-  function_type,
-}: CachedNervousFunctionDto): SnsNervousSystemFunction => ({
+export const convertNervousFunction = (
+  { id, name, description, function_type }: CachedNervousFunctionDto
+): SnsNervousSystemFunction => ({
   id: BigInt(id),
   name: name,
   description: toNullable(description),
@@ -99,13 +96,15 @@ const convertNeuronsFundParticipationConstraints = (
   constraints: CachedNeuronsFundParticipationConstraints
 ): SnsNeuronsFundParticipationConstraints => ({
   coefficient_intervals: constraints.coefficient_intervals.map(
-    ({
-      slope_numerator,
-      intercept_icp_e8s,
-      from_direct_participation_icp_e8s,
-      slope_denominator,
-      to_direct_participation_icp_e8s,
-    }) => ({
+    (
+      {
+        slope_numerator,
+        intercept_icp_e8s,
+        from_direct_participation_icp_e8s,
+        slope_denominator,
+        to_direct_participation_icp_e8s,
+      }
+    ) => ({
       slope_numerator: toNullable(convertOptionalNumToBigInt(slope_numerator)),
       intercept_icp_e8s: toNullable(
         convertOptionalNumToBigInt(intercept_icp_e8s)
@@ -256,15 +255,17 @@ const convertSwapParams = (params: CachedSwapParamsDto): SnsParams => ({
   ),
 });
 
-const convertDerived = ({
-  sns_tokens_per_icp,
-  buyer_total_icp_e8s,
-  cf_participant_count,
-  direct_participant_count,
-  cf_neuron_count,
-  direct_participation_icp_e8s,
-  neurons_fund_participation_icp_e8s,
-}: CachedSnsSwapDerivedDto): SnsSwapDerivedState => ({
+const convertDerived = (
+  {
+    sns_tokens_per_icp,
+    buyer_total_icp_e8s,
+    cf_participant_count,
+    direct_participant_count,
+    cf_neuron_count,
+    direct_participation_icp_e8s,
+    neurons_fund_participation_icp_e8s,
+  }: CachedSnsSwapDerivedDto
+): SnsSwapDerivedState => ({
   sns_tokens_per_icp,
   buyer_total_icp_e8s: BigInt(buyer_total_icp_e8s),
   cf_participant_count: nonNullish(cf_participant_count)
@@ -289,7 +290,7 @@ export const convertIcrc1Metadata = (
 ): IcrcTokenMetadataResponse => {
   return icrc1Metadata.map(([key, value]) => {
     if ("Int" in value) {
-      return [key, { Int: BigInt(value.Int[0]) }];
+      return [key, { Int: candidNatArrayToBigInt(value.Int) }];
     }
     if ("Nat" in value) {
       return [key, { Nat: candidNatArrayToBigInt(value.Nat) }];
@@ -404,22 +405,24 @@ const isValidSummary = (entry: PartialSummary): entry is SnsSummary =>
   nonNullish(entry.init) &&
   nonNullish(entry.swapParams);
 
-export const convertDtoToSnsSummary = ({
-  canister_ids: {
-    root_canister_id,
-    swap_canister_id,
-    governance_canister_id,
-    ledger_canister_id,
-    index_canister_id,
-  },
-  meta,
-  icrc1_metadata,
-  swap_state,
-  derived_state,
-  init,
-  swap_params,
-  lifecycle,
-}: CachedSnsDto): SnsSummaryWrapper | undefined => {
+export const convertDtoToSnsSummary = (
+  {
+    canister_ids: {
+      root_canister_id,
+      swap_canister_id,
+      governance_canister_id,
+      ledger_canister_id,
+      index_canister_id,
+    },
+    meta,
+    icrc1_metadata,
+    swap_state,
+    derived_state,
+    init,
+    swap_params,
+    lifecycle,
+  }: CachedSnsDto
+): SnsSummaryWrapper | undefined => {
   const partialSummary: PartialSummary = {
     rootCanisterId: Principal.from(root_canister_id),
     swapCanisterId: Principal.from(swap_canister_id),

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -32,7 +32,7 @@ import type {
   SnsSwapDerivedState,
   SnsSwapInit,
 } from "@dfinity/sns";
-import { isNullish, nonNullish, toNullable } from "@dfinity/utils";
+import {candidNatArrayToBigInt, isNullish, nonNullish, toNullable} from "@dfinity/utils";
 import { mapOptionalToken } from "./icrc-tokens.utils";
 import { isPngAsset } from "./utils";
 
@@ -287,7 +287,7 @@ export const convertIcrc1Metadata = (
       return [key, { Int: BigInt(value.Int[0]) }];
     }
     if ("Nat" in value) {
-      return [key, { Nat: BigInt(value.Nat[0]) }];
+      return [key, { Nat: candidNatArrayToBigInt(value.Nat) }];
     }
     return [key, value];
   });

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -81,9 +81,12 @@ const convertFunctionType = (
   };
 };
 
-export const convertNervousFunction = (
-  { id, name, description, function_type }: CachedNervousFunctionDto
-): SnsNervousSystemFunction => ({
+export const convertNervousFunction = ({
+  id,
+  name,
+  description,
+  function_type,
+}: CachedNervousFunctionDto): SnsNervousSystemFunction => ({
   id: BigInt(id),
   name: name,
   description: toNullable(description),
@@ -96,15 +99,13 @@ const convertNeuronsFundParticipationConstraints = (
   constraints: CachedNeuronsFundParticipationConstraints
 ): SnsNeuronsFundParticipationConstraints => ({
   coefficient_intervals: constraints.coefficient_intervals.map(
-    (
-      {
-        slope_numerator,
-        intercept_icp_e8s,
-        from_direct_participation_icp_e8s,
-        slope_denominator,
-        to_direct_participation_icp_e8s,
-      }
-    ) => ({
+    ({
+      slope_numerator,
+      intercept_icp_e8s,
+      from_direct_participation_icp_e8s,
+      slope_denominator,
+      to_direct_participation_icp_e8s,
+    }) => ({
       slope_numerator: toNullable(convertOptionalNumToBigInt(slope_numerator)),
       intercept_icp_e8s: toNullable(
         convertOptionalNumToBigInt(intercept_icp_e8s)
@@ -255,17 +256,15 @@ const convertSwapParams = (params: CachedSwapParamsDto): SnsParams => ({
   ),
 });
 
-const convertDerived = (
-  {
-    sns_tokens_per_icp,
-    buyer_total_icp_e8s,
-    cf_participant_count,
-    direct_participant_count,
-    cf_neuron_count,
-    direct_participation_icp_e8s,
-    neurons_fund_participation_icp_e8s,
-  }: CachedSnsSwapDerivedDto
-): SnsSwapDerivedState => ({
+const convertDerived = ({
+  sns_tokens_per_icp,
+  buyer_total_icp_e8s,
+  cf_participant_count,
+  direct_participant_count,
+  cf_neuron_count,
+  direct_participation_icp_e8s,
+  neurons_fund_participation_icp_e8s,
+}: CachedSnsSwapDerivedDto): SnsSwapDerivedState => ({
   sns_tokens_per_icp,
   buyer_total_icp_e8s: BigInt(buyer_total_icp_e8s),
   cf_participant_count: nonNullish(cf_participant_count)
@@ -405,24 +404,22 @@ const isValidSummary = (entry: PartialSummary): entry is SnsSummary =>
   nonNullish(entry.init) &&
   nonNullish(entry.swapParams);
 
-export const convertDtoToSnsSummary = (
-  {
-    canister_ids: {
-      root_canister_id,
-      swap_canister_id,
-      governance_canister_id,
-      ledger_canister_id,
-      index_canister_id,
-    },
-    meta,
-    icrc1_metadata,
-    swap_state,
-    derived_state,
-    init,
-    swap_params,
-    lifecycle,
-  }: CachedSnsDto
-): SnsSummaryWrapper | undefined => {
+export const convertDtoToSnsSummary = ({
+  canister_ids: {
+    root_canister_id,
+    swap_canister_id,
+    governance_canister_id,
+    ledger_canister_id,
+    index_canister_id,
+  },
+  meta,
+  icrc1_metadata,
+  swap_state,
+  derived_state,
+  init,
+  swap_params,
+  lifecycle,
+}: CachedSnsDto): SnsSummaryWrapper | undefined => {
   const partialSummary: PartialSummary = {
     rootCanisterId: Principal.from(root_canister_id),
     swapCanisterId: Principal.from(swap_canister_id),

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -33,7 +33,7 @@ import type {
   SnsSwapInit,
 } from "@dfinity/sns";
 import {
-  candidNatArrayToBigInt,
+  candidNumberArrayToBigInt,
   isNullish,
   nonNullish,
   toNullable,
@@ -289,10 +289,10 @@ export const convertIcrc1Metadata = (
 ): IcrcTokenMetadataResponse => {
   return icrc1Metadata.map(([key, value]) => {
     if ("Int" in value) {
-      return [key, { Int: candidNatArrayToBigInt(value.Int) }];
+      return [key, { Int: candidNumberArrayToBigInt(value.Int) }];
     }
     if ("Nat" in value) {
-      return [key, { Nat: candidNatArrayToBigInt(value.Nat) }];
+      return [key, { Nat: candidNumberArrayToBigInt(value.Nat) }];
     }
     return [key, value];
   });

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -1,4 +1,7 @@
-import type { CachedSnsDto } from "$lib/types/sns-aggregator";
+import type {
+  CachedSnsDto,
+  CachedSnsTokenMetadataDto,
+} from "$lib/types/sns-aggregator";
 import { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import {
   convertDtoToSnsSummary,
@@ -19,6 +22,21 @@ describe("sns aggregator converters utils", () => {
           ["icrc1:fee", { Nat: 100000n }],
         ]
       );
+    });
+
+    it("converts icrc1:fee using not only lower parts of a 64-bit value", () => {
+      const metadata = aggregatorSnsMockDto.icrc1_metadata.map(
+        ([key, value]) => [
+          key,
+          key === "icrc1:fee" ? { Nat: [705032704, 1] } : value,
+        ]
+      ) as CachedSnsTokenMetadataDto;
+      expect(convertIcrc1Metadata(metadata)).toEqual([
+        ["icrc1:decimals", { Nat: 8n }],
+        ["icrc1:name", { Text: "CatalyzeDAO" }],
+        ["icrc1:symbol", { Text: "CAT" }],
+        ["icrc1:fee", { Nat: 5_000_000_000n }],
+      ]);
     });
 
     it("converts aggregator nervous function to ic-js types", () => {


### PR DESCRIPTION
# Motivation

In the [forum](https://forum.dfinity.org/t/dogmi-sns-transfer-wrong-transfer-fee/34114/1) it was reported that the fees of the DOGMI SNS DAO were correctly interpreted in the NNS dapp and Oisy. After debugging, we discovered that the issue was linked to the SNS aggregator providing ICRC fees encoded in Candid Nat, and our transformation to BigInt wasn't accurate. It only interpreted the lower parts of a 64-bit value, i.e., only interpreting the first 32 bits.

To resolve the issue, we implemented a new utility, `candidNatArrayToBigInt`, which is included in `@dfinity/utils`.

# Notes

The upgrade of the utils that provides the new function was provided in PR #5315.

# Changes

- Use new function to convert the SNS aggregator response to ICRC fee.
- We also use the new utility to convert potential `Value.Int`.
- Update aggregator types `Nat` and `Int` from single array number to a potential `[number, number?]` type.
