### PR TITLE
Bump ic-js and fix test

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Bump ic-js so that NNS Dapp can parse `InstallCode` proposal correctly.
+
 #### Deprecated
 
 #### Removed

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -250,9 +250,9 @@
       }
     },
     "node_modules/@dfinity/ckbtc": {
-      "version": "2.5.0-next-2024-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.5.0-next-2024-08-14.tgz",
-      "integrity": "sha512-5SMG6P27i9SxYncWxxSPCjcs3+grSjDyPnkQlKOe3x32fq06wL8/K3+QlffECUIG5w4LTJLyVRvY1F3v5MRRnw==",
+      "version": "2.5.0-next-2024-08-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.5.0-next-2024-08-19.tgz",
+      "integrity": "sha512-+YGbw9k3VnzYET4gokfHf2ppC+IWW+4cC087Y+mpYcADBf3Q1k00858JDquo5Ya6HLFsQYQk53uVNqclz9tKgQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@dfinity/cmc": {
-      "version": "3.1.0-next-2024-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.1.0-next-2024-08-14.tgz",
-      "integrity": "sha512-e+41xHdpzfVNJCPmT3jedJeb1eUjvZbaxvF7+/kUctyL9ISuRm0vHqsoqisc0xD1dqQSb3KxRUZqPp0kB7WcUw==",
+      "version": "3.1.0-next-2024-08-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.1.0-next-2024-08-19.tgz",
+      "integrity": "sha512-W9ElF3WRT0TIHWZ/xU0VgWzLIfWAbEHS5/3pd9tWfRn/YlHzgsYeoqU5kBLcTlqQ/QVBMD9z5QCFGpMWOA3yNw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -294,9 +294,9 @@
       }
     },
     "node_modules/@dfinity/ic-management": {
-      "version": "5.1.0-next-2024-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.1.0-next-2024-08-14.tgz",
-      "integrity": "sha512-PZDARsdOAdw4HGsUKw7AlJGQ6ZCsYkdSs7H2u3S7521Bd2ZygTt0hdtf9QTvV5Xoft+5Zd0Tc3ek491Hx8DNpw==",
+      "version": "5.1.0-next-2024-08-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.1.0-next-2024-08-19.tgz",
+      "integrity": "sha512-tC2nqHfmlbAP3/xvSKUOcR/TT/qo2TOCM0lEuTj48I8IKdNqDGjQtbhISVgm4qFM4fYrkX+EyDQzhja0NZ6tFw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -321,9 +321,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.4.0-next-2024-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.4.0-next-2024-08-14.tgz",
-      "integrity": "sha512-ejY8Kf0/8A4+GjFqrNYk4Lwf7i7+9j3btP6vCKth37ZAxPrOeDzInkLQCwIfEjUqLLIpLvHK4vn+oHOUArsB7A==",
+      "version": "2.4.0-next-2024-08-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.4.0-next-2024-08-19.tgz",
+      "integrity": "sha512-YOG6cPJWyBTNEOga/7dyeyM0zhon8mnA3FvhI46g/Z8eoAOc/BPIry6CMSWn0qOzoqqgVcJqn1HBptkb/poazw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -333,9 +333,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.4.0-next-2024-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.4.0-next-2024-08-14.tgz",
-      "integrity": "sha512-msVzW4QuWY79/K++SBoUAmglUWlvwmApX0fAVmWsHnBy/EsQ3YXIKHssu5gezG5ZNYF27kPt7HDDoem5mGDB/w==",
+      "version": "2.4.0-next-2024-08-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.4.0-next-2024-08-19.tgz",
+      "integrity": "sha512-kbIreGfF/F0E9SLciyHYJBvnIIW3D6HcmqiKw6L9Xyqp5GNSIF3LAynrm0OfALBUZZSHQ0fctwLJ39V01n28yw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -345,9 +345,9 @@
       }
     },
     "node_modules/@dfinity/nns": {
-      "version": "5.2.0-next-2024-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.2.0-next-2024-08-14.tgz",
-      "integrity": "sha512-tLoARJUc7mKEpqdLVWPmJVxVRFXD5qAAqD4Y3rTcMF44Vs6mOu0XC0MQPqmx0S2pzpU4DFXS2afObmmEVzpYQw==",
+      "version": "5.2.0-next-2024-08-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.2.0-next-2024-08-19.tgz",
+      "integrity": "sha512-kJXgR20vrvuWES3pZgbI0x9WVuWsnGGcx4mFSmvwyRpsKGuTbASxfJY0Uy0QSpH4Vqu0tK8Ym9G2GuIusEaj5w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
@@ -370,9 +370,9 @@
       }
     },
     "node_modules/@dfinity/sns": {
-      "version": "3.1.0-next-2024-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.1.0-next-2024-08-14.tgz",
-      "integrity": "sha512-urqGyxB3IoabPD7AIfZxuRsiwHR1lNOlGxvgDoUKM/3MfHiHVQ+N+1Wo1c1JH0qX6mc1qSM12BhnH55HEFRd2w==",
+      "version": "3.1.0-next-2024-08-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.1.0-next-2024-08-19.tgz",
+      "integrity": "sha512-qVTwUOhsJkTL7q8u6w7Q98lTMa+LS+nWIHYhdDkOCkcBI05o8sJa8vld8wzFRR8tnCySWzQ6yWq4TKmf21hc5g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2"
@@ -386,9 +386,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.4.0-next-2024-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.4.0-next-2024-08-14.tgz",
-      "integrity": "sha512-LP5ZKCC5suzDFstuLnvr3/keZWPUZ5MLKDUmoAj2S8QulsBAFQ4mMD6nsghfBvLrG6YoVsJ5BMJhneuP1lQw2g==",
+      "version": "2.4.0-next-2024-08-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.4.0-next-2024-08-19.tgz",
+      "integrity": "sha512-U6AKO5R9nfNWopXx8izKA/VEeakmAW/ch2PH6zX+huk5SC2h8v5U00L9jRanP4FtChpXWTKdrCkn58NUUif17w==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@dfinity/agent": "*",
@@ -7044,9 +7044,9 @@
       "requires": {}
     },
     "@dfinity/ckbtc": {
-      "version": "2.5.0-next-2024-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.5.0-next-2024-08-14.tgz",
-      "integrity": "sha512-5SMG6P27i9SxYncWxxSPCjcs3+grSjDyPnkQlKOe3x32fq06wL8/K3+QlffECUIG5w4LTJLyVRvY1F3v5MRRnw==",
+      "version": "2.5.0-next-2024-08-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/ckbtc/-/ckbtc-2.5.0-next-2024-08-19.tgz",
+      "integrity": "sha512-+YGbw9k3VnzYET4gokfHf2ppC+IWW+4cC087Y+mpYcADBf3Q1k00858JDquo5Ya6HLFsQYQk53uVNqclz9tKgQ==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "base58-js": "^1.0.5",
@@ -7054,9 +7054,9 @@
       }
     },
     "@dfinity/cmc": {
-      "version": "3.1.0-next-2024-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.1.0-next-2024-08-14.tgz",
-      "integrity": "sha512-e+41xHdpzfVNJCPmT3jedJeb1eUjvZbaxvF7+/kUctyL9ISuRm0vHqsoqisc0xD1dqQSb3KxRUZqPp0kB7WcUw==",
+      "version": "3.1.0-next-2024-08-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/cmc/-/cmc-3.1.0-next-2024-08-19.tgz",
+      "integrity": "sha512-W9ElF3WRT0TIHWZ/xU0VgWzLIfWAbEHS5/3pd9tWfRn/YlHzgsYeoqU5kBLcTlqQ/QVBMD9z5QCFGpMWOA3yNw==",
       "requires": {}
     },
     "@dfinity/gix-components": {
@@ -7070,9 +7070,9 @@
       }
     },
     "@dfinity/ic-management": {
-      "version": "5.1.0-next-2024-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.1.0-next-2024-08-14.tgz",
-      "integrity": "sha512-PZDARsdOAdw4HGsUKw7AlJGQ6ZCsYkdSs7H2u3S7521Bd2ZygTt0hdtf9QTvV5Xoft+5Zd0Tc3ek491Hx8DNpw==",
+      "version": "5.1.0-next-2024-08-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/ic-management/-/ic-management-5.1.0-next-2024-08-19.tgz",
+      "integrity": "sha512-tC2nqHfmlbAP3/xvSKUOcR/TT/qo2TOCM0lEuTj48I8IKdNqDGjQtbhISVgm4qFM4fYrkX+EyDQzhja0NZ6tFw==",
       "requires": {}
     },
     "@dfinity/identity": {
@@ -7086,21 +7086,21 @@
       }
     },
     "@dfinity/ledger-icp": {
-      "version": "2.4.0-next-2024-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.4.0-next-2024-08-14.tgz",
-      "integrity": "sha512-ejY8Kf0/8A4+GjFqrNYk4Lwf7i7+9j3btP6vCKth37ZAxPrOeDzInkLQCwIfEjUqLLIpLvHK4vn+oHOUArsB7A==",
+      "version": "2.4.0-next-2024-08-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.4.0-next-2024-08-19.tgz",
+      "integrity": "sha512-YOG6cPJWyBTNEOga/7dyeyM0zhon8mnA3FvhI46g/Z8eoAOc/BPIry6CMSWn0qOzoqqgVcJqn1HBptkb/poazw==",
       "requires": {}
     },
     "@dfinity/ledger-icrc": {
-      "version": "2.4.0-next-2024-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.4.0-next-2024-08-14.tgz",
-      "integrity": "sha512-msVzW4QuWY79/K++SBoUAmglUWlvwmApX0fAVmWsHnBy/EsQ3YXIKHssu5gezG5ZNYF27kPt7HDDoem5mGDB/w==",
+      "version": "2.4.0-next-2024-08-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.4.0-next-2024-08-19.tgz",
+      "integrity": "sha512-kbIreGfF/F0E9SLciyHYJBvnIIW3D6HcmqiKw6L9Xyqp5GNSIF3LAynrm0OfALBUZZSHQ0fctwLJ39V01n28yw==",
       "requires": {}
     },
     "@dfinity/nns": {
-      "version": "5.2.0-next-2024-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.2.0-next-2024-08-14.tgz",
-      "integrity": "sha512-tLoARJUc7mKEpqdLVWPmJVxVRFXD5qAAqD4Y3rTcMF44Vs6mOu0XC0MQPqmx0S2pzpU4DFXS2afObmmEVzpYQw==",
+      "version": "5.2.0-next-2024-08-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/nns/-/nns-5.2.0-next-2024-08-19.tgz",
+      "integrity": "sha512-kJXgR20vrvuWES3pZgbI0x9WVuWsnGGcx4mFSmvwyRpsKGuTbASxfJY0Uy0QSpH4Vqu0tK8Ym9G2GuIusEaj5w==",
       "requires": {
         "@noble/hashes": "^1.3.2",
         "randombytes": "^2.1.0"
@@ -7115,17 +7115,17 @@
       }
     },
     "@dfinity/sns": {
-      "version": "3.1.0-next-2024-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.1.0-next-2024-08-14.tgz",
-      "integrity": "sha512-urqGyxB3IoabPD7AIfZxuRsiwHR1lNOlGxvgDoUKM/3MfHiHVQ+N+1Wo1c1JH0qX6mc1qSM12BhnH55HEFRd2w==",
+      "version": "3.1.0-next-2024-08-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/sns/-/sns-3.1.0-next-2024-08-19.tgz",
+      "integrity": "sha512-qVTwUOhsJkTL7q8u6w7Q98lTMa+LS+nWIHYhdDkOCkcBI05o8sJa8vld8wzFRR8tnCySWzQ6yWq4TKmf21hc5g==",
       "requires": {
         "@noble/hashes": "^1.3.2"
       }
     },
     "@dfinity/utils": {
-      "version": "2.4.0-next-2024-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.4.0-next-2024-08-14.tgz",
-      "integrity": "sha512-LP5ZKCC5suzDFstuLnvr3/keZWPUZ5MLKDUmoAj2S8QulsBAFQ4mMD6nsghfBvLrG6YoVsJ5BMJhneuP1lQw2g==",
+      "version": "2.4.0-next-2024-08-19",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.4.0-next-2024-08-19.tgz",
+      "integrity": "sha512-U6AKO5R9nfNWopXx8izKA/VEeakmAW/ch2PH6zX+huk5SC2h8v5U00L9jRanP4FtChpXWTKdrCkn58NUUif17w==",
       "requires": {}
     },
     "@esbuild/android-arm": {

--- a/frontend/src/tests/mocks/proposal.mock.ts
+++ b/frontend/src/tests/mocks/proposal.mock.ts
@@ -49,8 +49,8 @@ export const proposalActionNnsFunction21 = {
 export const proposalActionInstallCode = {
   InstallCode: {
     canisterId: "aaaaa-aa",
-    wasmModule: new Uint8Array([1, 2, 3]),
-    arg: new Uint8Array([4, 5, 6]),
+    wasmModuleHash: "abcd",
+    argHash: "efgh",
     skipStoppingBeforeInstalling: false,
     installMode: 3,
   },


### PR DESCRIPTION
# Motivation

ic-js has a recent change (https://github.com/dfinity/ic-js/pull/699) for interpreting `InstallCode` within proposals differently based on whether it's request/response. Bumping its version so that NNS Dapp can interpret the proposal correctly.

# Changes

* Bump ic-js version and fix a test.

# Tests

* Unit test

# Todos

- [x] Add entry to changelog (if necessary).
