### PR TITLE
Revert the change to display the Payload section for `InstallCode`

### DIFF
--- a/frontend/src/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.svelte
+++ b/frontend/src/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { loadProposalPayload } from "$lib/services/$public/proposals.services";
   import { proposalPayloadsStore } from "$lib/stores/proposals.store";
-  import { hasProposalPayload } from "$lib/utils/proposals.utils";
+  import { getNnsFunctionKey } from "$lib/utils/proposals.utils";
   import ProposalProposerPayloadEntry from "./ProposalProposerPayloadEntry.svelte";
   import type { Proposal } from "@dfinity/nns";
   import type { ProposalId } from "@dfinity/nns";
@@ -11,8 +11,8 @@
 
   let payload: object | undefined | null;
   // Only proposals with nnsFunctionKey and proposalId have payload
-  let shouldDisplayPayload: boolean;
-  $: shouldDisplayPayload = hasProposalPayload(proposal);
+  let nnsFunctionKey: string | undefined;
+  $: nnsFunctionKey = getNnsFunctionKey(proposal);
 
   $: $proposalPayloadsStore,
     (payload =
@@ -21,7 +21,7 @@
         : undefined);
   $: if (
     proposalId !== undefined &&
-    shouldDisplayPayload &&
+    nnsFunctionKey !== undefined &&
     !$proposalPayloadsStore.has(proposalId)
   ) {
     loadProposalPayload({
@@ -30,6 +30,6 @@
   }
 </script>
 
-{#if shouldDisplayPayload && proposalId !== undefined}
+{#if nnsFunctionKey !== undefined && proposalId !== undefined}
   <ProposalProposerPayloadEntry {payload} />
 {/if}

--- a/frontend/src/lib/utils/proposals.utils.ts
+++ b/frontend/src/lib/utils/proposals.utils.ts
@@ -75,16 +75,6 @@ export const getNnsFunctionKey = (
   return NnsFunction[nnsFunctionId];
 };
 
-export const hasProposalPayload = (proposal: Proposal | undefined): boolean => {
-  const action = proposalFirstActionKey(proposal);
-  // ExecuteNnsFunction has proposal payloads that we need to load from the NNS Dapp backend,
-  // because of 2 reasons: (1) candid files from various canisters (e.g. registry) are needed to
-  // decode the payload, which is not done in ic-js. (2) the payload can be large and we want to
-  // avoid loading on the client side, so NNS Dapp backend is used for calculating and caching the
-  // hash of the large payloads. For InstallCode, however, only the reason (2) applies.
-  return action === "ExecuteNnsFunction" || action === "InstallCode";
-};
-
 /**
  * Hide proposal that don't match filters
  */

--- a/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/NnsProposalProposerPayloadEntry.spec.ts
@@ -5,7 +5,6 @@ import { jsonRepresentationStore } from "$lib/stores/json-representation.store";
 import { proposalPayloadsStore } from "$lib/stores/proposals.store";
 import {
   mockProposalInfo,
-  proposalActionInstallCode,
   proposalActionMotion,
   proposalActionNnsFunction21,
 } from "$tests/mocks/proposal.mock";
@@ -59,45 +58,6 @@ describe("NnsProposalProposerPayloadEntry", () => {
       const { container } = render(NnsProposalProposerPayloadEntry, {
         props: {
           proposal: proposalWithNnsFunctionAction,
-          proposalId: mockProposalInfo.id,
-        },
-      });
-      await runResolvedPromises();
-      const po = JsonPreviewPo.under(new JestPageObjectElement(container));
-      expect(await po.getRawObject()).toEqual(payload);
-    });
-  });
-
-  describe("when proposal is InstallCode", () => {
-    const proposalWithInstallCodeAction = {
-      ...mockProposalInfo.proposal,
-      action: proposalActionInstallCode,
-    } as Proposal;
-
-    it("should trigger getProposalPayload", async () => {
-      nnsDappMock.getProposalPayload.mockImplementation(async () => payload);
-
-      expect(nnsDappMock.getProposalPayload).toBeCalledTimes(0);
-      render(NnsProposalProposerPayloadEntry, {
-        props: {
-          proposal: proposalWithInstallCodeAction,
-          proposalId: mockProposalInfo.id,
-        },
-      });
-
-      await runResolvedPromises();
-      expect(nnsDappMock.getProposalPayload).toBeCalledTimes(1);
-      expect(nnsDappMock.getProposalPayload).toBeCalledWith({
-        proposalId: mockProposalInfo.id,
-      });
-    });
-
-    it("should render payload", async () => {
-      nnsDappMock.getProposalPayload.mockImplementation(async () => payload);
-      jsonRepresentationStore.setMode("raw");
-      const { container } = render(NnsProposalProposerPayloadEntry, {
-        props: {
-          proposal: proposalWithInstallCodeAction,
           proposalId: mockProposalInfo.id,
         },
       });

--- a/frontend/src/tests/lib/utils/proposals.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/proposals.utils.spec.ts
@@ -9,7 +9,6 @@ import {
   getVotingBallot,
   getVotingPower,
   hasMatchingProposals,
-  hasProposalPayload,
   hideProposal,
   isProposalDeadlineInTheFuture,
   lastProposalId,
@@ -844,49 +843,6 @@ describe("proposals-utils", () => {
 
     it("should return undefined if undefined", () => {
       expect(getNnsFunctionKey(undefined)).toBeUndefined();
-    });
-  });
-
-  describe("hasProposalPayload", () => {
-    it("should return true for ExecuteNnsFunction", () => {
-      expect(
-        hasProposalPayload({
-          ...mockProposalInfo.proposal,
-          action: {
-            ExecuteNnsFunction: {
-              nnsFunctionId: 4,
-            },
-          },
-        } as Proposal)
-      ).toBe(true);
-    });
-
-    it("should return true for InstallCode", () => {
-      expect(
-        hasProposalPayload({
-          ...mockProposalInfo.proposal,
-          action: {
-            InstallCode: {
-              skipStoppingBeforeInstalling: false,
-              canisterId: "rrkah-fqaaa-aaaaa-aaaaq-cai",
-              installMode: 3,
-            },
-          },
-        } as Proposal)
-      ).toBe(true);
-    });
-
-    it("should return false for Motion", () => {
-      expect(
-        hasProposalPayload({
-          ...mockProposalInfo.proposal,
-          action: {
-            Motion: {
-              motionText: "motion text",
-            },
-          },
-        } as Proposal)
-      ).toBe(false);
     });
   });
 


### PR DESCRIPTION
# Motivation

Now that we implemented the ideal solution for displaying `InstallCode` proposals - NNS Governance returning the hashes for `wasm_module` and `arg`, we don't need a separate "Payload" section to display them.

# Changes

* Revert most of the previous change https://github.com/dfinity/nns-dapp/pull/5288 related to displaying the "Payload" section.
* Keeping the change to introduce the i18n for proposal types
* Keeping some changes on unit tests regarding showing the payload section.

# Tests

* Unit tests

# Todos

- [x] Add entry to changelog (if necessary).
