### PR TITLE
NNS1-3250: Dispatch event for click on non-link table row

### DIFF
--- a/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
+++ b/frontend/src/lib/components/ui/ResponsiveTableRow.svelte
@@ -7,6 +7,7 @@
   import type { ResponsiveTableColumn } from "$lib/types/responsive-table";
   import { getCellGridAreaName } from "$lib/utils/responsive-table.utils";
   import { isNullish, nonNullish } from "@dfinity/utils";
+  import { createEventDispatcher } from "svelte";
 
   export let rowData: RowDataType;
   export let columns: ResponsiveTableColumn<RowDataType>[];
@@ -19,6 +20,16 @@
   $: firstColumn = columns.at(0);
   $: middleColumns = columns.slice(1, -1);
   $: lastColumn = columns.at(-1);
+
+  const dispatcher = createEventDispatcher();
+
+  const onRowClick = () => {
+    if (nonNullish(rowData.rowHref)) {
+      // We don't interfere with normal link behavior.
+      return;
+    }
+    dispatcher("nnsAction", { rowData });
+  };
 
   const getCellStyle = ({
     column,
@@ -40,6 +51,7 @@
   role="row"
   tabindex="0"
   data-tid="responsive-table-row-component"
+  on:click={onRowClick}
   {style}
 >
   {#if firstColumn}

--- a/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
+++ b/frontend/src/tests/lib/components/ui/ResponsiveTable.spec.ts
@@ -76,7 +76,9 @@ describe("ResponsiveTable", () => {
     // navigation not being implemented. But the error is not logged immediately
     // and can happen during a different test. So we dissable error logging for
     // all tests.
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation((arg) => {
+      expect(arg).toMatch(/Error: Not implemented: navigation/);
+    });
   });
 
   const renderComponent = ({ onNnsAction = null, ...props }) => {


### PR DESCRIPTION
# Motivation

In the staking projects table, when you click on a project for which you don't have any neurons, instead of navigating to the (empty) neurons table for that project, we want to open the staking modal.
This means that those rows should not be links (which would cause navigation) but should clicks should instead dispatch an event which can be used to open the modal.

This PR only implements dispatching the event for non-link rows and does not yet do anything with it.

# Changes

When a non-link row is clicked in the `ResponsiveTable`, dispatch an `nnsAction` event with the `rowData` for that row as event payload.

# Tests

1. Unit test added.
2. Tested manually in another branch which already has the staking modal implemented: https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/staking/

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary