### PR TITLE
Explicitly upload checklist file in release-sop

### DIFF
--- a/scripts/nns-dapp/release-sop
+++ b/scripts/nns-dapp/release-sop
@@ -430,7 +430,7 @@ post_proposal_on_slack() {
 release_sop_tests_need_update() {
   if ! git diff --quiet origin/main scripts/nns-dapp/release-sop-*; then
     if ! git diff --quiet -- scripts/nns-dapp/release-sop-*; then
-      echo "Verify updates to relese-sop tests and commit." >&2
+      echo "Verify updates to release-sop tests and commit." >&2
       exit 1
     fi
     echo "Tests have been updated."
@@ -525,4 +525,4 @@ A release has been deployed to production.
 - Increment the patch version of the nns-dapp."
 confirm_manual "Merge release PR" echo "Have the release PR reviewed and merge it."
 confirm_cmd rm scripts/nns-dapp/Release-2001-02-29.json
-confirm_cmd gh release upload "proposal-$PROPOSAL_ID" scripts/nns-dapp/Release-*.json
+confirm_cmd gh release upload "proposal-$PROPOSAL_ID" "$CHECKLIST_FILE"

--- a/scripts/nns-dapp/split-changelog
+++ b/scripts/nns-dapp/split-changelog
@@ -21,7 +21,7 @@ source "$SOURCE_DIR/../clap.bash"
 clap.define long=commit desc="Entries after this commit are considered new" variable=COMMIT default="tags/release-candidate"
 clap.define long=test-released-changelog desc="An alternate released CHANGELOG file for testing" variable=RELEASED_CHANGELOG default=""
 clap.define long=test-unreleased-changelog desc="An alternate unreleased CHANGELOG file for testing" variable=UNRELEASED_CHANGELOG default=""
-clap.define long=test-old-unreleased-changelog desc="An alternate old unrelesed CHANGELOG for testing" variable=OLD_UNRELEASED_CHANGELOG default=""
+clap.define long=test-old-unreleased-changelog desc="An alternate old unreleased CHANGELOG for testing" variable=OLD_UNRELEASED_CHANGELOG default=""
 clap.define long=test-proposal desc="An alternate proposal number for testing" variable=PROPOSAL_NUMBER default=""
 # Source the output file ------------------------------------------------------
 source "$(clap.build)"


### PR DESCRIPTION
# Motivation

In the NNS dapp release SOP checklist there is a step:
> gh release upload "proposal-$PROPOSAL_ID" scripts/nns-dapp/Release-*.json

To upload the release-sop JSON file to the release assets. Using `*` makes it easy to copy/paste the command but in the `release-sop` script we can be more precise and avoid matching other JSON.

When running the test there is a different JSON file but if an actual release is ongoing the test would see that file too.

# Changes

1. Explicitly upload the checklist file for the current release instead of using wild cards.
2. Drive-by: Fix typos of "relese" to "release".

# Tests

1. The existing `release-sop.test` still passes.
2. I tried running the test after doing `touch scripts/nns-dapp/Release-2024-02-29.json` and it failed without the change and passed with the change.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary