### PR TITLE
Implement transformRequest on mockIdentity

### DIFF
--- a/frontend/src/tests/mocks/auth.store.mock.ts
+++ b/frontend/src/tests/mocks/auth.store.mock.ts
@@ -10,14 +10,24 @@ export const mockPrincipalText =
 
 export const mockPrincipal = Principal.fromText(mockPrincipalText);
 
+const transformRequest = () => {
+  console.error(
+    "It looks like the agent is trying to make a request that should have been mocked at",
+    new Error().stack
+  );
+  throw new Error("Not implemented");
+};
+
 export const mockIdentity = {
   getPrincipal: () => mockPrincipal,
+  transformRequest,
 } as unknown as Identity;
 
 export const createMockIdentity = (p: number) => {
   const principal = Principal.fromHex(p.toString(16));
   return {
     getPrincipal: () => principal,
+    transformRequest,
   } as Identity;
 };
 


### PR DESCRIPTION
# Motivation

When writing a unit test of a larger component, it's easy to forget to mock out some of the API requests.
In that case the agent might try to make a real request. This will fail when the agent tries to call `transformRequest` on the mock identity, resulting in the following in the test output:
```
Error polling: id.transformRequest is not a function
```
This is not very clear or useful.
By implementing `transformRequest` on the mock identity, we can get something like that following instead:
```
It looks like the agent is trying to make a request that should have been mocked at Error: 
    at Object.transformRequest (/Users/dskloet/dev/nns-dapp/tree5/frontend/src/tests/mocks/auth.store.mock.ts:14:104)
    at HttpAgent.call (/Users/dskloet/dev/nns-dapp/tree5/frontend/node_modules/@dfinity/agent/src/agent/http/index.ts:641:21)
    at caller (/Users/dskloet/dev/nns-dapp/tree5/frontend/node_modules/@dfinity/agent/src/actor.ts:491:28)
    at NNSDappCanister.getAccount (/Users/dskloet/dev/nns-dapp/tree5/frontend/src/lib/canisters/nns-dapp/nns-dapp.canister.ts:91:7)
    at Module.queryAccount (/Users/dskloet/dev/nns-dapp/tree5/frontend/src/lib/api/nns-dapp.api.ts:25:19)
    at getOrCreateAccount (/Users/dskloet/dev/nns-dapp/tree5/frontend/src/lib/services/icp-accounts.services.ts:72:12)
    at loadAccountsStoresData (/Users/dskloet/dev/nns-dapp/tree5/frontend/src/lib/services/icp-accounts.services.ts:100:42)
    at Module.poll (/Users/dskloet/dev/nns-dapp/tree5/frontend/src/lib/utils/utils.ts:297:24)
    at Module.pollAccounts (/Users/dskloet/dev/nns-dapp/tree5/frontend/src/lib/services/icp-accounts.services.ts:496:50)
Error polling: Not implemented
```
This should help understand which request should be mocked.

# Changes

Implement `transformRequest` on `mockIdentity` to get more helpful output when you forget to mock some requests.

# Tests

I used this in another branch to debug a test that was making requests that I hadn't mocked.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary