### PR TITLE
Use isNullish instead of ! to check if fee is present

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -26,6 +26,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Staking for SNS with zero transaction fee.
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/services/sns-neurons.services.ts
+++ b/frontend/src/lib/services/sns-neurons.services.ts
@@ -55,6 +55,7 @@ import {
   assertNonNullish,
   fromDefinedNullable,
   fromNullable,
+  isNullish,
   nonNullish,
 } from "@dfinity/utils";
 import { get } from "svelte/store";
@@ -513,7 +514,7 @@ export const stakeNeuron = async ({
     const fee = get(snsTokensByRootCanisterIdStore)[rootCanisterId.toText()]
       ?.fee;
 
-    if (!fee) {
+    if (isNullish(fee)) {
       throw new Error("error.transaction_fee_not_found");
     }
 

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -543,6 +543,32 @@ describe("sns-neurons-services", () => {
       expect(success).toBe(false);
       expect(spyStake).not.toBeCalled();
     });
+
+    it("should call sns api stakeNeuron if fee is 0", async () => {
+      setSnsProjects([
+        {
+          rootCanisterId: mockPrincipal,
+          tokenMetadata: { ...mockSnsToken, fee: 0n },
+        },
+      ]);
+      const spyStake = vi
+        .spyOn(api, "stakeNeuron")
+        .mockImplementation(() => Promise.resolve(mockSnsNeuron.id[0]));
+      const spyQuery = vi
+        .spyOn(governanceApi, "querySnsNeurons")
+        .mockImplementation(() => Promise.resolve([mockSnsNeuron]));
+
+      const { success } = await stakeNeuron({
+        rootCanisterId: mockPrincipal,
+        amount: 2,
+        account: mockSnsMainAccount,
+      });
+
+      expect(success).toBeTruthy();
+      expect(spyStake).toBeCalled();
+      expect(spyQuery).toBeCalled();
+      expect(loadSnsAccounts).toBeCalled();
+    });
   });
 
   describe("increaseStakeNeuron", () => {


### PR DESCRIPTION
# Motivation

The `stakeNeuron` function in `sns-neurons.services.ts` checks if the fee is loaded before staking.
But it does this by checking if the fee is truthy, which fails if the fee is zero.
There currently aren't any SNSes with zero transaction fees but [mockToken](https://github.com/dfinity/nns-dapp/blob/b20eb25d72f8e93a450784adbf1f2ae0cc6dbf1a/frontend/src/tests/mocks/sns-projects.mock.ts#L206) happens to have a fee of 0 so I wasted some time debugging because of this.

# Changes

Use `isNullish` instead of `!` to check if the fee is present.

# Tests

1. There is an existing unit test with an absent fee.
2. I added a unit test with a zero fee.

# Todos

- [x] Add entry to changelog (if necessary).
