### PR TITLE
Remove text labels from proposal navigation buttons

### DIFF
--- a/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
+++ b/frontend/src/lib/components/proposal-detail/ProposalNavigation.svelte
@@ -70,9 +70,7 @@
     class:hidden={isNullish(previousId)}
     data-tid="proposal-nav-previous"
     data-test-proposal-id={previousId?.proposalId.toString() ?? ""}
-  >
-    <IconLeft />
-    {$i18n.proposal_detail.previous_short}</button
+    ><IconLeft /></button
   >
   <button
     class="ghost next"
@@ -82,10 +80,8 @@
     class:hidden={isNullish(nextId)}
     data-tid="proposal-nav-next"
     data-test-proposal-id={nextId?.proposalId.toString() ?? ""}
+    ><IconRight /></button
   >
-    {$i18n.proposal_detail.next_short}
-    <IconRight />
-  </button>
 </div>
 
 <style lang="scss">

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -512,8 +512,6 @@
     "remaining": "remaining",
     "next": "Navigate to next proposal",
     "previous": "Navigate to previous proposal",
-    "next_short": "Next",
-    "previous_short": "Previous",
     "sign_in": "Sign in to vote",
     "toggle_lable": "Switch between user-friendly and raw data representation",
     "toggle_tree": "Tree",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -535,8 +535,6 @@ interface I18nProposal_detail {
   remaining: string;
   next: string;
   previous: string;
-  next_short: string;
-  previous_short: string;
   sign_in: string;
   toggle_lable: string;
   toggle_tree: string;


### PR DESCRIPTION
# Motivation

Currently, the `Next` and `Previous` labels displayed next to the proposal navigation buttons. While `Next` navigates to the next item in the list, some users find it confusing because the next item is an older proposal. To improve this, here we’ve removed the labels, leaving only the arrow icons for navigation.

# Changes

- Remove the text labels from the navigation buttons.

# Tests

- Pass.
- Locally.

| Before | After |
|--------|--------|
| <img width="345" alt="image" src="https://github.com/user-attachments/assets/615fc720-6a62-4aad-b457-f04a911b6404"> | <img width="325" alt="image" src="https://github.com/user-attachments/assets/94bf42e0-3dd9-4e67-bf5c-7d43189dc3f6"> | 

# Todos

- [ ] Add entry to changelog (if necessary).

Not necessary.