### PR TITLE
NNS1-3250: Stake button for projects without neurons

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -15,6 +15,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+* Stake tokens, the first time, directly from the Nervous Systems table.
+
 #### Changed
 
 * Bump ic-js so that NNS Dapp can parse `InstallCode` proposal correctly.

--- a/frontend/src/lib/components/staking/ProjectNeuronsCell.svelte
+++ b/frontend/src/lib/components/staking/ProjectNeuronsCell.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import { i18n } from "$lib/stores/i18n";
   import type { TableProject } from "$lib/types/staking";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { nonNullish } from "@dfinity/utils";
 
   export let rowData: TableProject;
@@ -7,8 +9,23 @@
 
 <div data-tid="project-neurons-cell-component">
   {#if nonNullish(rowData.neuronCount)}
-    {rowData.neuronCount}
+    {#if rowData.neuronCount > 0}
+      {rowData.neuronCount}
+    {:else}
+      <!-- There is a click handler on the entire row so we don't need a specific click handler on the button. -->
+      <button data-tid="stake-button" class="stake-button"
+        >{replacePlaceholders($i18n.neurons.stake_token, {
+          $token: rowData.tokenSymbol,
+        })}</button
+      >
+    {/if}
   {:else}
     -/-
   {/if}
 </div>
+
+<style lang="scss">
+  .stake-button {
+    color: var(--primary);
+  }
+</style>

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -15,6 +15,7 @@
     getTableProjects,
     sortTableProjects,
   } from "$lib/utils/staking.utils";
+  import { createEventDispatcher } from "svelte";
 
   const columns: ProjectsTableColumn[] = [
     {
@@ -74,10 +75,21 @@
 
   let sortedTableProjects: TableProject[];
   $: sortedTableProjects = sortTableProjects(tableProjects);
+
+  const dispatcher = createEventDispatcher();
+
+  const handleAction = ({
+    detail: { rowData },
+  }: {
+    detail: { rowData: TableProject };
+  }) => {
+    dispatcher("nnsStakeTokens", { universeId: rowData.universeId });
+  };
 </script>
 
 <ResponsiveTable
   testId="projects-table-component"
   tableData={sortedTableProjects}
   {columns}
+  on:nnsAction={handleAction}
 ></ResponsiveTable>

--- a/frontend/src/lib/routes/Staking.svelte
+++ b/frontend/src/lib/routes/Staking.svelte
@@ -1,17 +1,32 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
   import SignInGuard from "$lib/components/common/SignInGuard.svelte";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
   import IslandWidthMain from "$lib/components/layout/IslandWidthMain.svelte";
   import ProjectsTable from "$lib/components/staking/ProjectsTable.svelte";
   import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";
+  import { snsProjectsRecordStore } from "$lib/derived/sns/sns-projects.derived";
+  import NnsStakeNeuronModal from "$lib/modals/neurons/NnsStakeNeuronModal.svelte";
+  import SnsStakeNeuronModal from "$lib/modals/sns/neurons/SnsStakeNeuronModal.svelte";
+  import { loadSnsAccounts } from "$lib/services/sns-accounts.services";
   import { i18n } from "$lib/stores/i18n";
   import { neuronsStore } from "$lib/stores/neurons.store";
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
   import type { Universe } from "$lib/types/universe";
+  import { buildNeuronsUrl } from "$lib/utils/navigation.utils";
   import { IconNeuronsPage, PageBanner } from "@dfinity/gix-components";
   import type { NeuronInfo } from "@dfinity/nns";
+  import type { Principal } from "@dfinity/principal";
   import type { SnsNeuron } from "@dfinity/sns";
+  import {
+    TokenAmountV2,
+    isNullish,
+    nonNullish,
+    type Token,
+  } from "@dfinity/utils";
+  import { get } from "svelte/store";
 
   const getShowStakingBanner = ({
     isSignedIn,
@@ -50,22 +65,116 @@
     nnsNeurons: $neuronsStore?.neurons,
     snsNeurons: $snsNeuronsStore,
   });
+
+  let isNnsStakingModalOpen: boolean = false;
+
+  const openNnsStakingModal = () => {
+    isNnsStakingModalOpen = true;
+  };
+
+  let snsStakingModalData:
+    | {
+        rootCanisterId: Principal;
+        governanceCanisterId: Principal;
+        token: Token;
+        transactionFee: TokenAmountV2;
+      }
+    | undefined = undefined;
+
+  const openSnsStakingModal = (rootCanisterIdText: string) => {
+    const summary = get(snsProjectsRecordStore)[rootCanisterIdText].summary;
+
+    // Accounts need to be loaded to display the account and balance used for
+    // staking.
+    loadSnsAccounts({
+      rootCanisterId: summary.rootCanisterId,
+    });
+
+    snsStakingModalData = {
+      rootCanisterId: summary.rootCanisterId,
+      governanceCanisterId: summary.governanceCanisterId,
+      token: summary.token,
+      transactionFee: TokenAmountV2.fromUlps({
+        amount: summary.token.fee,
+        token: summary.token,
+      }),
+    };
+  };
+
+  const openStakingModal = ({
+    detail: { universeId },
+  }: {
+    detail: { universeId: string };
+  }) => {
+    if (universeId === OWN_CANISTER_ID_TEXT) {
+      openNnsStakingModal();
+    } else {
+      openSnsStakingModal(universeId);
+    }
+  };
+
+  const closeNnsStakingModal = () => {
+    const neurons = get(neuronsStore).neurons;
+
+    // If a neuron was created, navigate to the neurons table.
+    if (nonNullish(neurons) && neurons?.length > 0) {
+      goto(buildNeuronsUrl({ universe: OWN_CANISTER_ID_TEXT }));
+    }
+    isNnsStakingModalOpen = false;
+  };
+
+  const closeSnsStakingModal = () => {
+    if (isNullish(snsStakingModalData)) {
+      // The modal can only be open if snsStakingModalData is not nullish.
+      return;
+    }
+    const snsNeurons = get(snsNeuronsStore);
+    const neuronCount =
+      snsNeurons[snsStakingModalData.rootCanisterId.toText()]?.neurons
+        ?.length ?? 0;
+
+    // If a neuron was created, navigate to the neurons table.
+    if (neuronCount > 0) {
+      goto(
+        buildNeuronsUrl({
+          universe: snsStakingModalData.rootCanisterId.toText(),
+        })
+      );
+    }
+    snsStakingModalData = undefined;
+  };
 </script>
 
-<IslandWidthMain testId="staking-component">
-  <div class="content">
-    {#if showStakingBanner}
-      <PageBanner testId="staking-page-banner">
-        <IconNeuronsPage slot="image" />
-        <svelte:fragment slot="title">{$i18n.staking.title}</svelte:fragment>
-        <p class="description" slot="description">{$i18n.staking.text}</p>
-        <SignInGuard slot="actions" />
-      </PageBanner>
-    {/if}
+<TestIdWrapper testId="staking-component">
+  <IslandWidthMain>
+    <div class="content">
+      {#if showStakingBanner}
+        <PageBanner testId="staking-page-banner">
+          <IconNeuronsPage slot="image" />
+          <svelte:fragment slot="title">{$i18n.staking.title}</svelte:fragment>
+          <p class="description" slot="description">{$i18n.staking.text}</p>
+          <SignInGuard slot="actions" />
+        </PageBanner>
+      {/if}
 
-    <ProjectsTable />
-  </div>
-</IslandWidthMain>
+      <ProjectsTable on:nnsStakeTokens={openStakingModal} />
+    </div>
+  </IslandWidthMain>
+
+  {#if isNnsStakingModalOpen}
+    <NnsStakeNeuronModal on:nnsClose={closeNnsStakingModal} />
+  {/if}
+
+  {#if nonNullish(snsStakingModalData)}
+    <SnsStakeNeuronModal
+      token={snsStakingModalData.token}
+      on:nnsClose={closeSnsStakingModal}
+      rootCanisterId={snsStakingModalData.rootCanisterId}
+      transactionFee={snsStakingModalData.transactionFee}
+      governanceCanisterId={snsStakingModalData.governanceCanisterId}
+    />
+  {/if}
+</TestIdWrapper>
 
 <style lang="scss">
   .content {

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -159,7 +159,10 @@ export const getTableProjects = ({
         nnsNeurons,
         snsNeurons,
       });
-    const rowHref = buildNeuronsUrl({ universe: universe.canisterId });
+    const rowHref =
+      isNullish(neuronCount) || neuronCount > 0
+        ? buildNeuronsUrl({ universe: universe.canisterId })
+        : undefined;
     const universeId = universe.canisterId;
     return {
       rowHref,

--- a/frontend/src/tests/e2e/disburse.spec.ts
+++ b/frontend/src/tests/e2e/disburse.spec.ts
@@ -23,15 +23,14 @@ test("Test disburse neuron", async ({ page, context }) => {
   step("Get some ICP");
   await appPo.getIcpTokens(10);
 
-  step("Go to the neurons tab");
-  await appPo.goToNnsNeurons();
+  step("Go to the staking tab");
+  await appPo.goToStaking();
 
   step("Stake a neuron");
   const stake = 3;
   await appPo
-    .getNeuronsPo()
-    .getNnsNeuronsFooterPo()
-    .stakeNeuron({ amount: stake, dissolveDelayDays: 0 });
+    .getStakingPo()
+    .stakeFirstNnsNeuron({ amount: stake, dissolveDelayDays: 0 });
 
   step("Check account balance before disburse");
   await appPo.goToAccounts();

--- a/frontend/src/tests/e2e/following.spec.ts
+++ b/frontend/src/tests/e2e/following.spec.ts
@@ -24,12 +24,13 @@ test("Test neuron following", async ({ page, context }) => {
   await appPo.getIcpTokens(20);
 
   step("Stake neuron");
-  await appPo.goToNnsNeurons();
-  await appPo.getNeuronsPo().getNnsNeuronsFooterPo().clickStakeNeuronsButton();
-  const stakeModal = appPo
-    .getNeuronsPo()
-    .getNnsNeuronsFooterPo()
-    .getNnsStakeNeuronModalPo();
+  await appPo.goToStaking();
+  const nnsRow = await appPo
+    .getStakingPo()
+    .getProjectsTablePo()
+    .getRowByTitle("Internet Computer");
+  await nnsRow.getStakeButtonPo().click();
+  const stakeModal = appPo.getStakingPo().getNnsStakeNeuronModalPo();
   await stakeModal.getNnsStakeNeuronPo().stake(10);
   await stakeModal.getSetDissolveDelayPo().setDissolveDelayDays("max");
   await stakeModal.getConfirmDissolveDelayPo().clickConfirm();

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -23,19 +23,21 @@ test("Test merge neurons", async ({ page, context }) => {
   step("Get some ICP");
   await appPo.getIcpTokens(20);
 
-  step("Go to the neurons tab");
-  await appPo.goToNnsNeurons();
+  step("Go to the staking tab");
+  await appPo.goToStaking();
 
   step("Stake a neuron");
-  const footerPo = appPo.getNeuronsPo().getNnsNeuronsFooterPo();
-  const neuronsPo = appPo.getNeuronsPo().getNnsNeuronsPo();
-
   const initialStake1 = 1;
   const dissolveDelayDays1 = 3 * 365;
-  await footerPo.stakeNeuron({
+  await appPo.getStakingPo().stakeFirstNnsNeuron({
     amount: initialStake1,
     dissolveDelayDays: dissolveDelayDays1,
   });
+
+  const neuronsPo = appPo.getNeuronsPo().getNnsNeuronsPo();
+  const footerPo = appPo.getNeuronsPo().getNnsNeuronsFooterPo();
+  await neuronsPo.waitFor();
+
   const neuronId1 = (await neuronsPo.getNeuronIds())[0];
 
   step("Stake a second neuron");

--- a/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
+++ b/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
@@ -25,12 +25,12 @@ test("Test neuron increase stake", async ({ page, context }) => {
   await appPo.getIcpTokens(20);
 
   step("Stake neuron");
-  await appPo.goToNnsNeurons();
+  await appPo.goToStaking();
   const initialStake = 10;
   await appPo
-    .getNeuronsPo()
-    .getNnsNeuronsFooterPo()
-    .stakeNeuron({ amount: initialStake, dissolveDelayDays: "max" });
+    .getStakingPo()
+    .stakeFirstNnsNeuron({ amount: initialStake, dissolveDelayDays: "max" });
+  await appPo.getNeuronsPo().waitFor();
 
   const neuronIds = await getNnsNeuronCardsIds(appPo);
   expect(neuronIds).toHaveLength(1);

--- a/frontend/src/tests/e2e/neurons-table.spec.ts
+++ b/frontend/src/tests/e2e/neurons-table.spec.ts
@@ -36,11 +36,10 @@ const createHotkeyNeuronsInOtherAccount = async ({
   const appPo = new AppPo(PlaywrightPageObjectElement.fromPage(page));
   await appPo.getIcpTokens(21);
 
-  await appPo.goToNnsNeurons();
+  await appPo.goToStaking();
   await appPo
-    .getNeuronsPo()
-    .getNnsNeuronsFooterPo()
-    .stakeNeuron({ amount: 10, dissolveDelayDays: "max" });
+    .getStakingPo()
+    .stakeFirstNnsNeuron({ amount: 10, dissolveDelayDays: "max" });
   await appPo
     .getNeuronsPo()
     .getNnsNeuronsFooterPo()
@@ -89,11 +88,11 @@ test("Test neurons table", async ({ page, context, browser }) => {
   await appPo.getIcpTokens(41);
 
   step("Stake a neuron");
-  await appPo.goToNnsNeurons();
+  await appPo.goToStaking();
   await appPo
-    .getNeuronsPo()
-    .getNnsNeuronsFooterPo()
-    .stakeNeuron({ amount: 20, dissolveDelayDays: 365 });
+    .getStakingPo()
+    .stakeFirstNnsNeuron({ amount: 20, dissolveDelayDays: 365 });
+  await appPo.getNeuronsPo().waitFor();
 
   const neuronIds = await appPo.getNeuronsPo().getNnsNeuronsPo().getNeuronIds();
   expect(neuronIds).toHaveLength(1);

--- a/frontend/src/tests/e2e/neurons.spec.ts
+++ b/frontend/src/tests/e2e/neurons.spec.ts
@@ -27,12 +27,12 @@ test("Test neuron voting", async ({ page, context }) => {
 
   // should be created before dummy proposals
   step("Stake neuron (for voting)");
-  await appPo.goToNnsNeurons();
+  await appPo.goToStaking();
   const stake = 15;
   await appPo
-    .getNeuronsPo()
-    .getNnsNeuronsFooterPo()
-    .stakeNeuron({ amount: stake, dissolveDelayDays: "max" });
+    .getStakingPo()
+    .stakeFirstNnsNeuron({ amount: stake, dissolveDelayDays: "max" });
+  await appPo.getNeuronsPo().waitFor();
 
   const neuronIds = await getNnsNeuronCardsIds(appPo);
   expect(neuronIds).toHaveLength(1);

--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -28,11 +28,10 @@ test("Test proposals", async ({ page, context }) => {
 
   // should be created before dummy proposals
   step("Stake a neuron for voting");
-  await appPo.goToNnsNeurons();
+  await appPo.goToStaking();
   await appPo
-    .getNeuronsPo()
-    .getNnsNeuronsFooterPo()
-    .stakeNeuron({ amount: 10, dissolveDelayDays: "max" });
+    .getStakingPo()
+    .stakeFirstNnsNeuron({ amount: 10, dissolveDelayDays: "max" });
 
   step("Create dummy proposals");
   const proposerNeuronId = await createDummyProposal(appPo);

--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -44,24 +44,13 @@ test("Test SNS governance", async ({ page, context }) => {
   expect(await snsUniverseRow.getBalanceNumber()).toEqual(askedAmount);
 
   step("Stake a neuron");
-  await appPo.goToStaking();
-
-  const snsRow = await appPo
-    .getStakingPo()
-    .getProjectsTablePo()
-    .getRowByTitle(snsProjectName);
-  await snsRow.click();
-
-  await appPo.getNeuronsPo().getSnsNeuronsPo().waitForContentLoaded();
-  expect(
-    await appPo.getNeuronsPo().getSnsNeuronsPo().getEmptyMessage()
-  ).toEqual(
-    "You have no Alfa Centauri neurons. Create a neuron by staking ALF to vote on Alfa Centauri proposals."
-  );
-
   const stake = 5;
   const formattedStake = "5.00";
-  await appPo.getNeuronsPo().getSnsNeuronsFooterPo().stakeNeuron(stake);
+  await appPo.goToStaking();
+  await appPo.getStakingPo().stakeFirstSnsNeuron({
+    projectName: snsProjectName,
+    amount: stake,
+  });
 
   step("SN001: User can see the list of neurons");
   await appPo.getNeuronsPo().getSnsNeuronsPo().waitForContentLoaded();

--- a/frontend/src/tests/lib/utils/staking.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking.utils.spec.ts
@@ -42,7 +42,7 @@ describe("staking.utils", () => {
     const snsHref = `/neurons/?u=${universeId2}`;
 
     const defaultExpectedNnsTableProject = {
-      rowHref: nnsHref,
+      rowHref: undefined,
       domKey: OWN_CANISTER_ID_TEXT,
       universeId: OWN_CANISTER_ID_TEXT,
       title: "Internet Computer",
@@ -58,7 +58,7 @@ describe("staking.utils", () => {
     };
 
     const defaultExpectedSnsTableProject = {
-      rowHref: snsHref,
+      rowHref: undefined,
       domKey: universeId2,
       universeId: universeId2,
       title: "title2",
@@ -146,7 +146,6 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedSnsTableProject,
-          rowHref: `/neurons/?u=${snsUniverseId}`,
           domKey: snsUniverseId,
           universeId: snsUniverseId,
         },
@@ -243,6 +242,7 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedNnsTableProject,
+          rowHref: nnsHref,
           neuronCount: 2,
           availableMaturity: maturity1 + maturity2,
         },
@@ -281,6 +281,7 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedNnsTableProject,
+          rowHref: nnsHref,
           neuronCount: 2,
           stake: TokenAmountV2.fromUlps({
             amount: 2n * stake,
@@ -345,6 +346,7 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedSnsTableProject,
+          rowHref: snsHref,
           neuronCount: 2,
           availableMaturity: maturity1 + maturity2,
         },
@@ -381,6 +383,7 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedSnsTableProject,
+          rowHref: snsHref,
           neuronCount: 2,
           stake: TokenAmountV2.fromUlps({
             amount: 2n * stake,
@@ -461,6 +464,7 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedNnsTableProject,
+          rowHref: nnsHref,
           neuronCount: undefined,
           stake: new UnavailableTokenAmount(ICPToken),
           availableMaturity: undefined,
@@ -468,6 +472,7 @@ describe("staking.utils", () => {
         },
         {
           ...defaultExpectedSnsTableProject,
+          rowHref: snsHref,
           neuronCount: undefined,
           stake: new UnavailableTokenAmount(snsToken),
           availableMaturity: undefined,
@@ -489,6 +494,7 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedNnsTableProject,
+          rowHref: nnsHref,
           neuronCount: undefined,
           stake: new UnavailableTokenAmount(ICPToken),
           availableMaturity: undefined,
@@ -496,6 +502,7 @@ describe("staking.utils", () => {
         },
         {
           ...defaultExpectedSnsTableProject,
+          rowHref: snsHref,
           neuronCount: undefined,
           stake: new UnavailableTokenAmount(snsToken),
           availableMaturity: undefined,

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -65,6 +65,7 @@ const createQueryMetadataResponse = ({
 
 export const aggregatorSnsMockWith = ({
   rootCanisterId = "4nwps-saaaa-aaaaa-aabjq-cai",
+  governanceCanisterId = "5grkr-3aaaa-aaaaq-aaa5a-cai",
   ledgerCanisterId = "5bqmf-wyaaa-aaaaq-aaa5q-cai",
   swapCanisterId = "5ux5i-xqaaa-aaaaq-aaa6a-cai",
   lifecycle = SnsSwapLifecycle.Committed,
@@ -78,6 +79,7 @@ export const aggregatorSnsMockWith = ({
   nnsProposalId,
 }: {
   rootCanisterId?: string;
+  governanceCanisterId?: string;
   ledgerCanisterId?: string;
   swapCanisterId?: string;
   lifecycle?: SnsSwapLifecycle;
@@ -96,6 +98,7 @@ export const aggregatorSnsMockWith = ({
   canister_ids: {
     ...aggregatorSnsMockDto.canister_ids,
     root_canister_id: rootCanisterId,
+    governance_canister_id: governanceCanisterId,
     ledger_canister_id: ledgerCanisterId,
     swap_canister_id: swapCanisterId,
   },

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -160,6 +160,11 @@ export class AppPo extends BasePageObject {
       .getProjectsTablePo()
       .getRowByTitle("Internet Computer");
     await nnsRow.click();
+    if (await nnsRow.getStakeButtonPo().isPresent()) {
+      throw new Error(
+        "Cannot navigate to NNS neurons because a neuron first needs to be staked."
+      );
+    }
     await this.getNeuronsPo().waitForContentLoaded();
   }
 

--- a/frontend/src/tests/page-objects/ProjectNeuronsCell.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectNeuronsCell.page-object.ts
@@ -1,3 +1,4 @@
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -6,6 +7,10 @@ export class ProjectNeuronsCellPo extends BasePageObject {
 
   static under(element: PageObjectElement): ProjectNeuronsCellPo {
     return new ProjectNeuronsCellPo(element.byTestId(ProjectNeuronsCellPo.TID));
+  }
+
+  getStakeButtonPo(): ButtonPo {
+    return this.getButton("stake-button");
   }
 
   async getNeuronCount(): Promise<string> {

--- a/frontend/src/tests/page-objects/ProjectsTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/ProjectsTableRow.page-object.ts
@@ -1,3 +1,4 @@
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { ProjectMaturityCellPo } from "$tests/page-objects/ProjectMaturityCell.page-object";
 import { ProjectNeuronsCellPo } from "$tests/page-objects/ProjectNeuronsCell.page-object";
 import { ProjectStakeCellPo } from "$tests/page-objects/ProjectStakeCell.page-object";
@@ -32,6 +33,10 @@ export class ProjectsTableRowPo extends ResponsiveTableRowPo {
 
   getProjectNeuronsCellPo(): ProjectNeuronsCellPo {
     return ProjectNeuronsCellPo.under(this.root);
+  }
+
+  getStakeButtonPo(): ButtonPo {
+    return this.getProjectNeuronsCellPo().getStakeButtonPo();
   }
 
   getProjectTitle(): Promise<string> {

--- a/frontend/src/tests/page-objects/Staking.page-object.ts
+++ b/frontend/src/tests/page-objects/Staking.page-object.ts
@@ -35,4 +35,31 @@ export class StakingPo extends BasePageObject {
   getSnsStakeNeuronModalPo(): SnsStakeNeuronModalPo {
     return SnsStakeNeuronModalPo.under(this.root);
   }
+
+  async stakeFirstNnsNeuron({
+    amount,
+    dissolveDelayDays = "max",
+  }: {
+    amount: number;
+    dissolveDelayDays?: "max" | number;
+  }): Promise<void> {
+    const nnsRow =
+      await this.getProjectsTablePo().getRowByTitle("Internet Computer");
+    await nnsRow.getStakeButtonPo().click();
+    const modal = this.getNnsStakeNeuronModalPo();
+    await modal.stake({ amount, dissolveDelayDays });
+  }
+
+  async stakeFirstSnsNeuron({
+    projectName,
+    amount,
+  }: {
+    projectName: string;
+    amount: number;
+  }): Promise<void> {
+    const snsRow = await this.getProjectsTablePo().getRowByTitle(projectName);
+    await snsRow.getStakeButtonPo().click();
+    const modal = this.getSnsStakeNeuronModalPo();
+    await modal.stake(amount);
+  }
 }

--- a/frontend/src/tests/page-objects/Staking.page-object.ts
+++ b/frontend/src/tests/page-objects/Staking.page-object.ts
@@ -1,6 +1,8 @@
+import { NnsStakeNeuronModalPo } from "$tests/page-objects/NnsStakeNeuronModal.page-object";
 import { PageBannerPo } from "$tests/page-objects/PageBanner.page-object";
 import { ProjectsTablePo } from "$tests/page-objects/ProjectsTable.page-object";
 import { SignInPo } from "$tests/page-objects/SignIn.page-object";
+import { SnsStakeNeuronModalPo } from "$tests/page-objects/SnsStakeNeuronModal.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -24,5 +26,13 @@ export class StakingPo extends BasePageObject {
 
   getProjectsTablePo(): ProjectsTablePo {
     return ProjectsTablePo.under(this.root);
+  }
+
+  getNnsStakeNeuronModalPo(): NnsStakeNeuronModalPo {
+    return NnsStakeNeuronModalPo.under(this.root);
+  }
+
+  getSnsStakeNeuronModalPo(): SnsStakeNeuronModalPo {
+    return SnsStakeNeuronModalPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/TransactionForm.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionForm.page-object.ts
@@ -1,8 +1,9 @@
 import { AmountInputPo } from "$tests/page-objects/AmountInput.page-object";
-import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { SelectDestinationAddressPo } from "$tests/page-objects/SelectDestinationAddress.page-object";
+import { TransactionFormFeePo } from "$tests/page-objects/TransactionFormFee.page-object";
 import { TransactionFromAccountPo } from "$tests/page-objects/TransactionFromAccount.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class TransactionFormPo extends BasePageObject {
@@ -14,6 +15,10 @@ export class TransactionFormPo extends BasePageObject {
 
   getTransactionFromAccountPo(): TransactionFromAccountPo {
     return TransactionFromAccountPo.under(this.root);
+  }
+
+  getTransactionFormFeePo(): TransactionFormFeePo {
+    return TransactionFormFeePo.under(this.root);
   }
 
   getSourceAccounts(): Promise<string[]> {

--- a/frontend/src/tests/page-objects/TransactionFormFee.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionFormFee.page-object.ts
@@ -1,0 +1,15 @@
+import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class TransactionFormFeePo extends BasePageObject {
+  private static readonly TID = "transaction-form-fee";
+
+  static under(element: PageObjectElement): TransactionFormFeePo {
+    return new TransactionFormFeePo(element.byTestId(TransactionFormFeePo.TID));
+  }
+
+  getAmountDisplayPo(): AmountDisplayPo {
+    return AmountDisplayPo.under(this.root);
+  }
+}

--- a/frontend/src/tests/page-objects/TransactionFromAccount.page-object.ts
+++ b/frontend/src/tests/page-objects/TransactionFromAccount.page-object.ts
@@ -1,6 +1,7 @@
+import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
+import { SelectAccountDropdownPo } from "$tests/page-objects/SelectAccountDropdown.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { SelectAccountDropdownPo } from "./SelectAccountDropdown.page-object";
 
 export class TransactionFromAccountPo extends BasePageObject {
   private static readonly TID = "transaction-from-account";
@@ -9,6 +10,10 @@ export class TransactionFromAccountPo extends BasePageObject {
     return new TransactionFromAccountPo(
       element.byTestId(TransactionFromAccountPo.TID)
     );
+  }
+
+  getAmountDisplayPo(): AmountDisplayPo {
+    return AmountDisplayPo.under(this.root);
   }
 
   getSelectAccountDropdownPo(): SelectAccountDropdownPo {

--- a/frontend/src/tests/utils/sns.test-utils.ts
+++ b/frontend/src/tests/utils/sns.test-utils.ts
@@ -10,6 +10,7 @@ import { SnsSwapLifecycle, type SnsNervousSystemFunction } from "@dfinity/sns";
 export const setSnsProjects = (
   params: {
     rootCanisterId?: Principal;
+    governanceCanisterId?: Principal;
     ledgerCanisterId?: Principal;
     swapCanisterId?: Principal;
     lifecycle?: SnsSwapLifecycle;
@@ -27,6 +28,7 @@ export const setSnsProjects = (
     return aggregatorSnsMockWith({
       rootCanisterId:
         params.rootCanisterId?.toText() ?? principal(index).toText(),
+      governanceCanisterId: params.governanceCanisterId?.toText(),
       ledgerCanisterId: params.ledgerCanisterId?.toText(),
       swapCanisterId: params.swapCanisterId?.toText(),
       lifecycle: params.lifecycle ?? SnsSwapLifecycle.Committed,


### PR DESCRIPTION
# Motivation

When a user has 0 neurons for a project, instead of showing "0" in the table, we want to show a button to stake tokens for that project.
Clicking the button (or anywhere else on the row) will open the staking modal, and if the user does stake a neuron they will navigate to the neurons table afterwards.

# Changes

1. Show a "Stake XYZ" button in the neurons cell in the projects table, if the user has zero neuron.
2. When the user clicks on a non-link row in the projects table, dispatch a `nnsStakeTokens` event.
3. In the `Staking` component, when an `nnsStakeTokens` event is received, open the corresponding staking modal.
4. When the staking modal closes, check if there are now a positive number of neurons and if so, navigate to the neurons table.
5. Don't provide a `rowHref` for projects without neurons, to prevent navigating to the neurons table.

# Tests

1. Unit test for dispatching the `nnsStakeTokens` event.
2. Unit test for project rows without neurons not being a link.
3. Unit tests for staking modals.
4. Support setting a custom governance canister ID on mock SNSes.
5. Page object support.
6. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/staking/

# Todos

- [x] Add entry to changelog (if necessary).
