### PR TITLE
NNS1-3250: Make project rows not clickable when neuron count not available

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -21,6 +21,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Bump ic-js so that NNS Dapp can parse `InstallCode` proposal correctly.
 * Display of the new/renamed topics and proposals.
+* Staking project rows are not clickable when not signed in.
 
 #### Deprecated
 

--- a/frontend/src/lib/components/staking/ProjectActionsCell.svelte
+++ b/frontend/src/lib/components/staking/ProjectActionsCell.svelte
@@ -1,18 +1,26 @@
 <script lang="ts">
   import type { TableProject } from "$lib/types/staking";
   import { IconRight } from "@dfinity/gix-components";
+  import { nonNullish } from "@dfinity/utils";
 
   export let rowData: TableProject;
+
+  // The row is clickable if either:
+  // * it has a rowHref to navigate to the neurons table, or
+  // * it has 0 neurons because then you can click to stake a neuron.
+  //
+  // This means the row is not clickable if
+  // * the user is not signed in, or
+  // * neurons are still being loaded.
+  //
+  // The presence of the IconRight icon indicates that the row is clickable.
 </script>
 
-{#if false}
-  <!-- Satisfy the linter as it doesn't like unused props. -->
-  {rowData.title}
+{#if nonNullish(rowData.rowHref) || rowData.neuronCount === 0}
+  <div data-tid="go-to-neurons-table-action" class="container">
+    <IconRight />
+  </div>
 {/if}
-
-<div data-tid="go-to-neurons-table-action" class="container">
-  <IconRight />
-</div>
 
 <style lang="scss">
   .container {

--- a/frontend/src/lib/components/staking/ProjectsTable.svelte
+++ b/frontend/src/lib/components/staking/ProjectsTable.svelte
@@ -83,7 +83,9 @@
   }: {
     detail: { rowData: TableProject };
   }) => {
-    dispatcher("nnsStakeTokens", { universeId: rowData.universeId });
+    if (rowData.neuronCount === 0) {
+      dispatcher("nnsStakeTokens", { universeId: rowData.universeId });
+    }
   };
 </script>
 

--- a/frontend/src/lib/utils/staking.utils.ts
+++ b/frontend/src/lib/utils/staking.utils.ts
@@ -27,6 +27,7 @@ import {
   TokenAmountV2,
   asNonNullish,
   isNullish,
+  nonNullish,
   type Token,
 } from "@dfinity/utils";
 
@@ -160,7 +161,7 @@ export const getTableProjects = ({
         snsNeurons,
       });
     const rowHref =
-      isNullish(neuronCount) || neuronCount > 0
+      nonNullish(neuronCount) && neuronCount > 0
         ? buildNeuronsUrl({ universe: universe.canisterId })
         : undefined;
     const universeId = universe.canisterId;

--- a/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
+++ b/frontend/src/tests/lib/components/staking/ProjectsTable.spec.ts
@@ -315,13 +315,11 @@ describe("ProjectsTable", () => {
       const rowPos = await po.getProjectsTableRowPos();
       expect(rowPos).toHaveLength(2);
       expect(await rowPos[0].getNeuronCount()).toBe("-/-");
-      expect(await rowPos[0].getHref()).toBe(
-        `/neurons/?u=${OWN_CANISTER_ID_TEXT}`
-      );
-      expect(await rowPos[0].hasGoToNeuronsTableAction()).toBe(true);
+      expect(await rowPos[0].getHref()).toBe(null);
+      expect(await rowPos[0].hasGoToNeuronsTableAction()).toBe(false);
       expect(await rowPos[1].getNeuronCount()).toBe("-/-");
-      expect(await rowPos[1].getHref()).toBe(`/neurons/?u=${snsCanisterId}`);
-      expect(await rowPos[1].hasGoToNeuronsTableAction()).toBe(true);
+      expect(await rowPos[1].getHref()).toBe(null);
+      expect(await rowPos[1].hasGoToNeuronsTableAction()).toBe(false);
     });
 
     it("should not render SNS neurons count when not loaded", async () => {
@@ -329,13 +327,11 @@ describe("ProjectsTable", () => {
       const rowPos = await po.getProjectsTableRowPos();
       expect(rowPos).toHaveLength(2);
       expect(await rowPos[0].getNeuronCount()).toBe("-/-");
-      expect(await rowPos[0].getHref()).toBe(
-        `/neurons/?u=${OWN_CANISTER_ID_TEXT}`
-      );
-      expect(await rowPos[0].hasGoToNeuronsTableAction()).toBe(true);
+      expect(await rowPos[0].getHref()).toBe(null);
+      expect(await rowPos[0].hasGoToNeuronsTableAction()).toBe(false);
       expect(await rowPos[1].getNeuronCount()).toBe("-/-");
-      expect(await rowPos[1].getHref()).toBe(`/neurons/?u=${snsCanisterId}`);
-      expect(await rowPos[1].hasGoToNeuronsTableAction()).toBe(true);
+      expect(await rowPos[1].getHref()).toBe(null);
+      expect(await rowPos[1].hasGoToNeuronsTableAction()).toBe(false);
     });
 
     it("should render stake button with zero neurons", async () => {
@@ -378,6 +374,77 @@ describe("ProjectsTable", () => {
           universeId: snsCanisterId.toText(),
         },
       });
+    });
+
+    it("should dispatch nnsStakeTokens on row click with zero neurons", async () => {
+      neuronsStore.setNeurons({
+        neurons: [],
+        certified: true,
+      });
+      snsNeuronsStore.setNeurons({
+        rootCanisterId: snsCanisterId,
+        neurons: [],
+        certified: true,
+      });
+      const onNnsStakeTokens = vi.fn();
+      const po = renderComponent({ onNnsStakeTokens });
+      const rowPos = await po.getProjectsTableRowPos();
+      expect(rowPos).toHaveLength(2);
+
+      expect(onNnsStakeTokens).not.toBeCalled();
+      await rowPos[0].click();
+      expect(onNnsStakeTokens).toBeCalledTimes(1);
+      expect(onNnsStakeTokens).toBeCalledWith({
+        detail: {
+          universeId: OWN_CANISTER_ID_TEXT,
+        },
+      });
+
+      await rowPos[1].click();
+      expect(onNnsStakeTokens).toBeCalledTimes(2);
+      expect(onNnsStakeTokens).toBeCalledWith({
+        detail: {
+          universeId: snsCanisterId.toText(),
+        },
+      });
+    });
+
+    it("should not dispatch nnsStakeTokens on row click when not signed in", async () => {
+      setNoIdentity();
+      neuronsStore.setNeurons({
+        neurons: [],
+        certified: true,
+      });
+      snsNeuronsStore.setNeurons({
+        rootCanisterId: snsCanisterId,
+        neurons: [],
+        certified: true,
+      });
+      const onNnsStakeTokens = vi.fn();
+      const po = renderComponent({ onNnsStakeTokens });
+      const rowPos = await po.getProjectsTableRowPos();
+      expect(rowPos).toHaveLength(2);
+
+      expect(onNnsStakeTokens).not.toBeCalled();
+      await rowPos[0].click();
+      expect(onNnsStakeTokens).not.toBeCalled();
+
+      await rowPos[1].click();
+      expect(onNnsStakeTokens).not.toBeCalled();
+    });
+
+    it("should not dispatch nnsStakeTokens on row click when neurons not loaded", async () => {
+      const onNnsStakeTokens = vi.fn();
+      const po = renderComponent({ onNnsStakeTokens });
+      const rowPos = await po.getProjectsTableRowPos();
+      expect(rowPos).toHaveLength(2);
+
+      expect(onNnsStakeTokens).not.toBeCalled();
+      await rowPos[0].click();
+      expect(onNnsStakeTokens).not.toBeCalled();
+
+      await rowPos[1].click();
+      expect(onNnsStakeTokens).not.toBeCalled();
     });
   });
 

--- a/frontend/src/tests/lib/utils/staking.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/staking.utils.spec.ts
@@ -464,7 +464,6 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedNnsTableProject,
-          rowHref: nnsHref,
           neuronCount: undefined,
           stake: new UnavailableTokenAmount(ICPToken),
           availableMaturity: undefined,
@@ -472,7 +471,6 @@ describe("staking.utils", () => {
         },
         {
           ...defaultExpectedSnsTableProject,
-          rowHref: snsHref,
           neuronCount: undefined,
           stake: new UnavailableTokenAmount(snsToken),
           availableMaturity: undefined,
@@ -494,7 +492,6 @@ describe("staking.utils", () => {
       expect(tableProjects).toEqual([
         {
           ...defaultExpectedNnsTableProject,
-          rowHref: nnsHref,
           neuronCount: undefined,
           stake: new UnavailableTokenAmount(ICPToken),
           availableMaturity: undefined,
@@ -502,7 +499,6 @@ describe("staking.utils", () => {
         },
         {
           ...defaultExpectedSnsTableProject,
-          rowHref: snsHref,
           neuronCount: undefined,
           stake: new UnavailableTokenAmount(snsToken),
           availableMaturity: undefined,


### PR DESCRIPTION
# Motivation

We don't want users to navigate to the neurons table if they have no neurons.
For this reason, we added the "Stake XYZ" button when the user has 0 neurons for a project.

But we also don't want to navigate if the user is not signed in or neurons aren't loaded yet.

# Changes

1. When the number of neurons is not known, don't make the project row a link.
2. When a non-link project row is clicked, only dispatch `nnsStakeTokens` if the number of neurons is known to be 0.
3. Don't show the `>` icon when the row is neither a link nor clickable to stake a neuron.

# Tests

1. Unit test updated and added.
2. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/staking/

# Todos

- [x] Add entry to changelog (if necessary).
