### PR TITLE
getLedgerId api

### DIFF
--- a/frontend/src/lib/api/icrc-index.api.ts
+++ b/frontend/src/lib/api/icrc-index.api.ts
@@ -45,6 +45,22 @@ export const getTransactions = async ({
   };
 };
 
+export const getLedgerId = async ({
+  identity,
+  indexCanisterId,
+  certified,
+}: {
+  identity: Identity;
+  indexCanisterId: Principal;
+  certified?: boolean;
+}): Promise<Principal> => {
+  const {
+    canister: { ledgerId },
+  } = await indexCanister({ identity, canisterId: indexCanisterId });
+
+  return ledgerId({ certified });
+};
+
 const indexCanister = async ({
   identity,
   canisterId,

--- a/frontend/src/lib/components/accounts/WalletPageHeader.svelte
+++ b/frontend/src/lib/components/accounts/WalletPageHeader.svelte
@@ -10,7 +10,9 @@
 </script>
 
 <PageHeader testId="wallet-page-header-component">
-  <UniversePageSummary slot="start" {universe} />
+  <UniversePageSummary slot="start" {universe}>
+    <slot name="actions" slot="actions" />
+  </UniversePageSummary>
   <span
     slot="end"
     class="description header-end"

--- a/frontend/src/lib/components/tokens/LinkToDashboardCanister.svelte
+++ b/frontend/src/lib/components/tokens/LinkToDashboardCanister.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { IconOpenInNew } from "@dfinity/gix-components";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { i18n } from "$lib/stores/i18n";
+  import type { Principal } from "@dfinity/principal";
+
+  export let canisterId: Principal;
+  export let noLabel: boolean = false;
+
+  let href: string;
+  $: href = replacePlaceholders($i18n.import_token.link_to_dashboard, {
+    $canisterId: canisterId.toText(),
+  });
+</script>
+
+<a
+  class="button ghost with-icon"
+  class:noLabel
+  data-tid="link-to-dashboard-canister-component"
+  {href}
+  target="_blank"
+  rel="noopener noreferrer"
+>
+  <IconOpenInNew />
+  {#if !noLabel}
+    {$i18n.import_token.view_in_dashboard}
+  {/if}
+</a>
+
+<style lang="scss">
+  a.noLabel {
+    // Increase click area
+    padding: var(--padding-0_5x);
+
+    &:hover {
+      color: inherit;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/tokens/LinkToDashboardCanister.svelte
+++ b/frontend/src/lib/components/tokens/LinkToDashboardCanister.svelte
@@ -6,7 +6,6 @@
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let canisterId: Principal;
-  export let noLabel: boolean = false;
 
   let href: string;
   $: href = replacePlaceholders($i18n.import_token.link_to_dashboard, {
@@ -16,27 +15,13 @@
 
 <a
   class="button ghost with-icon"
-  class:noLabel
   data-tid="link-to-dashboard-canister-component"
   {href}
   target="_blank"
   rel="noopener noreferrer"
 >
   <IconOpenInNew />
-  {#if !noLabel}
-    <TestIdWrapper testId="label"
-      >{$i18n.import_token.view_in_dashboard}</TestIdWrapper
-    >
-  {/if}
+  <TestIdWrapper testId="label"
+    >{$i18n.import_token.view_in_dashboard}</TestIdWrapper
+  >
 </a>
-
-<style lang="scss">
-  a.noLabel {
-    // Increase click area
-    padding: var(--padding-0_5x);
-
-    &:hover {
-      color: inherit;
-    }
-  }
-</style>

--- a/frontend/src/lib/components/tokens/LinkToDashboardCanister.svelte
+++ b/frontend/src/lib/components/tokens/LinkToDashboardCanister.svelte
@@ -3,6 +3,7 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { i18n } from "$lib/stores/i18n";
   import type { Principal } from "@dfinity/principal";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let canisterId: Principal;
   export let noLabel: boolean = false;
@@ -23,7 +24,9 @@
 >
   <IconOpenInNew />
   {#if !noLabel}
-    {$i18n.import_token.view_in_dashboard}
+    <TestIdWrapper testId="label"
+      >{$i18n.import_token.view_in_dashboard}</TestIdWrapper
+    >
   {/if}
 </a>
 

--- a/frontend/src/lib/components/universe/UniversePageSummary.svelte
+++ b/frontend/src/lib/components/universe/UniversePageSummary.svelte
@@ -8,6 +8,7 @@
 <span class="summary" data-tid="universe-page-summary-component">
   <UniverseLogo {universe} framed horizontalPadding={false} />
   <span class="summary-title">{universe.title}</span>
+  <slot name="actions" />
 </span>
 
 <style lang="scss">

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1041,6 +1041,8 @@
     "placeholder": "00000-00000-00000-00000-000",
     "index_canister_description": "Index Canister allows to display a token balance and transaction history. <strong>Note:</strong> not all tokens have index canisters.",
     "review_token_info": "Review token info",
-    "warning": "<strong>Warning:</strong> Be careful what token you import! Anyone can create a token including one with the same name as existing tokens, such as ckBTC."
+    "warning": "<strong>Warning:</strong> Be careful what token you import! Anyone can create a token including one with the same name as existing tokens, such as ckBTC.",
+    "view_in_dashboard": "View in Dashboard",
+    "link_to_dashboard": "https://dashboard.internetcomputer.org/canister/$canisterId"
   }
 }

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -59,7 +59,7 @@
     mapToSelfTransactions,
     sortTransactionsByIdDescendingOrder,
   } from "$lib/utils/icp-transactions.utils";
-  import { Island, Spinner } from "@dfinity/gix-components";
+  import { IconDots, Island, Popover, Spinner } from "@dfinity/gix-components";
   import {
     ICPToken,
     TokenAmountV2,
@@ -68,6 +68,8 @@
   } from "@dfinity/utils";
   import { onMount, onDestroy, setContext } from "svelte";
   import { writable, type Readable } from "svelte/store";
+  import LinkToDashboardCanister from "$lib/components/tokens/LinkToDashboardCanister.svelte";
+  import { Principal } from "@dfinity/principal";
 
   $: if ($authSignedInStore) {
     pollAccounts();
@@ -293,6 +295,9 @@
 
   let isSubaccount: boolean;
   $: isSubaccount = $selectedAccountStore.account?.type === "subAccount";
+
+  let moreButton: HTMLButtonElement | undefined;
+  let morePopupVisible = false;
 </script>
 
 <TestIdWrapper testId="nns-wallet-component">
@@ -303,7 +308,18 @@
           <WalletPageHeader
             universe={$nnsUniverseStore}
             walletAddress={$selectedAccountStore.account?.identifier}
-          />
+          >
+            <svelte:fragment slot="actions">
+              <button
+                bind:this={moreButton}
+                class="icon-only"
+                data-tid="more-button"
+                on:click={() => (morePopupVisible = true)}
+              >
+                <IconDots />
+              </button>
+            </svelte:fragment>
+          </WalletPageHeader>
           <WalletPageHeading
             balance={nonNullish($selectedAccountStore.account)
               ? TokenAmountV2.fromUlps({
@@ -369,6 +385,17 @@
       selectedAccount={$selectedAccountStore.account}
     />
   {/if}
+
+  <Popover
+    bind:visible={morePopupVisible}
+    anchor={moreButton}
+    direction="rtl"
+    invisibleBackdrop
+  >
+    <LinkToDashboardCanister
+      canisterId={Principal.fromText($nnsUniverseStore.canisterId)}
+    />
+  </Popover>
 </TestIdWrapper>
 
 <style lang="scss">

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -70,6 +70,7 @@
   import { writable, type Readable } from "svelte/store";
   import LinkToDashboardCanister from "$lib/components/tokens/LinkToDashboardCanister.svelte";
   import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
+  import { ENABLE_IMPORT_TOKEN } from "$lib/stores/feature-flags.store";
 
   $: if ($authSignedInStore) {
     pollAccounts();
@@ -310,14 +311,16 @@
             walletAddress={$selectedAccountStore.account?.identifier}
           >
             <svelte:fragment slot="actions">
-              <button
-                bind:this={moreButton}
-                class="icon-only"
-                data-tid="more-button"
-                on:click={() => (morePopupVisible = true)}
-              >
-                <IconDots />
-              </button>
+              {#if $ENABLE_IMPORT_TOKEN}
+                <button
+                  bind:this={moreButton}
+                  class="icon-only"
+                  data-tid="more-button"
+                  on:click={() => (morePopupVisible = true)}
+                >
+                  <IconDots />
+                </button>
+              {/if}
             </svelte:fragment>
           </WalletPageHeader>
           <WalletPageHeading

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -69,7 +69,7 @@
   import { onMount, onDestroy, setContext } from "svelte";
   import { writable, type Readable } from "svelte/store";
   import LinkToDashboardCanister from "$lib/components/tokens/LinkToDashboardCanister.svelte";
-  import { Principal } from "@dfinity/principal";
+  import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 
   $: if ($authSignedInStore) {
     pollAccounts();
@@ -392,11 +392,7 @@
     direction="rtl"
     invisibleBackdrop
   >
-    <TestIdWrapper testId="more-popup-content">
-      <LinkToDashboardCanister
-        canisterId={Principal.fromText($nnsUniverseStore.canisterId)}
-      />
-    </TestIdWrapper>
+    <LinkToDashboardCanister canisterId={LEDGER_CANISTER_ID} />
   </Popover>
 </TestIdWrapper>
 

--- a/frontend/src/lib/pages/NnsWallet.svelte
+++ b/frontend/src/lib/pages/NnsWallet.svelte
@@ -392,9 +392,11 @@
     direction="rtl"
     invisibleBackdrop
   >
-    <LinkToDashboardCanister
-      canisterId={Principal.fromText($nnsUniverseStore.canisterId)}
-    />
+    <TestIdWrapper testId="more-popup-content">
+      <LinkToDashboardCanister
+        canisterId={Principal.fromText($nnsUniverseStore.canisterId)}
+      />
+    </TestIdWrapper>
   </Popover>
 </TestIdWrapper>
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1101,6 +1101,8 @@ interface I18nImport_token {
   index_canister_description: string;
   review_token_info: string;
   warning: string;
+  view_in_dashboard: string;
+  link_to_dashboard: string;
 }
 
 interface I18nNeuron_state {

--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -1,5 +1,6 @@
 import * as agent from "$lib/api/agent.api";
 import {
+  getLedgerId,
   getTransactions,
   type GetTransactionsParams,
 } from "$lib/api/icrc-index.api";
@@ -82,6 +83,43 @@ describe("icrc-index api", () => {
       indexCanisterMock.getTransactions.mockRejectedValue(err);
 
       const call = () => getTransactions(params);
+
+      expect(call).rejects.toThrowError(err);
+    });
+  });
+
+  describe("getLedgerId", () => {
+    const indexCanisterId = principal(0);
+    const ledgerCanisterId = principal(1);
+
+    it("returns list of transaction", async () => {
+      indexCanisterMock.ledgerId.mockResolvedValue(ledgerCanisterId);
+      const resultPrincipal = await getLedgerId({
+        identity: mockIdentity,
+        indexCanisterId,
+        certified: true,
+      });
+
+      expect(resultPrincipal).not.toBeUndefined();
+
+      expect(resultPrincipal).toEqual(ledgerCanisterId);
+
+      expect(indexCanisterMock.ledgerId).toBeCalledTimes(1);
+      expect(indexCanisterMock.ledgerId).toBeCalledWith({
+        certified: true,
+      });
+    });
+
+    it("throws an error if canister throws", () => {
+      const err = new Error("test");
+      indexCanisterMock.ledgerId.mockRejectedValue(err);
+
+      const call = () =>
+        getLedgerId({
+          identity: mockIdentity,
+          indexCanisterId,
+          certified: true,
+        });
 
       expect(call).rejects.toThrowError(err);
     });

--- a/frontend/src/tests/lib/components/tokens/LinkToDashboardCanister.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/LinkToDashboardCanister.spec.ts
@@ -1,0 +1,40 @@
+import LinkToDashboardCanister from "$lib/components/tokens/LinkToDashboardCanister.svelte";
+import { LinkToDashboardCanisterPo } from "$tests/page-objects/LinkToDashboardCanister.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { Principal } from "@dfinity/principal";
+import { render } from "@testing-library/svelte";
+
+describe("LinkToDashboardCanister", () => {
+  const canisterIdText = "aaaaa-aa";
+  const canisterId = Principal.fromText(canisterIdText);
+
+  const renderComponent = (props) => {
+    const { container } = render(LinkToDashboardCanister, { props });
+    return LinkToDashboardCanisterPo.under(
+      new JestPageObjectElement(container)
+    );
+  };
+
+  it("should render label", async () => {
+    const po = renderComponent({
+      canisterId,
+    });
+    expect(await po.getLabel().isPresent()).toEqual(true);
+    expect(await po.getLabelText()).toBe("View in Dashboard");
+  });
+
+  it("should render href", async () => {
+    const po = renderComponent({ canisterId });
+    expect(await po.getHref()).toBe(
+      "https://dashboard.internetcomputer.org/canister/aaaaa-aa"
+    );
+  });
+
+  it("should not render label when noLabel set", async () => {
+    const po = renderComponent({ canisterId, noLabel: true });
+    expect(await po.getLabel().isPresent()).toEqual(false);
+    expect(await po.getHref()).toBe(
+      "https://dashboard.internetcomputer.org/canister/aaaaa-aa"
+    );
+  });
+});

--- a/frontend/src/tests/lib/components/tokens/LinkToDashboardCanister.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/LinkToDashboardCanister.spec.ts
@@ -6,6 +6,8 @@ import { render } from "@testing-library/svelte";
 
 describe("LinkToDashboardCanister", () => {
   const canisterIdText = "aaaaa-aa";
+  const urlToDashboard =
+    "https://dashboard.internetcomputer.org/canister/aaaaa-aa";
   const canisterId = Principal.fromText(canisterIdText);
 
   const renderComponent = (props) => {
@@ -25,8 +27,6 @@ describe("LinkToDashboardCanister", () => {
 
   it("should render href", async () => {
     const po = renderComponent({ canisterId });
-    expect(await po.getHref()).toBe(
-      "https://dashboard.internetcomputer.org/canister/aaaaa-aa"
-    );
+    expect(await po.getHref()).toBe(urlToDashboard);
   });
 });

--- a/frontend/src/tests/lib/components/tokens/LinkToDashboardCanister.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/LinkToDashboardCanister.spec.ts
@@ -29,12 +29,4 @@ describe("LinkToDashboardCanister", () => {
       "https://dashboard.internetcomputer.org/canister/aaaaa-aa"
     );
   });
-
-  it("should not render label when noLabel set", async () => {
-    const po = renderComponent({ canisterId, noLabel: true });
-    expect(await po.getLabel().isPresent()).toEqual(false);
-    expect(await po.getHref()).toBe(
-      "https://dashboard.internetcomputer.org/canister/aaaaa-aa"
-    );
-  });
 });

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -252,7 +252,7 @@ describe("NnsWallet", () => {
       expect(await po.isMorePopupVisible()).toBe(false);
     });
 
-    it('should have "View to dashboard" in "more" popup', async () => {
+    it('should have "View in dashboard" link in "more" popup', async () => {
       const po = await renderWallet({});
 
       await po.clickMore();

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -4,7 +4,10 @@ import * as indexApi from "$lib/api/icp-index.api";
 import * as ledgerApi from "$lib/api/icp-ledger.api";
 import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import { SYNC_ACCOUNTS_RETRY_SECONDS } from "$lib/constants/accounts.constants";
-import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import {
+  LEDGER_CANISTER_ID,
+  OWN_CANISTER_ID_TEXT,
+} from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import NnsWallet from "$lib/pages/NnsWallet.svelte";
@@ -43,6 +46,7 @@ import {
   setAccountsForTesting,
 } from "$tests/utils/accounts.test-utils";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { render } from "$tests/utils/svelte.test-utils";
 import {
   advanceTime,
   runResolvedPromises,
@@ -50,7 +54,6 @@ import {
 import { toastsStore } from "@dfinity/gix-components";
 import type { TransactionWithId } from "@dfinity/ledger-icp";
 import { Principal } from "@dfinity/principal";
-import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 import type { SpyInstance } from "vitest";
 import AccountsTest from "./AccountsTest.svelte";
@@ -252,6 +255,13 @@ describe("NnsWallet", () => {
       expect(await po.getLinkToDashboardPo().isPresent()).toBe(false);
     });
 
+    it("should not display more button when ENABLE_IMPORT_TOKEN disabled", async () => {
+      overrideFeatureFlagsStore.setFlag("ENABLE_IMPORT_TOKEN", false);
+
+      const po = await renderWallet({});
+      expect(await po.hasMoreButton()).toBe(false);
+    });
+
     it('should have "View in dashboard" link in "more" popup', async () => {
       const po = await renderWallet({});
 
@@ -261,7 +271,7 @@ describe("NnsWallet", () => {
 
       expect(await po.getLinkToDashboardPo().isPresent()).toBe(true);
       expect(await po.getLinkToDashboardPo().getHref()).toBe(
-        `https://dashboard.internetcomputer.org/canister/${OWN_CANISTER_ID_TEXT}`
+        `https://dashboard.internetcomputer.org/canister/${LEDGER_CANISTER_ID.toText()}`
       );
     });
   });

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -241,6 +241,29 @@ describe("NnsWallet", () => {
         },
       ]);
     });
+
+    it('should render "more" button', async () => {
+      const po = await renderWallet({});
+      expect(await po.getMoreButton().isPresent()).toBe(true);
+    });
+
+    it('should not render "more" popup by default', async () => {
+      const po = await renderWallet({});
+      expect(await po.isMorePopupVisible()).toBe(false);
+    });
+
+    it('should have "View to dashboard" in "more" popup', async () => {
+      const po = await renderWallet({});
+
+      await po.clickMore();
+
+      await runResolvedPromises();
+
+      expect(await po.isMorePopupVisible()).toBe(true);
+      expect(await po.getLinkToDashboardPo().getHref()).toBe(
+        `https://dashboard.internetcomputer.org/canister/${OWN_CANISTER_ID_TEXT}`
+      );
+    });
   });
 
   describe("no accounts", () => {

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -249,7 +249,7 @@ describe("NnsWallet", () => {
 
     it('should not render "more" popup by default', async () => {
       const po = await renderWallet({});
-      expect(await po.isMorePopupVisible()).toBe(false);
+      expect(await po.getLinkToDashboardPo().isPresent()).toBe(false);
     });
 
     it('should have "View in dashboard" link in "more" popup', async () => {
@@ -259,7 +259,7 @@ describe("NnsWallet", () => {
 
       await runResolvedPromises();
 
-      expect(await po.isMorePopupVisible()).toBe(true);
+      expect(await po.getLinkToDashboardPo().isPresent()).toBe(true);
       expect(await po.getLinkToDashboardPo().getHref()).toBe(
         `https://dashboard.internetcomputer.org/canister/${OWN_CANISTER_ID_TEXT}`
       );

--- a/frontend/src/tests/page-objects/LinkToDashboardCanister.page-object.ts
+++ b/frontend/src/tests/page-objects/LinkToDashboardCanister.page-object.ts
@@ -1,0 +1,24 @@
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class LinkToDashboardCanisterPo extends BasePageObject {
+  private static readonly TID = "link-to-dashboard-canister-component";
+
+  static under(element: PageObjectElement): LinkToDashboardCanisterPo {
+    return new LinkToDashboardCanisterPo(
+      element.byTestId(LinkToDashboardCanisterPo.TID)
+    );
+  }
+
+  getLabel(): PageObjectElement {
+    return this.root.byTestId("label");
+  }
+
+  getHref(): Promise<string> {
+    return this.root.getAttribute("href");
+  }
+
+  async getLabelText(): Promise<string> {
+    return (await this.getLabel().getText()).trim();
+  }
+}

--- a/frontend/src/tests/page-objects/NnsWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsWallet.page-object.ts
@@ -87,6 +87,10 @@ export class NnsWalletPo extends BasePageObject {
     return this.getRenameButtonPo().click();
   }
 
+  hasMoreButton(): Promise<boolean> {
+    return this.getMoreButton().isPresent();
+  }
+
   clickMore(): Promise<void> {
     return this.getMoreButton().click();
   }

--- a/frontend/src/tests/page-objects/NnsWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsWallet.page-object.ts
@@ -1,5 +1,6 @@
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { IcpTransactionModalPo } from "$tests/page-objects/IcpTransactionModal.page-object";
+import { LinkToDashboardCanisterPo } from "$tests/page-objects/LinkToDashboardCanister.page-object";
 import { SignInPo } from "$tests/page-objects/SignIn.page-object";
 import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-object";
 import { WalletPageHeadingPo } from "$tests/page-objects/WalletPageHeading.page-object";
@@ -54,6 +55,22 @@ export class NnsWalletPo extends BasePageObject {
     return this.getButton("ledger-show-button");
   }
 
+  getMoreButton(): ButtonPo {
+    return this.getButton("more-button");
+  }
+
+  getMorePopupContent(): PageObjectElement {
+    return this.root.byTestId("more-popup-content");
+  }
+
+  isMorePopupVisible(): Promise<boolean> {
+    return this.getMorePopupContent().isPresent();
+  }
+
+  getLinkToDashboardPo(): LinkToDashboardCanisterPo {
+    return LinkToDashboardCanisterPo.under(this.getMorePopupContent());
+  }
+
   hasSignInButton(): Promise<boolean> {
     return this.getSignInPo().isPresent();
   }
@@ -76,6 +93,10 @@ export class NnsWalletPo extends BasePageObject {
 
   clickRename(): Promise<void> {
     return this.getRenameButtonPo().click();
+  }
+
+  clickMore(): Promise<void> {
+    return this.getMoreButton().click();
   }
 
   async transferToAccount({

--- a/frontend/src/tests/page-objects/NnsWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsWallet.page-object.ts
@@ -59,16 +59,8 @@ export class NnsWalletPo extends BasePageObject {
     return this.getButton("more-button");
   }
 
-  getMorePopupContent(): PageObjectElement {
-    return this.root.byTestId("more-popup-content");
-  }
-
-  isMorePopupVisible(): Promise<boolean> {
-    return this.getMorePopupContent().isPresent();
-  }
-
   getLinkToDashboardPo(): LinkToDashboardCanisterPo {
-    return LinkToDashboardCanisterPo.under(this.getMorePopupContent());
+    return LinkToDashboardCanisterPo.under(this.root);
   }
 
   hasSignInButton(): Promise<boolean> {


### PR DESCRIPTION
# Motivation

To validate the index/ledger canister IDs, we need to retrieve the associated ledger canister from the index canister.

# Changes

- Add `getLedgerId` api.

# Tests

- Unit tests have been added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.