### PR TITLE
Get ledger id api

### DIFF
--- a/frontend/src/lib/api/icrc-index.api.ts
+++ b/frontend/src/lib/api/icrc-index.api.ts
@@ -45,6 +45,22 @@ export const getTransactions = async ({
   };
 };
 
+export const getLedgerId = async ({
+  identity,
+  indexCanisterId,
+  certified,
+}: {
+  identity: Identity;
+  indexCanisterId: Principal;
+  certified?: boolean;
+}): Promise<Principal> => {
+  const {
+    canister: { ledgerId },
+  } = await indexCanister({ identity, canisterId: indexCanisterId });
+
+  return ledgerId({ certified });
+};
+
 const indexCanister = async ({
   identity,
   canisterId,

--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -108,8 +108,6 @@ describe("icrc-index api", () => {
         canisterId: indexCanisterId,
       });
 
-      expect(resultPrincipal).not.toBeUndefined();
-
       expect(resultPrincipal).toEqual(ledgerCanisterId);
 
       expect(indexCanisterMock.ledgerId).toBeCalledTimes(1);

--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -1,5 +1,6 @@
 import * as agent from "$lib/api/agent.api";
 import {
+  getLedgerId,
   getTransactions,
   type GetTransactionsParams,
 } from "$lib/api/icrc-index.api";
@@ -82,6 +83,43 @@ describe("icrc-index api", () => {
       indexCanisterMock.getTransactions.mockRejectedValue(err);
 
       const call = () => getTransactions(params);
+
+      expect(call).rejects.toThrowError(err);
+    });
+  });
+
+  describe("getLedgerId", () => {
+    const indexCanisterId = principal(0);
+    const ledgerCanisterId = principal(1);
+
+    it("returns list of transaction", async () => {
+      indexCanisterMock.ledgerId.mockResolvedValue(ledgerCanisterId);
+      const resultPrincipal = await getLedgerId({
+        identity: mockIdentity,
+        indexCanisterId,
+        certified: true,
+      });
+
+      expect(resultPrincipal).not.toBeUndefined();
+
+      expect(resultPrincipal).toEqual(ledgerCanisterId);
+
+      expect(indexCanisterMock.ledgerId).toBeCalledTimes(1);
+      expect(indexCanisterMock.ledgerId).toBeCalledWith({
+        certified: true,
+      });
+    });
+
+    it("throws an error if canister throws", () => {
+      const err = new Error("test");
+      indexCanisterMock.ledgerId.mockRejectedValue(err);
+
+      const call = () =>
+        getLedgerId({
+          identity: mockIdentity,
+          indexCanisterId,
+          certified: true,
+        });
 
       expect(call).rejects.toThrowError(err);
     });

--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -22,13 +22,15 @@ describe("icrc-index api", () => {
   };
 
   const indexCanisterMock = mock<IcrcIndexCanister>();
+  const agentMock = mock<HttpAgent>();
+  let spyOnIndexCanisterCreate;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(IcrcIndexCanister, "create").mockImplementation(
-      () => indexCanisterMock
-    );
-    vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
+    spyOnIndexCanisterCreate = vi
+      .spyOn(IcrcIndexCanister, "create")
+      .mockImplementation(() => indexCanisterMock);
+    vi.spyOn(agent, "createAgent").mockResolvedValue(agentMock);
   });
 
   afterEach(() => {
@@ -92,12 +94,18 @@ describe("icrc-index api", () => {
     const indexCanisterId = principal(0);
     const ledgerCanisterId = principal(1);
 
-    it("returns list of transaction", async () => {
+    it("returns ledger id", async () => {
       indexCanisterMock.ledgerId.mockResolvedValue(ledgerCanisterId);
       const resultPrincipal = await getLedgerId({
         identity: mockIdentity,
         indexCanisterId,
         certified: true,
+      });
+
+      expect(spyOnIndexCanisterCreate).toBeCalledTimes(1);
+      expect(spyOnIndexCanisterCreate).toBeCalledWith({
+        agent: agentMock,
+        canisterId: indexCanisterId,
       });
 
       expect(resultPrincipal).not.toBeUndefined();


### PR DESCRIPTION
# Motivation

To validate the index/ledger canister IDs, we need to retrieve the associated ledger canister from the index canister.

# Changes

- Add `getLedgerId` api.

# Tests

- Unit tests have been added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.