### PR TITLE
Update SNS aggregator changelog for proposal 129614

### DIFF
--- a/CHANGELOG-Sns_Aggregator.md
+++ b/CHANGELOG-Sns_Aggregator.md
@@ -9,10 +9,6 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 ## Unreleased
 
 ### Added
-
-- Include SNS nervous system parameters.
-- Add common code snippets for developers to the "Documentation" chapter on the landing page.
-
 ### Changed
 ### Deprecated
 ### Removed
@@ -21,6 +17,10 @@ The SNS Aggregator is released through proposals in the Network Nervous System. 
 
 - Decoding quota of 10,000 in the `http_request` method.
 
+## [Proposal 129614](https://dashboard.internetcomputer.org/proposal/129614)
+### Added
+- Include SNS nervous system parameters.
+- Add common code snippets for developers to the "Documentation" chapter on the landing page.
 
 ## [Proposal 126006](https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=126006)
 ### Changed


### PR DESCRIPTION
# Motivation

We forgot to update the SNS aggregator changelog after the [upgrade](https://dashboard.internetcomputer.org/proposal/129614) back in May.

# Changes

Move the entries that were already there before the previous upgrade, to a separate section.

I also updated the release SOP for the aggregator to include an item about the changelog.

# Tests

n/a

# Todos

- [x] Add entry to changelog (if necessary).
