### PR TITLE
Refactor import token canister

### DIFF
--- a/frontend/src/lib/components/accounts/ImportTokenCanisterId.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenCanisterId.svelte
@@ -1,23 +1,22 @@
 <script lang="ts">
   import { Copy } from "@dfinity/gix-components";
   import { nonNullish } from "@dfinity/utils";
-  import LinkIcon from "$lib/components/common/LinkIcon.svelte";
+  import LinkToDashboardCanister from "$lib/components/common/LinkToDashboardCanister.svelte";
+  import type { Principal } from "@dfinity/principal";
 
   export let label: string;
-  export let canisterId: string | undefined = undefined;
-  export let canisterLinkHref: string | undefined = undefined;
+  export let testId: string = "import-token-canister-id-component";
+  export let canisterId: Principal | undefined = undefined;
   export let canisterIdFallback: string | undefined = undefined;
 </script>
 
-<div class="container" data-tid="import-token-canister-id-component">
+<div class="container" data-tid={testId}>
   <span data-tid="label">{label}</span>
   <div class="canister-id">
     {#if nonNullish(canisterId)}
       <span class="value description" data-tid="canister-id">{canisterId}</span>
-      <Copy value={canisterId} />
-      {#if nonNullish(canisterLinkHref)}
-        <LinkIcon href={canisterLinkHref} />
-      {/if}
+      <Copy value={canisterId.toText()} />
+      <LinkToDashboardCanister noLabel {canisterId} />
     {:else if nonNullish(canisterIdFallback)}
       <span class="fallback description" data-tid="canister-id-fallback"
         >{canisterIdFallback}</span

--- a/frontend/src/lib/components/accounts/ImportTokenCanisterId.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenCanisterId.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Copy } from "@dfinity/gix-components";
   import { nonNullish } from "@dfinity/utils";
-  import LinkToDashboardCanister from "$lib/components/common/LinkToDashboardCanister.svelte";
+  import LinkToDashboardCanister from "$lib/components/tokens/LinkToDashboardCanister.svelte";
   import type { Principal } from "@dfinity/principal";
 
   export let label: string;

--- a/frontend/src/lib/components/tokens/LinkToDashboardCanister.svelte
+++ b/frontend/src/lib/components/tokens/LinkToDashboardCanister.svelte
@@ -3,6 +3,7 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { i18n } from "$lib/stores/i18n";
   import type { Principal } from "@dfinity/principal";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let canisterId: Principal;
   export let noLabel: boolean = false;
@@ -13,7 +14,6 @@
   });
 </script>
 
-@@ -0,0 +1,45 @@
 <a
   class="button ghost with-icon"
   class:noLabel
@@ -24,7 +24,9 @@
 >
   <IconOpenInNew />
   {#if !noLabel}
-    {$i18n.import_token.view_in_dashboard}
+    <TestIdWrapper testId="label"
+      >{$i18n.import_token.view_in_dashboard}</TestIdWrapper
+    >
   {/if}
 </a>
 

--- a/frontend/src/lib/components/tokens/LinkToDashboardCanister.svelte
+++ b/frontend/src/lib/components/tokens/LinkToDashboardCanister.svelte
@@ -3,9 +3,9 @@
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { i18n } from "$lib/stores/i18n";
   import type { Principal } from "@dfinity/principal";
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let canisterId: Principal;
+  export let noLabel: boolean = false;
 
   let href: string;
   $: href = replacePlaceholders($i18n.import_token.link_to_dashboard, {
@@ -13,15 +13,34 @@
   });
 </script>
 
+@@ -0,0 +1,45 @@
 <a
   class="button ghost with-icon"
+  class:noLabel
   data-tid="link-to-dashboard-canister-component"
   {href}
   target="_blank"
   rel="noopener noreferrer"
 >
   <IconOpenInNew />
-  <TestIdWrapper testId="label"
-    >{$i18n.import_token.view_in_dashboard}</TestIdWrapper
-  >
+  {#if !noLabel}
+    {$i18n.import_token.view_in_dashboard}
+  {/if}
 </a>
+
+<style lang="scss">
+  a {
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &.noLabel {
+      // Increase click area
+      padding: var(--padding-0_5x);
+
+      &:hover {
+        color: inherit;
+      }
+    }
+  }
+</style>

--- a/frontend/src/tests/lib/components/accounts/ImportTokenCanisterId.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenCanisterId.spec.ts
@@ -1,20 +1,22 @@
 import ImportTokenCanisterId from "$lib/components/accounts/ImportTokenCanisterId.svelte";
 import { ImportTokenCanisterIdPo } from "$tests/page-objects/ImportTokenCanisterId.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { Principal } from "@dfinity/principal";
 import { render } from "@testing-library/svelte";
 
 describe("ImportTokenCanisterId", () => {
   const props = {
     label: "test label",
-    canisterId: "aaaaa-aa",
-    canisterLinkHref: "http://test.com",
+    canisterId: Principal.fromText("aaaaa-aa"),
     canisterIdFallback: "test fallback",
   };
   const renderComponent = (props) => {
     const { container } = render(ImportTokenCanisterId, {
       props,
     });
-    return ImportTokenCanisterIdPo.under(new JestPageObjectElement(container));
+    return ImportTokenCanisterIdPo.under({
+      element: new JestPageObjectElement(container),
+    });
   };
 
   it("should render label, canister id and buttons", async () => {
@@ -25,15 +27,17 @@ describe("ImportTokenCanisterId", () => {
     expect(await po.getCanisterId().isPresent()).toEqual(true);
     expect(await po.getCanisterIdText()).toEqual("aaaaa-aa");
     expect(await po.getCopyButtonPo().isPresent()).toEqual(true);
-    expect(await po.getLinkIconPo().isPresent()).toEqual(true);
+    expect(await po.getLinkToDashboardCanisterPo().isPresent()).toEqual(true);
   });
 
   it("should render buttons", async () => {
     const po = renderComponent(props);
 
     expect(await po.getCopyButtonPo().isPresent()).toEqual(true);
-    expect(await po.getLinkIconPo().isPresent()).toEqual(true);
-    expect(await po.getLinkIconPo().getHref()).toEqual("http://test.com");
+    expect(await po.getLinkToDashboardCanisterPo().isPresent()).toEqual(true);
+    expect(await po.getLinkToDashboardCanisterPo().getHref()).toEqual(
+      "https://dashboard.internetcomputer.org/canister/aaaaa-aa"
+    );
   });
 
   it("should not render a fallback when canister id provided", async () => {
@@ -46,7 +50,6 @@ describe("ImportTokenCanisterId", () => {
   it("should render fallback when canister id not provided", async () => {
     const po = renderComponent({
       label: "test label",
-      canisterLinkHref: "http://test.com",
       canisterIdFallback: "test fallback",
     });
 
@@ -61,12 +64,11 @@ describe("ImportTokenCanisterId", () => {
   it("should render no buttons when canister id not provided", async () => {
     const po = renderComponent({
       label: "test label",
-      canisterLinkHref: "http://test.com",
       canisterIdFallback: "test fallback",
     });
 
     expect(await po.getCopyButtonPo().isPresent()).toEqual(false);
-    expect(await po.getLinkIconPo().isPresent()).toEqual(false);
+    expect(await po.getLinkToDashboardCanisterPo().isPresent()).toEqual(false);
   });
 
   it("Should render neither the canister id nor the fallback when both parameters are not provided", async () => {

--- a/frontend/src/tests/page-objects/ImportTokenCanisterId.page-object.ts
+++ b/frontend/src/tests/page-objects/ImportTokenCanisterId.page-object.ts
@@ -1,14 +1,20 @@
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
-import { LinkIconPo } from "$tests/page-objects/LinkIcon.page-object";
+import { LinkToDashboardCanisterPo } from "$tests/page-objects/LinkToDashboardCanister.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
 export class ImportTokenCanisterIdPo extends BasePageObject {
   private static readonly TID = "import-token-canister-id-component";
 
-  static under(element: PageObjectElement): ImportTokenCanisterIdPo {
+  static under({
+    element,
+    testId,
+  }: {
+    element: PageObjectElement;
+    testId?: string;
+  }): ImportTokenCanisterIdPo {
     return new ImportTokenCanisterIdPo(
-      element.byTestId(ImportTokenCanisterIdPo.TID)
+      element.byTestId(testId ?? ImportTokenCanisterIdPo.TID)
     );
   }
 
@@ -36,8 +42,8 @@ export class ImportTokenCanisterIdPo extends BasePageObject {
     return this.getButton("copy-component");
   }
 
-  getLinkIconPo(): LinkIconPo {
-    return LinkIconPo.under(this.root);
+  getLinkToDashboardCanisterPo(): LinkToDashboardCanisterPo {
+    return LinkToDashboardCanisterPo.under(this.root);
   }
 
   getCanisterIdFallbackText(): Promise<string> {

--- a/frontend/src/tests/page-objects/ImportTokenModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ImportTokenModal.page-object.ts
@@ -1,4 +1,5 @@
 import { ImportTokenFormPo } from "$tests/page-objects/ImportTokenForm.page-object";
+import { ImportTokenReviewPo } from "$tests/page-objects/ImportTokenReview.page-object";
 import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -11,5 +12,9 @@ export class ImportTokenModalPo extends ModalPo {
 
   getImportTokenFormPo(): ImportTokenFormPo {
     return ImportTokenFormPo.under(this.root);
+  }
+
+  getImportTokenReviewPo(): ImportTokenReviewPo {
+    return ImportTokenReviewPo.under(this.root);
   }
 }

--- a/frontend/src/tests/page-objects/ImportTokenModal.page-object.ts
+++ b/frontend/src/tests/page-objects/ImportTokenModal.page-object.ts
@@ -1,5 +1,4 @@
 import { ImportTokenFormPo } from "$tests/page-objects/ImportTokenForm.page-object";
-import { ImportTokenReviewPo } from "$tests/page-objects/ImportTokenReview.page-object";
 import { ModalPo } from "$tests/page-objects/Modal.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -12,9 +11,5 @@ export class ImportTokenModalPo extends ModalPo {
 
   getImportTokenFormPo(): ImportTokenFormPo {
     return ImportTokenFormPo.under(this.root);
-  }
-
-  getImportTokenReviewPo(): ImportTokenReviewPo {
-    return ImportTokenReviewPo.under(this.root);
   }
 }


### PR DESCRIPTION
# Motivation

The `ImportTokenCanisterId` component will be reused in different places on the token page. To simplify its reusability, we are providing some small refactoring and enhancements.

# Changes

**ImportTokenCanisterId**

- Add a `testId` parameter to accommodate the use of multiple components within a single parent.
- Provide canisterId as a Principal (instead of a string) to enforce stricter typing.
- Use `LinkToDashboardCanister` instead of `LinkIcon`, as it is more appropriate for linking to the canister on the dashboard.

**LinkToDashboardCanister**

- Add a `noLabel` parameter to have an icon-only component version.

# Tests

- POs and tests updated.
- Can be tested on [beta](https://beta.nns.ic0.app/).

<img width="327" alt="image" src="https://github.com/user-attachments/assets/c699531c-683a-44f0-bc25-fe929a11fc9b">

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.