### PR TITLE
Imported tokens review component

### DIFF
--- a/frontend/src/lib/components/accounts/ImportTokenReview.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenReview.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import type { Principal } from "@dfinity/principal";
+  import { i18n } from "$lib/stores/i18n";
+  import { createEventDispatcher } from "svelte";
+  import type { IcrcTokenMetadata } from "$lib/types/icrc";
+  import Logo from "$lib/components/ui/Logo.svelte";
+  import ImportTokenCanisterId from "$lib/components/accounts/ImportTokenCanisterId.svelte";
+  import CalloutWarning from "$lib/components/common/CalloutWarning.svelte";
+
+  export let ledgerCanisterId: Principal;
+  export let indexCanisterId: Principal | undefined = undefined;
+  export let tokenMetaData: IcrcTokenMetadata;
+
+  const dispatch = createEventDispatcher();
+</script>
+
+<div class="container" data-tid="import-token-review-component">
+  <div class="meta">
+    <Logo
+      testId="token-logo"
+      src={tokenMetaData?.logo ?? ""}
+      alt={tokenMetaData.name}
+      size="medium"
+      framed
+    />
+    <div class="token-name">
+      <div data-tid="token-name">{tokenMetaData.name}</div>
+      <div data-tid="token-symbol" class="description">
+        {tokenMetaData.symbol}
+      </div>
+    </div>
+  </div>
+
+  <ImportTokenCanisterId
+    testId="ledger-canister-id"
+    label={$i18n.import_token.ledger_label}
+    canisterId={ledgerCanisterId}
+  />
+
+  <ImportTokenCanisterId
+    testId="index-canister-id"
+    label={$i18n.import_token.index_label}
+    canisterId={indexCanisterId}
+    canisterIdFallback={$i18n.import_token.index_fallback_label}
+  />
+
+  <CalloutWarning htmlText={$i18n.import_token.warning} />
+
+  <div class="toolbar">
+    <button
+      class="secondary"
+      data-tid="back-button"
+      on:click={() => dispatch("nnsBack")}
+    >
+      {$i18n.core.back}
+    </button>
+
+    <button
+      data-tid="confirm-button"
+      class="primary"
+      on:click={() => dispatch("nnsConfirm")}
+    >
+      {$i18n.import_token.import_button}
+    </button>
+  </div>
+</div>
+
+<style lang="scss">
+  .container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-3x);
+  }
+
+  .meta {
+    display: flex;
+    align-items: center;
+    gap: var(--padding-1_5x);
+    padding: var(--padding) var(--padding-1_5x);
+  }
+
+  .token-name {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-0_5x);
+  }
+</style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1040,6 +1040,9 @@
     "index_canister_description": "Index Canister allows to display a token balance and transaction history. <strong>Note:</strong> not all tokens have index canisters.",
     "review_token_info": "Review token info",
     "warning": "<strong>Warning:</strong> Be careful what token you import! Anyone can create a token including one with the same name as existing tokens, such as ckBTC.",
+    "index_label": "Index Canister ID",
+    "index_fallback_label": "Transaction history won’t be displayed.",
+    "import_button": "Import",
     "view_in_dashboard": "View in Dashboard",
     "link_to_dashboard": "https://dashboard.internetcomputer.org/canister/$canisterId"
   }

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1099,6 +1099,9 @@ interface I18nImport_token {
   index_canister_description: string;
   review_token_info: string;
   warning: string;
+  index_label: string;
+  index_fallback_label: string;
+  import_button: string;
   view_in_dashboard: string;
   link_to_dashboard: string;
 }

--- a/frontend/src/tests/lib/components/accounts/ImportTokenReview.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenReview.spec.ts
@@ -1,0 +1,114 @@
+import ImportTokenReview from "$lib/components/accounts/ImportTokenReview.svelte";
+import type { IcrcTokenMetadata } from "$lib/types/icrc";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { ImportTokenReviewPo } from "$tests/page-objects/ImportTokenReview.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { render } from "$tests/utils/svelte.test-utils";
+import type { Principal } from "@dfinity/principal";
+
+describe("ImportTokenReview", () => {
+  const tokenMetaData = {
+    name: "Tetris",
+    symbol: "TET",
+    logo: "https://tetris.tet/logo.png",
+  } as IcrcTokenMetadata;
+  const renderComponent = (props: {
+    ledgerCanisterId: Principal;
+    indexCanisterId: Principal | undefined;
+    tokenMetaData: IcrcTokenMetadata;
+  }) => {
+    const { container, component } = render(ImportTokenReview, {
+      props,
+    });
+
+    const onConfirm = vi.fn();
+    component.$on("nnsConfirm", onConfirm);
+    const onBack = vi.fn();
+    component.$on("nnsBack", onBack);
+
+    return {
+      po: ImportTokenReviewPo.under(new JestPageObjectElement(container)),
+      onConfirm,
+      onBack,
+    };
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should render token meta information", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+      tokenMetaData,
+    });
+
+    expect(await po.getTokenName()).toEqual("Tetris");
+    expect(await po.getTokenSymbol()).toEqual("TET");
+    expect(await po.getLogoSource()).toEqual("https://tetris.tet/logo.png");
+  });
+
+  it("should render ledger canister id", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+      tokenMetaData,
+    });
+
+    expect(await po.getLedgerCanisterIdPo().getCanisterIdText()).toEqual(
+      principal(0).toText()
+    );
+    expect(await po.getLedgerCanisterIdPo().getLabelText()).toEqual(
+      "Ledger Canister ID"
+    );
+  });
+
+  it("should render index canister id", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: principal(1),
+      tokenMetaData,
+    });
+
+    expect(await po.getIndexCanisterIdPo().getCanisterIdText()).toEqual(
+      principal(1).toText()
+    );
+    expect(await po.getIndexCanisterIdPo().getLabelText()).toEqual(
+      "Index Canister ID"
+    );
+  });
+
+  it("should render a warning message", async () => {
+    const { po } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+      tokenMetaData,
+    });
+
+    expect((await po.getWarningPo().getText()).trim()).toEqual(
+      "Warning: Be careful what token you import! Anyone can create a token including one with the same name as existing tokens, such as ckBTC."
+    );
+  });
+
+  it("should dispatch events on buttons click", async () => {
+    const { po, onBack, onConfirm } = renderComponent({
+      ledgerCanisterId: principal(0),
+      indexCanisterId: undefined,
+      tokenMetaData,
+    });
+
+    expect(onBack).not.toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    await po.getConfirmButtonPo().click();
+
+    expect(onBack).not.toHaveBeenCalled();
+    expect(onConfirm).toBeCalledTimes(1);
+
+    await po.getBackButtonPo().click();
+
+    expect(onBack).toBeCalledTimes(1);
+    expect(onConfirm).toBeCalledTimes(1);
+  });
+});

--- a/frontend/src/tests/page-objects/ImportTokenReview.page-object.ts
+++ b/frontend/src/tests/page-objects/ImportTokenReview.page-object.ts
@@ -1,0 +1,57 @@
+import { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { CalloutWarningPo } from "$tests/page-objects/CalloutWarning.page-object";
+import { ImportTokenCanisterIdPo } from "$tests/page-objects/ImportTokenCanisterId.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ImportTokenReviewPo extends BasePageObject {
+  private static readonly TID = "import-token-review-component";
+
+  static under(element: PageObjectElement): ImportTokenReviewPo {
+    return new ImportTokenReviewPo(element.byTestId(ImportTokenReviewPo.TID));
+  }
+
+  getLogoSource(): Promise<string> {
+    return this.getElement("token-logo").getAttribute("src");
+  }
+
+  getTokenName(): Promise<string> {
+    return this.getText("token-name");
+  }
+
+  getTokenSymbol(): Promise<string> {
+    return this.getText("token-symbol");
+  }
+
+  getLedgerCanisterIdPo(): ImportTokenCanisterIdPo {
+    return ImportTokenCanisterIdPo.under({
+      element: this.root,
+      testId: "ledger-canister-id",
+    });
+  }
+
+  getIndexCanisterIdPo(): ImportTokenCanisterIdPo {
+    return ImportTokenCanisterIdPo.under({
+      element: this.root,
+      testId: "index-canister-id",
+    });
+  }
+
+  getWarningPo(): CalloutWarningPo {
+    return CalloutWarningPo.under(this.root);
+  }
+
+  getBackButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "back-button",
+    });
+  }
+
+  getConfirmButtonPo(): ButtonPo {
+    return ButtonPo.under({
+      element: this.root,
+      testId: "confirm-button",
+    });
+  }
+}


### PR DESCRIPTION
# Motivation

After entering imported token canister ID(s), the next step is to review the entered date. Here we create the review component that will be used to display the token details before it will be imported.

# Changes

- New ImportTokenReview component.

# Tests

- PO and unit tests added.
- Available on beta.

<img width="616" alt="image" src="https://github.com/user-attachments/assets/6652a445-ba15-4008-9897-1903aa353a30">

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.