### PR TITLE
Match ledger index pair

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -120,7 +120,9 @@
     "adding_permissions": "There was an error adding permissions.",
     "canister_invalid_transaction": "Sorry, there was a problem with the transaction.",
     "qrcode_camera_error": "An error occurred while initializing the camera to read the QR code.",
-    "qrcode_token_incompatible": "The payment token you are attempting to use is not compatible with this transaction."
+    "qrcode_token_incompatible": "The payment token you are attempting to use is not compatible with this transaction.",
+    "invalid_ledger_index_pair": "The provided index canister ID does not match the associated ledger canister ID.",
+    "index_canister_validation": "An error occurred while validating the index canister ID. It appears that $indexCanister might not be a valid index canister ID."
   },
   "warning": {
     "auth_sign_out": "You have been logged out because your session has expired.",

--- a/frontend/src/lib/services/icrc-index.services.ts
+++ b/frontend/src/lib/services/icrc-index.services.ts
@@ -1,0 +1,57 @@
+import { getLedgerId as getLedgerIdApi } from "$lib/api/icrc-index.api";
+import { getAuthenticatedIdentity } from "$lib/services/auth.services";
+import { toastsError } from "$lib/stores/toasts.store";
+import type { Principal } from "@dfinity/principal";
+
+const getLedgerId = async ({
+  indexCanisterId,
+  certified,
+}: {
+  indexCanisterId: Principal;
+  certified: boolean;
+}): Promise<Principal> => {
+  const identity = await getAuthenticatedIdentity();
+  const ledgerId = await getLedgerIdApi({
+    identity,
+    indexCanisterId,
+    certified,
+  });
+  return ledgerId;
+};
+
+/**
+ * Validates whether the provided index canister ID corresponds to the given ledger canister ID.
+ * This function uses `ledger_id` icrc1 index canister api to check if the indexCanisterId is correctly associated with
+ * the provided ledgerCanisterId.
+ */
+export const matchLedgerIndexPair = async ({
+  ledgerCanisterId,
+  indexCanisterId,
+}: {
+  ledgerCanisterId: Principal;
+  indexCanisterId: Principal;
+}): Promise<boolean> => {
+  try {
+    const ledgerIdFromIndexCaniter = await getLedgerId({
+      indexCanisterId,
+      certified: false,
+    });
+    const match =
+      ledgerIdFromIndexCaniter.toText() === ledgerCanisterId.toText();
+
+    if (!match) {
+      toastsError({
+        labelKey: "error.invalid_ledger_index_pair",
+      });
+    }
+    return match;
+  } catch (err) {
+    console.error(err);
+    toastsError({
+      labelKey: "error.index_canister_validation",
+      err,
+    });
+  }
+
+  return false;
+};

--- a/frontend/src/lib/services/icrc-index.services.ts
+++ b/frontend/src/lib/services/icrc-index.services.ts
@@ -49,6 +49,9 @@ export const matchLedgerIndexPair = async ({
     console.error(err);
     toastsError({
       labelKey: "error.index_canister_validation",
+      substitutions: {
+        $indexCanister: indexCanisterId.toText(),
+      },
       err,
     });
   }

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -125,6 +125,8 @@ interface I18nError {
   canister_invalid_transaction: string;
   qrcode_camera_error: string;
   qrcode_token_incompatible: string;
+  invalid_ledger_index_pair: string;
+  index_canister_validation: string;
 }
 
 interface I18nWarning {

--- a/frontend/src/tests/lib/services/icrc-index.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-index.services.spec.ts
@@ -1,0 +1,68 @@
+import * as icrcIndexApi from "$lib/api/icrc-index.api";
+import { matchLedgerIndexPair } from "$lib/services/icrc-index.services";
+import * as toastsStore from "$lib/stores/toasts.store";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
+
+describe("icrc-index.services", () => {
+  describe("matchLedgerIndexPair", () => {
+    const indexCanisterId = principal(0);
+    const ledgerCanisterId = principal(1);
+    const differentLedgerCanisterId = principal(11);
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      resetIdentity();
+    });
+
+    it("should return true when the ledger canister IDs match", async () => {
+      vi.spyOn(icrcIndexApi, "getLedgerId").mockResolvedValue(ledgerCanisterId);
+
+      const result = await matchLedgerIndexPair({
+        ledgerCanisterId,
+        indexCanisterId,
+      });
+
+      expect(result).toEqual(true);
+    });
+
+    it("should return false when the ledger canister IDs don't match", async () => {
+      const spyToastError = vi.spyOn(toastsStore, "toastsError");
+      vi.spyOn(icrcIndexApi, "getLedgerId").mockResolvedValue(
+        differentLedgerCanisterId
+      );
+
+      expect(spyToastError).not.toBeCalled();
+      const result = await matchLedgerIndexPair({
+        ledgerCanisterId,
+        indexCanisterId,
+      });
+
+      expect(result).toEqual(false);
+      expect(spyToastError).toBeCalledTimes(1);
+      expect(spyToastError).toBeCalledWith({
+        labelKey: "error.invalid_ledger_index_pair",
+      });
+    });
+
+    it("should handle errors", async () => {
+      vi.spyOn(console, "error").mockReturnValue();
+      const spyToastError = vi.spyOn(toastsStore, "toastsError");
+      const error = new Error("test");
+      vi.spyOn(icrcIndexApi, "getLedgerId").mockRejectedValue(error);
+
+      expect(spyToastError).not.toBeCalled();
+      const result = await matchLedgerIndexPair({
+        ledgerCanisterId,
+        indexCanisterId,
+      });
+
+      expect(result).toEqual(false);
+      expect(spyToastError).toBeCalledTimes(1);
+      expect(spyToastError).toBeCalledWith({
+        labelKey: "error.index_canister_validation",
+        err: error,
+      });
+    });
+  });
+});

--- a/frontend/src/tests/lib/services/icrc-index.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-index.services.spec.ts
@@ -61,6 +61,9 @@ describe("icrc-index.services", () => {
       expect(spyToastError).toBeCalledTimes(1);
       expect(spyToastError).toBeCalledWith({
         labelKey: "error.index_canister_validation",
+        substitutions: {
+          $indexCanister: indexCanisterId.toText(),
+        },
         err: error,
       });
     });


### PR DESCRIPTION
# Motivation

For validating the ledger and index canister IDs entered by the user, we will use the `ledgerId` API of the index canister. When the entered ledger canister ID matches the ledgerId response from the entered index canister ID, we can confirm that this pair of IDs is suitable for each other. Here, we add a service that validates the ID matching.

# Changes

- New `matchLedgerIndexPair` service.

# Tests

- Unit test for it.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.