### PR TITLE
Imported tokens utils

### DIFF
--- a/frontend/src/lib/utils/imported-tokens.utils.ts
+++ b/frontend/src/lib/utils/imported-tokens.utils.ts
@@ -1,6 +1,7 @@
 import type { ImportedToken } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import type { ImportedTokenData } from "$lib/types/imported-tokens";
-import { fromNullable, toNullable } from "@dfinity/utils";
+import type { Principal } from "@dfinity/principal";
+import { fromNullable, nonNullish, toNullable } from "@dfinity/utils";
 
 export const toImportedTokenData = ({
   ledger_canister_id,
@@ -17,3 +18,16 @@ export const fromImportedTokenData = ({
   ledger_canister_id: ledgerCanisterId,
   index_canister_id: toNullable(indexCanisterId),
 });
+
+export const isImportedToken = ({
+  ledgerCanisterId,
+  importedTokens,
+}: {
+  ledgerCanisterId: Principal | undefined;
+  importedTokens: ImportedTokenData[] | undefined;
+}): boolean =>
+  nonNullish(ledgerCanisterId) &&
+  nonNullish(importedTokens) &&
+  importedTokens.some(
+    ({ ledgerCanisterId: id }) => id.toText() === ledgerCanisterId.toText()
+  );

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -211,9 +211,11 @@ export const isSnsLedgerCanisterId = ({
   ledgerCanisterId,
   snsProjects,
 }: {
-  ledgerCanisterId: Principal;
-  snsProjects: SnsFullProject[];
+  ledgerCanisterId: Principal | undefined;
+  snsProjects: SnsFullProject[] | undefined;
 }): boolean =>
+  nonNullish(ledgerCanisterId) &&
+  nonNullish(snsProjects) &&
   snsProjects.some(
     ({ summary }) =>
       summary.ledgerCanisterId.toText() === ledgerCanisterId.toText()

--- a/frontend/src/lib/utils/sns.utils.ts
+++ b/frontend/src/lib/utils/sns.utils.ts
@@ -1,5 +1,6 @@
 import { SECONDS_IN_DAY } from "$lib/constants/constants";
 import { MIN_VALID_SNS_GENERIC_NERVOUS_SYSTEM_FUNCTION_ID } from "$lib/constants/sns-proposals.constants";
+import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
 import type { SnsTicketsStoreData } from "$lib/stores/sns-tickets.store";
 import type { TicketStatus } from "$lib/types/sale";
 import type { SnsSwapCommitment } from "$lib/types/sns";
@@ -202,3 +203,18 @@ export const isSnsGenericNervousSystemTypeProposal = ({
   action,
 }: SnsProposalData): boolean =>
   action >= MIN_VALID_SNS_GENERIC_NERVOUS_SYSTEM_FUNCTION_ID;
+
+/**
+ * Returns true if the ledgerId is one of the SNS projects.
+ */
+export const isSnsLedgerCanisterId = ({
+  ledgerCanisterId,
+  snsProjects,
+}: {
+  ledgerCanisterId: Principal;
+  snsProjects: SnsFullProject[];
+}): boolean =>
+  snsProjects.some(
+    ({ summary }) =>
+      summary.ledgerCanisterId.toText() === ledgerCanisterId.toText()
+  );

--- a/frontend/src/tests/lib/utils/imported-tokens.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/imported-tokens.utils.spec.ts
@@ -2,6 +2,7 @@ import type { ImportedToken } from "$lib/canisters/nns-dapp/nns-dapp.types";
 import type { ImportedTokenData } from "$lib/types/imported-tokens";
 import {
   fromImportedTokenData,
+  isImportedToken,
   toImportedTokenData,
 } from "$lib/utils/imported-tokens.utils";
 import { principal } from "$tests/mocks/sns-projects.mock";
@@ -49,6 +50,62 @@ describe("imported tokens utils", () => {
       expect(fromImportedTokenData(importedTokenDataWithoutIndex)).toEqual(
         importedTokenWithoutIndex
       );
+    });
+  });
+
+  describe("isImportedToken", () => {
+    it("should return true when in the list", () => {
+      expect(
+        isImportedToken({
+          ledgerCanisterId: principal(1),
+          importedTokens: [
+            {
+              ledgerCanisterId: principal(0),
+            } as ImportedTokenData,
+            {
+              ledgerCanisterId: principal(1),
+            } as ImportedTokenData,
+          ],
+        })
+      ).toEqual(true);
+    });
+
+    it("should return false when not in the list", () => {
+      expect(
+        isImportedToken({
+          ledgerCanisterId: principal(1),
+          importedTokens: [
+            {
+              ledgerCanisterId: principal(0),
+            } as ImportedTokenData,
+          ],
+        })
+      ).toEqual(false);
+    });
+
+    it("should return false when not enough information", () => {
+      expect(
+        isImportedToken({
+          ledgerCanisterId: undefined,
+          importedTokens: [
+            {
+              ledgerCanisterId: principal(0),
+            } as ImportedTokenData,
+          ],
+        })
+      ).toEqual(false);
+      expect(
+        isImportedToken({
+          ledgerCanisterId: principal(0),
+          importedTokens: undefined,
+        })
+      ).toEqual(false);
+      expect(
+        isImportedToken({
+          ledgerCanisterId: undefined,
+          importedTokens: undefined,
+        })
+      ).toEqual(false);
     });
   });
 });

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -1,4 +1,5 @@
 import { SECONDS_IN_DAY, SECONDS_IN_MONTH } from "$lib/constants/constants";
+import type { SnsFullProject } from "$lib/derived/sns/sns-projects.derived";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
 import {
@@ -10,6 +11,7 @@ import {
   isSnsFinalizing,
   isSnsGenericNervousSystemFunction,
   isSnsGenericNervousSystemTypeProposal,
+  isSnsLedgerCanisterId,
   isSnsNativeNervousSystemFunction,
   parseSnsSwapSaleBuyerCount,
   swapEndedMoreThanOneWeekAgo,
@@ -24,6 +26,7 @@ import {
   createBuyersState,
   createSummary,
   mockDerivedResponse,
+  mockSnsFullProject,
   principal,
 } from "$tests/mocks/sns-projects.mock";
 import { mockSnsProposal } from "$tests/mocks/sns-proposals.mock";
@@ -385,6 +388,49 @@ sale_participants_count ${saleBuyerCount} 1677707139456
         isSnsGenericNervousSystemTypeProposal({
           ...mockSnsProposal,
           action: nativeNervousSystemFunctionMock.id,
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("isSnsLedgerCanisterId", () => {
+    const snsProjects = [
+      {
+        ...mockSnsFullProject,
+        summary: {
+          ...mockSnsFullProject.summary,
+          ledgerCanisterId: principal(0),
+        },
+      },
+      {
+        ...mockSnsFullProject,
+        summary: {
+          ...mockSnsFullProject.summary,
+          ledgerCanisterId: principal(1),
+        },
+      },
+    ] as SnsFullProject[];
+
+    it("should return true when in the list", () => {
+      expect(
+        isSnsLedgerCanisterId({
+          ledgerCanisterId: principal(0),
+          snsProjects,
+        })
+      ).toBe(true);
+      expect(
+        isSnsLedgerCanisterId({
+          ledgerCanisterId: principal(1),
+          snsProjects,
+        })
+      ).toBe(true);
+    });
+
+    it("should return false if not in the list", () => {
+      expect(
+        isSnsLedgerCanisterId({
+          ledgerCanisterId: principal(2),
+          snsProjects,
         })
       ).toBe(false);
     });

--- a/frontend/src/tests/lib/utils/sns.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns.utils.spec.ts
@@ -434,5 +434,26 @@ sale_participants_count ${saleBuyerCount} 1677707139456
         })
       ).toBe(false);
     });
+
+    it("should return false when not enough information", () => {
+      expect(
+        isSnsLedgerCanisterId({
+          ledgerCanisterId: undefined,
+          snsProjects,
+        })
+      ).toBe(false);
+      expect(
+        isSnsLedgerCanisterId({
+          ledgerCanisterId: principal(0),
+          snsProjects: undefined,
+        })
+      ).toBe(false);
+      expect(
+        isSnsLedgerCanisterId({
+          ledgerCanisterId: undefined,
+          snsProjects: undefined,
+        })
+      ).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
# Motivation

For validating the addition of imported tokens, we need to ensure that the entered ledger canister hasn’t already been imported and that it isn’t an SNS ledger canister ID. To facilitate this, we’ve added a pair of utility functions that will simplify the validation process.

# Changes

- Add `isImportedToken` util.
- Add `isSnsLedgerCanisterId` util.

# Tests

- Added unit tests for new utils.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.