### PR TITLE
cargo update without --worksapce

### DIFF
--- a/scripts/update-ic-cargo-deps
+++ b/scripts/update-ic-cargo-deps
@@ -30,4 +30,4 @@ for cargo_toml_file in "Cargo.toml" $(find "$TOP_DIR/rs" -name "Cargo.toml"); do
   done
 done
 
-cargo update --workspace
+cargo update


### PR DESCRIPTION
# Motivation

The latest run of "Update IC Cargo Dependencies" failed with:
```
error: failed to select a version for `ic-cdk`.
    ... required by package `pocket-ic v4.0.0`
    ... which satisfies dependency `pocket-ic = "^4.0.0"` (locked to 4.0.0) of package `nns-dapp v2.0.87 (/home/runner/work/nns-dapp/nns-dapp/rs/backend)`
versions that meet the requirements `^0.13.2` (locked to 0.13.2) are: 0.13.2

all possible versions conflict with previously selected packages.

  previously selected package `ic-cdk v0.13.5`
    ... which satisfies dependency `ic-cdk = "^0.13.5"` of package `icp-ledger v0.9.0 (https://github.com/dfinity/ic?rev=release-2024-08-21_15-36-canister-snapshots#3d6a76ef)`
    ... which satisfies git dependency `icp-ledger` of package `nns-dapp v2.0.87 (/home/runner/work/nns-dapp/nns-dapp/rs/backend)`

failed to select a version for `ic-cdk` which could resolve this conflict
```

When we run `cargo update` in [update-ic-cargo-deps](https://github.com/dfinity/nns-dapp/blob/b9a7a40c23a285b05a1f46275bc1f9e83ff301bd/scripts/update-ic-cargo-deps#L33), we use the `--workspace` flag which has help text `Only update the workspace packages`.

Not updating all the packages seems to be causing unnecessary conflicts.

I originally included the `--workspace` flag when I added the `cargo update` command in https://github.com/dfinity/nns-dapp/pull/4856

I don't remember why I included the flag and there doesn't appear to be a good reason for it.

# Changes

Remove `--workspace` from `update-ic-cargo-deps`.

# Tests

I ran `scripts/update-ic-cargo-deps --ref "release-2024-08-21_15-36-canister-snapshots"` and it no longer has the error listed above.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary