### PR TITLE
Remove payload rendering for InstallCode proposal

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -24,7 +24,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Removed
 
-* Rendering for `BlessReplicaVersion` and `RetireReplicaVersion` proposals.
+* Rendering for `InstallCode`, `BlessReplicaVersion` and `RetireReplicaVersion` proposals.
 
 #### Fixed
 

--- a/rs/proposals/src/def.rs
+++ b/rs/proposals/src/def.rs
@@ -9,10 +9,7 @@
 #![allow(missing_docs)]
 use crate::{
     canister_arg_types,
-    canisters::{
-        nns_governance::api::InstallCode,
-        sns_wasm::api::{SnsUpgrade, SnsVersion},
-    },
+    canisters::sns_wasm::api::{SnsUpgrade, SnsVersion},
     decode_arg, Json,
 };
 
@@ -502,29 +499,4 @@ pub struct SubnetRentalRequest {
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, Clone, Copy, Debug)]
 pub enum RentalConditionId {
     App13CH,
-}
-
-#[derive(CandidType, Serialize, Deserialize, Clone)]
-pub struct InstallCodeTrimmed {
-    pub wasm_module_hash: String,
-    pub arg_hex: String,
-    pub arg_hash: String,
-}
-
-impl From<&InstallCode> for InstallCodeTrimmed {
-    fn from(install_code: &InstallCode) -> Self {
-        InstallCodeTrimmed {
-            wasm_module_hash: install_code
-                .wasm_module
-                .as_ref()
-                .map(|wasm_module| calculate_hash_string(wasm_module))
-                .unwrap_or_default(),
-            arg_hex: install_code.arg.as_ref().map(hex::encode).unwrap_or_default(),
-            arg_hash: install_code
-                .arg
-                .as_ref()
-                .map(|arg| calculate_hash_string(arg))
-                .unwrap_or_default(),
-        }
-    }
 }

--- a/rs/proposals/src/lib.rs
+++ b/rs/proposals/src/lib.rs
@@ -9,11 +9,11 @@ use crate::def::{
     CompleteCanisterMigrationPayload, CreateSubnetPayload, DeployGuestosToAllSubnetNodesPayload,
     DeployGuestosToAllUnassignedNodesPayload, DeployGuestosToSomeApiBoundaryNodesPayload,
     DeployHostosToSomeNodesPayload, InsertUpgradePathEntriesRequest, InsertUpgradePathEntriesRequestHumanReadable,
-    InstallCodeTrimmed, PrepareCanisterMigrationPayload, RecoverSubnetPayload, RemoveApiBoundaryNodesPayload,
-    RemoveFirewallRulesPayload, RemoveNodeOperatorsPayload, RemoveNodeOperatorsPayloadHumanReadable,
-    RemoveNodesFromSubnetPayload, RemoveNodesPayload, RerouteCanisterRangesPayload,
-    ReviseElectedGuestosVersionsPayload, ReviseElectedHostosVersionsPayload, SetAuthorizedSubnetworkListArgs,
-    SetFirewallConfigPayload, StopOrStartNnsCanisterProposal, SubnetRentalRequest, UpdateAllowedPrincipalsRequest,
+    PrepareCanisterMigrationPayload, RecoverSubnetPayload, RemoveApiBoundaryNodesPayload, RemoveFirewallRulesPayload,
+    RemoveNodeOperatorsPayload, RemoveNodeOperatorsPayloadHumanReadable, RemoveNodesFromSubnetPayload,
+    RemoveNodesPayload, RerouteCanisterRangesPayload, ReviseElectedGuestosVersionsPayload,
+    ReviseElectedHostosVersionsPayload, SetAuthorizedSubnetworkListArgs, SetFirewallConfigPayload,
+    StopOrStartNnsCanisterProposal, SubnetRentalRequest, UpdateAllowedPrincipalsRequest,
     UpdateApiBoundaryNodesVersionPayload, UpdateElectedHostosVersionsPayload, UpdateFirewallRulesPayload,
     UpdateIcpXdrConversionRatePayload, UpdateNodeOperatorConfigPayload, UpdateNodeRewardsTableProposalPayload,
     UpdateNodesHostosVersionPayload, UpdateSnsSubnetListRequest, UpdateSshReadOnlyAccessForAllUnassignedNodesPayload,
@@ -29,7 +29,6 @@ use idl2json::candid_types::internal_candid_type_to_idl_type;
 use idl2json::{idl_args2json_with_weak_names, BytesFormat, Idl2JsonOptions};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use serde_json::json;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
@@ -121,10 +120,6 @@ pub fn process_proposal_payload(proposal_info: &ProposalInfo) -> Json {
                 let error_msg = "Unable to deserialize payload";
                 serde_json::to_string(&format!("{error_msg}: {e:.400}")).unwrap_or_else(|_| format!("\"{error_msg}\""))
             })
-        }
-        Some(Action::InstallCode(install_code)) => {
-            let trimmed = InstallCodeTrimmed::from(install_code);
-            json!(trimmed).to_string()
         }
         _ => serde_json::to_string("Proposal has no payload")
             .unwrap_or_else(|err| unreachable!("Surely a fixed string can be serialized as JSON?  Err: {err:?}")),

--- a/rs/proposals/src/tests/mod.rs
+++ b/rs/proposals/src/tests/mod.rs
@@ -19,31 +19,3 @@ fn payload_deserialization() {
         println!("{}", transformed.unwrap());
     }
 }
-
-/// Constructs a `ProposalInfo` with the given action for testing.
-fn proposal_info_with_action(action: Action) -> ProposalInfo {
-    ProposalInfo {
-        id: Some(NeuronId { id: 1 }),
-        status: 1,
-        topic: 1,
-        failure_reason: None,
-        ballots: vec![],
-        proposal_timestamp_seconds: 1,
-        reward_event_round: 1,
-        deadline_timestamp_seconds: None,
-        failed_timestamp_seconds: 0,
-        reject_cost_e8s: 0,
-        derived_proposal_information: None,
-        latest_tally: None,
-        reward_status: 1,
-        decided_timestamp_seconds: 1,
-        proposal: Some(Box::new(Proposal {
-            url: "".to_string(),
-            summary: "".to_string(),
-            title: None,
-            action: Some(action),
-        })),
-        proposer: None,
-        executed_timestamp_seconds: 1,
-    }
-}

--- a/rs/proposals/src/tests/mod.rs
+++ b/rs/proposals/src/tests/mod.rs
@@ -1,12 +1,7 @@
 //! Tests that the proposals crate can indeed express proposals as JSON.
 use super::*;
 
-use crate::{
-    canisters::nns_governance::api::{InstallCode, NeuronId, Proposal},
-    tests::payloads::get_payloads,
-};
-
-use ic_principal::Principal;
+use crate::tests::payloads::get_payloads;
 
 mod args;
 mod payloads;

--- a/rs/proposals/src/tests/mod.rs
+++ b/rs/proposals/src/tests/mod.rs
@@ -47,23 +47,3 @@ fn proposal_info_with_action(action: Action) -> ProposalInfo {
         executed_timestamp_seconds: 1,
     }
 }
-
-#[test]
-fn process_proposal_payload_install_code() {
-    let install_code_action = Action::InstallCode(InstallCode {
-        canister_id: Some(Principal::from_text("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap()),
-        wasm_module: Some(vec![1, 2, 3, 4].into()),
-        arg: Some(vec![5, 6, 7, 8].into()),
-        skip_stopping_before_installing: Some(false),
-        install_mode: Some(1),
-    });
-    let proposal_info = proposal_info_with_action(install_code_action);
-
-    assert_eq!(
-        process_proposal_payload(&proposal_info),
-        "{\"arg_hash\":\"55e5509f8052998294266ee5b50cb592938191fb5d67f73cac2e60b0276b1bdd\",\
-         \"arg_hex\":\"05060708\",\
-         \"wasm_module_hash\":\"9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a\"}"
-            .to_string()
-    );
-}


### PR DESCRIPTION
# Motivation

The latest [Candid import](https://github.com/dfinity/nns-dapp/pull/5355) breaks rendering of `InstallCode` proposal payload in the nns-dapp canister because its fields have changed.
But we no longer fetch the proposal payload for `InstallCode` proposals from the nns-dapp canister anyway (since https://github.com/dfinity/nns-dapp/pull/5332) so we no longer need to maintain this code.

# Changes

Remove code to render `InstallCode` payload from the nns-dapp backend canister.

# Tests

Unit test removed.

# Todos

- [x] Add entry to changelog (if necessary).
