### PR TITLE
bot: Update proposals candid bindings

### DIFF
--- a/declarations/used_by_proposals/nns_governance/nns_governance.did
+++ b/declarations/used_by_proposals/nns_governance/nns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-02_01-30-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record { hash : blob };
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
@@ -138,6 +138,10 @@ type CreateServiceNervousSystem = record {
   swap_parameters : opt SwapParameters;
   initial_token_distribution : opt InitialTokenDistribution;
 };
+type DateRangeFilter = record {
+  start_timestamp_seconds : opt nat64;
+  end_timestamp_seconds : opt nat64;
+};
 type Decimal = record { human_readable : opt text };
 type DerivedProposalInformation = record {
   swap_background_information : opt SwapBackgroundInformation;
@@ -267,6 +271,13 @@ type InitialTokenDistribution = record {
   swap_distribution : opt SwapDistribution;
 };
 type InstallCode = record {
+  skip_stopping_before_installing : opt bool;
+  wasm_module_hash : opt blob;
+  canister_id : opt principal;
+  arg_hash : opt blob;
+  install_mode : opt int32;
+};
+type InstallCodeRequest = record {
   arg : opt blob;
   wasm_module : opt blob;
   skip_stopping_before_installing : opt bool;
@@ -295,6 +306,12 @@ type ListNeuronsResponse = record {
   neuron_infos : vec record { nat64; NeuronInfo };
   full_neurons : vec Neuron;
 };
+type ListNodeProviderRewardsRequest = record {
+  date_filter : opt DateRangeFilter;
+};
+type ListNodeProviderRewardsResponse = record {
+  rewards : vec MonthlyNodeProviderRewards;
+};
 type ListNodeProvidersResponse = record { node_providers : vec NodeProvider };
 type ListProposalInfo = record {
   include_reward_status : vec int32;
@@ -306,6 +323,12 @@ type ListProposalInfo = record {
   include_status : vec int32;
 };
 type ListProposalInfoResponse = record { proposal_info : vec ProposalInfo };
+type MakeProposalRequest = record {
+  url : text;
+  title : opt text;
+  action : opt ProposalActionRequest;
+  summary : text;
+};
 type MakeProposalResponse = record {
   message : opt text;
   proposal_id : opt NeuronId;
@@ -318,6 +341,25 @@ type MakingSnsProposal = record {
 type ManageNeuron = record {
   id : opt NeuronId;
   command : opt Command;
+  neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
+};
+type ManageNeuronCommandRequest = variant {
+  Spawn : Spawn;
+  Split : Split;
+  Follow : Follow;
+  ClaimOrRefresh : ClaimOrRefresh;
+  Configure : Configure;
+  RegisterVote : RegisterVote;
+  Merge : Merge;
+  DisburseToNeuron : DisburseToNeuron;
+  MakeProposal : MakeProposalRequest;
+  StakeMaturity : StakeMaturity;
+  MergeMaturity : MergeMaturity;
+  Disburse : Disburse;
+};
+type ManageNeuronRequest = record {
+  id : opt NeuronId;
+  command : opt ManageNeuronCommandRequest;
   neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
 };
 type ManageNeuronResponse = record { command : opt Command_1 };
@@ -539,6 +581,24 @@ type Proposal = record {
   action : opt Action;
   summary : text;
 };
+type ProposalActionRequest = variant {
+  RegisterKnownNeuron : KnownNeuron;
+  ManageNeuron : ManageNeuronRequest;
+  UpdateCanisterSettings : UpdateCanisterSettings;
+  InstallCode : InstallCodeRequest;
+  StopOrStartCanister : StopOrStartCanister;
+  CreateServiceNervousSystem : CreateServiceNervousSystem;
+  ExecuteNnsFunction : ExecuteNnsFunction;
+  RewardNodeProvider : RewardNodeProvider;
+  OpenSnsTokenSwap : OpenSnsTokenSwap;
+  SetSnsTokenSwapOpenTimeWindow : SetSnsTokenSwapOpenTimeWindow;
+  SetDefaultFollowees : SetDefaultFollowees;
+  RewardNodeProviders : RewardNodeProviders;
+  ManageNetworkEconomics : NetworkEconomics;
+  ApproveGenesisKyc : Principals;
+  AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
+  Motion : Motion;
+};
 type ProposalData = record {
   id : opt NeuronId;
   failure_reason : opt GovernanceError;
@@ -750,16 +810,19 @@ service : (Governance) -> {
   get_restore_aging_summary : () -> (RestoreAgingSummary) query;
   list_known_neurons : () -> (ListKnownNeuronsResponse) query;
   list_neurons : (ListNeurons) -> (ListNeuronsResponse) query;
+  list_node_provider_rewards : (ListNodeProviderRewardsRequest) -> (
+      ListNodeProviderRewardsResponse,
+    ) query;
   list_node_providers : () -> (ListNodeProvidersResponse) query;
   list_proposals : (ListProposalInfo) -> (ListProposalInfoResponse) query;
-  manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
+  manage_neuron : (ManageNeuronRequest) -> (ManageNeuronResponse);
   settle_community_fund_participation : (SettleCommunityFundParticipation) -> (
       Result,
     );
   settle_neurons_fund_participation : (
       SettleNeuronsFundParticipationRequest,
     ) -> (SettleNeuronsFundParticipationResponse);
-  simulate_manage_neuron : (ManageNeuron) -> (ManageNeuronResponse);
+  simulate_manage_neuron : (ManageNeuronRequest) -> (ManageNeuronResponse);
   transfer_gtc_neuron : (NeuronId, NeuronId) -> (Result);
   update_node_provider : (UpdateNodeProvider) -> (Result);
 }

--- a/declarations/used_by_proposals/nns_registry/nns_registry.did
+++ b/declarations/used_by_proposals/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-02_01-30-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/registry/canister/canister/registry.did>
 // A brief note about the history of this file: This file used to be
 // automatically generated, but now, it is hand-crafted, because the
 // auto-generator has some some pretty degenerate behaviors. The worst of those
@@ -53,18 +53,6 @@ type AddNodesToSubnetPayload = record {
 type AddOrRemoveDataCentersProposalPayload = record {
   data_centers_to_add : vec DataCenterRecord;
   data_centers_to_remove : vec text;
-};
-
-type BlessReplicaVersionPayload = record {
-  release_package_urls : opt vec text;
-  node_manager_sha256_hex : text;
-  release_package_url : text;
-  sha256_hex : text;
-  guest_launch_measurement_sha256_hex : opt text;
-  replica_version_id : text;
-  release_package_sha256_hex : text;
-  node_manager_binary_url : text;
-  binary_url : text;
 };
 
 type CanisterIdRange = record { end : principal; start : principal };
@@ -280,8 +268,6 @@ type RerouteCanisterRangesPayload = record {
   destination_subnet : principal;
 };
 
-type RetireReplicaVersionPayload = record { replica_version_ids : vec text };
-
 type ReviseElectedGuestosVersionsPayload = record {
   release_package_urls : vec text;
   replica_versions_to_unelect : vec text;
@@ -309,7 +295,19 @@ type UpdateApiBoundaryNodesVersionPayload = record {
   node_ids : vec principal;
 };
 
+type DeployGuestosToSomeApiBoundaryNodes = record {
+  version : text;
+  node_ids : vec principal;
+};
+
 type UpdateElectedHostosVersionsPayload = record {
+  release_package_urls : vec text;
+  hostos_version_to_elect : opt text;
+  hostos_versions_to_unelect : vec text;
+  release_package_sha256_hex : opt text;
+};
+
+type ReviseElectedHostosVersionsPayload = record {
   release_package_urls : vec text;
   hostos_version_to_elect : opt text;
   hostos_versions_to_unelect : vec text;
@@ -361,6 +359,11 @@ type UpdateNodeRewardsTableProposalPayload = record {
 };
 
 type UpdateNodesHostosVersionPayload = record {
+  hostos_version_id : opt text;
+  node_ids : vec principal;
+};
+
+type DeployHostosToSomeNodes = record {
   hostos_version_id : opt text;
   node_ids : vec principal;
 };
@@ -421,7 +424,6 @@ service : {
   add_node_operator : (AddNodeOperatorPayload) -> ();
   add_nodes_to_subnet : (AddNodesToSubnetPayload) -> ();
   add_or_remove_data_centers : (AddOrRemoveDataCentersProposalPayload) -> ();
-  bless_replica_version : (BlessReplicaVersionPayload) -> ();
   change_subnet_membership : (ChangeSubnetMembershipPayload) -> ();
   clear_provisional_whitelist : () -> ();
   complete_canister_migration : (CompleteCanisterMigrationPayload) -> ();
@@ -432,6 +434,8 @@ service : {
   deploy_guestos_to_all_unassigned_nodes : (
     DeployGuestosToAllUnassignedNodesPayload
   ) -> ();
+  deploy_guestos_to_some_api_boundary_nodes : (DeployGuestosToSomeApiBoundaryNodes) -> ();
+  deploy_hostos_to_some_nodes : (DeployHostosToSomeNodes) -> ();
   get_build_metadata : () -> (text) query;
   get_node_operators_and_dcs_of_node_provider : (principal) -> (GetNodeOperatorsAndDcsOfNodeProviderResponse) query;
   get_node_providers_monthly_xdr_rewards : () -> (GetNodeProvidersMonthlyXdrRewardsResponse) query;
@@ -445,12 +449,12 @@ service : {
   remove_nodes : (RemoveNodesPayload) -> ();
   remove_nodes_from_subnet : (RemoveNodesPayload) -> ();
   reroute_canister_ranges : (RerouteCanisterRangesPayload) -> ();
-  retire_replica_version : (RetireReplicaVersionPayload) -> ();
+  revise_elected_guestos_versions : (ReviseElectedGuestosVersionsPayload) -> ();
   revise_elected_replica_versions : (ReviseElectedGuestosVersionsPayload) -> ();
   set_firewall_config : (SetFirewallConfigPayload) -> ();
   update_api_boundary_nodes_version : (UpdateApiBoundaryNodesVersionPayload) -> ();
   update_elected_hostos_versions : (UpdateElectedHostosVersionsPayload) -> ();
-  update_elected_replica_versions : (ReviseElectedGuestosVersionsPayload) -> ();
+  revise_elected_hostos_versions : (ReviseElectedHostosVersionsPayload) -> ();
   update_firewall_rules : (UpdateFirewallRulesPayload) -> ();
   update_node_directly : (UpdateNodeDirectlyPayload) -> ();
   update_node_domain_directly : (UpdateNodeDomainDirectlyPayload) -> (UpdateNodeDomainDirectlyResponse);
@@ -467,6 +471,5 @@ service : {
     UpdateSshReadOnlyAccessForAllUnassignedNodesPayload
   ) -> ();
   update_subnet : (UpdateSubnetPayload) -> ();
-  update_subnet_replica_version : (DeployGuestosToAllSubnetNodesPayload) -> ();
   update_unassigned_nodes_config : (UpdateUnassignedNodesConfigPayload) -> ();
 };

--- a/declarations/used_by_proposals/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_proposals/sns_wasm/sns_wasm.did
@@ -1,19 +1,8 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-02_01-30-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
 type AddWasmResponse = record { result : opt Result };
 type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
 type Canister = record { id : opt principal };
-type CfNeuron = record {
-  has_created_neuron_recipes : opt bool;
-  hotkeys : opt Principals;
-  nns_neuron_id : nat64;
-  amount_icp_e8s : nat64;
-};
-type CfParticipant = record {
-  controller : opt principal;
-  hotkey_principal : text;
-  cf_neurons : vec CfNeuron;
-};
 type Countries = record { iso_codes : vec text };
 type DappCanisters = record { canisters : vec Canister };
 type DappCanistersTransferResult = record {
@@ -112,7 +101,6 @@ type NeuronDistribution = record {
   stake_e8s : nat64;
   vesting_period_seconds : opt nat64;
 };
-type NeuronsFundParticipants = record { participants : vec CfParticipant };
 type NeuronsFundParticipationConstraints = record {
   coefficient_intervals : vec LinearScalingCoefficient;
   max_neurons_fund_participation_icp_e8s : opt nat64;
@@ -128,7 +116,6 @@ type PrettySnsVersion = record {
   governance_wasm_hash : text;
   index_wasm_hash : text;
 };
-type Principals = record { principals : vec principal };
 type Result = variant { Error : SnsWasmError; Hash : blob };
 type Result_1 = variant { Ok : Ok; Error : SnsWasmError };
 type SnsCanisterIds = record {
@@ -166,7 +153,6 @@ type SnsInitPayload = record {
   transaction_fee_e8s : opt nat64;
   dapp_canisters : opt DappCanisters;
   neurons_fund_participation_constraints : opt NeuronsFundParticipationConstraints;
-  neurons_fund_participants : opt NeuronsFundParticipants;
   max_age_bonus_percentage : opt nat64;
   initial_token_distribution : opt InitialTokenDistribution;
   reward_rate_transition_duration_seconds : opt nat64;

--- a/dfx.json
+++ b/dfx.json
@@ -387,7 +387,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-08-21",
-        "IC_COMMIT_FOR_PROPOSALS": "release-2024-08-02_01-30-base",
+        "IC_COMMIT_FOR_PROPOSALS": "release-2024-08-21_15-36-canister-snapshots",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-08-02_01-30-base"
       },
       "packtool": ""

--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-02_01-30-base/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -190,10 +190,10 @@ pub struct UpdateCanisterSettings {
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct InstallCode {
-    pub arg: Option<serde_bytes::ByteBuf>,
-    pub wasm_module: Option<serde_bytes::ByteBuf>,
     pub skip_stopping_before_installing: Option<bool>,
+    pub wasm_module_hash: Option<serde_bytes::ByteBuf>,
     pub canister_id: Option<Principal>,
+    pub arg_hash: Option<serde_bytes::ByteBuf>,
     pub install_mode: Option<i32>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
@@ -910,6 +910,19 @@ pub struct ListNeuronsResponse {
     pub full_neurons: Vec<Neuron>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct DateRangeFilter {
+    pub start_timestamp_seconds: Option<u64>,
+    pub end_timestamp_seconds: Option<u64>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct ListNodeProviderRewardsRequest {
+    pub date_filter: Option<DateRangeFilter>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct ListNodeProviderRewardsResponse {
+    pub rewards: Vec<MonthlyNodeProviderRewards>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct ListNodeProvidersResponse {
     pub node_providers: Vec<NodeProvider>,
 }
@@ -926,6 +939,61 @@ pub struct ListProposalInfo {
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ListProposalInfoResponse {
     pub proposal_info: Vec<ProposalInfo>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct InstallCodeRequest {
+    pub arg: Option<serde_bytes::ByteBuf>,
+    pub wasm_module: Option<serde_bytes::ByteBuf>,
+    pub skip_stopping_before_installing: Option<bool>,
+    pub canister_id: Option<Principal>,
+    pub install_mode: Option<i32>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub enum ProposalActionRequest {
+    RegisterKnownNeuron(KnownNeuron),
+    ManageNeuron(Box<ManageNeuronRequest>),
+    UpdateCanisterSettings(UpdateCanisterSettings),
+    InstallCode(InstallCodeRequest),
+    StopOrStartCanister(StopOrStartCanister),
+    CreateServiceNervousSystem(CreateServiceNervousSystem),
+    ExecuteNnsFunction(ExecuteNnsFunction),
+    RewardNodeProvider(RewardNodeProvider),
+    OpenSnsTokenSwap(OpenSnsTokenSwap),
+    SetSnsTokenSwapOpenTimeWindow(SetSnsTokenSwapOpenTimeWindow),
+    SetDefaultFollowees(SetDefaultFollowees),
+    RewardNodeProviders(RewardNodeProviders),
+    ManageNetworkEconomics(NetworkEconomics),
+    ApproveGenesisKyc(Principals),
+    AddOrRemoveNodeProvider(AddOrRemoveNodeProvider),
+    Motion(Motion),
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct MakeProposalRequest {
+    pub url: String,
+    pub title: Option<String>,
+    pub action: Option<ProposalActionRequest>,
+    pub summary: String,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub enum ManageNeuronCommandRequest {
+    Spawn(Spawn),
+    Split(Split),
+    Follow(Follow),
+    ClaimOrRefresh(ClaimOrRefresh),
+    Configure(Configure),
+    RegisterVote(RegisterVote),
+    Merge(Merge),
+    DisburseToNeuron(DisburseToNeuron),
+    MakeProposal(MakeProposalRequest),
+    StakeMaturity(StakeMaturity),
+    MergeMaturity(MergeMaturity),
+    Disburse(Disburse),
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct ManageNeuronRequest {
+    pub id: Option<NeuronId>,
+    pub command: Option<ManageNeuronCommandRequest>,
+    pub neuron_id_or_subaccount: Option<NeuronIdOrSubaccount>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct SpawnResponse {
@@ -1110,13 +1178,19 @@ impl Service {
     pub async fn list_neurons(&self, arg0: ListNeurons) -> CallResult<(ListNeuronsResponse,)> {
         ic_cdk::call(self.0, "list_neurons", (arg0,)).await
     }
+    pub async fn list_node_provider_rewards(
+        &self,
+        arg0: ListNodeProviderRewardsRequest,
+    ) -> CallResult<(ListNodeProviderRewardsResponse,)> {
+        ic_cdk::call(self.0, "list_node_provider_rewards", (arg0,)).await
+    }
     pub async fn list_node_providers(&self) -> CallResult<(ListNodeProvidersResponse,)> {
         ic_cdk::call(self.0, "list_node_providers", ()).await
     }
     pub async fn list_proposals(&self, arg0: ListProposalInfo) -> CallResult<(ListProposalInfoResponse,)> {
         ic_cdk::call(self.0, "list_proposals", (arg0,)).await
     }
-    pub async fn manage_neuron(&self, arg0: ManageNeuron) -> CallResult<(ManageNeuronResponse,)> {
+    pub async fn manage_neuron(&self, arg0: ManageNeuronRequest) -> CallResult<(ManageNeuronResponse,)> {
         ic_cdk::call(self.0, "manage_neuron", (arg0,)).await
     }
     pub async fn settle_community_fund_participation(
@@ -1131,7 +1205,7 @@ impl Service {
     ) -> CallResult<(SettleNeuronsFundParticipationResponse,)> {
         ic_cdk::call(self.0, "settle_neurons_fund_participation", (arg0,)).await
     }
-    pub async fn simulate_manage_neuron(&self, arg0: ManageNeuron) -> CallResult<(ManageNeuronResponse,)> {
+    pub async fn simulate_manage_neuron(&self, arg0: ManageNeuronRequest) -> CallResult<(ManageNeuronResponse,)> {
         ic_cdk::call(self.0, "simulate_manage_neuron", (arg0,)).await
     }
     pub async fn transfer_gtc_neuron(&self, arg0: NeuronId, arg1: NeuronId) -> CallResult<(Result_,)> {

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-02_01-30-base/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -98,18 +98,6 @@ pub struct DataCenterRecord {
 pub struct AddOrRemoveDataCentersProposalPayload {
     pub data_centers_to_add: Vec<DataCenterRecord>,
     pub data_centers_to_remove: Vec<String>,
-}
-#[derive(Serialize, CandidType, Deserialize)]
-pub struct BlessReplicaVersionPayload {
-    pub release_package_urls: Option<Vec<String>>,
-    pub node_manager_sha256_hex: String,
-    pub release_package_url: String,
-    pub sha256_hex: String,
-    pub guest_launch_measurement_sha256_hex: Option<String>,
-    pub replica_version_id: String,
-    pub release_package_sha256_hex: String,
-    pub node_manager_binary_url: String,
-    pub binary_url: String,
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ChangeSubnetMembershipPayload {
@@ -240,6 +228,16 @@ pub struct DeployGuestosToAllUnassignedNodesPayload {
     pub elected_replica_version: String,
 }
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct DeployGuestosToSomeApiBoundaryNodes {
+    pub version: String,
+    pub node_ids: Vec<Principal>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct DeployHostosToSomeNodes {
+    pub hostos_version_id: Option<String>,
+    pub node_ids: Vec<Principal>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct NodeOperatorRecord {
     pub ipv6: Option<String>,
     pub node_operator_principal_id: serde_bytes::ByteBuf,
@@ -318,15 +316,18 @@ pub struct RerouteCanisterRangesPayload {
     pub destination_subnet: Principal,
 }
 #[derive(Serialize, CandidType, Deserialize)]
-pub struct RetireReplicaVersionPayload {
-    pub replica_version_ids: Vec<String>,
-}
-#[derive(Serialize, CandidType, Deserialize)]
 pub struct ReviseElectedGuestosVersionsPayload {
     pub release_package_urls: Vec<String>,
     pub replica_versions_to_unelect: Vec<String>,
     pub replica_version_to_elect: Option<String>,
     pub guest_launch_measurement_sha256_hex: Option<String>,
+    pub release_package_sha256_hex: Option<String>,
+}
+#[derive(Serialize, CandidType, Deserialize)]
+pub struct ReviseElectedHostosVersionsPayload {
+    pub release_package_urls: Vec<String>,
+    pub hostos_version_to_elect: Option<String>,
+    pub hostos_versions_to_unelect: Vec<String>,
     pub release_package_sha256_hex: Option<String>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
@@ -489,9 +490,6 @@ impl Service {
     pub async fn add_or_remove_data_centers(&self, arg0: AddOrRemoveDataCentersProposalPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "add_or_remove_data_centers", (arg0,)).await
     }
-    pub async fn bless_replica_version(&self, arg0: BlessReplicaVersionPayload) -> CallResult<()> {
-        ic_cdk::call(self.0, "bless_replica_version", (arg0,)).await
-    }
     pub async fn change_subnet_membership(&self, arg0: ChangeSubnetMembershipPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "change_subnet_membership", (arg0,)).await
     }
@@ -515,6 +513,15 @@ impl Service {
         arg0: DeployGuestosToAllUnassignedNodesPayload,
     ) -> CallResult<()> {
         ic_cdk::call(self.0, "deploy_guestos_to_all_unassigned_nodes", (arg0,)).await
+    }
+    pub async fn deploy_guestos_to_some_api_boundary_nodes(
+        &self,
+        arg0: DeployGuestosToSomeApiBoundaryNodes,
+    ) -> CallResult<()> {
+        ic_cdk::call(self.0, "deploy_guestos_to_some_api_boundary_nodes", (arg0,)).await
+    }
+    pub async fn deploy_hostos_to_some_nodes(&self, arg0: DeployHostosToSomeNodes) -> CallResult<()> {
+        ic_cdk::call(self.0, "deploy_hostos_to_some_nodes", (arg0,)).await
     }
     pub async fn get_build_metadata(&self) -> CallResult<(String,)> {
         ic_cdk::call(self.0, "get_build_metadata", ()).await
@@ -563,8 +570,11 @@ impl Service {
     pub async fn reroute_canister_ranges(&self, arg0: RerouteCanisterRangesPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "reroute_canister_ranges", (arg0,)).await
     }
-    pub async fn retire_replica_version(&self, arg0: RetireReplicaVersionPayload) -> CallResult<()> {
-        ic_cdk::call(self.0, "retire_replica_version", (arg0,)).await
+    pub async fn revise_elected_guestos_versions(&self, arg0: ReviseElectedGuestosVersionsPayload) -> CallResult<()> {
+        ic_cdk::call(self.0, "revise_elected_guestos_versions", (arg0,)).await
+    }
+    pub async fn revise_elected_hostos_versions(&self, arg0: ReviseElectedHostosVersionsPayload) -> CallResult<()> {
+        ic_cdk::call(self.0, "revise_elected_hostos_versions", (arg0,)).await
     }
     pub async fn revise_elected_replica_versions(&self, arg0: ReviseElectedGuestosVersionsPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "revise_elected_replica_versions", (arg0,)).await
@@ -580,9 +590,6 @@ impl Service {
     }
     pub async fn update_elected_hostos_versions(&self, arg0: UpdateElectedHostosVersionsPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "update_elected_hostos_versions", (arg0,)).await
-    }
-    pub async fn update_elected_replica_versions(&self, arg0: ReviseElectedGuestosVersionsPayload) -> CallResult<()> {
-        ic_cdk::call(self.0, "update_elected_replica_versions", (arg0,)).await
     }
     pub async fn update_firewall_rules(&self, arg0: UpdateFirewallRulesPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "update_firewall_rules", (arg0,)).await
@@ -625,9 +632,6 @@ impl Service {
     }
     pub async fn update_subnet(&self, arg0: UpdateSubnetPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "update_subnet", (arg0,)).await
-    }
-    pub async fn update_subnet_replica_version(&self, arg0: DeployGuestosToAllSubnetNodesPayload) -> CallResult<()> {
-        ic_cdk::call(self.0, "update_subnet_replica_version", (arg0,)).await
     }
     pub async fn update_unassigned_nodes_config(&self, arg0: UpdateUnassignedNodesConfigPayload) -> CallResult<()> {
         ic_cdk::call(self.0, "update_unassigned_nodes_config", (arg0,)).await

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-02_01-30-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -80,27 +80,6 @@ pub struct NeuronsFundParticipationConstraints {
     pub ideal_matched_participation_function: Option<IdealMatchedParticipationFunction>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
-pub struct Principals {
-    pub principals: Vec<Principal>,
-}
-#[derive(Serialize, CandidType, Deserialize)]
-pub struct CfNeuron {
-    pub has_created_neuron_recipes: Option<bool>,
-    pub hotkeys: Option<Principals>,
-    pub nns_neuron_id: u64,
-    pub amount_icp_e8s: u64,
-}
-#[derive(Serialize, CandidType, Deserialize)]
-pub struct CfParticipant {
-    pub controller: Option<Principal>,
-    pub hotkey_principal: String,
-    pub cf_neurons: Vec<CfNeuron>,
-}
-#[derive(Serialize, CandidType, Deserialize)]
-pub struct NeuronsFundParticipants {
-    pub participants: Vec<CfParticipant>,
-}
-#[derive(Serialize, CandidType, Deserialize)]
 pub struct TreasuryDistribution {
     pub total_e8s: u64,
 }
@@ -169,7 +148,6 @@ pub struct SnsInitPayload {
     pub transaction_fee_e8s: Option<u64>,
     pub dapp_canisters: Option<DappCanisters>,
     pub neurons_fund_participation_constraints: Option<NeuronsFundParticipationConstraints>,
-    pub neurons_fund_participants: Option<NeuronsFundParticipants>,
     pub max_age_bonus_percentage: Option<u64>,
     pub initial_token_distribution: Option<InitialTokenDistribution>,
     pub reward_rate_transition_duration_seconds: Option<u64>,


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.
Even with no changes, just updating the reference is good practice.

# Changes
* Update the version of `IC_COMMIT_FOR_PROPOSALS` specified in `dfx.json`.
* Updated the `proposals` candid files to the versions in that commit.
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants