### PR TITLE
Use icd_cdk::api::time() instead of ic0::time()

### DIFF
--- a/rs/backend/src/time.rs
+++ b/rs/backend/src/time.rs
@@ -1,9 +1,5 @@
-use dfn_core::api::ic0;
-
-/// Gets time.
-///
-/// TODO: Replace with: `ic_cdk::api::time`
+/// Gets current timestamp, in nanoseconds since the epoch (1970-01-01)
 #[must_use]
 pub fn time() -> u64 {
-    unsafe { ic0::time() }
+    ic_cdk::api::time()
 }


### PR DESCRIPTION
# Motivation

We had a TODO to replace a usage of `ic0::time()` with `ic_cdk::api::time()`.
Both return time in nanoseconds:
https://github.com/dfinity/ic/blob/62c2ed16a02cd0155964013cb0849eadafe22069/rs/rust_canisters/dfn_core/src/api.rs#L223
https://github.com/dfinity/cdk-rs/blob/3e54016734c8f73fb3acabc9c9e72c960c85eb3b/src/ic-cdk/src/api/mod.rs#L27C1-L27C72

# Changes

1. Fulfill the TODO by using `ic_cdk::api::time()` instead of `ic0::time()`.
2. Document what it actually returns.

# Tests

Not tested. Existing tests pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary