### PR TITLE
NNS1-3281: Add update_locked_icp_e8s for TVL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4033,6 +4033,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tar",
+ "tokio",
 ]
 
 [[package]]

--- a/rs/backend/Cargo.toml
+++ b/rs/backend/Cargo.toml
@@ -51,6 +51,7 @@ pocket-ic = "4.0.0"
 pretty_assertions = "1.4.0"
 proptest = "1.5.0"
 rand = "0.8.5"
+tokio = "1.39.3"
 
 [features]
 # Build flavours; these should not normally be referred to directly in code.

--- a/rs/backend/src/canisters/governance.rs
+++ b/rs/backend/src/canisters/governance.rs
@@ -1,6 +1,9 @@
 use dfn_candid::candid;
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
-use ic_nns_governance::pb::v1::{ClaimOrRefreshNeuronFromAccount, ClaimOrRefreshNeuronFromAccountResponse};
+pub use ic_nns_governance::pb::v1::{
+    governance::GovernanceCachedMetrics, ClaimOrRefreshNeuronFromAccount, ClaimOrRefreshNeuronFromAccountResponse,
+    GovernanceError,
+};
 
 pub async fn claim_or_refresh_neuron_from_account(
     request: ClaimOrRefreshNeuronFromAccount,
@@ -13,4 +16,54 @@ pub async fn claim_or_refresh_neuron_from_account(
     )
     .await
     .map_err(|e| e.1)
+}
+
+#[cfg(not(test))]
+pub use prod::get_metrics;
+
+#[cfg(test)]
+pub use testing::get_metrics;
+
+#[cfg(not(test))]
+mod prod {
+    use super::{candid, GovernanceCachedMetrics, GovernanceError, GOVERNANCE_CANISTER_ID};
+
+    pub async fn get_metrics() -> Result<Result<GovernanceCachedMetrics, GovernanceError>, String> {
+        dfn_core::call(GOVERNANCE_CANISTER_ID, "get_metrics", candid, ())
+            .await
+            .map_err(|e| e.1)
+    }
+}
+
+#[cfg(test)]
+pub mod testing {
+    use super::*;
+    use std::{cell::RefCell, collections::VecDeque};
+
+    thread_local! {
+        pub static RESPONSES:
+        RefCell<VecDeque<Result<Result<GovernanceCachedMetrics, GovernanceError>, String>>> = RefCell::default();
+    }
+
+    pub async fn get_metrics() -> Result<Result<GovernanceCachedMetrics, GovernanceError>, String> {
+        RESPONSES.with(|responses| {
+            responses
+                .borrow_mut()
+                .pop_front()
+                .expect("The test must provide a response before get_metrics is called.")
+        })
+    }
+
+    pub fn add_metrics_response(response: Result<Result<GovernanceCachedMetrics, GovernanceError>, String>) {
+        RESPONSES.with(|responses| responses.borrow_mut().push_back(response));
+    }
+
+    pub fn add_metrics_response_with_total_locked_e8s(total_locked_e8s: u64) {
+        let response = Ok(Ok(GovernanceCachedMetrics {
+            // total_locked_e8s is the only field our code cares about.
+            total_locked_e8s,
+            ..GovernanceCachedMetrics::default()
+        }));
+        add_metrics_response(response);
+    }
 }

--- a/rs/backend/src/canisters/governance.rs
+++ b/rs/backend/src/canisters/governance.rs
@@ -28,7 +28,7 @@ type GetMetricsCallResult = Result<Result<GovernanceCachedMetrics, GovernanceErr
 
 #[cfg(not(test))]
 mod prod {
-    use super::{candid, GovernanceCachedMetrics, GovernanceError, GOVERNANCE_CANISTER_ID};
+    use super::{candid, GetMetricsCallResult, GOVERNANCE_CANISTER_ID};
 
     pub async fn get_metrics() -> GetMetricsCallResult {
         dfn_core::call(GOVERNANCE_CANISTER_ID, "get_metrics", candid, ())

--- a/rs/backend/src/lib.rs
+++ b/rs/backend/src/lib.rs
@@ -13,5 +13,8 @@ pub mod perf;
 pub mod state;
 pub mod stats;
 pub mod time;
+pub mod tvl {
+    pub mod state;
+}
 
 use crate::state::{StableState, STATE};

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -39,6 +39,7 @@ mod periodic_tasks_runner;
 mod state;
 mod stats;
 mod time;
+mod tvl;
 
 type Cycles = u128;
 

--- a/rs/backend/src/state/tests.rs
+++ b/rs/backend/src/state/tests.rs
@@ -4,6 +4,7 @@ use crate::{
         partitions::{Partitions, PartitionsMaybe},
         AccountsDbAsMap, AssetHashes, Assets, PerformanceCounts, StableState, State,
     },
+    tvl::state::TvlState,
 };
 use ic_stable_structures::{DefaultMemoryImpl, VectorMemory};
 use pretty_assertions::assert_eq;
@@ -18,6 +19,7 @@ pub fn setup_test_state() -> State {
         asset_hashes: RefCell::new(AssetHashes::default()),
         performance: RefCell::new(PerformanceCounts::test_data()),
         partitions_maybe: RefCell::new(PartitionsMaybe::None(VectorMemory::default())),
+        tvl_state: RefCell::new(TvlState::default()),
     }
 }
 

--- a/rs/backend/src/tvl.rs
+++ b/rs/backend/src/tvl.rs
@@ -1,0 +1,34 @@
+use crate::{canisters::governance, state::STATE};
+
+pub mod state;
+
+// TODO(NNS1-3281): Remove #[allow(unused)].
+#[allow(unused)]
+pub async fn update_locked_icp_e8s() {
+    let metrics_result = governance::get_metrics().await;
+    STATE.with(|s| {
+        match metrics_result {
+            Ok(Ok(metrics)) => {
+                s.tvl_state.borrow_mut().total_locked_icp_e8s = metrics.total_locked_e8s;
+                ic_cdk::println!("Updated total_locked_icp_e8s for TVL to {}", metrics.total_locked_e8s);
+            }
+            Ok(Err(err)) => {
+                ic_cdk::println!(
+                    "Keeping total_locked_icp_e8s for TVL at {} because of response error: {}",
+                    s.tvl_state.borrow().total_locked_icp_e8s,
+                    err
+                );
+            }
+            Err(err) => {
+                ic_cdk::println!(
+                    "Keeping total_locked_icp_e8s for TVL at {} because of call error: {}",
+                    s.tvl_state.borrow().total_locked_icp_e8s,
+                    err
+                );
+            }
+        };
+    });
+}
+
+#[cfg(test)]
+pub(crate) mod tests;

--- a/rs/backend/src/tvl/state.rs
+++ b/rs/backend/src/tvl/state.rs
@@ -1,0 +1,7 @@
+use candid::CandidType;
+use serde::Deserialize;
+
+#[derive(CandidType, Default, Debug, Deserialize)]
+pub struct TvlState {
+    pub total_locked_icp_e8s: u64,
+}

--- a/rs/backend/src/tvl/tests.rs
+++ b/rs/backend/src/tvl/tests.rs
@@ -13,13 +13,17 @@ async fn update_locked_icp_e8s() {
     let initial_locked_icp_e8s = 50_000_000_000;
     let later_locked_icp_e8s = 90_000_000_000;
 
+    // Step 1: Set up the environment.
     set_total_locked_icp_e8s(initial_locked_icp_e8s);
-    assert_eq!(get_total_locked_icp_e8s(), initial_locked_icp_e8s);
-
     governance::testing::add_metrics_response_with_total_locked_e8s(later_locked_icp_e8s);
 
+    // Step 2: Verify the state before calling the code under test.
+    assert_eq!(get_total_locked_icp_e8s(), initial_locked_icp_e8s);
+
+    // Step 3: Call the code under test.
     tvl::update_locked_icp_e8s().await;
 
+    // Step 4: Verify the state after calling the code under test.
     assert_eq!(get_total_locked_icp_e8s(), later_locked_icp_e8s);
 }
 
@@ -27,13 +31,17 @@ async fn update_locked_icp_e8s() {
 async fn update_locked_icp_e8s_with_call_error() {
     let initial_locked_icp_e8s = 50_000_000_000;
 
+    // Step 1: Set up the environment.
     set_total_locked_icp_e8s(initial_locked_icp_e8s);
-    assert_eq!(get_total_locked_icp_e8s(), initial_locked_icp_e8s);
-
     governance::testing::add_metrics_response(Err("Canister is stopped".to_string()));
 
+    // Step 2: Verify the state before calling the code under test.
+    assert_eq!(get_total_locked_icp_e8s(), initial_locked_icp_e8s);
+
+    // Step 3: Call the code under test.
     tvl::update_locked_icp_e8s().await;
 
+    // Step 4: Verify the state after calling the code under test.
     // The total locked ICP should not have been updated because of the error.
     assert_eq!(get_total_locked_icp_e8s(), initial_locked_icp_e8s);
 }
@@ -42,16 +50,20 @@ async fn update_locked_icp_e8s_with_call_error() {
 async fn update_locked_icp_e8s_with_method_error() {
     let initial_locked_icp_e8s = 50_000_000_000;
 
+    // Step 1: Set up the environment.
     set_total_locked_icp_e8s(initial_locked_icp_e8s);
-    assert_eq!(get_total_locked_icp_e8s(), initial_locked_icp_e8s);
-
     governance::testing::add_metrics_response(Ok(Err(governance::GovernanceError {
         error_type: 123,
         error_message: "Some error message".to_string(),
     })));
 
+    // Step 2: Verify the state before calling the code under test.
+    assert_eq!(get_total_locked_icp_e8s(), initial_locked_icp_e8s);
+
+    // Step 3: Call the code under test.
     tvl::update_locked_icp_e8s().await;
 
+    // Step 4: Verify the state after calling the code under test.
     // The total locked ICP should not have been updated because of the error.
     assert_eq!(get_total_locked_icp_e8s(), initial_locked_icp_e8s);
 }

--- a/rs/backend/src/tvl/tests.rs
+++ b/rs/backend/src/tvl/tests.rs
@@ -1,0 +1,57 @@
+use crate::tvl::{self, governance};
+
+fn get_total_locked_icp_e8s() -> u64 {
+    tvl::STATE.with(|s| s.tvl_state.borrow().total_locked_icp_e8s)
+}
+
+fn set_total_locked_icp_e8s(new_value: u64) {
+    tvl::STATE.with(|s| s.tvl_state.borrow_mut().total_locked_icp_e8s = new_value);
+}
+
+#[tokio::test]
+async fn update_locked_icp_e8s() {
+    let initial_locked_icp_e8s = 50_000_000_000;
+    let later_locked_icp_e8s = 90_000_000_000;
+
+    set_total_locked_icp_e8s(initial_locked_icp_e8s);
+    assert_eq!(get_total_locked_icp_e8s(), initial_locked_icp_e8s);
+
+    governance::testing::add_metrics_response_with_total_locked_e8s(later_locked_icp_e8s);
+
+    tvl::update_locked_icp_e8s().await;
+
+    assert_eq!(get_total_locked_icp_e8s(), later_locked_icp_e8s);
+}
+
+#[tokio::test]
+async fn update_locked_icp_e8s_with_call_error() {
+    let initial_locked_icp_e8s = 50_000_000_000;
+
+    set_total_locked_icp_e8s(initial_locked_icp_e8s);
+    assert_eq!(get_total_locked_icp_e8s(), initial_locked_icp_e8s);
+
+    governance::testing::add_metrics_response(Err("Canister is stopped".to_string()));
+
+    tvl::update_locked_icp_e8s().await;
+
+    // The total locked ICP should not have been updated because of the error.
+    assert_eq!(get_total_locked_icp_e8s(), initial_locked_icp_e8s);
+}
+
+#[tokio::test]
+async fn update_locked_icp_e8s_with_method_error() {
+    let initial_locked_icp_e8s = 50_000_000_000;
+
+    set_total_locked_icp_e8s(initial_locked_icp_e8s);
+    assert_eq!(get_total_locked_icp_e8s(), initial_locked_icp_e8s);
+
+    governance::testing::add_metrics_response(Ok(Err(governance::GovernanceError {
+        error_type: 123,
+        error_message: "Some error message".to_string(),
+    })));
+
+    tvl::update_locked_icp_e8s().await;
+
+    // The total locked ICP should not have been updated because of the error.
+    assert_eq!(get_total_locked_icp_e8s(), initial_locked_icp_e8s);
+}


### PR DESCRIPTION
# Motivation

The NNS dapp displays the USD value of the total amount of ICP locked in neurons.
It gets this information from the TVL canister but we want to move this functionality to the nns-dapp canister and remove the TVL canister.

There are 2 inputs to this data:
1. The amount of ICP locked in neurons
2. The price of ICP in USD.

We plan to periodically load both values and cache them in the canister state. When the user requests the TVL, it will be computed from the currently cached state.

In this PR we only add a function which can load the amount of locked ICP into the nns-dapp state.
The function is not yet called, and the state is not yet persisted in this PR.

# Changes

1. Add `get_metrics` function to call the `get_metrics` function on the governance canister. There is a separate implementation for testing.
2. Add a `TvlState` type which will hold all the state necessary to compute the TVL. In this PR it will only have the `total_locked_icp_e8s` for now.
3. Add the `TvlState` to the canister state. It's not yet included in what is persisted to stable memory but should be in the future.
4. Add `update_locked_icp_e8s` which calls `get_metrics` and stores `total_locked_icp_e8s` in the state.

# Tests

1. Added unit tests for the success and error cases.
2. Manually tested the feature end to end in a branch which has all the other changes.


# Todos

- [ ] Add entry to changelog (if necessary).
Will add when the code is functional.