### PR TITLE
FOLLOW-1337: Disable FORCE_CALL_STRATEGY

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -20,6 +20,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Staking project rows are not clickable when not signed in.
 * Changes for cleaning up the stable structure migration.
 * Upgrade agent-js to version 2.
+* Make more update calls in cases where we were only doing query calls.
 
 #### Deprecated
 

--- a/frontend/src/lib/constants/mockable.constants.ts
+++ b/frontend/src/lib/constants/mockable.constants.ts
@@ -8,7 +8,7 @@ export const DEV = import.meta.env.DEV;
 // Disable TVL or transaction rate warning locally because that information is not crucial when we develop
 export const ENABLE_METRICS = !DEV;
 
-export const FORCE_CALL_STRATEGY: "query" | undefined = "query";
+export const FORCE_CALL_STRATEGY: "query" | undefined = undefined;
 
 export const IS_TEST_ENV = process.env.NODE_ENV === "test";
 

--- a/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
+++ b/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
@@ -98,6 +98,11 @@ test("Test neuron increase stake", async ({ page, context }) => {
   await appPo.getAccountsPo().waitFor();
   await appPo.goBack();
   await appPo.goToNeuronDetails(neuronId);
+  // The neuron info is cached in the governance.api-service for 5 minutes.
+  // This cache is cleared every time we do an operation on the governance API
+  // but not when we transfer the ICP directly to the neuron account. So to see
+  // the new stake we reload the page to avoid hitting the api-service cache.
+  await page.reload();
   const neuronStake3 = Number(
     await appPo
       .getNeuronDetailPo()


### PR DESCRIPTION
# Motivation

`FORCE_CALL_STRATEGY` is currently used to limit the number of update calls made to the Internet Computer for certain cases.
We want to stop doing this to avoid the possibility of displaying incorrect data from a malicious node.

# Changes

Change `FORCE_CALL_STRATEGY` from `"query"` to `undefined`.
This makes sure we do a query and update in all the [places where FORCE_CALL_STRATEGY is used](https://github.com/search?q=repo%3Adfinity%2Fnns-dapp+%22%3A+FORCE_CALL_STRATEGY%22&type=code).

# Tests

1. Fixed an e2e test which got broken because some caching started working again because it only caches certified results.
2. Other existing tests pass (`FORCE_CALL_STRATEGY` was [still set to](https://github.com/dfinity/nns-dapp/blob/e09ed215565c5521b6403a02ddeb15f8e3876365/frontend/vitest.setup.ts#L67) `undefined` by default in unit tests).
3. Temporarily added some logging to manually test that 2 requests are made to load account balances.

# Todos

- [x] Add entry to changelog (if necessary).