### PR TITLE
Populate icrc store with imported tokens

### DIFF
--- a/frontend/src/lib/services/imported-tokens.services.ts
+++ b/frontend/src/lib/services/imported-tokens.services.ts
@@ -44,9 +44,14 @@ export const loadImportedTokens = async ({
         certified,
       });
 
-      const icrcCanistersStoreData = get(icrcCanistersStore);
+      if (!certified && notForceCallStrategy()) {
+        return;
+      }
+
+      // Populate icrcCanistersStore with the imported tokens.
       for (const { ledgerCanisterId, indexCanisterId } of importedTokens) {
-        if (isNullish(icrcCanistersStoreData[ledgerCanisterId.toText()])) {
+        // If the imported token is not already in the store, add it.
+        if (isNullish(get(icrcCanistersStore)[ledgerCanisterId.toText()])) {
           icrcCanistersStore.setCanisters({
             ledgerCanisterId,
             indexCanisterId,

--- a/frontend/src/lib/stores/icrc-canisters.store.ts
+++ b/frontend/src/lib/stores/icrc-canisters.store.ts
@@ -7,7 +7,7 @@ import { writable } from "svelte/store";
 
 export interface IcrcCanisters {
   ledgerCanisterId: Principal;
-  indexCanisterId: Principal;
+  indexCanisterId: Principal | undefined;
 }
 
 export type IcrcCanistersStoreData = Record<


### PR DESCRIPTION
# Motivation

The imported tokens are ICRC tokens. The only new difference is that the index canister is optional. To make the NNS-dapp work with them, the only change needed is to modify the ICRC store to support entries without the index canister ([here](https://github.com/dfinity/nns-dapp/compare/mstr/populate-icrc-store-with-imported-tokens?expand=1#diff-e9c4a61372b9f3381f9d094ad3c92aaddac32fcdb556d6e5a9432879cf8df2a9R10)).

Once the ICRC store supports tokens without an index canister, we can add imported tokens to the ICRC store, and they will be displayed in the tokens table and on the wallet page.

# Changes

- Make indexCanisterId optional in `IcrcCanistersStore`.
- Add imported tokens to `IcrcCanistersStore` after loading them.

# Tests

- Unit test that the icrsStore was populated after imported tokens loading.
- Other parts were tested manually:

The existence of the [work-around](https://github.com/dfinity/nns-dapp/blob/8515ad43376675f242ab7390deb2ef674f95a3d5/frontend/src/lib/stores/icrc-canisters.store.ts#L82) suggests that not specifying an index canister already works.

The index canister is optional in [IcrcWallet](https://github.com/dfinity/nns-dapp/blob/8515ad43376675f242ab7390deb2ef674f95a3d5/frontend/src/lib/pages/IcrcWallet.svelte#L22).

The transaction list is now shown when [no index canister](https://github.com/dfinity/nns-dapp/blob/8515ad43376675f242ab7390deb2ef674f95a3d5/frontend/src/lib/pages/IcrcWallet.svelte#L50-L52).
```svelte
{#if nonNullish($selectedAccountStore.account) && nonNullish($selectedIcrcTokenUniverseIdStore) && nonNullish(indexCanisterId)}
  <IcrcWalletTransactionsList
```
Index canister is not used in [GetTokensModal](https://github.com/dfinity/nns-dapp/blob/8515ad43376675f242ab7390deb2ef674f95a3d5/frontend/src/lib/components/ic/GetTokensModal.svelte#L127).

The index canister is not used in the logic of derived stores that uses icrcStore:
- `icrc-universes.derived`
- `selectable-universe.derived`
- `selected-universe.derived store`

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.