### PR TITLE
Include the shard number in the playwright failure results name

### DIFF
--- a/.github/actions/test-e2e/action.yml
+++ b/.github/actions/test-e2e/action.yml
@@ -63,7 +63,7 @@ runs:
       uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
-        name: playwright-failure-results
+        name: playwright-failure-results-${{ inputs.shard_number }}
         path: |
           frontend/playwright-report/*
           frontend/playwright-results/*


### PR DESCRIPTION
# Motivation

When a Playwright e2e test fails, we upload the failure results to GitHub so we can debug the failed test.
The e2e tests are run in 2 separate shards.
But the name for the uploaded failure results is the same for both shards.
So if both shards fail, one of the failure results overrides the other and we can only debug one of the shards.

# Changes

Include the shard number in the failure results artifact name.

# Tests

Deliberately made both shards fail in this run and checked that there were 2 separate failure results artifacts:
https://github.com/dfinity/nns-dapp/actions/runs/10632674253
<img width="667" alt="image" src="https://github.com/user-attachments/assets/a6bb3d89-139f-4c2b-baa8-3e89a449a63e">

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary