### PR TITLE
Switch to the `InstallCode` proposal type for canister upgrade proposals

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -40,6 +40,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+* Change the release process to submitting `InstallCode` proposals.
+
 #### Deprecated
 
 #### Removed

--- a/scripts/nns-dapp/release
+++ b/scripts/nns-dapp/release
@@ -139,7 +139,7 @@ test -e "${SUMMARY_FILE:-}" || {
 } >&2
 
 # Prepares the command
-set ic-admin "${AUTH_ARGS[@]}" --nns-url "$DFX_NNS_URL" propose-to-change-nns-canister --proposer "$DFX_NEURON_ID" --canister-id "$NNS_DAPP_CANISTER_ID" --mode upgrade --wasm-module-path "$WASM" --summary-file "$SUMMARY_FILE" --wasm-module-sha256 "$SHA" --arg "$ARG_PATH"
+set ic-admin "${AUTH_ARGS[@]}" --nns-url "$DFX_NNS_URL" propose-to-change-nns-canister --proposer "$DFX_NEURON_ID" --canister-id "$NNS_DAPP_CANISTER_ID" --mode upgrade --wasm-module-path "$WASM" --summary-file "$SUMMARY_FILE" --wasm-module-sha256 "$SHA" --arg "$ARG_PATH" --use-explicit-action-type
 # ... just checking...
 echo
 echo PLEASE REVIEW THIS COMMAND:

--- a/scripts/nns-dapp/release-template
+++ b/scripts/nns-dapp/release-template
@@ -89,7 +89,7 @@ field in the proposal.
 
 \`\`\`
 cat nns-dapp-arg-${DFX_NETWORK}.did
-didc encode "\$(cat nns-dapp-arg-${DFX_NETWORK}.did)"
+didc encode "\$(cat nns-dapp-arg-${DFX_NETWORK}.did)" | xxd -r -p | sha256sum
 \`\`\`
 EOF
 
@@ -116,7 +116,7 @@ field in the proposal.
 
 \`\`\`
 cat nns-dapp-arg-${DFX_NETWORK}.did
-didc encode "\$(cat nns-dapp-arg-${DFX_NETWORK}.did)"
+didc encode "\$(cat nns-dapp-arg-${DFX_NETWORK}.did)" | xxd -r -p | sha256sum
 \`\`\`
 EOF
 

--- a/scripts/propose-to/propose-to-upgrade-nns-dapp
+++ b/scripts/propose-to/propose-to-upgrade-nns-dapp
@@ -18,4 +18,4 @@ test -e "$WASM_FILE" || ./scripts/docker-build --network "$DFX_NETWORK"
 SHA="$(sha256sum "$WASM_FILE" | awk '{print $1}')"
 CANISTER_ID="$(get_canister_id)"
 
-set ic-admin --nns-url "$NNS_URL" propose-to-change-nns-canister --test-neuron-proposer --canister-id "$CANISTER_ID" --mode upgrade --wasm-module-path "$WASM_FILE" --wasm-module-sha256 "$SHA" --summary-file ./README.md
+set ic-admin --nns-url "$NNS_URL" propose-to-change-nns-canister --test-neuron-proposer --canister-id "$CANISTER_ID" --mode upgrade --wasm-module-path "$WASM_FILE" --wasm-module-sha256 "$SHA" --summary-file ./README.md --use-explicit-action-type

--- a/scripts/sns/aggregator/release
+++ b/scripts/sns/aggregator/release
@@ -49,7 +49,7 @@ if grep -w "$FORUM_PLACEHOLDER" "$PROPOSAL_TEXT"; then
   } >&2
 fi
 
-set ic-admin --pin "$DFX_HSM_PIN" --nns-url https://ic0.app --use-hsm --key-id 01 --slot 0 propose-to-change-nns-canister --proposer "$NEURON" --canister-id "$AGGREGATOR_CANISTER_ID" --mode upgrade --wasm-module-path "$WASM" --summary-file "$PROPOSAL_TEXT" --wasm-module-sha256 "$SHA" --arg "$ARG_PATH"
+set ic-admin --pin "$DFX_HSM_PIN" --nns-url https://ic0.app --use-hsm --key-id 01 --slot 0 propose-to-change-nns-canister --proposer "$NEURON" --canister-id "$AGGREGATOR_CANISTER_ID" --mode upgrade --wasm-module-path "$WASM" --summary-file "$PROPOSAL_TEXT" --wasm-module-sha256 "$SHA" --arg "$ARG_PATH" --use-explicit-action-type
 
 echo
 echo PLEASE REVIEW THIS COMMAND:


### PR DESCRIPTION
# Motivation

The `InstallCode` proposal type is replacing the `NnsCanisterUpgrade` NNS function. Adapt the NNS Dapp and SNS aggregator release scripts for the new type.

# Changes

* Since the `InstallCode` proposal type returns hash of the upgrade args, change the verification instruction to verify the hash.
* Pass an additional argument `--use-explicit-action-type` to ic-admin

# Tests

N/A

# Todos

- [x] Add entry to changelog (if necessary).
