### PR TITLE
bot: Update proposals candid bindings

### DIFF
--- a/declarations/used_by_proposals/nns_governance/nns_governance.did
+++ b/declarations/used_by_proposals/nns_governance/nns_governance.did
@@ -1,5 +1,8 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/nns/governance/canister/governance.did>
-type AccountIdentifier = record { hash : blob };
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-29_01-30-base/rs/nns/governance/canister/governance.did>
+type AccountIdentifier = record {
+  hash : blob;
+};
+
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
   ManageNeuron : ManageNeuron;
@@ -18,18 +21,43 @@ type Action = variant {
   AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
   Motion : Motion;
 };
-type AddHotKey = record { new_hot_key : opt principal };
-type AddOrRemoveNodeProvider = record { change : opt Change };
-type Amount = record { e8s : nat64 };
-type ApproveGenesisKyc = record { principals : vec principal };
-type Ballot = record { vote : int32; voting_power : nat64 };
-type BallotInfo = record { vote : int32; proposal_id : opt NeuronId };
+
+type AddHotKey = record {
+  new_hot_key : opt principal;
+};
+
+type AddOrRemoveNodeProvider = record {
+  change : opt Change;
+};
+
+type Amount = record {
+  e8s : nat64;
+};
+
+type ApproveGenesisKyc = record {
+  principals : vec principal;
+};
+
+type Ballot = record {
+  vote : int32;
+  voting_power : nat64;
+};
+
+type BallotInfo = record {
+  vote : int32;
+  proposal_id : opt NeuronId;
+};
+
 type By = variant {
   NeuronIdOrSubaccount : record {};
   MemoAndController : ClaimOrRefreshNeuronFromAccount;
   Memo : nat64;
 };
-type Canister = record { id : opt principal };
+
+type Canister = record {
+  id : opt principal;
+};
+
 type CanisterSettings = record {
   freezing_threshold : opt nat64;
   controllers : opt Controllers;
@@ -38,6 +66,7 @@ type CanisterSettings = record {
   memory_allocation : opt nat64;
   compute_allocation : opt nat64;
 };
+
 type CanisterStatusResultV2 = record {
   status : opt int32;
   freezing_threshold : opt nat64;
@@ -47,32 +76,38 @@ type CanisterStatusResultV2 = record {
   idle_cycles_burned_per_day : opt nat64;
   module_hash : blob;
 };
+
 type CanisterSummary = record {
   status : opt CanisterStatusResultV2;
   canister_id : opt principal;
 };
-type CfNeuron = record {
-  has_created_neuron_recipes : opt bool;
-  hotkeys : opt Principals;
-  nns_neuron_id : nat64;
-  amount_icp_e8s : nat64;
+
+type Change = variant {
+  ToRemove : NodeProvider;
+  ToAdd : NodeProvider;
 };
-type CfParticipant = record {
-  controller : opt principal;
-  hotkey_principal : text;
-  cf_neurons : vec CfNeuron;
-};
-type Change = variant { ToRemove : NodeProvider; ToAdd : NodeProvider };
+
 type ChangeAutoStakeMaturity = record {
   requested_setting_for_auto_stake_maturity : bool;
 };
-type ClaimOrRefresh = record { by : opt By };
+
+type ClaimOrRefresh = record {
+  by : opt By;
+};
+
 type ClaimOrRefreshNeuronFromAccount = record {
   controller : opt principal;
   memo : nat64;
 };
-type ClaimOrRefreshNeuronFromAccountResponse = record { result : opt Result_1 };
-type ClaimOrRefreshResponse = record { refreshed_neuron_id : opt NeuronId };
+
+type ClaimOrRefreshNeuronFromAccountResponse = record {
+  result : opt Result_1;
+};
+
+type ClaimOrRefreshResponse = record {
+  refreshed_neuron_id : opt NeuronId;
+};
+
 type Command = variant {
   Spawn : Spawn;
   Split : Split;
@@ -87,6 +122,7 @@ type Command = variant {
   MergeMaturity : MergeMaturity;
   Disburse : Disburse;
 };
+
 type Command_1 = variant {
   Error : GovernanceError;
   Spawn : SpawnResponse;
@@ -102,6 +138,7 @@ type Command_1 = variant {
   MergeMaturity : MergeMaturityResponse;
   Disburse : DisburseResponse;
 };
+
 type Command_2 = variant {
   Spawn : NeuronId;
   Split : Split;
@@ -113,19 +150,31 @@ type Command_2 = variant {
   MergeMaturity : MergeMaturity;
   Disburse : Disburse;
 };
+
 type Committed = record {
   total_direct_contribution_icp_e8s : opt nat64;
   total_neurons_fund_contribution_icp_e8s : opt nat64;
   sns_governance_canister_id : opt principal;
 };
+
 type Committed_1 = record {
   total_direct_participation_icp_e8s : opt nat64;
   total_neurons_fund_participation_icp_e8s : opt nat64;
   sns_governance_canister_id : opt principal;
 };
-type Configure = record { operation : opt Operation };
-type Controllers = record { controllers : vec principal };
-type Countries = record { iso_codes : vec text };
+
+type Configure = record {
+  operation : opt Operation;
+};
+
+type Controllers = record {
+  controllers : vec principal;
+};
+
+type Countries = record {
+  iso_codes : vec text;
+};
+
 type CreateServiceNervousSystem = record {
   url : opt text;
   governance_parameters : opt GovernanceParameters;
@@ -138,22 +187,33 @@ type CreateServiceNervousSystem = record {
   swap_parameters : opt SwapParameters;
   initial_token_distribution : opt InitialTokenDistribution;
 };
+
 type DateRangeFilter = record {
   start_timestamp_seconds : opt nat64;
   end_timestamp_seconds : opt nat64;
 };
-type Decimal = record { human_readable : opt text };
+
+type Decimal = record {
+  human_readable : opt text;
+};
+
 type DerivedProposalInformation = record {
   swap_background_information : opt SwapBackgroundInformation;
 };
+
 type DeveloperDistribution = record {
   developer_neurons : vec NeuronDistribution;
 };
+
 type Disburse = record {
   to_account : opt AccountIdentifier;
   amount : opt Amount;
 };
-type DisburseResponse = record { transfer_block_height : nat64 };
+
+type DisburseResponse = record {
+  transfer_block_height : nat64;
+};
+
 type DisburseToNeuron = record {
   dissolve_delay_seconds : nat64;
   kyc_verified : bool;
@@ -161,19 +221,50 @@ type DisburseToNeuron = record {
   new_controller : opt principal;
   nonce : nat64;
 };
+
 type DissolveState = variant {
   DissolveDelaySeconds : nat64;
   WhenDissolvedTimestampSeconds : nat64;
 };
-type Duration = record { seconds : opt nat64 };
-type ExecuteNnsFunction = record { nns_function : int32; payload : blob };
-type Follow = record { topic : int32; followees : vec NeuronId };
-type Followees = record { followees : vec NeuronId };
-type Followers = record { followers : vec NeuronId };
-type FollowersMap = record { followers_map : vec record { nat64; Followers } };
-type GetNeuronsFundAuditInfoRequest = record { nns_proposal_id : opt NeuronId };
-type GetNeuronsFundAuditInfoResponse = record { result : opt Result_6 };
-type GlobalTimeOfDay = record { seconds_after_utc_midnight : opt nat64 };
+
+type Duration = record {
+  seconds : opt nat64;
+};
+
+type ExecuteNnsFunction = record {
+  nns_function : int32;
+  payload : blob;
+};
+
+type Follow = record {
+  topic : int32;
+  followees : vec NeuronId;
+};
+
+type Followees = record {
+  followees : vec NeuronId;
+};
+
+type Followers = record {
+  followers : vec NeuronId;
+};
+
+type FollowersMap = record {
+  followers_map : vec record { nat64; Followers };
+};
+
+type GetNeuronsFundAuditInfoRequest = record {
+  nns_proposal_id : opt NeuronId;
+};
+
+type GetNeuronsFundAuditInfoResponse = record {
+  result : opt Result_6;
+};
+
+type GlobalTimeOfDay = record {
+  seconds_after_utc_midnight : opt nat64;
+};
+
 type Governance = record {
   default_followees : vec record { int32; Followees };
   making_sns_proposal : opt MakingSnsProposal;
@@ -198,6 +289,7 @@ type Governance = record {
   neurons : vec record { nat64; Neuron };
   genesis_timestamp_seconds : nat64;
 };
+
 type GovernanceCachedMetrics = record {
   total_maturity_e8s_equivalent : nat64;
   not_dissolving_neurons_e8s_buckets : vec record { nat64; float64 };
@@ -245,7 +337,12 @@ type GovernanceCachedMetrics = record {
   timestamp_seconds : nat64;
   seed_neuron_count : nat64;
 };
-type GovernanceError = record { error_message : text; error_type : int32 };
+
+type GovernanceError = record {
+  error_message : text;
+  error_type : int32;
+};
+
 type GovernanceParameters = record {
   neuron_maximum_dissolve_delay_bonus : opt Percentage;
   neuron_maximum_age_for_age_bonus : opt Duration;
@@ -258,18 +355,25 @@ type GovernanceParameters = record {
   proposal_rejection_fee : opt Tokens;
   voting_reward_parameters : opt VotingRewardParameters;
 };
+
 type IdealMatchedParticipationFunction = record {
   serialized_representation : opt text;
 };
-type Image = record { base64_encoding : opt text };
+
+type Image = record {
+  base64_encoding : opt text;
+};
+
 type IncreaseDissolveDelay = record {
   additional_dissolve_delay_seconds : nat32;
 };
+
 type InitialTokenDistribution = record {
   treasury_distribution : opt SwapDistribution;
   developer_distribution : opt DeveloperDistribution;
   swap_distribution : opt SwapDistribution;
 };
+
 type InstallCode = record {
   skip_stopping_before_installing : opt bool;
   wasm_module_hash : opt blob;
@@ -277,6 +381,7 @@ type InstallCode = record {
   arg_hash : opt blob;
   install_mode : opt int32;
 };
+
 type InstallCodeRequest = record {
   arg : opt blob;
   wasm_module : opt blob;
@@ -284,35 +389,52 @@ type InstallCodeRequest = record {
   canister_id : opt principal;
   install_mode : opt int32;
 };
+
 type KnownNeuron = record {
   id : opt NeuronId;
   known_neuron_data : opt KnownNeuronData;
 };
-type KnownNeuronData = record { name : text; description : opt text };
+
+type KnownNeuronData = record {
+  name : text;
+  description : opt text;
+};
+
 type LedgerParameters = record {
   transaction_fee : opt Tokens;
   token_symbol : opt text;
   token_logo : opt Image;
   token_name : opt text;
 };
-type ListKnownNeuronsResponse = record { known_neurons : vec KnownNeuron };
+
+type ListKnownNeuronsResponse = record {
+  known_neurons : vec KnownNeuron;
+};
+
 type ListNeurons = record {
   include_public_neurons_in_full_neurons : opt bool;
   neuron_ids : vec nat64;
   include_empty_neurons_readable_by_caller : opt bool;
   include_neurons_readable_by_caller : bool;
 };
+
 type ListNeuronsResponse = record {
   neuron_infos : vec record { nat64; NeuronInfo };
   full_neurons : vec Neuron;
 };
+
 type ListNodeProviderRewardsRequest = record {
   date_filter : opt DateRangeFilter;
 };
+
 type ListNodeProviderRewardsResponse = record {
   rewards : vec MonthlyNodeProviderRewards;
 };
-type ListNodeProvidersResponse = record { node_providers : vec NodeProvider };
+
+type ListNodeProvidersResponse = record {
+  node_providers : vec NodeProvider;
+};
+
 type ListProposalInfo = record {
   include_reward_status : vec int32;
   omit_large_fields : opt bool;
@@ -322,27 +444,35 @@ type ListProposalInfo = record {
   include_all_manage_neuron_proposals : opt bool;
   include_status : vec int32;
 };
-type ListProposalInfoResponse = record { proposal_info : vec ProposalInfo };
+
+type ListProposalInfoResponse = record {
+  proposal_info : vec ProposalInfo;
+};
+
 type MakeProposalRequest = record {
   url : text;
   title : opt text;
   action : opt ProposalActionRequest;
   summary : text;
 };
+
 type MakeProposalResponse = record {
   message : opt text;
   proposal_id : opt NeuronId;
 };
+
 type MakingSnsProposal = record {
   proposal : opt Proposal;
   caller : opt principal;
   proposer_id : opt NeuronId;
 };
+
 type ManageNeuron = record {
   id : opt NeuronId;
   command : opt Command;
   neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
 };
+
 type ManageNeuronCommandRequest = variant {
   Spawn : Spawn;
   Split : Split;
@@ -357,33 +487,48 @@ type ManageNeuronCommandRequest = variant {
   MergeMaturity : MergeMaturity;
   Disburse : Disburse;
 };
+
 type ManageNeuronRequest = record {
   id : opt NeuronId;
   command : opt ManageNeuronCommandRequest;
   neuron_id_or_subaccount : opt NeuronIdOrSubaccount;
 };
-type ManageNeuronResponse = record { command : opt Command_1 };
-type Merge = record { source_neuron_id : opt NeuronId };
-type MergeMaturity = record { percentage_to_merge : nat32 };
+
+type ManageNeuronResponse = record {
+  command : opt Command_1;
+};
+
+type Merge = record {
+  source_neuron_id : opt NeuronId;
+};
+
+type MergeMaturity = record {
+  percentage_to_merge : nat32;
+};
+
 type MergeMaturityResponse = record {
   merged_maturity_e8s : nat64;
   new_stake_e8s : nat64;
 };
+
 type MergeResponse = record {
   target_neuron : opt Neuron;
   source_neuron : opt Neuron;
   target_neuron_info : opt NeuronInfo;
   source_neuron_info : opt NeuronInfo;
 };
+
 type Migration = record {
   status : opt int32;
   failure_reason : opt text;
   progress : opt Progress;
 };
+
 type Migrations = record {
   neuron_indexes_migration : opt Migration;
   copy_inactive_neurons_to_stable_memory_migration : opt Migration;
 };
+
 type MonthlyNodeProviderRewards = record {
   minimum_xdr_permyriad_per_icp : opt nat64;
   registry_version : opt nat64;
@@ -393,7 +538,11 @@ type MonthlyNodeProviderRewards = record {
   xdr_conversion_rate : opt XdrConversionRate;
   maximum_node_provider_rewards_e8s : opt nat64;
 };
-type Motion = record { motion_text : text };
+
+type Motion = record {
+  motion_text : text;
+};
+
 type NetworkEconomics = record {
   neuron_minimum_stake_e8s : nat64;
   max_proposals_to_keep_per_topic : nat32;
@@ -405,6 +554,7 @@ type NetworkEconomics = record {
   maximum_node_provider_rewards_e8s : nat64;
   neurons_fund_economics : opt NeuronsFundEconomics;
 };
+
 type Neuron = record {
   id : opt NeuronId;
   staked_maturity_e8s_equivalent : opt nat64;
@@ -429,14 +579,17 @@ type Neuron = record {
   known_neuron_data : opt KnownNeuronData;
   spawn_at_timestamp_seconds : opt nat64;
 };
+
 type NeuronBasketConstructionParameters = record {
   dissolve_delay_interval : opt Duration;
   count : opt nat64;
 };
+
 type NeuronBasketConstructionParameters_1 = record {
   dissolve_delay_interval_seconds : nat64;
   count : nat64;
 };
+
 type NeuronDistribution = record {
   controller : opt principal;
   dissolve_delay : opt Duration;
@@ -444,12 +597,21 @@ type NeuronDistribution = record {
   vesting_period : opt Duration;
   stake : opt Tokens;
 };
-type NeuronId = record { id : nat64 };
-type NeuronIdOrSubaccount = variant { Subaccount : blob; NeuronId : NeuronId };
+
+type NeuronId = record {
+  id : nat64;
+};
+
+type NeuronIdOrSubaccount = variant {
+  Subaccount : blob;
+  NeuronId : NeuronId;
+};
+
 type NeuronInFlightCommand = record {
   command : opt Command_2;
   timestamp : nat64;
 };
+
 type NeuronInfo = record {
   dissolve_delay_seconds : nat64;
   recent_ballots : vec BallotInfo;
@@ -464,6 +626,7 @@ type NeuronInfo = record {
   voting_power : nat64;
   age_seconds : nat64;
 };
+
 type NeuronStakeTransfer = record {
   to_subaccount : blob;
   neuron_stake_e8s : nat64;
@@ -473,6 +636,7 @@ type NeuronStakeTransfer = record {
   transfer_timestamp : nat64;
   block_height : nat64;
 };
+
 type NeuronSubsetMetrics = record {
   total_maturity_e8s_equivalent : opt nat64;
   maturity_e8s_equivalent_buckets : vec record { nat64; nat64 };
@@ -485,27 +649,32 @@ type NeuronSubsetMetrics = record {
   total_voting_power : opt nat64;
   count_buckets : vec record { nat64; nat64 };
 };
+
 type NeuronsFundAuditInfo = record {
   final_neurons_fund_participation : opt NeuronsFundParticipation;
   initial_neurons_fund_participation : opt NeuronsFundParticipation;
   neurons_fund_refunds : opt NeuronsFundSnapshot;
 };
+
 type NeuronsFundData = record {
   final_neurons_fund_participation : opt NeuronsFundParticipation;
   initial_neurons_fund_participation : opt NeuronsFundParticipation;
   neurons_fund_refunds : opt NeuronsFundSnapshot;
 };
+
 type NeuronsFundEconomics = record {
   maximum_icp_xdr_rate : opt Percentage;
   neurons_fund_matched_funding_curve_coefficients : opt NeuronsFundMatchedFundingCurveCoefficients;
   max_theoretical_neurons_fund_participation_amount_xdr : opt Decimal;
   minimum_icp_xdr_rate : opt Percentage;
 };
+
 type NeuronsFundMatchedFundingCurveCoefficients = record {
   contribution_threshold_xdr : opt Decimal;
   one_third_participation_milestone_xdr : opt Decimal;
   full_participation_milestone_xdr : opt Decimal;
 };
+
 type NeuronsFundNeuron = record {
   controller : opt principal;
   hotkey_principal : opt text;
@@ -514,6 +683,7 @@ type NeuronsFundNeuron = record {
   nns_neuron_id : opt nat64;
   amount_icp_e8s : opt nat64;
 };
+
 type NeuronsFundNeuronPortion = record {
   controller : opt principal;
   hotkey_principal : opt principal;
@@ -523,6 +693,7 @@ type NeuronsFundNeuronPortion = record {
   nns_neuron_id : opt NeuronId;
   amount_icp_e8s : opt nat64;
 };
+
 type NeuronsFundParticipation = record {
   total_maturity_equivalent_icp_e8s : opt nat64;
   intended_neurons_fund_participation_icp_e8s : opt nat64;
@@ -533,20 +704,30 @@ type NeuronsFundParticipation = record {
   ideal_matched_participation_function : opt IdealMatchedParticipationFunction;
   allocated_neurons_fund_participation_icp_e8s : opt nat64;
 };
+
 type NeuronsFundSnapshot = record {
   neurons_fund_neuron_portions : vec NeuronsFundNeuronPortion;
 };
+
 type NodeProvider = record {
   id : opt principal;
   reward_account : opt AccountIdentifier;
 };
-type Ok = record { neurons_fund_audit_info : opt NeuronsFundAuditInfo };
-type Ok_1 = record { neurons_fund_neuron_portions : vec NeuronsFundNeuron };
+
+type Ok = record {
+  neurons_fund_audit_info : opt NeuronsFundAuditInfo;
+};
+
+type Ok_1 = record {
+  neurons_fund_neuron_portions : vec NeuronsFundNeuron;
+};
+
 type OpenSnsTokenSwap = record {
   community_fund_investment_e8s : opt nat64;
   target_swap_canister_id : opt principal;
   params : opt Params;
 };
+
 type Operation = variant {
   RemoveHotKey : RemoveHotKey;
   AddHotKey : AddHotKey;
@@ -559,6 +740,7 @@ type Operation = variant {
   LeaveCommunityFund : record {};
   SetDissolveTimestamp : SetDissolveTimestamp;
 };
+
 type Params = record {
   min_participant_icp_e8s : nat64;
   neuron_basket_construction_parameters : opt NeuronBasketConstructionParameters_1;
@@ -572,15 +754,26 @@ type Params = record {
   min_icp_e8s : nat64;
   max_direct_participation_icp_e8s : opt nat64;
 };
-type Percentage = record { basis_points : opt nat64 };
-type Principals = record { principals : vec principal };
-type Progress = variant { LastNeuronId : NeuronId };
+
+type Percentage = record {
+  basis_points : opt nat64;
+};
+
+type Principals = record {
+  principals : vec principal;
+};
+
+type Progress = variant {
+  LastNeuronId : NeuronId;
+};
+
 type Proposal = record {
   url : text;
   title : opt text;
   action : opt Action;
   summary : text;
 };
+
 type ProposalActionRequest = variant {
   RegisterKnownNeuron : KnownNeuron;
   ManageNeuron : ManageNeuronRequest;
@@ -599,10 +792,10 @@ type ProposalActionRequest = variant {
   AddOrRemoveNodeProvider : AddOrRemoveNodeProvider;
   Motion : Motion;
 };
+
 type ProposalData = record {
   id : opt NeuronId;
   failure_reason : opt GovernanceError;
-  cf_participants : vec CfParticipant;
   ballots : vec record { nat64; Ballot };
   proposal_timestamp_seconds : nat64;
   reward_event_round : nat64;
@@ -619,6 +812,7 @@ type ProposalData = record {
   executed_timestamp_seconds : nat64;
   original_total_community_fund_maturity_e8s_equivalent : opt nat64;
 };
+
 type ProposalInfo = record {
   id : opt NeuronId;
   status : int32;
@@ -638,29 +832,81 @@ type ProposalInfo = record {
   proposer : opt NeuronId;
   executed_timestamp_seconds : nat64;
 };
-type RegisterVote = record { vote : int32; proposal : opt NeuronId };
-type RemoveHotKey = record { hot_key_to_remove : opt principal };
+
+type RegisterVote = record {
+  vote : int32;
+  proposal : opt NeuronId;
+};
+
+type RemoveHotKey = record {
+  hot_key_to_remove : opt principal;
+};
+
 type RestoreAgingNeuronGroup = record {
   count : opt nat64;
   previous_total_stake_e8s : opt nat64;
   current_total_stake_e8s : opt nat64;
   group_type : int32;
 };
+
 type RestoreAgingSummary = record {
   groups : vec RestoreAgingNeuronGroup;
   timestamp_seconds : opt nat64;
 };
-type Result = variant { Ok; Err : GovernanceError };
-type Result_1 = variant { Error : GovernanceError; NeuronId : NeuronId };
-type Result_10 = variant { Ok : Ok_1; Err : GovernanceError };
-type Result_2 = variant { Ok : Neuron; Err : GovernanceError };
-type Result_3 = variant { Ok : GovernanceCachedMetrics; Err : GovernanceError };
-type Result_4 = variant { Ok : RewardNodeProviders; Err : GovernanceError };
-type Result_5 = variant { Ok : NeuronInfo; Err : GovernanceError };
-type Result_6 = variant { Ok : Ok; Err : GovernanceError };
-type Result_7 = variant { Ok : NodeProvider; Err : GovernanceError };
-type Result_8 = variant { Committed : Committed; Aborted : record {} };
-type Result_9 = variant { Committed : Committed_1; Aborted : record {} };
+
+type Result = variant {
+  Ok;
+  Err : GovernanceError;
+};
+
+type Result_1 = variant {
+  Error : GovernanceError;
+  NeuronId : NeuronId;
+};
+
+type Result_10 = variant {
+  Ok : Ok_1;
+  Err : GovernanceError;
+};
+
+type Result_2 = variant {
+  Ok : Neuron;
+  Err : GovernanceError;
+};
+
+type Result_3 = variant {
+  Ok : GovernanceCachedMetrics;
+  Err : GovernanceError;
+};
+
+type Result_4 = variant {
+  Ok : MonthlyNodeProviderRewards;
+  Err : GovernanceError;
+};
+
+type Result_5 = variant {
+  Ok : NeuronInfo;
+  Err : GovernanceError;
+};
+
+type Result_6 = variant {
+  Ok : Ok;
+  Err : GovernanceError;
+};
+
+type Result_7 = variant {
+  Ok : NodeProvider;
+  Err : GovernanceError;
+};
+
+type Result_8 = variant {
+  Committed : Committed;
+  Aborted : record {} };
+
+type Result_9 = variant {
+  Committed : Committed_1;
+  Aborted : record {} };
+
 type RewardEvent = record {
   rounds_since_last_distribution : opt nat64;
   day_after_genesis : nat64;
@@ -670,56 +916,94 @@ type RewardEvent = record {
   distributed_e8s_equivalent : nat64;
   settled_proposals : vec NeuronId;
 };
+
 type RewardMode = variant {
   RewardToNeuron : RewardToNeuron;
   RewardToAccount : RewardToAccount;
 };
+
 type RewardNodeProvider = record {
   node_provider : opt NodeProvider;
   reward_mode : opt RewardMode;
   amount_e8s : nat64;
 };
+
 type RewardNodeProviders = record {
   use_registry_derived_rewards : opt bool;
   rewards : vec RewardNodeProvider;
 };
-type RewardToAccount = record { to_account : opt AccountIdentifier };
-type RewardToNeuron = record { dissolve_delay_seconds : nat64 };
+
+type RewardToAccount = record {
+  to_account : opt AccountIdentifier;
+};
+
+type RewardToNeuron = record {
+  dissolve_delay_seconds : nat64;
+};
+
 type SetDefaultFollowees = record {
   default_followees : vec record { int32; Followees };
 };
-type SetDissolveTimestamp = record { dissolve_timestamp_seconds : nat64 };
-type SetOpenTimeWindowRequest = record { open_time_window : opt TimeWindow };
+
+type SetDissolveTimestamp = record {
+  dissolve_timestamp_seconds : nat64;
+};
+
+type SetOpenTimeWindowRequest = record {
+  open_time_window : opt TimeWindow;
+};
+
 type SetSnsTokenSwapOpenTimeWindow = record {
   request : opt SetOpenTimeWindowRequest;
   swap_canister_id : opt principal;
 };
-type SetVisibility = record { visibility : opt int32 };
+
+type SetVisibility = record {
+  visibility : opt int32;
+};
+
 type SettleCommunityFundParticipation = record {
   result : opt Result_8;
   open_sns_token_swap_proposal_id : opt nat64;
 };
+
 type SettleNeuronsFundParticipationRequest = record {
   result : opt Result_9;
   nns_proposal_id : opt nat64;
 };
-type SettleNeuronsFundParticipationResponse = record { result : opt Result_10 };
+
+type SettleNeuronsFundParticipationResponse = record {
+  result : opt Result_10;
+};
+
 type Spawn = record {
   percentage_to_spawn : opt nat32;
   new_controller : opt principal;
   nonce : opt nat64;
 };
-type SpawnResponse = record { created_neuron_id : opt NeuronId };
-type Split = record { amount_e8s : nat64 };
-type StakeMaturity = record { percentage_to_stake : opt nat32 };
+
+type SpawnResponse = record {
+  created_neuron_id : opt NeuronId;
+};
+
+type Split = record {
+  amount_e8s : nat64;
+};
+
+type StakeMaturity = record {
+  percentage_to_stake : opt nat32;
+};
+
 type StakeMaturityResponse = record {
   maturity_e8s : nat64;
   staked_maturity_e8s : nat64;
 };
+
 type StopOrStartCanister = record {
   action : opt int32;
   canister_id : opt principal;
 };
+
 type SwapBackgroundInformation = record {
   ledger_index_canister_summary : opt CanisterSummary;
   fallback_controller_principal_ids : vec principal;
@@ -730,7 +1014,11 @@ type SwapBackgroundInformation = record {
   root_canister_summary : opt CanisterSummary;
   dapp_canister_summaries : vec CanisterSummary;
 };
-type SwapDistribution = record { total : opt Tokens };
+
+type SwapDistribution = record {
+  total : opt Tokens;
+};
+
 type SwapParameters = record {
   minimum_participants : opt nat64;
   neurons_fund_participation : opt bool;
@@ -747,38 +1035,54 @@ type SwapParameters = record {
   neurons_fund_investment_icp : opt Tokens;
   restricted_countries : opt Countries;
 };
+
 type SwapParticipationLimits = record {
   min_participant_icp_e8s : opt nat64;
   max_participant_icp_e8s : opt nat64;
   min_direct_participation_icp_e8s : opt nat64;
   max_direct_participation_icp_e8s : opt nat64;
 };
+
 type Tally = record {
   no : nat64;
   yes : nat64;
   total : nat64;
   timestamp_seconds : nat64;
 };
+
 type TimeWindow = record {
   start_timestamp_seconds : nat64;
   end_timestamp_seconds : nat64;
 };
-type Tokens = record { e8s : opt nat64 };
+
+type Tokens = record {
+  e8s : opt nat64;
+};
+
 type UpdateCanisterSettings = record {
   canister_id : opt principal;
   settings : opt CanisterSettings;
 };
-type UpdateNodeProvider = record { reward_account : opt AccountIdentifier };
+
+type UpdateNodeProvider = record {
+  reward_account : opt AccountIdentifier;
+};
+
 type VotingRewardParameters = record {
   reward_rate_transition_duration : opt Duration;
   initial_reward_rate : opt Percentage;
   final_reward_rate : opt Percentage;
 };
-type WaitForQuietState = record { current_deadline_timestamp_seconds : nat64 };
+
+type WaitForQuietState = record {
+  current_deadline_timestamp_seconds : nat64;
+};
+
 type XdrConversionRate = record {
   xdr_permyriad_per_icp : opt nat64;
   timestamp_seconds : opt nat64;
 };
+
 service : (Governance) -> {
   claim_gtc_neurons : (principal, vec NeuronId) -> (Result);
   claim_or_refresh_neuron_from_account : (ClaimOrRefreshNeuronFromAccount) -> (

--- a/declarations/used_by_proposals/nns_registry/nns_registry.did
+++ b/declarations/used_by_proposals/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-29_01-30-base/rs/registry/canister/canister/registry.did>
 // A brief note about the history of this file: This file used to be
 // automatically generated, but now, it is hand-crafted, because the
 // auto-generator has some some pretty degenerate behaviors. The worst of those

--- a/declarations/used_by_proposals/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_proposals/sns_wasm/sns_wasm.did
@@ -1,22 +1,46 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/nns/sns-wasm/canister/sns-wasm.did>
-type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
-type AddWasmResponse = record { result : opt Result };
-type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
-type Canister = record { id : opt principal };
-type Countries = record { iso_codes : vec text };
-type DappCanisters = record { canisters : vec Canister };
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-29_01-30-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+type AddWasmRequest = record {
+  hash : blob;
+  wasm : opt SnsWasm;
+};
+
+type AddWasmResponse = record {
+  result : opt Result;
+};
+
+type AirdropDistribution = record {
+  airdrop_neurons : vec NeuronDistribution;
+};
+
+type Canister = record {
+  id : opt principal;
+};
+
+type Countries = record {
+  iso_codes : vec text;
+};
+
+type DappCanisters = record {
+  canisters : vec Canister;
+};
+
 type DappCanistersTransferResult = record {
   restored_dapp_canisters : vec Canister;
   nns_controlled_dapp_canisters : vec Canister;
   sns_controlled_dapp_canisters : vec Canister;
 };
-type DeployNewSnsRequest = record { sns_init_payload : opt SnsInitPayload };
+
+type DeployNewSnsRequest = record {
+  sns_init_payload : opt SnsInitPayload;
+};
+
 type DeployNewSnsResponse = record {
   dapp_canisters_transfer_result : opt DappCanistersTransferResult;
   subnet_id : opt principal;
   error : opt SnsWasmError;
   canisters : opt SnsCanisterIds;
 };
+
 type DeployedSns = record {
   root_canister_id : opt principal;
   governance_canister_id : opt principal;
@@ -24,49 +48,89 @@ type DeployedSns = record {
   swap_canister_id : opt principal;
   ledger_canister_id : opt principal;
 };
+
 type DeveloperDistribution = record {
   developer_neurons : vec NeuronDistribution;
 };
+
 type FractionalDeveloperVotingPower = record {
   treasury_distribution : opt TreasuryDistribution;
   developer_distribution : opt DeveloperDistribution;
   airdrop_distribution : opt AirdropDistribution;
   swap_distribution : opt SwapDistribution;
 };
+
 type GetAllowedPrincipalsResponse = record {
   allowed_principals : vec principal;
 };
-type GetDeployedSnsByProposalIdRequest = record { proposal_id : nat64 };
+
+type GetDeployedSnsByProposalIdRequest = record {
+  proposal_id : nat64;
+};
+
 type GetDeployedSnsByProposalIdResponse = record {
   get_deployed_sns_by_proposal_id_result : opt GetDeployedSnsByProposalIdResult;
 };
+
 type GetDeployedSnsByProposalIdResult = variant {
   Error : SnsWasmError;
   DeployedSns : DeployedSns;
 };
+
 type GetNextSnsVersionRequest = record {
   governance_canister_id : opt principal;
   current_version : opt SnsVersion;
 };
-type GetNextSnsVersionResponse = record { next_version : opt SnsVersion };
-type GetProposalIdThatAddedWasmRequest = record { hash : blob };
-type GetProposalIdThatAddedWasmResponse = record { proposal_id : opt nat64 };
-type GetSnsSubnetIdsResponse = record { sns_subnet_ids : vec principal };
-type GetWasmMetadataRequest = record { hash : opt blob };
-type GetWasmMetadataResponse = record { result : opt Result_1 };
-type GetWasmRequest = record { hash : blob };
-type GetWasmResponse = record { wasm : opt SnsWasm };
+
+type GetNextSnsVersionResponse = record {
+  next_version : opt SnsVersion;
+};
+
+type GetProposalIdThatAddedWasmRequest = record {
+  hash : blob;
+};
+
+type GetProposalIdThatAddedWasmResponse = record {
+  proposal_id : opt nat64;
+};
+
+type GetSnsSubnetIdsResponse = record {
+  sns_subnet_ids : vec principal;
+};
+
+type GetWasmMetadataRequest = record {
+  hash : opt blob;
+};
+
+type GetWasmMetadataResponse = record {
+  result : opt Result_1;
+};
+
+type GetWasmRequest = record {
+  hash : blob;
+};
+
+type GetWasmResponse = record {
+  wasm : opt SnsWasm;
+};
+
 type IdealMatchedParticipationFunction = record {
   serialized_representation : opt text;
 };
+
 type InitialTokenDistribution = variant {
   FractionalDeveloperVotingPower : FractionalDeveloperVotingPower;
 };
+
 type InsertUpgradePathEntriesRequest = record {
   upgrade_path : vec SnsUpgrade;
   sns_governance_canister_id : opt principal;
 };
-type InsertUpgradePathEntriesResponse = record { error : opt SnsWasmError };
+
+type InsertUpgradePathEntriesResponse = record {
+  error : opt SnsWasmError;
+};
+
 type LinearScalingCoefficient = record {
   slope_numerator : opt nat64;
   intercept_icp_e8s : opt nat64;
@@ -74,26 +138,37 @@ type LinearScalingCoefficient = record {
   slope_denominator : opt nat64;
   to_direct_participation_icp_e8s : opt nat64;
 };
-type ListDeployedSnsesResponse = record { instances : vec DeployedSns };
+
+type ListDeployedSnsesResponse = record {
+  instances : vec DeployedSns;
+};
+
 type ListUpgradeStep = record {
   pretty_version : opt PrettySnsVersion;
   version : opt SnsVersion;
 };
+
 type ListUpgradeStepsRequest = record {
   limit : nat32;
   starting_at : opt SnsVersion;
   sns_governance_canister_id : opt principal;
 };
-type ListUpgradeStepsResponse = record { steps : vec ListUpgradeStep };
+
+type ListUpgradeStepsResponse = record {
+  steps : vec ListUpgradeStep;
+};
+
 type MetadataSection = record {
   contents : opt blob;
   name : opt text;
   visibility : opt text;
 };
+
 type NeuronBasketConstructionParameters = record {
   dissolve_delay_interval_seconds : nat64;
   count : nat64;
 };
+
 type NeuronDistribution = record {
   controller : opt principal;
   dissolve_delay_seconds : nat64;
@@ -101,13 +176,18 @@ type NeuronDistribution = record {
   stake_e8s : nat64;
   vesting_period_seconds : opt nat64;
 };
+
 type NeuronsFundParticipationConstraints = record {
   coefficient_intervals : vec LinearScalingCoefficient;
   max_neurons_fund_participation_icp_e8s : opt nat64;
   min_direct_participation_threshold_icp_e8s : opt nat64;
   ideal_matched_participation_function : opt IdealMatchedParticipationFunction;
 };
-type Ok = record { sections : vec MetadataSection };
+
+type Ok = record {
+  sections : vec MetadataSection;
+};
+
 type PrettySnsVersion = record {
   archive_wasm_hash : text;
   root_wasm_hash : text;
@@ -116,8 +196,17 @@ type PrettySnsVersion = record {
   governance_wasm_hash : text;
   index_wasm_hash : text;
 };
-type Result = variant { Error : SnsWasmError; Hash : blob };
-type Result_1 = variant { Ok : Ok; Error : SnsWasmError };
+
+type Result = variant {
+  Error : SnsWasmError;
+  Hash : blob;
+};
+
+type Result_1 = variant {
+  Ok : Ok;
+  Error : SnsWasmError;
+};
+
 type SnsCanisterIds = record {
   root : opt principal;
   swap : opt principal;
@@ -125,6 +214,7 @@ type SnsCanisterIds = record {
   index : opt principal;
   governance : opt principal;
 };
+
 type SnsInitPayload = record {
   url : opt text;
   max_dissolve_delay_seconds : opt nat64;
@@ -165,10 +255,12 @@ type SnsInitPayload = record {
   min_icp_e8s : opt nat64;
   max_direct_participation_icp_e8s : opt nat64;
 };
+
 type SnsUpgrade = record {
   next_version : opt SnsVersion;
   current_version : opt SnsVersion;
 };
+
 type SnsVersion = record {
   archive_wasm_hash : blob;
   root_wasm_hash : blob;
@@ -177,38 +269,55 @@ type SnsVersion = record {
   governance_wasm_hash : blob;
   index_wasm_hash : blob;
 };
+
 type SnsWasm = record {
   wasm : blob;
   proposal_id : opt nat64;
   canister_type : int32;
 };
+
 type SnsWasmCanisterInitPayload = record {
   allowed_principals : vec principal;
   access_controls_enabled : bool;
   sns_subnet_ids : vec principal;
 };
-type SnsWasmError = record { message : text };
+
+type SnsWasmError = record {
+  message : text;
+};
+
 type SwapDistribution = record {
   total_e8s : nat64;
   initial_swap_amount_e8s : nat64;
 };
-type TreasuryDistribution = record { total_e8s : nat64 };
+
+type TreasuryDistribution = record {
+  total_e8s : nat64;
+};
+
 type UpdateAllowedPrincipalsRequest = record {
   added_principals : vec principal;
   removed_principals : vec principal;
 };
+
 type UpdateAllowedPrincipalsResponse = record {
   update_allowed_principals_result : opt UpdateAllowedPrincipalsResult;
 };
+
 type UpdateAllowedPrincipalsResult = variant {
   Error : SnsWasmError;
   AllowedPrincipals : GetAllowedPrincipalsResponse;
 };
+
 type UpdateSnsSubnetListRequest = record {
   sns_subnet_ids_to_add : vec principal;
   sns_subnet_ids_to_remove : vec principal;
 };
-type UpdateSnsSubnetListResponse = record { error : opt SnsWasmError };
+
+type UpdateSnsSubnetListResponse = record {
+  error : opt SnsWasmError;
+};
+
 service : (SnsWasmCanisterInitPayload) -> {
   add_wasm : (AddWasmRequest) -> (AddWasmResponse);
   deploy_new_sns : (DeployNewSnsRequest) -> (DeployNewSnsResponse);

--- a/dfx.json
+++ b/dfx.json
@@ -387,7 +387,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-08-28",
-        "IC_COMMIT_FOR_PROPOSALS": "release-2024-08-21_15-36-canister-snapshots",
+        "IC_COMMIT_FOR_PROPOSALS": "release-2024-08-29_01-30-base",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-08-21_15-36-canister-snapshots"
       },
       "packtool": ""

--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-29_01-30-base/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -598,19 +598,6 @@ pub struct GovernanceError {
     pub error_type: i32,
 }
 #[derive(Serialize, CandidType, Deserialize)]
-pub struct CfNeuron {
-    pub has_created_neuron_recipes: Option<bool>,
-    pub hotkeys: Option<Principals>,
-    pub nns_neuron_id: u64,
-    pub amount_icp_e8s: u64,
-}
-#[derive(Serialize, CandidType, Deserialize)]
-pub struct CfParticipant {
-    pub controller: Option<Principal>,
-    pub hotkey_principal: String,
-    pub cf_neurons: Vec<CfNeuron>,
-}
-#[derive(Serialize, CandidType, Deserialize)]
 pub struct Ballot {
     pub vote: i32,
     pub voting_power: u64,
@@ -702,7 +689,6 @@ pub struct WaitForQuietState {
 pub struct ProposalData {
     pub id: Option<NeuronId>,
     pub failure_reason: Option<GovernanceError>,
-    pub cf_participants: Vec<CfParticipant>,
     pub ballots: Vec<(u64, Ballot)>,
     pub proposal_timestamp_seconds: u64,
     pub reward_event_round: u64,
@@ -822,7 +808,7 @@ pub enum Result3 {
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum Result4 {
-    Ok(RewardNodeProviders),
+    Ok(MonthlyNodeProviderRewards),
     Err(GovernanceError),
 }
 #[derive(Serialize, CandidType, Deserialize)]

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-29_01-30-base/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-29_01-30-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.
Even with no changes, just updating the reference is good practice.

# Changes
* Update the version of `IC_COMMIT_FOR_PROPOSALS` specified in `dfx.json`.
* Updated the `proposals` candid files to the versions in that commit.
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants