### PR TITLE
Imported token tag

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
@@ -1,9 +1,19 @@
 <script lang="ts">
   import type { UserTokenData, UserTokenLoading } from "$lib/types/tokens-page";
+  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
+  import { isImportedToken } from "$lib/utils/imported-tokens.utils";
   import Logo from "../../ui/Logo.svelte";
   import { nonNullish } from "@dfinity/utils";
+  import { Tag } from "@dfinity/gix-components";
+  import { i18n } from "$lib/stores/i18n";
 
   export let rowData: UserTokenData | UserTokenLoading;
+
+  let importedToken = false;
+  $: importedToken = isImportedToken({
+    ledgerCanisterId: rowData?.universeId,
+    importedTokens: $importedTokensStore.importedTokens,
+  });
 </script>
 
 <div class="title-logo-wrapper">
@@ -16,6 +26,9 @@
       >
     {/if}
   </div>
+  {#if importedToken}
+    <Tag testId="imported-token-tag">{$i18n.import_token.imported_token}</Tag>
+  {/if}
 </div>
 
 <style lang="scss">

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -19,6 +19,7 @@ import { createActionEvent } from "$tests/utils/actions.test-utils";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { render, waitFor } from "@testing-library/svelte";
 import type { Mock } from "vitest";
+import { importedTokensStore } from "../../../../lib/stores/imported-tokens.store";
 import TokensTableTest from "./TokensTableTest.svelte";
 
 describe("TokensTable", () => {
@@ -375,5 +376,33 @@ describe("TokensTable", () => {
         data: userToken,
       })
     );
+  });
+
+  it("should render an imported token tag", async () => {
+    const token1 = createUserToken({
+      universeId: OWN_CANISTER_ID,
+    });
+    const importedTokenLedgerId = principal(0);
+    const token2 = createUserToken({
+      universeId: importedTokenLedgerId,
+    });
+
+    importedTokensStore.set({
+      importedTokens: [
+        {
+          ledgerCanisterId: importedTokenLedgerId,
+          indexCanisterId: undefined,
+        },
+      ],
+      certified: true,
+    });
+
+    const po = renderTable({ userTokensData: [token1, token2] });
+    const rows = await po.getRows();
+    const row1Po = rows[0];
+    const row2Po = rows[1];
+
+    expect(await row1Po.hasImportedTokenTag()).toBe(false);
+    expect(await row2Po.hasImportedTokenTag()).toBe(true);
   });
 });

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -118,4 +118,8 @@ export class TokensTableRowPo extends ResponsiveTableRowPo {
   hasGoToDetailIcon(): Promise<boolean> {
     return this.getGoToDetailIcon().isPresent();
   }
+
+  hasImportedTokenTag(): Promise<boolean> {
+    return this.root.byTestId("imported-token-tag").isPresent();
+  }
 }


### PR DESCRIPTION
# Motivation

To distinguish the imported tokens from the default ones, we display a special tag next to the token’s name.

# Changes

- Display the import token tag when the token canister ID belongs to imported tokens.

# Tests

- Unit test added.

<img width="749" alt="image" src="https://github.com/user-attachments/assets/d53a6208-ba75-42d8-913f-f639e7e40e21">


# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.