### PR TITLE
Revert "FOLLOW-1337: Disable FORCE_CALL_STRATEGY (#5376)"

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -20,7 +20,6 @@ proposal is successful, the changes it released will be moved from this file to
 * Staking project rows are not clickable when not signed in.
 * Changes for cleaning up the stable structure migration.
 * Upgrade agent-js to version 2.
-* Make more update calls in cases where we were only doing query calls.
 
 #### Deprecated
 

--- a/frontend/src/lib/constants/mockable.constants.ts
+++ b/frontend/src/lib/constants/mockable.constants.ts
@@ -8,7 +8,7 @@ export const DEV = import.meta.env.DEV;
 // Disable TVL or transaction rate warning locally because that information is not crucial when we develop
 export const ENABLE_METRICS = !DEV;
 
-export const FORCE_CALL_STRATEGY: "query" | undefined = undefined;
+export const FORCE_CALL_STRATEGY: "query" | undefined = "query";
 
 export const IS_TEST_ENV = process.env.NODE_ENV === "test";
 

--- a/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
+++ b/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
@@ -98,11 +98,6 @@ test("Test neuron increase stake", async ({ page, context }) => {
   await appPo.getAccountsPo().waitFor();
   await appPo.goBack();
   await appPo.goToNeuronDetails(neuronId);
-  // The neuron info is cached in the governance.api-service for 5 minutes.
-  // This cache is cleared every time we do an operation on the governance API
-  // but not when we transfer the ICP directly to the neuron account. So to see
-  // the new stake we reload the page to avoid hitting the api-service cache.
-  await page.reload();
   const neuronStake3 = Number(
     await appPo
       .getNeuronDetailPo()


### PR DESCRIPTION
This reverts commit [3e064af8b3988c818d7422e7cdb69a7378aa0d87](https://github.com/dfinity/nns-dapp/commit/3e064af8b3988c818d7422e7cdb69a7378aa0d87).

# Motivation

In https://github.com/dfinity/nns-dapp/pull/5376 we disabled `FORCE_CALL_STRATEGY`.
This has resulted in [flakiness](https://github.com/dfinity/nns-dapp/actions/runs/10663467367/job/29552954194?pr=5391) in the end-to-end test `proposals.spec.ts` caused by a response to an update call for an old request coming back after a query call for a newer request, resulting in old data being display in the UI.
We've had similar issues in the past. They can be solved using the `queuedStore` but until we make the change for loading proposals, we don't want the test to be so flaky.

Additionally, there have been some concerns regarding extra load caused by enabling `queryAndUpdate` and I want to make sure we are all on the same page before we release the change.

For both these reasons, I've decided to revert the change for now.

# Changes

Ran `git revert 3e064af8b3988c818d7422e7cdb69a7378aa0d87`.

# Tests

Pass

# Todos

- [x] Add entry to changelog (if necessary).
