### PR TITLE
Remove imported token

### DIFF
--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -31,7 +31,6 @@
   import { importedTokensStore } from "$lib/stores/imported-tokens.store";
   import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { removeImportedTokens } from "$lib/services/imported-tokens.services";
-  import { accountsPathStore } from "$lib/derived/paths.derived";
   import ImportTokenRemoveConfirmation from "./ImportTokenRemoveConfirmation.svelte";
   import type { Universe } from "$lib/types/universe";
   import { selectableUniversesStore } from "$lib/derived/selectable-universes.derived";

--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -190,7 +190,7 @@
       });
 
       if (success) {
-        goto($accountsPathStore);
+        goto(AppPath.Tokens);
       }
     } finally {
       stopBusy("import-token-removing");

--- a/frontend/src/lib/components/accounts/WalletMorePopover.svelte
+++ b/frontend/src/lib/components/accounts/WalletMorePopover.svelte
@@ -40,7 +40,7 @@
 
         <button
           class="remove-button button ghost with-icon"
-          data-tid="remove-imported-token-button"
+          data-tid="remove-button"
           on:click={() => dispatch("nnsRemove")}
         >
           <IconBin />

--- a/frontend/src/lib/components/accounts/WalletMorePopover.svelte
+++ b/frontend/src/lib/components/accounts/WalletMorePopover.svelte
@@ -1,15 +1,20 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
-  import { Popover } from "@dfinity/gix-components";
+  import { IconBin, Popover } from "@dfinity/gix-components";
   import type { Principal } from "@dfinity/principal";
   import { nonNullish } from "@dfinity/utils";
   import LinkToDashboardCanister from "$lib/components/tokens/LinkToDashboardCanister.svelte";
   import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
+  import Separator from "../ui/Separator.svelte";
+  import { createEventDispatcher } from "svelte";
 
   export let anchor: HTMLElement | undefined;
   export let visible: boolean | undefined;
   export let ledgerCanisterId: Principal | undefined;
   export let indexCanisterId: Principal | undefined;
+  export let showRemoveButton = false;
+
+  const dispatch = createEventDispatcher();
 </script>
 
 <TestIdWrapper testId="wallet-more-popover-component">
@@ -29,6 +34,19 @@
           canisterId={indexCanisterId}
         />
       {/if}
+
+      {#if showRemoveButton}
+        <Separator spacing="none" />
+
+        <button
+          class="remove-button button ghost with-icon"
+          data-tid="remove-imported-token-button"
+          on:click={() => dispatch("nnsRemove")}
+        >
+          <IconBin />
+          {$i18n.core.remove}
+        </button>
+      {/if}
     </div>
   </Popover>
 </TestIdWrapper>
@@ -38,5 +56,13 @@
     display: flex;
     flex-direction: column;
     gap: var(--padding-2x);
+  }
+
+  .remove-button {
+    padding: 0;
+    color: var(--negative-emphasis);
+    &:hover {
+      color: var(--negative-emphasis);
+    }
   }
 </style>

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1042,6 +1042,7 @@
     "imported_token": "Imported Token",
     "verifying": "Verifying token details...",
     "importing": "Importing new token...",
+    "removing": "Removing imported token...",
     "description": "To import a new token to your NNS dapp wallet, you will need to find, and paste the ledger canister id of the token. If you want to see your transaction history, you need to import the token’s index canister.",
     "ledger_label": "Ledger Canister ID",
     "index_label_optional": "Index Canister ID <span class='description'>(Optional)</span>",

--- a/frontend/src/lib/stores/busy.store.ts
+++ b/frontend/src/lib/stores/busy.store.ts
@@ -47,7 +47,8 @@ export type BusyStateInitiatorType =
   | "update-ckbtc-balance"
   | "reload-receive-account"
   | "import-token-validation"
-  | "import-token-importing";
+  | "import-token-importing"
+  | "import-token-removing";
 
 export interface BusyState {
   initiator: BusyStateInitiatorType;

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1101,6 +1101,7 @@ interface I18nImport_token {
   imported_token: string;
   verifying: string;
   importing: string;
+  removing: string;
   description: string;
   ledger_label: string;
   index_label_optional: string;

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -37,6 +37,7 @@ import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { busyStore, toastsStore } from "@dfinity/gix-components";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
+import { mockIcrcMainAccount } from "../../mocks/icrc-accounts.mock";
 
 const expectedBalanceAfterTransfer = 11_111n;
 
@@ -498,10 +499,10 @@ describe("IcrcWallet", () => {
       tokensStore.setTokens(mockUniversesTokens);
       icrcAccountsStore.set({
         accounts: {
-          accounts: [mockCkETHMainAccount],
+          accounts: [mockIcrcMainAccount],
           certified: true,
         },
-        ledgerCanisterId: CKETHSEPOLIA_LEDGER_CANISTER_ID,
+        ledgerCanisterId,
       });
       importedTokensStore.set({
         importedTokens: [
@@ -518,7 +519,7 @@ describe("IcrcWallet", () => {
       });
       icrcAccountsStore.set({
         accounts: {
-          accounts: [mockCkETHMainAccount],
+          accounts: [mockIcrcMainAccount],
           certified: true,
         },
         ledgerCanisterId,

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -535,7 +535,12 @@ describe("IcrcWallet", () => {
       const spyOnGetImportedTokens = vi
         .spyOn(importedTokensApi, "getImportedTokens")
         .mockResolvedValue({
-          imported_tokens: [],
+          imported_tokens: [
+            {
+              ledger_canister_id: ledgerCanisterId2,
+              index_canister_id: [],
+            },
+          ],
         });
 
       const po = await renderWallet({});
@@ -557,6 +562,16 @@ describe("IcrcWallet", () => {
       expect(await confirmationPo.isPresent()).toBe(true);
       await confirmationPo.clickYes();
 
+      expect(get(importedTokensStore).importedTokens).toEqual([
+        {
+          ledgerCanisterId,
+          indexCanisterId: undefined,
+        },
+        {
+          ledgerCanisterId: ledgerCanisterId2,
+          indexCanisterId: undefined,
+        },
+      ]);
       expect(get(busyStore)).toEqual([
         {
           initiator: "import-token-removing",
@@ -582,6 +597,12 @@ describe("IcrcWallet", () => {
 
       expect(get(busyStore)).toEqual([]);
       expect(get(pageStore).path).toEqual(AppPath.Tokens);
+      expect(get(importedTokensStore).importedTokens).toEqual([
+        {
+          ledgerCanisterId: ledgerCanisterId2,
+          indexCanisterId: undefined,
+        },
+      ]);
     });
 
     it("should stay on the same page when removal is unsuccessful", async () => {

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -27,6 +27,7 @@ import {
   mockCkETHMainAccount,
   mockCkETHTESTToken,
 } from "$tests/mocks/cketh-accounts.mock";
+import { mockIcrcMainAccount } from "$tests/mocks/icrc-accounts.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { mockUniversesTokens } from "$tests/mocks/tokens.mock";
 import { IcrcWalletPo } from "$tests/page-objects/IcrcWallet.page-object";
@@ -34,10 +35,10 @@ import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { createDeferredPromise } from "$tests/utils/utils.test-utils";
 import { busyStore, toastsStore } from "@dfinity/gix-components";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
-import { mockIcrcMainAccount } from "../../mocks/icrc-accounts.mock";
 
 const expectedBalanceAfterTransfer = 11_111n;
 
@@ -527,9 +528,10 @@ describe("IcrcWallet", () => {
     });
 
     it("should remove imported tokens", async () => {
+      const setImportedTokensDeferred = createDeferredPromise<void>();
       const spyOnSetImportedTokens = vi
         .spyOn(importedTokensApi, "setImportedTokens")
-        .mockResolvedValue(undefined);
+        .mockReturnValue(setImportedTokensDeferred);
       const spyOnGetImportedTokens = vi
         .spyOn(importedTokensApi, "getImportedTokens")
         .mockResolvedValue({
@@ -562,6 +564,7 @@ describe("IcrcWallet", () => {
         },
       ]);
 
+      setImportedTokensDeferred.resolve();
       await runResolvedPromises();
 
       // The token should be removed.

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -35,7 +35,6 @@ import { ReceiveModalPo } from "$tests/page-objects/ReceiveModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
-import { createDeferredPromise } from "$tests/utils/utils.test-utils";
 import { busyStore, toastsStore } from "@dfinity/gix-components";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -528,10 +527,13 @@ describe("IcrcWallet", () => {
     });
 
     it("should remove imported tokens", async () => {
-      const setImportedTokensDeferred = createDeferredPromise<void>();
+      let resolveSetImportedTokens;
       const spyOnSetImportedTokens = vi
         .spyOn(importedTokensApi, "setImportedTokens")
-        .mockReturnValue(setImportedTokensDeferred);
+        .mockImplementation(
+          () =>
+            new Promise<void>((resolve) => (resolveSetImportedTokens = resolve))
+        );
       const spyOnGetImportedTokens = vi
         .spyOn(importedTokensApi, "getImportedTokens")
         .mockResolvedValue({
@@ -579,7 +581,7 @@ describe("IcrcWallet", () => {
         },
       ]);
 
-      setImportedTokensDeferred.resolve();
+      resolveSetImportedTokens();
       await runResolvedPromises();
 
       // The token should be removed.

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -607,12 +607,24 @@ describe("IcrcWallet", () => {
 
     it("should stay on the same page when removal is unsuccessful", async () => {
       vi.spyOn(console, "error").mockReturnValue();
-      vi.spyOn(importedTokensApi, "setImportedTokens").mockRejectedValue(
-        new Error()
+      const spyOnSetImportedTokens = vi
+        .spyOn(importedTokensApi, "setImportedTokens")
+        .mockRejectedValue(new Error());
+      const spyOnGetImportedTokens = vi.spyOn(
+        importedTokensApi,
+        "getImportedTokens"
       );
-      vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
-        imported_tokens: [],
-      });
+
+      expect(get(importedTokensStore).importedTokens).toEqual([
+        {
+          ledgerCanisterId,
+          indexCanisterId: undefined,
+        },
+        {
+          ledgerCanisterId: ledgerCanisterId2,
+          indexCanisterId: undefined,
+        },
+      ]);
 
       const po = await renderWallet({});
       const morePopoverPo = po.getWalletMorePopoverPo();
@@ -624,8 +636,21 @@ describe("IcrcWallet", () => {
       await runResolvedPromises();
       await confirmationPo.clickYes();
       await runResolvedPromises();
+      expect(spyOnSetImportedTokens).toBeCalledTimes(1);
       // should stay on wallet page
       expect(get(pageStore).path).toEqual(AppPath.Wallet);
+      // without data change
+      expect(spyOnGetImportedTokens).toBeCalledTimes(0);
+      expect(get(importedTokensStore).importedTokens).toEqual([
+        {
+          ledgerCanisterId,
+          indexCanisterId: undefined,
+        },
+        {
+          ledgerCanisterId: ledgerCanisterId2,
+          indexCanisterId: undefined,
+        },
+      ]);
     });
   });
 });

--- a/frontend/src/tests/page-objects/IcrcWallet.page-object.ts
+++ b/frontend/src/tests/page-objects/IcrcWallet.page-object.ts
@@ -1,5 +1,6 @@
 import type { ButtonPo } from "$tests/page-objects/Button.page-object";
 import { IcrcWalletFooterPo } from "$tests/page-objects/IcrcWalletFooter.page-object";
+import { ImportTokenRemoveConfirmationPo } from "$tests/page-objects/ImportTokenRemoveConfirmation.page-object";
 import { SignInPo } from "$tests/page-objects/SignIn.page-object";
 import { WalletMorePopoverPo } from "$tests/page-objects/WalletMorePopover.page-object";
 import { WalletPageHeaderPo } from "$tests/page-objects/WalletPageHeader.page-object";
@@ -36,6 +37,10 @@ export class IcrcWalletPo extends BasePageObject {
 
   getWalletMorePopoverPo(): WalletMorePopoverPo {
     return WalletMorePopoverPo.under(this.root);
+  }
+
+  getImportTokenRemoveConfirmationPo(): ImportTokenRemoveConfirmationPo {
+    return ImportTokenRemoveConfirmationPo.under(this.root);
   }
 
   hasSignInButton(): Promise<boolean> {

--- a/frontend/src/tests/page-objects/WalletMorePopover.page-object.ts
+++ b/frontend/src/tests/page-objects/WalletMorePopover.page-object.ts
@@ -1,6 +1,7 @@
 import { LinkToDashboardCanisterPo } from "$tests/page-objects/LinkToDashboardCanister.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import type { ButtonPo } from "./Button.page-object";
 
 export class WalletMorePopoverPo extends BasePageObject {
   private static readonly TID = "wallet-more-popover-component";
@@ -21,5 +22,9 @@ export class WalletMorePopoverPo extends BasePageObject {
       element: this.root,
       testId: "link-to-index-canister",
     });
+  }
+
+  getRemoveButtonPo(): ButtonPo {
+    return this.getButton("remove-button");
   }
 }

--- a/frontend/src/tests/utils/utils.test-utils.ts
+++ b/frontend/src/tests/utils/utils.test-utils.ts
@@ -44,31 +44,3 @@ export const isNotVisible = (element: Element): boolean => {
     return nonNullish(heightString) && Number(heightString) === 0;
   }
 };
-
-// Return a promise-like object that exposes its resolve and reject functions.
-export const createDeferredPromise = <T>(): Promise<T> & {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-  reject: (reason?: unknown) => void;
-} => {
-  let resolve: (value: T) => void;
-  let reject: (reason?: unknown) => void;
-
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {
-    promise,
-    resolve,
-    reject,
-    then: (onFulfilled, onRejected) => promise.then(onFulfilled, onRejected),
-    catch: (onRejected) => promise.catch(onRejected),
-    finally: (onFinally) => promise.finally(onFinally),
-  } as Promise<T> & {
-    promise: Promise<T>;
-    resolve: (value: T) => void;
-    reject: (reason?: unknown) => void;
-  };
-};

--- a/frontend/src/tests/utils/utils.test-utils.ts
+++ b/frontend/src/tests/utils/utils.test-utils.ts
@@ -44,3 +44,31 @@ export const isNotVisible = (element: Element): boolean => {
     return nonNullish(heightString) && Number(heightString) === 0;
   }
 };
+
+// Return a promise-like object that exposes its resolve and reject functions.
+export const createDeferredPromise = <T>(): Promise<T> & {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+} => {
+  let resolve: (value: T) => void;
+  let reject: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return {
+    promise,
+    resolve,
+    reject,
+    then: (onFulfilled, onRejected) => promise.then(onFulfilled, onRejected),
+    catch: (onRejected) => promise.catch(onRejected),
+    finally: (onFinally) => promise.finally(onFinally),
+  } as Promise<T> & {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+    reject: (reason?: unknown) => void;
+  };
+};


### PR DESCRIPTION
# Motivation

The imported tokens should be removable. This PR addresses the issue by providing a workflow for removing imported tokens, allowing users to open the context menu on the wallet page, click "Remove", and be navigated to the tokens list after successful removal.

# Changes

- Add "Remove" button in WalletMorePopover.
- Extend busy initiator with "import-token-removing" entry.
- Show a remove confirmation dialog when the ‘Remove’ button is clicked, and proceed with the token removal.

# Tests

- Add createDeferredPromise helper.
- Added "should remove imported tokens".
- Tested manually as well.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
