### PR TITLE
bot: Update sns_aggregator candid bindings

### DIFF
--- a/declarations/used_by_sns_aggregator/sns_governance/sns_governance.did
+++ b/declarations/used_by_sns_aggregator/sns_governance/sns_governance.did
@@ -1,5 +1,9 @@
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/sns/governance/canister/governance.did>
-type Account = record { owner : opt principal; subaccount : opt Subaccount };
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-29_01-30-base/rs/sns/governance/canister/governance.did>
+type Account = record {
+  owner : opt principal;
+  subaccount : opt Subaccount;
+};
+
 type Action = variant {
   ManageNervousSystemParameters : NervousSystemParameters;
   AddGenericNervousSystemFunction : NervousSystemFunction;
@@ -17,24 +21,32 @@ type Action = variant {
   ManageLedgerParameters : ManageLedgerParameters;
   Motion : Motion;
 };
+
 type ActionAuxiliary = variant {
   TransferSnsTreasuryFunds : MintSnsTokensActionAuxiliary;
   MintSnsTokens : MintSnsTokensActionAuxiliary;
 };
+
 type AddNeuronPermissions = record {
   permissions_to_add : opt NeuronPermissionList;
   principal_id : opt principal;
 };
-type Amount = record { e8s : nat64 };
+
+type Amount = record {
+  e8s : nat64;
+};
+
 type Ballot = record {
   vote : int32;
   cast_timestamp_seconds : nat64;
   voting_power : nat64;
 };
+
 type By = variant {
   MemoAndController : MemoAndController;
   NeuronId : record {};
 };
+
 type CanisterStatusResultV2 = record {
   status : CanisterStatusType;
   memory_size : nat;
@@ -43,21 +55,43 @@ type CanisterStatusResultV2 = record {
   idle_cycles_burned_per_day : nat;
   module_hash : opt blob;
 };
-type CanisterStatusType = variant { stopped; stopping; running };
+
+type CanisterStatusType = variant {
+  stopped;
+  stopping;
+  running;
+};
+
 type ChangeAutoStakeMaturity = record {
   requested_setting_for_auto_stake_maturity : bool;
 };
-type ClaimOrRefresh = record { by : opt By };
-type ClaimOrRefreshResponse = record { refreshed_neuron_id : opt NeuronId };
+
+type ClaimOrRefresh = record {
+  by : opt By;
+};
+
+type ClaimOrRefreshResponse = record {
+  refreshed_neuron_id : opt NeuronId;
+};
+
 type ClaimSwapNeuronsRequest = record {
   neuron_recipes : opt NeuronRecipes;
   neuron_parameters : vec NeuronParameters;
 };
+
 type ClaimSwapNeuronsResponse = record {
   claim_swap_neurons_result : opt ClaimSwapNeuronsResult;
 };
-type ClaimSwapNeuronsResult = variant { Ok : ClaimedSwapNeurons; Err : int32 };
-type ClaimedSwapNeurons = record { swap_neurons : vec SwapNeuron };
+
+type ClaimSwapNeuronsResult = variant {
+  Ok : ClaimedSwapNeurons;
+  Err : int32;
+};
+
+type ClaimedSwapNeurons = record {
+  swap_neurons : vec SwapNeuron;
+};
+
 type Command = variant {
   Split : Split;
   Follow : Follow;
@@ -72,6 +106,7 @@ type Command = variant {
   MergeMaturity : MergeMaturity;
   Disburse : Disburse;
 };
+
 type Command_1 = variant {
   Error : GovernanceError;
   Split : SplitResponse;
@@ -87,6 +122,7 @@ type Command_1 = variant {
   Disburse : DisburseResponse;
   AddNeuronPermission : record {};
 };
+
 type Command_2 = variant {
   Split : Split;
   Follow : Follow;
@@ -102,80 +138,134 @@ type Command_2 = variant {
   MergeMaturity : MergeMaturity;
   Disburse : Disburse;
 };
-type Configure = record { operation : opt Operation };
-type Decimal = record { human_readable : opt text };
-type DefaultFollowees = record { followees : vec record { nat64; Followees } };
+
+type Configure = record {
+  operation : opt Operation;
+};
+
+type Decimal = record {
+  human_readable : opt text;
+};
+
+type DefaultFollowees = record {
+  followees : vec record { nat64; Followees };
+};
+
 type DefiniteCanisterSettingsArgs = record {
   freezing_threshold : nat;
   controllers : vec principal;
+  wasm_memory_limit : opt nat;
   memory_allocation : nat;
   compute_allocation : nat;
 };
+
 type DeregisterDappCanisters = record {
   canister_ids : vec principal;
   new_controllers : vec principal;
 };
-type Disburse = record { to_account : opt Account; amount : opt Amount };
+
+type Disburse = record {
+  to_account : opt Account;
+  amount : opt Amount;
+};
+
 type DisburseMaturity = record {
   to_account : opt Account;
   percentage_to_disburse : nat32;
 };
+
 type DisburseMaturityInProgress = record {
   timestamp_of_disbursement_seconds : nat64;
   amount_e8s : nat64;
   account_to_disburse_to : opt Account;
   finalize_disbursement_timestamp_seconds : opt nat64;
 };
+
 type DisburseMaturityResponse = record {
   amount_disbursed_e8s : nat64;
   amount_deducted_e8s : opt nat64;
 };
-type DisburseResponse = record { transfer_block_height : nat64 };
+
+type DisburseResponse = record {
+  transfer_block_height : nat64;
+};
+
 type DissolveState = variant {
   DissolveDelaySeconds : nat64;
   WhenDissolvedTimestampSeconds : nat64;
 };
+
 type ExecuteGenericNervousSystemFunction = record {
   function_id : nat64;
   payload : blob;
 };
+
 type FinalizeDisburseMaturity = record {
   amount_to_be_disbursed_e8s : nat64;
   to_account : opt Account;
 };
-type Follow = record { function_id : nat64; followees : vec NeuronId };
-type Followees = record { followees : vec NeuronId };
+
+type Follow = record {
+  function_id : nat64;
+  followees : vec NeuronId;
+};
+
+type Followees = record {
+  followees : vec NeuronId;
+};
+
 type FunctionType = variant {
   NativeNervousSystemFunction : record {};
   GenericNervousSystemFunction : GenericNervousSystemFunction;
 };
+
 type GenericNervousSystemFunction = record {
   validator_canister_id : opt principal;
   target_canister_id : opt principal;
   validator_method_name : opt text;
   target_method_name : opt text;
 };
+
 type GetMaturityModulationResponse = record {
   maturity_modulation : opt MaturityModulation;
 };
+
 type GetMetadataResponse = record {
   url : opt text;
   logo : opt text;
   name : opt text;
   description : opt text;
 };
-type GetModeResponse = record { mode : opt int32 };
-type GetNeuron = record { neuron_id : opt NeuronId };
-type GetNeuronResponse = record { result : opt Result };
-type GetProposal = record { proposal_id : opt ProposalId };
-type GetProposalResponse = record { result : opt Result_1 };
+
+type GetModeResponse = record {
+  mode : opt int32;
+};
+
+type GetNeuron = record {
+  neuron_id : opt NeuronId;
+};
+
+type GetNeuronResponse = record {
+  result : opt Result;
+};
+
+type GetProposal = record {
+  proposal_id : opt ProposalId;
+};
+
+type GetProposalResponse = record {
+  result : opt Result_1;
+};
+
 type GetRunningSnsVersionResponse = record {
   deployed_version : opt Version;
   pending_version : opt UpgradeInProgress;
 };
+
 type GetSnsInitializationParametersResponse = record {
   sns_initialization_parameters : text;
 };
+
 type Governance = record {
   root_canister_id : opt principal;
   id_to_nervous_system_functions : vec record { nat64; NervousSystemFunction };
@@ -196,6 +286,7 @@ type Governance = record {
   neurons : vec record { text; Neuron };
   genesis_timestamp_seconds : nat64;
 };
+
 type GovernanceCachedMetrics = record {
   not_dissolving_neurons_e8s_buckets : vec record { nat64; float64 };
   garbage_collectable_neurons_count : nat64;
@@ -213,20 +304,31 @@ type GovernanceCachedMetrics = record {
   dissolving_neurons_e8s_buckets : vec record { nat64; float64 };
   timestamp_seconds : nat64;
 };
-type GovernanceError = record { error_message : text; error_type : int32 };
+
+type GovernanceError = record {
+  error_message : text;
+  error_type : int32;
+};
+
 type IncreaseDissolveDelay = record {
   additional_dissolve_delay_seconds : nat32;
 };
+
 type ListNervousSystemFunctionsResponse = record {
   reserved_ids : vec nat64;
   functions : vec NervousSystemFunction;
 };
+
 type ListNeurons = record {
   of_principal : opt principal;
   limit : nat32;
   start_page_at : opt NeuronId;
 };
-type ListNeuronsResponse = record { neurons : vec Neuron };
+
+type ListNeuronsResponse = record {
+  neurons : vec Neuron;
+};
+
 type ListProposals = record {
   include_reward_status : vec int32;
   before_proposal : opt ProposalId;
@@ -234,10 +336,12 @@ type ListProposals = record {
   exclude_type : vec nat64;
   include_status : vec int32;
 };
+
 type ListProposalsResponse = record {
   include_ballots_by_caller : opt bool;
   proposals : vec ProposalData;
 };
+
 type ManageDappCanisterSettings = record {
   freezing_threshold : opt nat64;
   canister_ids : vec principal;
@@ -247,44 +351,71 @@ type ManageDappCanisterSettings = record {
   memory_allocation : opt nat64;
   compute_allocation : opt nat64;
 };
+
 type ManageLedgerParameters = record {
   token_symbol : opt text;
   transfer_fee : opt nat64;
   token_logo : opt text;
   token_name : opt text;
 };
-type ManageNeuron = record { subaccount : blob; command : opt Command };
-type ManageNeuronResponse = record { command : opt Command_1 };
+
+type ManageNeuron = record {
+  subaccount : blob;
+  command : opt Command;
+};
+
+type ManageNeuronResponse = record {
+  command : opt Command_1;
+};
+
 type ManageSnsMetadata = record {
   url : opt text;
   logo : opt text;
   name : opt text;
   description : opt text;
 };
+
 type MaturityModulation = record {
   current_basis_points : opt int32;
   updated_at_timestamp_seconds : opt nat64;
 };
-type MemoAndController = record { controller : opt principal; memo : nat64 };
-type MergeMaturity = record { percentage_to_merge : nat32 };
+
+type MemoAndController = record {
+  controller : opt principal;
+  memo : nat64;
+};
+
+type MergeMaturity = record {
+  percentage_to_merge : nat32;
+};
+
 type MergeMaturityResponse = record {
   merged_maturity_e8s : nat64;
   new_stake_e8s : nat64;
 };
+
 type MintSnsTokens = record {
   to_principal : opt principal;
   to_subaccount : opt Subaccount;
   memo : opt nat64;
   amount_e8s : opt nat64;
 };
-type MintSnsTokensActionAuxiliary = record { valuation : opt Valuation };
-type Motion = record { motion_text : text };
+
+type MintSnsTokensActionAuxiliary = record {
+  valuation : opt Valuation;
+};
+
+type Motion = record {
+  motion_text : text;
+};
+
 type NervousSystemFunction = record {
   id : nat64;
   name : text;
   description : opt text;
   function_type : opt FunctionType;
 };
+
 type NervousSystemParameters = record {
   default_followees : opt DefaultFollowees;
   max_dissolve_delay_seconds : opt nat64;
@@ -307,6 +438,7 @@ type NervousSystemParameters = record {
   maturity_modulation_disabled : opt bool;
   max_number_of_principals_per_neuron : opt nat64;
 };
+
 type Neuron = record {
   id : opt NeuronId;
   staked_maturity_e8s_equivalent : opt nat64;
@@ -324,12 +456,20 @@ type Neuron = record {
   followees : vec record { nat64; Followees };
   neuron_fees_e8s : nat64;
 };
-type NeuronId = record { id : blob };
-type NeuronIds = record { neuron_ids : vec NeuronId };
+
+type NeuronId = record {
+  id : blob;
+};
+
+type NeuronIds = record {
+  neuron_ids : vec NeuronId;
+};
+
 type NeuronInFlightCommand = record {
   command : opt Command_2;
   timestamp : nat64;
 };
+
 type NeuronParameters = record {
   controller : opt principal;
   dissolve_delay_seconds : opt nat64;
@@ -339,11 +479,16 @@ type NeuronParameters = record {
   hotkey : opt principal;
   neuron_id : opt NeuronId;
 };
+
 type NeuronPermission = record {
   "principal" : opt principal;
   permission_type : vec int32;
 };
-type NeuronPermissionList = record { permissions : vec int32 };
+
+type NeuronPermissionList = record {
+  permissions : vec int32;
+};
+
 type NeuronRecipe = record {
   controller : opt principal;
   dissolve_delay_seconds : opt nat64;
@@ -352,12 +497,17 @@ type NeuronRecipe = record {
   followees : opt NeuronIds;
   neuron_id : opt NeuronId;
 };
-type NeuronRecipes = record { neuron_recipes : vec NeuronRecipe };
+
+type NeuronRecipes = record {
+  neuron_recipes : vec NeuronRecipe;
+};
+
 type NeuronsFund = record {
   nns_neuron_hotkeys : opt Principals;
   nns_neuron_controller : opt principal;
   nns_neuron_id : opt nat64;
 };
+
 type Operation = variant {
   ChangeAutoStakeMaturity : ChangeAutoStakeMaturity;
   StopDissolving : record {};
@@ -365,15 +515,27 @@ type Operation = variant {
   IncreaseDissolveDelay : IncreaseDissolveDelay;
   SetDissolveTimestamp : SetDissolveTimestamp;
 };
-type Participant = variant { NeuronsFund : NeuronsFund; Direct : record {} };
-type Percentage = record { basis_points : opt nat64 };
-type Principals = record { principals : vec principal };
+
+type Participant = variant {
+  NeuronsFund : NeuronsFund;
+  Direct : record {};
+};
+
+type Percentage = record {
+  basis_points : opt nat64;
+};
+
+type Principals = record {
+  principals : vec principal;
+};
+
 type Proposal = record {
   url : text;
   title : text;
   action : opt Action;
   summary : text;
 };
+
 type ProposalData = record {
   id : opt ProposalId;
   payload_text_rendering : opt text;
@@ -398,15 +560,35 @@ type ProposalData = record {
   is_eligible_for_rewards : bool;
   executed_timestamp_seconds : nat64;
 };
-type ProposalId = record { id : nat64 };
-type RegisterDappCanisters = record { canister_ids : vec principal };
-type RegisterVote = record { vote : int32; proposal : opt ProposalId };
+
+type ProposalId = record {
+  id : nat64;
+};
+
+type RegisterDappCanisters = record {
+  canister_ids : vec principal;
+};
+
+type RegisterVote = record {
+  vote : int32;
+  proposal : opt ProposalId;
+};
+
 type RemoveNeuronPermissions = record {
   permissions_to_remove : opt NeuronPermissionList;
   principal_id : opt principal;
 };
-type Result = variant { Error : GovernanceError; Neuron : Neuron };
-type Result_1 = variant { Error : GovernanceError; Proposal : ProposalData };
+
+type Result = variant {
+  Error : GovernanceError;
+  Neuron : Neuron;
+};
+
+type Result_1 = variant {
+  Error : GovernanceError;
+  Proposal : ProposalData;
+};
+
 type RewardEvent = record {
   rounds_since_last_distribution : opt nat64;
   actual_timestamp_seconds : nat64;
@@ -416,24 +598,53 @@ type RewardEvent = record {
   round : nat64;
   settled_proposals : vec ProposalId;
 };
-type SetDissolveTimestamp = record { dissolve_timestamp_seconds : nat64 };
-type SetMode = record { mode : int32 };
-type Split = record { memo : nat64; amount_e8s : nat64 };
-type SplitResponse = record { created_neuron_id : opt NeuronId };
-type StakeMaturity = record { percentage_to_stake : opt nat32 };
+
+type SetDissolveTimestamp = record {
+  dissolve_timestamp_seconds : nat64;
+};
+
+type SetMode = record {
+  mode : int32;
+};
+
+type Split = record {
+  memo : nat64;
+  amount_e8s : nat64;
+};
+
+type SplitResponse = record {
+  created_neuron_id : opt NeuronId;
+};
+
+type StakeMaturity = record {
+  percentage_to_stake : opt nat32;
+};
+
 type StakeMaturityResponse = record {
   maturity_e8s : nat64;
   staked_maturity_e8s : nat64;
 };
-type Subaccount = record { subaccount : blob };
-type SwapNeuron = record { id : opt NeuronId; status : int32 };
+
+type Subaccount = record {
+  subaccount : blob;
+};
+
+type SwapNeuron = record {
+  id : opt NeuronId;
+  status : int32;
+};
+
 type Tally = record {
   no : nat64;
   yes : nat64;
   total : nat64;
   timestamp_seconds : nat64;
 };
-type Tokens = record { e8s : opt nat64 };
+
+type Tokens = record {
+  e8s : opt nat64;
+};
+
 type TransferSnsTreasuryFunds = record {
   from_treasury : int32;
   to_principal : opt principal;
@@ -441,29 +652,34 @@ type TransferSnsTreasuryFunds = record {
   memo : opt nat64;
   amount_e8s : nat64;
 };
+
 type UpgradeInProgress = record {
   mark_failed_at_seconds : nat64;
   checking_upgrade_lock : nat64;
   proposal_id : nat64;
   target_version : opt Version;
 };
+
 type UpgradeSnsControlledCanister = record {
   new_canister_wasm : blob;
   mode : opt int32;
   canister_id : opt principal;
   canister_upgrade_arg : opt blob;
 };
+
 type Valuation = record {
   token : opt int32;
   account : opt Account;
   valuation_factors : opt ValuationFactors;
   timestamp_seconds : opt nat64;
 };
+
 type ValuationFactors = record {
   xdrs_per_icp : opt Decimal;
   icps_per_token : opt Decimal;
   tokens : opt Tokens;
 };
+
 type Version = record {
   archive_wasm_hash : blob;
   root_wasm_hash : blob;
@@ -472,13 +688,18 @@ type Version = record {
   governance_wasm_hash : blob;
   index_wasm_hash : blob;
 };
+
 type VotingRewardsParameters = record {
   final_reward_rate_basis_points : opt nat64;
   initial_reward_rate_basis_points : opt nat64;
   reward_rate_transition_duration_seconds : opt nat64;
   round_duration_seconds : opt nat64;
 };
-type WaitForQuietState = record { current_deadline_timestamp_seconds : nat64 };
+
+type WaitForQuietState = record {
+  current_deadline_timestamp_seconds : nat64;
+};
+
 service : (Governance) -> {
   claim_swap_neurons : (ClaimSwapNeuronsRequest) -> (ClaimSwapNeuronsResponse);
   fail_stuck_upgrade_in_progress : (record {}) -> (record {});

--- a/declarations/used_by_sns_aggregator/sns_ledger/sns_ledger.did
+++ b/declarations/used_by_sns_aggregator/sns_ledger/sns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/rosetta-api/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-29_01-30-base/rs/rosetta-api/icrc1/ledger/ledger.did>
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.

--- a/declarations/used_by_sns_aggregator/sns_root/sns_root.did
+++ b/declarations/used_by_sns_aggregator/sns_root/sns_root.did
@@ -1,7 +1,19 @@
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/sns/root/canister/root.did>
-type CanisterCallError = record { code : opt int32; description : text };
-type CanisterIdRecord = record { canister_id : principal };
-type CanisterInstallMode = variant { reinstall; upgrade; install };
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-29_01-30-base/rs/sns/root/canister/root.did>
+type CanisterCallError = record {
+  code : opt int32;
+  description : text;
+};
+
+type CanisterIdRecord = record {
+  canister_id : principal;
+};
+
+type CanisterInstallMode = variant {
+  reinstall;
+  upgrade;
+  install;
+};
+
 type CanisterStatusResult = record {
   status : CanisterStatusType;
   memory_size : nat;
@@ -11,6 +23,7 @@ type CanisterStatusResult = record {
   module_hash : opt blob;
   reserved_cycles : opt nat;
 };
+
 type CanisterStatusResultV2 = record {
   status : CanisterStatusType;
   memory_size : nat;
@@ -19,11 +32,18 @@ type CanisterStatusResultV2 = record {
   idle_cycles_burned_per_day : nat;
   module_hash : opt blob;
 };
-type CanisterStatusType = variant { stopped; stopping; running };
+
+type CanisterStatusType = variant {
+  stopped;
+  stopping;
+  running;
+};
+
 type CanisterSummary = record {
   status : opt CanisterStatusResultV2;
   canister_id : opt principal;
 };
+
 type ChangeCanisterRequest = record {
   arg : blob;
   wasm_module : blob;
@@ -33,6 +53,7 @@ type ChangeCanisterRequest = record {
   memory_allocation : opt nat;
   compute_allocation : opt nat;
 };
+
 type DefiniteCanisterSettings = record {
   freezing_threshold : opt nat;
   controllers : vec principal;
@@ -42,17 +63,24 @@ type DefiniteCanisterSettings = record {
   memory_allocation : opt nat;
   compute_allocation : opt nat;
 };
+
 type DefiniteCanisterSettingsArgs = record {
   freezing_threshold : nat;
   controllers : vec principal;
+  wasm_memory_limit : opt nat;
   memory_allocation : nat;
   compute_allocation : nat;
 };
+
 type FailedUpdate = record {
   err : opt CanisterCallError;
   dapp_canister_id : opt principal;
 };
-type GetSnsCanistersSummaryRequest = record { update_canister_list : opt bool };
+
+type GetSnsCanistersSummaryRequest = record {
+  update_canister_list : opt bool;
+};
+
 type GetSnsCanistersSummaryResponse = record {
   root : opt CanisterSummary;
   swap : opt CanisterSummary;
@@ -62,6 +90,7 @@ type GetSnsCanistersSummaryResponse = record {
   dapps : vec CanisterSummary;
   archives : vec CanisterSummary;
 };
+
 type ListSnsCanistersResponse = record {
   root : opt principal;
   swap : opt principal;
@@ -71,7 +100,12 @@ type ListSnsCanistersResponse = record {
   dapps : vec principal;
   archives : vec principal;
 };
-type LogVisibility = variant { controllers; public };
+
+type LogVisibility = variant {
+  controllers;
+  public;
+};
+
 type ManageDappCanisterSettingsRequest = record {
   freezing_threshold : opt nat64;
   canister_ids : vec principal;
@@ -81,14 +115,28 @@ type ManageDappCanisterSettingsRequest = record {
   memory_allocation : opt nat64;
   compute_allocation : opt nat64;
 };
-type ManageDappCanisterSettingsResponse = record { failure_reason : opt text };
-type RegisterDappCanisterRequest = record { canister_id : opt principal };
-type RegisterDappCanistersRequest = record { canister_ids : vec principal };
+
+type ManageDappCanisterSettingsResponse = record {
+  failure_reason : opt text;
+};
+
+type RegisterDappCanisterRequest = record {
+  canister_id : opt principal;
+};
+
+type RegisterDappCanistersRequest = record {
+  canister_ids : vec principal;
+};
+
 type SetDappControllersRequest = record {
   canister_ids : opt RegisterDappCanistersRequest;
   controller_principal_ids : vec principal;
 };
-type SetDappControllersResponse = record { failed_updates : vec FailedUpdate };
+
+type SetDappControllersResponse = record {
+  failed_updates : vec FailedUpdate;
+};
+
 type SnsRootCanister = record {
   dapp_canister_ids : vec principal;
   testflight : bool;
@@ -99,6 +147,7 @@ type SnsRootCanister = record {
   swap_canister_id : opt principal;
   ledger_canister_id : opt principal;
 };
+
 service : (SnsRootCanister) -> {
   canister_status : (CanisterIdRecord) -> (CanisterStatusResult);
   change_canister : (ChangeCanisterRequest) -> ();

--- a/declarations/used_by_sns_aggregator/sns_swap/sns_swap.did
+++ b/declarations/used_by_sns_aggregator/sns_swap/sns_swap.did
@@ -1,9 +1,14 @@
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-29_01-30-base/rs/sns/swap/canister/swap.did>
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;
 };
-type CanisterCallError = record { code : opt int32; description : text };
+
+type CanisterCallError = record {
+  code : opt int32;
+  description : text;
+};
+
 type CanisterStatusResultV2 = record {
   status : CanisterStatusType;
   memory_size : nat;
@@ -12,31 +17,45 @@ type CanisterStatusResultV2 = record {
   idle_cycles_burned_per_day : nat;
   module_hash : opt blob;
 };
-type CanisterStatusType = variant { stopped; stopping; running };
+
+type CanisterStatusType = variant {
+  stopped;
+  stopping;
+  running;
+};
+
 type CfInvestment = record {
   controller : opt principal;
   hotkey_principal : text;
   hotkeys : opt Principals;
   nns_neuron_id : nat64;
 };
+
 type CfNeuron = record {
   has_created_neuron_recipes : opt bool;
   hotkeys : opt Principals;
   nns_neuron_id : nat64;
   amount_icp_e8s : nat64;
 };
+
 type CfParticipant = record {
   controller : opt principal;
   hotkey_principal : text;
   cf_neurons : vec CfNeuron;
 };
-type Countries = record { iso_codes : vec text };
+
+type Countries = record {
+  iso_codes : vec text;
+};
+
 type DefiniteCanisterSettingsArgs = record {
   freezing_threshold : nat;
   controllers : vec principal;
+  wasm_memory_limit : opt nat;
   memory_allocation : nat;
   compute_allocation : nat;
 };
+
 type DerivedState = record {
   sns_tokens_per_icp : float32;
   buyer_total_icp_e8s : nat64;
@@ -46,21 +65,43 @@ type DerivedState = record {
   direct_participant_count : opt nat64;
   cf_neuron_count : opt nat64;
 };
-type DirectInvestment = record { buyer_principal : text };
-type Err = record { description : opt text; error_type : opt int32 };
-type Err_1 = record { error_type : opt int32 };
+
+type DirectInvestment = record {
+  buyer_principal : text;
+};
+
+type Err = record {
+  description : opt text;
+  error_type : opt int32;
+};
+
+type Err_1 = record {
+  error_type : opt int32;
+};
+
 type Err_2 = record {
   invalid_user_amount : opt InvalidUserAmount;
   existing_ticket : opt Ticket;
   error_type : int32;
 };
-type Error = record { message : opt text };
-type ErrorRefundIcpRequest = record { source_principal_id : opt principal };
-type ErrorRefundIcpResponse = record { result : opt Result };
+
+type Error = record {
+  message : opt text;
+};
+
+type ErrorRefundIcpRequest = record {
+  source_principal_id : opt principal;
+};
+
+type ErrorRefundIcpResponse = record {
+  result : opt Result;
+};
+
 type FailedUpdate = record {
   err : opt CanisterCallError;
   dapp_canister_id : opt principal;
 };
+
 type FinalizeSwapResponse = record {
   set_dapp_controllers_call_result : opt SetDappControllersCallResult;
   create_sns_neuron_recipes_result : opt SweepResult;
@@ -72,14 +113,25 @@ type FinalizeSwapResponse = record {
   claim_neuron_result : opt SweepResult;
   sweep_sns_result : opt SweepResult;
 };
+
 type GetAutoFinalizationStatusResponse = record {
   auto_finalize_swap_response : opt FinalizeSwapResponse;
   has_auto_finalize_been_attempted : opt bool;
   is_auto_finalize_enabled : opt bool;
 };
-type GetBuyerStateRequest = record { principal_id : opt principal };
-type GetBuyerStateResponse = record { buyer_state : opt BuyerState };
-type GetBuyersTotalResponse = record { buyers_total : nat64 };
+
+type GetBuyerStateRequest = record {
+  principal_id : opt principal;
+};
+
+type GetBuyerStateResponse = record {
+  buyer_state : opt BuyerState;
+};
+
+type GetBuyersTotalResponse = record {
+  buyers_total : nat64;
+};
+
 type GetDerivedStateResponse = record {
   sns_tokens_per_icp : opt float64;
   buyer_total_icp_e8s : opt nat64;
@@ -89,20 +141,44 @@ type GetDerivedStateResponse = record {
   direct_participant_count : opt nat64;
   cf_neuron_count : opt nat64;
 };
-type GetInitResponse = record { init : opt Init };
+
+type GetInitResponse = record {
+  init : opt Init;
+};
+
 type GetLifecycleResponse = record {
   decentralization_sale_open_timestamp_seconds : opt nat64;
   lifecycle : opt int32;
   decentralization_swap_termination_timestamp_seconds : opt nat64;
 };
-type GetOpenTicketResponse = record { result : opt Result_1 };
-type GetSaleParametersResponse = record { params : opt Params };
-type GetStateResponse = record { swap : opt Swap; derived : opt DerivedState };
-type GovernanceError = record { error_message : text; error_type : int32 };
-type Icrc1Account = record { owner : opt principal; subaccount : opt blob };
+
+type GetOpenTicketResponse = record {
+  result : opt Result_1;
+};
+
+type GetSaleParametersResponse = record {
+  params : opt Params;
+};
+
+type GetStateResponse = record {
+  swap : opt Swap;
+  derived : opt DerivedState;
+};
+
+type GovernanceError = record {
+  error_message : text;
+  error_type : int32;
+};
+
+type Icrc1Account = record {
+  owner : opt principal;
+  subaccount : opt blob;
+};
+
 type IdealMatchedParticipationFunction = record {
   serialized_representation : opt text;
 };
+
 type Init = record {
   nns_proposal_id : opt nat64;
   sns_root_canister_id : text;
@@ -130,14 +206,17 @@ type Init = record {
   min_icp_e8s : opt nat64;
   max_direct_participation_icp_e8s : opt nat64;
 };
+
 type InvalidUserAmount = record {
   min_amount_icp_e8s_included : nat64;
   max_amount_icp_e8s_included : nat64;
 };
+
 type Investor = variant {
   CommunityFund : CfInvestment;
   Direct : DirectInvestment;
 };
+
 type LinearScalingCoefficient = record {
   slope_numerator : opt nat64;
   intercept_icp_e8s : opt nat64;
@@ -145,52 +224,78 @@ type LinearScalingCoefficient = record {
   slope_denominator : opt nat64;
   to_direct_participation_icp_e8s : opt nat64;
 };
+
 type ListCommunityFundParticipantsRequest = record {
   offset : opt nat64;
   limit : opt nat32;
 };
+
 type ListCommunityFundParticipantsResponse = record {
   cf_participants : vec CfParticipant;
 };
+
 type ListDirectParticipantsRequest = record {
   offset : opt nat32;
   limit : opt nat32;
 };
-type ListDirectParticipantsResponse = record { participants : vec Participant };
+
+type ListDirectParticipantsResponse = record {
+  participants : vec Participant;
+};
+
 type ListSnsNeuronRecipesRequest = record {
   offset : opt nat64;
   limit : opt nat32;
 };
+
 type ListSnsNeuronRecipesResponse = record {
   sns_neuron_recipes : vec SnsNeuronRecipe;
 };
+
 type NeuronAttributes = record {
   dissolve_delay_seconds : nat64;
   memo : nat64;
   followees : vec NeuronId;
 };
+
 type NeuronBasketConstructionParameters = record {
   dissolve_delay_interval_seconds : nat64;
   count : nat64;
 };
-type NeuronId = record { id : blob };
+
+type NeuronId = record {
+  id : blob;
+};
+
 type NeuronsFundParticipationConstraints = record {
   coefficient_intervals : vec LinearScalingCoefficient;
   max_neurons_fund_participation_icp_e8s : opt nat64;
   min_direct_participation_threshold_icp_e8s : opt nat64;
   ideal_matched_participation_function : opt IdealMatchedParticipationFunction;
 };
+
 type NewSaleTicketRequest = record {
   subaccount : opt blob;
   amount_icp_e8s : nat64;
 };
-type NewSaleTicketResponse = record { result : opt Result_2 };
-type Ok = record { block_height : opt nat64 };
+
+type NewSaleTicketResponse = record {
+  result : opt Result_2;
+};
+
+type Ok = record {
+  block_height : opt nat64;
+};
+
 type Ok_1 = record {
   neurons_fund_participation_icp_e8s : opt nat64;
   neurons_fund_neurons_count : opt nat64;
 };
-type Ok_2 = record { ticket : opt Ticket };
+
+type Ok_2 = record {
+  ticket : opt Ticket;
+};
+
 type Params = record {
   min_participant_icp_e8s : nat64;
   neuron_basket_construction_parameters : opt NeuronBasketConstructionParameters;
@@ -204,45 +309,92 @@ type Params = record {
   min_icp_e8s : nat64;
   max_direct_participation_icp_e8s : opt nat64;
 };
+
 type Participant = record {
   participation : opt BuyerState;
   participant_id : opt principal;
 };
+
 type Possibility = variant {
   Ok : SetDappControllersResponse;
   Err : CanisterCallError;
 };
-type Possibility_1 = variant { Ok : Response; Err : CanisterCallError };
-type Possibility_2 = variant { Ok : Ok_1; Err : Error };
-type Possibility_3 = variant { Ok : record {}; Err : CanisterCallError };
-type Principals = record { principals : vec principal };
+
+type Possibility_1 = variant {
+  Ok : Response;
+  Err : CanisterCallError;
+};
+
+type Possibility_2 = variant {
+  Ok : Ok_1;
+  Err : Error;
+};
+
+type Possibility_3 = variant {
+  Ok : record {};
+  Err : CanisterCallError;
+};
+
+type Principals = record {
+  principals : vec principal;
+};
+
 type RefreshBuyerTokensRequest = record {
   confirmation_text : opt text;
   buyer : text;
 };
+
 type RefreshBuyerTokensResponse = record {
   icp_accepted_participation_e8s : nat64;
   icp_ledger_account_balance_e8s : nat64;
 };
-type Response = record { governance_error : opt GovernanceError };
-type Result = variant { Ok : Ok; Err : Err };
-type Result_1 = variant { Ok : Ok_2; Err : Err_1 };
-type Result_2 = variant { Ok : Ok_2; Err : Err_2 };
-type SetDappControllersCallResult = record { possibility : opt Possibility };
-type SetDappControllersResponse = record { failed_updates : vec FailedUpdate };
-type SetModeCallResult = record { possibility : opt Possibility_3 };
+
+type Response = record {
+  governance_error : opt GovernanceError;
+};
+
+type Result = variant {
+  Ok : Ok;
+  Err : Err;
+};
+
+type Result_1 = variant {
+  Ok : Ok_2;
+  Err : Err_1;
+};
+
+type Result_2 = variant {
+  Ok : Ok_2;
+  Err : Err_2;
+};
+
+type SetDappControllersCallResult = record {
+  possibility : opt Possibility;
+};
+
+type SetDappControllersResponse = record {
+  failed_updates : vec FailedUpdate;
+};
+
+type SetModeCallResult = record {
+  possibility : opt Possibility_3;
+};
+
 type SettleCommunityFundParticipationResult = record {
   possibility : opt Possibility_1;
 };
+
 type SettleNeuronsFundParticipationResult = record {
   possibility : opt Possibility_2;
 };
+
 type SnsNeuronRecipe = record {
   sns : opt TransferableAmount;
   claimed_status : opt int32;
   neuron_attributes : opt NeuronAttributes;
   investor : opt Investor;
 };
+
 type Swap = record {
   auto_finalize_swap_response : opt FinalizeSwapResponse;
   neuron_recipes : vec SnsNeuronRecipe;
@@ -262,6 +414,7 @@ type Swap = record {
   params : opt Params;
   open_sns_token_swap_proposal_id : opt nat64;
 };
+
 type SweepResult = record {
   failure : nat32;
   skipped : nat32;
@@ -269,12 +422,14 @@ type SweepResult = record {
   success : nat32;
   global_failures : nat32;
 };
+
 type Ticket = record {
   creation_time : nat64;
   ticket_id : nat64;
   account : opt Icrc1Account;
   amount_icp_e8s : nat64;
 };
+
 type TransferableAmount = record {
   transfer_fee_paid_e8s : opt nat64;
   transfer_start_timestamp_seconds : nat64;
@@ -282,6 +437,7 @@ type TransferableAmount = record {
   amount_transferred_e8s : opt nat64;
   transfer_success_timestamp_seconds : nat64;
 };
+
 service : (Init) -> {
   error_refund_icp : (ErrorRefundIcpRequest) -> (ErrorRefundIcpResponse);
   finalize_swap : (record {}) -> (FinalizeSwapResponse);

--- a/declarations/used_by_sns_aggregator/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_sns_aggregator/sns_wasm/sns_wasm.did
@@ -1,22 +1,46 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/nns/sns-wasm/canister/sns-wasm.did>
-type AddWasmRequest = record { hash : blob; wasm : opt SnsWasm };
-type AddWasmResponse = record { result : opt Result };
-type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
-type Canister = record { id : opt principal };
-type Countries = record { iso_codes : vec text };
-type DappCanisters = record { canisters : vec Canister };
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-29_01-30-base/rs/nns/sns-wasm/canister/sns-wasm.did>
+type AddWasmRequest = record {
+  hash : blob;
+  wasm : opt SnsWasm;
+};
+
+type AddWasmResponse = record {
+  result : opt Result;
+};
+
+type AirdropDistribution = record {
+  airdrop_neurons : vec NeuronDistribution;
+};
+
+type Canister = record {
+  id : opt principal;
+};
+
+type Countries = record {
+  iso_codes : vec text;
+};
+
+type DappCanisters = record {
+  canisters : vec Canister;
+};
+
 type DappCanistersTransferResult = record {
   restored_dapp_canisters : vec Canister;
   nns_controlled_dapp_canisters : vec Canister;
   sns_controlled_dapp_canisters : vec Canister;
 };
-type DeployNewSnsRequest = record { sns_init_payload : opt SnsInitPayload };
+
+type DeployNewSnsRequest = record {
+  sns_init_payload : opt SnsInitPayload;
+};
+
 type DeployNewSnsResponse = record {
   dapp_canisters_transfer_result : opt DappCanistersTransferResult;
   subnet_id : opt principal;
   error : opt SnsWasmError;
   canisters : opt SnsCanisterIds;
 };
+
 type DeployedSns = record {
   root_canister_id : opt principal;
   governance_canister_id : opt principal;
@@ -24,49 +48,89 @@ type DeployedSns = record {
   swap_canister_id : opt principal;
   ledger_canister_id : opt principal;
 };
+
 type DeveloperDistribution = record {
   developer_neurons : vec NeuronDistribution;
 };
+
 type FractionalDeveloperVotingPower = record {
   treasury_distribution : opt TreasuryDistribution;
   developer_distribution : opt DeveloperDistribution;
   airdrop_distribution : opt AirdropDistribution;
   swap_distribution : opt SwapDistribution;
 };
+
 type GetAllowedPrincipalsResponse = record {
   allowed_principals : vec principal;
 };
-type GetDeployedSnsByProposalIdRequest = record { proposal_id : nat64 };
+
+type GetDeployedSnsByProposalIdRequest = record {
+  proposal_id : nat64;
+};
+
 type GetDeployedSnsByProposalIdResponse = record {
   get_deployed_sns_by_proposal_id_result : opt GetDeployedSnsByProposalIdResult;
 };
+
 type GetDeployedSnsByProposalIdResult = variant {
   Error : SnsWasmError;
   DeployedSns : DeployedSns;
 };
+
 type GetNextSnsVersionRequest = record {
   governance_canister_id : opt principal;
   current_version : opt SnsVersion;
 };
-type GetNextSnsVersionResponse = record { next_version : opt SnsVersion };
-type GetProposalIdThatAddedWasmRequest = record { hash : blob };
-type GetProposalIdThatAddedWasmResponse = record { proposal_id : opt nat64 };
-type GetSnsSubnetIdsResponse = record { sns_subnet_ids : vec principal };
-type GetWasmMetadataRequest = record { hash : opt blob };
-type GetWasmMetadataResponse = record { result : opt Result_1 };
-type GetWasmRequest = record { hash : blob };
-type GetWasmResponse = record { wasm : opt SnsWasm };
+
+type GetNextSnsVersionResponse = record {
+  next_version : opt SnsVersion;
+};
+
+type GetProposalIdThatAddedWasmRequest = record {
+  hash : blob;
+};
+
+type GetProposalIdThatAddedWasmResponse = record {
+  proposal_id : opt nat64;
+};
+
+type GetSnsSubnetIdsResponse = record {
+  sns_subnet_ids : vec principal;
+};
+
+type GetWasmMetadataRequest = record {
+  hash : opt blob;
+};
+
+type GetWasmMetadataResponse = record {
+  result : opt Result_1;
+};
+
+type GetWasmRequest = record {
+  hash : blob;
+};
+
+type GetWasmResponse = record {
+  wasm : opt SnsWasm;
+};
+
 type IdealMatchedParticipationFunction = record {
   serialized_representation : opt text;
 };
+
 type InitialTokenDistribution = variant {
   FractionalDeveloperVotingPower : FractionalDeveloperVotingPower;
 };
+
 type InsertUpgradePathEntriesRequest = record {
   upgrade_path : vec SnsUpgrade;
   sns_governance_canister_id : opt principal;
 };
-type InsertUpgradePathEntriesResponse = record { error : opt SnsWasmError };
+
+type InsertUpgradePathEntriesResponse = record {
+  error : opt SnsWasmError;
+};
+
 type LinearScalingCoefficient = record {
   slope_numerator : opt nat64;
   intercept_icp_e8s : opt nat64;
@@ -74,26 +138,37 @@ type LinearScalingCoefficient = record {
   slope_denominator : opt nat64;
   to_direct_participation_icp_e8s : opt nat64;
 };
-type ListDeployedSnsesResponse = record { instances : vec DeployedSns };
+
+type ListDeployedSnsesResponse = record {
+  instances : vec DeployedSns;
+};
+
 type ListUpgradeStep = record {
   pretty_version : opt PrettySnsVersion;
   version : opt SnsVersion;
 };
+
 type ListUpgradeStepsRequest = record {
   limit : nat32;
   starting_at : opt SnsVersion;
   sns_governance_canister_id : opt principal;
 };
-type ListUpgradeStepsResponse = record { steps : vec ListUpgradeStep };
+
+type ListUpgradeStepsResponse = record {
+  steps : vec ListUpgradeStep;
+};
+
 type MetadataSection = record {
   contents : opt blob;
   name : opt text;
   visibility : opt text;
 };
+
 type NeuronBasketConstructionParameters = record {
   dissolve_delay_interval_seconds : nat64;
   count : nat64;
 };
+
 type NeuronDistribution = record {
   controller : opt principal;
   dissolve_delay_seconds : nat64;
@@ -101,13 +176,18 @@ type NeuronDistribution = record {
   stake_e8s : nat64;
   vesting_period_seconds : opt nat64;
 };
+
 type NeuronsFundParticipationConstraints = record {
   coefficient_intervals : vec LinearScalingCoefficient;
   max_neurons_fund_participation_icp_e8s : opt nat64;
   min_direct_participation_threshold_icp_e8s : opt nat64;
   ideal_matched_participation_function : opt IdealMatchedParticipationFunction;
 };
-type Ok = record { sections : vec MetadataSection };
+
+type Ok = record {
+  sections : vec MetadataSection;
+};
+
 type PrettySnsVersion = record {
   archive_wasm_hash : text;
   root_wasm_hash : text;
@@ -116,8 +196,17 @@ type PrettySnsVersion = record {
   governance_wasm_hash : text;
   index_wasm_hash : text;
 };
-type Result = variant { Error : SnsWasmError; Hash : blob };
-type Result_1 = variant { Ok : Ok; Error : SnsWasmError };
+
+type Result = variant {
+  Error : SnsWasmError;
+  Hash : blob;
+};
+
+type Result_1 = variant {
+  Ok : Ok;
+  Error : SnsWasmError;
+};
+
 type SnsCanisterIds = record {
   root : opt principal;
   swap : opt principal;
@@ -125,6 +214,7 @@ type SnsCanisterIds = record {
   index : opt principal;
   governance : opt principal;
 };
+
 type SnsInitPayload = record {
   url : opt text;
   max_dissolve_delay_seconds : opt nat64;
@@ -165,10 +255,12 @@ type SnsInitPayload = record {
   min_icp_e8s : opt nat64;
   max_direct_participation_icp_e8s : opt nat64;
 };
+
 type SnsUpgrade = record {
   next_version : opt SnsVersion;
   current_version : opt SnsVersion;
 };
+
 type SnsVersion = record {
   archive_wasm_hash : blob;
   root_wasm_hash : blob;
@@ -177,38 +269,55 @@ type SnsVersion = record {
   governance_wasm_hash : blob;
   index_wasm_hash : blob;
 };
+
 type SnsWasm = record {
   wasm : blob;
   proposal_id : opt nat64;
   canister_type : int32;
 };
+
 type SnsWasmCanisterInitPayload = record {
   allowed_principals : vec principal;
   access_controls_enabled : bool;
   sns_subnet_ids : vec principal;
 };
-type SnsWasmError = record { message : text };
+
+type SnsWasmError = record {
+  message : text;
+};
+
 type SwapDistribution = record {
   total_e8s : nat64;
   initial_swap_amount_e8s : nat64;
 };
-type TreasuryDistribution = record { total_e8s : nat64 };
+
+type TreasuryDistribution = record {
+  total_e8s : nat64;
+};
+
 type UpdateAllowedPrincipalsRequest = record {
   added_principals : vec principal;
   removed_principals : vec principal;
 };
+
 type UpdateAllowedPrincipalsResponse = record {
   update_allowed_principals_result : opt UpdateAllowedPrincipalsResult;
 };
+
 type UpdateAllowedPrincipalsResult = variant {
   Error : SnsWasmError;
   AllowedPrincipals : GetAllowedPrincipalsResponse;
 };
+
 type UpdateSnsSubnetListRequest = record {
   sns_subnet_ids_to_add : vec principal;
   sns_subnet_ids_to_remove : vec principal;
 };
-type UpdateSnsSubnetListResponse = record { error : opt SnsWasmError };
+
+type UpdateSnsSubnetListResponse = record {
+  error : opt SnsWasmError;
+};
+
 service : (SnsWasmCanisterInitPayload) -> {
   add_wasm : (AddWasmRequest) -> (AddWasmResponse);
   deploy_new_sns : (DeployNewSnsRequest) -> (DeployNewSnsResponse);

--- a/dfx.json
+++ b/dfx.json
@@ -388,7 +388,7 @@
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-08-28",
         "IC_COMMIT_FOR_PROPOSALS": "release-2024-08-29_01-30-base",
-        "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-08-21_15-36-canister-snapshots"
+        "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-08-29_01-30-base"
       },
       "packtool": ""
     }

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_governance --out ic_sns_governance.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-29_01-30-base/rs/sns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
@@ -605,6 +605,7 @@ pub enum CanisterStatusType {
 pub struct DefiniteCanisterSettingsArgs {
     pub freezing_threshold: candid::Nat,
     pub controllers: Vec<Principal>,
+    pub wasm_memory_limit: Option<candid::Nat>,
     pub memory_allocation: candid::Nat,
     pub compute_allocation: candid::Nat,
 }

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_ledger --out ic_sns_ledger.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/rosetta-api/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-29_01-30-base/rs/rosetta-api/icrc1/ledger/ledger.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_root --out ic_sns_root.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-29_01-30-base/rs/sns/root/canister/root.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
@@ -94,6 +94,7 @@ pub struct GetSnsCanistersSummaryRequest {
 pub struct DefiniteCanisterSettingsArgs {
     pub freezing_threshold: candid::Nat,
     pub controllers: Vec<Principal>,
+    pub wasm_memory_limit: Option<candid::Nat>,
     pub memory_allocation: candid::Nat,
     pub compute_allocation: candid::Nat,
 }

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_swap --out ic_sns_swap.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-29_01-30-base/rs/sns/swap/canister/swap.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
@@ -234,6 +234,7 @@ pub enum CanisterStatusType {
 pub struct DefiniteCanisterSettingsArgs {
     pub freezing_threshold: candid::Nat,
     pub controllers: Vec<Principal>,
+    pub wasm_memory_limit: Option<candid::Nat>,
     pub memory_allocation: candid::Nat,
     pub compute_allocation: candid::Nat,
 }

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out ic_sns_wasm.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-21_15-36-canister-snapshots/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-08-29_01-30-base/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
We would like to parse all the latest SNS data. To do so, we update the candid interfaces for the SNS aggregator.
Even with no changes, just updating the reference is good practice.

# Changes
* Update the version of `IC_COMMIT_FOR_SNS_AGGREGATOR` specified in `dfx.json`.
* Updated the `sns_aggregator` candid files to the versions in that commit.
* Updated the Rust code derived from `.did` files in the aggregator.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  Breaking changes are:
    * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants