### PR TITLE
NNS1-3281: Function to initialize locked ICP timers for TVL

### DIFF
--- a/rs/backend/src/tvl.rs
+++ b/rs/backend/src/tvl.rs
@@ -15,7 +15,7 @@ const UPDATE_INTERVAL_SECONDS: u64 = 6 * 60 * 60; // 4 times a day
 
 // TODO(NNS1-3281): Remove #[allow(unused)].
 #[allow(unused)]
-pub fn init_exchange_rate_timers() {
+pub fn start_updating_exchange_rate_in_background() {
     set_timer_interval(Duration::from_secs(UPDATE_INTERVAL_SECONDS), || {
         spawn::spawn(update_exchange_rate());
     });
@@ -28,7 +28,7 @@ pub fn init_exchange_rate_timers() {
 
 // TODO(NNS1-3281): Remove #[allow(unused)].
 #[allow(unused)]
-fn init_locked_icp_timers() {
+fn start_updating_locked_icp_in_the_background() {
     set_timer_interval(Duration::from_secs(UPDATE_INTERVAL_SECONDS), || {
         spawn::spawn(update_locked_icp_e8s());
     });

--- a/rs/backend/src/tvl.rs
+++ b/rs/backend/src/tvl.rs
@@ -26,6 +26,19 @@ pub fn init_exchange_rate_timers() {
     });
 }
 
+// TODO(NNS1-3281): Remove #[allow(unused)].
+#[allow(unused)]
+fn init_locked_icp_timers() {
+    set_timer_interval(Duration::from_secs(UPDATE_INTERVAL_SECONDS), || {
+        spawn::spawn(update_locked_icp_e8s());
+    });
+    // `set_timer_interval` does not run the callback immediately so we also
+    // call it after 1 second to have an exchange rate available soon.
+    set_timer(Duration::from_secs(1), || {
+        spawn::spawn(update_locked_icp_e8s());
+    });
+}
+
 /// Converts a number such that it can be interpreted as a fixed-point number
 /// with 8 decimal places.
 ///

--- a/rs/backend/src/tvl/tests.rs
+++ b/rs/backend/src/tvl/tests.rs
@@ -315,7 +315,7 @@ async fn update_locked_icp_e8s_with_method_error() {
 }
 
 #[tokio::test]
-async fn init_exchange_rate_timers() {
+async fn start_updating_exchange_rate_in_background() {
     tvl::time::testing::set_time(NOW_SECONDS * 1_000_000_000);
 
     let initial_usd_e8s_per_icp = 850_000_000;
@@ -341,7 +341,7 @@ async fn init_exchange_rate_timers() {
 
     // Step 2: Call the code under test.
     // This should set both a 1-time timer and an interval timer.
-    tvl::init_exchange_rate_timers();
+    tvl::start_updating_exchange_rate_in_background();
 
     // Phase 2: Calling the 1-time timer.
 
@@ -432,7 +432,7 @@ async fn init_exchange_rate_timers() {
 }
 
 #[tokio::test]
-async fn init_locked_icp_timers() {
+async fn start_updating_locked_icp_in_the_background() {
     let initial_locked_icp_e8s = 1_500_000_000;
     let later_locked_icp_e8s = 2_300_000_000;
 
@@ -452,7 +452,7 @@ async fn init_locked_icp_timers() {
 
     // Step 2: Call the code under test.
     // This should set both a 1-time timer and an interval timer.
-    tvl::init_locked_icp_timers();
+    tvl::start_updating_locked_icp_in_the_background();
 
     // Phase 2: Calling the 1-time timer.
 

--- a/rs/backend/src/tvl/tests.rs
+++ b/rs/backend/src/tvl/tests.rs
@@ -489,7 +489,10 @@ async fn init_locked_icp_timers() {
     // Step 1: Set up the environment.
     governance::testing::add_metrics_response_with_total_locked_e8s(later_locked_icp_e8s);
 
-    // Step 2: Call the interval timer.
+    // Step 2: Verify the state before calling the interval timers.
+    assert_eq!(get_total_locked_icp_e8s(), initial_locked_icp_e8s);
+
+    // Step 3: Call the interval timer.
     {
         let mut timers = timer::testing::drain_timer_intervals();
         assert_eq!(timers.len(), 1);
@@ -507,6 +510,6 @@ async fn init_locked_icp_timers() {
         spawned_futures.pop().unwrap().await;
     }
 
-    // Step 3: Verify the state after calling interval timer.
+    // Step 4: Verify the state after calling interval timer.
     assert_eq!(get_total_locked_icp_e8s(), later_locked_icp_e8s);
 }


### PR DESCRIPTION
# Motivation

The NNS dapp displays the USD value of the total amount of ICP locked in neurons.
It gets this information from the TVL canister but we want to move this functionality to the nns-dapp canister and remove the TVL canister.

We already have a function to fetch the current amount of ICP locked in neurons. We want to call this periodically to have a reasonably up-to-date value.

Given that the total_locked_e8s exposed by the governance canister only updates once a day, updating the exchange rate 4 times a day, seems often enough.

# Changes

1. Add `init_locked_icp_timers` to set up both a 1-time timer (for a quick initial value) and an interval timer.

# Tests

1. Added a unit test that verifies the timers are set up and do the right thing when called.
2. Tested manually in a more fully developed branch.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet