### PR TITLE
NNS1-3281: Add function to get TVL

### DIFF
--- a/rs/backend/src/constants.rs
+++ b/rs/backend/src/constants.rs
@@ -1,5 +1,6 @@
 use icp_ledger::Memo;
 
+pub const E8S_PER_UNIT: u64 = 100_000_000;
 pub const NANOS_PER_UNIT: u64 = 1_000_000_000;
 
 pub const MEMO_CREATE_CANISTER: Memo = Memo(0x4145_5243); // == 'CREA'

--- a/rs/backend/src/tvl/tests.rs
+++ b/rs/backend/src/tvl/tests.rs
@@ -1,5 +1,6 @@
 use crate::timer;
 use crate::tvl::{self, exchange_rate_canister, governance, spawn, time, STATE};
+use candid::Nat;
 use lazy_static::lazy_static;
 
 const NOW_SECONDS: u64 = 1_234_567_890;
@@ -312,6 +313,26 @@ async fn update_locked_icp_e8s_with_method_error() {
     // Step 4: Verify the state after calling the code under test.
     // The total locked ICP should not have been updated because of the error.
     assert_eq!(get_total_locked_icp_e8s(), initial_locked_icp_e8s);
+}
+
+#[test]
+fn get_tvl() {
+    let timestamp = 1_738_485_470;
+    let locked_icp_units = 15_000;
+    let usd_per_icp_units = 8;
+    let expected_tvl_in_usd = locked_icp_units * usd_per_icp_units;
+
+    set_total_locked_icp_e8s(locked_icp_units * 100_000_000);
+    set_usd_e8s_per_icp(usd_per_icp_units * 100_000_000);
+    set_exchange_rate_timestamp_seconds(timestamp);
+
+    assert_eq!(
+        tvl::get_tvl(),
+        tvl::TvlResponse::Ok(tvl::TvlResult {
+            tvl: Nat::from(expected_tvl_in_usd),
+            time_sec: Nat::from(timestamp),
+        })
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Motivation

The NNS dapp displays the USD value of the total amount of ICP locked in neurons.
It gets this information from the TVL canister but we want to move this functionality to the nns-dapp canister and remove the TVL canister.

There are 2 inputs to this data:
1. The amount of ICP locked in neurons
2. The price of ICP in USD.

We already have functions which periodically fetch this data and store it in the canister state.

This PR adds a function to get the TVL calculated from these 2 inputs.

# Changes

Add `get_tvl` which returns the current TVL. The return type is the way it is to make it compatible with the existing TVL canister. This allows us to migrate the frontend from using the TVL canister to getting the same data from the nns-dapp canister without changing frontend code.

# Tests

1. Unit test added.
2. Tested manually in another branch which has more changes.
3. Will add an integration test when the feature is ready.

# Todos

- [ ] Add entry to changelog (if necessary).
not yet.