### PR TITLE
Stop loading neurons in NnsProposals

### DIFF
--- a/frontend/src/lib/pages/NnsProposals.svelte
+++ b/frontend/src/lib/pages/NnsProposals.svelte
@@ -1,17 +1,14 @@
 <script lang="ts">
   import NnsProposalsList from "$lib/components/proposals/NnsProposalsList.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
-  import { authSignedInStore } from "$lib/derived/auth.derived";
   import {
-    sortedProposals,
     filteredProposals,
+    sortedProposals,
   } from "$lib/derived/proposals.derived";
   import {
     listNextProposals,
     listProposals,
   } from "$lib/services/$public/proposals.services";
-  import { listNeurons } from "$lib/services/neurons.services";
-  import { definedNeuronsStore } from "$lib/stores/neurons.store";
   import {
     proposalsFiltersStore,
     proposalsStore,
@@ -29,10 +26,6 @@
 
   // It's exported so that we can test the value
   export let disableInfiniteScroll = false;
-
-  $: if ($authSignedInStore) {
-    listNeurons();
-  }
 
   let loading = true;
   let hidden = false;
@@ -119,12 +112,7 @@
     debounceFindProposals?.();
   };
 
-  // Neurons and proposals are loaded at the same time. But once neurons are
-  // loaded, proposals are loaded again. So it's possible that the component
-  // goes back into loading state immediately after proposals are loaded.
-  // TODO: Fix NnsProposals to load proposals only once and remove the
-  // work-around from NnsProposalList.page-object.ts
-  $: $definedNeuronsStore, $proposalsFiltersStore, applyFilter();
+  $: $proposalsFiltersStore, applyFilter();
 
   const updateNothingFound = () => {
     // Update the "nothing found" UI information only when the results of the certified query has been received to minimize UI glitches

--- a/frontend/src/tests/e2e/neurons.spec.ts
+++ b/frontend/src/tests/e2e/neurons.spec.ts
@@ -63,7 +63,6 @@ test("Test neuron voting", async ({ page, context }) => {
 
   step("Open proposals list");
   await appPo.goToProposals();
-  await appPo.getProposalsPo().getNnsProposalListPo().waitForContentLoaded();
 
   step("Open Internet Computer proposals");
   await appPo.openUniverses();

--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -38,12 +38,11 @@ test("Test proposals", async ({ page, context }) => {
 
   step("Open proposals list");
   await appPo.goToProposals();
-  const nnsProposalListPo = appPo.getProposalsPo().getNnsProposalListPo();
-  await nnsProposalListPo.waitForContentLoaded();
 
   step("Open Internet Computer proposals");
   await appPo.openUniverses();
   await appPo.getSelectUniverseListPo().clickOnInternetComputer();
+  const nnsProposalListPo = appPo.getProposalsPo().getNnsProposalListPo();
   await nnsProposalListPo.waitForContentLoaded();
 
   step('Switch to "All Proposals"');

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -105,7 +105,7 @@ describe("NnsProposals", () => {
         expect(await po.getSkeletonCardPo().isPresent()).toEqual(false);
       });
 
-      it("should reload transactions when proposal filter is set", async () => {
+      it("should reload proposals when proposal filter is set", async () => {
         let resolveQueryProposals;
         const queryProposalsSpy = vi
           .spyOn(proposalsApi, "queryProposals")

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -108,7 +108,8 @@ describe("NnsProposals", () => {
       it("should reload transactions when proposal filter is set", async () => {
         let resolveQueryProposals;
         vi.spyOn(proposalsApi, "queryProposals").mockImplementation(
-          () => new Promise<ProposalInfo[]>((resolve) => {
+          () =>
+            new Promise<ProposalInfo[]>((resolve) => {
               resolveQueryProposals = resolve;
             })
         );

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -14,7 +14,7 @@ import {
   proposalsFiltersStore,
   proposalsStore,
 } from "$lib/stores/proposals.store";
-import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { IntersectionObserverActive } from "$tests/mocks/infinitescroll.mock";
 import { mockProposals } from "$tests/mocks/proposals.store.mock";
 import { NnsProposalListPo } from "$tests/page-objects/NnsProposalList.page-object";
@@ -62,30 +62,6 @@ describe("NnsProposals", () => {
   });
 
   describe("logged in user", () => {
-    describe("neurons", () => {
-      beforeEach(() => {
-        vi.spyOn(governanceApi, "queryNeurons").mockResolvedValue([]);
-        actionableProposalsSegmentStore.set("all");
-      });
-
-      it("should load neurons", async () => {
-        await renderComponent();
-
-        await waitFor(() =>
-          expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
-            identity: mockIdentity,
-            certified: true,
-            includeEmptyNeurons: false,
-          })
-        );
-        expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
-          identity: mockIdentity,
-          certified: false,
-          includeEmptyNeurons: false,
-        });
-      });
-    });
-
     describe("Matching results", () => {
       beforeEach(() => {
         overrideFeatureFlagsStore.reset();
@@ -111,8 +87,42 @@ describe("NnsProposals", () => {
       });
 
       it("should render a skeleton while searching proposals", async () => {
+        let resolveQueryProposals;
+        vi.spyOn(proposalsApi, "queryProposals").mockImplementation(
+          () =>
+            new Promise<ProposalInfo[]>((resolve) => {
+              resolveQueryProposals = resolve;
+            })
+        );
+
         const po = await renderComponent();
 
+        expect(await po.getSkeletonCardPo().isPresent()).toEqual(true);
+
+        // Let the proposals load.
+        resolveQueryProposals(mockProposals);
+        await runResolvedPromises();
+        expect(await po.getSkeletonCardPo().isPresent()).toEqual(false);
+      });
+
+      it("should reload transactions when proposal filter is set", async () => {
+        let resolveQueryProposals;
+        vi.spyOn(proposalsApi, "queryProposals").mockImplementation(
+          () => new Promise<ProposalInfo[]>((resolve) => {
+              resolveQueryProposals = resolve;
+            })
+        );
+
+        const po = await renderComponent();
+
+        // Let the proposals load the first time.
+        resolveQueryProposals(mockProposals);
+        resolveQueryProposals = undefined;
+
+        await runResolvedPromises();
+        expect(await po.getSkeletonCardPo().isPresent()).toEqual(false);
+
+        // Setting the filter should reload the proposals.
         proposalsFiltersStore.filterTopics(DEFAULT_PROPOSALS_FILTERS.topics);
         await runResolvedPromises();
 
@@ -120,6 +130,11 @@ describe("NnsProposals", () => {
 
         // Stop waiting for the debounce to load proposals.
         await advanceTime();
+
+        // Let the proposals load the second time.
+        resolveQueryProposals(mockProposals);
+        await runResolvedPromises();
+
         expect(await po.getSkeletonCardPo().isPresent()).toEqual(false);
       });
 
@@ -155,11 +170,7 @@ describe("NnsProposals", () => {
 
         const po = await renderComponent();
 
-        proposalsFiltersStore.filterTopics(DEFAULT_PROPOSALS_FILTERS.topics);
-        await runResolvedPromises();
-
-        // Stop waiting for the debounce to load the first page of proposals.
-        await advanceTime();
+        // The first page of proposals loads immediately.
 
         // Now the infinite scroll is loading the second page of proposals.
         expect(await po.hasListLoaderSpinner()).toEqual(true);

--- a/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsProposalList.page-object.ts
@@ -123,15 +123,8 @@ export class NnsProposalListPo extends BasePageObject {
   }
 
   async waitForContentLoaded(): Promise<void> {
-    this.getSkeletonCardPo().waitForAbsent();
-    // The NnsProposals component loads neurons and proposals at the same time.
-    // But once neurons are loaded, it loads proposals again. So it's possible
-    // that the component goes back into loading state immediately after
-    // proposals are loaded.
-    // TODO: Fix NnsProposals to load proposals only once and remove the 2 lines
-    // below.
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    this.getSkeletonCardPo().waitForAbsent();
+    await this.waitFor();
+    await this.getSkeletonCardPo().waitForAbsent();
   }
 
   async getVisibleProposalIds(proposerNeuronId: string): Promise<string[]> {

--- a/frontend/src/tests/workflows/NnsProposals.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposals.spec.ts
@@ -82,24 +82,6 @@ describe('NnsProposals when "all proposals" selected', () => {
         identity: mockIdentity,
       });
     });
-
-    it("should query neurons", async () => {
-      page.mock({ data: { universe: OWN_CANISTER_ID_TEXT } });
-      render(NnsProposals);
-
-      await waitFor(() =>
-        expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
-          identity: mockIdentity,
-          certified: true,
-          includeEmptyNeurons: false,
-        })
-      );
-      expect(governanceApi.queryNeurons).toHaveBeenCalledWith({
-        identity: mockIdentity,
-        certified: false,
-        includeEmptyNeurons: false,
-      });
-    });
   });
 
   describe("when not signed in user", () => {


### PR DESCRIPTION
# Motivation

There used to be a checkbox on the `NnsProposals` page to only show proposals that you can vote on.
This applied a filter on `list_proposals` to only load proposals with ballots matching your neurons.
For this reason we needed to reload the proposals when your neurons changed.
But we no longer have this checkbox (we have the actionable proposals tab instead) so we no longer need:
1. load neurons in `NnsProposals`
2. reload proposals when the neurons change

# Changes

1. Stop loading neurons in `NnsProposals`.
2. Stop listening to `definedNeuronsStore` to reload proposals.

# Tests

1. With the reloading on neurons removed, the tests no longer hit the debounce, so instead we use an unresolved promise to test the skeleton cards and the spinner.
2. Two tests were setting `proposalsFiltersStore` immediate after rendering the component, for no apparently reason. This was causing proposals to be reloaded, making the test more complicated. I've removed the unnecessary setting of `proposalsFiltersStore`.
3. I added a separate test to test that proposals are reloaded when the `proposalsFiltersStore` is set.
4. Remove a work-around which is no longer necessary from `NnsProposalListPo.waitForContentLoaded`.
5. `NnsProposalListPo.waitForContentLoaded` was actually broken because the `.waitForAbsent()` calls weren't awaited. This wasn't noticed because the 1 second delay was enough for the content to load, but fixing the `waitForContentLoaded` method exposed that we were waiting for `NnsProposalListPo` on the actionable proposals page which does not have `NnsProposalListPo`. So I removed this wait from `neurons.spec.ts` and `proposals.spec.ts`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary