### PR TITLE
Wait for navigation after staking first neuron

### DIFF
--- a/frontend/src/tests/page-objects/Staking.page-object.ts
+++ b/frontend/src/tests/page-objects/Staking.page-object.ts
@@ -48,6 +48,7 @@ export class StakingPo extends BasePageObject {
     await nnsRow.getStakeButtonPo().click();
     const modal = this.getNnsStakeNeuronModalPo();
     await modal.stake({ amount, dissolveDelayDays });
+    await this.waitForAbsent();
   }
 
   async stakeFirstSnsNeuron({

--- a/frontend/src/tests/page-objects/Staking.page-object.ts
+++ b/frontend/src/tests/page-objects/Staking.page-object.ts
@@ -48,6 +48,7 @@ export class StakingPo extends BasePageObject {
     await nnsRow.getStakeButtonPo().click();
     const modal = this.getNnsStakeNeuronModalPo();
     await modal.stake({ amount, dissolveDelayDays });
+    // After staking the first neuron, we get redirected to the neurons page.
     await this.waitForAbsent();
   }
 


### PR DESCRIPTION
# Motivation

Before you have your first neuron, you can't navigate to the neurons page.
So the first neuron is staked from the staking page and if successful, you automatically navigate to the neurons page.
This caused some flakiness in e2e tests when we try to navigate back after staking the first neuron, but before the redirect happens.
To make this more consistent we should wait for the redirect to happen before returning from `stakeFirstNnsNeuron`.
Since this happens from `StakingPo`, we can't wait for `NnsNeuronsPo` to be present but we can at least wait for `StakingPo` to be absent.

# Changes

Wait for `StakingPo` to be absent after staking the first NNS neuron.

# Tests

On my local machine, `e2e/proposals.spec.ts` was failing consistently without this change and passed with this change.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary