### PR TITLE
Load minimum stake when staking from staking table

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,6 +30,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Enforce minimum stake when staking SNS tokens from the staking table.
+
 #### Security
 
 #### Not Published

--- a/frontend/src/lib/routes/Staking.svelte
+++ b/frontend/src/lib/routes/Staking.svelte
@@ -11,6 +11,7 @@
   import NnsStakeNeuronModal from "$lib/modals/neurons/NnsStakeNeuronModal.svelte";
   import SnsStakeNeuronModal from "$lib/modals/sns/neurons/SnsStakeNeuronModal.svelte";
   import { loadSnsAccounts } from "$lib/services/sns-accounts.services";
+  import { loadSnsParameters } from "$lib/services/sns-parameters.services";
   import { i18n } from "$lib/stores/i18n";
   import { neuronsStore } from "$lib/stores/neurons.store";
   import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
@@ -89,6 +90,8 @@
     loadSnsAccounts({
       rootCanisterId: summary.rootCanisterId,
     });
+    // SNS parameters need to be loaded for the minimum stake amount.
+    loadSnsParameters(summary.rootCanisterId);
 
     snsStakingModalData = {
       rootCanisterId: summary.rootCanisterId,

--- a/frontend/src/lib/routes/Staking.svelte
+++ b/frontend/src/lib/routes/Staking.svelte
@@ -82,7 +82,7 @@
       }
     | undefined = undefined;
 
-  const openSnsStakingModal = (rootCanisterIdText: string) => {
+  const openSnsStakingModal = async (rootCanisterIdText: string) => {
     const summary = get(snsProjectsRecordStore)[rootCanisterIdText].summary;
 
     // Accounts need to be loaded to display the account and balance used for
@@ -91,7 +91,7 @@
       rootCanisterId: summary.rootCanisterId,
     });
     // SNS parameters need to be loaded for the minimum stake amount.
-    loadSnsParameters(summary.rootCanisterId);
+    await loadSnsParameters(summary.rootCanisterId);
 
     snsStakingModalData = {
       rootCanisterId: summary.rootCanisterId,


### PR DESCRIPTION
# Motivation

In https://github.com/dfinity/nns-dapp/pull/5339 we added the staking button to the staking table.
This opens the SNS staking modal via a different code path, which didn't load the SNS parameters.
This meant that the minimum neuron stake wasn't available.
Instead of requiring the minimum stake to be available, the `SnsStakeNeuronModal` component happily ignores this and allows the user to try staking any amount.
But if the amount it too small, claiming the neuron after transferring the tokens fails.

This PR makes sure the parameters are loaded.
We should additionally fix `SnsStakeNeuronModal` to require the minimum stake to be present but that will be a separate PR.

# Changes

Make sure the SNS parameters (which include the minimum stake) are loaded before opening the `SnsStakeNeuronModal` from the `Staking` page.

# Tests

1. Unit test added.
2. Tested manually.
3. Also tested that staking ICP was not affected and already enforced the minimum stake.

# Todos

- [x] Add entry to changelog (if necessary).
