### PR TITLE
Remove the --use-explicit-action-type flag since it's no longer needed

### DIFF
--- a/scripts/propose-to/propose-to-upgrade-nns-dapp
+++ b/scripts/propose-to/propose-to-upgrade-nns-dapp
@@ -18,4 +18,4 @@ test -e "$WASM_FILE" || ./scripts/docker-build --network "$DFX_NETWORK"
 SHA="$(sha256sum "$WASM_FILE" | awk '{print $1}')"
 CANISTER_ID="$(get_canister_id)"
 
-set ic-admin --nns-url "$NNS_URL" propose-to-change-nns-canister --test-neuron-proposer --canister-id "$CANISTER_ID" --mode upgrade --wasm-module-path "$WASM_FILE" --wasm-module-sha256 "$SHA" --summary-file ./README.md --use-explicit-action-type
+set ic-admin --nns-url "$NNS_URL" propose-to-change-nns-canister --test-neuron-proposer --canister-id "$CANISTER_ID" --mode upgrade --wasm-module-path "$WASM_FILE" --wasm-module-sha256 "$SHA" --summary-file ./README.md

--- a/scripts/sns/aggregator/release
+++ b/scripts/sns/aggregator/release
@@ -49,7 +49,7 @@ if grep -w "$FORUM_PLACEHOLDER" "$PROPOSAL_TEXT"; then
   } >&2
 fi
 
-set ic-admin --pin "$DFX_HSM_PIN" --nns-url https://ic0.app --use-hsm --key-id 01 --slot 0 propose-to-change-nns-canister --proposer "$NEURON" --canister-id "$AGGREGATOR_CANISTER_ID" --mode upgrade --wasm-module-path "$WASM" --summary-file "$PROPOSAL_TEXT" --wasm-module-sha256 "$SHA" --arg "$ARG_PATH" --use-explicit-action-type
+set ic-admin --pin "$DFX_HSM_PIN" --nns-url https://ic0.app --use-hsm --key-id 01 --slot 0 propose-to-change-nns-canister --proposer "$NEURON" --canister-id "$AGGREGATOR_CANISTER_ID" --mode upgrade --wasm-module-path "$WASM" --summary-file "$PROPOSAL_TEXT" --wasm-module-sha256 "$SHA" --arg "$ARG_PATH"
 
 echo
 echo PLEASE REVIEW THIS COMMAND:


### PR DESCRIPTION
# Motivation

Remove the --use-explicit-action-type flag since it's already the default behavior of ic-admin.

# Changes

Remove the flag.

# Tests

N/A

# Changelog

The change log entry "Change the release process to submitting `InstallCode` proposals." is still accurate. Some of the release process is changed (verifying hash), but part of it was reverted (the flag)
