### PR TITLE
bot: Update IC Cargo Dependencies to release-2024-09-06_01-30-canister-snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,12 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
- "gimli 0.29.0",
+ "gimli 0.31.0",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -133,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
 
 [[package]]
 name = "arbitrary"
@@ -239,17 +233,17 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets",
 ]
 
 [[package]]
@@ -606,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.15"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
 dependencies = [
  "shlex",
 ]
@@ -684,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive 4.5.13",
@@ -694,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
@@ -844,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -971,7 +965,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1141,7 +1135,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1153,7 +1147,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1162,7 +1156,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1174,7 +1168,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1187,7 +1181,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "on_wire",
  "prost",
@@ -1371,7 +1365,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1422,7 +1416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.0",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1576,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "glob"
@@ -1783,16 +1777,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1846,17 +1840,20 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "byte-unit",
  "bytes",
  "candid",
  "comparable",
+ "hex",
  "ic-crypto-sha2",
  "ic-protobuf",
  "phantom_newtype",
  "prost",
  "serde",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
@@ -1873,7 +1870,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-replica-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -1886,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -1899,7 +1896,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "serde",
 ]
@@ -1907,7 +1904,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -1916,7 +1913,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -2083,14 +2080,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-constants"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
-
-[[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -2104,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "getrandom",
 ]
@@ -2112,7 +2104,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "hex",
  "ic-types",
@@ -2122,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -2144,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -2162,7 +2154,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2170,7 +2162,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2189,7 +2181,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2202,7 +2194,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "sha2",
 ]
@@ -2210,7 +2202,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "base64 0.13.1",
  "cached",
@@ -2236,7 +2228,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2266,7 +2258,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "arrayvec 0.7.6",
  "hex",
@@ -2283,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2301,7 +2293,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "hmac",
  "k256",
@@ -2317,7 +2309,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "serde",
  "zeroize",
@@ -2326,7 +2318,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2334,7 +2326,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2347,7 +2339,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -2360,7 +2352,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2370,7 +2362,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2380,7 +2372,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-protobuf",
  "ic-utils",
@@ -2392,7 +2384,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "ciborium",
@@ -2415,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "ciborium",
@@ -2443,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "async-trait",
  "candid",
@@ -2461,6 +2453,7 @@ dependencies = [
  "ic-ledger-core",
  "ic-ledger-hash-of",
  "ic-metrics-encoder",
+ "ic-stable-structures",
  "icrc-ledger-client",
  "icrc-ledger-types",
  "num-traits",
@@ -2471,7 +2464,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -2483,15 +2476,15 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "async-trait",
  "candid",
  "ic-base-types",
  "ic-canister-log",
- "ic-constants",
  "ic-ledger-core",
  "ic-ledger-hash-of",
+ "ic-limits",
  "ic-management-canister-types",
  "ic-utils",
  "num-traits",
@@ -2501,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -2513,7 +2506,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "hex",
@@ -2521,9 +2514,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-limits"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+
+[[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2549,7 +2547,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "async-trait",
  "candid",
@@ -2572,12 +2570,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2613,12 +2611,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -2631,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -2643,12 +2641,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "comparable",
@@ -2661,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-base-types",
 ]
@@ -2669,7 +2667,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "dfn_core",
@@ -2685,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "async-trait",
  "candid",
@@ -2698,17 +2696,17 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 
 [[package]]
 name = "ic-nervous-system-temporary"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -2721,7 +2719,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "comparable",
@@ -2747,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -2756,7 +2754,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2826,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "bytes",
  "candid",
@@ -2853,7 +2851,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "csv",
  "ic-base-types",
@@ -2870,12 +2868,12 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "async-trait",
  "candid",
@@ -2890,7 +2888,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "bincode",
  "candid",
@@ -2904,7 +2902,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-canister-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2915,7 +2913,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2927,7 +2925,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-node-provider-rewards"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-base-types",
  "ic-protobuf",
@@ -2936,7 +2934,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2947,7 +2945,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "ic-management-canister-types",
@@ -2958,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -2970,7 +2968,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2982,7 +2980,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3039,7 +3037,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -3047,7 +3045,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -3058,7 +3056,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3079,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -3106,7 +3104,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3135,7 +3133,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3173,7 +3171,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "comparable",
@@ -3188,7 +3186,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3234,7 +3232,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3243,11 +3241,11 @@ dependencies = [
  "hex",
  "ic-base-types",
  "ic-btc-replica-types",
- "ic-constants",
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
  "ic-crypto-tree-hash",
  "ic-error-types",
+ "ic-limits",
  "ic-management-canister-types",
  "ic-protobuf",
  "ic-utils",
@@ -3271,7 +3269,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3282,7 +3280,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "ic-validate-eq-derive",
 ]
@@ -3290,7 +3288,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq-derive"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -3300,13 +3298,13 @@ dependencies = [
 
 [[package]]
 name = "ic-wasm"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cd6705c8489fba80aa4bbef0f083d9ead20d7c2471b7e3a60ca2790c91344a"
+checksum = "5574bf249d201ddd2c27c3fdf178ddacb1be1c705c8a5b4c1339c393758f2bf2"
 dependencies = [
  "anyhow",
  "candid",
- "clap 4.5.16",
+ "clap 4.5.17",
  "libflate",
  "rustc-demangle",
  "serde",
@@ -3375,7 +3373,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "comparable",
@@ -3405,7 +3403,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3416,7 +3414,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.6"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "base32",
  "candid",
@@ -3628,9 +3626,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3955,15 +3953,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
@@ -4176,7 +4165,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 
 [[package]]
 name = "once_cell"
@@ -4278,9 +4267,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.11"
+version = "2.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
 dependencies = [
  "memchr",
  "thiserror",
@@ -4289,9 +4278,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.11"
+version = "2.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
+checksum = "664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4299,9 +4288,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.11"
+version = "2.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
+checksum = "a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe"
 dependencies = [
  "pest",
  "pest_meta",
@@ -4312,9 +4301,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.11"
+version = "2.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
+checksum = "0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174"
 dependencies = [
  "once_cell",
  "pest",
@@ -4334,7 +4323,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "candid",
  "serde",
@@ -4687,9 +4676,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1f9bf148c15500d44581654fb9260bc9d82970f3ef777a79a40534f6aa784f"
+checksum = "aa37f80ca58604976033fae9515a8a2989fc13797d953f7c04fb8fa36a11f205"
 dependencies = [
  "cc",
 ]
@@ -4722,9 +4711,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -4740,9 +4729,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
  "rand",
@@ -4757,15 +4746,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
+checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4889,7 +4878,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-08-29_01-30-base#35bfcadd0f2a474057e42393917b8b3ac269627a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
 dependencies = [
  "build-info",
  "build-info-build",
@@ -4967,7 +4956,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -5106,9 +5095,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.35"
+version = "0.38.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
+checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -5136,6 +5125,19 @@ name = "rustls-native-certs"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
@@ -5206,11 +5208,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5303,9 +5305,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
@@ -5331,9 +5333,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5353,9 +5355,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
  "memchr",
@@ -5930,9 +5932,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,23 +14,23 @@ ic-cdk = "0.16.0"
 ic-cdk-macros = "0.16.0"
 ic-cdk-timers = "0.9.0"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
-ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-08-29_01-30-base" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
 
 [profile.release]
 lto = false


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
We want to keep our Cargo dependencies up to date.

# Changes
* Ran `scripts/update-ic-cargo-deps` to update the Cargo.toml dependencies to the latest IC release.

# Tests
* See CI