### PR TITLE
Update IC Cargo Dependencies on Sundays

### DIFF
--- a/.github/workflows/update-ic-cargo-deps.yaml
+++ b/.github/workflows/update-ic-cargo-deps.yaml
@@ -2,8 +2,8 @@
 name: Update IC Cargo Dependencies
 on:
   schedule:
-    # Check for new IC releases every wednesday at 7:30.
-    - cron: '30 7 * * MON'
+    # Check for new IC releases every Sunday at 7:30am UTC.
+    - cron: '30 7 * * SUN'
   workflow_dispatch:
 jobs:
   update-ic-cargo-deps:


### PR DESCRIPTION
# Motivation

Dependabot often sends PRs on Monday morning.
We also update our cargo dependency to the latest IC release on Monday morning.
The IC release is usually made on Thursday or Friday.
I prefer to merge the IC cargo dependencies PR first because
1. It makes sure the dependabot changes aren't incompatible with the newest IC release
2. Some of the dependabot changes tend to become obsolete once the IC deps are updated.

Currently I wait until 9:30 on Monday for the IC dependencies PR to be created. It would be nice to be able to do it earlier.

# Changes

Change the schedule of `.github/workflows/update-ic-cargo-deps.yaml` to run on Sundays.

# Tests

n/a

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary