### PR TITLE
NNS1-3158: Failed imported tokens store

### DIFF
--- a/frontend/src/lib/derived/icrc-canisters.derived.ts
+++ b/frontend/src/lib/derived/icrc-canisters.derived.ts
@@ -1,5 +1,5 @@
+import { loadedImportedTokensStore } from "$lib/derived/imported-tokens.derived";
 import { defaultIcrcCanistersStore } from "$lib/stores/default-icrc-canisters.store";
-import { importedTokensStore } from "$lib/stores/imported-tokens.store";
 import type { UniverseCanisterIdText } from "$lib/types/universe";
 import type { Principal } from "@dfinity/principal";
 import { derived, type Readable } from "svelte/store";
@@ -17,17 +17,15 @@ export type IcrcCanistersStoreData = Record<
 export type IcrcCanistersStore = Readable<IcrcCanistersStoreData>;
 
 export const icrcCanistersStore: IcrcCanistersStore = derived(
-  [defaultIcrcCanistersStore, importedTokensStore],
-  ([defaultIcrcCanisters, importedTokensStore]) => {
+  [defaultIcrcCanistersStore, loadedImportedTokensStore],
+  ([defaultIcrcCanisters, loadedImportedTokens]) => {
     return {
       ...defaultIcrcCanisters,
       ...Object.fromEntries(
-        importedTokensStore?.importedTokens?.map(
-          ({ ledgerCanisterId, indexCanisterId }) => [
-            ledgerCanisterId.toText(),
-            { ledgerCanisterId, indexCanisterId },
-          ]
-        ) ?? []
+        loadedImportedTokens.map(({ ledgerCanisterId, indexCanisterId }) => [
+          ledgerCanisterId.toText(),
+          { ledgerCanisterId, indexCanisterId },
+        ])
       ),
     };
   }

--- a/frontend/src/lib/derived/imported-tokens.derived.ts
+++ b/frontend/src/lib/derived/imported-tokens.derived.ts
@@ -9,9 +9,7 @@ export const loadedImportedTokensStore = derived(
   ([importedTokensStore, failedImportedTokenLedgerIds]) => {
     return (importedTokensStore.importedTokens ?? []).filter(
       ({ ledgerCanisterId }) =>
-        !failedImportedTokenLedgerIds.some(
-          (id) => id.toText() === ledgerCanisterId.toText()
-        )
+        !failedImportedTokenLedgerIds.includes(ledgerCanisterId.toText())
     );
   }
 );

--- a/frontend/src/lib/derived/imported-tokens.derived.ts
+++ b/frontend/src/lib/derived/imported-tokens.derived.ts
@@ -1,0 +1,17 @@
+import {
+  failedImportedTokenLedgerIdsStore,
+  importedTokensStore,
+} from "$lib/stores/imported-tokens.store";
+import { derived } from "svelte/store";
+
+export const loadedImportedTokensStore = derived(
+  [importedTokensStore, failedImportedTokenLedgerIdsStore],
+  ([importedTokensStore, failedImportedTokensStore]) => {
+    return (importedTokensStore.importedTokens ?? []).filter(
+      ({ ledgerCanisterId }) =>
+        !failedImportedTokensStore.some(
+          (id) => id.toText() === ledgerCanisterId.toText()
+        )
+    );
+  }
+);

--- a/frontend/src/lib/derived/imported-tokens.derived.ts
+++ b/frontend/src/lib/derived/imported-tokens.derived.ts
@@ -6,10 +6,10 @@ import { derived } from "svelte/store";
 
 export const loadedImportedTokensStore = derived(
   [importedTokensStore, failedImportedTokenLedgerIdsStore],
-  ([importedTokensStore, failedImportedTokensStore]) => {
+  ([importedTokensStore, failedImportedTokenLedgerIds]) => {
     return (importedTokensStore.importedTokens ?? []).filter(
       ({ ledgerCanisterId }) =>
-        !failedImportedTokensStore.some(
+        !failedImportedTokenLedgerIds.some(
           (id) => id.toText() === ledgerCanisterId.toText()
         )
     );

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -34,11 +34,6 @@ import { isNullish, nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { queryAndUpdate, type QueryAndUpdateStrategy } from "./utils.services";
 
-const isFailedImportedToken = (ledgerCanisterId: Principal) =>
-  get(failedImportedTokenLedgerIdsStore).some(
-    (id) => id.toText() === ledgerCanisterId.toText()
-  );
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const getIcrcAccountIdentity = (_: Account): Promise<Identity> => {
   // TODO: Support Hardware Wallets
@@ -69,7 +64,9 @@ export const loadIcrcToken = ({
     // SNS tokens are derived from aggregator data instead.
     return;
   }
-  if (isFailedImportedToken(ledgerCanisterId)) {
+  if (
+    get(failedImportedTokenLedgerIdsStore).includes(ledgerCanisterId.toText())
+  ) {
     // Ensures that imported tokens that failed to load are not fetched again.
     return;
   }
@@ -103,7 +100,7 @@ export const loadIcrcToken = ({
         })
       ) {
         // Do not display error toasts for imported tokens, as this is not an NNS-dapp error.
-        failedImportedTokenLedgerIdsStore.add(ledgerCanisterId);
+        failedImportedTokenLedgerIdsStore.add(ledgerCanisterId.toText());
       } else {
         // Explicitly handle only UPDATE errors
         toastsError({
@@ -165,7 +162,9 @@ export const loadAccounts = async ({
   ledgerCanisterId: Principal;
   strategy?: QueryAndUpdateStrategy;
 }): Promise<void> => {
-  if (isFailedImportedToken(ledgerCanisterId)) {
+  if (
+    get(failedImportedTokenLedgerIdsStore).includes(ledgerCanisterId.toText())
+  ) {
     // Ensures that imported tokens that failed to load are not fetched again.
     return;
   }
@@ -201,7 +200,7 @@ export const loadAccounts = async ({
         })
       ) {
         // Do not display error toasts for imported tokens, as this is not an NNS-dapp error.
-        failedImportedTokenLedgerIdsStore.add(ledgerCanisterId);
+        failedImportedTokenLedgerIdsStore.add(ledgerCanisterId.toText());
       } else {
         toastsError(
           toToastError({

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -89,6 +89,7 @@ export const loadIcrcToken = ({
     onLoad: async ({ response: token, certified }) =>
       tokensStore.setToken({ certified, canisterId: ledgerCanisterId, token }),
     onError: ({ error: err, certified }) => {
+      // Explicitly handle only UPDATE errors
       if (!certified && notForceCallStrategy()) {
         return;
       }
@@ -102,7 +103,6 @@ export const loadIcrcToken = ({
         // Do not display error toasts for imported tokens, as this is not an NNS-dapp error.
         failedImportedTokenLedgerIdsStore.add(ledgerCanisterId.toText());
       } else {
-        // Explicitly handle only UPDATE errors
         toastsError({
           labelKey: "error.token_not_found",
           err,

--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -100,7 +100,8 @@ export const loadIcrcToken = ({
           importedTokens: get(importedTokensStore)?.importedTokens,
         })
       ) {
-        // Do not display error toasts for imported tokens, as this is not an NNS-dapp error.
+        // Do not display error toasts for imported tokens.
+        // Failed imported tokens will be shown with a warning icon in the UI.
         failedImportedTokenLedgerIdsStore.add(ledgerCanisterId.toText());
       } else {
         toastsError({
@@ -199,7 +200,8 @@ export const loadAccounts = async ({
           importedTokens: get(importedTokensStore)?.importedTokens,
         })
       ) {
-        // Do not display error toasts for imported tokens, as this is not an NNS-dapp error.
+        // Do not display error toasts for imported tokens.
+        // Failed imported tokens will be shown with a warning icon in the UI.
         failedImportedTokenLedgerIdsStore.add(ledgerCanisterId.toText());
       } else {
         toastsError(

--- a/frontend/src/lib/stores/imported-tokens.store.ts
+++ b/frontend/src/lib/stores/imported-tokens.store.ts
@@ -1,5 +1,5 @@
 import type { ImportedTokenData } from "$lib/types/imported-tokens";
-import { CanisterIdString } from "@dfinity/nns";
+import type { CanisterIdString } from "@dfinity/nns";
 import { writable } from "svelte/store";
 
 export interface ImportedTokensStore {

--- a/frontend/src/lib/stores/imported-tokens.store.ts
+++ b/frontend/src/lib/stores/imported-tokens.store.ts
@@ -1,4 +1,5 @@
 import type { ImportedTokenData } from "$lib/types/imported-tokens";
+import { Principal } from "@dfinity/principal";
 import { writable } from "svelte/store";
 
 export interface ImportedTokensStore {
@@ -41,3 +42,31 @@ const initImportedTokensStore = () => {
 };
 
 export const importedTokensStore = initImportedTokensStore();
+
+/**
+ * A store that contains ledger canister IDs of imported tokens that failed to load
+ */
+const initFailedImportedTokenLedgerIdsStore = () => {
+  const { subscribe, set, update } = writable<Principal[]>([]);
+
+  return {
+    subscribe,
+
+    add(ledgerCanisterId: Principal) {
+      update((failedLedgerCanisterIds) =>
+        Array.from(
+          new Set([
+            ...failedLedgerCanisterIds.map((principal) => principal.toText()),
+            ledgerCanisterId.toText(),
+          ])
+        ).map((text) => Principal.fromText(text))
+      );
+    },
+
+    reset() {
+      set([]);
+    },
+  };
+};
+export const failedImportedTokenLedgerIdsStore =
+  initFailedImportedTokenLedgerIdsStore();

--- a/frontend/src/lib/stores/imported-tokens.store.ts
+++ b/frontend/src/lib/stores/imported-tokens.store.ts
@@ -1,5 +1,5 @@
 import type { ImportedTokenData } from "$lib/types/imported-tokens";
-import { Principal } from "@dfinity/principal";
+import { CanisterIdString } from "@dfinity/nns";
 import { writable } from "svelte/store";
 
 export interface ImportedTokensStore {
@@ -47,19 +47,16 @@ export const importedTokensStore = initImportedTokensStore();
  * A store that contains ledger canister IDs of imported tokens that failed to load
  */
 const initFailedImportedTokenLedgerIdsStore = () => {
-  const { subscribe, set, update } = writable<Principal[]>([]);
+  const { subscribe, set, update } = writable<CanisterIdString[]>([]);
 
   return {
     subscribe,
 
-    add(ledgerCanisterId: Principal) {
+    add(ledgerCanisterId: CanisterIdString) {
       update((failedLedgerCanisterIds) =>
-        Array.from(
-          new Set([
-            ...failedLedgerCanisterIds.map((principal) => principal.toText()),
-            ledgerCanisterId.toText(),
-          ])
-        ).map((text) => Principal.fromText(text))
+        failedLedgerCanisterIds.includes(ledgerCanisterId)
+          ? failedLedgerCanisterIds
+          : [...failedLedgerCanisterIds, ledgerCanisterId]
       );
     },
 

--- a/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
+++ b/frontend/src/tests/lib/components/tokens/TokensTable.spec.ts
@@ -1,6 +1,7 @@
 import TokensTable from "$lib/components/tokens/TokensTable/TokensTable.svelte";
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
+import { importedTokensStore } from "$lib/stores/imported-tokens.store";
 import { ActionType } from "$lib/types/actions";
 import {
   UserTokenAction,
@@ -19,7 +20,6 @@ import { createActionEvent } from "$tests/utils/actions.test-utils";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { render, waitFor } from "@testing-library/svelte";
 import type { Mock } from "vitest";
-import { importedTokensStore } from "../../../../lib/stores/imported-tokens.store";
 import TokensTableTest from "./TokensTableTest.svelte";
 
 describe("TokensTable", () => {

--- a/frontend/src/tests/lib/derived/icrc-canisters.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icrc-canisters.derived.spec.ts
@@ -64,7 +64,7 @@ describe("icrcCanistersStore", () => {
       ],
       certified: true,
     });
-    failedImportedTokenLedgerIdsStore.add(ledgerCanisterId);
+    failedImportedTokenLedgerIdsStore.add(ledgerCanisterId.toText());
 
     expect(get(icrcCanistersStore)).toEqual({});
   });

--- a/frontend/src/tests/lib/derived/icrc-canisters.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icrc-canisters.derived.spec.ts
@@ -11,6 +11,7 @@ describe("icrcCanistersStore", () => {
   const ledgerCanisterId = principal(0);
   const indexCanisterId = principal(1);
   const ledgerCanisterId2 = principal(2);
+  const ledgerCanisterId3 = principal(3);
 
   beforeEach(() => {
     defaultIcrcCanistersStore.reset();
@@ -54,19 +55,35 @@ describe("icrcCanistersStore", () => {
     });
   });
 
-  it("ignores failed imported tokens", () => {
+  it("excludes failed imported tokens", () => {
+    defaultIcrcCanistersStore.setCanisters({
+      ledgerCanisterId,
+      indexCanisterId,
+    });
     importedTokensStore.set({
       importedTokens: [
         {
-          ledgerCanisterId,
+          ledgerCanisterId: ledgerCanisterId2,
+          indexCanisterId: undefined,
+        },
+        {
+          ledgerCanisterId: ledgerCanisterId3,
           indexCanisterId: undefined,
         },
       ],
       certified: true,
     });
-    failedImportedTokenLedgerIdsStore.add(ledgerCanisterId.toText());
+    failedImportedTokenLedgerIdsStore.add(ledgerCanisterId2.toText());
 
-    expect(get(icrcCanistersStore)).toEqual({});
+    expect(get(icrcCanistersStore)).toEqual({
+      [ledgerCanisterId.toText()]: {
+        ledgerCanisterId,
+        indexCanisterId,
+      },
+      [ledgerCanisterId3.toText()]: {
+        ledgerCanisterId: ledgerCanisterId2,
+      },
+    });
   });
 
   it("return data from the defaultIcrcCanistersStore and the importedTokensStore", () => {

--- a/frontend/src/tests/lib/derived/icrc-canisters.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icrc-canisters.derived.spec.ts
@@ -81,7 +81,7 @@ describe("icrcCanistersStore", () => {
         indexCanisterId,
       },
       [ledgerCanisterId3.toText()]: {
-        ledgerCanisterId: ledgerCanisterId2,
+        ledgerCanisterId: ledgerCanisterId3,
       },
     });
   });

--- a/frontend/src/tests/lib/derived/icrc-canisters.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/icrc-canisters.derived.spec.ts
@@ -1,6 +1,9 @@
 import { icrcCanistersStore } from "$lib/derived/icrc-canisters.derived";
 import { defaultIcrcCanistersStore } from "$lib/stores/default-icrc-canisters.store";
-import { importedTokensStore } from "$lib/stores/imported-tokens.store";
+import {
+  failedImportedTokenLedgerIdsStore,
+  importedTokensStore,
+} from "$lib/stores/imported-tokens.store";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { get } from "svelte/store";
 
@@ -12,6 +15,7 @@ describe("icrcCanistersStore", () => {
   beforeEach(() => {
     defaultIcrcCanistersStore.reset();
     importedTokensStore.reset();
+    failedImportedTokenLedgerIdsStore.reset();
   });
 
   it("returns empty object when no icrc tokens are present", () => {
@@ -48,6 +52,21 @@ describe("icrcCanistersStore", () => {
         ledgerCanisterId,
       },
     });
+  });
+
+  it("ignores failed imported tokens", () => {
+    importedTokensStore.set({
+      importedTokens: [
+        {
+          ledgerCanisterId,
+          indexCanisterId: undefined,
+        },
+      ],
+      certified: true,
+    });
+    failedImportedTokenLedgerIdsStore.add(ledgerCanisterId);
+
+    expect(get(icrcCanistersStore)).toEqual({});
   });
 
   it("return data from the defaultIcrcCanistersStore and the importedTokensStore", () => {

--- a/frontend/src/tests/lib/derived/imported-tokens.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/imported-tokens.derived.spec.ts
@@ -41,7 +41,9 @@ describe("imported tokens derived stores", () => {
         importedTokens: [importedTokenA, importedTokenB],
         certified: true,
       });
-      failedImportedTokenLedgerIdsStore.add(importedTokenA.ledgerCanisterId);
+      failedImportedTokenLedgerIdsStore.add(
+        importedTokenA.ledgerCanisterId.toText()
+      );
       expect(get(loadedImportedTokensStore)).toEqual([importedTokenB]);
     });
   });

--- a/frontend/src/tests/lib/derived/imported-tokens.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/imported-tokens.derived.spec.ts
@@ -3,7 +3,7 @@ import {
   failedImportedTokenLedgerIdsStore,
   importedTokensStore,
 } from "$lib/stores/imported-tokens.store";
-import { ImportedTokenData } from "$lib/types/imported-tokens";
+import type { ImportedTokenData } from "$lib/types/imported-tokens";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { get } from "svelte/store";
 

--- a/frontend/src/tests/lib/derived/imported-tokens.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/imported-tokens.derived.spec.ts
@@ -1,0 +1,48 @@
+import { loadedImportedTokensStore } from "$lib/derived/imported-tokens.derived";
+import {
+  failedImportedTokenLedgerIdsStore,
+  importedTokensStore,
+} from "$lib/stores/imported-tokens.store";
+import { ImportedTokenData } from "$lib/types/imported-tokens";
+import { principal } from "$tests/mocks/sns-projects.mock";
+import { get } from "svelte/store";
+
+describe("imported tokens derived stores", () => {
+  beforeEach(() => {
+    importedTokensStore.reset();
+    failedImportedTokenLedgerIdsStore.reset();
+  });
+
+  describe("loadedImportedTokensStore", () => {
+    const importedTokenA: ImportedTokenData = {
+      ledgerCanisterId: principal(0),
+      indexCanisterId: principal(1),
+    };
+    const importedTokenB: ImportedTokenData = {
+      ledgerCanisterId: principal(2),
+      indexCanisterId: undefined,
+    };
+
+    it("should contain imported tokens", () => {
+      expect(get(loadedImportedTokensStore)).toEqual([]);
+      importedTokensStore.set({
+        importedTokens: [importedTokenA, importedTokenB],
+        certified: true,
+      });
+      expect(get(loadedImportedTokensStore)).toEqual([
+        importedTokenA,
+        importedTokenB,
+      ]);
+    });
+
+    it("should not contain failed tokens", () => {
+      expect(get(loadedImportedTokensStore)).toEqual([]);
+      importedTokensStore.set({
+        importedTokens: [importedTokenA, importedTokenB],
+        certified: true,
+      });
+      failedImportedTokenLedgerIdsStore.add(importedTokenA.ledgerCanisterId);
+      expect(get(loadedImportedTokensStore)).toEqual([importedTokenB]);
+    });
+  });
+});

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -234,7 +234,7 @@ describe("icrc-accounts-services", () => {
     });
 
     it("doesn't load imported token if in failed imported tokens store", async () => {
-      failedImportedTokenLedgerIdsStore.add(ledgerCanisterId);
+      failedImportedTokenLedgerIdsStore.add(ledgerCanisterId.toText());
       expect(ledgerApi.queryIcrcBalance).not.toBeCalled();
       await loadAccounts({ ledgerCanisterId });
       expect(ledgerApi.queryIcrcBalance).not.toBeCalled();
@@ -257,7 +257,7 @@ describe("icrc-accounts-services", () => {
       await loadAccounts({ ledgerCanisterId });
       expect(ledgerApi.queryIcrcBalance).toBeCalledTimes(2);
       expect(get(failedImportedTokenLedgerIdsStore)).toEqual([
-        ledgerCanisterId,
+        ledgerCanisterId.toText(),
       ]);
     });
 
@@ -450,7 +450,7 @@ describe("icrc-accounts-services", () => {
     });
 
     it("doesn't load imported token if in failed imported tokens store", async () => {
-      failedImportedTokenLedgerIdsStore.add(ledgerCanisterId);
+      failedImportedTokenLedgerIdsStore.add(ledgerCanisterId.toText());
       expect(ledgerApi.queryIcrcToken).not.toBeCalled();
       await loadIcrcToken({ ledgerCanisterId });
       expect(ledgerApi.queryIcrcToken).not.toBeCalled();
@@ -473,7 +473,7 @@ describe("icrc-accounts-services", () => {
       await loadIcrcToken({ ledgerCanisterId });
       expect(ledgerApi.queryIcrcToken).toBeCalledTimes(2);
       expect(get(failedImportedTokenLedgerIdsStore)).toEqual([
-        ledgerCanisterId,
+        ledgerCanisterId.toText(),
       ]);
     });
 

--- a/frontend/src/tests/lib/stores/imported-tokens.store.spec.ts
+++ b/frontend/src/tests/lib/stores/imported-tokens.store.spec.ts
@@ -1,10 +1,16 @@
-import { importedTokensStore } from "$lib/stores/imported-tokens.store";
+import {
+  failedImportedTokenLedgerIdsStore,
+  importedTokensStore,
+} from "$lib/stores/imported-tokens.store";
 import type { ImportedTokenData } from "$lib/types/imported-tokens";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { get } from "svelte/store";
 
 describe("imported-tokens-store", () => {
-  afterEach(() => importedTokensStore.reset());
+  afterEach(() => {
+    importedTokensStore.reset();
+    failedImportedTokenLedgerIdsStore.reset();
+  });
 
   describe("importedTokensStore", () => {
     const importedTokenA: ImportedTokenData = {
@@ -50,6 +56,28 @@ describe("imported-tokens-store", () => {
         importedTokens: undefined,
         certified: undefined,
       });
+    });
+  });
+
+  describe("failedImportedTokenLedgerIdsStore", () => {
+    const canisterIdA = principal(0);
+    const canisterIdB = principal(1);
+
+    it("should add canister IDs", () => {
+      expect(get(failedImportedTokenLedgerIdsStore)).toEqual([]);
+      failedImportedTokenLedgerIdsStore.add(canisterIdA);
+      expect(get(failedImportedTokenLedgerIdsStore)).toEqual([canisterIdA]);
+      failedImportedTokenLedgerIdsStore.add(canisterIdB);
+      expect(get(failedImportedTokenLedgerIdsStore)).toContain(canisterIdA);
+      expect(get(failedImportedTokenLedgerIdsStore)).toContain(canisterIdB);
+    });
+
+    it("should not add duplicates", () => {
+      expect(get(failedImportedTokenLedgerIdsStore)).toEqual([]);
+      failedImportedTokenLedgerIdsStore.add(canisterIdA);
+      expect(get(failedImportedTokenLedgerIdsStore)).toEqual([canisterIdA]);
+      failedImportedTokenLedgerIdsStore.add(canisterIdA);
+      expect(get(failedImportedTokenLedgerIdsStore)).toEqual([canisterIdA]);
     });
   });
 });

--- a/frontend/src/tests/lib/stores/imported-tokens.store.spec.ts
+++ b/frontend/src/tests/lib/stores/imported-tokens.store.spec.ts
@@ -68,8 +68,10 @@ describe("imported-tokens-store", () => {
       failedImportedTokenLedgerIdsStore.add(canisterIdA);
       expect(get(failedImportedTokenLedgerIdsStore)).toEqual([canisterIdA]);
       failedImportedTokenLedgerIdsStore.add(canisterIdB);
-      expect(get(failedImportedTokenLedgerIdsStore)).toContain(canisterIdA);
-      expect(get(failedImportedTokenLedgerIdsStore)).toContain(canisterIdB);
+      expect(get(failedImportedTokenLedgerIdsStore)).toEqual([
+        canisterIdA,
+        canisterIdB,
+      ]);
     });
 
     it("should not add duplicates", () => {

--- a/frontend/src/tests/lib/stores/imported-tokens.store.spec.ts
+++ b/frontend/src/tests/lib/stores/imported-tokens.store.spec.ts
@@ -7,7 +7,7 @@ import { principal } from "$tests/mocks/sns-projects.mock";
 import { get } from "svelte/store";
 
 describe("imported-tokens-store", () => {
-  afterEach(() => {
+  beforeEach(() => {
     importedTokensStore.reset();
     failedImportedTokenLedgerIdsStore.reset();
   });
@@ -60,8 +60,8 @@ describe("imported-tokens-store", () => {
   });
 
   describe("failedImportedTokenLedgerIdsStore", () => {
-    const canisterIdA = principal(0);
-    const canisterIdB = principal(1);
+    const canisterIdA = "aaaaa-aa";
+    const canisterIdB = "bbbbb-bb";
 
     it("should add canister IDs", () => {
       expect(get(failedImportedTokenLedgerIdsStore)).toEqual([]);


### PR DESCRIPTION
# Motivation

There is no guarantee that the imported token ledger canister’s API won’t be updated in a way that makes it incompatible, or the canister became unreachable. As a result, any call to this canister could potentially fail. To provide appropriate user feedback, the NNS-dapp should display all such imported tokens as failed. As the first step toward this, we will collect the failed imported token ledger IDs and display only the remaining valid ones.

# Changes

- Add `failedImportedTokenLedgerIdsStore` to store failed ledger canister IDs.
- Update `failedImportedTokenLedgerIdsStore`. Currently, `IcrcWalletPage` calls [syncAccounts](https://github.com/dfinity/nns-dapp/blob/c80f3f202d8a90c329a3c283b00f9daf027e74ac/frontend/src/lib/services/icrc-accounts.services.ts#L220), which calls `loadAccounts` and `loadIcrcToken` in parallel. Each call can fail, so on any error, we mark the imported token as failed by adding a record to the failedImportedTokens store. And skip displaying a toast with the error, since this is not directly an NNS-dapp issue.
- Add `loadedImportedTokens` store, a derived store that returns imported tokens that are not in `failedImportedTokens`.
- Switch `icrcCanistersStore` (source of the displayed tokens) from `importedTokensStore` to `loadedImportedTokens`.

# Tests

- Unit tests updated.
- Tested locally.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.