### PR TITLE
NNS1-3281: Add get_tvl to nns-dapp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,7 +243,7 @@ jobs:
         run: scripts/nns-dapp/e2e-test-metrics-present
       - name: Test TVL
         run: |
-          scripts/nns-dapp/test-tvl --nns_dapp_wasm nns-dapp.wasm.gz --nns_dapp_args nns-dapp-arg-local.did
+          scripts/nns-dapp/test-tvl --nns_dapp_wasm nns-dapp.wasm.gz --nns_dapp_arg nns-dapp-arg-local.did
       - name: Release
         run: |
           for tag in $(git tag --points-at HEAD) ; do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,6 +241,9 @@ jobs:
           scripts/dfx-wasm-metadata-add.test --verbose
       - name: Verify that metrics are present
         run: scripts/nns-dapp/e2e-test-metrics-present
+      - name: Test TVL
+        run: |
+          scripts/nns-dapp/test-tvl --nns_dapp_wasm nns-dapp.wasm.gz --nns_dapp_args nns-dapp-arg-local.did
       - name: Release
         run: |
           for tag in $(git tag --points-at HEAD) ; do

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -15,6 +15,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+* Added `get_tvl` method to `nns-dapp` canister.
+
 #### Changed
 
 #### Deprecated

--- a/rs/backend/nns-dapp-exports-production.txt
+++ b/rs/backend/nns-dapp-exports-production.txt
@@ -9,6 +9,7 @@ canister_query get_exceptional_transactions
 canister_query get_histogram
 canister_query get_imported_tokens
 canister_query get_stats
+canister_query get_tvl
 canister_query http_request
 canister_update <ic-cdk internal> timer_executor
 canister_update add_account

--- a/rs/backend/nns-dapp-exports-test.txt
+++ b/rs/backend/nns-dapp-exports-test.txt
@@ -10,6 +10,7 @@ canister_query get_histogram
 canister_query get_imported_tokens
 canister_query get_stats
 canister_query get_toy_account
+canister_query get_tvl
 canister_query http_request
 canister_update <ic-cdk internal> timer_executor
 canister_update add_account

--- a/rs/backend/nns-dapp.did
+++ b/rs/backend/nns-dapp.did
@@ -210,6 +210,17 @@ type GetImportedTokensResponse =
         AccountNotFound;
     };
 
+type TvlResult =
+    record {
+        tvl : nat;
+        time_sec: nat
+    };
+
+type TvlResponse =
+    variant {
+        Ok : TvlResult;
+    };
+
 service: (opt Config) -> {
     get_account: () -> (GetAccountResponse) query;
     add_account: () -> (AccountIdentifier);
@@ -226,6 +237,7 @@ service: (opt Config) -> {
     get_stats: () -> (Stats) query;
     get_histogram: () -> (Histogram) query;
     get_exceptional_transactions: () -> (opt vec nat64) query;
+    get_tvl : () -> (TvlResponse) query;
 
     http_request: (request: HttpRequest) -> (HttpResponse) query;
     add_stable_asset: (asset: blob) -> ();

--- a/rs/backend/src/tvl.rs
+++ b/rs/backend/src/tvl.rs
@@ -25,8 +25,11 @@ pub enum TvlResponse {
     Ok(TvlResult),
 }
 
-// TODO(NNS1-3281): Remove #[allow(unused)].
-#[allow(unused)]
+pub fn init_timers() {
+    start_updating_exchange_rate_in_background();
+    start_updating_locked_icp_in_the_background();
+}
+
 pub fn start_updating_exchange_rate_in_background() {
     set_timer_interval(Duration::from_secs(UPDATE_INTERVAL_SECONDS), || {
         spawn::spawn(update_exchange_rate());
@@ -38,8 +41,6 @@ pub fn start_updating_exchange_rate_in_background() {
     });
 }
 
-// TODO(NNS1-3281): Remove #[allow(unused)].
-#[allow(unused)]
 fn start_updating_locked_icp_in_the_background() {
     set_timer_interval(Duration::from_secs(UPDATE_INTERVAL_SECONDS), || {
         spawn::spawn(update_locked_icp_e8s());
@@ -72,8 +73,6 @@ fn convert_to_e8s(amount: u64, decimals: u32) -> u64 {
     }
 }
 
-// TODO(NNS1-3281): Remove #[allow(unused)].
-#[allow(unused)]
 pub async fn update_exchange_rate() {
     // We query XRC data slightly in the past to be sure to have a price with consensus.
     //
@@ -140,8 +139,6 @@ pub async fn update_exchange_rate() {
     ic_cdk::println!("Updated usd_e8s_per_icp for TVL to {}", usd_e8s_per_icp);
 }
 
-// TODO(NNS1-3281): Remove #[allow(unused)].
-#[allow(unused)]
 pub async fn update_locked_icp_e8s() {
     let metrics_result = governance::get_metrics().await;
     STATE.with(|s| {
@@ -168,8 +165,6 @@ pub async fn update_locked_icp_e8s() {
     });
 }
 
-// TODO(NNS1-3281): Remove #[allow(unused)].
-#[allow(unused)]
 pub fn get_tvl() -> TvlResponse {
     STATE.with(|s| {
         let state = s.tvl_state.borrow();

--- a/scripts/nns-dapp/test-tvl
+++ b/scripts/nns-dapp/test-tvl
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.."
+
+print_help() {
+  cat <<-EOF
+
+	Sets mock exchange rate and tests that nns-dapp uses it for the TVL
+	calculation.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=w long=nns_dapp_wasm desc="The NNS dapp wasm to install to calculate the new TVL value" variable=NNS_DAPP_WASM default="nns-dapp.wasm.gz"
+clap.define short=a long=nns_dapp_arg desc="The argument file to use when installing the nns-dapp" variable=NNS_DAPP_ARG default="nns-dapp-arg-local.did"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+E8S_PER_UNIT="100000000"
+TOTAL_ICP_LOCKED_E8S="$(dfx canister call nns-governance get_metrics | idl2json | jq -r '.Ok.total_locked_e8s')"
+
+test_exchange_rate() {
+  exchange_rate="$1"
+  exchange_rate_e8s="$(echo "$exchange_rate $E8S_PER_UNIT" | awk '{ printf "%d\n", $1 * $2 }')"
+  expected_tvl="$(echo "$TOTAL_ICP_LOCKED_E8S $exchange_rate $E8S_PER_UNIT" | awk '{ printf "%d\n", $1 * $2 / $3}')"
+
+  dfx canister call xrc set_exchange_rate "(record{base_asset=\"ICP\"; quote_asset=\"USD\"; rate=$exchange_rate_e8s:nat64})"
+
+  # We upgrade nns-dapp to avoid waiting for its timer to update the TVL value.
+  dfx canister install nns-dapp --wasm "$NNS_DAPP_WASM" --upgrade-unchanged --mode upgrade --yes -v --argument "$(cat "$NNS_DAPP_ARG")"
+
+  actual_tvl="$(dfx canister call nns-dapp get_tvl | idl2json | jq -r '.Ok.tvl' | sed -e 's/_//g')"
+
+  if [[ "$actual_tvl" -ne "$expected_tvl" ]]; then
+    echo "Expected TVL: $expected_tvl, Actual TVL: $actual_tvl"
+    exit 1
+  fi
+}
+
+test_exchange_rate "10"
+test_exchange_rate "12.34567891"
+test_exchange_rate "0.00012345"
+test_exchange_rate "12345.87654321"


### PR DESCRIPTION
# Motivation

The NNS dapp displays the USD value of the total amount of ICP locked in neurons.
It gets this information from the TVL canister but we want to move this functionality to the nns-dapp canister and remove the TVL canister.

The functionality to fetch the amount of locked ICP and the exchange rate and to get the TVL was already implemented in the `tvl` module.

This PR exposes the `get_tvl` method (which just calls `tvl::get_tvl`) on the canister and initializes the timers to fetch the necessary data.

# Changes

1. Initialize the timers to update the amount of locked ICP and exchange rate periodically, when installing or upgrading the canister.
2. Add `get_tvl` canister method.
3. Updated the candid file to match the canister interface.
4. Ran `scripts/nns-dapp/test-exports --wasm nns-dapp_test.wasm.gz --update-golden --flavour test` and `scripts/nns-dapp/test-exports --wasm nns-dapp_production.wasm.gz --update-golden --flavour production` to update golden exports files.

# Tests

1. Added a script to test getting the TVL value from the canister.
2. Test manually end-to-end in another branch.

# Todos

- [x] Add entry to changelog (if necessary).
