### PR TITLE
bot: Update snsdemo to release-2024-09-10

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -386,7 +386,7 @@
         "DIDC_VERSION": "2024-05-14",
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
-        "SNSDEMO_RELEASE": "release-2024-09-04",
+        "SNSDEMO_RELEASE": "release-2024-09-10",
         "IC_COMMIT_FOR_PROPOSALS": "release-2024-09-06_01-30-canister-snapshots",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-09-06_01-30-canister-snapshots"
       },


### PR DESCRIPTION
# Motivation
We would like to keep the testing environment, provided by snsdemo, up to date.

# Changes
* Updated `snsdemo` version in `dfx.json`.
* Ensured that the `dfx` version in `dfx.json` matches `snsdemo`.

# Tests
CI should pass.