### PR TITLE
NNS1-3281: Encode TVL state to stable memory

### DIFF
--- a/rs/backend/src/tvl/state.rs
+++ b/rs/backend/src/tvl/state.rs
@@ -1,9 +1,34 @@
+use crate::state::StableState;
 use candid::CandidType;
+use dfn_candid::Candid;
+use on_wire::{FromWire, IntoWire};
 use serde::Deserialize;
 
-#[derive(CandidType, Default, Debug, Deserialize)]
+#[derive(CandidType, Default, Debug, Deserialize, PartialEq)]
 pub struct TvlState {
     pub total_locked_icp_e8s: u64,
     pub usd_e8s_per_icp: u64,
     pub exchange_rate_timestamp_seconds: u64,
+}
+
+impl StableState for TvlState {
+    fn encode(&self) -> Vec<u8> {
+        Candid((self,)).into_bytes().unwrap_or_default()
+    }
+
+    fn decode(bytes: Vec<u8>) -> Result<Self, String> {
+        let (ans,) = Candid::from_bytes(bytes).map(|c| c.0).unwrap_or_default();
+        Ok(ans)
+    }
+}
+
+impl TvlState {
+    #[cfg(test)]
+    pub fn test_data() -> Self {
+        Self {
+            total_locked_icp_e8s: 12_345_678_900_000_000,
+            usd_e8s_per_icp: 750_000_000,
+            exchange_rate_timestamp_seconds: 1_234_567_890,
+        }
+    }
 }


### PR DESCRIPTION
# Motivation

The nns-dapp loads the input to the TVL calculation right after upgrade. But if this is slow or it fails, it might not be able to provide a TVL value. So we also want to store the TVL state in stable memory during the upgrade.

We can't read the TVL state from stable memory unless it's first written to stable memory.
So we implement the encoding first and only implement the decoding once we've had 1 release that has written the state to stable memory.

# Changes

1. Implemented both encoding and decoding of the TVL state, but commented out the decoding and added TODOs.

# Tests

1. Added a test that encoding is done but decoding is not.
2. Added a commented-out assert that decoding is done.
3. Existing upgrade-downgrade test still passes: https://github.com/dfinity/nns-dapp/actions/runs/10792784452/job/29933422210?pr=5431

# Todos

- [ ] Add entry to changelog (if necessary).
covered under existing entry