### PR TITLE
NNS1-3281: Decode TVL state from stable memory

### DIFF
--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -156,18 +156,13 @@ impl StableState for State {
         let (
             account_store_bytes,
             assets_bytes,
-            // TODO(NNS1-3281): Restore TVL state from stable memory after we've
-            // had a release that has written the TVL state to stable memory.
-            // tvl_state_bytes,
+            tvl_state_bytes,
         ) = Candid::from_bytes(bytes).map(|c| c.0)?;
 
         let assets = Assets::decode(assets_bytes)?;
         let asset_hashes = AssetHashes::from(&assets);
         let performance = PerformanceCounts::default();
-        let tvl_state = TvlState::default();
-        // TODO(NNS1-3281): Restore TVL state from stable memory after we've had
-        // a release that has written the TVL state to stable memory.  let
-        // let tvl_state = TvlState::decode(tvl_state_bytes)?;
+        let tvl_state = TvlState::decode(tvl_state_bytes)?;
 
         Ok(State {
             accounts_store: AccountsStore::decode(account_store_bytes)?,

--- a/rs/backend/src/state.rs
+++ b/rs/backend/src/state.rs
@@ -153,11 +153,7 @@ impl StableState for State {
     }
 
     fn decode(bytes: Vec<u8>) -> Result<Self, String> {
-        let (
-            account_store_bytes,
-            assets_bytes,
-            tvl_state_bytes,
-        ) = Candid::from_bytes(bytes).map(|c| c.0)?;
+        let (account_store_bytes, assets_bytes, tvl_state_bytes) = Candid::from_bytes(bytes).map(|c| c.0)?;
 
         let assets = Assets::decode(assets_bytes)?;
         let asset_hashes = AssetHashes::from(&assets);

--- a/rs/backend/src/state/tests.rs
+++ b/rs/backend/src/state/tests.rs
@@ -3,9 +3,7 @@ use crate::{
     state::{partitions::PartitionsMaybe, AssetHashes, Assets, PerformanceCounts, StableState, State},
     tvl::state::TvlState,
 };
-use dfn_candid::Candid;
 use ic_stable_structures::{DefaultMemoryImpl, VectorMemory};
-use on_wire::FromWire;
 use pretty_assertions::assert_eq;
 use proptest::proptest;
 use std::rc::Rc;

--- a/rs/backend/src/state/tests.rs
+++ b/rs/backend/src/state/tests.rs
@@ -41,23 +41,7 @@ fn state_heap_contents_can_be_serialized_and_deserialized() {
     // It's nice if we keep these:
     assert_eq!(toy_state.assets, parsed.assets, "Assets have changed");
     assert_eq!(toy_state.asset_hashes, parsed.asset_hashes, "Asset hashes have changed");
-    // TODO(NNS1-3281): Verify TVL state once it's read from stable memory.
-    // assert_eq!(toy_state.tvl_state, parsed.tvl_state, "TVL state has changed");
-}
-
-// TODO(NNS1-3281): Remove this test, and uncomment the assert in the
-// previous test, once TVL state is decoded.
-#[test]
-fn state_encodes_but_does_not_decode_tvl_state() {
-    let toy_state = setup_test_state();
-    let bytes: Vec<u8> = toy_state.encode();
-    let (_, _, tvl_state_bytes): (Vec<u8>, Vec<u8>, Vec<u8>) = Candid::from_bytes(bytes.clone()).map(|c| c.0).unwrap();
-    let parsed_tvl_state = TvlState::decode(tvl_state_bytes).unwrap();
-
-    assert_eq!(toy_state.tvl_state, parsed_tvl_state, "TVL state should be encoded");
-
-    let parsed = State::decode(bytes).expect("Failed to parse");
-    assert_eq!(parsed.tvl_state, TvlState::default(), "TVL state should not be decoded");
+    assert_eq!(toy_state.tvl_state, parsed.tvl_state, "TVL state has changed");
 }
 
 #[test]


### PR DESCRIPTION
# Motivation

This is the follow-up to https://github.com/dfinity/nns-dapp/pull/5431
In that PR we stored the TVL state to stable memory but we couldn't yet restore the TVL state from stable memory because we didn't have a release that made sure there was TVL state to be restored from stable memory.

After the most recent upgrade we now do so we can complete the TODOs left in that PR.

# Changes

1. Load TVL state from stable memory.
2. Decode loaded TVL state into canister state.

# Tests

1. Remove test that checks TVL state is not decoded.
2. Update test to make sure that TVL state is decoded.

# Todos

- [ ] Add entry to changelog (if necessary).
covered