### PR TITLE
Add aggregator types for nervous system parameters

### DIFF
--- a/frontend/src/lib/types/sns-aggregator.ts
+++ b/frontend/src/lib/types/sns-aggregator.ts
@@ -42,6 +42,49 @@ export type CachedNervousFunctionDto = {
   function_type: CachedFunctionTypeDto | null;
 };
 
+export type CachedNeuronIdDto = {
+  id: Uint8Array;
+};
+
+export type CachedDefaultFolloweesDto = {
+  followees: CachedNeuronIdDto[];
+};
+
+export type CachedNeuronPermissionListDto = {
+  permissions: number[];
+}
+
+export type CachedVotingRewardsParametersDto = {
+  final_reward_rate_basis_points?: number;
+  initial_reward_rate_basis_points?: number;
+  reward_rate_transition_duration_seconds?: number;
+  round_duration_seconds?: number;
+};
+
+
+export type CachedNervousSystemParametersDto = {
+  default_followees?: CachedDefaultFolloweesDto;
+  max_dissolve_delay_seconds?: number;
+  max_dissolve_delay_bonus_percentage?: number;
+  max_followees_per_function?: number;
+  neuron_claimer_permissions?: CachedNeuronPermissionListDto;
+  neuron_minimum_stake_e8s?: number;
+  max_neuron_age_for_age_bonus?: number;
+  initial_voting_period_seconds?: number;
+  neuron_minimum_dissolve_delay_to_vote_seconds?: number;
+  reject_cost_e8s?: number;
+  max_proposals_to_keep_per_action?: number;
+  wait_for_quiet_deadline_increase_seconds?: number;
+  max_number_of_neurons?: number;
+  transaction_fee_e8s?: number;
+  max_number_of_proposals_with_ballots?: number;
+  max_age_bonus_percentage?: number;
+  neuron_grantable_permissions?: CachedNeuronPermissionListDto;
+  voting_rewards_parameters?: CachedVotingRewardsParametersDto;
+  maturity_modulation_disabled?: boolean;
+  max_number_of_principals_per_neuron?: number;
+};
+
 type CachedCountriesDto = {
   iso_codes: string[];
 };
@@ -171,6 +214,7 @@ export type CachedSnsDto = {
     functions: CachedNervousFunctionDto[];
     reserved_ids: number[];
   };
+  nervous_system_parameters: CachedNervousSystemParametersDto;
   // @deprecated
   swap_state: {
     swap: CachedSnsSwapDto;

--- a/frontend/src/lib/types/sns-aggregator.ts
+++ b/frontend/src/lib/types/sns-aggregator.ts
@@ -52,7 +52,7 @@ export type CachedDefaultFolloweesDto = {
 
 export type CachedNeuronPermissionListDto = {
   permissions: number[];
-}
+};
 
 export type CachedVotingRewardsParametersDto = {
   final_reward_rate_basis_points?: number;
@@ -60,7 +60,6 @@ export type CachedVotingRewardsParametersDto = {
   reward_rate_transition_duration_seconds?: number;
   round_duration_seconds?: number;
 };
-
 
 export type CachedNervousSystemParametersDto = {
   default_followees?: CachedDefaultFolloweesDto;

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -177,37 +177,37 @@ describe("sns aggregator converters utils", () => {
         ],
       },
       nervous_system_parameters: {
-        "default_followees": {
-          "followees": []
+        default_followees: {
+          followees: [],
         },
-        "max_dissolve_delay_seconds": 252460800,
-        "max_dissolve_delay_bonus_percentage": 100,
-        "max_followees_per_function": 15,
-        "neuron_claimer_permissions": {
-          "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8]
+        max_dissolve_delay_seconds: 252460800,
+        max_dissolve_delay_bonus_percentage: 100,
+        max_followees_per_function: 15,
+        neuron_claimer_permissions: {
+          permissions: [0, 1, 2, 3, 4, 5, 6, 7, 8],
         },
-        "neuron_minimum_stake_e8s": 100000000000,
-        "max_neuron_age_for_age_bonus": 252460800,
-        "initial_voting_period_seconds": 345600,
-        "neuron_minimum_dissolve_delay_to_vote_seconds": 2629800,
-        "reject_cost_e8s": 5000000000000,
-        "max_proposals_to_keep_per_action": 100,
-        "wait_for_quiet_deadline_increase_seconds": 86400,
-        "max_number_of_neurons": 200000,
-        "transaction_fee_e8s": 100000,
-        "max_number_of_proposals_with_ballots": 700,
-        "max_age_bonus_percentage": 25,
-        "neuron_grantable_permissions": {
-          "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8]
+        neuron_minimum_stake_e8s: 100000000000,
+        max_neuron_age_for_age_bonus: 252460800,
+        initial_voting_period_seconds: 345600,
+        neuron_minimum_dissolve_delay_to_vote_seconds: 2629800,
+        reject_cost_e8s: 5000000000000,
+        max_proposals_to_keep_per_action: 100,
+        wait_for_quiet_deadline_increase_seconds: 86400,
+        max_number_of_neurons: 200000,
+        transaction_fee_e8s: 100000,
+        max_number_of_proposals_with_ballots: 700,
+        max_age_bonus_percentage: 25,
+        neuron_grantable_permissions: {
+          permissions: [0, 1, 2, 3, 4, 5, 6, 7, 8],
         },
-        "voting_rewards_parameters": {
-          "final_reward_rate_basis_points": 0,
-          "initial_reward_rate_basis_points": 0,
-          "reward_rate_transition_duration_seconds": 31557600,
-          "round_duration_seconds": 86400
+        voting_rewards_parameters: {
+          final_reward_rate_basis_points: 0,
+          initial_reward_rate_basis_points: 0,
+          reward_rate_transition_duration_seconds: 31557600,
+          round_duration_seconds: 86400,
         },
-        "maturity_modulation_disabled": null,
-        "max_number_of_principals_per_neuron": 5
+        maturity_modulation_disabled: null,
+        max_number_of_principals_per_neuron: 5,
       },
       swap_state: {
         swap: {

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -176,6 +176,39 @@ describe("sns aggregator converters utils", () => {
           },
         ],
       },
+      nervous_system_parameters: {
+        "default_followees": {
+          "followees": []
+        },
+        "max_dissolve_delay_seconds": 252460800,
+        "max_dissolve_delay_bonus_percentage": 100,
+        "max_followees_per_function": 15,
+        "neuron_claimer_permissions": {
+          "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8]
+        },
+        "neuron_minimum_stake_e8s": 100000000000,
+        "max_neuron_age_for_age_bonus": 252460800,
+        "initial_voting_period_seconds": 345600,
+        "neuron_minimum_dissolve_delay_to_vote_seconds": 2629800,
+        "reject_cost_e8s": 5000000000000,
+        "max_proposals_to_keep_per_action": 100,
+        "wait_for_quiet_deadline_increase_seconds": 86400,
+        "max_number_of_neurons": 200000,
+        "transaction_fee_e8s": 100000,
+        "max_number_of_proposals_with_ballots": 700,
+        "max_age_bonus_percentage": 25,
+        "neuron_grantable_permissions": {
+          "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8]
+        },
+        "voting_rewards_parameters": {
+          "final_reward_rate_basis_points": 0,
+          "initial_reward_rate_basis_points": 0,
+          "reward_rate_transition_duration_seconds": 31557600,
+          "round_duration_seconds": 86400
+        },
+        "maturity_modulation_disabled": null,
+        "max_number_of_principals_per_neuron": 5
+      },
       swap_state: {
         swap: {
           lifecycle: 2,

--- a/frontend/src/tests/mocks/sns-aggregator.mock.json
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.json
@@ -22,99 +22,168 @@
       "archives": ["zmbi7-fyaaa-aaaaq-aaahq-cai"]
     },
     "meta": {
-      "url": "https://dragginz.io",
+      "url": "https://dragginz.io/",
       "name": "Dragginz",
-      "description": "A virtual pets game from the creators of Neopets.  Non-profit, 100% on-chain.  We've got baby dragons, crowdsourced world building, magic spells, and a prince in disguise!"
+      "description": "A virtual pets game from the creators of Neopets.  Non-profit, 100% on-chain.  We've got baby dragons, crowdsourced world building, magic spells, and a prince in disguise!",
+      "logo": "/v1/sns/root/zxeu2-7aaaa-aaaaq-aaafa-cai/logo.png"
     },
     "parameters": {
-      "reserved_ids": [],
+      "reserved_ids": [1001],
       "functions": [
         {
           "id": 0,
-          "name": "Unspecified",
-          "description": "Catch-all w.r.t to following for all types of proposals.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "name": "All non-critical topics",
+          "description": "Catch-all w.r.t to following for non-critical proposals.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 1,
           "name": "Motion",
           "description": "Side-effect-less proposals to set general governance direction.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 2,
           "name": "Manage nervous system parameters",
           "description": "Proposal to change the core parameters of SNS governance.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 3,
           "name": "Upgrade SNS controlled canister",
           "description": "Proposal to upgrade the wasm of an SNS controlled canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 4,
           "name": "Add nervous system function",
-          "description": "Proposal to add a new, user-defined, nervous system function:a canister call which can then be executed by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "description": "Proposal to add a new, user-defined, nervous system function: a canister call which can then be executed by proposal.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 5,
           "name": "Remove nervous system function",
-          "description": "Proposal to remove a user-defined nervous system function,which will be no longer executable by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "description": "Proposal to remove a user-defined nervous system function, which will be no longer executable by proposal.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 6,
           "name": "Execute nervous system function",
-          "description": "Proposal to execute a user-defined nervous system function,previously added by an AddNervousSystemFunction proposal. A canister call will be made when executed.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "description": "Proposal to execute a user-defined nervous system function, previously added by an AddNervousSystemFunction proposal. A canister call will be made when executed.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 7,
           "name": "Upgrade SNS to next version",
           "description": "Proposal to upgrade the WASM of a core SNS canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 8,
           "name": "Manage SNS metadata",
           "description": "Proposal to change the metadata associated with an SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 9,
           "name": "Transfer SNS treasury funds",
           "description": "Proposal to transfer funds from an SNS Governance controlled treasury account",
-          "function_type": { "NativeNervousSystemFunction": {} }
-        },
-        {
-          "id": 11,
-          "name": "Register dapp canisters",
-          "description": "Proposal to register a dapp canister with the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 10,
-          "name": "Deegister Dapp Canisters",
-          "description": "Proposal to deregister a previously-registered dapp canister from the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "name": "Register dapp canisters",
+          "description": "Proposal to register a dapp canister with the SNS.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
-          "id": 1001,
-          "name": "addNewSnsToTaggrBot",
-          "description": "Adds a new SNS to the @snsproposals Taggr bot",
+          "id": 11,
+          "name": "Deregister Dapp Canisters",
+          "description": "Proposal to deregister a previously-registered dapp canister from the SNS.",
           "function_type": {
-            "GenericNervousSystemFunction": {
-              "validator_canister_id": "thhc2-kiaaa-aaaao-ajnha-cai",
-              "target_canister_id": "thhc2-kiaaa-aaaao-ajnha-cai",
-              "validator_method_name": "snsDataValidator",
-              "target_method_name": "addNewSns"
-            }
+            "NativeNervousSystemFunction": {}
+          }
+        },
+        {
+          "id": 12,
+          "name": "Mint SNS tokens",
+          "description": "Proposal to mint SNS tokens to a specified recipient.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
+        },
+        {
+          "id": 13,
+          "name": "Manage ledger parameters",
+          "description": "Proposal to change some parameters in the ledger canister.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
+        },
+        {
+          "id": 14,
+          "name": "Manage dapp canister settings",
+          "description": "Proposal to change canister settings for some dapp canisters.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
           }
         }
       ]
+    },
+    "nervous_system_parameters": {
+      "default_followees": {
+        "followees": []
+      },
+      "max_dissolve_delay_seconds": 252460800,
+      "max_dissolve_delay_bonus_percentage": 100,
+      "max_followees_per_function": 15,
+      "neuron_claimer_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8]
+      },
+      "neuron_minimum_stake_e8s": 100000000000,
+      "max_neuron_age_for_age_bonus": 252460800,
+      "initial_voting_period_seconds": 345600,
+      "neuron_minimum_dissolve_delay_to_vote_seconds": 2629800,
+      "reject_cost_e8s": 5000000000000,
+      "max_proposals_to_keep_per_action": 100,
+      "wait_for_quiet_deadline_increase_seconds": 86400,
+      "max_number_of_neurons": 200000,
+      "transaction_fee_e8s": 100000,
+      "max_number_of_proposals_with_ballots": 700,
+      "max_age_bonus_percentage": 25,
+      "neuron_grantable_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8]
+      },
+      "voting_rewards_parameters": {
+        "final_reward_rate_basis_points": 0,
+        "initial_reward_rate_basis_points": 0,
+        "reward_rate_transition_duration_seconds": 31557600,
+        "round_duration_seconds": 86400
+      },
+      "maturity_modulation_disabled": null,
+      "max_number_of_principals_per_neuron": 5
     },
     "swap_state": {
       "swap": {
@@ -122,6 +191,7 @@
         "init": {
           "nns_proposal_id": null,
           "sns_root_canister_id": "zxeu2-7aaaa-aaaaq-aaafa-cai",
+          "neurons_fund_participation": null,
           "min_participant_icp_e8s": null,
           "neuron_basket_construction_parameters": null,
           "fallback_controller_principal_ids": [
@@ -139,12 +209,15 @@
           "transaction_fee_e8s": 1000,
           "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
           "sns_ledger_canister_id": "zfcdd-tqaaa-aaaaq-aaaga-cai",
+          "neurons_fund_participation_constraints": null,
           "neurons_fund_participants": null,
           "should_auto_finalize": null,
           "max_participant_icp_e8s": null,
           "sns_governance_canister_id": "zqfso-syaaa-aaaaq-aaafq-cai",
+          "min_direct_participation_icp_e8s": null,
           "restricted_countries": null,
-          "min_icp_e8s": null
+          "min_icp_e8s": null,
+          "max_direct_participation_icp_e8s": null
         },
         "params": {
           "min_participant_icp_e8s": 10000000,
@@ -158,24 +231,58 @@
           "sns_token_e8s": 314100000000,
           "sale_delay_seconds": null,
           "max_participant_icp_e8s": 100000000,
-          "min_icp_e8s": 5000000000
+          "min_direct_participation_icp_e8s": null,
+          "min_icp_e8s": 5000000000,
+          "max_direct_participation_icp_e8s": null
         },
         "open_sns_token_swap_proposal_id": 93763,
         "decentralization_sale_open_timestamp_seconds": null
       },
       "derived": {
         "buyer_total_icp_e8s": 314100000000,
-        "sns_tokens_per_icp": 1.0
+        "sns_tokens_per_icp": 1
       }
     },
     "icrc1_metadata": [
-      ["icrc1:decimals", { "Nat": [8] }],
-      ["icrc1:name", { "Text": "SNS-1" }],
-      ["icrc1:symbol", { "Text": "SNS1" }],
-      ["icrc1:fee", { "Nat": [1000] }]
+      [
+        "icrc1:logo",
+        {
+          "Text": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAACXBIWXMAAAsSAAALEgHS3X78AAAgAElEQVR4nOy9d5glR33v/anQ3SdPnp3NSVmrLCEhiaCIEAIkUABhMMlcwBjbgN/XNr44YexrwsXGNsbGgMGAjAADBhNkEAIhlCWUd7WrjbOzMzvx5NPdVfX+UadnZle7q1VA+Hle/Z7p55zpWF2/b/1y1YHn6Dl6jp6j5+g5eo6eo+dofxJPcOxQx5+jJ0G/7M4UgHyK5+uDXJu1Vz2Ndj1H+A7MOvOXAYLFzHwy95fsy9z9QVAElnS/K54DwlOirFMLAnq63HkmQZDdKw+seRLnh8B/Ao8C/wgc392/GBR/ATjgXYuuXQzm5+gJKGP+tcBOYEbABd19z8RoyhgRAd+JdGikEMfs9+xDXbMRz2ALxMBrusfC7uffd48b4OvAmYva/hwInoAyBr9Y+E5MN5R63anlys8A5JPT14d8hoBPgHCnDq5wa0s9n/T7xKEAlj37NGArvn0OaADHLjrvld39bTxIHPBhPHgW3+c5OgBlDPisEjhEofPrS9cl39xwkgPepvz4CZ7G/bPOPxVIpc6lv7HyWHflsjUzwCopxOJzDnV9H/B24AE8g/9Xd38mBT7NAgiS7vfv41XOEz3j/9eUdcz3tJSOsJBetWSVdedc4K4eXlYDTtWeSfop3j+77hOBDlyQLyVXLV2X/vWxpzgt5N91jwXddmTbgSgT5SXgMmDpfu0XwD/gGR8Dne73H3evWXyP/5H0q0aolNIL/FQg0tTY/7tibWlDqfyN1LmjNaQcWhJknRuwYO1L/HV54KWBDkA4ubHTFEPFPGf09V8GVKQQ2Yi13S3PwsjeAPwxMMgCmL4N7Ok+px9YiWfyO4Hf7LYhwIPgRcB38OrAsa/LqPkfBIpfNQCEUgoEVG1C1SEHpDZfPeLYlesLpR+mcIr2jNp/tGadncN3qux+191PgJOFEOuREpyTVZvKsbhjrli3ejXwBwLKwOnAicDR3Wvi7mcd+A9gFg+KV+DVSRHP1AYeNGuAs4GbgI/hmR/hAfhCFlRGpvJM95jjf4ix+KsCgOt+lqXSBAJ2JDE1a5mNU3VEFJrvH7th+fOHRn6SOnelgkQIIYHCojY7fIcbPDNa+E79I+A24JtaBwghEIATsLPeVCcv7ed5S5f8nnFuVArxE+DnwH14ff5pvNv3p937JsBxwMvxgNgNPAhcD1wKzAC3AA8D7wWOAV4HfBnP6Jfs994fAP4foLd7/185AH5VDRB4Bt4RRdHpQRCY1Dr1nXXHc4RRhDnHQE7ahtLiXRPjfHHLox+Txn4MIWrWOYMXwSN45jwE/B4wAFS7x04WQvTk83knhRAGyKF5w8hyTl/VR74v5678xs2iGErX7LRxzu3fDxaYxjN8CPgMsB14M3BW97jES4z/AD4O3MECUx2wDO9J/AAPVICbgXOAceA6PCCqi6551ulXDYCfCCFeUCoUTM0Y9f6l63hLvpeqaXHEshLOWJc3yn5CGPVHDzzwi8bs3JeVEKFx7jy86B5gXx2bkQuCwEVRJJ1zKCGopob3L1vLq3oGWX9aD2+/c6O77r5d5FRCO0lgwZWDA4vnDrAXWL7o3Ow8B9wN3AXUgE/gATOIlwjf6P5/BnAjXpWA9xguebqd+XToVxW+1PhOPKO7Wam1HE9jXt4zzEynQy+CCCfaSSpfjDbnH3P00nslF45OTp2npVwrpcxb5zLmZ8ack1K6IAhkGIbzDBRAKhyt1PB7lWFUu825pw2JH+6sidFaW2hhhHX72BjZPTNAGLzN0cO+xmZ2TOCBcSreJrgWbyfcgQ9ufRF4HvBTvNcwAqzvtvkzeHXxKxmMvyoAZB0cAtcYa11eB3J3ErM6V+DYsMieJGY4r1FC0EhTua7asK9dt8a6tSvsnXunSVqxKBULUgdaKKWF1lp2GS+13td7dEAkBFuTmFN7Chyf5AhDy4WnDHPTjibj9SZaWOzj25hti0Eh9jsnO2YXbZnb+Hrgm3g74beB3wCOwgeMfhf4O7ydkTXzWadfdQJjJz7EOmCttVoH4rG4xUt7h+hYSzuFAaWQQtCRQujJOXlpVJIvOOt4sSWU4tGdE2AhnwuRQoI4+CCSQtBxlpoxvHagn7nJlKVDmlecOMIDe2K21NsUcgFKKZTWaK0JgoAwDNFaI6XEOSe80DkgLZYMmUTqw0cMz2QhV7AeeBPefrkNb2ssViXPKv0qARDgI2gl4ALnnMkpLcdtinSS8yp97E5ShBP0KoGzDqskrVqT9eNNXnPUGlaetp6Hag3GxqYQSMJQ4Q7Sh5kU2NjucFaxxAm5HNPjMUOrAq4+YTn1WcUte2cJIkWkNEJJpPRSXgiB7oIiky7W2gM+p0sZGCxeRRRZ8P9NtznHAW/r/n9L91zFswyCZxsA2ejI3LkU3xGXATiBKAYh9zWbbIhKHFHIM9pJUFJSUQprHUIp2tbCjinOjiVXvvBEykcv58HxGaYmZ5BCEQYHBoIEOs6yNU64dnCANElpT6aUjpVcdmI/69s9/HDnFHMiIUJiD3QPKdFao5TCOcchJAIsAGGx6sikhMH3/0XAhXj7YJIF++hZoWcLAIv1ZBbZC/HBkz/uHhNSSsIgIMFyd6vGBYV++kPFrjhFSkG/1l3zW+AiTbPeobBxgotLFS6/6GTya4fZODbD1NQsIIlCDQIyHjkgJyWb221AcelAL3tn2qQzhtw6y8lHFrhQDnD3rgZbbYecEPtAQAnhmQ4IIQmCACkl1trDAcLB+sQAq4E3ApvxeQfNsyQJni0AOPwLH4cf/SfjQ6UXs2h0SCm9/gWmTMojzRaXlgYoa8mOTkqCoE9rjyQHUklspGiOzdGzcZJLlwxx+aWnUVm3hMcmakxMTGMNhIFGygXmRVJwU73KmlyJ51fKbN45RyQCcitg+XLFVZVh9u6x3NWpoedZJ2kYixSCQIp5CaOUQmuNEOKJ1MKBKJMQBj8gru72x408S7z5ZT8kE38X4S3fW4C34K3ffrwKyEbCvHh1QE4otqZtNrU7vKTUT4+S7IpTaqmlJ9DkhSAL34hQYbSgsXWa3of3csmSIa687FSWH7+S3dUOu3bPEMcxgdZo3fXeBHx/bpYTihWOiCK2b2tQqEQEA4JwMOWKniVM7nb8vFUlxXJ6scLvLFnOz+sNZm1CvmsfZMM0sw+cc08FCItdygvwIeb/4FmI1P4yAZBZtcN4pv8Eb/2+hYMEXDIAADgceSl5NG3xi1aD84p9LA0CxpOUqSRFS0lRqXlLC0DkNUZAfcteCveP86JSD9e+5BROOutIqkKwbfc0jXoD5wSFICDF8e3ZaQajPMdERRrbEpzQuEqAGjBooblu816khgjJZ1at5BU9PWxqGR5pNwmVQLKgJoQQBIH3JOAJDcUD9ZfEh5efj4+PXMeBA13PGP2yAVDCv9B9wEfwkiBlIYGz7wXdDszIAXkh2Zq2+XFzliOjIkfm8sTOMZ4YGg4iJSlIgRCCLCwkI40V0Nw6Cffs5tRY8tqzjuKC848nt6SX3dU2E3vnsJ0UKwU/alV52HRQShPtcfTEIaXhiFKv4PpHpqgmhrZznF+ucFqguWrVIJocN03OYrUjEHIfhf0UgWC6ffIufIbxQ8CL8UGkrD+fcfplAiDCN/p4/Og/Gs/8g6ZDM3drMXl1IJm2Cd+vT1M1lrVRgaEgpGlhLDa0LOQE5LqJn2xMypxGhpLWxBzxvaOsHm3y8uVLefVZx3PMyStoFwJ2723QqjXY2qzzw06Nn5gGD+9sMDqaMDKcZ2/TcNeeKokUnF0qcVIQ0eg1vPTCQU5Me/nh6AwzLiYv9eO8hsUeAzwhEDI7qQN8Fl9m9hf4COJ1LKjTZ5SeaVRlElnjmX0GPhmSZb8OCrissxZLgAPduGEsS3WOi0r9nF/pY3WQx1kLzlBE0hdARUIkusJZOIxwOATEFtMxBH0hpf4ezFF9bFwd8c2Ne/nOHdu4b/Mu2rUqaAEyYCAM6Y9CxhsxVZfytsFhPrViGdNxTO6CiEJ/xMN3W17/35u4qzlDT6RID8JkIQTGGOI4xhhzoFMyUd8CTsHXJK4G/hv4ET61nPXrM0bPpATIeKTwzD4Ln+w4KPOzER+G4XzEbb5hSuKsxViHkgt6NicldWe5u1nlpsYcG+OWVxVKo6WibaFuoO0siXM4BxLpXTgrKZxZJP9iTWO8SfOGvayYrXLBmRV+/cxVvOSkIxhZuoR2CtO1NrV2m1pqiAJJ6iBxjtf29aNTh5QKNwwjSyVXrR7hoV0J981UKQTqgPGD7H2DIDiYoZi5hCFebd6Izyf8PfDn+DqHW3iG4wTPJAAccC6wCy/2f4C39B/HfKnUPNMzX3qfRilJrdYkF+XoKZVodtqIbpjXAqFUlHTAdNJhW7vJTc1ZbqzPcl+7wY40ZtqkTDvLlHNMG5hKJTMGmoklLQkK/Qo77pAdSXvG0N5WJ98/x6qgzvkrcvz6hmEuWtVHJBXb5hKmGh1CLZk2hvMrZY4KIlqtlNzKkNQ6ij2GK48Z4rE9KXdO1ChEEnuIuIDWGmvtwUAg8BLgO/gKJAvcgE8a/QzYwTMYMXwmAJDppkuAK/EZsB/j6+f2Yb7WmiiKyEeRD6A49zgdpJSkWm1w8YtP4q8++Cb+66b7qc/V0drfJhsmF/QM8+rKEAXpE0Z1Z9iWdLgvbnFXu8Ed7Tp3txrcGze5L2mhUsuADoinDNF2h5qyIB0yFDALVmrkMk1Sb6PTNqv7NC87pp/XHDVAhRybJtpMJU0KYchlw/205jrIiiIcDEg6ApUzXH7cAJvGOtw1USMfqkMGh5RSpOnjpHnmOeWAl+HVwWZgDD+Y/gJfsBLzDKnvZ+Immcj/AvAVvBV7MQsGH1LK+dEugFqrTT6KyGlNK4npVul2md/k2ledzWf+5bcI79nFtb/2ca6b2kslUJguYCyAE7x1YCWv6xlmJukwnibMOsOsMbStxWCRDnqk5oR8xFFhSEUJIgHOWqz0ry+kQKQOJ6D0kjwqZ33eAQHWEWiBUAHbbmjzJ49s4zuNGW45+USWKUEqU8rnFXHGYRwE0tISZS791/v4ya4JeguaxBxYIWQ2QavVOlCfZvMNND44dD3eiH4E+CTeS8j6/Wkz75mgEJ/2fD9wBYuYH4YhURQRhgHtVpumMZx25GouWrWc0VqTaruDlsIzv9bixWcfy79/6b20b94Kn7mRdfk8X9oziVuk9jQ+CHRzfZbHkg6nFCqsCkL6VcDqMOLoMMdRYZ71QY5jo4hzSiF56VDOYbE4IeahL6xDKHAJqD6JyEuIQeELSawBIxN6Q8UrG0PcmdR5eKbBZSuHqHcMQV6iehVYMIkhN1jhnBedyfU/vp/JZodAS2/DHAAFUvqE00EkQSY9E7xHUANehS9FuxHYxjOgCp4JAFTwBZbX4AFgAK21JpfLEQQ+lVqt1ll55Ao+9vpLeVehn7urc/z3lp0UQ40TYIylkAv50hffy+CmKu3Pfh+OgHxvwLc3TTLejgmVxCJoWUsgBHmleKTT4OetOUo6ZEWYQwBNa2g5SwdH2xgC6cgriRU+j2ABhGey6H4XSOSwjyiaRGBji0kA4xAGkryjMQ6nyiIfnhrjhaLI8FBEp2WIRiRYgdQaMz3N0OpB1g8vZWayxp5mwlwrJgqUN0T3Z4BS89JgP8oipMfg7akxfOlbD74a6nM8A4UkTxcACjgPP3nifUAkhBD5fF6EYdg13By1WoPXvu58vvT2V/GC/9rI3bNTfH58LxOzdQLtR0G93uAdb7uUN553OlPvvY7CKkESSXoIuGH7LI/M1dFS0K9CzisP8EC7gQMqSjFrEm6qz7IlaVFRAcNhjrLShF2VWk0NCEleSvJSUNGCSEgSHEJJRAqyrBFrA2y3rMA5n2+wVpAagZOWVAmWTIU0Zcq/Te7lteV+mj0CHTh0UWINyEDjpiZZV4Qr1lZ49XFDTDYtD040iK0lUo8ftAcBQWYPKOByfHHJEd1jd+PnLY7yNOMDTxcA2TSo/5durVwURb4ixzkQ0Kh3+LM//zU++tJzCP7yBvbsnuSBI0p87aHtGGuQ0o/+XBjxNx/+DXL/dgfq3u3I4wpY4SiqgDvGGty2Z4pcoIit5S+GV3F8UOCeTpMpExNKSV4otsUtbmxMc3erxrRJsUIQCkUgJTUDs8YxlcCtjSZ3xg2OzkWoGAgF4rg8LufASm+8Cek5oOR88klXoJnA2UmJ/2pPM15NOKe/TNwnCELZzU34YJRK20ShY0lFcfUJA7xweR+bRg2b600C9XiuKaUOpA4yEBTwIfUsd/I94P7uOVlR6VOipzrzBjx42sBr8WIqVUrpLCEipaBWa/GRj7yZ95x1Mnve8SXKxtAZLLArTZipt8mFEikE9WaTSy46naNknr3f+wV9pRBSA8rhSDimL4/35qFmDZs7La4pDXB8UORrzWl+0JhhT9pBCoFG8HC7zoOtGpFU9CpNWWokgra1SCk4K1/gNysDRAl0hhTi6ADKFhx4JZPlj4WPV6egnB+huSMUNpB8OFjPR/eMce9Ym+OGI+iXCOttEycApcFBEjtsanjRiUV+oI/i//7nbj7U2EnHGiIh5y0b59y8l9TpdBb38+Kax4zRxwFb8FnV0UXnPGl6qgDIUpgn4vUSgApDP7HGW/N13v2ul/Oey85h9A2fpSRSCBSdUDKdJKSpQUZZGZfhhS84EW7fSlJtIoZ7kQacliSJ48iegHw3S2iBx5IO7YLh6KLi9/USri32cmu7we2dJluSFjMmpW0NsXPMpilSwxG5HOeUe7kiV+EMXSAdgWS1pa9cQDQkyW5DGhtIDCIF6xypApeXiAKIPPOuqFoLg0OaP5xYQ7sSYy2kLdD5bu1BlxUChwrANaG62VA40vH+DSOcsqXEm6c2MZMmRFLsA4IgCLDWkiRZqWD3Vgv1FODXJZjEG9+9+AksT4meDgAsvrAxD6RBEGivy6DR6HDyCev54/e8mtH3f4toto7tzWEaKWk5pNppgvPv4qwDodiweoTGDzbRRmBiRxBbdNERWcEZq0ssL4bsanZQQnJf3KRtLEvyliAURO2Ao4I+rin1UnUpc9bQdhapBAOhZlUYMBQGBLEgrUDzeCjIkNZOww13zPLQdJ0OliCQBFKggVN6S5y+JqIpDQiBDCQ65yWWwOFKjoEhgxIaIxym3R35DkB4OwLfS7rfkW51dHY4Os8zXLq7zBeXr+eKnY+SYlCLMorOOcIwxFp7sJAxLKjuHXjpe+sinjwpeioAyEq5VuODFQAqC3Fmxswf/sE16J9uo/WzTRRGyhAbROSQSxXxZte1vAWpsZQqRZYqTXXTGB2taKeWYBqKa3NsnGzwidvHmYlTtPTp13tadR4zCVENllUUI0VJx1icE4wQEIiQANDdmoEYR7NlcP2GcINAP6b51C/G+ODe3YzaDlILnr9ygDOX9rC2p8DynoDKYIDtV1RCseCMxY4ktb4YxUmQrjtDRCLybj4bicuqkDwKXCLIr3U0fmGQTjB3aswF9xX545HlvG/XdiqBxOznJ0ZRRKvV2j+YlP1T635uwWdY4SmGh58MADJ8Z0h7B37WTKq11lJKhIB6o8PZZx7LJaccw853fI5cKcJZizMW0SuQeYF2wot+AdYYypUy+bkOzdk6qQAtoTYp+eC3RvnUwzuYaSUQess9JyVzxvDp6l7+un8Fo7MxIxXl3bxuhYgBUuuli5QgLMgehT0mR3ssQU5DpaQ5p1NmdyfHlEm4d+sUP9u8x7+oUvRGmmWFkPV9JU4ZKXHGihKnjxRY0huABBcb0hSEFMiue7mYRV4COJwTCAc2kRSPl1RvM4glkvpQwtv29vGV4jR3tuoUF6kCWAie7WcPZADY0v1sAU181HWMp2ALPBkAzBe/4AMS13T/V1m6UwiBswnXXHMe8p6d1DaNkVvSg8ASO8gVFSGCfCAXYvvOEeVCzGSNpJMyUi5yS9zmAw9t5hfVGjqU9BcCzo7KbI7bPJK06FOaG2rT/JlQvKdnmGILinlJUQmMAOFAaoHF0bYWKwXmyABXEMg1AW6V5Zp4mNc0R6jOJVSrMZNzhi0zCXdUa9zVqnN/0uDB2RYP7m3wrY17kUoxUgo5a1mZVx49wMuO7GGgL+gCwSFkV1F3Y0zt2IEU5ANvzwoETmhKp8Dcz1LiimSoKHhL7yC3N2sIIVkcLcqMwjRND6QKphd934mXxr80AGQ3HQCm8LNfvtjdjxBCZFm8NDVUymXOO+NYJv7xx6RKIvGiMbBej+akoxJqokBjbBbadYi5Bn0qz2dqs3x0cpSWNehQsVyFnFXo4fX5PvIBvHtiBw92GlRUwNerE9zfqfPqQh+ndPKsL4SUlSRxjkeTDm3nuCwqYZdrXB+4jkEIiZBQ1QZbMYg+6BERg4nkhKbmldVBmnMp28fbfGZsip8lc4x22jSNZbaV8h+PTPH1R6ZY3ZvjdRsGefvpI6wcCjGdFGN85lKIbgZnU40LjihTjgSpcQgrkHlN+VTL3M0JtVBzfrHM0iBkxiReZS3ueCEIw3BxuDjzAkYWnTaKn2vAk2X+4QIgowIeAK9jURw6K4gUAtrtmDPOOJYVBGy9fztJ1M1cdnWik9CTtywrBPTn8sy0WwghSGNDda7FByd38BVbJcRLiPdWBlkb5nnXxChfm9vLRcUe/nbJKr42N8U/VycpK8W2uM1ftjNPyI+0fqU5O8jxO8PDaCVxKxRSCaxU3qF3YIVDG4uzvvw7lo5WwWDLIJYJjlxf4D17ciT3OK4bb5LKFCWhHHo/f0+rxYd+uoPP3LOX3zxjKe8+ewmVgiRupVghKRUkp67I8c93TPLOM4eJtM8XyEQQDIaUTobGrSlLo4Cjwxw/bsaUhdynnN05N1902o0PZAA4Db8+wW78VHaBn3vQ+GUAIDNtduKlwEXAv+EjU05rnUkCrE057rjVBLtnqE3XiIs5pJMI4ZDOkVroXZayekYy3FtkfFedXKhIqi3e/qObeTieJVCKHiX5q75lXFmukCsqvtSc5uZ6ne82ZhlPE/55ZBW3x03u7jQoCEmfDlgf5ulTig1BxIvDAs+LInqLEY28IzcIUjqchNQ6rBUY43BOgvWzhjDW1/dZgROCWEne88ijfH3XOMWgW1yi5HzpWT4nKYcB9Zbhf9+4jX9/aC8fvXgNFx/bQ9pOaCewekmO0+di/uTGXfyfS1Zh09TbPR1BtDqkPWkINsOaMA+NOcQBBHjmGu4HgEEWFdPig0GDXQA8KTVwuFWn2XkvwYNmGkBKabtTpuZbsnrFIO2te6knFoRvoxACpEC3LONzKfGM4IiRfm9RCkGz3WHL7kmclKwNQv59ZC2XF3qIQ0uoJK/s7cE6S79W3N1p8PaJXfTrHNI5EiwlqfiX4VX808AKfrs8yMmFArKgqVuDLAoIwAkHGnQkiPJQyAvyBYjyoAKHUD4zaHFUIsWf3LaDGzbPclSxjHEWKSXNRpO5uSrVapXZ2TmmatO4IKG/oHl0ssXLvvQgv/ftnaRocqGgWUt40TE9lHKSD/54FF3QmG44x6WCwrEBwWDAkjUrwBw6ddy1s7JYQBk/tTyzG2dZWL7mSUUFn2zZ8WX4xQ8GYEH8L6a+Yp7arhlSocAJUgsIidTQnLbccqvlhLLi3KVleoolktQQKklbCU4Ic1w3soZjZEASGnKBJLWOc4olSiqg7RwVJbm3U+cnjRly0huVjyVtftCq+krTHJQKCh1IBAIRZW+ZBfnBOYGTAqkFQQ5yecgXIIygryi4Z6LGLaM1ThvoZXdcR0tFvV7n3Becyz/8wyf58pe+xL98+tO89U1vBBwtEnKRoBREfOSWnVz4uYfYOB5TKAYk9Zj3nTvEDx6b4Z6tdcJIeN1pQWoQLyphV/VBYkAenHeLqqWyk17Nwsomu/ASGp6kHXA4AMhSk314t+P/AOdKKQmC4HGTJTWWuNZCSF8pG1t/g0hLtjUMs1XH2qWCi1aHlMMAKaBmLSeGeb4wsobBRNGyjnLO5+oS51gbRIxo7Uu88CV7SmTln4JAwEdm9vCoTSkIiRNd9wu6n2LhTboVxF0XHb82hEBIiQqBAuzsGFYXS+xo10mBer3GVVdfyX/f8N+84x1v56qrr+bNb3kLAytW0Gg2EUqSiIRYtektam7dWeMFn32QL945hdYh+b6Aq44a5FN37vU+rvUegksMrB1mWh6ab5kt0B1smRTowReLXoy3A0az0w+Dp/N0uAAAb/0/gl8rb00Yhq67bMs+p8adGBOn3q1B0jA+6CO1ZGOnhdQpYUnzz7ftZNfMLKkQrNMR/zK8mn6jSJdKepfqbqBQYqyjIjVLgoDU+cBLRYYYfN2fRJATitEk5rf27mBLxxKhsM76Ed/xab39Jw6LRZLSZdZ3N4zbnwuZ7iRMxm1snLB82VI+9pGPorWm0WyilOLfv/lNvvDnH+SGDSdzZbGXpnEo4YiJKRUEc3HC67+xidd8ZRP3PtBmZkZw53gDWhYl/TOlA0o9jE7P8ERxHCnlfHUx+4biV+PDVEP78euw6HAAkJ1zBl4CvFUIgVLKHqjkaWa2ns30QwhBw3jjz0nBQ/WYvFZ87vZxPn7rdqJQURaaTw6tYpnUVBNL/4aA0pEal3bdKecIhZ8XiLM0rOHiYoV/GF7DMhVRtYYER4/S3Ndu8PrdW3iwndCjNKlw2LrDdcS+ptGiLnL4Zzjh3zQ18J3HZmkkBiEVcRLzildcxvIVK2l3Yor5HCnw1Y//Df91zLFc2NfPRcVs3QgPq9RZjiyUCCPB1zZN8Yrrt/Cnd2+nEjhQWb7A203tXJ6903NIcegSMmAxABa/xdtYWDIne6XDpidjAxyPX+DgEh/123f0u26b9kzO4JTAdn2HlrPUE4d0MGETvvzYHP/7x9vIRYrEWT40uIwTwxxzxhKGgumbOsS/SJGhd9ect8384fAAACAASURBVB/p1RrX7eC2Tbk8X+G64XW8vbKUvNDMmJSS0jwct7li26Pc1mzSGyrSpsFMW4T2EbmsrVkvKSkIA18AIIWgnViOHSxQiARF6bPdZ599TvdCnya+8ee3cuqjWzhuSR/1Psnq/jIFvAGpEDRczKmFPH81tILjinlkABuG8/zF+cth0UIUUkuaQjFXbaGUOCTrfIZ1ny7PpMDpwFvx6eGQX4IEyMJQR+JFztJFFuk+DQTJ9j0zpMHCvDkD7E1BW0Gg4Rs7d1CPE9o43lIe4opCDzPGoLPQcApzTYMTIKTDSb9/RbfGQAnYYxImTMKS0PGHfUN8cWgNry0NknrVypiJuWzrZr5Xr9MXSNrb2z7pBPuAQCvYNWe4aUtC0F2eNFKCN55aZqgIcerXjRkc6GfxC2+57Q7OHS6QHlUiWg8DI7luKNqHfwMhuLU5w8uLZf6tfyVfuWAlP33r0Tx/dQ9J2rVfHAghiVNHux0j5OOrhR7HLCn3B0HWpNfhk3Lx4y56ons+wfFMcPYAa7N9SinkftOhnAOtJNt2T9OMmK/ll0IynTraRtKvA9CCFpbjwxzv6R2iZgyy+x4OP+KbiWOmakg6BuF8Evi4XA4EBEKyPekwbQxSCgplx0nFkA/1LeXzg2s4J1cmdTBnLa9+7DGub9aoTEN7PEEE7BOrtxaGCoLeguDWHR0m29anfIUjCEBZn6+vVmtdBvh2BmM7WH9ED7MuJShbghGDXQSsUEh2pwn3ph2KwOqmouQUSWr39ZocCOMe50kdlBle9e7Pv8wWuLK7b9Ui3j0hHQ4AAFbgK1JACKGk5Jj+3iyjC3gJEIWanWPT7LIdwlzYNdocygp+3uzw+epecsKPlD/sW0pFKF+WJRwOhxRQCiWDRUUp5611CRjjODVXpE/5Iq+xNGVj0kalCo2gXFAUC4IzCzn+sX8lf9i3jLxQdLC8afsObm62CbekGNvNQnaZZYUgDCQnLdesH9B8+YFZxloGOoql+Rxhl+G33XFHt7MEMbBUJBQChUh9LrAVWGJr5ztTAk1n2Z3EKCmYnkjodNw80LOedcZQsjGVSgFr7KFWuJmn/QCwmEe/iZ+L+aSqvA4XACu7n1aACKKIc49bR0GrfeIXSkua1RZ3TcyS78ljjMU46FGaT82MsSvu0HGWV5V6uTBfYs6m84suFLRgsKCo5L1ODgLp078dQcdYjgxDTszl6VhH4hw/7tSJraDatigEhUBQKSpKkeRtlUE+PriKQaFppAl/NLGHeK8l3t6VAhayueUO6MQw1KO5/OgKH7t5Nzc/ZtlRleQU9IdFvvXt71KtVlFB4Nd7ycS1EZgG9OUVYbhQ+eujhZYpk3pJ2ACtrY+LzReL+KhksTHD6RvWkhrzuAky+1PmDh7AFrD4dYiejw8SHctCBPeQdLgAWAUghbDOOU7bsJ6Xb1jHut4ScWrm6/q7ZYDc/NgophhhDZRlwOa0wXfr0xSkpFcp3lkZInZmPvTZk1P05xRKg+mmVl0iEBWJPCcglYJAKF5Z6cEYS1EKbmjOsdMlNDuONNPvAnoLiigPl5bKfHRgFb0q4Ke1Kj9o1SlsNHSqBqG7UsB5XawkxB3L6oGAVx3by+/+eCN1Y4gixfJSH5s3beTzn/vX+d6olCpefCvB7GzKykjxmiVLaSbJ/MqkIHzACYGTj+9QnPORp53beOt5xxEUSpg0fUJ1cAA1AAvm4xvx08qy30V42gDIaMQ/3P9z6pErWDo6y4uOGGGx3LLOkQ809+3Yw/ZGi5zQlITky/VJWtbQdJarSn0cG0Y0nEU5QX9eUcpJbE82grrdJ/AFmglICW2T8rreQY7KFzHOsTvp8K2WXwpmvJWgRDfvjpcmUQSvqPTwgd5lYC3/ND1N2nHE93W6RTtunlEASgnijuPslQX+7OVHMdtTZOfcNCtURLlY5k8/+Ods2fQoxjpGq22k0KgArBbMbnV8IFrOmwdW0Tauqw4EvVIgEkfPEo3Ki31UJvgVTpJqk3OZ4PfffgX1RhOJQ6lDs+UAAMguOB/4Sxaqh5/QJTxcAAwufBWsWzpEYbTB6eUCJ60YoNFJ56WAVpJau813du5khc7xWNrhxsYMkZD0CcW1pX7a1iCcoCevyIUSYwWk3ovO4OQk2KolvT3FGYik5hfttDs1VpATgq/UJhkVjtmWZbrtK4ZwHkhKCWzO8b8GB7my3M/3Zme5M2lTGnc0N8XIruuX2d4OUALiRPDSEcnX3/Z8LrzqAra2GpyZlpjcu5drX3ctY9u3sSXIMzlpCBJwM5b2tpQkbfPG4gB/NriO5UGRQMALwwJTwPQKv9Td47jhHCKfx2x6lD89qcjvvev1VDuWRq3hf4RIysdJhMwd3G9/9s8wfpHKK/BL1WYFPAelwwVAvtteZBgwUMnTqSX07G5y9SkrfUSr2wTrHHmp+H59L1Vn+H5zlrpJaWO5uFjhmCCkYSylQFGMFs0PbNKdseM3JwRWOVQEkQv4m8kpXrXtYXYlTbTwlvZoEvPl+hTFMGJbLaaRGLScr64DLITwoZEVVJTi01PTqEiTPhzTGUsRoT9NLLZjpCDupAw9cg9fvXQNf/Opt/Kya89j/ZIV3H7nnVx24UWMSbhrLKWy0VHeLsh3ICcVLSmYEpaJuMnVYQ+jrYQfDrVZuizyJUoHEMjCOVy+gHnwXv56A3ztA2/i5DNPpe4s1VqDNPF2klzE8P2igvvcDu8VPB94waJ9B6UnshgzN/Aa4EQQNl8syDe/5Gwat24lX00ojBSIC5p7t01TyCmsA4Wg6Sx7TMId7Sot61299/eNsFIFpA76CxrRHbH+rdhXnQA5J2nFiveM7eKvJnajtPexs5x5IAT3txqcVexjmQqYbsf0RdqvEI+XKIlzLAsD1oYRfzs5ybW9ffQKSXvCoJZodF7gzD6PRkqBVRq3YztHJnOc8YL1vOyV57B6w3Fs2zPF17/1HW6fmWX75Bz3z9Z4YK7KLXNVPj+5hy9Pj1Lq7ePklUP0HSV43TmDDISOxLHg7go3XzokMg7pADM9wYb2LJeX13LKKSfAYD9jzSYz1TrWOkKpsiocnHMHqhRyXZ5uxq9XPPEE/H1CIyEr/Pgq8GqBMKX+HvXtP3sHtb+7iSiOsYFl8owyf/7Dh9k0WaOU06RdHdhxllBI2s5xYpjn+pG1OOdX2lpS9guF+EJKsU9LjHMUUOxsOn5j9zZ+1JijEgg/r6/baIl3EavOcHJU5tNLj6TTblEJYXU58tOzhUeCcZZeFfKmHds5Opfj95cMMdc2iIokf3aILkhs0gXhghLyUihOkJ0YVS4g1q7BjKxmW0dz1+i0X5twukGj1sY5S18h5OTBEicNhKxt7aEnqWGtnI8RLJY0+69PLrr1g2hD+74a4gGFPGIJmyoFvrt3husf2cy9k+No4Vc5Sw89sVTg7YEbF/HwoAw+FGWOyyuAE6WQNszn5GtefDLpXbuYSw3FVGHrKSc9b4ifb52m3jFE2ov2QAiU8HP53tAzxIvzRZrOIgDdDcHOi/1u5xgcJad5qGm5anQzt3Wq9ARynvngF2poOkuCoCIVW5M2MXBhpY/pTooQ0BOqbsfL7uh2PK9Y5GvVKhcWi2gFru1I9hjkgEKXvSTw3FiI6wspIRdijcXsHkNueZSBvTs4XtU5b0Bw6fKIy1dFXL484JJ+y8lyhpHqGFGnTdJdCmleX2evesBh132elQTLQqp7OjQ3T9E/McW5qeDKch/HyYD7Wi2mugMrNemBqoYzNfDX+LkDi7MgTxoACi+NLwFOk1JYqbW86vyTMb8YI00MLekoNBU6dZx6+gi3b5um2p0MabvZuwDB+/qWMCy1D/wgSFOHFoJAdStqncMAZaG5u5Fw9egmNqVN+pTCdFf78NFHwZIg5PxCL8tljkfiJj1Sc0erxpCKOD1fYqKTEElJMfCZVyEEsbUs0QHOCcZMyjFhSKxAdCDelUIAslf4soH5OThdP8GHNBFhCGGIcWAaLdKZOezeKczUDGZ2DlNvYhKLlRontZ9DIHjCJM8iDHi3tBuWjifA5ENarQRaHc4a7uPCvn6+PT5JVYJwFrPvIhMZsyV+9D/ME8wdPBwJYPE/f3K2FMIaJ+SrLjqF3MYZWvU2QklaOMpVCBI45fQRHpussXu2RT5QtJzjmLDAO3oGSJ1nek8kKeWUt9q7doBxUJaae5spV+18lB2mTa9U1Kyhg2N5UGDOWJ5XqPDpJet5SVTigkKZTUnMw3GLHhnwk8Yc68MCG3IFdncSClpSCHzIVwpJ6hwrg4A55xjRCmMFgZKU0NhdDqYEQa/CFa2f5rVoMlampQQeUFJLpNbIIOhuGqkVUor58zhUzx+CBCACaG5OkC3QZUl4zSnEVxzP6jeeS+I03/3ZfeTzIfG+M4iyy7PfMpzGzyE4qKo/XAAcD1wipbAmMfLSl5zB0FiLmbE5dKhBCmIp6KsL6nMxa05YQic1jM40SAS8tNjLZYUysbMM5BTl5xXQayV2zC+1bx2UpGJzR3Dljo3sMG3yQjBnDUfkCvxu/zIuyvfxreoUl1X6OS/KM2W8gL2gVOG+OGZrp0NeSn7YnOWIXInjowJjzQ4lLcgFopuo8SpppVZ0gFBK6jj+dGKc392zky/vmiK/R3KiLuB6HCICYRY4L+iK7wNa835/FsqYP/fJksAnvSJBIVEEqxXByRHFXINw23ZcX4niCev5t6/egsMdaG2BbF2BCL8a+QSHkAKH6wbWFr5aRmer9KzsJU26D3cOK6AmoTqXsOLhmLJRWOl766Qoh7NQiiSBEhjlkAWPPWcFkRDMWMWv79rM5sQbNqFUvGdoBf80vI7X5PvAGnCOYRWQCofq6tYluYBPLV3JaYUSNWtAwHvHH+MbzTn6wzzb5xJm24ZAeZ/fAZ2uaDY4vjgzyxAhl5b72Wzb/NqWR/idH+8g/qmB0RQb2O7kEi+pxEGGtBOLevgARt/hknPe/5+oGf6z0Ka5PqTQG2DbCQQC9bNb6J+YothfwRpzoKBRBrsj8T+ns6hFj6cnAkB24axvnMf0g5vH6Fnej3QOm4WBcYRKsIUOnRh27alhhKMoJUfpCAQUQomTkNzdoX1TG2cEOEuE5j27d3Jbs4YAzipU+MzIet5UGEBbx6wz3mUUEAqBc36G0LpyQDGSjESaT48s56xciao1aAl/NPEYn5gdpxDkGa85dtVSEA4tHcJ5OyS2cE2lh/ctGeCjI8u4/YjjeHXfIH87tZMrHtrM9ls6BHemxDWDC+nWUAuEZWFzB9i6ht7hSoDHqQzpaMSOt3xjI8f/zV188ueTBKFmfp3xuRrW0i3HPygAjsav1LZ43+PocCXAbgDnfFT7rvu3kRQDyjogccbHu7v+ea9QfKk9wYRMEA4GtWap0mjdTRELiXA+8pcCJRXwickpvjA9jhLwht5hPj6wihVCMWvS+dKpilAgBA2TEgnByrJEa0uIIQoFK4oRn1++ilcVeqkaQ04qPjmzm9+d3E5da9I44NGZhGrsVwwROALhqCiYtTEzrsOyUPLvq9fxwaWr+X5thvO3b+brD86iftpG392BiRSbWpzGb4t/5mG/LQPD/oGmfTi16JzsPAl0Ysv6JTmuv+o4ZlsJ7/zP+/nfP9yJVhIkNOstOp1kn+DQfgDIDMHTu/ueshGY3UzgFyoMtVRuut4W55+0jqXba0zGyaLaAEdRKf5zboI5m5A4OCbM8WvFPgqRQClB9gNdRgjKUnFfJ+YNO7fSwfLewWW8szJMy6TE+MIJAT7SiOArjRlWq5DX9FewymIQWPzsI6SgoDSXl3vJC81PmzWQgsdMh+/MTbIyV+DosMhMyzCXGvJaEsluha4QKASpsyRYLuopc0RU4Kszs3yhOsk9rQ7BNPTugcq4Rc+C7IB0/leIbcACKMQiz4EFZ0Is+r5P7+6/dTmXJJYjl+RZWS7y3dEO/QquPmYAAnhgMuUzt2wmVJAac6Dl5jKe/St++fmD2gCHmzu2wBuAvjAMXNxJRblc4AJZZmK2jgkU0g9qBqRmIk14qF3DIjgzV+LyUg9B1K3GXZSCkVLxpp07eLhZ5Z2Dy3hbaYhZk0B3FnDWcRZHRSl+1Koxg+E3lwyRU90lX4QkFBLp/PMtcGGxzPNLPTxQbzDWaNI31MvXZvayI+mwIV+h34bsbSc0nSWvBKFc1Kpu3OJ5hTwXVHrY1Em5YW6O6+szfLle42ezLTaPd5jZlZDuMASjkJsAPQOqCcqCDAUutDiVqYEF20G4BQwckP9dsEsBaWo5bWWBlZV+zlrex9F9Apzmv+7fw3ceGScfSZL0gADI1h3+BX6Z3qcFAIEvNToHON6BDcNAjk3XuDDXSy611PGTQCwQScmMMdzRmsUgeEG+xCWlEjJceOXUOXq05rPTs3x8fJSLegb4/b5l1I3p6rUFkAgc1kFZ+oUav1md4metFg+1O+xIYiZMyoRJsEJSkf51mhiOjOGy4WFe/b6LufTcDfzglk3cUZ/mu61ZmkKyRhcoOsVcbGlbi1aCUIr5uHsTy+pQ87rePs4sltFSMZbE3NZs8KPGDNfVpvmn2Wm+MDnNN8bm+OmuGpu3N5nZkaJ2OyozgqCpUE4iQ3Chw3YlhHDdWMP+vbzfDiEE1lhOHHAMFBQyhaCl+dTPJ7inWiXSkiRJD7YGscAvHvEFDrGu4OFMDcvKjr4HXGWMIR8Jds5U+Qqj/MbQUmY7bdrdYId1grY183CrSG/5WxzdP3JSMp4YPjg+SikM+K2+pRizEOYViwInAoGS0LCWq0v9rAvz7ExjxtuG8XabHlJS5xgVU3x+zRqMcKQzHWaOG2blb5/Hzbds5N0f/ir1uE1PEFB3KZ+Y3c71tXEuKfbzknwPR1pNmjjy2lEIfRWyQlJzIIXjZeUSL6tUmElSHks6PNhp80inzWNxws4kZlccc2ezQaeWwl6ItkuOCHI8LyrygkqZsweLrBuKCAYDGABXspgABBLhwGUGZdciy8wCwE9HC6A/MTR3wsyuNj8dmyIIfBj9IEGmjNnH4jO5OzlIRPBw5waCX7C4ARStcy6vAvG16iQX9/QxFATsSZIuzHzFTva4HiGRwpdf+YCPo6w0H947zvZWg3ePrGStCphNjW9MFwULutPfyCDIWcnFYYUgEkgkJhtJDt49u5nxpMOymqN92gqWvfcC/uCTN/BXn/ke+XyEVpLUWRRQkZpZl/C56hhfqe/lhLDA83JFTowKrIlzjGhFWQiKUiKFpK5AKUdBKE7LFzijUALhsM6SWEfTOqasZU8asy2JebjT4oF2hx+2anxubBK9W3B0kONFhQoX91Y4e6jA4EAIAw7XA6bssNKvIaAU8x4PzkHdkOxOqW1JWGI0X52p8qhpUe7+AsoheCbw6wiMH4q5hwOA7GdStwG3SSnPF1JahVMTpsOnJ8f5wNJVlIRgzhhvpZrUV90KwaAK5vFogbyU7Ipj/n5ygiWFAq8o9tE0xgcEuy4UXeb7ELGfH5hTiv+vvTOPsqyu7v3nN5zhDnVr6qmqu6nuhmZWbEQEJA5MwlMcEmd8S0iUFV9enj5XWDHxPaPJczlHSRAHkjwFRSOg8hQw0ggKMs+TNDRDdVdP1TXf+Z7z+/3eH79z+lY3DXQzS9hr3VXDPXXq3LP32b/92/u7vzsaDKEgcFisE7jE0Wk5Cs2Aw9J+Trrrfr71+sM56awT+PS3ruIL/3Y5lUrJM3+6bt3f4NBARSoMjlvbVW5qzRFLxZAOWR5ELA9C9lERwyJgaRAxoDULtaKsJSWgoCSRkkQCIg39OPYLFceKGKiAhTkLjyYJN7fqXFOrcll9hu9snGBgTPHaqMzJ5Qpv6i2zujckqCiIUlqhoK182sPOWMRECzqwMNSMOcsXJrYQiK6Wn8AI8l9O4d3/E3YO72l7eJ4RvMFae5xzzlkBZan5j9oUR86VOaWvn2bD+Py0yKZpCZfV+2VmAJZIKn4wPcm2dpMzFy1lsQyYsSl63ucQXu8E0jEYK8pWElQC5EiIcybbfznPCOIELnV8aniYg4ZKHHDWG/nZ2nv4h/Mup6enlA102v0dyheqYraftjg2JS0e67R2lJyVEIRCEKEooygpSZ8KWKg0w4FmWAcsDUJGwohloWKR0vRpiRJQkY7DYs1hcS8f6eujahzrk4Qbmw2urtf4SnUbn53ewkodcnRY5vXFEq8qxgwHGcehBKcDRAnua6acuXGMhztNSlnfxR5MLUvwiOFL8NXBxy0Fe2oA+R9cBXwqSRIZRRHWGZQSnDO5mf3iAsvCgHpqiLOuYONgu/M4N4clQDCbWi6YmUQHAccVK3Ss6UYnueczjnIgGC4oglhihcBFktQmkHZRQ9Y5n1MAjOtw+kdexyYd8hdf/Blh7PsI9qQOY+d9xFB4PuHcaB2+oNXBsJ2UbSmYtJl5FLcjaldC0Kc0S1TIqijilYUChxeKvCKKWaY1BSnpkZY1cciaOOSj/QPUjOO+dpNrW3Wub9RZOzdLMuNYoDXLwoglStOD5JFOwpXVKpO2TUl1C1x7MK2shVf8fvgJ6OfiA/8d+eM9NYA8zLwN2Jym6XAQBE4IIQJg0nb4P9s28JWlqxgMNL1Kkavp4STBZsZQUYqLZma5r9HgqJ4Kq1RIK+vL31EqtY5KAMvLCqkF+rURsuJojQpMGxAC6XzSSZGBK9opZrgPXj3C5z93GZunpuitFEnN3vMmdQOwnW+sT8J1t6ZCyG6ohTfGhktZl6Tc16nz8zmP91+oQg6Oi7ymWOJ1xRKHhUUWa0UkHEUcr4liXhsXcP2LmMOyoZPwcLPDTMcwIiOua1T5wcw2ilpRVPMZk9ldHWBXqdN1/e/EG8BO2IC98QAKT0TwE+fcf+90OjaOY2WdoyQF93dqfHbrKP80vIoDgzgD+AjubTeZs5ai8i3wP5ieAmc4olCmICRt7I4ZMs46ihKW9fgGOhsr1KBEaIvuFZit7Ojhly6zSiFwqaXnmFWsH5vjh7+6nUIx2rVM+ozFPe57t6uNoBBo4Y3DQxwccy7lN/UZrqlN81UhWKoLvDIqcGRYYk1YZESHlKUgEI5AwDIpWKmLpEpwWb3KhfUpilqh2Fn51tonM4D8yprA5dn3K+ku5TuWgadDE3czeOtLkoQgCDDOUZGSm5oz/M2Wx/jLviGW6IhttsO6Tou7m01OjMrc22pxbb2K1JoDwxiD67JiCJDOMVRUKCkwTiCqltY9beSgJJ32reS+6dePgBFO4FKDqRQID13GT86/ialqld5K4Wk9/c9UdvIemQo0EEjPL2hxbLMtLq83uKw+SUEoluqI1WHMCh0woPxMxO3GcHu7ye2tKlL4kbfzP40Qgna7vSc4gyl82/hZeIqfPKDfcbq9pYkDH1QAuE6n0yU6xtEjFb9uTDNlDJHQKDo0rOX/Tk9yYn8/NzammEo6LAgjluqAtvXdMvnT3xcIyqEkddk4Nusw96QkQiD3Vdiir8qJzA87B6Jl0asHQQf88voHfN/9ngIwngfJjSLfhYQIYulvu8ExmrZYnzTYOU/jG1VL0o/Anf9phBAkSbIn7h+6mMCv0133d3oy9qY7OL+Otfnf5sDE7jgXR4+U3N+usqXTRgIlJflRdZIrZmd4uNMG5xjSAQfqiJLMnL8PeOmPJFY4H7xZcAsUcoVElARYD+xw1mWASHBOYFJLceVCNozPcf+jW4kj/aTjWl5oyXcf+Q4kEoKK1FSUoiKzl9KUsl3Jrp/EWkun85Q9oHmG9zN4Ms+U7sjeneTpLAF5H7rIL2inC8QRSoHLhmQLPHr3zzduoKgFQmtqzvLt2QmaxnJ63yJwhkh54IbL8ubqkIBgpUIIRzqR0hwFYSRYg5PCw6lTi5GScKiP9aNTTMzVKRbVi9oAdpUd29HHBxm7lT10/b6E4kEh5+JnEE2xm2zgnnqA+SXrrFme1uOOyrYnbqfV0BEhmUoTHus0CYVAI5EW7mrWubVdoywUgcomhXVA9CuClRpScIkkWKiJhgXSCM/lbQSYbB8cKKjEbNw8hbGJz6K9BEUI8USkkbuTPBOY4tv6/jL7/eP0vacG4PAsFBo/veIn+JFwOOeMy8gVIh2RpvZxdWorDChDJKHtDAdHBT49MMR/61vMBTPjtB0UlPLlVSegkG2xcp4fCzLynka6LH/uJC51CO1Ru1PVJrnHeSmKc25XBvEnk/xJz5eCj+M7vPMq4Q55KgPI31+Gnwa2HfgYPsN0LYC1HnzdSQ1vWDrEUF+FequD2qXT1dFNxzadZb1p8+pCkWU65OvTW1msQowFoQRu0mBbICMQAQjt6IwmIPxWK3aaolREzs8ChHxy9x+O698byZ/+vZhFPIcPAAVeV33ACdl7e2UAuRTxPHR9+NmApwJ3AI9aazXOuTZwfCr421ceytCiAeZqLVRGpDzvoyCApvW9hDWb8omBpVzXrHJxfYqyUiTCIpqQ3NIm2WIwUymt2xKaD3boE4rzt0zwztvuZ121TcM6vvnYOFMtw2BPjC9FvTRlD5WfH/Q74JPZ93n0v2p3f/BUeIAcWjSBp4k7Gr/2F+gGg8NaCJdKKQ7RJc7UJfr2W8J0LHlkyxTGQTgPuGhxlKTirT0DWOuoCMmhUZFPbNvEmmKBg6OYprPIhsCMWcyooT1lWRCHXDNZ49LtU7wvHuDCjVtZu22GfaziuLesYWu7zY8uv5tgXp/+S0XyXdYebP3yff7ZwHnAocBh2Xv/ih/ivVMguCeAkPzgX2Vfj8tOsi9+TpAHi2pNIiVn9A6yfHuN1SOLGFi1kMlqk+3VhidRzpr2LIJTyv30IGlg2FeF7Fsoc+amDewbhhxeLJI6ixECIwX9UcAdzSaf3riBzy9ayhtfuZDj+3o5cbCfo2yAPWQJ4bJeLvh/t9C26RNh5f6gRUqJMeapnBG+sQAAFXdJREFUSsASv0x/HI/k/hmeRfxqvAE8zo3sDZ1I3m1yEb71+CCyoMI5R6w04zbljZV+DowjFmyuclBPiYUHLGZoYT8Pjs+SpilKSurWcGyxl5EgJHGOurH8UbnEUb0lTn9slBnjOKGnh4IQFJRm7dwcn9m2mS8vXsqhi3qovVoQLoV4taTlOrSTIkPHruLStffw2LZpolC/ZL3Ak+wC8gDvXHyQns8YvgW4gWeICZx//ASeoRK8NzCAVFLQEoJYaN7aO0DNWVYUBFMlzcEL+ukVlmtHt1MKNXVjWRnGHFko+0FOQlB3htdXSpxaqfCl8W18c3KC/aOYtbNzfH96mm8sW86BccRskhI0QJYUqk/CtKG1oU355AMZG53kmtsfohCHf1C5gD2VJxgyCd2Ivw78KR7Gn98AzS7p3/mytwaQn7QE3IqnKR0mq1DGYcgD7SYnl/tZokJqJmV4acg1D89y9LIh7puZZVO1iVA+y3VyuR+bgySdI1CO5VHAhwcHqRrDZ7ZuZVkYcvbypfRrQS1D9DBpsNsT7IzFjqa42QbR4ctZPLKQ7192O6nrMo+9lERkbeG7CQjztf96fNp3PgjU8iQ0pHtrAPmJ1wD/jvcEJ4KPA0KlqDrLjHG8d2AB1XpCqU/RWxacd/smHBEbGjUCKRg3Ka8r9jKsPAWss1DWHv9nnOP4SoXTBwY4ubcHi6ONRxgJgU9qpmAnDUiJarZplSKWn3QI998zxm3rxigUXnpewJehxe68QL7+fwXv8p+0IXS+PB0PIPHs1B/Eu5cH8dGmMdbKchRxZ7POqrDI0cUK042E5fsUeE1fke1zCePNlKl2m2ZG+nhCqZeWtVlHjaQv8v30LWuJBLSt79OX+X/Pvwo88TKezNFM1igcM8K+I4v5/uV3+OHRe/nhXmhRUmYglt1xB/o0uUSSpjslhCxdUoiPspdkkc9kcuha4D48WPTDQOCcc1IKESjNb+eqvKnSz4gNmXGW3uGINy2ucNqyYe6dbvDAXJ0NNuGAqMD+YYEWxrOKhQqtfMXPZvj4Jw7qhe8uDhRyskEjVKw45RCaky2uuvUBCsUIa1/8XsAr3lKtt3BaE2qNnUdw7fdtkn4R03aGxHTmP9958Pf3+OTcB+hOFX3q//0MrruKR5xuyy7gTYCx1sk4CJhzhuuqVd7SP0h/VVDThnavJNKWYxcu4LKxSba2OzzQaXFcuY8eqWhbixa+JOzwdX9LFgHvTo8iqxA6gdAKMzqFOXgBxx13KL+9aZQHN26j+CIOCGXWA1GvNUjDgDcffRgfOfJwbnt0E42kjco6lmrWcnBUZmEY82inhkjT/HbkwV8V+BC+F/BHwDeANk/QCzBfnokBSLpJhd8BbwBWOecMAlkMNJvSDtfVqxzX009x3GIKFltWLAg1+5XKXLphG+M2ZXPa5i2VAVIcbWPpDQVaOiLpx8Gl1mLYnScQFKXyDFahotROSR+bgaOWc/wR+3Lx2vuYrbcIg6dm4n6+RSlJu9mmaRyvf8Nr+OZ7juetPT2M/X6Un45uJNaeD6jtYEAFfHhgKb+YG6djUkw3Bpj/9K/FJ+dW4Ef6+N77p7qOZ/AZ8pJf3jjyOzxpcclaa5XWoigVo0mbK2tzHBL1sHhKkEaWpEfwir4+jBH8dssEoy5BIXhDqcJc0sY6WBJHXF+rc/HMLEeVixSkpJ3RuotsPQyF5MZGnY1JgnMwIeBrdz7Cjx8e54wPHctr9x3i4rX30uqkBIF+0RiBn6tcY9WB+/G1j/wxX1m5BG57kGvuHuO+WoNbpycpKIlB0HGOc4ZWc31jlptbc+g0zeFuBh+D3YJfgg2+ifeHzAN9PpU80+nh0HVDE8A64H2AM8agAi1iJZnopFxRm0VLxchMSJRKmkV44/KFrJ9uct9klbvSJstkyFGlHn5YneNTWzZx3sQkv6rVuGRujoMKBQ6IYwIBifNFoTZw1qaNbGwbrpypsrY+iy4oPjiT0C8E+7/9VRy5cgk/vfp+6q02cRy84DGBFIJqrcFpHziFH/zJGznmgYcQo5s5b+MsCwlZNzfN3c0akVTUjOOcJfsSCMXnJjZQwNL2YJD8wWvhSaI3sheR/3x5NgwgvyCN56SpA292zhlrrZRaEUpIsVxTr3Jn2qBQ0yyoSwohvHn1cq4bn2J0rs5daYtrWw2uqE6TGsfXlgzz5X2GublW51ObN/O7Rp0lQcSKKKIYhnx+62ZeERb47H7LOWFlhfeqXk6tVFheiOncs4kGcPDbD+NNh4yw9saH2ToxQ7EQ7sDZCCHQGV5PCJGlq8XOyfJnUbzym5z1iQ/yz0fuh/75dUzPprRrAd/auIWjVZF1rQZ3NaoYIfnS4hGODns4Y8t6UgxJu5lfV+76/wr4aXbv9wgosKs829mSnJLs62RlYyllEMexJzc0iob1LvDoQolTevo4ZfkiRH+R999wO/dXq2gp+frQCKdGJaZNh8XFiEWR4tZajXMnZri2UWNxFLI0CAit4VtD+5AuEogRibw99egaIfyFtDqkbzuUwdOOYPOGGT78mYu54qZ7KJUKaCWptxPS9vxdk1/VAh0QRyFSebazp/Ia+dzEbitbdmud24FOVlIyV23wx+8+jh++5dU0Lvot1VrIzHZLf6r5H1PrGU87rOvUqTvHV5as4L8U+3jHxoe4J6ki2y1Sf64Ur/AL8B3bz8hen20DyJFDFj9d9ANAIoQI4jj2AFLnEb11Z9BOsZKYEwd6GSiX+M7GTcyYlDWFAmcvGaEI1G3KykLIwtAzA86mKdfWa9zfavPhBQMUlaTjsh4B8DFCniewAltvkxwzQuWMI1GVIl/91q/57HfXUm+1OHT5Yl7/6gNZuXqEKAoZn6lz/+hW7njwMTaMbsE0G0glieNotzdKZgOokiQlaXs6+hwKB774VSh4iLxz4JTi6o+fyqEPjTP2UBuqnlFsbWOaf5we49FWnX3jAl9asoLXhWVO3zzKL1vTxKZNy7v+XPk348vyy/Ds4I+r8u2Nwp5tyc8p8YWjd+JBCUEYhoRh6Plus0MS60fA9KiAUGhS46haw2sKRc4ZWkEEJCZhZU+EFn4wU0H6cXUNY0izVEDWLoM3L+dpx4sSZxxuqkO6rIfw/Wso/9H+3HXLI3zkiz9heNZy9uH7MTJQwkUhdkGZZMkASaHILRNVfvH7R7jpzvXcs34D1pqdPqAQgkajhbGW3sF+lg0tYumCQeLemHIYUQxC3Fydi66+AScs1Y7l+KWDXHLEaqbWGURbsS5t8M8zm7miOgFCcmy5l38aWsFiNH+1dTM/qG6nrBJqjQZ0yZ8exbO2jQF34rd85+ENY4+Dv12V9WxLHpBovBG8ncwItNZEUbQjry3wa2PqHDiBthotBLPGsiYucPbSlVQcdGyH/SoROgsCfWdQ1/VC9h9xYBxyUBG+JsQ2UpLbLG46JXEG89oV9L3nVeihXs658DrO+ZdrWDXd4ozhRbxxQR99gwWuDByTSvHWVQfw77U5/ubS/6DTbPn4IDO2WifhqNcezJ+eegzHrh5hKA4ouJSoY3lw0xSlVPK9a+/if/38GnrjgJl2ypcPWM3HosXcOFXnwsY2LpjeSt0a3lwewEnLxxcv5yhd4q+3buTfpqYoR45qaw5rbK78h4Dj8UGfwuMzbsM3gDwteS4rJvON4Lv45SAFlJRShGGI1k+0NROEVlNLHfvHMV8eGmGFULRdwqpKSCAdO/V95CR+uQEkIIcU0esihLa0rmtjxhxOC9pzLVQp4s7Dl3DYe45AlzRn//RmLvzZbfRumGE4UGyNYr564KF8fdMjXDQ2SqkQ7LhRxvlc6yffcRxnrTmAwqYJGlsnaTca9GrJr7fNcmWjymGLlvBnV11PIQpQOJoO/qJ/GaQp/zq7japJOLLUy2n9C7mrWeX4Yi8nFvv59Pgm/mV6glIIzaRBp5Pkyt+OJ4Bex1PQv+6NPNclM0E3T/A1PFAhv3AVBAFBEJCPn91JnCSyAXVjWaA1n1u8nGOiAnXXYZ+ePEE07wPssgI661ArNSICsz7xSGIpMUgKnZS126e4Ccvfn7IG9/qVNBb0cOnvH+P8tXfz6N2baU83GW1OI1VEoASBlkjlAalfWn0QZy4cYsuG7bQAoQOUlLSU5bSxdXxhzUF87qFHuXrTOD2homWN91rWEkrB8cV+TutbxFFxkdQ4vjG1nYPiArc25vju7BTlUNIxbVqtVq78KeAU/No/39U/YZl3bxT0fEhusWfi4Upx9rMSQpAbQr4s7BAnCZyiYz2t28cGl/CByiDSJQwUoRKqrifYjSNxqQMrEKHLgnLfxWRxxE7wtxvH+FB5gGWBhMVleg9bijx4IWNlwQ0btnPb77dy07pNPDg2yeRMi3azxZCKeX95gFqnQ1yIEdIXsYpCsi5pcH27ytsqg3x7agtIQSwFi1TAgVGRY+MKr4vKrFAhVgjmbMogmm2J5d3jDzKWtunRkrbt0G62jfN98BN45d/K01znn0yeDwM4GE8u0cJb66H4oOUoulEtT2QIDtBOgvHDoE+o9HJW3xArlaIQGXoLOSp4Nx9mXmzgu8hzngI/aPK8bduwQnPmggVsrzcRrQSsJB7upfyKRYiVPaQVzdZOwoZam4cnazy4fZoHJufYNtNiutpgrtEhaRmiVEBiWCwDeqRmhQxYrjSrg5iRIGJAaoKMgKrhDBGSktT8sj7LF6fHmCAhEoJWktBut/L7Moqf13wvz4Hy59+i50Jy9/S3+HXrEvxgwwSv1+/gB1Hmbs5fUGYIWms/HMl5GnVlNdpJZq1hURDw0f6FvL1YYXEEhdjvs63jSZk8QeBENtTCCR5oJVwwPc0XhoaZNQnSCIIRjeuD5m1tRAhBJaLQFxNVIihHECsIBBhBs52STLWRUylnj41xamGA/ZWm3UyYanRw2s8raDlHkrWDxUJSEZr1nQ7fnBnn8vqU7352jlan7VJf7A/wwd078NH+s7bm7ypPpzVsTyV3zp+nq+AOXUv+Cn4feyJdBy6cc3Q6HZIkQWu9wxCsMiQWKkIyl6Z8ZvsYVxR6OL0yyHFpkaVFgdLQwe1ExcaOE4OVDu0EsVO0rODXtRlSHM76bakwFhU79FCALafQsdjpFo3ZNk0pQCqszLiJOpaKk2Dhc9s3MFIsc2jBMdduMNZIaQmxY1ilEoKyVJSFZlOScn5tGxfOTrA9NZQC6KQJtU7H4pwnV4dL8XWVOs+h8uH5WQLmh2e5V1gDXIEnMjwI7+agC23a6bqUUv6lFVIotAlQTlK1Binh2LiH91Z6OaWvzLKCJhWWhvXsIPnJBL60Ot4x/Lpe56palaWB5qMDg/QrjRXOIxAcfngQlpzv1Xk6LgS+QFPwTE7c1Kjx/alx3lDq44MDg9Rth7GaZc5atPR8xz3CD9l8uNPhF3NTXFyb4DHbNAUppUaIZqdNmiQpXtEC+Dt8dU/OuyfPmTzfwLncGCTeAE7C969/H/gE3vpzDFu+g9jpGqWShCpEywgtPfNow4DC8Yo45p09fbxroJfV5RCcLy83raWiAs6dmOC39QZHxAVOKvdycBhSwyIUgEPhE007Rrrk8wVd1oeIQAvJ9Y0Gv6lV6aSOD/Qv4LBCgTmXMN60tJyjR2sCB5Op5Y5Wjcvq01xdr7LdddJQChE6VCftkKSpyWIdld2H0/Fl3XxOw3NeuXq2ikF7I7kRXITf3iTA/8bzDy3GLwsRXeUbujdDOOdEalIS0yFxKRZLLKULpBSbEsOVtRqXzMxyV7OJRTCoAwa0RqExVrAtSfjM4mVE1jKHgGwaCRa0IJvxJz2lbcYN778IrHOUteLS6hzDrshZi5exKFB0nKORShIHVWe4pdHgezPb+cepLZxfneDupI4V1sWgTJLIZtK60Bgb053G9m3g3XiEleZ5Un6ujBdC5tcMcgnwxvAq4M/wMwr2xXe35tl98PFD7h0sGbBGq5BYFdFS0rGOhjEoIdknDDi8WOCIuMQJvX2cO7mV9/YMclJvhVSCcxbnjG+eV8YTMlixo83UEzjPw+g5iUXxpa3jnFDuIxCOO1pN7m01uK9V5/ftJlvTlLYwBMLZAIw1RidpYoy1P8JTthyJz4n8CvgsHs073+CfN3mhsdMh8GN8h9ElwDlADW8MEu8R3oNnJdkPGMHD0OdLigdC7IOAOCwQyshjCZ2knTqa1uCEo6wUkRIsUSGHFYosDwMWas1SHbAoVBQ1FBDEWYkY58e7No2jZg0TScqGJGG8k3Bdq8EjnQScY9y0SUjxywhoh3PWmtSkyuZj1eHP8U/6QcD78Ur/ZfYZnjeXv6u8kAaQP8Hfw5c1Aa4D3ozPbUdABZile53L8MmkUTwY9ZN4jxHgb6wFkFJKqaTTMiQUgZDSK9NY3zyaWkfLWpAWlEE6hUZl8wgFQe728VyEiS8v0MZiRAJYAusJqq0zgMFZi7PWQxS7HuouvJJvxxv6crrIHTHv9bw+9fPlhfYAuZyMh5mfhp9R+GP8DbwBr9y/A36D3xYZvHEcjDeQvwaOwY+4n79UACCEMDrQBDoQCimEUy6joxZOWJywGQogg4k4icu2jP5ELstFWJyxuaIxbke7ex60djcc3mi/k73WZ5eSj5xoZF8dL6Dic3kxGMD8beJy/BIwnf2c1w8sHn18FT5/8Bh+eQjwRaY+YH88KLKMB0bOZu8XwSeYpJQIKZBCopR0UiqTre07UBw5+6azFmONs8ZKY62Yl6LOXXUOhcuvX+C5ec/Dz1kcx+c9guzrfMbuFwc48UUkip13JPmN6sfXvB3dDOINdMfZ50NUAP4Bv5UazY67Bx9M/k/g53jw5GZ8hm0OcEopFwSB01o7rbVTSjkpZa7c/GWz/52PI9j1/UfxDZlvy64XvNKX89wm2p4VeTF4gPmSl5DzJ8rhb+qP8QwXLbz7bwBn4LeSER4DfwF+GZmfVKnjA64rsnNH2WsJPqA8CB9XHIBfTorZdeT/u4onVlhK96ndhCfHuBFvZFdl1zMfmQDPcQLnP4vkT3eIV3C+buZP4rvmHXsAXhGOrsvNlbg6O0ax81O5AM99BDsrT8w77nS8W38fPoNZyH5fwFc182PVbs7xsjwLIukuD+/CI4/9nsv3Jcbzjn03/qnPDcXh3f1Q9n6u1JXAN/GxQm4UOWMteBc+/+f5ovBxxnxv8bI8x7JrWvhP8E92ilcmdJW7AvgCPla4DV9xnH8O8AGjA87Pfn6yjKikayC7PuUvy/MsfhqzlwOB/8rOytuThuBcgR/NXnv6dy/Li0QEe/bEiic59uWn+CUguaKfruy69XxZXpaX5WX5Tyb/H80TYJ8sN1Y9AAAAAElFTkSuQmCC"
+        }
+      ],
+      [
+        "icrc1:decimals",
+        {
+          "Nat": [8]
+        }
+      ],
+      [
+        "icrc1:name",
+        {
+          "Text": "Draggin Karma Points"
+        }
+      ],
+      [
+        "icrc1:symbol",
+        {
+          "Text": "DKP"
+        }
+      ],
+      [
+        "icrc1:fee",
+        {
+          "Nat": [100000]
+        }
+      ],
+      [
+        "icrc1:max_memo_length",
+        {
+          "Nat": [32]
+        }
+      ]
     ],
-    "icrc1_fee": [1000],
-    "icrc1_total_supply": 999715984000,
+    "icrc1_fee": [100000],
+    "icrc1_total_supply": 799999985564494000,
     "swap_params": {
       "params": {
         "min_participant_icp_e8s": 10000000,
@@ -189,13 +296,16 @@
         "sns_token_e8s": 314100000000,
         "sale_delay_seconds": null,
         "max_participant_icp_e8s": 100000000,
-        "min_icp_e8s": 5000000000
+        "min_direct_participation_icp_e8s": null,
+        "min_icp_e8s": 5000000000,
+        "max_direct_participation_icp_e8s": null
       }
     },
     "init": {
       "init": {
         "nns_proposal_id": null,
         "sns_root_canister_id": "zxeu2-7aaaa-aaaaq-aaafa-cai",
+        "neurons_fund_participation": null,
         "min_participant_icp_e8s": null,
         "neuron_basket_construction_parameters": null,
         "fallback_controller_principal_ids": [
@@ -213,24 +323,30 @@
         "transaction_fee_e8s": 1000,
         "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
         "sns_ledger_canister_id": "zfcdd-tqaaa-aaaaq-aaaga-cai",
+        "neurons_fund_participation_constraints": null,
         "neurons_fund_participants": null,
         "should_auto_finalize": null,
         "max_participant_icp_e8s": null,
         "sns_governance_canister_id": "zqfso-syaaa-aaaaq-aaafq-cai",
+        "min_direct_participation_icp_e8s": null,
         "restricted_countries": null,
-        "min_icp_e8s": null
+        "min_icp_e8s": null,
+        "max_direct_participation_icp_e8s": null
       }
     },
     "derived_state": {
-      "sns_tokens_per_icp": 1.0,
+      "sns_tokens_per_icp": 1,
       "buyer_total_icp_e8s": 314100000000,
       "cf_participant_count": null,
+      "neurons_fund_participation_icp_e8s": null,
+      "direct_participation_icp_e8s": null,
       "direct_participant_count": null,
       "cf_neuron_count": null
     },
     "lifecycle": {
       "decentralization_sale_open_timestamp_seconds": null,
-      "lifecycle": 3
+      "lifecycle": 3,
+      "decentralization_swap_termination_timestamp_seconds": null
     }
   },
   {
@@ -251,7 +367,7 @@
       "dapps": [
         "6hsbt-vqaaa-aaaaf-aaafq-cai",
         "4glvk-ryaaa-aaaaf-aaaia-cai",
-        "4bkt6-4aaaa-aaaaf-aaaiq-cai",
+        "s4yi7-yiaaa-aaaar-qacpq-cai",
         "4ijyc-kiaaa-aaaaf-aaaja-cai",
         "3vlw6-fiaaa-aaaaf-aaa3a-cai",
         "rturd-qaaaa-aaaaf-aabaq-cai",
@@ -259,89 +375,148 @@
         "iywa7-ayaaa-aaaaf-aemga-cai",
         "wkype-7qaaa-aaaar-ajfyq-cai",
         "r2pvs-tyaaa-aaaar-ajcwq-cai",
-        "cpi5u-yiaaa-aaaar-aqw5a-cai"
+        "cpi5u-yiaaa-aaaar-aqw5a-cai",
+        "tktqu-nyaaa-aaaar-qackq-cai",
+        "4bkt6-4aaaa-aaaaf-aaaiq-cai",
+        "lxq5i-mqaaa-aaaaf-bih7q-cai",
+        "6ofpc-2aaaa-aaaaf-biibq-cai",
+        "6klfq-niaaa-aaaar-qadbq-cai",
+        "64dy3-wqaaa-aaaaf-biicq-cai",
+        "2notu-qyaaa-aaaar-qaeha-cai",
+        "2kpva-5aaaa-aaaar-qaehq-cai",
+        "zi2i7-nqaaa-aaaar-qaemq-cai",
+        "62rh2-kiaaa-aaaaf-bmy5q-cai"
       ],
       "archives": ["2sqpr-ciaaa-aaaaq-aaaoq-cai"]
     },
     "meta": {
       "url": "https://oc.app",
       "name": "OpenChat",
-      "description": "A decentralized chat app governed by the people for the people"
+      "description": "A decentralized chat app governed by the people for the people",
+      "logo": "/v1/sns/root/3e3x2-xyaaa-aaaaq-aaalq-cai/logo.png"
     },
     "parameters": {
-      "reserved_ids": [1005, 1006, 1007, 5000],
+      "reserved_ids": [1005, 1006, 1007, 5000, 100000, 100001, 100002, 100003],
       "functions": [
         {
           "id": 0,
-          "name": "All Topics",
-          "description": "Catch-all w.r.t to following for all types of proposals.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "name": "All non-critical topics",
+          "description": "Catch-all w.r.t to following for non-critical proposals.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 1,
           "name": "Motion",
           "description": "Side-effect-less proposals to set general governance direction.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 2,
           "name": "Manage nervous system parameters",
           "description": "Proposal to change the core parameters of SNS governance.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 3,
           "name": "Upgrade SNS controlled canister",
           "description": "Proposal to upgrade the wasm of an SNS controlled canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 4,
           "name": "Add nervous system function",
-          "description": "Proposal to add a new, user-defined, nervous system function:a canister call which can then be executed by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "description": "Proposal to add a new, user-defined, nervous system function: a canister call which can then be executed by proposal.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 5,
           "name": "Remove nervous system function",
-          "description": "Proposal to remove a user-defined nervous system function,which will be no longer executable by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "description": "Proposal to remove a user-defined nervous system function, which will be no longer executable by proposal.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 6,
           "name": "Execute nervous system function",
-          "description": "Proposal to execute a user-defined nervous system function,previously added by an AddNervousSystemFunction proposal. A canister call will be made when executed.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "description": "Proposal to execute a user-defined nervous system function, previously added by an AddNervousSystemFunction proposal. A canister call will be made when executed.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 7,
           "name": "Upgrade SNS to next version",
           "description": "Proposal to upgrade the WASM of a core SNS canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 8,
           "name": "Manage SNS metadata",
           "description": "Proposal to change the metadata associated with an SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 9,
           "name": "Transfer SNS treasury funds",
           "description": "Proposal to transfer funds from an SNS Governance controlled treasury account",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 10,
           "name": "Register dapp canisters",
           "description": "Proposal to register a dapp canister with the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 11,
           "name": "Deregister Dapp Canisters",
           "description": "Proposal to deregister a previously-registered dapp canister from the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
+        },
+        {
+          "id": 12,
+          "name": "Mint SNS tokens",
+          "description": "Proposal to mint SNS tokens to a specified recipient.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
+        },
+        {
+          "id": 13,
+          "name": "Manage ledger parameters",
+          "description": "Proposal to change some parameters in the ledger canister.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
+        },
+        {
+          "id": 14,
+          "name": "Manage dapp canister settings",
+          "description": "Proposal to change canister settings for some dapp canisters.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 1000,
@@ -695,32 +870,117 @@
           }
         },
         {
-          "id": 100000,
-          "name": "Call receive_tokens on InfinitySwap's CHAT/ICP Swap canister",
-          "description": "After transferring CHAT or ICP to InfinitySwap, the OpenChat SNS needs to call `receive_tokens` to notify InfinitySwap of the transfer.",
+          "id": 7001,
+          "name": "Update token details in the Registry",
+          "description": "This will update the specified token's details in the Registry, updating the value of each field provided in the payload.",
           "function_type": {
             "GenericNervousSystemFunction": {
-              "validator_canister_id": "wkype-7qaaa-aaaar-ajfyq-cai",
-              "target_canister_id": "vahkw-kaaaa-aaaal-acaza-cai",
-              "validator_method_name": "infinity_swap_receive_tokens_validate",
-              "target_method_name": "receive_tokens"
+              "validator_canister_id": "cpi5u-yiaaa-aaaar-aqw5a-cai",
+              "target_canister_id": "cpi5u-yiaaa-aaaar-aqw5a-cai",
+              "validator_method_name": "update_token_validate",
+              "target_method_name": "update_token"
             }
           }
         },
         {
-          "id": 100001,
-          "name": "Call mint on InfinitySwap's CHAT/ICP Swap canister",
-          "description": "Calling `mint` on InfinitySwap's CHAT/ICP Swap canister instructs it to 'mint' new liquidity from the tokens it has been transferred.",
+          "id": 8000,
+          "name": "Stake NNS neuron",
+          "description": "This will instruct the NeuronController canister to stake a new neuron with 1 ICP.\n\nSubsequent 'ManageNnsNeuron' and 'TransferFromTreasury' proposals can be made to update the neuron's configuration and increase its stake.",
+          "function_type": {
+            "GenericNervousSystemFunction": {
+              "validator_canister_id": "tktqu-nyaaa-aaaar-qackq-cai",
+              "target_canister_id": "tktqu-nyaaa-aaaar-qackq-cai",
+              "validator_method_name": "stake_nns_neuron_validate",
+              "target_method_name": "stake_nns_neuron"
+            }
+          }
+        },
+        {
+          "id": 8001,
+          "name": "Manage NNS neuron",
+          "description": "This will instruct the NeuronController canister to call 'manage_neuron' on the NNS governance canister to manage one of the neurons it controls.\n\nThis can be used to configure the neuron, set up following, spawn a new neuron, etc.",
+          "function_type": {
+            "GenericNervousSystemFunction": {
+              "validator_canister_id": "tktqu-nyaaa-aaaar-qackq-cai",
+              "target_canister_id": "tktqu-nyaaa-aaaar-qackq-cai",
+              "validator_method_name": "manage_nns_neuron_validate",
+              "target_method_name": "manage_nns_neuron"
+            }
+          }
+        },
+        {
+          "id": 101000,
+          "name": "Call trade_tokens on the CHAT/CYCLES trading pair canister at the CYCLES-TRANSFER-STATION.",
+          "description": null,
+          "function_type": {
+            "GenericNervousSystemFunction": {
+              "validator_canister_id": "w7lbn-qyaaa-aaaar-qacuq-cai",
+              "target_canister_id": "w7lbn-qyaaa-aaaar-qacuq-cai",
+              "validator_method_name": "sns_validate_trade_tokens",
+              "target_method_name": "trade_tokens"
+            }
+          }
+        },
+        {
+          "id": 101001,
+          "name": "Cancel an open position/order on the CHAT/CYCLES trading pair canister at the CYCLES-TRANSFER-STATION.",
+          "description": null,
+          "function_type": {
+            "GenericNervousSystemFunction": {
+              "validator_canister_id": "w7lbn-qyaaa-aaaar-qacuq-cai",
+              "target_canister_id": "w7lbn-qyaaa-aaaar-qacuq-cai",
+              "validator_method_name": "sns_validate_void_position",
+              "target_method_name": "void_position"
+            }
+          }
+        },
+        {
+          "id": 102000,
+          "name": "Call manage_neuron on the NNS Governance canister",
+          "description": "This will enable the OpenChat SNS Governance canister to manage NNS neurons, allowing it to perform actions such as voting on NNS proposals",
           "function_type": {
             "GenericNervousSystemFunction": {
               "validator_canister_id": "wkype-7qaaa-aaaar-ajfyq-cai",
-              "target_canister_id": "vahkw-kaaaa-aaaal-acaza-cai",
-              "validator_method_name": "infinity_swap_mint_validate",
-              "target_method_name": "mint"
+              "target_canister_id": "rrkah-fqaaa-aaaaa-aaaaq-cai",
+              "validator_method_name": "nns_governance_manage_neuron_validate",
+              "target_method_name": "manage_neuron"
             }
           }
         }
       ]
+    },
+    "nervous_system_parameters": {
+      "default_followees": {
+        "followees": []
+      },
+      "max_dissolve_delay_seconds": 31536000,
+      "max_dissolve_delay_bonus_percentage": 100,
+      "max_followees_per_function": 15,
+      "neuron_claimer_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "neuron_minimum_stake_e8s": 400000000,
+      "max_neuron_age_for_age_bonus": 15768000,
+      "initial_voting_period_seconds": 345600,
+      "neuron_minimum_dissolve_delay_to_vote_seconds": 2628000,
+      "reject_cost_e8s": 1000000000,
+      "max_proposals_to_keep_per_action": 100,
+      "wait_for_quiet_deadline_increase_seconds": 86400,
+      "max_number_of_neurons": 200000,
+      "transaction_fee_e8s": 100000,
+      "max_number_of_proposals_with_ballots": 700,
+      "max_age_bonus_percentage": 25,
+      "neuron_grantable_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "voting_rewards_parameters": {
+        "final_reward_rate_basis_points": 250,
+        "initial_reward_rate_basis_points": 250,
+        "reward_rate_transition_duration_seconds": 0,
+        "round_duration_seconds": 86400
+      },
+      "maturity_modulation_disabled": null,
+      "max_number_of_principals_per_neuron": 5
     },
     "swap_state": {
       "swap": {
@@ -728,6 +988,7 @@
         "init": {
           "nns_proposal_id": null,
           "sns_root_canister_id": "3e3x2-xyaaa-aaaaq-aaalq-cai",
+          "neurons_fund_participation": null,
           "min_participant_icp_e8s": null,
           "neuron_basket_construction_parameters": null,
           "fallback_controller_principal_ids": [
@@ -744,12 +1005,15 @@
           "transaction_fee_e8s": 100000,
           "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
           "sns_ledger_canister_id": "2ouva-viaaa-aaaaq-aaamq-cai",
+          "neurons_fund_participation_constraints": null,
           "neurons_fund_participants": null,
           "should_auto_finalize": null,
           "max_participant_icp_e8s": null,
           "sns_governance_canister_id": "2jvtu-yqaaa-aaaaq-aaama-cai",
+          "min_direct_participation_icp_e8s": null,
           "restricted_countries": null,
-          "min_icp_e8s": null
+          "min_icp_e8s": null,
+          "max_direct_participation_icp_e8s": null
         },
         "params": {
           "min_participant_icp_e8s": 100000000,
@@ -763,24 +1027,52 @@
           "sns_token_e8s": 2500000000000000,
           "sale_delay_seconds": 82128,
           "max_participant_icp_e8s": 10000000000000,
-          "min_icp_e8s": 50000000000000
+          "min_direct_participation_icp_e8s": null,
+          "min_icp_e8s": 50000000000000,
+          "max_direct_participation_icp_e8s": null
         },
         "open_sns_token_swap_proposal_id": 109811,
         "decentralization_sale_open_timestamp_seconds": 1677826762
       },
       "derived": {
         "buyer_total_icp_e8s": 100000000000000,
-        "sns_tokens_per_icp": 25.0
+        "sns_tokens_per_icp": 25
       }
     },
     "icrc1_metadata": [
-      ["icrc1:decimals", { "Nat": [8] }],
-      ["icrc1:name", { "Text": "CHAT" }],
-      ["icrc1:symbol", { "Text": "CHAT" }],
-      ["icrc1:fee", { "Nat": [100000] }]
+      [
+        "icrc1:decimals",
+        {
+          "Nat": [8]
+        }
+      ],
+      [
+        "icrc1:name",
+        {
+          "Text": "CHAT"
+        }
+      ],
+      [
+        "icrc1:symbol",
+        {
+          "Text": "CHAT"
+        }
+      ],
+      [
+        "icrc1:fee",
+        {
+          "Nat": [100000]
+        }
+      ],
+      [
+        "icrc1:max_memo_length",
+        {
+          "Nat": [32]
+        }
+      ]
     ],
     "icrc1_fee": [100000],
-    "icrc1_total_supply": 10002917143216362,
+    "icrc1_total_supply": 10107452365299028,
     "swap_params": {
       "params": {
         "min_participant_icp_e8s": 100000000,
@@ -794,13 +1086,16 @@
         "sns_token_e8s": 2500000000000000,
         "sale_delay_seconds": 82128,
         "max_participant_icp_e8s": 10000000000000,
-        "min_icp_e8s": 50000000000000
+        "min_direct_participation_icp_e8s": null,
+        "min_icp_e8s": 50000000000000,
+        "max_direct_participation_icp_e8s": null
       }
     },
     "init": {
       "init": {
         "nns_proposal_id": null,
         "sns_root_canister_id": "3e3x2-xyaaa-aaaaq-aaalq-cai",
+        "neurons_fund_participation": null,
         "min_participant_icp_e8s": null,
         "neuron_basket_construction_parameters": null,
         "fallback_controller_principal_ids": [
@@ -817,24 +1112,30 @@
         "transaction_fee_e8s": 100000,
         "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
         "sns_ledger_canister_id": "2ouva-viaaa-aaaaq-aaamq-cai",
+        "neurons_fund_participation_constraints": null,
         "neurons_fund_participants": null,
         "should_auto_finalize": null,
         "max_participant_icp_e8s": null,
         "sns_governance_canister_id": "2jvtu-yqaaa-aaaaq-aaama-cai",
+        "min_direct_participation_icp_e8s": null,
         "restricted_countries": null,
-        "min_icp_e8s": null
+        "min_icp_e8s": null,
+        "max_direct_participation_icp_e8s": null
       }
     },
     "derived_state": {
-      "sns_tokens_per_icp": 25.0,
+      "sns_tokens_per_icp": 25,
       "buyer_total_icp_e8s": 100000000000000,
       "cf_participant_count": null,
+      "neurons_fund_participation_icp_e8s": null,
+      "direct_participation_icp_e8s": null,
       "direct_participant_count": null,
       "cf_neuron_count": null
     },
     "lifecycle": {
       "decentralization_sale_open_timestamp_seconds": 1677826762,
-      "lifecycle": 3
+      "lifecycle": 3,
+      "decentralization_swap_termination_timestamp_seconds": null
     }
   },
   {
@@ -858,7 +1159,8 @@
     "meta": {
       "url": "https://app.sonic.ooo",
       "name": "SONIC",
-      "description": "The open DeFi suite on Internet Computer blockchain by the people for the people. Sonic unleashes the potential of crypto trading through innovative DeFi products. https://app.sonic.ooo"
+      "description": "The open DeFi suite on Internet Computer blockchain by the people for the people. Sonic unleashes the potential of crypto trading through innovative DeFi products. https://app.sonic.ooo",
+      "logo": "/v1/sns/root/23ten-uaaaa-aaaaq-aaapa-cai/logo.png"
     },
     "parameters": {
       "reserved_ids": [],
@@ -867,75 +1169,132 @@
           "id": 0,
           "name": "All Topics",
           "description": "Catch-all w.r.t to following for all types of proposals.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 1,
           "name": "Motion",
           "description": "Side-effect-less proposals to set general governance direction.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 2,
           "name": "Manage nervous system parameters",
           "description": "Proposal to change the core parameters of SNS governance.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 3,
           "name": "Upgrade SNS controlled canister",
           "description": "Proposal to upgrade the wasm of an SNS controlled canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 4,
           "name": "Add nervous system function",
           "description": "Proposal to add a new, user-defined, nervous system function:a canister call which can then be executed by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 5,
           "name": "Remove nervous system function",
           "description": "Proposal to remove a user-defined nervous system function,which will be no longer executable by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 6,
           "name": "Execute nervous system function",
           "description": "Proposal to execute a user-defined nervous system function,previously added by an AddNervousSystemFunction proposal. A canister call will be made when executed.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 7,
           "name": "Upgrade SNS to next version",
           "description": "Proposal to upgrade the WASM of a core SNS canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 8,
           "name": "Manage SNS metadata",
           "description": "Proposal to change the metadata associated with an SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 9,
           "name": "Transfer SNS treasury funds",
           "description": "Proposal to transfer funds from an SNS Governance controlled treasury account",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 10,
           "name": "Register dapp canisters",
           "description": "Proposal to register a dapp canister with the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 11,
           "name": "Deregister Dapp Canisters",
           "description": "Proposal to deregister a previously-registered dapp canister from the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         }
       ]
+    },
+    "nervous_system_parameters": {
+      "default_followees": {
+        "followees": []
+      },
+      "max_dissolve_delay_seconds": 31557600,
+      "max_dissolve_delay_bonus_percentage": 100,
+      "max_followees_per_function": 15,
+      "neuron_claimer_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "neuron_minimum_stake_e8s": 500000000,
+      "max_neuron_age_for_age_bonus": 15778800,
+      "initial_voting_period_seconds": 345600,
+      "neuron_minimum_dissolve_delay_to_vote_seconds": 2629800,
+      "reject_cost_e8s": 12500000000,
+      "max_proposals_to_keep_per_action": 100,
+      "wait_for_quiet_deadline_increase_seconds": 86400,
+      "max_number_of_neurons": 200000,
+      "transaction_fee_e8s": 100000,
+      "max_number_of_proposals_with_ballots": 700,
+      "max_age_bonus_percentage": 25,
+      "neuron_grantable_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "voting_rewards_parameters": {
+        "final_reward_rate_basis_points": 100,
+        "initial_reward_rate_basis_points": 200,
+        "reward_rate_transition_duration_seconds": 157788000,
+        "round_duration_seconds": 86400
+      },
+      "maturity_modulation_disabled": null,
+      "max_number_of_principals_per_neuron": 5
     },
     "swap_state": {
       "swap": {
@@ -943,6 +1302,7 @@
         "init": {
           "nns_proposal_id": null,
           "sns_root_canister_id": "23ten-uaaaa-aaaaq-aaapa-cai",
+          "neurons_fund_participation": null,
           "min_participant_icp_e8s": null,
           "neuron_basket_construction_parameters": null,
           "fallback_controller_principal_ids": [
@@ -959,32 +1319,61 @@
           "transaction_fee_e8s": 100000,
           "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
           "sns_ledger_canister_id": "7ajy4-sqaaa-aaaaq-aaaqa-cai",
+          "neurons_fund_participation_constraints": null,
           "neurons_fund_participants": null,
           "should_auto_finalize": null,
           "max_participant_icp_e8s": null,
           "sns_governance_canister_id": "24scz-zyaaa-aaaaq-aaapq-cai",
+          "min_direct_participation_icp_e8s": null,
           "restricted_countries": null,
-          "min_icp_e8s": null
+          "min_icp_e8s": null,
+          "max_direct_participation_icp_e8s": null
         },
         "params": null,
         "open_sns_token_swap_proposal_id": null,
         "decentralization_sale_open_timestamp_seconds": null
       },
-      "derived": { "buyer_total_icp_e8s": 0, "sns_tokens_per_icp": 0.0 }
+      "derived": {
+        "buyer_total_icp_e8s": 0,
+        "sns_tokens_per_icp": 0
+      }
     },
     "icrc1_metadata": [
-      ["icrc1:decimals", { "Nat": [8] }],
-      ["icrc1:name", { "Text": "SONIC" }],
-      ["icrc1:symbol", { "Text": "SOC" }],
-      ["icrc1:fee", { "Nat": [100000] }]
+      [
+        "icrc1:decimals",
+        {
+          "Nat": [8]
+        }
+      ],
+      [
+        "icrc1:name",
+        {
+          "Text": "SONIC"
+        }
+      ],
+      [
+        "icrc1:symbol",
+        {
+          "Text": "SOC"
+        }
+      ],
+      [
+        "icrc1:fee",
+        {
+          "Nat": [100000]
+        }
+      ]
     ],
     "icrc1_fee": [100000],
     "icrc1_total_supply": 12500000000000000,
-    "swap_params": { "params": null },
+    "swap_params": {
+      "params": null
+    },
     "init": {
       "init": {
         "nns_proposal_id": null,
         "sns_root_canister_id": "23ten-uaaaa-aaaaq-aaapa-cai",
+        "neurons_fund_participation": null,
         "min_participant_icp_e8s": null,
         "neuron_basket_construction_parameters": null,
         "fallback_controller_principal_ids": [
@@ -1001,24 +1390,30 @@
         "transaction_fee_e8s": 100000,
         "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
         "sns_ledger_canister_id": "7ajy4-sqaaa-aaaaq-aaaqa-cai",
+        "neurons_fund_participation_constraints": null,
         "neurons_fund_participants": null,
         "should_auto_finalize": null,
         "max_participant_icp_e8s": null,
         "sns_governance_canister_id": "24scz-zyaaa-aaaaq-aaapq-cai",
+        "min_direct_participation_icp_e8s": null,
         "restricted_countries": null,
-        "min_icp_e8s": null
+        "min_icp_e8s": null,
+        "max_direct_participation_icp_e8s": null
       }
     },
     "derived_state": {
-      "sns_tokens_per_icp": 0.0,
+      "sns_tokens_per_icp": 0,
       "buyer_total_icp_e8s": 0,
       "cf_participant_count": null,
+      "neurons_fund_participation_icp_e8s": null,
+      "direct_participation_icp_e8s": null,
       "direct_participant_count": null,
       "cf_neuron_count": null
     },
     "lifecycle": {
       "decentralization_sale_open_timestamp_seconds": null,
-      "lifecycle": 4
+      "lifecycle": 4,
+      "decentralization_swap_termination_timestamp_seconds": null
     }
   },
   {
@@ -1040,89 +1435,141 @@
         "msqgt-mqaaa-aaaaf-qaj2a-cai",
         "nw5jb-vqaaa-aaaaf-qaj4a-cai",
         "74iy7-xqaaa-aaaaf-qagra-cai",
-        "ny7ej-oaaaa-aaaaf-qaj5a-cai"
+        "ny7ej-oaaaa-aaaaf-qaj5a-cai",
+        "va3nt-myaaa-aaaak-afjga-cai",
+        "xcvai-qiaaa-aaaak-afowq-cai",
+        "xfug4-5qaaa-aaaak-afowa-cai"
       ],
       "archives": ["6yan7-4qaaa-aaaaq-aaaua-cai"]
     },
     "meta": {
       "url": "https://kinic.io/",
       "name": "Kinic",
-      "description": "The first and only dedicated search engine for web3 content that is hosted on blockchain or decentralized storage networks"
+      "description": "The home of portable and verifiable AI.  A DAO for push to deploy vector DB, zkML, search, trading bots and much more.",
+      "logo": "/v1/sns/root/7jkta-eyaaa-aaaaq-aaarq-cai/logo.png"
     },
     "parameters": {
       "reserved_ids": [],
       "functions": [
         {
           "id": 0,
-          "name": "All Topics",
-          "description": "Catch-all w.r.t to following for all types of proposals.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "name": "All non-critical topics",
+          "description": "Catch-all w.r.t to following for non-critical proposals.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 1,
           "name": "Motion",
           "description": "Side-effect-less proposals to set general governance direction.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 2,
           "name": "Manage nervous system parameters",
           "description": "Proposal to change the core parameters of SNS governance.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 3,
           "name": "Upgrade SNS controlled canister",
           "description": "Proposal to upgrade the wasm of an SNS controlled canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 4,
           "name": "Add nervous system function",
-          "description": "Proposal to add a new, user-defined, nervous system function:a canister call which can then be executed by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "description": "Proposal to add a new, user-defined, nervous system function: a canister call which can then be executed by proposal.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 5,
           "name": "Remove nervous system function",
-          "description": "Proposal to remove a user-defined nervous system function,which will be no longer executable by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "description": "Proposal to remove a user-defined nervous system function, which will be no longer executable by proposal.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 6,
           "name": "Execute nervous system function",
-          "description": "Proposal to execute a user-defined nervous system function,previously added by an AddNervousSystemFunction proposal. A canister call will be made when executed.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "description": "Proposal to execute a user-defined nervous system function, previously added by an AddNervousSystemFunction proposal. A canister call will be made when executed.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 7,
           "name": "Upgrade SNS to next version",
           "description": "Proposal to upgrade the WASM of a core SNS canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 8,
           "name": "Manage SNS metadata",
           "description": "Proposal to change the metadata associated with an SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 9,
           "name": "Transfer SNS treasury funds",
           "description": "Proposal to transfer funds from an SNS Governance controlled treasury account",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 10,
           "name": "Register dapp canisters",
           "description": "Proposal to register a dapp canister with the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 11,
           "name": "Deregister Dapp Canisters",
           "description": "Proposal to deregister a previously-registered dapp canister from the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
+        },
+        {
+          "id": 12,
+          "name": "Mint SNS tokens",
+          "description": "Proposal to mint SNS tokens to a specified recipient.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
+        },
+        {
+          "id": 13,
+          "name": "Manage ledger parameters",
+          "description": "Proposal to change some parameters in the ledger canister.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
+        },
+        {
+          "id": 14,
+          "name": "Manage dapp canister settings",
+          "description": "Proposal to change canister settings for some dapp canisters.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 1000,
@@ -1162,8 +1609,106 @@
               "target_method_name": "commit_proposed_batch"
             }
           }
+        },
+        {
+          "id": 1004,
+          "name": "grant_permission",
+          "description": "grant permission to asset canister",
+          "function_type": {
+            "GenericNervousSystemFunction": {
+              "validator_canister_id": "va3nt-myaaa-aaaak-afjga-cai",
+              "target_canister_id": "va3nt-myaaa-aaaak-afjga-cai",
+              "validator_method_name": "validate_grant_permission",
+              "target_method_name": "grant_permission"
+            }
+          }
+        },
+        {
+          "id": 1005,
+          "name": "commit_proposed_batch",
+          "description": "commit the batch that proposed by community who has Prepare permission",
+          "function_type": {
+            "GenericNervousSystemFunction": {
+              "validator_canister_id": "va3nt-myaaa-aaaak-afjga-cai",
+              "target_canister_id": "va3nt-myaaa-aaaak-afjga-cai",
+              "validator_method_name": "validate_commit_proposed_batch",
+              "target_method_name": "commit_proposed_batch"
+            }
+          }
+        },
+        {
+          "id": 1006,
+          "name": "commit_proposed_batch_of_kinic_ui",
+          "description": "commit the batch that proposed by community who has Prepare permission",
+          "function_type": {
+            "GenericNervousSystemFunction": {
+              "validator_canister_id": "xcvai-qiaaa-aaaak-afowq-cai",
+              "target_canister_id": "xcvai-qiaaa-aaaak-afowq-cai",
+              "validator_method_name": "validate_commit_proposed_batch",
+              "target_method_name": "commit_proposed_batch"
+            }
+          }
+        },
+        {
+          "id": 101000,
+          "name": "Call `trade_tokens` on the KINIC trading pair canister at the CYCLES-TRANSFER-STATION.",
+          "description": null,
+          "function_type": {
+            "GenericNervousSystemFunction": {
+              "validator_canister_id": "y2hpc-naaaa-aaaar-qadua-cai",
+              "target_canister_id": "y2hpc-naaaa-aaaar-qadua-cai",
+              "validator_method_name": "sns_validate_trade_tokens",
+              "target_method_name": "trade_tokens"
+            }
+          }
+        },
+        {
+          "id": 101001,
+          "name": "Call the `cycles_out` method on the CYCLES-TRANSFER-STATION CYCLES-BANK.",
+          "description": null,
+          "function_type": {
+            "GenericNervousSystemFunction": {
+              "validator_canister_id": "wwikr-gqaaa-aaaar-qacva-cai",
+              "target_canister_id": "wwikr-gqaaa-aaaar-qacva-cai",
+              "validator_method_name": "sns_validate_cycles_out",
+              "target_method_name": "cycles_out"
+            }
+          }
         }
       ]
+    },
+    "nervous_system_parameters": {
+      "default_followees": {
+        "followees": []
+      },
+      "max_dissolve_delay_seconds": 31557600,
+      "max_dissolve_delay_bonus_percentage": 100,
+      "max_followees_per_function": 15,
+      "neuron_claimer_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "neuron_minimum_stake_e8s": 10000000,
+      "max_neuron_age_for_age_bonus": 15778800,
+      "initial_voting_period_seconds": 432000,
+      "neuron_minimum_dissolve_delay_to_vote_seconds": 2628000,
+      "reject_cost_e8s": 500000000,
+      "max_proposals_to_keep_per_action": 100,
+      "wait_for_quiet_deadline_increase_seconds": 86400,
+      "max_number_of_neurons": 200000,
+      "transaction_fee_e8s": 100000,
+      "max_number_of_proposals_with_ballots": 700,
+      "max_age_bonus_percentage": 25,
+      "neuron_grantable_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "voting_rewards_parameters": {
+        "final_reward_rate_basis_points": 250,
+        "initial_reward_rate_basis_points": 250,
+        "reward_rate_transition_duration_seconds": 157788000,
+        "round_duration_seconds": 86400
+      },
+      "maturity_modulation_disabled": false,
+      "max_number_of_principals_per_neuron": 5
     },
     "swap_state": {
       "swap": {
@@ -1171,6 +1716,7 @@
         "init": {
           "nns_proposal_id": null,
           "sns_root_canister_id": "7jkta-eyaaa-aaaaq-aaarq-cai",
+          "neurons_fund_participation": null,
           "min_participant_icp_e8s": null,
           "neuron_basket_construction_parameters": null,
           "fallback_controller_principal_ids": [
@@ -1187,12 +1733,17 @@
           "transaction_fee_e8s": 100000,
           "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
           "sns_ledger_canister_id": "73mez-iiaaa-aaaaq-aaasq-cai",
+          "neurons_fund_participation_constraints": null,
           "neurons_fund_participants": null,
           "should_auto_finalize": null,
           "max_participant_icp_e8s": null,
           "sns_governance_canister_id": "74ncn-fqaaa-aaaaq-aaasa-cai",
-          "restricted_countries": { "iso_codes": ["US"] },
-          "min_icp_e8s": null
+          "min_direct_participation_icp_e8s": null,
+          "restricted_countries": {
+            "iso_codes": ["US"]
+          },
+          "min_icp_e8s": null,
+          "max_direct_participation_icp_e8s": null
         },
         "params": {
           "min_participant_icp_e8s": 100000000,
@@ -1206,7 +1757,9 @@
           "sns_token_e8s": 150000000000000,
           "sale_delay_seconds": 86400,
           "max_participant_icp_e8s": 10000000000000,
-          "min_icp_e8s": 50000000000000
+          "min_direct_participation_icp_e8s": null,
+          "min_icp_e8s": 50000000000000,
+          "max_direct_participation_icp_e8s": null
         },
         "open_sns_token_swap_proposal_id": 122749,
         "decentralization_sale_open_timestamp_seconds": 1686150901
@@ -1217,13 +1770,39 @@
       }
     },
     "icrc1_metadata": [
-      ["icrc1:decimals", { "Nat": [8] }],
-      ["icrc1:name", { "Text": "KINIC" }],
-      ["icrc1:symbol", { "Text": "KINIC" }],
-      ["icrc1:fee", { "Nat": [100000] }]
+      [
+        "icrc1:decimals",
+        {
+          "Nat": [8]
+        }
+      ],
+      [
+        "icrc1:name",
+        {
+          "Text": "KINIC"
+        }
+      ],
+      [
+        "icrc1:symbol",
+        {
+          "Text": "KINIC"
+        }
+      ],
+      [
+        "icrc1:fee",
+        {
+          "Nat": [100000]
+        }
+      ],
+      [
+        "icrc1:max_memo_length",
+        {
+          "Nat": [32]
+        }
+      ]
     ],
     "icrc1_fee": [100000],
-    "icrc1_total_supply": 600010562900687,
+    "icrc1_total_supply": 607710412355844,
     "swap_params": {
       "params": {
         "min_participant_icp_e8s": 100000000,
@@ -1237,13 +1816,16 @@
         "sns_token_e8s": 150000000000000,
         "sale_delay_seconds": 86400,
         "max_participant_icp_e8s": 10000000000000,
-        "min_icp_e8s": 50000000000000
+        "min_direct_participation_icp_e8s": null,
+        "min_icp_e8s": 50000000000000,
+        "max_direct_participation_icp_e8s": null
       }
     },
     "init": {
       "init": {
         "nns_proposal_id": null,
         "sns_root_canister_id": "7jkta-eyaaa-aaaaq-aaarq-cai",
+        "neurons_fund_participation": null,
         "min_participant_icp_e8s": null,
         "neuron_basket_construction_parameters": null,
         "fallback_controller_principal_ids": [
@@ -1260,24 +1842,32 @@
         "transaction_fee_e8s": 100000,
         "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
         "sns_ledger_canister_id": "73mez-iiaaa-aaaaq-aaasq-cai",
+        "neurons_fund_participation_constraints": null,
         "neurons_fund_participants": null,
         "should_auto_finalize": null,
         "max_participant_icp_e8s": null,
         "sns_governance_canister_id": "74ncn-fqaaa-aaaaq-aaasa-cai",
-        "restricted_countries": { "iso_codes": ["US"] },
-        "min_icp_e8s": null
+        "min_direct_participation_icp_e8s": null,
+        "restricted_countries": {
+          "iso_codes": ["US"]
+        },
+        "min_icp_e8s": null,
+        "max_direct_participation_icp_e8s": null
       }
     },
     "derived_state": {
       "sns_tokens_per_icp": 2.941617488861084,
       "buyer_total_icp_e8s": 50992351828093,
       "cf_participant_count": 90,
+      "neurons_fund_participation_icp_e8s": null,
+      "direct_participation_icp_e8s": null,
       "direct_participant_count": 741,
       "cf_neuron_count": 130
     },
     "lifecycle": {
       "decentralization_sale_open_timestamp_seconds": 1686150901,
-      "lifecycle": 3
+      "lifecycle": 3,
+      "decentralization_swap_termination_timestamp_seconds": null
     }
   },
   {
@@ -1297,92 +1887,140 @@
       "governance": "6wcax-haaaa-aaaaq-aaava-cai",
       "dapps": [
         "jwktp-qyaaa-aaaag-abcfa-cai",
-        "y6yjf-jyaaa-aaaal-qbd6q-cai",
+        "efsfj-sqaaa-aaaap-qatwa-cai",
         "vyatz-hqaaa-aaaam-qauea-cai",
-        "rimrc-piaaa-aaaao-aaljq-cai",
-        "efsfj-sqaaa-aaaap-qatwa-cai"
+        "74zq4-iqaaa-aaaam-ab53a-cai"
       ],
       "archives": ["4zzzg-yyaaa-aaaaq-aaazq-cai"]
     },
     "meta": {
-      "url": "https://hotornot.wtf",
-      "name": "Hot or Not",
-      "description": "A decentralized short-video social media platform governed by the people for the people"
+      "url": "https://yral.com",
+      "name": "YRAL",
+      "description": "A decentralized short-video social media platform governed by the people for the people",
+      "logo": "/v1/sns/root/67bll-riaaa-aaaaq-aaauq-cai/logo.png"
     },
     "parameters": {
       "reserved_ids": [],
       "functions": [
         {
           "id": 0,
-          "name": "All Topics",
-          "description": "Catch-all w.r.t to following for all types of proposals.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "name": "All non-critical topics",
+          "description": "Catch-all w.r.t to following for non-critical proposals.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 1,
           "name": "Motion",
           "description": "Side-effect-less proposals to set general governance direction.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 2,
           "name": "Manage nervous system parameters",
           "description": "Proposal to change the core parameters of SNS governance.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 3,
           "name": "Upgrade SNS controlled canister",
           "description": "Proposal to upgrade the wasm of an SNS controlled canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 4,
           "name": "Add nervous system function",
-          "description": "Proposal to add a new, user-defined, nervous system function:a canister call which can then be executed by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "description": "Proposal to add a new, user-defined, nervous system function: a canister call which can then be executed by proposal.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 5,
           "name": "Remove nervous system function",
-          "description": "Proposal to remove a user-defined nervous system function,which will be no longer executable by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "description": "Proposal to remove a user-defined nervous system function, which will be no longer executable by proposal.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 6,
           "name": "Execute nervous system function",
-          "description": "Proposal to execute a user-defined nervous system function,previously added by an AddNervousSystemFunction proposal. A canister call will be made when executed.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "description": "Proposal to execute a user-defined nervous system function, previously added by an AddNervousSystemFunction proposal. A canister call will be made when executed.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 7,
           "name": "Upgrade SNS to next version",
           "description": "Proposal to upgrade the WASM of a core SNS canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 8,
           "name": "Manage SNS metadata",
           "description": "Proposal to change the metadata associated with an SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 9,
           "name": "Transfer SNS treasury funds",
           "description": "Proposal to transfer funds from an SNS Governance controlled treasury account",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 10,
           "name": "Register dapp canisters",
           "description": "Proposal to register a dapp canister with the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 11,
           "name": "Deregister Dapp Canisters",
           "description": "Proposal to deregister a previously-registered dapp canister from the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
+        },
+        {
+          "id": 12,
+          "name": "Mint SNS tokens",
+          "description": "Proposal to mint SNS tokens to a specified recipient.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
+        },
+        {
+          "id": 13,
+          "name": "Manage ledger parameters",
+          "description": "Proposal to change some parameters in the ledger canister.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
+        },
+        {
+          "id": 14,
+          "name": "Manage dapp canister settings",
+          "description": "Proposal to change canister settings for some dapp canisters.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 1000,
@@ -1409,8 +2047,67 @@
               "target_method_name": "revoke_permission"
             }
           }
+        },
+        {
+          "id": 4001,
+          "name": "Reset Individual User Canisters",
+          "description": "Generic proposal to reset indiviudal user canisters",
+          "function_type": {
+            "GenericNervousSystemFunction": {
+              "validator_canister_id": "rimrc-piaaa-aaaao-aaljq-cai",
+              "target_canister_id": "rimrc-piaaa-aaaao-aaljq-cai",
+              "validator_method_name": "validate_reset_user_individual_canisters",
+              "target_method_name": "reset_user_individual_canisters"
+            }
+          }
+        },
+        {
+          "id": 4002,
+          "name": "Generic Function Platform Orchestrator ",
+          "description": "Generic proposal to execute commands from platform orchestrator",
+          "function_type": {
+            "GenericNervousSystemFunction": {
+              "validator_canister_id": "74zq4-iqaaa-aaaam-ab53a-cai",
+              "target_canister_id": "74zq4-iqaaa-aaaam-ab53a-cai",
+              "validator_method_name": "validate_platform_orchestrator_generic_function",
+              "target_method_name": "platform_orchestrator_generic_function"
+            }
+          }
         }
       ]
+    },
+    "nervous_system_parameters": {
+      "default_followees": {
+        "followees": []
+      },
+      "max_dissolve_delay_seconds": 126230400,
+      "max_dissolve_delay_bonus_percentage": 100,
+      "max_followees_per_function": 15,
+      "neuron_claimer_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "neuron_minimum_stake_e8s": 500000000,
+      "max_neuron_age_for_age_bonus": 63115200,
+      "initial_voting_period_seconds": 345600,
+      "neuron_minimum_dissolve_delay_to_vote_seconds": 7889400,
+      "reject_cost_e8s": 10000000000,
+      "max_proposals_to_keep_per_action": 100,
+      "wait_for_quiet_deadline_increase_seconds": 86400,
+      "max_number_of_neurons": 200000,
+      "transaction_fee_e8s": 100000,
+      "max_number_of_proposals_with_ballots": 700,
+      "max_age_bonus_percentage": 25,
+      "neuron_grantable_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "voting_rewards_parameters": {
+        "final_reward_rate_basis_points": 500,
+        "initial_reward_rate_basis_points": 1000,
+        "reward_rate_transition_duration_seconds": 315576000,
+        "round_duration_seconds": 86400
+      },
+      "maturity_modulation_disabled": false,
+      "max_number_of_principals_per_neuron": 5
     },
     "swap_state": {
       "swap": {
@@ -1418,6 +2115,7 @@
         "init": {
           "nns_proposal_id": null,
           "sns_root_canister_id": "67bll-riaaa-aaaaq-aaauq-cai",
+          "neurons_fund_participation": null,
           "min_participant_icp_e8s": null,
           "neuron_basket_construction_parameters": null,
           "fallback_controller_principal_ids": [
@@ -1434,12 +2132,15 @@
           "transaction_fee_e8s": 100000,
           "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
           "sns_ledger_canister_id": "6rdgd-kyaaa-aaaaq-aaavq-cai",
+          "neurons_fund_participation_constraints": null,
           "neurons_fund_participants": null,
           "should_auto_finalize": null,
           "max_participant_icp_e8s": null,
           "sns_governance_canister_id": "6wcax-haaaa-aaaaq-aaava-cai",
+          "min_direct_participation_icp_e8s": null,
           "restricted_countries": null,
-          "min_icp_e8s": null
+          "min_icp_e8s": null,
+          "max_direct_participation_icp_e8s": null
         },
         "params": {
           "min_participant_icp_e8s": 100000000,
@@ -1453,7 +2154,9 @@
           "sns_token_e8s": 33000000000000000,
           "sale_delay_seconds": 36000,
           "max_participant_icp_e8s": 15000000000000,
-          "min_icp_e8s": 100000000000000
+          "min_direct_participation_icp_e8s": null,
+          "min_icp_e8s": 100000000000000,
+          "max_direct_participation_icp_e8s": null
         },
         "open_sns_token_swap_proposal_id": 123252,
         "decentralization_sale_open_timestamp_seconds": 1687832383
@@ -1464,13 +2167,39 @@
       }
     },
     "icrc1_metadata": [
-      ["icrc1:decimals", { "Nat": [8] }],
-      ["icrc1:name", { "Text": "HotOrNot" }],
-      ["icrc1:symbol", { "Text": "HOT" }],
-      ["icrc1:fee", { "Nat": [100000] }]
+      [
+        "icrc1:decimals",
+        {
+          "Nat": [8]
+        }
+      ],
+      [
+        "icrc1:name",
+        {
+          "Text": "YRAL"
+        }
+      ],
+      [
+        "icrc1:symbol",
+        {
+          "Text": "DOLR"
+        }
+      ],
+      [
+        "icrc1:fee",
+        {
+          "Nat": [100000]
+        }
+      ],
+      [
+        "icrc1:max_memo_length",
+        {
+          "Nat": [32]
+        }
+      ]
     ],
     "icrc1_fee": [100000],
-    "icrc1_total_supply": 100000001544666698,
+    "icrc1_total_supply": 102095095865607020,
     "swap_params": {
       "params": {
         "min_participant_icp_e8s": 100000000,
@@ -1484,13 +2213,16 @@
         "sns_token_e8s": 33000000000000000,
         "sale_delay_seconds": 36000,
         "max_participant_icp_e8s": 15000000000000,
-        "min_icp_e8s": 100000000000000
+        "min_direct_participation_icp_e8s": null,
+        "min_icp_e8s": 100000000000000,
+        "max_direct_participation_icp_e8s": null
       }
     },
     "init": {
       "init": {
         "nns_proposal_id": null,
         "sns_root_canister_id": "67bll-riaaa-aaaaq-aaauq-cai",
+        "neurons_fund_participation": null,
         "min_participant_icp_e8s": null,
         "neuron_basket_construction_parameters": null,
         "fallback_controller_principal_ids": [
@@ -1507,24 +2239,30 @@
         "transaction_fee_e8s": 100000,
         "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
         "sns_ledger_canister_id": "6rdgd-kyaaa-aaaaq-aaavq-cai",
+        "neurons_fund_participation_constraints": null,
         "neurons_fund_participants": null,
         "should_auto_finalize": null,
         "max_participant_icp_e8s": null,
         "sns_governance_canister_id": "6wcax-haaaa-aaaaq-aaava-cai",
+        "min_direct_participation_icp_e8s": null,
         "restricted_countries": null,
-        "min_icp_e8s": null
+        "min_icp_e8s": null,
+        "max_direct_participation_icp_e8s": null
       }
     },
     "derived_state": {
       "sns_tokens_per_icp": 307.25457763671875,
       "buyer_total_icp_e8s": 107402789035875,
       "cf_participant_count": 142,
+      "neurons_fund_participation_icp_e8s": null,
+      "direct_participation_icp_e8s": null,
       "direct_participant_count": 1157,
       "cf_neuron_count": 179
     },
     "lifecycle": {
       "decentralization_sale_open_timestamp_seconds": 1687832383,
-      "lifecycle": 3
+      "lifecycle": 3,
+      "decentralization_swap_termination_timestamp_seconds": null
     }
   },
   {
@@ -1548,7 +2286,8 @@
     "meta": {
       "url": "https://yadjb-mqaaa-aaaan-qaqlq-cai.raw.ic0.app/",
       "name": "ICGhost",
-      "description": "The First Decentralized Meme Coin on IC"
+      "description": "The First Decentralized Meme Coin on IC",
+      "logo": "/v1/sns/root/6kg2g-qaaaa-aaaaq-aaaxa-cai/logo.png"
     },
     "parameters": {
       "reserved_ids": [],
@@ -1557,75 +2296,132 @@
           "id": 0,
           "name": "All Topics",
           "description": "Catch-all w.r.t to following for all types of proposals.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 1,
           "name": "Motion",
           "description": "Side-effect-less proposals to set general governance direction.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 2,
           "name": "Manage nervous system parameters",
           "description": "Proposal to change the core parameters of SNS governance.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 3,
           "name": "Upgrade SNS controlled canister",
           "description": "Proposal to upgrade the wasm of an SNS controlled canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 4,
           "name": "Add nervous system function",
           "description": "Proposal to add a new, user-defined, nervous system function:a canister call which can then be executed by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 5,
           "name": "Remove nervous system function",
           "description": "Proposal to remove a user-defined nervous system function,which will be no longer executable by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 6,
           "name": "Execute nervous system function",
           "description": "Proposal to execute a user-defined nervous system function,previously added by an AddNervousSystemFunction proposal. A canister call will be made when executed.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 7,
           "name": "Upgrade SNS to next version",
           "description": "Proposal to upgrade the WASM of a core SNS canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 8,
           "name": "Manage SNS metadata",
           "description": "Proposal to change the metadata associated with an SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 9,
           "name": "Transfer SNS treasury funds",
           "description": "Proposal to transfer funds from an SNS Governance controlled treasury account",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 10,
           "name": "Register dapp canisters",
           "description": "Proposal to register a dapp canister with the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 11,
           "name": "Deregister Dapp Canisters",
           "description": "Proposal to deregister a previously-registered dapp canister from the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         }
       ]
+    },
+    "nervous_system_parameters": {
+      "default_followees": {
+        "followees": []
+      },
+      "max_dissolve_delay_seconds": 31536000,
+      "max_dissolve_delay_bonus_percentage": 25,
+      "max_followees_per_function": 15,
+      "neuron_claimer_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "neuron_minimum_stake_e8s": 1000000000000,
+      "max_neuron_age_for_age_bonus": 15768000,
+      "initial_voting_period_seconds": 345600,
+      "neuron_minimum_dissolve_delay_to_vote_seconds": 604800,
+      "reject_cost_e8s": 10000000000000,
+      "max_proposals_to_keep_per_action": 100,
+      "wait_for_quiet_deadline_increase_seconds": 86400,
+      "max_number_of_neurons": 200000,
+      "transaction_fee_e8s": 100000000,
+      "max_number_of_proposals_with_ballots": 700,
+      "max_age_bonus_percentage": 25,
+      "neuron_grantable_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "voting_rewards_parameters": {
+        "final_reward_rate_basis_points": 125,
+        "initial_reward_rate_basis_points": 125,
+        "reward_rate_transition_duration_seconds": 0,
+        "round_duration_seconds": 86400
+      },
+      "maturity_modulation_disabled": false,
+      "max_number_of_principals_per_neuron": 5
     },
     "swap_state": {
       "swap": {
@@ -1633,6 +2429,7 @@
         "init": {
           "nns_proposal_id": null,
           "sns_root_canister_id": "6kg2g-qaaaa-aaaaq-aaaxa-cai",
+          "neurons_fund_participation": null,
           "min_participant_icp_e8s": null,
           "neuron_basket_construction_parameters": null,
           "fallback_controller_principal_ids": [
@@ -1649,32 +2446,61 @@
           "transaction_fee_e8s": 100000000,
           "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
           "sns_ledger_canister_id": "4q2s2-oqaaa-aaaaq-aaaya-cai",
+          "neurons_fund_participation_constraints": null,
           "neurons_fund_participants": null,
           "should_auto_finalize": null,
           "max_participant_icp_e8s": null,
           "sns_governance_canister_id": "6nh4s-5yaaa-aaaaq-aaaxq-cai",
+          "min_direct_participation_icp_e8s": null,
           "restricted_countries": null,
-          "min_icp_e8s": null
+          "min_icp_e8s": null,
+          "max_direct_participation_icp_e8s": null
         },
         "params": null,
         "open_sns_token_swap_proposal_id": null,
         "decentralization_sale_open_timestamp_seconds": null
       },
-      "derived": { "buyer_total_icp_e8s": 0, "sns_tokens_per_icp": 0.0 }
+      "derived": {
+        "buyer_total_icp_e8s": 0,
+        "sns_tokens_per_icp": 0
+      }
     },
     "icrc1_metadata": [
-      ["icrc1:decimals", { "Nat": [8] }],
-      ["icrc1:name", { "Text": "GHOST" }],
-      ["icrc1:symbol", { "Text": "GHOST" }],
-      ["icrc1:fee", { "Nat": [100000000] }]
+      [
+        "icrc1:decimals",
+        {
+          "Nat": [8]
+        }
+      ],
+      [
+        "icrc1:name",
+        {
+          "Text": "GHOST"
+        }
+      ],
+      [
+        "icrc1:symbol",
+        {
+          "Text": "GHOST"
+        }
+      ],
+      [
+        "icrc1:fee",
+        {
+          "Nat": [100000000]
+        }
+      ]
     ],
     "icrc1_fee": [100000000],
-    "icrc1_total_supply": 1000000000000000000,
-    "swap_params": { "params": null },
+    "icrc1_total_supply": 1e18,
+    "swap_params": {
+      "params": null
+    },
     "init": {
       "init": {
         "nns_proposal_id": null,
         "sns_root_canister_id": "6kg2g-qaaaa-aaaaq-aaaxa-cai",
+        "neurons_fund_participation": null,
         "min_participant_icp_e8s": null,
         "neuron_basket_construction_parameters": null,
         "fallback_controller_principal_ids": [
@@ -1691,24 +2517,30 @@
         "transaction_fee_e8s": 100000000,
         "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
         "sns_ledger_canister_id": "4q2s2-oqaaa-aaaaq-aaaya-cai",
+        "neurons_fund_participation_constraints": null,
         "neurons_fund_participants": null,
         "should_auto_finalize": null,
         "max_participant_icp_e8s": null,
         "sns_governance_canister_id": "6nh4s-5yaaa-aaaaq-aaaxq-cai",
+        "min_direct_participation_icp_e8s": null,
         "restricted_countries": null,
-        "min_icp_e8s": null
+        "min_icp_e8s": null,
+        "max_direct_participation_icp_e8s": null
       }
     },
     "derived_state": {
-      "sns_tokens_per_icp": 0.0,
+      "sns_tokens_per_icp": 0,
       "buyer_total_icp_e8s": 0,
       "cf_participant_count": 0,
+      "neurons_fund_participation_icp_e8s": null,
+      "direct_participation_icp_e8s": null,
       "direct_participant_count": 0,
       "cf_neuron_count": 0
     },
     "lifecycle": {
       "decentralization_sale_open_timestamp_seconds": null,
-      "lifecycle": 4
+      "lifecycle": 4,
+      "decentralization_swap_termination_timestamp_seconds": null
     }
   },
   {
@@ -1726,90 +2558,205 @@
       "ledger": "4c4fd-caaaa-aaaaq-aaa3a-cai",
       "index": "5ithz-aqaaa-aaaaq-aaa4a-cai",
       "governance": "4l7o7-uiaaa-aaaaq-aaa2q-cai",
-      "dapps": [],
+      "dapps": [
+        "xzcnc-myaaa-aaaak-abk7a-cai",
+        "fjbi2-fyaaa-aaaan-qanjq-cai",
+        "yadjb-mqaaa-aaaan-qaqlq-cai",
+        "p3sub-gqaaa-aaaal-acwza-cai",
+        "77bch-kaaaa-aaaan-qa4vq-cai",
+        "gfcya-pyaaa-aaaan-qbxda-cai"
+      ],
       "archives": ["52vqa-maaaa-aaaaq-aaa7a-cai"]
     },
     "meta": {
       "url": "https://yadjb-mqaaa-aaaan-qaqlq-cai.raw.ic0.app/",
       "name": "ICGhost",
-      "description": "The First Decentralized Meme Coin on IC"
+      "description": "The First Decentralized Meme Coin on IC",
+      "logo": "/v1/sns/root/4m6il-zqaaa-aaaaq-aaa2a-cai/logo.png"
     },
     "parameters": {
       "reserved_ids": [],
       "functions": [
         {
           "id": 0,
-          "name": "All Topics",
-          "description": "Catch-all w.r.t to following for all types of proposals.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "name": "All non-critical topics",
+          "description": "Catch-all w.r.t to following for non-critical proposals.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 1,
           "name": "Motion",
           "description": "Side-effect-less proposals to set general governance direction.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 2,
           "name": "Manage nervous system parameters",
           "description": "Proposal to change the core parameters of SNS governance.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 3,
           "name": "Upgrade SNS controlled canister",
           "description": "Proposal to upgrade the wasm of an SNS controlled canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 4,
           "name": "Add nervous system function",
-          "description": "Proposal to add a new, user-defined, nervous system function:a canister call which can then be executed by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "description": "Proposal to add a new, user-defined, nervous system function: a canister call which can then be executed by proposal.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 5,
           "name": "Remove nervous system function",
-          "description": "Proposal to remove a user-defined nervous system function,which will be no longer executable by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "description": "Proposal to remove a user-defined nervous system function, which will be no longer executable by proposal.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 6,
           "name": "Execute nervous system function",
-          "description": "Proposal to execute a user-defined nervous system function,previously added by an AddNervousSystemFunction proposal. A canister call will be made when executed.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "description": "Proposal to execute a user-defined nervous system function, previously added by an AddNervousSystemFunction proposal. A canister call will be made when executed.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 7,
           "name": "Upgrade SNS to next version",
           "description": "Proposal to upgrade the WASM of a core SNS canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 8,
           "name": "Manage SNS metadata",
           "description": "Proposal to change the metadata associated with an SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 9,
           "name": "Transfer SNS treasury funds",
           "description": "Proposal to transfer funds from an SNS Governance controlled treasury account",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 10,
           "name": "Register dapp canisters",
           "description": "Proposal to register a dapp canister with the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 11,
           "name": "Deregister Dapp Canisters",
           "description": "Proposal to deregister a previously-registered dapp canister from the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
+        },
+        {
+          "id": 12,
+          "name": "Mint SNS tokens",
+          "description": "Proposal to mint SNS tokens to a specified recipient.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
+        },
+        {
+          "id": 13,
+          "name": "Manage ledger parameters",
+          "description": "Proposal to change some parameters in the ledger canister.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
+        },
+        {
+          "id": 14,
+          "name": "Manage dapp canister settings",
+          "description": "Proposal to change canister settings for some dapp canisters.",
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
+        },
+        {
+          "id": 1000,
+          "name": "burn",
+          "description": null,
+          "function_type": {
+            "GenericNervousSystemFunction": {
+              "validator_canister_id": "p3sub-gqaaa-aaaal-acwza-cai",
+              "target_canister_id": "p3sub-gqaaa-aaaal-acwza-cai",
+              "validator_method_name": "validate_burn",
+              "target_method_name": "burn"
+            }
+          }
+        },
+        {
+          "id": 2000,
+          "name": "transferGovernancePosition",
+          "description": null,
+          "function_type": {
+            "GenericNervousSystemFunction": {
+              "validator_canister_id": "3eiym-hqaaa-aaaal-adqia-cai",
+              "target_canister_id": "dwahc-eyaaa-aaaag-qcgnq-cai",
+              "validator_method_name": "validate_transfer_position",
+              "target_method_name": "transferPosition"
+            }
+          }
         }
       ]
+    },
+    "nervous_system_parameters": {
+      "default_followees": {
+        "followees": []
+      },
+      "max_dissolve_delay_seconds": 31536000,
+      "max_dissolve_delay_bonus_percentage": 25,
+      "max_followees_per_function": 15,
+      "neuron_claimer_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "neuron_minimum_stake_e8s": 1000000000000,
+      "max_neuron_age_for_age_bonus": 15768000,
+      "initial_voting_period_seconds": 345600,
+      "neuron_minimum_dissolve_delay_to_vote_seconds": 604800,
+      "reject_cost_e8s": 10000000000000,
+      "max_proposals_to_keep_per_action": 100,
+      "wait_for_quiet_deadline_increase_seconds": 86400,
+      "max_number_of_neurons": 200000,
+      "transaction_fee_e8s": 100000000,
+      "max_number_of_proposals_with_ballots": 700,
+      "max_age_bonus_percentage": 25,
+      "neuron_grantable_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "voting_rewards_parameters": {
+        "final_reward_rate_basis_points": 125,
+        "initial_reward_rate_basis_points": 125,
+        "reward_rate_transition_duration_seconds": 0,
+        "round_duration_seconds": 86400
+      },
+      "maturity_modulation_disabled": false,
+      "max_number_of_principals_per_neuron": 5
     },
     "swap_state": {
       "swap": {
@@ -1817,6 +2764,7 @@
         "init": {
           "nns_proposal_id": null,
           "sns_root_canister_id": "4m6il-zqaaa-aaaaq-aaa2a-cai",
+          "neurons_fund_participation": null,
           "min_participant_icp_e8s": null,
           "neuron_basket_construction_parameters": null,
           "fallback_controller_principal_ids": [
@@ -1833,12 +2781,15 @@
           "transaction_fee_e8s": 100000000,
           "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
           "sns_ledger_canister_id": "4c4fd-caaaa-aaaaq-aaa3a-cai",
+          "neurons_fund_participation_constraints": null,
           "neurons_fund_participants": null,
           "should_auto_finalize": null,
           "max_participant_icp_e8s": null,
           "sns_governance_canister_id": "4l7o7-uiaaa-aaaaq-aaa2q-cai",
+          "min_direct_participation_icp_e8s": null,
           "restricted_countries": null,
-          "min_icp_e8s": null
+          "min_icp_e8s": null,
+          "max_direct_participation_icp_e8s": null
         },
         "params": {
           "min_participant_icp_e8s": 100000000,
@@ -1849,27 +2800,55 @@
           "max_icp_e8s": 2000000000000,
           "swap_due_timestamp_seconds": 1690462231,
           "min_participants": 200,
-          "sns_token_e8s": 200000000000000000,
+          "sns_token_e8s": 2e17,
           "sale_delay_seconds": null,
           "max_participant_icp_e8s": 5000000000,
-          "min_icp_e8s": 1000000000000
+          "min_direct_participation_icp_e8s": null,
+          "min_icp_e8s": 1000000000000,
+          "max_direct_participation_icp_e8s": null
         },
         "open_sns_token_swap_proposal_id": 123592,
         "decentralization_sale_open_timestamp_seconds": 1690203041
       },
       "derived": {
         "buyer_total_icp_e8s": 2000000000000,
-        "sns_tokens_per_icp": 100000.0
+        "sns_tokens_per_icp": 100000
       }
     },
     "icrc1_metadata": [
-      ["icrc1:decimals", { "Nat": [8] }],
-      ["icrc1:name", { "Text": "GHOST" }],
-      ["icrc1:symbol", { "Text": "GHOST" }],
-      ["icrc1:fee", { "Nat": [100000000] }]
+      [
+        "icrc1:decimals",
+        {
+          "Nat": [8]
+        }
+      ],
+      [
+        "icrc1:name",
+        {
+          "Text": "GHOST"
+        }
+      ],
+      [
+        "icrc1:symbol",
+        {
+          "Text": "GHOST"
+        }
+      ],
+      [
+        "icrc1:fee",
+        {
+          "Nat": [100000000]
+        }
+      ],
+      [
+        "icrc1:max_memo_length",
+        {
+          "Nat": [32]
+        }
+      ]
     ],
     "icrc1_fee": [100000000],
-    "icrc1_total_supply": 999999169800000000,
+    "icrc1_total_supply": 925531620743132900,
     "swap_params": {
       "params": {
         "min_participant_icp_e8s": 100000000,
@@ -1880,16 +2859,19 @@
         "max_icp_e8s": 2000000000000,
         "swap_due_timestamp_seconds": 1690462231,
         "min_participants": 200,
-        "sns_token_e8s": 200000000000000000,
+        "sns_token_e8s": 2e17,
         "sale_delay_seconds": null,
         "max_participant_icp_e8s": 5000000000,
-        "min_icp_e8s": 1000000000000
+        "min_direct_participation_icp_e8s": null,
+        "min_icp_e8s": 1000000000000,
+        "max_direct_participation_icp_e8s": null
       }
     },
     "init": {
       "init": {
         "nns_proposal_id": null,
         "sns_root_canister_id": "4m6il-zqaaa-aaaaq-aaa2a-cai",
+        "neurons_fund_participation": null,
         "min_participant_icp_e8s": null,
         "neuron_basket_construction_parameters": null,
         "fallback_controller_principal_ids": [
@@ -1906,24 +2888,30 @@
         "transaction_fee_e8s": 100000000,
         "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
         "sns_ledger_canister_id": "4c4fd-caaaa-aaaaq-aaa3a-cai",
+        "neurons_fund_participation_constraints": null,
         "neurons_fund_participants": null,
         "should_auto_finalize": null,
         "max_participant_icp_e8s": null,
         "sns_governance_canister_id": "4l7o7-uiaaa-aaaaq-aaa2q-cai",
+        "min_direct_participation_icp_e8s": null,
         "restricted_countries": null,
-        "min_icp_e8s": null
+        "min_icp_e8s": null,
+        "max_direct_participation_icp_e8s": null
       }
     },
     "derived_state": {
-      "sns_tokens_per_icp": 100000.0,
+      "sns_tokens_per_icp": 100000,
       "buyer_total_icp_e8s": 2000000000000,
       "cf_participant_count": 0,
+      "neurons_fund_participation_icp_e8s": null,
+      "direct_participation_icp_e8s": null,
       "direct_participant_count": 586,
       "cf_neuron_count": 0
     },
     "lifecycle": {
       "decentralization_sale_open_timestamp_seconds": 1690203041,
-      "lifecycle": 3
+      "lifecycle": 3,
+      "decentralization_swap_termination_timestamp_seconds": null
     }
   },
   {
@@ -1941,20 +2929,14 @@
       "ledger": "5bqmf-wyaaa-aaaaq-aaa5q-cai",
       "index": "5tw34-2iaaa-aaaaq-aaa6q-cai",
       "governance": "5grkr-3aaaa-aaaaq-aaa5a-cai",
-      "dapps": [
-        "7xnbj-wqaaa-aaaap-aa4ea-cai",
-        "5escj-6iaaa-aaaap-aa4kq-cai",
-        "443xk-qiaaa-aaaap-aa4oq-cai",
-        "4sz2c-lyaaa-aaaap-aa4pq-cai",
-        "zjdgt-niaaa-aaaap-aa4qq-cai",
-        "zhbl3-wyaaa-aaaap-aa4rq-cai"
-      ],
+      "dapps": [],
       "archives": []
     },
     "meta": {
       "url": "https://catalyze.one",
       "name": "Catalyze",
-      "description": "Catalyze is a one-stop social-fi application for organising your Web3 experience"
+      "description": "Catalyze is a one-stop social-fi application for organising your Web3 experience",
+      "logo": "/v1/sns/root/5psbn-niaaa-aaaaq-aaa4q-cai/logo.png"
     },
     "parameters": {
       "reserved_ids": [],
@@ -1963,82 +2945,140 @@
           "id": 0,
           "name": "All Topics",
           "description": "Catch-all w.r.t to following for all types of proposals.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 1,
           "name": "Motion",
           "description": "Side-effect-less proposals to set general governance direction.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 2,
           "name": "Manage nervous system parameters",
           "description": "Proposal to change the core parameters of SNS governance.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 3,
           "name": "Upgrade SNS controlled canister",
           "description": "Proposal to upgrade the wasm of an SNS controlled canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 4,
           "name": "Add nervous system function",
           "description": "Proposal to add a new, user-defined, nervous system function:a canister call which can then be executed by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 5,
           "name": "Remove nervous system function",
           "description": "Proposal to remove a user-defined nervous system function,which will be no longer executable by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 6,
           "name": "Execute nervous system function",
           "description": "Proposal to execute a user-defined nervous system function,previously added by an AddNervousSystemFunction proposal. A canister call will be made when executed.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 7,
           "name": "Upgrade SNS to next version",
           "description": "Proposal to upgrade the WASM of a core SNS canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 8,
           "name": "Manage SNS metadata",
           "description": "Proposal to change the metadata associated with an SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 9,
           "name": "Transfer SNS treasury funds",
           "description": "Proposal to transfer funds from an SNS Governance controlled treasury account",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 10,
           "name": "Register dapp canisters",
           "description": "Proposal to register a dapp canister with the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 11,
           "name": "Deregister Dapp Canisters",
           "description": "Proposal to deregister a previously-registered dapp canister from the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         }
       ]
     },
+    "nervous_system_parameters": {
+      "default_followees": {
+        "followees": []
+      },
+      "max_dissolve_delay_seconds": 63113852,
+      "max_dissolve_delay_bonus_percentage": 150,
+      "max_followees_per_function": 15,
+      "neuron_claimer_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "neuron_minimum_stake_e8s": 400000000,
+      "max_neuron_age_for_age_bonus": 15778463,
+      "initial_voting_period_seconds": 86400,
+      "neuron_minimum_dissolve_delay_to_vote_seconds": 2629000,
+      "reject_cost_e8s": 10000000000,
+      "max_proposals_to_keep_per_action": 100,
+      "wait_for_quiet_deadline_increase_seconds": 43200,
+      "max_number_of_neurons": 200000,
+      "transaction_fee_e8s": 100000,
+      "max_number_of_proposals_with_ballots": 700,
+      "max_age_bonus_percentage": 25,
+      "neuron_grantable_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "voting_rewards_parameters": {
+        "final_reward_rate_basis_points": 150,
+        "initial_reward_rate_basis_points": 500,
+        "reward_rate_transition_duration_seconds": 157788000,
+        "round_duration_seconds": 86400
+      },
+      "maturity_modulation_disabled": false,
+      "max_number_of_principals_per_neuron": 5
+    },
     "swap_state": {
       "swap": {
-        "lifecycle": 2,
+        "lifecycle": 4,
         "init": {
           "nns_proposal_id": null,
           "sns_root_canister_id": "5psbn-niaaa-aaaaq-aaa4q-cai",
+          "neurons_fund_participation": null,
           "min_participant_icp_e8s": null,
           "neuron_basket_construction_parameters": null,
           "fallback_controller_principal_ids": [
@@ -2056,12 +3096,17 @@
           "transaction_fee_e8s": 100000,
           "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
           "sns_ledger_canister_id": "5bqmf-wyaaa-aaaaq-aaa5q-cai",
+          "neurons_fund_participation_constraints": null,
           "neurons_fund_participants": null,
           "should_auto_finalize": null,
           "max_participant_icp_e8s": null,
           "sns_governance_canister_id": "5grkr-3aaaa-aaaaq-aaa5a-cai",
-          "restricted_countries": { "iso_codes": ["US"] },
-          "min_icp_e8s": null
+          "min_direct_participation_icp_e8s": null,
+          "restricted_countries": {
+            "iso_codes": ["US"]
+          },
+          "min_icp_e8s": null,
+          "max_direct_participation_icp_e8s": null
         },
         "params": {
           "min_participant_icp_e8s": 100000000,
@@ -2075,24 +3120,46 @@
           "sns_token_e8s": 11250000000000000,
           "sale_delay_seconds": null,
           "max_participant_icp_e8s": 15000000000000,
-          "min_icp_e8s": 65000000000000
+          "min_direct_participation_icp_e8s": null,
+          "min_icp_e8s": 65000000000000,
+          "max_direct_participation_icp_e8s": null
         },
         "open_sns_token_swap_proposal_id": 123772,
         "decentralization_sale_open_timestamp_seconds": 1690786778
       },
       "derived": {
-        "buyer_total_icp_e8s": 50669291278205,
-        "sns_tokens_per_icp": 222.02797
+        "buyer_total_icp_e8s": 62620913601795,
+        "sns_tokens_per_icp": 179.65244
       }
     },
     "icrc1_metadata": [
-      ["icrc1:decimals", { "Nat": [8] }],
-      ["icrc1:name", { "Text": "CatalyzeDAO" }],
-      ["icrc1:symbol", { "Text": "CAT" }],
-      ["icrc1:fee", { "Nat": [100000] }]
+      [
+        "icrc1:decimals",
+        {
+          "Nat": [8]
+        }
+      ],
+      [
+        "icrc1:name",
+        {
+          "Text": "CatalyzeDAO"
+        }
+      ],
+      [
+        "icrc1:symbol",
+        {
+          "Text": "CAT"
+        }
+      ],
+      [
+        "icrc1:fee",
+        {
+          "Nat": [100000]
+        }
+      ]
     ],
     "icrc1_fee": [100000],
-    "icrc1_total_supply": 50000000000000000,
+    "icrc1_total_supply": 5e16,
     "swap_params": {
       "params": {
         "min_participant_icp_e8s": 100000000,
@@ -2106,13 +3173,16 @@
         "sns_token_e8s": 11250000000000000,
         "sale_delay_seconds": null,
         "max_participant_icp_e8s": 15000000000000,
-        "min_icp_e8s": 65000000000000
+        "min_direct_participation_icp_e8s": null,
+        "min_icp_e8s": 65000000000000,
+        "max_direct_participation_icp_e8s": null
       }
     },
     "init": {
       "init": {
         "nns_proposal_id": null,
         "sns_root_canister_id": "5psbn-niaaa-aaaaq-aaa4q-cai",
+        "neurons_fund_participation": null,
         "min_participant_icp_e8s": null,
         "neuron_basket_construction_parameters": null,
         "fallback_controller_principal_ids": [
@@ -2130,24 +3200,32 @@
         "transaction_fee_e8s": 100000,
         "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
         "sns_ledger_canister_id": "5bqmf-wyaaa-aaaaq-aaa5q-cai",
+        "neurons_fund_participation_constraints": null,
         "neurons_fund_participants": null,
         "should_auto_finalize": null,
         "max_participant_icp_e8s": null,
         "sns_governance_canister_id": "5grkr-3aaaa-aaaaq-aaa5a-cai",
-        "restricted_countries": { "iso_codes": ["US"] },
-        "min_icp_e8s": null
+        "min_direct_participation_icp_e8s": null,
+        "restricted_countries": {
+          "iso_codes": ["US"]
+        },
+        "min_icp_e8s": null,
+        "max_direct_participation_icp_e8s": null
       }
     },
     "derived_state": {
-      "sns_tokens_per_icp": 222.02796936035156,
-      "buyer_total_icp_e8s": 50669291278205,
+      "sns_tokens_per_icp": 179.65243530273438,
+      "buyer_total_icp_e8s": 62620913601795,
       "cf_participant_count": 145,
-      "direct_participant_count": 224,
+      "neurons_fund_participation_icp_e8s": null,
+      "direct_participation_icp_e8s": null,
+      "direct_participant_count": 398,
       "cf_neuron_count": 178
     },
     "lifecycle": {
       "decentralization_sale_open_timestamp_seconds": 1690786778,
-      "lifecycle": 2
+      "lifecycle": 4,
+      "decentralization_swap_termination_timestamp_seconds": null
     }
   },
   {
@@ -2171,7 +3249,8 @@
     "meta": {
       "url": "https://edgematrix.pro/",
       "name": "Edge Matrix Computing",
-      "description": "The Next Generation of Decentralized Computing Network in AI Era"
+      "description": "The Next Generation of Decentralized Computing Network in AI Era",
+      "logo": "/v1/sns/root/55uwu-byaaa-aaaaq-aaa7q-cai/logo.png"
     },
     "parameters": {
       "reserved_ids": [],
@@ -2180,82 +3259,140 @@
           "id": 0,
           "name": "All Topics",
           "description": "Catch-all w.r.t to following for all types of proposals.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 1,
           "name": "Motion",
           "description": "Side-effect-less proposals to set general governance direction.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 2,
           "name": "Manage nervous system parameters",
           "description": "Proposal to change the core parameters of SNS governance.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 3,
           "name": "Upgrade SNS controlled canister",
           "description": "Proposal to upgrade the wasm of an SNS controlled canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 4,
           "name": "Add nervous system function",
           "description": "Proposal to add a new, user-defined, nervous system function:a canister call which can then be executed by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 5,
           "name": "Remove nervous system function",
           "description": "Proposal to remove a user-defined nervous system function,which will be no longer executable by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 6,
           "name": "Execute nervous system function",
           "description": "Proposal to execute a user-defined nervous system function,previously added by an AddNervousSystemFunction proposal. A canister call will be made when executed.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 7,
           "name": "Upgrade SNS to next version",
           "description": "Proposal to upgrade the WASM of a core SNS canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 8,
           "name": "Manage SNS metadata",
           "description": "Proposal to change the metadata associated with an SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 9,
           "name": "Transfer SNS treasury funds",
           "description": "Proposal to transfer funds from an SNS Governance controlled treasury account",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 10,
           "name": "Register dapp canisters",
           "description": "Proposal to register a dapp canister with the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 11,
           "name": "Deregister Dapp Canisters",
           "description": "Proposal to deregister a previously-registered dapp canister from the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         }
       ]
     },
+    "nervous_system_parameters": {
+      "default_followees": {
+        "followees": []
+      },
+      "max_dissolve_delay_seconds": 31557600,
+      "max_dissolve_delay_bonus_percentage": 200,
+      "max_followees_per_function": 15,
+      "neuron_claimer_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "neuron_minimum_stake_e8s": 100000000,
+      "max_neuron_age_for_age_bonus": 15778800,
+      "initial_voting_period_seconds": 345600,
+      "neuron_minimum_dissolve_delay_to_vote_seconds": 2629800,
+      "reject_cost_e8s": 5000000000,
+      "max_proposals_to_keep_per_action": 100,
+      "wait_for_quiet_deadline_increase_seconds": 86400,
+      "max_number_of_neurons": 200000,
+      "transaction_fee_e8s": 100000,
+      "max_number_of_proposals_with_ballots": 700,
+      "max_age_bonus_percentage": 125,
+      "neuron_grantable_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "voting_rewards_parameters": {
+        "final_reward_rate_basis_points": 0,
+        "initial_reward_rate_basis_points": 0,
+        "reward_rate_transition_duration_seconds": 94672800,
+        "round_duration_seconds": 86400
+      },
+      "maturity_modulation_disabled": false,
+      "max_number_of_principals_per_neuron": 5
+    },
     "swap_state": {
       "swap": {
-        "lifecycle": 1,
+        "lifecycle": 4,
         "init": {
           "nns_proposal_id": null,
           "sns_root_canister_id": "55uwu-byaaa-aaaaq-aaa7q-cai",
+          "neurons_fund_participation": null,
           "min_participant_icp_e8s": null,
           "neuron_basket_construction_parameters": null,
           "fallback_controller_principal_ids": ["htsl7-baaaa-aaaam-ablva-cai"],
@@ -2270,32 +3407,61 @@
           "transaction_fee_e8s": 100000,
           "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
           "sns_ledger_canister_id": "wedc6-xiaaa-aaaaq-aabaq-cai",
+          "neurons_fund_participation_constraints": null,
           "neurons_fund_participants": null,
           "should_auto_finalize": null,
           "max_participant_icp_e8s": null,
           "sns_governance_canister_id": "wdcek-2qaaa-aaaaq-aabaa-cai",
+          "min_direct_participation_icp_e8s": null,
           "restricted_countries": null,
-          "min_icp_e8s": null
+          "min_icp_e8s": null,
+          "max_direct_participation_icp_e8s": null
         },
         "params": null,
         "open_sns_token_swap_proposal_id": null,
         "decentralization_sale_open_timestamp_seconds": null
       },
-      "derived": { "buyer_total_icp_e8s": 0, "sns_tokens_per_icp": 0.0 }
+      "derived": {
+        "buyer_total_icp_e8s": 0,
+        "sns_tokens_per_icp": 0
+      }
     },
     "icrc1_metadata": [
-      ["icrc1:decimals", { "Nat": [8] }],
-      ["icrc1:name", { "Text": "EdgeMatrixComputing" }],
-      ["icrc1:symbol", { "Text": "EMC" }],
-      ["icrc1:fee", { "Nat": [100000] }]
+      [
+        "icrc1:decimals",
+        {
+          "Nat": [8]
+        }
+      ],
+      [
+        "icrc1:name",
+        {
+          "Text": "EdgeMatrixComputing"
+        }
+      ],
+      [
+        "icrc1:symbol",
+        {
+          "Text": "EMC"
+        }
+      ],
+      [
+        "icrc1:fee",
+        {
+          "Nat": [100000]
+        }
+      ]
     ],
     "icrc1_fee": [100000],
-    "icrc1_total_supply": 210000000000000000,
-    "swap_params": { "params": null },
+    "icrc1_total_supply": 2.1e17,
+    "swap_params": {
+      "params": null
+    },
     "init": {
       "init": {
         "nns_proposal_id": null,
         "sns_root_canister_id": "55uwu-byaaa-aaaaq-aaa7q-cai",
+        "neurons_fund_participation": null,
         "min_participant_icp_e8s": null,
         "neuron_basket_construction_parameters": null,
         "fallback_controller_principal_ids": ["htsl7-baaaa-aaaam-ablva-cai"],
@@ -2310,24 +3476,30 @@
         "transaction_fee_e8s": 100000,
         "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
         "sns_ledger_canister_id": "wedc6-xiaaa-aaaaq-aabaq-cai",
+        "neurons_fund_participation_constraints": null,
         "neurons_fund_participants": null,
         "should_auto_finalize": null,
         "max_participant_icp_e8s": null,
         "sns_governance_canister_id": "wdcek-2qaaa-aaaaq-aabaa-cai",
+        "min_direct_participation_icp_e8s": null,
         "restricted_countries": null,
-        "min_icp_e8s": null
+        "min_icp_e8s": null,
+        "max_direct_participation_icp_e8s": null
       }
     },
     "derived_state": {
-      "sns_tokens_per_icp": 0.0,
+      "sns_tokens_per_icp": 0,
       "buyer_total_icp_e8s": 0,
       "cf_participant_count": 0,
+      "neurons_fund_participation_icp_e8s": null,
+      "direct_participation_icp_e8s": null,
       "direct_participant_count": 0,
       "cf_neuron_count": 0
     },
     "lifecycle": {
       "decentralization_sale_open_timestamp_seconds": null,
-      "lifecycle": 1
+      "lifecycle": 4,
+      "decentralization_swap_termination_timestamp_seconds": null
     }
   },
   {
@@ -2345,19 +3517,14 @@
       "ledger": "wrett-waaaa-aaaaq-aabda-cai",
       "index": "x3lrj-uqaaa-aaaaq-aabea-cai",
       "governance": "wyhyp-aiaaa-aaaaq-aabcq-cai",
-      "dapps": [
-        "gdtip-xiaaa-aaaah-qdbnq-cai",
-        "gwuzc-waaaa-aaaah-qdboa-cai",
-        "grv7w-3yaaa-aaaah-qdboq-cai",
-        "g7xs6-aiaaa-aaaah-qdbpq-cai",
-        "ddmi3-laaaa-aaaah-qdbqa-cai"
-      ],
+      "dapps": [],
       "archives": []
     },
     "meta": {
       "url": "https://modclub.app",
       "name": "Modclub",
-      "description": "Modclub is a decentralized crowdwork platform built on the IC that aims to support dApps by handing resource-intensive tasks such as moderation, user verification and data labeling."
+      "description": "Modclub is a decentralized crowdwork platform built on the IC that aims to support dApps by handing resource-intensive tasks such as moderation, user verification and data labeling.",
+      "logo": "/v1/sns/root/w7g63-nqaaa-aaaaq-aabca-cai/logo.png"
     },
     "parameters": {
       "reserved_ids": [],
@@ -2366,82 +3533,140 @@
           "id": 0,
           "name": "All Topics",
           "description": "Catch-all w.r.t to following for all types of proposals.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 1,
           "name": "Motion",
           "description": "Side-effect-less proposals to set general governance direction.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 2,
           "name": "Manage nervous system parameters",
           "description": "Proposal to change the core parameters of SNS governance.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 3,
           "name": "Upgrade SNS controlled canister",
           "description": "Proposal to upgrade the wasm of an SNS controlled canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 4,
           "name": "Add nervous system function",
           "description": "Proposal to add a new, user-defined, nervous system function:a canister call which can then be executed by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 5,
           "name": "Remove nervous system function",
           "description": "Proposal to remove a user-defined nervous system function,which will be no longer executable by proposal.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 6,
           "name": "Execute nervous system function",
           "description": "Proposal to execute a user-defined nervous system function,previously added by an AddNervousSystemFunction proposal. A canister call will be made when executed.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 7,
           "name": "Upgrade SNS to next version",
           "description": "Proposal to upgrade the WASM of a core SNS canister.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 8,
           "name": "Manage SNS metadata",
           "description": "Proposal to change the metadata associated with an SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 9,
           "name": "Transfer SNS treasury funds",
           "description": "Proposal to transfer funds from an SNS Governance controlled treasury account",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 10,
           "name": "Register dapp canisters",
           "description": "Proposal to register a dapp canister with the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         },
         {
           "id": 11,
           "name": "Deregister Dapp Canisters",
           "description": "Proposal to deregister a previously-registered dapp canister from the SNS.",
-          "function_type": { "NativeNervousSystemFunction": {} }
+          "function_type": {
+            "NativeNervousSystemFunction": {}
+          }
         }
       ]
     },
+    "nervous_system_parameters": {
+      "default_followees": {
+        "followees": []
+      },
+      "max_dissolve_delay_seconds": 31557600,
+      "max_dissolve_delay_bonus_percentage": 100,
+      "max_followees_per_function": 15,
+      "neuron_claimer_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "neuron_minimum_stake_e8s": 3600000000,
+      "max_neuron_age_for_age_bonus": 63115200,
+      "initial_voting_period_seconds": 345600,
+      "neuron_minimum_dissolve_delay_to_vote_seconds": 2629800,
+      "reject_cost_e8s": 20000000000,
+      "max_proposals_to_keep_per_action": 100,
+      "wait_for_quiet_deadline_increase_seconds": 86400,
+      "max_number_of_neurons": 200000,
+      "transaction_fee_e8s": 10000,
+      "max_number_of_proposals_with_ballots": 700,
+      "max_age_bonus_percentage": 25,
+      "neuron_grantable_permissions": {
+        "permissions": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      },
+      "voting_rewards_parameters": {
+        "final_reward_rate_basis_points": 150,
+        "initial_reward_rate_basis_points": 150,
+        "reward_rate_transition_duration_seconds": 94672800,
+        "round_duration_seconds": 86400
+      },
+      "maturity_modulation_disabled": false,
+      "max_number_of_principals_per_neuron": 5
+    },
     "swap_state": {
       "swap": {
-        "lifecycle": 1,
+        "lifecycle": 4,
         "init": {
           "nns_proposal_id": null,
           "sns_root_canister_id": "w7g63-nqaaa-aaaaq-aabca-cai",
+          "neurons_fund_participation": null,
           "min_participant_icp_e8s": null,
           "neuron_basket_construction_parameters": null,
           "fallback_controller_principal_ids": [
@@ -2460,32 +3685,63 @@
           "transaction_fee_e8s": 10000,
           "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
           "sns_ledger_canister_id": "wrett-waaaa-aaaaq-aabda-cai",
+          "neurons_fund_participation_constraints": null,
           "neurons_fund_participants": null,
           "should_auto_finalize": true,
           "max_participant_icp_e8s": null,
           "sns_governance_canister_id": "wyhyp-aiaaa-aaaaq-aabcq-cai",
-          "restricted_countries": { "iso_codes": ["US"] },
-          "min_icp_e8s": null
+          "min_direct_participation_icp_e8s": null,
+          "restricted_countries": {
+            "iso_codes": ["US"]
+          },
+          "min_icp_e8s": null,
+          "max_direct_participation_icp_e8s": null
         },
         "params": null,
         "open_sns_token_swap_proposal_id": null,
         "decentralization_sale_open_timestamp_seconds": null
       },
-      "derived": { "buyer_total_icp_e8s": 0, "sns_tokens_per_icp": 0.0 }
+      "derived": {
+        "buyer_total_icp_e8s": 0,
+        "sns_tokens_per_icp": 0
+      }
     },
     "icrc1_metadata": [
-      ["icrc1:decimals", { "Nat": [8] }],
-      ["icrc1:name", { "Text": "Modclub" }],
-      ["icrc1:symbol", { "Text": "MOD" }],
-      ["icrc1:fee", { "Nat": [10000] }]
+      [
+        "icrc1:decimals",
+        {
+          "Nat": [8]
+        }
+      ],
+      [
+        "icrc1:name",
+        {
+          "Text": "Modclub"
+        }
+      ],
+      [
+        "icrc1:symbol",
+        {
+          "Text": "MOD"
+        }
+      ],
+      [
+        "icrc1:fee",
+        {
+          "Nat": [10000]
+        }
+      ]
     ],
     "icrc1_fee": [10000],
     "icrc1_total_supply": 97999996400000000,
-    "swap_params": { "params": null },
+    "swap_params": {
+      "params": null
+    },
     "init": {
       "init": {
         "nns_proposal_id": null,
         "sns_root_canister_id": "w7g63-nqaaa-aaaaq-aabca-cai",
+        "neurons_fund_participation": null,
         "min_participant_icp_e8s": null,
         "neuron_basket_construction_parameters": null,
         "fallback_controller_principal_ids": [
@@ -2504,24 +3760,32 @@
         "transaction_fee_e8s": 10000,
         "icp_ledger_canister_id": "ryjl3-tyaaa-aaaaa-aaaba-cai",
         "sns_ledger_canister_id": "wrett-waaaa-aaaaq-aabda-cai",
+        "neurons_fund_participation_constraints": null,
         "neurons_fund_participants": null,
         "should_auto_finalize": true,
         "max_participant_icp_e8s": null,
         "sns_governance_canister_id": "wyhyp-aiaaa-aaaaq-aabcq-cai",
-        "restricted_countries": { "iso_codes": ["US"] },
-        "min_icp_e8s": null
+        "min_direct_participation_icp_e8s": null,
+        "restricted_countries": {
+          "iso_codes": ["US"]
+        },
+        "min_icp_e8s": null,
+        "max_direct_participation_icp_e8s": null
       }
     },
     "derived_state": {
-      "sns_tokens_per_icp": 0.0,
+      "sns_tokens_per_icp": 0,
       "buyer_total_icp_e8s": 0,
       "cf_participant_count": 0,
+      "neurons_fund_participation_icp_e8s": null,
+      "direct_participation_icp_e8s": null,
       "direct_participant_count": 0,
       "cf_neuron_count": 0
     },
     "lifecycle": {
       "decentralization_sale_open_timestamp_seconds": null,
-      "lifecycle": 1
+      "lifecycle": 4,
+      "decentralization_swap_termination_timestamp_seconds": null
     }
   }
 ]


### PR DESCRIPTION
# Motivation

The SNS aggregator has exposed `nervous_system_parameters` since https://github.com/dfinity/nns-dapp/pull/4014 but it wasn't used in the NNS dapp frontend yet.
We want to start using it instead of loading the params separately.

This PR just adds the types to the CachedSnsDto.
This PR does not implement any kind of conversion.
The plan is to replace the `snsParametersStore` with a derived store based on this data, rather than exposing it in the `SnsSummary`.

# Changes

1. Manually added types to `frontend/src/lib/types/sns-aggregator.ts` based on the [Rust type](https://github.com/dfinity/nns-dapp/blob/712fd337ae5cf6cdcfae39badc5a389751f67720/rs/sns_aggregator/src/types/ic_sns_governance.rs#L85-L106).

# Tests

1. Updated `frontend/src/tests/mocks/sns-aggregator.mock.json` by copying `frontend/src/tests/workflows/Launchpad/sns-agg-page-0.json` to make sure that the mock defined [here](https://github.com/dfinity/nns-dapp/blob/712fd337ae5cf6cdcfae39badc5a389751f67720/frontend/src/tests/mocks/sns-aggregator.mock.ts#L13) has the required `nervous_system_parameters` fields.
2. Also copied `nervous_system_parameters` from the above files into `frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts` to satisfy the type of the input data to the conversion test.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary
