### PR TITLE
Simplify the lifecycle and access points of `State`

### DIFF
--- a/rs/backend/src/lib.rs
+++ b/rs/backend/src/lib.rs
@@ -17,4 +17,4 @@ pub mod tvl {
     pub mod state;
 }
 
-use crate::state::{StableState, STATE};
+use crate::state::StableState;

--- a/rs/backend/src/perf.rs
+++ b/rs/backend/src/perf.rs
@@ -1,6 +1,7 @@
 //! Capture and store performance counters.
+use crate::state::with_state_mut;
 use crate::stats::Stats;
-use crate::{StableState, STATE};
+use crate::StableState;
 use candid::CandidType;
 use dfn_candid::Candid;
 use ic_cdk::api::instruction_counter;
@@ -113,5 +114,5 @@ pub fn record_instruction_count(name: &str) {
 
 /// Saves an instruction count; useful if the instruction count was captured independently.
 pub fn save_instruction_count(count: PerformanceCount) {
-    STATE.with(|s| s.performance.borrow_mut().save_instruction_count(count));
+    with_state_mut(|s| s.performance.save_instruction_count(count));
 }

--- a/rs/backend/src/periodic_tasks_runner.rs
+++ b/rs/backend/src/periodic_tasks_runner.rs
@@ -1,7 +1,8 @@
 use crate::canisters::{cmc, governance};
+use crate::ledger_sync;
 use crate::multi_part_transactions_processor::MultiPartTransactionToBeProcessed;
-use crate::state::STATE;
-use crate::{ledger_sync, Cycles};
+use crate::state::with_state_mut;
+use crate::Cycles;
 use cycles_minting_canister::{NotifyCreateCanister, NotifyError, NotifyTopUp};
 use dfn_core::api::{CanisterId, PrincipalId};
 use ic_nns_common::types::NeuronId;
@@ -11,12 +12,11 @@ use icp_ledger::{BlockIndex, Memo};
 pub async fn run_periodic_tasks() {
     ledger_sync::sync_transactions().await;
 
-    STATE.with(|state| {
-        state.performance.borrow_mut().increment_periodic_tasks_run();
+    with_state_mut(|state| {
+        state.performance.increment_periodic_tasks_run();
     });
 
-    let maybe_transaction_to_process =
-        STATE.with(|s| s.accounts_store.borrow_mut().try_take_next_transaction_to_process());
+    let maybe_transaction_to_process = with_state_mut(|s| s.accounts_store.try_take_next_transaction_to_process());
     if let Some((block_height, transaction_to_process)) = maybe_transaction_to_process {
         match transaction_to_process {
             MultiPartTransactionToBeProcessed::ParticipateSwap(_principal, _from, _to, _swap_canister_id) => {
@@ -41,10 +41,8 @@ pub async fn run_periodic_tasks() {
 
 async fn handle_stake_neuron(principal: PrincipalId, memo: Memo) {
     match claim_or_refresh_neuron(principal, memo).await {
-        Ok(neuron_id) => STATE.with(|s| {
-            s.accounts_store
-                .borrow_mut()
-                .mark_neuron_created(&principal, memo, neuron_id);
+        Ok(neuron_id) => with_state_mut(|s| {
+            s.accounts_store.mark_neuron_created(&principal, memo, neuron_id);
         }),
         Err(_error) => (),
     }
@@ -52,21 +50,19 @@ async fn handle_stake_neuron(principal: PrincipalId, memo: Memo) {
 
 async fn handle_top_up_neuron(principal: PrincipalId, memo: Memo) {
     match claim_or_refresh_neuron(principal, memo).await {
-        Ok(_) => STATE.with(|s| s.accounts_store.borrow_mut().mark_neuron_topped_up()),
+        Ok(_) => with_state_mut(|s| s.accounts_store.mark_neuron_topped_up()),
         Err(_error) => (),
     }
 }
 
 async fn handle_create_canister_v2(block_height: BlockIndex, controller: PrincipalId) {
     match create_canister_v2(block_height, controller).await {
-        Ok(Ok(canister_id)) => STATE.with(|s| {
-            s.accounts_store
-                .borrow_mut()
-                .attach_newly_created_canister(controller, canister_id);
+        Ok(Ok(canister_id)) => with_state_mut(|s| {
+            s.accounts_store.attach_newly_created_canister(controller, canister_id);
         }),
         Ok(Err(NotifyError::Processing)) => {
-            STATE.with(|s| {
-                s.accounts_store.borrow_mut().enqueue_multi_part_transaction(
+            with_state_mut(|s| {
+                s.accounts_store.enqueue_multi_part_transaction(
                     block_height,
                     MultiPartTransactionToBeProcessed::CreateCanisterV2(controller),
                 );
@@ -81,8 +77,8 @@ async fn handle_top_up_canister_v2(block_height: BlockIndex, principal: Principa
     match top_up_canister_v2(block_height, canister_id).await {
         Ok(Ok(_)) => (),
         Ok(Err(NotifyError::Processing)) => {
-            STATE.with(|s| {
-                s.accounts_store.borrow_mut().enqueue_multi_part_transaction(
+            with_state_mut(|s| {
+                s.accounts_store.enqueue_multi_part_transaction(
                     block_height,
                     MultiPartTransactionToBeProcessed::CreateCanisterV2(principal),
                 );

--- a/rs/backend/src/state/with_accounts_in_stable_memory.rs
+++ b/rs/backend/src/state/with_accounts_in_stable_memory.rs
@@ -12,7 +12,7 @@ impl State {
     pub fn save_heap_to_managed_memory(&self) {
         println!("START state::save_heap: ()");
         let bytes = self.encode();
-        match &*self.partitions_maybe.borrow() {
+        match &self.partitions_maybe {
             PartitionsMaybe::Partitions(partitions) => {
                 let len = bytes.len();
                 let length_field = u64::try_from(len)

--- a/rs/backend/src/tvl/tests.rs
+++ b/rs/backend/src/tvl/tests.rs
@@ -1,5 +1,6 @@
+use crate::state::{init_state, with_state, with_state_mut};
 use crate::timer;
-use crate::tvl::{self, exchange_rate_canister, governance, spawn, time, STATE};
+use crate::tvl::{self, exchange_rate_canister, governance, spawn, time};
 use candid::Nat;
 use lazy_static::lazy_static;
 
@@ -21,19 +22,19 @@ lazy_static! {
 }
 
 fn get_usd_e8s_per_icp() -> u64 {
-    STATE.with(|s| s.tvl_state.borrow().usd_e8s_per_icp)
+    with_state(|s| s.tvl_state.usd_e8s_per_icp)
 }
 
 fn set_usd_e8s_per_icp(new_value: u64) {
-    STATE.with(|s| s.tvl_state.borrow_mut().usd_e8s_per_icp = new_value);
+    with_state_mut(|s| s.tvl_state.usd_e8s_per_icp = new_value);
 }
 
 fn get_exchange_rate_timestamp_seconds() -> u64 {
-    STATE.with(|s| s.tvl_state.borrow().exchange_rate_timestamp_seconds)
+    with_state(|s| s.tvl_state.exchange_rate_timestamp_seconds)
 }
 
 fn set_exchange_rate_timestamp_seconds(new_value: u64) {
-    STATE.with(|s| s.tvl_state.borrow_mut().exchange_rate_timestamp_seconds = new_value);
+    with_state_mut(|s| s.tvl_state.exchange_rate_timestamp_seconds = new_value);
 }
 
 fn get_only_xrc_request() -> exchange_rate_canister::GetExchangeRateRequest {
@@ -43,15 +44,16 @@ fn get_only_xrc_request() -> exchange_rate_canister::GetExchangeRateRequest {
 }
 
 fn get_total_locked_icp_e8s() -> u64 {
-    STATE.with(|s| s.tvl_state.borrow().total_locked_icp_e8s)
+    with_state(|s| s.tvl_state.total_locked_icp_e8s)
 }
 
 fn set_total_locked_icp_e8s(new_value: u64) {
-    STATE.with(|s| s.tvl_state.borrow_mut().total_locked_icp_e8s = new_value);
+    with_state_mut(|s| s.tvl_state.total_locked_icp_e8s = new_value);
 }
 
 #[tokio::test]
 async fn update_exchange_rate() {
+    init_state();
     let initial_usd_e8s_per_icp = 850_000_000;
     let later_usd_e8s_per_icp = 920_000_000;
     let decimals = 8;
@@ -91,6 +93,7 @@ async fn update_exchange_rate() {
 
 #[tokio::test]
 async fn update_exchange_rate_with_3_decimals() {
+    init_state();
     let initial_usd_e8s_per_icp = 850_000_000;
     let later_usd_e8s_per_icp = 920_000_000;
     let decimals = 3;
@@ -131,6 +134,7 @@ async fn update_exchange_rate_with_3_decimals() {
 
 #[tokio::test]
 async fn update_exchange_rate_with_12_decimals() {
+    init_state();
     let initial_usd_e8s_per_icp = 850_000_000;
     let later_usd_e8s_per_icp = 920_000_000;
     let decimals = 12;
@@ -171,6 +175,7 @@ async fn update_exchange_rate_with_12_decimals() {
 
 #[tokio::test]
 async fn update_exchange_rate_with_call_error() {
+    init_state();
     let initial_usd_e8s_per_icp = 0;
     let initial_exchange_rate_timestamp_seconds = 0;
 
@@ -212,6 +217,7 @@ async fn update_exchange_rate_with_call_error() {
 
 #[tokio::test]
 async fn update_exchange_rate_with_method_error() {
+    init_state();
     let initial_usd_e8s_per_icp = 0;
     let initial_exchange_rate_timestamp_seconds = 0;
 
@@ -257,6 +263,7 @@ async fn update_exchange_rate_with_method_error() {
 
 #[tokio::test]
 async fn update_locked_icp_e8s() {
+    init_state();
     let initial_locked_icp_e8s = 50_000_000_000;
     let later_locked_icp_e8s = 90_000_000_000;
 
@@ -276,6 +283,7 @@ async fn update_locked_icp_e8s() {
 
 #[tokio::test]
 async fn update_locked_icp_e8s_with_call_error() {
+    init_state();
     let initial_locked_icp_e8s = 50_000_000_000;
 
     // Step 1: Set up the environment.
@@ -295,6 +303,7 @@ async fn update_locked_icp_e8s_with_call_error() {
 
 #[tokio::test]
 async fn update_locked_icp_e8s_with_method_error() {
+    init_state();
     let initial_locked_icp_e8s = 50_000_000_000;
 
     // Step 1: Set up the environment.
@@ -317,6 +326,7 @@ async fn update_locked_icp_e8s_with_method_error() {
 
 #[test]
 fn get_tvl() {
+    init_state();
     let timestamp = 1_738_485_470;
     let locked_icp_units = 15_000;
     let usd_per_icp_units = 8;
@@ -337,6 +347,7 @@ fn get_tvl() {
 
 #[tokio::test]
 async fn start_updating_exchange_rate_in_background() {
+    init_state();
     tvl::time::testing::set_time(NOW_SECONDS * 1_000_000_000);
 
     let initial_usd_e8s_per_icp = 850_000_000;
@@ -454,6 +465,7 @@ async fn start_updating_exchange_rate_in_background() {
 
 #[tokio::test]
 async fn start_updating_locked_icp_in_the_background() {
+    init_state();
     let initial_locked_icp_e8s = 1_500_000_000;
     let later_locked_icp_e8s = 2_300_000_000;
 


### PR DESCRIPTION
# Motivation

The initialization of the `STATE` currently is rather complicated - it had a `State::default()` before reading from the stable memory, and there is some logic to replace it with the correct value, which makes it difficult to reason about the value of each of its field. Instead, making `STATE` itself a `RefCell<Option<State>>` seems simpler - there is a `Some(State)` or None. 

Each field in `State` does not need `Default`, which is helpful because not all objects have reasonable `Default` (like `Partitions` and `AccountStore`)

# Changes

* Encapsulate `STATE` within `state.rs` and define its accessors
* Replace `STATE.with(...)` with those accessors
* Remove the `Default` of `State`
* Change default->replace to initializing `State` directly in the post_upgrade

# Tests

N/A

# Todos

- [x] Add entry to changelog (if necessary).
