### PR TITLE
Test cleanup ConfirmSnsDissolveDelay.spec.ts

### DIFF
--- a/frontend/src/lib/components/sns-neurons/ConfirmSnsDissolveDelay.svelte
+++ b/frontend/src/lib/components/sns-neurons/ConfirmSnsDissolveDelay.svelte
@@ -47,7 +47,7 @@
 
 <div class="wrapper" data-tid="confirm-dissolve-delay-container">
   <div class="main-info">
-    <h3>
+    <h3 data-tid="dissolve-delay">
       {secondsToDuration({ seconds: BigInt(delayInSeconds), i18n: $i18n.time })}
     </h3>
   </div>
@@ -57,7 +57,7 @@
   </div>
   <div>
     <p class="label">{$i18n.neurons.neuron_balance}</p>
-    <p>
+    <p data-tid="neuron-stake">
       <Html
         text={replacePlaceholders($i18n.sns_neurons.token_stake, {
           $amount: valueSpan(
@@ -70,7 +70,7 @@
   </div>
   <div class="voting-power">
     <p class="label">{$i18n.neurons.voting_power}</p>
-    <p class="value">
+    <p class="value" data-tid="voting-power">
       {#if votingPower !== undefined}
         {formatVotingPower(votingPower)}
       {/if}
@@ -78,6 +78,7 @@
   </div>
   <div class="toolbar">
     <button
+      data-tid="edit-delay-button"
       class="secondary"
       disabled={$busy}
       on:click={() => dispatcher("nnsBack")}

--- a/frontend/src/tests/lib/components/sns-neurons/ConfirmSnsDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/ConfirmSnsDissolveDelay.spec.ts
@@ -20,8 +20,6 @@ describe("ConfirmSnsDissolveDelay", () => {
   });
 
   beforeEach(() => {
-    //vi.useFakeTimers().setSystemTime(Date.now());
-
     snsParametersStore.setParameters({
       certified: true,
       rootCanisterId: mockPrincipal,

--- a/frontend/src/tests/lib/components/sns-neurons/ConfirmSnsDissolveDelay.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neurons/ConfirmSnsDissolveDelay.spec.ts
@@ -1,38 +1,26 @@
 import ConfirmSnsDissolveDelay from "$lib/components/sns-neurons/ConfirmSnsDissolveDelay.svelte";
-import { SECONDS_IN_DAY } from "$lib/constants/constants";
+import { SECONDS_IN_DAY, SECONDS_IN_YEAR } from "$lib/constants/constants";
 import { snsParametersStore } from "$lib/stores/sns-parameters.store";
-import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
-import { formatVotingPower } from "$lib/utils/neuron.utils";
-import {
-  getSnsNeuronIdAsHexString,
-  getSnsNeuronStake,
-  snsNeuronVotingPower,
-} from "$lib/utils/sns-neuron.utils";
-import { formatTokenE8s } from "$lib/utils/token.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
-import en from "$tests/mocks/i18n.mock";
 import {
-  mockSnsNeuron,
+  createMockSnsNeuron,
   snsNervousSystemParametersMock,
 } from "$tests/mocks/sns-neurons.mock";
-import type { SnsNeuron } from "@dfinity/sns";
-import { ICPToken, secondsToDuration } from "@dfinity/utils";
+import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
+import { ConfirmSnsDissolveDelayPo } from "$tests/page-objects/ConfirmSnsDissolveDelay.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { NeuronState } from "@dfinity/nns";
+import { nonNullish } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
 describe("ConfirmSnsDissolveDelay", () => {
   const delayInSeconds = Math.round(12.3 * SECONDS_IN_DAY);
-  const neuron: SnsNeuron = {
-    ...mockSnsNeuron,
-    dissolve_state: [
-      {
-        DissolveDelaySeconds: 0n,
-      },
-    ],
-  };
+  const neuron = createMockSnsNeuron({
+    state: NeuronState.Dissolved,
+  });
 
-  // freeze time
-  beforeAll(() => {
-    vi.useFakeTimers().setSystemTime(Date.now());
+  beforeEach(() => {
+    //vi.useFakeTimers().setSystemTime(Date.now());
 
     snsParametersStore.setParameters({
       certified: true,
@@ -41,103 +29,147 @@ describe("ConfirmSnsDissolveDelay", () => {
     });
   });
 
-  afterAll(() => {
-    vi.useRealTimers();
-    snsParametersStore.reset();
-  });
-
-  it("renders a delay", () => {
-    const { getByText } = render(ConfirmSnsDissolveDelay, {
-      props: {
-        rootCanisterId: mockPrincipal,
-        delayInSeconds,
-        neuron,
-        token: ICPToken,
-      },
-    });
-
-    expect(
-      getByText(secondsToDuration({ seconds: BigInt(delayInSeconds) }))
-    ).toBeInTheDocument();
-  });
-
-  it("renders a neuron ID", () => {
-    const { getAllByText } = render(ConfirmSnsDissolveDelay, {
-      props: {
-        rootCanisterId: mockPrincipal,
-        delayInSeconds,
-        neuron,
-        token: ICPToken,
-      },
-    });
-    const id = shortenWithMiddleEllipsis(
-      getSnsNeuronIdAsHexString(mockSnsNeuron)
+  const renderComponent = ({
+    props,
+    onNnsBack = null,
+    onNnsConfirm = null,
+  }) => {
+    const { container, component } = render(ConfirmSnsDissolveDelay, props);
+    if (nonNullish(onNnsBack)) {
+      component.$on("nnsBack", onNnsBack);
+    }
+    if (nonNullish(onNnsConfirm)) {
+      component.$on("nnsConfirm", onNnsConfirm);
+    }
+    return ConfirmSnsDissolveDelayPo.under(
+      new JestPageObjectElement(container)
     );
+  };
 
-    expect(getAllByText(id).length).toBeGreaterThan(0);
-  });
-
-  it("renders a neuron stake", () => {
-    const { getByText } = render(ConfirmSnsDissolveDelay, {
-      props: {
-        rootCanisterId: mockPrincipal,
-        delayInSeconds,
-        neuron,
-        token: ICPToken,
-      },
-    });
-
-    expect(
-      getByText(
-        formatTokenE8s({
-          value: getSnsNeuronStake(mockSnsNeuron),
-          detailed: true,
-        })
-      )
-    ).toBeInTheDocument();
-  });
-
-  it("renders voting power", () => {
-    const { getByText } = render(ConfirmSnsDissolveDelay, {
-      props: {
-        rootCanisterId: mockPrincipal,
-        delayInSeconds,
-        neuron,
-        token: ICPToken,
-      },
-    });
-    const value = formatVotingPower(
-      snsNeuronVotingPower({
-        neuron,
-        newDissolveDelayInSeconds: BigInt(delayInSeconds),
-        snsParameters: snsNervousSystemParametersMock,
-      })
+  it("renders a delay", async () => {
+    const delayInSeconds = Math.round(
+      2 * SECONDS_IN_YEAR + 10 * SECONDS_IN_DAY
     );
+    const delayDuration = "2 years, 10 days";
 
-    expect(getByText(value)).toBeInTheDocument();
-  });
-
-  it("renders cancel button", () => {
-    const { getByText } = render(ConfirmSnsDissolveDelay, {
+    const po = renderComponent({
       props: {
         rootCanisterId: mockPrincipal,
         delayInSeconds,
         neuron,
-        token: ICPToken,
+        token: mockSnsToken,
       },
     });
-    expect(getByText(en.neurons.edit_delay)).toBeInTheDocument();
+
+    expect(await po.getDissolveDelay()).toBe(delayDuration);
   });
 
-  it("renders confirm button", () => {
-    const { getByText } = render(ConfirmSnsDissolveDelay, {
+  it("renders a neuron ID", async () => {
+    const neuron = createMockSnsNeuron({
+      id: [1, 2, 3, 4, 10, 11, 12, 13],
+    });
+    const po = renderComponent({
       props: {
         rootCanisterId: mockPrincipal,
         delayInSeconds,
         neuron,
-        token: ICPToken,
+        token: mockSnsToken,
       },
     });
-    expect(getByText(en.neurons.confirm_update_delay)).toBeInTheDocument();
+
+    expect(await po.getNeuronId()).toBe("010203040a0b0c0d");
+  });
+
+  it("renders a neuron stake", async () => {
+    const neuron = createMockSnsNeuron({
+      stake: 12_300_000_000n,
+    });
+    const tokenSymbol = "ZZZ";
+    const po = renderComponent({
+      props: {
+        rootCanisterId: mockPrincipal,
+        delayInSeconds,
+        neuron,
+        token: {
+          ...mockSnsToken,
+          symbol: tokenSymbol,
+        },
+      },
+    });
+
+    expect(await po.getNeuronStake()).toBe("123.00 ZZZ Stake");
+  });
+
+  it("renders voting power", async () => {
+    // Stake of 20.00 with max dissolve delay will result in 40.00 voting power.
+    snsParametersStore.setParameters({
+      certified: true,
+      rootCanisterId: mockPrincipal,
+      parameters: {
+        ...snsNervousSystemParametersMock,
+        neuron_minimum_dissolve_delay_to_vote_seconds: [
+          BigInt(delayInSeconds / 5),
+        ],
+        max_dissolve_delay_seconds: [BigInt(delayInSeconds)],
+        max_dissolve_delay_bonus_percentage: [100n],
+        max_age_bonus_percentage: [0n],
+      },
+    });
+    const neuron = createMockSnsNeuron({
+      stake: 2_000_000_000n,
+      stakedMaturity: 0n,
+    });
+
+    const po = renderComponent({
+      props: {
+        rootCanisterId: mockPrincipal,
+        delayInSeconds,
+        neuron,
+        token: mockSnsToken,
+      },
+    });
+
+    expect(await po.getVotingPower()).toBe("40.00");
+  });
+
+  it("edit button dispatches nnsBack", async () => {
+    const onNnsBack = vi.fn();
+    const onNnsConfirm = vi.fn();
+    const po = renderComponent({
+      props: {
+        rootCanisterId: mockPrincipal,
+        delayInSeconds,
+        neuron,
+        token: mockSnsToken,
+      },
+      onNnsBack,
+      onNnsConfirm,
+    });
+
+    expect(onNnsBack).toBeCalledTimes(0);
+    await po.getEditButtonPo().click();
+    expect(onNnsBack).toBeCalledTimes(1);
+
+    expect(onNnsConfirm).toBeCalledTimes(0);
+  });
+
+  it("confirm button dispatches nnsConfirm", async () => {
+    const onNnsBack = vi.fn();
+    const onNnsConfirm = vi.fn();
+    const po = renderComponent({
+      props: {
+        rootCanisterId: mockPrincipal,
+        delayInSeconds,
+        neuron,
+        token: mockSnsToken,
+      },
+      onNnsBack,
+      onNnsConfirm,
+    });
+    expect(onNnsConfirm).toBeCalledTimes(0);
+    await po.getConfirmButtonPo().click();
+    expect(onNnsConfirm).toBeCalledTimes(1);
+
+    expect(onNnsBack).toBeCalledTimes(0);
   });
 });

--- a/frontend/src/tests/mocks/sns-neurons.mock.ts
+++ b/frontend/src/tests/mocks/sns-neurons.mock.ts
@@ -43,7 +43,7 @@ export const mockActiveDisbursement: DisburseMaturityInProgress = {
 
 export const createMockSnsNeuron = ({
   stake = 1_000_000_000n,
-  id,
+  id = [1, 5, 3, 9, 9, 3, 2],
   state,
   permissions = [],
   vesting,
@@ -60,7 +60,7 @@ export const createMockSnsNeuron = ({
   activeDisbursementsE8s = [],
 }: {
   stake?: bigint;
-  id: number[];
+  id?: number[];
   state?: NeuronState;
   permissions?: NeuronPermission[];
   // `undefined` means no vesting at all (default)
@@ -131,10 +131,7 @@ export const mockSnsNeuronId = {
   id: arrayOfNumberToUint8Array([1, 5, 3, 9, 9, 3, 2]),
 };
 
-export const mockSnsNeuron = createMockSnsNeuron({
-  stake: 1_000_000_000n,
-  id: [1, 5, 3, 9, 9, 3, 2],
-});
+export const mockSnsNeuron = createMockSnsNeuron({});
 
 export const mockSnsNeuronWithPermissions = (
   permissions: SnsNeuronPermissionType[]

--- a/frontend/src/tests/page-objects/ConfirmSnsDissolveDelay.page-object.ts
+++ b/frontend/src/tests/page-objects/ConfirmSnsDissolveDelay.page-object.ts
@@ -1,0 +1,42 @@
+import type { ButtonPo } from "$tests/page-objects/Button.page-object";
+import { HashPo } from "$tests/page-objects/Hash.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
+import type { PageObjectElement } from "$tests/types/page-object.types";
+
+export class ConfirmSnsDissolveDelayPo extends BasePageObject {
+  private static readonly TID = "confirm-dissolve-delay-container";
+
+  static under(element: PageObjectElement): ConfirmSnsDissolveDelayPo {
+    return new ConfirmSnsDissolveDelayPo(
+      element.byTestId(ConfirmSnsDissolveDelayPo.TID)
+    );
+  }
+
+  getHashPo(): HashPo {
+    return HashPo.under(this.root);
+  }
+
+  getEditButtonPo(): ButtonPo {
+    return this.getButton("edit-delay-button");
+  }
+
+  getConfirmButtonPo(): ButtonPo {
+    return this.getButton("confirm-delay-button");
+  }
+
+  getNeuronId(): Promise<string> {
+    return this.getHashPo().getFullText();
+  }
+
+  getDissolveDelay(): Promise<string> {
+    return this.getText("dissolve-delay");
+  }
+
+  getNeuronStake(): Promise<string> {
+    return this.getText("neuron-stake");
+  }
+
+  getVotingPower(): Promise<string> {
+    return this.getText("voting-power");
+  }
+}


### PR DESCRIPTION
# Motivation

Make the test in `ConfirmSnsDissolveDelay.spec.ts` easier to read and maintain and less brittle.

# Changes

1. Use a page object.
2. Don't use fake timers as they serve no purpose.
3. Use `beforeEach` instead of `beforeAll` and remove `afterAll`.
4. Use explicit test values and define them in the specific tests that use them.
5. Make `id` in `createMockSnsNeuron` optional so it's easier to create mock neurons when we don't care about the `id`.
6. Use `mockSnsToken` instead of `ICPToken` since it's unrealistic and potentially confusing to use ICP as an SNS token.

# Tests

Test change only

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary