### PR TITLE
Add convertNervousSystemParameters function

### DIFF
--- a/frontend/src/lib/types/sns-aggregator.ts
+++ b/frontend/src/lib/types/sns-aggregator.ts
@@ -46,8 +46,12 @@ export type CachedNeuronIdDto = {
   id: Uint8Array;
 };
 
-export type CachedDefaultFolloweesDto = {
+export type CachedFolloweesDto = {
   followees: CachedNeuronIdDto[];
+};
+
+export type CachedDefaultFolloweesDto = {
+  followees: Array<[number, CachedFolloweesDto]>;
 };
 
 export type CachedNeuronPermissionListDto = {

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -115,8 +115,6 @@ const convertDefaultFollowees = (
       ]),
     },
   ];
-  /*.map(([functionId, followees]) => Principal.from(id)),
-   */
 };
 
 const numberToNullableBigInt = (num?: number): [] | [bigint] =>

--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -8,9 +8,11 @@ import type {
   SnsSummarySwap,
 } from "$lib/types/sns";
 import type {
+  CachedDefaultFolloweesDto,
   CachedFunctionTypeDto,
   CachedLifecycleResponseDto,
   CachedNervousFunctionDto,
+  CachedNervousSystemParametersDto,
   CachedNeuronsFundParticipationConstraints,
   CachedSnsDto,
   CachedSnsMetadataDto,
@@ -19,18 +21,22 @@ import type {
   CachedSnsTokenMetadataDto,
   CachedSwapInitParamsDto,
   CachedSwapParamsDto,
+  CachedVotingRewardsParametersDto,
 } from "$lib/types/sns-aggregator";
 import { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
 import type { IcrcTokenMetadataResponse } from "@dfinity/ledger-icrc";
 import { Principal } from "@dfinity/principal";
 import type {
+  SnsDefaultFollowees,
   SnsFunctionType,
   SnsGetLifecycleResponse,
   SnsNervousSystemFunction,
+  SnsNervousSystemParameters,
   SnsNeuronsFundParticipationConstraints,
   SnsParams,
   SnsSwapDerivedState,
   SnsSwapInit,
+  SnsVotingRewardsParameters,
 } from "@dfinity/sns";
 import {
   candidNumberArrayToBigInt,
@@ -93,6 +99,118 @@ export const convertNervousFunction = ({
   function_type: nonNullish(function_type)
     ? toNullable(convertFunctionType(function_type))
     : [],
+});
+
+const convertDefaultFollowees = (
+  defaultFollowees: undefined | CachedDefaultFolloweesDto
+): [] | [SnsDefaultFollowees] => {
+  if (isNullish(defaultFollowees)) {
+    return [];
+  }
+  return [
+    {
+      followees: defaultFollowees.followees.map(([functionId, followees]) => [
+        BigInt(functionId),
+        followees,
+      ]),
+    },
+  ];
+  /*.map(([functionId, followees]) => Principal.from(id)),
+   */
+};
+
+const numberToNullableBigInt = (num?: number): [] | [bigint] =>
+  toNullable(convertOptionalNumToBigInt(num));
+
+const convertVotingRewardsParameters = (
+  votingRewardsParameters: undefined | CachedVotingRewardsParametersDto
+): [] | [SnsVotingRewardsParameters] => {
+  if (isNullish(votingRewardsParameters)) {
+    return [];
+  }
+  return [
+    {
+      final_reward_rate_basis_points: numberToNullableBigInt(
+        votingRewardsParameters.final_reward_rate_basis_points
+      ),
+      initial_reward_rate_basis_points: numberToNullableBigInt(
+        votingRewardsParameters.initial_reward_rate_basis_points
+      ),
+      reward_rate_transition_duration_seconds: numberToNullableBigInt(
+        votingRewardsParameters.reward_rate_transition_duration_seconds
+      ),
+      round_duration_seconds: numberToNullableBigInt(
+        votingRewardsParameters.round_duration_seconds
+      ),
+    },
+  ];
+};
+
+export const convertNervousSystemParameters = ({
+  default_followees,
+  max_dissolve_delay_seconds,
+  max_dissolve_delay_bonus_percentage,
+  max_followees_per_function,
+  neuron_claimer_permissions,
+  neuron_minimum_stake_e8s,
+  max_neuron_age_for_age_bonus,
+  initial_voting_period_seconds,
+  neuron_minimum_dissolve_delay_to_vote_seconds,
+  reject_cost_e8s,
+  max_proposals_to_keep_per_action,
+  wait_for_quiet_deadline_increase_seconds,
+  max_number_of_neurons,
+  transaction_fee_e8s,
+  max_number_of_proposals_with_ballots,
+  max_age_bonus_percentage,
+  neuron_grantable_permissions,
+  voting_rewards_parameters,
+  maturity_modulation_disabled,
+  max_number_of_principals_per_neuron,
+}: CachedNervousSystemParametersDto): SnsNervousSystemParameters => ({
+  default_followees: convertDefaultFollowees(default_followees),
+  max_dissolve_delay_seconds: numberToNullableBigInt(
+    max_dissolve_delay_seconds
+  ),
+  max_dissolve_delay_bonus_percentage: numberToNullableBigInt(
+    max_dissolve_delay_bonus_percentage
+  ),
+  max_followees_per_function: numberToNullableBigInt(
+    max_followees_per_function
+  ),
+  //
+  neuron_claimer_permissions: toNullable(neuron_claimer_permissions),
+  neuron_minimum_stake_e8s: numberToNullableBigInt(neuron_minimum_stake_e8s),
+  max_neuron_age_for_age_bonus: numberToNullableBigInt(
+    max_neuron_age_for_age_bonus
+  ),
+  initial_voting_period_seconds: numberToNullableBigInt(
+    initial_voting_period_seconds
+  ),
+  neuron_minimum_dissolve_delay_to_vote_seconds: numberToNullableBigInt(
+    neuron_minimum_dissolve_delay_to_vote_seconds
+  ),
+  reject_cost_e8s: numberToNullableBigInt(reject_cost_e8s),
+  max_proposals_to_keep_per_action: toNullable(
+    max_proposals_to_keep_per_action
+  ),
+  wait_for_quiet_deadline_increase_seconds: numberToNullableBigInt(
+    wait_for_quiet_deadline_increase_seconds
+  ),
+  max_number_of_neurons: numberToNullableBigInt(max_number_of_neurons),
+  transaction_fee_e8s: numberToNullableBigInt(transaction_fee_e8s),
+  max_number_of_proposals_with_ballots: numberToNullableBigInt(
+    max_number_of_proposals_with_ballots
+  ),
+  max_age_bonus_percentage: numberToNullableBigInt(max_age_bonus_percentage),
+  neuron_grantable_permissions: toNullable(neuron_grantable_permissions),
+  voting_rewards_parameters: convertVotingRewardsParameters(
+    voting_rewards_parameters
+  ),
+  maturity_modulation_disabled: toNullable(maturity_modulation_disabled),
+  max_number_of_principals_per_neuron: numberToNullableBigInt(
+    max_number_of_principals_per_neuron
+  ),
 });
 
 const convertNeuronsFundParticipationConstraints = (

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -1,4 +1,6 @@
 import type {
+  CachedNervousSystemParametersDto,
+  CachedNeuronIdDto,
   CachedSnsDto,
   CachedSnsTokenMetadataDto,
 } from "$lib/types/sns-aggregator";
@@ -7,9 +9,11 @@ import {
   convertDtoToSnsSummary,
   convertIcrc1Metadata,
   convertNervousFunction,
+  convertNervousSystemParameters,
 } from "$lib/utils/sns-aggregator-converters.utils";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import { Principal } from "@dfinity/principal";
+import type { SnsNervousSystemParameters } from "@dfinity/sns";
 
 describe("sns aggregator converters utils", () => {
   describe("convertDtoData", () => {
@@ -683,6 +687,151 @@ describe("sns aggregator converters utils", () => {
         ],
         function_type: [],
       });
+    });
+  });
+
+  describe("convertNervousSystemParameters", () => {
+    it("converts nervous system parameters to ic-js type", () => {
+      const neuronId1: CachedNeuronIdDto = { id: Uint8Array.from([1, 2, 3]) };
+      const neuronId2: CachedNeuronIdDto = { id: Uint8Array.from([4, 5, 6]) };
+      const neuronId3: CachedNeuronIdDto = { id: Uint8Array.from([7, 8, 9]) };
+      const nervousSystemParameterData: CachedNervousSystemParametersDto = {
+        default_followees: {
+          followees: [
+            [2, { followees: [neuronId1, neuronId2] }],
+            [5, { followees: [neuronId2, neuronId3] }],
+          ],
+        },
+        max_dissolve_delay_seconds: 252460800,
+        max_dissolve_delay_bonus_percentage: 100,
+        max_followees_per_function: 15,
+        neuron_claimer_permissions: {
+          permissions: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+        },
+        neuron_minimum_stake_e8s: 100000000000,
+        max_neuron_age_for_age_bonus: 252460800,
+        initial_voting_period_seconds: 345600,
+        neuron_minimum_dissolve_delay_to_vote_seconds: 2629800,
+        reject_cost_e8s: 5000000000000,
+        max_proposals_to_keep_per_action: 150,
+        wait_for_quiet_deadline_increase_seconds: 86400,
+        max_number_of_neurons: 200000,
+        transaction_fee_e8s: 100000,
+        max_number_of_proposals_with_ballots: 700,
+        max_age_bonus_percentage: 25,
+        neuron_grantable_permissions: {
+          permissions: [0, 1, 2, 3, 4],
+        },
+        voting_rewards_parameters: {
+          final_reward_rate_basis_points: 75,
+          initial_reward_rate_basis_points: 20,
+          reward_rate_transition_duration_seconds: 31557600,
+          round_duration_seconds: 86400,
+        },
+        maturity_modulation_disabled: true,
+        max_number_of_principals_per_neuron: 5,
+      };
+
+      const expectedSnsNervousSystemParameters: SnsNervousSystemParameters = {
+        default_followees: [
+          {
+            followees: [
+              [2n, { followees: [neuronId1, neuronId2] }],
+              [5n, { followees: [neuronId2, neuronId3] }],
+            ],
+          },
+        ],
+        max_dissolve_delay_seconds: [252460800n],
+        max_dissolve_delay_bonus_percentage: [100n],
+        max_followees_per_function: [15n],
+        neuron_claimer_permissions: [
+          {
+            permissions: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+          },
+        ],
+        neuron_minimum_stake_e8s: [100000000000n],
+        max_neuron_age_for_age_bonus: [252460800n],
+        initial_voting_period_seconds: [345600n],
+        neuron_minimum_dissolve_delay_to_vote_seconds: [2629800n],
+        reject_cost_e8s: [5000000000000n],
+        max_proposals_to_keep_per_action: [150],
+        wait_for_quiet_deadline_increase_seconds: [86400n],
+        max_number_of_neurons: [200000n],
+        transaction_fee_e8s: [100000n],
+        max_number_of_proposals_with_ballots: [700n],
+        max_age_bonus_percentage: [25n],
+        neuron_grantable_permissions: [
+          {
+            permissions: [0, 1, 2, 3, 4],
+          },
+        ],
+        voting_rewards_parameters: [
+          {
+            final_reward_rate_basis_points: [75n],
+            initial_reward_rate_basis_points: [20n],
+            reward_rate_transition_duration_seconds: [31557600n],
+            round_duration_seconds: [86400n],
+          },
+        ],
+        maturity_modulation_disabled: [true],
+        max_number_of_principals_per_neuron: [5n],
+      };
+
+      expect(
+        convertNervousSystemParameters(nervousSystemParameterData)
+      ).toEqual(expectedSnsNervousSystemParameters);
+    });
+
+    it("converts nervous system parameters with empty optionals to ic-js type", () => {
+      const nervousSystemParameterData: CachedNervousSystemParametersDto = {
+        default_followees: null,
+        max_dissolve_delay_seconds: null,
+        max_dissolve_delay_bonus_percentage: null,
+        max_followees_per_function: null,
+        neuron_claimer_permissions: null,
+        neuron_minimum_stake_e8s: null,
+        max_neuron_age_for_age_bonus: null,
+        initial_voting_period_seconds: null,
+        neuron_minimum_dissolve_delay_to_vote_seconds: null,
+        reject_cost_e8s: null,
+        max_proposals_to_keep_per_action: null,
+        wait_for_quiet_deadline_increase_seconds: null,
+        max_number_of_neurons: null,
+        transaction_fee_e8s: null,
+        max_number_of_proposals_with_ballots: null,
+        max_age_bonus_percentage: null,
+        neuron_grantable_permissions: null,
+        voting_rewards_parameters: null,
+        maturity_modulation_disabled: null,
+        max_number_of_principals_per_neuron: null,
+      };
+
+      const expectedSnsNervousSystemParameters: SnsNervousSystemParameters = {
+        default_followees: [],
+        max_dissolve_delay_seconds: [],
+        max_dissolve_delay_bonus_percentage: [],
+        max_followees_per_function: [],
+        neuron_claimer_permissions: [],
+        neuron_minimum_stake_e8s: [],
+        max_neuron_age_for_age_bonus: [],
+        initial_voting_period_seconds: [],
+        neuron_minimum_dissolve_delay_to_vote_seconds: [],
+        reject_cost_e8s: [],
+        max_proposals_to_keep_per_action: [],
+        wait_for_quiet_deadline_increase_seconds: [],
+        max_number_of_neurons: [],
+        transaction_fee_e8s: [],
+        max_number_of_proposals_with_ballots: [],
+        max_age_bonus_percentage: [],
+        neuron_grantable_permissions: [],
+        voting_rewards_parameters: [],
+        maturity_modulation_disabled: [],
+        max_number_of_principals_per_neuron: [],
+      };
+
+      expect(
+        convertNervousSystemParameters(nervousSystemParameterData)
+      ).toEqual(expectedSnsNervousSystemParameters);
     });
   });
 });


### PR DESCRIPTION
# Motivation

Instead of loading nervous system parameters from the SNS governance canister, we want to use the parameters present in the SNS aggregator data that is already loaded. We'll do this by making `snsParametersStore` a derived store so that we don't have to change how the parameters are accessed.

However, the type of the parameters in the aggregator data is different from the type used in the store. So we'll have to convert the data.

In this PR we just add the conversion function.

# Changes

1. Fix the type of `CachedDefaultFolloweesDto` which was wrong before but wasn't caught until used.
2. Add `convertNervousSystemParameters` to convert the parameters from `CachedNervousSystemParametersDto` to `SnsNervousSystemParameters`.

# Tests

Added unit tests for full and empty values.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary