### PR TITLE
Fix a bug where the perf counter is blown away in init

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -28,6 +28,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
+* Fixed a bug where perf counter in `init` is wiped during state initialization.
+
 #### Security
 
 #### Not Published

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -28,7 +28,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Fixed
 
-* Fixed a bug where perf counter in `init` is wiped during state initialization.
+* Fixed a bug where a performance counter in `init` is wiped during state initialization.
 
 #### Security
 

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -50,13 +50,16 @@ type Cycles = u128;
 fn init(args: Option<CanisterArguments>) {
     println!("START init with args: {args:#?}");
     set_canister_arguments(args);
-    perf::record_instruction_count("init after set_canister_arguments");
+    // Saving the instruction counter now will not have the desired effect
+    // as the storage is about to be wiped out and replaced with stable memory.
+    let counter_before = PerformanceCount::new("init set_canister_arguments");
     let stable_memory = DefaultMemoryImpl::default();
     let state = State::new(stable_memory);
     STATE.with(|s| {
         s.replace(state);
         println!("init state after: {s:?}");
     });
+    perf::save_instruction_count(counter_before);
     // Legacy:
     assets::init_assets();
     tvl::init_timers();

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -49,18 +49,18 @@ type Cycles = u128;
 #[init]
 fn init(args: Option<CanisterArguments>) {
     println!("START init with args: {args:#?}");
-    let counter_start = PerformanceCount::new("init start");
-    set_canister_arguments(args);
-    let counter_set_canister_arguments = PerformanceCount::new("init set_canister_arguments");
+    // Saving the instruction counter now will not have the desired effect
+    // as the storage is about to be wiped out and replaced with stable memory.
+    let counter_before = PerformanceCount::new("init start");
     let stable_memory = DefaultMemoryImpl::default();
     let state = State::new(stable_memory);
     STATE.with(|s| {
         s.replace(state);
         println!("init state after: {s:?}");
     });
-    // Saving the instruction counters now that the state is initialized.
-    perf::save_instruction_count(counter_start);
-    perf::save_instruction_count(counter_set_canister_arguments);
+    perf::save_instruction_count(counter_before);
+    set_canister_arguments(args);
+    perf::record_instruction_count("init after set_canister_arguments");
     // Legacy:
     assets::init_assets();
     tvl::init_timers();

--- a/rs/backend/src/main.rs
+++ b/rs/backend/src/main.rs
@@ -49,17 +49,18 @@ type Cycles = u128;
 #[init]
 fn init(args: Option<CanisterArguments>) {
     println!("START init with args: {args:#?}");
+    let counter_start = PerformanceCount::new("init start");
     set_canister_arguments(args);
-    // Saving the instruction counter now will not have the desired effect
-    // as the storage is about to be wiped out and replaced with stable memory.
-    let counter_before = PerformanceCount::new("init set_canister_arguments");
+    let counter_set_canister_arguments = PerformanceCount::new("init set_canister_arguments");
     let stable_memory = DefaultMemoryImpl::default();
     let state = State::new(stable_memory);
     STATE.with(|s| {
         s.replace(state);
         println!("init state after: {s:?}");
     });
-    perf::save_instruction_count(counter_before);
+    // Saving the instruction counters now that the state is initialized.
+    perf::save_instruction_count(counter_start);
+    perf::save_instruction_count(counter_set_canister_arguments);
     // Legacy:
     assets::init_assets();
     tvl::init_timers();


### PR DESCRIPTION
# Motivation

The perf counter was recorded right before getting wiped by replacing the state, so `init set_canister_arguments` is never visible through `get_stats`. Although, this is not very important for mainnet since we don't expect init to execute there.

# Changes

* Similar to `post_upgrade`, the counter is saved before the state initialization, but recorded (to the state) after initialization
* Additional changes to make `init` more consistent with `post_upgrade`

# Tests

N/A

# Todos

- [x] Add entry to changelog (if necessary).
