### PR TITLE
bot: Update IC Cargo Dependencies to release-2024-09-12_01-30-base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "arbitrary"
@@ -965,7 +965,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1135,7 +1135,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1147,7 +1147,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1156,7 +1156,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1168,7 +1168,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1181,7 +1181,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "on_wire",
  "prost",
@@ -1365,7 +1365,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1796,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1840,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -1870,7 +1870,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-replica-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -1896,7 +1896,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "serde",
 ]
@@ -1904,7 +1904,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -1913,7 +1913,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -2041,7 +2041,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -2055,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "getrandom",
 ]
@@ -2063,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "hex",
  "ic-types",
@@ -2073,7 +2073,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -2113,7 +2113,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2121,7 +2121,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2140,7 +2140,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2153,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "sha2",
 ]
@@ -2161,7 +2161,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "base64 0.13.1",
  "cached",
@@ -2187,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2217,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "arrayvec 0.7.6",
  "hex",
@@ -2234,7 +2234,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2252,7 +2252,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "hmac",
  "k256",
@@ -2268,7 +2268,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "serde",
  "zeroize",
@@ -2277,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2298,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -2311,7 +2311,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2321,7 +2321,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2331,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-protobuf",
  "ic-utils",
@@ -2343,7 +2343,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "ciborium",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "ciborium",
@@ -2394,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "async-trait",
  "candid",
@@ -2423,7 +2423,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -2435,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "async-trait",
  "candid",
@@ -2453,7 +2453,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -2465,7 +2465,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "hex",
@@ -2475,12 +2475,12 @@ dependencies = [
 [[package]]
 name = "ic-limits"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2504,9 +2504,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 
 [[package]]
+name = "ic-nervous-system-canisters"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+dependencies = [
+ "async-trait",
+ "dfn_core",
+ "dfn_protobuf",
+ "ic-base-types",
+ "ic-ledger-core",
+ "ic-nervous-system-common",
+ "ic-nervous-system-runtime",
+ "ic-nns-constants",
+ "icp-ledger",
+ "icrc-ledger-types",
+]
+
+[[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "async-trait",
  "candid",
@@ -2529,12 +2546,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2570,12 +2587,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -2588,7 +2605,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -2600,12 +2617,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "comparable",
@@ -2618,7 +2635,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-base-types",
 ]
@@ -2626,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "dfn_core",
@@ -2642,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "async-trait",
  "candid",
@@ -2655,17 +2672,17 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 
 [[package]]
 name = "ic-nervous-system-temporary"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -2678,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "comparable",
@@ -2704,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -2713,7 +2730,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2734,6 +2751,7 @@ dependencies = [
  "ic-ledger-core",
  "ic-management-canister-types",
  "ic-metrics-encoder",
+ "ic-nervous-system-canisters",
  "ic-nervous-system-clients",
  "ic-nervous-system-common",
  "ic-nervous-system-common-build-metadata",
@@ -2783,7 +2801,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "bytes",
  "candid",
@@ -2810,7 +2828,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "csv",
  "ic-base-types",
@@ -2827,12 +2845,12 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "async-trait",
  "candid",
@@ -2847,7 +2865,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "bincode",
  "candid",
@@ -2861,7 +2879,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-canister-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2872,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2884,7 +2902,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-node-provider-rewards"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-base-types",
  "ic-protobuf",
@@ -2893,7 +2911,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2904,7 +2922,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "ic-management-canister-types",
@@ -2915,7 +2933,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -2927,7 +2945,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2939,7 +2957,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2960,6 +2978,7 @@ dependencies = [
  "ic-ledger-core",
  "ic-management-canister-types",
  "ic-metrics-encoder",
+ "ic-nervous-system-canisters",
  "ic-nervous-system-clients",
  "ic-nervous-system-collections-union-multi-map",
  "ic-nervous-system-common",
@@ -2996,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -3004,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -3015,7 +3034,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "async-trait",
  "candid",
@@ -3036,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -3063,7 +3082,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3092,7 +3111,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3107,6 +3126,7 @@ dependencies = [
  "ic-canisters-http-types",
  "ic-ledger-core",
  "ic-metrics-encoder",
+ "ic-nervous-system-canisters",
  "ic-nervous-system-clients",
  "ic-nervous-system-common",
  "ic-nervous-system-proto",
@@ -3130,7 +3150,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "comparable",
@@ -3145,7 +3165,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "async-trait",
  "candid",
@@ -3191,7 +3211,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3228,7 +3248,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3239,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "ic-validate-eq-derive",
 ]
@@ -3247,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq-derive"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -3332,7 +3352,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
  "comparable",
@@ -3362,7 +3382,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "async-trait",
  "candid",
@@ -3373,7 +3393,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.6"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "base32",
  "candid",
@@ -4124,13 +4144,13 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
 
 [[package]]
 name = "openssl-probe"
@@ -4282,9 +4302,10 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "candid",
+ "num-traits",
  "serde",
  "slog",
 ]
@@ -4772,9 +4793,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -4837,7 +4858,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-06_01-30-canister-snapshots#843e71b994e1bf28edf80ad7746a7355259de91a"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
 dependencies = [
  "build-info",
  "build-info-build",
@@ -4855,6 +4876,7 @@ dependencies = [
  "ic-crypto-utils-ni-dkg",
  "ic-management-canister-types",
  "ic-metrics-encoder",
+ "ic-nervous-system-canisters",
  "ic-nervous-system-common",
  "ic-nervous-system-common-build-metadata",
  "ic-nns-common",
@@ -5054,9 +5076,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.36"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -5067,9 +5089,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
  "once_cell",
  "ring",
@@ -5123,9 +5145,9 @@ checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.7"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5564,7 +5586,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6079,9 +6101,9 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
@@ -6094,9 +6116,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -6197,9 +6219,9 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467611cafbc8a84834b77d2b4bb191fd2f5769752def8340407e924390c6883b"
+checksum = "160c3708e3ad718ab4d84bec8de8c3d3450cd2902bd6c3ee3bbf50ad7529c2ad"
 dependencies = [
  "anyhow",
  "gimli 0.26.2",
@@ -6382,7 +6404,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,23 +14,23 @@ ic-cdk = "0.16.0"
 ic-cdk-macros = "0.16.0"
 ic-cdk-timers = "0.10.0"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
-ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-06_01-30-canister-snapshots" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
 
 [profile.release]
 lto = false


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
We want to keep our Cargo dependencies up to date.

# Changes
* Ran `scripts/update-ic-cargo-deps` to update the Cargo.toml dependencies to the latest IC release.

# Tests
* See CI