### PR TITLE
Move remove imported token logic to confirm dialog

### DIFF
--- a/frontend/src/lib/components/accounts/ImportTokenRemoveConfirmation.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenRemoveConfirmation.svelte
@@ -10,7 +10,7 @@
   import { removeImportedTokens } from "$lib/services/imported-tokens.services";
   import { AppPath } from "$lib/constants/routes.constants";
   import { goto } from "$app/navigation";
-  import { Principal } from "@dfinity/principal";
+  import type { Principal } from "@dfinity/principal";
   import { createEventDispatcher } from "svelte";
 
   export let universe: Universe | undefined = undefined;

--- a/frontend/src/lib/components/accounts/ImportTokenRemoveConfirmation.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenRemoveConfirmation.svelte
@@ -5,14 +5,48 @@
   import { nonNullish } from "@dfinity/utils";
   import ConfirmationModal from "$lib/modals/common/ConfirmationModal.svelte";
   import { Tag } from "@dfinity/gix-components";
+  import { startBusy, stopBusy } from "$lib/stores/busy.store";
+  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
+  import { removeImportedTokens } from "$lib/services/imported-tokens.services";
+  import { AppPath } from "$lib/constants/routes.constants";
+  import { goto } from "$app/navigation";
+  import { Principal } from "@dfinity/principal";
+  import { createEventDispatcher } from "svelte";
 
-  export let universe: Universe | undefined;
+  export let universe: Universe | undefined = undefined;
+  export let ledgerCanisterId: Principal;
+
+  const dispatch = createEventDispatcher();
+  const removeImportedToken = async () => {
+    startBusy({
+      initiator: "import-token-removing",
+      labelKey: "import_token.removing",
+    });
+
+    try {
+      const importedTokens = $importedTokensStore.importedTokens ?? [];
+      const { success } = await removeImportedTokens({
+        tokensToRemove: importedTokens.filter(
+          ({ ledgerCanisterId: id }) =>
+            id.toText() === ledgerCanisterId.toText()
+        ),
+        importedTokens,
+      });
+
+      if (success) {
+        dispatch("nnsClose");
+        goto(AppPath.Tokens);
+      }
+    } finally {
+      stopBusy("import-token-removing");
+    }
+  };
 </script>
 
 <ConfirmationModal
   testId="import-token-remove-confirmation-component"
   on:nnsClose
-  on:nnsConfirm
+  on:nnsConfirm={removeImportedToken}
   yesLabel={$i18n.core.remove}
 >
   <div class="content">

--- a/frontend/src/lib/components/accounts/ImportTokenRemoveConfirmation.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenRemoveConfirmation.svelte
@@ -5,7 +5,7 @@
   import { nonNullish } from "@dfinity/utils";
   import ConfirmationModal from "$lib/modals/common/ConfirmationModal.svelte";
   import { Tag } from "@dfinity/gix-components";
-  import { startBusy, stopBusy } from "$lib/stores/busy.store";
+
   import { importedTokensStore } from "$lib/stores/imported-tokens.store";
   import { removeImportedTokens } from "$lib/services/imported-tokens.services";
   import { AppPath } from "$lib/constants/routes.constants";
@@ -18,27 +18,17 @@
 
   const dispatch = createEventDispatcher();
   const removeImportedToken = async () => {
-    startBusy({
-      initiator: "import-token-removing",
-      labelKey: "import_token.removing",
+    const importedTokens = $importedTokensStore.importedTokens ?? [];
+    const { success } = await removeImportedTokens({
+      tokensToRemove: importedTokens.filter(
+        ({ ledgerCanisterId: id }) => id.toText() === ledgerCanisterId.toText()
+      ),
+      importedTokens,
     });
 
-    try {
-      const importedTokens = $importedTokensStore.importedTokens ?? [];
-      const { success } = await removeImportedTokens({
-        tokensToRemove: importedTokens.filter(
-          ({ ledgerCanisterId: id }) =>
-            id.toText() === ledgerCanisterId.toText()
-        ),
-        importedTokens,
-      });
-
-      if (success) {
-        dispatch("nnsClose");
-        goto(AppPath.Tokens);
-      }
-    } finally {
-      stopBusy("import-token-removing");
+    if (success) {
+      dispatch("nnsClose");
+      goto(AppPath.Tokens);
     }
   };
 </script>

--- a/frontend/src/tests/lib/components/accounts/ImportTokenRemoveConfirmation.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenRemoveConfirmation.spec.ts
@@ -1,12 +1,27 @@
+import * as importedTokensApi from "$lib/api/imported-tokens.api";
 import ImportTokenRemoveConfirmation from "$lib/components/accounts/ImportTokenRemoveConfirmation.svelte";
+import { AppPath } from "$lib/constants/routes.constants";
+import { pageStore } from "$lib/derived/page.derived";
+import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
+import { importedTokensStore } from "$lib/stores/imported-tokens.store";
+import { tokensStore } from "$lib/stores/tokens.store";
 import type { Universe } from "$lib/types/universe";
+import { page } from "$mocks/$app/stores";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIcrcMainAccount } from "$tests/mocks/icrc-accounts.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
+import { mockUniversesTokens } from "$tests/mocks/tokens.mock";
 import { ImportTokenRemoveConfirmationPo } from "$tests/page-objects/ImportTokenRemoveConfirmation.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "$tests/utils/svelte.test-utils";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import { busyStore } from "@dfinity/gix-components";
+import type { Principal } from "@dfinity/principal";
+import { get } from "svelte/store";
 
 describe("ImportTokenRemoveConfirmation", () => {
-  const ledgerCanisterId = principal(1);
+  const ledgerCanisterId = principal(0);
+  const ledgerCanisterId2 = principal(1);
   const tokenLogo = "data:image/svg+xml;base64,PHN2ZyB3...";
   const tokenName = "ckTest";
   const mockUniverse: Universe = {
@@ -14,15 +29,19 @@ describe("ImportTokenRemoveConfirmation", () => {
     title: tokenName,
     logo: tokenLogo,
   };
-  const renderComponent = () => {
+  const renderComponent = (
+    props: {
+      ledgerCanisterId: Principal;
+      universe: Universe;
+    } = {
+      ledgerCanisterId: ledgerCanisterId,
+      universe: mockUniverse,
+    }
+  ) => {
     const { container, component } = render(ImportTokenRemoveConfirmation, {
-      props: {
-        universe: mockUniverse,
-      },
+      props,
     });
 
-    const nnsConfirm = vi.fn();
-    component.$on("nnsConfirm", nnsConfirm);
     const nnsClose = vi.fn();
     component.$on("nnsClose", nnsClose);
 
@@ -30,13 +49,49 @@ describe("ImportTokenRemoveConfirmation", () => {
       po: ImportTokenRemoveConfirmationPo.under(
         new JestPageObjectElement(container)
       ),
-      nnsConfirm,
       nnsClose,
     };
   };
 
   beforeEach(() => {
+    vi.clearAllMocks();
+    vi.clearAllTimers();
     vi.restoreAllMocks();
+    resetIdentity();
+    busyStore.resetForTesting();
+    page.mock({
+      data: { universe: ledgerCanisterId.toText() },
+      routeId: AppPath.Wallet,
+    });
+    tokensStore.setTokens(mockUniversesTokens);
+    icrcAccountsStore.set({
+      accounts: {
+        accounts: [mockIcrcMainAccount],
+        certified: true,
+      },
+      ledgerCanisterId,
+    });
+
+    importedTokensStore.set({
+      importedTokens: [
+        {
+          ledgerCanisterId,
+          indexCanisterId: undefined,
+        },
+        {
+          ledgerCanisterId: ledgerCanisterId2,
+          indexCanisterId: undefined,
+        },
+      ],
+      certified: true,
+    });
+    icrcAccountsStore.set({
+      accounts: {
+        accounts: [mockIcrcMainAccount],
+        certified: true,
+      },
+      ledgerCanisterId,
+    });
   });
 
   it("should render token logo", async () => {
@@ -50,14 +105,131 @@ describe("ImportTokenRemoveConfirmation", () => {
   });
 
   it("should dispatch events", async () => {
-    const { po, nnsClose, nnsConfirm } = renderComponent();
+    const { po, nnsClose } = renderComponent();
 
     expect(nnsClose).not.toBeCalled();
     await po.clickNo();
     expect(nnsClose).toBeCalledTimes(1);
 
-    expect(nnsConfirm).not.toBeCalled();
+    nnsClose.mockClear();
+  });
+
+  it("should work w/o universe", async () => {
+    const { po, nnsClose } = renderComponent({
+      ledgerCanisterId,
+      universe: undefined,
+    });
+    expect(await po.getUniverseSummaryPo().isPresent()).toEqual(false);
+    expect(nnsClose).not.toBeCalled();
+    await po.clickNo();
+    expect(nnsClose).toBeCalledTimes(1);
+  });
+
+  it("should remove imported tokens", async () => {
+    let resolveSetImportedTokens;
+    const spyOnSetImportedTokens = vi
+      .spyOn(importedTokensApi, "setImportedTokens")
+      .mockImplementation(
+        () =>
+          new Promise<void>((resolve) => (resolveSetImportedTokens = resolve))
+      );
+    const spyOnGetImportedTokens = vi
+      .spyOn(importedTokensApi, "getImportedTokens")
+      .mockResolvedValue({
+        imported_tokens: [
+          {
+            ledger_canister_id: ledgerCanisterId2,
+            index_canister_id: [],
+          },
+        ],
+      });
+
+    const { po, nnsClose } = await renderComponent();
+
+    expect(get(pageStore).path).toEqual(AppPath.Wallet);
+    expect(nnsClose).toBeCalledTimes(0);
+    expect(get(busyStore)).toEqual([]);
     await po.clickYes();
-    expect(nnsConfirm).toBeCalledTimes(1);
+    expect(get(importedTokensStore).importedTokens).toEqual([
+      {
+        ledgerCanisterId,
+        indexCanisterId: undefined,
+      },
+      {
+        ledgerCanisterId: ledgerCanisterId2,
+        indexCanisterId: undefined,
+      },
+    ]);
+    expect(get(busyStore)).toEqual([
+      {
+        initiator: "import-token-removing",
+        text: "Removing imported token...",
+      },
+    ]);
+
+    resolveSetImportedTokens();
+    await runResolvedPromises();
+
+    // The token should be removed.
+    expect(spyOnSetImportedTokens).toBeCalledTimes(1);
+    expect(spyOnSetImportedTokens).toHaveBeenCalledWith({
+      identity: mockIdentity,
+      importedTokens: [
+        {
+          ledger_canister_id: ledgerCanisterId2,
+          index_canister_id: [],
+        },
+      ],
+    });
+    expect(spyOnGetImportedTokens).toBeCalledTimes(2);
+
+    expect(get(busyStore)).toEqual([]);
+    expect(get(pageStore).path).toEqual(AppPath.Tokens);
+    expect(get(importedTokensStore).importedTokens).toEqual([
+      {
+        ledgerCanisterId: ledgerCanisterId2,
+        indexCanisterId: undefined,
+      },
+    ]);
+    expect(nnsClose).toBeCalledTimes(1);
+  });
+
+  it("should stay on the same page when removal is unsuccessful", async () => {
+    vi.spyOn(console, "error").mockReturnValue();
+    const spyOnSetImportedTokens = vi
+      .spyOn(importedTokensApi, "setImportedTokens")
+      .mockRejectedValue(new Error());
+    const spyOnGetImportedTokens = vi.spyOn(
+      importedTokensApi,
+      "getImportedTokens"
+    );
+    const { po } = await renderComponent();
+    expect(get(importedTokensStore).importedTokens).toEqual([
+      {
+        ledgerCanisterId,
+        indexCanisterId: undefined,
+      },
+      {
+        ledgerCanisterId: ledgerCanisterId2,
+        indexCanisterId: undefined,
+      },
+    ]);
+    await po.clickYes();
+    await runResolvedPromises();
+    expect(spyOnSetImportedTokens).toBeCalledTimes(1);
+    // should stay on wallet page
+    expect(get(pageStore).path).toEqual(AppPath.Wallet);
+    // without data change
+    expect(spyOnGetImportedTokens).toBeCalledTimes(0);
+    expect(get(importedTokensStore).importedTokens).toEqual([
+      {
+        ledgerCanisterId,
+        indexCanisterId: undefined,
+      },
+      {
+        ledgerCanisterId: ledgerCanisterId2,
+        indexCanisterId: undefined,
+      },
+    ]);
   });
 });


### PR DESCRIPTION
# Motivation

Currently the imported token can be removed only from the wallet page. With the upcoming functionality to remove failed imported tokens from the tokens table, we need to apply the same logic in another place. To avoid code duplication, the removal logic has been moved to the confirmation dialog component.

# Changes

- Move the `removeImportedToken` function to the `ImportTokenRemoveConfirmation` component.
- Confirmation component properties have been changed to ensure the confirmation dialog works also when only the ledger canister ID is available.

# Tests

- Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
