### PR TITLE
Move more logic of remove imported into service

### DIFF
--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -29,7 +29,6 @@
   import WalletMorePopover from "./WalletMorePopover.svelte";
   import { isImportedToken as checkImportedToken } from "$lib/utils/imported-tokens.utils";
   import { importedTokensStore } from "$lib/stores/imported-tokens.store";
-  import { startBusy, stopBusy } from "$lib/stores/busy.store";
   import { removeImportedTokens } from "$lib/services/imported-tokens.services";
   import ImportTokenRemoveConfirmation from "./ImportTokenRemoveConfirmation.svelte";
   import type { Universe } from "$lib/types/universe";

--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -173,26 +173,9 @@
     // Just for type safety. This should never happen.
     if (isNullish(ledgerCanisterId)) return;
 
-    startBusy({
-      initiator: "import-token-removing",
-      labelKey: "import_token.removing",
-    });
-
-    try {
-      const importedTokens = $importedTokensStore.importedTokens ?? [];
-      const { success } = await removeImportedTokens({
-        tokensToRemove: importedTokens.filter(
-          ({ ledgerCanisterId: id }) =>
-            id.toText() === ledgerCanisterId?.toText()
-        ),
-        importedTokens,
-      });
-
-      if (success) {
-        goto(AppPath.Tokens);
-      }
-    } finally {
-      stopBusy("import-token-removing");
+    const { success } = await removeImportedTokens(ledgerCanisterId);
+    if (success) {
+      goto(AppPath.Tokens);
     }
   };
 </script>

--- a/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
+++ b/frontend/src/tests/lib/services/imported-tokens.services.spec.ts
@@ -15,7 +15,11 @@ import * as toastsStore from "$lib/stores/toasts.store";
 import type { ImportedTokenData } from "$lib/types/imported-tokens";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
-import { toastsStore as toastsStoreEntry } from "@dfinity/gix-components";
+import { runResolvedPromises } from "$tests/utils/timers.test-utils";
+import {
+  busyStore,
+  toastsStore as toastsStoreEntry,
+} from "@dfinity/gix-components";
 import * as dfinityUtils from "@dfinity/utils";
 import { get } from "svelte/store";
 
@@ -43,6 +47,7 @@ describe("imported-tokens-services", () => {
     resetIdentity();
     importedTokensStore.reset();
     toastsStoreEntry.reset();
+    busyStore.resetForTesting();
     vi.spyOn(console, "error").mockReturnValue();
     vi.spyOn(dfinityUtils, "createAgent").mockReturnValue(undefined);
   });
@@ -271,12 +276,15 @@ describe("imported-tokens-services", () => {
       const spySetImportedTokens = vi
         .spyOn(importedTokensApi, "setImportedTokens")
         .mockResolvedValue(undefined);
+      importedTokensStore.set({
+        importedTokens: [importedTokenDataA, importedTokenDataB],
+        certified: true,
+      });
       expect(spySetImportedTokens).toBeCalledTimes(0);
 
-      const { success } = await removeImportedTokens({
-        tokensToRemove: [importedTokenDataA],
-        importedTokens: [importedTokenDataA, importedTokenDataB],
-      });
+      const { success } = await removeImportedTokens(
+        importedTokenDataA.ledgerCanisterId
+      );
 
       expect(success).toEqual(true);
       expect(spySetImportedTokens).toBeCalledTimes(1);
@@ -286,23 +294,36 @@ describe("imported-tokens-services", () => {
       });
     });
 
-    it("should remove multiple tokens", async () => {
-      const spySetImportedTokens = vi
+    it("should display busy store", async () => {
+      let resolveSetImportedTokens;
+      const spyOnSetImportedTokens = vi
         .spyOn(importedTokensApi, "setImportedTokens")
-        .mockResolvedValue(undefined);
-      expect(spySetImportedTokens).toBeCalledTimes(0);
-
-      const { success } = await removeImportedTokens({
-        tokensToRemove: [importedTokenDataA, importedTokenDataB],
+        .mockImplementation(
+          () =>
+            new Promise<void>((resolve) => (resolveSetImportedTokens = resolve))
+        );
+      importedTokensStore.set({
         importedTokens: [importedTokenDataA, importedTokenDataB],
+        certified: true,
       });
+      expect(spyOnSetImportedTokens).toBeCalledTimes(0);
+      expect(get(busyStore)).toEqual([]);
 
-      expect(success).toEqual(true);
-      expect(spySetImportedTokens).toBeCalledTimes(1);
-      expect(spySetImportedTokens).toBeCalledWith({
-        identity: mockIdentity,
-        importedTokens: [],
-      });
+      removeImportedTokens(importedTokenDataA.ledgerCanisterId);
+      await runResolvedPromises();
+
+      expect(spyOnSetImportedTokens).toBeCalledTimes(1);
+      expect(get(busyStore)).toEqual([
+        {
+          initiator: "import-token-removing",
+          text: "Removing imported token...",
+        },
+      ]);
+
+      resolveSetImportedTokens();
+      await runResolvedPromises();
+
+      expect(get(busyStore)).toEqual([]);
     });
 
     it("should update the store", async () => {
@@ -324,10 +345,7 @@ describe("imported-tokens-services", () => {
         certified: true,
       });
 
-      await removeImportedTokens({
-        tokensToRemove: [importedTokenDataA],
-        importedTokens: [importedTokenDataA, importedTokenDataB],
-      });
+      await removeImportedTokens(importedTokenDataA.ledgerCanisterId);
 
       expect(spyGetImportedTokens).toBeCalledTimes(2);
       expect(get(importedTokensStore)).toEqual({
@@ -344,12 +362,12 @@ describe("imported-tokens-services", () => {
       vi.spyOn(importedTokensApi, "getImportedTokens").mockResolvedValue({
         imported_tokens: [importedTokenB],
       });
-      expect(spyToastSuccess).not.toBeCalled();
-
-      await removeImportedTokens({
-        tokensToRemove: [importedTokenDataA],
+      importedTokensStore.set({
         importedTokens: [importedTokenDataA, importedTokenDataB],
+        certified: true,
       });
+      expect(spyToastSuccess).not.toBeCalled();
+      await removeImportedTokens(importedTokenDataA.ledgerCanisterId);
 
       expect(spyToastSuccess).toBeCalledTimes(1);
       expect(spyToastSuccess).toBeCalledWith({
@@ -362,12 +380,14 @@ describe("imported-tokens-services", () => {
       vi.spyOn(importedTokensApi, "setImportedTokens").mockRejectedValue(
         testError
       );
-      expect(spyToastError).not.toBeCalled();
-
-      const { success } = await removeImportedTokens({
-        tokensToRemove: [importedTokenDataA],
+      importedTokensStore.set({
         importedTokens: [importedTokenDataA, importedTokenDataB],
+        certified: true,
       });
+      expect(spyToastError).not.toBeCalled();
+      const { success } = await removeImportedTokens(
+        importedTokenDataA.ledgerCanisterId
+      );
 
       expect(success).toEqual(false);
       expect(spyToastError).toBeCalledTimes(1);


### PR DESCRIPTION
# Motivation

Currently the imported token can be removed only from the wallet page. With the upcoming functionality to remove failed imported tokens from the tokens table, we need to apply the same logic in another place. To avoid code duplication, the removal logic has been moved to the service function.

# Changes

- Simplify the `removeImportedTokens` arguments.
- Move the busy screen handling into the service.

# Tests

- Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
