### PR TITLE
Fix confusing use of 'multiplier'

### DIFF
--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -10,8 +10,8 @@ export const MATURITY_MODULATION_VARIANCE_PERCENTAGE = 0.95;
 // Neuron ids are random u64. Max digits of a u64 is 20.
 export const MAX_NEURON_ID_DIGITS = 20;
 
-export const MAX_DISSOLVE_DELAY_BONUS = 1;
-export const MAX_AGE_BONUS = 0.25;
+export const MAX_DISSOLVE_DELAY_BONUS = 1; // = +100%
+export const MAX_AGE_BONUS = 0.25; // = +25%
 export const NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE = SECONDS_IN_HALF_YEAR;
 
 const FIRST_TOPICS = [

--- a/frontend/src/lib/constants/neurons.constants.ts
+++ b/frontend/src/lib/constants/neurons.constants.ts
@@ -10,8 +10,8 @@ export const MATURITY_MODULATION_VARIANCE_PERCENTAGE = 0.95;
 // Neuron ids are random u64. Max digits of a u64 is 20.
 export const MAX_NEURON_ID_DIGITS = 20;
 
-export const DISSOLVE_DELAY_MULTIPLIER = 1;
-export const AGE_MULTIPLIER = 0.25;
+export const MAX_DISSOLVE_DELAY_BONUS = 1;
+export const MAX_AGE_BONUS = 0.25;
 export const NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE = SECONDS_IN_HALF_YEAR;
 
 const FIRST_TOPICS = [

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -748,8 +748,8 @@ export const snsNeuronVotingPower = ({
       stakeE8s,
       dissolveDelay,
       ageSeconds: neuronAge(neuron),
-      ageBonusMultiplier: Number(maxAgeBonusPercentage) / 100,
-      dissolveBonusMultiplier: Number(maxDissolveDelayBonusPercentage) / 100,
+      maxAgeBonus: Number(maxAgeBonusPercentage) / 100,
+      maxDissolveDelayBonus: Number(maxDissolveDelayBonusPercentage) / 100,
       maxDissolveDelaySeconds: Number(maxDissolveDelaySeconds),
       maxAgeSeconds: Number(maxNeuronAgeForAgeBonus),
       minDissolveDelaySeconds: Number(neuronMinimumDissolveDelayToVoteSeconds),
@@ -794,8 +794,8 @@ export const dissolveDelayMultiplier = ({
 
   return bonusMultiplier({
     amount: dissolveDelay,
-    multiplier: Number(maxDissolveDelayBonusPercentage) / 100,
-    max: Number(maxDissolveDelaySeconds),
+    maxBonus: Number(maxDissolveDelayBonusPercentage) / 100,
+    maxAmount: Number(maxDissolveDelaySeconds),
   });
 };
 
@@ -813,8 +813,8 @@ export const ageMultiplier = ({
 
   return bonusMultiplier({
     amount: neuronAge(neuron),
-    multiplier: Number(maxAgeBonusPercentage) / 100,
-    max: Number(maxNeuronAgeForAgeBonus),
+    maxBonus: Number(maxAgeBonusPercentage) / 100,
+    maxAmount: Number(maxNeuronAgeForAgeBonus),
   });
 };
 

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -288,32 +288,32 @@ describe("neuron-utils", () => {
       expect(
         bonusMultiplier({
           amount: 300n,
-          multiplier: 0.25,
-          max: 600,
+          maxBonus: 0.25,
+          maxAmount: 600,
         })
       ).toBe(1.125);
 
       expect(
         bonusMultiplier({
           amount: 600n,
-          multiplier: 0.5,
-          max: 600,
+          maxBonus: 0.5,
+          maxAmount: 600,
         })
       ).toBe(1.5);
 
       expect(
         bonusMultiplier({
           amount: 400n,
-          multiplier: 1,
-          max: 200,
+          maxBonus: 1,
+          maxAmount: 200,
         })
       ).toBe(2);
 
       expect(
         bonusMultiplier({
           amount: 400n,
-          multiplier: 0.25,
-          max: 0,
+          maxBonus: 0.25,
+          maxAmount: 0,
         })
       ).toBe(1);
     });


### PR DESCRIPTION
# Motivation

We apply several bonuses to the voting power, such as dissolve delay bonus and age bonus.
This is implemented by multiplying the voting power with a "multiplier".
For example, if you have a bonus percentage of 25, this means the voting power gets multiplied by 1.25.
This number 1.25 is the bonus multiplier.

The code was using the name `multiplier` for things that were not multipliers, which made the code very confusing.

# Changes

1. Fix inappropriate usages of the term "multiplier".
2. Add a comment on the `bonusMultiplier` function clarifying the parameters.

# Tests

Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary