### PR TITLE
Display failed imported tokens

### DIFF
--- a/frontend/src/lib/components/tokens/TokensTable/TokenActionsCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenActionsCell.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {
     UserTokenAction,
+    type UserTokenFailed,
     type UserTokenData,
     type UserTokenLoading,
   } from "$lib/types/tokens-page";
@@ -11,7 +12,7 @@
   import { nonNullish } from "@dfinity/utils";
   import type { SvelteComponent, ComponentType } from "svelte";
 
-  export let rowData: UserTokenData | UserTokenLoading;
+  export let rowData: UserTokenData | UserTokenLoading | UserTokenFailed;
 
   const actionMapper: Record<
     UserTokenAction,

--- a/frontend/src/lib/components/tokens/TokensTable/TokenBalanceCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenBalanceCell.svelte
@@ -1,17 +1,27 @@
 <script lang="ts">
   import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
-  import type { UserTokenData, UserTokenLoading } from "$lib/types/tokens-page";
+  import type {
+    UserTokenData,
+    UserTokenFailed,
+    UserTokenLoading,
+  } from "$lib/types/tokens-page";
   import { Spinner } from "@dfinity/gix-components";
+  import {
+    isUserTokenData,
+    isUserTokenLoading,
+  } from "$lib/utils/user-token.utils";
 
-  export let rowData: UserTokenData | UserTokenLoading;
+  export let rowData: UserTokenData | UserTokenLoading | UserTokenFailed;
 </script>
 
-{#if rowData.balance === "loading"}
+{#if isUserTokenLoading(rowData)}
   <span data-tid="token-value-label" class="balance-spinner"
     ><Spinner inline size="tiny" /></span
   >
-{:else}
+{:else if isUserTokenData(rowData)}
   <AmountDisplay singleLine amount={rowData.balance} />
+{:else}
+  <span data-tid="unavailable-balance" class="value">-/-</span>
 {/if}
 
 <style lang="scss">

--- a/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
@@ -25,12 +25,7 @@
 <div class="title-logo-wrapper">
   <Logo src={rowData.logo} alt={rowData.title} size="medium" framed />
   {#if isUserTokenFailed(rowData)}
-    <Hash
-      id="failed-ledger-canister-id"
-      text={`${rowData.universeId.toText()}`}
-      tagName="span"
-      tooltipTop
-    />
+    <Hash text={`${rowData.universeId.toText()}`} tagName="span" tooltipTop />
   {:else}
     <div class="title-wrapper">
       <h5 data-tid="project-name">{rowData.title}</h5>

--- a/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
@@ -54,6 +54,8 @@
 </div>
 
 <style lang="scss">
+  @use "@dfinity/gix-components/dist/styles/mixins/media";
+
   h5 {
     margin: 0;
   }
@@ -62,8 +64,12 @@
     display: flex;
     align-items: center;
     gap: var(--padding);
+
     // Fix squashed logo on mobile for failed imported tokens caused by too many elements being displayed.
     flex-wrap: wrap;
+    @include media.min-width(medium) {
+      flex-wrap: nowrap;
+    }
 
     .title-wrapper {
       display: flex;

--- a/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
@@ -26,6 +26,7 @@
   <Logo src={rowData.logo} alt={rowData.title} size="medium" framed />
   {#if isUserTokenFailed(rowData)}
     <Hash
+      id="failed-ledger-canister-id"
       testId="failed-ledger-canister-id"
       text={`${rowData.universeId.toText()}`}
       tagName="span"
@@ -46,13 +47,11 @@
     <Tag testId="imported-token-tag">{$i18n.import_token.imported_token}</Tag>
   {/if}
   {#if isUserTokenFailed(rowData)}
-    <Tooltip
-      id="failed-imported-token"
-      testId="failed-imported-token-tooltip"
-      text={$i18n.import_token.failed_tooltip}
-    >
-      <div class="failed-token-icon"><IconError size="20px" /></div>
-    </Tooltip>
+    <div data-tid="failed-token-info" class="failed-token-info">
+      <Tooltip id="failed-token-info" text={$i18n.import_token.failed_tooltip}>
+        <IconError size="20px" />
+      </Tooltip>
+    </div>
   {/if}
 </div>
 
@@ -75,7 +74,7 @@
     }
   }
 
-  .failed-token-icon {
+  .failed-token-info {
     color: var(--orange);
     line-height: 0;
   }

--- a/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
-  import type { UserTokenData, UserTokenLoading } from "$lib/types/tokens-page";
+  import type {
+    UserTokenData,
+    UserTokenFailed,
+    UserTokenLoading,
+  } from "$lib/types/tokens-page";
   import { importedTokensStore } from "$lib/stores/imported-tokens.store";
   import { isImportedToken } from "$lib/utils/imported-tokens.utils";
-  import Logo from "../../ui/Logo.svelte";
+  import Logo from "$lib/components/ui/Logo.svelte";
   import { nonNullish } from "@dfinity/utils";
-  import { Tag } from "@dfinity/gix-components";
+  import { IconError, Tag, Tooltip } from "@dfinity/gix-components";
   import { i18n } from "$lib/stores/i18n";
+  import Hash from "$lib/components/ui/Hash.svelte";
+  import { isUserTokenFailed } from "$lib/utils/user-token.utils";
 
-  export let rowData: UserTokenData | UserTokenLoading;
+  export let rowData: UserTokenData | UserTokenLoading | UserTokenFailed;
 
   let importedToken = false;
   $: importedToken = isImportedToken({
@@ -18,16 +24,34 @@
 
 <div class="title-logo-wrapper">
   <Logo src={rowData.logo} alt={rowData.title} size="medium" framed />
-  <div class="title-wrapper">
-    <h5 data-tid="project-name">{rowData.title}</h5>
-    {#if nonNullish(rowData.subtitle)}
-      <span data-tid="project-subtitle" class="description"
-        >{rowData.subtitle}</span
-      >
-    {/if}
-  </div>
+  {#if isUserTokenFailed(rowData)}
+    <Hash
+      testId="failed-ledger-canister-id"
+      text={`${rowData.universeId.toText()}`}
+      tagName="span"
+      splitLength={6}
+      tooltipTop
+    />
+  {:else}
+    <div class="title-wrapper">
+      <h5 data-tid="project-name">{rowData.title}</h5>
+      {#if nonNullish(rowData.subtitle)}
+        <span data-tid="project-subtitle" class="description"
+          >{rowData.subtitle}</span
+        >
+      {/if}
+    </div>
+  {/if}
   {#if importedToken}
     <Tag testId="imported-token-tag">{$i18n.import_token.imported_token}</Tag>
+  {/if}
+  {#if isUserTokenFailed(rowData)}
+    <Tooltip
+      id="failed-imported-token"
+      text={$i18n.import_token.failed_tooltip}
+    >
+      <div class="failed-token-icon"><IconError size="20px" /></div>
+    </Tooltip>
   {/if}
 </div>
 
@@ -40,11 +64,18 @@
     display: flex;
     align-items: center;
     gap: var(--padding);
+    // Fix squashed logo for failed imported tokens caused by too many elements being displayed.
+    flex-wrap: wrap;
 
     .title-wrapper {
       display: flex;
       flex-direction: column;
       gap: var(--padding-0_5x);
     }
+  }
+
+  .failed-token-icon {
+    color: var(--orange);
+    line-height: 0;
   }
 </style>

--- a/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
@@ -66,7 +66,7 @@
     display: flex;
     align-items: center;
     gap: var(--padding);
-    // Fix squashed logo for failed imported tokens caused by too many elements being displayed.
+    // Fix squashed logo on mobile for failed imported tokens caused by too many elements being displayed.
     flex-wrap: wrap;
 
     .title-wrapper {

--- a/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
@@ -48,6 +48,7 @@
   {#if isUserTokenFailed(rowData)}
     <Tooltip
       id="failed-imported-token"
+      testId="failed-imported-token-tooltip"
       text={$i18n.import_token.failed_tooltip}
     >
       <div class="failed-token-icon"><IconError size="20px" /></div>

--- a/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
@@ -12,6 +12,7 @@
   import { i18n } from "$lib/stores/i18n";
   import Hash from "$lib/components/ui/Hash.svelte";
   import { isUserTokenFailed } from "$lib/utils/user-token.utils";
+  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let rowData: UserTokenData | UserTokenLoading | UserTokenFailed;
 
@@ -25,14 +26,15 @@
 <div class="title-logo-wrapper">
   <Logo src={rowData.logo} alt={rowData.title} size="medium" framed />
   {#if isUserTokenFailed(rowData)}
-    <Hash
-      id="failed-ledger-canister-id"
-      testId="failed-ledger-canister-id"
-      text={`${rowData.universeId.toText()}`}
-      tagName="span"
-      splitLength={6}
-      tooltipTop
-    />
+    <TestIdWrapper testId="failed-ledger-canister-id">
+      <Hash
+        id="failed-ledger-canister-id"
+        text={`${rowData.universeId.toText()}`}
+        tagName="span"
+        splitLength={6}
+        tooltipTop
+      />
+    </TestIdWrapper>
   {:else}
     <div class="title-wrapper">
       <h5 data-tid="project-name">{rowData.title}</h5>

--- a/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
@@ -29,7 +29,6 @@
       id="failed-ledger-canister-id"
       text={`${rowData.universeId.toText()}`}
       tagName="span"
-      splitLength={6}
       tooltipTop
     />
   {:else}

--- a/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
+++ b/frontend/src/lib/components/tokens/TokensTable/TokenTitleCell.svelte
@@ -12,7 +12,6 @@
   import { i18n } from "$lib/stores/i18n";
   import Hash from "$lib/components/ui/Hash.svelte";
   import { isUserTokenFailed } from "$lib/utils/user-token.utils";
-  import TestIdWrapper from "$lib/components/common/TestIdWrapper.svelte";
 
   export let rowData: UserTokenData | UserTokenLoading | UserTokenFailed;
 
@@ -26,15 +25,13 @@
 <div class="title-logo-wrapper">
   <Logo src={rowData.logo} alt={rowData.title} size="medium" framed />
   {#if isUserTokenFailed(rowData)}
-    <TestIdWrapper testId="failed-ledger-canister-id">
-      <Hash
-        id="failed-ledger-canister-id"
-        text={`${rowData.universeId.toText()}`}
-        tagName="span"
-        splitLength={6}
-        tooltipTop
-      />
-    </TestIdWrapper>
+    <Hash
+      id="failed-ledger-canister-id"
+      text={`${rowData.universeId.toText()}`}
+      tagName="span"
+      splitLength={6}
+      tooltipTop
+    />
   {:else}
     <div class="title-wrapper">
       <h5 data-tid="project-name">{rowData.title}</h5>

--- a/frontend/src/lib/derived/tokens-list-user.derived.ts
+++ b/frontend/src/lib/derived/tokens-list-user.derived.ts
@@ -1,4 +1,5 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+import { failedImportedTokenLedgerIdsStore } from "$lib/stores/imported-tokens.store";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import {
   UserTokenAction,
@@ -8,6 +9,7 @@ import {
 import { sumAccounts } from "$lib/utils/accounts.utils";
 import { buildAccountsUrl, buildWalletUrl } from "$lib/utils/navigation.utils";
 import { isUniverseNns } from "$lib/utils/universe.utils";
+import { toUserTokenFailed } from "$lib/utils/user-token.utils";
 import { TokenAmountV2, isNullish } from "@dfinity/utils";
 import { derived, type Readable } from "svelte/store";
 import type { UniversesAccounts } from "./accounts-list.derived";
@@ -75,16 +77,24 @@ export const tokensListUserStore = derived<
     Readable<UserTokenBase[]>,
     Readable<UniversesAccounts>,
     Readable<Record<string, IcrcTokenMetadata>>,
+    Readable<Array<string>>,
   ],
   UserToken[]
 >(
-  [tokensListBaseStore, universesAccountsStore, tokensByUniverseIdStore],
-  ([tokensList, accounts, tokensByUniverse]) =>
-    tokensList.map((baseTokenData) =>
+  [
+    tokensListBaseStore,
+    universesAccountsStore,
+    tokensByUniverseIdStore,
+    failedImportedTokenLedgerIdsStore,
+  ],
+  ([tokensList, accounts, tokensByUniverse, failedImportedTokenLedgerIds]) => [
+    ...tokensList.map((baseTokenData) =>
       convertToUserTokenData({
         baseTokenData,
         accounts,
         tokensByUniverse,
       })
-    )
+    ),
+    ...failedImportedTokenLedgerIds.map(toUserTokenFailed),
+  ]
 );

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1061,6 +1061,6 @@
     "link_to_dashboard": "https://dashboard.internetcomputer.org/canister/$canisterId",
     "add_index_canister": "Add Index Canister",
     "add_index_description": "Transaction history is not available. To see this token’s transaction history in the NNS dapp, you need to provide an index canister. <strong>Note:</strong> not all tokens have index canisters.",
-    "failed_tooltip": "The NNS dapp couldn’t load your token. Please try again later, or contact the developers."
+    "failed_tooltip": "The NNS dapp couldn’t load an imported token. Please try again later, or contact the developers."
   }
 }

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1060,6 +1060,7 @@
     "import_button": "Import",
     "link_to_dashboard": "https://dashboard.internetcomputer.org/canister/$canisterId",
     "add_index_canister": "Add Index Canister",
-    "add_index_description": "Transaction history is not available. To see this token’s transaction history in the NNS dapp, you need to provide an index canister. <strong>Note:</strong> not all tokens have index canisters."
+    "add_index_description": "Transaction history is not available. To see this token’s transaction history in the NNS dapp, you need to provide an index canister. <strong>Note:</strong> not all tokens have index canisters.",
+    "failed_tooltip": "The NNS dapp couldn’t load your token. Please try again later, or contact the developers."
   }
 }

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1120,6 +1120,7 @@ interface I18nImport_token {
   link_to_dashboard: string;
   add_index_canister: string;
   add_index_description: string;
+  failed_tooltip: string;
 }
 
 interface I18nNeuron_state {

--- a/frontend/src/lib/types/tokens-page.ts
+++ b/frontend/src/lib/types/tokens-page.ts
@@ -3,6 +3,7 @@
  *
  * - `UserTokenBase` is not used directly, but it is used to create the `UserTokenLoading` and `UserTokenData` types.
  * - `UserTokenLoading` is to render a loading row in the tokens table. Used when either balance or token are not present.
+ * - `UserTokenFailed` is to render a failed token row in the tokens table. Used when an error occurred while fetching the imported token data.
  * - `UserTokenData` is used to render a row in the tokens table. Used when both balance and token are present.
  * - `UserTokenAction` is a list of actions supported by the tokens page and hardcoded in the TokensTable.
  * - `UserToken` is the union of `UserTokenLoading` and `UserTokenData`.
@@ -40,6 +41,11 @@ export type UserTokenLoading = UserTokenBase & {
   domKey: string;
 };
 
+export type UserTokenFailed = UserTokenBase & {
+  balance: "failed";
+  domKey: string;
+};
+
 export type UserTokenData = UserTokenBase & {
   balance: TokenAmountV2 | UnavailableTokenAmount;
   // Identifier of the account related to the row (only if the row represents one account, not multiple)
@@ -51,5 +57,5 @@ export type UserTokenData = UserTokenBase & {
   domKey: string;
 };
 
-export type UserToken = UserTokenLoading | UserTokenData;
+export type UserToken = UserTokenLoading | UserTokenFailed | UserTokenData;
 export type TokensTableColumn = ResponsiveTableColumn<UserToken>;

--- a/frontend/src/lib/utils/user-token.utils.ts
+++ b/frontend/src/lib/utils/user-token.utils.ts
@@ -1,8 +1,8 @@
 import UNKNOWN_LOGO from "$lib/assets/question-mark.svg";
-import {
-  type UserTokenData,
-  type UserTokenFailed,
-  type UserTokenLoading,
+import type {
+  UserTokenData,
+  UserTokenFailed,
+  UserTokenLoading,
 } from "$lib/types/tokens-page";
 import { Principal } from "@dfinity/principal";
 

--- a/frontend/src/lib/utils/user-token.utils.ts
+++ b/frontend/src/lib/utils/user-token.utils.ts
@@ -1,7 +1,38 @@
-import type { UserTokenData, UserTokenLoading } from "$lib/types/tokens-page";
+import UNKNOWN_LOGO from "$lib/assets/question-mark.svg";
+import {
+  UserTokenAction,
+  type UserTokenData,
+  type UserTokenFailed,
+  type UserTokenLoading,
+} from "$lib/types/tokens-page";
+import { Principal } from "@dfinity/principal";
+
+export const isUserTokenLoading = (
+  userToken: UserTokenData | UserTokenLoading | UserTokenFailed
+): userToken is UserTokenLoading => {
+  return userToken.balance === "loading";
+};
+
+export const isUserTokenFailed = (
+  userToken: UserTokenData | UserTokenLoading | UserTokenFailed
+): userToken is UserTokenFailed => {
+  return userToken.balance === "failed";
+};
 
 export const isUserTokenData = (
-  userToken: UserTokenData | UserTokenLoading
+  userToken: UserTokenData | UserTokenLoading | UserTokenFailed
 ): userToken is UserTokenData => {
-  return userToken.balance !== "loading";
+  return !isUserTokenLoading(userToken) && !isUserTokenFailed(userToken);
 };
+
+export const toUserTokenFailed = (
+  ledgerCanisterIdText: string
+): UserTokenFailed => ({
+  universeId: Principal.fromText(ledgerCanisterIdText),
+  // Title will be used for sorting.
+  title: ledgerCanisterIdText,
+  logo: UNKNOWN_LOGO,
+  balance: "failed",
+  domKey: ledgerCanisterIdText,
+  actions: [UserTokenAction.GoToDashboard, UserTokenAction.Remove],
+});

--- a/frontend/src/lib/utils/user-token.utils.ts
+++ b/frontend/src/lib/utils/user-token.utils.ts
@@ -1,6 +1,5 @@
 import UNKNOWN_LOGO from "$lib/assets/question-mark.svg";
 import {
-  UserTokenAction,
   type UserTokenData,
   type UserTokenFailed,
   type UserTokenLoading,
@@ -34,5 +33,5 @@ export const toUserTokenFailed = (
   logo: UNKNOWN_LOGO,
   balance: "failed",
   domKey: ledgerCanisterIdText,
-  actions: [UserTokenAction.GoToDashboard, UserTokenAction.Remove],
+  actions: [],
 });

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -1,6 +1,8 @@
 import { ResponsiveTableRowPo } from "$tests/page-objects/ResponsiveTableRow.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 import { AmountDisplayPo } from "./AmountDisplay.page-object";
+import { HashPo } from "./Hash.page-object";
+import { TooltipPo } from "./Tooltip.page-object";
 
 export type TokensTableRowData = {
   projectName: string;
@@ -53,6 +55,18 @@ export class TokensTableRowPo extends ResponsiveTableRowPo {
 
   async getBalanceNumber(): Promise<number> {
     return Number(await AmountDisplayPo.under(this.root).getAmount());
+  }
+
+  hasUnavailableBalance(): Promise<boolean> {
+    return this.root.byTestId("unavailable-balance").isPresent();
+  }
+
+  getFailedLedgerCanisterHashPo(): HashPo {
+    return new HashPo(this.root.byTestId("failed-ledger-canister-id"));
+  }
+
+  getFailedTokenTooltipPo(): TooltipPo {
+    return TooltipPo.under(this.root);
   }
 
   async waitForBalance(): Promise<void> {

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -51,7 +51,7 @@ export class TokensTableRowPo extends ResponsiveTableRowPo {
     // Loaded or failed project name.
     return nonNullish(loadedProjectName)
       ? loadedProjectName.trim()
-      : (await this.getFailedLedgerCanisterHashPo().getText())?.trim();
+      : (await this.getFailedLedgerCanisterHashPo().getFullText())?.trim();
   }
 
   getBalance(): Promise<string> {

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -67,7 +67,7 @@ export class TokensTableRowPo extends ResponsiveTableRowPo {
   }
 
   getFailedLedgerCanisterHashPo(): HashPo {
-    return new HashPo(this.root.byTestId("failed-ledger-canister-id"));
+    return HashPo.under(this.root);
   }
 
   getFailedTokenTooltipPo(): TooltipPo {

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -50,8 +50,8 @@ export class TokensTableRowPo extends ResponsiveTableRowPo {
     const loadedProjectName = await this.getText("project-name");
     // Loaded or failed project name.
     return nonNullish(loadedProjectName)
-      ? loadedProjectName
-      : this.getFailedLedgerCanisterHashPo().getText();
+      ? loadedProjectName.trim()
+      : (await this.getFailedLedgerCanisterHashPo().getText())?.trim();
   }
 
   getBalance(): Promise<string> {

--- a/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
+++ b/frontend/src/tests/page-objects/TokensTableRow.page-object.ts
@@ -1,5 +1,6 @@
 import { ResponsiveTableRowPo } from "$tests/page-objects/ResponsiveTableRow.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
+import { nonNullish } from "@dfinity/utils";
 import { AmountDisplayPo } from "./AmountDisplay.page-object";
 import { HashPo } from "./Hash.page-object";
 import { TooltipPo } from "./Tooltip.page-object";
@@ -45,8 +46,12 @@ export class TokensTableRowPo extends ResponsiveTableRowPo {
       .map((el) => new TokensTableRowPo(el));
   }
 
-  getProjectName(): Promise<string> {
-    return this.getText("project-name");
+  async getProjectName(): Promise<string> {
+    const loadedProjectName = await this.getText("project-name");
+    // Loaded or failed project name.
+    return nonNullish(loadedProjectName)
+      ? loadedProjectName
+      : this.getFailedLedgerCanisterHashPo().getText();
   }
 
   getBalance(): Promise<string> {
@@ -66,7 +71,7 @@ export class TokensTableRowPo extends ResponsiveTableRowPo {
   }
 
   getFailedTokenTooltipPo(): TooltipPo {
-    return TooltipPo.under(this.root);
+    return TooltipPo.under(this.root.byTestId("failed-token-info"));
   }
 
   async waitForBalance(): Promise<void> {

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -106,7 +106,8 @@ describe("Tokens route", () => {
     fee: 4_000n,
     decimals: 6,
   } as IcrcTokenMetadata;
-  const importedToken2Id = principal(101);
+  const importedToken2IdText = "fzkl3-c3fae";
+  const importedToken2Id = Principal.fromText(importedToken2IdText);
   const importedToken2Metadata = {
     name: "ATOKEN2",
     symbol: "ATOKEN2",
@@ -687,8 +688,10 @@ describe("Tokens route", () => {
         const tokensPagePo = po.getTokensPagePo();
         const tokenNames = await tokensPagePo.getTokenNames();
 
-        expect(tokenNames.includes("ATOKEN2")).toEqual(true);
+        // failed
         expect(tokenNames.includes(failedTokenHash)).toEqual(true);
+        // loaded
+        expect(tokenNames.includes("ATOKEN2")).toEqual(true);
       });
 
       it("should render multiple failed imported tokens", async () => {
@@ -698,7 +701,7 @@ describe("Tokens route", () => {
         const tokensPagePo = po.getTokensPagePo();
         const tokenNames = await tokensPagePo.getTokenNames();
 
-        expect(tokenNames.includes("xlmdg-...rh-oqe")).toEqual(true);
+        expect(tokenNames.includes(importedToken2IdText)).toEqual(true);
         expect(tokenNames.includes(failedTokenHash)).toEqual(true);
       });
 
@@ -712,7 +715,6 @@ describe("Tokens route", () => {
         expect(
           await failedTokenRow.getFailedLedgerCanisterHashPo().getFullText()
         ).toEqual(failedTokenLedgerIdText);
-
         expect(await failedTokenRow.hasUnavailableBalance()).toEqual(true);
         expect(
           await failedTokenRow.getFailedTokenTooltipPo().getTooltipText()

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -670,7 +670,7 @@ describe("Tokens route", () => {
     describe("failed imported tokens", () => {
       // "ZTOKEN1" token.
       const failedTokenLedgerIdText = importedToken1Id.toText();
-      const failedTokenHash = "xlmdg-...rh-oqe";
+      const failedTokenHash = "xlmdg-v...4rh-oqe";
 
       beforeEach(() => {
         resetIdentity();
@@ -719,7 +719,7 @@ describe("Tokens route", () => {
         expect(
           await failedTokenRow.getFailedTokenTooltipPo().getTooltipText()
         ).toEqual(
-          "The NNS dapp couldn’t load your token. Please try again later, or contact the developers."
+          "The NNS dapp couldn’t load an imported token. Please try again later, or contact the developers."
         );
       });
 

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -605,19 +605,10 @@ describe("Tokens route", () => {
               canisterId: importedToken1Id,
               token: importedToken1Metadata,
             });
-            defaultIcrcCanistersStore.setCanisters({
-              ledgerCanisterId: importedToken1Id,
-              indexCanisterId: undefined,
-            });
             tokensStore.setToken({
               canisterId: importedToken2Id,
               token: importedToken2Metadata,
             });
-            defaultIcrcCanistersStore.setCanisters({
-              ledgerCanisterId: importedToken2Id,
-              indexCanisterId: undefined,
-            });
-
             importedTokensStore.set({
               importedTokens: [importedToken1Data, importedToken2Data],
               certified: true,

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -668,10 +668,6 @@ describe("Tokens route", () => {
     });
 
     describe("failed imported tokens", () => {
-      // "ZTOKEN1" token.
-      const failedTokenLedgerIdText = importedToken1Id.toText();
-      const failedTokenHash = "xlmdg-v...4rh-oqe";
-
       beforeEach(() => {
         resetIdentity();
 
@@ -680,7 +676,7 @@ describe("Tokens route", () => {
           importedTokens: [importedToken1Data, importedToken2Data],
           certified: true,
         });
-        failedImportedTokenLedgerIdsStore.add(failedTokenLedgerIdText);
+        failedImportedTokenLedgerIdsStore.add(importedToken1Id.toText());
       });
 
       it("should render failed imported tokens in the table", async () => {
@@ -696,7 +692,7 @@ describe("Tokens route", () => {
           "ATOKEN2", // loaded imported token
           "Pacman",
           "Tetris",
-          "xlmdg-v...4rh-oqe", // failed imported token
+          importedToken1Id.toText(), // failed imported token
         ]);
       });
 
@@ -712,10 +708,10 @@ describe("Tokens route", () => {
           "ckBTC",
           "ckETH",
           "ckUSDC",
-          "fzkl3-c3fae", // failed imported token
+          importedToken2Id.toText(),
           "Pacman",
           "Tetris",
-          "xlmdg-v...4rh-oqe", // failed imported token
+          importedToken1Id.toText(),
         ]);
       });
 
@@ -724,11 +720,11 @@ describe("Tokens route", () => {
         const tokensPagePo = po.getTokensPagePo();
         const failedTokenRow = await tokensPagePo
           .getTokensTable()
-          .getRowByName(failedTokenHash);
+          .getRowByName(importedToken1Id.toText());
 
         expect(
           await failedTokenRow.getFailedLedgerCanisterHashPo().getFullText()
-        ).toEqual(failedTokenLedgerIdText);
+        ).toEqual(importedToken1Id.toText());
         expect(await failedTokenRow.hasUnavailableBalance()).toEqual(true);
         expect(
           await failedTokenRow.getFailedTokenTooltipPo().getTooltipText()
@@ -753,7 +749,7 @@ describe("Tokens route", () => {
         };
 
         for (const rowPo of rowsPos) {
-          if ((await rowPo.getProjectName()) !== failedTokenHash) {
+          if ((await rowPo.getProjectName()) !== importedToken1Id.toText()) {
             await checkForFailedUI(rowPo);
           }
         }

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -688,10 +688,16 @@ describe("Tokens route", () => {
         const tokensPagePo = po.getTokensPagePo();
         const tokenNames = await tokensPagePo.getTokenNames();
 
-        // failed
-        expect(tokenNames.includes(failedTokenHash)).toEqual(true);
-        // loaded
-        expect(tokenNames.includes("ATOKEN2")).toEqual(true);
+        expect(tokenNames).toEqual([
+          "Internet Computer",
+          "ckBTC",
+          "ckETH",
+          "ckUSDC",
+          "ATOKEN2", // loaded imported token
+          "Pacman",
+          "Tetris",
+          "xlmdg-v...4rh-oqe", // failed imported token
+        ]);
       });
 
       it("should render multiple failed imported tokens", async () => {
@@ -701,8 +707,16 @@ describe("Tokens route", () => {
         const tokensPagePo = po.getTokensPagePo();
         const tokenNames = await tokensPagePo.getTokenNames();
 
-        expect(tokenNames.includes(importedToken2IdText)).toEqual(true);
-        expect(tokenNames.includes(failedTokenHash)).toEqual(true);
+        expect(tokenNames).toEqual([
+          "Internet Computer",
+          "ckBTC",
+          "ckETH",
+          "ckUSDC",
+          "fzkl3-c3fae", // failed imported token
+          "Pacman",
+          "Tetris",
+          "xlmdg-v...4rh-oqe", // failed imported token
+        ]);
       });
 
       it("should display failed imported token UI", async () => {

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -685,9 +685,10 @@ describe("Tokens route", () => {
       it("should render failed imported tokens in the table", async () => {
         const po = await renderPage();
         const tokensPagePo = po.getTokensPagePo();
+        const tokenNames = await tokensPagePo.getTokenNames();
 
-        expect(await tokensPagePo.getTokenNames()).toContain("ATOKEN2");
-        expect(await tokensPagePo.getTokenNames()).toContain(failedTokenHash);
+        expect(tokenNames.includes("ATOKEN2")).toEqual(true);
+        expect(tokenNames.includes(failedTokenHash)).toEqual(true);
       });
 
       it("should render multiple failed imported tokens", async () => {
@@ -695,9 +696,10 @@ describe("Tokens route", () => {
 
         const po = await renderPage();
         const tokensPagePo = po.getTokensPagePo();
+        const tokenNames = await tokensPagePo.getTokenNames();
 
-        expect(await tokensPagePo.getTokenNames()).toContain("fzkl3-c3fae");
-        expect(await tokensPagePo.getTokenNames()).toContain(failedTokenHash);
+        expect(tokenNames.includes("xlmdg-...rh-oqe")).toEqual(true);
+        expect(tokenNames.includes(failedTokenHash)).toEqual(true);
       });
 
       it("should display failed imported token UI", async () => {
@@ -707,9 +709,9 @@ describe("Tokens route", () => {
           .getTokensTable()
           .getRowByName(failedTokenHash);
 
-        // expect(
-        //   await failedTokenRow.getFailedLedgerCanisterHashPo().getFullText()
-        // ).toEqual(failedTokenLedgerIdText);
+        expect(
+          await failedTokenRow.getFailedLedgerCanisterHashPo().getFullText()
+        ).toEqual(failedTokenLedgerIdText);
 
         expect(await failedTokenRow.hasUnavailableBalance()).toEqual(true);
         expect(


### PR DESCRIPTION
# Motivation

Imported tokens that fail to load still need to be displayed in the table to avoid confusing users about missing tokens. With this PR, we display failed imported tokens in the tokens table using a custom UI (since we don’t have other token information when loading fails).

Note: Sorting and updating the actions cell for failed tokens will be handled in a separate PR.

# Changes

- New type `UserTokenFailed` to represent failed tokens.
- Extend the `tokensListUserStore` with the records of the failed tokens.
- Added `UserTokenFailed` support to the token table’s title and balance cell components.

# Tests

- Updated POs (getProjectName returns the hash for the failed projects)
- Moved imported tokens related setup to the top of the test file.
- Added tests for failed rows.
- Locally.
<img width="794" alt="image" src="https://github.com/user-attachments/assets/648a1da8-c301-4976-b380-4a5d7c63f0ed">


# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
