### PR TITLE
Fix flakiness in e2e/sns-governance.spec.ts

### DIFF
--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -87,7 +87,6 @@ describe("SnsNeurons", () => {
       const po = await renderComponent();
 
       expect(await po.hasSpinner()).toBe(true);
-      expect(await po.getSkeletonCardPo().isPresent()).toBe(false);
     });
 
     it("should not render empty text", async () => {

--- a/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
@@ -1,6 +1,4 @@
 import { NeuronsTablePo } from "$tests/page-objects/NeuronsTable.page-object";
-import { SkeletonCardPo } from "$tests/page-objects/SkeletonCard.page-object";
-import { SnsNeuronCardPo } from "$tests/page-objects/SnsNeuronCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 
@@ -15,11 +13,6 @@ export class SnsNeuronsPo extends BasePageObject {
     return NeuronsTablePo.under(this.root);
   }
 
-  getSkeletonCardPo(): SkeletonCardPo {
-    // There are multiple but we only need one.
-    return SkeletonCardPo.under(this.root);
-  }
-
   getNeuronCardPos(): Promise<SnsNeuronCardPo[]> {
     return SnsNeuronCardPo.allUnder(this.root);
   }
@@ -29,14 +22,12 @@ export class SnsNeuronsPo extends BasePageObject {
   }
 
   async isContentLoading(): Promise<boolean> {
-    return (
-      (await this.getSkeletonCardPo().isPresent()) || (await this.hasSpinner())
-    );
+    return await this.hasSpinner();
   }
 
   async waitForContentLoaded(): Promise<void> {
     await this.waitFor();
-    await this.getSkeletonCardPo().waitForAbsent();
+    await this.waitForAbsent("spinner");
   }
 
   getEmptyMessage(): Promise<string> {

--- a/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
+++ b/frontend/src/tests/page-objects/SnsNeurons.page-object.ts
@@ -1,4 +1,5 @@
 import { NeuronsTablePo } from "$tests/page-objects/NeuronsTable.page-object";
+import { SnsNeuronCardPo } from "$tests/page-objects/SnsNeuronCard.page-object";
 import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
 

--- a/frontend/src/tests/page-objects/Staking.page-object.ts
+++ b/frontend/src/tests/page-objects/Staking.page-object.ts
@@ -63,5 +63,7 @@ export class StakingPo extends BasePageObject {
     await snsRow.getStakeButtonPo().click();
     const modal = this.getSnsStakeNeuronModalPo();
     await modal.stake(amount);
+    // After staking the first neuron, we get redirected to the SNS neurons page.
+    await this.waitForAbsent();
   }
 }


### PR DESCRIPTION
# Motivation

I noticed some flakiness in `e2e/sns-governance.spec.ts` because it was waiting for skeleton cards to disappear while the neurons table we have now has a spinner instead of skeleton cards.
This was already fixed for NNS in https://github.com/dfinity/nns-dapp/commit/2395a228b10930469e1f3165e67bf7fc5faeff64#diff-34fb0aee6c9d4c7899b1a1d5a88c149c53c205559da5a91eb977e2798203500a but we somehow skipped SNS.

# Changes

1. Wait for the spinner to go away in `waitForContentLoaded`.
2. Remove irrelevant code in the PO related to skeleton cards.
3. Drive-by: Make `stakeFirstSnsNeuron` consistent with `stakeFirstNnsNeuron` by waiting for the staking view to disappear after staking the SNS neuron.

# Tests

Without the change, `e2e/sns-governance.spec.ts` failed 2 out of 12 times. With the change I ran it 24 times without failure.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary