### PR TITLE
build: remove marked from package.json

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,8 +26,7 @@
         "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.8",
         "@ledgerhq/hw-transport-webhid": "^6.27.8",
         "@zondax/ledger-icp": "^0.6.1",
-        "buffer": "^6.0.3",
-        "marked": "^9.1.0"
+        "buffer": "^6.0.3"
       },
       "devDependencies": {
         "@playwright/test": "^1.39",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,8 +79,7 @@
     "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.8",
     "@ledgerhq/hw-transport-webhid": "^6.27.8",
     "@zondax/ledger-icp": "^0.6.1",
-    "buffer": "^6.0.3",
-    "marked": "^9.1.0"
+    "buffer": "^6.0.3"
   },
   "overrides": {
     "semver": "^7.5.3"


### PR DESCRIPTION
# Motivation

The markdown component has been moved to gix-cmp. The `marked` library is inherited therefore we can remove it as explicit dependency.

# Changes

- `npm rm marked`
