### PR TITLE
Clean up ENABLE_PROJECTS_TABLE feature flag code

### DIFF
--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -6,16 +6,13 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import { authSignedInStore } from "$lib/derived/auth.derived";
   import { pageStore } from "$lib/derived/page.derived";
-  import {
-    neuronsPathStore,
-    proposalsPathStore,
-  } from "$lib/derived/paths.derived";
-  import { ENABLE_PROJECTS_TABLE } from "$lib/stores/feature-flags.store";
+  import { proposalsPathStore } from "$lib/derived/paths.derived";
   import { i18n } from "$lib/stores/i18n";
   import {
     ACTIONABLE_PROPOSALS_URL,
     isSelectedPath,
   } from "$lib/utils/navigation.utils";
+  import SourceCodeButton from "./SourceCodeButton.svelte";
   import {
     IconNeurons,
     IconRocketLaunch,
@@ -23,9 +20,8 @@
     IconWallet,
     MenuItem,
   } from "@dfinity/gix-components";
-  import type { ComponentType } from "svelte";
-  import SourceCodeButton from "./SourceCodeButton.svelte";
   import { layoutMenuOpen, menuCollapsed } from "@dfinity/gix-components";
+  import type { ComponentType } from "svelte";
 
   let routes: {
     context: string;
@@ -52,7 +48,7 @@
     },
     {
       context: "neurons",
-      href: $ENABLE_PROJECTS_TABLE ? AppPath.Staking : $neuronsPathStore,
+      href: AppPath.Staking,
       selected: isSelectedPath({
         currentPath: $pageStore.path,
         paths: [AppPath.Staking, AppPath.Neurons, AppPath.Neuron],

--- a/frontend/src/routes/(app)/(u)/(list)/neurons/+layout.svelte
+++ b/frontend/src/routes/(app)/(u)/(list)/neurons/+layout.svelte
@@ -3,9 +3,7 @@
   import Content from "$lib/components/layout/Content.svelte";
   import Layout from "$lib/components/layout/Layout.svelte";
   import LayoutList from "$lib/components/layout/LayoutList.svelte";
-  import UniverseSplitContent from "$lib/components/layout/UniverseSplitContent.svelte";
   import { AppPath } from "$lib/constants/routes.constants";
-  import { ENABLE_PROJECTS_TABLE } from "$lib/stores/feature-flags.store";
   import { i18n } from "$lib/stores/i18n";
 
   const back = (): Promise<void> => goto(AppPath.Staking);
@@ -13,14 +11,8 @@
 
 <LayoutList title={$i18n.navigation.neurons}>
   <Layout>
-    {#if $ENABLE_PROJECTS_TABLE}
-      <Content {back}>
-        <slot />
-      </Content>
-    {:else}
-      <UniverseSplitContent>
-        <slot />
-      </UniverseSplitContent>
-    {/if}
+    <Content {back}>
+      <slot />
+    </Content>
   </Layout>
 </LayoutList>

--- a/frontend/src/tests/e2e/disburse.spec.ts
+++ b/frontend/src/tests/e2e/disburse.spec.ts
@@ -1,20 +1,11 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test disburse neuron", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_PROJECTS_TABLE",
-    value: true,
-  });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/following.spec.ts
+++ b/frontend/src/tests/e2e/following.spec.ts
@@ -1,20 +1,11 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test neuron following", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_PROJECTS_TABLE",
-    value: true,
-  });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/merge-neurons.spec.ts
+++ b/frontend/src/tests/e2e/merge-neurons.spec.ts
@@ -1,20 +1,11 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test merge neurons", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_PROJECTS_TABLE",
-    value: true,
-  });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
+++ b/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
@@ -1,21 +1,12 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { getNnsNeuronCardsIds } from "$tests/utils/e2e.nns-neuron.test-utils";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test neuron increase stake", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_PROJECTS_TABLE",
-    value: true,
-  });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/neurons-table.spec.ts
+++ b/frontend/src/tests/e2e/neurons-table.spec.ts
@@ -2,7 +2,6 @@ import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import {
   replaceContent,
-  setFeatureFlag,
   signInWithNewUser,
   step,
 } from "$tests/utils/e2e.test-utils";
@@ -26,11 +25,6 @@ const createHotkeyNeuronsInOtherAccount = async ({
   const page = await context.newPage();
   await page.goto("/");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_PROJECTS_TABLE",
-    value: true,
-  });
   await signInWithNewUser({ page, context });
 
   const appPo = new AppPo(PlaywrightPageObjectElement.fromPage(page));
@@ -66,11 +60,6 @@ const createHotkeyNeuronsInOtherAccount = async ({
 test("Test neurons table", async ({ page, context, browser }) => {
   await page.goto("/canisters");
   await expect(page).toHaveTitle("Canisters / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_PROJECTS_TABLE",
-    value: true,
-  });
 
   const appPo = new AppPo(PlaywrightPageObjectElement.fromPage(page));
 

--- a/frontend/src/tests/e2e/neurons.spec.ts
+++ b/frontend/src/tests/e2e/neurons.spec.ts
@@ -2,21 +2,12 @@ import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { getNnsNeuronCardsIds } from "$tests/utils/e2e.nns-neuron.test-utils";
 import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test neuron voting", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_PROJECTS_TABLE",
-    value: true,
-  });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -2,22 +2,13 @@ import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
 import { createDummyProposal } from "$tests/utils/e2e.nns-proposals.test-utils";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { ProposalStatus, Topic } from "@dfinity/nns";
 import { expect, test } from "@playwright/test";
 
 test("Test proposals", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_PROJECTS_TABLE",
-    value: true,
-  });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/e2e/sns-governance.spec.ts
+++ b/frontend/src/tests/e2e/sns-governance.spec.ts
@@ -1,20 +1,11 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import {
-  setFeatureFlag,
-  signInWithNewUser,
-  step,
-} from "$tests/utils/e2e.test-utils";
+import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 test("Test SNS governance", async ({ page, context }) => {
   await page.goto("/");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
-  await setFeatureFlag({
-    page,
-    featureFlag: "ENABLE_PROJECTS_TABLE",
-    value: true,
-  });
   await signInWithNewUser({ page, context });
 
   const pageElement = PlaywrightPageObjectElement.fromPage(page);

--- a/frontend/src/tests/lib/components/common/MenuItems.spec.ts
+++ b/frontend/src/tests/lib/components/common/MenuItems.spec.ts
@@ -3,7 +3,6 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
 import { actionableSnsProposalsStore } from "$lib/stores/actionable-sns-proposals.store";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { page } from "$mocks/$app/stores";
 import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
@@ -55,17 +54,7 @@ describe("MenuItems", () => {
   it("should render accounts menu item", () =>
     shouldRenderMenuItem({ context: "accounts", labelKey: "tokens" }));
 
-  it("should render neurons menu item without projects table", () => {
-    overrideFeatureFlagsStore.setFlag("ENABLE_PROJECTS_TABLE", false);
-    shouldRenderMenuItem({
-      context: "neurons",
-      labelKey: "neurons",
-      href: "/neurons/?u=qhbym-qaaaa-aaaaa-aaafq-cai",
-    });
-  });
-
-  it("should render neurons menu item with projects table", () => {
-    overrideFeatureFlagsStore.setFlag("ENABLE_PROJECTS_TABLE", true);
+  it("should render neurons menu item", () => {
     shouldRenderMenuItem({
       context: "neurons",
       labelKey: "neurons",

--- a/frontend/src/tests/routes/app/neurons/layout.spec.ts
+++ b/frontend/src/tests/routes/app/neurons/layout.spec.ts
@@ -1,6 +1,5 @@
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
-import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import NeuronsLayout from "$routes/(app)/(u)/(list)/neurons/+layout.svelte";
 import { render } from "@testing-library/svelte";
@@ -21,7 +20,6 @@ describe("Neurons layout", () => {
   });
 
   it("should have a back button", () => {
-    overrideFeatureFlagsStore.setFlag("ENABLE_PROJECTS_TABLE", true);
     const { getByTestId } = render(NeuronsLayout);
     const backButton = getByTestId("back");
     expect(backButton).toBeInTheDocument();

--- a/frontend/src/tests/routes/app/neurons/layout.spec.ts
+++ b/frontend/src/tests/routes/app/neurons/layout.spec.ts
@@ -3,17 +3,10 @@ import { pageStore } from "$lib/derived/page.derived";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { layoutTitleStore } from "$lib/stores/layout.store";
 import NeuronsLayout from "$routes/(app)/(u)/(list)/neurons/+layout.svelte";
-import { SelectUniverseDropdownPo } from "$tests/page-objects/SelectUniverseDropdown.page-object";
-import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("Neurons layout", () => {
-  const hasUniverseNav = (container: HTMLElement): Promise<boolean> =>
-    SelectUniverseDropdownPo.under(
-      new JestPageObjectElement(container)
-    ).isPresent();
-
   beforeEach(() => {
     layoutTitleStore.set({ title: "" });
   });
@@ -27,40 +20,13 @@ describe("Neurons layout", () => {
     });
   });
 
-  describe("when ENABLE_PROJECTS_TABLE is disabled", () => {
-    beforeEach(() => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_PROJECTS_TABLE", false);
-    });
-
-    it("should not have a back button", () => {
-      const { getByTestId } = render(NeuronsLayout);
-      expect(() => getByTestId("back")).toThrow();
-    });
-
-    it("should have universe navigation", async () => {
-      const { container } = render(NeuronsLayout);
-      expect(await hasUniverseNav(container)).toBe(true);
-    });
-  });
-
-  describe("when ENABLE_PROJECTS_TABLE is enabled", () => {
-    beforeEach(() => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_PROJECTS_TABLE", true);
-    });
-
-    it("should have a back button", () => {
-      overrideFeatureFlagsStore.setFlag("ENABLE_PROJECTS_TABLE", true);
-      const { getByTestId } = render(NeuronsLayout);
-      const backButton = getByTestId("back");
-      expect(backButton).toBeInTheDocument();
-      expect(get(pageStore).path).not.toBe(AppPath.Staking);
-      backButton.click();
-      expect(get(pageStore).path).toBe(AppPath.Staking);
-    });
-
-    it("should not have universe navigation", async () => {
-      const { container } = render(NeuronsLayout);
-      expect(await hasUniverseNav(container)).toBe(false);
-    });
+  it("should have a back button", () => {
+    overrideFeatureFlagsStore.setFlag("ENABLE_PROJECTS_TABLE", true);
+    const { getByTestId } = render(NeuronsLayout);
+    const backButton = getByTestId("back");
+    expect(backButton).toBeInTheDocument();
+    expect(get(pageStore).path).not.toBe(AppPath.Staking);
+    backButton.click();
+    expect(get(pageStore).path).toBe(AppPath.Staking);
   });
 });


### PR DESCRIPTION
# Motivation

The feature has been enable a while ago.

# Changes

Remove the code paths for when `ENABLE_PROJECTS_TABLE` is disabled.
The feature flag itself will be removed in another PR.

# Tests

Removed/updated

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary