### PR TITLE
Check for minimum stake when staking SNS tokens

### DIFF
--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -460,6 +460,7 @@ describe("sns-neurons-services", () => {
         {
           rootCanisterId: mockPrincipal,
           tokenMetadata: { ...mockSnsToken, fee: 100n },
+          neuronMinimumStakeE8s: 100_000_000n,
         },
       ]);
       const spyStake = vi
@@ -502,6 +503,7 @@ describe("sns-neurons-services", () => {
         {
           rootCanisterId: mockPrincipal,
           tokenMetadata: { ...mockSnsToken, fee: 0n },
+          neuronMinimumStakeE8s: 100_000_000n,
         },
       ]);
       const spyStake = vi
@@ -521,6 +523,33 @@ describe("sns-neurons-services", () => {
       expect(spyStake).toBeCalled();
       expect(spyQuery).toBeCalled();
       expect(loadSnsAccounts).toBeCalled();
+    });
+
+    it("should fail if staked amount is too low", async () => {
+      setSnsProjects([
+        {
+          rootCanisterId: mockPrincipal,
+          tokenMetadata: { ...mockSnsToken, fee: 100n },
+          neuronMinimumStakeE8s: 200_000_001n,
+        },
+      ]);
+      const spyStake = vi
+        .spyOn(api, "stakeNeuron")
+        .mockImplementation(() => Promise.resolve(mockSnsNeuron.id[0]));
+      const spyQuery = vi
+        .spyOn(governanceApi, "querySnsNeurons")
+        .mockImplementation(() => Promise.resolve([mockSnsNeuron]));
+
+      const { success } = await stakeNeuron({
+        rootCanisterId: mockPrincipal,
+        amount: 2,
+        account: mockSnsMainAccount,
+      });
+
+      expect(success).toBe(false);
+      expect(spyStake).not.toBeCalled();
+      expect(spyQuery).not.toBeCalled();
+      expect(loadSnsAccounts).not.toBeCalled();
     });
   });
 

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -550,6 +550,15 @@ describe("sns-neurons-services", () => {
       expect(spyStake).not.toBeCalled();
       expect(spyQuery).not.toBeCalled();
       expect(loadSnsAccounts).not.toBeCalled();
+
+      expect(toastsError).toBeCalledWith({
+        err: new Error(
+          "The caller should make sure the amount is at least the minimum stake"
+        ),
+        labelKey: "error__sns.sns_stake",
+        renderAsHtml: false,
+      });
+      expect(toastsError).toBeCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
# Motivation

We recently had an issue where the `SnsStakeNeuronModal` failed to check the minimum stake amount, which resulted in some people trying to stake too little.

In this PR I add an extra check in the service to make sure we don't try to stake too little.
Providing a proper error message requires passing in more information about the token and i18n so I didn't do this.
It's still the responsibility of the component calling the service to check this, but now we have an extra safety check.

# Changes

1. When staking SNS tokens, check that the staked amount is at least the minimum stake.

# Tests

1. Update some tests that were accidentally affected by this.
2. Add a test with a staked amount that's too small.
3. Tested manually after temporarily removing the check in the component.
4. Tested manually that increasing an existing stake by a small amount is still possible.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary