### PR TITLE
Use GitHub runners instead of dind-small

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,10 +38,7 @@ jobs:
                   exit 1
           }
   spelling:
-    runs-on:
-      labels: dind-small
-    container:
-      image: ghcr.io/dfinity/minimal-runner-image:0.1
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,10 +52,7 @@ jobs:
       - name: Spellcheck changelog
         run: scripts/spellcheck-changelog
   cargo-tests:
-    runs-on:
-      labels: dind-small
-    container:
-      image: ghcr.io/dfinity/minimal-runner-image:0.1
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -162,10 +156,7 @@ jobs:
           fi
   release-templating-works:
     name: Release template
-    runs-on:
-      labels: dind-small
-    container:
-      image: ghcr.io/dfinity/minimal-runner-image:0.1
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# Motivation

`dind-small` is having network issues making our tests flaky.
For example: [one](https://github.com/dfinity/nns-dapp/actions/runs/10918905453/job/30305412108), [two](https://github.com/dfinity/nns-dapp/actions/runs/10918905453/job/30305412765), [three](https://github.com/dfinity/nns-dapp/actions/runs/10920886302/job/30311750178).
I also [heard from IDX](https://dfinity.slack.com/archives/CL7Q2RXUM/p1726661669207729) that using `dind-small` wasn't actually necessary.

# Changes

Basically the opposite of https://github.com/dfinity/nns-dapp/commit/9c0d83da34ee9892b12e9e197eef84ffbf9e9618 except we don't re-introduce the unnecessary singleton matrix.

# Tests

CI should pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary