### PR TITLE
Extract snsAggregatorDerived function

### DIFF
--- a/frontend/src/lib/derived/sns-aggregator.derived.ts
+++ b/frontend/src/lib/derived/sns-aggregator.derived.ts
@@ -1,0 +1,18 @@
+import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+import type { CachedSnsDto } from "$lib/types/sns-aggregator";
+import { derived, type Readable } from "svelte/store";
+
+/**
+ * Creates a derived store, which maps root canister IDs to some data derived
+ * from SNS aggregator data.
+ */
+export const snsAggregatorDerived = <T>(
+  mapFn: (sns: CachedSnsDto) => T
+): Readable<Record<string, T>> =>
+  derived(snsAggregatorStore, (aggregatorStore) =>
+    Object.fromEntries(
+      aggregatorStore.data?.map((sns) => {
+        return [sns.canister_ids.root_canister_id, mapFn(sns)];
+      }) ?? []
+    )
+  );

--- a/frontend/src/lib/derived/sns-functions.derived.ts
+++ b/frontend/src/lib/derived/sns-functions.derived.ts
@@ -1,7 +1,7 @@
-import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
 import { convertNervousFunction } from "$lib/utils/sns-aggregator-converters.utils";
 import type { SnsNervousSystemFunction } from "@dfinity/sns";
-import { derived, type Readable } from "svelte/store";
+import { type Readable } from "svelte/store";
+import { snsAggregatorDerived } from "./sns-aggregator.derived";
 
 interface SnsNervousSystemFunctions {
   nsFunctions: SnsNervousSystemFunction[];
@@ -18,15 +18,7 @@ export interface SnsNervousSystemFunctionsStore
 /**
  * A store that contains the nervous system functions for each sns project.
  */
-export const snsFunctionsStore: SnsNervousSystemFunctionsStore = derived(
-  snsAggregatorStore,
-  (aggregatorStore) =>
-    Object.fromEntries(
-      aggregatorStore.data?.map((sns) => [
-        sns.canister_ids.root_canister_id,
-        {
-          nsFunctions: sns.parameters.functions.map(convertNervousFunction),
-        },
-      ]) ?? []
-    )
-);
+export const snsFunctionsStore: SnsNervousSystemFunctionsStore =
+  snsAggregatorDerived((sns) => ({
+    nsFunctions: sns.parameters.functions.map(convertNervousFunction),
+  }));

--- a/frontend/src/lib/derived/sns-parameters.derived.ts
+++ b/frontend/src/lib/derived/sns-parameters.derived.ts
@@ -1,7 +1,7 @@
-import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+import { snsAggregatorDerived } from "$lib/derived/sns-aggregator.derived";
 import { convertNervousSystemParameters } from "$lib/utils/sns-aggregator-converters.utils";
 import type { SnsNervousSystemParameters } from "@dfinity/sns";
-import { derived, type Readable } from "svelte/store";
+import { type Readable } from "svelte/store";
 
 export interface SnsParameters {
   parameters: SnsNervousSystemParameters;
@@ -15,19 +15,7 @@ export interface SnsParametersStore {
 /**
  * A store that contains the sns nervous system parameters for each project.
  */
-export const snsParametersStore: Readable<SnsParametersStore> = derived(
-  snsAggregatorStore,
-  (aggregatorStore) =>
-    Object.fromEntries(
-      aggregatorStore.data?.map((sns) => {
-        return [
-          sns.canister_ids.root_canister_id,
-          {
-            parameters: convertNervousSystemParameters(
-              sns.nervous_system_parameters
-            ),
-          },
-        ];
-      }) ?? []
-    )
-);
+export const snsParametersStore: Readable<SnsParametersStore> =
+  snsAggregatorDerived((sns) => ({
+    parameters: convertNervousSystemParameters(sns.nervous_system_parameters),
+  }));

--- a/frontend/src/lib/derived/sns-total-token-supply.derived.ts
+++ b/frontend/src/lib/derived/sns-total-token-supply.derived.ts
@@ -1,6 +1,6 @@
-import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
 import type { RootCanisterIdText } from "$lib/types/sns";
-import { derived, type Readable } from "svelte/store";
+import { type Readable } from "svelte/store";
+import { snsAggregatorDerived } from "./sns-aggregator.derived";
 
 interface ProjectTotalSupplyData {
   totalSupply: bigint;
@@ -17,15 +17,7 @@ export interface SnsTotalTokenSupplyStore
 /**
  * A store that contains the total token supply of SNS projects.
  */
-export const snsTotalTokenSupplyStore: SnsTotalTokenSupplyStore = derived(
-  snsAggregatorStore,
-  (aggregatorStore) =>
-    Object.fromEntries(
-      aggregatorStore.data?.map((sns) => [
-        sns.canister_ids.root_canister_id,
-        {
-          totalSupply: BigInt(sns.icrc1_total_supply),
-        },
-      ]) ?? []
-    )
-);
+export const snsTotalTokenSupplyStore: SnsTotalTokenSupplyStore =
+  snsAggregatorDerived((sns) => ({
+    totalSupply: BigInt(sns.icrc1_total_supply),
+  }));

--- a/frontend/src/tests/lib/derived/sns-aggregator.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-aggregator.derived.spec.ts
@@ -1,0 +1,36 @@
+import { snsAggregatorDerived } from "$lib/derived/sns-aggregator.derived";
+import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
+import { get } from "svelte/store";
+
+describe("snsAggregatorDerived", () => {
+  beforeEach(() => {
+    snsAggregatorStore.reset();
+  });
+
+  it("should create a derived store", () => {
+    const rootCanisterId = "3uikt-kqsgq-aaaaa-aaaaa-cai";
+    const ledgerCanisterId = "zjv33-2isgu-aaaaa-aaaaa-cai";
+
+    const snsLedgerCanisterIdStore = snsAggregatorDerived(
+      (sns) => sns.canister_ids.ledger_canister_id
+    );
+
+    expect(get(snsLedgerCanisterIdStore)).toEqual({});
+
+    snsAggregatorStore.setData([
+      {
+        ...aggregatorSnsMockDto,
+        canister_ids: {
+          ...aggregatorSnsMockDto.canister_ids,
+          root_canister_id: rootCanisterId,
+          ledger_canister_id: ledgerCanisterId,
+        },
+      },
+    ]);
+
+    expect(get(snsLedgerCanisterIdStore)).toEqual({
+      [rootCanisterId]: ledgerCanisterId,
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

We have a number of stores derived from `snsAggregatorStore` which all map the aggregator data to some record with the root canister ID as the key.
These all have very similar code.

# Changes

Extracted the duplicate code into a function and used it for `snsFunctionsStore`, `snsParametersStore` and `snsTotalTokenSupplyStore`.

# Tests

1. Added a unit test for the new function.
2. The changed derived stores were already covered by tests that are still passing.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary