### PR TITLE
FOLLOW-1337: Stop making unnecessary requests for SNS proposal

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,6 +30,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Removed
 
+* Stop making unnecessary calls to load the SNS proposal every time we load the derived state.
+
 #### Fixed
 
 * Fixed a bug where a performance counter in `init` is wiped during state initialization.

--- a/frontend/src/lib/components/project-detail/ProjectProposal.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectProposal.svelte
@@ -15,7 +15,7 @@
 
   let proposalInfo: ProposalInfo | undefined;
 
-  const loadProposalFromId = (proposalId: ProposalId) => {
+  const loadProposalFromId = (proposalId: ProposalId | undefined) => {
     if (nonNullish(proposalId)) {
       loadProposal({
         proposalId,

--- a/frontend/src/lib/components/project-detail/ProjectProposal.svelte
+++ b/frontend/src/lib/components/project-detail/ProjectProposal.svelte
@@ -4,15 +4,18 @@
   import { i18n } from "$lib/stores/i18n";
   import type { SnsSummary } from "$lib/types/sns";
   import NnsProposalCard from "../proposals/NnsProposalCard.svelte";
+  import type { ProposalId } from "@dfinity/nns";
   import type { ProposalInfo } from "@dfinity/nns";
   import { nonNullish } from "@dfinity/utils";
 
   export let summary: SnsSummary;
 
+  let proposalId: ProposalId | undefined;
+  $: proposalId = getProjectProposal(summary);
+
   let proposalInfo: ProposalInfo | undefined;
 
-  $: {
-    const proposalId = getProjectProposal(summary);
+  const loadProposalFromId = (proposalId: ProposalId) => {
     if (nonNullish(proposalId)) {
       loadProposal({
         proposalId,
@@ -27,7 +30,9 @@
         silentUpdateErrorMessages: true,
       });
     }
-  }
+  };
+
+  $: loadProposalFromId(proposalId);
 </script>
 
 {#if nonNullish(proposalInfo)}

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -337,7 +337,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
       });
 
       it("should not reload proposal when derived state updates", async () => {
-        const { unmount } = render(ProjectDetail, props);
+        render(ProjectDetail, props);
 
         await runResolvedPromises();
 

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -320,7 +320,8 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
         setSnsProjects([
           {
             rootCanisterId,
-            lifecycle: SnsSwapLifecycle.Committed,
+            // Open lifecycle makes the watcher poll for derived state.
+            lifecycle: SnsSwapLifecycle.Open,
             certified: true,
             nnsProposalId: Number(mockProposalInfo.id),
           },
@@ -333,6 +334,25 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
         await runResolvedPromises();
 
         expect(queryByTestId("proposal-card")).toBeInTheDocument();
+      });
+
+      it("should not reload proposal when derived state updates", async () => {
+        const { unmount } = render(ProjectDetail, props);
+
+        await runResolvedPromises();
+
+        vi.mocked(proposalsApi.queryProposal).mockClear();
+
+        expect(snsApi.querySnsDerivedState).toBeCalledTimes(0);
+        expect(proposalsApi.queryProposal).toBeCalledTimes(0);
+
+        await advanceTime(WATCH_SALE_STATE_EVERY_MILLISECONDS);
+
+        // There used to be a bug where the proposal get reloaded every time the
+        // derived state was updated, even though the proposal card won't change.
+        // So we verify that the derived state is queried but the proposal is not.
+        expect(snsApi.querySnsDerivedState).toBeCalledTimes(1);
+        expect(proposalsApi.queryProposal).toBeCalledTimes(0);
       });
     });
   });


### PR DESCRIPTION
# Motivation

When there is an open SNS swap on the project detail page, we make a request every 10 seconds for the number of participants and commitment, as these might change during an open SNS.

However, this also caused the proposal to be refetched each time. This happened because the proposal fetch logic was derived from the summary store, which is updated each time the derived state is fetched. This is useless because the SNS proposal won't change if the swap is already open.

By adding an intermediate `proposalId` variable, we make sure that we don't fetch the proposal again when the summary changes, but the proposal ID doesn't.

# Changes

Change `ProjectProposal.svelte` to only load the proposal when the proposal ID changes.

# Tests

1. I first created the test to see the proposal being fetched multiple times. After the changes the test passed.
2. I also tested it manually with a log statement inside `queryAndUpdate`.

# Todos

- [x] Add entry to changelog (if necessary).
