### PR TITLE
Fix checksum for ICRC-1 addresses

### DIFF
--- a/scripts/convert-id
+++ b/scripts/convert-id
@@ -144,16 +144,16 @@ function hex_to_icrc1() {
   subaccount_hex="$(get_subaccount_hex)"
 
   # Remove leading zeros.
-  subaccount_hex="$(echo -n "$subaccount_hex" | sed -e 's@^0*@@')"
+  trimmed_subaccount_hex="$(echo -n "$subaccount_hex" | sed -e 's@^0*@@')"
 
-  if [[ -z "$subaccount_hex" ]]; then
+  if [[ -z "$trimmed_subaccount_hex" ]]; then
     echo -n "$hex" | hex_to_text
     return
   fi
 
   checksum="$(echo -n "${hex}${subaccount_hex}" | xxd -r -p | /usr/bin/crc32 /dev/stdin | xxd -p -r | base32 | tr -d = | tr '[:upper:]' '[:lower:]')"
 
-  echo "$(echo "$hex" | hex_to_text)-${checksum}.${subaccount_hex}"
+  echo "$(echo "$hex" | hex_to_text)-${checksum}.${trimmed_subaccount_hex}"
 }
 
 function check_hex() {

--- a/scripts/convert-id.test
+++ b/scripts/convert-id.test
@@ -8,7 +8,7 @@ function expect_convert() {
   SCRIPT_UNDER_TEST="$SOURCE_DIR/convert-id"
   actual_output=$("$SCRIPT_UNDER_TEST" "$@")
   if [ "$expected_output" != "$actual_output" ]; then
-    printf "Command: %s " "$(basename "$SCRIPT_UNDER_TEST")"
+    printf "Command: %s" "$(basename "$SCRIPT_UNDER_TEST")"
     printf " %q" "$@"
     echo
     echo "Expected: $expected_output"
@@ -59,7 +59,7 @@ expect_convert "$SUBACCOUNT_IDENTIFIER" --output account_identifier --input text
 expect_convert "$HEX_AS_SUBACCOUNT" --output hex --as_subaccount --input text "$TEXT"
 expect_convert "$SUBACCOUNT_IDENTIFIER" --output account_identifier --input text --subaccount_format hex "$TEXT2" "$HEX_AS_SUBACCOUNT"
 
-ICRC1_CHECKSUM="3vbe6yq"
+ICRC1_CHECKSUM="vyqwuvy"
 ICRC1="$TEXT2-$ICRC1_CHECKSUM.1"
 expect_convert "$ICRC1" --output icrc1 --input icrc1 "$ICRC1"
 expect_convert "$ICRC1" --output icrc1 --input text "$TEXT2" 1


### PR DESCRIPTION
# Motivation

The textual address format of an ICRC-1 account with subaccount has leading zeros removed from the subaccount.
The address also contains a checksum of the account and subaccount but when calculating the checksum, the leading zeros should not be removed from the subaccount.
The `convert-id` script did this wrong.

# Changes

Calculate the checksum with the subaccount without leading zeros removed.

# Tests

Test updated.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary