### PR TITLE
Clean up magic numbers from SNS neuron tests

### DIFF
--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeading.spec.ts
@@ -1,7 +1,12 @@
 import SnsNeuronPageHeading from "$lib/components/sns-neuron-detail/SnsNeuronPageHeading.svelte";
-import { SECONDS_IN_EIGHT_YEARS } from "$lib/constants/constants";
+import {
+  SECONDS_IN_DAY,
+  SECONDS_IN_EIGHT_YEARS,
+  SECONDS_IN_FOUR_YEARS,
+} from "$lib/constants/constants";
 import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
 import { authStore } from "$lib/stores/auth.store";
+import { nowInSeconds } from "$lib/utils/date.utils";
 import {
   mockAuthStoreSubscribe,
   mockIdentity,
@@ -19,7 +24,14 @@ import type { SnsNeuron } from "@dfinity/sns";
 import { render } from "@testing-library/svelte";
 
 describe("SnsNeuronPageHeading", () => {
-  const minDissolveDelayToVote = 2_629_800n;
+  const minDissolveDelayToVote = BigInt(30 * SECONDS_IN_DAY);
+  const maxDissolveDelay = BigInt(SECONDS_IN_EIGHT_YEARS);
+  const maxDissolveDelayBonusMultiplier = 2;
+  const maxDissolveDelayBonusPercentage =
+    100 * (maxDissolveDelayBonusMultiplier - 1);
+  const maxAgeForBonus = BigInt(SECONDS_IN_FOUR_YEARS);
+  const maxAgeBonusMultiplier = 1.25;
+  const maxAgeBonusPercentage = 100 * (maxAgeBonusMultiplier - 1);
 
   const renderSnsNeuronCmp = (neuron: SnsNeuron) => {
     const { container } = render(SnsNeuronPageHeading, {
@@ -27,14 +39,16 @@ describe("SnsNeuronPageHeading", () => {
         neuron,
         parameters: {
           ...snsNervousSystemParametersMock,
-          max_dissolve_delay_seconds: [3_155_760_000n],
-          max_dissolve_delay_bonus_percentage: [100n],
+          max_dissolve_delay_seconds: [maxDissolveDelay],
+          max_dissolve_delay_bonus_percentage: [
+            BigInt(maxDissolveDelayBonusPercentage),
+          ],
           neuron_minimum_stake_e8s: [100_000_000n],
-          max_neuron_age_for_age_bonus: [15_778_800n],
+          max_neuron_age_for_age_bonus: [maxAgeForBonus],
           neuron_minimum_dissolve_delay_to_vote_seconds: [
             minDissolveDelayToVote,
           ],
-          max_age_bonus_percentage: [25n],
+          max_age_bonus_percentage: [BigInt(maxAgeBonusPercentage)],
         },
       },
     });
@@ -44,6 +58,9 @@ describe("SnsNeuronPageHeading", () => {
 
   beforeEach(() => {
     vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    // Make sure that nowInSeconds() returns a fixed value for the calculation
+    // of the neuron age.
+    vi.useFakeTimers();
   });
 
   it("should render the neuron's stake", async () => {
@@ -57,17 +74,23 @@ describe("SnsNeuronPageHeading", () => {
   });
 
   it("should render the neuron's voting power", async () => {
-    const stake = 314_000_000n;
     const neuron = createMockSnsNeuron({
       id: [1],
       state: NeuronState.Locked,
-      dissolveDelaySeconds: BigInt(SECONDS_IN_EIGHT_YEARS),
+      stake: 200_000_000n,
       stakedMaturity: 100_000_000n,
-      stake,
+      dissolveDelaySeconds: maxDissolveDelay,
+      ageSinceTimestampSeconds: BigInt(nowInSeconds()) - 2n * maxAgeForBonus,
     });
     const po = renderSnsNeuronCmp(neuron);
 
-    expect(await po.getVotingPower()).toEqual("Voting Power: 5.59");
+    // Expected voting power is:
+    // (stake + staked maturity)
+    //   * max dissolve delay multiplier
+    //   * max age bonus multiplier
+    // = (2.00 + 1.00) * 2.00 * 1.25
+    // = 7.50
+    expect(await po.getVotingPower()).toEqual("Voting Power: 7.50");
   });
 
   it("should render no votig power if neuron can't vote", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.spec.ts
@@ -1,5 +1,9 @@
 import SnsNeuronVotingPowerSection from "$lib/components/sns-neuron-detail/SnsNeuronVotingPowerSection.svelte";
-import { SECONDS_IN_YEAR } from "$lib/constants/constants";
+import {
+  SECONDS_IN_DAY,
+  SECONDS_IN_EIGHT_YEARS,
+  SECONDS_IN_YEAR,
+} from "$lib/constants/constants";
 import {
   createMockSnsNeuron,
   mockSnsNeuron,
@@ -14,19 +18,26 @@ import { render } from "@testing-library/svelte";
 
 describe("NnsStakeItemAction", () => {
   const nowInSeconds = 1689843195;
-  const minDissolveDelayToVote = 2_629_800n;
+  const minDissolveDelayToVote = BigInt(30 * SECONDS_IN_DAY);
+  const maxDissolveDelay = BigInt(SECONDS_IN_EIGHT_YEARS);
+  const maxDissolveDelayBonusMultiplier = 2;
+  const maxDissolveDelayBonusPercentage =
+    100 * (maxDissolveDelayBonusMultiplier - 1);
+  const maxAgeForBonus = BigInt(SECONDS_IN_YEAR);
+  const maxAgeBonusMultiplier = 1.25;
+  const maxAgeBonusPercentage = 100 * (maxAgeBonusMultiplier - 1);
 
   const neuronCanVote = createMockSnsNeuron({
     id: [1],
-    stake: 314000000n,
-    stakedMaturity: 100000000n,
+    stake: 300_000_000n,
+    stakedMaturity: 100_000_000n,
     state: NeuronState.Locked,
-    dissolveDelaySeconds: minDissolveDelayToVote,
-    ageSinceTimestampSeconds: BigInt(nowInSeconds - SECONDS_IN_YEAR),
+    dissolveDelaySeconds: maxDissolveDelay,
+    ageSinceTimestampSeconds: BigInt(nowInSeconds) - maxAgeForBonus,
   });
   const neuronCanNotVote = createMockSnsNeuron({
     id: [1],
-    stake: 314000000n,
+    stake: 314_000_000n,
     state: NeuronState.Locked,
     dissolveDelaySeconds: minDissolveDelayToVote - 1n,
   });
@@ -36,13 +47,16 @@ describe("NnsStakeItemAction", () => {
         neuron,
         parameters: {
           ...snsNervousSystemParametersMock,
-          max_dissolve_delay_seconds: [3_155_760_000n],
-          max_dissolve_delay_bonus_percentage: [100n],
+          max_dissolve_delay_seconds: [maxDissolveDelay],
+          max_dissolve_delay_bonus_percentage: [
+            BigInt(maxDissolveDelayBonusPercentage),
+          ],
           neuron_minimum_stake_e8s: [100_000_000n],
-          max_neuron_age_for_age_bonus: [15_778_800n],
+          max_neuron_age_for_age_bonus: [maxAgeForBonus],
           neuron_minimum_dissolve_delay_to_vote_seconds: [
             minDissolveDelayToVote,
           ],
+          max_age_bonus_percentage: [BigInt(maxAgeBonusPercentage)],
         },
         token: mockToken,
       },
@@ -58,11 +72,6 @@ describe("NnsStakeItemAction", () => {
     vi.setSystemTime(nowInSeconds * 1000);
   });
 
-  it("should render voting power", async () => {
-    const po = renderComponent(neuronCanVote);
-    expect(await po.getVotingPower()).toBe("5.18");
-  });
-
   it("should render no voting power if neuron can't vote", async () => {
     const po = renderComponent(neuronCanNotVote);
     expect(await po.getVotingPower()).toBe("None");
@@ -72,15 +81,16 @@ describe("NnsStakeItemAction", () => {
     const po = renderComponent(neuronCanNotVote);
 
     expect(await po.getDescription()).toBe(
-      "The dissolve delay must be at least 30 days, 10 hours for the neuron to have voting power. Learn more about voting power on the dashboard."
+      "The dissolve delay must be at least 30 days for the neuron to have voting power. Learn more about voting power on the dashboard."
     );
   });
 
-  it("should render voting power description if neuron can vote", async () => {
+  it("should render voting power and description if neuron can vote", async () => {
     const po = renderComponent(neuronCanVote);
 
+    expect(await po.getVotingPower()).toBe("10.00");
     expect(await po.getDescription()).toBe(
-      "voting_power = (3.14 + 1.00) × 1.25 × 1.00 = 5.18"
+      "voting_power = (3.00 + 1.00) × 1.25 × 2.00 = 10.00"
     );
   });
 


### PR DESCRIPTION
# Motivation

These 2 tests had some unexplained numbers in them.
I tried to make the numbers in the setup more explicit so it's clearer where the numbers in the tests come from.

# Changes

1. Declare constants with specific value.
2. Explain how the expected results derive from the inputs.
3. Merge `"should render voting power"` into `"should render voting power and description if neuron can vote"` because the second expectation explains the value of the first expectation.

# Tests

Only tests.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary