### PR TITLE
bot: Update IC Cargo Dependencies to release-2024-09-19_01-31-base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,9 +491,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cached"
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.19"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d74707dde2ba56f86ae90effb3b43ddd369504387e718014de010cec7959800"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "shlex",
 ]
@@ -672,19 +672,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.13",
+ "clap_derive 4.5.18",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -934,7 +934,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1104,7 +1104,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1116,7 +1116,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1125,7 +1125,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "on_wire",
  "prost",
@@ -1334,7 +1334,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1667,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1691,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -1721,7 +1721,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-replica-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "serde",
 ]
@@ -1755,7 +1755,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -1764,7 +1764,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1892,7 +1892,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1906,7 +1906,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "getrandom",
 ]
@@ -1914,7 +1914,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "hex",
  "ic-types",
@@ -1924,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -1946,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -1964,7 +1964,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -1972,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -1991,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2004,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "sha2",
 ]
@@ -2012,7 +2012,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "base64 0.13.1",
  "cached",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2068,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "arrayvec 0.7.6",
  "hex",
@@ -2085,7 +2085,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "hmac",
  "k256",
@@ -2119,7 +2119,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "serde",
  "zeroize",
@@ -2128,7 +2128,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2136,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2149,7 +2149,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -2162,7 +2162,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2172,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2182,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-protobuf",
  "ic-utils",
@@ -2194,7 +2194,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "ciborium",
@@ -2217,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "ciborium",
@@ -2245,7 +2245,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "async-trait",
  "candid",
@@ -2274,7 +2274,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -2286,7 +2286,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "async-trait",
  "candid",
@@ -2304,7 +2304,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -2316,7 +2316,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "hex",
@@ -2326,12 +2326,12 @@ dependencies = [
 [[package]]
 name = "ic-limits"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2357,11 +2357,11 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-canisters"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "async-trait",
+ "candid",
  "dfn_core",
- "dfn_protobuf",
  "ic-base-types",
  "ic-ledger-core",
  "ic-nervous-system-common",
@@ -2374,7 +2374,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "async-trait",
  "candid",
@@ -2397,12 +2397,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2411,7 +2411,6 @@ dependencies = [
  "by_address",
  "bytes",
  "dfn_core",
- "dfn_protobuf",
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
@@ -2438,12 +2437,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -2454,9 +2453,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-nervous-system-common-validation"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
+
+[[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -2468,12 +2472,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "comparable",
@@ -2486,7 +2490,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-base-types",
 ]
@@ -2494,7 +2498,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "dfn_core",
@@ -2510,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "async-trait",
  "candid",
@@ -2523,17 +2527,17 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 
 [[package]]
 name = "ic-nervous-system-temporary"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -2546,7 +2550,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "comparable",
@@ -2572,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -2581,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2652,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "bytes",
  "candid",
@@ -2660,6 +2664,7 @@ dependencies = [
  "ic-base-types",
  "ic-crypto-sha2",
  "ic-nervous-system-clients",
+ "ic-nervous-system-common-validation",
  "ic-nervous-system-proto",
  "ic-nns-common",
  "ic-protobuf",
@@ -2679,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "csv",
  "ic-base-types",
@@ -2696,12 +2701,12 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "async-trait",
  "candid",
@@ -2716,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "bincode",
  "candid",
@@ -2730,7 +2735,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-canister-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2741,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2753,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-node-provider-rewards"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-base-types",
  "ic-protobuf",
@@ -2762,7 +2767,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2773,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "ic-management-canister-types",
@@ -2784,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -2796,7 +2801,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2808,7 +2813,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2834,6 +2839,7 @@ dependencies = [
  "ic-nervous-system-collections-union-multi-map",
  "ic-nervous-system-common",
  "ic-nervous-system-common-build-metadata",
+ "ic-nervous-system-common-validation",
  "ic-nervous-system-governance",
  "ic-nervous-system-lock",
  "ic-nervous-system-proto",
@@ -2866,7 +2872,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -2874,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -2885,7 +2891,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "async-trait",
  "candid",
@@ -2906,7 +2912,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -2918,6 +2924,7 @@ dependencies = [
  "ic-nervous-system-common",
  "ic-nervous-system-proto",
  "ic-nns-constants",
+ "ic-nns-governance-api",
  "ic-sns-governance",
  "ic-sns-root",
  "ic-sns-swap",
@@ -2933,7 +2940,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2946,6 +2953,7 @@ dependencies = [
  "ic-canisters-http-types",
  "ic-cdk 0.13.5",
  "ic-cdk-macros 0.9.0",
+ "ic-cdk-timers 0.7.0",
  "ic-management-canister-types",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
@@ -2953,6 +2961,7 @@ dependencies = [
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
+ "ic-nns-constants",
  "ic-sns-swap",
  "icrc-ledger-types",
  "prost",
@@ -2962,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3001,7 +3010,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "comparable",
@@ -3016,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "async-trait",
  "candid",
@@ -3062,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3099,7 +3108,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3110,7 +3119,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "ic-validate-eq-derive",
 ]
@@ -3118,7 +3127,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq-derive"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -3134,7 +3143,7 @@ checksum = "5574bf249d201ddd2c27c3fdf178ddacb1be1c705c8a5b4c1339c393758f2bf2"
 dependencies = [
  "anyhow",
  "candid",
- "clap 4.5.17",
+ "clap 4.5.18",
  "libflate",
  "rustc-demangle",
  "serde",
@@ -3203,7 +3212,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "comparable",
@@ -3233,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "async-trait",
  "candid",
@@ -3244,7 +3253,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.6"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "base32",
  "candid",
@@ -3531,9 +3540,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -3959,13 +3968,13 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 
 [[package]]
 name = "once_cell"
-version = "1.20.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "os_str_bytes"
@@ -4049,9 +4058,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
 dependencies = [
  "memchr",
  "thiserror",
@@ -4060,9 +4069,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d"
+checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4070,9 +4079,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe"
+checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
 dependencies = [
  "pest",
  "pest_meta",
@@ -4083,9 +4092,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174"
+checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
 dependencies = [
  "once_cell",
  "pest",
@@ -4105,7 +4114,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "candid",
  "num-traits",
@@ -4562,7 +4571,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-12_01-30-base#afe1a18291987667fdb52dac3ca44b1aebf7176e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-09-19_01-31-base#0441f40482386397f7c688bf508ddd901ca6c1b7"
 dependencies = [
  "build-info",
  "build-info-build",
@@ -5356,9 +5365,9 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
 dependencies = [
  "indexmap 2.5.0",
  "toml_datetime",
@@ -5403,9 +5412,9 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
@@ -5418,15 +5427,15 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,23 +14,23 @@ ic-cdk = "0.16.0"
 ic-cdk-macros = "0.16.0"
 ic-cdk-timers = "0.10.0"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-12_01-30-base" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
+ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-19_01-31-base" }
 
 [profile.release]
 lto = false


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
We want to keep our Cargo dependencies up to date.

# Changes
* Ran `scripts/update-ic-cargo-deps` to update the Cargo.toml dependencies to the latest IC release.

# Tests
* See CI