### PR TITLE
Update remove imported dialog props to support principal only

### DIFF
--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -21,7 +21,7 @@
   } from "$lib/utils/accounts.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { IconDots, Island, Spinner } from "@dfinity/gix-components";
-  import type { Principal } from "@dfinity/principal";
+  import { Principal } from "@dfinity/principal";
   import { TokenAmountV2, isNullish, nonNullish } from "@dfinity/utils";
   import type { Writable } from "svelte/store";
   import { ENABLE_IMPORT_TOKEN } from "$lib/stores/feature-flags.store";
@@ -255,7 +255,7 @@
 
   {#if removeImportedTokenConfirmationVisible && nonNullish(universe)}
     <ImportTokenRemoveConfirmation
-      {universe}
+      tokenToRemove={{ universe }}
       on:nnsClose={() => (removeImportedTokenConfirmationVisible = false)}
       on:nnsConfirm={removeImportedToken}
     />

--- a/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
+++ b/frontend/src/lib/components/accounts/IcrcWalletPage.svelte
@@ -21,7 +21,7 @@
   } from "$lib/utils/accounts.utils";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { IconDots, Island, Spinner } from "@dfinity/gix-components";
-  import { Principal } from "@dfinity/principal";
+  import type { Principal } from "@dfinity/principal";
   import { TokenAmountV2, isNullish, nonNullish } from "@dfinity/utils";
   import type { Writable } from "svelte/store";
   import { ENABLE_IMPORT_TOKEN } from "$lib/stores/feature-flags.store";

--- a/frontend/src/lib/components/accounts/ImportTokenRemoveConfirmation.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenRemoveConfirmation.svelte
@@ -2,11 +2,13 @@
   import { i18n } from "$lib/stores/i18n";
   import UniverseSummary from "$lib/components/universe/UniverseSummary.svelte";
   import type { Universe } from "$lib/types/universe";
-  import { nonNullish } from "@dfinity/utils";
   import ConfirmationModal from "$lib/modals/common/ConfirmationModal.svelte";
   import { Tag } from "@dfinity/gix-components";
+  import { Principal } from "@dfinity/principal";
 
-  export let universe: Universe | undefined;
+  export let tokenToRemove:
+    | { universe: Universe }
+    | { ledgerCanisterId: Principal };
 </script>
 
 <ConfirmationModal
@@ -18,7 +20,13 @@
   <div class="content">
     <h4>{$i18n.import_token.remove_confirmation_header}</h4>
     <div class="token">
-      {#if nonNullish(universe)}<UniverseSummary {universe} />{/if}
+      {#if "universe" in tokenToRemove}
+        <UniverseSummary universe={tokenToRemove.universe} />
+      {:else}
+        <span class="value" data-tid="ledger-canister-id"
+          >{tokenToRemove.ledgerCanisterId.toText()}</span
+        >
+      {/if}
       <Tag>{$i18n.import_token.imported_token}</Tag>
     </div>
     <p class="description text_small">

--- a/frontend/src/lib/components/accounts/ImportTokenRemoveConfirmation.svelte
+++ b/frontend/src/lib/components/accounts/ImportTokenRemoveConfirmation.svelte
@@ -4,7 +4,7 @@
   import type { Universe } from "$lib/types/universe";
   import ConfirmationModal from "$lib/modals/common/ConfirmationModal.svelte";
   import { Tag } from "@dfinity/gix-components";
-  import { Principal } from "@dfinity/principal";
+  import type { Principal } from "@dfinity/principal";
 
   export let tokenToRemove:
     | { universe: Universe }

--- a/frontend/src/tests/lib/components/accounts/ImportTokenRemoveConfirmation.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenRemoveConfirmation.spec.ts
@@ -7,11 +7,11 @@ import { render } from "$tests/utils/svelte.test-utils";
 import type { Principal } from "@dfinity/principal";
 
 describe("ImportTokenRemoveConfirmation", () => {
-  const ledgerCanisterId1 = principal(0);
+  const ledgerCanisterId = principal(1);
   const tokenLogo = "data:image/svg+xml;base64,PHN2ZyB3...";
   const tokenName = "ckTest";
   const mockUniverse: Universe = {
-    canisterId: ledgerCanisterId1.toText(),
+    canisterId: ledgerCanisterId.toText(),
     title: tokenName,
     logo: tokenLogo,
   };
@@ -77,10 +77,10 @@ describe("ImportTokenRemoveConfirmation", () => {
   it("should display ledger ID when universe is not provided", async () => {
     const po = renderComponent({
       tokenToRemove: {
-        ledgerCanisterId: ledgerCanisterId1,
+        ledgerCanisterId,
       },
     });
     expect(await po.getUniverseSummaryPo().isPresent()).toEqual(false);
-    expect(await po.getLedgerCanisterId()).toEqual(ledgerCanisterId1.toText());
+    expect(await po.getLedgerCanisterId()).toEqual(ledgerCanisterId.toText());
   });
 });

--- a/frontend/src/tests/page-objects/ImportTokenRemoveConfirmation.page-object.ts
+++ b/frontend/src/tests/page-objects/ImportTokenRemoveConfirmation.page-object.ts
@@ -14,4 +14,8 @@ export class ImportTokenRemoveConfirmationPo extends ConfirmationModalPo {
   getUniverseSummaryPo(): UniverseSummaryPo {
     return UniverseSummaryPo.under(this.root);
   }
+
+  getLedgerCanisterId(): Promise<string> {
+    return this.getText("ledger-canister-id");
+  }
 }


### PR DESCRIPTION
# Motivation

In the case of a failed imported token, we don’t have the token metadata, such as the logo and token name, but users should still be able to remove the imported token. To achieve this, we first need to make the confirmation dialog work with the ledger canister ID only.

# Changes

- Change the confirmation component props to work seamlessly with either the universe or the ledger canister ID.

# Tests

Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.