### PR TITLE
Failed tokens sorting

### DIFF
--- a/frontend/src/lib/utils/tokens-table.utils.ts
+++ b/frontend/src/lib/utils/tokens-table.utils.ts
@@ -16,7 +16,7 @@ export const compareTokensIcpFirst = createDescendingComparator(
   (token: UserToken) => token.universeId.toText() === OWN_CANISTER_ID_TEXT
 );
 
-export const compareFailedTokensFirst = createDescendingComparator(
+export const compareFailedTokensLast = createAscendingComparator(
   (token: UserToken) => isUserTokenFailed(token)
 );
 
@@ -28,10 +28,7 @@ export const compareTokensWithBalanceOrImportedFirst = ({
   createDescendingComparator(
     (token: UserToken) =>
       getTokenBalanceOrZero(token) > 0n ||
-      // We treat failed imported tokens as if they are not imported,
-      // to move them after tokens with a balance and other imported tokens.
-      (importedTokenIds.has(token.universeId.toText()) &&
-        !isUserTokenFailed(token))
+      importedTokenIds.has(token.universeId.toText())
   );
 
 // These tokens should be placed before others (but after ICP)
@@ -58,7 +55,7 @@ export const compareTokensForTokensTable = ({
   mergeComparators([
     compareTokensIcpFirst,
     compareTokensWithBalanceOrImportedFirst({ importedTokenIds }),
-    compareFailedTokensFirst,
+    compareFailedTokensLast,
     compareTokensByImportance,
     compareTokensAlphabetically,
   ]);

--- a/frontend/src/lib/utils/tokens-table.utils.ts
+++ b/frontend/src/lib/utils/tokens-table.utils.ts
@@ -6,6 +6,7 @@ import {
   createDescendingComparator,
   mergeComparators,
 } from "$lib/utils/responsive-table.utils";
+import { isUserTokenFailed } from "$lib/utils/user-token.utils";
 import { TokenAmountV2 } from "@dfinity/utils";
 
 const getTokenBalanceOrZero = (token: UserToken) =>
@@ -23,7 +24,8 @@ export const compareTokensWithBalanceOrImportedFirst = ({
   createDescendingComparator(
     (token: UserToken) =>
       getTokenBalanceOrZero(token) > 0n ||
-      importedTokenIds.has(token.universeId.toText())
+      (importedTokenIds.has(token.universeId.toText()) &&
+        !isUserTokenFailed(token))
   );
 
 // These tokens should be placed before others (but after ICP)
@@ -50,6 +52,7 @@ export const compareTokensForTokensTable = ({
   mergeComparators([
     compareTokensIcpFirst,
     compareTokensWithBalanceOrImportedFirst({ importedTokenIds }),
+    compareFailedTokensFirst,
     compareTokensByImportance,
     compareTokensAlphabetically,
   ]);

--- a/frontend/src/lib/utils/tokens-table.utils.ts
+++ b/frontend/src/lib/utils/tokens-table.utils.ts
@@ -28,6 +28,8 @@ export const compareTokensWithBalanceOrImportedFirst = ({
   createDescendingComparator(
     (token: UserToken) =>
       getTokenBalanceOrZero(token) > 0n ||
+      // We treat failed imported tokens as if they are not imported,
+      // to move them after tokens with a balance and other imported tokens.
       (importedTokenIds.has(token.universeId.toText()) &&
         !isUserTokenFailed(token))
   );

--- a/frontend/src/lib/utils/tokens-table.utils.ts
+++ b/frontend/src/lib/utils/tokens-table.utils.ts
@@ -16,6 +16,10 @@ export const compareTokensIcpFirst = createDescendingComparator(
   (token: UserToken) => token.universeId.toText() === OWN_CANISTER_ID_TEXT
 );
 
+export const compareFailedTokensFirst = createDescendingComparator(
+  (token: UserToken) => isUserTokenFailed(token)
+);
+
 export const compareTokensWithBalanceOrImportedFirst = ({
   importedTokenIds,
 }: {

--- a/frontend/src/tests/lib/utils/tokens-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/tokens-table.utils.spec.ts
@@ -166,8 +166,8 @@ describe("tokens-table.utils", () => {
       expect(
         compareTokensWithBalanceOrImportedFirst({
           importedTokenIds,
-        })(importedTokenNoBalance, token1)
-      ).toEqual(0);
+        })(importedTokenNoBalance, token0)
+      ).toEqual(-1);
       expect(
         compareTokensWithBalanceOrImportedFirst({
           importedTokenIds,
@@ -176,8 +176,26 @@ describe("tokens-table.utils", () => {
       expect(
         compareTokensWithBalanceOrImportedFirst({
           importedTokenIds,
-        })(importedTokenWithBalance, token0)
+        })(importedTokenWithBalance, importedTokenNoBalance)
+      ).toEqual(0);
+    });
+
+    it("should treat failed imported tokens as being not imported", () => {
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(failedImportedToken, importedTokenWithBalance)
+      ).toEqual(1);
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(importedTokenWithBalance, failedImportedToken)
       ).toEqual(-1);
+      expect(
+        compareTokensWithBalanceOrImportedFirst({
+          importedTokenIds,
+        })(token0, failedImportedToken)
+      ).toEqual(0);
     });
 
     it("should treat token in loading state as having a balance of 0", () => {

--- a/frontend/src/tests/lib/utils/tokens-table.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/tokens-table.utils.spec.ts
@@ -3,7 +3,7 @@ import { CKETH_UNIVERSE_CANISTER_ID } from "$lib/constants/cketh-canister-ids.co
 import { CKUSDC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckusdc-canister-ids.constants";
 import type { UserTokenData, UserTokenFailed } from "$lib/types/tokens-page";
 import {
-  compareFailedTokensFirst,
+  compareFailedTokensLast,
   compareTokensAlphabetically,
   compareTokensByImportance,
   compareTokensIcpFirst,
@@ -188,24 +188,6 @@ describe("tokens-table.utils", () => {
       ).toEqual(0);
     });
 
-    it("should treat failed imported tokens as being not imported", () => {
-      expect(
-        compareTokensWithBalanceOrImportedFirst({
-          importedTokenIds,
-        })(failedImportedToken, importedTokenWithBalance)
-      ).toEqual(1);
-      expect(
-        compareTokensWithBalanceOrImportedFirst({
-          importedTokenIds,
-        })(importedTokenWithBalance, failedImportedToken)
-      ).toEqual(-1);
-      expect(
-        compareTokensWithBalanceOrImportedFirst({
-          importedTokenIds,
-        })(token0, failedImportedToken)
-      ).toEqual(0);
-    });
-
     it("should treat token in loading state as having a balance of 0", () => {
       expect(
         compareTokensWithBalanceOrImportedFirst({
@@ -225,31 +207,29 @@ describe("tokens-table.utils", () => {
     });
   });
 
-  describe("compareFailedTokensFirst", () => {
-    it("should keep ICP first", () => {
+  describe("compareFailedTokensLast", () => {
+    it("should keep failed tokens last", () => {
       const icpToken = createIcpUserToken();
       const ckBTCUserToken = createUserToken(ckBTCTokenBase);
 
       expect(
-        compareFailedTokensFirst(importedTokenNoBalance, failedImportedToken)
+        compareFailedTokensLast(failedImportedToken, importedTokenNoBalance)
       ).toEqual(1);
       expect(
-        compareFailedTokensFirst(importedTokenWithBalance, failedImportedToken)
+        compareFailedTokensLast(failedImportedToken, importedTokenWithBalance)
       ).toEqual(1);
-      expect(compareFailedTokensFirst(icpToken, failedImportedToken)).toEqual(
-        1
-      );
+      expect(compareFailedTokensLast(failedImportedToken, icpToken)).toEqual(1);
       expect(
-        compareFailedTokensFirst(ckBTCUserToken, failedImportedToken)
+        compareFailedTokensLast(failedImportedToken, ckBTCUserToken)
       ).toEqual(1);
       expect(
-        compareFailedTokensFirst(failedImportedToken, importedTokenNoBalance)
+        compareFailedTokensLast(importedTokenNoBalance, failedImportedToken)
       ).toEqual(-1);
       expect(
-        compareFailedTokensFirst(failedImportedToken, failedImportedToken)
+        compareFailedTokensLast(failedImportedToken, failedImportedToken)
       ).toEqual(0);
       expect(
-        compareFailedTokensFirst(
+        compareFailedTokensLast(
           importedTokenWithBalance,
           importedTokenWithBalance
         )

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -697,7 +697,7 @@ describe("Tokens route", () => {
           }
         );
 
-        // Add 2 imported tokens
+        // Add 3 imported tokens
         importedTokensStore.set({
           importedTokens: [
             importedToken1Data,

--- a/frontend/src/tests/routes/app/tokens/page.spec.ts
+++ b/frontend/src/tests/routes/app/tokens/page.spec.ts
@@ -741,8 +741,8 @@ describe("Tokens route", () => {
           "Internet Computer",
           "ckBTC",
           "ckUSDC",
-          "ZTOKEN1",
           "Tetris",
+          "ZTOKEN1",
           failedImportedTokenIdText, // failed
           importedToken2Id.toText(), // failed
           "ckETH",


### PR DESCRIPTION
# Motivation

Failed imported tokens should be placed in the tokens table below tokens with a balance, so the user is aware of the issues.

# Changes

- Update the `compareTokensWithBalanceOrImportedFirst` comparator to treat failed tokens as tokens w/o balance.
- New comparator `compareFailedTokensFirst`.

# Tests

- Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.