### PR TITLE
Clarify parameter of bonusMultiplier

### DIFF
--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -169,12 +169,12 @@ export const votingPower = ({
   const dissolveDelayMultiplier = bonusMultiplier({
     amount: dissolveDelay,
     maxBonus: maxDissolveDelayBonus,
-    maxAmount: maxDissolveDelaySeconds,
+    amountForMaxBonus: maxDissolveDelaySeconds,
   });
   const ageMultiplier = bonusMultiplier({
     amount: ageSeconds,
     maxBonus: maxAgeBonus,
-    maxAmount: maxAgeSeconds,
+    amountForMaxBonus: maxAgeSeconds,
   });
   // We don't use dissolveDelayMultiplier and ageMultiplier directly because those are specific to NNS.
   // This function is generic and could be used for SNS.
@@ -187,21 +187,21 @@ export const dissolveDelayMultiplier = (delayInSeconds: bigint): number =>
   bonusMultiplier({
     amount: delayInSeconds,
     maxBonus: MAX_DISSOLVE_DELAY_BONUS,
-    maxAmount: SECONDS_IN_EIGHT_YEARS,
+    amountForMaxBonus: SECONDS_IN_EIGHT_YEARS,
   });
 
 export const ageMultiplier = (ageSeconds: bigint): number =>
   bonusMultiplier({
     amount: ageSeconds,
     maxBonus: MAX_AGE_BONUS,
-    maxAmount: SECONDS_IN_FOUR_YEARS,
+    amountForMaxBonus: SECONDS_IN_FOUR_YEARS,
   });
 
 // Calculates the bonus multiplier for an amount (such as dissolve delay or age)
 // which results in bonus eligibility which scales linearly from 1 to
 // `maxBonus`. For example for dissolve delay, the values
 //   amount: 4 years
-//   maxBonusAmount: 8 years
+//   amountForMaxBonus: 8 years
 //   maxBonus: 1
 // Would mean that there is a maximum bonus of 1 = 100% (which means a
 // multiplier of 2) but with a dissolve delay of 4 years out of a maximum of
@@ -209,15 +209,17 @@ export const ageMultiplier = (ageSeconds: bigint): number =>
 // So in this case the return value would be 1.5.
 export const bonusMultiplier = ({
   amount,
-  maxAmount,
+  amountForMaxBonus,
   maxBonus,
 }: {
   amount: bigint;
-  maxAmount: number;
+  amountForMaxBonus: number;
   maxBonus: number;
 }): number => {
   const bonusProportion =
-    maxAmount === 0 ? 0 : Math.min(Number(amount), maxAmount) / maxAmount;
+    amountForMaxBonus === 0
+      ? 0
+      : Math.min(Number(amount), amountForMaxBonus) / amountForMaxBonus;
   return 1 + maxBonus * bonusProportion;
 };
 

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -795,7 +795,7 @@ export const dissolveDelayMultiplier = ({
   return bonusMultiplier({
     amount: dissolveDelay,
     maxBonus: Number(maxDissolveDelayBonusPercentage) / 100,
-    maxAmount: Number(maxDissolveDelaySeconds),
+    amountForMaxBonus: Number(maxDissolveDelaySeconds),
   });
 };
 
@@ -814,7 +814,7 @@ export const ageMultiplier = ({
   return bonusMultiplier({
     amount: neuronAge(neuron),
     maxBonus: Number(maxAgeBonusPercentage) / 100,
-    maxAmount: Number(maxNeuronAgeForAgeBonus),
+    amountForMaxBonus: Number(maxNeuronAgeForAgeBonus),
   });
 };
 

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -289,7 +289,7 @@ describe("neuron-utils", () => {
         bonusMultiplier({
           amount: 300n,
           maxBonus: 0.25,
-          maxAmount: 600,
+          amountForMaxBonus: 600,
         })
       ).toBe(1.125);
 
@@ -297,7 +297,7 @@ describe("neuron-utils", () => {
         bonusMultiplier({
           amount: 600n,
           maxBonus: 0.5,
-          maxAmount: 600,
+          amountForMaxBonus: 600,
         })
       ).toBe(1.5);
 
@@ -305,7 +305,7 @@ describe("neuron-utils", () => {
         bonusMultiplier({
           amount: 400n,
           maxBonus: 1,
-          maxAmount: 200,
+          amountForMaxBonus: 200,
         })
       ).toBe(2);
 
@@ -313,7 +313,7 @@ describe("neuron-utils", () => {
         bonusMultiplier({
           amount: 400n,
           maxBonus: 0.25,
-          maxAmount: 0,
+          amountForMaxBonus: 0,
         })
       ).toBe(1);
     });


### PR DESCRIPTION
# Motivation

The age of a neuron can be more than 4 years but the maximum age bonus is reached at 4 years.
Taking this into account, the parameter `maxAmount` of `bonusMultiplier` is a bit confusing.
Because the amount can actually bigger.
`amountForMaxBonus` is more accurate.

# Changes

Change `maxAmount` to `amountForMaxBonus`.

# Tests

Updated

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary