### PR TITLE
Fix release script for new proposal type

### DIFF
--- a/scripts/nns-dapp/release
+++ b/scripts/nns-dapp/release
@@ -139,7 +139,7 @@ test -e "${SUMMARY_FILE:-}" || {
 } >&2
 
 # Prepares the command
-set ic-admin "${AUTH_ARGS[@]}" --nns-url "$DFX_NNS_URL" propose-to-change-nns-canister --proposer "$DFX_NEURON_ID" --canister-id "$NNS_DAPP_CANISTER_ID" --mode upgrade --wasm-module-path "$WASM" --summary-file "$SUMMARY_FILE" --wasm-module-sha256 "$SHA" --arg "$ARG_PATH" --use-explicit-action-type
+set ic-admin "${AUTH_ARGS[@]}" --nns-url "$DFX_NNS_URL" propose-to-change-nns-canister --proposer "$DFX_NEURON_ID" --canister-id "$NNS_DAPP_CANISTER_ID" --mode upgrade --wasm-module-path "$WASM" --summary-file "$SUMMARY_FILE" --wasm-module-sha256 "$SHA" --arg "$ARG_PATH"
 # ... just checking...
 echo
 echo PLEASE REVIEW THIS COMMAND:
@@ -150,18 +150,16 @@ echo
 read -rp "Execute? (y/N) " COMMAND_OK
 if [[ "$COMMAND_OK" = [yY] ]]; then
   if [[ "${PROPOSAL_ID_FILE:-}" ]]; then
-    # The ic-admin command writes 1 line (among others) to stderr with the following format:
-    # submit_proposal for Upgrade NNS Canister: qoctq-giaaa-aaaaa-aaaea-cai to wasm with hash: 35315f0a44a16b1221a295ba253d018ed824e18cb1d2458c7933fe588efb45f4 response: Ok(proposal 213)
-    # We want to parse the proposal ID out of that. First we redirect stderr to
-    # stdout, then we use sed to extract the proposal ID, then we tee it to a
-    # file, then we direct it back to stderr.
-    (
-      "${@}" 2>&1 1>&3 |
-        grep -E 'proposal [0-9]+' |
-        head -1 |
-        sed -E 's/.*\(proposal (.*)\)/\1/' |
-        tee "$PROPOSAL_ID_FILE"
-    ) 3>&1 >&2
+    # The ic-admin command writes 1 line (among others) to stdout with the following format:
+    # proposal proposal <proposal_id>
+    # We want to parse the proposal ID out of that. First we tee stdout to
+    # /dev/tty so the user can also see the output, then we use grep and sed to
+    # extract the proposal ID and write it to a file.
+    "${@}" |
+      tee /dev/tty |
+      (grep -E 'proposal [0-9]+' || true) |
+      head -1 |
+      sed -E 's/.*proposal ([0-9]+)/\1/' >"$PROPOSAL_ID_FILE"
   else
     "${@}"
   fi


### PR DESCRIPTION
# Motivation

`ic-admin` now installs canisters with the `InstallCode` proposal type instead of with an NNS function.
This also results in different output from `ic-admin`.

Additionally, https://github.com/dfinity/nns-dapp/pull/5415 missed one of the instances of `--use-explicit-action-type` that should have been removed.

# Changes

1. Stop passing `--use-explicit-action-type` to `ic-admin`.
2. Change the way we parse the proposal ID out of the output.
3. Make sure the output is also visible on the terminal (with `tee /dev/tty`) so nothing is hidden in case anything goes wrong.

# Tests

Tested manually on Mac against a local network.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary