### PR TITLE
Fix canister IDs import script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,6 +244,13 @@ jobs:
       - name: Test TVL
         run: |
           scripts/nns-dapp/test-tvl --nns_dapp_wasm nns-dapp.wasm.gz --nns_dapp_arg nns-dapp-arg-local.did
+      - name: Test import canister IDs
+        run: |
+          ./scripts/canister_ids --import-from-index-html http://qsgjb-riaaa-aaaaa-aaaga-cai.localhost:8080/ --network local --create
+          diff canister_ids.json scripts/canister_ids.local.golden
+          rm canister_ids.json
+          ./scripts/canister_ids --import-from-index-html https://nns.ic0.app --network mainnet --create
+          diff canister_ids.json scripts/canister_ids.mainnet.golden
       - name: Release
         run: |
           for tag in $(git tag --points-at HEAD) ; do

--- a/scripts/canister_ids
+++ b/scripts/canister_ids
@@ -127,9 +127,6 @@ canister_id_from_url() {
 if [ "$command" = "import-from-index-html" ]; then
   tmp_index_html="$(mktemp)"
   trap 'rm -f "$tmp_index_html"' EXIT
-  if [[ $IMPORT_FROM != *".raw."* ]]; then
-    IMPORT_FROM=${IMPORT_FROM/./.raw.}
-  fi
   curl -sS "$IMPORT_FROM" >"$tmp_index_html"
   if [ "$(file --brief --mime-type "$tmp_index_html")" = "application/gzip" ]; then
     mv "$tmp_index_html" "${tmp_index_html}.gz"

--- a/scripts/canister_ids.local.golden
+++ b/scripts/canister_ids.local.golden
@@ -1,7 +1,6 @@
 {
   "nns-index": {
-    "local": "bkyz2-fmaaa-aaaaa-qaaaq-cai",
-    "hello": "bye"
+    "local": "bkyz2-fmaaa-aaaaa-qaaaq-cai"
   },
   "ckbtc_index": {
     "local": "olzyh-buaaa-aaaaa-qabga-cai"

--- a/scripts/canister_ids.local.golden
+++ b/scripts/canister_ids.local.golden
@@ -1,0 +1,39 @@
+{
+  "nns-index": {
+    "local": "bkyz2-fmaaa-aaaaa-qaaaq-cai",
+    "hello": "bye"
+  },
+  "ckbtc_index": {
+    "local": "olzyh-buaaa-aaaaa-qabga-cai"
+  },
+  "ckbtc_ledger": {
+    "local": "oz7p6-neaaa-aaaaa-qabfa-cai"
+  },
+  "ckbtc_minter": {
+    "local": "o66jk-a4aaa-aaaaa-qabfq-cai"
+  },
+  "cketh_index": {
+    "local": "of3vp-2eaaa-aaaaa-qabha-cai"
+  },
+  "cketh_ledger": {
+    "local": "omy6t-mmaaa-aaaaa-qabgq-cai"
+  },
+  "ckusdc_index": {
+    "local": "m7h5t-euaaa-aaaaa-qabia-cai"
+  },
+  "ckusdc_ledger": {
+    "local": "oc2t3-x4aaa-aaaaa-qabhq-cai"
+  },
+  "nns-sns-wasm": {
+    "local": "qaa6y-5yaaa-aaaaa-aaafa-cai"
+  },
+  "internet_identity": {
+    "local": "http://qhbym-qaaaa-aaaaa-aaafq-cai.localhost:8080"
+  },
+  "nns-dapp": {
+    "local": "qsgjb-riaaa-aaaaa-aaaga-cai"
+  },
+  "sns_aggregator": {
+    "local": "http://sgymv-uiaaa-aaaaa-aaaia-cai.localhost:8080"
+  }
+}

--- a/scripts/canister_ids.mainnet.golden
+++ b/scripts/canister_ids.mainnet.golden
@@ -1,0 +1,38 @@
+{
+  "nns-index": {
+    "mainnet": "qhbym-qaaaa-aaaaa-aaafq-cai"
+  },
+  "ckbtc_index": {
+    "mainnet": "n5wcd-faaaa-aaaar-qaaea-cai"
+  },
+  "ckbtc_ledger": {
+    "mainnet": "mxzaz-hqaaa-aaaar-qaada-cai"
+  },
+  "ckbtc_minter": {
+    "mainnet": "mqygn-kiaaa-aaaar-qaadq-cai"
+  },
+  "cketh_index": {
+    "mainnet": "s3zol-vqaaa-aaaar-qacpa-cai"
+  },
+  "cketh_ledger": {
+    "mainnet": "ss2fx-dyaaa-aaaar-qacoq-cai"
+  },
+  "ckusdc_index": {
+    "mainnet": "xrs4b-hiaaa-aaaar-qafoa-cai"
+  },
+  "ckusdc_ledger": {
+    "mainnet": "xevnm-gaaaa-aaaar-qafnq-cai"
+  },
+  "nns-sns-wasm": {
+    "mainnet": "qaa6y-5yaaa-aaaaa-aaafa-cai"
+  },
+  "internet_identity": {
+    "mainnet": "identity"
+  },
+  "nns-dapp": {
+    "mainnet": "qoctq-giaaa-aaaaa-aaaea-cai"
+  },
+  "sns_aggregator": {
+    "mainnet": "3r4gx-wqaaa-aaaaq-aaaia-cai"
+  }
+}


### PR DESCRIPTION
# Motivation

The replica with dfx 0.23.0 does not appear to serve `.raw.` URLs correctly.
Before the service worker was removed, we could only use `curl` to fetch raw URLs.
So when importing canister IDs from a URL, we would insert `.raw` into the URL before fetching it with `curl`.
This no longer works, but is also no longer necessary.

# Changes

Remove the code that inserts `.raw` into the URL to fetch canister IDs from.

# Tests

1. Tested manually.
2. Added golden tests to CI that use the script on the local replica and on mainnet.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary