### PR TITLE
Add get-sns convenience script

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -343,7 +343,7 @@ jobs:
           Swap canister ID:       n223b-vqaaa-aaaaq-aadsa-cai
           Transaction fee:      50
           Minimum neuron stake: 100
-          Proposal fee:         1500")
+          Proposal fee:         15000")
   checks-pass:
     needs:
       - formatting

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -334,16 +334,16 @@ jobs:
       - name: Get SNS tool
         run: |
           diff <(scripts/sns/aggregator/get-sns dog) <(echo "Name:   DOGMI
-Symbol: DOGMI
-Aggregator URL:         https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io/v1/sns/root/nb7he-piaaa-aaaaq-aadqq-cai/slow.json
-Root canister ID:       nb7he-piaaa-aaaaq-aadqq-cai
-Governance canister ID: ni4my-zaaaa-aaaaq-aadra-cai
-Ledger canister ID:     np5km-uyaaa-aaaaq-aadrq-cai
-Index canister ID:      n535v-yiaaa-aaaaq-aadsq-cai
-Swap canister ID:       n223b-vqaaa-aaaaq-aadsa-cai
-Transaction fee:      50
-Minimum neuron stake: 100
-Proposal fee:         1500")
+          Symbol: DOGMI
+          Aggregator URL:         https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io/v1/sns/root/nb7he-piaaa-aaaaq-aadqq-cai/slow.json
+          Root canister ID:       nb7he-piaaa-aaaaq-aadqq-cai
+          Governance canister ID: ni4my-zaaaa-aaaaq-aadra-cai
+          Ledger canister ID:     np5km-uyaaa-aaaaq-aadrq-cai
+          Index canister ID:      n535v-yiaaa-aaaaq-aadsq-cai
+          Swap canister ID:       n223b-vqaaa-aaaaq-aadsa-cai
+          Transaction fee:      50
+          Minimum neuron stake: 100
+          Proposal fee:         1500")
   checks-pass:
     needs:
       - formatting

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -331,6 +331,19 @@ jobs:
         run: scripts/convert-id.test
       - name: Getting network config works
         run: scripts/network-config.test
+      - name: Get SNS tool
+        run: |
+          [[ "$(scripts/sns/aggregator/get-sns dog)" == "Name:   DOGMI
+Symbol: DOGMI
+Aggregator URL:         https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io/v1/sns/root/nb7he-piaaa-aaaaq-aadqq-cai/slow.json
+Root canister ID:       nb7he-piaaa-aaaaq-aadqq-cai
+Governance canister ID: ni4my-zaaaa-aaaaq-aadra-cai
+Ledger canister ID:     np5km-uyaaa-aaaaq-aadrq-cai
+Index canister ID:      n535v-yiaaa-aaaaq-aadsq-cai
+Swap canister ID:       n223b-vqaaa-aaaaq-aadsa-cai
+Transaction fee:      50
+Minimum neuron stake: 100
+Proposal fee:         1500" ]]
   checks-pass:
     needs:
       - formatting

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -333,7 +333,7 @@ jobs:
         run: scripts/network-config.test
       - name: Get SNS tool
         run: |
-          [[ "$(scripts/sns/aggregator/get-sns dog)" == "Name:   DOGMI
+          diff <(scripts/sns/aggregator/get-sns dog) <(echo "Name:   DOGMI
 Symbol: DOGMI
 Aggregator URL:         https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io/v1/sns/root/nb7he-piaaa-aaaaq-aadqq-cai/slow.json
 Root canister ID:       nb7he-piaaa-aaaaq-aadqq-cai
@@ -343,7 +343,7 @@ Index canister ID:      n535v-yiaaa-aaaaq-aadsq-cai
 Swap canister ID:       n223b-vqaaa-aaaaq-aadsa-cai
 Transaction fee:      50
 Minimum neuron stake: 100
-Proposal fee:         1500" ]]
+Proposal fee:         1500")
   checks-pass:
     needs:
       - formatting

--- a/scripts/sns/aggregator/get-sns
+++ b/scripts/sns/aggregator/get-sns
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/../../clap.bash"
+clap.define long=json desc="Output as json" variable="ENABLE_JSON" nargs=0
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+SEARCH_PATTERN="$1"
+
+# These exist for a frontend test but they are kept up-to-date weekly so they
+# are useful to have quick access to the list of SNSes. We only use them to
+# find which SNS to query but then get the actual data from the aggregator.
+AGGREGATOR_PAGES=("$SOURCE_DIR"/../../../frontend/src/tests/workflows/Launchpad/sns-agg-page-*.json)
+
+ROOT_CANISTER_ID="$(jq -c '.[] | select(.lifecycle.lifecycle != 4) | .canister_ids * {name: .meta.name, symbol: (.icrc1_metadata | .[] | select(.[0] == "icrc1:symbol") | .[1].Text) }' "${AGGREGATOR_PAGES[@]}" | grep -m 1 -i "$SEARCH_PATTERN" | jq -r .root_canister_id)"
+
+AGGREGATOR_URL="https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io/v1/sns/root/$ROOT_CANISTER_ID/slow.json"
+
+get_sns_data() {
+  curl -LsSf "$AGGREGATOR_URL"
+}
+
+if [[ "${ENABLE_JSON:-}" == "true" ]]; then
+  get_sns_data
+  exit 0
+fi
+
+get_sns_field() {
+  field_path="$1"
+  echo "$SNS_DATA" | jq -r "$field_path"
+}
+
+SNS_DATA="$(get_sns_data)"
+
+echo "Name:   $(get_sns_field .meta.name)"
+echo "Symbol: $(echo "$SNS_DATA" | jq -r '.icrc1_metadata | .[] | select(.[0] == "icrc1:symbol") | .[1].Text')"
+echo "Aggregator URL:         $AGGREGATOR_URL"
+echo "Root canister ID:       $(get_sns_field .canister_ids.root_canister_id)"
+echo "Governance canister ID: $(get_sns_field .canister_ids.governance_canister_id)"
+echo "Ledger canister ID:     $(get_sns_field .canister_ids.ledger_canister_id)"
+echo "Index canister ID:      $(get_sns_field .canister_ids.index_canister_id)"
+echo "Swap canister ID:       $(get_sns_field .canister_ids.swap_canister_id)"
+echo "Transaction fee:      $(get_sns_field '.nervous_system_parameters.transaction_fee_e8s / 100000000')"
+echo "Minimum neuron stake: $(get_sns_field '.nervous_system_parameters.neuron_minimum_stake_e8s / 100000000')"
+echo "Proposal fee:         $(get_sns_field '.nervous_system_parameters.reject_cost_e8s / 100000000')"


### PR DESCRIPTION
# Motivation

I wrote this script for some investigation and it seemed useful enough to keep.
It lets you find some quick information about an SNS based on a partial match of the name, symbol or canister ID.
Example:
```
$ scripts/sns/aggregator/get-sns dog
Name:   DOGMI
Symbol: DOGMI
Aggregator URL:         https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io/v1/sns/root/nb7he-piaaa-aaaaq-aadqq-cai/slow.json
Root canister ID:       nb7he-piaaa-aaaaq-aadqq-cai
Governance canister ID: ni4my-zaaaa-aaaaq-aadra-cai
Ledger canister ID:     np5km-uyaaa-aaaaq-aadrq-cai
Index canister ID:      n535v-yiaaa-aaaaq-aadsq-cai
Swap canister ID:       n223b-vqaaa-aaaaq-aadsa-cai
Transaction fee:      50
Minimum neuron stake: 100
Proposal fee:         15000
```

The listed information is just what I needed but we can add more later.

# Changes

1. Added `get-sns` script.


# Tests

1. Added a simple test in the GitHub workflow.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary