### PR TITLE
Use hardcoded nns-icp-index canister ID

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -35,7 +35,8 @@
       "remote": {
         "id": {
           "app": "qhbym-qaaaa-aaaaa-aaafq-cai",
-          "mainnet": "qhbym-qaaaa-aaaaa-aaafq-cai"
+          "mainnet": "qhbym-qaaaa-aaaaa-aaafq-cai",
+          "local": "q3fc5-haaaa-aaaaa-aaahq-cai"
         }
       }
     },

--- a/scripts/canister_ids.local.golden
+++ b/scripts/canister_ids.local.golden
@@ -1,6 +1,6 @@
 {
   "nns-index": {
-    "local": "bkyz2-fmaaa-aaaaa-qaaaq-cai"
+    "local": "q3fc5-haaaa-aaaaa-aaahq-cai"
   },
   "ckbtc_index": {
     "local": "olzyh-buaaa-aaaaa-qabga-cai"


### PR DESCRIPTION
# Motivation

Snsdemo install an ICP index canister but `dfx nns install` now also installs one (it didn't before) so each snapshot has 2 ICP index canisters.
Before we can stop installing the second one in snsdemo, we need to make sure we are using the default one in nns-dapp.
The one installed by `dfx nns install` has a [hardcoded](https://github.com/dfinity/dfx-extensions/blob/5471d0353f8395c33daf7a6ba9a0778f8b6fc7a8/extensions-utils/src/dependencies/download_wasms/nns.rs#L149) canister ID of `q3fc5-haaaa-aaaaa-aaahq-cai`.

# Changes

Set the canister ID of `nns-index` in `dfx.json` so that the one installed by `dfx nns install` will be used.

# Tests

1. I ran `DFX_NETWORK=local ./config.sh` and verified that the new canister ID is used.
2. I ran `npm run dev` and checked that transactions load correctly locally.
3. Updated golden file for workflow test for `scripts/canister_ids`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary