### PR TITLE
Fix Transfer Funds dummy SNS proposal

### DIFF
--- a/frontend/src/lib/api/sns-dummy.api.ts
+++ b/frontend/src/lib/api/sns-dummy.api.ts
@@ -164,7 +164,7 @@ const transferFundsProposal = {
         to_principal: [Principal.fromText("pin7y-wyaaa-aaaaa-aacpa-cai")],
         to_subaccount: [],
         memo: [33_333n],
-        amount_e8s: 100_000_000_000n,
+        amount_e8s: 10_000_000_000n,
       },
     },
   ] as [SnsAction],


### PR DESCRIPTION
# Motivation

Clicking the "Make dummy proposals" on an SNS neuron in the test environment resulted in an error because the "transfer funds" proposal tried to transfer too many funds.

# Changes

Reduce the amounts of funds transferred in the SNS dummy proposal.

# Tests

Tested manually

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary