### PR TITLE
Script to deploy nns-dapp in chunks

### DIFF
--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -106,6 +106,7 @@ jobs:
             --assets "out/assets.tar.xz" \
             --network "$DFX_NETWORK" \
             --mode "${{ inputs.mode || 'upgrade' }}" \
+            --wasm "out/nns-dapp_noassets.wasm.gz" \
             --argument_file "out/nns-dapp-arg-${DFX_NETWORK}.did"
       - name: Deploy sns_aggregator
         if: (inputs.canisters == 'all') || (inputs.canisters == 'sns_aggregator') || ( github.event_name != 'workflow_dispatch' )

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -80,15 +80,6 @@ jobs:
           jq 'del(.canisters[env.CANISTER_NAME].remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
           DFX_NETWORK="$DFX_NETWORK" jq 'del(.canisters.internet_identity.remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
           dfx-canister set-id --network "$DFX_NETWORK" --canister_name "$CANISTER_NAME" --canister_id "$SNS_AGGREGATOR_APP_SUBNET_CANISTER_ID"
-      - name: Do dfx commands
-        run: |
-          set -x
-          dfx canister status nns-dapp --network "$DFX_NETWORK"
-          dfx canister update-settings nns-dapp --compute-allocation 0 --network "$DFX_NETWORK"
-          dfx canister status nns-dapp --network "$DFX_NETWORK"
-          dfx canister update-settings nns-dapp --freezing-threshold 2592000 --network "$DFX_NETWORK"
-          dfx canister status nns-dapp --network "$DFX_NETWORK"
-          false
       - name: Build wasms and config
         uses: ./.github/actions/build_nns_dapp # Builds sns_aggregator as well.
         with:
@@ -104,6 +95,11 @@ jobs:
             dfx canister status --network app "$canister"
             set +x
           done
+      - name: Set compute allocation of nns-dapp
+        run: |
+          set -x
+          dfx canister update-settings nns-dapp --freezing-threshold 10000 --network "$DFX_NETWORK"
+          dfx canister update-settings sns_aggregator --compute-allocation 1 --network "$DFX_NETWORK"
       - name: Deploy nns-dapp
         if: (inputs.canisters == 'all') || (inputs.canisters == 'nns-dapp') || ( github.event_name != 'workflow_dispatch' )
         run: |
@@ -120,6 +116,11 @@ jobs:
             --mode "${{ inputs.mode || 'upgrade' }}" \
             --wasm "out/nns-dapp_noassets.wasm.gz" \
             --argument_file "out/nns-dapp-arg-${DFX_NETWORK}.did"
+      - name: Restore compute allocation of nns-dapp
+        if: always()
+        run: |
+          set -x
+          dfx canister update-settings nns-dapp --compute-allocation 0 --network "$DFX_NETWORK"
           dfx canister update-settings nns-dapp --freezing-threshold 2592000 --network "$DFX_NETWORK"
       - name: Deploy sns_aggregator
         if: (inputs.canisters == 'all') || (inputs.canisters == 'sns_aggregator') || ( github.event_name != 'workflow_dispatch' )

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -102,7 +102,11 @@ jobs:
           CANISTER_NAME="nns-dapp"
           # Note: inputs.mode is set if this workflow is run manually, using `workflow_dispatch` defined above.
           #       If the workflow is triggered in another way, the inputs are not defined so we need to specify a default again.
-          scripts/nns-dapp/deploy-in-chunks --assets "out/assets.tar.xz" --network "$DFX_NETWORK" --mode "${{ inputs.mode || 'upgrade' }}"
+          scripts/nns-dapp/deploy-in-chunks \
+            --assets "out/assets.tar.xz" \
+            --network "$DFX_NETWORK" \
+            --mode "${{ inputs.mode || 'upgrade' }}" \
+            --argument_file "out/nns-dapp-arg-${DFX_NETWORK}.did"
       - name: Deploy sns_aggregator
         if: (inputs.canisters == 'all') || (inputs.canisters == 'sns_aggregator') || ( github.event_name != 'workflow_dispatch' )
         run: |

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -99,7 +99,7 @@ jobs:
         run: |
           set -x
           dfx canister update-settings nns-dapp --freezing-threshold 10000 --network "$DFX_NETWORK"
-          dfx canister update-settings sns_aggregator --compute-allocation 1 --network "$DFX_NETWORK"
+          dfx canister update-settings nns-dapp --compute-allocation 1 --network "$DFX_NETWORK"
       - name: Deploy nns-dapp
         if: (inputs.canisters == 'all') || (inputs.canisters == 'nns-dapp') || ( github.event_name != 'workflow_dispatch' )
         run: |

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -80,6 +80,15 @@ jobs:
           jq 'del(.canisters[env.CANISTER_NAME].remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
           DFX_NETWORK="$DFX_NETWORK" jq 'del(.canisters.internet_identity.remote.id[env.DFX_NETWORK])' dfx.json | sponge dfx.json
           dfx-canister set-id --network "$DFX_NETWORK" --canister_name "$CANISTER_NAME" --canister_id "$SNS_AGGREGATOR_APP_SUBNET_CANISTER_ID"
+      - name: Do dfx commands
+        run: |
+          set -x
+          dfx canister status nns-dapp --network "$DFX_NETWORK"
+          dfx canister update-settings nns-dapp --compute-allocation 0 --network "$DFX_NETWORK"
+          dfx canister status nns-dapp --network "$DFX_NETWORK"
+          dfx canister update-settings nns-dapp --freezing-threshold 2592000 --network "$DFX_NETWORK"
+          dfx canister status nns-dapp --network "$DFX_NETWORK"
+          false
       - name: Build wasms and config
         uses: ./.github/actions/build_nns_dapp # Builds sns_aggregator as well.
         with:

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -102,7 +102,7 @@ jobs:
           CANISTER_NAME="nns-dapp"
           # Note: inputs.mode is set if this workflow is run manually, using `workflow_dispatch` defined above.
           #       If the workflow is triggered in another way, the inputs are not defined so we need to specify a default again.
-          scripts/nns-dapp/deploy-in-chunks --network "$DFX_NETWORK" --mode "${{ inputs.mode || 'upgrade' }}"
+          scripts/nns-dapp/deploy-in-chunks --assets "out/assets.tar.xz" --network "$DFX_NETWORK" --mode "${{ inputs.mode || 'upgrade' }}"
       - name: Deploy sns_aggregator
         if: (inputs.canisters == 'all') || (inputs.canisters == 'sns_aggregator') || ( github.event_name != 'workflow_dispatch' )
         run: |

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -102,6 +102,7 @@ jobs:
           CANISTER_NAME="nns-dapp"
           # Note: inputs.mode is set if this workflow is run manually, using `workflow_dispatch` defined above.
           #       If the workflow is triggered in another way, the inputs are not defined so we need to specify a default again.
+          dfx canister update-settings nns-dapp --freezing-threshold 10000 --network "$DFX_NETWORK"
           dfx canister update-settings nns-dapp --compute-allocation 1 --network "$DFX_NETWORK"
           dfx canister status nns-dapp --network "$DFX_NETWORK"
           scripts/nns-dapp/deploy-in-chunks \
@@ -110,6 +111,7 @@ jobs:
             --mode "${{ inputs.mode || 'upgrade' }}" \
             --wasm "out/nns-dapp_noassets.wasm.gz" \
             --argument_file "out/nns-dapp-arg-${DFX_NETWORK}.did"
+          dfx canister update-settings nns-dapp --freezing-threshold 2592000 --network "$DFX_NETWORK"
       - name: Deploy sns_aggregator
         if: (inputs.canisters == 'all') || (inputs.canisters == 'sns_aggregator') || ( github.event_name != 'workflow_dispatch' )
         run: |

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -102,6 +102,8 @@ jobs:
           CANISTER_NAME="nns-dapp"
           # Note: inputs.mode is set if this workflow is run manually, using `workflow_dispatch` defined above.
           #       If the workflow is triggered in another way, the inputs are not defined so we need to specify a default again.
+          dfx canister update-settings nns-dapp --compute-allocation 1 --network "$DFX_NETWORK"
+          dfx canister status nns-dapp --network "$DFX_NETWORK"
           scripts/nns-dapp/deploy-in-chunks \
             --assets "out/assets.tar.xz" \
             --network "$DFX_NETWORK" \

--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -100,24 +100,9 @@ jobs:
         run: |
           set -x
           CANISTER_NAME="nns-dapp"
-          scripts/nns-dapp/split-assets
           # Note: inputs.mode is set if this workflow is run manually, using `workflow_dispatch` defined above.
           #       If the workflow is triggered in another way, the inputs are not defined so we need to specify a default again.
-          ARGUMENT="$(cat "out/nns-dapp-arg-${DFX_NETWORK}.did")"
-          # There have been issues with the uploading of assets causing
-          # "heap out of bounds" so we output logs to help debug when it happens
-          # again.
-          # The canister only keeps a small amount of logs so we output them
-          # before and after every step to miss as little as possible.
-          dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
-          dfx canister install --mode "${{ inputs.mode || 'upgrade' }}" --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --argument "$ARGUMENT" --wasm out/nns-dapp_noassets.wasm.gz
-          dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
-          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xaa.tar.xz
-          dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
-          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xab.tar.xz
-          dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
-          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xac.tar.xz
-          dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
+          scripts/nns-dapp/deploy-in-chunks --network "$DFX_NETWORK" --mode "${{ inputs.mode || 'upgrade' }}"
       - name: Deploy sns_aggregator
         if: (inputs.canisters == 'all') || (inputs.canisters == 'sns_aggregator') || ( github.event_name != 'workflow_dispatch' )
         run: |

--- a/scripts/nns-dapp/deploy-in-chunks
+++ b/scripts/nns-dapp/deploy-in-chunks
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.."
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="${DFX_IDENTITY:-$(dfx identity whoami)}"
+clap.define long=mode desc="The dfx install mode" variable=DFX_MODE default="upgrade"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+mkdir -p out
+CANISTER_NAME="nns-dapp"
+
+"$SOURCE_DIR/nns-dapp/split-assets" --assets assets.tar.xz
+
+ARGUMENT="$(cat "nns-dapp-arg-${DFX_NETWORK}.did")"
+
+# There have been issues with the uploading of assets causing
+# "heap out of bounds" so we output logs to help debug when it happens
+# again.
+# The canister only keeps a small amount of logs so we output them
+# before and after every step to miss as little as possible.
+dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
+
+dfx canister install --mode upgrade --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --argument "$ARGUMENT" --wasm nns-dapp_noassets.wasm.gz
+
+dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
+./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xaa.tar.xz
+
+dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
+./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xab.tar.xz
+
+dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
+./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xac.tar.xz
+
+dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"

--- a/scripts/nns-dapp/deploy-in-chunks
+++ b/scripts/nns-dapp/deploy-in-chunks
@@ -8,13 +8,14 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="${DFX_IDENTITY:-$(dfx identity whoami)}"
 clap.define long=mode desc="The dfx install mode" variable=DFX_MODE default="upgrade"
+clap.define short=a long=assets desc="The assets.tar.xz to split" variable=ORIGINAL_ASSETS_TAR_XZ default="out/assets.tar.xz"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
 mkdir -p out
 CANISTER_NAME="nns-dapp"
 
-"$SOURCE_DIR/nns-dapp/split-assets" --assets assets.tar.xz
+"$SOURCE_DIR/nns-dapp/split-assets" --assets "$ORIGINAL_ASSETS_TAR_XZ"
 
 ARGUMENT="$(cat "nns-dapp-arg-${DFX_NETWORK}.did")"
 

--- a/scripts/nns-dapp/deploy-in-chunks
+++ b/scripts/nns-dapp/deploy-in-chunks
@@ -21,7 +21,7 @@ CANISTER_NAME="nns-dapp"
 
 "$SOURCE_DIR/nns-dapp/split-assets" --assets "$ORIGINAL_ASSETS_TAR_XZ"
 
-ls -l out
+ls -l out/chunks
 
 ARGUMENT="$(cat "$ARGUMENT_FILE")"
 

--- a/scripts/nns-dapp/deploy-in-chunks
+++ b/scripts/nns-dapp/deploy-in-chunks
@@ -30,7 +30,7 @@ ARGUMENT="$(cat "$ARGUMENT_FILE")"
 # before and after every step to miss as little as possible.
 dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
 
-dfx canister install --mode upgrade --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --argument "$ARGUMENT" --wasm "$WASM"
+dfx canister install --mode "$DFX_MODE" --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --argument "$ARGUMENT" --wasm "$WASM"
 
 dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
 ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xaa.tar.xz

--- a/scripts/nns-dapp/deploy-in-chunks
+++ b/scripts/nns-dapp/deploy-in-chunks
@@ -14,6 +14,8 @@ clap.define short=w long=wasm desc="The canister WASM to install" variable=WASM 
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
+set -x
+
 mkdir -p out
 CANISTER_NAME="nns-dapp"
 

--- a/scripts/nns-dapp/deploy-in-chunks
+++ b/scripts/nns-dapp/deploy-in-chunks
@@ -10,6 +10,7 @@ clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_ID
 clap.define long=mode desc="The dfx install mode" variable=DFX_MODE default="upgrade"
 clap.define short=a long=assets desc="The assets.tar.xz to split" variable=ORIGINAL_ASSETS_TAR_XZ default="out/assets.tar.xz"
 clap.define long=argument_file desc="The .did file with the canister argument" variable=ARGUMENT_FILE default="out/nns-dapp-arg-local.did"
+clap.define short=w long=wasm desc="The canister WASM to install" variable=WASM default="out/nns-dapp_noassets.wasm.gz"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -27,7 +28,7 @@ ARGUMENT="$(cat "$ARGUMENT_FILE")"
 # before and after every step to miss as little as possible.
 dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
 
-dfx canister install --mode upgrade --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --argument "$ARGUMENT" --wasm nns-dapp_noassets.wasm.gz
+dfx canister install --mode upgrade --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --argument "$ARGUMENT" --wasm "$WASM"
 
 dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
 ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xaa.tar.xz

--- a/scripts/nns-dapp/deploy-in-chunks
+++ b/scripts/nns-dapp/deploy-in-chunks
@@ -9,6 +9,7 @@ clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETW
 clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="${DFX_IDENTITY:-$(dfx identity whoami)}"
 clap.define long=mode desc="The dfx install mode" variable=DFX_MODE default="upgrade"
 clap.define short=a long=assets desc="The assets.tar.xz to split" variable=ORIGINAL_ASSETS_TAR_XZ default="out/assets.tar.xz"
+clap.define long=argument_file desc="The .did file with the canister argument" variable=ARGUMENT_FILE default="out/nns-dapp-arg-local.did"
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -17,7 +18,7 @@ CANISTER_NAME="nns-dapp"
 
 "$SOURCE_DIR/nns-dapp/split-assets" --assets "$ORIGINAL_ASSETS_TAR_XZ"
 
-ARGUMENT="$(cat "nns-dapp-arg-${DFX_NETWORK}.did")"
+ARGUMENT="$(cat "$ARGUMENT_FILE")"
 
 # There have been issues with the uploading of assets causing
 # "heap out of bounds" so we output logs to help debug when it happens

--- a/scripts/nns-dapp/deploy-in-chunks
+++ b/scripts/nns-dapp/deploy-in-chunks
@@ -21,6 +21,8 @@ CANISTER_NAME="nns-dapp"
 
 "$SOURCE_DIR/nns-dapp/split-assets" --assets "$ORIGINAL_ASSETS_TAR_XZ"
 
+ls -l out
+
 ARGUMENT="$(cat "$ARGUMENT_FILE")"
 
 # There have been issues with the uploading of assets causing

--- a/scripts/nns-dapp/deploy-in-chunks
+++ b/scripts/nns-dapp/deploy-in-chunks
@@ -32,9 +32,13 @@ ARGUMENT="$(cat "$ARGUMENT_FILE")"
 # before and after every step to miss as little as possible.
 dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
 
-dfx canister install --mode "$DFX_MODE" --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --argument "$ARGUMENT" --wasm "$WASM"
+#dfx canister install --mode "$DFX_MODE" --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --argument "$ARGUMENT" --wasm "$WASM"
+dfx canister install --mode "$DFX_MODE" --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --argument "$ARGUMENT" --wasm "out/nns-dapp.wasm.gz"
 
 dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
+
+exit 0
+
 ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xaa.tar.xz
 
 dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"

--- a/scripts/nns-dapp/split-assets
+++ b/scripts/nns-dapp/split-assets
@@ -22,6 +22,19 @@ clap.define short=o long=out desc="The output directory; a subdirectory 'chunks'
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
+# we need GNU tar so we check early
+if tar --help | grep GNU >/dev/null; then
+  echo "found GNU tar as tar"
+  tar="tar"
+elif command -v gtar >/dev/null; then
+  echo "found GNU tar as gtar"
+  tar="gtar"
+else
+  echo "did not find GNU tar, please install"
+  echo "  brew install gnu-tar"
+  exit 1
+fi
+
 ORIGINAL_ASSETS_TAR_XZ="$(realpath "$ORIGINAL_ASSETS_TAR_XZ")"
 test -d "$OUTPUT_DIR" || {
   echo "ERROR: The output directory should exist: '$OUTPUT_DIR'"
@@ -37,7 +50,7 @@ WORKDIR="$(mktemp -d)"
   cd "$WORKDIR"
   mkdir assets
   cd assets
-  tar -Jxf "$ORIGINAL_ASSETS_TAR_XZ"
+  "$tar" -Jxf "$ORIGINAL_ASSETS_TAR_XZ"
 )
 
 # Prints paths of assets in the tarball
@@ -82,7 +95,7 @@ FILES_PER_CHUNK="$(
   cd assets
   list_manifests | while read -r chunk_manifest; do
     chunk_name="$WORKDIR/chunks/assets.$(basename "$chunk_manifest").tar.xz"
-    tar cJ \
+    "$tar" cJ \
       --mtime='2021-05-07 17:00Z' \
       --sort=name \
       --owner=0 \


### PR DESCRIPTION
# Motivation

When deploying nns-dapp to an application subnet, the WASM is too big.
To work around this, we deploy a WASM without assets and then upload the assets in separate chunks.
This is done in a GitHub workflow but it would be useful to do it locally for testing as well.

# Changes

1. Fix `scripts/nns-dapp/split-assets` so it can work on Mac by using `gtar` instead of `tar`.
2. Copy deployment code from the workflow to `.github/workflows/deploy-to-app.yaml`.
3. Call `.github/workflows/deploy-to-app.yaml` from the workflow.

# Tests

Tested manually on a local replica.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary