### PR TITLE
Redirection on unknown token.

### DIFF
--- a/frontend/src/lib/routes/Wallet.svelte
+++ b/frontend/src/lib/routes/Wallet.svelte
@@ -16,9 +16,9 @@
   import { i18n } from "$lib/stores/i18n";
   import { layoutTitleStore } from "$lib/stores/layout.store";
   import { nonNullish } from "@dfinity/utils";
-  import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
   import { AppPath } from "$lib/constants/routes.constants";
   import { goto } from "$app/navigation";
+  import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
 
   export let accountIdentifier: string | undefined | null = undefined;
 
@@ -33,7 +33,7 @@
     !$isIcrcTokenUniverseStore &&
     // We can't be sure that the token is unknown
     // before we have the list of Sns projects.
-    $snsProjectsStore.length > 0 &&
+    nonNullish($snsAggregatorStore.data) &&
     !nonNullish($snsProjectSelectedStore);
   $: if (isUnknownToken) {
     // This will also cover the case when the user was logged out

--- a/frontend/src/lib/routes/Wallet.svelte
+++ b/frontend/src/lib/routes/Wallet.svelte
@@ -16,12 +16,32 @@
   import { i18n } from "$lib/stores/i18n";
   import { layoutTitleStore } from "$lib/stores/layout.store";
   import { nonNullish } from "@dfinity/utils";
+  import { snsProjectsStore } from "$lib/derived/sns/sns-projects.derived";
+  import { AppPath } from "$lib/constants/routes.constants";
+  import { goto } from "$app/navigation";
 
   export let accountIdentifier: string | undefined | null = undefined;
 
   layoutTitleStore.set({
     title: $i18n.wallet.title,
   });
+
+  let isUnknownToken = false;
+  $: isUnknownToken =
+    !$isNnsUniverseStore &&
+    !$isCkBTCUniverseStore &&
+    !$isIcrcTokenUniverseStore &&
+    // We can't be sure that the token is unknown
+    // before we have the list of Sns projects.
+    $snsProjectsStore.length > 0 &&
+    !nonNullish($snsProjectSelectedStore);
+  $: if (isUnknownToken) {
+    // This will also cover the case when the user was logged out
+    // being on the wallet page of an imported token
+    // (imported tokens are not available when signed out).
+    goto(AppPath.Tokens);
+  }
+
 </script>
 
 <TestIdWrapper testId="wallet-component">

--- a/frontend/src/lib/routes/Wallet.svelte
+++ b/frontend/src/lib/routes/Wallet.svelte
@@ -41,7 +41,6 @@
     // (imported tokens are not available when signed out).
     goto(AppPath.Tokens);
   }
-
 </script>
 
 <TestIdWrapper testId="wallet-component">

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -1,5 +1,6 @@
 import * as ckbtcMinterApi from "$lib/api/ckbtc-minter.api";
 import * as governanceApi from "$lib/api/governance.api";
+import * as icpIndexApi from "$lib/api/icp-index.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { CKBTC_UNIVERSE_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
@@ -31,7 +32,7 @@ import { WalletPo } from "$tests/page-objects/Wallet.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setAccountsForTesting } from "$tests/utils/accounts.test-utils";
 import { setCkETHCanisters } from "$tests/utils/cketh.test-utils";
-import { setSnsProjects } from "$tests/utils/sns.test-utils";
+import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { encodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { SnsSwapLifecycle } from "@dfinity/sns";
@@ -40,7 +41,6 @@ import { get } from "svelte/store";
 
 vi.mock("$lib/api/icrc-ledger.api");
 vi.mock("$lib/api/ckbtc-minter.api");
-vi.mock("$lib/api/icp-index.api");
 
 vi.mock("$lib/services/icrc-transactions.services", () => {
   return {
@@ -277,34 +277,33 @@ describe("Wallet", () => {
   describe("unknown token", () => {
     const unknownUniverseId = "aaaaa-aa";
 
+    beforeEach(() => {
+      // Mock the getTransactions call from the Tokens page.
+      vi.spyOn(icpIndexApi, "getTransactions").mockResolvedValue({
+        transactions: [],
+        oldestTxId: undefined,
+      } as icpIndexApi.GetTransactionsResponse);
+    });
+
     it("redirect to tokens when unknown universe", async () => {
-      // Ignore errors after redirect.
-      vi.spyOn(console, "error").mockReturnValue();
       page.mock({
         data: { universe: unknownUniverseId },
         routeId: AppPath.Wallet,
       });
-      setSnsProjects([]);
+      resetSnsProjects();
 
       expect(get(pageStore).path).toEqual(AppPath.Wallet);
 
       render(Wallet, {
         props: {
           accountIdentifier: undefined,
-          // accountIdentifier: mockIcrcMainAccount.identifier,
         },
       });
       await runResolvedPromises();
 
       // Waits for the sns projects to be available
       expect(get(pageStore).path).toEqual(AppPath.Wallet);
-      setSnsProjects([
-        {
-          rootCanisterId: mockSnsFullProject.rootCanisterId,
-          ledgerCanisterId: mockSnsFullProject.summary.ledgerCanisterId,
-          lifecycle: SnsSwapLifecycle.Committed,
-        },
-      ]);
+      setSnsProjects([{}]);
       await runResolvedPromises();
 
       expect(get(pageStore).path).toEqual(AppPath.Tokens);


### PR DESCRIPTION
# Motivation

When the user is on the imported token wallet page and the sign-out timer expires, the page reloads, leaving the user on an empty page. This happens because imported tokens are available only when the user is signed in. Upon sign-out, we no longer know the type of the token (whether it’s ICRC or not). Rather than making guesses, it’s more reliable to navigate the user to the main tokens page in this case.

# Changes

- Navigate to the tokens table when it’s not possible to identify the token. Since this logic is not intended to be reused, it is implemented directly in the component rather than in a derived store.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.