### PR TITLE
FOLLOW-1337: Use queuedStore for proposalsStore

### DIFF
--- a/frontend/src/lib/pages/NnsProposals.svelte
+++ b/frontend/src/lib/pages/NnsProposals.svelte
@@ -107,7 +107,14 @@
 
     // Show spinner right away avoiding debounce
     loading = true;
-    proposalsStore.setProposals({ proposals: [], certified: undefined });
+    const mutableProposalsStore =
+      proposalsStore.getSingleMutationProposalsStore();
+    mutableProposalsStore.set({
+      // This `certified` is what the subscriber of the store sees.
+      data: { proposals: [], certified: undefined },
+      // This `certified` indicates that the store mutation is final.
+      certified: true,
+    });
 
     debounceFindProposals?.();
   };

--- a/frontend/src/lib/services/nns-vote-registration.services.ts
+++ b/frontend/src/lib/services/nns-vote-registration.services.ts
@@ -61,7 +61,12 @@ export const registerNnsVotes = async ({
       );
 
       // the one that was called
-      proposalsStore.replaceProposals([updatedProposalInfo]);
+      const mutableProposalsStore =
+        proposalsStore.getSingleMutationProposalsStore();
+      mutableProposalsStore.replaceProposals({
+        proposals: [updatedProposalInfo],
+        certified: true,
+      });
       updateProposalContext(updatedProposalInfo);
 
       // Reset and reload actionable nns proposals.

--- a/frontend/src/tests/lib/derived/proposals.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/proposals.derived.spec.ts
@@ -43,7 +43,7 @@ describe("proposals-derived", () => {
       },
     ];
 
-    proposalsStore.setProposals({
+    proposalsStore.setProposalsForTesting({
       proposals: storeProposals as ProposalInfo[],
       certified: true,
     });
@@ -54,13 +54,13 @@ describe("proposals-derived", () => {
 
   describe("filteredActionableProposals", () => {
     beforeEach(() => {
-      proposalsStore.reset();
+      proposalsStore.resetForTesting();
       proposalsFiltersStore.reset();
       actionableNnsProposalsStore.reset();
     });
 
     it("should append isActionable", () => {
-      proposalsStore.setProposals({
+      proposalsStore.setProposalsForTesting({
         proposals: [...mockProposals],
         certified: true,
       });
@@ -87,7 +87,7 @@ describe("proposals-derived", () => {
     });
 
     it("should add isActionable=undefined when actionables not available", () => {
-      proposalsStore.setProposals({
+      proposalsStore.setProposalsForTesting({
         proposals: [...mockProposals],
         certified: true,
       });

--- a/frontend/src/tests/lib/pages/NnsProposals.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposals.spec.ts
@@ -46,7 +46,7 @@ describe("NnsProposals", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    proposalsStore.reset();
+    proposalsStore.resetForTesting();
     resetNeuronsApiService();
     neuronsStore.reset();
     proposalsFiltersStore.reset();
@@ -308,8 +308,7 @@ describe("NnsProposals", () => {
         await runResolvedPromises();
         // We should still see both proposals from the request from after the
         // filter was removed.
-        // TODO: Change this to 2 when the bug is fixed.
-        expect(await po.getProposalCardPos()).toHaveLength(1);
+        expect(await po.getProposalCardPos()).toHaveLength(2);
       });
 
       it("should not have actionable parameter in a proposal card href", async () => {

--- a/frontend/src/tests/lib/services/public/proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/proposals.services.spec.ts
@@ -27,7 +27,7 @@ import { get } from "svelte/store";
 describe("proposals-services", () => {
   beforeEach(() => {
     toastsStore.reset();
-    proposalsStore.setProposals({ proposals: [], certified: true });
+    proposalsStore.setProposalsForTesting({ proposals: [], certified: true });
     proposalPayloadsStore.reset();
     vi.clearAllMocks();
     vi.spyOn(console, "error").mockRestore();
@@ -93,7 +93,7 @@ describe("proposals-services", () => {
       });
 
       it("should push new proposals to the list", async () => {
-        proposalsStore.setProposals({
+        proposalsStore.setProposalsForTesting({
           proposals: [mockProposals[0]],
           certified: true,
         });
@@ -176,7 +176,7 @@ describe("proposals-services", () => {
       beforeEach(() => {
         spyQueryProposal.mockResolvedValue(
           { ...mockProposals[0], id: 666n });
-        proposalsStore.setProposals({
+        proposalsStore.setProposalsForTesting({
           proposals: mockProposals,
           certified: true,
         });
@@ -223,7 +223,7 @@ describe("proposals-services", () => {
       });
 
       it("should not push empty proposals to the list", async () => {
-        proposalsStore.setProposals({
+        proposalsStore.setProposalsForTesting({
           proposals: mockProposals,
           certified: true,
         });

--- a/frontend/src/tests/lib/services/vote-registration.services.spec.ts
+++ b/frontend/src/tests/lib/services/vote-registration.services.spec.ts
@@ -76,12 +76,12 @@ describe("vote-registration-services", () => {
     // Cleanup:
     vi.clearAllMocks();
     voteRegistrationStore.reset();
-    proposalsStore.reset();
+    proposalsStore.resetForTesting();
     resetIdentity();
 
     // Setup:
     proposal = proposalInfo();
-    proposalsStore.setProposals({
+    proposalsStore.setProposalsForTesting({
       proposals: [proposal],
       certified: true,
     });

--- a/frontend/src/tests/lib/stores/proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/proposals.store.spec.ts
@@ -9,9 +9,15 @@ import { ProposalStatus, Topic } from "@dfinity/nns";
 import { get } from "svelte/store";
 
 describe("proposals-store", () => {
+  beforeEach(() => {
+    proposalsStore.resetForTesting();
+    proposalsFiltersStore.reset();
+  });
+
   describe("proposals", () => {
     it("should set proposals", () => {
-      proposalsStore.setProposals({
+      const mutationStore = proposalsStore.getSingleMutationProposalsStore();
+      mutationStore.setProposals({
         proposals: generateMockProposals(10),
         certified: true,
       });
@@ -20,20 +26,118 @@ describe("proposals-store", () => {
       expect(proposals).toEqual(generateMockProposals(10));
     });
 
+    it("should apply set proposals in correct order", () => {
+      const allProposals = generateMockProposals(10);
+      const initialProposals = allProposals.slice(0, 5);
+
+      const mutation1 = proposalsStore.getSingleMutationProposalsStore();
+      mutation1.setProposals({
+        proposals: initialProposals,
+        certified: false,
+      });
+      expect(get(proposalsStore)).toEqual({
+        proposals: initialProposals,
+        certified: false,
+      });
+
+      // Simulate a second request before the update call of the first request
+      // returns.
+      const mutation2 = proposalsStore.getSingleMutationProposalsStore();
+      mutation2.setProposals({
+        proposals: allProposals,
+        certified: false,
+      });
+      expect(get(proposalsStore)).toEqual({
+        proposals: allProposals,
+        certified: false,
+      });
+
+      // When the update call of the original request returns, it should not
+      // override the result from the later request.
+      mutation1.setProposals({
+        proposals: initialProposals,
+        certified: true,
+      });
+      expect(get(proposalsStore)).toEqual({
+        proposals: allProposals,
+        certified: false,
+      });
+
+      // And finally the update call of the second request returns.
+      mutation2.setProposals({
+        proposals: allProposals,
+        certified: true,
+      });
+      expect(get(proposalsStore)).toEqual({
+        proposals: allProposals,
+        certified: true,
+      });
+    });
+
     it("should push proposals", () => {
       const allProposals = generateMockProposals(10);
-      proposalsStore.setProposals({
+      proposalsStore.setProposalsForTesting({
         proposals: allProposals.slice(0, 5),
         certified: true,
       });
 
-      proposalsStore.pushProposals({
+      const mutationStore = proposalsStore.getSingleMutationProposalsStore();
+      mutationStore.pushProposals({
         proposals: allProposals.slice(5),
         certified: true,
       });
 
       const { proposals } = get(proposalsStore);
       expect(proposals).toEqual(allProposals);
+    });
+
+    it("should apply push proposals in correct order", () => {
+      const allProposals = generateMockProposals(10);
+      const initialProposals = allProposals.slice(0, 5);
+      const newProposals = allProposals.slice(5);
+
+      const setMutation = proposalsStore.getSingleMutationProposalsStore();
+      setMutation.setProposals({
+        proposals: initialProposals,
+        certified: false,
+      });
+      expect(get(proposalsStore)).toEqual({
+        proposals: initialProposals,
+        certified: false,
+      });
+
+      // Simulate a second request before the update call of the first request
+      // returns.
+      const pushMutation = proposalsStore.getSingleMutationProposalsStore();
+      pushMutation.pushProposals({
+        proposals: newProposals,
+        certified: false,
+      });
+      expect(get(proposalsStore)).toEqual({
+        proposals: allProposals,
+        certified: false,
+      });
+
+      // When the update call of the original request returns, it should not
+      // override the result from the later request.
+      setMutation.setProposals({
+        proposals: initialProposals,
+        certified: true,
+      });
+      expect(get(proposalsStore)).toEqual({
+        proposals: allProposals,
+        certified: false,
+      });
+
+      // And finally the update call of the second request returns.
+      pushMutation.pushProposals({
+        proposals: newProposals,
+        certified: true,
+      });
+      expect(get(proposalsStore)).toEqual({
+        proposals: allProposals,
+        certified: true,
+      });
     });
 
     it("should push proposals with certified-version replacement", () => {
@@ -43,11 +147,12 @@ describe("proposals-store", () => {
       const updateProposals = generateMockProposals(10, {
         proposalTimestampSeconds: 1n,
       });
-      proposalsStore.setProposals({
+      proposalsStore.setProposalsForTesting({
         proposals: queryProposals,
         certified: true,
       });
-      proposalsStore.pushProposals({
+      const mutationStore = proposalsStore.getSingleMutationProposalsStore();
+      mutationStore.pushProposals({
         proposals: updateProposals,
         certified: true,
       });
@@ -57,11 +162,12 @@ describe("proposals-store", () => {
     });
 
     it("should reset proposals", () => {
-      proposalsStore.setProposals({
+      proposalsStore.setProposalsForTesting({
         proposals: generateMockProposals(2),
         certified: true,
       });
-      proposalsStore.setProposals({ proposals: [], certified: true });
+      const mutationStore = proposalsStore.getSingleMutationProposalsStore();
+      mutationStore.setProposals({ proposals: [], certified: true });
 
       const { proposals } = get(proposalsStore);
       expect(proposals).toEqual([]);
@@ -69,11 +175,69 @@ describe("proposals-store", () => {
 
     it("should remove proposals", () => {
       const allProposals = generateMockProposals(10);
-      proposalsStore.setProposals({ proposals: allProposals, certified: true });
-      proposalsStore.removeProposals(allProposals.slice(0, 5));
+      proposalsStore.setProposalsForTesting({
+        proposals: allProposals,
+        certified: true,
+      });
+      const mutationStore = proposalsStore.getSingleMutationProposalsStore();
+      mutationStore.removeProposals({
+        proposalsToRemove: allProposals.slice(0, 5),
+        certified: true,
+      });
 
       const { proposals } = get(proposalsStore);
       expect(proposals).toEqual(allProposals.slice(5));
+    });
+
+    it("should apply remove proposals in correct order", () => {
+      const allProposals = generateMockProposals(10);
+      const removedProposals = allProposals.slice(0, 5);
+      const remainingProposals = allProposals.slice(5);
+
+      const setMutation = proposalsStore.getSingleMutationProposalsStore();
+      setMutation.setProposals({
+        proposals: allProposals,
+        certified: false,
+      });
+      expect(get(proposalsStore)).toEqual({
+        proposals: allProposals,
+        certified: false,
+      });
+
+      // Simulate a second request before the update call of the first request
+      // returns.
+      const removeMutation = proposalsStore.getSingleMutationProposalsStore();
+      removeMutation.removeProposals({
+        proposalsToRemove: removedProposals,
+        certified: false,
+      });
+      expect(get(proposalsStore)).toEqual({
+        proposals: remainingProposals,
+        certified: false,
+      });
+
+      // When the update call of the original request returns, it should not
+      // override the result from the later request.
+      setMutation.setProposals({
+        proposals: allProposals,
+        certified: true,
+      });
+      expect(get(proposalsStore)).toEqual({
+        proposals: remainingProposals,
+        // certified: true because the remaining proposals are certified even
+        // though removing the others wasn't.
+        certified: true,
+      });
+
+      // And finally the update call of the second request returns.
+      removeMutation.removeProposals({
+        proposalsToRemove: removedProposals,
+        certified: true,
+      });
+      expect(get(proposalsStore)).toEqual({
+        proposals: remainingProposals,
+        certified: true,
+      });
     });
 
     it("should replace proposals", () => {
@@ -81,11 +245,69 @@ describe("proposals-store", () => {
       const replacedProposals = generateMockProposals(10, {
         proposalTimestampSeconds: 666n,
       });
-      proposalsStore.setProposals({ proposals: allProposals, certified: true });
-      proposalsStore.replaceProposals(replacedProposals);
+      proposalsStore.setProposalsForTesting({
+        proposals: allProposals,
+        certified: true,
+      });
+      const mutationStore = proposalsStore.getSingleMutationProposalsStore();
+      mutationStore.replaceProposals({
+        proposals: replacedProposals,
+        certified: true,
+      });
 
       const { proposals } = get(proposalsStore);
       expect(proposals).toEqual(replacedProposals);
+    });
+
+    it("should apply replace proposals in correct order", () => {
+      const oldProposals = generateMockProposals(10);
+      const newProposals = generateMockProposals(5, {
+        proposalTimestampSeconds: 666n,
+      });
+      const expectedProposals = [...newProposals, ...oldProposals.slice(5)];
+
+      const setMutation = proposalsStore.getSingleMutationProposalsStore();
+      setMutation.setProposals({
+        proposals: oldProposals,
+        certified: false,
+      });
+      expect(get(proposalsStore)).toEqual({
+        proposals: oldProposals,
+        certified: false,
+      });
+
+      // Simulate a second request before the update call of the first request
+      // returns.
+      const replaceMutation = proposalsStore.getSingleMutationProposalsStore();
+      replaceMutation.replaceProposals({
+        proposals: newProposals,
+        certified: false,
+      });
+      expect(get(proposalsStore)).toEqual({
+        proposals: expectedProposals,
+        certified: false,
+      });
+
+      // When the update call of the original request returns, it should not
+      // override the result from the later request.
+      setMutation.setProposals({
+        proposals: oldProposals,
+        certified: true,
+      });
+      expect(get(proposalsStore)).toEqual({
+        proposals: expectedProposals,
+        certified: false,
+      });
+
+      // And finally the update call of the second request returns.
+      replaceMutation.replaceProposals({
+        proposals: newProposals,
+        certified: true,
+      });
+      expect(get(proposalsStore)).toEqual({
+        proposals: expectedProposals,
+        certified: true,
+      });
     });
   });
 


### PR DESCRIPTION
# Motivation

We want to re-enable the update calls that are disabled via FORCE_CALL_STRATEGY.
But this currently results in a race condition. See https://github.com/dfinity/nns-dapp/pull/5522 for details.

To fix the race condition, we use a `queuedStore`, similar to https://github.com/dfinity/nns-dapp/blob/main/frontend/src/lib/stores/icp-account-balances.store.ts

# Changes

1. Change `proposalsStore` to use a `queuedStore`.
2. Change calls to modify `proposalsStore` to use the single-mutation store as necessary to use a queued store.

# Tests

1. Update tests to use `...ForTesting` mutation functions which hide the use of a single-mutation store.
2. Resolve the TODO in `frontend/src/tests/lib/pages/NnsProposals.spec.ts` which was added to observe the race condition.
3. Add unit tests for `proposalsStore` which check the correct order of mutations.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary until we actually enable query+update again.