### PR TITLE
Clean up pages/NnsProposalDetail.spec.ts

### DIFF
--- a/frontend/src/tests/e2e/proposals.spec.ts
+++ b/frontend/src/tests/e2e/proposals.spec.ts
@@ -119,8 +119,7 @@ test("Test proposals", async ({ page, context }) => {
   const nnsProposalPo = appPo.getProposalDetailPo().getNnsProposalPo();
 
   // System info
-  const systemInfoSectionPo =
-    nnsProposalPo.getProposalProposalSystemInfoSectionPo();
+  const systemInfoSectionPo = nnsProposalPo.getProposalSystemInfoSectionPo();
 
   expect(await systemInfoSectionPo.getProposalTypeText()).toBe("Motion");
   expect(await systemInfoSectionPo.getProposalTopicText()).toBe("Governance");

--- a/frontend/src/tests/page-objects/NnsProposal.page-object.ts
+++ b/frontend/src/tests/page-objects/NnsProposal.page-object.ts
@@ -22,7 +22,7 @@ export class NnsProposalPo extends BasePageObject {
     return VotesResultPo.under(this.root);
   }
 
-  getProposalProposalSystemInfoSectionPo(): ProposalSystemInfoSectionPo {
+  getProposalSystemInfoSectionPo(): ProposalSystemInfoSectionPo {
     return ProposalSystemInfoSectionPo.under(this.root);
   }
 


### PR DESCRIPTION
# Motivation

Make the test easier to maintain.

Also there was a bug in the `"should NOT query neurons"` test. Because the setup was mixing `mutableMockAuthStoreSubscribe` and `mockAuthStoreSubscribe`, the user was actually signed in.
But
```
      await waitFor(() =>
        expect(governanceApi.queryNeurons).not.toHaveBeenCalled()
      );
```
succeeded before the code had a chance to query the neurons.
This is why we should never use `waitFor` and always use `runResolvedPromises` instead.

# Changes

1. Import the component as its actual name instead of as `ProposalDetail`.
2. Use `resetIdentity()` and `setNoIdentity()` instead of mocking the `authStore`.
3. Don't mock `proposalsStore` or `neuronsStore`.
4. `proposalsApi.queryProposal` instead of mocking the governance canister.
5. Use a page object.
6. Use `runResolvedPromises` instead of `waitFor`


Drive-by: Fix type with double `Proposal` in `getProposalProposalSystemInfoSectionPo`.

# Tests

Test only

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary