### PR TITLE
Verify imported ledger with certified call

### DIFF
--- a/frontend/src/lib/services/icrc-index.services.ts
+++ b/frontend/src/lib/services/icrc-index.services.ts
@@ -34,7 +34,7 @@ export const matchLedgerIndexPair = async ({
   try {
     const ledgerIdFromIndexCaniter = await getLedgerId({
       indexCanisterId,
-      certified: false,
+      certified: true,
     });
     const match =
       ledgerIdFromIndexCaniter.toText() === ledgerCanisterId.toText();

--- a/frontend/src/lib/services/icrc-index.services.ts
+++ b/frontend/src/lib/services/icrc-index.services.ts
@@ -32,12 +32,12 @@ export const matchLedgerIndexPair = async ({
   indexCanisterId: Principal;
 }): Promise<boolean> => {
   try {
-    const ledgerIdFromIndexCaniter = await getLedgerId({
+    const ledgerIdFromIndexCanister = await getLedgerId({
       indexCanisterId,
       certified: true,
     });
     const match =
-      ledgerIdFromIndexCaniter.toText() === ledgerCanisterId.toText();
+      ledgerIdFromIndexCanister.toText() === ledgerCanisterId.toText();
 
     if (!match) {
       toastsError({

--- a/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/IcrcWallet.spec.ts
@@ -804,7 +804,7 @@ describe("IcrcWallet", () => {
         expect(get(busyStore)).toEqual([]);
         expect(spyOnGetLedgerId).toBeCalledTimes(1);
         expect(spyOnGetLedgerId).toBeCalledWith({
-          certified: false,
+          certified: true,
           identity: mockIdentity,
           indexCanisterId,
         });

--- a/frontend/src/tests/lib/services/icrc-index.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-index.services.spec.ts
@@ -1,7 +1,7 @@
 import * as icrcIndexApi from "$lib/api/icrc-index.api";
 import { matchLedgerIndexPair } from "$lib/services/icrc-index.services";
 import * as toastsStore from "$lib/stores/toasts.store";
-import { resetIdentity } from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 
 describe("icrc-index.services", () => {
@@ -16,14 +16,23 @@ describe("icrc-index.services", () => {
     });
 
     it("should return true when the ledger canister IDs match", async () => {
-      vi.spyOn(icrcIndexApi, "getLedgerId").mockResolvedValue(ledgerCanisterId);
+      const spyOnGetLedgerId = vi
+        .spyOn(icrcIndexApi, "getLedgerId")
+        .mockResolvedValue(ledgerCanisterId);
 
+      expect(spyOnGetLedgerId).toBeCalledTimes(0);
       const result = await matchLedgerIndexPair({
         ledgerCanisterId,
         indexCanisterId,
       });
 
       expect(result).toEqual(true);
+      expect(spyOnGetLedgerId).toBeCalledTimes(1);
+      expect(spyOnGetLedgerId).toBeCalledWith({
+        certified: true,
+        identity: mockIdentity,
+        indexCanisterId,
+      });
     });
 
     it("should return false when the ledger canister IDs don't match", async () => {


### PR DESCRIPTION
# Motivation

Use an update call to make sure that the canister ID is correct and was not manipulated by a malicious node.

# Changes

- Call `ledger_id` with certified request.

Drive-by change: fixed a typo.

# Tests

- Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.
