### PR TITLE
Use a non-aborted SNS as mock data

### DIFF
--- a/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
+++ b/frontend/src/lib/utils/sns-aggregator-converters.utils.ts
@@ -417,7 +417,7 @@ const convertDtoToSnsSummaryMetadata = (
 /**
  * Token metadata is given only if all IcrcTokenMetadata properties are defined.
  */
-const convertDtoToTokenMetadata = (
+export const convertDtoToTokenMetadata = (
   data: CachedSnsTokenMetadataDto
 ): IcrcTokenMetadata | undefined =>
   mapOptionalToken(convertIcrc1Metadata(data));

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/StakeNeuronToVote.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/StakeNeuronToVote.spec.ts
@@ -1,6 +1,9 @@
 import StakeNeuronToVote from "$lib/components/proposal-detail/VotingCard/StakeNeuronToVote.svelte";
 import { page } from "$mocks/$app/stores";
-import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
+import {
+  mockSnsFullProject,
+  mockSnsToken,
+} from "$tests/mocks/sns-projects.mock";
 import { StakeNeuronToVotePo } from "$tests/page-objects/StakeNeuronToVote.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
@@ -61,6 +64,12 @@ describe("StakeNeuronToVote", () => {
 
   describe("for SNS", () => {
     const rootCanisterId = mockSnsFullProject.rootCanisterId;
+    const projectName = "Fish tank";
+    const tokenSymbol = "FISH";
+    const tokenMetadata = {
+      ...mockSnsToken,
+      symbol: tokenSymbol,
+    };
     beforeEach(() => {
       page.mock({
         data: { universe: rootCanisterId.toText() },
@@ -68,6 +77,8 @@ describe("StakeNeuronToVote", () => {
       setSnsProjects([
         {
           rootCanisterId,
+          projectName,
+          tokenMetadata,
           lifecycle: SnsSwapLifecycle.Committed,
         },
       ]);
@@ -83,7 +94,7 @@ describe("StakeNeuronToVote", () => {
       const po = await renderAndExpand();
 
       expect(await po.getTitleText()).toBe(
-        "You don't have any Catalyze neurons to vote"
+        `You don't have any ${projectName} neurons to vote`
       );
     });
 
@@ -91,14 +102,16 @@ describe("StakeNeuronToVote", () => {
       const po = await renderAndExpand();
 
       expect(await po.getDescriptionText()).toBe(
-        "You have no Catalyze neurons. Create a neuron by staking CAT to vote on Catalyze proposals."
+        `You have no ${projectName} neurons. Create a neuron by staking ${tokenSymbol} to vote on ${projectName} proposals.`
       );
     });
 
     it("should display SNS version of the button", async () => {
       const po = await renderAndExpand();
 
-      await expect(await po.getGotoNeuronsLinkText()).toBe("Stake CAT");
+      await expect(await po.getGotoNeuronsLinkText()).toBe(
+        `Stake ${tokenSymbol}`
+      );
     });
 
     it("should navigate to sns neurons page", async () => {

--- a/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
+++ b/frontend/src/tests/lib/components/universe/SelectUniverseNav.spec.ts
@@ -50,6 +50,7 @@ describe("SelectUniverseNav", () => {
   });
 
   it("should display actionable proposal count", async () => {
+    const projectName = "Fish tank";
     const votableProposal: ProposalInfo = {
       ...mockProposalInfo,
       id: 0n,
@@ -78,7 +79,12 @@ describe("SelectUniverseNav", () => {
       proposals: [votableSnsProposal1, votableSnsProposal2],
     });
 
-    setSnsProjects([{ lifecycle: SnsSwapLifecycle.Committed }]);
+    setSnsProjects([
+      {
+        projectName,
+        lifecycle: SnsSwapLifecycle.Committed,
+      },
+    ]);
     const po = await renderComponent();
     await runResolvedPromises();
 
@@ -98,7 +104,7 @@ describe("SelectUniverseNav", () => {
     // nns is the second card
     expect(await cardPos[1].getName()).toEqual("Internet Computer");
     expect((await cardPos[1].getActionableProposalCount()).trim()).toEqual("1");
-    expect(await cardPos[2].getName()).toEqual("Catalyze");
+    expect(await cardPos[2].getName()).toEqual(projectName);
     expect((await cardPos[2].getActionableProposalCount()).trim()).toEqual("2");
   });
 });

--- a/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-aggregator-converters.utils.spec.ts
@@ -18,23 +18,27 @@ import type { SnsNervousSystemParameters } from "@dfinity/sns";
 describe("sns aggregator converters utils", () => {
   describe("convertDtoData", () => {
     it("converts aggregator icrc metadata to ic-js types", () => {
-      expect(convertIcrc1Metadata(aggregatorSnsMockDto.icrc1_metadata)).toEqual(
-        [
-          ["icrc1:decimals", { Nat: 8n }],
-          ["icrc1:name", { Text: "CatalyzeDAO" }],
-          ["icrc1:symbol", { Text: "CAT" }],
-          ["icrc1:fee", { Nat: 100000n }],
-        ]
-      );
+      const metadata: CachedSnsTokenMetadataDto = [
+        ["icrc1:decimals", { Nat: [8] }],
+        ["icrc1:name", { Text: "CatalyzeDAO" }],
+        ["icrc1:symbol", { Text: "CAT" }],
+        ["icrc1:fee", { Nat: [100000] }],
+      ];
+      expect(convertIcrc1Metadata(metadata)).toEqual([
+        ["icrc1:decimals", { Nat: 8n }],
+        ["icrc1:name", { Text: "CatalyzeDAO" }],
+        ["icrc1:symbol", { Text: "CAT" }],
+        ["icrc1:fee", { Nat: 100000n }],
+      ]);
     });
 
     it("converts icrc1:fee using not only lower parts of a 64-bit value", () => {
-      const metadata = aggregatorSnsMockDto.icrc1_metadata.map(
-        ([key, value]) => [
-          key,
-          key === "icrc1:fee" ? { Nat: [705032704, 1] } : value,
-        ]
-      ) as CachedSnsTokenMetadataDto;
+      const metadata: CachedSnsTokenMetadataDto = [
+        ["icrc1:decimals", { Nat: [8] }],
+        ["icrc1:name", { Text: "CatalyzeDAO" }],
+        ["icrc1:symbol", { Text: "CAT" }],
+        ["icrc1:fee", { Nat: [705032704, 1] }],
+      ];
       expect(convertIcrc1Metadata(metadata)).toEqual([
         ["icrc1:decimals", { Nat: 8n }],
         ["icrc1:name", { Text: "CatalyzeDAO" }],

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -4,6 +4,7 @@ import type {
   CachedSnsDto,
   CachedSnsTokenMetadataDto,
 } from "$lib/types/sns-aggregator";
+import { convertDtoToTokenMetadata } from "$lib/utils/sns-aggregator-converters.utils";
 import tenAggregatedSnses from "$tests/mocks/sns-aggregator.mock.json";
 import { IcrcMetadataResponseEntries } from "@dfinity/ledger-icrc";
 import { SnsSwapLifecycle, type SnsNervousSystemFunction } from "@dfinity/sns";
@@ -12,17 +13,21 @@ import { mockQueryTokenResponse } from "./sns-projects.mock";
 
 export const aggregatorMockSnsesDataDto: CachedSnsDto[] = tenAggregatedSnses;
 
-// It should match the token below
-export const aggregatorTokenMock: IcrcTokenMetadata = {
-  name: "CatalyzeDAO",
-  symbol: "CAT",
-  fee: 100000n,
-  decimals: 8,
+export const aggregatorSnsMockDto: CachedSnsDto = {
+  // This is the YRAL (fka HotOrNot) SNS.
+  // We picked this as a suitable mock because:
+  // 1. It was not aborted.
+  // 2. It was not sold out, so it doesn't prevent testing additional sales.
+  // 3. It did not have restricted countries.
+  // But any test that depends on specific values should declare those
+  // explcitily in the test.
+  ...aggregatorMockSnsesDataDto[4],
 };
 
-export const aggregatorSnsMockDto: CachedSnsDto = {
-  ...aggregatorMockSnsesDataDto[7],
-};
+// It should match the token in the aggregatorSnsMockDto above.
+export const aggregatorTokenMock: IcrcTokenMetadata = convertDtoToTokenMetadata(
+  aggregatorSnsMockDto.icrc1_metadata
+);
 
 const convertToNervousFunctionDto = ({
   id,


### PR DESCRIPTION
# Motivation

The `aggregatorSnsMockDto` has data for an aborted SNS. This makes it very non-standard/surprising when used in a test.
While in principal, a test should specify all the fields that it cares about, I think it's reasonable to expect the test data not to be for an aborted SNS.

# Changes

1. Use `aggregatorMockSnsesDataDto[4]` instead of `aggregatorMockSnsesDataDto[7]` as `aggregatorSnsMockDto`.
2. Added a comment explaining why `4`.
3. `export convertDtoToTokenMetadata` to make sure `aggregatorTokenMock` matches `aggregatorSnsMockDto` (as required by the comment) without having to hard code the same data.

# Tests

Updated tests that started failing by specifying more data explicitly in the tests.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary