### PR TITLE
Restore changelog after rollback

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -14,13 +14,27 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+* Added `get_tvl` method to `nns-dapp` canister.
+* Display of principal Id and main ICP account Id in the account menu.
+
 #### Changed
+
+* Changes for cleaning up the stable structure migration.
+* Move Canisters button from sidebar to account menu.
+* Move GitHub button from account menu to sidebar.
+* Reduce calls to `sns-governance` canister by getting `nervous_system_parameters` from the aggregator instead.
+* Move theme toggle from account menu to sidebar.
+* The `Markdown` UI component was migrated to `@dfinity/gix-components`.
 
 #### Deprecated
 
 #### Removed
 
+* Stop making unnecessary calls to load the SNS proposal every time we load the derived state.
+
 #### Fixed
+
+* Fixed a bug where a performance counter in `init` is wiped during state initialization.
 
 #### Security
 
@@ -35,6 +49,8 @@ proposal is successful, the changes it released will be moved from this file to
 #### Deprecated
 
 #### Removed
+
+* Removed unused `pocket-ic` dependency.
 
 #### Fixed
 


### PR DESCRIPTION
# Motivation

After last week's upgrade, we had to revert to the previous version.
I kept the changelog for the proposal but I think it makes sense to restore the unreleased changelog so that the changes are reflected in the next proposal as what has changed since the current prod release.

# Changes

Revert just `CHANGELOG-Nns-Dapp-unreleased.md` from https://github.com/dfinity/nns-dapp/pull/5536

# Tests

no

# Todos

- [x] Add entry to changelog (if necessary).
