### PR TITLE
Filter aborted SNSes from snsAggregatorStore

### DIFF
--- a/.config/spellcheck.dic
+++ b/.config/spellcheck.dic
@@ -13,6 +13,7 @@ OWASP
 +
 iframe
 SNSs
+SNSes
 deserialization
 Stringifies
 xz

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -35,6 +35,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Fixed a bug where a performance counter in `init` is wiped during state initialization.
+* Bug with parsing nervous system parameters from aborted SNSes.
 
 #### Security
 

--- a/frontend/src/lib/services/public/sns.services.ts
+++ b/frontend/src/lib/services/public/sns.services.ts
@@ -3,7 +3,7 @@ import { queryProposals } from "$lib/api/proposals.api";
 import { buildAndStoreWrapper } from "$lib/api/sns-wrapper.api";
 import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { queryAndUpdate } from "$lib/services/utils.services";
-import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+import { snsAggregatorIncludingAbortedProjectsStore } from "$lib/stores/sns-aggregator.store";
 import { snsProposalsStore } from "$lib/stores/sns.store";
 import { toastsError } from "$lib/stores/toasts.store";
 import { isForceCallStrategy } from "$lib/utils/env.utils";
@@ -48,7 +48,7 @@ export const loadSnsProjects = async (): Promise<void> => {
     // This call is not necessary because the canister ids are already provided by the SNS aggregator.
     // As soon as the aggregator store is filled, SNS components may start rendering, resulting in calls on the SNS wrappers.
     // We set the aggregator store after building the wrappers' caches to avoid calls to the root canister when the SNS wrapper is initialized.
-    snsAggregatorStore.setData(aggregatorData);
+    snsAggregatorIncludingAbortedProjectsStore.setData(aggregatorData);
     // TODO: PENDING to be implemented, load SNS parameters.
   } catch (err) {
     toastsError(

--- a/frontend/src/lib/stores/sns-aggregator.store.ts
+++ b/frontend/src/lib/stores/sns-aggregator.store.ts
@@ -1,5 +1,6 @@
 import type { CachedSnsDto } from "$lib/types/sns-aggregator";
-import { writable, type Readable } from "svelte/store";
+import { SnsSwapLifecycle } from "@dfinity/sns";
+import { derived, writable, type Readable } from "svelte/store";
 
 /**
  * `undefined` means that the data is not loaded yet.
@@ -8,19 +9,35 @@ export interface SnsAggregatorData {
   data: CachedSnsDto[] | undefined;
 }
 
-export interface SnsAggregatorStore extends Readable<SnsAggregatorData> {
+export interface SnsAggregatorStore extends Readable<SnsAggregatorData> {}
+
+export interface SnsAggregatorIncludingAbortedProjectsStore
+  extends SnsAggregatorStore {
   setData: (data: CachedSnsDto[]) => void;
   reset: () => void;
 }
 
-const initSnsAggreagatorStore = (): SnsAggregatorStore => {
-  const { subscribe, set } = writable<SnsAggregatorData>({ data: undefined });
+const initSnsAggreagatorStore =
+  (): SnsAggregatorIncludingAbortedProjectsStore => {
+    const { subscribe, set } = writable<SnsAggregatorData>({ data: undefined });
 
-  return {
-    subscribe,
-    setData: (data) => set({ data }),
-    reset: () => set({ data: undefined }),
+    return {
+      subscribe,
+      setData: (data) => set({ data }),
+      reset: () => set({ data: undefined }),
+    };
   };
-};
 
-export const snsAggregatorStore = initSnsAggreagatorStore();
+export const snsAggregatorIncludingAbortedProjectsStore =
+  initSnsAggreagatorStore();
+
+export const snsAggregatorStore: SnsAggregatorStore = derived(
+  snsAggregatorIncludingAbortedProjectsStore,
+  (store) => {
+    return {
+      data: store.data?.filter(
+        (sns) => sns.lifecycle.lifecycle !== SnsSwapLifecycle.Aborted
+      ),
+    };
+  }
+);

--- a/frontend/src/lib/stores/sns-aggregator.store.ts
+++ b/frontend/src/lib/stores/sns-aggregator.store.ts
@@ -33,11 +33,9 @@ export const snsAggregatorIncludingAbortedProjectsStore =
 
 export const snsAggregatorStore: SnsAggregatorStore = derived(
   snsAggregatorIncludingAbortedProjectsStore,
-  (store) => {
-    return {
-      data: store.data?.filter(
-        (sns) => sns.lifecycle.lifecycle !== SnsSwapLifecycle.Aborted
-      ),
-    };
-  }
+  (store) => ({
+    data: store.data?.filter(
+      (sns) => sns.lifecycle.lifecycle !== SnsSwapLifecycle.Aborted
+    ),
+  })
 );

--- a/frontend/src/tests/lib/derived/sns-aggregator.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-aggregator.derived.spec.ts
@@ -1,11 +1,11 @@
 import { snsAggregatorDerived } from "$lib/derived/sns-aggregator.derived";
-import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+import { snsAggregatorIncludingAbortedProjectsStore } from "$lib/stores/sns-aggregator.store";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import { get } from "svelte/store";
 
 describe("snsAggregatorDerived", () => {
   beforeEach(() => {
-    snsAggregatorStore.reset();
+    snsAggregatorIncludingAbortedProjectsStore.reset();
   });
 
   it("should create a derived store", () => {
@@ -18,7 +18,7 @@ describe("snsAggregatorDerived", () => {
 
     expect(get(snsLedgerCanisterIdStore)).toEqual({});
 
-    snsAggregatorStore.setData([
+    snsAggregatorIncludingAbortedProjectsStore.setData([
       {
         ...aggregatorSnsMockDto,
         canister_ids: {

--- a/frontend/src/tests/lib/derived/sns-functions.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-functions.derived.spec.ts
@@ -1,7 +1,11 @@
 import { snsFunctionsStore } from "$lib/derived/sns-functions.derived";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import {
+  resetSnsProjects,
+  setProdSnsProjects,
+  setSnsProjects,
+} from "$tests/utils/sns.test-utils";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 
@@ -92,5 +96,11 @@ describe("sns functions store", () => {
     ]);
     const store2 = get(snsFunctionsStore);
     expect(store2[mockPrincipal.toText()]?.nsFunctions).toEqual([]);
+  });
+
+  it("should convert prod SNSes without error", async () => {
+    await setProdSnsProjects();
+    const store = get(snsFunctionsStore);
+    expect(Object.keys(store).length).toBeGreaterThan(25);
   });
 });

--- a/frontend/src/tests/lib/derived/sns-parameters.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-parameters.derived.spec.ts
@@ -1,21 +1,24 @@
 import { snsParametersStore } from "$lib/derived/sns-parameters.derived";
-import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+import { snsAggregatorIncludingAbortedProjectsStore } from "$lib/stores/sns-aggregator.store";
 import type { CachedSnsDto } from "$lib/types/sns-aggregator";
 import { convertNervousSystemParameters } from "$lib/utils/sns-aggregator-converters.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
-import { resetSnsProjects } from "$tests/utils/sns.test-utils";
+import {
+  resetSnsProjects,
+  setProdSnsProjects,
+} from "$tests/utils/sns.test-utils";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 
 describe("SNS Parameters store", () => {
   beforeEach(() => {
-    snsAggregatorStore.reset();
+    snsAggregatorIncludingAbortedProjectsStore.reset();
   });
 
   describe("snsParametersStore", () => {
     it("should set parameters for a project", () => {
-      snsAggregatorStore.setData([
+      snsAggregatorIncludingAbortedProjectsStore.setData([
         {
           ...aggregatorSnsMockDto,
           canister_ids: {
@@ -34,7 +37,7 @@ describe("SNS Parameters store", () => {
     });
 
     it("should reset parameters for a project", () => {
-      snsAggregatorStore.setData([
+      snsAggregatorIncludingAbortedProjectsStore.setData([
         {
           ...aggregatorSnsMockDto,
           canister_ids: {
@@ -74,7 +77,7 @@ describe("SNS Parameters store", () => {
         },
       };
 
-      snsAggregatorStore.setData([project1, project2]);
+      snsAggregatorIncludingAbortedProjectsStore.setData([project1, project2]);
 
       const parametersInStore = get(snsParametersStore);
       expect(
@@ -86,5 +89,11 @@ describe("SNS Parameters store", () => {
           .max_age_bonus_percentage
       ).toEqual([321n]);
     });
+  });
+
+  it("should convert prod SNSes without error", async () => {
+    await setProdSnsProjects();
+    const store = get(snsParametersStore);
+    expect(Object.keys(store).length).toBeGreaterThan(25);
   });
 });

--- a/frontend/src/tests/lib/derived/sns-swap-canister-accounts.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-swap-canister-accounts.derived.spec.ts
@@ -1,5 +1,5 @@
 import { createSwapCanisterAccountsStore } from "$lib/derived/sns-swap-canisters-accounts.derived";
-import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+import { snsAggregatorIncludingAbortedProjectsStore } from "$lib/stores/sns-aggregator.store";
 import { getSwapCanisterAccount } from "$lib/utils/sns.utils";
 import { mockPrincipal } from "$tests/mocks/auth.store.mock";
 import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
@@ -17,11 +17,11 @@ describe("sns swap canisters accounts store", () => {
   };
 
   beforeEach(() => {
-    snsAggregatorStore.reset();
+    snsAggregatorIncludingAbortedProjectsStore.reset();
   });
 
   it("should convert swap canisters to accounts for a given controller", () => {
-    snsAggregatorStore.setData([aggregatorData]);
+    snsAggregatorIncludingAbortedProjectsStore.setData([aggregatorData]);
 
     const controller = mockPrincipal;
     const store = createSwapCanisterAccountsStore(controller);
@@ -39,7 +39,7 @@ describe("sns swap canisters accounts store", () => {
   });
 
   it("should empty array if no controller", () => {
-    snsAggregatorStore.setData([aggregatorData]);
+    snsAggregatorIncludingAbortedProjectsStore.setData([aggregatorData]);
 
     const store = createSwapCanisterAccountsStore(undefined);
 
@@ -55,7 +55,10 @@ describe("sns swap canisters accounts store", () => {
         swap_canister_id: swapCanisterId2.toText(),
       },
     };
-    snsAggregatorStore.setData([aggregatorData, aggregatorData2]);
+    snsAggregatorIncludingAbortedProjectsStore.setData([
+      aggregatorData,
+      aggregatorData2,
+    ]);
 
     const controller = mockPrincipal;
     const store = createSwapCanisterAccountsStore(controller);

--- a/frontend/src/tests/lib/derived/sns-total-token-supply.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns-total-token-supply.derived.spec.ts
@@ -1,7 +1,11 @@
 import { snsTotalTokenSupplyStore } from "$lib/derived/sns-total-token-supply.derived";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import {
+  resetSnsProjects,
+  setProdSnsProjects,
+  setSnsProjects,
+} from "$tests/utils/sns.test-utils";
 import { get } from "svelte/store";
 
 describe("SNS Total Tokens Supply store", () => {
@@ -78,5 +82,11 @@ describe("SNS Total Tokens Supply store", () => {
     ]);
     const store = get(snsTotalTokenSupplyStore);
     expect(store[rootCanisterId.toText()].totalSupply).toEqual(newSupply);
+  });
+
+  it("should convert prod SNSes without error", async () => {
+    await setProdSnsProjects();
+    const store = get(snsTotalTokenSupplyStore);
+    expect(Object.keys(store).length).toBeGreaterThan(25);
   });
 });

--- a/frontend/src/tests/lib/derived/sns/sns-tokens.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-tokens.derived.spec.ts
@@ -3,7 +3,11 @@ import {
   snsTokensByRootCanisterIdStore,
 } from "$lib/derived/sns/sns-tokens.derived";
 import { mockSnsToken } from "$tests/mocks/sns-projects.mock";
-import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import {
+  resetSnsProjects,
+  setProdSnsProjects,
+  setSnsProjects,
+} from "$tests/utils/sns.test-utils";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
 
@@ -51,6 +55,12 @@ describe("sns-tokens.derived", () => {
         [batmanRootCanisterIdText]: batmanToken,
         [robinRootCanisterIdText]: robinToken,
       });
+    });
+
+    it("should convert prod SNSes without error", async () => {
+      await setProdSnsProjects();
+      const store = get(snsTokensByRootCanisterIdStore);
+      expect(Object.keys(store).length).toBeGreaterThan(25);
     });
   });
 

--- a/frontend/src/tests/lib/services/public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns.services.spec.ts
@@ -4,7 +4,7 @@ import * as aggregatorApi from "$lib/api/sns-aggregator.api";
 import { clearWrapperCache, wrapper } from "$lib/api/sns-wrapper.api";
 import { loadSnsProjects } from "$lib/services/public/sns.services";
 import { authStore } from "$lib/stores/auth.store";
-import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+import { snsAggregatorStore, snsAggregatorIncludingAbortedProjectsStore } from "$lib/stores/sns-aggregator.store";
 import { snsFunctionsStore } from "$lib/derived/sns-functions.derived";
 import { snsTotalTokenSupplyStore } from "$lib/derived/sns-total-token-supply.derived";
 import { tokensStore } from "$lib/stores/tokens.store";
@@ -79,7 +79,7 @@ describe("SNS public services", () => {
 
   describe("loadSnsProjects", () => {
     beforeEach(() => {
-      snsAggregatorStore.reset();
+      snsAggregatorIncludingAbortedProjectsStore.reset();
       clearWrapperCache();
       vi.clearAllMocks();
       vi.spyOn(authStore, "subscribe").mockImplementation(
@@ -160,7 +160,7 @@ describe("SNS public services", () => {
 
       await loadSnsProjects();
 
-      expect(get(snsAggregatorStore).data).toEqual(aggregatorMockSnsesDataDto);
+      expect(get(snsAggregatorIncludingAbortedProjectsStore).data).toEqual(aggregatorMockSnsesDataDto);
     });
 
     it("should load and map total token supply", async () => {

--- a/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-aggregator.store.spec.ts
@@ -1,37 +1,112 @@
-import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+import {
+  snsAggregatorIncludingAbortedProjectsStore,
+  snsAggregatorStore,
+} from "$lib/stores/sns-aggregator.store";
+import type { CachedSnsDto } from "$lib/types/sns-aggregator";
 import { aggregatorMockSnsesDataDto } from "$tests/mocks/sns-aggregator.mock";
+import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("sns-aggregator store", () => {
-  describe("snsAggregatorStore", () => {
-    beforeEach(() => {
-      snsAggregatorStore.reset();
-    });
+  beforeEach(() => {
+    snsAggregatorIncludingAbortedProjectsStore.reset();
+  });
 
+  describe("snsAggregatorIncludingAbortedProjectsStore", () => {
     it("should set aggregator data", () => {
-      snsAggregatorStore.setData(aggregatorMockSnsesDataDto);
+      snsAggregatorIncludingAbortedProjectsStore.setData(
+        aggregatorMockSnsesDataDto
+      );
 
-      expect(get(snsAggregatorStore).data).toEqual(aggregatorMockSnsesDataDto);
+      expect(get(snsAggregatorIncludingAbortedProjectsStore).data).toEqual(
+        aggregatorMockSnsesDataDto
+      );
     });
 
     it("should reset data", () => {
-      snsAggregatorStore.setData(aggregatorMockSnsesDataDto);
+      snsAggregatorIncludingAbortedProjectsStore.setData(
+        aggregatorMockSnsesDataDto
+      );
 
-      expect(get(snsAggregatorStore).data).toEqual(aggregatorMockSnsesDataDto);
+      expect(get(snsAggregatorIncludingAbortedProjectsStore).data).toEqual(
+        aggregatorMockSnsesDataDto
+      );
 
-      snsAggregatorStore.reset();
-      expect(get(snsAggregatorStore).data).toBeUndefined();
+      snsAggregatorIncludingAbortedProjectsStore.reset();
+      expect(
+        get(snsAggregatorIncludingAbortedProjectsStore).data
+      ).toBeUndefined();
     });
 
     it("should set data even when data is populated", () => {
-      snsAggregatorStore.setData(aggregatorMockSnsesDataDto);
+      snsAggregatorIncludingAbortedProjectsStore.setData(
+        aggregatorMockSnsesDataDto
+      );
 
-      expect(get(snsAggregatorStore).data).toEqual(aggregatorMockSnsesDataDto);
+      expect(get(snsAggregatorIncludingAbortedProjectsStore).data).toEqual(
+        aggregatorMockSnsesDataDto
+      );
 
-      snsAggregatorStore.setData([aggregatorMockSnsesDataDto[0]]);
-      expect(get(snsAggregatorStore).data).toEqual([
+      snsAggregatorIncludingAbortedProjectsStore.setData([
         aggregatorMockSnsesDataDto[0],
       ]);
+      expect(get(snsAggregatorIncludingAbortedProjectsStore).data).toEqual([
+        aggregatorMockSnsesDataDto[0],
+      ]);
+    });
+  });
+
+  describe("snsAggregatorStore", () => {
+    const snsWithLifecycle = (
+      sns: CachedSnsDto,
+      lifecycle: SnsSwapLifecycle
+    ) => ({
+      ...sns,
+      swap_state: {
+        ...sns.swap_state,
+        swap: {
+          ...sns.swap_state.swap,
+          lifecycle,
+        },
+      },
+      lifecycle: {
+        ...sns.lifecycle,
+        lifecycle,
+      },
+    });
+
+    const nonAbortedData = [
+      snsWithLifecycle(aggregatorMockSnsesDataDto[0], SnsSwapLifecycle.Pending),
+      snsWithLifecycle(aggregatorMockSnsesDataDto[1], SnsSwapLifecycle.Open),
+      snsWithLifecycle(
+        aggregatorMockSnsesDataDto[2],
+        SnsSwapLifecycle.Committed
+      ),
+      snsWithLifecycle(aggregatorMockSnsesDataDto[3], SnsSwapLifecycle.Adopted),
+    ];
+
+    it("should start empty", () => {
+      expect(get(snsAggregatorStore).data).toBeUndefined();
+    });
+
+    it("should hold non-aborted projects", () => {
+      snsAggregatorIncludingAbortedProjectsStore.setData(nonAbortedData);
+      expect(get(snsAggregatorStore).data).toEqual(nonAbortedData);
+    });
+
+    it("should not hold aborted projects", () => {
+      const abortedProject1 = snsWithLifecycle(
+        aggregatorMockSnsesDataDto[4],
+        SnsSwapLifecycle.Aborted
+      );
+      const abortedProject2 = snsWithLifecycle(
+        aggregatorMockSnsesDataDto[5],
+        SnsSwapLifecycle.Aborted
+      );
+      const data = [abortedProject1, ...nonAbortedData, abortedProject2];
+
+      snsAggregatorIncludingAbortedProjectsStore.setData(data);
+      expect(get(snsAggregatorStore).data).toEqual(nonAbortedData);
     });
   });
 });

--- a/frontend/src/tests/lib/stores/sns.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns.store.spec.ts
@@ -1,4 +1,4 @@
-import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+import { snsAggregatorIncludingAbortedProjectsStore } from "$lib/stores/sns-aggregator.store";
 import { snsDerivedStateStore } from "$lib/stores/sns-derived-state.store";
 import { snsLifecycleStore } from "$lib/stores/sns-lifecycle.store";
 import {
@@ -33,7 +33,7 @@ import { get } from "svelte/store";
 describe("sns.store", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    snsAggregatorStore.reset();
+    snsAggregatorIncludingAbortedProjectsStore.reset();
     snsDerivedStateStore.reset();
     snsLifecycleStore.reset();
   });
@@ -119,10 +119,12 @@ describe("sns.store", () => {
 
   describe("isLoadingSnsProjectsStore", () => {
     it("should not be loading if sns aggregator store is set", () => {
-      snsAggregatorStore.reset();
+      snsAggregatorIncludingAbortedProjectsStore.reset();
       expect(get(isLoadingSnsProjectsStore)).toBe(true);
 
-      snsAggregatorStore.setData([aggregatorSnsMockDto]);
+      snsAggregatorIncludingAbortedProjectsStore.setData([
+        aggregatorSnsMockDto,
+      ]);
       expect(get(isLoadingSnsProjectsStore)).toBe(false);
     });
   });
@@ -131,7 +133,9 @@ describe("sns.store", () => {
     const rootCanisterId = rootCanisterIdMock;
 
     it("uses snsAggregator as source of data", () => {
-      snsAggregatorStore.setData([aggregatorSnsMockDto]);
+      snsAggregatorIncludingAbortedProjectsStore.setData([
+        aggregatorSnsMockDto,
+      ]);
 
       expect(get(snsSummariesStore)).toHaveLength(1);
     });
@@ -141,7 +145,7 @@ describe("sns.store", () => {
       const aggregatorData = aggregatorSnsMockWith({
         rootCanisterId: rootCanisterId.toText(),
       });
-      snsAggregatorStore.setData([aggregatorData]);
+      snsAggregatorIncludingAbortedProjectsStore.setData([aggregatorData]);
 
       expect(get(snsSummariesStore)[0].derived.sns_tokens_per_icp).not.toBe(
         newSnsTokensPerIcp
@@ -167,7 +171,7 @@ describe("sns.store", () => {
       const aggregatorData = aggregatorSnsMockWith({
         rootCanisterId: rootCanisterId.toText(),
       });
-      snsAggregatorStore.setData([aggregatorData]);
+      snsAggregatorIncludingAbortedProjectsStore.setData([aggregatorData]);
 
       expect(get(snsSummariesStore)[0].swap.lifecycle).not.toBe(newLifecycle);
 

--- a/frontend/src/tests/mocks/sns-aggregator.mock.ts
+++ b/frontend/src/tests/mocks/sns-aggregator.mock.ts
@@ -1,6 +1,7 @@
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
 import type {
   CachedNervousFunctionDto,
+  CachedNervousSystemParametersDto,
   CachedSnsDto,
   CachedSnsTokenMetadataDto,
 } from "$lib/types/sns-aggregator";
@@ -84,6 +85,7 @@ export const aggregatorSnsMockWith = ({
   swapDueTimestampSeconds,
   nnsProposalId,
   totalTokenSupply,
+  nervousSystemParameters,
   neuronMinimumDissolveDelayToVoteSeconds,
   maxDissolveDelaySeconds,
   maxDissolveDelayBonusPercentage,
@@ -106,6 +108,7 @@ export const aggregatorSnsMockWith = ({
   swapDueTimestampSeconds?: number;
   nnsProposalId?: number;
   totalTokenSupply?: bigint;
+  nervousSystemParameters?: CachedNervousSystemParametersDto;
   neuronMinimumDissolveDelayToVoteSeconds?: bigint;
   maxDissolveDelaySeconds?: bigint;
   maxDissolveDelayBonusPercentage?: number;
@@ -161,29 +164,35 @@ export const aggregatorSnsMockWith = ({
       nervousFunctions?.map(convertToNervousFunctionDto) ??
       aggregatorSnsMockDto.parameters.functions,
   },
-  nervous_system_parameters: {
-    ...aggregatorSnsMockDto.nervous_system_parameters,
-    neuron_minimum_dissolve_delay_to_vote_seconds: nonNullish(
-      neuronMinimumDissolveDelayToVoteSeconds
-    )
-      ? Number(neuronMinimumDissolveDelayToVoteSeconds)
-      : aggregatorSnsMockDto.nervous_system_parameters
-          .neuron_minimum_dissolve_delay_to_vote_seconds,
-    max_dissolve_delay_seconds: nonNullish(maxDissolveDelaySeconds)
-      ? Number(maxDissolveDelaySeconds)
-      : aggregatorSnsMockDto.nervous_system_parameters
-          .max_dissolve_delay_seconds,
-    max_dissolve_delay_bonus_percentage:
-      maxDissolveDelayBonusPercentage ??
-      aggregatorSnsMockDto.nervous_system_parameters
-        .max_dissolve_delay_bonus_percentage,
-    max_age_bonus_percentage:
-      maxAgeBonusPercentage ??
-      aggregatorSnsMockDto.nervous_system_parameters.max_age_bonus_percentage,
-    neuron_minimum_stake_e8s: nonNullish(neuronMinimumStakeE8s)
-      ? Number(neuronMinimumStakeE8s)
-      : aggregatorSnsMockDto.nervous_system_parameters.neuron_minimum_stake_e8s,
-  },
+  // Don't use `isNullish` to allow setting to `null`.
+  nervous_system_parameters:
+    nervousSystemParameters !== undefined
+      ? nervousSystemParameters
+      : {
+          ...aggregatorSnsMockDto.nervous_system_parameters,
+          neuron_minimum_dissolve_delay_to_vote_seconds: nonNullish(
+            neuronMinimumDissolveDelayToVoteSeconds
+          )
+            ? Number(neuronMinimumDissolveDelayToVoteSeconds)
+            : aggregatorSnsMockDto.nervous_system_parameters
+                .neuron_minimum_dissolve_delay_to_vote_seconds,
+          max_dissolve_delay_seconds: nonNullish(maxDissolveDelaySeconds)
+            ? Number(maxDissolveDelaySeconds)
+            : aggregatorSnsMockDto.nervous_system_parameters
+                .max_dissolve_delay_seconds,
+          max_dissolve_delay_bonus_percentage:
+            maxDissolveDelayBonusPercentage ??
+            aggregatorSnsMockDto.nervous_system_parameters
+              .max_dissolve_delay_bonus_percentage,
+          max_age_bonus_percentage:
+            maxAgeBonusPercentage ??
+            aggregatorSnsMockDto.nervous_system_parameters
+              .max_age_bonus_percentage,
+          neuron_minimum_stake_e8s: nonNullish(neuronMinimumStakeE8s)
+            ? Number(neuronMinimumStakeE8s)
+            : aggregatorSnsMockDto.nervous_system_parameters
+                .neuron_minimum_stake_e8s,
+        },
   meta: {
     ...aggregatorSnsMockDto.meta,
     name: projectName ?? aggregatorSnsMockDto.meta.name,

--- a/frontend/src/tests/utils/sns.test-utils.ts
+++ b/frontend/src/tests/utils/sns.test-utils.ts
@@ -1,7 +1,11 @@
-import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+import { snsAggregatorIncludingAbortedProjectsStore } from "$lib/stores/sns-aggregator.store";
 import { snsDerivedStateStore } from "$lib/stores/sns-derived-state.store";
 import { snsLifecycleStore } from "$lib/stores/sns-lifecycle.store";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
+import type {
+  CachedNervousSystemParametersDto,
+  CachedSnsDto,
+} from "$lib/types/sns-aggregator";
 import { aggregatorSnsMockWith } from "$tests/mocks/sns-aggregator.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import type { Principal } from "@dfinity/principal";
@@ -24,6 +28,7 @@ export const setSnsProjects = (
     swapDueTimestampSeconds?: number;
     nnsProposalId?: number;
     totalTokenSupply?: bigint;
+    nervousSystemParameters?: CachedNervousSystemParametersDto;
     neuronMinimumDissolveDelayToVoteSeconds?: bigint;
     maxDissolveDelaySeconds?: bigint;
     maxDissolveDelayBonusPercentage?: number;
@@ -48,6 +53,7 @@ export const setSnsProjects = (
       swapDueTimestampSeconds: params.swapDueTimestampSeconds,
       nnsProposalId: params.nnsProposalId,
       totalTokenSupply: params.totalTokenSupply,
+      nervousSystemParameters: params.nervousSystemParameters,
       neuronMinimumDissolveDelayToVoteSeconds:
         params.neuronMinimumDissolveDelayToVoteSeconds,
       maxDissolveDelaySeconds: params.maxDissolveDelaySeconds,
@@ -58,11 +64,36 @@ export const setSnsProjects = (
   });
   snsLifecycleStore.reset();
   snsDerivedStateStore.reset();
-  snsAggregatorStore.setData(aggregatorProjects);
+  snsAggregatorIncludingAbortedProjectsStore.setData(aggregatorProjects);
 };
 
 export const resetSnsProjects = () => {
   snsLifecycleStore.reset();
   snsDerivedStateStore.reset();
-  snsAggregatorStore.reset();
+  snsAggregatorIncludingAbortedProjectsStore.reset();
+};
+
+export const setProdSnsProjects = async () => {
+  const allAggregatorData: CachedSnsDto[] = [];
+  let page = 0;
+  try {
+    for (;;) {
+      const moduleData = (await import(
+        `../workflows/LaunchPad/sns-agg-page-${page}.json`
+      )) as unknown as { default: CachedSnsDto[] };
+      if (moduleData.default.length === 0) {
+        break;
+      }
+      allAggregatorData.push(...moduleData.default);
+      page++;
+    }
+  } catch (e) {
+    if (page === 0) {
+      throw e;
+    }
+    // Ignore because we've reached past the last page.
+  }
+  snsLifecycleStore.reset();
+  snsDerivedStateStore.reset();
+  snsAggregatorIncludingAbortedProjectsStore.setData(allAggregatorData);
 };

--- a/frontend/src/tests/utils/sns.test-utils.ts
+++ b/frontend/src/tests/utils/sns.test-utils.ts
@@ -79,7 +79,7 @@ export const setProdSnsProjects = async () => {
   try {
     for (;;) {
       const moduleData = (await import(
-        `../workflows/LaunchPad/sns-agg-page-${page}.json`
+        `../workflows/Launchpad/sns-agg-page-${page}.json`
       )) as unknown as { default: CachedSnsDto[] };
       if (moduleData.default.length === 0) {
         break;


### PR DESCRIPTION
# Motivation

We had a bug because we tried to parse nervous system parameters on aborted SNSes.
All live SNSes do have nervous system parameters and we don't display aborted SNSes so there is no reason to parse them.

# Changes

1. Rename `snsAggregatorStore` to `snsAggregatorIncludingAbortedProjectsStore` to avoid confusion and add `snsAggregatorStore` as a derived store which does not contain aborted SNSes.

# Tests

1. Update sets which (re)set data on `snsAggregatorStore` to set it on `snsAggregatorIncludingAbortedProjectsStore`.
2. Add a utility to test with prod SNS data.
3. Updated `setSnsProjects` to allow setting `nervousSystemParameters: null`.
4. Add tests that `SnsProposalDetail` can render with aborted SNSes (explicitly) and with prod SNSes (which also contain aborted SNSes).
5. Add unit tests for new derived `snsAggregatorStore`.
6. Test that stores derived from `snsAggregatorStore` can be subscribed with prod data.
7. Tested manually against mainnet.

# Todos

- [x] Add entry to changelog (if necessary).
