### PR TITLE
Add changeNeuronVisibility into api and services and update i18n and …

### DIFF
--- a/frontend/src/lib/api-services/governance.api-service.ts
+++ b/frontend/src/lib/api-services/governance.api-service.ts
@@ -1,6 +1,7 @@
 import {
   addHotkey,
   autoStakeMaturity,
+  changeNeuronVisibility,
   claimOrRefreshNeuron,
   disburse,
   increaseDissolveDelay,
@@ -23,6 +24,7 @@ import {
   startDissolving,
   stopDissolving,
   type ApiAutoStakeMaturityParams,
+  type ApiChangeNeuronVisibilityParams,
   type ApiDisburseParams,
   type ApiIncreaseDissolveDelayParams,
   type ApiManageHotkeyParams,
@@ -203,5 +205,8 @@ export const governanceApiService = {
   },
   stopDissolving(params: ApiManageNeuronParams) {
     return clearCacheAfter(stopDissolving(params));
+  },
+  changeNeuronVisibility(params: ApiChangeNeuronVisibilityParams) {
+    return clearCacheAfter(changeNeuronVisibility(params));
   },
 };

--- a/frontend/src/lib/api/governance.api.ts
+++ b/frontend/src/lib/api/governance.api.ts
@@ -15,7 +15,11 @@ import type {
   Topic,
   Vote,
 } from "@dfinity/nns";
-import { GovernanceCanister, type RewardEvent } from "@dfinity/nns";
+import {
+  GovernanceCanister,
+  NeuronVisibility,
+  type RewardEvent,
+} from "@dfinity/nns";
 import type { Principal } from "@dfinity/principal";
 import { ledgerCanister as getLedgerCanister } from "./icp-ledger.api";
 
@@ -573,4 +577,28 @@ export const governanceCanister = async ({
     canister,
     agent,
   };
+};
+export type ApiChangeNeuronVisibilityParams = ApiCallParams & {
+  neuronIds: NeuronId[];
+  visibility: NeuronVisibility;
+};
+
+export const changeNeuronVisibility = async ({
+  neuronIds,
+  visibility,
+  identity,
+}: ApiChangeNeuronVisibilityParams): Promise<void> => {
+  logWithTimestamp(
+    `Changing visibility for ${neuronIds.length} neurons. IDs: ${neuronIds.join(", ")}. New visibility: ${visibility}`
+  );
+
+  const { canister } = await governanceCanister({ identity });
+
+  await Promise.all(
+    neuronIds.map((neuronId) => canister.setVisibility(neuronId, visibility))
+  );
+
+  logWithTimestamp(
+    `Visibility change complete for ${neuronIds.length} neurons. IDs: ${neuronIds.join(", ")}. New visibility: ${visibility}`
+  );
 };

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -688,8 +688,8 @@
     "created": "Date Created",
     "neuron_state_tooltip": "Your neuron can be locked, unlocked or dissolving. In a locked state, it is accruing age bonus, while its dissolve delay stays constant. If the neuron is in a dissolving state, its age bonus is set to 0, while dissolve delay decreases with time. After dissolve delay reaches 0, the neuron is unlocked, and $token held in it can be sent to any $token account.",
     "dissolve_delay_tooltip": "Dissolve delay is the minimum amount of time you have to wait for the neuron to unlock, and $token to be available again. If your neuron is dissolving, your $token will be available in $duration.",
-    "change_neuron_visibility_partial_failure": "$failedCount of $totalCount neurons failed to update. Please try again later. You can always change neuron visibility settings under \"Advanced Details & Settings\".",
-    "change_neuron_visibility_failure": "All neurons have failed to update their visibility. Please try again later. You can always change neuron visibility settings under \"Advanced Details & Settings\"."
+    "change_neuron_visibility_partial_failure": "$failedCount out of $totalCount neurons have failed to update their visibility, please try again later. You can always change neuron visibility under \"Advanced Details & Settings\".",
+    "change_neuron_visibility_failure": "Your neurons have failed to update their visibility, please try again later. You can always change neuron visibility under \"Advanced Details & Settings\"."
   },
   "sns_launchpad": {
     "header": "Launchpad",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -687,7 +687,9 @@
     "amount_maturity": "$amount maturity",
     "created": "Date Created",
     "neuron_state_tooltip": "Your neuron can be locked, unlocked or dissolving. In a locked state, it is accruing age bonus, while its dissolve delay stays constant. If the neuron is in a dissolving state, its age bonus is set to 0, while dissolve delay decreases with time. After dissolve delay reaches 0, the neuron is unlocked, and $token held in it can be sent to any $token account.",
-    "dissolve_delay_tooltip": "Dissolve delay is the minimum amount of time you have to wait for the neuron to unlock, and $token to be available again. If your neuron is dissolving, your $token will be available in $duration."
+    "dissolve_delay_tooltip": "Dissolve delay is the minimum amount of time you have to wait for the neuron to unlock, and $token to be available again. If your neuron is dissolving, your $token will be available in $duration.",
+    "change_neuron_visibility_partial_failure": "$failedCount of $totalCount neurons failed to update. Please try again later. You can always change neuron visibility settings under \"Advanced Details & Settings\".",
+    "change_neuron_visibility_failure": "All neurons have failed to update their visibility. Please try again later. You can always change neuron visibility settings under \"Advanced Details & Settings\"."
   },
   "sns_launchpad": {
     "header": "Launchpad",

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -1021,7 +1021,7 @@ export const changeNeuronVisibility = async ({
   neurons: NeuronInfo[];
   makePublic: boolean;
 }): Promise<{ success: boolean }> => {
-  const results = await Promise.allSettled(
+  const results = await Promise.all(
     neurons.map(async (neuron) => {
       try {
         const identity: Identity = await getIdentityOfControllerByNeuronId(
@@ -1046,9 +1046,7 @@ export const changeNeuronVisibility = async ({
     })
   );
 
-  const failedCount = results.filter(
-    (result) => result.status === "rejected" || result.value === false
-  ).length;
+  const failedCount = results.filter((result) => result === false).length;
 
   if (failedCount === 0) {
     return { success: true };

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -332,7 +332,12 @@ interface I18nNeurons {
   merge_neurons_more_info: string;
   stake_amount: string;
   state: string;
-  public: string;
+  public_neuron_tooltip: string;
+  public_neuron: string;
+  private_neuron: string;
+  public_neuron_description: string;
+  private_neuron_description: string;
+  learn_more: string;
 }
 
 interface I18nNew_followee {
@@ -714,6 +719,8 @@ interface I18nNeuron_detail {
   created: string;
   neuron_state_tooltip: string;
   dissolve_delay_tooltip: string;
+  change_neuron_visibility_partial_failure: string;
+  change_neuron_visibility_failure: string;
 }
 
 interface I18nSns_launchpad {

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -332,12 +332,7 @@ interface I18nNeurons {
   merge_neurons_more_info: string;
   stake_amount: string;
   state: string;
-  public_neuron_tooltip: string;
-  public_neuron: string;
-  private_neuron: string;
-  public_neuron_description: string;
-  private_neuron_description: string;
-  learn_more: string;
+  public: string;
 }
 
 interface I18nNew_followee {

--- a/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
+++ b/frontend/src/tests/lib/api-services/governance.api-service.spec.ts
@@ -15,7 +15,7 @@ import {
 } from "$tests/mocks/neurons.mock";
 import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
-import { Topic, Vote } from "@dfinity/nns";
+import { NeuronVisibility, Topic, Vote } from "@dfinity/nns";
 import type { RewardEvent } from "@dfinity/nns/dist/candid/governance";
 import type { Mock } from "vitest";
 
@@ -1082,6 +1082,36 @@ describe("neurons api-service", () => {
       await shouldInvalidateCacheOnFailure({
         apiFunc: api.registerVote,
         apiServiceFunc: governanceApiService.registerVote,
+        params,
+      });
+    });
+  });
+
+  describe("changeNeuronVisibility", () => {
+    const params: api.ApiChangeNeuronVisibilityParams = {
+      neuronIds: [neuronId],
+      identity: mockIdentity,
+      visibility: NeuronVisibility.Public,
+    };
+
+    it("should call changeNeuronVisibility api", () => {
+      governanceApiService.changeNeuronVisibility(params);
+      expect(api.changeNeuronVisibility).toHaveBeenCalledWith(params);
+      expect(api.changeNeuronVisibility).toHaveBeenCalledTimes(1);
+    });
+
+    it("should invalidate the cache", async () => {
+      await shouldInvalidateCache({
+        apiFunc: api.changeNeuronVisibility,
+        apiServiceFunc: governanceApiService.changeNeuronVisibility,
+        params,
+      });
+    });
+
+    it("should invalidate the cache on failure", async () => {
+      await shouldInvalidateCacheOnFailure({
+        apiFunc: api.changeNeuronVisibility,
+        apiServiceFunc: governanceApiService.changeNeuronVisibility,
         params,
       });
     });

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -741,6 +741,8 @@ describe("neurons-api", () => {
     const visibility = NeuronVisibility.Public;
 
     it("changes visibility for multiple neurons", async () => {
+      expect(mockGovernanceCanister.setVisibility).not.toHaveBeenCalled();
+
       mockGovernanceCanister.setVisibility.mockResolvedValue(undefined);
 
       await changeNeuronVisibility({
@@ -759,6 +761,8 @@ describe("neurons-api", () => {
     });
 
     it("throws error when changing visibility fails", async () => {
+      expect(mockGovernanceCanister.setVisibility).not.toHaveBeenCalled();
+
       const error = new Error("Visibility change failed");
       mockGovernanceCanister.setVisibility.mockRejectedValue(error);
 

--- a/frontend/src/tests/lib/api/governance.api.spec.ts
+++ b/frontend/src/tests/lib/api/governance.api.spec.ts
@@ -1,6 +1,7 @@
 import {
   addHotkey,
   autoStakeMaturity,
+  changeNeuronVisibility,
   disburse,
   increaseDissolveDelay,
   joinCommunityFund,
@@ -27,7 +28,12 @@ import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import type { Agent } from "@dfinity/agent";
 import { LedgerCanister } from "@dfinity/ledger-icp";
-import { GovernanceCanister, Topic, Vote } from "@dfinity/nns";
+import {
+  GovernanceCanister,
+  NeuronVisibility,
+  Topic,
+  Vote,
+} from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { mock } from "vitest-mock-extended";
 
@@ -727,6 +733,44 @@ describe("neurons-api", () => {
       expect(mockGovernanceCanister.getLastestRewardEvent).toHaveBeenCalledWith(
         certified
       );
+    });
+  });
+
+  describe("changeNeuronVisibility", () => {
+    const neuronIds = [10n, 20n, 30n];
+    const visibility = NeuronVisibility.Public;
+
+    it("changes visibility for multiple neurons", async () => {
+      mockGovernanceCanister.setVisibility.mockResolvedValue(undefined);
+
+      await changeNeuronVisibility({
+        neuronIds,
+        visibility,
+        identity: mockIdentity,
+      });
+
+      expect(mockGovernanceCanister.setVisibility).toHaveBeenCalledTimes(3);
+      neuronIds.forEach((neuronId) => {
+        expect(mockGovernanceCanister.setVisibility).toHaveBeenCalledWith(
+          neuronId,
+          visibility
+        );
+      });
+    });
+
+    it("throws error when changing visibility fails", async () => {
+      const error = new Error("Visibility change failed");
+      mockGovernanceCanister.setVisibility.mockRejectedValue(error);
+
+      await expect(
+        changeNeuronVisibility({
+          neuronIds,
+          visibility,
+          identity: mockIdentity,
+        })
+      ).rejects.toThrow(error);
+
+      expect(mockGovernanceCanister.setVisibility).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -1923,7 +1923,7 @@ describe("neurons-services", () => {
       expect(spyChangeNeuronVisibility).toBeCalledTimes(2);
       expect(spyGetNeuron).toBeCalledTimes(1);
       expectToastError(
-        '1 of 2 neurons failed to update. Please try again later. You can always change neuron visibility settings under "Advanced Details & Settings".'
+        '1 out of 2 neurons have failed to update their visibility, please try again later. You can always change neuron visibility under "Advanced Details & Settings".'
       );
     });
 
@@ -1942,7 +1942,7 @@ describe("neurons-services", () => {
       expect(spyChangeNeuronVisibility).toBeCalledTimes(1);
       expect(spyGetNeuron).not.toBeCalled();
       expectToastError(
-        'All neurons have failed to update their visibility. Please try again later. You can always change neuron visibility settings under "Advanced Details & Settings".'
+        'Your neurons have failed to update their visibility, please try again later. You can always change neuron visibility under "Advanced Details & Settings".'
       );
     });
 

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -1863,7 +1863,10 @@ describe("neurons-services", () => {
   });
 
   describe("changeNeuronVisibility", () => {
-    it("should change visibility to public for all neurons", async () => {
+    it("should call changeNeuronVisibility and getNeuron", async () => {
+      expect(spyChangeNeuronVisibility).not.toHaveBeenCalled();
+      expect(spyGetNeuron).not.toHaveBeenCalled();
+
       neuronsStore.setNeurons({ neurons: [controlledNeuron], certified: true });
 
       const { success } = await changeNeuronVisibility({
@@ -1882,6 +1885,8 @@ describe("neurons-services", () => {
     });
 
     it("should change visibility to private for all neurons", async () => {
+      expect(spyChangeNeuronVisibility).not.toHaveBeenCalled();
+      expect(spyGetNeuron).not.toHaveBeenCalled();
       neuronsStore.setNeurons({ neurons: [controlledNeuron], certified: true });
 
       const { success } = await changeNeuronVisibility({
@@ -1900,6 +1905,8 @@ describe("neurons-services", () => {
     });
 
     it("should handle partial failure", async () => {
+      expect(spyChangeNeuronVisibility).not.toHaveBeenCalled();
+      expect(spyGetNeuron).not.toHaveBeenCalled();
       const neuron1 = { ...controlledNeuron, neuronId: 1n };
       const neuron2 = { ...controlledNeuron, neuronId: 2n };
       neuronsStore.setNeurons({ neurons: [neuron1, neuron2], certified: true });
@@ -1921,6 +1928,8 @@ describe("neurons-services", () => {
     });
 
     it("should handle complete failure", async () => {
+      expect(spyChangeNeuronVisibility).not.toHaveBeenCalled();
+      expect(spyGetNeuron).not.toHaveBeenCalled();
       neuronsStore.setNeurons({ neurons: [controlledNeuron], certified: true });
       spyChangeNeuronVisibility.mockRejectedValue(new Error("Test error"));
 
@@ -1938,6 +1947,8 @@ describe("neurons-services", () => {
     });
 
     it("should handle multiple neurons", async () => {
+      expect(spyChangeNeuronVisibility).not.toHaveBeenCalled();
+      expect(spyGetNeuron).not.toHaveBeenCalled();
       const neuron1 = { ...controlledNeuron, neuronId: 1n };
       const neuron2 = { ...controlledNeuron, neuronId: 2n };
       neuronsStore.setNeurons({ neurons: [neuron1, neuron2], certified: true });

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -40,7 +40,7 @@ import type { Identity } from "@dfinity/agent";
 import { AnonymousIdentity } from "@dfinity/agent";
 import { toastsStore } from "@dfinity/gix-components";
 import { LedgerCanister } from "@dfinity/ledger-icp";
-import { Topic, type NeuronInfo } from "@dfinity/nns";
+import { NeuronVisibility, Topic, type NeuronInfo } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
 import { LedgerError, type ResponseVersion } from "@zondax/ledger-icp";
 import { tick } from "svelte";
@@ -65,6 +65,7 @@ const {
   simulateMergeNeurons,
   reloadNeuron,
   topUpNeuron,
+  changeNeuronVisibility,
 } = services;
 
 const expectToastError = (contained: string) =>
@@ -159,6 +160,7 @@ describe("neurons-services", () => {
   const spyStopDissolving = vi.spyOn(api, "stopDissolving");
   const spySetFollowees = vi.spyOn(api, "setFollowees");
   const spyClaimOrRefresh = vi.spyOn(api, "claimOrRefreshNeuron");
+  const spyChangeNeuronVisibility = vi.spyOn(api, "changeNeuronVisibility");
 
   beforeEach(() => {
     spyGetNeuron.mockClear();
@@ -197,6 +199,7 @@ describe("neurons-services", () => {
     spyStopDissolving.mockResolvedValue();
     spySetFollowees.mockResolvedValue();
     spyClaimOrRefresh.mockResolvedValue(undefined);
+    spyChangeNeuronVisibility.mockResolvedValue(undefined);
     resetIdentity();
     vi.spyOn(authServices, "getAuthenticatedIdentity").mockImplementation(
       mockGetIdentity
@@ -1856,6 +1859,97 @@ describe("neurons-services", () => {
       expect(transferICP).not.toBeCalled();
       expect(spyClaimOrRefresh).not.toBeCalled();
       expect(spyGetNeuron).not.toBeCalled();
+    });
+  });
+
+  describe("changeNeuronVisibility", () => {
+    it("should change visibility to public for all neurons", async () => {
+      neuronsStore.setNeurons({ neurons: [controlledNeuron], certified: true });
+
+      const { success } = await changeNeuronVisibility({
+        neurons: [controlledNeuron],
+        makePublic: true,
+      });
+
+      expect(success).toBe(true);
+      expect(spyChangeNeuronVisibility).toBeCalledWith({
+        neuronIds: [controlledNeuron.neuronId],
+        identity: mockIdentity,
+        visibility: NeuronVisibility.Public,
+      });
+      expect(spyChangeNeuronVisibility).toBeCalledTimes(1);
+      expect(spyGetNeuron).toBeCalled();
+    });
+
+    it("should change visibility to private for all neurons", async () => {
+      neuronsStore.setNeurons({ neurons: [controlledNeuron], certified: true });
+
+      const { success } = await changeNeuronVisibility({
+        neurons: [controlledNeuron],
+        makePublic: false,
+      });
+
+      expect(success).toBe(true);
+      expect(spyChangeNeuronVisibility).toBeCalledWith({
+        neuronIds: [controlledNeuron.neuronId],
+        identity: mockIdentity,
+        visibility: NeuronVisibility.Private,
+      });
+      expect(spyChangeNeuronVisibility).toBeCalledTimes(1);
+      expect(spyGetNeuron).toBeCalled();
+    });
+
+    it("should handle partial failure", async () => {
+      const neuron1 = { ...controlledNeuron, neuronId: 1n };
+      const neuron2 = { ...controlledNeuron, neuronId: 2n };
+      neuronsStore.setNeurons({ neurons: [neuron1, neuron2], certified: true });
+
+      spyChangeNeuronVisibility.mockResolvedValueOnce(undefined);
+      spyChangeNeuronVisibility.mockRejectedValueOnce(new Error("Test error"));
+
+      const { success } = await changeNeuronVisibility({
+        neurons: [neuron1, neuron2],
+        makePublic: true,
+      });
+
+      expect(success).toBe(false);
+      expect(spyChangeNeuronVisibility).toBeCalledTimes(2);
+      expect(spyGetNeuron).toBeCalledTimes(1);
+      expectToastError(
+        '1 of 2 neurons failed to update. Please try again later. You can always change neuron visibility settings under "Advanced Details & Settings".'
+      );
+    });
+
+    it("should handle complete failure", async () => {
+      neuronsStore.setNeurons({ neurons: [controlledNeuron], certified: true });
+      spyChangeNeuronVisibility.mockRejectedValue(new Error("Test error"));
+
+      const { success } = await changeNeuronVisibility({
+        neurons: [controlledNeuron],
+        makePublic: true,
+      });
+
+      expect(success).toBe(false);
+      expect(spyChangeNeuronVisibility).toBeCalledTimes(1);
+      expect(spyGetNeuron).not.toBeCalled();
+      expectToastError(
+        'All neurons have failed to update their visibility. Please try again later. You can always change neuron visibility settings under "Advanced Details & Settings".'
+      );
+    });
+
+    it("should handle multiple neurons", async () => {
+      const neuron1 = { ...controlledNeuron, neuronId: 1n };
+      const neuron2 = { ...controlledNeuron, neuronId: 2n };
+      neuronsStore.setNeurons({ neurons: [neuron1, neuron2], certified: true });
+
+      const { success } = await changeNeuronVisibility({
+        neurons: [neuron1, neuron2],
+        makePublic: true,
+      });
+
+      expect(success).toBe(true);
+      expect(spyChangeNeuronVisibility).toBeCalledTimes(2);
+      expect(spyGetNeuron).toBeCalledTimes(2);
     });
   });
 });

--- a/frontend/src/tests/mocks/modal.mock.ts
+++ b/frontend/src/tests/mocks/modal.mock.ts
@@ -6,7 +6,7 @@ import {
 import ContextWrapperTest from "$tests/lib/components/ContextWrapperTest.svelte";
 import type { RenderResult } from "@testing-library/svelte";
 import { render, waitFor } from "@testing-library/svelte";
-import type { ComponentProps, ComponentType, SvelteComponent } from "svelte";
+import type { SvelteComponent } from "svelte";
 import { writable } from "svelte/store";
 
 // TODO: rename and move this modal.mock.ts to modal.test-utils.ts
@@ -27,13 +27,14 @@ export const waitModalIntroEnd = async ({
 
 export const modalToolbarSelector = "div.content";
 
-export const renderModal = async <T extends SvelteComponent>({
+export const renderModal = async ({
   component,
   props,
 }: {
-  component: ComponentType<T>;
-  props?: ComponentProps<T>;
-}): Promise<RenderResult<T>> => {
+  component: typeof SvelteComponent;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  props?: Record<string, any>;
+}): Promise<RenderResult<SvelteComponent>> => {
   const modal = render(component, {
     props,
   });

--- a/frontend/src/tests/mocks/modal.mock.ts
+++ b/frontend/src/tests/mocks/modal.mock.ts
@@ -6,7 +6,7 @@ import {
 import ContextWrapperTest from "$tests/lib/components/ContextWrapperTest.svelte";
 import type { RenderResult } from "@testing-library/svelte";
 import { render, waitFor } from "@testing-library/svelte";
-import type { SvelteComponent } from "svelte";
+import type { ComponentProps, ComponentType, SvelteComponent } from "svelte";
 import { writable } from "svelte/store";
 
 // TODO: rename and move this modal.mock.ts to modal.test-utils.ts
@@ -27,14 +27,13 @@ export const waitModalIntroEnd = async ({
 
 export const modalToolbarSelector = "div.content";
 
-export const renderModal = async ({
+export const renderModal = async <T extends SvelteComponent>({
   component,
   props,
 }: {
-  component: typeof SvelteComponent;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  props?: Record<string, any>;
-}): Promise<RenderResult<SvelteComponent>> => {
+  component: ComponentType<T>;
+  props?: ComponentProps<T>;
+}): Promise<RenderResult<T>> => {
   const modal = render(component, {
     props,
   });


### PR DESCRIPTION
# Motivation

To have a method in api and services to be able to update neruonVisibility in the app

# Changes

governance api, services and neurons services has been updated.
Test are updated accordingly
i18n en.json entry and types have been updated.

# Tests

New tests are added to cover changeNeuronVisibility method.

# Todos

- [ ] Add entry to changelog (if necessary).
