### PR TITLE
Fix not loaded balances on failed imported

### DIFF
--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -196,7 +196,7 @@ export const loadAccounts = async ({
       }
 
       // hide unproven data
-      icrcAccountsStore.reset();
+      icrcAccountsStore.resetUniverse(ledgerCanisterId);
       icrcTransactionsStore.resetUniverse(ledgerCanisterId);
 
       if (

--- a/frontend/src/lib/stores/icrc-accounts.store.ts
+++ b/frontend/src/lib/stores/icrc-accounts.store.ts
@@ -1,4 +1,5 @@
 import type { Account } from "$lib/types/account";
+import { removeKeys } from "$lib/utils/utils";
 import type { Principal } from "@dfinity/principal";
 import type { Readable } from "svelte/store";
 import { writable } from "svelte/store";
@@ -21,6 +22,7 @@ export interface IcrcAccountsStore extends Readable<IcrcAccountStoreData> {
     accounts: IcrcAccounts;
     ledgerCanisterId: Principal;
   }) => void;
+  resetUniverse: (ledgerCanisterId: Principal) => void;
   reset: () => void;
 }
 
@@ -70,6 +72,15 @@ const initIcrcAccountsStore = (): IcrcAccountsStore => {
           certified,
         },
       }));
+    },
+
+    resetUniverse: (ledgerCanisterId: Principal) => {
+      update((currentState: IcrcAccountStoreData) =>
+        removeKeys({
+          obj: currentState,
+          keysToRemove: [ledgerCanisterId.toText()],
+        })
+      );
     },
 
     reset: () => set(initialAccounts),

--- a/frontend/src/tests/lib/stores/icrc-accounts.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icrc-accounts.store.spec.ts
@@ -11,6 +11,7 @@ import {
   mockSnsSubAccount,
 } from "$tests/mocks/sns-accounts.mock";
 import { get } from "svelte/store";
+import { principal } from "../../mocks/sns-projects.mock";
 
 describe("icrc Accounts store", () => {
   afterEach(() => icrcAccountsStore.reset());
@@ -87,5 +88,51 @@ describe("icrc Accounts store", () => {
       accounts: [mockSnsMainAccount, updateSnsSubAccount],
       certified: true,
     });
+  });
+
+  it("should reset for a project", () => {
+    const ledgerCanisterId1 = principal(0);
+    const ledgerCanisterId2 = principal(1);
+    const accounts: Account[] = [mockSnsMainAccount, mockSnsSubAccount];
+    icrcAccountsStore.set({
+      accounts: {
+        accounts,
+        certified: true,
+      },
+      ledgerCanisterId: ledgerCanisterId1,
+    });
+    icrcAccountsStore.set({
+      accounts: {
+        accounts,
+        certified: false,
+      },
+      ledgerCanisterId: ledgerCanisterId2,
+    });
+
+    expect(get(icrcAccountsStore)[ledgerCanisterId1.toText()]).toEqual({
+      accounts,
+      certified: true,
+    });
+    expect(get(icrcAccountsStore)[ledgerCanisterId2.toText()]).toEqual({
+      accounts,
+      certified: false,
+    });
+
+    icrcAccountsStore.resetUniverse(ledgerCanisterId1);
+    expect(get(icrcAccountsStore)[ledgerCanisterId1.toText()]).toEqual(
+      undefined
+    );
+    expect(get(icrcAccountsStore)[ledgerCanisterId2.toText()]).toEqual({
+      accounts,
+      certified: false,
+    });
+
+    icrcAccountsStore.resetUniverse(ledgerCanisterId2);
+    expect(get(icrcAccountsStore)[ledgerCanisterId1.toText()]).toEqual(
+      undefined
+    );
+    expect(get(icrcAccountsStore)[ledgerCanisterId2.toText()]).toEqual(
+      undefined
+    );
   });
 });

--- a/frontend/src/tests/lib/stores/icrc-accounts.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icrc-accounts.store.spec.ts
@@ -109,30 +109,26 @@ describe("icrc Accounts store", () => {
       ledgerCanisterId: ledgerCanisterId2,
     });
 
-    expect(get(icrcAccountsStore)[ledgerCanisterId1.toText()]).toEqual({
-      accounts,
-      certified: true,
-    });
-    expect(get(icrcAccountsStore)[ledgerCanisterId2.toText()]).toEqual({
-      accounts,
-      certified: false,
+    expect(get(icrcAccountsStore)).toEqual({
+      [ledgerCanisterId1.toText()]: {
+        accounts,
+        certified: true,
+      },
+      [ledgerCanisterId2.toText()]: {
+        accounts,
+        certified: false,
+      },
     });
 
     icrcAccountsStore.resetUniverse(ledgerCanisterId1);
-    expect(get(icrcAccountsStore)[ledgerCanisterId1.toText()]).toEqual(
-      undefined
-    );
-    expect(get(icrcAccountsStore)[ledgerCanisterId2.toText()]).toEqual({
-      accounts,
-      certified: false,
+    expect(get(icrcAccountsStore)).toEqual({
+      [ledgerCanisterId2.toText()]: {
+        accounts,
+        certified: false,
+      },
     });
 
     icrcAccountsStore.resetUniverse(ledgerCanisterId2);
-    expect(get(icrcAccountsStore)[ledgerCanisterId1.toText()]).toEqual(
-      undefined
-    );
-    expect(get(icrcAccountsStore)[ledgerCanisterId2.toText()]).toEqual(
-      undefined
-    );
+    expect(get(icrcAccountsStore)).toEqual({});
   });
 });

--- a/frontend/src/tests/lib/stores/icrc-accounts.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icrc-accounts.store.spec.ts
@@ -10,8 +10,8 @@ import {
   mockSnsMainAccount,
   mockSnsSubAccount,
 } from "$tests/mocks/sns-accounts.mock";
+import { principal } from "$tests/mocks/sns-projects.mock";
 import { get } from "svelte/store";
-import { principal } from "../../mocks/sns-projects.mock";
 
 describe("icrc Accounts store", () => {
   afterEach(() => icrcAccountsStore.reset());


### PR DESCRIPTION
# Motivation

When testing under real network conditions (not locally), there’s a high chance that when a call fails, some unrelated balances in the tokens table will display a loading state, even though all of them were successfully loaded. The reason for this behaviour is that, on a failed call (e.g. failed imported token) in the `loadAccounts` function, the whole accounts store gets reset.

To reproduce, there should be at least one failed imported token in the table.

Presumably, this was implemented this way because initially, [only a single ICRC1 token](https://github.com/dfinity/nns-dapp/pull/1918/files#diff-4be3667b0d4ed46a702674d48f6e1e4c2b18ef0bf68e2e89170d78ea1bf22758R48) was supported by the NNS dapp.

To avoid this, we now reset the store only for the failed account.

# Changes

- Added `resetUniverse` to `icrcAccountsStore`.
- Use `resetUniverse` instead of `reset` on failed account call.

# Tests

- Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.