### PR TITLE
Disable import button on maximum

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1061,6 +1061,7 @@
     "link_to_dashboard": "https://dashboard.internetcomputer.org/canister/$canisterId",
     "add_index_canister": "Add Index Canister",
     "add_index_description": "Transaction history is not available. To see this token’s transaction history in the NNS dapp, you need to provide an index canister. <strong>Note:</strong> not all tokens have index canisters.",
-    "failed_tooltip": "The NNS dapp couldn’t load an imported token. Please try again later, or contact the developers."
+    "failed_tooltip": "The NNS dapp couldn’t load an imported token. Please try again later, or contact the developers.",
+    "maximum_reached_tooltip": "You can import maximum $max tokens."
   }
 }

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1062,6 +1062,6 @@
     "add_index_canister": "Add Index Canister",
     "add_index_description": "Transaction history is not available. To see this token’s transaction history in the NNS dapp, you need to provide an index canister. <strong>Note:</strong> not all tokens have index canisters.",
     "failed_tooltip": "The NNS dapp couldn’t load an imported token. Please try again later, or contact the developers.",
-    "maximum_reached_tooltip": "You can import maximum $max tokens. You need to remove another token before you can import more."
+    "maximum_reached_tooltip": "You can import maximum $max tokens. You need to remove a token before you can import more."
   }
 }

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1062,6 +1062,6 @@
     "add_index_canister": "Add Index Canister",
     "add_index_description": "Transaction history is not available. To see this token’s transaction history in the NNS dapp, you need to provide an index canister. <strong>Note:</strong> not all tokens have index canisters.",
     "failed_tooltip": "The NNS dapp couldn’t load an imported token. Please try again later, or contact the developers.",
-    "maximum_reached_tooltip": "You can import maximum $max tokens. You need to remove a token before you can import more."
+    "maximum_reached_tooltip": "You've already imported the maximum number of $max tokens. You need to remove another token before you can import more."
   }
 }

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -1062,6 +1062,6 @@
     "add_index_canister": "Add Index Canister",
     "add_index_description": "Transaction history is not available. To see this token’s transaction history in the NNS dapp, you need to provide an index canister. <strong>Note:</strong> not all tokens have index canisters.",
     "failed_tooltip": "The NNS dapp couldn’t load an imported token. Please try again later, or contact the developers.",
-    "maximum_reached_tooltip": "You can import maximum $max tokens."
+    "maximum_reached_tooltip": "You can import maximum $max tokens. You need to remove another token before you can import more."
   }
 }

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -15,6 +15,7 @@
   import { importedTokensStore } from "../stores/imported-tokens.store";
   import { MAX_IMPORTED_TOKENS } from "../constants/imported-tokens.constants";
   import { replacePlaceholders } from "../utils/i18n.utils";
+  import { isImportedToken } from "$lib/utils/imported-tokens.utils";
 
   export let userTokensData: UserToken[];
 

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -69,7 +69,7 @@
       >
     </div>
     <div slot="last-row">
-      {#if $ENABLE_IMPORT_TOKEN && nonNullish($importedTokensStore.importedTokens)}
+      {#if $ENABLE_IMPORT_TOKEN}
         <div class="last-row">
           {#if shouldHideZeroBalances}
             <div class="show-all-button-container">
@@ -84,31 +84,26 @@
             </div>
           {/if}
 
-          {#if maximumImportedTokensReached}
+          {#if nonNullish($importedTokensStore.importedTokens)}
             <Tooltip
+              top
               testId="maximum-imported-tokens-tooltip"
-              text={replacePlaceholders(
-                $i18n.import_token.maximum_reached_tooltip,
-                { $max: `${MAX_IMPORTED_TOKENS}` }
-              )}
+              text={maximumImportedTokensReached
+                ? replacePlaceholders(
+                    $i18n.import_token.maximum_reached_tooltip,
+                    { $max: `${MAX_IMPORTED_TOKENS}` }
+                  )
+                : undefined}
             >
               <button
                 data-tid="import-token-button"
                 class="ghost with-icon import-token-button"
-                disabled
+                on:click={() => (showImportTokenModal = true)}
+                disabled={maximumImportedTokensReached}
               >
                 <IconPlus />{$i18n.import_token.import_token}
               </button>
             </Tooltip>
-          {:else}
-            <button
-              data-tid="import-token-button"
-              class="ghost with-icon import-token-button"
-              on:click={() => (showImportTokenModal = true)}
-              disabled={maximumImportedTokensReached}
-            >
-              <IconPlus />{$i18n.import_token.import_token}
-            </button>
           {/if}
         </div>
       {:else if shouldHideZeroBalances}

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -12,10 +12,9 @@
   import { TokenAmountV2, nonNullish } from "@dfinity/utils";
   import { ENABLE_IMPORT_TOKEN } from "$lib/stores/feature-flags.store";
   import ImportTokenModal from "$lib/modals/accounts/ImportTokenModal.svelte";
-  import { importedTokensStore } from "../stores/imported-tokens.store";
-  import { MAX_IMPORTED_TOKENS } from "../constants/imported-tokens.constants";
-  import { replacePlaceholders } from "../utils/i18n.utils";
-  import { isImportedToken } from "$lib/utils/imported-tokens.utils";
+  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
+  import { MAX_IMPORTED_TOKENS } from "$lib/constants/imported-tokens.constants";
+  import { replacePlaceholders } from "$lib/utils/i18n.utils";
 
   export let userTokensData: UserToken[];
 

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -69,7 +69,7 @@
       >
     </div>
     <div slot="last-row">
-      {#if $ENABLE_IMPORT_TOKEN}
+      {#if $ENABLE_IMPORT_TOKEN && nonNullish($importedTokensStore.importedTokens)}
         <div class="last-row">
           {#if shouldHideZeroBalances}
             <div class="show-all-button-container">

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -1121,6 +1121,7 @@ interface I18nImport_token {
   add_index_canister: string;
   add_index_description: string;
   failed_tooltip: string;
+  maximum_reached_tooltip: string;
 }
 
 interface I18nNeuron_state {

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -1,7 +1,9 @@
+import { MAX_IMPORTED_TOKENS } from "$lib/constants/imported-tokens.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
 import TokensPage from "$lib/pages/Tokens.svelte";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { hideZeroBalancesStore } from "$lib/stores/hide-zero-balances.store";
+import { importedTokensStore } from "$lib/stores/imported-tokens.store";
 import type { UserTokenData } from "$lib/types/tokens-page";
 import { UnavailableTokenAmount } from "$lib/utils/token.utils";
 import { mockSnsToken, principal } from "$tests/mocks/sns-projects.mock";
@@ -12,7 +14,10 @@ import {
 } from "$tests/mocks/tokens-page.mock";
 import { TokensPagePo } from "$tests/page-objects/TokensPage.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
-import { advanceTime } from "$tests/utils/timers.test-utils";
+import {
+  advanceTime,
+  runResolvedPromises,
+} from "$tests/utils/timers.test-utils";
 import { TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 
@@ -65,6 +70,8 @@ describe("Tokens page", () => {
     overrideFeatureFlagsStore.reset();
     hideZeroBalancesStore.resetForTesting();
     vi.useFakeTimers();
+
+    importedTokensStore.set({ importedTokens: [], certified: true });
   });
 
   it("should render the tokens table", async () => {
@@ -211,6 +218,42 @@ describe("Tokens page", () => {
 
       expect(await po.getShowAllButtonPo().isPresent()).toBe(true);
       expect(await po.getImportTokenButtonPo().isPresent()).toBe(true);
+    });
+
+    it("should not display import token button before imported tokens are available", async () => {
+      importedTokensStore.reset();
+      const po = renderPage([]);
+
+      expect(await po.getImportTokenButtonPo().isPresent()).toBe(false);
+
+      importedTokensStore.set({ importedTokens: [], certified: true });
+      await runResolvedPromises();
+      expect(await po.getImportTokenButtonPo().isPresent()).toBe(true);
+    });
+
+    it("should disable import token button when maximum imported", async () => {
+      const setImportedTokens = (count: number) =>
+        importedTokensStore.set({
+          importedTokens: Array.from({ length: count }, (_, i) => ({
+            ledgerCanisterId: principal(i),
+            indexCanisterId: undefined,
+          })),
+          certified: true,
+        });
+
+      setImportedTokens(MAX_IMPORTED_TOKENS - 1);
+      const po = renderPage([]);
+
+      expect(await po.getImportTokenButtonPo().isPresent()).toBe(true);
+      expect(await po.getImportTokenButtonPo().isDisabled()).toBe(false);
+
+      setImportedTokens(MAX_IMPORTED_TOKENS);
+      await runResolvedPromises();
+      expect(await po.getImportTokenButtonPo().isDisabled()).toBe(true);
+
+      setImportedTokens(MAX_IMPORTED_TOKENS + 1);
+      await runResolvedPromises();
+      expect(await po.getImportTokenButtonPo().isDisabled()).toBe(true);
     });
 
     it("should open import token modal", async () => {

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -243,6 +243,7 @@ describe("Tokens page", () => {
 
       setImportedTokens(MAX_IMPORTED_TOKENS - 1);
       const po = renderPage([]);
+      await runResolvedPromises();
 
       expect(await po.getImportTokenButtonPo().isPresent()).toBe(true);
       expect(await po.getImportTokenButtonPo().isDisabled()).toBe(false);


### PR DESCRIPTION
# Motivation

Due to backend validation, it is currently not possible to import more than 20 tokens. To improve the user experience, we disable the import button when the user has already imported the maximum number of custom tokens.

# Changes

- Display a disabled import button when maximum reached.
- Don’t display the import button until the imported tokens have loaded, to ensure its correct status is shown.

# Tests

- Unit tests updated.
- Manually:

| Enabled | Disabled |
|--------|--------|
| <img width="166" alt="image" src="https://github.com/user-attachments/assets/1e3b656f-d9a2-4479-831b-e7fde16ec533"> | <img width="213" alt="image" src="https://github.com/user-attachments/assets/8d35cec2-585a-4759-b21a-2feb66a835d7"> | 


# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.