### PR TITLE
Remove separate uploading of assets from deploy-to-app.yaml

### DIFF
--- a/.github/workflows/deploy-to-app.yaml
+++ b/.github/workflows/deploy-to-app.yaml
@@ -100,24 +100,10 @@ jobs:
         run: |
           set -x
           CANISTER_NAME="nns-dapp"
-          scripts/nns-dapp/split-assets
           # Note: inputs.mode is set if this workflow is run manually, using `workflow_dispatch` defined above.
           #       If the workflow is triggered in another way, the inputs are not defined so we need to specify a default again.
           ARGUMENT="$(cat "out/nns-dapp-arg-${DFX_NETWORK}.did")"
-          # There have been issues with the uploading of assets causing
-          # "heap out of bounds" so we output logs to help debug when it happens
-          # again.
-          # The canister only keeps a small amount of logs so we output them
-          # before and after every step to miss as little as possible.
-          dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
-          dfx canister install --mode "${{ inputs.mode || 'upgrade' }}" --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --argument "$ARGUMENT" --wasm out/nns-dapp_noassets.wasm.gz
-          dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
-          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xaa.tar.xz
-          dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
-          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xab.tar.xz
-          dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
-          ./scripts/nns-dapp/upload-asset-tarball --network "$DFX_NETWORK" --chunk out/chunks/assets.xac.tar.xz
-          dfx canister logs --network "$DFX_NETWORK" "$CANISTER_NAME"
+          dfx canister install --mode "${{ inputs.mode || 'upgrade' }}" --yes --network "$DFX_NETWORK" "$CANISTER_NAME" --argument "$ARGUMENT" --wasm out/nns-dapp.wasm.gz
       - name: Deploy sns_aggregator
         if: (inputs.canisters == 'all') || (inputs.canisters == 'sns_aggregator') || ( github.event_name != 'workflow_dispatch' )
         run: |


### PR DESCRIPTION
# Motivation

The nns-dapp wasm is bigger than 2 MB. When the `deploy-to-app` workflow was created, this meant that the wasm couldn't be installed to an application subnet.
The "real" nns-dapp isn't affected by this because the NNS subnet allows larger messages.
To work around this, a mechanism was implemented to build and install a wasm without assets and upload the assets separately.
This is no longer necessary because the IC now supports uploading the wasm in chunks and then installing the wasm from chunks. `dfx` also supports this transparently.
So we can simply call `dfx` to install the large wasm and everything happens correctly behind the scenes.

# Changes

1. Remove the calls to split the assets.
2. Install the standard wasm instead of the `noassets` wasm.
3. Remove the calls to upload the assets.

# Tests

https://beta.nns.ic0.app/ is working again because it was installed and upgraded this way:
* reinstall: https://github.com/dfinity/nns-dapp/actions/runs/11125543897
* upgrade: https://github.com/dfinity/nns-dapp/actions/runs/11125814854

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary