### PR TITLE
Restore console.error spy between tests

### DIFF
--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -161,8 +161,11 @@ describe("neurons-services", () => {
   const spySetFollowees = vi.spyOn(api, "setFollowees");
   const spyClaimOrRefresh = vi.spyOn(api, "claimOrRefreshNeuron");
   const spyChangeNeuronVisibility = vi.spyOn(api, "changeNeuronVisibility");
+  let spyConsoleError;
 
   beforeEach(() => {
+    spyConsoleError?.mockRestore();
+    spyConsoleError = vi.spyOn(console, "error");
     spyGetNeuron.mockClear();
     vi.clearAllMocks();
     neuronsStore.reset();
@@ -1636,7 +1639,6 @@ describe("neurons-services", () => {
     });
 
     it("should call the api to get neuron if not in store", async () => {
-      vi.spyOn(console, "error").mockReturnValue();
       expect(spyGetNeuron).not.toBeCalled();
       await loadNeuron({
         neuronId: mockNeuron.neuronId,
@@ -1905,6 +1907,7 @@ describe("neurons-services", () => {
     });
 
     it("should handle partial failure", async () => {
+      spyConsoleError.mockReturnValue();
       expect(spyChangeNeuronVisibility).not.toHaveBeenCalled();
       expect(spyGetNeuron).not.toHaveBeenCalled();
       const neuron1 = { ...controlledNeuron, neuronId: 1n };
@@ -1928,6 +1931,7 @@ describe("neurons-services", () => {
     });
 
     it("should handle complete failure", async () => {
+      spyConsoleError.mockReturnValue();
       expect(spyChangeNeuronVisibility).not.toHaveBeenCalled();
       expect(spyGetNeuron).not.toHaveBeenCalled();
       neuronsStore.setNeurons({ neurons: [controlledNeuron], certified: true });


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/5553 added 2 tests that produce `console.error()` output.
They relied on a third test, that mocks out `console.error` to be run first so that the logging is ignored.
So these tests fail when run in isolation.
And the third test didn't even need `console.error` to be mocked out.

# Changes

1. Restore and recreate the `console.error` spy before each test.
2. Remove mocking `console.error` from the test that doesn't need it.
3. Add mocking `console.error` to the tests that do need it.

# Tests

Tests only

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary