### PR TITLE
close account menu before directing to canisters page

### DIFF
--- a/frontend/src/lib/components/header/AccountMenu.svelte
+++ b/frontend/src/lib/components/header/AccountMenu.svelte
@@ -36,7 +36,7 @@
 
         <SettingsButton on:nnsLink={() => (visible = false)} />
 
-        <LinkToCanisters on:nnsLink={() => (visible = false)} />
+        <LinkToCanisters on:closeMenu={() => (visible = false)} />
 
         <Logout on:nnsLogoutTriggered={toggle} />
       </div>

--- a/frontend/src/lib/components/header/AccountMenu.svelte
+++ b/frontend/src/lib/components/header/AccountMenu.svelte
@@ -36,7 +36,7 @@
 
         <SettingsButton on:nnsLink={() => (visible = false)} />
 
-        <LinkToCanisters />
+        <LinkToCanisters on:nnsLink={() => (visible = false)} />
 
         <Logout on:nnsLogoutTriggered={toggle} />
       </div>

--- a/frontend/src/lib/components/header/LinkToCanisters.svelte
+++ b/frontend/src/lib/components/header/LinkToCanisters.svelte
@@ -1,10 +1,25 @@
 <script lang="ts">
   import { i18n } from "$lib/stores/i18n";
   import { IconExplore } from "@dfinity/gix-components";
-  import { canistersPathStore } from "$lib/derived/paths.derived";
+  import { goto } from "$app/navigation";
+  import { createEventDispatcher } from "svelte";
+  import { AppPath } from "$lib/constants/routes.constants";
+
+  const dispatcher = createEventDispatcher();
+
+  function navigateToCanisters(event: MouseEvent) {
+    event.preventDefault();
+    goto(AppPath.Canisters);
+    dispatcher("closeMenu");
+  }
 </script>
 
-<a data-tid="canisters-button" href={$canistersPathStore} class="text">
+<a
+  data-tid="canisters-button"
+  href={AppPath.Canisters}
+  on:click={navigateToCanisters}
+  class="text"
+>
   <IconExplore />
   {$i18n.navigation.canisters}
 </a>

--- a/frontend/src/lib/components/header/LinkToCanisters.svelte
+++ b/frontend/src/lib/components/header/LinkToCanisters.svelte
@@ -3,20 +3,20 @@
   import { IconExplore } from "@dfinity/gix-components";
   import { goto } from "$app/navigation";
   import { createEventDispatcher } from "svelte";
-  import { AppPath } from "$lib/constants/routes.constants";
+  import { canistersPathStore } from "$lib/derived/paths.derived";
 
   const dispatcher = createEventDispatcher();
 
   function navigateToCanisters(event: MouseEvent) {
     event.preventDefault();
-    goto(AppPath.Canisters);
+    goto($canistersPathStore);
     dispatcher("closeMenu");
   }
 </script>
 
 <a
   data-tid="canisters-button"
-  href={AppPath.Canisters}
+  href={$canistersPathStore}
   on:click={navigateToCanisters}
   class="text"
 >


### PR DESCRIPTION
# Motivation

Fix reload issue of canister button click

# Changes

New onclick event added to LinkToCanisters which also closes account menu modal and prevent defaults


# Tests

Currently pages from account menu is rendered like an overlay which makes the app look like it is broken.

https://github.com/user-attachments/assets/3c083202-7c67-49bb-bdf3-6c13eb596cec

The recording of just using the old LinkToCanisters button in MenuItems instead of AccountMenu:

https://github.com/user-attachments/assets/30fee6c9-d84d-4480-88a0-6acc67432535


# Todos

- [ ] Add entry to changelog (if necessary).
