### PR TITLE
Fix uncertified error in loadIcrcToken

### DIFF
--- a/frontend/src/lib/services/icrc-accounts.services.ts
+++ b/frontend/src/lib/services/icrc-accounts.services.ts
@@ -20,7 +20,6 @@ import { toastsError } from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import type { Account } from "$lib/types/account";
 import type { IcrcTokenMetadata } from "$lib/types/icrc";
-import { notForceCallStrategy } from "$lib/utils/env.utils";
 import { toToastError } from "$lib/utils/error.utils";
 import { isImportedToken } from "$lib/utils/imported-tokens.utils";
 import { ledgerErrorToToastError } from "$lib/utils/sns-ledger.utils";
@@ -80,8 +79,10 @@ export const loadIcrcToken = ({
     return;
   }
 
+  const strategy = certified ? FORCE_CALL_STRATEGY : "query";
+
   return queryAndUpdate<IcrcTokenMetadata, unknown>({
-    strategy: certified ? FORCE_CALL_STRATEGY : "query",
+    strategy,
     identityType: "current",
     request: ({ certified, identity }) =>
       queryIcrcToken({
@@ -93,7 +94,7 @@ export const loadIcrcToken = ({
       tokensStore.setToken({ certified, canisterId: ledgerCanisterId, token }),
     onError: ({ error: err, certified }) => {
       // Explicitly handle only UPDATE errors
-      if (!certified && notForceCallStrategy()) {
+      if (!certified && strategy !== "query") {
         return;
       }
 

--- a/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icrc-accounts.services.spec.ts
@@ -490,6 +490,68 @@ describe("icrc-accounts-services", () => {
       expect(get(toastsStore)).toMatchObject([]);
       await loadIcrcToken({ ledgerCanisterId });
       expect(ledgerApi.queryIcrcToken).toBeCalledTimes(2);
+      expect(ledgerApi.queryIcrcToken).toBeCalledWith({
+        certified: false,
+        canisterId: ledgerCanisterId,
+        identity: mockIdentity,
+      });
+      expect(ledgerApi.queryIcrcToken).toBeCalledWith({
+        certified: true,
+        canisterId: ledgerCanisterId,
+        identity: mockIdentity,
+      });
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "Sorry, there was an error loading the token metadata information. test",
+        },
+      ]);
+    });
+
+    it("displays no toast on uncertified error", async () => {
+      vi.spyOn(ledgerApi, "queryIcrcToken").mockImplementation(
+        async ({ certified }) => {
+          if (!certified) {
+            throw new Error("test");
+          }
+          return mockToken;
+        }
+      );
+      expect(ledgerApi.queryIcrcToken).not.toBeCalled();
+      expect(get(toastsStore)).toEqual([]);
+      await loadIcrcToken({ ledgerCanisterId });
+      expect(ledgerApi.queryIcrcToken).toBeCalledTimes(2);
+      expect(ledgerApi.queryIcrcToken).toBeCalledWith({
+        certified: false,
+        canisterId: ledgerCanisterId,
+        identity: mockIdentity,
+      });
+      expect(ledgerApi.queryIcrcToken).toBeCalledWith({
+        certified: true,
+        canisterId: ledgerCanisterId,
+        identity: mockIdentity,
+      });
+      expect(get(toastsStore)).toEqual([]);
+    });
+
+    it("displays a toast on uncertified error for query call", async () => {
+      vi.spyOn(ledgerApi, "queryIcrcToken").mockImplementation(
+        async ({ certified }) => {
+          if (!certified) {
+            throw new Error("test");
+          }
+          return mockToken;
+        }
+      );
+      expect(ledgerApi.queryIcrcToken).not.toBeCalled();
+      expect(get(toastsStore)).toEqual([]);
+      await loadIcrcToken({ ledgerCanisterId, certified: false });
+      expect(ledgerApi.queryIcrcToken).toBeCalledTimes(1);
+      expect(ledgerApi.queryIcrcToken).toBeCalledWith({
+        certified: false,
+        canisterId: ledgerCanisterId,
+        identity: mockIdentity,
+      });
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",

--- a/frontend/src/tests/workflows/Launchpad/ProdLaunchpad.spec.ts
+++ b/frontend/src/tests/workflows/Launchpad/ProdLaunchpad.spec.ts
@@ -1,7 +1,9 @@
 import * as agent from "$lib/api/agent.api";
+import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import * as proposalsApi from "$lib/api/proposals.api";
 import { queryFinalizationStatus } from "$lib/api/sns-sale.api";
 import { authStore } from "$lib/stores/auth.store";
+import { mockToken } from "$tests/mocks/sns-projects.mock";
 import { LaunchpadPo } from "$tests/page-objects/Launchpad.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import Launchpad from "$tests/workflows/Launchpad/LaunchpadWithLayout.svelte";
@@ -32,6 +34,8 @@ describe("Launchpad", () => {
 
     // TODO: agent mocked because some calls to global.fetch were exposed when we migrated to agent-js v0.20.2
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
+
+    vi.spyOn(icrcLedgerApi, "queryIcrcToken").mockResolvedValue(mockToken);
 
     // Depends on the `snsAggregatorUrl` set in `vi-setup.ts`.
     const aggUrlRegex =


### PR DESCRIPTION
# Motivation

In `loadIcrcToken` we try to ignore errors on query calls if there is also an update call.
For this we use the following logic:
```
      if (!certified && notForceCallStrategy()) {
        return;
      }
```
This assumes that we make an update call unless `notForceCallStrategy()` returns `false`.

But it's also possible to pass `certified: false` into `loadIcrcToken` and then we also don't make an update call, but the error is still skipped on query calls so in that case we ignore all errors.

# Changes

1. Take the `certified` that's passed `loadIcrcToken` into into account to determine whether to ignore errors.

# Tests

1. Add unit tests for `loadIcrcToken`.
2. Mock `queryIcrcToken` in `workflows/Launchpad/ProdLaunchpad.spec.ts` as it is now showing errors that were always there about not being able to destructure its result.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary