### PR TITLE
NNS1-3377 Update menu footer as we no longer adjust padding here

### DIFF
--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -121,10 +121,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--padding);
-    // To accomodate the 100% on-chain logo
-    // if that logo changes please update this margin as well
-    margin: auto var(--padding-3x) calc(var(--padding-8x) + var(--padding-1_5x))
-      0;
+    margin: auto var(--padding-3x) 0 0;
     // Handle menu collapse animation
     visibility: visible;
     opacity: 1;


### PR DESCRIPTION
# Motivation

Make menu scrollable on smaller screens 

# Changes

menu footer paddings are adjusted as they are no longer controlled here, but [here ](https://github.com/dfinity/gix-components/pull/492)

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

# Todos

- [ ] Add entry to changelog (if necessary).
