### PR TITLE
Remove mockAuthStoreSubscribe

### DIFF
--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.spec.ts
@@ -1,10 +1,6 @@
 import NeuronFollowingCard from "$lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.svelte";
 import { listKnownNeurons } from "$lib/services/known-neurons.services";
-import { authStore } from "$lib/stores/auth.store";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { Topic, type NeuronInfo } from "@dfinity/nns";
@@ -33,7 +29,7 @@ describe("NeuronFollowingCard", () => {
     },
   };
   beforeEach(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   afterEach(() => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsAvailableMaturityItemAction.spec.ts
@@ -1,9 +1,5 @@
 import NnsAvailableMaturityItemAction from "$lib/components/neuron-detail/NnsAvailableMaturityItemAction.svelte";
-import { authStore } from "$lib/stores/auth.store";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import {
   mockHardwareWalletAccount,
@@ -35,7 +31,7 @@ describe("NnsAvailableMaturityItemAction", () => {
   };
 
   beforeEach(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
     resetAccountsForTesting();
   });
 

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronAdvancedSection.spec.ts
@@ -3,13 +3,9 @@ import {
   SECONDS_IN_FOUR_YEARS,
   SECONDS_IN_MONTH,
 } from "$lib/constants/constants";
-import { authStore } from "$lib/stores/auth.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { nnsLatestRewardEventStore } from "$lib/stores/nns-latest-reward-event.store";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import {
   mockHardwareWalletAccount,
@@ -53,7 +49,7 @@ describe("NnsNeuronAdvancedSection", () => {
     overrideFeatureFlagsStore.reset();
     vi.useFakeTimers();
     vi.setSystemTime(nowInSeconds * 1000);
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
     resetAccountsForTesting();
   });
 

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.spec.ts
@@ -1,10 +1,6 @@
 import NnsNeuronDissolveDelayItemAction from "$lib/components/neuron-detail/NnsNeuronDissolveDelayItemAction.svelte";
 import { SECONDS_IN_MONTH, SECONDS_IN_YEAR } from "$lib/constants/constants";
-import { authStore } from "$lib/stores/auth.store";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockHardwareWalletAccount,
   mockMainAccount,
@@ -44,7 +40,7 @@ describe("NnsNeuronDissolveDelayItemAction", () => {
 
   beforeEach(() => {
     resetAccountsForTesting();
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   it("should render dissolve delay text and bonus if neuron is locked", async () => {

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronHotkeysCard.spec.ts
@@ -2,11 +2,7 @@ import NnsNeuronHotkeysCard from "$lib/components/neuron-detail/NnsNeuronHotkeys
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import { removeHotkey } from "$lib/services/neurons.services";
-import { authStore } from "$lib/stores/auth.store";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockFullNeuron, mockNeuron } from "$tests/mocks/neurons.mock";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
@@ -43,7 +39,7 @@ describe("NnsNeuronHotkeysCard", () => {
   };
 
   beforeEach(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
     vi.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronPageHeading.spec.ts
@@ -1,10 +1,6 @@
 import NnsNeuronPageHeading from "$lib/components/neuron-detail/NnsNeuronPageHeading.svelte";
 import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
-import { authStore } from "$lib/stores/auth.store";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockHardwareWalletAccount,
   mockMainAccount,
@@ -28,7 +24,7 @@ describe("NnsNeuronPageHeading", () => {
   };
 
   beforeEach(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
     resetAccountsForTesting();
   });
 

--- a/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NnsNeuronStateItemAction.spec.ts
@@ -1,10 +1,6 @@
 import NnsNeuronStateItemAction from "$lib/components/neuron-detail/NnsNeuronStateItemAction.svelte";
 import { SECONDS_IN_FOUR_YEARS } from "$lib/constants/constants";
-import { authStore } from "$lib/stores/auth.store";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockHardwareWalletAccount,
   mockMainAccount,
@@ -48,7 +44,7 @@ describe("NnsNeuronStateItemAction", () => {
   };
 
   beforeEach(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   it("should render locked text and Start dissolving button if neuron is locked", async () => {

--- a/frontend/src/tests/lib/components/neurons/BallotSummary.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/BallotSummary.spec.ts
@@ -1,7 +1,6 @@
 import * as agent from "$lib/api/agent.api";
 import BallotSummary from "$lib/components/neuron-detail/Ballots/BallotSummary.svelte";
-import { authStore } from "$lib/stores/auth.store";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { MockGovernanceCanister } from "$tests/mocks/governance.canister.mock";
 import { mockProposals } from "$tests/mocks/proposals.store.mock";
 import { BallotSummaryPo } from "$tests/page-objects/BallotSummary.page-object";
@@ -30,7 +29,7 @@ describe("BallotSummary", () => {
       (): GovernanceCanister => mockGovernanceCanister
     );
 
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 

--- a/frontend/src/tests/lib/components/neurons/Ballots.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/Ballots.spec.ts
@@ -1,7 +1,6 @@
 import * as agent from "$lib/api/agent.api";
 import Ballots from "$lib/components/neuron-detail/Ballots/Ballots.svelte";
-import { authStore } from "$lib/stores/auth.store";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { MockGovernanceCanister } from "$tests/mocks/governance.canister.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
@@ -28,7 +27,7 @@ describe("Ballots", () => {
       (): GovernanceCanister => mockGovernanceCanister
     );
 
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 

--- a/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/NnsNeuronCard.spec.ts
@@ -1,11 +1,7 @@
 import NnsNeuronCard from "$lib/components/neurons/NnsNeuronCard.svelte";
 import { SECONDS_IN_YEAR } from "$lib/constants/constants";
-import { authStore } from "$lib/stores/auth.store";
 import { formatTokenE8s } from "$lib/utils/token.utils";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import {
   mockHardwareWalletAccount,
@@ -26,7 +22,7 @@ describe("NnsNeuronCard", () => {
   const nowInSeconds = 1689843195;
   beforeEach(() => {
     vi.useFakeTimers().setSystemTime(nowInSeconds * 1000);
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
 
     resetAccountsForTesting();
   });

--- a/frontend/src/tests/lib/components/neurons/VoteHistoryCard.spec.ts
+++ b/frontend/src/tests/lib/components/neurons/VoteHistoryCard.spec.ts
@@ -1,7 +1,6 @@
 import * as agent from "$lib/api/agent.api";
 import VotingHistoryCard from "$lib/components/neurons/VotingHistoryCard.svelte";
-import { authStore } from "$lib/stores/auth.store";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { MockGovernanceCanister } from "$tests/mocks/governance.canister.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
@@ -40,7 +39,7 @@ describe("VoteHistoryCard", () => {
       (): GovernanceCanister => mockGovernanceCanister
     );
 
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 

--- a/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
+++ b/frontend/src/tests/lib/components/project-detail/ProjectStatusSection.spec.ts
@@ -1,9 +1,8 @@
 import ProjectStatusSection from "$lib/components/project-detail/ProjectStatusSection.svelte";
-import { authStore } from "$lib/stores/auth.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
 import type { SnsSwapCommitment } from "$lib/types/sns";
 import type { SnsSummaryWrapper } from "$lib/types/sns-summary-wrapper";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   createBuyersState,
   mockSnsFullProject,
@@ -19,7 +18,7 @@ describe("ProjectStatusSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     snsTicketsStore.reset();
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   const render = ({

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/SnsVotingCard.spec.ts
@@ -2,15 +2,11 @@ import * as api from "$lib/api/sns-governance.api";
 import * as snsGovernanceApi from "$lib/api/sns-governance.api";
 import SnsVotingCard from "$lib/components/sns-proposals/SnsVotingCard.svelte";
 import { SECONDS_IN_DAY } from "$lib/constants/constants";
-import { authStore } from "$lib/stores/auth.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { votingNeuronSelectStore } from "$lib/stores/vote-registration.store";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { page } from "$mocks/$app/stores";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { createMockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
 import { mockSnsCanisterId } from "$tests/mocks/sns.api.mock";
@@ -114,7 +110,7 @@ describe("SnsVotingCard", () => {
   beforeEach(() => {
     vi.useFakeTimers().setSystemTime(nowInSeconds * 1000);
     snsNeuronsStore.reset();
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
 
     spyOnReloadProposal.mockClear();
     spyRegisterVote.mockClear();

--- a/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingCard.spec.ts
+++ b/frontend/src/tests/lib/components/proposal-detail/VotingCard/VotingCard.spec.ts
@@ -1,9 +1,8 @@
 import VotingCard from "$lib/components/proposal-detail/VotingCard/VotingCard.svelte";
-import { authStore } from "$lib/stores/auth.store";
 import { votingNeuronSelectStore } from "$lib/stores/vote-registration.store";
 import type { CompactNeuronInfo } from "$lib/utils/neuron.utils";
 import { nnsNeuronToVotingNeuron } from "$lib/utils/proposals.utils";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import { VotingCardPo } from "$tests/page-objects/VotingCard.page-object";
@@ -97,9 +96,7 @@ describe("VotingCard", () => {
 
   describe("Signed in", () => {
     beforeEach(() => {
-      vi.spyOn(authStore, "subscribe").mockImplementation(
-        mockAuthStoreSubscribe
-      );
+      resetIdentity();
     });
 
     it("should display voting buttons when no neurons available", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.spec.ts
@@ -1,9 +1,5 @@
 import SnsAvailableMaturityItemAction from "$lib/components/sns-neuron-detail/SnsAvailableMaturityItemAction.svelte";
-import { authStore } from "$lib/stores/auth.store";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   allSnsNeuronPermissions,
   createMockSnsNeuron,
@@ -63,7 +59,7 @@ describe("SnsAvailableMaturityItemAction", () => {
   };
 
   beforeEach(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   it("should render available maturity", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronAdvancedSection.spec.ts
@@ -4,11 +4,10 @@ import {
   SECONDS_IN_FOUR_YEARS,
   SECONDS_IN_MONTH,
 } from "$lib/constants/constants";
-import { authStore } from "$lib/stores/auth.store";
 import {
-  mockAuthStoreSubscribe,
   mockIdentity,
   mockPrincipal,
+  resetIdentity,
 } from "$tests/mocks/auth.store.mock";
 import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.mock";
 import {
@@ -63,7 +62,7 @@ describe("SnsNeuronAdvancedSection", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(nowInSeconds * 1000);
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   it("should render neuron data", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronDissolveDelayItemAction.spec.ts
@@ -5,11 +5,7 @@ import {
   SECONDS_IN_HALF_YEAR,
   SECONDS_IN_YEAR,
 } from "$lib/constants/constants";
-import { authStore } from "$lib/stores/auth.store";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   allSnsNeuronPermissions,
   createMockSnsNeuron,
@@ -75,7 +71,7 @@ describe("SnsNeuronDissolveDelayItemAction", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(nowInSeconds * 1000);
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   it("should render dissolve delay text and bonus if neuron is locked", async () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronFollowingCard.spec.ts
@@ -1,11 +1,7 @@
 import SnsNeuronFollowingCard from "$lib/components/sns-neuron-detail/SnsNeuronFollowingCard.svelte";
-import { authStore } from "$lib/stores/auth.store";
 import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
-import {
-  mockAuthStoreSubscribe,
-  mockPrincipal,
-} from "$tests/mocks/auth.store.mock";
+import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.mock";
 import { nervousSystemFunctionMock } from "$tests/mocks/sns-functions.mock";
 import {
@@ -22,7 +18,7 @@ import {
 
 describe("SnsNeuronFollowingCard", () => {
   beforeAll(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   describe("user has permissions to manage followees", () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
@@ -1,12 +1,8 @@
 import SnsNeuronHotkeysCard from "$lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.svelte";
 import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
 import { removeHotkey } from "$lib/services/sns-neurons.services";
-import { authStore } from "$lib/stores/auth.store";
 import { enumValues } from "$lib/utils/enum.utils";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { renderSelectedSnsNeuronContext } from "$tests/mocks/context-wrapper.mock";
 import en from "$tests/mocks/i18n.mock";
 import {
@@ -70,7 +66,7 @@ describe("SnsNeuronHotkeysCard", () => {
     });
 
   beforeAll(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   afterEach(() => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeading.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronPageHeading.spec.ts
@@ -5,12 +5,8 @@ import {
   SECONDS_IN_FOUR_YEARS,
 } from "$lib/constants/constants";
 import { HOTKEY_PERMISSIONS } from "$lib/constants/sns-neurons.constants";
-import { authStore } from "$lib/stores/auth.store";
 import { nowInSeconds } from "$lib/utils/date.utils";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   createMockSnsNeuron,
   mockSnsNeuron,
@@ -57,7 +53,7 @@ describe("SnsNeuronPageHeading", () => {
   };
 
   beforeEach(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
     // Make sure that nowInSeconds() returns a fixed value for the calculation
     // of the neuron age.
     vi.useFakeTimers();

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronStateItemAction.spec.ts
@@ -1,10 +1,6 @@
 import SnsNeuronStateItemAction from "$lib/components/sns-neuron-detail/SnsNeuronStateItemAction.svelte";
 import { SECONDS_IN_FOUR_YEARS } from "$lib/constants/constants";
-import { authStore } from "$lib/stores/auth.store";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   allSnsNeuronPermissions,
   createMockSnsNeuron,
@@ -61,7 +57,7 @@ describe("SnsNeuronStateItemAction", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(nowInSeconds * 1000);
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   it("should render locked text and Start dissolving button if neuron is locked", async () => {

--- a/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/CkBTCTransactionModal.spec.ts
@@ -8,17 +8,13 @@ import CkBTCTransactionModal from "$lib/modals/accounts/CkBTCTransactionModal.sv
 import * as services from "$lib/services/ckbtc-convert.services";
 import { convertCkBTCToBtcIcrc2 } from "$lib/services/ckbtc-convert.services";
 import { transferTokens } from "$lib/services/icrc-accounts.services";
-import { authStore } from "$lib/stores/auth.store";
 import { ckBTCInfoStore } from "$lib/stores/ckbtc-info.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import type { Account } from "$lib/types/account";
 import { TransactionNetwork } from "$lib/types/transaction";
 import { ulpsToNumber } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCkBTCAdditionalCanisters } from "$tests/mocks/canisters.mock";
 import {
   mockBTCAddressTestnet,
@@ -92,7 +88,7 @@ describe("CkBTCTransactionModal", () => {
     ckBTCInfoStore.reset();
 
     vi.mocked(transferTokens).mockResolvedValue({ blockIndex: undefined });
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
 
     icrcAccountsStore.set({
       accounts: {

--- a/frontend/src/tests/lib/modals/accounts/HardwareWalletNeuronAddHotkeyModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/HardwareWalletNeuronAddHotkeyModal.spec.ts
@@ -1,11 +1,9 @@
 import * as api from "$lib/api/governance.api";
 import HardwareWalletNeuronAddHotkeyModal from "$lib/modals/accounts/HardwareWalletNeuronAddHotkeyModal.svelte";
 import { getLedgerIdentityProxy } from "$lib/proxy/icp-ledger.services.proxy";
-import { authStore } from "$lib/stores/auth.store";
 import HardwareWalletAddNeuronHotkeyTest from "$tests/lib/components/accounts/HardwareWalletAddNeuronHotkeyTest.svelte";
 import {
   createMockIdentity,
-  mockAuthStoreSubscribe,
   mockIdentity,
   resetIdentity,
 } from "$tests/mocks/auth.store.mock";
@@ -42,7 +40,7 @@ describe("HardwareWalletNeuronAddHotkeyModal", () => {
       .spyOn(api, "queryNeuron")
       .mockImplementation(() => Promise.resolve(mockNeuron));
 
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   it("should display modal", () => {

--- a/frontend/src/tests/lib/modals/accounts/IcpTransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/accounts/IcpTransactionModal.spec.ts
@@ -1,8 +1,7 @@
 import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import IcpTransactionModal from "$lib/modals/accounts/IcpTransactionModal.svelte";
 import { transferICP } from "$lib/services/icp-accounts.services";
-import { authStore } from "$lib/stores/auth.store";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountsStoreSubscribe,
   mockSubAccount,
@@ -21,7 +20,7 @@ vi.mock("$lib/services/icp-accounts.services", () => {
 
 describe("IcpTransactionModal", () => {
   beforeAll(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   const renderTransactionModal = () =>

--- a/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/IncreaseNeuronStakeModal.spec.ts
@@ -2,8 +2,7 @@ import * as ledgerApi from "$lib/api/icp-ledger.api";
 import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import IncreaseNeuronStakeModal from "$lib/modals/neurons/IncreaseNeuronStakeModal.svelte";
 import { topUpNeuron } from "$lib/services/neurons.services";
-import { authStore } from "$lib/stores/auth.store";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountDetails,
   mockAccountsStoreData,
@@ -35,7 +34,7 @@ describe("IncreaseNeuronStakeModal", () => {
     });
 
   beforeEach(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   describe("when accounts store is empty", () => {

--- a/frontend/src/tests/lib/modals/neurons/JoinCommunityFundModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/JoinCommunityFundModal.spec.ts
@@ -1,9 +1,5 @@
 import JoinCommunityFundModal from "$lib/modals/neurons/JoinCommunityFundModal.svelte";
-import { authStore } from "$lib/stores/auth.store";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { JoinCommunityFundModalPo } from "$tests/page-objects/JoinCommunityFundModal.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
@@ -25,7 +21,7 @@ describe("ConfirmationModal", () => {
   };
 
   beforeEach(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   it("should render leave text if neuron is part of the Neurons' Fund", async () => {

--- a/frontend/src/tests/lib/modals/neurons/NewFolloweeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NewFolloweeModal.spec.ts
@@ -1,8 +1,7 @@
 import NewFolloweeModal from "$lib/modals/neurons/NewFolloweeModal.svelte";
 import { addFollowee, removeFollowee } from "$lib/services/neurons.services";
-import { authStore } from "$lib/stores/auth.store";
 import { knownNeuronsStore } from "$lib/stores/known-neurons.store";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import {
   mockFullNeuron,
@@ -40,7 +39,7 @@ describe("NewFolloweeModal", () => {
     },
   };
   beforeEach(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   afterEach(() => {

--- a/frontend/src/tests/lib/modals/sns/neurons/SnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/neurons/SnsStakeNeuronModal.spec.ts
@@ -2,13 +2,9 @@ import { selectedUniverseIdStore } from "$lib/derived/selected-universe.derived"
 import { snsSelectedTransactionFeeStore } from "$lib/derived/sns/sns-selected-transaction-fee.store";
 import SnsStakeNeuronModal from "$lib/modals/sns/neurons/SnsStakeNeuronModal.svelte";
 import { stakeNeuron } from "$lib/services/sns-neurons.services";
-import { authStore } from "$lib/stores/auth.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { page } from "$mocks/$app/stores";
-import {
-  mockAuthStoreSubscribe,
-  mockPrincipal,
-} from "$tests/mocks/auth.store.mock";
+import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { renderModal } from "$tests/mocks/modal.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
@@ -45,7 +41,7 @@ describe("SnsStakeNeuronModal", () => {
     });
 
   beforeAll(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   beforeEach(() => {

--- a/frontend/src/tests/lib/modals/sns/sale/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/sale/ParticipateSwapModal.spec.ts
@@ -4,7 +4,6 @@ import { SYNC_ACCOUNTS_RETRY_SECONDS } from "$lib/constants/accounts.constants";
 import ParticipateSwapModal from "$lib/modals/sns/sale/ParticipateSwapModal.svelte";
 import { cancelPollAccounts } from "$lib/services/icp-accounts.services";
 import { initiateSnsSaleParticipation } from "$lib/services/sns-sale.services";
-import { authStore } from "$lib/stores/auth.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
 import {
   PROJECT_DETAIL_CONTEXT_KEY,
@@ -12,10 +11,7 @@ import {
   type ProjectDetailStore,
 } from "$lib/types/project-detail.context";
 import type { SnsSwapCommitment } from "$lib/types/sns";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountDetails,
   mockAccountsStoreData,
@@ -72,7 +68,7 @@ describe("ParticipateSwapModal", () => {
   beforeEach(() => {
     cancelPollAccounts();
     vi.clearAllMocks();
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
     vi.mocked(initiateSnsSaleParticipation).mockClear();
     resetAccountsForTesting();
     snsTicketsStore.setNoTicket(rootCanisterIdMock);

--- a/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
+++ b/frontend/src/tests/lib/modals/transaction/TransactionModal.spec.ts
@@ -1,15 +1,11 @@
 import { OWN_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
 import TransactionModal from "$lib/modals/transaction/TransactionModal.svelte";
-import { authStore } from "$lib/stores/auth.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import type { Account } from "$lib/types/account";
 import type { ValidateAmountFn } from "$lib/types/transaction";
 import { formatTokenE8s } from "$lib/utils/token.utils";
-import {
-  mockAuthStoreSubscribe,
-  mockPrincipal,
-} from "$tests/mocks/auth.store.mock";
+import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockHardwareWalletAccount,
   mockMainAccount,
@@ -75,7 +71,7 @@ describe("TransactionModal", () => {
     });
 
   beforeAll(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   beforeEach(() => {

--- a/frontend/src/tests/lib/pages/Canisters.spec.ts
+++ b/frontend/src/tests/lib/pages/Canisters.spec.ts
@@ -2,10 +2,7 @@ import Canisters from "$lib/pages/Canisters.svelte";
 import { listCanisters } from "$lib/services/canisters.services";
 import { authStore } from "$lib/stores/auth.store";
 import { canistersStore } from "$lib/stores/canisters.store";
-import {
-  mockAuthStoreSubscribe,
-  mockPrincipal,
-} from "$tests/mocks/auth.store.mock";
+import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockCanistersStoreSubscribe } from "$tests/mocks/canisters.mock";
 import en from "$tests/mocks/i18n.mock";
 import { nnsUniverseMock } from "$tests/mocks/universe.mock";
@@ -40,9 +37,8 @@ describe("Canisters", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    authStoreMock = vi
-      .spyOn(authStore, "subscribe")
-      .mockImplementation(mockAuthStoreSubscribe);
+    authStoreMock = vi.spyOn(authStore, "subscribe");
+    resetIdentity();
 
     vi.spyOn(canistersStore, "subscribe").mockImplementation(
       mockCanistersStoreSubscribe

--- a/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/ProjectDetail.spec.ts
@@ -11,7 +11,6 @@ import { NOT_LOADED } from "$lib/constants/stores.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import ProjectDetail from "$lib/pages/ProjectDetail.svelte";
 import { cancelPollGetOpenTicket } from "$lib/services/sns-sale.services";
-import { authStore } from "$lib/stores/auth.store";
 import { getOrCreateSnsFinalizationStatusStore } from "$lib/stores/sns-finalization-status.store";
 import { snsSwapMetricsStore } from "$lib/stores/sns-swap-metrics.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
@@ -22,9 +21,9 @@ import { formatTokenE8s, numberToE8s } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
 import * as fakeLocationApi from "$tests/fakes/location-api.fake";
 import {
-  mockAuthStoreNoIdentitySubscribe,
-  mockAuthStoreSubscribe,
   mockPrincipal,
+  resetIdentity,
+  setNoIdentity,
 } from "$tests/mocks/auth.store.mock";
 import { mockCanisterId } from "$tests/mocks/canisters.mock";
 import {
@@ -126,9 +125,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
   describe("not logged in user", () => {
     beforeEach(() => {
       page.mock({ data: { universe: null } });
-      vi.spyOn(authStore, "subscribe").mockImplementation(
-        mockAuthStoreNoIdentitySubscribe
-      );
+      setNoIdentity();
     });
 
     // TODO: Remove once all SNSes support buyers count in derived state
@@ -359,9 +356,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
 
   describe("logged in user", () => {
     beforeEach(() => {
-      vi.spyOn(authStore, "subscribe").mockImplementation(
-        mockAuthStoreSubscribe
-      );
+      resetIdentity();
 
       vi.spyOn(snsSaleApi, "getOpenTicket").mockResolvedValue(undefined);
       vi.spyOn(snsApi, "querySnsLifecycle").mockResolvedValue({
@@ -786,9 +781,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
         },
       ]);
       page.mock({ data: { universe: null } });
-      vi.spyOn(authStore, "subscribe").mockImplementation(
-        mockAuthStoreNoIdentitySubscribe
-      );
+      setNoIdentity();
     });
 
     it("should redirect to launchpad", async () => {
@@ -815,9 +808,7 @@ sale_buyer_count ${saleBuyerCount} 1677707139456
         },
       ]);
       page.mock({ data: { universe: null } });
-      vi.spyOn(authStore, "subscribe").mockImplementation(
-        mockAuthStoreNoIdentitySubscribe
-      );
+      setNoIdentity();
     });
 
     it("should redirect to launchpad", async () => {

--- a/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeuronDetail.spec.ts
@@ -9,7 +9,6 @@ import {
 import { pageStore } from "$lib/derived/page.derived";
 import SnsNeuronDetail from "$lib/pages/SnsNeuronDetail.svelte";
 import * as checkNeuronsService from "$lib/services/sns-neurons-check-balances.services";
-import { authStore } from "$lib/stores/auth.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { tokensStore } from "$lib/stores/tokens.store";
@@ -21,10 +20,7 @@ import { numberToE8s } from "$lib/utils/token.utils";
 import { page } from "$mocks/$app/stores";
 import * as fakeSnsApi from "$tests/fakes/sns-api.fake";
 import * as fakeSnsGovernanceApi from "$tests/fakes/sns-governance-api.fake";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import {
   createMockSnsNeuron,
@@ -83,7 +79,7 @@ describe("SnsNeuronDetail", () => {
       routeId: AppPath.Neuron,
     });
 
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   const renderComponent = async (props) => {

--- a/frontend/src/tests/lib/routes/ProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/ProposalDetail.spec.ts
@@ -1,9 +1,8 @@
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import ProposalDetail from "$lib/routes/ProposalDetail.svelte";
-import { authStore } from "$lib/stores/auth.store";
 import { page } from "$mocks/$app/stores";
-import { mockAuthStoreSubscribe } from "$tests/mocks/auth.store.mock";
+import { resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockSnsFullProject } from "$tests/mocks/sns-projects.mock";
 import { setSnsProjects } from "$tests/utils/sns.test-utils";
 import { SnsSwapLifecycle } from "@dfinity/sns";
@@ -28,7 +27,7 @@ describe("ProposalDetail", () => {
         lifecycle: SnsSwapLifecycle.Committed,
       },
     ]);
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   it("should render NnsProposalDetail by default", () => {

--- a/frontend/src/tests/lib/routes/Settings.spec.ts
+++ b/frontend/src/tests/lib/routes/Settings.spec.ts
@@ -1,10 +1,7 @@
 import Settings from "$lib/routes/Settings.svelte";
-import { authRemainingTimeStore, authStore } from "$lib/stores/auth.store";
+import { authRemainingTimeStore } from "$lib/stores/auth.store";
 import { layoutTitleStore } from "$lib/stores/layout.store";
-import {
-  mockAuthStoreSubscribe,
-  mockPrincipalText,
-} from "$tests/mocks/auth.store.mock";
+import { mockPrincipalText, resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { render } from "@testing-library/svelte";
 import { get } from "svelte/store";
@@ -12,7 +9,7 @@ import { get } from "svelte/store";
 describe("Settings", () => {
   beforeEach(() => {
     authRemainingTimeStore.set(undefined);
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   it("should set title", async () => {

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -11,14 +11,10 @@ import {
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import Wallet from "$lib/routes/Wallet.svelte";
-import { authStore } from "$lib/stores/auth.store";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockCkBTCMainAccount,
   mockCkBTCToken,
@@ -134,7 +130,7 @@ describe("Wallet", () => {
   });
 
   beforeAll(() => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   describe("nns context", () => {

--- a/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-proposals.services.spec.ts
@@ -2,12 +2,8 @@ import * as governanceApi from "$lib/api/governance.api";
 import * as api from "$lib/api/proposals.api";
 import { loadActionableProposals } from "$lib/services/actionable-proposals.services";
 import { actionableNnsProposalsStore } from "$lib/stores/actionable-nns-proposals.store";
-import { authStore } from "$lib/stores/auth.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import { silentConsoleErrors } from "$tests/utils/utils.test-utils";
@@ -87,9 +83,7 @@ describe("actionable-proposals.services", () => {
       vi.clearAllMocks();
       neuronsStore.reset();
       actionableNnsProposalsStore.reset();
-      vi.spyOn(authStore, "subscribe").mockImplementation(
-        mockAuthStoreSubscribe
-      );
+      resetIdentity();
       spyQueryProposals = vi
         .spyOn(api, "queryProposals")
         .mockImplementation((requestData) =>

--- a/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
@@ -5,16 +5,11 @@ import {
   actionableSnsProposalsStore,
   failedActionableSnsesStore,
 } from "$lib/stores/actionable-sns-proposals.store";
-import { authStore } from "$lib/stores/auth.store";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
 import { enumValues } from "$lib/utils/enum.utils";
 import { getSnsNeuronIdAsHexString } from "$lib/utils/sns-neuron.utils";
 import { snsProposalId } from "$lib/utils/sns-proposals.utils";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-  resetIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { principal } from "$tests/mocks/sns-projects.mock";
 import { createSnsProposal } from "$tests/mocks/sns-proposals.mock";
@@ -139,9 +134,7 @@ describe("actionable-sns-proposals.services", () => {
       actionableSnsProposalsStore.resetForTesting();
       resetIdentity();
 
-      vi.spyOn(authStore, "subscribe").mockImplementation(
-        mockAuthStoreSubscribe
-      );
+      resetIdentity();
       vi.spyOn(snsProjectsCommittedStore, "subscribe").mockClear();
 
       spyQuerySnsNeurons = vi

--- a/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
@@ -5,7 +5,6 @@ import {
   loadSnsProposals,
   registerVote,
 } from "$lib/services/public/sns-proposals.services";
-import { authStore } from "$lib/stores/auth.store";
 import { snsFiltersStore } from "$lib/stores/sns-filters.store";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
 import * as toastsFunctions from "$lib/stores/toasts.store";
@@ -13,8 +12,8 @@ import type { Filter, SnsProposalTypeFilterId } from "$lib/types/filters";
 import { ALL_SNS_GENERIC_PROPOSAL_TYPES_ID } from "$lib/types/filters";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import {
-  mockAuthStoreNoIdentitySubscribe,
-  mockAuthStoreSubscribe,
+  setNoIdentity,
+  resetIdentity,
   mockIdentity,
   mockPrincipal,
 } from "$tests/mocks/auth.store.mock";
@@ -66,9 +65,7 @@ describe("sns-proposals services", () => {
         snsFiltersStore.reset();
         snsProposalsStore.reset();
         vi.clearAllMocks();
-        vi.spyOn(authStore, "subscribe").mockImplementation(
-          mockAuthStoreNoIdentitySubscribe
-        );
+        setNoIdentity();
       });
       it("should call queryProposals with the default params", async () => {
         await loadSnsProposals({
@@ -231,9 +228,7 @@ describe("sns-proposals services", () => {
       beforeEach(() => {
         snsProposalsStore.reset();
         vi.clearAllMocks();
-        vi.spyOn(authStore, "subscribe").mockImplementation(
-          mockAuthStoreSubscribe
-        );
+        resetIdentity();
       });
 
       it("should call queryProposals with user's identity", async () => {
@@ -293,9 +288,7 @@ describe("sns-proposals services", () => {
 
     beforeEach(() => {
       vi.clearAllMocks();
-      vi.spyOn(authStore, "subscribe").mockImplementation(
-        mockAuthStoreSubscribe
-      );
+      resetIdentity();
     });
 
     it("should call registerVote api", async () => {
@@ -349,9 +342,7 @@ describe("sns-proposals services", () => {
 
     describe("not logged in", () => {
       beforeEach(() => {
-        vi.spyOn(authStore, "subscribe").mockImplementation(
-          mockAuthStoreNoIdentitySubscribe
-        );
+        setNoIdentity();
       });
 
       it("should call api regardless of having a certified proposal in store", () =>
@@ -384,9 +375,7 @@ describe("sns-proposals services", () => {
 
     describe("logged in", () => {
       beforeEach(() => {
-        vi.spyOn(authStore, "subscribe").mockImplementation(
-          mockAuthStoreSubscribe
-        );
+        resetIdentity();
       });
 
       it("should call api regardless of having a certified proposal in store", async () => {

--- a/frontend/src/tests/lib/services/public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns.services.spec.ts
@@ -3,13 +3,12 @@ import * as agent from "$lib/api/agent.api";
 import * as aggregatorApi from "$lib/api/sns-aggregator.api";
 import { clearWrapperCache, wrapper } from "$lib/api/sns-wrapper.api";
 import { loadSnsProjects } from "$lib/services/public/sns.services";
-import { authStore } from "$lib/stores/auth.store";
 import { snsAggregatorStore, snsAggregatorIncludingAbortedProjectsStore } from "$lib/stores/sns-aggregator.store";
 import { snsFunctionsStore } from "$lib/derived/sns-functions.derived";
 import { snsTotalTokenSupplyStore } from "$lib/derived/sns-total-token-supply.derived";
 import { tokensStore } from "$lib/stores/tokens.store";
 import {
-  mockAuthStoreSubscribe,
+  resetIdentity,
   mockIdentity,
 } from "$tests/mocks/auth.store.mock";
 import {
@@ -82,9 +81,7 @@ describe("SNS public services", () => {
       snsAggregatorIncludingAbortedProjectsStore.reset();
       clearWrapperCache();
       vi.clearAllMocks();
-      vi.spyOn(authStore, "subscribe").mockImplementation(
-        mockAuthStoreSubscribe
-      );
+      resetIdentity();
     });
 
     it("loads sns stores with data", async () => {

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -22,9 +22,9 @@ import { tokensStore } from "$lib/stores/tokens.store";
 import { nanoSecondsToDateTime } from "$lib/utils/date.utils";
 import { formatTokenE8s } from "$lib/utils/token.utils";
 import {
-  mockAuthStoreSubscribe,
   mockIdentity,
   mockPrincipal,
+  resetIdentity,
 } from "$tests/mocks/auth.store.mock";
 import {
   mockMainAccount,
@@ -220,7 +220,7 @@ describe("sns-api", () => {
       (): SnsSwapCanister => snsSwapCanister
     );
 
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
   });
 
   describe("loadOpenTicket", () => {
@@ -1226,14 +1226,9 @@ describe("sns-api", () => {
         ticket: testTicket,
       });
       // corrupt the current identity principal
-      vi.spyOn(authStore, "subscribe").mockImplementation((run) => {
-        run({
-          identity: {
-            ...mockIdentity,
-            getPrincipal: () => Principal.fromText("aaaaa-aa"),
-          },
-        });
-        return () => undefined;
+      authStore.setForTesting({
+        ...mockIdentity,
+        getPrincipal: () => Principal.fromText("aaaaa-aa"),
       });
 
       await participateInSnsSale({

--- a/frontend/src/tests/lib/services/utils.services.spec.ts
+++ b/frontend/src/tests/lib/services/utils.services.spec.ts
@@ -1,10 +1,9 @@
 import { queryAndUpdate } from "$lib/services/utils.services";
-import { authStore } from "$lib/stores/auth.store";
 import * as devUtils from "$lib/utils/dev.utils";
 import {
-  mockAuthStoreNoIdentitySubscribe,
-  mockAuthStoreSubscribe,
   mockIdentity,
+  resetIdentity,
+  setNoIdentity,
 } from "$tests/mocks/auth.store.mock";
 import { tick } from "svelte";
 
@@ -13,9 +12,7 @@ describe("api-utils", () => {
     describe("not logged in user", () => {
       beforeEach(() => {
         vi.clearAllMocks();
-        vi.spyOn(authStore, "subscribe").mockImplementation(
-          mockAuthStoreNoIdentitySubscribe
-        );
+        setNoIdentity();
       });
 
       it("should raise error if another strategy than 'query' is passed", async () => {
@@ -42,9 +39,7 @@ describe("api-utils", () => {
     describe("logged in user", () => {
       beforeEach(() => {
         vi.clearAllMocks();
-        vi.spyOn(authStore, "subscribe").mockImplementation(
-          mockAuthStoreSubscribe
-        );
+        resetIdentity();
       });
       it("should request twice", async () => {
         const request = vi

--- a/frontend/src/tests/mocks/auth.store.mock.ts
+++ b/frontend/src/tests/mocks/auth.store.mock.ts
@@ -46,25 +46,6 @@ export const mockGetIdentity = async () => {
 };
 
 /**
- * A static mock of the auth store. The component that uses it will be rendered for test with a value that is already defined on mount.
- */
-export const mockAuthStoreSubscribe = (
-  run?: Subscriber<AuthStoreData>
-): (() => void) => {
-  run?.({ identity: mockIdentity });
-
-  return () => undefined;
-};
-
-export const mockAuthStoreNoIdentitySubscribe = (
-  run: Subscriber<AuthStoreData>
-): (() => void) => {
-  run({ identity: undefined });
-
-  return () => undefined;
-};
-
-/**
  * A dynamic mock of the auth store. The component that uses it will be rendered for test with an undefined value on mount.
  * Within the test suite, the mock can then be used to trigger state changes to simulate re-render.
  */

--- a/frontend/src/tests/workflows/CreateSubaccount.spec.ts
+++ b/frontend/src/tests/workflows/CreateSubaccount.spec.ts
@@ -4,12 +4,8 @@ import * as ledgerApi from "$lib/api/icp-ledger.api";
 import * as nnsDappApi from "$lib/api/nns-dapp.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import Accounts from "$lib/routes/Accounts.svelte";
-import { authStore } from "$lib/stores/auth.store";
 import { page } from "$mocks/$app/stores";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   mockAccountDetails,
   mockMainAccount,
@@ -41,7 +37,7 @@ describe("Accounts", () => {
   };
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(authStore, "subscribe").mockImplementation(mockAuthStoreSubscribe);
+    resetIdentity();
     vi.spyOn(console, "error").mockImplementation(vi.fn);
 
     vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(0n);

--- a/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposalDetail.spec.ts
@@ -4,13 +4,12 @@ import { queryProposal } from "$lib/api/proposals.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import NnsProposalDetail from "$lib/pages/NnsProposalDetail.svelte";
 import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
-import { authStore } from "$lib/stores/auth.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { page } from "$mocks/$app/stores";
 import {
-  mockAuthStoreNoIdentitySubscribe,
-  mockAuthStoreSubscribe,
   mockIdentity,
+  resetIdentity,
+  setNoIdentity,
 } from "$tests/mocks/auth.store.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
@@ -83,9 +82,7 @@ describe("Proposal detail page when not logged in user", () => {
           });
         }
       );
-      vi.spyOn(authStore, "subscribe").mockImplementation(
-        mockAuthStoreSubscribe
-      );
+      resetIdentity();
     });
 
     it("should render proposal with certified data", async () => {
@@ -175,9 +172,7 @@ describe("Proposal detail page when not logged in user", () => {
   describe("when not logged in user", () => {
     beforeEach(() => {
       vi.spyOn(governanceApi, "queryNeurons").mockResolvedValue([]);
-      vi.spyOn(authStore, "subscribe").mockImplementation(
-        mockAuthStoreNoIdentitySubscribe
-      );
+      setNoIdentity();
     });
 
     it("should render proposal with uncertified data", async () => {

--- a/frontend/src/tests/workflows/NnsProposals.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposals.spec.ts
@@ -8,10 +8,7 @@ import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposal
 import { authStore, type AuthStoreData } from "$lib/stores/auth.store";
 import { neuronsStore } from "$lib/stores/neurons.store";
 import { page } from "$mocks/$app/stores";
-import {
-  mockAuthStoreSubscribe,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import { mockProposalInfo } from "$tests/mocks/proposal.mock";
 import { AnonymousIdentity } from "@dfinity/agent";
 import { ProposalRewardStatus, ProposalStatus, Topic } from "@dfinity/nns";
@@ -53,9 +50,7 @@ describe('NnsProposals when "all proposals" selected', () => {
   describe("when signed in user", () => {
     beforeEach(() => {
       vi.spyOn(governanceApi, "queryNeurons").mockResolvedValue([]);
-      vi.spyOn(authStore, "subscribe").mockImplementation(
-        mockAuthStoreSubscribe
-      );
+      resetIdentity();
     });
 
     it("should list proposals certified and uncertified", async () => {


### PR DESCRIPTION
# Motivation

Svelte stores are light weight objects that don't need to be mocked in tests.
One store that is mocked particularly often is the `authStore`.
For new tests we already use the real `authStore` (mostly via `resetIdentity` and `setNoIdentity`) but we still have a lot of old test that mock it.
Keeping bad practices around is bad because it makes it harder to copy existing code and do the right thing.
It can also be confusing because once the `authStore` is mocked, setting the real `authStore` has no effect. So mixing old and new practices in the same file doesn't work.

# Changes

1. Replace `mockAuthStoreSubscribe` with `resetIdentity` and `mockAuthStoreNoIdentitySubscribe` with `setNoIdentity`.
2. In `frontend/src/tests/lib/services/sns-sale.services.spec.ts` replace a custom `subscribe` mock with `setForTesting`.
3. Remove `mockAuthStoreSubscribe` and `mockAuthStoreNoIdentitySubscribe`.

# Tests

Tests only.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary