### PR TITLE
Fix replacement of neuron ID in screenshot test

### DIFF
--- a/frontend/src/tests/e2e/neuron-details.spec.ts
+++ b/frontend/src/tests/e2e/neuron-details.spec.ts
@@ -47,7 +47,7 @@ test("Test neuron details", async ({ page, context }) => {
   await replaceContent({
     page,
     selectors: ['[data-tid="identifier"]', '[data-tid="neuron-id"]'],
-    pattern: /[0-9a-f]{19}/,
+    pattern: /^[0-9a-f]+$/,
     replacements: ["7737260276268288098", "7737260276268288098"],
   });
   await replaceContent({

--- a/frontend/src/tests/utils/e2e.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.test-utils.ts
@@ -110,13 +110,18 @@ export const replaceContent = async ({
   pattern: RegExp;
   replacements: string[];
 }): Promise<void> => {
-  await page.evaluate(
-    ({ selectors, pattern, replacements }) =>
+  const replacementCount = await page.evaluate(
+    ({ selectors, pattern, replacements }) => {
+      let replacementCount = 0;
       document.querySelectorAll(selectors.join(", ")).forEach((el, i) => {
         if (pattern.test(el.innerHTML)) {
           el.innerHTML = replacements[i % replacements.length];
+          replacementCount++;
         }
-      }),
+      });
+      return replacementCount;
+    },
     { selectors, pattern, replacements }
   );
+  expect(replacementCount).toBeGreaterThan(0);
 };


### PR DESCRIPTION
# Motivation

In the neuron details e2e test we replace the neuron ID with a fixed value so that it doesn't cause the screenshot to be different each time.
When doing this we expect the existing neuron to have 19 digits, but neuron IDs can also have fewer than 19 digits.
And when the existing neuron ID doesn't match the expected pattern it's not replaced which results in test flakiness.

# Changes

1. Relax the expected neuron ID pattern.
2. Expect the number of replacements for each call to `replaceContent` to be greater than 0 to help catch cases where nothing is replaced without having to download the screenshot.

# Tests

Only tests.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary