### PR TITLE
Use head instead of grep -m

### DIFF
--- a/scripts/sns/aggregator/get-sns
+++ b/scripts/sns/aggregator/get-sns
@@ -15,7 +15,7 @@ SEARCH_PATTERN="$1"
 # find which SNS to query but then get the actual data from the aggregator.
 AGGREGATOR_PAGES=("$SOURCE_DIR"/../../../frontend/src/tests/workflows/Launchpad/sns-agg-page-*.json)
 
-ROOT_CANISTER_ID="$(jq -c '.[] | select(.lifecycle.lifecycle != 4) | .canister_ids * {name: .meta.name, symbol: (.icrc1_metadata | .[] | select(.[0] == "icrc1:symbol") | .[1].Text) }' "${AGGREGATOR_PAGES[@]}" | grep -m 1 -i "$SEARCH_PATTERN" | jq -r .root_canister_id)"
+ROOT_CANISTER_ID="$(jq -c '.[] | select(.lifecycle.lifecycle != 4) | .canister_ids * {name: .meta.name, symbol: (.icrc1_metadata | .[] | select(.[0] == "icrc1:symbol") | .[1].Text) }' "${AGGREGATOR_PAGES[@]}" | grep -i "$SEARCH_PATTERN" | head -n 1 | jq -r .root_canister_id)"
 
 AGGREGATOR_URL="https://3r4gx-wqaaa-aaaaq-aaaia-cai.icp0.io/v1/sns/root/$ROOT_CANISTER_ID/slow.json"
 


### PR DESCRIPTION
# Motivation

With the latest "Update SNS Aggregator Response" PR, the CI test for the `get-sns` script started failing with [Error: writing output failed: Broken pipe](https://github.com/dfinity/nns-dapp/actions/runs/11181791065/job/31086597771).

This happens because the script uses `grep -m 1` which stops reading input after the first match is found but the command on the other side of the pipe still wants to write to it.
If we use `head -n 1` instead, `grep` will read all its input but `head` will not, so theoretically this just moves the problem.
But in practice the size of the input is already reduced so much that the problem goes away (hopefully).

# Changes

In `get-sns`, use `| head -n 1` instead of passing `-m 1` to `grep`.

# Tests

Tested on CI on https://github.com/dfinity/nns-dapp/pull/5566 where this test was failing until I applied this fix.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary