### PR TITLE
Only ignore `/public` instead of `public`

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -3,7 +3,7 @@ node_modules
 /build
 /.svelte-kit
 /package
-public
+/public
 .env
 .env.*
 !.env.example

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -13,5 +13,5 @@ pnpm-lock.yaml
 package-lock.json
 yarn.lock
 
-public
-static/assets/libs
+/public
+/static/assets/libs

--- a/frontend/src/lib/services/public/app.services.ts
+++ b/frontend/src/lib/services/public/app.services.ts
@@ -1,6 +1,6 @@
 import { browser } from "$app/environment";
-import { loadSnsProjects } from "$lib/services/public/sns.services";
 import { displayAndCleanLogoutMsg } from "$lib/services/auth.services";
+import { loadSnsProjects } from "$lib/services/public/sns.services";
 import { authStore } from "$lib/stores/auth.store";
 import { layoutAuthReady } from "$lib/stores/layout.store";
 import { toastsError } from "$lib/stores/toasts.store";

--- a/frontend/src/lib/services/public/sns.services.ts
+++ b/frontend/src/lib/services/public/sns.services.ts
@@ -82,9 +82,7 @@ export const loadProposalsSnsCF = async (): Promise<void> => {
     onError: ({ error: err, certified, strategy }) => {
       console.error(err);
 
-      if (
-        isLastCall({ strategy, certified })
-      ) {
+      if (isLastCall({ strategy, certified })) {
         snsProposalsStore.reset();
 
         toastsError(

--- a/frontend/src/tests/lib/services/public/proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/proposals.services.spec.ts
@@ -168,12 +168,14 @@ describe("proposals-services", () => {
 
       it("show no error message from api on uncertified error", async () => {
         const errorMessage = "Error message from api.";
-        vi.spyOn(api, "queryProposals").mockImplementation(async ({certified}) => {
-          if (!certified) {
-            throw new Error(errorMessage);
+        vi.spyOn(api, "queryProposals").mockImplementation(
+          async ({ certified }) => {
+            if (!certified) {
+              throw new Error(errorMessage);
+            }
+            return mockProposals;
           }
-          return mockProposals;
-        });
+        );
         await listProposals({
           loadFinished: () => {
             // do nothing here

--- a/frontend/src/tests/lib/services/public/proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/proposals.services.spec.ts
@@ -3,22 +3,19 @@ import {
   ProposalPayloadNotFoundError,
   ProposalPayloadTooLargeError,
 } from "$lib/canisters/nns-dapp/nns-dapp.errors";
+import { getCurrentIdentity } from "$lib/services/auth.services";
 import {
   listNextProposals,
   listProposals,
   loadProposal,
   loadProposalPayload,
 } from "$lib/services/public/proposals.services";
-import { getCurrentIdentity } from "$lib/services/auth.services";
 import {
   proposalPayloadsStore,
   proposalsFiltersStore,
   proposalsStore,
 } from "$lib/stores/proposals.store";
-import {
-  resetIdentity,
-  setNoIdentity,
-} from "$tests/mocks/auth.store.mock";
+import { resetIdentity, setNoIdentity } from "$tests/mocks/auth.store.mock";
 import { mockProposals } from "$tests/mocks/proposals.store.mock";
 import { toastsStore } from "@dfinity/gix-components";
 import type { ProposalInfo } from "@dfinity/nns";
@@ -191,8 +188,7 @@ describe("proposals-services", () => {
       const spyQueryProposal = vi.spyOn(api, "queryProposal");
 
       beforeEach(() => {
-        spyQueryProposal.mockResolvedValue(
-          { ...mockProposals[0], id: 666n });
+        spyQueryProposal.mockResolvedValue({ ...mockProposals[0], id: 666n });
         proposalsStore.setProposalsForTesting({
           proposals: mockProposals,
           certified: true,
@@ -215,9 +211,9 @@ describe("proposals-services", () => {
       let spyQueryProposal;
 
       beforeEach(() => {
-        spyQueryProposal = vi.spyOn(api, "queryProposal").mockRejectedValue(
-          new Error("test-message")
-        );
+        spyQueryProposal = vi
+          .spyOn(api, "queryProposal")
+          .mockRejectedValue(new Error("test-message"));
         vi.spyOn(console, "error").mockReturnValue();
       });
 
@@ -228,10 +224,12 @@ describe("proposals-services", () => {
           proposalId: 0n,
           setProposal: vi.fn,
         });
-        expect(get(toastsStore)).toMatchObject([{
-          level: "error",
-          text: "An error occurred while loading the proposal. id: \"0\". test-message",
-        }]);
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "error",
+            text: 'An error occurred while loading the proposal. id: "0". test-message',
+          },
+        ]);
 
         // `queryProposal` gave an error twice (query + update) but it should
         // result only in a single toast message.
@@ -320,7 +318,7 @@ describe("proposals-services", () => {
     it("should load proposal if no identity", async () => {
       const spyQueryProposal = vi
         .spyOn(api, "queryProposal")
-        .mockResolvedValue({ ...mockProposals[0], id: 666n })
+        .mockResolvedValue({ ...mockProposals[0], id: 666n });
       expect(spyQueryProposal).not.toBeCalled();
 
       let result;
@@ -382,9 +380,9 @@ describe("proposals-services", () => {
       expect(get(proposalPayloadsStore)).toEqual(new Map());
       await loadProposalPayload({ proposalId: 0n });
 
-      expect(get(proposalPayloadsStore)).toEqual(new Map([
-        [0n, mockProposalPayload],
-      ]));
+      expect(get(proposalPayloadsStore)).toEqual(
+        new Map([[0n, mockProposalPayload]])
+      );
     });
 
     it("should update proposalPayloadsStore with null if the payload was not found", async () => {

--- a/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
@@ -12,10 +12,10 @@ import type { Filter, SnsProposalTypeFilterId } from "$lib/types/filters";
 import { ALL_SNS_GENERIC_PROPOSAL_TYPES_ID } from "$lib/types/filters";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import {
-  setNoIdentity,
-  resetIdentity,
   mockIdentity,
   mockPrincipal,
+  resetIdentity,
+  setNoIdentity,
 } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import {

--- a/frontend/src/tests/lib/services/public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns.services.spec.ts
@@ -2,15 +2,15 @@ import { clearSnsAggregatorCache } from "$lib/api-services/sns-aggregator.api-se
 import * as agent from "$lib/api/agent.api";
 import * as aggregatorApi from "$lib/api/sns-aggregator.api";
 import { clearWrapperCache, wrapper } from "$lib/api/sns-wrapper.api";
-import { loadSnsProjects } from "$lib/services/public/sns.services";
-import { snsAggregatorStore, snsAggregatorIncludingAbortedProjectsStore } from "$lib/stores/sns-aggregator.store";
 import { snsFunctionsStore } from "$lib/derived/sns-functions.derived";
 import { snsTotalTokenSupplyStore } from "$lib/derived/sns-total-token-supply.derived";
-import { tokensStore } from "$lib/stores/tokens.store";
+import { loadSnsProjects } from "$lib/services/public/sns.services";
 import {
-  resetIdentity,
-  mockIdentity,
-} from "$tests/mocks/auth.store.mock";
+  snsAggregatorIncludingAbortedProjectsStore,
+  snsAggregatorStore,
+} from "$lib/stores/sns-aggregator.store";
+import { tokensStore } from "$lib/stores/tokens.store";
+import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
 import {
   aggregatorMockSnsesDataDto,
   aggregatorSnsMockDto,
@@ -157,7 +157,9 @@ describe("SNS public services", () => {
 
       await loadSnsProjects();
 
-      expect(get(snsAggregatorIncludingAbortedProjectsStore).data).toEqual(aggregatorMockSnsesDataDto);
+      expect(get(snsAggregatorIncludingAbortedProjectsStore).data).toEqual(
+        aggregatorMockSnsesDataDto
+      );
     });
 
     it("should load and map total token supply", async () => {


### PR DESCRIPTION
# Motivation

We had `public` in several `.*ignore` files to avoid acting on the build output in `/frontend/public`.
But this also matched paths with `public` deeper down in the path.

# Changes

1. Change `public` to `/public` in `frontend/.gitignore` and `frontend/.prettierignore`.
2. Format file that were previously ignored by `prettier`.

# Tests

not tested, just CI.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary