### PR TITLE
Changelog entry for dissolve delay issue

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -23,6 +23,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Fixed
 
 * Bug where neurons are displayed as eligible to vote, even though they have already voted.
+* Issue with setting exact dissolve delay on SNS neurons.
 
 #### Security
 


### PR DESCRIPTION
# Motivation

Changelog entry was missing from https://github.com/dfinity/nns-dapp/pull/5560

# Changes

Added missing changelog entry.

# Tests

no

# Todos

- [x] Add entry to changelog (if necessary).
