### PR TITLE
Move isForceCallStrategy and notForceCallStrategy to mockable.constants.ts

### DIFF
--- a/frontend/src/lib/components/proposal-detail/VotingCard/NnsVotingCard.svelte
+++ b/frontend/src/lib/components/proposal-detail/VotingCard/NnsVotingCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import VotingCard from "$lib/components/proposal-detail/VotingCard/VotingCard.svelte";
   import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
+  import { isForceCallStrategy } from "$lib/constants/mockable.constants";
   import { NNS_MINIMUM_DISSOLVE_DELAY_TO_VOTE } from "$lib/constants/neurons.constants";
   import { registerNnsVotes } from "$lib/services/nns-vote-registration.services";
   import { definedNeuronsStore, neuronsStore } from "$lib/stores/neurons.store";
@@ -13,23 +14,22 @@
     SELECTED_PROPOSAL_CONTEXT_KEY,
     type SelectedProposalContext,
   } from "$lib/types/selected-proposal.context";
-  import { isForceCallStrategy } from "$lib/utils/env.utils";
   import {
-    type CompactNeuronInfo,
     filterIneligibleNnsNeurons,
-    type IneligibleNeuronData,
     votedNeuronDetails,
+    type CompactNeuronInfo,
+    type IneligibleNeuronData,
   } from "$lib/utils/neuron.utils";
   import {
     isProposalDeadlineInTheFuture,
     nnsNeuronToVotingNeuron,
   } from "$lib/utils/proposals.utils";
+  import type { NeuronInfo } from "@dfinity/nns";
   import {
+    votableNeurons as getVotableNeurons,
     type ProposalInfo,
     type Vote,
-    votableNeurons as getVotableNeurons,
   } from "@dfinity/nns";
-  import type { NeuronInfo } from "@dfinity/nns";
   import { getContext } from "svelte";
 
   export let proposalInfo: ProposalInfo;

--- a/frontend/src/lib/constants/mockable.constants.ts
+++ b/frontend/src/lib/constants/mockable.constants.ts
@@ -10,6 +10,11 @@ export const ENABLE_METRICS = !DEV;
 
 export const FORCE_CALL_STRATEGY: "query" | undefined = "query";
 
+export const isForceCallStrategy = (): boolean =>
+  FORCE_CALL_STRATEGY === "query";
+
+export const notForceCallStrategy = (): boolean => !isForceCallStrategy();
+
 export const IS_TEST_ENV = process.env.NODE_ENV === "test";
 
 // When the QR code is rendered (draw), it triggers an event that is replicated to a property to get to know if the QR code has been or not rendered.

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -16,6 +16,7 @@
   import SkeletonHeader from "$lib/components/ui/SkeletonHeader.svelte";
   import SkeletonHeading from "$lib/components/ui/SkeletonHeading.svelte";
   import { IS_TESTNET } from "$lib/constants/environment.constants";
+  import { isForceCallStrategy } from "$lib/constants/mockable.constants";
   import { AppPath } from "$lib/constants/routes.constants";
   import { pageStore } from "$lib/derived/page.derived";
   import NnsNeuronModals from "$lib/modals/neurons/NnsNeuronModals.svelte";
@@ -30,7 +31,6 @@
     NnsNeuronStore,
   } from "$lib/types/nns-neuron-detail.context";
   import { NNS_NEURON_CONTEXT_KEY } from "$lib/types/nns-neuron-detail.context";
-  import { isForceCallStrategy } from "$lib/utils/env.utils";
   import {
     getNeuronById,
     isSpawning,

--- a/frontend/src/lib/pages/NnsProposals.svelte
+++ b/frontend/src/lib/pages/NnsProposals.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import NnsProposalsList from "$lib/components/proposals/NnsProposalsList.svelte";
+  import { notForceCallStrategy } from "$lib/constants/mockable.constants";
   import { AppPath } from "$lib/constants/routes.constants";
   import {
     filteredProposals,
@@ -15,7 +16,6 @@
   } from "$lib/stores/proposals.store";
   import { referrerPathStore } from "$lib/stores/routes.store";
   import { toastsError } from "$lib/stores/toasts.store";
-  import { notForceCallStrategy } from "$lib/utils/env.utils";
   import { reloadRouteData } from "$lib/utils/navigation.utils";
   import {
     hasMatchingProposals,

--- a/frontend/src/lib/services/icp-accounts.services.ts
+++ b/frontend/src/lib/services/icp-accounts.services.ts
@@ -14,7 +14,10 @@ import {
   SYNC_ACCOUNTS_RETRY_MAX_ATTEMPTS,
   SYNC_ACCOUNTS_RETRY_SECONDS,
 } from "$lib/constants/accounts.constants";
-import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
+import {
+  FORCE_CALL_STRATEGY,
+  isForceCallStrategy,
+} from "$lib/constants/mockable.constants";
 import { nnsAccountsListStore } from "$lib/derived/accounts-list.derived";
 import { icpAccountsStore } from "$lib/derived/icp-accounts.derived";
 import { mainTransactionFeeE8sStore } from "$lib/derived/main-transaction-fee.derived";
@@ -39,7 +42,6 @@ import {
   invalidIcrcAddress,
   toIcpAccountIdentifier,
 } from "$lib/utils/accounts.utils";
-import { isForceCallStrategy } from "$lib/utils/env.utils";
 import { toToastError } from "$lib/utils/error.utils";
 import {
   cancelPoll,

--- a/frontend/src/lib/utils/ckbtc.utils.ts
+++ b/frontend/src/lib/utils/ckbtc.utils.ts
@@ -1,9 +1,9 @@
+import { notForceCallStrategy } from "$lib/constants/mockable.constants";
 import type { CkBTCInfoStoreUniverseData } from "$lib/stores/ckbtc-info.store";
 import { i18n } from "$lib/stores/i18n";
 import type { Account } from "$lib/types/account";
 import { CkBTCErrorRetrieveBtcMinAmount } from "$lib/types/ckbtc.errors";
 import { assertEnoughAccountFunds } from "$lib/utils/accounts.utils";
-import { notForceCallStrategy } from "$lib/utils/env.utils";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
 import { formatTokenE8s, numberToE8s } from "$lib/utils/token.utils";
 import { isNullish } from "@dfinity/utils";

--- a/frontend/src/lib/utils/env.utils.ts
+++ b/frontend/src/lib/utils/env.utils.ts
@@ -1,4 +1,3 @@
-import { FORCE_CALL_STRATEGY } from "$lib/constants/mockable.constants";
 import { NNS_IC_ORG_ALTERNATIVE_ORIGINS } from "$lib/constants/origin.constants";
 
 /**
@@ -45,9 +44,6 @@ export const addRawToUrl = (urlString: string): string => {
 export const isLocalhost = (hostname: string) =>
   hostname.includes("localhost") || hostname.includes("127.0.0.1");
 
-export const isForceCallStrategy = (): boolean =>
-  FORCE_CALL_STRATEGY === "query";
-
 // Given the used strategy and whether the current call is certified, returns
 // whether this is the last call.
 //
@@ -60,5 +56,3 @@ export const isLastCall = ({
   strategy: "query_and_update" | "query" | "update";
   certified: boolean;
 }): boolean => certified || strategy !== "query_and_update";
-
-export const notForceCallStrategy = (): boolean => !isForceCallStrategy();

--- a/frontend/src/tests/utils/mockable-constants.test-utils.ts
+++ b/frontend/src/tests/utils/mockable-constants.test-utils.ts
@@ -16,6 +16,8 @@ export const mockedConstants: MockableConstants = {
   IS_TEST_ENV: undefined,
   QR_CODE_RENDERED_DEFAULT_STATE: undefined,
   ENABLE_QR_CODE_READER: undefined,
+  isForceCallStrategy: undefined,
+  notForceCallStrategy: undefined,
 };
 
 export const resetMockedConstants = () => {

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -69,6 +69,12 @@ setDefaultTestConstants({
   IS_TEST_ENV: true,
   QR_CODE_RENDERED_DEFAULT_STATE: true,
   ENABLE_QR_CODE_READER: false,
+  isForceCallStrategy: function () {
+    return this.FORCE_CALL_STRATEGY === "query";
+  },
+  notForceCallStrategy: function () {
+    return !this.isForceCallStrategy();
+  },
 });
 
 failTestsThatLogToConsole();


### PR DESCRIPTION
# Motivation

`isForceCallStrategy` and `notForceCallStrategy` only depend on `FORCE_CALL_STRATEGY`.
By putting them in a different file, it creates additional dependencies for workers that depend on anything else in that file.

I noticed this while making a PR to initialize `FORCE_CALL_STRATEGY` randomly for a percentage rollout and logging what it was initialized to, because I noticed 2 log lines every time I loaded the app: 1 from the main app and 1 from a worker.

# Changes

1. Move `isForceCallStrategy` and `notForceCallStrategy` into same file as `FORCE_CALL_STRATEGY`.
2. Update imports.
3. Add default mock values for the functions to satisfy the compiler.

# Tests

By adding a log statement, tested that `frontend/src/lib/constants/mockable.constants.ts` is now loaded once instead of twice.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary