### PR TITLE
Include actor in bump PR description

### DIFF
--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -51,7 +51,9 @@ jobs:
           title: "bot: Bump ${{ inputs.gix_components && 'gix-components' || '' }}${{ inputs.gix_components && inputs.ic_js && ' and ' || '' }}${{ inputs.ic_js && 'ic-js' || '' }}"
           body: |
             # Motivation
+
             We want to pull in the latest changes.
+            This PR was requested by ${{ github.actor }}.
 
             # Changes
 


### PR DESCRIPTION
# Motivation

We have a GitHub workflow to create gix-components or ic-js bump PRs.
Usually the person requesting the bump PR can also approve it themselves.
But sometimes peterpeterparker requests one and then I approve it.
So it's useful to see who requested the PR.

# Changes

Mention the workflow actor in the PR description.

# Tests

Created https://github.com/dfinity/nns-dapp/pull/5587

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary