### PR TITLE
Don't hide neurons which only have staked maturity

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -27,6 +27,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Bug where neurons are displayed as eligible to vote, even though they have already voted.
 * Issue with setting exact dissolve delay on SNS neurons.
 * Error on canister page for canisters that are not controlled by the user.
+* Don't hide neurons which have only staked maturity.
 
 #### Security
 

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -230,7 +230,8 @@ export const hasValidStake = (neuron: NeuronInfo): boolean =>
   // Ignore if we can't validate the stake
   nonNullish(neuron.fullNeuron)
     ? neuron.fullNeuron.cachedNeuronStake +
-        neuron.fullNeuron.maturityE8sEquivalent >
+        neuronAvailableMaturity(neuron) +
+        neuronStakedMaturity(neuron) >
       BigInt(DEFAULT_TRANSACTION_FEE_E8S)
     : false;
 

--- a/frontend/src/lib/utils/sns-neuron.utils.ts
+++ b/frontend/src/lib/utils/sns-neuron.utils.ts
@@ -433,7 +433,10 @@ export const isSnsNeuron = (
  * @returns {boolean}
  */
 export const hasValidStake = (neuron: SnsNeuron): boolean =>
-  neuron.cached_neuron_stake_e8s + neuron.maturity_e8s_equivalent > 0n;
+  neuron.cached_neuron_stake_e8s +
+    getSnsNeuronAvailableMaturity(neuron) +
+    getSnsNeuronStakedMaturity(neuron) >
+  0n;
 
 /*
 - The amount to split minus the transfer fee is more than the minimum stake (thus the child neuron will have at least the minimum stake)

--- a/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
@@ -44,6 +44,7 @@ describe("definedSnsNeuronStore", () => {
           id: [1, 5, 3, 9, 1, 1, 1],
         }),
         maturity_e8s_equivalent: 0n,
+        staked_maturity_e8s_equivalent: [0n],
       },
       {
         ...createMockSnsNeuron({
@@ -213,6 +214,7 @@ describe("sortedSnsNeuronStore", () => {
           id: [1, 5, 3, 9, 1, 1, 1],
         }),
         maturity_e8s_equivalent: 0n,
+        staked_maturity_e8s_equivalent: [0n],
       },
       {
         ...createMockSnsNeuron({

--- a/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
+++ b/frontend/src/tests/lib/pages/SnsNeurons.spec.ts
@@ -37,6 +37,7 @@ describe("SnsNeurons", () => {
     id: [1, 2, 5],
     stake: disbursedNeuronStake,
     maturity: 0n,
+    stakedMaturity: 0n,
   });
   const neuronNFStake = 400_000_000n;
   const neuronNF: SnsNeuron = {

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -322,39 +322,63 @@ describe("neuron-utils", () => {
   });
 
   describe("hasValidStake", () => {
-    it("returns whether the stake is valid or not", () => {
+    it("returns true for ordinary stake", () => {
       const fullNeuronWithEnoughStake = {
         ...mockFullNeuron,
         cachedNeuronStake: 3_000_000_000n,
+        maturityE8sEquivalent: 0n,
+        stakedMaturityE8sEquivalent: 0n,
       };
       const neuronWithEnoughStake = {
         ...mockNeuron,
         fullNeuron: fullNeuronWithEnoughStake,
       };
       expect(hasValidStake(neuronWithEnoughStake)).toBeTruthy();
+    });
 
+    it("returns true for maturity", () => {
       const fullNeuronWithEnoughStakeInMaturity = {
         ...mockFullNeuron,
-        cachedNeuronStake: 100_000_000n,
+        cachedNeuronStake: 0n,
         maturityE8sEquivalent: 3_000_000_000n,
+        stakedMaturityE8sEquivalent: 0n,
       };
       const neuronWithEnoughStakeInMaturity = {
         ...mockNeuron,
         fullNeuron: fullNeuronWithEnoughStakeInMaturity,
       };
       expect(hasValidStake(neuronWithEnoughStakeInMaturity)).toBeTruthy();
+    });
 
+    it("returns true for staked maturity", () => {
+      const fullNeuronWithEnoughStakeInStakedMaturity = {
+        ...mockFullNeuron,
+        cachedNeuronStake: 0n,
+        maturityE8sEquivalent: 0n,
+        stakedMaturityE8sEquivalent: 3_000_000_000n,
+      };
+      const neuronWithEnoughStakeInStakedMaturity = {
+        ...mockNeuron,
+        fullNeuron: fullNeuronWithEnoughStakeInStakedMaturity,
+      };
+      expect(hasValidStake(neuronWithEnoughStakeInStakedMaturity)).toBeTruthy();
+    });
+
+    it("returns false for total stake and maturity below fee", () => {
       const fullNeuronWithoutEnoughStake = {
         ...mockFullNeuron,
         cachedNeuronStake: BigInt(DEFAULT_TRANSACTION_FEE_E8S / 4),
         maturityE8sEquivalent: BigInt(DEFAULT_TRANSACTION_FEE_E8S / 4),
+        stakedMaturityE8sEquivalent: BigInt(DEFAULT_TRANSACTION_FEE_E8S / 4),
       };
       const neuronWithoutEnoughStake = {
         ...mockNeuron,
         fullNeuron: fullNeuronWithoutEnoughStake,
       };
       expect(hasValidStake(neuronWithoutEnoughStake)).toBe(false);
+    });
 
+    it("returns false for absent full neuron", () => {
       const neuronWithoutFullNeuron = {
         ...mockNeuron,
       };

--- a/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/sns-neuron.utils.spec.ts
@@ -1234,6 +1234,7 @@ describe("sns-neuron utils", () => {
         ...mockSnsNeuron,
         cached_neuron_stake_e8s: 10_000_000n,
         maturity_e8s_equivalent: 0n,
+        staked_maturity_e8s_equivalent: [0n],
       };
       expect(hasValidStake(neuron)).toBeTruthy();
     });
@@ -1243,6 +1244,7 @@ describe("sns-neuron utils", () => {
         ...mockSnsNeuron,
         cached_neuron_stake_e8s: 0n,
         maturity_e8s_equivalent: 10_000_000n,
+        staked_maturity_e8s_equivalent: [0n],
       };
       expect(hasValidStake(neuron)).toBeTruthy();
     });
@@ -1252,6 +1254,17 @@ describe("sns-neuron utils", () => {
         ...mockSnsNeuron,
         cached_neuron_stake_e8s: 10_000_000n,
         maturity_e8s_equivalent: 10_000_000n,
+        staked_maturity_e8s_equivalent: [0n],
+      };
+      expect(hasValidStake(neuron)).toBeTruthy();
+    });
+
+    it("returns true if neuron has staked maturity greater than 0", () => {
+      const neuron: SnsNeuron = {
+        ...mockSnsNeuron,
+        cached_neuron_stake_e8s: 0n,
+        maturity_e8s_equivalent: 0n,
+        staked_maturity_e8s_equivalent: [10_000_000n],
       };
       expect(hasValidStake(neuron)).toBeTruthy();
     });
@@ -1261,6 +1274,7 @@ describe("sns-neuron utils", () => {
         ...mockSnsNeuron,
         cached_neuron_stake_e8s: 0n,
         maturity_e8s_equivalent: 0n,
+        staked_maturity_e8s_equivalent: [0n],
       };
       expect(hasValidStake(neuron)).toBe(false);
     });


### PR DESCRIPTION
# Motivation

We hide neurons with zero stake.
The exact logic we use for this is that we hide neurons for which the `stake+maturity < fee` (or `< 0` for SNS).
The problem is that this fails to take staked maturity into accounts.

It's tricky to get a neuron with staked maturity without stake because if the neuron doesn't have a dissolve delay, the staked maturity is automatically reverted to normal maturity. So the repro steps are:

1. Stake a neuron
2. Set a dissolve delay on the neuron.
3. Wait for maturity > fee to build up.
4. Dissolve the neuron.
5. Disburse the neuron.
6. Add a dissolve delay to the neuron.
7. Stake the maturity.

In the test environment, steps 2-4 can be replaced with just adding maturity.

# Changes

Take staked maturity into account for wether to hide NNS and SNS neurons.

# Tests

1. Unit tests added.
2. Tested manually.

# Todos

- [x] Add entry to changelog (if necessary).