### PR TITLE
Ignore zero balance filter for imported tokens

### DIFF
--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -16,6 +16,7 @@
   import { MAX_IMPORTED_TOKENS } from "$lib/constants/imported-tokens.constants";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
   import { isImportedToken } from "$lib/utils/imported-tokens.utils";
+  import type { ImportedTokenData } from "$lib/types/imported-tokens";
 
   export let userTokensData: UserToken[];
 
@@ -29,18 +30,29 @@
   let shouldHideZeroBalances: boolean;
   $: shouldHideZeroBalances = $hideZeroBalancesStore === "hide";
 
+  const getNonZeroBalanceTokensData = ({
+    userTokensData,
+    importedTokens,
+  }: {
+    userTokensData: UserToken[];
+    importedTokens: ImportedTokenData[] | undefined;
+  }) =>
+    userTokensData.filter(
+      (token) =>
+        // Internet Computer is shown, even with zero balance.
+        token.universeId.toText() === OWN_CANISTER_ID_TEXT ||
+        // Imported tokens are shown, even with zero balance.
+        isImportedToken({
+          ledgerCanisterId: token.universeId,
+          importedTokens: $importedTokensStore.importedTokens,
+        }) ||
+        (token.balance instanceof TokenAmountV2 && token.balance.toUlps() > 0n)
+    );
   let nonZeroBalanceTokensData: UserToken[] = [];
-  $: nonZeroBalanceTokensData = userTokensData.filter(
-    (token) =>
-      // Internet Computer is shown, even with zero balance.
-      token.universeId.toText() === OWN_CANISTER_ID_TEXT ||
-      // Imported tokens are shown, even with zero balance.
-      isImportedToken({
-        ledgerCanisterId: token.universeId,
-        importedTokens: $importedTokensStore.importedTokens,
-      }) ||
-      (token.balance instanceof TokenAmountV2 && token.balance.toUlps() > 0n)
-  );
+  $: nonZeroBalanceTokensData = getNonZeroBalanceTokensData({
+    userTokensData,
+    importedTokens: $importedTokensStore.importedTokens,
+  });
 
   let shownTokensData: UserToken[] = [];
   $: shownTokensData = shouldHideZeroBalances

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -44,7 +44,7 @@
         // Imported tokens are shown, even with zero balance.
         isImportedToken({
           ledgerCanisterId: token.universeId,
-          importedTokens: $importedTokensStore.importedTokens,
+          importedTokens,
         }) ||
         (token.balance instanceof TokenAmountV2 && token.balance.toUlps() > 0n)
     );

--- a/frontend/src/lib/pages/Tokens.svelte
+++ b/frontend/src/lib/pages/Tokens.svelte
@@ -15,6 +15,7 @@
   import { importedTokensStore } from "$lib/stores/imported-tokens.store";
   import { MAX_IMPORTED_TOKENS } from "$lib/constants/imported-tokens.constants";
   import { replacePlaceholders } from "$lib/utils/i18n.utils";
+  import { isImportedToken } from "$lib/utils/imported-tokens.utils";
 
   export let userTokensData: UserToken[];
 
@@ -33,6 +34,11 @@
     (token) =>
       // Internet Computer is shown, even with zero balance.
       token.universeId.toText() === OWN_CANISTER_ID_TEXT ||
+      // Imported tokens are shown, even with zero balance.
+      isImportedToken({
+        ledgerCanisterId: token.universeId,
+        importedTokens: $importedTokensStore.importedTokens,
+      }) ||
       (token.balance instanceof TokenAmountV2 && token.balance.toUlps() > 0n)
   );
 

--- a/frontend/src/tests/lib/pages/Tokens.spec.ts
+++ b/frontend/src/tests/lib/pages/Tokens.spec.ts
@@ -134,6 +134,35 @@ describe("Tokens page", () => {
     ]);
   });
 
+  it("should not hide imported tokens, even if they have a zero balance.", async () => {
+    importedTokensStore.set({
+      importedTokens: [
+        {
+          ledgerCanisterId: zeroBalance.universeId,
+          indexCanisterId: undefined,
+        },
+      ],
+      certified: true,
+    });
+    const po = renderPage([positiveBalance, zeroBalance]);
+
+    expect(await po.getTokensTable().getTokenNames()).toEqual([
+      "Positive balance",
+      "Zero balance",
+    ]);
+
+    await po.getSettingsButtonPo().click();
+    await po.getHideZeroBalancesTogglePo().getTogglePo().toggle();
+
+    // Finish transitions
+    await advanceTime();
+
+    expect(await po.getTokensTable().getTokenNames()).toEqual([
+      "Positive balance",
+      "Zero balance",
+    ]);
+  });
+
   it("should hide tokens without balance", async () => {
     const po = renderPage([unavailableBalance, positiveBalance]);
 


### PR DESCRIPTION
# Motivation

Imported tokens should always be shown to the user, regardless of the hide-zero-balance filter. This will help avoid confusion if a user can’t find a custom token after importing it due to the filter being active.

# Changes

- Exclude imported tokens from the zero-balance filter.

# Tests

- Added and tested that it fails w/o changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.