### PR TITLE
FOLLOW-1337: Disable FORCE_CALL_STRATEGY for 10% of sessions

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Fetch TVL from NNS dapp canister instead of TVL canister.
+* 10% rollout of re-enabling of certification of certain calls.
 
 #### Deprecated
 

--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,7 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 * Fetch TVL from NNS dapp canister instead of TVL canister.
-* 10% rollout of re-enabling of certification of certain calls.
+* `10%` rollout of re-enabling of certification of certain calls.
 
 #### Deprecated
 

--- a/frontend/src/lib/constants/mockable.constants.ts
+++ b/frontend/src/lib/constants/mockable.constants.ts
@@ -20,13 +20,6 @@ const RESTORE_QUERY_AND_UPDATE_ROLLOUT_PERCENTAGE: number = 10;
 const getForceCallStrategyForPercentage = (
   percentage: number
 ): undefined | "query" => {
-  // Treat 0 and 100 explicitly to avoid edge cases.
-  if (percentage === 0) {
-    return "query";
-  }
-  if (percentage === 100) {
-    return undefined;
-  }
   return Math.random() * 100 <= percentage ? undefined : "query";
 };
 

--- a/frontend/src/lib/constants/mockable.constants.ts
+++ b/frontend/src/lib/constants/mockable.constants.ts
@@ -5,7 +5,40 @@
 
 export const DEV = import.meta.env.DEV;
 
-export const FORCE_CALL_STRATEGY: "query" | undefined = "query";
+// We use FORCE_CALL_STRATEGY to turn query+update into just a query call in a
+// number of places. We want to go back to doing query+update calls in all these
+// places. We want to do this as a percentage rollout.
+//
+//   0: means we still do only query calls in these places.
+// 100: means we do query+update calls in all these places.
+//  10: means we do query+update calls in these places for 10% of sessions.
+//
+// Whether we do query+update calls remains fixed for the duration of the
+// sessions, by which we mean until the next time the app/page is reloaded.
+const RESTORE_QUERY_AND_UPDATE_ROLLOUT_PERCENTAGE: number = 10;
+
+const getForceCallStrategyForPercentage = (
+  percentage: number
+): undefined | "query" => {
+  // Treat 0 and 100 explicitly to avoid edge cases.
+  if (percentage === 0) {
+    return "query";
+  }
+  if (percentage === 100) {
+    return undefined;
+  }
+  return Math.random() * 100 <= percentage ? undefined : "query";
+};
+
+const initForceCallStrategy = (): undefined | "query" => {
+  const strategy = getForceCallStrategyForPercentage(
+    RESTORE_QUERY_AND_UPDATE_ROLLOUT_PERCENTAGE
+  );
+  console.info("FORCE_CALL_STRATEGY is initialized to:", strategy);
+  return strategy;
+};
+
+export const FORCE_CALL_STRATEGY: "query" | undefined = initForceCallStrategy();
 
 export const isForceCallStrategy = (): boolean =>
   FORCE_CALL_STRATEGY === "query";


### PR DESCRIPTION
# Motivation

We want to re-enable the update calls that are disabled via FORCE_CALL_STRATEGY.
Because this may result in higher subnet load, we want to first roll this out for 10% of sessions.

# Changes

1. Initialize `FORCE_CALL_STRATEGY` on app load, to `"query"` 90% of the time and to `undefined` 10% of the time.
2. Output what it was initialized to, in case we need to know this later for trouble shooting.

# Tests

1. Manually tested by checking the logged value and by adding additional logging in `queryAndUpdate`.
2. `FORCE_CALL_STRATEGY` itself has existing test coverage so it should work either way.

# Todos

- [x] Add entry to changelog (if necessary).
