### PR TITLE
Fix flakiness in neuron-increase-stake.spec.ts

### DIFF
--- a/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
+++ b/frontend/src/tests/e2e/neuron-increase-stake.spec.ts
@@ -77,7 +77,6 @@ test("Test neuron increase stake", async ({ page, context }) => {
     .getAdvancedSectionPo()
     .neuronAccount();
 
-  await appPo.goBack();
   await appPo.goToAccounts();
   await appPo.goToNnsMainAccountWallet();
   await appPo.getWalletPo().getNnsWalletPo().transferToAddress({
@@ -85,10 +84,9 @@ test("Test neuron increase stake", async ({ page, context }) => {
     amount: increase2,
   });
 
-  await appPo.goBack();
-  await appPo.getAccountsPo().waitFor();
-  await appPo.goBack();
   await appPo.goToNeuronDetails(neuronId);
+  // Reload the page to bypass the governance.api-service.ts cache.
+  await page.reload();
   const neuronStake3 = Number(
     await appPo
       .getNeuronDetailPo()

--- a/frontend/src/tests/page-objects/App.page-object.ts
+++ b/frontend/src/tests/page-objects/App.page-object.ts
@@ -264,7 +264,7 @@ export class AppPo extends BasePageObject {
       }
 
       await this.getButton("back").click();
-      currentView.waitForAbsent();
+      await currentView.waitForAbsent();
     }
   }
 


### PR DESCRIPTION
# Motivation

Enabling query+update for `listNeurons` causes some flakiness in the `neuron-increase-stake.spec.ts` e2e test.

We have a cache in `governance.api-service.ts` but it only caches certified responses. Making more certified calls means that we hit the cache more often, which can also result in seeing stale data.
When topping up a neuron by making a direct transfer to the neuron account, the app doesn't know the neuron is being topped up so it doesn't invalidate the cache. So to see the result we need to reload the page in the e2e test.

I also found a missing `await` in the function which navigates back as far as possible which caused it to sometimes not realize it had already navigated.

And there was a race condition between the e2e test navigating back (and not waiting for the navigation to finish) and `AppPo` navigating back.

# Changes

1. Remove unnecessary back navigation from the e2e test. They are unnecessary because the `appPo.goTo*()` methods now always navigate back all the way before opening the menu.
2. Reload the page before seeing the final neuron stake.
3. Add missing `await`.

# Tests

Ran the test 20 times with `FORCE_CALL_STRATEGY` fixed as `undefined`.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary