### PR TITLE
Fix navigation on imported reload

### DIFF
--- a/frontend/src/lib/routes/Wallet.svelte
+++ b/frontend/src/lib/routes/Wallet.svelte
@@ -19,6 +19,7 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import { goto } from "$app/navigation";
   import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
+  import { importedTokensStore } from "$lib/stores/imported-tokens.store";
 
   export let accountIdentifier: string | undefined | null = undefined;
 
@@ -34,6 +35,8 @@
     // We can't be sure that the token is unknown
     // before we have the list of Sns projects.
     nonNullish($snsAggregatorStore.data) &&
+    // and imported tokens being loaded
+    nonNullish($importedTokensStore.importedTokens) &&
     !nonNullish($snsProjectSelectedStore);
   $: if (isUnknownToken) {
     // This will also cover the case when the user was logged out

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -12,6 +12,7 @@ import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
 import Wallet from "$lib/routes/Wallet.svelte";
 import { icrcAccountsStore } from "$lib/stores/icrc-accounts.store";
+import { importedTokensStore } from "$lib/stores/imported-tokens.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { page } from "$mocks/$app/stores";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
@@ -289,6 +290,10 @@ describe("Wallet", () => {
       resetSnsProjects();
 
       expect(get(pageStore).path).toEqual(AppPath.Wallet);
+      importedTokensStore.set({
+        importedTokens: [],
+        certified: true,
+      });
 
       render(Wallet, {
         props: {

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -82,6 +82,7 @@ describe("Wallet", () => {
   let ckEthBalance = 1000000000000000000n;
   beforeEach(() => {
     vi.clearAllMocks();
+    importedTokensStore.reset();
     setCkETHCanisters();
     setSnsProjects([
       {
@@ -288,12 +289,12 @@ describe("Wallet", () => {
         routeId: AppPath.Wallet,
       });
       resetSnsProjects();
-
-      expect(get(pageStore).path).toEqual(AppPath.Wallet);
       importedTokensStore.set({
         importedTokens: [],
         certified: true,
       });
+
+      expect(get(pageStore).path).toEqual(AppPath.Wallet);
 
       render(Wallet, {
         props: {
@@ -301,12 +302,42 @@ describe("Wallet", () => {
         },
       });
       await runResolvedPromises();
+      expect(get(pageStore).path).toEqual(AppPath.Wallet);
 
       // Waits for the sns projects to be available
-      expect(get(pageStore).path).toEqual(AppPath.Wallet);
       setSnsProjects([{}]);
       await runResolvedPromises();
 
+      expect(get(pageStore).path).toEqual(AppPath.Tokens);
+    });
+
+    it("waits for imported tokens being loaded before initiate the redirection", async () => {
+      page.mock({
+        data: { universe: unknownUniverseId },
+        routeId: AppPath.Wallet,
+      });
+      setSnsProjects([{}]);
+      expect(get(importedTokensStore)).toEqual({
+        importedTokens: undefined,
+        certified: undefined,
+      });
+
+      expect(get(pageStore).path).toEqual(AppPath.Wallet);
+
+      render(Wallet, {
+        props: {
+          accountIdentifier: undefined,
+        },
+      });
+      await runResolvedPromises();
+      expect(get(pageStore).path).toEqual(AppPath.Wallet);
+
+      // Waits for the imported tokens to be available
+      importedTokensStore.set({
+        importedTokens: [],
+        certified: true,
+      });
+      await runResolvedPromises();
       expect(get(pageStore).path).toEqual(AppPath.Tokens);
     });
   });


### PR DESCRIPTION
# Motivation

Depending on which response arrives first, reloading the imported token page could automatically navigate the user to the tokens page, which is unintended behaviour. This happens because the check for whether the current token is unknown occurs before the imported tokens are fully loaded.

# Changes

- Wait for the imported tokens being loaded before checking for navigation.

# Tests

- Updated. The current test fails after changes.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.