### PR TITLE
Ignore imported tokens for redirection when signed out

### DIFF
--- a/frontend/src/lib/routes/Wallet.svelte
+++ b/frontend/src/lib/routes/Wallet.svelte
@@ -20,6 +20,7 @@
   import { goto } from "$app/navigation";
   import { snsAggregatorStore } from "$lib/stores/sns-aggregator.store";
   import { importedTokensStore } from "$lib/stores/imported-tokens.store";
+  import { authSignedInStore } from "$lib/derived/auth.derived";
 
   export let accountIdentifier: string | undefined | null = undefined;
 
@@ -36,7 +37,7 @@
     // before we have the list of Sns projects.
     nonNullish($snsAggregatorStore.data) &&
     // and imported tokens being loaded
-    nonNullish($importedTokensStore.importedTokens) &&
+    (!$authSignedInStore || nonNullish($importedTokensStore.importedTokens)) &&
     !nonNullish($snsProjectSelectedStore);
   $: if (isUnknownToken) {
     // This will also cover the case when the user was logged out

--- a/frontend/src/tests/lib/routes/Wallet.spec.ts
+++ b/frontend/src/tests/lib/routes/Wallet.spec.ts
@@ -353,7 +353,7 @@ describe("Wallet", () => {
       expect(get(pageStore).path).toEqual(AppPath.Tokens);
     });
 
-    it("not waits for imported tokens being loaded when signed out", async () => {
+    it("redirects to tokens for unknown universe when not signed in", async () => {
       setNoIdentity();
       page.mock({
         data: { universe: unknownUniverseId },


### PR DESCRIPTION
# Motivation

In PR [#5596](https://github.com/dfinity/nns-dapp/pull/5596), we began checking for the loading of imported tokens to handle navigation from the wallet page for unknown tokens. This fixed the targeted issue but unintentionally broke redirection to the tokens page after sign-out. To restore the sign-out redirection, we also need to consider the login state.

# Changes

- Ignore imported token readiness when signed out, as we don’t load them in this state.

# Tests

- Added.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.