### PR TITLE
Fix race condition in proposal loading

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -30,6 +30,7 @@ proposal is successful, the changes it released will be moved from this file to
 * Error on canister page for canisters that are not controlled by the user.
 * Don't hide neurons which have only staked maturity.
 * Not showing the "no proposals" message when not signed in.
+* Race condition in proposal loading.
 
 #### Security
 


### PR DESCRIPTION
# Motivation

A race condition in `NnsProposals.svelte` was exposed by `e2e/proposals.spec.ts` when query+update is enabled.
The problem is that `loading = false` is set when any request for proposals finishes.
But if there are multiple simultaneous requests, an old request can finish while a new request is still in flight.
Then `loading = false` will be set because of the old request while we should still be showing skeleton cards because of the new request.

# Changes

1. Create an opaque "token" every time we load proposals. When we finish loading proposals, check if the current token is still the same and only set `loading = false` if it is.
2. Wrap this logic in a function which is shared between `findProposals` and `findNextProposals`.

# Tests

1. Added a unit test which makes multiple simultaneous requests.
2. Run the `proposals.spec.ts` e2e test with `FORCE_CALL_STRATEGY` fixed to `undefined`. Before this PR, it would fail about 1/10 times. With this PR, I was able to run it 30 times without failing.

# Todos

- [x] Add entry to changelog (if necessary).
