### PR TITLE
Make vote script vote in parallel

### DIFF
--- a/scripts/vote
+++ b/scripts/vote
@@ -89,14 +89,17 @@ get_all_proposal_ids() {
 }
 
 if [[ "${PROPOSAL_ID:-}" == "all" ]]; then
+  pids=()
   for proposal_id in $(get_all_proposal_ids); do
     "$0" \
       --neuron "$NEURON_ID" \
       --proposal "$proposal_id" \
       "${MAYBE_REJECT[@]}" \
       --identity "$DFX_IDENTITY" \
-      --network "$DFX_NETWORK"
+      --network "$DFX_NETWORK" &
+    pids+=("$!")
   done
+  wait "${pids[@]}"
   exit 0
 fi
 


### PR DESCRIPTION
# Motivation

Voting on a lot of proposals can be quite slow.

# Changes

Call the script multiple times in parallel when voting on multiple proposals.
The `&` at the end of the command runs the command in the background.
At the end we wait for all the processes before exiting the script.

# Tests

Tested manually

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary