### PR TITLE
Import icp validation

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -856,7 +856,8 @@
     "ledger_canister_loading": "Unable to load token details using the provided ledger canister ID.",
     "is_duplication": "You have already imported this token, you can find it in the token list.",
     "is_sns": "You cannot import SNS tokens, they are added by the NNS.",
-    "is_important": "This token is already in the token list."
+    "is_important": "This token is already in the token list.",
+    "is_icp": "You cannot import ICP."
   },
   "error__sns": {
     "undefined_project": "The requested project is invalid or throws an error.",

--- a/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
+++ b/frontend/src/lib/modals/accounts/ImportTokenModal.svelte
@@ -25,6 +25,7 @@
   import { goto } from "$app/navigation";
   import { get } from "svelte/store";
   import { DISABLE_IMPORT_TOKEN_VALIDATION_FOR_TESTING } from "$lib/stores/feature-flags.store";
+  import { LEDGER_CANISTER_ID } from "../../constants/canister-ids.constants";
 
   let currentStep: WizardStep | undefined = undefined;
 
@@ -65,6 +66,9 @@
   const validateLedgerCanister = (
     ledgerCanisterId: Principal
   ): { errorLabelKey: string | undefined } => {
+    if (ledgerCanisterId.toText() === LEDGER_CANISTER_ID.toText()) {
+      return { errorLabelKey: "error__imported_tokens.is_icp" };
+    }
     if (
       isImportedToken({
         ledgerCanisterId,

--- a/frontend/src/lib/services/imported-tokens.services.ts
+++ b/frontend/src/lib/services/imported-tokens.services.ts
@@ -106,8 +106,6 @@ export const addImportedToken = async ({
   tokenToAdd: ImportedTokenData;
   importedTokens: ImportedTokenData[];
 }): Promise<{ success: boolean }> => {
-  // TODO: validate importedToken (not sns, not ck, is unique, etc.)
-
   const tokens = [...importedTokens, tokenToAdd];
   const { err } = await saveImportedToken({ tokens });
 

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -895,6 +895,7 @@ interface I18nError__imported_tokens {
   is_duplication: string;
   is_sns: string;
   is_important: string;
+  is_icp: string;
 }
 
 interface I18nError__sns {

--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -1,6 +1,7 @@
 import * as icrcIndexApi from "$lib/api/icrc-index.api";
 import * as ledgerApi from "$lib/api/icrc-ledger.api";
 import * as importedTokensApi from "$lib/api/imported-tokens.api";
+import { LEDGER_CANISTER_ID } from "$lib/constants/canister-ids.constants";
 import { CKBTC_LEDGER_CANISTER_ID } from "$lib/constants/ckbtc-canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import { pageStore } from "$lib/derived/page.derived";
@@ -69,6 +70,26 @@ describe("ImportTokenModal", () => {
   });
 
   describe("Form Step", () => {
+    it("should catch icp", async () => {
+      const po = renderComponent();
+      const formPo = po.getImportTokenFormPo();
+
+      await formPo
+        .getLedgerCanisterInputPo()
+        .typeText(LEDGER_CANISTER_ID.toText());
+
+      expect(queryIcrcTokenSpy).toBeCalledTimes(0);
+      expect(await formPo.isPresent()).toEqual(true);
+
+      await formPo.getSubmitButtonPo().click();
+
+      expect(get(busyStore)).toEqual([]);
+      expectToastError("You cannot import ICP.");
+      expect(queryIcrcTokenSpy).toBeCalledTimes(0);
+      // Stays on the form.
+      expect(await formPo.isPresent()).toEqual(true);
+    });
+
     it("should catch duplications", async () => {
       importedTokensStore.set({
         importedTokens: [


### PR DESCRIPTION
# Motivation

To avoid confusion and ensure consistency with the inability to add other existing tokens, ICP should not be importable.

# Changes

- Extend validation to prevent importing the ICP ledger canister id.

# Tests

- Updated.

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.