### PR TITLE
Update IC cargo deps to 45eee81e4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1104,7 +1104,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1116,7 +1116,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1125,7 +1125,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "on_wire",
  "prost",
@@ -1334,7 +1334,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -1727,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-replica-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -1740,7 +1740,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -1753,7 +1753,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "serde",
 ]
@@ -1761,7 +1761,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -1770,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1898,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1912,7 +1912,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "getrandom",
 ]
@@ -1920,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "hex",
  "ic-types",
@@ -1930,7 +1930,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -1952,7 +1952,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -1970,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -1978,7 +1978,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -1997,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2010,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "sha2",
 ]
@@ -2018,7 +2018,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "base64 0.13.1",
  "cached",
@@ -2044,7 +2044,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2074,7 +2074,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "arrayvec 0.7.6",
  "hex",
@@ -2091,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2109,7 +2109,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "hmac",
  "k256",
@@ -2125,7 +2125,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "serde",
  "zeroize",
@@ -2134,7 +2134,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2142,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2155,7 +2155,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -2168,7 +2168,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2178,7 +2178,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2188,7 +2188,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-protobuf",
  "ic-utils",
@@ -2200,7 +2200,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "ciborium",
@@ -2223,7 +2223,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "ciborium",
@@ -2251,7 +2251,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "async-trait",
  "candid",
@@ -2280,7 +2280,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "async-trait",
  "candid",
@@ -2310,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -2322,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "hex",
@@ -2332,12 +2332,12 @@ dependencies = [
 [[package]]
 name = "ic-limits"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2363,7 +2363,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-canisters"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "async-trait",
  "candid",
@@ -2380,7 +2380,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "async-trait",
  "candid",
@@ -2403,12 +2403,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2443,12 +2443,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -2461,12 +2461,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -2478,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-initial-supply"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "async-trait",
  "candid",
@@ -2492,12 +2492,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "comparable",
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-base-types",
 ]
@@ -2518,7 +2518,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "dfn_core",
@@ -2534,7 +2534,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "async-trait",
  "candid",
@@ -2547,17 +2547,17 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 
 [[package]]
 name = "ic-nervous-system-temporary"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -2570,7 +2570,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "comparable",
@@ -2596,7 +2596,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -2605,7 +2605,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2622,6 +2622,7 @@ dependencies = [
  "ic-canisters-http-types",
  "ic-cdk 0.13.5",
  "ic-cdk-macros 0.9.0",
+ "ic-cdk-timers 0.7.0",
  "ic-crypto-getrandom-for-wasm",
  "ic-crypto-sha2",
  "ic-ledger-core",
@@ -2677,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "bytes",
  "candid",
@@ -2705,7 +2706,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "csv",
  "ic-base-types",
@@ -2722,12 +2723,12 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "async-trait",
  "candid",
@@ -2742,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "bincode",
  "candid",
@@ -2756,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-canister-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2767,7 +2768,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2779,7 +2780,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-node-provider-rewards"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-base-types",
  "ic-protobuf",
@@ -2788,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2799,7 +2800,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "ic-management-canister-types",
@@ -2810,7 +2811,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -2822,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2834,7 +2835,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2893,7 +2894,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -2901,7 +2902,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -2912,7 +2913,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "async-trait",
  "candid",
@@ -2934,7 +2935,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -2962,7 +2963,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2983,7 +2984,6 @@ dependencies = [
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
- "ic-nns-constants",
  "ic-sns-swap",
  "icrc-ledger-types",
  "prost",
@@ -2993,7 +2993,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3032,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "comparable",
@@ -3047,7 +3047,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "async-trait",
  "candid",
@@ -3093,7 +3093,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3130,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "ic-validate-eq-derive",
 ]
@@ -3149,7 +3149,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq-derive"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -3234,7 +3234,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "comparable",
@@ -3264,7 +3264,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "async-trait",
  "candid",
@@ -3275,7 +3275,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.6"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "base32",
  "candid",
@@ -3990,7 +3990,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 
 [[package]]
 name = "once_cell"
@@ -4136,7 +4136,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "candid",
  "num-traits",
@@ -4395,9 +4395,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -4405,13 +4405,13 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -4426,12 +4426,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -4439,9 +4439,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
 dependencies = [
  "prost",
 ]
@@ -4593,7 +4593,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-09-26_01-31-no-canister-snapshots#c43a4880199c00135c8415957851e823b3fb769e"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
 dependencies = [
  "build-info",
  "build-info-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1104,7 +1104,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1116,7 +1116,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1125,7 +1125,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "on_wire",
  "prost",
@@ -1334,7 +1334,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -1727,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-replica-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -1740,7 +1740,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -1753,7 +1753,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "serde",
 ]
@@ -1761,7 +1761,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -1770,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1898,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1912,7 +1912,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "getrandom",
 ]
@@ -1920,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "hex",
  "ic-types",
@@ -1930,7 +1930,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -1952,7 +1952,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -1970,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -1978,7 +1978,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -1997,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2010,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "sha2",
 ]
@@ -2018,7 +2018,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "base64 0.13.1",
  "cached",
@@ -2044,7 +2044,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2074,7 +2074,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "arrayvec 0.7.6",
  "hex",
@@ -2091,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2109,7 +2109,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "hmac",
  "k256",
@@ -2125,7 +2125,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "serde",
  "zeroize",
@@ -2134,7 +2134,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2142,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2155,7 +2155,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -2168,7 +2168,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2178,7 +2178,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2188,7 +2188,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-protobuf",
  "ic-utils",
@@ -2200,7 +2200,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "ciborium",
@@ -2223,7 +2223,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "ciborium",
@@ -2231,7 +2231,7 @@ dependencies = [
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
- "ic-cdk 0.13.5",
+ "ic-cdk 0.16.0",
  "ic-cdk-macros 0.9.0",
  "ic-cdk-timers 0.7.0",
  "ic-crypto-sha2",
@@ -2251,7 +2251,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "async-trait",
  "candid",
@@ -2260,7 +2260,7 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.13.5",
+ "ic-cdk 0.16.0",
  "ic-cdk-macros 0.9.0",
  "ic-crypto-tree-hash",
  "ic-icrc1",
@@ -2280,7 +2280,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "async-trait",
  "candid",
@@ -2310,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -2322,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "hex",
@@ -2332,12 +2332,12 @@ dependencies = [
 [[package]]
 name = "ic-limits"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2363,7 +2363,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-canisters"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "async-trait",
  "candid",
@@ -2380,7 +2380,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "async-trait",
  "candid",
@@ -2403,12 +2403,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2443,12 +2443,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -2461,12 +2461,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -2478,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-initial-supply"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "async-trait",
  "candid",
@@ -2492,12 +2492,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "comparable",
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-base-types",
 ]
@@ -2518,11 +2518,11 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "dfn_core",
- "ic-cdk 0.13.5",
+ "ic-cdk 0.16.0",
  "ic-crypto-sha2",
  "ic-management-canister-types",
  "ic-nervous-system-clients",
@@ -2534,30 +2534,30 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "async-trait",
  "candid",
  "dfn_candid",
  "dfn_core",
  "ic-base-types",
- "ic-cdk 0.13.5",
+ "ic-cdk 0.16.0",
 ]
 
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 
 [[package]]
 name = "ic-nervous-system-temporary"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -2570,7 +2570,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "comparable",
@@ -2596,7 +2596,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -2605,7 +2605,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2620,7 +2620,7 @@ dependencies = [
  "futures",
  "ic-base-types",
  "ic-canisters-http-types",
- "ic-cdk 0.13.5",
+ "ic-cdk 0.16.0",
  "ic-cdk-macros 0.9.0",
  "ic-cdk-timers 0.7.0",
  "ic-crypto-getrandom-for-wasm",
@@ -2678,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "bytes",
  "candid",
@@ -2706,7 +2706,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "csv",
  "ic-base-types",
@@ -2723,12 +2723,12 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "async-trait",
  "candid",
@@ -2743,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "bincode",
  "candid",
@@ -2757,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-canister-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2768,7 +2768,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2780,7 +2780,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-node-provider-rewards"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-base-types",
  "ic-protobuf",
@@ -2789,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2800,7 +2800,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "ic-management-canister-types",
@@ -2811,7 +2811,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -2823,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2835,7 +2835,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2844,13 +2844,14 @@ dependencies = [
  "candid",
  "clap 3.2.25",
  "comparable",
- "dfn_candid",
- "dfn_core",
+ "futures",
  "hex",
  "ic-base-types",
  "ic-canister-log",
  "ic-canister-profiler",
  "ic-canisters-http-types",
+ "ic-cdk 0.16.0",
+ "ic-cdk-macros 0.9.0",
  "ic-crypto-sha2",
  "ic-icrc1-ledger",
  "ic-ledger-core",
@@ -2894,7 +2895,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -2902,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -2913,14 +2914,14 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "async-trait",
  "candid",
  "cycles-minting-canister",
  "futures",
  "ic-base-types",
- "ic-cdk 0.13.5",
+ "ic-cdk 0.16.0",
  "ic-nervous-system-common",
  "ic-nervous-system-initial-supply",
  "ic-nervous-system-runtime",
@@ -2935,7 +2936,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -2963,7 +2964,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2974,7 +2975,7 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
- "ic-cdk 0.13.5",
+ "ic-cdk 0.16.0",
  "ic-cdk-macros 0.9.0",
  "ic-cdk-timers 0.7.0",
  "ic-management-canister-types",
@@ -2993,19 +2994,20 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "async-trait",
  "build-info",
  "build-info-build",
  "candid",
  "comparable",
- "dfn_candid",
- "dfn_core",
  "hex",
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
+ "ic-cdk 0.16.0",
+ "ic-cdk-macros 0.9.0",
+ "ic-cdk-timers 0.7.0",
  "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-nervous-system-canisters",
@@ -3032,7 +3034,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "comparable",
@@ -3047,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "async-trait",
  "candid",
@@ -3057,7 +3059,7 @@ dependencies = [
  "futures",
  "hex",
  "ic-base-types",
- "ic-cdk 0.13.5",
+ "ic-cdk 0.16.0",
  "ic-crypto-sha2",
  "ic-management-canister-types",
  "ic-metrics-encoder",
@@ -3093,7 +3095,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3130,7 +3132,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3141,7 +3143,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "ic-validate-eq-derive",
 ]
@@ -3149,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq-derive"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -3234,7 +3236,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "comparable",
@@ -3244,7 +3246,7 @@ dependencies = [
  "dfn_protobuf",
  "hex",
  "ic-base-types",
- "ic-cdk 0.13.5",
+ "ic-cdk 0.16.0",
  "ic-crypto-sha2",
  "ic-ledger-canister-core",
  "ic-ledger-core",
@@ -3264,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "async-trait",
  "candid",
@@ -3275,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.6"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "base32",
  "candid",
@@ -3288,6 +3290,7 @@ dependencies = [
  "serde_bytes",
  "sha2",
  "strum",
+ "strum_macros",
  "time",
 ]
 
@@ -3990,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 
 [[package]]
 name = "once_cell"
@@ -4136,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "candid",
  "num-traits",
@@ -4593,7 +4596,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=release-2024-10-03_01-30-base#d2657773d007e1b4c0b2dd715c628d24c0d7b5fb"
+source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
 dependencies = [
  "build-info",
  "build-info-build",
@@ -4603,7 +4606,7 @@ dependencies = [
  "dfn_http_metrics",
  "futures",
  "ic-base-types",
- "ic-cdk 0.13.5",
+ "ic-cdk 0.16.0",
  "ic-certified-map 0.3.4",
  "ic-crypto-node-key-validation",
  "ic-crypto-sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,23 +14,23 @@ ic-cdk = "0.16.0"
 ic-cdk-macros = "0.16.0"
 ic-cdk-timers = "0.10.0"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
-ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
 
 [profile.release]
 lto = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,23 +14,23 @@ ic-cdk = "0.16.0"
 ic-cdk-macros = "0.16.0"
 ic-cdk-timers = "0.10.0"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
-ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-09-26_01-31-no-canister-snapshots" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-03_01-30-base" }
 
 [profile.release]
 lto = false


### PR DESCRIPTION
# Motivation

The IC repo has failed to make a release for the past 2 weeks.
There have been release tags so I tried updating to `release-2024-10-11_14-35-base` but the Cargo build of `icrc-ledger-types` is actually broken at that commit.
The Cargo build works at the latest (untagged) commit `45eee81e4604c07306e29622aac41c600b024185` so let's update to that.

# Changes

Ran `scripts/update-ic-cargo-deps --ref 45eee81e4604c07306e29622aac41c600b024185`.

# Tests

CI passes

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary