### PR TITLE
Download ledger.did from new path

### DIFF
--- a/declarations/used_by_sns_aggregator/sns_governance/sns_governance.did
+++ b/declarations/used_by_sns_aggregator/sns_governance/sns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-09-26_01-31-no-canister-snapshots/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-11_14-35-overload/rs/sns/governance/canister/governance.did>
 type Account = record {
   owner : opt principal;
   subaccount : opt Subaccount;
@@ -265,6 +265,12 @@ type GetSnsInitializationParametersResponse = record {
   sns_initialization_parameters : text;
 };
 
+type CachedUpgradeSteps = record {
+  upgrade_steps : opt Versions;
+  requested_timestamp_seconds : opt nat64;
+  response_timestamp_seconds : opt nat64;
+};
+
 type Governance = record {
   root_canister_id : opt principal;
   id_to_nervous_system_functions : vec record { nat64; NervousSystemFunction };
@@ -274,6 +280,7 @@ type Governance = record {
   parameters : opt NervousSystemParameters;
   is_finalizing_disburse_maturity : opt bool;
   deployed_version : opt Version;
+  cached_upgrade_steps : opt CachedUpgradeSteps;
   sns_initialization_parameters : text;
   latest_reward_event : opt RewardEvent;
   pending_version : opt UpgradeInProgress;
@@ -284,7 +291,6 @@ type Governance = record {
   sns_metadata : opt ManageSnsMetadata;
   neurons : vec record { text; Neuron };
   genesis_timestamp_seconds : nat64;
-  migrated_root_wasm_memory_limit : opt bool;
 };
 
 type GovernanceCachedMetrics = record {
@@ -689,6 +695,8 @@ type Version = record {
   index_wasm_hash : blob;
 };
 
+type Versions = record { versions : vec Version };
+
 type VotingRewardsParameters = record {
   final_reward_rate_basis_points : opt nat64;
   initial_reward_rate_basis_points : opt nat64;
@@ -698,6 +706,13 @@ type VotingRewardsParameters = record {
 
 type WaitForQuietState = record {
   current_deadline_timestamp_seconds : nat64;
+};
+
+type GetUpgradeJournalRequest = record {};
+
+type GetUpgradeJournalResponse = record {
+  upgrade_steps : opt Versions;
+  response_timestamp_seconds : opt nat64;
 };
 
 service : (Governance) -> {
@@ -716,6 +731,7 @@ service : (Governance) -> {
   get_sns_initialization_parameters : (record {}) -> (
       GetSnsInitializationParametersResponse,
     ) query;
+  get_upgrade_journal : (GetUpgradeJournalRequest) -> (GetUpgradeJournalResponse) query;
   list_nervous_system_functions : () -> (
       ListNervousSystemFunctionsResponse,
     ) query;

--- a/declarations/used_by_sns_aggregator/sns_ledger/sns_ledger.did
+++ b/declarations/used_by_sns_aggregator/sns_ledger/sns_ledger.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-09-26_01-31-no-canister-snapshots/rs/rosetta-api/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-11_14-35-overload/rs/ledger_suite/icrc1/ledger/ledger.did>
 type BlockIndex = nat;
 type Subaccount = blob;
 // Number of nanoseconds since the UNIX epoch in UTC timezone.

--- a/declarations/used_by_sns_aggregator/sns_root/sns_root.did
+++ b/declarations/used_by_sns_aggregator/sns_root/sns_root.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-09-26_01-31-no-canister-snapshots/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-11_14-35-overload/rs/sns/root/canister/root.did>
 type CanisterCallError = record {
   code : opt int32;
   description : text;

--- a/declarations/used_by_sns_aggregator/sns_swap/sns_swap.did
+++ b/declarations/used_by_sns_aggregator/sns_swap/sns_swap.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-09-26_01-31-no-canister-snapshots/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-11_14-35-overload/rs/sns/swap/canister/swap.did>
 type BuyerState = record {
   icp : opt TransferableAmount;
   has_created_neuron_recipes : opt bool;

--- a/declarations/used_by_sns_aggregator/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_sns_aggregator/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-09-26_01-31-no-canister-snapshots/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-11_14-35-overload/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;

--- a/dfx.json
+++ b/dfx.json
@@ -404,7 +404,7 @@
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-10-09",
         "IC_COMMIT_FOR_PROPOSALS": "release-2024-09-26_01-31-no-canister-snapshots",
-        "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-09-26_01-31-no-canister-snapshots"
+        "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-10-11_14-35-overload"
       },
       "packtool": ""
     }

--- a/rs/sns_aggregator/src/types/ic_sns_governance.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_governance.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_governance --out ic_sns_governance.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-09-26_01-31-no-canister-snapshots/rs/sns/governance/canister/governance.did>
+//! Candid for canister `sns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-11_14-35-overload/rs/sns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]
@@ -16,6 +16,25 @@ use ic_cdk::api::call::CallResult;
 // use candid::{self, CandidType, Deserialize, Principal};
 // use ic_cdk::api::call::CallResult as Result;
 
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Version {
+    pub archive_wasm_hash: serde_bytes::ByteBuf,
+    pub root_wasm_hash: serde_bytes::ByteBuf,
+    pub swap_wasm_hash: serde_bytes::ByteBuf,
+    pub ledger_wasm_hash: serde_bytes::ByteBuf,
+    pub governance_wasm_hash: serde_bytes::ByteBuf,
+    pub index_wasm_hash: serde_bytes::ByteBuf,
+}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct Versions {
+    pub versions: Vec<Version>,
+}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct CachedUpgradeSteps {
+    pub upgrade_steps: Option<Versions>,
+    pub response_timestamp_seconds: Option<u64>,
+    pub requested_timestamp_seconds: Option<u64>,
+}
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GenericNervousSystemFunction {
     pub validator_canister_id: Option<Principal>,
@@ -103,15 +122,6 @@ pub struct NervousSystemParameters {
     pub voting_rewards_parameters: Option<VotingRewardsParameters>,
     pub maturity_modulation_disabled: Option<bool>,
     pub max_number_of_principals_per_neuron: Option<u64>,
-}
-#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
-pub struct Version {
-    pub archive_wasm_hash: serde_bytes::ByteBuf,
-    pub root_wasm_hash: serde_bytes::ByteBuf,
-    pub swap_wasm_hash: serde_bytes::ByteBuf,
-    pub ledger_wasm_hash: serde_bytes::ByteBuf,
-    pub governance_wasm_hash: serde_bytes::ByteBuf,
-    pub index_wasm_hash: serde_bytes::ByteBuf,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct ProposalId {
@@ -458,6 +468,7 @@ pub struct Neuron {
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct Governance {
     pub root_canister_id: Option<Principal>,
+    pub cached_upgrade_steps: Option<CachedUpgradeSteps>,
     pub id_to_nervous_system_functions: Vec<(u64, NervousSystemFunction)>,
     pub metrics: Option<GovernanceCachedMetrics>,
     pub maturity_modulation: Option<MaturityModulation>,
@@ -473,7 +484,6 @@ pub struct Governance {
     pub proposals: Vec<(u64, ProposalData)>,
     pub in_flight_commands: Vec<(String, NeuronInFlightCommand)>,
     pub sns_metadata: Option<ManageSnsMetadata>,
-    pub migrated_root_wasm_memory_limit: Option<bool>,
     pub neurons: Vec<(String, Neuron)>,
     pub genesis_timestamp_seconds: u64,
 }
@@ -620,6 +630,13 @@ pub struct GetSnsInitializationParametersArg {}
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
 pub struct GetSnsInitializationParametersResponse {
     pub sns_initialization_parameters: String,
+}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct GetUpgradeJournalRequest {}
+#[derive(Serialize, Clone, Debug, CandidType, Deserialize)]
+pub struct GetUpgradeJournalResponse {
+    pub upgrade_steps: Option<Versions>,
+    pub response_timestamp_seconds: Option<u64>,
 }
 #[derive(Serialize, Clone, Debug, CandidType, Deserialize, Default)]
 pub struct ListNervousSystemFunctionsResponse {
@@ -779,6 +796,12 @@ impl Service {
         arg0: GetSnsInitializationParametersArg,
     ) -> CallResult<(GetSnsInitializationParametersResponse,)> {
         ic_cdk::call(self.0, "get_sns_initialization_parameters", (arg0,)).await
+    }
+    pub async fn get_upgrade_journal(
+        &self,
+        arg0: GetUpgradeJournalRequest,
+    ) -> CallResult<(GetUpgradeJournalResponse,)> {
+        ic_cdk::call(self.0, "get_upgrade_journal", (arg0,)).await
     }
     pub async fn list_nervous_system_functions(&self) -> CallResult<(ListNervousSystemFunctionsResponse,)> {
         ic_cdk::call(self.0, "list_nervous_system_functions", ()).await

--- a/rs/sns_aggregator/src/types/ic_sns_ledger.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_ledger.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_ledger --out ic_sns_ledger.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-09-26_01-31-no-canister-snapshots/rs/rosetta-api/icrc1/ledger/ledger.did>
+//! Candid for canister `sns_ledger` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-11_14-35-overload/rs/ledger_suite/icrc1/ledger/ledger.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_root.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_root.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_root --out ic_sns_root.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-09-26_01-31-no-canister-snapshots/rs/sns/root/canister/root.did>
+//! Candid for canister `sns_root` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-11_14-35-overload/rs/sns/root/canister/root.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_swap.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_swap.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_swap --out ic_sns_swap.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-09-26_01-31-no-canister-snapshots/rs/sns/swap/canister/swap.did>
+//! Candid for canister `sns_swap` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-11_14-35-overload/rs/sns/swap/canister/swap.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/rs/sns_aggregator/src/types/ic_sns_wasm.rs
+++ b/rs/sns_aggregator/src/types/ic_sns_wasm.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out ic_sns_wasm.rs --header did2rs.header --traits Serialize\,\ Clone\,\ Debug`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-09-26_01-31-no-canister-snapshots/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-11_14-35-overload/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(unused_imports)]
 #![allow(missing_docs)]

--- a/scripts/update_ic_commit
+++ b/scripts/update_ic_commit
@@ -52,7 +52,7 @@ bump_ic_commit() {
     mkdir -p "$(dirname "$local_path")"
     {
       echo "//! Candid for canister \`$canister\` obtained by \`scripts/update_ic_commit\` from: <$IC_URL$upstream_path>"
-      curl -sfL --retry 5 "$IC_URL$upstream_path"
+      curl -SsfL --retry 5 "$IC_URL$upstream_path"
     } >"${local_path}"
   }
   if [[ "$CRATE" = "proposals" ]]; then
@@ -66,7 +66,7 @@ bump_ic_commit() {
     did_curl sns_aggregator sns_root /rs/sns/root/canister/root.did
     did_curl sns_aggregator sns_swap /rs/sns/swap/canister/swap.did
     did_curl sns_aggregator sns_wasm /rs/nns/sns-wasm/canister/sns-wasm.did
-    did_curl sns_aggregator sns_ledger /rs/rosetta-api/icrc1/ledger/ledger.did
+    did_curl sns_aggregator sns_ledger /rs/ledger_suite/icrc1/ledger/ledger.did
   else
     echo "ERROR: --crate should be 'proposals' or 'sns_aggregator' or 'all'."
     exit 1


### PR DESCRIPTION
# Motivation

"Update sns_aggregator candid bindings" [failed](https://github.com/dfinity/nns-dapp/actions/runs/11338847183/job/31540786783) because ledger and Index Candid files were moved to a different directory in https://github.com/dfinity/ic/pull/1682

After fixing the path in the script, I had to also update the candid files to the new commit, because we have a [test](https://github.com/dfinity/nns-dapp/blob/a360d0281792040f8930f089c59aef9996188024/.github/workflows/checks.yml#L140-L143) that checks that the current code matches what would be generated at the current version in `dfx.json` and without updating `dfx.json` it would try to download from the new path at the old version which also fails.

The important changes are in the first commit and updating the candid and bindings is in the second commit.

# Changes

1. Change the path where we download the `ledger.did` to the new path.
2. Add `-S` to `curl` to get slightly better error messages.
3. Ran `scripts/update_ic_commit --crate sns_aggregator --ic_commit "release-2024-10-11_14-35-overload"`.
4. Ran `scripts/sns/aggregator/mk_nns_types.sh`.

# Tests

Ran `scripts/update_ic_commit --crate sns_aggregator --ic_commit "release-2024-10-11_14-35-overload"` with and without the new changes and saw it first fail and then pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary