### PR TITLE
Rename DIDC_VERSION to DIDC_RELEASE

### DIFF
--- a/.github/actions/build_nns_dapp/action.yaml
+++ b/.github/actions/build_nns_dapp/action.yaml
@@ -56,7 +56,7 @@ runs:
         set -euxo pipefail
         if command -v didc
         then echo "Skipping didc installation, as didc is already installed"
-        else dfx-software-didc-install --release "$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+        else dfx-software-didc-install --release "$(jq -r .defaults.build.config.DIDC_RELEASE dfx.json)"
         fi
     - name: Create local arguments
       shell: bash

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -134,7 +134,7 @@ jobs:
           USER_BIN="$HOME/.local/bin"
           mkdir -p "$USER_BIN"
           echo "$USER_BIN" >> $GITHUB_PATH
-          version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+          version="$(jq -r .defaults.build.config.DIDC_RELEASE dfx.json)"
           # TODO: Make `didc` support `binstall`, then use `binstall` here.
           curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
       - name: Check didc
@@ -166,7 +166,7 @@ jobs:
           USER_BIN="$HOME/.local/bin"
           mkdir -p "$USER_BIN"
           echo "$USER_BIN" >> $GITHUB_PATH
-          version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+          version="$(jq -r .defaults.build.config.DIDC_RELEASE dfx.json)"
           # TODO: Use `binstall`, once `didc` supports it.
           curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
       - name: Check didc
@@ -221,7 +221,7 @@ jobs:
           USER_BIN="$HOME/.local/bin"
           mkdir -p "$USER_BIN"
           echo "$USER_BIN" >> $GITHUB_PATH
-          version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+          version="$(jq -r .defaults.build.config.DIDC_RELEASE dfx.json)"
           # TODO: Make `didc` support `binstall`, then use `binstall` here.
           curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
       - name: Install cargo binstall

--- a/.github/workflows/update-aggregator.yml
+++ b/.github/workflows/update-aggregator.yml
@@ -20,7 +20,7 @@ jobs:
           USER_BIN="$HOME/.local/bin"
           mkdir -p "$USER_BIN"
           echo "$USER_BIN" >> $GITHUB_PATH
-          version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+          version="$(jq -r .defaults.build.config.DIDC_RELEASE dfx.json)"
           # TODO: Make `didc` support `binstall`, then use `binstall` here.
           curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
       - name: Find newer IC release, if any

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           pwd
           find .github/actions
-          current_didc_release=$(jq -r '.defaults.build.config.DIDC_VERSION' dfx.json)
+          current_didc_release=$(jq -r '.defaults.build.config.DIDC_RELEASE' dfx.json)
           echo "current didc release '$current_didc_release'"
 
           latest_didc_release=$(curl -sSL https://api.github.com/repos/dfinity/candid/releases/latest | jq .tag_name -r)
@@ -27,14 +27,14 @@ jobs:
           then
             echo didc needs an update
             sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
-            DIDC_RELEASE="$latest_didc_release" jq '.defaults.build.config.DIDC_VERSION=(env.DIDC_RELEASE)' dfx.json  | sponge dfx.json
+            DIDC_RELEASE="$latest_didc_release" jq '.defaults.build.config.DIDC_RELEASE=(env.DIDC_RELEASE)' dfx.json  | sponge dfx.json
             echo "updated=1" >> "$GITHUB_OUTPUT"
             echo "version=$latest_didc_release" >> "$GITHUB_OUTPUT"
           else
             echo "updated=0" >> "$GITHUB_OUTPUT"
           fi
 
-          jq '.defaults.build.config.DIDC_VERSION' dfx.json
+          jq '.defaults.build.config.DIDC_RELEASE' dfx.json
           echo "Git status:"
           git status
           echo "Changes:"

--- a/.github/workflows/update-proposals.yml
+++ b/.github/workflows/update-proposals.yml
@@ -20,7 +20,7 @@ jobs:
           USER_BIN="$HOME/.local/bin"
           mkdir -p "$USER_BIN"
           echo "$USER_BIN" >> $GITHUB_PATH
-          version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+          version="$(jq -r .defaults.build.config.DIDC_RELEASE dfx.json)"
           # TODO: Make `didc` support `binstall`, then use `binstall` here.
           curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
       - name: Find newer IC release, if any

--- a/.github/workflows/update-snsdemo.yml
+++ b/.github/workflows/update-snsdemo.yml
@@ -44,7 +44,7 @@ jobs:
           set -x
           echo snsdemo needs an update
           # Install `didc`
-          snsdemo/bin/dfx-software-didc-install --release "$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+          snsdemo/bin/dfx-software-didc-install --release "$(jq -r .defaults.build.config.DIDC_RELEASE dfx.json)"
           # Install sponge
           sudo apt-get update -yy && sudo apt-get install -yy moreutils && command -v sponge
           # Update

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY dfx.json dfx.json
 ENV NODE_VERSION=16.17.1
 RUN jq -r .dfx dfx.json > config/dfx_version
 RUN jq -r '.defaults.build.config.NODE_VERSION' dfx.json > config/node_version
-RUN jq -r '.defaults.build.config.DIDC_VERSION' dfx.json > config/didc_version
+RUN jq -r '.defaults.build.config.DIDC_RELEASE' dfx.json > config/didc_version
 RUN jq -r '.defaults.build.config.OPTIMIZER_VERSION' dfx.json > config/optimizer_version
 RUN jq -r '.defaults.build.config.IC_WASM_VERSION' dfx.json > config/ic_wasm_version
 RUN jq -r '.defaults.build.config.BINSTALL_VERSION' dfx.json > config/binstall_version

--- a/dfx.json
+++ b/dfx.json
@@ -399,7 +399,7 @@
         "IDL2JSON_VERSION": "0.8.8",
         "OPTIMIZER_VERSION": "0.3.6",
         "BINSTALL_VERSION": "1.3.0",
-        "DIDC_VERSION": "2024-05-14",
+        "DIDC_RELEASE": "2024-05-14",
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-10-09",

--- a/scripts/setup
+++ b/scripts/setup
@@ -258,13 +258,13 @@ install_idl2json() {
 
 install_didc_linux() {
   local version
-  version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+  version="$(jq -r .defaults.build.config.DIDC_RELEASE dfx.json)"
   # TODO: Use binstall
   curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-linux64" | install -m 755 /dev/stdin "$USER_BIN/didc"
 }
 install_didc_darwin() {
   local version
-  version="$(jq -r .defaults.build.config.DIDC_VERSION dfx.json)"
+  version="$(jq -r .defaults.build.config.DIDC_RELEASE dfx.json)"
   tempfile="$(mktemp ,didc-XXXXXXXX)"
   curl -Lf "https://github.com/dfinity/candid/releases/download/${version}/didc-macos" >"$tempfile"
   install -m 755 "$tempfile" "$USER_BIN/didc"


### PR DESCRIPTION
# Motivation

The current `didc` version (that is the output of `didc --version`) is `0.4.0` which is installed from release `2024-05-14`.

While trying to debug why the recent "Update sns_aggregator candid bindings" [failed](https://github.com/dfinity/nns-dapp/actions/runs/11338847183), I got very confused because I had a different version installed.
So I want to change our scripts to check that you have the correct version installed.
For this, I need to add what is the correct version to our repo config.
To obvious name for this is `DIDC_VERSION` but we already use `DIDC_VERSION` to denote the current release.

So before adding `DIDC_VERSION` we should rename `DIDC_VERSION` to `DIDC_RELEASE` to more accurately reflect what it is.

# Changes

Rename `DIDC_VERSION` in `dfx.json` (and everywhere that refers to it) to `DIDC_RELEASE`.

# Tests

CI passes

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary