### PR TITLE
Change ICA neuron name

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Changed
 
+- Change Internet Computer Association neuron title.
+
 #### Deprecated
 
 #### Removed

--- a/frontend/src/lib/constants/api.constants.ts
+++ b/frontend/src/lib/constants/api.constants.ts
@@ -6,7 +6,7 @@ export const DFINITY_NEURON = {
 
 export const IC_NEURON = {
   id: 28n,
-  name: "Internet Computer Association",
+  name: "Internet Computer Association (winding down)",
   description: undefined,
 };
 


### PR DESCRIPTION
# Motivation

There are plans to wind down the Internet Computer Association neuron in the future (refer [to this forum post](https://forum.dfinity.org/t/strengthening-governance-by-aligning-neuron-28s-voting-power-under-neuron-27/35957) for more information). To make this clearer to users who follow this neuron, we’re changing its name.

# Changes

- Change the neuron name.

# Tests

- Manually
<img width="335" alt="image" src="https://github.com/user-attachments/assets/bffb6825-7287-402d-b0e1-99e1d634bcdd">
<img width="465" alt="image" src="https://github.com/user-attachments/assets/cd94bbe1-2ead-4c89-bed7-18fef7c6a493">

# Todos

- [x] Add entry to changelog (if necessary).
