### PR TITLE
Specify artifact name in download-ci-wasm

### DIFF
--- a/scripts/nns-dapp/download-ci-wasm
+++ b/scripts/nns-dapp/download-ci-wasm
@@ -32,7 +32,7 @@ ci_build_run_id="$("$SOURCE_DIR/get-ci-build-run" --commit "$COMMIT" --limit "$L
 
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf $tmp_dir' EXIT
-gh run download "$ci_build_run_id" --dir "$tmp_dir"
+gh run download "$ci_build_run_id" --dir "$tmp_dir" -n nns-dapp
 
 mkdir -p "$OUTPUT_DIR"
 dst_wasm_file="$OUTPUT_DIR/$WASM_FILENAME"


### PR DESCRIPTION
# Motivation

CI is currently failing when trying to download `nns-dapp.wasz.gz` from a GitHub CI run with the following error:
```
error downloading dfinity~nns-dapp~QD3EC4.dockerbuild: error extracting zip archive: zip: not a valid zip file
```
Example failure: https://github.com/dfinity/nns-dapp/actions/runs/11344052055/job/31548002318

I have no idea why this is happening but passing the artifact name to `gh run download` seems to help.

# Changes

Pass `-n nns-dapp` to `gh run download` in `scripts/nns-dapp/download-ci-wasm`.

# Tests

CI passes again.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary