### PR TITLE
Shard frontend tests

### DIFF
--- a/.github/actions/vitest/action.yml
+++ b/.github/actions/vitest/action.yml
@@ -27,5 +27,5 @@ runs:
       working-directory: ./frontend
     - name: Test
       shell: bash
-      run: npm run test -- $(find frontend/src/tests -name '*.spec.ts' | grep -v '^frontend/src/tests/e2e' | sed -e 's@^frontend/@@' | split -n r/${{ inputs.shard_number }}/${{ inputs.shard_count }})
+      run: npm run test -- $(find src/tests -name '*.spec.ts' | sort | grep -v '^src/tests/e2e' | split -n r/${{ inputs.shard_number }}/${{ inputs.shard_count }})
       working-directory: ./frontend

--- a/.github/actions/vitest/action.yml
+++ b/.github/actions/vitest/action.yml
@@ -1,0 +1,31 @@
+name: 'Run vitest shard'
+description: |
+  Install dependencies and run (non-e2e) frontend tests with `npm run test`.
+inputs:
+  shard_count:
+    description: "The total number shards to split the tests into"
+    required: false
+    default: 1
+  shard_number:
+    description: "Which of the shards to run"
+    required: false
+    default: 1
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout nns-dapp
+      uses: actions/checkout@v4
+    - name: Get node version
+      shell: bash
+      run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+    - name: Install dependencies
+      shell: bash
+      run: npm ci
+      working-directory: ./frontend
+    - name: Test
+      shell: bash
+      run: npm run test -- $(find frontend/src/tests -name '*.spec.ts' | grep -v '^frontend/src/tests/e2e' | sed -e 's@^frontend/@@' | split -n r/${{ inputs.shard_number }}/${{ inputs.shard_count }})
+      working-directory: ./frontend

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           shard_number: 1
           shard_count: 2
-  vitest-shard-1-of-2:
+  vitest-shard-2-of-2:
     runs-on: ubuntu-latest-m
     steps:
       - name: Checkout nns-dapp

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -92,27 +92,6 @@ jobs:
         with:
           shard_number: 2
           shard_count: 2
-  svelte-tests:
-    runs-on: ubuntu-latest-m
-    defaults:
-      run:
-        shell: bash
-    env:
-      DFX_NETWORK: mainnet
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Get node version
-        run: jq -r '"NODE_VERSION=\(.defaults.build.config.NODE_VERSION)"' dfx.json >> $GITHUB_ENV
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-      - name: Install dependencies
-        run: npm ci
-        working-directory: ./frontend
-      - name: Test
-        run: npm run test
-        working-directory: ./frontend
   svelte-lint:
     runs-on: ubuntu-20.04
     defaults:
@@ -353,7 +332,8 @@ jobs:
       - spelling
       - cargo-tests
       - svelte-lint
-      - svelte-tests
+      - vitest-shard-1-of-2
+      - vitest-shard-2-of-2
       - shell-checks
       - ic-commit-consistency
       - release-templating-works

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -72,6 +72,26 @@ jobs:
           RUST_BACKTRACE: 1
       - name: Lint rustdoc
         run: ./scripts/lint-rustdoc
+  vitest-shard-1-of-2:
+    runs-on: ubuntu-latest-m
+    steps:
+      - name: Checkout nns-dapp
+        uses: actions/checkout@v4
+      - name: Run vitest shard 1/2
+        uses: ./.github/actions/vitest
+        with:
+          shard_number: 1
+          shard_count: 2
+  vitest-shard-1-of-2:
+    runs-on: ubuntu-latest-m
+    steps:
+      - name: Checkout nns-dapp
+        uses: actions/checkout@v4
+      - name: Run vitest shard 2/2
+        uses: ./.github/actions/vitest
+        with:
+          shard_number: 2
+          shard_count: 2
   svelte-tests:
     runs-on: ubuntu-latest-m
     defaults:


### PR DESCRIPTION
# Motivation

Frontend unit tests can take quite long to run. Typically about 12 minutes.
If we split running the tests in 2 jobs, we don't have to wait as long.

# Changes

1. Created a GitHub action to run a shard of frontend unit test.
2. Used the new action to split frontend unit tests into 2 shards.

# Tests

Ran CI with both the old and the new job: https://github.com/dfinity/nns-dapp/actions/runs/11367971323
All `svelte-tests`:
```
Test Files  559 passed (559)
      Tests  4455 passed | 3 skipped (4458)
   Start at  14:39:08
   Duration  708.75s (transform 17.17s, setup 500.00s, collect 988.65s, tests 102.32s, environment 257.01s, prepare 66.20s)
```

`vitest-shard-1-of-2`:
```
Test Files  280 passed (280)
      Tests  2423 passed | 2 skipped (2425)
   Start at  14:38:38
   Duration  374.15s (transform 15.70s, setup 263.12s, collect 536.14s, tests 50.23s, environment 129.54s, prepare 34.09s)
```

`vitest-shard-2-of-2`:
```
Test Files  279 passed (279)
      Tests  2032 passed | 1 skipped (2033)
   Start at  14:38:37
   Duration  365.27s (transform 15.17s, setup 254.67s, collect 526.92s, tests 54.62s, environment 124.42s, prepare 32.55s)
```

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary