### PR TITLE
Enable checkbox in auto stake maturity tests

### DIFF
--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsAutoStakeMaturity.spec.ts
@@ -1,5 +1,6 @@
 import NnsAutoStakeMaturity from "$lib/components/neuron-detail/actions/NnsAutoStakeMaturity.svelte";
 import { toggleAutoStakeMaturity } from "$lib/services/neurons.services";
+import { mockPrincipalText, resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockNeuron } from "$tests/mocks/neurons.mock";
 import { toastsStore } from "@dfinity/gix-components";
@@ -14,9 +15,10 @@ vi.mock("$lib/services/neurons.services", () => {
 });
 
 describe("NnsAutoStakeMaturity", () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
     toastsStore.reset();
+    resetIdentity();
   });
 
   it("renders checkbox", () => {
@@ -37,6 +39,7 @@ describe("NnsAutoStakeMaturity", () => {
     ...mockNeuron,
     fullNeuron: {
       ...mockNeuron.fullNeuron,
+      controller: mockPrincipalText,
       autoStakeMaturity,
     },
   });
@@ -87,6 +90,20 @@ describe("NnsAutoStakeMaturity", () => {
 
     expect(inputElement.checked).toBeTruthy();
     expect(inputElement.disabled).toBeTruthy();
+  });
+
+  it("renders a enabled checkbox if neuron is controllable", async () => {
+    const { queryByTestId } = render(NeuronContextActionsTest, {
+      props: {
+        neuron: neuronProps(true),
+        testComponent: NnsAutoStakeMaturity,
+      },
+    });
+
+    const inputElement = queryByTestId("checkbox") as HTMLInputElement;
+
+    expect(inputElement.checked).toBeTruthy();
+    expect(inputElement.disabled).toBeFalsy();
   });
 
   const toggleAutoStake = async ({

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.spec.ts
@@ -1,11 +1,12 @@
 import SnsAutoStakeMaturity from "$lib/components/sns-neuron-detail/actions/SnsAutoStakeMaturity.svelte";
 import { snsTokenSymbolSelectedStore } from "$lib/derived/sns/sns-token-symbol-selected.store";
 import { toggleAutoStakeMaturity } from "$lib/services/sns-neurons.services";
-import { mockPrincipal } from "$tests/mocks/auth.store.mock";
+import { mockPrincipal, resetIdentity } from "$tests/mocks/auth.store.mock";
 import en from "$tests/mocks/i18n.mock";
 import { mockSnsNeuron } from "$tests/mocks/sns-neurons.mock";
 import { mockTokenStore } from "$tests/mocks/sns-projects.mock";
 import { toastsStore } from "@dfinity/gix-components";
+import { SnsNeuronPermissionType } from "@dfinity/sns";
 import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
@@ -20,6 +21,7 @@ describe("SnsAutoStakeMaturity", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     toastsStore.reset();
+    resetIdentity();
     vi.spyOn(snsTokenSymbolSelectedStore, "subscribe").mockImplementation(
       mockTokenStore
     );
@@ -88,6 +90,32 @@ describe("SnsAutoStakeMaturity", () => {
     expect(inputElement.disabled).toBeTruthy();
   });
 
+  it("renders an enabled checkbox if neuron is controllable", async () => {
+    const { queryByTestId } = render(SnsNeuronContextTest, {
+      props: {
+        neuron: {
+          ...mockSnsNeuron,
+          auto_stake_maturity: [true],
+          permissions: [
+            {
+              principal: [mockPrincipal],
+              permission_type: Int32Array.from([
+                SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_STAKE_MATURITY,
+              ]),
+            },
+          ],
+        },
+        rootCanisterId: mockPrincipal,
+        testComponent: SnsAutoStakeMaturity,
+      },
+    });
+
+    const inputElement = queryByTestId("checkbox") as HTMLInputElement;
+
+    expect(inputElement.checked).toBeTruthy();
+    expect(inputElement.disabled).toBeFalsy();
+  });
+
   const toggleAutoStake = async ({
     neuronAutoStakeMaturity,
   }: {
@@ -98,6 +126,14 @@ describe("SnsAutoStakeMaturity", () => {
         neuron: {
           ...mockSnsNeuron,
           auto_stake_maturity: [neuronAutoStakeMaturity],
+          permissions: [
+            {
+              principal: [mockPrincipal],
+              permission_type: Int32Array.from([
+                SnsNeuronPermissionType.NEURON_PERMISSION_TYPE_STAKE_MATURITY,
+              ]),
+            },
+          ],
         },
         rootCanisterId: mockPrincipal,
         testComponent: SnsAutoStakeMaturity,


### PR DESCRIPTION
# Motivation

A recent PR in gix-components (https://github.com/dfinity/gix-components/pull/505) prevents click evens in unit tests from clicking on disabled checkboxes.

This revealed that the checkboxes in `NnsAutoStakeMaturity.spec.ts` and `SnsAutoStakeMaturity.spec.ts` were always disabled and working while they should not have been working.

While there was a test that the checkbox could be disabled, there was not test checking that the checkbox could also be enabled.

# Changes

1. Add missing test coverage that the checkbox can be enabled.
2. Make sure the checkbox is enabled in the tests that need it to be enabled.
3. Drive-by fix: Use `beforeEach` instead of `afterEach`.

# Tests

Temporarily updated gix-components dependency to make sure these 2 tests work with the new gix-comeponents.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary