### PR TITLE
Bump gix-components and stop hiding bottom logo and menu collapse button

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -17,6 +17,7 @@ proposal is successful, the changes it released will be moved from this file to
 #### Changed
 
 - Change Internet Computer Association neuron title.
+* Stop hiding the bottom menu logo and collapse button on small screens.
 
 #### Deprecated
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@dfinity/gix-components": {
-      "version": "4.7.0-next-2024-10-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.7.0-next-2024-10-16.tgz",
-      "integrity": "sha512-dBw3Uxw6yj6aU3W22DY89drRPyaWXD9XXyj7guMrSeujEAez4hPCr799tiLGgKDwxpEGOx508/IZyhiQ8o8zvw==",
+      "version": "4.7.0-next-2024-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.7.0-next-2024-10-17.1.tgz",
+      "integrity": "sha512-33JcHLhZFnrZUyGMHqVBpkKzF4U/e0Wt8Is1b7H5KrQ5Vy3DS9SbKFZYDswUNSzKkk7k1dze/YESaXHiF/cHUA==",
       "dependencies": {
         "dompurify": "^3.1.6",
         "html5-qrcode": "^2.3.8",
@@ -7236,9 +7236,9 @@
       "requires": {}
     },
     "@dfinity/gix-components": {
-      "version": "4.7.0-next-2024-10-16",
-      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.7.0-next-2024-10-16.tgz",
-      "integrity": "sha512-dBw3Uxw6yj6aU3W22DY89drRPyaWXD9XXyj7guMrSeujEAez4hPCr799tiLGgKDwxpEGOx508/IZyhiQ8o8zvw==",
+      "version": "4.7.0-next-2024-10-17.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-4.7.0-next-2024-10-17.1.tgz",
+      "integrity": "sha512-33JcHLhZFnrZUyGMHqVBpkKzF4U/e0Wt8Is1b7H5KrQ5Vy3DS9SbKFZYDswUNSzKkk7k1dze/YESaXHiF/cHUA==",
       "requires": {
         "dompurify": "^3.1.6",
         "html5-qrcode": "^2.3.8",

--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -120,10 +120,6 @@
     gap: var(--padding);
     margin-top: auto;
     margin-right: var(--padding-3x);
-    // This 65px matches the design with 24px above the logo + 17px for the
-    // logo + 24px below the logo. This is temporary until the logo takes up
-    // its own space and this bottom margin can be removed.
-    margin-bottom: 65px;
     // Handle menu collapse animation
     visibility: visible;
     opacity: 1;


### PR DESCRIPTION
# Motivation

With https://github.com/dfinity/gix-components/pull/498 the bottom logo in the menu is now directly taking space in the menu DOM. So we no longer need to add a bottom margin below the Source code button.

# Changes

1. Ran `npm run update:gix`.
2. Removed the bottom margin in the menu footer.

# Tests

Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [x] Add entry to changelog (if necessary).
