### PR TITLE
Use page objects for Hash.spec.ts

### DIFF
--- a/frontend/src/tests/lib/components/ui/Hash.spec.ts
+++ b/frontend/src/tests/lib/components/ui/Hash.spec.ts
@@ -1,49 +1,50 @@
 import Hash from "$lib/components/ui/Hash.svelte";
-import { shortenWithMiddleEllipsis } from "$lib/utils/format.utils";
+import { HashPo } from "$tests/page-objects/Hash.page-object";
+import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { render } from "@testing-library/svelte";
 
 describe("Hash", () => {
   const identifier = "12345678901234567890";
+  const shortenedIdentifier = "1234567...4567890";
   const testId = "tests-hash";
 
-  it("should render a hashed identifier", () => {
-    const { getByTestId } = render(Hash, {
+  const renderComponent = (props) => {
+    const { container } = render(Hash, props);
+    return HashPo.under(new JestPageObjectElement(container));
+  };
+
+  it("should render a hashed identifier", async () => {
+    const po = renderComponent({
       props: { text: identifier, testId, id: identifier },
     });
 
-    const small = getByTestId(testId);
-    expect(small?.textContent).toEqual(shortenWithMiddleEllipsis(identifier));
+    expect(await po.getDisplayedText()).toEqual(shortenedIdentifier);
   });
 
-  it("should use the splitLength prop", () => {
+  it("should use the splitLength prop", async () => {
     const splitLength = 3;
-    const { getByTestId } = render(Hash, {
+    const po = renderComponent({
       props: { text: identifier, testId, id: identifier, splitLength },
     });
 
-    const small = getByTestId(testId);
-    expect(small?.textContent).toEqual(
-      shortenWithMiddleEllipsis(identifier, splitLength)
-    );
+    expect(await po.getDisplayedText()).toEqual("123...890");
   });
 
-  it("should render a tooltip with all identifier", () => {
-    const { container } = render(Hash, {
+  it("should render a tooltip with full identifier", async () => {
+    const po = renderComponent({
       props: { text: identifier, testId, id: identifier },
     });
 
-    const tooltipElement = container.querySelector("[role='tooltip']");
-    expect(tooltipElement?.textContent).toEqual(identifier);
+    expect(await po.getTooltipPo().getTooltipText()).toBe(identifier);
   });
 
-  it("should render the identifier as aria-label when copy icon", () => {
-    const { container } = render(Hash, {
+  it("should render the identifier as aria-label when copy icon", async () => {
+    const po = renderComponent({
       props: { text: identifier, testId, id: identifier, showCopy: true },
     });
 
-    const button = container.querySelector("button");
-    expect(
-      button?.getAttribute("aria-label").includes(identifier)
-    ).toBeTruthy();
+    expect(await po.getCopyButtonPo().getAriaLabel()).toBe(
+      `Copy to clipboard: ${identifier}`
+    );
   });
 });

--- a/frontend/src/tests/page-objects/Hash.page-object.ts
+++ b/frontend/src/tests/page-objects/Hash.page-object.ts
@@ -18,6 +18,10 @@ export class HashPo extends BasePageObject {
     return this.getButton("copy-component");
   }
 
+  getDisplayedText(): Promise<string> {
+    return this.getTooltipPo().getDisplayedText();
+  }
+
   getFullText(): Promise<string> {
     return this.getTooltipPo().getTooltipText();
   }

--- a/frontend/src/tests/page-objects/Tooltip.page-object.ts
+++ b/frontend/src/tests/page-objects/Tooltip.page-object.ts
@@ -30,9 +30,14 @@ export class TooltipPo extends BasePageObject {
   }
 
   async getTooltipElement(): Promise<PageObjectElement> {
+    // This could be done with CSS.escape but that's not available in
+    // Playwright tests which run in NodeJS.
+    // This is necessary for IDs that start with a digit.
+    const cssEscape = (id: string) =>
+      `\\${id.charCodeAt(0).toString(16)} ${id.substr(1)}`;
     const id = await this.getAriaDescribedBy();
     const body = await this.root.getDocumentBody();
-    const tooltipElements = await body.querySelectorAll(`#${CSS.escape(id)}`);
+    const tooltipElements = await body.querySelectorAll(`#${cssEscape(id)}`);
     if (tooltipElements.length !== 1) {
       throw new Error(
         `Found ${tooltipElements.length} tooltip elements with id ${id}`

--- a/frontend/src/tests/page-objects/Tooltip.page-object.ts
+++ b/frontend/src/tests/page-objects/Tooltip.page-object.ts
@@ -32,7 +32,7 @@ export class TooltipPo extends BasePageObject {
   async getTooltipElement(): Promise<PageObjectElement> {
     const id = await this.getAriaDescribedBy();
     const body = await this.root.getDocumentBody();
-    const tooltipElements = await body.querySelectorAll(`#${id}`);
+    const tooltipElements = await body.querySelectorAll(`#${CSS.escape(id)}`);
     if (tooltipElements.length !== 1) {
       throw new Error(
         `Found ${tooltipElements.length} tooltip elements with id ${id}`


### PR DESCRIPTION
# Motivation

Make the test easier to maintain.
In particular this helps with updating the test dependencies because the rendered container is no longer the document body so the way this test tries to find the tooltip doesn't work.

# Changes

1. Use page objects.
2. Expect explicit values instead of constructing values the same way the code under test does.
3. Escape the element ID passed to `body.querySelectorAll` because apparently these are not allowed to start with a digit. This could be done with `CSS.escape` but unfortunately that's not supported in Playwright tests.

# Tests

The test still passes.
I did not verify that this work with the new dependencies, but if it doesn't we should fix it in the page object, not in the test.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary