### PR TITLE
Replace SpyInstance with MockInstance

### DIFF
--- a/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/ImportTokenModal.spec.ts
@@ -18,7 +18,7 @@ import { render } from "$tests/utils/svelte.test-utils";
 import { runResolvedPromises } from "$tests/utils/timers.test-utils";
 import { busyStore, toastsStore } from "@dfinity/gix-components";
 import { get } from "svelte/store";
-import type { SpyInstance } from "vitest";
+import type { MockInstance } from "vitest";
 
 const expectToastError = (contained: string) =>
   expect(get(toastsStore)).toMatchObject([
@@ -43,7 +43,7 @@ describe("ImportTokenModal", () => {
 
     return po;
   };
-  let queryIcrcTokenSpy: SpyInstance;
+  let queryIcrcTokenSpy: MockInstance;
 
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/DisburseNnsNeuronModal.spec.ts
@@ -30,7 +30,7 @@ import type { NeuronInfo } from "@dfinity/nns";
 import type { RenderResult } from "@testing-library/svelte";
 import type { SvelteComponent } from "svelte";
 import { get } from "svelte/store";
-import type { SpyInstance } from "vitest";
+import type { MockInstance } from "vitest";
 
 vi.mock("$lib/api/nns-dapp.api");
 vi.mock("$lib/api/icp-ledger.api");
@@ -169,7 +169,7 @@ describe("DisburseNnsNeuronModal", () => {
   });
 
   describe("when no accounts and user navigates away", () => {
-    let spyQueryAccount: SpyInstance;
+    let spyQueryAccount: MockInstance;
     beforeEach(() => {
       resetAccountsForTesting();
       vi.clearAllTimers();

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -36,7 +36,7 @@ import { LedgerCanister } from "@dfinity/ledger-icp";
 import type { NeuronInfo } from "@dfinity/nns";
 import { GovernanceCanister } from "@dfinity/nns";
 import { get } from "svelte/store";
-import type { SpyInstance } from "vitest";
+import type { MockInstance } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 vi.mock("$lib/api/nns-dapp.api");
@@ -80,7 +80,7 @@ vi.mock("$lib/stores/toasts.store", () => {
 });
 
 describe("NnsStakeNeuronModal", () => {
-  let queryBalanceSpy: SpyInstance;
+  let queryBalanceSpy: MockInstance;
   const newBalanceE8s = 10_000_000n;
 
   beforeEach(() => {
@@ -445,7 +445,7 @@ describe("NnsStakeNeuronModal", () => {
   });
 
   describe("when no accounts and user navigates away", () => {
-    let spyQueryAccount: SpyInstance;
+    let spyQueryAccount: MockInstance;
     beforeEach(() => {
       resetAccountsForTesting();
       vi.clearAllTimers();

--- a/frontend/src/tests/lib/modals/sns/sale/ParticipateSwapModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/sale/ParticipateSwapModal.spec.ts
@@ -39,7 +39,7 @@ import {
 } from "$tests/utils/timers.test-utils";
 import { AccountIdentifier } from "@dfinity/ledger-icp";
 import { writable } from "svelte/store";
-import type { SpyInstance } from "vitest";
+import type { MockInstance } from "vitest";
 
 vi.mock("$lib/api/nns-dapp.api");
 vi.mock("$lib/api/icp-ledger.api");
@@ -279,8 +279,8 @@ describe("ParticipateSwapModal", () => {
 
   describe("when accounts are not available", () => {
     const mainBalanceE8s = 10_000_000n;
-    let queryAccountSpy: SpyInstance;
-    let queryAccountBalanceSpy: SpyInstance;
+    let queryAccountSpy: MockInstance;
+    let queryAccountBalanceSpy: MockInstance;
     let resolveQueryAccounts;
 
     beforeEach(() => {
@@ -319,7 +319,7 @@ describe("ParticipateSwapModal", () => {
       spy,
       params,
     }: {
-      spy: SpyInstance;
+      spy: MockInstance;
       params: object;
     }) => {
       expect(spy).toBeCalledWith({
@@ -352,7 +352,7 @@ describe("ParticipateSwapModal", () => {
   });
 
   describe("when no accounts and user navigates away", () => {
-    let spyQueryAccount: SpyInstance;
+    let spyQueryAccount: MockInstance;
     beforeEach(() => {
       resetAccountsForTesting();
       vi.clearAllTimers();

--- a/frontend/src/tests/lib/pages/Canisters.spec.ts
+++ b/frontend/src/tests/lib/pages/Canisters.spec.ts
@@ -10,7 +10,7 @@ import { UniverseSummaryPo } from "$tests/page-objects/UniverseSummary.page-obje
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
 import { fireEvent } from "@testing-library/dom";
 import { render, waitFor } from "@testing-library/svelte";
-import type { SpyInstance } from "vitest";
+import type { MockInstance } from "vitest";
 
 vi.mock("$lib/services/canisters.services", () => {
   return {
@@ -33,7 +33,7 @@ vi.mock("$lib/services/worker-cycles.services", () => ({
 }));
 
 describe("Canisters", () => {
-  let authStoreMock: SpyInstance;
+  let authStoreMock: MockInstance;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsAccounts.spec.ts
@@ -17,7 +17,7 @@ import {
 } from "$tests/utils/timers.test-utils";
 import { TokenAmount } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
-import type { SpyInstance } from "vitest";
+import type { MockInstance } from "vitest";
 
 vi.mock("$lib/api/nns-dapp.api");
 vi.mock("$lib/api/icp-ledger.api");
@@ -104,7 +104,7 @@ describe("NnsAccounts", () => {
 
   // TODO: Move the pollAccounts to Accounts route when universe selected is NNS instead of the child.
   describe("when no accounts and user navigates away", () => {
-    let spyQueryAccount: SpyInstance;
+    let spyQueryAccount: MockInstance;
     beforeEach(() => {
       vi.clearAllTimers();
       vi.clearAllMocks();

--- a/frontend/src/tests/lib/pages/NnsWallet.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsWallet.spec.ts
@@ -56,7 +56,7 @@ import { toastsStore } from "@dfinity/gix-components";
 import type { TransactionWithId } from "@dfinity/ledger-icp";
 import { Principal } from "@dfinity/principal";
 import { get } from "svelte/store";
-import type { SpyInstance } from "vitest";
+import type { MockInstance } from "vitest";
 import AccountsTest from "./AccountsTest.svelte";
 
 vi.mock("$lib/api/nns-dapp.api");
@@ -921,7 +921,7 @@ describe("NnsWallet", () => {
   });
 
   describe("when no accounts and user navigates away", () => {
-    let spyQueryAccount: SpyInstance;
+    let spyQueryAccount: MockInstance;
     beforeEach(() => {
       const now = Date.now();
       vi.useFakeTimers().setSystemTime(now);

--- a/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/actionable-sns-proposals.services.spec.ts
@@ -28,7 +28,7 @@ import {
   type SnsNeuronId,
   type SnsProposalData,
 } from "@dfinity/sns";
-import type { SpyInstance } from "@vitest/spy";
+import type { MockInstance } from "@vitest/spy";
 import { get } from "svelte/store";
 
 describe("actionable-sns-proposals.services", () => {
@@ -124,7 +124,7 @@ describe("actionable-sns-proposals.services", () => {
       limit: 20,
     };
 
-    let spyQuerySnsProposals: SpyInstance;
+    let spyQuerySnsProposals: MockInstance;
     let spyQuerySnsNeurons;
     let spyConsoleError;
 

--- a/frontend/src/tests/lib/services/canisters.services.spec.ts
+++ b/frontend/src/tests/lib/services/canisters.services.spec.ts
@@ -35,7 +35,7 @@ import { blockAllCallsTo } from "$tests/utils/module.test-utils";
 import { toastsStore } from "@dfinity/gix-components";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
-import type { SpyInstance } from "vitest";
+import type { MockInstance } from "vitest";
 
 vi.mock("$lib/api/icp-ledger.api");
 vi.mock("$lib/api/canisters.api");
@@ -46,16 +46,16 @@ describe("canisters-services", () => {
 
   const newBalanceE8s = 100_000_000n;
   const exchangeRate = 10_000n;
-  let spyQueryCanisters: SpyInstance;
-  let spyQueryAccountBalance: SpyInstance;
-  let spyAttachCanister: SpyInstance;
-  let spyRenameCanister: SpyInstance;
-  let spyDetachCanister: SpyInstance;
-  let spyUpdateSettings: SpyInstance;
-  let spyCreateCanister: SpyInstance;
-  let spyTopUpCanister: SpyInstance;
-  let spyQueryCanisterDetails: SpyInstance;
-  let spyGetExchangeRate: SpyInstance;
+  let spyQueryCanisters: MockInstance;
+  let spyQueryAccountBalance: MockInstance;
+  let spyAttachCanister: MockInstance;
+  let spyRenameCanister: MockInstance;
+  let spyDetachCanister: MockInstance;
+  let spyUpdateSettings: MockInstance;
+  let spyCreateCanister: MockInstance;
+  let spyTopUpCanister: MockInstance;
+  let spyQueryCanisterDetails: MockInstance;
+  let spyGetExchangeRate: MockInstance;
 
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -60,7 +60,7 @@ import { AccountIdentifier } from "@dfinity/ledger-icp";
 import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { get } from "svelte/store";
-import type { SpyInstance } from "vitest";
+import type { MockInstance } from "vitest";
 
 vi.mock("$lib/proxy/icp-ledger.services.proxy", () => {
   return {
@@ -492,7 +492,7 @@ describe("icp-accounts.services", () => {
   describe("services", () => {
     const mainBalanceE8s = 10_000_000n;
 
-    let spyCreateSubAccount: SpyInstance;
+    let spyCreateSubAccount: MockInstance;
     beforeEach(() => {
       vi.spyOn(ledgerApi, "queryAccountBalance").mockResolvedValue(
         mainBalanceE8s
@@ -551,8 +551,8 @@ describe("icp-accounts.services", () => {
       destinationAddress: mockSubAccount.identifier,
       amount: 1,
     };
-    let queryAccountBalanceSpy: SpyInstance;
-    let spySendICP: SpyInstance;
+    let queryAccountBalanceSpy: MockInstance;
+    let spySendICP: MockInstance;
     beforeEach(() => {
       queryAccountBalanceSpy = vi
         .spyOn(ledgerApi, "queryAccountBalance")
@@ -655,9 +655,9 @@ describe("icp-accounts.services", () => {
   });
 
   describe("rename", () => {
-    let queryAccountBalanceSpy: SpyInstance;
-    let queryAccountSpy: SpyInstance;
-    let spyRenameSubAccount: SpyInstance;
+    let queryAccountBalanceSpy: MockInstance;
+    let queryAccountSpy: MockInstance;
+    let spyRenameSubAccount: MockInstance;
     beforeEach(() => {
       queryAccountBalanceSpy = vi
         .spyOn(ledgerApi, "queryAccountBalance")

--- a/frontend/src/tests/lib/services/nns-reward-event.services.spec.ts
+++ b/frontend/src/tests/lib/services/nns-reward-event.services.spec.ts
@@ -10,10 +10,10 @@ import {
 } from "$tests/mocks/auth.store.mock";
 import { mockRewardEvent } from "$tests/mocks/nns-reward-event.mock";
 import { get } from "svelte/store";
-import type { SpyInstance } from "vitest";
+import type { MockInstance } from "vitest";
 
 describe("nns-reward-event-services", () => {
-  let spyQueryLatestRewardEvent: SpyInstance;
+  let spyQueryLatestRewardEvent: MockInstance;
 
   beforeEach(() => {
     nnsLatestRewardEventStore.reset();

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -54,7 +54,7 @@ import {
 } from "@dfinity/utils";
 import { tick } from "svelte";
 import { get } from "svelte/store";
-import type { SpyInstance } from "vitest";
+import type { MockInstance } from "vitest";
 
 const {
   syncSnsNeurons,
@@ -664,7 +664,7 @@ describe("sns-neurons-services", () => {
     const owner = Principal.fromText(ownerText);
     const subaccount = new Uint8Array(32).fill(0);
     subaccount[31] = 1;
-    let spyOnDisburseMaturity: SpyInstance;
+    let spyOnDisburseMaturity: MockInstance;
 
     beforeEach(() => {
       spyOnDisburseMaturity = vi
@@ -1049,8 +1049,8 @@ describe("sns-neurons-services", () => {
 
   describe("splitNeuron", () => {
     const transactionFee = 100n;
-    let snsNeuronsStoreSpy: SpyInstance;
-    let snsTokenSymbolSelectedStoreSpy: SpyInstance;
+    let snsNeuronsStoreSpy: MockInstance;
+    let snsTokenSymbolSelectedStoreSpy: MockInstance;
 
     beforeEach(() => {
       snsNeuronsStoreSpy = vi

--- a/frontend/src/tests/lib/services/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns.services.spec.ts
@@ -28,7 +28,7 @@ import type {
 import { SnsSwapLifecycle } from "@dfinity/sns";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
-import type { SpyInstance } from "vitest";
+import type { MockInstance } from "vitest";
 
 const {
   getSwapAccount,
@@ -282,7 +282,7 @@ describe("sns-services", () => {
   });
 
   describe("loadSnsSwapCommitment", () => {
-    let queryCommitmentSpy: SpyInstance;
+    let queryCommitmentSpy: MockInstance;
     const commitment1 = mockSnsSwapCommitment(principal(0));
     beforeEach(() => {
       queryCommitmentSpy = vi


### PR DESCRIPTION
# Motivation

In newer versions of `vitest`, `SpyInstance` is no longer available and `MockInstance` should be used instead.

# Changes

Replace `SpyInstance` with `MockInstance` in unit tests.

# Tests

Still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary