### PR TITLE
Update rust version to 1.82.0

### DIFF
--- a/rs/backend/src/tvl.rs
+++ b/rs/backend/src/tvl.rs
@@ -168,9 +168,9 @@ pub async fn update_locked_icp_e8s() {
 pub fn get_tvl() -> TvlResponse {
     with_state(|s| {
         let state = &s.tvl_state;
-        let locked_u128 = state.total_locked_icp_e8s as u128;
-        let rate_u128 = state.usd_e8s_per_icp as u128;
-        let e8s_per_unit = E8S_PER_UNIT as u128;
+        let locked_u128 = u128::from(state.total_locked_icp_e8s);
+        let rate_u128 = u128::from(state.usd_e8s_per_icp);
+        let e8s_per_unit = u128::from(E8S_PER_UNIT);
         let tvl = locked_u128 * rate_u128 / e8s_per_unit / e8s_per_unit;
         let time_sec = state.exchange_rate_timestamp_seconds;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Please, from time to time, update this to the latest stable version on Rust Forge: https://forge.rust-lang.org/
-channel = "1.81.0"
+channel = "1.82.0"
 components = ["rustfmt", "clippy"]
 targets = [ "wasm32-unknown-unknown"]


### PR DESCRIPTION
# Motivation

The [automatic update PR](https://github.com/dfinity/nns-dapp/pull/5644) had lint failures because Rust 1.82.0 wants a different syntax for type casts from `u64` to `u128`.
```
error: casts from `u64` to `u128` can be expressed infallibly using `From`
   --> rs/backend/src/tvl.rs:171:27
    |
171 |         let locked_u128 = state.total_locked_icp_e8s as u128;
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: an `as` cast can become silently lossy if the types change in the future
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cast_lossless
    = note: `-D clippy::cast-lossless` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::cast_lossless)]`
help: use `u128::from` instead
    |
171 |         let locked_u128 = u128::from(state.total_locked_icp_e8s);
    |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

# Changes

1. Update Rust version to 1.82.0.
2. Update code to use `u128::from` syntax for casts from `u64` to `u128`.

# Tests

`scripts/lint-rs` passes again.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary