### PR TITLE
Get canister ID with dfx in e2e test

### DIFF
--- a/frontend/src/tests/e2e/import-token.spec.ts
+++ b/frontend/src/tests/e2e/import-token.spec.ts
@@ -1,13 +1,18 @@
 import { AppPo } from "$tests/page-objects/App.page-object";
 import { PlaywrightPageObjectElement } from "$tests/page-objects/playwright.page-object";
-import { signInWithNewUser, step } from "$tests/utils/e2e.test-utils";
+import {
+  dfxCanisterId,
+  signInWithNewUser,
+  step,
+} from "$tests/utils/e2e.test-utils";
 import { expect, test } from "@playwright/test";
 
 const TEST_TOKEN_NAME = "ckRED";
-const TEST_LEDGER_CANISTER_ID = "myg3h-jmaaa-aaaaa-qabiq-cai";
-const TEST_INDEX_CANISTER_ID = "mrfq3-7eaaa-aaaaa-qabja-cai";
 
 test("Test imported tokens", async ({ page, context }) => {
+  const testLedgerCanisterId = await dfxCanisterId("ckred_ledger");
+  const testIndexCanisterId = await dfxCanisterId("ckred_index");
+
   await page.goto("/tokens");
   await expect(page).toHaveTitle("Tokens / NNS Dapp");
   await signInWithNewUser({ page, context });
@@ -36,8 +41,8 @@ test("Test imported tokens", async ({ page, context }) => {
 
   await importTokenModalPo.waitFor();
 
-  await formPo.getLedgerCanisterInputPo().typeText(TEST_LEDGER_CANISTER_ID);
-  await formPo.getIndexCanisterInputPo().typeText(TEST_INDEX_CANISTER_ID);
+  await formPo.getLedgerCanisterInputPo().typeText(testLedgerCanisterId);
+  await formPo.getIndexCanisterInputPo().typeText(testIndexCanisterId);
 
   await formPo.getSubmitButtonPo().click();
   await reviewPo.waitFor();
@@ -46,10 +51,10 @@ test("Test imported tokens", async ({ page, context }) => {
 
   expect(await reviewPo.getTokenName()).toBe(TEST_TOKEN_NAME);
   expect(await reviewPo.getLedgerCanisterIdPo().getCanisterIdText()).toBe(
-    TEST_LEDGER_CANISTER_ID
+    testLedgerCanisterId
   );
   expect(await reviewPo.getIndexCanisterIdPo().getCanisterIdText()).toBe(
-    TEST_INDEX_CANISTER_ID
+    testIndexCanisterId
   );
 
   step("First import / Import the token");
@@ -105,7 +110,7 @@ test("Test imported tokens", async ({ page, context }) => {
 
   await importButtonPo.click();
   await importTokenModalPo.waitFor();
-  await formPo.getLedgerCanisterInputPo().typeText(TEST_LEDGER_CANISTER_ID);
+  await formPo.getLedgerCanisterInputPo().typeText(testLedgerCanisterId);
 
   await formPo.getSubmitButtonPo().click();
   await reviewPo.waitFor();
@@ -114,7 +119,7 @@ test("Test imported tokens", async ({ page, context }) => {
 
   expect(await reviewPo.getTokenName()).toBe(TEST_TOKEN_NAME);
   expect(await reviewPo.getLedgerCanisterIdPo().getCanisterIdText()).toBe(
-    TEST_LEDGER_CANISTER_ID
+    testLedgerCanisterId
   );
   expect(
     await reviewPo.getIndexCanisterIdPo().getCanisterIdFallback().isPresent()

--- a/frontend/src/tests/utils/e2e.test-utils.ts
+++ b/frontend/src/tests/utils/e2e.test-utils.ts
@@ -1,5 +1,6 @@
 import type { FeatureKey } from "$lib/constants/environment.constants";
 import { expect, test, type BrowserContext, type Page } from "@playwright/test";
+import { exec } from "child_process";
 
 let resolvePreviousStep = () => {
   /* this function will be replaced at each step */
@@ -124,4 +125,15 @@ export const replaceContent = async ({
     { selectors, pattern, replacements }
   );
   expect(replacementCount).toBeGreaterThan(0);
+};
+
+export const dfxCanisterId = async (canisterName: string) => {
+  return new Promise<string>((resolve, reject) => {
+    exec(`dfx canister id ${canisterName}`, (error, stdout, _stderr) => {
+      if (error) {
+        reject(error);
+      }
+      resolve(stdout.trim());
+    });
+  });
 };


### PR DESCRIPTION
# Motivation

The ledger and index canister of ckRED are hard coded in `frontend/src/tests/e2e/import-token.spec.ts`.
But the canister IDs are not guaranteed to remain the same in snsdemo.
In particular, with the latest snapshot, they are different, resulting in test failures in the [automatic update PR](https://github.com/dfinity/nns-dapp/pull/5645).

# Changes

1. Add a utility function that calls `dfx` to get a canister ID.
2. Use the new function to get the correct canister IDs in the e2e test.

# Tests

The test passes locally with a newer snapshot and still passes on current CI as well.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary