### PR TITLE
Remove menu footer when menu is collapsed

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -18,6 +18,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 - Change Internet Computer Association neuron title.
 * Stop hiding the bottom menu logo and collapse button on small screens.
+* Remove menu footer on collapsed menu.
 
 #### Deprecated
 

--- a/frontend/src/lib/components/common/MenuItems.svelte
+++ b/frontend/src/lib/components/common/MenuItems.svelte
@@ -23,6 +23,8 @@
   } from "@dfinity/gix-components";
   import { layoutMenuOpen, menuCollapsed } from "@dfinity/gix-components";
   import type { ComponentType } from "svelte";
+  import { cubicIn, cubicOut } from "svelte/easing";
+  import { scale } from "svelte/transition";
 
   let routes: {
     context: string;
@@ -97,13 +99,20 @@
     <GetTokens />
   {/if}
 
-  <div class="menu-footer" class:hidden={$menuCollapsed && !$layoutMenuOpen}>
-    <TotalValueLocked layout="stacked" />
-    <div class="menu-footer-buttons">
-      <div class="grow-item"><SourceCodeButton /></div>
-      <ThemeToggleButton />
+  {#if !$menuCollapsed || $layoutMenuOpen}
+    <div
+      data-tid="menu-footer"
+      class="menu-footer"
+      out:scale={{ duration: 200, easing: cubicOut }}
+      in:scale={{ duration: 200, easing: cubicIn }}
+    >
+      <TotalValueLocked layout="stacked" />
+      <div class="menu-footer-buttons">
+        <div class="grow-item"><SourceCodeButton /></div>
+        <ThemeToggleButton />
+      </div>
     </div>
-  </div>
+  {/if}
 </div>
 
 <style lang="scss">
@@ -120,20 +129,6 @@
     gap: var(--padding);
     margin-top: auto;
     margin-right: var(--padding-3x);
-    // Handle menu collapse animation
-    visibility: visible;
-    opacity: 1;
-    transition:
-      transform linear var(--animation-time-normal),
-      opacity linear var(--animation-time-normal);
-    &.hidden {
-      visibility: hidden;
-      opacity: 0;
-      transform: translate(-300%, 0);
-      transition:
-        transform linear var(--animation-time-short),
-        opacity linear calc(var(--animation-time-short) / 2);
-    }
   }
   .menu-footer-buttons {
     display: flex;

--- a/frontend/src/tests/page-objects/MenuItems.page-object.ts
+++ b/frontend/src/tests/page-objects/MenuItems.page-object.ts
@@ -45,4 +45,8 @@ export class MenuItemsPo extends BasePageObject {
   getGetTokensPo(): GetTokensPo {
     return GetTokensPo.under(this.root);
   }
+
+  hasFooter(): Promise<boolean> {
+    return this.isPresent("menu-footer");
+  }
 }


### PR DESCRIPTION
# Motivation

When the menu is collapsed, the menu footer (with TVL and code/theme buttons) is moved out of view, but it still takes up space in the DOM. This means the scrollbar appears sooner than necessary on small screens.

# Changes

1. Use `{#if}` to remove the menu footer when the menu is collapsed.
2. Use Svelte animation to animate the dis/reappearance instead of CSS transition. Use `cubicIn` and `cubicOut` because they make sure the element is always smaller than the space it has, which avoids strange looking reflowing of the content.

# Tests

1. Unit tests added.
2. Tested manually at https://qsgjb-riaaa-aaaaa-aaaga-cai.dskloet-ingress.devenv.dfinity.network/

# Todos

- [x] Add entry to changelog (if necessary).
