### PR TITLE
Fix typo with vi.fn

### DIFF
--- a/frontend/src/tests/lib/services/public/proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/proposals.services.spec.ts
@@ -220,11 +220,12 @@ describe("proposals-services", () => {
       });
 
       it("should show one error message in details", async () => {
+        const setProposalSpy = vi.fn();
         expect(get(toastsStore)).toEqual([]);
 
         await loadProposal({
           proposalId: 0n,
-          setProposal: vi.fn,
+          setProposal: setProposalSpy,
         });
         expect(get(toastsStore)).toMatchObject([
           {
@@ -236,6 +237,7 @@ describe("proposals-services", () => {
         // `queryProposal` gave an error twice (query + update) but it should
         // result only in a single toast message.
         expect(spyQueryProposal).toBeCalledTimes(2);
+        expect(setProposalSpy).not.toBeCalled();
       });
     });
 


### PR DESCRIPTION
# Motivation

In  `"should show one error message in details"` in `public/proposals.services.spec.ts` an error is simulated so `setProposals` is not called.
So it doesn't really matter what is passed as `setProposals` so the original author passed `vi.fn`.
This may look like a mock function is passed but in fact, it's the function that creates mock functions that is passed.
This was caught because a newer version of `vitest` declares `vi.fn` with a different type and this caused a compile error.

# Changes

Change the test to actually make sure that `setProposal` is not called. Using `vi.fn()` instead of `vi.fn` to fix the type issue.

# Tests

1. The test still passes.
2. Checked that it no longer causes a compiler error with vitest 2.1.3 and vitest-mock-extended 2.0.2.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary