### PR TITLE
Wait longer for lifecycle in aggregator test

### DIFF
--- a/scripts/sns/aggregator/test-fast
+++ b/scripts/sns/aggregator/test-fast
@@ -152,7 +152,7 @@ MAY_BUY="$(curl -sSL --fail "$AGGREGATOR_URL" | jq '(.swap_params.params.max_par
 dfx-sns-sale-buy --icp "$MAY_BUY"
 EXPECTED_FIELDS="$(curl -sSL --fail "$AGGREGATOR_URL" | jq -c '{buyer_total_icp_e8s: .swap_params.params.max_participant_icp_e8s, direct_participant_count: 1, lifecycle: 3}')"
 printf "Waiting for the SNS lifecycle to change..."
-wait_for_aggregator_to_contain "$EXPECTED_FIELDS"
+wait_for_aggregator_to_contain "$EXPECTED_FIELDS" 60
 
 : TODO: Make a slow update counter. Verify that the last number of slow updates is as expected.
 : TODO: Make a fast update counter. Verify that the number of fast updates is as expected.


### PR DESCRIPTION
# Motivation

The aggregator test on CI [is flaky](https://github.com/dfinity/nns-dapp/actions/runs/11403403979/job/31730884616?pr=5652).
Waiting for the lifecycle to change timed out because swap canisters no longer update their state on every heartbeat but only once a minute.

# Changes

Increase the timeout when waiting for the lifecycle to change.

# Tests

Not tested except for on CI.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary