### PR TITLE
bot: Update IC Cargo Dependencies to release-2024-10-17_03-07-scheduler-changes-guestos-revert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "arbitrary"
@@ -182,7 +182,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
  "synstructure",
 ]
 
@@ -194,7 +194,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -205,7 +205,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -376,7 +376,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
  "syn_derive",
 ]
 
@@ -548,7 +548,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.30"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "shlex",
 ]
@@ -714,7 +714,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -928,13 +928,13 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1017,7 +1017,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1039,14 +1039,14 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "dary_heap"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
+checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
 
 [[package]]
 name = "data-encoding"
@@ -1098,13 +1098,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1116,7 +1116,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1125,7 +1125,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "on_wire",
  "prost",
@@ -1203,7 +1203,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1334,7 +1334,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1471,7 +1471,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -1727,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-replica-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -1740,7 +1740,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -1753,7 +1753,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "serde",
 ]
@@ -1761,7 +1761,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -1770,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1843,7 +1843,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_tokenstream 0.2.2",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1898,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1912,7 +1912,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "getrandom",
 ]
@@ -1920,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "hex",
  "ic-types",
@@ -1930,7 +1930,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -1952,7 +1952,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -1970,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -1978,7 +1978,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -1997,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2010,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "sha2",
 ]
@@ -2018,7 +2018,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "base64 0.13.1",
  "cached",
@@ -2042,9 +2042,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-crypto-internal-threshold-sig-ecdsa"
+name = "ic-crypto-internal-threshold-sig-canister-threshold-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2074,7 +2074,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "arrayvec 0.7.6",
  "hex",
@@ -2091,14 +2091,14 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "hex",
  "ic-base-types",
  "ic-crypto-internal-basic-sig-ed25519",
  "ic-crypto-internal-multi-sig-bls12381",
  "ic-crypto-internal-threshold-sig-bls12381",
- "ic-crypto-internal-threshold-sig-ecdsa",
+ "ic-crypto-internal-threshold-sig-canister-threshold-sig",
  "ic-crypto-internal-types",
  "ic-crypto-tls-cert-validation",
  "ic-protobuf",
@@ -2109,7 +2109,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "hmac",
  "k256",
@@ -2125,7 +2125,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "serde",
  "zeroize",
@@ -2134,7 +2134,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2142,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2155,7 +2155,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -2168,7 +2168,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2178,7 +2178,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2188,7 +2188,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-protobuf",
  "ic-utils",
@@ -2200,7 +2200,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "ciborium",
@@ -2223,7 +2223,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "ciborium",
@@ -2251,7 +2251,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "async-trait",
  "candid",
@@ -2280,7 +2280,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "async-trait",
  "candid",
@@ -2310,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -2322,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "hex",
@@ -2332,12 +2332,12 @@ dependencies = [
 [[package]]
 name = "ic-limits"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2363,7 +2363,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-canisters"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "async-trait",
  "candid",
@@ -2380,7 +2380,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "async-trait",
  "candid",
@@ -2403,12 +2403,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2443,12 +2443,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -2461,12 +2461,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -2478,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-initial-supply"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "async-trait",
  "candid",
@@ -2492,12 +2492,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "comparable",
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-base-types",
 ]
@@ -2518,7 +2518,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "dfn_core",
@@ -2534,7 +2534,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "async-trait",
  "candid",
@@ -2547,17 +2547,17 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 
 [[package]]
 name = "ic-nervous-system-temporary"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -2570,7 +2570,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "comparable",
@@ -2596,7 +2596,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -2605,7 +2605,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2678,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "bytes",
  "candid",
@@ -2706,7 +2706,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "csv",
  "ic-base-types",
@@ -2723,12 +2723,12 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "async-trait",
  "candid",
@@ -2743,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "bincode",
  "candid",
@@ -2757,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-canister-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2768,7 +2768,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2780,7 +2780,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-node-provider-rewards"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-base-types",
  "ic-protobuf",
@@ -2789,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2800,7 +2800,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "ic-management-canister-types",
@@ -2811,7 +2811,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -2823,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2835,7 +2835,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2895,7 +2895,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -2903,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -2914,7 +2914,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "async-trait",
  "candid",
@@ -2936,7 +2936,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -2964,7 +2964,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2994,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3034,7 +3034,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "comparable",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "async-trait",
  "candid",
@@ -3095,7 +3095,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3132,7 +3132,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3143,7 +3143,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "ic-validate-eq-derive",
 ]
@@ -3151,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq-derive"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -3236,7 +3236,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "comparable",
@@ -3266,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "async-trait",
  "candid",
@@ -3277,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.6"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "base32",
  "candid",
@@ -3409,7 +3409,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -3634,9 +3634,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libflate"
@@ -3727,7 +3727,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -3834,7 +3834,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -3993,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 
 [[package]]
 name = "once_cell"
@@ -4083,9 +4083,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
  "thiserror",
@@ -4094,9 +4094,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
+checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4104,22 +4104,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
+checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
+checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
 dependencies = [
  "once_cell",
  "pest",
@@ -4139,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "candid",
  "num-traits",
@@ -4260,12 +4260,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "910d41a655dac3b764f1ade94821093d3610248694320cd072303a8eedcf221d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -4328,9 +4328,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
@@ -4423,7 +4423,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.79",
+ "syn 2.0.81",
  "tempfile",
 ]
 
@@ -4437,7 +4437,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -4596,7 +4596,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=45eee81e4604c07306e29622aac41c600b024185#45eee81e4604c07306e29622aac41c600b024185"
+source = "git+https://github.com/dfinity/ic?rev=release-2024-10-17_03-07-scheduler-changes-guestos-revert#3c76b9142f67da01393d9280c705f88b6e522a93"
 dependencies = [
  "build-info",
  "build-info-build",
@@ -4758,9 +4758,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "rusty-fork"
@@ -4866,14 +4866,14 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -4901,7 +4901,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5147,7 +5147,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5169,9 +5169,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "198514704ca887dd5a1e408c6c6cdcba43672f9b4062e1b24aa34e74e6d7faae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5187,7 +5187,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5198,7 +5198,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5280,7 +5280,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5380,7 +5380,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5507,9 +5507,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 
 [[package]]
 name = "version_check"
@@ -5592,7 +5592,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
  "wasm-bindgen-shared",
 ]
 
@@ -5614,7 +5614,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5869,7 +5869,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
  "synstructure",
 ]
 
@@ -5891,7 +5891,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5911,7 +5911,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
  "synstructure",
 ]
 
@@ -5932,7 +5932,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5954,5 +5954,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,23 +14,23 @@ ic-cdk = "0.16.0"
 ic-cdk-macros = "0.16.0"
 ic-cdk-timers = "0.10.0"
 
-cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
-dfn_candid = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
-dfn_core = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
-dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
-ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
-ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
-ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
-ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
-ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
-ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
-ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
-ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
-ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
-icp-ledger = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
-on_wire = { git = "https://github.com/dfinity/ic", rev = "45eee81e4604c07306e29622aac41c600b024185" }
+cycles-minting-canister = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
+dfn_candid = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
+dfn_core = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
+dfn_protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
+ic-crypto-sha2 = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
+ic-management-canister-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
+ic-ledger-core = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
+ic-nervous-system-root = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
+ic-nns-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
+ic-nns-constants = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
+ic-nns-governance = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
+ic-protobuf = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
+ic-sns-swap = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
+icp-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
+on_wire = { git = "https://github.com/dfinity/ic", rev = "release-2024-10-17_03-07-scheduler-changes-guestos-revert" }
 
 [profile.release]
 lto = false


### PR DESCRIPTION
# Motivation
A newer release of the internet computer is available.
We want to keep our Cargo dependencies up to date.

# Changes
* Ran `scripts/update-ic-cargo-deps` to update the Cargo.toml dependencies to the latest IC release.

# Tests
* See CI