### PR TITLE
bot: Update proposals candid bindings

### DIFF
--- a/declarations/used_by_proposals/nns_governance/nns_governance.did
+++ b/declarations/used_by_proposals/nns_governance/nns_governance.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-09-26_01-31-no-canister-snapshots/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-17_03-07-scheduler-changes-guestos-revert/rs/nns/governance/canister/governance.did>
 type AccountIdentifier = record {
   hash : blob;
 };
@@ -45,7 +45,7 @@ type Ballot = record {
 
 type BallotInfo = record {
   vote : int32;
-  proposal_id : opt NeuronId;
+  proposal_id : opt ProposalId;
 };
 
 type By = variant {
@@ -254,7 +254,7 @@ type FollowersMap = record {
 };
 
 type GetNeuronsFundAuditInfoRequest = record {
-  nns_proposal_id : opt NeuronId;
+  nns_proposal_id : opt ProposalId;
 };
 
 type GetNeuronsFundAuditInfoResponse = record {
@@ -438,7 +438,7 @@ type ListNodeProvidersResponse = record {
 type ListProposalInfo = record {
   include_reward_status : vec int32;
   omit_large_fields : opt bool;
-  before_proposal : opt NeuronId;
+  before_proposal : opt ProposalId;
   limit : nat32;
   exclude_topic : vec int32;
   include_all_manage_neuron_proposals : opt bool;
@@ -458,7 +458,7 @@ type MakeProposalRequest = record {
 
 type MakeProposalResponse = record {
   message : opt text;
-  proposal_id : opt NeuronId;
+  proposal_id : opt ProposalId;
 };
 
 type MakingSnsProposal = record {
@@ -599,6 +599,10 @@ type NeuronDistribution = record {
 };
 
 type NeuronId = record {
+  id : nat64;
+};
+
+type ProposalId = record {
   id : nat64;
 };
 
@@ -789,7 +793,7 @@ type ProposalActionRequest = variant {
 };
 
 type ProposalData = record {
-  id : opt NeuronId;
+  id : opt ProposalId;
   failure_reason : opt GovernanceError;
   ballots : vec record { nat64; Ballot };
   proposal_timestamp_seconds : nat64;
@@ -809,7 +813,7 @@ type ProposalData = record {
 };
 
 type ProposalInfo = record {
-  id : opt NeuronId;
+  id : opt ProposalId;
   status : int32;
   topic : int32;
   failure_reason : opt GovernanceError;
@@ -830,7 +834,7 @@ type ProposalInfo = record {
 
 type RegisterVote = record {
   vote : int32;
-  proposal : opt NeuronId;
+  proposal : opt ProposalId;
 };
 
 type RemoveHotKey = record {
@@ -909,7 +913,7 @@ type RewardEvent = record {
   total_available_e8s_equivalent : nat64;
   latest_round_available_e8s_equivalent : opt nat64;
   distributed_e8s_equivalent : nat64;
-  settled_proposals : vec NeuronId;
+  settled_proposals : vec ProposalId;
 };
 
 type RewardMode = variant {

--- a/declarations/used_by_proposals/nns_registry/nns_registry.did
+++ b/declarations/used_by_proposals/nns_registry/nns_registry.did
@@ -1,4 +1,4 @@
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-09-26_01-31-no-canister-snapshots/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-17_03-07-scheduler-changes-guestos-revert/rs/registry/canister/canister/registry.did>
 // A brief note about the history of this file: This file used to be
 // automatically generated, but now, it is hand-crafted, because the
 // auto-generator has some some pretty degenerate behaviors. The worst of those
@@ -43,6 +43,7 @@ type AddNodePayload = record {
   transport_tls_cert : blob;
   ni_dkg_dealing_encryption_pk : blob;
   p2p_flow_endpoints : vec text;
+  node_reward_type : opt text;
 };
 
 type AddNodesToSubnetPayload = record {

--- a/declarations/used_by_proposals/sns_wasm/sns_wasm.did
+++ b/declarations/used_by_proposals/sns_wasm/sns_wasm.did
@@ -1,4 +1,4 @@
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-09-26_01-31-no-canister-snapshots/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-17_03-07-scheduler-changes-guestos-revert/rs/nns/sns-wasm/canister/sns-wasm.did>
 type AddWasmRequest = record {
   hash : blob;
   wasm : opt SnsWasm;

--- a/dfx.json
+++ b/dfx.json
@@ -404,7 +404,7 @@
         "POCKETIC_VERSION": "3.0.1",
         "CARGO_SORT_VERSION": "1.0.9",
         "SNSDEMO_RELEASE": "release-2024-10-16",
-        "IC_COMMIT_FOR_PROPOSALS": "release-2024-09-26_01-31-no-canister-snapshots",
+        "IC_COMMIT_FOR_PROPOSALS": "release-2024-10-17_03-07-scheduler-changes-guestos-revert",
         "IC_COMMIT_FOR_SNS_AGGREGATOR": "release-2024-10-11_14-35-overload"
       },
       "packtool": ""

--- a/rs/proposals/src/canisters/nns_governance/api.rs
+++ b/rs/proposals/src/canisters/nns_governance/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_governance --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-09-26_01-31-no-canister-snapshots/rs/nns/governance/canister/governance.did>
+//! Candid for canister `nns_governance` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-17_03-07-scheduler-changes-guestos-revert/rs/nns/governance/canister/governance.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -107,9 +107,13 @@ pub struct Configure {
     pub operation: Option<Operation>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
+pub struct ProposalId {
+    pub id: u64,
+}
+#[derive(Serialize, CandidType, Deserialize)]
 pub struct RegisterVote {
     pub vote: i32,
-    pub proposal: Option<NeuronId>,
+    pub proposal: Option<ProposalId>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct Merge {
@@ -557,7 +561,7 @@ pub struct RewardEvent {
     pub total_available_e8s_equivalent: u64,
     pub latest_round_available_e8s_equivalent: Option<u64>,
     pub distributed_e8s_equivalent: u64,
-    pub settled_proposals: Vec<NeuronId>,
+    pub settled_proposals: Vec<ProposalId>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronStakeTransfer {
@@ -686,7 +690,7 @@ pub struct WaitForQuietState {
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ProposalData {
-    pub id: Option<NeuronId>,
+    pub id: Option<ProposalId>,
     pub failure_reason: Option<GovernanceError>,
     pub ballots: Vec<(u64, Ballot)>,
     pub proposal_timestamp_seconds: u64,
@@ -724,7 +728,7 @@ pub struct NeuronInFlightCommand {
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct BallotInfo {
     pub vote: i32,
-    pub proposal_id: Option<NeuronId>,
+    pub proposal_id: Option<ProposalId>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub enum DissolveState {
@@ -832,7 +836,7 @@ pub enum Result5 {
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct GetNeuronsFundAuditInfoRequest {
-    pub nns_proposal_id: Option<NeuronId>,
+    pub nns_proposal_id: Option<ProposalId>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct NeuronsFundAuditInfo {
@@ -860,7 +864,7 @@ pub enum Result7 {
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct ProposalInfo {
-    pub id: Option<NeuronId>,
+    pub id: Option<ProposalId>,
     pub status: i32,
     pub topic: i32,
     pub failure_reason: Option<GovernanceError>,
@@ -915,7 +919,7 @@ pub struct ListNodeProvidersResponse {
 pub struct ListProposalInfo {
     pub include_reward_status: Vec<i32>,
     pub omit_large_fields: Option<bool>,
-    pub before_proposal: Option<NeuronId>,
+    pub before_proposal: Option<ProposalId>,
     pub limit: u32,
     pub exclude_topic: Vec<i32>,
     pub include_all_manage_neuron_proposals: Option<bool>,
@@ -995,7 +999,7 @@ pub struct MergeResponse {
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct MakeProposalResponse {
     pub message: Option<String>,
-    pub proposal_id: Option<NeuronId>,
+    pub proposal_id: Option<ProposalId>,
 }
 #[derive(Serialize, CandidType, Deserialize)]
 pub struct StakeMaturityResponse {

--- a/rs/proposals/src/canisters/nns_registry/api.rs
+++ b/rs/proposals/src/canisters/nns_registry/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister nns_registry --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-09-26_01-31-no-canister-snapshots/rs/registry/canister/canister/registry.did>
+//! Candid for canister `nns_registry` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-17_03-07-scheduler-changes-guestos-revert/rs/registry/canister/canister/registry.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
@@ -63,6 +63,7 @@ pub struct AddNodePayload {
     pub xnet_endpoint: String,
     pub chip_id: Option<serde_bytes::ByteBuf>,
     pub committee_signing_pk: serde_bytes::ByteBuf,
+    pub node_reward_type: Option<String>,
     pub node_signing_pk: serde_bytes::ByteBuf,
     pub transport_tls_cert: serde_bytes::ByteBuf,
     pub ni_dkg_dealing_encryption_pk: serde_bytes::ByteBuf,

--- a/rs/proposals/src/canisters/sns_wasm/api.rs
+++ b/rs/proposals/src/canisters/sns_wasm/api.rs
@@ -1,5 +1,5 @@
 //! Rust code created from candid by: `scripts/did2rs.sh --canister sns_wasm --out api.rs --header did2rs.header --traits Serialize`
-//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-09-26_01-31-no-canister-snapshots/rs/nns/sns-wasm/canister/sns-wasm.did>
+//! Candid for canister `sns_wasm` obtained by `scripts/update_ic_commit` from: <https://raw.githubusercontent.com/dfinity/ic/release-2024-10-17_03-07-scheduler-changes-guestos-revert/rs/nns/sns-wasm/canister/sns-wasm.did>
 #![allow(clippy::all)]
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]


### PR DESCRIPTION
# Motivation
We would like to render all the latest proposal types.
Even with no changes, just updating the reference is good practice.

# Changes
* Update the version of `IC_COMMIT_FOR_PROPOSALS` specified in `dfx.json`.
* Updated the `proposals` candid files to the versions in that commit.
* Updated the Rust code derived from `.did` files in the proposals payload rendering crate.

# Tests
  - [ ] Please check the API updates for any breaking changes that affect our code.
  - [ ] Please check for new proposal types and add tests for them.

Breaking changes are:
  * New mandatory fields
    * Removing mandatory fields
    * Renaming fields
    * Changing the type of a field
    * Adding new variants