### PR TITLE
Ignore query call after certified without finally

### DIFF
--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -253,6 +253,8 @@ export const listNeurons = async ({
   callback?: (certified: boolean) => void;
   strategy?: QueryAndUpdateStrategy;
 } = {}): Promise<void> => {
+  let hasCertified = false;
+
   return queryAndUpdate<NeuronInfo[], unknown>({
     strategy: strategy ?? FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
@@ -262,6 +264,11 @@ export const listNeurons = async ({
         includeEmptyNeurons: false,
       }),
     onLoad: async ({ response: neurons, certified }) => {
+      if (certified === false && hasCertified) {
+        return;
+      }
+      hasCertified ||= certified;
+
       neuronsStore.setNeurons({ neurons, certified });
 
       callback?.(certified);

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -253,8 +253,6 @@ export const listNeurons = async ({
   callback?: (certified: boolean) => void;
   strategy?: QueryAndUpdateStrategy;
 } = {}): Promise<void> => {
-  let hasCertified = false;
-
   return queryAndUpdate<NeuronInfo[], unknown>({
     strategy: strategy ?? FORCE_CALL_STRATEGY,
     request: ({ certified, identity }) =>
@@ -264,11 +262,6 @@ export const listNeurons = async ({
         includeEmptyNeurons: false,
       }),
     onLoad: async ({ response: neurons, certified }) => {
-      if (certified === false && hasCertified) {
-        return;
-      }
-      hasCertified ||= certified;
-
       neuronsStore.setNeurons({ neurons, certified });
 
       callback?.(certified);

--- a/frontend/src/lib/services/utils.services.ts
+++ b/frontend/src/lib/services/utils.services.ts
@@ -85,14 +85,16 @@ export const queryAndUpdate = async <R, E>({
     request({ certified, identity })
       .then((response) => {
         if (certifiedDone) return;
+        certifiedDone ||= certified;
+
         onLoad({ certified, strategy: currentStrategy, response });
         log({ postfix: ` ${certified ? "update" : "query"} complete.` });
       })
       .catch((error: E) => {
         if (certifiedDone) return;
+        certifiedDone ||= certified;
         onError?.({ certified, strategy: currentStrategy, error, identity });
-      })
-      .finally(() => (certifiedDone = certifiedDone || certified));
+      });
 
   // apply fetching strategy
   if (currentStrategy === "query") {

--- a/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
@@ -5,6 +5,7 @@ import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
 import NnsProposalDetail from "$lib/pages/NnsProposalDetail.svelte";
 import { actionableProposalsSegmentStore } from "$lib/stores/actionable-proposals-segment.store";
+import { neuronsStore } from "$lib/stores/neurons.store";
 import { page } from "$mocks/$app/stores";
 import {
   mockIdentity,
@@ -58,6 +59,7 @@ describe("NnsProposalDetail", () => {
     vi.restoreAllMocks();
     resetNeuronsApiService();
     toastsStore.reset();
+    neuronsStore.reset();
     vi.spyOn(governanceApi, "queryNeurons").mockResolvedValue(testNeurons);
 
     actionableProposalsSegmentStore.set("all");
@@ -136,6 +138,71 @@ describe("NnsProposalDetail", () => {
     });
 
     it("should update votable neurons after voting", async () => {
+      let beforeVoting = true;
+      const spyOnQueryProposal = vi
+        .spyOn(proposalsApi, "queryProposal")
+        .mockImplementation(() =>
+          Promise.resolve(
+            beforeVoting
+              ? testProposal
+              : {
+                  ...testProposal,
+                  ballots: [
+                    {
+                      neuronId: neuronId1,
+                      vote: Vote.Yes,
+                      votingPower: BigInt(1),
+                    },
+                    {
+                      neuronId: neuronId2,
+                      vote: Vote.Yes,
+                      votingPower: BigInt(1),
+                    },
+                  ],
+                }
+          )
+        );
+
+      const po = renderComponent();
+      const votingCardPo = po.getVotingCardPo();
+      await runResolvedPromises();
+
+      expect(await votingCardPo.isPresent()).toBe(true);
+      expect(
+        await po.getVotingCardPo().getVotingNeuronSelectListPo().isPresent()
+      ).toBe(true);
+      expect(await votingCardPo.getVoteYesButtonPo().isDisabled()).toBe(false);
+      expect(await votingCardPo.getVoteNoButtonPo().isDisabled()).toBe(false);
+
+      const votingNeuronListItemPos = await po
+        .getVotingCardPo()
+        .getVotingNeuronSelectListPo()
+        .getVotingNeuronListItemPos();
+      expect(votingNeuronListItemPos.length).toBe(testNeurons.length);
+      expect(await votingNeuronListItemPos[0].getNeuronId()).toBe(
+        `${neuronId1}`
+      );
+      expect(await votingNeuronListItemPos[1].getNeuronId()).toBe(
+        `${neuronId2}`
+      );
+      expect(spyOnQueryProposal).toBeCalledTimes(2);
+
+      beforeVoting = false;
+      await votingCardPo.voteYes();
+      await runResolvedPromises();
+
+      expect(spyOnQueryProposal).toBeCalledTimes(3);
+      expect(
+        (
+          await po
+            .getVotingCardPo()
+            .getVotingNeuronSelectListPo()
+            .getVotingNeuronListItemPos()
+        ).length
+      ).toBe(0);
+    });
+
+    it("It should work when the queryNeuron update response comes before the query", async () => {
       let beforeVoting = true;
       let resolveListNeuronsUpdate: (value: NeuronInfo[]) => void;
       let resolveListNeuronsQuery: (value: NeuronInfo[]) => void;

--- a/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
@@ -141,7 +141,7 @@ describe("NnsProposalDetail", () => {
       let resolveListNeuronsQuery: (value: NeuronInfo[]) => void;
       const spyQueryNeurons = vi
         .spyOn(governanceApi, "queryNeurons")
-        .mockImplementationOnce(({ certified }: { certified: boolean }) =>
+        .mockImplementation(({ certified }: { certified: boolean }) =>
           beforeVoting
             ? certified
               ? new Promise((resolve) => (resolveListNeuronsUpdate = resolve))
@@ -203,6 +203,7 @@ describe("NnsProposalDetail", () => {
       );
       expect(spyOnQueryProposal).toBeCalledTimes(2);
 
+      // Vote
       beforeVoting = false;
       await votingCardPo.voteYes();
       await runResolvedPromises();

--- a/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
+++ b/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts
@@ -202,6 +202,10 @@ describe("NnsProposalDetail", () => {
       ).toBe(0);
     });
 
+    // There was a bug where queryAndUpdate failed to hide the query response
+    // after an update response was already returned.
+    // In this case neuronsReady in NnsVotingCard.svelte would be set to false
+    // and the VotingNeuronSelectList would not be displayed.
     it("It should work when the queryNeuron update response comes before the query", async () => {
       let beforeVoting = true;
       let resolveListNeuronsUpdate: (value: NeuronInfo[]) => void;

--- a/frontend/src/tests/lib/services/utils.services.spec.ts
+++ b/frontend/src/tests/lib/services/utils.services.spec.ts
@@ -235,11 +235,16 @@ describe("api-utils", () => {
         expect(onLoad).toBeCalledTimes(0);
         expect(onError).toBeCalledTimes(0);
 
-        resolveUpdate({});
-        resolveQuery({});
+        resolveUpdate({ update: true });
+        resolveQuery({ query: true });
         await runResolvedPromises();
 
         expect(onLoad).toBeCalledTimes(1);
+        expect(onLoad).toBeCalledWith({
+          certified: true,
+          response: { update: true },
+          strategy: "query_and_update",
+        });
         expect(onError).toBeCalledTimes(0);
       });
 


### PR DESCRIPTION
# Motivation

After updating the dependencies, the test ["should update votable neurons after voting"](https://github.com/dfinity/nns-dapp/blob/29fffda7583518c59991a1c01f31836305475f24/frontend/src/tests/lib/pages/NnsProposalDetail.spec.ts#L138) is broken. The logs show that the service, after calling queryNeurons, first receives the certified response and then the uncertified query (with the current test dependencies the uncertified one comes first). For an unknown reason, the store listener is triggered only once, for the second call (which became an uncertified response, since it's the last one), which breaks the logic [in NnsVotingCard](https://github.com/dfinity/nns-dapp/blob/29fffda7583518c59991a1c01f31836305475f24/frontend/src/lib/components/proposal-detail/VotingCard/NnsVotingCard.svelte#L117) because `$neuronsStore.certified` is false (switching to `get(store)` doesn’t help).

To ensure this issue doesn’t occur in the real app, we update the certifiedDone not in the finally block but in then and catch blocks.

From the logs, the finally block is called only after both the query and update calls are completed. The only difference is that after the test dependency upgrade, the update call returns sooner than the query. So the finally block in both cases is called to late to affect the flow.

### Before
```
➡️ listNeurons Start 0 { strategy: 'query_and_update' }
  ⚙️ queryAndUpdate Start { callIndex: 1 }
  ⚙️ queryAndUpdate response { callIndex: 1, certified: false }
➡️ listNeurons onLoad 0 { certified: false }
  ⚙️ queryAndUpdate response { callIndex: 1, certified: true }
➡️ listNeurons onLoad 0 { certified: true }
  ⚙️ queryAndUpdate finally { callIndex: 1, certifiedDone: false, certified: false }
  ⚙️ queryAndUpdate finally { callIndex: 1, certifiedDone: false, certified: true }
```
### After
```
➡️ listNeurons Start 0 { strategy: 'query_and_update' }
  ⚙️ queryAndUpdate Start { callIndex: 1 }
  ⚙️ queryAndUpdate response { callIndex: 1, certified: true }
➡️ listNeurons onLoad 0 { certified: true }
  ⚙️ queryAndUpdate response { callIndex: 1, certified: false }
➡️ listNeurons onLoad 0 { certified: false }
  ⚙️ queryAndUpdate finally { callIndex: 1, certifiedDone: false, certified: true }
  ⚙️ queryAndUpdate finally { callIndex: 1, certifiedDone: true, certified: false }
```

# Changes

- Move the `certifiedDone` update closer to responses.

# Tests

- Updated.
  - Updated tests in `utils.services.spec.ts` fail with finally block.
  - Updated test in `NnsProposalDetail.spec.ts` fail with finally block (but only when it's run as `only`).

# Todos

- [ ] Add entry to changelog (if necessary).
Not necessary.