### PR TITLE
Stop mocking toastsStore

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -910,7 +910,8 @@
     "sns_remove_followee": "There was an error while unfollowing the neuron.",
     "sns_add_hotkey": "There was an error adding the hotkey.",
     "sns_stake_maturity": "There was an error while staking the maturity of the neuron.",
-    "sns_disburse_maturity": "There was an error while disbursing the maturity of the neuron."
+    "sns_disburse_maturity": "There was an error while disbursing the maturity of the neuron.",
+    "sns_amount_not_enough_stake_neuron": "Sorry, the amount is too small. You need a minimum of $minimum $token to stake a neuron."
   },
   "auth_accounts": {
     "title": "100% on-chain governance",

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -911,7 +911,7 @@
     "sns_add_hotkey": "There was an error adding the hotkey.",
     "sns_stake_maturity": "There was an error while staking the maturity of the neuron.",
     "sns_disburse_maturity": "There was an error while disbursing the maturity of the neuron.",
-    "sns_amount_not_enough_stake_neuron": "Sorry, the amount is too small. You need a minimum of $minimum $token to stake a neuron."
+    "sns_amount_not_enough_stake_neuron": "Sorry, the amount is too small. You need a minimum of $minimum $token to stake."
   },
   "auth_accounts": {
     "title": "100% on-chain governance",

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -950,6 +950,7 @@ interface I18nError__sns {
   sns_add_hotkey: string;
   sns_stake_maturity: string;
   sns_disburse_maturity: string;
+  sns_amount_not_enough_stake_neuron: string;
 }
 
 interface I18nAuth_accounts {

--- a/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/LinkCanisterModal.spec.ts
@@ -14,13 +14,6 @@ vi.mock("$lib/services/canisters.services", () => {
   };
 });
 
-vi.mock("$lib/stores/toasts.store", () => {
-  return {
-    toastsShow: vi.fn(),
-    toastsSuccess: vi.fn(),
-  };
-});
-
 describe("LinkCanisterModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NnsStakeNeuronModal.spec.ts
@@ -71,14 +71,6 @@ vi.mock("$lib/services/known-neurons.services", () => {
   };
 });
 
-vi.mock("$lib/stores/toasts.store", () => {
-  return {
-    toastsError: vi.fn(),
-    toastsShow: vi.fn(),
-    toastsSuccess: vi.fn(),
-  };
-});
-
 describe("NnsStakeNeuronModal", () => {
   let queryBalanceSpy: MockInstance;
   const newBalanceE8s = 10_000_000n;

--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -11,7 +11,6 @@ import { bitcoinAddressStore } from "$lib/stores/bitcoin.store";
 import * as busyStore from "$lib/stores/busy.store";
 import { ckbtcPendingUtxosStore } from "$lib/stores/ckbtc-pending-utxos.store";
 import { ckbtcRetrieveBtcStatusesStore } from "$lib/stores/ckbtc-retrieve-btc-statuses.store";
-import * as toastsStore from "$lib/stores/toasts.store";
 import { ApiErrorKey } from "$lib/types/api.errors";
 import { page } from "$mocks/$app/stores";
 import { mockIdentity, resetIdentity } from "$tests/mocks/auth.store.mock";
@@ -28,12 +27,14 @@ import {
   MinterNoNewUtxosError,
   MinterTemporaryUnavailableError,
 } from "@dfinity/ckbtc";
+import { toastsStore } from "@dfinity/gix-components";
 import { waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("ckbtc-minter-services", () => {
   beforeEach(() => {
     resetIdentity();
+    toastsStore.reset();
     ckbtcRetrieveBtcStatusesStore.reset();
   });
 
@@ -201,14 +202,17 @@ describe("ckbtc-minter-services", () => {
         });
       });
 
-      const spyOnToastsSuccess = vi.spyOn(toastsStore, "toastsSuccess");
+      expect(get(toastsStore)).toEqual([]);
 
       const result = await services.updateBalance(params);
 
       expect(result).toEqual({ success: true });
-      expect(spyOnToastsSuccess).toHaveBeenCalledWith({
-        labelKey: "error__ckbtc.no_new_confirmed_btc",
-      });
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "success",
+          text: "Updated available ckBTC : No new confirmed BTC.",
+        },
+      ]);
 
       expect(get(ckbtcPendingUtxosStore)).toEqual({
         [CKBTC_UNIVERSE_CANISTER_ID.toText()]: [],
@@ -228,16 +232,18 @@ describe("ckbtc-minter-services", () => {
         });
       });
 
-      const spyOnToastsSuccess = vi.spyOn(toastsStore, "toastsSuccess");
+      expect(get(toastsStore)).toEqual([]);
 
       const result = await services.updateBalance(params);
 
       expect(result).toEqual({ success: true });
 
-      expect(spyOnToastsSuccess).toBeCalledTimes(1);
-      expect(spyOnToastsSuccess).toBeCalledWith({
-        labelKey: "error__ckbtc.no_new_confirmed_btc",
-      });
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "success",
+          text: "Updated available ckBTC : No new confirmed BTC.",
+        },
+      ]);
 
       expect(get(ckbtcPendingUtxosStore)).toEqual({
         [CKBTC_UNIVERSE_CANISTER_ID.toText()]: [pendingUtxo],
@@ -259,15 +265,17 @@ describe("ckbtc-minter-services", () => {
           });
         });
 
-      const spyOnToastsSuccess = vi.spyOn(toastsStore, "toastsSuccess");
+      expect(get(toastsStore)).toEqual([]);
 
       const result = await services.updateBalance(params);
 
       expect(result).toEqual({ success: true });
-      expect(spyOnToastsSuccess).toBeCalledTimes(1);
-      expect(spyOnToastsSuccess).toBeCalledWith({
-        labelKey: "ckbtc.ckbtc_balance_updated",
-      });
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "success",
+          text: "Updated available ckBTC : New confirmed BTC.",
+        },
+      ]);
 
       expect(get(ckbtcPendingUtxosStore)).toEqual({
         [CKBTC_UNIVERSE_CANISTER_ID.toText()]: [pendingUtxo],
@@ -279,17 +287,19 @@ describe("ckbtc-minter-services", () => {
         .spyOn(minterApi, "updateBalance")
         .mockResolvedValue(mockUpdateBalanceOk);
 
-      const spyOnToastsSuccess = vi.spyOn(toastsStore, "toastsSuccess");
+      expect(get(toastsStore)).toEqual([]);
 
       const result = await services.updateBalance(params);
 
       expect(result).toEqual({ success: true });
       expect(updateBalanceSpy).toBeCalledTimes(3);
 
-      expect(spyOnToastsSuccess).toBeCalledTimes(1);
-      expect(spyOnToastsSuccess).toBeCalledWith({
-        labelKey: "ckbtc.ckbtc_balance_updated",
-      });
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "success",
+          text: "Updated available ckBTC : New confirmed BTC.",
+        },
+      ]);
     });
 
     it("should return generic error even if no ui indicators", async () => {
@@ -341,7 +351,7 @@ describe("ckbtc-minter-services", () => {
           .spyOn(minterApi, "updateBalance")
           .mockResolvedValue(mockUpdateBalanceOk);
 
-        const spyOnToastsShow = vi.spyOn(toastsStore, "toastsShow");
+        expect(get(toastsStore)).toEqual([]);
 
         await services.updateBalance({
           ...params,
@@ -355,7 +365,7 @@ describe("ckbtc-minter-services", () => {
           })
         );
 
-        expect(spyOnToastsShow).not.toHaveBeenCalled();
+        expect(get(toastsStore)).toEqual([]);
       });
 
       it("should not toast error on error if no ui indicators", async () => {
@@ -365,7 +375,7 @@ describe("ckbtc-minter-services", () => {
             throw new MinterAlreadyProcessingError();
           });
 
-        const spyOnToastsError = vi.spyOn(toastsStore, "toastsError");
+        expect(get(toastsStore)).toEqual([]);
 
         await services.updateBalance({
           ...params,
@@ -379,7 +389,7 @@ describe("ckbtc-minter-services", () => {
           })
         );
 
-        expect(spyOnToastsError).not.toHaveBeenCalled();
+        expect(get(toastsStore)).toEqual([]);
       });
 
       it("should not handle no new UTXOs success if no ui indicators", async () => {
@@ -390,7 +400,7 @@ describe("ckbtc-minter-services", () => {
           });
         });
 
-        const spyOnToastsShow = vi.spyOn(toastsStore, "toastsShow");
+        expect(get(toastsStore)).toEqual([]);
 
         const result = await services.updateBalance({
           ...params,
@@ -398,7 +408,7 @@ describe("ckbtc-minter-services", () => {
         });
 
         expect(result).toEqual({ success: true });
-        expect(spyOnToastsShow).not.toHaveBeenCalled();
+        expect(get(toastsStore)).toEqual([]);
       });
     });
   });

--- a/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
+++ b/frontend/src/tests/lib/services/icp-accounts.services.spec.ts
@@ -25,7 +25,6 @@ import {
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { icpAccountBalancesStore } from "$lib/stores/icp-account-balances.store";
 import { icpAccountDetailsStore } from "$lib/stores/icp-account-details.store";
-import * as toastsFunctions from "$lib/stores/toasts.store";
 import type { NewTransaction } from "$lib/types/transaction";
 import { toIcpAccountIdentifier } from "$lib/utils/accounts.utils";
 import {
@@ -524,21 +523,20 @@ describe("icp-accounts.services", () => {
     });
 
     it("should not add subaccount if no identity", async () => {
-      const spyToastError = vi.spyOn(toastsFunctions, "toastsError");
-
       setNoIdentity();
+
+      expect(get(toastsStore)).toEqual([]);
 
       await addSubAccount({
         name: "test subaccount",
       });
 
-      expect(spyToastError).toBeCalled();
-      expect(spyToastError).toBeCalledWith({
-        labelKey: "error__account.create_subaccount",
-        err: new Error(en.error.missing_identity),
-        renderAsHtml: false,
-      });
-
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "Sorry, there was an unexpected error when creating your linked account, please try again. The operation cannot be executed without any identity.",
+        },
+      ]);
       resetIdentity();
     });
   });
@@ -716,59 +714,55 @@ describe("icp-accounts.services", () => {
     });
 
     it("should not rename subaccount if no identity", async () => {
-      const spyToastError = vi.spyOn(toastsFunctions, "toastsError");
-
       setNoIdentity();
+
+      expect(get(toastsStore)).toEqual([]);
 
       await renameSubAccount({
         newName: "test subaccount",
         selectedAccount: mockSubAccount,
       });
 
-      expect(spyToastError).toBeCalled();
-      expect(spyToastError).toBeCalledWith({
-        labelKey: "error.rename_subaccount",
-        err: new Error(en.error.missing_identity),
-        renderAsHtml: false,
-      });
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "An error occurred while renaming your linked account. The operation cannot be executed without any identity.",
+        },
+      ]);
 
       resetIdentity();
-
-      spyToastError.mockClear();
     });
 
     it("should not rename subaccount if no selected account", async () => {
-      const spyToastError = vi.spyOn(toastsFunctions, "toastsError");
+      expect(get(toastsStore)).toEqual([]);
 
       await renameSubAccount({
         newName: "test subaccount",
         selectedAccount: undefined,
       });
 
-      expect(spyToastError).toBeCalled();
-      expect(spyToastError).toBeCalledWith({
-        labelKey: "error.rename_subaccount_no_account",
-        renderAsHtml: false,
-      });
-
-      spyToastError.mockClear();
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "No linked account provided.",
+        },
+      ]);
     });
 
     it("should not rename subaccount if type is not subaccount", async () => {
-      const spyToastError = vi.spyOn(toastsFunctions, "toastsError");
+      expect(get(toastsStore)).toEqual([]);
 
       await renameSubAccount({
         newName: "test subaccount",
         selectedAccount: mockMainAccount,
       });
 
-      expect(spyToastError).toBeCalled();
-      expect(spyToastError).toBeCalledWith({
-        labelKey: "error.rename_subaccount_type",
-        renderAsHtml: false,
-      });
-
-      spyToastError.mockClear();
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "The account provided is not a linked account. Only linked account can be renamed.",
+        },
+      ]);
     });
   });
 

--- a/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns-proposals.services.spec.ts
@@ -7,7 +7,6 @@ import {
 } from "$lib/services/public/sns-proposals.services";
 import { snsFiltersStore } from "$lib/stores/sns-filters.store";
 import { snsProposalsStore } from "$lib/stores/sns-proposals.store";
-import * as toastsFunctions from "$lib/stores/toasts.store";
 import type { Filter, SnsProposalTypeFilterId } from "$lib/types/filters";
 import { ALL_SNS_GENERIC_PROPOSAL_TYPES_ID } from "$lib/types/filters";
 import { replacePlaceholders } from "$lib/utils/i18n.utils";
@@ -317,7 +316,7 @@ describe("sns-proposals services", () => {
     it("should handle errors", async () => {
       vi.spyOn(console, "error").mockImplementation(() => undefined);
       vi.spyOn(api, "registerVote").mockRejectedValue(new Error());
-      const spyToastError = vi.spyOn(toastsFunctions, "toastsError");
+      expect(get(toastsStore)).toEqual([]);
 
       const result = await registerVote({
         rootCanisterId: mockPrincipal,
@@ -328,11 +327,12 @@ describe("sns-proposals services", () => {
 
       expect(result).toEqual({ success: false });
 
-      expect(spyToastError).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error__sns.sns_register_vote",
-        })
-      );
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "There was an error while registering vote (Neuron: 010203). ",
+        },
+      ]);
     });
   });
 

--- a/frontend/src/tests/lib/services/public/sns.services.spec.ts
+++ b/frontend/src/tests/lib/services/public/sns.services.spec.ts
@@ -33,11 +33,6 @@ import { mock } from "vitest-mock-extended";
 vi.mock("$lib/api/sns.api");
 vi.mock("$lib/api/sns-aggregator.api");
 vi.mock("$lib/api/sns-governance.api");
-vi.mock("$lib/stores/toasts.store", () => {
-  return {
-    toastsError: vi.fn(),
-  };
-});
 
 const listSnsesSpy = vi.fn().mockResolvedValue(deployedSnsMock);
 const initSnsWrapperSpy = vi.fn().mockResolvedValue(

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -15,7 +15,6 @@ import {
   updateDelay,
 } from "$lib/services/sns-neurons.services";
 import { snsNeuronsStore } from "$lib/stores/sns-neurons.store";
-import { toastsError } from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
 import { enumValues } from "$lib/utils/enum.utils";
 import {
@@ -38,6 +37,7 @@ import {
 import { mockSnsToken, mockTokenStore } from "$tests/mocks/sns-projects.mock";
 import { resetMockedConstants } from "$tests/utils/mockable-constants.test-utils";
 import { resetSnsProjects, setSnsProjects } from "$tests/utils/sns.test-utils";
+import { toastsStore } from "@dfinity/gix-components";
 import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { NeuronState } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
@@ -67,12 +67,6 @@ const {
   addFollowee,
 } = services;
 
-vi.mock("$lib/stores/toasts.store", () => {
-  return {
-    toastsError: vi.fn(),
-  };
-});
-
 vi.mock("$lib/services/sns-accounts.services", () => {
   return {
     loadSnsAccounts: vi.fn(),
@@ -99,9 +93,11 @@ describe("sns-neurons-services", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    toastsStore.reset();
     resetIdentity();
     resetMockedConstants();
     resetSnsProjects();
+    vi.spyOn(console, "error").mockReturnValue(undefined);
   });
 
   describe("syncSnsNeurons", () => {
@@ -571,6 +567,8 @@ describe("sns-neurons-services", () => {
         .spyOn(governanceApi, "querySnsNeurons")
         .mockImplementation(() => Promise.resolve([mockSnsNeuron]));
 
+      expect(get(toastsStore)).toEqual([]);
+
       const { success } = await stakeNeuron({
         rootCanisterId: mockPrincipal,
         amount: 2,
@@ -582,14 +580,12 @@ describe("sns-neurons-services", () => {
       expect(spyQuery).not.toBeCalled();
       expect(loadSnsAccounts).not.toBeCalled();
 
-      expect(toastsError).toBeCalledWith({
-        err: new Error(
-          "The caller should make sure the amount is at least the minimum stake"
-        ),
-        labelKey: "error__sns.sns_stake",
-        renderAsHtml: false,
-      });
-      expect(toastsError).toBeCalledTimes(1);
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "There was an error while staking the neuron. The caller should make sure the amount is at least the minimum stake",
+        },
+      ]);
     });
   });
 
@@ -718,6 +714,7 @@ describe("sns-neurons-services", () => {
       const wrongChecksum = "wrong";
       const destinationAddress = `${ownerText}-${wrongChecksum}.1`;
       expect(spyOnDisburseMaturity).not.toBeCalled();
+      expect(get(toastsStore)).toEqual([]);
       await disburseMaturity({
         rootCanisterId,
         neuronId: mockSnsNeuron.id[0],
@@ -726,10 +723,12 @@ describe("sns-neurons-services", () => {
       });
 
       expect(spyOnDisburseMaturity).not.toBeCalled();
-      expect(toastsError).toBeCalledWith({
-        err: new Error("Invalid account. Invalid checksum."),
-        labelKey: "error__sns.sns_disburse_maturity",
-      });
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "There was an error while disbursing the maturity of the neuron. Invalid account. Invalid checksum.",
+        },
+      ]);
     });
   });
 
@@ -805,6 +804,7 @@ describe("sns-neurons-services", () => {
       vi.spyOn(governanceApi, "querySnsNeuron").mockResolvedValue(
         mockSnsNeuron
       );
+      expect(get(toastsStore)).toEqual([]);
       const neuron: SnsNeuron = {
         ...mockSnsNeuron,
         followees: [[functionId, { followees: [followee2] }]],
@@ -817,7 +817,12 @@ describe("sns-neurons-services", () => {
       });
 
       expect(setFolloweesSpy).not.toBeCalled();
-      expect(toastsError).toBeCalled();
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "You are already following this neuron.",
+        },
+      ]);
     });
 
     it("should call sns api setFollowees when new followee is the same neuron", async () => {
@@ -844,6 +849,7 @@ describe("sns-neurons-services", () => {
 
     it("should not call sns api setFollowees when new followee does not exist", async () => {
       vi.spyOn(governanceApi, "querySnsNeuron").mockResolvedValue(undefined);
+      expect(get(toastsStore)).toEqual([]);
       const neuronIdHext = getSnsNeuronIdAsHexString(mockSnsNeuron);
       await addFollowee({
         rootCanisterId,
@@ -853,7 +859,12 @@ describe("sns-neurons-services", () => {
       });
 
       expect(setFolloweesSpy).not.toBeCalled();
-      expect(toastsError).toBeCalled();
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: `Neuron with id ${neuronIdHext} does not exist.`,
+        },
+      ]);
     });
   });
 
@@ -921,6 +932,7 @@ describe("sns-neurons-services", () => {
       vi.spyOn(governanceApi, "querySnsNeuron").mockResolvedValue(
         mockSnsNeuron
       );
+      expect(get(toastsStore)).toEqual([]);
       const neuron: SnsNeuron = {
         ...mockSnsNeuron,
         followees: [[functionId, { followees: [followee2] }]],
@@ -933,7 +945,12 @@ describe("sns-neurons-services", () => {
       });
 
       expect(setFolloweesSpy).not.toBeCalled();
-      expect(toastsError).toBeCalled();
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "Sorry, you can't unfollow neuron $neuronId because you are not following it.",
+        },
+      ]);
     });
   });
 
@@ -1114,6 +1131,7 @@ describe("sns-neurons-services", () => {
         .mockReset();
       const amount = 0.00001;
       const neuronMinimumStake = 2_000n;
+      expect(get(toastsStore)).toEqual([]);
       const { success } = await splitNeuron({
         neuronId: mockSnsNeuron.id[0] as SnsNeuronId,
         rootCanisterId: mockPrincipal,
@@ -1121,7 +1139,12 @@ describe("sns-neurons-services", () => {
         neuronMinimumStake,
       });
 
-      expect(toastsError).toBeCalled();
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "Sorry, the amount is too small. You need a minimum of 0.00002 TST to stake a neuron.",
+        },
+      ]);
       expect(success).toBe(false);
       expect(spySplitNeuron).not.toBeCalled();
     });

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -1142,7 +1142,7 @@ describe("sns-neurons-services", () => {
       expect(get(toastsStore)).toMatchObject([
         {
           level: "error",
-          text: "Sorry, the amount is too small. You need a minimum of 0.00002 TST to stake a neuron.",
+          text: "Sorry, the amount is too small. You need a minimum of 0.00002 TST to stake.",
         },
       ]);
       expect(success).toBe(false);

--- a/frontend/src/tests/lib/services/sns-sale.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-sale.services.spec.ts
@@ -17,10 +17,7 @@ import {
 import { authStore } from "$lib/stores/auth.store";
 import * as busyStore from "$lib/stores/busy.store";
 import { snsTicketsStore } from "$lib/stores/sns-tickets.store";
-import * as toastsStore from "$lib/stores/toasts.store";
 import { tokensStore } from "$lib/stores/tokens.store";
-import { nanoSecondsToDateTime } from "$lib/utils/date.utils";
-import { formatTokenE8s } from "$lib/utils/token.utils";
 import {
   mockIdentity,
   mockPrincipal,
@@ -55,6 +52,7 @@ import {
   runResolvedPromises,
 } from "$tests/utils/timers.test-utils";
 import type { Agent, Identity } from "@dfinity/agent";
+import { toastsStore } from "@dfinity/gix-components";
 import {
   InsufficientFundsError,
   TransferError,
@@ -132,10 +130,6 @@ describe("sns-api", () => {
   const newBalanceE8s = 100_000_000n;
   const spyOnQueryBalance = vi.spyOn(ledgerApi, "queryAccountBalance");
   const spyOnNotifyParticipation = vi.fn();
-  const spyOnToastsShow = vi.spyOn(toastsStore, "toastsShow");
-  const spyOnToastsSuccess = vi.spyOn(toastsStore, "toastsSuccess");
-  const spyOnToastsError = vi.spyOn(toastsStore, "toastsError");
-  const spyOnToastsHide = vi.spyOn(toastsStore, "toastsHide");
   const testRootCanisterId = rootCanisterIdMock;
   const swapCanisterId = swapCanisterIdMock;
   const testSnsTicket = snsTicketMock({
@@ -155,13 +149,6 @@ describe("sns-api", () => {
     spyOnSendICP.mockReset();
     spyOnSendICP.mockReset();
     spyOnNotifyParticipation.mockReset();
-    spyOnToastsShow.mockReset();
-    // `mockReset` seems to add a mock not calling the actual function and not only reset the spy.
-    // And because the service relies on the return value of the spy, we need to mock the return value.
-    // Jest was calling the original function instead.
-    spyOnToastsShow.mockReturnValue(Symbol("toast-id"));
-    spyOnToastsSuccess.mockReset();
-    spyOnToastsError.mockReset();
     snsSwapCanister.getOpenTicket.mockReset();
     spyOnNewSaleTicketApi.mockReset();
     spyOnNotifyPaymentFailureApi.mockReset();
@@ -169,6 +156,7 @@ describe("sns-api", () => {
     vi.useFakeTimers();
     vi.clearAllMocks();
 
+    toastsStore.reset();
     snsTicketsStore.reset();
     resetAccountsForTesting();
     tokensStore.reset();
@@ -350,17 +338,20 @@ describe("sns-api", () => {
           new SnsSwapGetOpenTicketError(GetOpenTicketErrorType.TYPE_SALE_CLOSED)
         );
 
+        expect(get(toastsStore)).toEqual([]);
+
         await loadOpenTicket({
           rootCanisterId: testSnsTicket.rootCanisterId,
           swapCanisterId: swapCanisterIdMock,
           certified: true,
         });
 
-        expect(spyOnToastsError).toBeCalledWith(
-          expect.objectContaining({
-            labelKey: "error__sns.sns_sale_closed",
-          })
-        );
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "error",
+            text: "Sorry, the swap was already closed. Please reload the page.",
+          },
+        ]);
       });
 
       it("should set store to `null` on unspecified type error", async () => {
@@ -384,17 +375,20 @@ describe("sns-api", () => {
           new SnsSwapGetOpenTicketError(GetOpenTicketErrorType.TYPE_UNSPECIFIED)
         );
 
+        expect(get(toastsStore)).toEqual([]);
+
         await loadOpenTicket({
           rootCanisterId: testSnsTicket.rootCanisterId,
           swapCanisterId: swapCanisterIdMock,
           certified: true,
         });
 
-        expect(spyOnToastsError).toBeCalledWith(
-          expect.objectContaining({
-            labelKey: "error__sns.sns_sale_final_error",
-          })
-        );
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "error",
+            text: "Sorry, there was an unexpected error connection with the SNS swap. Please reload the page and try again.",
+          },
+        ]);
       });
 
       it("should set store to `null` on not open error", async () => {
@@ -422,17 +416,20 @@ describe("sns-api", () => {
           )
         );
 
+        expect(get(toastsStore)).toEqual([]);
+
         await loadOpenTicket({
           rootCanisterId: testSnsTicket.rootCanisterId,
           swapCanisterId: swapCanisterIdMock,
           certified: true,
         });
 
-        expect(spyOnToastsError).toBeCalledWith(
-          expect.objectContaining({
-            labelKey: "error__sns.sns_sale_not_open",
-          })
-        );
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "error",
+            text: "Sorry, the swap is not yet open. Please reload the page.",
+          },
+        ]);
       });
 
       it("should show 'high load' toast after 6 failures", async () => {
@@ -460,17 +457,27 @@ describe("sns-api", () => {
           expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(expectedCalls);
 
           if (expectedCalls < expectFailuresBeforeToast) {
-            expect(spyOnToastsError).not.toBeCalled();
+            expect(get(toastsStore)).toMatchObject([
+              {
+                level: "info",
+                text: "We're connecting with the SNS swap. This might take more than a minute.",
+              },
+            ]);
           }
         }
         expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(
           expectFailuresBeforeToast
         );
-        expect(spyOnToastsError).toBeCalledWith(
-          expect.objectContaining({
-            labelKey: "error.high_load_retrying",
-          })
-        );
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "info",
+            text: "We're connecting with the SNS swap. This might take more than a minute.",
+          },
+          {
+            level: "error",
+            text: "The Internet Computer is experiencing high load. We'll keep retrying.",
+          },
+        ]);
       });
     });
 
@@ -525,9 +532,14 @@ describe("sns-api", () => {
           maxAttempts: 10,
         });
 
-        expect(spyOnToastsShow).toBeCalledTimes(0);
+        expect(get(toastsStore)).toEqual([]);
         await runResolvedPromises();
-        expect(spyOnToastsShow).toBeCalledTimes(1);
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "info",
+            text: "We're connecting with the SNS swap. This might take more than a minute.",
+          },
+        ]);
 
         let expectedCalls = 1;
         expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(expectedCalls);
@@ -541,12 +553,16 @@ describe("sns-api", () => {
           expectedCalls += 1;
           expect(snsSwapCanister.getOpenTicket).toBeCalledTimes(expectedCalls);
         }
-        expect(spyOnToastsShow).toBeCalledTimes(1);
-        expect(spyOnToastsHide).not.toBeCalled();
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "info",
+            text: "We're connecting with the SNS swap. This might take more than a minute.",
+          },
+        ]);
         cancelPollGetOpenTicket();
 
         await runResolvedPromises();
-        expect(spyOnToastsHide).toBeCalledTimes(1);
+        expect(get(toastsStore)).toEqual([]);
       });
     });
   });
@@ -582,17 +598,20 @@ describe("sns-api", () => {
         })
       );
 
+      expect(get(toastsStore)).toEqual([]);
+
       await loadNewSaleTicket({
         rootCanisterId: testSnsTicket.rootCanisterId,
         amount_icp_e8s: 0n,
       });
 
       expect(spyOnNewSaleTicketApi).toBeCalled();
-      expect(spyOnToastsError).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error__sns.sns_sale_closed",
-        })
-      );
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "Sorry, the swap was already closed. Please reload the page. ",
+        },
+      ]);
       expect(ticketFromStore()?.ticket).toEqual(null);
     });
 
@@ -603,17 +622,20 @@ describe("sns-api", () => {
         })
       );
 
+      expect(get(toastsStore)).toEqual([]);
+
       await loadNewSaleTicket({
         rootCanisterId: testSnsTicket.rootCanisterId,
         amount_icp_e8s: 0n,
       });
 
       expect(spyOnNewSaleTicketApi).toBeCalled();
-      expect(spyOnToastsError).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error__sns.sns_sale_not_open",
-        })
-      );
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "Sorry, the swap is not yet open. Please reload the page. ",
+        },
+      ]);
       expect(ticketFromStore()?.ticket).toEqual(null);
     });
 
@@ -625,21 +647,20 @@ describe("sns-api", () => {
         })
       );
 
+      expect(get(toastsStore)).toEqual([]);
+
       await loadNewSaleTicket({
         rootCanisterId: testSnsTicket.rootCanisterId,
         amount_icp_e8s: 0n,
       });
 
       expect(spyOnNewSaleTicketApi).toBeCalled();
-      expect(spyOnToastsError).toBeCalledTimes(1);
-      expect(spyOnToastsError).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error__sns.sns_sale_proceed_with_existing_ticket",
-          substitutions: {
-            $time: nanoSecondsToDateTime(testSnsTicket.ticket.creation_time),
-          },
-        })
-      );
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "There is an existing participation started at Jan 1, 1970 12:00 AM. Completing that participation.",
+        },
+      ]);
       expect(ticketFromStore()?.ticket).toEqual(testTicket);
     });
 
@@ -656,21 +677,20 @@ describe("sns-api", () => {
         })
       );
 
+      expect(get(toastsStore)).toEqual([]);
+
       await loadNewSaleTicket({
         rootCanisterId: testSnsTicket.rootCanisterId,
         amount_icp_e8s: 0n,
       });
 
       expect(spyOnNewSaleTicketApi).toBeCalled();
-      expect(spyOnToastsError).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error__sns.sns_sale_invalid_amount",
-          substitutions: {
-            $min: formatTokenE8s({ value: min_amount_icp_e8s_included }),
-            $max: formatTokenE8s({ value: max_amount_icp_e8s_included }),
-          },
-        })
-      );
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "Can't participate with the selected amount. Please participate with a different amount (0.00000123 - 0.00000321).",
+        },
+      ]);
       expect(ticketFromStore()?.ticket).toEqual(null);
     });
 
@@ -681,17 +701,20 @@ describe("sns-api", () => {
         })
       );
 
+      expect(get(toastsStore)).toEqual([]);
+
       await loadNewSaleTicket({
         rootCanisterId: testSnsTicket.rootCanisterId,
         amount_icp_e8s: 0n,
       });
 
       expect(spyOnNewSaleTicketApi).toBeCalled();
-      expect(spyOnToastsError).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error__sns.sns_sale_invalid_subaccount",
-        })
-      );
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "Can't participate with the selected subaccount.",
+        },
+      ]);
       expect(ticketFromStore()?.ticket).toEqual(null);
     });
 
@@ -702,17 +725,20 @@ describe("sns-api", () => {
         })
       );
 
+      expect(get(toastsStore)).toEqual([]);
+
       await loadNewSaleTicket({
         rootCanisterId: testSnsTicket.rootCanisterId,
         amount_icp_e8s: 0n,
       });
 
       expect(spyOnNewSaleTicketApi).toBeCalled();
-      expect(spyOnToastsError).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error__sns.sns_sale_try_later",
-        })
-      );
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "Sorry, there was an unexpected error while participating. Please try again later.",
+        },
+      ]);
       expect(ticketFromStore()?.ticket).toEqual(null);
     });
 
@@ -800,15 +826,16 @@ describe("sns-api", () => {
         expect(spyOnNewSaleTicketApi).toBeCalledTimes(expectedCalls);
 
         if (expectedCalls < expectFailuresBeforeToast) {
-          expect(spyOnToastsError).not.toBeCalled();
+          expect(get(toastsStore)).toEqual([]);
         }
       }
       expect(spyOnNewSaleTicketApi).toBeCalledTimes(expectFailuresBeforeToast);
-      expect(spyOnToastsError).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error.high_load_retrying",
-        })
-      );
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "The Internet Computer is experiencing high load. We'll keep retrying.",
+        },
+      ]);
     });
   });
 
@@ -817,6 +844,8 @@ describe("sns-api", () => {
       snsSwapCanister.getOpenTicket.mockResolvedValue(testSnsTicket.ticket);
       const postprocessSpy = vi.fn().mockResolvedValue(undefined);
       const updateProgressSpy = vi.fn().mockResolvedValue(undefined);
+
+      expect(get(toastsStore)).toEqual([]);
 
       await restoreSnsSaleParticipation({
         rootCanisterId: rootCanisterIdMock,
@@ -835,7 +864,16 @@ describe("sns-api", () => {
       // null after ready
       expect(ticketFromStore().ticket).toEqual(null);
       // no errors
-      expect(spyOnToastsError).not.toBeCalled();
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "warn",
+          text: "Your total committed: 0.00000666 ICP",
+        },
+        {
+          level: "success",
+          text: "Your participation has been successfully committed.",
+        },
+      ]);
     });
 
     it("should not start flow if no open ticket", async () => {
@@ -928,6 +966,8 @@ describe("sns-api", () => {
       const postprocessSpy = vi.fn().mockResolvedValue(undefined);
       const updateProgressSpy = vi.fn().mockResolvedValue(undefined);
 
+      expect(get(toastsStore)).toEqual([]);
+
       await initiateSnsSaleParticipation({
         rootCanisterId: rootCanisterIdMock,
         amount: TokenAmount.fromNumber({
@@ -952,14 +992,16 @@ describe("sns-api", () => {
       expect(updateProgressSpy).toBeCalledTimes(5);
       // null after ready
       expect(ticketFromStore().ticket).toEqual(null);
-      expect(spyOnToastsSuccess).toBeCalledTimes(1);
-      expect(spyOnToastsSuccess).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "sns_project_detail.participate_success",
-        })
-      );
-      // no errors
-      expect(spyOnToastsError).not.toBeCalled();
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "warn",
+          text: "Your total committed: 0.00000666 ICP",
+        },
+        {
+          level: "success",
+          text: "Your participation has been successfully committed.",
+        },
+      ]);
     });
 
     it("should handle errors", async () => {
@@ -976,6 +1018,8 @@ describe("sns-api", () => {
         }),
       };
 
+      expect(get(toastsStore)).toEqual([]);
+
       await initiateSnsSaleParticipation({
         rootCanisterId: rootCanisterIdMock,
         amount: TokenAmount.fromNumber({
@@ -989,7 +1033,12 @@ describe("sns-api", () => {
       });
 
       expect(spyOnNewSaleTicketApi).not.toBeCalled();
-      expect(spyOnToastsError).toBeCalled();
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "Sorry, the project was not found. Please refresh and try again",
+        },
+      ]);
       // null after ready
       expect(ticketFromStore().ticket).toEqual(null);
     });
@@ -1231,6 +1280,8 @@ describe("sns-api", () => {
         getPrincipal: () => Principal.fromText("aaaaa-aa"),
       });
 
+      expect(get(toastsStore)).toEqual([]);
+
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         swapCanisterId,
@@ -1242,11 +1293,12 @@ describe("sns-api", () => {
 
       expect(spyOnNotifyParticipation).not.toBeCalled();
       expect(spyOnNotifyPaymentFailureApi).not.toBeCalled();
-      expect(spyOnToastsError).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error__sns.sns_sale_unexpected_error",
-        })
-      );
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "Sorry, There was an unexpected error while participating. Please refresh the page and try again.",
+        },
+      ]);
       // do not enable the UI
       expect(ticketFromStore().ticket).not.toEqual(null);
     });
@@ -1298,6 +1350,8 @@ describe("sns-api", () => {
     it("should display transfer api unknown errors", async () => {
       spyOnSendICP.mockRejectedValue(new TransferError("test"));
 
+      expect(get(toastsStore)).toEqual([]);
+
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         swapCanisterId,
@@ -1309,16 +1363,19 @@ describe("sns-api", () => {
 
       expect(spyOnNotifyParticipation).not.toBeCalled();
       expect(spyOnNotifyPaymentFailureApi).not.toBeCalled();
-      expect(spyOnToastsError).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error__sns.sns_sale_unexpected_error",
-        })
-      );
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "Sorry, There was an unexpected error while participating. Please refresh the page and try again. test",
+        },
+      ]);
       expect(ticketFromStore().ticket).toEqual(null);
     });
 
     it("should display InsufficientFundsError errors", async () => {
       spyOnSendICP.mockRejectedValue(new InsufficientFundsError(0n));
+
+      expect(get(toastsStore)).toEqual([]);
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
@@ -1331,18 +1388,20 @@ describe("sns-api", () => {
 
       expect(spyOnNotifyParticipation).not.toBeCalled();
       expect(spyOnNotifyPaymentFailureApi).toBeCalledTimes(1);
-      expect(spyOnToastsError).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error__sns.ledger_insufficient_funds",
-        })
-      );
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "Sorry, the account doesn't have enough funds for this transaction. ",
+        },
+      ]);
       expect(ticketFromStore().ticket).toEqual(null);
-      expect(spyOnToastsSuccess).not.toBeCalled();
     });
 
     describe("TooOldError", () => {
       it("should succeed when no errors on notify participation", async () => {
         spyOnSendICP.mockRejectedValue(new TxTooOldError(0));
+
+        expect(get(toastsStore)).toEqual([]);
 
         await participateInSnsSale({
           rootCanisterId: testRootCanisterId,
@@ -1355,13 +1414,16 @@ describe("sns-api", () => {
 
         expect(spyOnNotifyParticipation).toBeCalledTimes(1);
         expect(spyOnNotifyPaymentFailureApi).not.toBeCalled();
-        expect(spyOnToastsError).not.toBeCalled();
-        expect(spyOnToastsSuccess).toBeCalledTimes(1);
-        expect(spyOnToastsSuccess).toBeCalledWith(
-          expect.objectContaining({
-            labelKey: "sns_project_detail.participate_success",
-          })
-        );
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "warn",
+            text: "Your total committed: 0.00000666 ICP",
+          },
+          {
+            level: "success",
+            text: "Your participation has been successfully committed.",
+          },
+        ]);
         // to enable the button/increase_participation
         expect(ticketFromStore().ticket).toEqual(null);
       });
@@ -1378,6 +1440,8 @@ describe("sns-api", () => {
         );
         spyOnSendICP.mockRejectedValue(new TxTooOldError(0));
 
+        expect(get(toastsStore)).toEqual([]);
+
         await participateInSnsSale({
           rootCanisterId: testRootCanisterId,
           swapCanisterId,
@@ -1389,13 +1453,12 @@ describe("sns-api", () => {
 
         expect(spyOnNotifyParticipation).toBeCalledTimes(1);
         expect(spyOnNotifyPaymentFailureApi).toBeCalledTimes(1);
-        expect(spyOnToastsError).toBeCalledTimes(1);
-        expect(spyOnToastsError).toBeCalledWith(
-          expect.objectContaining({
-            labelKey: "error__sns.sns_sale_unexpected_and_refresh",
-          })
-        );
-        expect(spyOnToastsSuccess).not.toBeCalled();
+        expect(get(toastsStore)).toMatchObject([
+          {
+            level: "error",
+            text: "Sorry, There was an unexpected error while participating. Please refresh and try again The token amount can only be refreshed when the canister is in the OPEN state",
+          },
+        ]);
         // the button/increase_participation should not be enabled
         expect(ticketFromStore().ticket).not.toBeNull();
       });
@@ -1404,7 +1467,7 @@ describe("sns-api", () => {
     it("should ignore Duplicate error", async () => {
       spyOnSendICP.mockRejectedValue(new TxDuplicateError(0n));
 
-      expect(spyOnToastsError).not.toBeCalled();
+      expect(get(toastsStore)).toEqual([]);
 
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
@@ -1416,7 +1479,16 @@ describe("sns-api", () => {
       });
 
       expect(spyOnNotifyParticipation).toBeCalled();
-      expect(spyOnToastsError).not.toBeCalled();
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "warn",
+          text: "Your total committed: 0.00000666 ICP",
+        },
+        {
+          level: "success",
+          text: "Your participation has been successfully committed.",
+        },
+      ]);
       expect(ticketFromStore().ticket).toEqual(null);
     });
 
@@ -1428,6 +1500,7 @@ describe("sns-api", () => {
       spyOnNotifyParticipation.mockResolvedValue({
         icp_accepted_participation_e8s: 100n,
       });
+      expect(get(toastsStore)).toEqual([]);
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         swapCanisterId,
@@ -1437,12 +1510,16 @@ describe("sns-api", () => {
         ticket,
       });
 
-      expect(spyOnToastsShow).toBeCalledWith(
-        expect.objectContaining({
+      expect(get(toastsStore)).toMatchObject([
+        {
           level: "warn",
-          labelKey: "error__sns.sns_sale_committed_not_equal_to_amount",
-        })
-      );
+          text: "Your total committed: 0.000001 ICP",
+        },
+        {
+          level: "success",
+          text: "Your participation has been successfully committed.",
+        },
+      ]);
       expect(ticketFromStore().ticket).toEqual(null);
     });
 
@@ -1454,6 +1531,7 @@ describe("sns-api", () => {
       spyOnNotifyParticipation.mockResolvedValue({
         icp_accepted_participation_e8s: 1n,
       });
+      expect(get(toastsStore)).toEqual([]);
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         swapCanisterId,
@@ -1463,11 +1541,12 @@ describe("sns-api", () => {
         ticket,
       });
 
-      expect(spyOnToastsShow).not.toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error__sns.sns_sale_committed_not_equal_to_amount",
-        })
-      );
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "success",
+          text: "Your participation has been successfully committed.",
+        },
+      ]);
     });
 
     it("should not display a waring when current_committed = ticket.amount for increase participation", async () => {
@@ -1478,6 +1557,7 @@ describe("sns-api", () => {
       spyOnNotifyParticipation.mockResolvedValue({
         icp_accepted_participation_e8s: 10n,
       });
+      expect(get(toastsStore)).toEqual([]);
       await participateInSnsSale({
         rootCanisterId: testRootCanisterId,
         swapCanisterId,
@@ -1487,11 +1567,12 @@ describe("sns-api", () => {
         ticket,
       });
 
-      expect(spyOnToastsShow).not.toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error__sns.sns_sale_committed_not_equal_to_amount",
-        })
-      );
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "success",
+          text: "Your participation has been successfully committed.",
+        },
+      ]);
     });
 
     it("should show 'high load' toast after 6 failures", async () => {
@@ -1520,17 +1601,18 @@ describe("sns-api", () => {
         expect(spyOnNotifyParticipation).toBeCalledTimes(expectedCalls);
 
         if (expectedCalls < expectFailuresBeforeToast) {
-          expect(spyOnToastsError).not.toBeCalled();
+          expect(get(toastsStore)).toEqual([]);
         }
       }
       expect(spyOnNotifyParticipation).toBeCalledTimes(
         expectFailuresBeforeToast
       );
-      expect(spyOnToastsError).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error.high_load_retrying",
-        })
-      );
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "The Internet Computer is experiencing high load. We'll keep retrying.",
+        },
+      ]);
     });
 
     it("transfer should show 'high load' toast after 6 failures", async () => {
@@ -1559,15 +1641,16 @@ describe("sns-api", () => {
         expect(spyOnSendICP).toBeCalledTimes(expectedCalls);
 
         if (expectedCalls < expectFailuresBeforeToast) {
-          expect(spyOnToastsError).not.toBeCalled();
+          expect(get(toastsStore)).toEqual([]);
         }
       }
       expect(spyOnSendICP).toBeCalledTimes(expectFailuresBeforeToast);
-      expect(spyOnToastsError).toBeCalledWith(
-        expect.objectContaining({
-          labelKey: "error.high_load_retrying",
-        })
-      );
+      expect(get(toastsStore)).toMatchObject([
+        {
+          level: "error",
+          text: "The Internet Computer is experiencing high load. We'll keep retrying.",
+        },
+      ]);
     });
   });
 });

--- a/frontend/src/tests/mocks/proposal.mock.ts
+++ b/frontend/src/tests/mocks/proposal.mock.ts
@@ -70,6 +70,7 @@ export const mockProposalInfo: ProposalInfo = {
     no: 400_000_000n,
     yes: 600_000_000n,
   },
+  // TODO: Change this to 4 (Governance) to be consistent with the Motion type.
   topic: 8,
   status: 2,
   rewardStatus: 3,


### PR DESCRIPTION
# Motivation

To make the tests more robust we should not mock stores but use real stores.

By doing so, I also found a bug:
In https://github.com/dfinity/nns-dapp/pull/4244 I removed `sns_amount_not_enough_stake_neuron` because I thought it was not used. But it turned out it was used and cleaning up the tests exposed that, so I restored it in this PR as well.

# Changes

1. Stop mocking `toastsStore` functions.
2. Expect the full contents of the store.
3. Expect the store to be empty before it's filled.
4. Expect actual messages instead of label keys.
5. Restore `sns_amount_not_enough_stake_neuron`. I also removed `a neuron` from the message, in line with the intent of https://github.com/dfinity/nns-dapp/pull/4244

# Tests

1. The updated tests still pass.
2. In one case the test showed that the toast was showing a label key instead of a message. The test has been fixed by adding back the removed message.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary