### PR TITLE
NNS1-3391: Add error messages for incorrect transaction timestamps

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -14,6 +14,8 @@ proposal is successful, the changes it released will be moved from this file to
 
 #### Added
 
+* Provide better error messages when the transaction timestamp is off.
+
 #### Changed
 
 * Change Internet Computer Association neuron title.

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -77,6 +77,8 @@
     "amount_not_enough_stake_neuron": "Sorry, the amount is too small. You need to stake a minimum of 1 ICP.",
     "amount_not_enough_top_up_neuron": "Sorry, the amount is too small. The amount plus the current stake need to be at least 1 ICP",
     "transaction_error": "Sorry, there was an error trying to execute the transaction.",
+    "transaction_too_old": "Transaction is too old, could not be completed. Make sure your computer’s clock is set correctly, and try again.",
+    "transaction_created_in_future": "Transaction was created in the future, could not be completed. Make sure your computer’s clock is set correctly, and try again.",
     "unexpected_number_neurons_merge": "Sorry, the number of neurons to merge should be only 2. Please try selecting again.",
     "cannot_merge": "Those two neurons cannot be merged.",
     "not_authorized_neuron_action": "Sorry, none of your principals is the controller of the neuron.",

--- a/frontend/src/lib/services/icp-accounts.services.ts
+++ b/frontend/src/lib/services/icp-accounts.services.ts
@@ -50,6 +50,7 @@ import {
   pollingLimit,
 } from "$lib/utils/utils";
 import type { Identity } from "@dfinity/agent";
+import { TxCreatedInFutureError, TxTooOldError } from "@dfinity/ledger-icp";
 import { decodeIcrcAccount } from "@dfinity/ledger-icrc";
 import { ICPToken, TokenAmount, isNullish, nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
@@ -327,17 +328,17 @@ export const transferICP = async ({
 
     return { success: true };
   } catch (err) {
-    return transferError({ labelKey: "error.transaction_error", err });
+    return transferError(err);
   }
 };
 
-const transferError = ({
-  labelKey,
-  err,
-}: {
-  labelKey: string;
-  err?: unknown;
-}): { success: boolean; err?: string } => {
+const transferError = (err: unknown): { success: boolean; err?: string } => {
+  let labelKey = "error.transaction_error";
+  if (err instanceof TxTooOldError) {
+    labelKey = "error.transaction_too_old";
+  } else if (err instanceof TxCreatedInFutureError) {
+    labelKey = "error.transaction_created_in_future";
+  }
   toastsError(
     toToastError({
       err,

--- a/frontend/src/lib/types/i18n.d.ts
+++ b/frontend/src/lib/types/i18n.d.ts
@@ -81,6 +81,8 @@ interface I18nError {
   amount_not_enough_stake_neuron: string;
   amount_not_enough_top_up_neuron: string;
   transaction_error: string;
+  transaction_too_old: string;
+  transaction_created_in_future: string;
   unexpected_number_neurons_merge: string;
   cannot_merge: string;
   not_authorized_neuron_action: string;


### PR DESCRIPTION
# Motivation

There was a [forum post](https://forum.dfinity.org/t/i-having-trouble-transferring-icp-from-the-nns-dapp/36038) from a user who kept getting errors when trying to transfer ICP.
In the end it turned out to be a problem with their computer's time settings.

To avoid this situation in the future we want to provide better error messages.

# Changes

1. Remove the `labelKey` parameter from `transferError` as `transferError` is only called in 1 place with a hardcoded `labelKey` argument.`
2. In `transferError` use the originally passed-in `labelKey` as default but use a different `labelKey` if the error is `TxTooOldError` or `TxCreatedInFutureError`.
3. Add new messages for the new label keys.

# Tests

1. Add missing test coverage for a generic error from `sendICP`.
2. Add tests for `TxTooOldError` and `TxCreatedInFutureError`.
3. I was unable to reproduce the issue manually because whenever I changed my clock settings, either nothing would change or I would got very severe errors before I could even try to make a transaction. So I just hardcoded the relevant errors in my local `ic-js` repo to test this manually.

# Todos

- [x] Add entry to changelog (if necessary).
