### PR TITLE
Stop adding .raw to aggregator URL

### DIFF
--- a/frontend/src/lib/constants/environment.constants.ts
+++ b/frontend/src/lib/constants/environment.constants.ts
@@ -1,5 +1,4 @@
 import { getEnvVars } from "$lib/utils/env-vars.utils";
-import { addRawToUrl, isBrowser, isLocalhost } from "$lib/utils/env.utils";
 
 const envVars = getEnvVars();
 
@@ -8,34 +7,7 @@ export const HOST = envVars.host;
 
 export const FETCH_ROOT_KEY: boolean = envVars.fetchRootKey === "true";
 
-const snsAggregatorUrlEnv = envVars.snsAggregatorUrl ?? "";
-const snsAggregatorUrl = (url: string) => {
-  try {
-    const { hostname } = new URL(url);
-    if (isLocalhost(hostname)) {
-      return url;
-    }
-
-    // If the nns-dapp is running in localhost, we need to add `raw` to the URL to avoid CORS issues.
-    if (isBrowser && isLocalhost(window.location.hostname)) {
-      return addRawToUrl(url);
-    }
-
-    return url;
-  } catch (e) {
-    console.error(`Invalid URL for SNS aggregator: ${url}`, e);
-    return undefined;
-  }
-};
-
-/**
- * If you are on a different domain from the canister that you are calling, the service worker will not be loaded for that domain.
- * If the service worker is not loaded then it will make a request to the boundary node directly which will fail CORS.
- *
- * Therefore, we add `raw` to the URL to avoid CORS issues in local development.
- */
-export const SNS_AGGREGATOR_CANISTER_URL: string | undefined =
-  snsAggregatorUrl(snsAggregatorUrlEnv);
+export const SNS_AGGREGATOR_CANISTER_URL = envVars.snsAggregatorUrl ?? "";
 
 export interface FeatureFlags<T> {
   ENABLE_CKBTC: T;

--- a/frontend/src/lib/utils/env.utils.ts
+++ b/frontend/src/lib/utils/env.utils.ts
@@ -20,27 +20,6 @@ export const isNnsAlternativeOrigin = (): boolean => {
   return NNS_IC_ORG_ALTERNATIVE_ORIGINS.includes(origin);
 };
 
-/**
- * Sets `raw` in the URL to avoid CORS issues.
- *
- * Used for local development only.
- *
- * @param urlString
- * @returns url with `raw` added
- */
-export const addRawToUrl = (urlString: string): string => {
-  const hasTrailingSlash = urlString.endsWith("/");
-  const url = new URL(urlString);
-
-  const [canisterId, ...rest] = url.host.split(".");
-
-  const newHost = [canisterId, "raw", ...rest].join(".");
-
-  url.host = newHost;
-
-  return hasTrailingSlash ? url.toString() : url.toString().slice(0, -1);
-};
-
 export const isLocalhost = (hostname: string) =>
   hostname.includes("localhost") || hostname.includes("127.0.0.1");
 

--- a/frontend/src/tests/lib/utils/env.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/env.utils.spec.ts
@@ -1,5 +1,4 @@
 import {
-  addRawToUrl,
   isLastCall,
   isLocalhost,
   isNnsAlternativeOrigin,
@@ -68,46 +67,6 @@ describe("env-utils", () => {
 
       setOrigin("https://beta.ic0.app");
       expect(isNnsAlternativeOrigin()).toBe(false);
-    });
-  });
-
-  describe("addRawToUrl", () => {
-    it("adds raw to url", () => {
-      expect(
-        addRawToUrl(
-          "https://53zcu-tiaaa-aaaaa-qaaba-cai.medium09.testnet.dfinity.network"
-        )
-      ).toBe(
-        "https://53zcu-tiaaa-aaaaa-qaaba-cai.raw.medium09.testnet.dfinity.network"
-      );
-
-      expect(
-        addRawToUrl(
-          "https://53zcu-tiaaa-aaaaa-qaaba-cai.nnsdapp.testnet.dfinity.network"
-        )
-      ).toBe(
-        "https://53zcu-tiaaa-aaaaa-qaaba-cai.raw.nnsdapp.testnet.dfinity.network"
-      );
-
-      expect(
-        addRawToUrl(
-          "https://53zcu-tiaaa-aaaaa-qaaba-cai.nnsdapp.testnet.dfinity.network/"
-        )
-      ).toBe(
-        "https://53zcu-tiaaa-aaaaa-qaaba-cai.raw.nnsdapp.testnet.dfinity.network/"
-      );
-    });
-
-    it("raises if url is not a valid url", () => {
-      const invalid1 = "http**://example.com";
-      expect(() => addRawToUrl(invalid1)).toThrow(
-        new TypeError(`Invalid URL: ${invalid1}`)
-      );
-
-      const invalid2 = "";
-      expect(() => addRawToUrl(invalid2)).toThrow(
-        new TypeError(`Invalid URL: ${invalid2}`)
-      );
     });
   });
 


### PR DESCRIPTION
# Motivation

When connecting from localhost to a non-local environment (such as DevEnv or mainnet) we add `.raw` to the SNS aggregator URL.
This was originally done to avoid being redirected by the boundary node to the service worker, because that would result in CORS issues when connecting from localhost.
But:
1. The boundary node no longer redirects to the service worker
2. Raw URLs stopped working on DevEnv ([slack thread](https://dfinity.slack.com/archives/CGA566TPV/p1727177718754779))

So adding `.raw` to the aggregator URL is no longer necessary and also breaks.
Time to remove this code.

# Changes

1. Stop adding `.raw` to the SNS aggregator URL.
2. Remove `addRawToUrl` as it is no longer user.

# Tests

Tested manually:
1. From localhost to localhost
2. From localhost to DevEnv
3. From DevEnv to DevEnv
4. From localhost to mainnet

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary