### PR TITLE
Stop using afterEach for cleanup

### DIFF
--- a/frontend/src/tests/lib/api/icrc-index.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-index.api.spec.ts
@@ -33,10 +33,6 @@ describe("icrc-index api", () => {
     vi.spyOn(agent, "createAgent").mockResolvedValue(agentMock);
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
   describe("getTransactions", () => {
     const transactions = [mockIcrcTransactionWithId];
     const oldestTxId = 1234n;

--- a/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
+++ b/frontend/src/tests/lib/api/icrc-ledger.api.spec.ts
@@ -30,10 +30,6 @@ describe("icrc-ledger api", () => {
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
   describe("execute transfer", () => {
     it("successfully calls transfer api", async () => {
       const transferSpy = vi.fn().mockResolvedValue(undefined);

--- a/frontend/src/tests/lib/api/proposals.api.spec.ts
+++ b/frontend/src/tests/lib/api/proposals.api.spec.ts
@@ -31,8 +31,6 @@ describe("proposals-api", () => {
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
   });
 
-  afterEach(() => spyListProposals.mockClear());
-
   describe("list", () => {
     it("should call the canister to list proposals", async () => {
       await queryProposals({

--- a/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
+++ b/frontend/src/tests/lib/api/sns-aggregator.api.spec.ts
@@ -3,10 +3,11 @@ import { aggregatorSnsMockDto } from "$tests/mocks/sns-aggregator.mock";
 import tenAggregatedSnses from "$tests/mocks/sns-aggregator.mock.json";
 
 describe("sns-aggregator api", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
   describe("querySnsProjects", () => {
-    afterEach(() => {
-      vi.resetAllMocks();
-    });
     it("should fetch json once if less than 10 SNSes", async () => {
       const mockFetch = vi.fn();
       const [_first, ...nineSnses] = tenAggregatedSnses;

--- a/frontend/src/tests/lib/components/accounts/AddAccountType.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/AddAccountType.spec.ts
@@ -10,7 +10,7 @@ import AddAccountTest from "./AddAccountTest.svelte";
 describe("AddAccountType", () => {
   const props = { testComponent: AddAccountType };
 
-  afterEach(() =>
+  beforeEach(() =>
     addAccountStoreMock.set({
       type: undefined,
       hardwareWalletName: undefined,

--- a/frontend/src/tests/lib/components/accounts/CkBTCUpdateBalanceButton.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/CkBTCUpdateBalanceButton.spec.ts
@@ -17,25 +17,20 @@ import { fireEvent, render } from "@testing-library/svelte";
 describe("CkBTCUpdateBalanceButton", () => {
   const now = Date.now();
 
-  beforeAll(() => {
-    page.mock({
-      data: { universe: CKTESTBTC_UNIVERSE_CANISTER_ID.toText() },
-      routeId: AppPath.Wallet,
-    });
-  });
-
   beforeEach(() => {
     resetIdentity();
     vi.useFakeTimers().setSystemTime(now);
+    vi.clearAllTimers();
     vi.spyOn(api, "updateBalance").mockRejectedValue(
       new MinterNoNewUtxosError({
         required_confirmations: 12,
         pending_utxos: [],
       })
     );
-  });
-  afterEach(() => {
-    vi.clearAllTimers();
+    page.mock({
+      data: { universe: CKTESTBTC_UNIVERSE_CANISTER_ID.toText() },
+      routeId: AppPath.Wallet,
+    });
   });
 
   const props = {

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletConnectAction.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletConnectAction.spec.ts
@@ -11,8 +11,7 @@ import type { Mock } from "vitest";
 vi.mock("$lib/proxy/icp-ledger.services.proxy");
 
 describe("HardwareWalletConnectAction", () => {
-  afterEach(() => {
-    vi.clearAllMocks();
+  beforeEach(() => {
     vi.restoreAllMocks();
   });
 
@@ -25,7 +24,7 @@ describe("HardwareWalletConnectAction", () => {
   });
 
   describe("connecting", () => {
-    beforeAll(() => {
+    beforeEach(() => {
       (connectToHardwareWalletProxy as Mock).mockImplementation(
         async (callback) =>
           callback({ connectionState: LedgerConnectionState.CONNECTING })
@@ -42,7 +41,7 @@ describe("HardwareWalletConnectAction", () => {
   });
 
   describe("connected", () => {
-    beforeAll(() => {
+    beforeEach(() => {
       (connectToHardwareWalletProxy as Mock).mockImplementation(
         async (callback) =>
           callback({
@@ -71,7 +70,7 @@ describe("HardwareWalletConnectAction", () => {
   });
 
   describe("not connected", () => {
-    beforeAll(() => {
+    beforeEach(() => {
       (connectToHardwareWalletProxy as Mock).mockImplementation(
         async (callback) =>
           callback({

--- a/frontend/src/tests/lib/components/accounts/HardwareWalletShowActionButton.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/HardwareWalletShowActionButton.spec.ts
@@ -7,14 +7,11 @@ import type { Mock } from "vitest";
 vi.mock("$lib/proxy/icp-ledger.services.proxy");
 
 describe("HardwareWalletShowActionButton", () => {
-  afterEach(() => {
-    vi.clearAllMocks();
-    vi.restoreAllMocks();
-  });
-
   let spy;
 
-  beforeAll(() => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
     spy = (
       showAddressAndPubKeyOnHardwareWalletProxy as Mock
     ).mockImplementation(async () => {

--- a/frontend/src/tests/lib/components/accounts/RenameSubAccountAction.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/RenameSubAccountAction.spec.ts
@@ -10,14 +10,11 @@ import type { Mock } from "vitest";
 vi.mock("$lib/services/icp-accounts.services");
 
 describe("RenameSubAccountAction", () => {
-  afterEach(() => {
-    vi.clearAllMocks();
-    vi.restoreAllMocks();
-  });
-
   let spy;
 
-  beforeAll(() => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
     spy = (renameSubAccount as Mock).mockImplementation(async () => {
       // Do nothing test
     });

--- a/frontend/src/tests/lib/components/accounts/UiTransactionsList.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/UiTransactionsList.spec.ts
@@ -27,7 +27,7 @@ describe("UiTransactionsList", () => {
     return UiTransactionsListPo.under(new JestPageObjectElement(container));
   };
 
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/components/canister-detail/RemoveCanisterControllerButton.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/RemoveCanisterControllerButton.spec.ts
@@ -15,7 +15,7 @@ describe("RemoveCanisterControllerButton", () => {
   const reloadDetailsMock = vi.fn();
   const props = { controller, reloadDetails: reloadDetailsMock };
 
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/components/canister-detail/UnlinkctionButton.spec.ts
+++ b/frontend/src/tests/lib/components/canister-detail/UnlinkctionButton.spec.ts
@@ -9,7 +9,7 @@ vitest.mock("$lib/services/canisters.services", () => {
 });
 
 describe("DissolveActionButton", () => {
-  afterEach(() => {
+  beforeEach(() => {
     vitest.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/components/metrics/TotalValueLocked.spec.ts
+++ b/frontend/src/tests/lib/components/metrics/TotalValueLocked.spec.ts
@@ -38,6 +38,8 @@ describe("TotalValueLocked", () => {
     currency?: FiatCurrency;
     symbol: string;
   }) => {
+    expect(metricsCallback).toBeUndefined();
+
     const { getByTestId } = render(TotalValueLockedTest);
 
     // Wait for initialization of the callback

--- a/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/NeuronFollowingCard/NeuronFollowingCard.spec.ts
@@ -29,12 +29,8 @@ describe("NeuronFollowingCard", () => {
     },
   };
   beforeEach(() => {
-    resetIdentity();
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
     vi.resetAllMocks();
+    resetIdentity();
   });
 
   it("should render texts", () => {

--- a/frontend/src/tests/lib/components/neuron-detail/actions/AddHotkeyButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/AddHotkeyButton.spec.ts
@@ -5,7 +5,7 @@ import { fireEvent, render } from "@testing-library/svelte";
 import NeuronContextTest from "../NeuronContextTest.svelte";
 
 describe("AddHotkeyButton", () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/components/neuron-detail/actions/DisburseButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/DisburseButton.spec.ts
@@ -7,7 +7,7 @@ import { fireEvent, render } from "@testing-library/svelte";
 import NeuronContextTest from "../NeuronContextTest.svelte";
 
 describe("DisburseButton", () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/components/neuron-detail/actions/DissolveActionButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/DissolveActionButton.spec.ts
@@ -17,7 +17,7 @@ vi.mock("$lib/services/neurons.services", () => {
 });
 
 describe("DissolveActionButton", () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/JoinCommunityFundCheckbox.spec.ts
@@ -11,7 +11,7 @@ vi.mock("$lib/services/neurons.services", () => {
 });
 
 describe("JoinCommunityFundCheckbox", () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/components/neuron-detail/actions/NnsStakeMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/NnsStakeMaturityButton.spec.ts
@@ -5,7 +5,7 @@ import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import NeuronContextActionsTest from "../NeuronContextActionsTest.svelte";
 
 describe("NnsStakeMaturityButton", () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/components/neuron-detail/actions/SplitNnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/SplitNnsNeuronButton.spec.ts
@@ -5,7 +5,7 @@ import { fireEvent, render } from "@testing-library/svelte";
 import NeuronContextActionsTest from "../NeuronContextActionsTest.svelte";
 
 describe("SplitNeuronButton", () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/components/neuron-detail/actions/StakeMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/neuron-detail/actions/StakeMaturityButton.spec.ts
@@ -3,7 +3,7 @@ import en from "$tests/mocks/i18n.mock";
 import { render, waitFor } from "@testing-library/svelte";
 
 describe("StakeMaturityButton", () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
+++ b/frontend/src/tests/lib/components/proposals/NnsProposalsFilters.spec.ts
@@ -44,6 +44,7 @@ describe("NnsProposalsFilters", () => {
 
   beforeEach(() => {
     actionableProposalsSegmentStore.resetForTesting();
+    proposalsFiltersStore.reset();
   });
 
   describe("default filters", () => {
@@ -84,10 +85,6 @@ describe("NnsProposalsFilters", () => {
   });
 
   describe("custom filter selection", () => {
-    afterEach(() => {
-      proposalsFiltersStore.reset();
-    });
-
     it("should not count deprecated selected filters in the count", () => {
       actionableProposalsSegmentStore.set("all");
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/SnsNeuronHotkeysCard.spec.ts
@@ -65,12 +65,9 @@ describe("SnsNeuronHotkeysCard", () => {
       },
     });
 
-  beforeAll(() => {
-    resetIdentity();
-  });
-
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
+    resetIdentity();
   });
 
   it("renders hotkeys title", () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/AddSnsHotkeyButton.spec.ts
@@ -6,7 +6,7 @@ import { fireEvent, render } from "@testing-library/svelte";
 import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
 describe("AddSnsHotkeyButton", () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/DisburseSnsButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/DisburseSnsButton.spec.ts
@@ -11,14 +11,12 @@ import { fireEvent, render } from "@testing-library/svelte";
 import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
 describe("DisburseSnsButton", () => {
-  beforeAll(() => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
     vi.spyOn(snsTokenSymbolSelectedStore, "subscribe").mockImplementation(
       mockTokenStore
     );
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
   });
 
   it("renders title", () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/DissolveSnsNeuronButton.spec.ts
@@ -19,7 +19,7 @@ vi.mock("$lib/services/sns-neurons.services", () => {
 });
 
 describe("DissolveSnsNeuronButton", () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/FollowSnsNeuronsButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/FollowSnsNeuronsButton.spec.ts
@@ -8,14 +8,12 @@ import { fireEvent, render } from "@testing-library/svelte";
 import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
 describe("FollowSnsNeuronsButton", () => {
-  beforeAll(() => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
     vi.spyOn(snsTokenSymbolSelectedStore, "subscribe").mockImplementation(
       mockTokenStore
     );
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
   });
 
   it("renders Follow Neurons message", () => {

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SnsStakeMaturityButton.spec.ts
@@ -5,7 +5,7 @@ import { fireEvent, render } from "@testing-library/svelte";
 import SnsNeuronContextTest from "../SnsNeuronContextTest.svelte";
 
 describe("SnsStakeMaturityButton", () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.spec.ts
+++ b/frontend/src/tests/lib/components/sns-neuron-detail/actions/SplitSnsNeuronButton.spec.ts
@@ -36,7 +36,7 @@ describe("SplitSnsNeuronButton", () => {
     token: mockToken,
   };
 
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
+++ b/frontend/src/tests/lib/derived/sns/sns-sorted-neurons.derived.spec.ts
@@ -318,7 +318,7 @@ describe("sortedSnsNeuronStore", () => {
 });
 
 describe("sortedSnsUserNeuronsStore", () => {
-  afterEach(() => snsNeuronsStore.reset());
+  beforeEach(() => snsNeuronsStore.reset());
   it("should not return CF neurons", async () => {
     const cfNeuron: SnsNeuron = {
       ...createMockSnsNeuron({
@@ -357,7 +357,7 @@ describe("sortedSnsUserNeuronsStore", () => {
 });
 
 describe("sortedSnsCFNeuronsStore", () => {
-  afterEach(() => snsNeuronsStore.reset());
+  beforeEach(() => snsNeuronsStore.reset());
   it("should not return CF neurons", async () => {
     const cfNeuron1: SnsNeuron = {
       ...createMockSnsNeuron({

--- a/frontend/src/tests/lib/directives/intersection.directives.spec.ts
+++ b/frontend/src/tests/lib/directives/intersection.directives.spec.ts
@@ -7,26 +7,18 @@ import { render } from "@testing-library/svelte";
 import IntersectionTest from "./IntersectionTest.svelte";
 
 describe("IntersectionDirectives", () => {
-  beforeAll(() => {
-    vi.stubGlobal("IntersectionObserver", IntersectionObserverActive);
-  });
-
-  afterAll(() => {
-    vi.unstubAllGlobals();
-  });
-
   let spy;
   let testIntersecting: boolean;
 
   beforeEach(() => {
+    vi.clearAllMocks();
+
     spy = vi
       .spyOn(dispatchEvents, "dispatchIntersecting")
       .mockImplementation(
         ($event) => (testIntersecting = $event?.intersecting ?? false)
       );
-  });
-  afterEach(() => {
-    vi.clearAllMocks();
+    vi.stubGlobal("IntersectionObserver", IntersectionObserverActive);
   });
 
   it("should trigger an intersect event", () => {

--- a/frontend/src/tests/lib/modals/canisters/AddControllerModal.spec.ts
+++ b/frontend/src/tests/lib/modals/canisters/AddControllerModal.spec.ts
@@ -22,7 +22,7 @@ describe("AddControllerModal", () => {
     });
   };
 
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/modals/neurons/NewFolloweeModal.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NewFolloweeModal.spec.ts
@@ -39,13 +39,11 @@ describe("NewFolloweeModal", () => {
     },
   };
   beforeEach(() => {
+    vi.clearAllMocks();
     resetIdentity();
+    knownNeuronsStore.setNeurons([]);
   });
 
-  afterEach(() => {
-    knownNeuronsStore.setNeurons([]);
-    vi.clearAllMocks();
-  });
   it("renders an input for a neuron address", () => {
     const { container } = render(NewFolloweeModal, {
       props: { neuron: mockNeuron, topic: Topic.Unspecified },

--- a/frontend/src/tests/lib/modals/sns/proposals/SnsFilterStatusModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/proposals/SnsFilterStatusModal.spec.ts
@@ -9,7 +9,7 @@ import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("SnsFilterStatusModal", () => {
-  afterEach(() => {
+  beforeEach(() => {
     snsFiltersStore.reset();
   });
   const filters: Filter<SnsProposalDecisionStatus>[] = [

--- a/frontend/src/tests/lib/modals/sns/proposals/SnsFilterTypesModal.spec.ts
+++ b/frontend/src/tests/lib/modals/sns/proposals/SnsFilterTypesModal.spec.ts
@@ -8,7 +8,7 @@ import { fireEvent, render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
 describe("SnsFilterTypesModal", () => {
-  afterEach(() => {
+  beforeEach(() => {
     snsFiltersStore.reset();
   });
   const filters: Filter<SnsProposalTypeFilterId>[] = [

--- a/frontend/src/tests/lib/pages/Launchpad.spec.ts
+++ b/frontend/src/tests/lib/pages/Launchpad.spec.ts
@@ -30,19 +30,19 @@ vi.mock("$lib/services/sns.services", () => {
 });
 
 describe("Launchpad", () => {
-  describe("signed in", () => {
-    vi.spyOn(authStore, "subscribe").mockImplementation(
-      mutableMockAuthStoreSubscribe
-    );
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-    beforeAll(() =>
+  describe("signed in", () => {
+    beforeEach(() => {
+      vi.spyOn(authStore, "subscribe").mockImplementation(
+        mutableMockAuthStoreSubscribe
+      );
+
       authStoreMock.next({
         identity: mockIdentity,
-      })
-    );
-
-    afterEach(() => {
-      vi.clearAllMocks();
+      });
     });
 
     it("should render titles", () => {

--- a/frontend/src/tests/lib/services/busy.services.spec.ts
+++ b/frontend/src/tests/lib/services/busy.services.spec.ts
@@ -13,7 +13,7 @@ describe("busy-services", () => {
     .spyOn(busyStore, "startBusy")
     .mockImplementation(vi.fn());
 
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 

--- a/frontend/src/tests/lib/services/ckbtc-info.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-info.services.spec.ts
@@ -158,10 +158,6 @@ describe("ckbtc-info-services", () => {
       });
     });
 
-    afterEach(() => {
-      vi.clearAllMocks();
-    });
-
     it("should not reload info if already loaded", async () => {
       const spyGetMinterInfo = vi
         .spyOn(minterApi, "minterInfo")

--- a/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
+++ b/frontend/src/tests/lib/services/ckbtc-minter.services.spec.ts
@@ -33,13 +33,10 @@ import { get } from "svelte/store";
 
 describe("ckbtc-minter-services", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     resetIdentity();
     toastsStore.reset();
     ckbtcRetrieveBtcStatusesStore.reset();
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
   });
 
   describe("loadBtcAddress", () => {

--- a/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-finalization.services.spec.ts
@@ -13,21 +13,21 @@ import { SnsSwapLifecycle } from "@dfinity/sns";
 import { get } from "svelte/store";
 
 describe("sns-finalization-services", () => {
+  const now = Date.now();
+
   beforeEach(() => {
     resetIdentity();
+    vi.clearAllMocks();
+    resetSnsProjects();
+    resetSnsFinalizationStatusStore();
+
+    vi.useFakeTimers().setSystemTime(now);
   });
 
   describe("loadSnsFinalizationStatus", () => {
     const rootCanisterId = principal(0);
-    const now = Date.now();
     const nowInSeconds = Math.floor(now / 1000);
     const yesterdayInSeconds = nowInSeconds - SECONDS_IN_DAY;
-    afterEach(() => {
-      vi.useFakeTimers().setSystemTime(now);
-      vi.clearAllMocks();
-      resetSnsProjects();
-      resetSnsFinalizationStatusStore();
-    });
 
     describe("if swap finished less than a week ago", () => {
       beforeEach(() => {

--- a/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/sns-neurons.services.spec.ts
@@ -1066,21 +1066,17 @@ describe("sns-neurons-services", () => {
 
   describe("splitNeuron", () => {
     const transactionFee = 100n;
-    let snsNeuronsStoreSpy: MockInstance;
-    let snsTokenSymbolSelectedStoreSpy: MockInstance;
 
     beforeEach(() => {
-      snsNeuronsStoreSpy = vi
-        .spyOn(snsNeuronsStore, "subscribe")
-        .mockImplementation(
-          buildMockSnsNeuronsStoreSubscribe({
-            rootCanisterId: mockPrincipal,
-            neurons: [mockSnsNeuron],
-          })
-        );
-      snsTokenSymbolSelectedStoreSpy = vi
-        .spyOn(snsTokenSymbolSelectedStore, "subscribe")
-        .mockImplementation(mockTokenStore);
+      vi.spyOn(snsNeuronsStore, "subscribe").mockImplementation(
+        buildMockSnsNeuronsStoreSubscribe({
+          rootCanisterId: mockPrincipal,
+          neurons: [mockSnsNeuron],
+        })
+      );
+      vi.spyOn(snsTokenSymbolSelectedStore, "subscribe").mockImplementation(
+        mockTokenStore
+      );
 
       tokensStore.reset();
       setSnsProjects([
@@ -1089,11 +1085,6 @@ describe("sns-neurons-services", () => {
           tokenMetadata: { ...mockSnsToken, fee: transactionFee },
         },
       ]);
-    });
-
-    afterEach(() => {
-      snsNeuronsStoreSpy.mockClear();
-      snsTokenSymbolSelectedStoreSpy.mockClear();
     });
 
     it("should call api.addNeuronPermissions", async () => {

--- a/frontend/src/tests/lib/stores/ckbtc-info.store.spec.ts
+++ b/frontend/src/tests/lib/stores/ckbtc-info.store.spec.ts
@@ -7,7 +7,7 @@ import { mockCkBTCMinterInfo } from "$tests/mocks/ckbtc-minter.mock";
 import { get } from "svelte/store";
 
 describe("ckBTC info store", () => {
-  afterEach(() => ckBTCInfoStore.reset());
+  beforeEach(() => ckBTCInfoStore.reset());
 
   const ckBtcData = {
     canisterId: CKBTC_UNIVERSE_CANISTER_ID,

--- a/frontend/src/tests/lib/stores/icrc-accounts.store.spec.ts
+++ b/frontend/src/tests/lib/stores/icrc-accounts.store.spec.ts
@@ -14,7 +14,7 @@ import { principal } from "$tests/mocks/sns-projects.mock";
 import { get } from "svelte/store";
 
 describe("icrc Accounts store", () => {
-  afterEach(() => icrcAccountsStore.reset());
+  beforeEach(() => icrcAccountsStore.reset());
 
   const accounts: Account[] = [mockCkBTCMainAccount];
 

--- a/frontend/src/tests/lib/stores/neurons.store.spec.ts
+++ b/frontend/src/tests/lib/stores/neurons.store.spec.ts
@@ -9,7 +9,7 @@ import type { NeuronInfo } from "@dfinity/nns";
 import { get } from "svelte/store";
 
 describe("neurons-store", () => {
-  afterEach(() => neuronsStore.reset());
+  beforeEach(() => neuronsStore.reset());
 
   describe("neuronsStore", () => {
     it("should set neurons", () => {

--- a/frontend/src/tests/lib/stores/sns-neurons.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-neurons.store.spec.ts
@@ -7,7 +7,7 @@ import { get } from "svelte/store";
 
 describe("SNS Neurons stores", () => {
   describe("snsNeurons store", () => {
-    afterEach(() => snsNeuronsStore.reset());
+    beforeEach(() => snsNeuronsStore.reset());
     it("should set neurons for a project", () => {
       const neurons: SnsNeuron[] = [
         createMockSnsNeuron({

--- a/frontend/src/tests/lib/stores/sns-proposals.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-proposals.store.spec.ts
@@ -19,7 +19,7 @@ describe("SNS Proposals stores", () => {
     id: [{ id: 3n }],
   };
   describe("snsProposalsStore", () => {
-    afterEach(() => snsProposalsStore.reset());
+    beforeEach(() => snsProposalsStore.reset());
     it("should set proposals for a project", () => {
       const proposals: SnsProposalData[] = [
         snsProposal1,

--- a/frontend/src/tests/lib/stores/sns-transactions.store.spec.ts
+++ b/frontend/src/tests/lib/stores/sns-transactions.store.spec.ts
@@ -10,7 +10,7 @@ import { get } from "svelte/store";
 
 describe("SNS Transactions store", () => {
   describe("snsTransactionsStore", () => {
-    afterEach(() => icrcTransactionsStore.reset());
+    beforeEach(() => icrcTransactionsStore.reset());
     it("should set transactions for a project and account when it doesn't exist", () => {
       icrcTransactionsStore.addTransactions({
         canisterId: mockPrincipal,

--- a/frontend/src/tests/lib/stores/tokens.store.spec.ts
+++ b/frontend/src/tests/lib/stores/tokens.store.spec.ts
@@ -9,7 +9,7 @@ import { mockTokens, mockUniversesTokens } from "$tests/mocks/tokens.mock";
 import { get } from "svelte/store";
 
 describe("Tokens store", () => {
-  afterEach(() => tokensStore.reset());
+  beforeEach(() => tokensStore.reset());
 
   const ckBtcData = {
     canisterId: CKBTC_UNIVERSE_CANISTER_ID,

--- a/frontend/src/tests/lib/stores/vote-registration.store.spec.ts
+++ b/frontend/src/tests/lib/stores/vote-registration.store.spec.ts
@@ -19,7 +19,7 @@ describe("voting-store", () => {
     proposalIdString: "2",
   };
 
-  afterEach(() => {
+  beforeEach(() => {
     voteRegistrationStore.reset();
   });
 

--- a/frontend/src/tests/lib/stores/writable-stored.spec.ts
+++ b/frontend/src/tests/lib/stores/writable-stored.spec.ts
@@ -3,7 +3,7 @@ import { writableStored } from "$lib/stores/writable-stored";
 import { get } from "svelte/store";
 
 describe("writableStored", () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
   });

--- a/frontend/src/tests/lib/utils/auth.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/auth.utils.spec.ts
@@ -8,6 +8,13 @@ import { AuthClient } from "@dfinity/auth-client";
 import { mock } from "vitest-mock-extended";
 
 describe("auth-utils", () => {
+  const { host: originalWindowLocationHost } = window.location;
+
+  beforeEach(() => {
+    // restore original host
+    window.location.host = originalWindowLocationHost;
+  });
+
   describe("isSignedIn", () => {
     it("should not be signed in", () => {
       expect(isSignedIn(undefined)).toBe(false);
@@ -52,13 +59,6 @@ describe("auth-utils", () => {
     });
   });
   describe("getIdentityProviderUrl", () => {
-    const { host } = window.location;
-
-    afterEach(() => {
-      // restore original host
-      window.location.host = host;
-    });
-
     it("should return old mainnet identity from ic0.app", async () => {
       Object.defineProperty(window, "location", {
         writable: true,

--- a/frontend/src/tests/lib/utils/neuron.utils.spec.ts
+++ b/frontend/src/tests/lib/utils/neuron.utils.spec.ts
@@ -104,12 +104,10 @@ import { ICPToken, TokenAmount } from "@dfinity/utils";
 import { get } from "svelte/store";
 
 describe("neuron-utils", () => {
-  beforeAll(() => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     vi.useFakeTimers().setSystemTime(Date.now());
-  });
-
-  afterAll(() => {
-    vi.useRealTimers();
+    neuronsStore.setNeurons({ neurons: [], certified: true });
   });
 
   describe("votingPower", () => {
@@ -1267,10 +1265,6 @@ describe("neuron-utils", () => {
   });
 
   describe("checkInvalidState", () => {
-    afterEach(() => {
-      vi.clearAllMocks();
-    });
-
     const stepName = "ok";
     const spyOnInvalid = vi.fn();
     const invalidStates: InvalidState<boolean>[] = [
@@ -2485,7 +2479,6 @@ describe("neuron-utils", () => {
   });
 
   describe("getNeuronById", () => {
-    afterEach(() => neuronsStore.setNeurons({ neurons: [], certified: true }));
     it("returns neuron when present in store", () => {
       const neuronId = 1_234n;
       const neuron = {

--- a/frontend/src/tests/workflows/NnsProposals.spec.ts
+++ b/frontend/src/tests/workflows/NnsProposals.spec.ts
@@ -38,13 +38,11 @@ describe('NnsProposals when "all proposals" selected', () => {
     DEFAULT_PROPOSALS_FILTERS;
 
   beforeEach(() => {
-    actionableProposalsSegmentStore.set("all");
-  });
-
-  afterEach(() => {
     vi.clearAllMocks();
     neuronsStore.reset();
     resetNeuronsApiService();
+
+    actionableProposalsSegmentStore.set("all");
   });
 
   describe("when signed in user", () => {

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -14,7 +14,7 @@ import {
 } from "./__mocks__/$app/navigation";
 import { navigating, page } from "./__mocks__/$app/stores";
 import { IntersectionObserverPassive } from "./src/tests/mocks/infinitescroll.mock";
-import { failTestsThatLogToConsole } from "./src/tests/utils/console.test-utils";
+// import { failTestsThatLogToConsole } from "./src/tests/utils/console.test-utils";
 import {
   mockedConstants,
   setDefaultTestConstants,
@@ -80,7 +80,7 @@ setDefaultTestConstants({
   },
 });
 
-failTestsThatLogToConsole();
+// failTestsThatLogToConsole();
 
 // Avoid using fetch in tests.
 // NOTE: This doesn't seem to work when all tests are run but works when

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -14,7 +14,7 @@ import {
 } from "./__mocks__/$app/navigation";
 import { navigating, page } from "./__mocks__/$app/stores";
 import { IntersectionObserverPassive } from "./src/tests/mocks/infinitescroll.mock";
-// import { failTestsThatLogToConsole } from "./src/tests/utils/console.test-utils";
+import { failTestsThatLogToConsole } from "./src/tests/utils/console.test-utils";
 import {
   mockedConstants,
   setDefaultTestConstants,
@@ -80,7 +80,7 @@ setDefaultTestConstants({
   },
 });
 
-// failTestsThatLogToConsole();
+failTestsThatLogToConsole();
 
 // Avoid using fetch in tests.
 // NOTE: This doesn't seem to work when all tests are run but works when


### PR DESCRIPTION
# Motivation

Cleanup should be done in `beforeEach`, not in `afterEach`.
`afterEach` should only be used to verify expectations such as that certain things did not happen during each test.

Remember: `beforeEach` is used for both cleanup and setup. Cleanup should come before setup and while setup can be done in the `beforeEach` of a `describe block that needs that setup, cleanup should always happen in the top-level `beforeEach`.

# Changes

1. Just remove `afterEach` if the same cleanup already happens in `beforeEach`.
2. Move contents of `afterEach` to `beforeEach`.
3. Change `afterEach` to `beforeEach` (if there isn't also a `beforeEach`) and move it to the top level `describe` if it isn't already.
4. In some cases, remove or merge `beforeAll`.
5. Remove `vi.clearAllMocks()` if there is also `vi.resetAllMocks()` as the latter is strictly stronger.
6. Remove `someMock.mockClear()` if the mock is anyway newly created in `beforeEach`.
7. Replace `vi.mock()` at the top of the file with `vi.spyOn()` in `beforeEach` to avoid the 1-time mock being reset by `vi.resetAllMocks()` in `beforeEach`.

# Tests

Changed tests still pass.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary