### PR TITLE
Add staked amount to neuronVisibilityRow

### DIFF
--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -59,6 +59,10 @@
       font-size: var(--token-font-size, var(--font-size-h3));
     }
 
+    .label {
+      color: var(--label-color, inherit);
+    }
+
     &.singleLine span:first-of-type {
       font-weight: normal;
       font-size: var(--font-size-h5);

--- a/frontend/src/lib/components/ic/AmountDisplay.svelte
+++ b/frontend/src/lib/components/ic/AmountDisplay.svelte
@@ -60,7 +60,7 @@
     }
 
     .label {
-      color: var(--label-color, inherit);
+      color: var(--amount-display-symbol-color, inherit);
     }
 
     &.singleLine span:first-of-type {

--- a/frontend/src/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.svelte
+++ b/frontend/src/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.svelte
@@ -90,7 +90,6 @@
 </script>
 
 <form
-  class="visibility-form-component"
   data-tid="change-bulk-visibility-component"
   on:submit|preventDefault={nnsSubmit}
 >
@@ -178,10 +177,6 @@
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/fonts";
 
-  .visibility-form-component {
-    row-gap: var(--padding-3x);
-  }
-
   .loading-container {
     width: 100%;
     min-height: 150px;
@@ -198,7 +193,7 @@
     padding: 0 var(--padding-2x);
   }
   .apply-to-all {
-    --checkbox-padding: 0;
+    --checkbox-padding: var(--padding) var(--padding) var(--padding-3x) 0;
     --checkbox-label-order: 1;
   }
 

--- a/frontend/src/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.svelte
+++ b/frontend/src/lib/modals/neurons/ChangeBulkNeuronVisibilityForm.svelte
@@ -90,6 +90,7 @@
 </script>
 
 <form
+  class="visibility-form-component"
   data-tid="change-bulk-visibility-component"
   on:submit|preventDefault={nnsSubmit}
 >
@@ -177,6 +178,10 @@
 <style lang="scss">
   @use "@dfinity/gix-components/dist/styles/mixins/fonts";
 
+  .visibility-form-component {
+    row-gap: var(--padding-3x);
+  }
+
   .loading-container {
     width: 100%;
     min-height: 150px;
@@ -193,7 +198,7 @@
     padding: 0 var(--padding-2x);
   }
   .apply-to-all {
-    --checkbox-padding: var(--padding) var(--padding) var(--padding-3x) 0;
+    --checkbox-padding: 0;
     --checkbox-label-order: 1;
   }
 

--- a/frontend/src/lib/modals/neurons/NeuronVisibilityRow.svelte
+++ b/frontend/src/lib/modals/neurons/NeuronVisibilityRow.svelte
@@ -85,18 +85,18 @@
 </div>
 
 <style lang="scss">
+  :global(.checkbox) {
+    width: 100%;
+  }
+
   .neuron-row {
     --checkbox-label-order: 1;
-    --checkbox-padding: var(--padding-1_5x) 0;
+    --checkbox-padding: 0 var(--padding) 0 0;
     display: flex;
 
     &.disabled {
       --value-color: var(--text-description-tint);
       --elements-badges: var(--text-description-tint);
-    }
-
-    :global(.checkbox) {
-      width: 100%;
     }
   }
 

--- a/frontend/src/lib/modals/neurons/NeuronVisibilityRow.svelte
+++ b/frontend/src/lib/modals/neurons/NeuronVisibilityRow.svelte
@@ -78,17 +78,18 @@
 </div>
 
 <style lang="scss">
-  :global(.checkbox) {
-    width: 100%;
-  }
-
   .neuron-row {
     --checkbox-label-order: 1;
-    --checkbox-padding: 0 var(--padding) 0 0;
+    --checkbox-padding: 0;
     display: flex;
+
     &.disabled {
       --value-color: var(--text-description-tint);
       --elements-badges: var(--text-description-tint);
+    }
+
+    :global(.checkbox) {
+      width: 100%;
     }
   }
 

--- a/frontend/src/lib/modals/neurons/NeuronVisibilityRow.svelte
+++ b/frontend/src/lib/modals/neurons/NeuronVisibilityRow.svelte
@@ -9,6 +9,7 @@
     Checkbox,
   } from "@dfinity/gix-components";
   import type { NeuronVisibilityRowData } from "$lib/types/neuron-visibility-row";
+  import AmountDisplay from "$lib/components/ic/AmountDisplay.svelte";
 
   const typeToIcon: {
     hardwareWallet: typeof IconLedger;
@@ -57,6 +58,12 @@
         {/if}
       </div>
 
+      {#if rowData.stake}
+        <span class="amount-display">
+          <AmountDisplay singleLine amount={rowData.stake} />
+        </span>
+      {/if}
+
       {#if rowData?.uncontrolledNeuronDetails}
         <span class="tags">
           <span class="uncontrolled-tag-icons">
@@ -80,7 +87,7 @@
 <style lang="scss">
   .neuron-row {
     --checkbox-label-order: 1;
-    --checkbox-padding: 0;
+    --checkbox-padding: var(--padding-1_5x) 0;
     display: flex;
 
     &.disabled {
@@ -91,6 +98,10 @@
     :global(.checkbox) {
       width: 100%;
     }
+  }
+
+  .amount-display {
+    --label-color: var(--text-description);
   }
 
   .label-container {
@@ -107,6 +118,9 @@
     .neuron-id-wrapper {
       display: inline-flex;
       align-items: center;
+    }
+    .neuron-id {
+      margin: 0;
     }
 
     .public-icon-container {

--- a/frontend/src/lib/modals/neurons/NeuronVisibilityRow.svelte
+++ b/frontend/src/lib/modals/neurons/NeuronVisibilityRow.svelte
@@ -62,9 +62,7 @@
         <span class="amount-display">
           <AmountDisplay singleLine amount={rowData.stake} />
         </span>
-      {/if}
-
-      {#if rowData?.uncontrolledNeuronDetails}
+      {:else if rowData?.uncontrolledNeuronDetails}
         <span class="tags">
           <span class="uncontrolled-tag-icons">
             <svelte:component
@@ -101,7 +99,7 @@
   }
 
   .amount-display {
-    --label-color: var(--text-description);
+    --amount-display-symbol-color: var(--text-description);
   }
 
   .label-container {

--- a/frontend/src/lib/modals/neurons/NeuronVisibilityRow.svelte
+++ b/frontend/src/lib/modals/neurons/NeuronVisibilityRow.svelte
@@ -119,9 +119,6 @@
       display: inline-flex;
       align-items: center;
     }
-    .neuron-id {
-      margin: 0;
-    }
 
     .public-icon-container {
       color: var(--elements-badges);

--- a/frontend/src/lib/types/neuron-visibility-row.ts
+++ b/frontend/src/lib/types/neuron-visibility-row.ts
@@ -1,7 +1,10 @@
+import type { TokenAmountV2 } from "@dfinity/utils";
+
 export type NeuronVisibilityRowData = {
   neuronId: string;
   isPublic: boolean;
   tags: string[];
+  stake?: TokenAmountV2;
   uncontrolledNeuronDetails?: UncontrolledNeuronDetailsData;
 };
 

--- a/frontend/src/lib/utils/neuron.utils.ts
+++ b/frontend/src/lib/utils/neuron.utils.ts
@@ -51,7 +51,13 @@ import {
   type ProposalInfo,
   type RewardEvent,
 } from "@dfinity/nns";
-import { ICPToken, fromNullable, isNullish, nonNullish } from "@dfinity/utils";
+import {
+  ICPToken,
+  TokenAmountV2,
+  fromNullable,
+  isNullish,
+  nonNullish,
+} from "@dfinity/utils";
 import type { ComponentType } from "svelte";
 import {
   getAccountByPrincipal,
@@ -484,6 +490,12 @@ export const createNeuronVisibilityRowData = ({
   return {
     neuronId: neuron.neuronId.toString(),
     isPublic: isPublicNeuron(neuron),
+    stake: isNeuronControllableByUser({ neuron, mainAccount: accounts.main })
+      ? TokenAmountV2.fromUlps({
+          amount: neuronStake(neuron),
+          token: ICPToken,
+        })
+      : undefined,
     tags: getNeuronTagsUnrelatedToController({
       neuron,
       i18n,

--- a/frontend/src/tests/lib/modals/neurons/NeuronVisibilityRow.spec.ts
+++ b/frontend/src/tests/lib/modals/neurons/NeuronVisibilityRow.spec.ts
@@ -2,6 +2,7 @@ import NeuronVisibilityRow from "$lib/modals/neurons/NeuronVisibilityRow.svelte"
 import type { NeuronVisibilityRowData } from "$lib/types/neuron-visibility-row";
 import { NeuronVisibilityRowPo } from "$tests/page-objects/NeuronVisibilityRow.page-object";
 import { JestPageObjectElement } from "$tests/page-objects/jest.page-object";
+import { ICPToken, TokenAmountV2 } from "@dfinity/utils";
 import { render } from "@testing-library/svelte";
 import { vi } from "vitest";
 
@@ -237,5 +238,34 @@ describe("NeuronVisibilityRow", () => {
     await checkboxPo.click();
 
     expect(nnsChangeMock).not.toHaveBeenCalled();
+  });
+
+  it("should display the correct amount when stake is provided", async () => {
+    const rowData: NeuronVisibilityRowData = {
+      neuronId: BigInt(123).toString(),
+      isPublic: false,
+      tags: [],
+      stake: TokenAmountV2.fromUlps({
+        amount: 1_000_000_000n,
+        token: ICPToken,
+      }),
+    };
+
+    const { po } = renderComponent({ rowData });
+
+    expect(await po.getAmountDisplayPo().isPresent()).toBe(true);
+    expect(await po.getAmountDisplayPo().getText()).toBe("10.00 ICP");
+  });
+
+  it("should not display amount when stake is not provided", async () => {
+    const rowData: NeuronVisibilityRowData = {
+      neuronId: BigInt(123).toString(),
+      isPublic: false,
+      tags: [],
+    };
+
+    const { po } = renderComponent({ rowData });
+
+    expect(await po.getAmountDisplayPo().isPresent()).toBe(false);
   });
 });

--- a/frontend/src/tests/page-objects/NeuronVisibilityRow.page-object.ts
+++ b/frontend/src/tests/page-objects/NeuronVisibilityRow.page-object.ts
@@ -1,7 +1,8 @@
-import { BasePageObject } from "$tests/page-objects/base.page-object";
+import { AmountDisplayPo } from "$tests/page-objects/AmountDisplay.page-object";
+import { CheckboxPo } from "$tests/page-objects/Checkbox.page-object";
 import { TooltipPo } from "$tests/page-objects/Tooltip.page-object";
+import { BasePageObject } from "$tests/page-objects/base.page-object";
 import type { PageObjectElement } from "$tests/types/page-object.types";
-import { CheckboxPo } from "./Checkbox.page-object";
 
 export class NeuronVisibilityRowPo extends BasePageObject {
   private static readonly BASE_TID = "neuron-visibility-row-component";
@@ -44,5 +45,9 @@ export class NeuronVisibilityRowPo extends BasePageObject {
     return CheckboxPo.under({
       element: this.root,
     });
+  }
+
+  getAmountDisplayPo(): AmountDisplayPo {
+    return AmountDisplayPo.under(this.root);
   }
 }


### PR DESCRIPTION
# Motivation

The design of form has been changed and now includes the staked ICP in neuron visibility row.

Still the rows needs to be sorted based on staked amount, this functionality added in a [seperate PR.](https://github.com/dfinity/nns-dapp/pull/5676)

# Changes

1. Add label color to AmountDisplay to control the color from parent.
2.  Add stake to NeuronVisibilityRowData and update createNeuronVisibilityRowData to provide stake data

# Tests

<img width="613" alt="Screenshot 2024-10-23 at 12 01 07" src="https://github.com/user-attachments/assets/ba166712-ab55-418b-8899-5f3e39310be5">


# Todos

- [ ] Add entry to changelog (if necessary).
not necessary
