### PR TITLE
Add scripts/propose-install-canister

### DIFF
--- a/scripts/get-neurons
+++ b/scripts/get-neurons
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+print_help() {
+  cat <<-EOF
+	
+	Get a list of neurons IDs for a dfx identity.
+	Optionally filtered by several criteria.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=v long=can-vote desc="Only include neurons with enough dissolve delay to vote" variable=CAN_VOTE nargs=0 default="false"
+clap.define short=p long=can-propose desc="Only include neurons with enough dissolve delay and stake to propose" variable=CAN_PROPOSE nargs=0 default="false"
+clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="snsdemo8"
+clap.define long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+SECONDS_IN_YEAR=$((60 * 60 * 24 * (4 * 365 + 1) / 4))
+MIN_DISSOLVE_DELAY_TO_VOTE=$((SECONDS_IN_YEAR / 2))
+MIN_STAKE_TO_PROPOSE=1000000000
+
+filter_can_vote() {
+  if [[ "$CAN_VOTE" != "true" ]]; then
+    cat
+    return
+  fi
+
+  jq "select((.[\"1\"].dissolve_delay_seconds | tonumber) >= $MIN_DISSOLVE_DELAY_TO_VOTE)"
+}
+
+filter_can_propose() {
+  if [[ "$CAN_PROPOSE" != "true" ]]; then
+    cat
+    return
+  fi
+
+  filter_can_vote | jq "select((.[\"1\"].stake_e8s | tonumber) >= $MIN_STAKE_TO_PROPOSE)"
+}
+
+dfx canister call nns-governance list_neurons \
+  --identity "$DFX_IDENTITY" \
+  --network "$DFX_NETWORK" \
+  '(
+    record {
+      include_public_neurons_in_full_neurons = null;
+      neuron_ids = vec {};
+      include_empty_neurons_readable_by_caller = null;
+      include_neurons_readable_by_caller = true;
+    },
+  )' | idl2json | jq '.neuron_infos[]' | filter_can_vote | filter_can_propose | jq -r '.["0"]'

--- a/scripts/propose-install-canister
+++ b/scripts/propose-install-canister
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+print_help() {
+  cat <<-EOF
+
+	Install a wasm to a canister via proposal
+
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=c long=canister desc="The name of the canister to install to" variable=CANISTER default=""
+clap.define short=w long=wasm desc="The WASM file to install" variable=WASM default=""
+clap.define short=m long=mode desc="The install mode to use" variable=MODE default="upgrade"
+clap.define short=a long=arg desc="Optional canister args binary file" variable=ARG_FILE default=""
+clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
+clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="snsdemo8"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+export DFX_NETWORK
+export DFX_IDENTITY
+
+if [[ -z "${CANISTER:-}" ]]; then
+  echo "Please provide a canister name with --canister"
+  exit 1
+fi
+
+if [[ -z "${WASM:-}" ]]; then
+  echo "Please provide a wasm file with --wasm"
+  exit 1
+fi
+
+TOP_DIR="$(git rev-parse --show-toplevel)"
+
+IDENTITY_PATH="$HOME/.config/dfx/identity/$DFX_IDENTITY"
+PEM="${IDENTITY_PATH}/identity.pem"
+
+CANISTER_ID="$(dfx canister id "$CANISTER" --network "$DFX_NETWORK")"
+WASM_HASH="$(sha256sum "$WASM" | cut -d ' ' -f 1)"
+SUMMARY="Upgrade canister $CANISTER with module hash $WASM_HASH"
+
+if [[ "$DFX_NETWORK" == "local" ]]; then
+  NNS_URL="http://localhost:$(
+    cd ~
+    dfx info replica-port
+  )"
+else
+  NNS_URL="$(jq -er '.networks | .[env.DFX_NETWORK].providers[0] | select (.!=null)' "$TOP_DIR/dfx.json")"
+fi
+
+PROPOSER_NEURON_ID="$("$SOURCE_DIR/get-neurons" --identity "$DFX_IDENTITY" --network "$DFX_NETWORK" --can-propose | head -n 1)"
+
+if [[ -z "${PROPOSER_NEURON_ID:-}" ]]; then
+  echo "Couldn't find a neuron, for identity ${DFX_IDENTITY}, that can propose."
+  exit 1
+fi
+
+ARG_ARGS=()
+if [[ -n "${ARG_FILE:-}" ]]; then
+  ARG_ARGS=(--arg "$ARG_FILE")
+fi
+
+set ic-admin \
+  --secret-key-pem "$PEM" \
+  --nns-url "$NNS_URL" \
+  propose-to-change-nns-canister \
+  --summary "$SUMMARY" \
+  --proposer "$PROPOSER_NEURON_ID" \
+  --mode "$MODE" \
+  --canister-id "$CANISTER_ID" \
+  --wasm-module-path "$WASM" \
+  --wasm-module-sha256 "$WASM_HASH" \
+  "${ARG_ARGS[@]}"
+
+printf "%q " "$@"
+echo "Do you want to execute this command? [y/N]"
+read -r response
+if [[ "$response" =~ ^[yY] ]]; then
+  "$@"
+fi

--- a/scripts/propose-install-canister
+++ b/scripts/propose-install-canister
@@ -16,7 +16,7 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=c long=canister desc="The name of the canister to install to" variable=CANISTER default=""
 clap.define short=w long=wasm desc="The WASM file to install" variable=WASM default=""
 clap.define short=m long=mode desc="The install mode to use" variable=MODE default="upgrade"
-clap.define short=a long=arg desc="Optional canister args binary file" variable=ARG_FILE default=""
+clap.define short=a long=arg-did-file desc="Optional canister args candid file" variable=ARG_DID_FILE default=""
 clap.define short=n long=network desc="The dfx network to use" variable=DFX_NETWORK default="local"
 clap.define short=i long=identity desc="The dfx identity to use" variable=DFX_IDENTITY default="snsdemo8"
 # Source the output file ----------------------------------------------------------
@@ -61,8 +61,10 @@ if [[ -z "${PROPOSER_NEURON_ID:-}" ]]; then
 fi
 
 ARG_ARGS=()
-if [[ -n "${ARG_FILE:-}" ]]; then
-  ARG_ARGS=(--arg "$ARG_FILE")
+if [[ -n "${ARG_DID_FILE:-}" ]]; then
+  ARG_BIN_FILE="$(mktemp "${ARG_DID_FILE}.XXXXXX.bin")"
+  didc encode "$(cat "$ARG_DID_FILE")" |xxd -r -p >"$ARG_BIN_FILE"
+  ARG_ARGS=(--arg "$ARG_BIN_FILE")
 fi
 
 set ic-admin \
@@ -78,6 +80,7 @@ set ic-admin \
   "${ARG_ARGS[@]}"
 
 printf "%q " "$@"
+echo
 echo "Do you want to execute this command? [y/N]"
 read -r response
 if [[ "$response" =~ ^[yY] ]]; then

--- a/scripts/propose-install-canister
+++ b/scripts/propose-install-canister
@@ -63,6 +63,7 @@ fi
 ARG_ARGS=()
 if [[ -n "${ARG_DID_FILE:-}" ]]; then
   ARG_BIN_FILE="$(mktemp "${ARG_DID_FILE}.XXXXXX.bin")"
+  trap 'rm -- "$ARG_BIN_FILE"' EXIT
   didc encode "$(cat "$ARG_DID_FILE")" | xxd -r -p >"$ARG_BIN_FILE"
   ARG_ARGS=(--arg "$ARG_BIN_FILE")
 fi

--- a/scripts/propose-install-canister
+++ b/scripts/propose-install-canister
@@ -63,7 +63,7 @@ fi
 ARG_ARGS=()
 if [[ -n "${ARG_DID_FILE:-}" ]]; then
   ARG_BIN_FILE="$(mktemp "${ARG_DID_FILE}.XXXXXX.bin")"
-  didc encode "$(cat "$ARG_DID_FILE")" |xxd -r -p >"$ARG_BIN_FILE"
+  didc encode "$(cat "$ARG_DID_FILE")" | xxd -r -p >"$ARG_BIN_FILE"
   ARG_ARGS=(--arg "$ARG_BIN_FILE")
 fi
 

--- a/scripts/vote
+++ b/scripts/vote
@@ -46,17 +46,10 @@ else
 fi
 
 get_all_neuron_ids() {
-  dfx canister call nns-governance list_neurons \
+  "$SOURCE_DIR/get-neurons" \
     --identity "$DFX_IDENTITY" \
     --network "$DFX_NETWORK" \
-    '(
-      record {
-        include_public_neurons_in_full_neurons = null;
-        neuron_ids = vec {};
-        include_empty_neurons_readable_by_caller = null;
-        include_neurons_readable_by_caller = true;
-      },
-    )' | idl2json | jq -r '.neuron_infos[]["0"]'
+    --can-vote
 }
 
 if [[ "${NEURON_ID:-}" == "all" ]]; then


### PR DESCRIPTION
# Motivation

When testing, it can be useful to replace one of the NNS canisters with a custom built version.
This can be tricky because for some of the canisters we are not the controller so they need to be installed via proposal, which requires a lot of arguments to be constructed for a shell command.
It would be convenient to have a script that does this for you.

# Changes

1. Extract `scripts/get-neurons` from `scripts/vote` to get neurons of an identity.
2. Add `scripts/propose-install-canister` which constructs and calls the `ic-admin` command to propose installing a canister.

# Tests

Tested manually with
```
# Propose installing nns-dapp
scripts/propose-install-canister --canister nns-dapp --wasm nns-dapp.wasm.gz --arg-did-file nns-dapp-arg-local.did 

# Propose installing nns-governance
scripts/propose-install-canister --canister nns-governance --wasm governance-canister-test.wasm.gz 

# Propose installing nns-governance on DevEnv
scripts/propose-install-canister --canister nns-governance --wasm governance-canister-test.wasm.gz --identity devenv-snsdemo8 --network devenv_dskloet
```

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary