### PR TITLE
Replace doMock with mock

### DIFF
--- a/frontend/src/tests/lib/components/accounts/BalancesObserver.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/BalancesObserver.spec.ts
@@ -6,22 +6,22 @@ import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { ledgerCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { render, waitFor } from "@testing-library/svelte";
 
-describe("IcrcBalancesObserver", () => {
-  let spyPostMessage;
+let spyPostMessage;
 
+vi.mock("$lib/workers/balances.worker?worker", () => ({
+  default: class BalancesWorker {
+    postMessage(data: {
+      msg: "nnsStartBalancesTimer" | "nnsStopBalancesTimer";
+      data?: PostMessageDataRequestBalances;
+    }) {
+      spyPostMessage(data);
+    }
+  },
+}));
+
+describe("IcrcBalancesObserver", () => {
   beforeEach(() => {
     spyPostMessage = vi.fn();
-
-    vi.doMock("$lib/workers/balances.worker?worker", () => ({
-      default: class BalancesWorker {
-        postMessage(data: {
-          msg: "nnsStartBalancesTimer" | "nnsStopBalancesTimer";
-          data?: PostMessageDataRequestBalances;
-        }) {
-          spyPostMessage(data);
-        }
-      },
-    }));
   });
 
   const data: BalancesObserverData = {

--- a/frontend/src/tests/lib/components/accounts/IcrcBalancesObserver.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcBalancesObserver.spec.ts
@@ -19,13 +19,32 @@ import { PostMessageMock } from "$tests/mocks/post-message.mocks";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
+type BalancesMessageEvent = MessageEvent<
+  PostMessage<PostMessageDataResponseBalances | PostMessageDataResponseSync>
+>;
+
+let postMessageMock: PostMessageMock<BalancesMessageEvent>;
+
+vi.mock("$lib/workers/balances.worker?worker", () => ({
+  default: class BalancesWorker {
+    constructor() {
+      postMessageMock.subscribe(async (msg) => await this.onmessage(msg));
+    }
+
+    postMessage(_data: {
+      msg: "nnsStartBalancesTimer" | "nnsStopBalancesTimer";
+      data?: PostMessageDataRequestBalances;
+    }) {
+      // Nothing here
+    }
+
+    onmessage = async (_params: BalancesMessageEvent) => {
+      // Nothing here
+    };
+  },
+}));
+
 describe("IcrcBalancesObserver", () => {
-  type BalancesMessageEvent = MessageEvent<
-    PostMessage<PostMessageDataResponseBalances | PostMessageDataResponseSync>
-  >;
-
-  let postMessageMock: PostMessageMock<BalancesMessageEvent>;
-
   beforeEach(() => {
     const accounts: Account[] = [mockCkBTCMainAccount];
     icrcAccountsStore.set({
@@ -39,25 +58,6 @@ describe("IcrcBalancesObserver", () => {
     });
 
     postMessageMock = new PostMessageMock();
-
-    vi.doMock("$lib/workers/balances.worker?worker", () => ({
-      default: class BalancesWorker {
-        constructor() {
-          postMessageMock.subscribe(async (msg) => await this.onmessage(msg));
-        }
-
-        postMessage(_data: {
-          msg: "nnsStartBalancesTimer" | "nnsStopBalancesTimer";
-          data?: PostMessageDataRequestBalances;
-        }) {
-          // Nothing here
-        }
-
-        onmessage = async (_params: BalancesMessageEvent) => {
-          // Nothing here
-        };
-      },
-    }));
   });
 
   it("should init data and render slotted content", async () => {

--- a/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsObserver.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/IcrcWalletTransactionsObserver.spec.ts
@@ -20,15 +20,32 @@ import { jsonReplacer } from "@dfinity/utils";
 import { render, waitFor } from "@testing-library/svelte";
 import { get } from "svelte/store";
 
+type TransactionsMessageEvent = MessageEvent<
+  PostMessage<PostMessageDataResponseTransactions | PostMessageDataResponseSync>
+>;
+
+let postMessageMock: PostMessageMock<TransactionsMessageEvent>;
+
+vi.mock("$lib/workers/transactions.worker?worker", () => ({
+  default: class TransactionsWorker {
+    constructor() {
+      postMessageMock.subscribe(async (msg) => await this.onmessage(msg));
+    }
+
+    postMessage(_data: {
+      msg: "nnsStartTransactionsTimer" | "nnsStopTransactionsTimer";
+      data?: PostMessageDataRequestTransactions;
+    }) {
+      // Nothing here
+    }
+
+    onmessage = async (_params: TransactionsMessageEvent) => {
+      // Nothing here
+    };
+  },
+}));
+
 describe("IcrcWalletTransactionsObserver", () => {
-  type TransactionsMessageEvent = MessageEvent<
-    PostMessage<
-      PostMessageDataResponseTransactions | PostMessageDataResponseSync
-    >
-  >;
-
-  let postMessageMock: PostMessageMock<TransactionsMessageEvent>;
-
   const transaction = {
     canisterId: CKTESTBTC_UNIVERSE_CANISTER_ID,
     transactions: [mockIcrcTransactionWithId],
@@ -46,25 +63,6 @@ describe("IcrcWalletTransactionsObserver", () => {
     });
 
     postMessageMock = new PostMessageMock();
-
-    vi.doMock("$lib/workers/transactions.worker?worker", () => ({
-      default: class TransactionsWorker {
-        constructor() {
-          postMessageMock.subscribe(async (msg) => await this.onmessage(msg));
-        }
-
-        postMessage(_data: {
-          msg: "nnsStartTransactionsTimer" | "nnsStopTransactionsTimer";
-          data?: PostMessageDataRequestTransactions;
-        }) {
-          // Nothing here
-        }
-
-        onmessage = async (_params: TransactionsMessageEvent) => {
-          // Nothing here
-        };
-      },
-    }));
   });
 
   it("should init data and render slotted content", async () => {

--- a/frontend/src/tests/lib/components/accounts/TransactionsObserver.spec.ts
+++ b/frontend/src/tests/lib/components/accounts/TransactionsObserver.spec.ts
@@ -6,22 +6,22 @@ import { mockMainAccount } from "$tests/mocks/icp-accounts.store.mock";
 import { indexCanisterIdMock } from "$tests/mocks/sns.api.mock";
 import { render, waitFor } from "@testing-library/svelte";
 
-describe("TransactionsObserver", () => {
-  let spyPostMessage;
+let spyPostMessage;
 
+vi.mock("$lib/workers/transactions.worker?worker", () => ({
+  default: class TransactionsWorker {
+    postMessage(data: {
+      msg: "nnsStartTransactionsTimer";
+      data: PostMessageDataRequestTransactions;
+    }) {
+      spyPostMessage(data);
+    }
+  },
+}));
+
+describe("TransactionsObserver", () => {
   beforeEach(() => {
     spyPostMessage = vi.fn();
-
-    vi.doMock("$lib/workers/transactions.worker?worker", () => ({
-      default: class TransactionsWorker {
-        postMessage(data: {
-          msg: "nnsStartTransactionsTimer";
-          data: PostMessageDataRequestTransactions;
-        }) {
-          spyPostMessage(data);
-        }
-      },
-    }));
   });
 
   const data: TransactionsObserverData = {

--- a/frontend/src/tests/lib/services/worker-balances.services.spec.ts
+++ b/frontend/src/tests/lib/services/worker-balances.services.spec.ts
@@ -8,34 +8,34 @@ import type { PostMessageDataResponseSync } from "$lib/types/post-message.sync";
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { ledgerCanisterIdMock } from "$tests/mocks/sns.api.mock";
 
-describe("initBalancesWorker", () => {
-  let spyPostMessage;
-  let workerOnMessage;
+let spyPostMessage;
+let workerOnMessage;
 
+vi.mock("$lib/workers/balances.worker?worker", () => ({
+  default: class BalancesWorker {
+    postMessage(data: {
+      msg: "nnsStartBalancesTimer";
+      data: PostMessageDataRequestBalances;
+    }) {
+      spyPostMessage(data);
+    }
+
+    set onmessage(
+      callback: (
+        event: MessageEvent<
+          PostMessageDataResponseBalances | PostMessageDataResponseSync
+        >
+      ) => void
+    ) {
+      workerOnMessage = callback;
+    }
+  },
+}));
+
+describe("initBalancesWorker", () => {
   beforeEach(() => {
     workerOnMessage = undefined;
     spyPostMessage = vi.fn();
-
-    vi.doMock("$lib/workers/balances.worker?worker", () => ({
-      default: class BalancesWorker {
-        postMessage(data: {
-          msg: "nnsStartBalancesTimer";
-          data: PostMessageDataRequestBalances;
-        }) {
-          spyPostMessage(data);
-        }
-
-        set onmessage(
-          callback: (
-            event: MessageEvent<
-              PostMessageDataResponseBalances | PostMessageDataResponseSync
-            >
-          ) => void
-        ) {
-          workerOnMessage = callback;
-        }
-      },
-    }));
   });
 
   it("should start worker with params", async () => {

--- a/frontend/src/tests/lib/services/worker-transactions.services.spec.ts
+++ b/frontend/src/tests/lib/services/worker-transactions.services.spec.ts
@@ -4,22 +4,22 @@ import type { PostMessageDataRequestTransactions } from "$lib/types/post-message
 import { mockSnsMainAccount } from "$tests/mocks/sns-accounts.mock";
 import { indexCanisterIdMock } from "$tests/mocks/sns.api.mock";
 
-describe("initTransactionsWorker", () => {
-  let spyPostMessage;
+let spyPostMessage;
 
+vi.mock("$lib/workers/transactions.worker?worker", () => ({
+  default: class TransactionsWorker {
+    postMessage(data: {
+      msg: "nnsStartTransactionsTimer";
+      data: PostMessageDataRequestTransactions;
+    }) {
+      spyPostMessage(data);
+    }
+  },
+}));
+
+describe("initTransactionsWorker", () => {
   beforeEach(() => {
     spyPostMessage = vi.fn();
-
-    vi.doMock("$lib/workers/transactions.worker?worker", () => ({
-      default: class TransactionsWorker {
-        postMessage(data: {
-          msg: "nnsStartTransactionsTimer";
-          data: PostMessageDataRequestTransactions;
-        }) {
-          spyPostMessage(data);
-        }
-      },
-    }));
   });
 
   it("should start worker with params", async () => {


### PR DESCRIPTION
# Motivation

Because [vi.doMock is not hoisted to the top of the file](https://vitest.dev/api/vi.html#vi-domock), only the next dynamic import of the module will be mocked. This could lead to unpredictable errors when some modules are not mocked (e.g., ReferenceError: Worker is not defined).

# Changes

- Replace doMock with mock.

# Tests

- Pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary.