### PR TITLE
Delete duplicate replacement in neuron-details.spec.ts

### DIFF
--- a/frontend/src/tests/e2e/neuron-details.spec.ts
+++ b/frontend/src/tests/e2e/neuron-details.spec.ts
@@ -48,7 +48,7 @@ test("Test neuron details", async ({ page, context }) => {
     page,
     selectors: ['[data-tid="identifier"]', '[data-tid="neuron-id"]'],
     pattern: /^[0-9a-f]+$/,
-    replacements: ["7737260276268288098", "7737260276268288098"],
+    replacements: ["7737260276268288098"],
   });
   await replaceContent({
     page,


### PR DESCRIPTION
# Motivation

There is a duplicate replacement for neruon id in neuron-details.spec.ts which is not needed. 

This issue is created when `NNS1-3349-add-neuron-details-spec` into `NNS1-3349-add-neuron-visibility-toggle` branch, later on `NNS1-3349-add-neuron-details-spec` is updated and removed that duplicate, because these changes are introduced and deleted in `NNS1-3349-add-neuron-details-spec` branch and when we we squash merge, the main had no clue about what happened in neuron-details.spec.ts , however on `NNS1-3349-add-neuron-visibility-toggle` there was still changes.

This was a result of squash merge strategy to main, fast-forward merging strategy and not merging base branch changes into side branches before merging the side branches to main.

This leaked duplicate was first found [here](https://github.com/dfinity/nns-dapp/pull/5516/files#r1787779453), but the following [PR](https://github.com/dfinity/nns-dapp/pull/5574/files) for fixing leaked code due to bad merge didn't include the changes related to this duplicate. It looks like it has never been fixed after the leak. 

# Changes

Delete duplicate replacement in neuron-details.spec.ts

# Tests

Test pass

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary
