### PR TITLE
Script to rerun failed GitHub actions run

### DIFF
--- a/scripts/github-rerun
+++ b/scripts/github-rerun
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+print_help() {
+  cat <<-EOF
+
+	Reruns a failed GitHub Actions run based on its URL.
+
+	EXAMPLE USAGE:
+		$0 https://github.com/dfinity/snsdemo/actions/runs/11514250845/job/32052488208
+	EOF
+}
+
+URL="${1:-}"
+URL_PATTERN="https://github.com/([^/]*/[^/]*)/actions/runs/([^/]*).*"
+
+if [[ -z "${URL:-}" ]]; then
+  print_help
+  exit 0
+fi
+
+if ! [[ "$URL" =~ $URL_PATTERN ]]; then
+  echo "Invalid URL: $URL" >&2
+  echo "URL should match the pattern: $URL_PATTERN" >&2
+  exit 1
+fi
+
+REPO=$(echo "$URL" | sed -E "s|$URL_PATTERN|\\1|")
+RUN_ID=$(echo "$URL" | sed -E "s|$URL_PATTERN|\\2|")
+
+echo "Rerunning $REPO run $RUN_ID..."
+COMMAND=(gh run rerun --repo "$REPO" --failed "$RUN_ID")
+while ! "${COMMAND[@]}"; do
+  echo "Failed. Retrying in 1 minute..."
+  sleep 60
+done


### PR DESCRIPTION
# Motivation

Sometimes when a test fails because of a network issue or other flakiness, we want to rerun the test.
Unfortunately, the rerun can only be triggered after all the other tests have also finished.
For that it can be useful to keep trying to rerun in a loop until it succeeds.

# Changes

Add `scripts/github-rerun` to which you can pass the URL of a run and it will try to rerun that run once a minute until it reruns.

# Tests

Tried manually with
```
scripts/github-rerun https://github.com/dfinity/snsdemo/actions/runs/11514250845/job/32052488208
```
and
```
scripts/github-rerun https://github.com/dfinity/snsdemo/actions/runs/11514250846
```

# Todos

- [ ] Add entry to changelog (if necessary).
not necesssary