### PR TITLE
Remove skipCheck left-overs

### DIFF
--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -259,7 +259,6 @@ export const stakeNeuron = async ({
  * This gets all neurons linked to the current user's principal, even those with a stake of 0. And adds them to the store
  *
  * @param {Object} params
- * @param {skipCheck} params.skipCheck it true, the neurons' balance won't be checked and those that are not synced won't be refreshed. It avoids possible infinite loops.
  * @param {callback} params.callback an optional callback that can be called when the data are successfully loaded (certified or not). Useful for example to close synchronously a busy spinner once all data have been fetched.
  */
 export const listNeurons = async ({
@@ -888,7 +887,6 @@ export const loadNeuron = ({
 }: {
   neuronId: NeuronId;
   forceFetch?: boolean;
-  skipCheck?: boolean;
   setNeuron: (params: { neuron: NeuronInfo; certified: boolean }) => void;
   handleError?: () => void;
   strategy?: QueryAndUpdateStrategy;


### PR DESCRIPTION
# Motivation

https://github.com/dfinity/nns-dapp/pull/999 removed `skipCheck` from `listNeurons` and `loadNeuron`.
But it left some traces in the function type and comments.

# Changes

Remove the references to the parameter that no longer exists.

# Tests

Lint passes.

# Todos

- [ ] Add entry to changelog (if necessary).
not necessary