### PR TITLE
FOLLOW-244: Add refreshNeuronIfNeeded service

### DIFF
--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -1026,7 +1026,7 @@ export const refreshNeuronIfNeeded = async (
     !checkedNeuronSubaccountsStore.addSubaccount({
       universeId: OWN_CANISTER_ID_TEXT,
       // It's not actually the subaccount but rather the full account
-      // identifier. But ic-js doesn't expect the neuron's subaccount and it
+      // identifier. But ic-js doesn't expose the neuron's subaccount and it
       // really just needs to be a unique consistent identifier to avoid
       // checking too often.
       subaccountHex: accountIdentifier,

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -1020,7 +1020,7 @@ export const refreshNeuronIfNeeded = async (
   }
   const accountIdentifier = neuron.fullNeuron.accountIdentifier;
 
-  // We only check neurons to recover from an interrupted stake/top-up.
+  // We only check neurons to recover from an interrupted top-up.
   // Doing this once per neuron per session is often enough.
   if (
     !checkedNeuronSubaccountsStore.addSubaccount({

--- a/frontend/src/lib/services/neurons.services.ts
+++ b/frontend/src/lib/services/neurons.services.ts
@@ -1,6 +1,8 @@
 import { governanceApiService } from "$lib/api-services/governance.api-service";
 import { makeDummyProposals as makeDummyProposalsApi } from "$lib/api/dev.api";
+import { queryAccountBalance } from "$lib/api/icp-ledger.api";
 import type { SubAccountArray } from "$lib/canisters/nns-dapp/nns-dapp.types";
+import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { IS_TESTNET } from "$lib/constants/environment.constants";
 import {
   CANDID_PARSER_VERSION,
@@ -13,6 +15,7 @@ import type { LedgerIdentity } from "$lib/identities/ledger.identity";
 import { getLedgerIdentityProxy } from "$lib/proxy/icp-ledger.services.proxy";
 import { loadActionableProposals } from "$lib/services/actionable-proposals.services";
 import { startBusy, stopBusy } from "$lib/stores/busy.store";
+import { checkedNeuronSubaccountsStore } from "$lib/stores/checked-neurons.store";
 import { definedNeuronsStore, neuronsStore } from "$lib/stores/neurons.store";
 import {
   toastsError,
@@ -53,10 +56,12 @@ import { AnonymousIdentity, type Identity } from "@dfinity/agent";
 import {
   NeuronVisibility,
   Topic,
+  type Neuron,
   type NeuronId,
   type NeuronInfo,
 } from "@dfinity/nns";
 import { Principal } from "@dfinity/principal";
+import { isNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
 import { getAuthenticatedIdentity } from "./auth.services";
 import {
@@ -993,6 +998,46 @@ export const topUpNeuron = async ({
   }
 
   return { success };
+};
+
+const neuronNeedsRefresh = async (fullNeuron: Neuron): Promise<boolean> => {
+  const expectedBalance: bigint = fullNeuron.cachedNeuronStake;
+  const actualBalance: bigint = await queryAccountBalance({
+    icpAccountIdentifier: fullNeuron.accountIdentifier,
+    identity: new AnonymousIdentity(),
+    // This is just a fallback. Worst case a malicious node prevents us from
+    // refreshing the neuron but then it will be refreshed next time.
+    certified: false,
+  });
+  return expectedBalance !== actualBalance;
+};
+
+export const refreshNeuronIfNeeded = async (
+  neuron: NeuronInfo
+): Promise<void> => {
+  if (isNullish(neuron.fullNeuron)) {
+    return;
+  }
+  const accountIdentifier = neuron.fullNeuron.accountIdentifier;
+
+  // We only check neurons to recover from an interrupted stake/top-up.
+  // Doing this once per neuron per session is often enough.
+  if (
+    !checkedNeuronSubaccountsStore.addSubaccount({
+      universeId: OWN_CANISTER_ID_TEXT,
+      // It's not actually the subaccount but rather the full account
+      // identifier. But ic-js doesn't expect the neuron's subaccount and it
+      // really just needs to be a unique consistent identifier to avoid
+      // checking too often.
+      subaccountHex: accountIdentifier,
+    })
+  ) {
+    return;
+  }
+
+  if (await neuronNeedsRefresh(neuron.fullNeuron)) {
+    await reloadNeuron(neuron.neuronId);
+  }
 };
 
 export const makeDummyProposals = async (neuronId: NeuronId): Promise<void> => {

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -2133,6 +2133,7 @@ describe("neurons-services", () => {
 
       await refreshNeuronIfNeeded(neuron);
       expect(spyQueryAccountBalance).toBeCalledTimes(1);
+      expect(spyClaimOrRefresh).toBeCalledTimes(0);
     });
   });
 

--- a/frontend/src/tests/lib/services/neurons.services.spec.ts
+++ b/frontend/src/tests/lib/services/neurons.services.spec.ts
@@ -1,5 +1,6 @@
 import { resetNeuronsApiService } from "$lib/api-services/governance.api-service";
 import * as api from "$lib/api/governance.api";
+import * as icpLedgerApi from "$lib/api/icp-ledger.api";
 import { DEFAULT_TRANSACTION_FEE_E8S } from "$lib/constants/icp.constants";
 import { MIN_NEURON_STAKE } from "$lib/constants/neurons.constants";
 import { NNS_TOKEN_DATA } from "$lib/constants/tokens.constants";
@@ -12,6 +13,7 @@ import {
 import * as services from "$lib/services/neurons.services";
 import { toggleAutoStakeMaturity } from "$lib/services/neurons.services";
 import * as busyStore from "$lib/stores/busy.store";
+import { checkedNeuronSubaccountsStore } from "$lib/stores/checked-neurons.store";
 import { overrideFeatureFlagsStore } from "$lib/stores/feature-flags.store";
 import { definedNeuronsStore, neuronsStore } from "$lib/stores/neurons.store";
 import { NotAuthorizedNeuronError } from "$lib/types/neurons.errors";
@@ -66,6 +68,7 @@ const {
   reloadNeuron,
   topUpNeuron,
   changeNeuronVisibility,
+  refreshNeuronIfNeeded,
 } = services;
 
 const expectToastError = (contained: string) =>
@@ -161,6 +164,7 @@ describe("neurons-services", () => {
   const spySetFollowees = vi.spyOn(api, "setFollowees");
   const spyClaimOrRefresh = vi.spyOn(api, "claimOrRefreshNeuron");
   const spyChangeNeuronVisibility = vi.spyOn(api, "changeNeuronVisibility");
+  const spyQueryAccountBalance = vi.spyOn(icpLedgerApi, "queryAccountBalance");
   let spyConsoleError;
 
   beforeEach(() => {
@@ -174,6 +178,7 @@ describe("neurons-services", () => {
     toastsStore.reset();
     resetNeuronsApiService();
     overrideFeatureFlagsStore.reset();
+    checkedNeuronSubaccountsStore.reset();
 
     spyStakeNeuron.mockImplementation(() =>
       Promise.resolve(mockNeuron.neuronId)
@@ -2022,6 +2027,112 @@ describe("neurons-services", () => {
       expect(transferICP).not.toBeCalled();
       expect(spyClaimOrRefresh).not.toBeCalled();
       expect(spyGetNeuron).not.toBeCalled();
+    });
+  });
+
+  describe("refreshNeuronIfNeeded", () => {
+    it("should refresh the neuron if its account balance doesn't match", async () => {
+      const oldStake = 1_000_000_000n;
+      const newStake = 2_000_000_000n;
+      const neuronId = 31n;
+      const neuronAccountIdentifier = "23847628347623847623847269";
+
+      const neuron = {
+        ...mockNeuron,
+        neuronId,
+        stake: oldStake,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          cachedNeuronStake: oldStake,
+          accountIdentifier: neuronAccountIdentifier,
+        },
+      };
+
+      spyQueryAccountBalance.mockResolvedValue(newStake);
+
+      expect(spyQueryAccountBalance).toBeCalledTimes(0);
+      expect(spyClaimOrRefresh).toBeCalledTimes(0);
+
+      await refreshNeuronIfNeeded(neuron);
+
+      expect(spyQueryAccountBalance).toBeCalledTimes(1);
+      expect(spyQueryAccountBalance).toBeCalledWith({
+        icpAccountIdentifier: neuronAccountIdentifier,
+        certified: false,
+        identity: new AnonymousIdentity(),
+      });
+      expect(spyClaimOrRefresh).toBeCalledTimes(1);
+      expect(spyClaimOrRefresh).toBeCalledWith({
+        identity: mockIdentity,
+        neuronId: neuronId,
+      });
+    });
+
+    it("should not refresh the neuron if its account balance does match", async () => {
+      const stake = 1_000_000_000n;
+      const neuronId = 31n;
+      const neuronAccountIdentifier = "23847628347623847623847269";
+
+      const neuron = {
+        ...mockNeuron,
+        neuronId,
+        stake,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          cachedNeuronStake: stake,
+          accountIdentifier: neuronAccountIdentifier,
+        },
+      };
+
+      spyQueryAccountBalance.mockResolvedValue(stake);
+
+      expect(spyQueryAccountBalance).toBeCalledTimes(0);
+      expect(spyClaimOrRefresh).toBeCalledTimes(0);
+
+      await refreshNeuronIfNeeded(neuron);
+
+      expect(spyQueryAccountBalance).toBeCalledTimes(1);
+      expect(spyQueryAccountBalance).toBeCalledWith({
+        icpAccountIdentifier: neuronAccountIdentifier,
+        certified: false,
+        identity: new AnonymousIdentity(),
+      });
+      expect(spyClaimOrRefresh).toBeCalledTimes(0);
+    });
+
+    it("should query neuron's balance only once per session", async () => {
+      const stake = 1_000_000_000n;
+      const neuronId = 31n;
+      const neuronAccountIdentifier = "23847628347623847623847269";
+
+      const neuron = {
+        ...mockNeuron,
+        neuronId,
+        stake,
+        fullNeuron: {
+          ...mockNeuron.fullNeuron,
+          cachedNeuronStake: stake,
+          accountIdentifier: neuronAccountIdentifier,
+        },
+      };
+
+      spyQueryAccountBalance.mockResolvedValue(stake);
+
+      expect(spyQueryAccountBalance).toBeCalledTimes(0);
+      expect(spyClaimOrRefresh).toBeCalledTimes(0);
+
+      await refreshNeuronIfNeeded(neuron);
+
+      expect(spyQueryAccountBalance).toBeCalledTimes(1);
+      expect(spyQueryAccountBalance).toBeCalledWith({
+        icpAccountIdentifier: neuronAccountIdentifier,
+        certified: false,
+        identity: new AnonymousIdentity(),
+      });
+      expect(spyClaimOrRefresh).toBeCalledTimes(0);
+
+      await refreshNeuronIfNeeded(neuron);
+      expect(spyQueryAccountBalance).toBeCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
# Motivation

Increasing a neurons' stake is a 2 step process:
1. Transfer ICP to the neuron's account.
2. Notify the governance canister to refresh the neurons.

Because this process can be interrupted after step 1, we need to be able to finish a half completed process.
Currently the nns-dapp canister has a list of neuron accounts for each user and it watches every ICP ledger transaction to see if it is to a neuron account and then it refreshes that neuron.
We want to stop keeping this list in the nns-dapp canister and we want to stop watching every transaction.
So instead we will check from the frontend if a neuron's stake matches its account's balance and refresh if needed.

This PR just adds a service function to check if the balance matches and refresh if it doesn't.
It also uses existing `checkedNeuronSubaccountsStore` to avoid checking too often.

# Changes

1. Add `refreshNeuronIfNeeded` function to `neurons.services.ts`.

# Tests

1. Unit tests added.
2. Tested manually in another branch in which the nns-dapp canister was changed to no longer perform this actions described above. I also tested with a neuron from which proposals were created to check that the expected stake still matches the balance.

# Todos

- [ ] Add entry to changelog (if necessary).
Will add when the service function is used.