### PR TITLE
FOLLOW-244: Refresh neuron from NeuronDetail page

### DIFF
--- a/CHANGELOG-Nns-Dapp-unreleased.md
+++ b/CHANGELOG-Nns-Dapp-unreleased.md
@@ -16,6 +16,7 @@ proposal is successful, the changes it released will be moved from this file to
 
 * Provide better error messages when the transaction timestamp is off.
 * A link to the imported tokens documentation page.
+* Refresh NNS neurons from neuron details page if needed.
 
 #### Changed
 

--- a/frontend/src/lib/pages/NnsNeuronDetail.svelte
+++ b/frontend/src/lib/pages/NnsNeuronDetail.svelte
@@ -20,7 +20,10 @@
   import { AppPath } from "$lib/constants/routes.constants";
   import { pageStore } from "$lib/derived/page.derived";
   import NnsNeuronModals from "$lib/modals/neurons/NnsNeuronModals.svelte";
-  import { listNeurons } from "$lib/services/neurons.services";
+  import {
+    listNeurons,
+    refreshNeuronIfNeeded,
+  } from "$lib/services/neurons.services";
   import { loadLatestRewardEvent } from "$lib/services/nns-reward-event.services";
   import { i18n } from "$lib/stores/i18n";
   import { neuronsStore } from "$lib/stores/neurons.store";
@@ -38,6 +41,7 @@
   } from "$lib/utils/neuron.utils";
   import { Island } from "@dfinity/gix-components";
   import type { NeuronId, NeuronInfo } from "@dfinity/nns";
+  import { nonNullish } from "@dfinity/utils";
   import { onMount, setContext } from "svelte";
   import { writable } from "svelte/store";
 
@@ -139,6 +143,10 @@
   setContext<NnsNeuronContext>(NNS_NEURON_CONTEXT_KEY, {
     store: selectedNeuronStore,
   });
+
+  $: if (nonNullish(neuron)) {
+    refreshNeuronIfNeeded(neuron);
+  }
 </script>
 
 <TestIdWrapper testId="nns-neuron-detail-component">

--- a/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
+++ b/frontend/src/tests/lib/routes/NeuronDetail.spec.ts
@@ -1,4 +1,5 @@
 import * as agent from "$lib/api/agent.api";
+import * as icpLedgerApi from "$lib/api/icp-ledger.api";
 import * as icrcLedgerApi from "$lib/api/icrc-ledger.api";
 import { OWN_CANISTER_ID_TEXT } from "$lib/constants/canister-ids.constants";
 import { AppPath } from "$lib/constants/routes.constants";
@@ -23,6 +24,7 @@ import { waitFor } from "@testing-library/dom";
 import { render } from "@testing-library/svelte";
 import { mock } from "vitest-mock-extended";
 
+vi.mock("$lib/api/icp-ledger.api");
 vi.mock("$lib/api/icrc-ledger.api");
 vi.mock("$lib/api/sns-aggregator.api");
 vi.mock("$lib/api/governance.api");
@@ -37,7 +39,7 @@ const nnsProps = {
   neuronId: testNnsNeuronId,
 };
 
-const blockedPaths = ["$lib/api/icrc-ledger.api"];
+const blockedPaths = ["$lib/api/icrc-ledger.api", "$lib/api/icp-ledger.api"];
 
 describe("NeuronDetail", () => {
   blockAllCallsTo(blockedPaths);
@@ -51,6 +53,7 @@ describe("NeuronDetail", () => {
     resetSnsProjects();
     vi.spyOn(agent, "createAgent").mockResolvedValue(mock<HttpAgent>());
     vi.spyOn(icrcLedgerApi, "queryIcrcBalance").mockResolvedValue(0n);
+    vi.spyOn(icpLedgerApi, "queryAccountBalance").mockResolvedValue(0n);
   });
 
   describe("nns neuron", () => {


### PR DESCRIPTION
# Motivation

Increasing a neurons' stake is a 2 step process:
1. Transfer ICP to the neuron's account.
2. Notify the governance canister to refresh the neurons.

Because this process can be interrupted after step 1, we need to be able to finish a half completed process.
Currently the nns-dapp canister has a list of neuron accounts for each user and it watches every ICP ledger transaction to see if it is to a neuron account and then it refreshes that neuron.
We want to stop keeping this list in the nns-dapp canister and we want to stop watching every transaction.
So instead we will check from the frontend if a neuron's stake matches its account's balance and refresh if needed.

In this PR we call the service added in https://github.com/dfinity/nns-dapp/pull/5696 from the `NnsNeuronDetail` component.


# Changes

1. Call `refreshNeuronIfNeeded` from `NnsNeuronDetail` once the neuron is loaded.

# Tests

1. Add missing `queryNeuron` and `claimOrRefreshNeuron` to fake governance API.
2. Add unit tests.
3. Manually tested after removing the corresponding logic from the canister.

# Todos

- [x] Add entry to changelog (if necessary).
